### PR TITLE
Added convenience functions to help with setting FreeJoint, EulerJoint, and BallJoint positions

### DIFF
--- a/dart/dynamics/BallJoint.cpp
+++ b/dart/dynamics/BallJoint.cpp
@@ -65,7 +65,7 @@ Eigen::Isometry3d BallJoint::convertToTransform(
 }
 
 //==============================================================================
-Eigen::Matrix3d BallJoint::convertToRotation(const Eigen::Vector3d &_positions)
+Eigen::Matrix3d BallJoint::convertToRotation(const Eigen::Vector3d& _positions)
 {
   return math::expMapRot(_positions);
 }

--- a/dart/dynamics/BallJoint.cpp
+++ b/dart/dynamics/BallJoint.cpp
@@ -58,12 +58,25 @@ BallJoint::~BallJoint()
 }
 
 //==============================================================================
+Eigen::Isometry3d BallJoint::convertToTransform(
+    const Eigen::Vector3d& _positions)
+{
+  return Eigen::Isometry3d(convertToRotation(_positions));
+}
+
+//==============================================================================
+Eigen::Matrix3d BallJoint::convertToRotation(const Eigen::Vector3d &_positions)
+{
+  return math::expMapRot(_positions);
+}
+
+//==============================================================================
 void BallJoint::integratePositions(double _dt)
 {
-  mR.linear() = mR.linear() * math::expMapRot(mJacobian.topRows<3>()
-                                              * mVelocities * _dt);
+  mR.linear() = mR.linear() * convertToRotation(mJacobian.topRows<3>()
+                                                * mVelocities * _dt);
 
-  mPositions = math::logMap(mR.linear());
+  mPositions = convertToPositions(mR.linear());
 }
 
 //==============================================================================
@@ -80,7 +93,7 @@ void BallJoint::updateDegreeOfFreedomNames()
 //==============================================================================
 void BallJoint::updateLocalTransform()
 {
-  mR.linear() = math::expMapRot(mPositions);
+  mR.linear() = convertToRotation(mPositions);
 
   mT = mT_ParentBodyToJoint * mR * mT_ChildBodyToJoint.inverse();
 

--- a/dart/dynamics/BallJoint.h
+++ b/dart/dynamics/BallJoint.h
@@ -66,6 +66,12 @@ public:
     return math::logMap(_rotation);
   }
 
+  /// Convert a BallJoint-style position vector into a transform
+  static Eigen::Isometry3d convertToTransform(const Eigen::Vector3d& _positions);
+
+  /// Convert a BallJoint-style position vector into a rotation matrix
+  static Eigen::Matrix3d convertToRotation(const Eigen::Vector3d& _positions);
+
 protected:
   // Documentation inherited
   virtual void integratePositions(double _dt);

--- a/dart/dynamics/BallJoint.h
+++ b/dart/dynamics/BallJoint.h
@@ -54,6 +54,18 @@ public:
   /// Destructor
   virtual ~BallJoint();
 
+  /// Convert a rotation into a 3D vector that can be used to set the positions
+  /// of a BallJoint. The positions returned by this function will result in a
+  /// relative transform of
+  /// getTransformFromParentBodyNode() * _rotation * getTransformFromChildBodyNode().inverse()
+  /// between the parent BodyNode and the child BodyNode frames when applied to
+  /// a BallJoint.
+  template <typename RotationType>
+  static Eigen::Vector3d convertToPositions(const RotationType& _rotation)
+  {
+    return math::logMap(_rotation);
+  }
+
 protected:
   // Documentation inherited
   virtual void integratePositions(double _dt);

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -74,8 +74,8 @@ EulerJoint::AxisOrder EulerJoint::getAxisOrder() const
 }
 
 //==============================================================================
-Eigen::Isometry3d EulerJoint::convertToTransform(const Eigen::Vector3d& _positions,
-                                                 AxisOrder _ordering)
+Eigen::Isometry3d EulerJoint::convertToTransform(
+    const Eigen::Vector3d& _positions, AxisOrder _ordering)
 {
   return Eigen::Isometry3d(convertToRotation(_positions, _ordering));
 }
@@ -88,8 +88,8 @@ Eigen::Isometry3d EulerJoint::convertToTransform(
 }
 
 //==============================================================================
