### PR TITLE
Reset functions for Simulation and Recording class

### DIFF
--- a/dart/simulation/Recording.cpp
+++ b/dart/simulation/Recording.cpp
@@ -132,6 +132,11 @@ Eigen::Vector3d Recording::getContactForce(int _frameIdx, int _contactIdx) const
 }
 
 //==============================================================================
+void Recording::clear() {
+  mBakedStates.clear();
+}
+
+//==============================================================================
 void Recording::addState(const Eigen::VectorXd& _state)
 {
   mBakedStates.push_back(_state);

--- a/dart/simulation/Recording.h
+++ b/dart/simulation/Recording.h
@@ -97,6 +97,9 @@ public:
   /// _frameIdx
   Eigen::Vector3d getContactForce(int _frameIdx, int _contactIdx) const;
 
+  /// \brief Clear the saved histories
+  void clear();  
+
   /// \brief Add state
   void addState(const Eigen::VectorXd& _state);
 

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -102,7 +102,16 @@ double World::getTimeStep() const
   return mTimeStep;
 }
 
+
 //==============================================================================
+
+void World::reset() {
+  mTime = 0.0;
+  mFrame = 0;
+  mRecording->clear();    
+}
+
+
 void World::step()
 {
   // Integrate velocity unconstrained skeletons

--- a/dart/simulation/World.h
+++ b/dart/simulation/World.h
@@ -136,6 +136,9 @@ public:
   // Simulation
   //--------------------------------------------------------------------------
 
+  /// Reset the time, frame counter and recorded histories
+  void reset();
+
   /// Calculate the dynamics and integrate the world for one step
   void step();
 


### PR DESCRIPTION
I added "reset" functions to World to reset the clock, frame counter, and recordings.
This is required for repetitive simulation runs in the optimization.
