### PR TITLE
Re-add feature for rendering scaled meshes

### DIFF
--- a/src/renderer/OpenGLRenderInterface.cpp
+++ b/src/renderer/OpenGLRenderInterface.cpp
@@ -385,8 +385,12 @@ void recursiveRender (const struct aiScene *sc, const struct aiNode* nd) {
 }
 
 void OpenGLRenderInterface::drawMesh(const Eigen::Vector3d& _size, const aiScene *_mesh) {
-    if(_mesh)
+    if(_mesh) {
+        glPushMatrix();
+        glScaled(_size(0), _size(1), _size(2));
         recursiveRender(_mesh, _mesh->mRootNode);
+        glPopMatrix();
+    }
 }
 
 void OpenGLRenderInterface::drawList(GLuint index) {
@@ -432,13 +436,13 @@ void OpenGLRenderInterface::compileList(dynamics::Shape *_shape) {
             if(shapeMesh == 0)
                 return;
 
-            shapeMesh->setDisplayList(compileList(shapeMesh->getMesh()));
+            shapeMesh->setDisplayList(compileList(shapeMesh->getDim(), shapeMesh->getMesh()));
 
             break;
     }
 }
 
-GLuint OpenGLRenderInterface::compileList(const aiScene *_mesh) {
+GLuint OpenGLRenderInterface::compileList(const Eigen::Vector3d& _scale, const aiScene *_mesh) {
     if(!_mesh)
         return 0;
 
@@ -446,7 +450,7 @@ GLuint OpenGLRenderInterface::compileList(const aiScene *_mesh) {
     GLuint index = glGenLists(1);
     // Compile list
     glNewList(index, GL_COMPILE);
-    drawMesh(Eigen::Vector3d::Ones(), _mesh);
+    drawMesh(_scale, _mesh);
     glEndList();
 
     return index;
@@ -534,7 +538,7 @@ void OpenGLRenderInterface::draw(dynamics::Shape *_shape) {
             else if(shapeMesh->getDisplayList())
                 drawList(shapeMesh->getDisplayList());
             else
-                drawMesh(Eigen::Vector3d::Ones(), shapeMesh->getMesh());
+                drawMesh(shapeMesh->getDim(), shapeMesh->getMesh());
 
             break;
     }

--- a/src/renderer/OpenGLRenderInterface.h
+++ b/src/renderer/OpenGLRenderInterface.h
@@ -87,7 +87,7 @@ public:
     void compileList(dynamics::Skeleton *_skel);
     void compileList(dynamics::BodyNode *_node);
     void compileList(dynamics::Shape *_shape);
-    GLuint compileList(const aiScene *_mesh);
+    GLuint compileList(const Eigen::Vector3d& _scale, const aiScene *_mesh);
 
     virtual void draw(dynamics::Skeleton *_skel, bool _vizCol = false, bool _colMesh = false);
     virtual void draw(dynamics::BodyNode *_node, bool _vizCol = false, bool _colMesh = false);


### PR DESCRIPTION
This feature was initially introduced in 09162037a542c3f360c7e526a540040c3c85d46a, but got lost when merging in the refactoring for version 3.0 in 8cec16336adac9e22501b8a8c843fc69fae4f955.
