### PR TITLE
Rename getDof() to getNumDofs()

### DIFF
--- a/apps/atlasRobot/Controller.cpp
+++ b/apps/atlasRobot/Controller.cpp
@@ -208,7 +208,7 @@ void Controller::printDebugInfo() const
 {
   std::cout << "[ATLAS Robot]"  << std::endl
             << " NUM NODES : " << mAtlasRobot->getNumBodyNodes() << std::endl
-            << " NUM DOF   : " << mAtlasRobot->getDof() << std::endl
+            << " NUM DOF   : " << mAtlasRobot->getNumDofs() << std::endl
             << " NUM JOINTS: " << mAtlasRobot->getNumBodyNodes() << std::endl;
 
   for(size_t i = 0; i < mAtlasRobot->getNumBodyNodes(); ++i)
@@ -219,7 +219,7 @@ void Controller::printDebugInfo() const
 
     std::cout << "  Joint [" << i << "]: "
               << joint->getName()
-              << " (" << joint->getDof() << ")"
+              << " (" << joint->getNumDofs() << ")"
               << std::endl;
     if (parentBody != NULL)
     {
@@ -817,9 +817,9 @@ void Controller::_setJointDamping()
   for (size_t i = 1; i < mAtlasRobot->getNumBodyNodes(); ++i)
   {
     Joint* joint = mAtlasRobot->getJoint(i);
-    if (joint->getDof() > 0)
+    if (joint->getNumDofs() > 0)
     {
-      for (size_t j = 0; j < joint->getDof(); ++j)
+      for (size_t j = 0; j < joint->getNumDofs(); ++j)
         joint->setDampingCoefficient(j, 80.0);
     }
   }

--- a/apps/atlasRobot/State.cpp
+++ b/apps/atlasRobot/State.cpp
@@ -73,7 +73,7 @@ State::State(Skeleton* _skeleton, const std::string& _name)
     mDesiredGlobalPelvisAngleOnSagital(0.0),
     mDesiredGlobalPelvisAngleOnCoronal(0.0)
 {
-  int dof = mSkeleton->getDof();
+  int dof = mSkeleton->getNumDofs();
 
   mDesiredJointPositions        = Eigen::VectorXd::Zero(dof);
   mDesiredJointPositionsBalance = Eigen::VectorXd::Zero(dof);
@@ -153,7 +153,7 @@ void State::computeControlForce(double _timestep)
 {
   assert(mNextState != NULL && "Next state should be set.");
 
-  int dof = mSkeleton->getDof();
+  int dof = mSkeleton->getNumDofs();
   VectorXd q = mSkeleton->getPositions();
   VectorXd dq = mSkeleton->getVelocities();
 

--- a/apps/balance/Controller.cpp
+++ b/apps/balance/Controller.cpp
@@ -51,7 +51,7 @@ Controller::Controller(dart::dynamics::Skeleton* _skel,
   mConstraintSolver = _constraintSolver;
   mTimestep = _t;
   mFrame = 0;
-  int nDof = mSkel->getDof();
+  int nDof = mSkel->getNumDofs();
   mKp = Eigen::MatrixXd::Identity(nDof, nDof);
   mKd = Eigen::MatrixXd::Identity(nDof, nDof);
   mConstrForces = Eigen::VectorXd::Zero(nDof);
@@ -94,7 +94,7 @@ void Controller::setDesiredDof(int _index, double _val) {
 void Controller::computeTorques(const Eigen::VectorXd& _dof,
                                 const Eigen::VectorXd& _dofVel) {
   // SPD tracking
-  //size_t nDof = mSkel->getDof();
+  //size_t nDof = mSkel->getNumDofs();
   Eigen::MatrixXd invM = (mSkel->getMassMatrix() + mKd * mTimestep).inverse();
   Eigen::VectorXd p = -mKp * (_dof + _dofVel * mTimestep - mDesiredDofs);
   Eigen::VectorXd d = -mKd * _dofVel;

--- a/apps/balance/Main.cpp
+++ b/apps/balance/Main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
   for (size_t i = 1; i < skeleton->getNumBodyNodes(); ++i)
   {
     dart::dynamics::Joint* joint = skeleton->getBodyNode(i)->getParentJoint();
-    for (size_t j = 0; j < joint->getDof(); ++j)
+    for (size_t j = 0; j < joint->getNumDofs(); ++j)
     {
 //      joint->setPositionLowerLimit(j, -0.1);
 //      joint->setPositionUpperLimit(j, 0.1);

--- a/apps/ballJointConstraintTest/Main.cpp
+++ b/apps/ballJointConstraintTest/Main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
     myWorld->setGravity(gravity);
     myWorld->setTimeStep(1.0/2000);
 
-    int dof =  myWorld->getSkeleton(0)->getDof();
+    int dof =  myWorld->getSkeleton(0)->getNumDofs();
     Eigen::VectorXd initPose(dof);
     for (int i = 0; i < dof; i++)
         initPose[i] = random(-0.5, 0.5);
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
     for (size_t i = 0; i < myWorld->getSkeleton(0)->getNumBodyNodes(); i++) {
         BodyNode *bd = myWorld->getSkeleton(0)->getBodyNode(i);
         Joint *jt = bd->getParentJoint();
-        for (size_t j = 0; j < jt->getDof(); j++)
+        for (size_t j = 0; j < jt->getNumDofs(); j++)
             jt->setDampingCoefficient(j, 0.02);
     }
 

--- a/apps/ballJointConstraintTest/MyWindow.cpp
+++ b/apps/ballJointConstraintTest/MyWindow.cpp
@@ -54,7 +54,7 @@ void MyWindow::timeStepping()
 
 Eigen::VectorXd MyWindow::computeDamping()
 {
-    int nDof = mWorld->getSkeleton(0)->getDof();
+    int nDof = mWorld->getSkeleton(0)->getNumDofs();
     Eigen::VectorXd damping = Eigen::VectorXd::Zero(nDof);
     // add damping to each joint; twist-dof has smaller damping
     damping = -0.01 * mWorld->getSkeleton(0)->getVelocities();

--- a/apps/closedLoop/Main.cpp
+++ b/apps/closedLoop/Main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
     myWorld->setGravity(gravity);
     myWorld->setTimeStep(1.0/2000);
 
-    int dof =  myWorld->getSkeleton(0)->getDof();
+    int dof =  myWorld->getSkeleton(0)->getNumDofs();
 
     Eigen::VectorXd initPose(dof);
     initPose.setZero();

--- a/apps/closedLoop/MyWindow.cpp
+++ b/apps/closedLoop/MyWindow.cpp
@@ -48,7 +48,7 @@ void MyWindow::timeStepping()
 
 Eigen::VectorXd MyWindow::computeDamping()
 {
-    int nDof = mWorld->getSkeleton(0)->getDof();
+    int nDof = mWorld->getSkeleton(0)->getNumDofs();
     Eigen::VectorXd damping = Eigen::VectorXd::Zero(nDof);
     // add damping to each joint; twist-dof has smaller damping
     damping = -0.01 * mWorld->getSkeleton(0)->getVelocities();

--- a/apps/forwardSim/Main.cpp
+++ b/apps/forwardSim/Main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
   myWorld->setGravity(gravity);
   myWorld->setTimeStep(1.0/2000);
 
-  int dof =  myWorld->getSkeleton(0)->getDof();
+  int dof =  myWorld->getSkeleton(0)->getNumDofs();
   Eigen::VectorXd initPose(dof);
   for (int i = 0; i < dof; i++)
     initPose[i] = dart::math::random(-0.5, 0.5);

--- a/apps/forwardSim/MyWindow.cpp
+++ b/apps/forwardSim/MyWindow.cpp
@@ -55,7 +55,7 @@ void MyWindow::timeStepping() {
 //==============================================================================
 Eigen::VectorXd MyWindow::computeDamping()
 {
-  int nDof = mWorld->getSkeleton(0)->getDof();
+  int nDof = mWorld->getSkeleton(0)->getNumDofs();
   Eigen::VectorXd damping = Eigen::VectorXd::Zero(nDof);
   // add damping to each joint; twist-dof has smaller damping
   damping = -0.01 * mWorld->getSkeleton(0)->getVelocities();

--- a/apps/hanging/Controller.cpp
+++ b/apps/hanging/Controller.cpp
@@ -57,7 +57,7 @@ Controller::Controller(dynamics::Skeleton* _skel,
   mConstraintSolver = _constraintSolver;
   mTimestep = _t;
   mFrame = 0;
-  int nDof = mSkel->getDof();
+  int nDof = mSkel->getNumDofs();
   mKp = MatrixXd::Identity(nDof, nDof);
   mKd = MatrixXd::Identity(nDof, nDof);
   mConstrForces = VectorXd::Zero(nDof);
@@ -88,7 +88,7 @@ Controller::Controller(dynamics::Skeleton* _skel,
 
 void Controller::computeTorques(const VectorXd& _dof, const VectorXd& _dofVel) {
   // SPD tracking
-  // int nDof = mSkel->getDof();
+  // int nDof = mSkel->getNumDofs();
   MatrixXd invM = (mSkel->getMassMatrix() + mKd * mTimestep).inverse();
   VectorXd p = -mKp * (_dof + _dofVel * mTimestep - mDesiredDofs);
   VectorXd d = -mKd * _dofVel;

--- a/apps/hanging/MyWindow.cpp
+++ b/apps/hanging/MyWindow.cpp
@@ -97,7 +97,7 @@ MyWindow::MyWindow(dart::simulation::World* _world)
                                mWorld->getConstraintSolver(),
                                mWorld->getTimeStep());
 
-  for (size_t i = 0; i < mWorld->getSkeleton(1)->getDof(); i++)
+  for (size_t i = 0; i < mWorld->getSkeleton(1)->getNumDofs(); i++)
     mController->setDesiredDof(i, mController->getSkeleton()->getPosition(i));
 
   // initialize constraint on the hand

--- a/apps/harnessTest/Controller.cpp
+++ b/apps/harnessTest/Controller.cpp
@@ -55,7 +55,7 @@ Controller::Controller(dynamics::Skeleton* _skel,
   mCollisionHandle = _collisionSolver;
   mTimestep = _t;
   mFrame = 0;
-  int nDof = mSkel->getDof();
+  int nDof = mSkel->getNumDofs();
   mKp = Eigen::MatrixXd::Identity(nDof, nDof);
   mKd = Eigen::MatrixXd::Identity(nDof, nDof);
   mConstrForces = Eigen::VectorXd::Zero(nDof);
@@ -90,7 +90,7 @@ void Controller::computeTorques(const Eigen::VectorXd& _dof,
                                 const Eigen::VectorXd& _dofVel)
 {
   // SPD tracking
-  // size_t nDof = mSkel->getDof();
+  // size_t nDof = mSkel->getNumDofs();
   Eigen::MatrixXd invM = (mSkel->getMassMatrix() + mKd * mTimestep).inverse();
   Eigen::VectorXd p = -mKp * (_dof + _dofVel * mTimestep - mDesiredDofs);
   Eigen::VectorXd d = -mKd * _dofVel;

--- a/apps/meshCollision/Main.cpp
+++ b/apps/meshCollision/Main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[]) {
   // Verify that our skeleton has something inside :)
   std::printf("Our skeleton has %zu nodes \n", MeshSkel->getNumBodyNodes());
   // std::printf("Our skeleton has %d joints \n", MeshSkel->getNumJoints());
-  std::printf("Our skeleton has %zu DOFs \n", MeshSkel->getDof());
+  std::printf("Our skeleton has %zu DOFs \n", MeshSkel->getNumDofs());
 
   MyWindow window;
   window.setWorld(myWorld);

--- a/apps/softArticulatedBodiesTest/Main.cpp
+++ b/apps/softArticulatedBodiesTest/Main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
           DART_DATA_PATH"skel/test/test_articulated_bodies_10bodies.skel");
   assert(myWorld != NULL);
 
-  int dof = myWorld->getSkeleton(1)->getDof();
+  int dof = myWorld->getSkeleton(1)->getNumDofs();
   Eigen::VectorXd initPose = Eigen::VectorXd::Zero(dof);
   for (int i = 0; i < 3; i++)
     initPose[i] = dart::math::random(-0.5, 0.5);

--- a/apps/softOpenChain/Main.cpp
+++ b/apps/softOpenChain/Main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
           DART_DATA_PATH"skel/soft_open_chain.skel");
   assert(myWorld != NULL);
 
-  int dof = myWorld->getSkeleton("skeleton 1")->getDof();
+  int dof = myWorld->getSkeleton("skeleton 1")->getNumDofs();
   Eigen::VectorXd initPose = Eigen::VectorXd::Zero(dof);
   for (int i = 0; i < 3; i++)
     initPose[i] = dart::math::random(-0.5, 0.5);

--- a/dart/constraint/JointLimitConstraint.cpp
+++ b/dart/constraint/JointLimitConstraint.cpp
@@ -196,7 +196,7 @@ void JointLimitConstraint::update()
   // Reset dimention
   mDim = 0;
 
-  size_t dof = mJoint->getDof();
+  size_t dof = mJoint->getNumDofs();
   for (size_t i = 0; i < dof; ++i)
   {
     // Lower bound check
@@ -253,7 +253,7 @@ void JointLimitConstraint::update()
 void JointLimitConstraint::getInformation(ConstraintInfo* _lcp)
 {
   size_t index = 0;
-  size_t dof = mJoint->getDof();
+  size_t dof = mJoint->getNumDofs();
   for (size_t i = 0; i < dof; ++i)
   {
     if (mActive[i] == false)
@@ -306,7 +306,7 @@ void JointLimitConstraint::applyUnitImpulse(size_t _index)
   size_t localIndex = 0;
   dynamics::Skeleton* skeleton = mJoint->getSkeleton();
 
-  size_t dof = mJoint->getDof();
+  size_t dof = mJoint->getNumDofs();
   for (size_t i = 0; i < dof; ++i)
   {
     if (mActive[i] == false)
@@ -332,7 +332,7 @@ void JointLimitConstraint::getVelocityChange(double* _delVel, bool _withCfm)
   assert(_delVel != NULL && "Null pointer is not allowed.");
 
   size_t localIndex = 0;
-  size_t dof = mJoint->getDof();
+  size_t dof = mJoint->getNumDofs();
   for (size_t i = 0; i < dof ; ++i)
   {
     if (mActive[i] == false)
@@ -373,7 +373,7 @@ void JointLimitConstraint::unexcite()
 void JointLimitConstraint::applyImpulse(double* _lambda)
 {
   size_t localIndex = 0;
-  size_t dof = mJoint->getDof();
+  size_t dof = mJoint->getNumDofs();
   for (size_t i = 0; i < dof ; ++i)
   {
     if (mActive[i] == false)

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -760,7 +760,7 @@ void BodyNode::init(Skeleton* _skeleton)
   else
     mDependentGenCoordIndices.clear();
 
-  for (size_t i = 0; i < mParentJoint->getDof(); i++)
+  for (size_t i = 0; i < mParentJoint->getNumDofs(); i++)
     mDependentGenCoordIndices.push_back(mParentJoint->getIndexInSkeleton(i));
 
   // Sort
@@ -956,7 +956,7 @@ void BodyNode::updateGeneralizedForce(bool _withDampingForces)
 {
   assert(mParentJoint != NULL);
 
-  size_t dof = mParentJoint->getDof();
+  size_t dof = mParentJoint->getNumDofs();
 
   if (dof > 0)
   {
@@ -1243,7 +1243,7 @@ void BodyNode::updateJointVelocityChange()
 //==============================================================================
 //void BodyNode::updateBodyVelocityChange()
 //{
-//  if (mParentJoint->getDof() > 0)
+//  if (mParentJoint->getNumDofs() > 0)
 //    mDelV = mParentJoint->getLocalJacobian() * mParentJoint->getVelsChange();
 //  else
 //    mDelV.setZero();
@@ -1310,7 +1310,7 @@ void BodyNode::aggregateGravityForceVector(Eigen::VectorXd* _g,
                           (*it)->mG_F);
   }
 
-  int nGenCoords = mParentJoint->getDof();
+  int nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0)
   {
     Eigen::VectorXd g = -(mParentJoint->getLocalJacobian().transpose() * mG_F);
@@ -1354,7 +1354,7 @@ void BodyNode::aggregateCombinedVector(Eigen::VectorXd* _Cg,
     mCg_F += math::dAdInvT((*it)->getParentJoint()->mT, (*it)->mCg_F);
   }
 
-  int nGenCoords = mParentJoint->getDof();
+  int nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0)
   {
     Eigen::VectorXd Cg
@@ -1376,7 +1376,7 @@ void BodyNode::aggregateExternalForces(Eigen::VectorXd* _Fext)
                              (*it)->mFext_F);
   }
 
-  int nGenCoords = mParentJoint->getDof();
+  int nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0)
   {
     Eigen::VectorXd Fext = mParentJoint->getLocalJacobian().transpose()*mFext_F;
@@ -1389,7 +1389,7 @@ void BodyNode::aggregateExternalForces(Eigen::VectorXd* _Fext)
 void BodyNode::updateMassMatrix()
 {
   mM_dV.setZero();
-  int dof = mParentJoint->getDof();
+  int dof = mParentJoint->getNumDofs();
   if (dof > 0)
   {
     mM_dV.noalias() += mParentJoint->getLocalJacobian()
@@ -1423,7 +1423,7 @@ void BodyNode::aggregateMassMatrix(Eigen::MatrixXd* _MCol, int _col)
   assert(!math::isNan(mM_F));
 
   //
-  int dof = mParentJoint->getDof();
+  int dof = mParentJoint->getNumDofs();
   if (dof > 0)
   {
     int iStart = mParentJoint->getIndexInSkeleton(0);
@@ -1456,7 +1456,7 @@ void BodyNode::aggregateAugMassMatrix(Eigen::MatrixXd* _MCol, int _col,
   assert(!math::isNan(mM_F));
 
   //
-  int dof = mParentJoint->getDof();
+  int dof = mParentJoint->getNumDofs();
   if (dof > 0)
   {
     Eigen::MatrixXd K = Eigen::MatrixXd::Zero(dof, dof);
@@ -1586,14 +1586,14 @@ void BodyNode::_updateBodyJacobian()
   //          n: number of dependent coordinates
   //--------------------------------------------------------------------------
 
-  const int localDof     = mParentJoint->getDof();
+  const int localDof     = mParentJoint->getNumDofs();
   const int ascendantDof = getNumDependentGenCoords() - localDof;
 
   // Parent Jacobian
   if (mParentBodyNode)
   {
     assert(mParentBodyNode->getBodyJacobian().cols()
-           + math::castUIntToInt(mParentJoint->getDof())
+           + math::castUIntToInt(mParentJoint->getNumDofs())
            == mBodyJacobian.cols());
 
     assert(mParentJoint);
@@ -1623,7 +1623,7 @@ void BodyNode::_updateBodyJacobianDeriv()
   //          n: number of dependent coordinates
   //--------------------------------------------------------------------------
 
-  const int numLocalDOFs = mParentJoint->getDof();
+  const int numLocalDOFs = mParentJoint->getNumDofs();
   const int numParentDOFs = getNumDependentGenCoords() - numLocalDOFs;
   math::Jacobian J = getBodyJacobian();
 
@@ -1631,7 +1631,7 @@ void BodyNode::_updateBodyJacobianDeriv()
   if (mParentBodyNode)
   {
     assert(mParentBodyNode->mBodyJacobianDeriv.cols()
-           + math::castUIntToInt(mParentJoint->getDof())
+           + math::castUIntToInt(mParentJoint->getNumDofs())
            == mBodyJacobianDeriv.cols());
 
     assert(mParentJoint);

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -134,7 +134,7 @@ void Joint::init(Skeleton* _skel)
 //==============================================================================
 //Eigen::VectorXd Joint::getDampingForces() const
 //{
-//  int numDofs = getDof();
+//  int numDofs = getNumDofs();
 //  Eigen::VectorXd dampingForce(numDofs);
 
 //  for (int i = 0; i < numDofs; ++i)
@@ -146,7 +146,7 @@ void Joint::init(Skeleton* _skel)
 //==============================================================================
 //Eigen::VectorXd Joint::getSpringForces(double _timeStep) const
 //{
-//  int dof = getDof();
+//  int dof = getNumDofs();
 //  Eigen::VectorXd springForce(dof);
 //  for (int i = 0; i < dof; ++i)
 //  {

--- a/dart/dynamics/Joint.h
+++ b/dart/dynamics/Joint.h
@@ -102,7 +102,10 @@ public:
   virtual size_t getIndexInSkeleton(size_t _index) const = 0;
 
   /// Get number of generalized coordinates
-  virtual size_t getDof() const = 0;
+  DEPRECATED(4.1) virtual size_t getDof() const = 0;
+
+  /// Get number of generalized coordinates
+  virtual size_t getNumDofs() const = 0;
 
   //----------------------------------------------------------------------------
   // Position

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -67,7 +67,10 @@ public:
   //----------------------------------------------------------------------------
 
   // Documentation inherited
-  virtual size_t getDof() const;
+  DEPRECATED(4.1) virtual size_t getDof() const;
+
+  // Documentation inherited
+  virtual size_t getNumDofs() const;
 
   // Documentation inherited
   virtual void setIndexInSkeleton(size_t _index, size_t _indexInSkeleton);
@@ -551,6 +554,13 @@ MultiDofJoint<DOF>::~MultiDofJoint()
 template <size_t DOF>
 size_t MultiDofJoint<DOF>::getDof() const
 {
+  return getNumDofs();
+}
+
+//==============================================================================
+template <size_t DOF>
+size_t MultiDofJoint<DOF>::getNumDofs() const
+{
   return DOF;
 }
 
@@ -559,7 +569,7 @@ template <size_t DOF>
 void MultiDofJoint<DOF>::setIndexInSkeleton(size_t _index,
                                             size_t _indexInSkeleton)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setIndexInSkeleton index[" << _index << "] out of range"
           << std::endl;
@@ -573,7 +583,7 @@ void MultiDofJoint<DOF>::setIndexInSkeleton(size_t _index,
 template <size_t DOF>
 size_t MultiDofJoint<DOF>::getIndexInSkeleton(size_t _index) const
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getIndexInSkeleton index[" << _index << "] out of range"
           << std::endl;
@@ -587,7 +597,7 @@ size_t MultiDofJoint<DOF>::getIndexInSkeleton(size_t _index) const
 template <size_t DOF>
 void MultiDofJoint<DOF>::setPosition(size_t _index, double _position)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setPosition index[" << _index << "] out of range" << std::endl;
     return;
@@ -600,7 +610,7 @@ void MultiDofJoint<DOF>::setPosition(size_t _index, double _position)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getPosition(size_t _index) const
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setPosition index[" << _index << "] out of range" << std::endl;
     return 0.0;
@@ -613,10 +623,10 @@ double MultiDofJoint<DOF>::getPosition(size_t _index) const
 template <size_t DOF>
 void MultiDofJoint<DOF>::setPositions(const Eigen::VectorXd& _positions)
 {
-  if (_positions.size() != getDof())
+  if (_positions.size() != getNumDofs())
   {
     dterr << "setPositions positions's size[" << _positions.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 
@@ -641,7 +651,7 @@ void MultiDofJoint<DOF>::resetPositions()
 template <size_t DOF>
 void MultiDofJoint<DOF>::setPositionLowerLimit(size_t _index, double _position)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setPositionLowerLimit index[" << _index << "] out of range"
           << std::endl;
@@ -655,7 +665,7 @@ void MultiDofJoint<DOF>::setPositionLowerLimit(size_t _index, double _position)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getPositionLowerLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getPositionLowerLimit index[" << _index << "] out of range"
           << std::endl;
@@ -669,7 +679,7 @@ double MultiDofJoint<DOF>::getPositionLowerLimit(size_t _index)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setPositionUpperLimit(size_t _index, double _position)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setPositionUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -683,7 +693,7 @@ void MultiDofJoint<DOF>::setPositionUpperLimit(size_t _index, double _position)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getPositionUpperLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getPositionUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -697,7 +707,7 @@ double MultiDofJoint<DOF>::getPositionUpperLimit(size_t _index)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setVelocity(size_t _index, double _velocity)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setVelocity index[" << _index << "] out of range" << std::endl;
     return;
@@ -710,7 +720,7 @@ void MultiDofJoint<DOF>::setVelocity(size_t _index, double _velocity)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getVelocity(size_t _index) const
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getVelocity index[" << _index << "] out of range" << std::endl;
     return 0.0;
@@ -723,10 +733,10 @@ double MultiDofJoint<DOF>::getVelocity(size_t _index) const
 template <size_t DOF>
 void MultiDofJoint<DOF>::setVelocities(const Eigen::VectorXd& _velocities)
 {
-  if (_velocities.size() != getDof())
+  if (_velocities.size() != getNumDofs())
   {
     dterr << "setVelocities velocities's size[" << _velocities.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 
@@ -751,7 +761,7 @@ void MultiDofJoint<DOF>::resetVelocities()
 template <size_t DOF>
 void MultiDofJoint<DOF>::setVelocityLowerLimit(size_t _index, double _velocity)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setVelocityLowerLimit index[" << _index << "] out of range"
           << std::endl;
@@ -765,7 +775,7 @@ void MultiDofJoint<DOF>::setVelocityLowerLimit(size_t _index, double _velocity)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getVelocityLowerLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getVelocityLowerLimit index[" << _index << "] out of range"
           << std::endl;
@@ -779,7 +789,7 @@ double MultiDofJoint<DOF>::getVelocityLowerLimit(size_t _index)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setVelocityUpperLimit(size_t _index, double _velocity)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setVelocityUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -793,7 +803,7 @@ void MultiDofJoint<DOF>::setVelocityUpperLimit(size_t _index, double _velocity)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getVelocityUpperLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getVelocityUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -807,7 +817,7 @@ double MultiDofJoint<DOF>::getVelocityUpperLimit(size_t _index)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setAcceleration(size_t _index, double _acceleration)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setAcceleration index[" << _index << "] out of range"
           << std::endl;
@@ -821,7 +831,7 @@ void MultiDofJoint<DOF>::setAcceleration(size_t _index, double _acceleration)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getAcceleration(size_t _index) const
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getAcceleration index[" << _index << "] out of range"
           << std::endl;
@@ -835,10 +845,10 @@ double MultiDofJoint<DOF>::getAcceleration(size_t _index) const
 template <size_t DOF>
 void MultiDofJoint<DOF>::setAccelerations(const Eigen::VectorXd& _accelerations)
 {
-  if (_accelerations.size() != getDof())
+  if (_accelerations.size() != getNumDofs())
   {
     dterr << "setAccelerations accelerations's size[" << _accelerations.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 
@@ -864,7 +874,7 @@ template <size_t DOF>
 void MultiDofJoint<DOF>::setAccelerationLowerLimit(size_t _index,
                                                    double _acceleration)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setAccelerationLowerLimit index[" << _index << "] out of range"
           << std::endl;
@@ -878,7 +888,7 @@ void MultiDofJoint<DOF>::setAccelerationLowerLimit(size_t _index,
 template <size_t DOF>
 double MultiDofJoint<DOF>::getAccelerationLowerLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getAccelerationLowerLimit index[" << _index << "] out of range"
           << std::endl;
@@ -893,7 +903,7 @@ template <size_t DOF>
 void MultiDofJoint<DOF>::setAccelerationUpperLimit(size_t _index,
                                                    double _acceleration)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setAccelerationUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -907,7 +917,7 @@ void MultiDofJoint<DOF>::setAccelerationUpperLimit(size_t _index,
 template <size_t DOF>
 double MultiDofJoint<DOF>::getAccelerationUpperLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getAccelerationUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -921,7 +931,7 @@ double MultiDofJoint<DOF>::getAccelerationUpperLimit(size_t _index)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setForce(size_t _index, double _force)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setForce index[" << _index << "] out of range" << std::endl;
     return;
@@ -934,7 +944,7 @@ void MultiDofJoint<DOF>::setForce(size_t _index, double _force)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getForce(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getForce index[" << _index << "] out of range" << std::endl;
     return 0.0;
@@ -947,10 +957,10 @@ double MultiDofJoint<DOF>::getForce(size_t _index)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setForces(const Eigen::VectorXd& _forces)
 {
-  if (_forces.size() != getDof())
+  if (_forces.size() != getNumDofs())
   {
     dterr << "setForces forces's size[" << _forces.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 
@@ -975,7 +985,7 @@ void MultiDofJoint<DOF>::resetForces()
 template <size_t DOF>
 void MultiDofJoint<DOF>::setForceLowerLimit(size_t _index, double _force)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setForceLowerLimit index[" << _index << "] out of range"
           << std::endl;
@@ -989,7 +999,7 @@ void MultiDofJoint<DOF>::setForceLowerLimit(size_t _index, double _force)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getForceLowerLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getForceMin index[" << _index << "] out of range" << std::endl;
     return 0.0;
@@ -1002,7 +1012,7 @@ double MultiDofJoint<DOF>::getForceLowerLimit(size_t _index)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setForceUpperLimit(size_t _index, double _force)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setForceUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -1016,7 +1026,7 @@ void MultiDofJoint<DOF>::setForceUpperLimit(size_t _index, double _force)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getForceUpperLimit(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getForceUpperLimit index[" << _index << "] out of range"
           << std::endl;
@@ -1031,7 +1041,7 @@ template <size_t DOF>
 void MultiDofJoint<DOF>::setVelocityChange(size_t _index,
                                            double _velocityChange)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setVelocityChange index[" << _index << "] out of range"
           << std::endl;
@@ -1045,7 +1055,7 @@ void MultiDofJoint<DOF>::setVelocityChange(size_t _index,
 template <size_t DOF>
 double MultiDofJoint<DOF>::getVelocityChange(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getVelocityChange index[" << _index << "] out of range"
           << std::endl;
@@ -1066,7 +1076,7 @@ void MultiDofJoint<DOF>::resetVelocityChanges()
 template <size_t DOF>
 void MultiDofJoint<DOF>::setConstraintImpulse(size_t _index, double _impulse)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setConstraintImpulse index[" << _index << "] out of range"
           << std::endl;
@@ -1080,7 +1090,7 @@ void MultiDofJoint<DOF>::setConstraintImpulse(size_t _index, double _impulse)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getConstraintImpulse(size_t _index)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getConstraintImpulse index[" << _index << "] out of range"
           << std::endl;
@@ -1115,7 +1125,7 @@ void MultiDofJoint<DOF>::integrateVelocities(double _dt)
 template <size_t DOF>
 void MultiDofJoint<DOF>::setSpringStiffness(size_t _index, double _k)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setSpringStiffness index[" << _index << "] out of range\n";
     return;
@@ -1130,7 +1140,7 @@ void MultiDofJoint<DOF>::setSpringStiffness(size_t _index, double _k)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getSpringStiffness(size_t _index) const
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getSpringStiffness index[" << _index << "] out of range\n";
     return 0.0;
@@ -1143,7 +1153,7 @@ double MultiDofJoint<DOF>::getSpringStiffness(size_t _index) const
 template <size_t DOF>
 void MultiDofJoint<DOF>::setRestPosition(size_t _index, double _q0)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setRestPosition index[" << _index << "] out of range\n";
     return;
@@ -1166,7 +1176,7 @@ void MultiDofJoint<DOF>::setRestPosition(size_t _index, double _q0)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getRestPosition(size_t _index) const
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getRestPosition index[" << _index << "] out of range\n";
     return 0.0;
@@ -1179,7 +1189,7 @@ double MultiDofJoint<DOF>::getRestPosition(size_t _index) const
 template <size_t DOF>
 void MultiDofJoint<DOF>::setDampingCoefficient(size_t _index, double _d)
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "setDampingCoefficient index[" << _index << "] out of range\n";
     return;
@@ -1195,7 +1205,7 @@ void MultiDofJoint<DOF>::setDampingCoefficient(size_t _index, double _d)
 template <size_t DOF>
 double MultiDofJoint<DOF>::getDampingCoefficient(size_t _index) const
 {
-  if (_index >= getDof())
+  if (_index >= getNumDofs())
   {
     dterr << "getDampingCoefficient index[" << _index << "] out of range\n";
     return 0.0;

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -144,7 +144,7 @@ bool PointMass::isColliding()
 }
 
 //==============================================================================
-size_t PointMass::getDof() const
+size_t PointMass::getNumDofs() const
 {
   return 3;
 }
@@ -436,7 +436,7 @@ Eigen::Vector3d PointMass::getConstraintImpulses() const
 //==============================================================================
 void PointMass::clearConstraintImpulse()
 {
-  assert(getDof() == 3);
+  assert(getNumDofs() == 3);
   mConstraintImpulses.setZero();
   mDelV.setZero();
   mImpB.setZero();

--- a/dart/dynamics/PointMass.h
+++ b/dart/dynamics/PointMass.h
@@ -93,7 +93,7 @@ public:
   //----------------------------------------------------------------------------
 
   // Documentation inherited
-  size_t getDof() const;
+  size_t getNumDofs() const;
 
 //  // Documentation inherited
 //  void setIndexInSkeleton(size_t _index, size_t _indexInSkeleton);

--- a/dart/dynamics/SingleDofJoint.cpp
+++ b/dart/dynamics/SingleDofJoint.cpp
@@ -87,6 +87,12 @@ SingleDofJoint::~SingleDofJoint()
 //==============================================================================
 size_t SingleDofJoint::getDof() const
 {
+  return getNumDofs();
+}
+
+//==============================================================================
+size_t SingleDofJoint::getNumDofs() const
+{
   return 1;
 }
 
@@ -143,10 +149,10 @@ double SingleDofJoint::getPosition(size_t _index) const
 //==============================================================================
 void SingleDofJoint::setPositions(const Eigen::VectorXd& _positions)
 {
-  if (_positions.size() != math::castUIntToInt(getDof()))
+  if (_positions.size() != math::castUIntToInt(getNumDofs()))
   {
     dterr << "setPositions positions's size[" << _positions.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 
@@ -244,10 +250,10 @@ double SingleDofJoint::getVelocity(size_t _index) const
 //==============================================================================
 void SingleDofJoint::setVelocities(const Eigen::VectorXd& _velocities)
 {
-  if (_velocities.size() != math::castUIntToInt(getDof()))
+  if (_velocities.size() != math::castUIntToInt(getNumDofs()))
   {
     dterr << "setVelocities velocities's size[" << _velocities.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 
@@ -347,10 +353,10 @@ double SingleDofJoint::getAcceleration(size_t _index) const
 //==============================================================================
 void SingleDofJoint::setAccelerations(const Eigen::VectorXd& _accelerations)
 {
-  if (_accelerations.size() != math::castUIntToInt(getDof()))
+  if (_accelerations.size() != math::castUIntToInt(getNumDofs()))
   {
     dterr << "setAccelerations accelerations's size[" << _accelerations.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 
@@ -450,10 +456,10 @@ double SingleDofJoint::getForce(size_t _index)
 //==============================================================================
 void SingleDofJoint::setForces(const Eigen::VectorXd& _forces)
 {
-  if (_forces.size() != math::castUIntToInt(getDof()))
+  if (_forces.size() != math::castUIntToInt(getNumDofs()))
   {
     dterr << "setForces forces's size[" << _forces.size()
-          << "] is different with the dof [" << getDof() << "]" << std::endl;
+          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
     return;
   }
 

--- a/dart/dynamics/SingleDofJoint.h
+++ b/dart/dynamics/SingleDofJoint.h
@@ -58,7 +58,10 @@ public:
   ~SingleDofJoint();
 
   // Documentation inherited
-  virtual size_t getDof() const;
+  DEPRECATED(4.1) virtual size_t getDof() const;
+
+  // Documentation inherited
+  virtual size_t getNumDofs() const;
 
   // Documentation inherited
   virtual void setIndexInSkeleton(size_t _index, size_t _indexInSkeleton);

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -329,7 +329,7 @@ void Skeleton::init(double _timeStep, const Eigen::Vector3d& _gravity)
   {
     Joint* joint = mBodyNodes[i]->getParentJoint();
 
-    for (size_t j = 0; j < joint->getDof(); ++j)
+    for (size_t j = 0; j < joint->getNumDofs(); ++j)
     {
       GenCoordInfo genCoord;
       genCoord.joint = joint;
@@ -341,14 +341,14 @@ void Skeleton::init(double _timeStep, const Eigen::Vector3d& _gravity)
     }
 
     mBodyNodes[i]->init(this);
-    mDof += mBodyNodes[i]->getParentJoint()->getDof();
+    mDof += mBodyNodes[i]->getParentJoint()->getNumDofs();
   }
 
   // Compute transformations, velocities, and partial accelerations
   computeForwardDynamicsRecursionPartA();
 
   // Set dimension of dynamics quantities
-  int dof = getDof();
+  size_t dof = getNumDofs();
   mM    = Eigen::MatrixXd::Zero(dof, dof);
   mAugM = Eigen::MatrixXd::Zero(dof, dof);
   mInvM = Eigen::MatrixXd::Zero(dof, dof);
@@ -373,13 +373,19 @@ void Skeleton::init(double _timeStep, const Eigen::Vector3d& _gravity)
 //==============================================================================
 size_t Skeleton::getDof() const
 {
+  return getNumDofs();
+}
+
+//==============================================================================
+size_t Skeleton::getNumDofs() const
+{
   return mDof;
 }
 
 //==============================================================================
 GenCoordInfo Skeleton::getGenCoordInfo(size_t _index) const
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   return mGenCoordInfos[_index];
 }
@@ -387,7 +393,7 @@ GenCoordInfo Skeleton::getGenCoordInfo(size_t _index) const
 //==============================================================================
 void Skeleton::setPosition(size_t _index, double _position)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setPosition(mGenCoordInfos[_index].localIndex,
                                             _position);
@@ -396,7 +402,7 @@ void Skeleton::setPosition(size_t _index, double _position)
 //==============================================================================
 double Skeleton::getPosition(size_t _index) const
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getPosition(
         mGenCoordInfos[_index].localIndex);
@@ -413,7 +419,7 @@ void Skeleton::setPositions(const Eigen::VectorXd& _configs)
   {
     joint = mBodyNodes[i]->getParentJoint();
 
-    dof = joint->getDof();
+    dof = joint->getNumDofs();
 
     if (dof)
     {
@@ -428,7 +434,7 @@ void Skeleton::setPositions(const Eigen::VectorXd& _configs)
 Eigen::VectorXd Skeleton::getPositions() const
 {
   size_t index = 0;
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
   Eigen::VectorXd pos(dof);
 
   for (size_t i = 0; i < dof; ++i)
@@ -488,7 +494,7 @@ void Skeleton::resetPositions()
 //==============================================================================
 void Skeleton::setPositionLowerLimit(size_t _index, double _position)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setPositionLowerLimit(
         mGenCoordInfos[_index].localIndex, _position);
@@ -497,7 +503,7 @@ void Skeleton::setPositionLowerLimit(size_t _index, double _position)
 //==============================================================================
 double Skeleton::getPositionLowerLimit(size_t _index)
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getPositionLowerLimit(
         mGenCoordInfos[_index].localIndex);
@@ -506,7 +512,7 @@ double Skeleton::getPositionLowerLimit(size_t _index)
 //==============================================================================
 void Skeleton::setPositionUpperLimit(size_t _index, double _position)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setPositionUpperLimit(
         mGenCoordInfos[_index].localIndex, _position);
@@ -515,7 +521,7 @@ void Skeleton::setPositionUpperLimit(size_t _index, double _position)
 //==============================================================================
 double Skeleton::getPositionUpperLimit(size_t _index)
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getPositionUpperLimit(
         mGenCoordInfos[_index].localIndex);
@@ -524,7 +530,7 @@ double Skeleton::getPositionUpperLimit(size_t _index)
 //==============================================================================
 void Skeleton::setVelocity(size_t _index, double _velocity)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setVelocity(mGenCoordInfos[_index].localIndex,
                                             _velocity);
@@ -533,7 +539,7 @@ void Skeleton::setVelocity(size_t _index, double _velocity)
 //==============================================================================
 double Skeleton::getVelocity(size_t _index) const
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getVelocity(
         mGenCoordInfos[_index].localIndex);
@@ -550,7 +556,7 @@ void Skeleton::setVelocities(const Eigen::VectorXd& _genVels)
   {
     joint = mBodyNodes[i]->getParentJoint();
 
-    dof = joint->getDof();
+    dof = joint->getNumDofs();
 
     if (dof)
     {
@@ -565,7 +571,7 @@ void Skeleton::setVelocities(const Eigen::VectorXd& _genVels)
 Eigen::VectorXd Skeleton::getVelocities() const
 {
   size_t index = 0;
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
   Eigen::VectorXd vel(dof);
 
   for (size_t i = 0; i < dof; ++i)
@@ -589,7 +595,7 @@ void Skeleton::resetVelocities()
 //==============================================================================
 void Skeleton::setVelocityLowerLimit(size_t _index, double _velocity)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setVelocityLowerLimit(
         mGenCoordInfos[_index].localIndex, _velocity);
@@ -598,7 +604,7 @@ void Skeleton::setVelocityLowerLimit(size_t _index, double _velocity)
 //==============================================================================
 double Skeleton::getVelocityLowerLimit(size_t _index)
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getVelocityLowerLimit(
         mGenCoordInfos[_index].localIndex);
@@ -607,7 +613,7 @@ double Skeleton::getVelocityLowerLimit(size_t _index)
 //==============================================================================
 void Skeleton::setVelocityUpperLimit(size_t _index, double _velocity)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setVelocityUpperLimit(
         mGenCoordInfos[_index].localIndex, _velocity);
@@ -616,7 +622,7 @@ void Skeleton::setVelocityUpperLimit(size_t _index, double _velocity)
 //==============================================================================
 double Skeleton::getVelocityUpperLimit(size_t _index)
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getVelocityUpperLimit(
         mGenCoordInfos[_index].localIndex);
@@ -625,7 +631,7 @@ double Skeleton::getVelocityUpperLimit(size_t _index)
 //==============================================================================
 void Skeleton::setAcceleration(size_t _index, double _acceleration)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setAcceleration(
         mGenCoordInfos[_index].localIndex, _acceleration);
@@ -634,7 +640,7 @@ void Skeleton::setAcceleration(size_t _index, double _acceleration)
 //==============================================================================
 double Skeleton::getAcceleration(size_t _index) const
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getAcceleration(
         mGenCoordInfos[_index].localIndex);
@@ -651,7 +657,7 @@ void Skeleton::setAccelerations(const Eigen::VectorXd& _accelerations)
   {
     joint = mBodyNodes[i]->getParentJoint();
 
-    dof = joint->getDof();
+    dof = joint->getNumDofs();
 
     if (dof)
     {
@@ -666,7 +672,7 @@ void Skeleton::setAccelerations(const Eigen::VectorXd& _accelerations)
 Eigen::VectorXd Skeleton::getAccelerations() const
 {
   size_t index = 0;
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
   Eigen::VectorXd acc(dof);
 
   for (size_t i = 0; i < dof; ++i)
@@ -690,7 +696,7 @@ void Skeleton::resetAccelerations()
 //==============================================================================
 void Skeleton::setForce(size_t _index, double _force)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setForce(
         mGenCoordInfos[_index].localIndex, _force);
@@ -699,7 +705,7 @@ void Skeleton::setForce(size_t _index, double _force)
 //==============================================================================
 double Skeleton::getForce(size_t _index)
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getForce(
         mGenCoordInfos[_index].localIndex);
@@ -716,7 +722,7 @@ void Skeleton::setForces(const Eigen::VectorXd& _forces)
   {
     joint = mBodyNodes[i]->getParentJoint();
 
-    dof = joint->getDof();
+    dof = joint->getNumDofs();
 
     if (dof)
     {
@@ -731,7 +737,7 @@ void Skeleton::setForces(const Eigen::VectorXd& _forces)
 Eigen::VectorXd Skeleton::getForces() const
 {
   size_t index = 0;
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
   Eigen::VectorXd force(dof);
 
   for (size_t i = 0; i < dof; ++i)
@@ -764,7 +770,7 @@ void Skeleton::resetForces()
 //==============================================================================
 void Skeleton::setForceLowerLimit(size_t _index, double _force)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setForceLowerLimit(
         mGenCoordInfos[_index].localIndex, _force);
@@ -773,7 +779,7 @@ void Skeleton::setForceLowerLimit(size_t _index, double _force)
 //==============================================================================
 double Skeleton::getForceLowerLimit(size_t _index)
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getForceLowerLimit(
         mGenCoordInfos[_index].localIndex);
@@ -782,7 +788,7 @@ double Skeleton::getForceLowerLimit(size_t _index)
 //==============================================================================
 void Skeleton::setForceUpperLimit(size_t _index, double _force)
 {
-  assert(_index < getDof());
+  assert(_index < getNumDofs());
 
   mGenCoordInfos[_index].joint->setForceUpperLimit(
         mGenCoordInfos[_index].localIndex, _force);
@@ -791,7 +797,7 @@ void Skeleton::setForceUpperLimit(size_t _index, double _force)
 //==============================================================================
 double Skeleton::getForceUpperLimit(size_t _index)
 {
-  assert(_index <getDof());
+  assert(_index <getNumDofs());
 
   return mGenCoordInfos[_index].joint->getForceUpperLimit(
         mGenCoordInfos[_index].localIndex);
@@ -801,7 +807,7 @@ double Skeleton::getForceUpperLimit(size_t _index)
 Eigen::VectorXd Skeleton::getVelocityChanges() const
 {
   size_t index = 0;
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
   Eigen::VectorXd velChange(dof);
 
   for (size_t i = 0; i < dof; ++i)
@@ -819,7 +825,7 @@ Eigen::VectorXd Skeleton::getVelocityChanges() const
 void Skeleton::setConstraintImpulses(const Eigen::VectorXd& _impulses)
 {
   size_t index = 0;
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
 
   for (size_t i = 0; i < dof; ++i)
   {
@@ -827,14 +833,14 @@ void Skeleton::setConstraintImpulses(const Eigen::VectorXd& _impulses)
           mGenCoordInfos[i].localIndex, _impulses[index++]);
   }
 
-  assert(index == getDof());
+  assert(index == getNumDofs());
 }
 
 //==============================================================================
 Eigen::VectorXd Skeleton::getConstraintImpulses() const
 {
   size_t index = 0;
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
   Eigen::VectorXd impulse(dof);
 
   for (size_t i = 0; i < dof; ++i)
@@ -863,7 +869,7 @@ void Skeleton::setState(const Eigen::VectorXd& _state)
   {
     joint = mBodyNodes[i]->getParentJoint();
 
-    dof = joint->getDof();
+    dof = joint->getNumDofs();
 
     if (dof)
     {
@@ -878,7 +884,7 @@ void Skeleton::setState(const Eigen::VectorXd& _state)
 //==============================================================================
 Eigen::VectorXd Skeleton::getState() const
 {
-  Eigen::VectorXd state(2 * getDof());
+  Eigen::VectorXd state(2 * getNumDofs());
 
   state << getPositions(), getVelocities();
 
@@ -1065,18 +1071,18 @@ void Skeleton::drawMarkers(renderer::RenderInterface* _ri,
 //==============================================================================
 void Skeleton::updateMassMatrix()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mM.cols() == math::castUIntToInt(getDof())
-         && mM.rows() == math::castUIntToInt(getDof()));
+  assert(mM.cols() == math::castUIntToInt(getNumDofs())
+         && mM.rows() == math::castUIntToInt(getNumDofs()));
 
   mM.setZero();
 
   // Backup the origianl internal force
   Eigen::VectorXd originalGenAcceleration = getAccelerations();
 
-  size_t dof = getDof();
+  size_t dof = getNumDofs();
   Eigen::VectorXd e = Eigen::VectorXd::Zero(dof);
   for (size_t j = 0; j < dof; ++j)
   {
@@ -1095,7 +1101,7 @@ void Skeleton::updateMassMatrix()
          it != mBodyNodes.rend(); ++it)
     {
       (*it)->aggregateMassMatrix(&mM, j);
-      size_t localDof = (*it)->mParentJoint->getDof();
+      size_t localDof = (*it)->mParentJoint->getNumDofs();
       if (localDof > 0)
       {
         size_t iStart = (*it)->mParentJoint->getIndexInSkeleton(0);
@@ -1118,18 +1124,18 @@ void Skeleton::updateMassMatrix()
 //==============================================================================
 void Skeleton::updateAugMassMatrix()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mAugM.cols() == math::castUIntToInt(getDof())
-         && mAugM.rows() == math::castUIntToInt(getDof()));
+  assert(mAugM.cols() == math::castUIntToInt(getNumDofs())
+         && mAugM.rows() == math::castUIntToInt(getNumDofs()));
 
   mAugM.setZero();
 
   // Backup the origianl internal force
   Eigen::VectorXd originalGenAcceleration = getAccelerations();
 
-  int dof = getDof();
+  int dof = getNumDofs();
   Eigen::VectorXd e = Eigen::VectorXd::Zero(dof);
   for (int j = 0; j < dof; ++j)
   {
@@ -1149,7 +1155,7 @@ void Skeleton::updateAugMassMatrix()
     for (int i = mBodyNodes.size() - 1; i > -1 ; --i)
     {
       mBodyNodes[i]->aggregateAugMassMatrix(&mAugM, j, mTimeStep);
-      int localDof = mBodyNodes[i]->mParentJoint->getDof();
+      int localDof = mBodyNodes[i]->mParentJoint->getNumDofs();
       if (localDof > 0)
       {
         int iStart =
@@ -1172,11 +1178,11 @@ void Skeleton::updateAugMassMatrix()
 //==============================================================================
 void Skeleton::updateInvMassMatrix()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mInvM.cols() == math::castUIntToInt(getDof())
-         && mInvM.rows() == math::castUIntToInt(getDof()));
+  assert(mInvM.cols() == math::castUIntToInt(getNumDofs())
+         && mInvM.rows() == math::castUIntToInt(getNumDofs()));
 
   // We don't need to set mInvM as zero matrix as long as the below is correct
   // mInvM.setZero();
@@ -1195,7 +1201,7 @@ void Skeleton::updateInvMassMatrix()
     mIsArticulatedInertiaDirty = false;
   }
 
-  int dof = getDof();
+  int dof = getNumDofs();
   Eigen::VectorXd e = Eigen::VectorXd::Zero(dof);
   for (int j = 0; j < dof; ++j)
   {
@@ -1215,7 +1221,7 @@ void Skeleton::updateInvMassMatrix()
     for (size_t i = 0; i < mBodyNodes.size(); ++i)
     {
       mBodyNodes[i]->aggregateInvMassMatrix(&mInvM, j);
-      int localDof = mBodyNodes[i]->mParentJoint->getDof();
+      int localDof = mBodyNodes[i]->mParentJoint->getNumDofs();
       if (localDof > 0)
       {
         int iStart =
@@ -1238,11 +1244,11 @@ void Skeleton::updateInvMassMatrix()
 //==============================================================================
 void Skeleton::updateInvAugMassMatrix()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mInvAugM.cols() == math::castUIntToInt(getDof())
-         && mInvAugM.rows() == math::castUIntToInt(getDof()));
+  assert(mInvAugM.cols() == math::castUIntToInt(getNumDofs())
+         && mInvAugM.rows() == math::castUIntToInt(getNumDofs()));
 
   // We don't need to set mInvM as zero matrix as long as the below is correct
   // mInvM.setZero();
@@ -1250,7 +1256,7 @@ void Skeleton::updateInvAugMassMatrix()
   // Backup the origianl internal force
   Eigen::VectorXd originalInternalForce = getForces();
 
-  int dof = getDof();
+  int dof = getNumDofs();
   Eigen::VectorXd e = Eigen::VectorXd::Zero(dof);
   for (int j = 0; j < dof; ++j)
   {
@@ -1270,7 +1276,7 @@ void Skeleton::updateInvAugMassMatrix()
     for (size_t i = 0; i < mBodyNodes.size(); ++i)
     {
       mBodyNodes[i]->aggregateInvAugMassMatrix(&mInvAugM, j, mTimeStep);
-      int localDof = mBodyNodes[i]->mParentJoint->getDof();
+      int localDof = mBodyNodes[i]->mParentJoint->getNumDofs();
       if (localDof > 0)
       {
         int iStart =
@@ -1293,10 +1299,10 @@ void Skeleton::updateInvAugMassMatrix()
 //==============================================================================
 void Skeleton::updateCoriolisForceVector()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mCvec.size() == math::castUIntToInt(getDof()));
+  assert(mCvec.size() == math::castUIntToInt(getNumDofs()));
 
   mCvec.setZero();
 
@@ -1318,10 +1324,10 @@ void Skeleton::updateCoriolisForceVector()
 //==============================================================================
 void Skeleton::updateGravityForceVector()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mG.size() == math::castUIntToInt(getDof()));
+  assert(mG.size() == math::castUIntToInt(getNumDofs()));
 
   // Calcualtion mass matrix, M
   mG.setZero();
@@ -1337,10 +1343,10 @@ void Skeleton::updateGravityForceVector()
 //==============================================================================
 void Skeleton::updateCombinedVector()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mCg.size() == math::castUIntToInt(getDof()));
+  assert(mCg.size() == math::castUIntToInt(getNumDofs()));
 
   mCg.setZero();
   for (std::vector<BodyNode*>::iterator it = mBodyNodes.begin();
@@ -1361,10 +1367,10 @@ void Skeleton::updateCombinedVector()
 //==============================================================================
 void Skeleton::updateExternalForceVector()
 {
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
-  assert(mFext.size() == math::castUIntToInt(getDof()));
+  assert(mFext.size() == math::castUIntToInt(getNumDofs()));
 
   // Clear external force.
   mFext.setZero();
@@ -1409,8 +1415,8 @@ void Skeleton::updateExternalForceVector()
 
 //==============================================================================
 //void Skeleton::updateDampingForceVector() {
-//  assert(mFd.size() == getDof());
-//  assert(getDof() > 0);
+//  assert(mFd.size() == getNumDofs());
+//  assert(getNumDofs() > 0);
 
 //  // Clear external force.
 //  mFd.setZero();
@@ -1557,7 +1563,7 @@ void Skeleton::computeInverseDynamicsRecursionB(bool _withExternalForces,
                                                 bool _withDampingForces)
 {
   // Skip immobile or 0-dof skeleton
-  if (getDof() == 0)
+  if (getNumDofs() == 0)
     return;
 
   // Backward recursion
@@ -1612,7 +1618,7 @@ void Skeleton::updateBiasImpulse(BodyNode* _bodyNode)
 {
   // Assertions
   assert(_bodyNode != NULL);
-  assert(getDof() > 0);
+  assert(getNumDofs() > 0);
 
   // This skeleton should contains _bodyNode
   assert(std::find(mBodyNodes.begin(), mBodyNodes.end(), _bodyNode)
@@ -1639,7 +1645,7 @@ void Skeleton::updateBiasImpulse(BodyNode* _bodyNode,
 {
   // Assertions
   assert(_bodyNode != NULL);
-  assert(getDof() > 0);
+  assert(getNumDofs() > 0);
 
   // This skeleton should contain _bodyNode
   assert(std::find(mBodyNodes.begin(), mBodyNodes.end(), _bodyNode)
@@ -1675,7 +1681,7 @@ void Skeleton::updateBiasImpulse(SoftBodyNode* _softBodyNode,
 {
   // Assertions
   assert(_softBodyNode != NULL);
-  assert(getDof() > 0);
+  assert(getNumDofs() > 0);
 
   // This skeleton should contain _bodyNode
   assert(std::find(mSoftBodyNodes.begin(), mSoftBodyNodes.end(), _softBodyNode)
@@ -1729,7 +1735,7 @@ bool Skeleton::isImpulseApplied() const
 void Skeleton::computeImpulseForwardDynamics()
 {
   // Skip immobile or 0-dof skeleton
-  if (!isMobile() || getDof() == 0)
+  if (!isMobile() || getNumDofs() == 0)
     return;
 
   // Backward recursion
@@ -1841,7 +1847,7 @@ Eigen::Vector3d Skeleton::getWorldCOMAcceleration()
 Eigen::MatrixXd Skeleton::getWorldCOMJacobian()
 {
   // Jacobian of COM
-  Eigen::MatrixXd J = Eigen::MatrixXd::Zero(3, getDof());
+  Eigen::MatrixXd J = Eigen::MatrixXd::Zero(3, getNumDofs());
 
   // Compute sum of each body's Jacobian of COM accelerations multiplied by
   // body's mass
@@ -1873,7 +1879,7 @@ Eigen::MatrixXd Skeleton::getWorldCOMJacobian()
 Eigen::MatrixXd Skeleton::getWorldCOMJacobianTimeDeriv()
 {
   // Jacobian time derivative of COM
-  Eigen::MatrixXd dJ = Eigen::MatrixXd::Zero(3, getDof());
+  Eigen::MatrixXd dJ = Eigen::MatrixXd::Zero(3, getNumDofs());
 
   // Compute sum of each body's Jacobian time derivative of COM accelerations
   // multiplied by body's mass

--- a/dart/dynamics/Skeleton.h
+++ b/dart/dynamics/Skeleton.h
@@ -183,7 +183,10 @@ public:
   //----------------------------------------------------------------------------
 
   /// Return degrees of freedom of this skeleton
-  size_t getDof() const;
+  DEPRECATED(4.1) size_t getDof() const;
+
+  /// Return degrees of freedom of this skeleton
+  size_t getNumDofs() const;
 
   ///
   GenCoordInfo getGenCoordInfo(size_t _index) const;

--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -121,7 +121,7 @@ void SoftBodyNode::init(Skeleton* _skeleton)
 //  for (size_t i = 0; i < getNumPointMasses(); ++i)
 //  {
 //    PointMass* pointMass = getPointMass(i);
-//    for (int j = 0; j < pointMass->getDof(); ++j)
+//    for (int j = 0; j < pointMass->getNumDofs(); ++j)
 //    {
 //      GenCoord* genCoord = pointMass->getGenCoord(j);
 //      genCoord->setSkeletonIndex(_genCoords->size());
@@ -557,7 +557,7 @@ void SoftBodyNode::aggregateMassMatrix(Eigen::MatrixXd* _MCol, int _col)
   assert(!math::isNan(mM_F));
 
   //
-  int dof = mParentJoint->getDof();
+  int dof = mParentJoint->getNumDofs();
   if (dof > 0)
   {
     int iStart = mParentJoint->getIndexInSkeleton(0);
@@ -594,7 +594,7 @@ void SoftBodyNode::aggregateAugMassMatrix(Eigen::MatrixXd* _MCol, int _col,
   }
   assert(!math::isNan(mM_F));
 
-  size_t dof = mParentJoint->getDof();
+  size_t dof = mParentJoint->getNumDofs();
   if (dof > 0)
   {
     Eigen::MatrixXd K = Eigen::MatrixXd::Zero(dof, dof);
@@ -782,7 +782,7 @@ void SoftBodyNode::aggregateGravityForceVector(Eigen::VectorXd* _g,
     mG_F.tail<3>() += (*it)->mG_F;
   }
 
-  int nGenCoords = mParentJoint->getDof();
+  int nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0)
   {
     Eigen::VectorXd g = -(mParentJoint->getLocalJacobian().transpose() * mG_F);
@@ -834,7 +834,7 @@ void SoftBodyNode::aggregateCombinedVector(Eigen::VectorXd* _Cg,
     mCg_F.tail<3>() += (*it)->mCg_F;
   }
 
-  int nGenCoords = mParentJoint->getDof();
+  int nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0)
   {
     Eigen::VectorXd Cg = mParentJoint->getLocalJacobian().transpose() * mCg_F;
@@ -867,7 +867,7 @@ void SoftBodyNode::aggregateExternalForces(Eigen::VectorXd* _Fext)
     mFext_F.tail<3>() += (*it)->mFext;
   }
 
-  int nGenCoords = mParentJoint->getDof();
+  int nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0)
   {
     Eigen::VectorXd Fext

--- a/dart/dynamics/ZeroDofJoint.cpp
+++ b/dart/dynamics/ZeroDofJoint.cpp
@@ -58,6 +58,12 @@ ZeroDofJoint::~ZeroDofJoint()
 //==============================================================================
 size_t ZeroDofJoint::getDof() const
 {
+  return getNumDofs();
+}
+
+//==============================================================================
+size_t ZeroDofJoint::getNumDofs() const
+{
   return 0;
 }
 

--- a/dart/dynamics/ZeroDofJoint.h
+++ b/dart/dynamics/ZeroDofJoint.h
@@ -61,8 +61,11 @@ public:
   // Interface for generalized coordinates
   //----------------------------------------------------------------------------
 
-  /// Get number of generalized coordinates
-  virtual size_t getDof() const;
+  // Documentation inherited
+  DEPRECATED(4.1) virtual size_t getDof() const;
+
+  // Documentation inherited
+  virtual size_t getNumDofs() const;
 
   // Documentation inherited
   virtual void setIndexInSkeleton(size_t _index, size_t _indexInSkeleton);

--- a/dart/gui/SimWindow.cpp
+++ b/dart/gui/SimWindow.cpp
@@ -107,7 +107,7 @@ void SimWindow::draw() {
       size_t nSkels = mWorld->getNumSkeletons();
       for (size_t i = 0; i < nSkels; i++) {
         // size_t start = mWorld->getIndex(i);
-        // size_t size = mWorld->getSkeleton(i)->getDof();
+        // size_t size = mWorld->getSkeleton(i)->getNumDofs();
         mWorld->getSkeleton(i)->setPositions(mWorld->getRecording()->getConfig(mPlayFrame, i));
         mWorld->getSkeleton(i)->computeForwardKinematics(true, false, false);
       }

--- a/dart/simulation/Recording.cpp
+++ b/dart/simulation/Recording.cpp
@@ -53,7 +53,7 @@ namespace simulation {
 Recording::Recording(const std::vector<dynamics::Skeleton*>& _skeletons)
 {
   for (size_t i = 0; i < _skeletons.size(); i++)
-    mNumGenCoordsForSkeletons.push_back(_skeletons[i]->getDof());
+    mNumGenCoordsForSkeletons.push_back(_skeletons[i]->getNumDofs());
 }
 
 //==============================================================================
@@ -81,7 +81,7 @@ int Recording::getNumSkeletons() const
 }
 
 //==============================================================================
-int Recording::getDof(int _skelIdx) const
+int Recording::getNumDofs(int _skelIdx) const
 {
   return mNumGenCoordsForSkeletons[_skelIdx];
 }
@@ -101,7 +101,7 @@ Eigen::VectorXd Recording::getConfig(int _frameIdx, int _skelIdx) const
   int index = 0;
   for (int i = 0; i < _skelIdx; i++)
     index += mNumGenCoordsForSkeletons[i];
-  return mBakedStates[_frameIdx].segment(index, getDof(_skelIdx));
+  return mBakedStates[_frameIdx].segment(index, getNumDofs(_skelIdx));
 }
 
 //==============================================================================
@@ -143,7 +143,7 @@ void Recording::updateNumGenCoords(
 {
   mNumGenCoordsForSkeletons.clear();
   for (size_t i = 0; i < _skeletons.size(); ++i)
-    mNumGenCoordsForSkeletons.push_back(_skeletons[i]->getDof());
+    mNumGenCoordsForSkeletons.push_back(_skeletons[i]->getNumDofs());
 }
 
 }  // namespace simulation

--- a/dart/simulation/Recording.h
+++ b/dart/simulation/Recording.h
@@ -76,7 +76,7 @@ public:
 
   /// \brief Get number of generalized coordinates of skeleton whoes index is
   /// _skelIdx
-  int getDof(int _skelIdx) const;
+  int getNumDofs(int _skelIdx) const;
 
   /// \brief Get number of contacts at frame number _frameIdx
   int getNumContacts(int _frameIdx) const;

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -232,7 +232,7 @@ void World::addSkeleton(dynamics::Skeleton* _skeleton)
 
   mSkeletons.push_back(_skeleton);
   _skeleton->init(mTimeStep, mGravity);
-  mIndices.push_back(mIndices.back() + _skeleton->getDof());
+  mIndices.push_back(mIndices.back() + _skeleton->getNumDofs());
   mConstraintSolver->addSkeleton(_skeleton);
 
   // Update recording
@@ -263,7 +263,7 @@ void World::removeSkeleton(dynamics::Skeleton* _skeleton)
 
   // Update mIndices.
   for (++i; i < mSkeletons.size() - 1; ++i)
-    mIndices[i] = mIndices[i+1] - _skeleton->getDof();
+    mIndices[i] = mIndices[i+1] - _skeleton->getNumDofs();
   mIndices.pop_back();
 
   // Remove _skeleton from constraint handler.
@@ -316,7 +316,7 @@ void World::bake()
   Eigen::VectorXd state(getIndex(nSkeletons) + 6 * nContacts);
   for (size_t i = 0; i < getNumSkeletons(); i++)
   {
-    state.segment(getIndex(i), getSkeleton(i)->getDof())
+    state.segment(getIndex(i), getSkeleton(i)->getNumDofs())
         = getSkeleton(i)->getPositions();
   }
   for (int i = 0; i < nContacts; i++)

--- a/dart/utils/FileInfoDof.cpp
+++ b/dart/utils/FileInfoDof.cpp
@@ -79,7 +79,7 @@ bool FileInfoDof::loadFile(const char* _fName)
   inFile >> buffer;
   inFile >> nDof;
 
-  if (mSkel == NULL || mSkel->getDof() != nDof)
+  if (mSkel == NULL || mSkel->getNumDofs() != nDof)
     return false;
 
   mDofs.resize(mNumFrames);
@@ -125,9 +125,9 @@ bool FileInfoDof::saveFile(const char* _fName, size_t _start, size_t _end,
   size_t last = _end < mNumFrames ? _end : mNumFrames - 1;
 
   outFile.precision(20);
-  outFile << "frames = " << last-first+1 << " dofs = " << mSkel->getDof() << std::endl;
+  outFile << "frames = " << last-first+1 << " dofs = " << mSkel->getNumDofs() << std::endl;
 
-  for (size_t i = 0; i < mSkel->getDof(); i++)
+  for (size_t i = 0; i < mSkel->getNumDofs(); i++)
   {
     dynamics::GenCoordInfo info = mSkel->getGenCoordInfo(i);
     outFile << info.joint->getName() << "." << info.localIndex << ' ';
@@ -137,7 +137,7 @@ bool FileInfoDof::saveFile(const char* _fName, size_t _start, size_t _end,
 
   for (size_t i = first; i <= last; i++)
   {
-    for (size_t j = 0; j < mSkel->getDof(); j++)
+    for (size_t j = 0; j < mSkel->getNumDofs(); j++)
       outFile << mDofs[i][j] << ' ';
     outFile << std::endl;
   }

--- a/dart/utils/FileInfoWorld.cpp
+++ b/dart/utils/FileInfoWorld.cpp
@@ -89,7 +89,7 @@ bool FileInfoWorld::loadFile(const char* _fName)
   {
     for (int j = 0; j < numSkeletons; j++)
     {
-      for (int k = 0; k < mRecord->getDof(j); k++)
+      for (int k = 0; k < mRecord->getNumDofs(j); k++)
       {
         inFile >> doubleVal;
         tempState.push_back(doubleVal);
@@ -137,13 +137,13 @@ bool FileInfoWorld::saveFile(const char* _fName, simulation::Recording* _record)
   outFile << "numFrames " << _record->getNumFrames() << std::endl;
   outFile << "numSkeletons " << _record->getNumSkeletons() << std::endl;
   for (int i = 0; i < _record->getNumSkeletons(); i++)
-    outFile << "Skeleton" << i << " " << _record->getDof(i) << " ";
+    outFile << "Skeleton" << i << " " << _record->getNumDofs(i) << " ";
   outFile << std::endl;
   for (int i = 0; i < _record->getNumFrames(); i++)
   {
     for (int j = 0; j < _record->getNumSkeletons(); j++)
     {
-      for (int k = 0; k < _record->getDof(j); k++)
+      for (int k = 0; k < _record->getNumDofs(j); k++)
         outFile << _record->getGenCoord(i, j, k) << " ";
       outFile << std::endl;
     }

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -271,7 +271,7 @@ dynamics::Joint* DartLoader::createDartJoint(const urdf::Joint* _jt)
   joint->setName(_jt->name);
   joint->setTransformFromParentBodyNode(toEigen(_jt->parent_to_joint_origin_transform));
   joint->setTransformFromChildBodyNode(Eigen::Isometry3d::Identity());
-  if(joint->getDof() == 1 && _jt->limits) {
+  if(joint->getNumDofs() == 1 && _jt->limits) {
     joint->setVelocityLowerLimit(0, -_jt->limits->velocity);
     joint->setVelocityUpperLimit(0, _jt->limits->velocity);
     joint->setForceLowerLimit(0, -_jt->limits->effort);

--- a/unittests/testBuilding.cpp
+++ b/unittests/testBuilding.cpp
@@ -119,7 +119,7 @@ TEST(BUILDING, BASIC)
     //EXPECT_TRUE(body3.getChildBodyNode(0) == NULL);
 
     EXPECT_TRUE(skel1->getNumBodyNodes() == 3);
-    EXPECT_TRUE(skel1->getDof() == 3);
+    EXPECT_TRUE(skel1->getNumDofs() == 3);
 
     EXPECT_TRUE(world->getNumSkeletons() == 1);
 

--- a/unittests/testConstraint.cpp
+++ b/unittests/testConstraint.cpp
@@ -154,7 +154,7 @@ void ConstraintTest::SingleContactTest(const std::string& _fileName)
   // BodyNode* ground = groundSkel->getBodyNode(0);
   world->addSkeleton(groundSkel);
   EXPECT_EQ(groundSkel->getGravity(), world->getGravity());
-  assert(ground);
+  // assert(ground);
 
   EXPECT_EQ(world->getNumSkeletons(), 2);
 

--- a/unittests/testDynamics.cpp
+++ b/unittests/testDynamics.cpp
@@ -129,7 +129,7 @@ const std::vector<std::string>& DynamicsTest::getList()
 //==============================================================================
 MatrixXd DynamicsTest::getMassMatrix(dynamics::Skeleton* _skel)
 {
-  int skelDof = _skel->getDof();
+  int skelDof = _skel->getNumDofs();
 
   MatrixXd skelM = MatrixXd::Zero(skelDof, skelDof);  // Mass matrix of skeleton
   MatrixXd M;  // Body mass
@@ -170,7 +170,7 @@ MatrixXd DynamicsTest::getMassMatrix(dynamics::Skeleton* _skel)
 //==============================================================================
 MatrixXd DynamicsTest::getAugMassMatrix(dynamics::Skeleton* _skel)
 {
-  int    dof = _skel->getDof();
+  int    dof = _skel->getNumDofs();
   double dt  = _skel->getTimeStep();
 
   MatrixXd M = getMassMatrix(_skel);
@@ -187,7 +187,7 @@ MatrixXd DynamicsTest::getAugMassMatrix(dynamics::Skeleton* _skel)
     EXPECT_TRUE(body  != NULL);
     EXPECT_TRUE(joint != NULL);
 
-    int dof = joint->getDof();
+    int dof = joint->getNumDofs();
 
     for (int j = 0; j < dof; ++j)
     {
@@ -239,7 +239,7 @@ void DynamicsTest::compareVelocities(const std::string& _fileName)
   {
     Skeleton* skeleton = world->getSkeleton(i);
     assert(skeleton != NULL);
-    int dof = skeleton->getDof();
+    int dof = skeleton->getNumDofs();
 
     for (int j = 0; j < nRandomItr; ++j)
     {
@@ -406,7 +406,7 @@ void DynamicsTest::compareAccelerations(const std::string& _fileName)
   {
     Skeleton* skeleton = world->getSkeleton(i);
     assert(skeleton != NULL);
-    int dof = skeleton->getDof();
+    int dof = skeleton->getNumDofs();
 
     for (int j = 0; j < nRandomItr; ++j)
     {
@@ -651,7 +651,7 @@ void DynamicsTest::compareEquationsOfMotion(const std::string& _fileName)
   {
     dynamics::Skeleton* skel = myWorld->getSkeleton(i);
 
-    size_t dof = skel->getDof();
+    size_t dof = skel->getNumDofs();
 //    int nBodyNodes = skel->getNumBodyNodes();
 
     if (dof == 0)
@@ -668,7 +668,7 @@ void DynamicsTest::compareEquationsOfMotion(const std::string& _fileName)
       {
         BodyNode* body     = skel->getBodyNode(k);
         Joint*    joint    = body->getParentJoint();
-        size_t    localDof = joint->getDof();
+        size_t    localDof = joint->getNumDofs();
 
         for (size_t l = 0; l < localDof; ++l)
         {
@@ -855,7 +855,7 @@ void DynamicsTest::centerOfMass(const std::string& _fileName)
   {
     dynamics::Skeleton* skel = myWorld->getSkeleton(i);
 
-    int dof            = skel->getDof();
+    int dof            = skel->getNumDofs();
 //    int nBodyNodes     = skel->getNumBodyNodes();
 
     if (dof == 0)
@@ -872,7 +872,7 @@ void DynamicsTest::centerOfMass(const std::string& _fileName)
       {
         BodyNode* body     = skel->getBodyNode(k);
         Joint*    joint    = body->getParentJoint();
-        int       localDof = joint->getDof();
+        int       localDof = joint->getNumDofs();
 
         for (int l = 0; l < localDof; ++l)
         {
@@ -971,7 +971,7 @@ void DynamicsTest::testImpulseBasedDynamics(const std::string& _fileName)
   {
     dynamics::Skeleton* skel = myWorld->getSkeleton(i);
 
-    int dof            = skel->getDof();
+    int dof            = skel->getNumDofs();
 //    int nBodyNodes     = skel->getNumBodyNodes();
 
     if (dof == 0 || !skel->isMobile())
@@ -988,7 +988,7 @@ void DynamicsTest::testImpulseBasedDynamics(const std::string& _fileName)
       {
         BodyNode* body     = skel->getBodyNode(k);
         Joint*    joint    = body->getParentJoint();
-        int       localDof = joint->getDof();
+        int       localDof = joint->getNumDofs();
 
         for (int l = 0; l < localDof; ++l)
         {

--- a/unittests/testInverseKinematics.cpp
+++ b/unittests/testInverseKinematics.cpp
@@ -108,7 +108,7 @@ Skeleton* createFreeFloatingTwoLinkRobot(Vector3d dim1,
 //                      Vector3d(0.3, 0.3, l1),
 //                      Vector3d(0.3, 0.3, l2), DOF_ROLL);
 //  robot->init();
-//  size_t dof = robot->getDof();
+//  size_t dof = robot->getNumDofs();
 //  VectorXd oldConfig = robot->getPositions();
 
 //  BodyNode* body1 = robot->getBodyNode(0);

--- a/unittests/testJoints.cpp
+++ b/unittests/testJoints.cpp
@@ -89,7 +89,7 @@ void JOINTS::kinematicsTest(Joint* _joint)
   skeleton.addBodyNode(bodyNode);
   skeleton.init();
 
-  int dof = _joint->getDof();
+  int dof = _joint->getNumDofs();
 
   //--------------------------------------------------------------------------
   //
@@ -111,7 +111,7 @@ void JOINTS::kinematicsTest(Joint* _joint)
     skeleton.setVelocities(dq);
     skeleton.computeForwardKinematics(true, true, false);
 
-    if (_joint->getDof() == 0)
+    if (_joint->getNumDofs() == 0)
       return;
 
     Eigen::Isometry3d T = _joint->getLocalTransform();
@@ -231,7 +231,7 @@ void JOINTS::kinematicsTest(Joint* _joint)
     skeleton.setPositions(q);
     skeleton.computeForwardKinematics(true, false, false);
 
-    if (_joint->getDof() == 0)
+    if (_joint->getNumDofs() == 0)
       return;
 
     Eigen::Isometry3d T = _joint->getLocalTransform();

--- a/unittests/testSoftDynamics.cpp
+++ b/unittests/testSoftDynamics.cpp
@@ -137,7 +137,7 @@ const std::vector<std::string>& SoftDynamicsTest::getList()
 //==============================================================================
 MatrixXd SoftDynamicsTest::getMassMatrix(dynamics::Skeleton* _skel)
 {
-  int skelDof = _skel->getDof();
+  int skelDof = _skel->getNumDofs();
 
   MatrixXd skelM = MatrixXd::Zero(skelDof, skelDof);  // Mass matrix of skeleton
   MatrixXd M;  // Body mass
@@ -217,7 +217,7 @@ MatrixXd SoftDynamicsTest::getMassMatrix(dynamics::Skeleton* _skel)
 //==============================================================================
 MatrixXd SoftDynamicsTest::getAugMassMatrix(dynamics::Skeleton* _skel)
 {
-  int    dof = _skel->getDof();
+  int    dof = _skel->getNumDofs();
   double dt  = _skel->getTimeStep();
 
   MatrixXd M = getMassMatrix(_skel);
@@ -234,7 +234,7 @@ MatrixXd SoftDynamicsTest::getAugMassMatrix(dynamics::Skeleton* _skel)
     EXPECT_TRUE(body  != NULL);
     EXPECT_TRUE(joint != NULL);
 
-    int dof = joint->getDof();
+    int dof = joint->getNumDofs();
 
     for (int j = 0; j < dof; ++j)
     {
@@ -319,7 +319,7 @@ void SoftDynamicsTest::compareEquationsOfMotion(const std::string& _fileName)
     dynamics::Skeleton* softSkel
         = dynamic_cast<dynamics::Skeleton*>(skel);
 
-    int dof            = skel->getDof();
+    int dof            = skel->getNumDofs();
 //    int nBodyNodes     = skel->getNumBodyNodes();
     int nSoftBodyNodes = 0;
     if (softSkel != NULL)
@@ -339,7 +339,7 @@ void SoftDynamicsTest::compareEquationsOfMotion(const std::string& _fileName)
       {
         BodyNode* body     = skel->getBodyNode(k);
         Joint*    joint    = body->getParentJoint();
-        int       localDof = joint->getDof();
+        int       localDof = joint->getNumDofs();
 
         for (int l = 0; l < localDof; ++l)
         {


### PR DESCRIPTION
- Rename `getDof()` to `getNumDofs()`
- `getDof()` is still there but marked as deprecated
- #207
