### PR TITLE
Version numbering of the shared libraries in debian packages

### DIFF
--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -69,16 +69,14 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 # Library
 add_library(dart-core ${core_srcs})
 target_link_libraries(dart-core ${DART_CORE_DEPENDENCIES})
-set_target_properties(dart-core PROPERTIES OUTPUT_NAME "dart-core${DART_MAJOR_VERSION}"
-                                           SOVERSION ${DART_MINOR_VERSION}
-                                           VERSION "${DART_MINOR_VERSION}.${DART_PATCH_VERSION}.0")
+set_target_properties(dart-core PROPERTIES SOVERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}"
+                                           VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}")
 
 if(NOT BUILD_CORE_ONLY)
   add_library(dart ${noncore_srcs})
   target_link_libraries(dart dart-core ${DART_DEPENDENCIES})
-  set_target_properties(dart PROPERTIES OUTPUT_NAME "dart${DART_MAJOR_VERSION}"
-                                        SOVERSION ${DART_MINOR_VERSION}
-                                        VERSION "${DART_MINOR_VERSION}.${DART_PATCH_VERSION}.0")
+  set_target_properties(dart PROPERTIES SOVERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}"
+                                        VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}")
 endif()
 
 

--- a/debian/libdart-core4-dev.install
+++ b/debian/libdart-core4-dev.install
@@ -11,3 +11,4 @@ usr/include/dart/simulation/*
 usr/share/dartcore/DARTCoreConfig.cmake
 usr/share/dartcore/DARTCoreConfigVersion.cmake
 usr/share/dartcore/DARTCoreTargets*.cmake
+usr/lib/libdart-core.so.*

--- a/debian/libdart-core4.2.install
+++ b/debian/libdart-core4.2.install
@@ -1,1 +1,1 @@
-usr/lib/libdart-core4.so*
+usr/lib/libdart-core.so

--- a/debian/libdart4-dev.install
+++ b/debian/libdart4-dev.install
@@ -5,3 +5,4 @@ usr/include/dart/gui/*
 usr/share/dart/DARTConfig.cmake
 usr/share/dart/DARTConfigVersion.cmake
 usr/share/dart/DARTTargets*.cmake
+usr/lib/libdart.so.*

--- a/debian/libdart4.2.install
+++ b/debian/libdart4.2.install
@@ -1,1 +1,1 @@
-usr/lib/libdart4.so*
+usr/lib/libdart.so


### PR DESCRIPTION
This PR changes naming of the shared libraries. Since ABI breaking is done per minor version up, minor version number needs to be appear to the shared libraries.

For example:
- `libdart-core4.2` package installs `libdart-core.so.4.2`
- `libdart-core4-dev` package install `libdart-core.so` symlink

This PR should fixes #281.
