### PR TITLE
[Fix #321] Remove unsupported axis orders of EulerJoint

### DIFF
--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -84,20 +84,10 @@ void EulerJoint::updateDegreeOfFreedomNames()
       affixes.push_back("_y");
       affixes.push_back("_x");
       break;
-    case AO_ZYZ:
-      affixes.push_back("_z");
-      affixes.push_back("_y");
-      affixes.push_back("_z");
-      break;
     case AO_XYZ:
       affixes.push_back("_x");
       affixes.push_back("_y");
       affixes.push_back("_z");
-      break;
-    case AO_ZXY:
-      affixes.push_back("_z");
-      affixes.push_back("_x");
-      affixes.push_back("_y");
       break;
     default:
       dterr << "Unsupported axis order in EulerJoint named '" << mName

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -52,9 +52,7 @@ public:
   enum AxisOrder
   {
     AO_ZYX = 0,
-    AO_ZYZ = 1,
-    AO_XYZ = 2,
-    AO_ZXY = 3
+    AO_XYZ = 1
   };
 
   /// Constructor
@@ -63,12 +61,13 @@ public:
   /// Destructor
   virtual ~EulerJoint();
 
-  /// \brief Set the axis order
+  /// Set the axis order
+  /// \param[in] _order Axis order
   /// \param[in] _renameDofs If true, the names of dofs in this joint will be
   /// renmaed according to the axis order.
   void setAxisOrder(AxisOrder _order, bool _renameDofs = true);
 
-  ///
+  /// Return the axis order
   AxisOrder getAxisOrder() const;
 
 protected:


### PR DESCRIPTION
Fixes #321 