### PR TITLE
Remove Joint alias functions from BodyNode

### DIFF
--- a/src/dynamics/BodyNode.cpp
+++ b/src/dynamics/BodyNode.cpp
@@ -212,9 +212,9 @@ void BodyNode::setDependDofList()
                               mParentBodyNode->mDependentDofIndexes.end());
     }
 
-    for (int i = 0; i < getNumLocalDofs(); i++)
+    for (int i = 0; i < mParentJoint->getNumGenCoords(); i++)
     {
-        int dofID = getLocalGenCoord(i)->getSkeletonIndex();
+        int dofID = mParentJoint->getGenCoord(i)->getSkeletonIndex();
         mDependentDofIndexes.push_back(dofID);
     }
 
@@ -236,21 +236,6 @@ bool BodyNode::dependsOn(int _dofIndex) const
     return binary_search(mDependentDofIndexes.begin(),
                          mDependentDofIndexes.end(),
                          _dofIndex);
-}
-
-int BodyNode::getNumLocalDofs() const
-{
-    return mParentJoint->getNumGenCoords();
-}
-
-GenCoord* BodyNode::getLocalGenCoord(int _idx) const
-{
-    return mParentJoint->getGenCoord(_idx);
-}
-
-bool BodyNode::isPresent(const GenCoord* _q) const
-{
-    return mParentJoint->isPresent(_q);
 }
 
 int BodyNode::getNumDependentDofs() const
@@ -532,13 +517,13 @@ void BodyNode::updateVelocity(bool _updateJacobian)
     //          n: number of dependent coordinates
     //--------------------------------------------------------------------------
 
-    const int numLocalDOFs = getNumLocalDofs();
+    const int numLocalDOFs = mParentJoint->getNumGenCoords();
     const int numParentDOFs = getNumDependentDofs()-numLocalDOFs;
 
     // Parent Jacobian
     if (mParentBodyNode != NULL)
     {
-        assert(mParentBodyNode->mBodyJacobian.cols() + getNumLocalDofs()
+        assert(mParentBodyNode->mBodyJacobian.cols() + mParentJoint->getNumGenCoords()
                == mBodyJacobian.cols());
 
         for (int i = 0; i < numParentDOFs; ++i)
@@ -609,13 +594,13 @@ void BodyNode::updateAcceleration(bool _updateJacobianDeriv)
     //          n: number of dependent coordinates
     //--------------------------------------------------------------------------
 
-    const int numLocalDOFs = getNumLocalDofs();
+    const int numLocalDOFs = mParentJoint->getNumGenCoords();
     const int numParentDOFs = getNumDependentDofs() - numLocalDOFs;
 
     // Parent Jacobian
     if (mParentBodyNode != NULL)
     {
-        assert(mParentBodyNode->mBodyJacobianDeriv.cols() + getNumLocalDofs()
+        assert(mParentBodyNode->mBodyJacobianDeriv.cols() + mParentJoint->getNumGenCoords()
                == mBodyJacobianDeriv.cols());
 
         for (int i = 0; i < numParentDOFs; ++i)

--- a/src/dynamics/BodyNode.h
+++ b/src/dynamics/BodyNode.h
@@ -237,15 +237,6 @@ public:
     /// efficiency.
     bool dependsOn(int _dofIndex) const;
 
-    /// @brief
-    int getNumLocalDofs() const;
-
-    /// @brief
-    GenCoord* getLocalGenCoord(int _idx) const;
-
-    /// @brief true if d is present in the dof list for the joint.
-    bool isPresent(const GenCoord* _q) const;
-
     /// @brief The number of the dofs by which this node is affected.
     int getNumDependentDofs() const;
 


### PR DESCRIPTION
There were functions in BodyNode that were just aliases for functions of the parent joint. This commit removes those functions. I think it makes the interface cleaner and it does not make the user code more complicated.

@jslee02, merge this if you are okay with this change.
