### PR TITLE
Added missing include 'cstdio' for sprintf

### DIFF
--- a/apps/Galileo/MyWindow.cpp
+++ b/apps/Galileo/MyWindow.cpp
@@ -1,6 +1,7 @@
 #include "MyWindow.h"
 #include "yui/GLFuncs.h"
 #include "Particle.h"
+#include <cstdio>
 
 using namespace Eigen;
 
@@ -50,7 +51,7 @@ void MyWindow::draw() {
 
     // Display the frame count in 2D text
     char buff[64];
-    sprintf(buff,"%d",mFrame);
+    std::sprintf(buff,"%d",mFrame);
     std::string frame(buff);
     glDisable(GL_LIGHTING);
     glColor3f(0.0,0.0,0.0);

--- a/apps/tinkertoy/MyWindow.cpp
+++ b/apps/tinkertoy/MyWindow.cpp
@@ -2,6 +2,7 @@
 #include "yui/GLFuncs.h"
 #include "Particle.h"
 #include <iostream>
+#include <cstdio>
 
 using namespace Eigen;
 
@@ -35,7 +36,7 @@ void MyWindow::draw() {
 
     // Display the frame count in 2D text
     char buff[64];
-    sprintf(buff,"%d",mFrame);
+    std::sprintf(buff,"%d",mFrame);
     std::string frame(buff);
     glDisable(GL_LIGHTING);
     glColor3f(0.0,0.0,0.0);


### PR DESCRIPTION
Current branch does not compile because it is missing the include for sprintf (cstdio), and the namespace scoping for sprintf (std::sprintf).
