### PR TITLE
Add -fPIC option for 64 bit linux machine compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,23 +25,6 @@ IF(NOT CMAKE_BUILD_TYPE)
       FORCE)
 ENDIF(NOT CMAKE_BUILD_TYPE)
 
-# 64-bit unix system compatibility (build with -fPIC option)
-# See: http://www.technovelty.org/c/position-independent-code-and-x86-64-libraries.html
-#      http://www.gentoo.org/proj/en/base/amd64/howtos/?part=1&chap=3
-if(UNIX AND NOT WIN32)
-  set (CMAKE_INSTALL_PREFIX "/usr" CACHE STRING "Install Prefix")
-  find_program(CMAKE_UNAME uname /bin /usr/bin /usr/local/bin )
-  if(CMAKE_UNAME)
-    exec_program(uname ARGS -m OUTPUT_VARIABLE CMAKE_SYSTEM_PROCESSOR)
-    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR} CACHE INTERNAL
-      "processor type (i386 and x86_64)")
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-      ADD_DEFINITIONS(-fPIC)
-    endif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-  endif(CMAKE_UNAME)
-endif()
-set (CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
-
 # GCCFilter, if appliciable
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCPP)
    option(COLOR_GCC "Use GCCFilter to color compiler output messages" OFF)
@@ -57,7 +40,7 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD /Zi /GL /Gy /W1 /EHsc /arch:SSE2 /openmp")
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/LTCG")
 elseif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "-msse2")
+  set(CMAKE_CXX_FLAGS "-msse2 -fPIC")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
   set(CMAKE_CXX_FLAGS_DEBUG "-g -fno-omit-frame-pointer -fno-inline-functions -fno-inline-functions-called-once -fno-optimize-sibling-calls")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG}")


### PR DESCRIPTION
When dart is linked to gazebo on 64 bit Ubuntu machine, the below error is occurred:
```
:-1: error: /usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib/libdartd.a(UtilsRotation.cpp.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
```
CMakeLists.txt was modified to fix this issue.