-Eigen::Matrix3d EulerJoint::convertToRotation(const Eigen::Vector3d &_positions,
-                                              AxisOrder _ordering)
+Eigen::Matrix3d EulerJoint::convertToRotation(
+    const Eigen::Vector3d& _positions, AxisOrder _ordering)
 {
   switch (_ordering)
   {
@@ -107,7 +107,7 @@ Eigen::Matrix3d EulerJoint::convertToRotation(const Eigen::Vector3d &_positions,
 }
 
 //==============================================================================
-Eigen::Matrix3d EulerJoint::convertToRotation(const Eigen::Vector3d &_positions)
+Eigen::Matrix3d EulerJoint::convertToRotation(const Eigen::Vector3d& _positions)
                                                                            const
 {
   return convertToRotation(_positions, mAxisOrder);

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -74,6 +74,46 @@ EulerJoint::AxisOrder EulerJoint::getAxisOrder() const
 }
 
 //==============================================================================
+Eigen::Isometry3d EulerJoint::convertToTransform(const Eigen::Vector3d& _positions,
+                                                 AxisOrder _ordering)
+{
+  return Eigen::Isometry3d(convertToRotation(_positions, _ordering));
+}
+
+//==============================================================================
+Eigen::Isometry3d EulerJoint::convertToTransform(
+    const Eigen::Vector3d &_positions) const
+{
+  return convertToTransform(_positions, mAxisOrder);
+}
+
+//==============================================================================
+Eigen::Matrix3d EulerJoint::convertToRotation(const Eigen::Vector3d &_positions,
+                                              AxisOrder _ordering)
+{
+  switch (_ordering)
+  {
+    case AO_XYZ:
+      return math::eulerXYZToMatrix(_positions);
+    case AO_ZYX:
+      return math::eulerZYXToMatrix(_positions);
+    default:
+    {
+      dterr << "[EulerJoint::convertToRotation] Invalid AxisOrder specified ("
+            << _ordering << ")\n";
+      return Eigen::Matrix3d::Identity();
+    }
+  }
+}
+
+//==============================================================================
+Eigen::Matrix3d EulerJoint::convertToRotation(const Eigen::Vector3d &_positions)
+                                                                           const
+{
+  return convertToRotation(_positions, mAxisOrder);
+}
+
+//==============================================================================
 void EulerJoint::updateDegreeOfFreedomNames()
 {
   std::vector<std::string> affixes;
@@ -117,28 +157,8 @@ void EulerJoint::updateDegreeOfFreedomNames()
 //==============================================================================
 void EulerJoint::updateLocalTransform()
 {
-  switch (mAxisOrder)
-  {
-    case AO_XYZ:
-    {
-      mT = mT_ParentBodyToJoint
-           * Eigen::Isometry3d(math::eulerXYZToMatrix(mPositions))
-           * mT_ChildBodyToJoint.inverse();
-      break;
-    }
-    case AO_ZYX:
-    {
-      mT = mT_ParentBodyToJoint
-           * Eigen::Isometry3d(math::eulerZYXToMatrix(mPositions))
-           * mT_ChildBodyToJoint.inverse();
-      break;
-    }
-    default:
-    {
-      dterr << "Undefined Euler axis order\n";
-      break;
-    }
-  }
+  mT = mT_ParentBodyToJoint * convertToTransform(mPositions)
+       * mT_ChildBodyToJoint.inverse();
 
   assert(math::verifyTransform(mT));
 }

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -68,6 +68,38 @@ public:
   /// renmaed according to the axis order.
   void setAxisOrder(AxisOrder _order, bool _renameDofs = true);
 
+  /// Convert a rotation into a 3D vector that can be used to set the positions
+  /// of an EulerJoint with the specified AxisOrder. The positions returned by
+  /// this function will result in a relative transform of
+  /// getTransformFromParentBodyNode() * _rotation * getTransformFromChildBodyNode().inverse()
+  /// between the parent BodyNode and the child BodyNode frames when applied to
+  /// an EulerJoint with the correct axis ordering.
+  template <typename RotationType>
+  static Eigen::Vector3d convertToPositions(
+      const RotationType& _rotation, AxisOrder _ordering)
+  {
+    switch(_ordering)
+    {
+      case AO_XYZ:
+        return math::matrixToEulerXYZ(_rotation);
+      case AO_ZYX:
+        return math::matrixToEulerZYX(_rotation);
+      default:
+        dtwarn << "[EulerJoint::convertToPositions] Unsupported AxisOrder ("
+               << _ordering << "), returning a zero vector\n";
+        return Eigen::Vector3d::Zero();
+    }
+  }
+
+  /// This is a version of EulerJoint::convertToPositions(const RotationType&,
+  /// AxisOrder) which will use the AxisOrder belonging to the joint instance
+  /// that it gets called on.
+  template <typename RotationType>
+  Eigen::Vector3d convertToPositions(const RotationType& _rotation)
+  {
+    return convertToPositions(_rotation, mAxisOrder);
+  }
+
   ///
   AxisOrder getAxisOrder() const;
 

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -116,7 +116,7 @@ public:
   static Eigen::Matrix3d convertToRotation(const Eigen::Vector3d& _positions,
                                            AxisOrder _ordering);
 
-  Eigen::Matrix3d convertToRotation(const Eigen::Vector3d &_positions) const;
+  Eigen::Matrix3d convertToRotation(const Eigen::Vector3d& _positions) const;
 
 protected:
   /// Set the names of this joint's DegreesOfFreedom. Used during construction

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -68,6 +68,9 @@ public:
   /// renmaed according to the axis order.
   void setAxisOrder(AxisOrder _order, bool _renameDofs = true);
 
+  ///
+  AxisOrder getAxisOrder() const;
+
   /// Convert a rotation into a 3D vector that can be used to set the positions
   /// of an EulerJoint with the specified AxisOrder. The positions returned by
   /// this function will result in a relative transform of
@@ -99,9 +102,6 @@ public:
   {
     return convertToPositions(_rotation, mAxisOrder);
   }
-
-  ///
-  AxisOrder getAxisOrder() const;
 
 protected:
   /// Set the names of this joint's DegreesOfFreedom. Used during construction

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -98,10 +98,25 @@ public:
   /// AxisOrder) which will use the AxisOrder belonging to the joint instance
   /// that it gets called on.
   template <typename RotationType>
-  Eigen::Vector3d convertToPositions(const RotationType& _rotation)
+  Eigen::Vector3d convertToPositions(const RotationType& _rotation) const
   {
     return convertToPositions(_rotation, mAxisOrder);
   }
+
+  /// Convert a set of Euler angle positions into a transform
+  static Eigen::Isometry3d convertToTransform(const Eigen::Vector3d& _positions,
+                                           AxisOrder _ordering);
+
+  /// This is a version of EulerJoint::convertToRotation(const Eigen::Vector3d&,
+  /// AxisOrder) which will use the AxisOrder belonging to the joint instance
+  /// that it gets called on.
+  Eigen::Isometry3d convertToTransform(const Eigen::Vector3d& _positions) const;
+
+  /// Convert a set of Euler angle positions into a rotation matrix
+  static Eigen::Matrix3d convertToRotation(const Eigen::Vector3d& _positions,
+                                           AxisOrder _ordering);
+
+  Eigen::Matrix3d convertToRotation(const Eigen::Vector3d &_positions) const;
 
 protected:
   /// Set the names of this joint's DegreesOfFreedom. Used during construction

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -61,7 +61,7 @@ FreeJoint::~FreeJoint()
 Eigen::Vector6d FreeJoint::convertToPositions(const Eigen::Isometry3d& _tf)
 {
   Eigen::Vector6d x;
-  x.head<3>() = math::logMap(_tf.rotation());
+  x.head<3>() = math::logMap(_tf.linear());
   x.tail<3>() = _tf.translation();
   return x;
 }

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -58,6 +58,15 @@ FreeJoint::~FreeJoint()
 }
 
 //==============================================================================
+Eigen::Vector6d FreeJoint::convertToPositions(const Eigen::Isometry3d& _tf)
+{
+  Eigen::Vector6d x;
+  x.head<3>() = math::logMap(_tf.rotation());
+  x.tail<3>() = _tf.translation();
+  return x;
+}
+
+//==============================================================================
 void FreeJoint::integratePositions(double _dt)
 {
   mQ.linear()      = mQ.linear() * math::expMapRot(mJacobian.topRows<3>()

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -67,14 +67,23 @@ Eigen::Vector6d FreeJoint::convertToPositions(const Eigen::Isometry3d& _tf)
 }
 
 //==============================================================================
+Eigen::Isometry3d FreeJoint::convertToTransform(
+    const Eigen::Vector6d& _positions)
+{
+  Eigen::Isometry3d tf;
+  tf.linear() = math::expMapRot(_positions.head<3>());
+  tf.translation() = _positions.tail<3>();
+  return tf;
+}
+
+//==============================================================================
 void FreeJoint::integratePositions(double _dt)
 {
   mQ.linear()      = mQ.linear() * math::expMapRot(mJacobian.topRows<3>()
                                                    * mVelocities * _dt);
   mQ.translation() = mQ.translation() + mVelocities.tail<3>() * _dt;
 
-  mPositions.head<3>() = math::logMap(mQ.linear());
-  mPositions.tail<3>() = mQ.translation();
+  mPositions = convertToPositions(mQ);
 }
 
 //==============================================================================
@@ -97,8 +106,7 @@ void FreeJoint::updateDegreeOfFreedomNames()
 //==============================================================================
 void FreeJoint::updateLocalTransform()
 {
-  mQ.linear()      = math::expMapRot(mPositions.head<3>());
-  mQ.translation() = mPositions.tail<3>();
+  mQ = convertToTransform(mPositions);
 
   mT = mT_ParentBodyToJoint * mQ * mT_ChildBodyToJoint.inverse();
 

--- a/dart/dynamics/FreeJoint.h
+++ b/dart/dynamics/FreeJoint.h
@@ -56,6 +56,14 @@ public:
   /// Destructor
   virtual ~FreeJoint();
 
+  /// Convert a transform into a 6D vector that can be used to set the positions
+  /// of a FreeJoint. The positions returned by this function will result in a
+  /// relative transform of
+  /// getTransformFromParentBodyNode() * _tf * getTransformFromChildBodyNode().inverse()
+  /// between the parent BodyNode and the child BodyNode frames when applied to
+  /// a FreeJoint.
+  static Eigen::Vector6d convertToPositions(const Eigen::Isometry3d& _tf);
+
 protected:
   // Documentation inherited
   virtual void integratePositions(double _dt);

--- a/dart/dynamics/FreeJoint.h
+++ b/dart/dynamics/FreeJoint.h
@@ -64,6 +64,9 @@ public:
   /// a FreeJoint.
   static Eigen::Vector6d convertToPositions(const Eigen::Isometry3d& _tf);
 
+  /// Convert a FreeJoint-style 6D vector into a transform
+  static Eigen::Isometry3d convertToTransform(const Eigen::Vector6d& _positions);
+
 protected:
   // Documentation inherited
   virtual void integratePositions(double _dt);

--- a/unittests/testJoints.cpp
+++ b/unittests/testJoints.cpp
@@ -573,7 +573,7 @@ TEST_F(JOINTS, CONVENIENCE_FUNCTIONS)
   Eigen::Isometry3d eulerjoint_tf = random_transform();
   eulerjoint_tf.translation() = Eigen::Vector3d::Zero();
   eulerjoint->setPositions(
-        eulerjoint->convertToPositions(eulerjoint_tf.rotation()));
+        eulerjoint->convertToPositions(eulerjoint_tf.linear()));
 
   // -- set up the BallJoint
   BodyNode* balljoint_bn = new BodyNode("balljoint_bn");
@@ -587,7 +587,7 @@ TEST_F(JOINTS, CONVENIENCE_FUNCTIONS)
   Eigen::Isometry3d balljoint_tf = random_transform();
   balljoint_tf.translation() = Eigen::Vector3d::Zero();
   balljoint->setPositions(
-        BallJoint::convertToPositions(balljoint_tf.rotation()));
+        BallJoint::convertToPositions(balljoint_tf.linear()));
 
   // -- set up Skeleton and compute forward kinematics
   Skeleton* skel = new Skeleton;


### PR DESCRIPTION
I found that setting FreeJoint and other joint types that have rotations can be confusing or can require more lines of code than it ought to, so I made some functions to help users convert transform and rotation types into joint position vectors that they can pass into Joint::setPositions(VectorXd).