### PR TITLE
Remove unnecessary line in drawRRT.cpp

### DIFF
--- a/apps/drawRRT/drawRRT.cpp
+++ b/apps/drawRRT/drawRRT.cpp
@@ -94,7 +94,6 @@ void draw (const RRT* t1, const RRT* t2) {
 	gnuplot = fopen(".gnuplot", "w");
 
 	// Set options
-	fprintf(gnuplot, "");
 	fprintf(gnuplot, "set terminal wxt size 600,600;\n");
 	fprintf(gnuplot, "set xrange [-3.14:3.14];\n");
 	fprintf(gnuplot, "set yrange [-3.14:3.14];\n");


### PR DESCRIPTION
I think the below code work for nothing.

```
fprintf(gnuplot, "");
```

This commit removes compiler warning:

```
/home/js/DRCDev/dart_master/apps/drawRRT/drawRRT.cpp: In function 'void draw(const dart::planning::RRT*, const dart::planning::RRT*)':
/home/js/DRCDev/dart_master/apps/drawRRT/drawRRT.cpp:97:22: warning: zero-length gnu_printf format string [-Wformat-zero-length]
   fprintf(gnuplot, "");
                      ^
```
