### PR TITLE
Implemented LineSegmentShape for visualizing line segments

### DIFF
--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -424,6 +424,20 @@ const Shape* BodyNode::getVisualizationShape(size_t _index) const
 //==============================================================================
 void BodyNode::addCollisionShape(Shape* _p)
 {
+  if(nullptr == _p)
+  {
+    dtwarn << "[BodyNode::addCollisionShape] Attempting to add a nullptr as a "
+           << "collision shape\n";
+    return;
+  }
+
+  if(_p->getShapeType() == Shape::LINE_SEGMENT)
+  {
+    dtwarn << "[BodyNode::addCollisionShape] Attempting to add a LINE_SEGMENT "
+           << "type shape as a collision shape. This is not supported.\n";
+    return;
+  }
+
   mColShapes.push_back(_p);
 }
 

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -138,6 +138,18 @@ void LineSegmentShape::removeVertex(size_t _idx)
 //==============================================================================
 void LineSegmentShape::setVertex(size_t _idx, const Eigen::Vector3d& v)
 {
+  if(_idx >= mVertices.size())
+  {
+    dtwarn << "[LineSegmentShape::setVertex] Attempting to set vertex #" << _idx
+           << ", but ";
+    if(mVertices.size() == 0)
+      dtwarn << "no vertices exist in this LineSegmentShape yet.\n";
+    else
+      dtwarn << "the vertices of this LineSegmentShape only go up to #"
+             << mVertices.size()-1 << ".\n";
+
+    return;
+  }
   mVertices[_idx] = v;
 }
 

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2015, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Michael X. Grey <mxgrey@gatech.edu>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/LineSegmentShape.h"
+#include "dart/common/Console.h"
+#include "dart/renderer/RenderInterface.h"
+#include "dart/math/Helpers.h"
+
+namespace dart {
+namespace dynamics {
+
+//==============================================================================
+LineSegmentShape::LineSegmentShape(float _thickness)
+  : Shape(LINE_SEGMENT),
+    mThickness(_thickness),
+    mDummyVertex(Eigen::Vector3d::Zero())
+{
+  computeVolume();
+}
+
+//==============================================================================
+LineSegmentShape::LineSegmentShape(const Eigen::Vector3d& v1,
+                                   const Eigen::Vector3d& v2,
+                                   float _thickness)
+  : Shape(LINE_SEGMENT),
+    mThickness(_thickness)
+{
+  addVertex(v1);
+  addVertex(v2);
+  computeVolume();
+}
+
+//==============================================================================
+void LineSegmentShape::setThickness(float _thickness)
+{
+  mThickness = _thickness;
+}
+
+//==============================================================================
+float LineSegmentShape::getThickness() const
+{
+  return mThickness;
+}
+
+//==============================================================================
+size_t LineSegmentShape::addVertex(const Eigen::Vector3d& v)
+{
+  size_t parent = mVertices.size();
+  if(parent > 0)
+    return addVertex(v, parent-1);
+
+  mVertices.push_back(v);
+  return 0;
+}
+
+//==============================================================================
+size_t LineSegmentShape::addVertex(const Eigen::Vector3d& v, size_t _parent)
+{
+  size_t index = mVertices.size();
+  mVertices.push_back(v);
+
+  if(_parent > mVertices.size())
+  {
+    if(mVertices.size() == 0)
+      dtwarn << "[LineSegmentShape::addVertex(const Eigen::Vector3d&, size_t)] "
+             << "Attempting to add a vertex to be a child of vertex #"
+             << _parent << ", but no vertices exist yet. No connection will be "
+             << "created for the new vertex yet.\n";
+    else
+      dtwarn << "[LineSegmentShape::addVertex(const Eigen::Vector3d&, size_t)] "
+             << "Attempting to add a vertex to be a child of vertex #"
+             << _parent << ", but the vertex indices only go up to "
+             << mVertices.size()-1 << ". No connection will be created for the "
+             << "new vertex yet.\n";
+  }
+  else
+  {
+    mConnections.push_back(Eigen::Vector2i(_parent, index));
+  }
+
+  return index;
+}
+
+//==============================================================================
+void LineSegmentShape::removeVertex(size_t _idx)
+{
+  if(_idx >= mVertices.size())
+  {
+    dtwarn << "[LineSegmentShape::removeVertex] Attempting to remove vertex #"
+           << _idx << ", but ";
+
+    if(mVertices.size() == 0)
+      dtwarn << "this LineSegmentShape contains no vertices. ";
+    else
+      dtwarn << "vertex indices only go up to #" << mVertices.size()-1 << ". ";
+
+    dtwarn << "No vertex will be removed.\n";
+
+    return;
+  }
+
+  mVertices.erase(mVertices.begin()+_idx);
+}
+
+//==============================================================================
+void LineSegmentShape::setVertex(size_t _idx, const Eigen::Vector3d& v)
+{
+  mVertices[_idx] = v;
+}
+
+//==============================================================================
+const Eigen::Vector3d& LineSegmentShape::getVertex(size_t _idx) const
+{
+  if(_idx < mVertices.size())
+    return mVertices[_idx];
+
+  if(mVertices.size()==0)
+    dtwarn << "[LineSegmentShape::getVertex] Requested vertex #" << _idx
+           << ", but no vertices currently exist in this LineSegmentShape\n";
+  else
+    dtwarn << "[LineSegmentShape::getVertex] Requested vertex #" << _idx
+           << ", but vertex indices currently only go up to "
+           << mVertices.size()-1 << "\n";
+
+  return mDummyVertex;
+}
+
+//==============================================================================
+const std::vector<Eigen::Vector3d>& LineSegmentShape::getVertices() const
+{
+  return mVertices;
+}
+
+//==============================================================================
+void LineSegmentShape::addConnection(size_t _idx1, size_t _idx2)
+{
+  if(_idx1 >= mVertices.size() || _idx2 >= mVertices.size())
+  {
+    dtwarn << "[LineSegmentShape::createConnection] Attempted to create a "
+           << "connection between vertex #" << _idx1 << " and vertex #" << _idx2;
+
+    if(mVertices.size() == 0)
+      dtwarn << ", but no vertices exist for this LineSegmentShape yet. ";
+    else
+      dtwarn << ", but the vertices only go up to #" << mVertices.size() << ". ";
+
+    dtwarn << "No connection will be made for these non-existent vertices.\n";
+
+    return;
+  }
+
+  mConnections.push_back(Eigen::Vector2i(_idx1, _idx2));
+}
+
+//==============================================================================
+void LineSegmentShape::removeConnection(size_t _vertexIdx1, size_t _vertexIdx2)
+{
+  // Search through all connections to remove any that match the request
+  std::vector<Eigen::Vector2i>::iterator it = mConnections.begin();
+  while(it != mConnections.end())
+  {
+    const Eigen::Vector2i c = (*it);
+    if(    (c[0] == (int)_vertexIdx1 && c[1] == (int)_vertexIdx2)
+        || (c[0] == (int)_vertexIdx2 && c[1] == (int)_vertexIdx1) )
+    {
+      // Erase this iterator, but not before stepping it forward to the next
+      // iterator in the sequence.
+      mConnections.erase(it++);
+    }
+    else
+      ++it;
+  }
+}
+
+//==============================================================================
+void LineSegmentShape::removeConnection(size_t _connectionIdx)
+{
+  if(_connectionIdx >= mConnections.size())
+  {
+    dtwarn << "[LineSegmentShape::removeConnection(size_t)] Attempting to "
+           << "remove connection #" << _connectionIdx << ", but ";
+    if(mConnections.size() == 0)
+      dtwarn << "no connections exist yet. ";
+    else
+      dtwarn << "connection indices only go up to #" << mConnections.size()-1
+             << ". ";
+
+    dtwarn << "No connection will be removed.\n";
+
+    return;
+  }
+
+  mConnections.erase(mConnections.begin()+_connectionIdx);
+}
+
+//==============================================================================
+const std::vector<Eigen::Vector2i>& LineSegmentShape::getConnections() const
+{
+  return mConnections;
+}
+
+//==============================================================================
+void LineSegmentShape::draw(renderer::RenderInterface* _ri,
+                            const Eigen::Vector4d& _color,
+                            bool _useDefaultColor) const
+{
+  if(!_ri)
+    return;
+
+  if(!_useDefaultColor)
+    _ri->setPenColor(_color);
+  else
+    _ri->setPenColor(mColor);
+
+  _ri->pushMatrix();
+  _ri->transform(mTransform);
+  _ri->drawLineSegments(mVertices, mConnections);
+  _ri->popMatrix();
+}
+
+//==============================================================================
+Eigen::Matrix3d LineSegmentShape::computeInertia(double _mass) const
+{
+  Eigen::Matrix3d inertia = Eigen::Matrix3d::Zero();
+
+  double totalLength = 0;
+  for(const Eigen::Vector2i& c : mConnections)
+  {
+    const Eigen::Vector3d& v0 = mVertices[c[0]];
+    const Eigen::Vector3d& v1 = mVertices[c[1]];
+
+    totalLength += (v1-v0).norm();
+  }
+
+  for(const Eigen::Vector2i& c : mConnections)
+  {
+    const Eigen::Vector3d& v0 = mTransform * mVertices[c[0]];
+    const Eigen::Vector3d& v1 = mTransform * mVertices[c[1]];
+
+    double radius = 1e-6;
+    double height = (v1-v0).norm();
+
+    double partialMass = _mass * height/totalLength;
+
+    Eigen::Matrix3d partialInertia = Eigen::Matrix3d::Zero();
+    partialInertia(0, 0) = partialMass * (3.0 * radius*radius + height*height) / 12.0;
+    partialInertia(1, 1) = partialInertia(0, 0);
+    partialInertia(2, 2) = 0.5 * _mass * radius * radius;
+
+    Eigen::Vector3d v = v1-v0;
+    Eigen::Vector3d axis;
+    double angle;
+    if(v.norm() == 0)
+    {
+      angle = 0;
+      axis = Eigen::Vector3d::UnitX();
+    }
+    else
+    {
+      v.normalize();
+      Eigen::Vector3d axis = Eigen::Vector3d::UnitZ().cross(v);
+      if(axis.norm() == 0)
+      {
+        angle = 0;
+        axis = Eigen::Vector3d::UnitX();
+      }
+      else
+      {
+        axis.normalize();
+        angle = acos(Eigen::Vector3d::UnitZ().dot(v));
+      }
+    }
+
+    Eigen::AngleAxisd R(angle, axis);
+    Eigen::Vector3d center = (v1+v0)/2.0;
+    inertia += R.matrix()
+        * math::parallelAxisTheorem(partialInertia, center, partialMass)
+        * R.matrix().transpose();
+  }
+
+  return inertia;
+}
+
+//==============================================================================
+void LineSegmentShape::computeVolume()
+{
+  mVolume = 0;
+}
+
+} // namespace dynamics
+} // namespace dart

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -37,7 +37,7 @@
 #include "dart/dynamics/LineSegmentShape.h"
 #include "dart/common/Console.h"
 #include "dart/renderer/RenderInterface.h"
