### PR TITLE
Fixing segfault in SoftSdfParser

### DIFF
--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -1192,12 +1192,13 @@ void SoftBodyNodeHelper::setBox(SoftBodyNode*            _softBodyNode,
 
   for (int i = 0; i < 3; ++i)
   {
-    if (frags[i] == 2)
+    if (frags[i] <= 2)
     {
       dtwarn << "Invalid property of soft body '" << _softBodyNode->getName()
              << "'. "
-             << "The number of vertices of each soft box edge should be "
-             << "equal to or greater than 3. It's set to 3."
+             << "The number of vertices assigned to soft box edge #" << i
+             << " is " << frags[i] << ", but it must be greater than or "
+             << "equal to 3. We will set it to 3."
              << std::endl;
       frags[i] = 3;
     }

--- a/dart/utils/sdf/SoftSdfParser.cpp
+++ b/dart/utils/sdf/SoftSdfParser.cpp
@@ -276,7 +276,7 @@ dynamics::Skeleton* SoftSdfParser::readSkeleton(
       dynamics::FreeJoint* newFreeJoint = new dynamics::FreeJoint;
 
       newFreeJoint->setTransformFromParentBodyNode(
-            bodyNode->getTransform());
+            sdfBodyNodes[i].initTransform);
       newFreeJoint->setTransformFromChildBodyNode(
             Eigen::Isometry3d::Identity());
 


### PR DESCRIPTION
The atlasSimbicon app is failing in master because of a segfault in the SoftSdfParser. It tries to call "getTransform()" on a BodyNode that does not yet have a parent joint, and this is guaranteed to result in a segfault, because the parent joint is strictly responsible for the relative transform of its child BodyNode. The parser has been corrected to set the transform-from-parent of the FreeJoint according to the initial transform as read by the SdfParser. However, we might want to consider setting that transform to Identity and using the initial transform to set the initial joint values of the FreeJoint. Either way works, but one might be semantically preferable over the other.

I also modified the warning message for the soft boxes to be a bit more clear.