### PR TITLE
Consistent Jacobian and its derivatives of BallJoint and FreeJoint

### DIFF
--- a/dart/dynamics/BallJoint.h
+++ b/dart/dynamics/BallJoint.h
@@ -55,9 +55,6 @@ public:
   virtual ~BallJoint();
 
   // Documentation inherited
-  virtual void setTransformFromChildBodyNode(const Eigen::Isometry3d& _T);
-
-  // Documentation inherited
   virtual Eigen::Vector6d getBodyConstraintWrench() const
   {
     return mWrench - mJacobian * mForces;

--- a/dart/dynamics/FreeJoint.h
+++ b/dart/dynamics/FreeJoint.h
@@ -57,9 +57,6 @@ public:
   virtual ~FreeJoint();
 
   // Documentation inherited
-  virtual void setTransformFromChildBodyNode(const Eigen::Isometry3d& _T);
-
-  // Documentation inherited
   virtual Eigen::Vector6d getBodyConstraintWrench() const
   {
     return mWrench - mJacobian * mForces;

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -481,10 +481,10 @@ protected:
   // For recursive dynamics algorithms
   //----------------------------------------------------------------------------
 
-  /// Spatial Jacobian
+  /// Spatial Jacobian expressed in the child body frame
   Eigen::Matrix<double, 6, DOF> mJacobian;
 
-  /// Time derivative of spatial Jacobian
+  /// Time derivative of spatial Jacobian expressed in the child body frame
   Eigen::Matrix<double, 6, DOF> mJacobianDeriv;
 
   /// Inverse of projected articulated inertia

--- a/dart/dynamics/SingleDofJoint.h
+++ b/dart/dynamics/SingleDofJoint.h
@@ -475,10 +475,10 @@ protected:
   // For recursive dynamics algorithms
   //----------------------------------------------------------------------------
 
-  /// Spatial Jacobian
+  /// Spatial Jacobian expressed in the child body frame
   Eigen::Vector6d mJacobian;
 
-  /// Time derivative of spatial Jacobian
+  /// Time derivative of spatial Jacobian expressed in the child body frame
   Eigen::Vector6d mJacobianDeriv;
 
   /// Inverse of projected articulated inertia

--- a/unittests/testDynamics.cpp
+++ b/unittests/testDynamics.cpp
@@ -428,20 +428,8 @@ void DynamicsTest::compareAccelerations(const std::string& _fileName)
 //        ddq[k] = 0.0;
       }
 
-      skeleton->setPositions(q);
-      skeleton->setVelocities(dq);
-      skeleton->setAccelerations(ddq);
-      skeleton->computeForwardKinematics(true, true, true);
-
-      // Integrate state
-      skeleton->integratePositions(timeStep);
-      skeleton->integrateVelocities(timeStep);
-
-      // Compute forward kinematics
-      skeleton->computeForwardKinematics(true, true, true);
-
-      VectorXd qNext  = skeleton->getPositions();
-      VectorXd dqNext = skeleton->getVelocities();
+      VectorXd qNext  =  q +  dq * timeStep;
+      VectorXd dqNext = dq + ddq * timeStep;
 
       // For each body node
       for (size_t k = 0; k < skeleton->getNumBodyNodes(); ++k)

--- a/unittests/testJoints.cpp
+++ b/unittests/testJoints.cpp
@@ -165,16 +165,10 @@ void JOINTS::kinematicsTest(Joint* _joint)
       numericJ.col(i) = Ji;
     }
 
-    if (dynamic_cast<BallJoint*>(_joint) || dynamic_cast<FreeJoint*>(_joint))
+    for (int i = 0; i < dof; ++i)
     {
-      // Skip this test for BallJoint and FreeJoint since Jacobian of BallJoint
-      // and FreeJoint is not obtained by the above method.
-    }
-    else
-    {
-      for (int i = 0; i < dof; ++i)
-        for (int j = 0; j < 6; ++j)
-          EXPECT_NEAR(J.col(i)(j), numericJ.col(i)(j), JOINT_TOL);
+      for (int j = 0; j < 6; ++j)
+        EXPECT_NEAR(J.col(i)(j), numericJ.col(i)(j), JOINT_TOL);
     }
 
     //--------------------------------------------------------------------------
@@ -204,18 +198,10 @@ void JOINTS::kinematicsTest(Joint* _joint)
       numeric_dJ += dJ_dq * dq(i);
     }
 
-
-    if (dynamic_cast<BallJoint*>(_joint) || dynamic_cast<FreeJoint*>(_joint))
+    for (int i = 0; i < dof; ++i)
     {
-      // Skip this test for BallJoint and FreeJoint since time derivative of
-      // Jacobian of BallJoint and FreeJoint is not obtained by the above
-      // method.
-    }
-    else
-    {
-      for (int i = 0; i < dof; ++i)
-        for (int j = 0; j < 6; ++j)
-          EXPECT_NEAR(dJ.col(i)(j), numeric_dJ.col(i)(j), JOINT_TOL);
+      for (int j = 0; j < 6; ++j)
+        EXPECT_NEAR(dJ.col(i)(j), numeric_dJ.col(i)(j), JOINT_TOL);
     }
   }
 
@@ -402,5 +388,4 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-
 


### PR DESCRIPTION
This pull request change the computation of the Jacobians and Jacobian derivatives in consistent way. Previously, the generalized velocities and accelerations of `BallJoint` and `FreeJoint` were the spatial velocities and spatial accelerations, which are relative velocities and accelerations between the parent body node and the child body node, so their Jacobians and its derivatives were identity and zero matrices, respectively. The benefit of doing so is that the Jacobians and its derivatives don't need to be computed over simulation steps but the problem is that the velocities, accelerations, Jacobians and Jacobian derivatives are not consistent with the generalized coordinates.

Note that the target branch of this PR is release-4.2.
