### PR TITLE
Parse marker

### DIFF
--- a/dart/dynamics/Marker.cpp
+++ b/dart/dynamics/Marker.cpp
@@ -47,8 +47,8 @@ namespace dynamics {
 int Marker::msMarkerCount = 0;
 
 Marker::Marker(const std::string& _name, const Eigen::Vector3d& _offset,
-               ConstraintType _type)
-  : mName(_name), mOffset(_offset), mType(_type) {
+               BodyNode* _bodyNode, ConstraintType _type)
+  : mName(_name), mOffset(_offset), mBodyNode(_bodyNode), mType(_type) {
   mID = Marker::msMarkerCount++;
 }
 
@@ -86,12 +86,16 @@ void Marker::draw(renderer::RenderInterface* _ri, bool _offset,
   _ri->popName();
 }
 
-Eigen::Vector3d Marker::getLocalCoords() const {
+const Eigen::Vector3d& Marker::getLocalPosition() const {
   return mOffset;
 }
 
-void Marker::setLocalCoords(const Eigen::Vector3d& _offset) {
-  mOffset = _offset;
+void Marker::setLocalPosition(const Eigen::Vector3d& _offset) {
+    mOffset = _offset;
+}
+
+Eigen::Vector3d Marker::getWorldPosition() const {
+  return mBodyNode->getWorldTransform() * mOffset;
 }
 
 int Marker::getSkeletonIndex() const {

--- a/dart/dynamics/Marker.h
+++ b/dart/dynamics/Marker.h
@@ -50,6 +50,8 @@ class RenderInterface;
 namespace dart {
 namespace dynamics {
 
+class BodyNode;
+
 class Marker {
 public:
   enum ConstraintType {
@@ -60,7 +62,7 @@ public:
 
   /// \brief
   Marker(const std::string& _name, const Eigen::Vector3d& _offset,
-         ConstraintType _type = NO);
+         BodyNode* _bodyNode, ConstraintType _type = NO);
 
   /// \brief
   virtual ~Marker();
@@ -71,10 +73,13 @@ public:
             bool _useDefaultColor = true) const;
 
   /// \brief
-  Eigen::Vector3d getLocalCoords() const;
+  const Eigen::Vector3d& getLocalPosition() const;
 
   /// \brief
-  void setLocalCoords(const Eigen::Vector3d& _offset);
+  void setLocalPosition(const Eigen::Vector3d& _offset);
+
+  /// \brief Get position w.r.t. world frame
+  Eigen::Vector3d getWorldPosition() const;
 
   /// \brief
   int getSkeletonIndex() const;
@@ -99,6 +104,9 @@ public:
   void setConstraintType(ConstraintType _type);
 
 protected:
+  /// \brief BodyNode this marker belongs to
+  BodyNode* mBodyNode;
+
   /// \brief local coordinates in the links.
   Eigen::Vector3d mOffset;
 

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -349,7 +349,7 @@ SkelParser::SkelBodyNode SkelParser::readBodyNode(
   ElementEnumerator markers(_bodyNodeElement, "marker");
   while (markers.next())
   {
-    dynamics::Marker* newMarker = readMarker(markers.get());
+    dynamics::Marker* newMarker = readMarker(markers.get(), newBodyNode);
     newBodyNode->addMarker(newMarker);
   }
 
@@ -417,7 +417,8 @@ dynamics::Shape* SkelParser::readShape(tinyxml2::XMLElement* vizEle) {
   return newShape;
 }
 
-dynamics::Marker* SkelParser::readMarker(tinyxml2::XMLElement* _markerElement)
+dynamics::Marker* SkelParser::readMarker(tinyxml2::XMLElement* _markerElement,
+                                         dynamics::BodyNode* _bodyNode)
 {
   // Name attribute
   std::string name = getAttribute(_markerElement, "name");
@@ -427,7 +428,7 @@ dynamics::Marker* SkelParser::readMarker(tinyxml2::XMLElement* _markerElement)
   if (hasElement(_markerElement, "offset"))
     offset = getValueVector3d(_markerElement, "offset");
 
-  dynamics::Marker* newMarker = new dynamics::Marker(name, offset);
+  dynamics::Marker* newMarker = new dynamics::Marker(name, offset, _bodyNode);
 
   return newMarker;
 }

--- a/dart/utils/SkelParser.h
+++ b/dart/utils/SkelParser.h
@@ -108,7 +108,8 @@ protected:
 
     /// \brief Read marker
     static dart::dynamics::Marker* readMarker(
-        tinyxml2::XMLElement* _markerElement);
+            tinyxml2::XMLElement* _markerElement,
+            dynamics::BodyNode* _bodyNode);
 
     /// \brief
     static dynamics::Joint* readJoint(

--- a/dart/utils/SoftParser.cpp
+++ b/dart/utils/SoftParser.cpp
@@ -583,7 +583,7 @@ SkelParser::SkelBodyNode SoftSkelParser::readSoftBodyNode(
   ElementEnumerator markers(_softBodyNodeElement, "marker");
   while (markers.next())
   {
-    dynamics::Marker* newMarker = readMarker(markers.get());
+    dynamics::Marker* newMarker = readMarker(markers.get(), newSoftBodyNode);
     newSoftBodyNode->addMarker(newMarker);
   }
 


### PR DESCRIPTION
Parse markers on BodyNode. BodyNode can contain multiple markers.

Here is an example `skel` file for markers.

``` xml
<?xml version="1.0" ?>
<skel version="1.0">
        <skeleton name="box skeleton">
            <body name="box">
                <marker name="box_marker1">
                    <offset>1 2 3</offset>
                </marker>                                
                <marker name="box_marker2">
                    <offset>-1 -1 -1</offset>
                </marker>                                
            </body>
        </skeleton> 
</skel>
```
