### PR TITLE
Parse markers for CS4496 branch

### DIFF
--- a/src/dynamics/Marker.cpp
+++ b/src/dynamics/Marker.cpp
@@ -45,9 +45,11 @@ namespace dynamics {
 
 int Marker::msMarkerCount = 0;
 
-Marker::Marker(const std::string& _name, Eigen::Vector3d& _offset,
+Marker::Marker(const std::string& _name,
+               const Eigen::Vector3d& _offset,
+               BodyNode* _bodyNode,
                ConstraintType _type)
-    : mName(_name), mOffset(_offset), mType(_type)
+    : mName(_name), mOffset(_offset), mBodyNode(_bodyNode), mType(_type)
 {
     mID = Marker::msMarkerCount++;
 }
@@ -92,14 +94,19 @@ void Marker::draw(renderer::RenderInterface* _ri, bool _offset,
     _ri->popName();
 }
 
-Eigen::Vector3d Marker::getLocalCoords() const
+const Eigen::Vector3d& Marker::getLocalPosition() const
 {
     return mOffset;
 }
 
-void Marker::setLocalCoords(Eigen::Vector3d& _offset)
+void Marker::setLocalPosition(Eigen::Vector3d& _offset)
 {
     mOffset = _offset;
+}
+
+Eigen::Vector3d Marker::getWorldPosition() const
+{
+    return mBodyNode->getWorldTransform() * mOffset;
 }
 
 int Marker::getSkeletonIndex() const

--- a/src/dynamics/Marker.h
+++ b/src/dynamics/Marker.h
@@ -44,6 +44,8 @@ namespace dart {
 namespace renderer { class RenderInterface; }
 namespace dynamics {
 
+class BodyNode;
+
 class Marker
 {
 public:
@@ -55,7 +57,9 @@ public:
     };
     
     /// @brief
-    Marker(const std::string& _name, Eigen::Vector3d& _offset,
+    Marker(const std::string& _name,
+           const Eigen::Vector3d& _offset,
+           BodyNode* _bodyNode,
            ConstraintType _type = NO);
 
     /// @brief
@@ -67,10 +71,13 @@ public:
               bool _useDefaultColor = true) const;
 
     /// @brief
-    Eigen::Vector3d getLocalCoords() const;
+    const Eigen::Vector3d& getLocalPosition() const;
 
     /// @brief
-    void setLocalCoords(Eigen::Vector3d& _offset);
+    void setLocalPosition(Eigen::Vector3d& _offset);
+
+    /// @brief Get position w.r.t. world frame
+    Eigen::Vector3d getWorldPosition() const;
 
     /// @brief
     int getSkeletonIndex() const;
@@ -95,7 +102,10 @@ public:
     void setConstraintType(ConstraintType _type);
     
 protected:
-    /// @brief local coordinates in the links.
+    /// @brief BodyNode this marker belongs to
+    BodyNode* mBodyNode;
+
+    /// @brief local position in the links.
     Eigen::Vector3d mOffset;
 
     /// @brief name of this marker.

--- a/src/utils/SkelParser.cpp
+++ b/src/utils/SkelParser.cpp
@@ -341,7 +341,7 @@ SkelParser::SkelBodyNode SkelParser::readBodyNode(
     ElementEnumerator markers(_bodyNodeElement, "marker");
     while (markers.next())
     {
-        dynamics::Marker* newMarker = readMarker(markers.get());
+        dynamics::Marker* newMarker = readMarker(markers.get(), newBodyNode);
         newBodyNode->addMarker(newMarker);
     }
 
@@ -410,7 +410,8 @@ dynamics::Shape* SkelParser::readShape(tinyxml2::XMLElement* vizElement)
     return newShape;
 }
 
-dynamics::Marker* SkelParser::readMarker(tinyxml2::XMLElement* _markerElement)
+dynamics::Marker* SkelParser::readMarker(tinyxml2::XMLElement* _markerElement,
+                                         dynamics::BodyNode* _bodyNode)
 {
     // Name attribute
     std::string name = getAttribute(_markerElement, "name");
@@ -420,7 +421,7 @@ dynamics::Marker* SkelParser::readMarker(tinyxml2::XMLElement* _markerElement)
     if (hasElement(_markerElement, "offset"))
         offset = getValueVector3d(_markerElement, "offset");
 
-    dynamics::Marker* newMarker = new dynamics::Marker(name, offset);
+    dynamics::Marker* newMarker = new dynamics::Marker(name, offset, _bodyNode);
 
     return newMarker;
 }

--- a/src/utils/SkelParser.h
+++ b/src/utils/SkelParser.h
@@ -109,7 +109,8 @@ private:
 
     /// \brief Read marker
     static dart::dynamics::Marker* readMarker(
-            tinyxml2::XMLElement* _markerElement);
+            tinyxml2::XMLElement* _markerElement,
+            dynamics::BodyNode* _bodyNode);
 
     /// @brief
     static dynamics::Joint* readJoint(


### PR DESCRIPTION
Parse markers on BodyNode. BodyNode can contain multiple markers.

Here is an example `skel` file for markers.

``` xml
<?xml version="1.0" ?>
<skel version="1.0">
        <skeleton name="box skeleton">
            <body name="box">
                <marker name="box_marker1">
                    <offset>1 2 3</offset>
                </marker>                                
                <marker name="box_marker2">
                    <offset>-1 -1 -1</offset>
                </marker>                                
            </body>
        </skeleton> 
</skel>
```

Note: This pull request is for only CS4496 branch
