### PR TITLE
Add back deprecated functions to support gazebo 3.1

### DIFF
--- a/dart/common/Deprecated.h
+++ b/dart/common/Deprecated.h
@@ -38,10 +38,10 @@
 #define DART_COMMON_DEPRECATED_H_
 
 #ifdef __GNUC__
-  #define DEPRECATED __attribute__ ((deprecated))
+  #define DEPRECATED(version) __attribute__ ((deprecated))
   #define FORCEINLINE __attribute__((always_inline))
 #elif defined(_MSC_VER)
-  #define DEPRECATED __declspec(deprecated)
+  #define DEPRECATED(version) __declspec(deprecated)
   #define FORCEINLINE __forceinline
 #else
   #define DEPRECATED(version) ()

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -56,6 +56,10 @@ BoxShape::BoxShape(const Eigen::Vector3d& _size)
 BoxShape::~BoxShape() {
 }
 
+void BoxShape::setDim(const Eigen::Vector3d& _size) {
+  setSize(_size);
+}
+
 void BoxShape::setSize(const Eigen::Vector3d& _size) {
   assert(_size[0] > 0.0);
   assert(_size[1] > 0.0);

--- a/dart/dynamics/BoxShape.h
+++ b/dart/dynamics/BoxShape.h
@@ -38,6 +38,7 @@
 #ifndef DART_DYNAMICS_BOXSHAPE_H_
 #define DART_DYNAMICS_BOXSHAPE_H_
 
+#include "dart/common/Deprecated.h"
 #include "dart/dynamics/Shape.h"
 
 namespace dart {
@@ -50,6 +51,9 @@ public:
 
   /// \brief Destructor.
   virtual ~BoxShape();
+
+  /// \brief Set size of this box.
+  void setDim(const Eigen::Vector3d& _size) DEPRECATED(4.0);
 
   /// \brief Set size of this box.
   void setSize(const Eigen::Vector3d& _size);

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -51,6 +51,10 @@ EllipsoidShape::EllipsoidShape(const Eigen::Vector3d& _size)
 EllipsoidShape::~EllipsoidShape() {
 }
 
+void EllipsoidShape::setDim(const Eigen::Vector3d& _size) {
+  setSize(_size);
+}
+
 void EllipsoidShape::setSize(const Eigen::Vector3d& _size) {
   assert(_size[0] > 0.0);
   assert(_size[1] > 0.0);

--- a/dart/dynamics/EllipsoidShape.h
+++ b/dart/dynamics/EllipsoidShape.h
@@ -38,6 +38,7 @@
 #ifndef DART_DYNAMICS_ELLIPSOIDSHAPE_H_
 #define DART_DYNAMICS_ELLIPSOIDSHAPE_H_
 
+#include "dart/common/Deprecated.h"
 #include "dart/dynamics/Shape.h"
 
 namespace dart {
@@ -50,6 +51,9 @@ public:
 
   /// \brief Destructor.
   virtual ~EllipsoidShape();
+
+  /// \brief Set size of this box.
+  void setDim(const Eigen::Vector3d& _size) DEPRECATED(4.0);
 
   /// \brief Set size of this box.
   void setSize(const Eigen::Vector3d& _size);


### PR DESCRIPTION
Gazebo 3.0 will be released with DART 3.0 at Apr 11. DART 4.0 will be supported by Gazebo 3.1 not breaking ABI of Gazebo in next one or two months. Not to break ABI, DART 4.0 needs to keep deprecated API which is exposed at header files of Gazebo 3.0.

We found the API we need to bring back are `EllipsoidShape::setDim()` and `BoxShape::setDim`.
