### PR TITLE
Remove Skeleton::setWorldTransform 

### DIFF
--- a/src/dynamics/BodyNode.cpp
+++ b/src/dynamics/BodyNode.cpp
@@ -224,13 +224,6 @@ int BodyNode::getDependentDof(int _arrayIndex) const
     return mDependentDofIndexes[_arrayIndex];
 }
 
-void BodyNode::setWorldTransform(const Eigen::Isometry3d &_W)
-{
-    assert(math::verifyTransform(_W));
-
-    mW = _W;
-}
-
 const Eigen::Isometry3d& BodyNode::getWorldTransform() const
 {
     return mW;

--- a/src/dynamics/BodyNode.h
+++ b/src/dynamics/BodyNode.h
@@ -234,13 +234,6 @@ public:
     //--------------------------------------------------------------------------
     // Properties updated by dynamics (kinematics)
     //--------------------------------------------------------------------------
-
-    /// @brief
-    /// This function should be called only in modeling process. The
-    /// transformation of this link will be updating by dynamics algorithms
-    /// automatically.
-    void setWorldTransform(const Eigen::Isometry3d& _W);
-
     /// @brief Transformation from the local coordinates of this body node to
     /// the world coordinates.
     const Eigen::Isometry3d& getWorldTransform() const;

--- a/src/utils/SkelParser.h
+++ b/src/utils/SkelParser.h
@@ -81,6 +81,12 @@ public:
     static simulation::World* readSkelFile(const std::string& _filename);
 
 private:
+    struct SkelBodyNode
+    {
+        dynamics::BodyNode* bodyNode;
+        Eigen::Isometry3d initTransform;
+    };
+
     /// @brief
     static simulation::World* readWorld(tinyxml2::XMLElement* _worldElement);
 
@@ -90,7 +96,7 @@ private:
             simulation::World* _world);
 
     /// @brief
-    static dynamics::BodyNode* readBodyNode(
+    static SkelBodyNode readBodyNode(
             tinyxml2::XMLElement* _bodyElement,
             dynamics::Skeleton* _skeleton,
             const Eigen::Isometry3d& _skeletonFrame);
@@ -102,7 +108,7 @@ private:
     /// @brief
     static dynamics::Joint* readJoint(
             tinyxml2::XMLElement* _jointElement,
-            const std::vector<dynamics::BodyNode*>& _bodies);
+            const std::vector<SkelBodyNode>& _bodies);
 
     /// @brief
     static dynamics::PrismaticJoint* readPrismaticJoint(

--- a/src/utils/sdf/SdfParser.h
+++ b/src/utils/sdf/SdfParser.h
@@ -41,6 +41,12 @@ public:
     static simulation::World* readSdfFile(const std::string& _filename);
 
 private:
+    struct SDFBodyNode
+    {
+        dynamics::BodyNode* bodyNode;
+        Eigen::Isometry3d initTransform;
+    };
+
     /// @brief
     static simulation::World* readWorld(tinyxml2::XMLElement* _worldElement);
 
@@ -55,7 +61,7 @@ private:
             simulation::World* _world);
 
     /// @brief
-    static dynamics::BodyNode* readBodyNode(
+    static SDFBodyNode readBodyNode(
             tinyxml2::XMLElement* _bodyNodeElement,
             dynamics::Skeleton* _skeleton,
             const Eigen::Isometry3d& _skeletonFrame);
@@ -67,7 +73,7 @@ private:
     /// @brief
     static dynamics::Joint* readJoint(
             tinyxml2::XMLElement* _jointElement,
-            const std::vector<dynamics::BodyNode*>& _bodies);
+            const std::vector<SDFBodyNode>& _bodies);
 
     /// @brief
     static dynamics::PrismaticJoint* readPrismaticJoint(
@@ -96,6 +102,8 @@ private:
 
     static dart::dynamics::WeldJoint* readWeldJoint(
             tinyxml2::XMLElement* _jointElement);
+
+
 };
 
 } // namespace utils


### PR DESCRIPTION
Remove BodyNode::setWorldTransform() because the world transformation of body node should be updated by dynamics algorithm not by the user.

(The title should be changed to "Remove BodyNode::setWorldTransform". Sorry for the confusing.)
