### PR TITLE
undef for IX before redef, add to CMakeLists

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -6,6 +6,7 @@ foreach(APPDIR
         Galileo
         tinkertoy
         rigidBodies
+        fluid
 	)
     add_subdirectory(${APPDIR})
     if(WIN32)

--- a/apps/fluid/MyWindow.cpp
+++ b/apps/fluid/MyWindow.cpp
@@ -3,7 +3,10 @@
 #include <iostream>
 #include <cstdio>
 
+#ifdef IX
+#undef IX
 #define IX(i, j) ((i)+(mWorld->getNumCells()+2)*(j))
+#endif
 
 using namespace Eigen;
 


### PR DESCRIPTION
Adding an undef to prevent warnings / errors on W4, adding to CMakeLists.
