### PR TITLE
Create DART_INCLUDE_DIRS in DartConfig.cmake

### DIFF
--- a/cmake/DARTConfig.cmake.in
+++ b/cmake/DARTConfig.cmake.in
@@ -7,6 +7,7 @@
 # This sets the following variables:
 # DART_FOUND - True if DART was found.
 # DART_INCLUDEDIR - Directories containing the DART include files.
+# DART_INCLUDE_DIRS - Directories containing the DART include files.
 # DART_LIBRARIES - Libraries needed to use DART.
 # DART_DEFINITIONS - Compiler flags for DART.
 
@@ -42,5 +43,8 @@ set(DART_LIBRARIES optimized ${DART_LIBS} debug ${DART_LIBS}d)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(DART DEFAULT_MSG DART_FOUND_2)
 
-mark_as_advanced(DART_FOUND DART_LIBRARY_DIRS DART_INCLUDEDIR DART_LIBRARIES)
+set(DART_INCLUDE_DIRS ${DART_INCLUDEDIR})
+
+mark_as_advanced(DART_FOUND DART_LIBRARY_DIRS DART_INCLUDEDIR DART_LIBRARIES
+                 DART_INCLUDE_DIRS)
 

--- a/cmake/FindDARTExt.cmake.in
+++ b/cmake/FindDARTExt.cmake.in
@@ -3,6 +3,7 @@
 # This sets the following variables:
 # DARTExt_FOUND - If all the Dart externals were found or not
 # DARTExt_INCLUDEDIR - Directories containing the DART external include files.
+# DARTExt_INCLUDE_DIRS - Directories containing the DART external include files.
 # DARTExt_LIBRARIES - Libraries needed to use DART External.
 # DARTExt_DEFINITIONS - Compiler flags for DART External.
 # Boost_LIBRARIES - Boost Libraries required for DART
@@ -214,6 +215,9 @@ ${urdfdom_INCLUDE_DIRS} )
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(DARTExt DEFAULT_MSG DARTExt_FOUND)
 
-mark_as_advanced(DARTExt_LIBRARY_DIRS DARTExt_INCLUDEDIR DARTExt_LIBRARIES FLANN_LIBRARIES CCD_LIBRARIES FCL_LIBRARIES Boost_LIBRARIES)
+set(DARTExt_INCLUDE_DIRS ${DARTExt_INCLUDEDIR})
+
+mark_as_advanced(DARTExt_LIBRARY_DIRS DARTExt_INCLUDEDIR DARTExt_LIBRARIES FLANN_LIBRARIES CCD_LIBRARIES FCL_LIBRARIES Boost_LIBRARIES
+                 DARTExt_INCLUDE_DIRS)
 
 


### PR DESCRIPTION
Copy DART_INCLUDEDIR into DART_INCLUDE_DIRS variable, which
matches cmake conventions.
