### PR TITLE
Fix bug in collision checking when a body node has multiple collision shapes

### DIFF
--- a/dart/collision/fcl_mesh/FCLMeshCollisionNode.cpp
+++ b/dart/collision/fcl_mesh/FCLMeshCollisionNode.cpp
@@ -177,7 +177,12 @@ bool FCLMeshCollisionNode::detectCollision(FCLMeshCollisionNode* _otherNode,
         collision = true;
 
       if (!_contactPoints)
-        return collision;
+      {
+        if (collision)
+          return true;
+        else
+          continue;
+      }
 
 
       int numCoplanarContacts = 0;


### PR DESCRIPTION
Fix bug: Only the first collision shape of a body node is considered when checking for collision without calculating contact points

The change is smaller than it seems here. When ignoring whitespace changes, only 3 lines are changed.

I have only tested this bug fix with DART 3, but it should be the same for DART 4.