### PR TITLE
Fix #41: don't force CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,11 @@ set(CMAKE_DEBUG_POSTFIX "d")
 
 # System Install paths
 if(WIN32)
-  set(CMAKE_INSTALL_PREFIX "C:/Golems" CACHE PATH "Install prefix" FORCE)
+  set(CMAKE_INSTALL_PREFIX "C:/Golems" CACHE PATH "Install prefix")
 elseif(APPLE)
-  set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE PATH "Install prefix" FORCE)
+  set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE PATH "Install prefix")
 else()
-  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Install prefix" FORCE)
+  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Install prefix")
 endif()
 
 ###############


### PR DESCRIPTION
Remove the FORCE modifier from CMAKE_INSTALL_PREFIX,
so users can install to their own path.

Fixes #41 
