### PR TITLE
Fixed naming issues for Skeletons in World and created regression tests

### DIFF
--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -231,7 +231,8 @@ std::string World::addSkeleton(dynamics::Skeleton* _skeleton)
   }
 
   mSkeletons.push_back(_skeleton);
-  mNameMgrForSkeletons.issueNewNameAndAdd(_skeleton->getName(), _skeleton);
+  _skeleton->setName(mNameMgrForSkeletons.issueNewNameAndAdd(
+                       _skeleton->getName(), _skeleton));
   _skeleton->init(mTimeStep, mGravity);
   mIndices.push_back(mIndices.back() + _skeleton->getNumDofs());
   mConstraintSolver->addSkeleton(_skeleton);
@@ -270,7 +271,6 @@ void World::removeSkeleton(dynamics::Skeleton* _skeleton)
   mIndices.pop_back();
 
   // Remove _skeleton from constraint handler.
-//  mConstraintHandler->removeSkeleton(_skeleton);
   mConstraintSolver->removeSkeleton(_skeleton);
 
   // Remove _skeleton in mSkeletons and delete it.
@@ -279,6 +279,9 @@ void World::removeSkeleton(dynamics::Skeleton* _skeleton)
 
   // Update recording
   mRecording->updateNumGenCoords(mSkeletons);
+
+  // Remove from NameManager
+  mNameMgrForSkeletons.removeName(_skeleton->getName());
 
   delete _skeleton;
 }

--- a/unittests/testWorld.cpp
+++ b/unittests/testWorld.cpp
@@ -101,11 +101,20 @@ TEST(WORLD, ADDING_AND_REMOVING_SKELETONS)
     for (int i = 0; i < nSteps; ++i)
         world->step();
 
+    std::string s1name = skeleton1->getName();
+    std::string s2name = skeleton2->getName();
+    EXPECT_TRUE(skeleton1 == world->getSkeleton(s1name));
+    EXPECT_TRUE(skeleton2 == world->getSkeleton(s2name));
+
     // Remove skeleton2
     world->removeSkeleton(skeleton2);
     EXPECT_TRUE(world->getNumSkeletons() == 1);
     for (int i = 0; i < nSteps; ++i)
         world->step();
+
+    EXPECT_TRUE(skeleton1 == world->getSkeleton(s1name));
+    EXPECT_FALSE(skeleton2 == world->getSkeleton(s2name));
+    EXPECT_TRUE(world->getSkeleton(s2name) == NULL);
 
     // Add skeleton3, skeleton4
     world->addSkeleton(skeleton3);
@@ -114,17 +123,33 @@ TEST(WORLD, ADDING_AND_REMOVING_SKELETONS)
     for (int i = 0; i < nSteps; ++i)
         world->step();
 
+    std::string s3name = skeleton3->getName();
+    std::string s4name = skeleton4->getName();
+
+    EXPECT_TRUE(s3name == s2name);
+    EXPECT_TRUE(skeleton3 == world->getSkeleton(s3name));
+    EXPECT_TRUE(skeleton4 == world->getSkeleton(s4name));
+
     // Remove skeleton1
     world->removeSkeleton(skeleton1);
     EXPECT_TRUE(world->getNumSkeletons() == 2);
     for (int i = 0; i < nSteps; ++i)
         world->step();
 
+    EXPECT_FALSE(skeleton1 == world->getSkeleton(s1name));
+    EXPECT_TRUE(world->getSkeleton(s1name) == NULL);
+
     // Remove all the skeletons
     world->removeAllSkeletons();
     EXPECT_EQ(world->getNumSkeletons(), 0);
     for (int i = 0; i < nSteps; ++i)
         world->step();
+
+    EXPECT_FALSE(skeleton3 == world->getSkeleton(s3name));
+    EXPECT_TRUE(world->getSkeleton(s3name) == NULL);
+
+    EXPECT_FALSE(skeleton4 == world->getSkeleton(s4name));
+    EXPECT_TRUE(world->getSkeleton(s4name) == NULL);
 
     delete world;
 }


### PR DESCRIPTION
This fix addresses two issues:

1) Skeleton names were not getting removed from the name manager in the World when those Skeletons were removed.

2) Skeletons were not being reassigned names when a Skeleton with a repeated name was added to the World

This fixes have been made and a regression test was created to ensure that these issues are fixed and remain fixed.