-#include "dart/math/Helpers.h"
+#include "dart/math/Geometry.h"
 
 namespace dart {
 namespace dynamics {

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -48,24 +48,48 @@ LineSegmentShape::LineSegmentShape(float _thickness)
     mThickness(_thickness),
     mDummyVertex(Eigen::Vector3d::Zero())
 {
+  if (_thickness <= 0.0f)
+  {
+    dtwarn << "[LineSegmentShape::LineSegmentShape] Attempting to set "
+           << "non-positive thickness. We set the thickness to 1.0f instead."
+           << std::endl;
+    mThickness = 1.0f;
+  }
+
   computeVolume();
 }
 
 //==============================================================================
-LineSegmentShape::LineSegmentShape(const Eigen::Vector3d& v1,
-                                   const Eigen::Vector3d& v2,
+LineSegmentShape::LineSegmentShape(const Eigen::Vector3d& _v1,
+                                   const Eigen::Vector3d& _v2,
                                    float _thickness)
   : Shape(LINE_SEGMENT),
     mThickness(_thickness)
 {
-  addVertex(v1);
-  addVertex(v2);
+  if (_thickness <= 0.0f)
+  {
+    dtwarn << "[LineSegmentShape::LineSegmentShape] Attempting to set "
+           << "non-positive thickness. We set the thickness to 1.0f instead."
+           << std::endl;
+    mThickness = 1.0f;
+  }
+
+  addVertex(_v1);
+  addVertex(_v2);
   computeVolume();
 }
 
 //==============================================================================
 void LineSegmentShape::setThickness(float _thickness)
 {
+  if (_thickness <= 0.0f)
+  {
+    dtwarn << "[LineSegmentShape::setThickness] Attempting to set non-positive "
+           << "thickness. We set the thickness to 1.0f instead." << std::endl;
+    mThickness = 1.0f;
+    return;
+  }
+
   mThickness = _thickness;
 }
 
@@ -76,21 +100,21 @@ float LineSegmentShape::getThickness() const
 }
 
 //==============================================================================
-size_t LineSegmentShape::addVertex(const Eigen::Vector3d& v)
+size_t LineSegmentShape::addVertex(const Eigen::Vector3d& _v)
 {
   size_t parent = mVertices.size();
   if(parent > 0)
-    return addVertex(v, parent-1);
+    return addVertex(_v, parent-1);
 
-  mVertices.push_back(v);
+  mVertices.push_back(_v);
   return 0;
 }
 
 //==============================================================================
-size_t LineSegmentShape::addVertex(const Eigen::Vector3d& v, size_t _parent)
+size_t LineSegmentShape::addVertex(const Eigen::Vector3d& _v, size_t _parent)
 {
   size_t index = mVertices.size();
-  mVertices.push_back(v);
+  mVertices.push_back(_v);
 
   if(_parent > mVertices.size())
   {
@@ -136,7 +160,7 @@ void LineSegmentShape::removeVertex(size_t _idx)
 }
 
 //==============================================================================
-void LineSegmentShape::setVertex(size_t _idx, const Eigen::Vector3d& v)
+void LineSegmentShape::setVertex(size_t _idx, const Eigen::Vector3d& _v)
 {
   if(_idx >= mVertices.size())
   {
@@ -150,7 +174,7 @@ void LineSegmentShape::setVertex(size_t _idx, const Eigen::Vector3d& v)
 
     return;
   }
-  mVertices[_idx] = v;
+  mVertices[_idx] = _v;
 }
 
 //==============================================================================

--- a/dart/dynamics/LineSegmentShape.h
+++ b/dart/dynamics/LineSegmentShape.h
@@ -50,11 +50,11 @@ class LineSegmentShape : public Shape
 {
 public:
   /// Default constructor
-  LineSegmentShape(float _thickness = 1.0);
+  LineSegmentShape(float _thickness = 1.0f);
 
   /// Constructor for creating a simple line segment that connects two vertices
-  LineSegmentShape(const Eigen::Vector3d& v1, const Eigen::Vector3d& v2,
-                   float _thickness = 1.0);
+  LineSegmentShape(const Eigen::Vector3d& _v1, const Eigen::Vector3d& _v2,
+                   float _thickness = 1.0f);
 
   /// Set the line thickness/width for rendering
   void setThickness(float _thickness);
@@ -63,10 +63,10 @@ public:
   float getThickness() const;
 
   /// Add a vertex as a child to the last vertex that was added
-  size_t addVertex(const Eigen::Vector3d& v);
+  size_t addVertex(const Eigen::Vector3d& _v);
 
   /// Add a vertex as a child to the specified vertex
-  size_t addVertex(const Eigen::Vector3d& v, size_t _parent);
+  size_t addVertex(const Eigen::Vector3d& _v, size_t _parent);
 
   /// Remove a vertex from the list of vertices. IMPORTANT: Note that this
   /// alters the indices of all vertices that follow it in the list, which also
@@ -76,7 +76,7 @@ public:
   void removeVertex(size_t _idx);
 
   /// Change the location of the specified vertex
-  void setVertex(size_t _idx, const Eigen::Vector3d& v);
+  void setVertex(size_t _idx, const Eigen::Vector3d& _v);
 
   /// Get the location of the specified vertex. Returns a zero vector if an
   /// out-of-bounds vertex is requested.
@@ -111,7 +111,7 @@ public:
 
 protected:
 
-  /// Line thickness for rendering
+  // Documentation inherited
   void computeVolume() override;
 
   /// Line thickness for rendering
@@ -123,7 +123,8 @@ protected:
   /// Vector of connections
   std::vector<Eigen::Vector2i> mConnections;
 
-  /// A dummy vertex that can be returned when an out-of-bounds vertex is requested
+  /// A dummy vertex that can be returned when an out-of-bounds vertex is
+  /// requested
   const Eigen::Vector3d mDummyVertex;
 };
 

--- a/dart/dynamics/LineSegmentShape.h
+++ b/dart/dynamics/LineSegmentShape.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2015, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Michael X. Grey <mxgrey@gatech.edu>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_LINESEGMENTSHAPE_H_
+#define DART_DYNAMICS_LINESEGMENTSHAPE_H_
+
+#include "dart/dynamics/Shape.h"
+
+namespace dart {
+namespace dynamics {
+
+/// The LineSegmentShape facilitates creating graphs of line segments. The graph
+/// can consist of a single line segment or many interconnected line segments.
+/// Note: LineSegmentShape may NOT be used as a collision shape for BodyNodes,
+/// but it may be used for visualization purposes.
+class LineSegmentShape : public Shape
+{
+public:
+  /// Default constructor
+  LineSegmentShape(float _thickness = 1.0);
+
+  /// Constructor for creating a simple line segment that connects two vertices
+  LineSegmentShape(const Eigen::Vector3d& v1, const Eigen::Vector3d& v2,
+                   float _thickness = 1.0);
+
+  /// Set the line thickness/width for rendering
+  void setThickness(float _thickness);
+
+  /// Get the line thickness/width used for rendering
+  float getThickness() const;
+
+  /// Add a vertex as a child to the last vertex that was added
+  size_t addVertex(const Eigen::Vector3d& v);
+
+  /// Add a vertex as a child to the specified vertex
+  size_t addVertex(const Eigen::Vector3d& v, size_t _parent);
+
+  /// Remove a vertex from the list of vertices. IMPORTANT: Note that this
+  /// alters the indices of all vertices that follow it in the list, which also
+  /// clobbers the validity of the list of connections for all those vertices.
+  /// A safer and more efficient method might be to recycle vertices by moving
+  /// them around with setVertex() and/or altering their connections.
+  void removeVertex(size_t _idx);
+
+  /// Change the location of the specified vertex
+  void setVertex(size_t _idx, const Eigen::Vector3d& v);
+
+  /// Get the location of the specified vertex. Returns a zero vector if an
+  /// out-of-bounds vertex is requested.
+  const Eigen::Vector3d& getVertex(size_t _idx) const;
+
+  /// Get all the vertices
+  const std::vector<Eigen::Vector3d>& getVertices() const;
+
+  /// Create a connection between the two specified vertices
+  void addConnection(size_t _idx1, size_t _idx2);
+
+  /// Search for a connection between two vertices and break it if it exists.
+  /// This is less efficient but more robust than removeConnection(size_t).
+  void removeConnection(size_t _vertexIdx1, size_t _vertexIdx2);
+
+  /// Remove the specified connection entry. Note that this will impact the
+  /// indices of all connections that come after _connectionIdx. This is more
+  /// efficient but less robust than removeConnection(size_t,size_t)
+  void removeConnection(size_t _connectionIdx);
+
+  /// Get all the connections
+  const std::vector<Eigen::Vector2i>& getConnections() const;
+
+  // Documentation inherited
+  virtual void draw(renderer::RenderInterface* _ri,
+                    const Eigen::Vector4d& _color,
+                    bool _useDefaultColor) const override;
+
+  /// The returned inertia matrix will be like a very thin cylinder. The _mass
+  /// will be evenly distributed across all lines.
+  virtual Eigen::Matrix3d computeInertia(double _mass) const override;
+
+protected:
+
+  /// Line thickness for rendering
+  void computeVolume() override;
+
+  /// Line thickness for rendering
+  float mThickness;
+
+  /// Vector of vertices
+  std::vector<Eigen::Vector3d> mVertices;
+
+  /// Vector of connections
+  std::vector<Eigen::Vector2i> mConnections;
+
+  /// A dummy vertex that can be returned when an out-of-bounds vertex is requested
+  const Eigen::Vector3d mDummyVertex;
+};
+
+} // namespace dynamics
+} // namespace dart
+
+#endif // DART_DYNAMICS_LINESEGMENTSHAPE_H_

--- a/dart/dynamics/Shape.h
+++ b/dart/dynamics/Shape.h
@@ -62,7 +62,8 @@ public:
     CYLINDER,
     PLANE,
     MESH,
-    SOFT_MESH
+    SOFT_MESH,
+    LINE_SEGMENT
   };
 
   /// \brief Constructor

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -1387,6 +1387,19 @@ Inertia transformInertia(const Eigen::Isometry3d& _T, const Inertia& _I) {
   return ret;
 }
 
+Eigen::Matrix3d parallelAxisTheorem(const Eigen::Matrix3d& _original,
+                                    const Eigen::Vector3d& _comShift,
+                                    double _mass)
+{
+  const Eigen::Vector3d& p = _comShift;
+  Eigen::Matrix3d result(_original);
+  for(size_t i=0; i<3; ++i)
+    for(size_t j=0; j<3; ++j)
+      result(i,j) += _mass * ( delta(i,j)*p.dot(p) - p(i)*p(j) );
+
+  return result;
+}
+
 bool verifyRotation(const Eigen::Matrix3d& _T) {
   return !isNan(_T)
       && fabs(_T.determinant() - 1.0) <= DART_EPSILON;

--- a/dart/math/Geometry.h
+++ b/dart/math/Geometry.h
@@ -407,6 +407,12 @@ Eigen::Vector6d dad(const Eigen::Vector6d& _s, const Eigen::Vector6d& _t);
 /// \brief
 Inertia transformInertia(const Eigen::Isometry3d& _T, const Inertia& _AI);
 
+/// Use the Parallel Axis Theorem to compute the moment of inertia of a body
+/// whose center of mass has been shifted from the origin
+Eigen::Matrix3d parallelAxisTheorem(const Eigen::Matrix3d& _original,
+                                    const Eigen::Vector3d& _comShift,
+                                    double _mass);
+
 /// Generate frame given origin and z-axis
 Eigen::Isometry3d getFrameOriginAxisZ(const Eigen::Vector3d& _origin,
                                       const Eigen::Vector3d& _axisZ);

--- a/dart/math/Helpers.h
+++ b/dart/math/Helpers.h
@@ -69,6 +69,19 @@ inline int delta(int _i, int _j) {
   return 0;
 }
 
+inline Eigen::Matrix3d parallelAxisTheorem(const Eigen::Matrix3d& _original,
+                                           const Eigen::Vector3d& _comShift,
+                                           double _mass)
+{
+  const Eigen::Vector3d& p = _comShift;
+  Eigen::Matrix3d result(_original);
+  for(size_t i=0; i<3; ++i)
+    for(size_t j=0; j<3; ++j)
+      result(i,j) += _mass * ( delta(i,j)*p.dot(p) - p(i)*p(j) );
+
+  return result;
+}
+
 inline int sgn(double _a) {
   if (_a < 0)
     return -1;

--- a/dart/math/Helpers.h
+++ b/dart/math/Helpers.h
@@ -69,19 +69,6 @@ inline int delta(int _i, int _j) {
   return 0;
 }
 
-inline Eigen::Matrix3d parallelAxisTheorem(const Eigen::Matrix3d& _original,
-                                           const Eigen::Vector3d& _comShift,
-                                           double _mass)
-{
-  const Eigen::Vector3d& p = _comShift;
-  Eigen::Matrix3d result(_original);
-  for(size_t i=0; i<3; ++i)
-    for(size_t j=0; j<3; ++j)
-      result(i,j) += _mass * ( delta(i,j)*p.dot(p) - p(i)*p(j) );
-
-  return result;
-}
-
 inline int sgn(double _a) {
   if (_a < 0)
     return -1;

--- a/dart/renderer/OpenGLRenderInterface.h
+++ b/dart/renderer/OpenGLRenderInterface.h
@@ -97,9 +97,13 @@ public:
     virtual void drawCylinder(double _radius, double _height);
     virtual void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh);
     virtual void drawList(GLuint index);
+    virtual void drawLineSegments(const std::vector<Eigen::Vector3d>& _vertices,
+                                  const std::vector<Eigen::Vector2i>& _connections) override;
 
     virtual void setPenColor(const Eigen::Vector4d& _col);
     virtual void setPenColor(const Eigen::Vector3d& _col);
+
+    virtual void setLineWidth(float _width);
 
     virtual void saveToImage(const char* _filename, DecoBufferType _buffType = BT_Back);
     virtual void readFrameBuffer(DecoBufferType _buffType, DecoColorChannel _ch, void* _pixels);

--- a/dart/renderer/RenderInterface.cpp
+++ b/dart/renderer/RenderInterface.cpp
@@ -140,6 +140,10 @@ void RenderInterface::drawList(unsigned int indeX)
 {
 }
 
+void RenderInterface::drawLineSegments(const std::vector<Eigen::Vector3d>&, const std::vector<Eigen::Vector2i>&)
+{
+}
+
 unsigned int RenderInterface::compileDisplayList(const Eigen::Vector3d& _size, const aiScene* _mesh)
 {
     return 0;
@@ -158,6 +162,10 @@ void RenderInterface::setPenColor(const Eigen::Vector4d& _col)
 }
 
 void RenderInterface::setPenColor(const Eigen::Vector3d& _col)
+{
+}
+
+void RenderInterface::setLineWidth(float)
 {
 }
 

--- a/dart/renderer/RenderInterface.h
+++ b/dart/renderer/RenderInterface.h
@@ -106,11 +106,15 @@ public:
     virtual void drawCylinder(double _radius, double _height);
     virtual void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh);
     virtual void drawList(unsigned int index);
+    virtual void drawLineSegments(const std::vector<Eigen::Vector3d>& _vertices,
+                                  const std::vector<Eigen::Vector2i>& _connections);
 
     virtual unsigned int compileDisplayList(const Eigen::Vector3d& _size, const aiScene* _mesh);
 
     virtual void setPenColor(const Eigen::Vector4d& _col);
     virtual void setPenColor(const Eigen::Vector3d& _col);
+
+    virtual void setLineWidth(float _width);
 
     virtual void saveToImage(const char* _filename, DecoBufferType _buffType = BT_Back);
     virtual void readFrameBuffer(DecoBufferType _buffType, DecoColorChannel _ch, void* _pixels);


### PR DESCRIPTION
Line segments can now be added as visualization shapes for Entities (but not as collision shapes for BodyNodes). Collision checking with LineSegmentShape has **not** been implemented yet.