### PR TITLE
Add a conflict with libdart-core3-dev file issue #199

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Package: libdart-core4-dev
 Section: libdevel
 Architecture: any
 Pre-Depends: multiarch-support
+Conflicts: libdart-core3-dev
 Depends: ${misc:Depends},
          libdart-core4.0 (= ${binary:Version}),
          libeigen3-dev,


### PR DESCRIPTION
Development version of the package needs to conflict with previous libdart-core3-dev.
Resolve #199
