### PR TITLE
Implemented ArrowShape for visualizing arrows

### DIFF
--- a/apps/simpleFrames/Main.cpp
+++ b/apps/simpleFrames/Main.cpp
@@ -34,12 +34,7 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "dart/dynamics/SimpleFrame.h"
-#include "dart/simulation/World.h"
-#include "dart/gui/SimWindow.h"
-
-#include "dart/dynamics/BoxShape.h"
-#include "dart/dynamics/EllipsoidShape.h"
+#include "dart/dart.h"
 
 using namespace dart::dynamics;
 
@@ -81,6 +76,13 @@ int main(int argc, char* argv[])
   A3.addVisualizationShape(new EllipsoidShape(Eigen::Vector3d(0.01,0.01,0.01)));
 
   myWorld.addEntity(&A);
+
+  SimpleFrame arrow(Frame::World(), "arrow");
+  arrow.addVisualizationShape(new ArrowShape(Eigen::Vector3d(0.1,-0.1, 0.0),
+                                             Eigen::Vector3d(0.1, 0.0, 0.0),
+                                             ArrowShape::Properties(0.002, 1.8),
+                                             Eigen::Vector3d(1.0, 0.5, 0.5)));
+  myWorld.addEntity(&arrow);
 
   // CAREFUL: For an Entity (or Frame) that gets added to the world to be
   // rendered correctly, it must be a child of the World Frame

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -218,11 +218,14 @@ void ArrowShape::configureArrow(const Eigen::Vector3d& _tail,
   Eigen::Vector3d v = mHead - mTail;
   Eigen::Vector3d z = Eigen::Vector3d::UnitZ();
 
-  if(v.norm() > 0 && v.cross(z).norm() > 0)
+  if(v.norm() > 0)
   {
     v.normalize();
     Eigen::Vector3d axis = z.cross(v);
-    axis.normalize();
+    if(axis.norm() > 0)
+      axis.normalize();
+    else
+      axis = Eigen::Vector3d::UnitY(); // Any vector in the X/Y plane can be used
     tf.rotate(Eigen::AngleAxisd(acos(z.dot(v)), axis));
   }
 

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2015, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Michael X. Grey <mxgrey@gatech.edu>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/ArrowShape.h"
+
+namespace dart {
+namespace dynamics {
+
+//==============================================================================
+ArrowShape::Properties::Properties(double _radius, double _headRadiusScale,
+                                   double _headLengthScale,
+                                   double _minHeadLength, double _maxHeadLength,
+                                   bool _doubleArrow)
+  : mRadius(_radius),
+    mHeadRadiusScale(_headRadiusScale),
+    mHeadLengthScale(_headLengthScale),
+    mMinHeadLength(_minHeadLength),
+    mMaxHeadLength(_maxHeadLength),
+    mDoubleArrow(_doubleArrow)
+{
+
+}
+
+//==============================================================================
+ArrowShape::ArrowShape(const Eigen::Vector3d& _tail,
+                       const Eigen::Vector3d& _head,
+                       const Properties& _properties,
+                       const Eigen::Vector3d& _color,
+                       size_t _resolution)
+  : MeshShape(Eigen::Vector3d::Ones(), nullptr),
+    mTail(_tail),
+    mHead(_head),
+    mProperties(_properties)
+{
+  mColor = _color;
+  instantiate(_resolution);
+  configureArrow(mTail, mHead, mProperties);
+}
+
+//==============================================================================
+void ArrowShape::setPositions(const Eigen::Vector3d& _tail,
+                              const Eigen::Vector3d& _head)
+{
+  configureArrow(_tail, _head, mProperties);
+}
+
+//==============================================================================
+const Eigen::Vector3d& ArrowShape::getTail() const
+{
+  return mTail;
+}
+
+//==============================================================================
+const Eigen::Vector3d& ArrowShape::getHead() const
+{
+  return mHead;
+}
+
+//==============================================================================
+void ArrowShape::setProperties(const Properties& _properties)
+{
+  configureArrow(mTail, mHead, _properties);
+}
+
+//==============================================================================
+void ArrowShape::setColor(const Eigen::Vector3d& _color)
+{
+  mColor = _color;
+  for(size_t i=0; i<mMesh->mNumMeshes; ++i)
+  {
+    aiMesh* mesh = mMesh->mMeshes[i];
+    for(size_t j=0; j<mesh->mNumVertices; ++j)
+    {
+      mesh->mColors[0][j] = aiColor4D(_color.x(), _color.y(), _color.z(), 1.0f);
+    }
+  }
+}
+
+//==============================================================================
+const ArrowShape::Properties& ArrowShape::getProperties() const
+{
+  return mProperties;
+}
+
+//==============================================================================
+static void constructArrowTip(aiMesh* mesh, double base, double tip,
+                              const ArrowShape::Properties& properties)
+{
+  size_t resolution = (mesh->mNumVertices-1)/2;
+  for(size_t i=0; i<resolution; ++i)
+  {
+    double theta = (double)(i)/(double)(resolution)*2*M_PI;
+
+    double R = properties.mRadius;
+    double x = R*cos(theta);
+    double y = R*sin(theta);
+    double z = base;
+    mesh->mVertices[2*i].Set(x, y, z);
+
+    if(base != tip)
+    {
+      x *= properties.mHeadRadiusScale;
+      y *= properties.mHeadRadiusScale;
+    }
+
+    mesh->mVertices[2*i+1].Set(x, y, z);
+  }
+
+  mesh->mVertices[mesh->mNumVertices-1].Set(0,0,tip);
+}
+
+//==============================================================================
+static void constructArrowBody(aiMesh* mesh, double z1, double z2,
+                               const ArrowShape::Properties& properties)
+{
+  size_t resolution = mesh->mNumVertices/2;
+  for(size_t i=0; i<resolution; ++i)
+  {
+    double theta = (double)(i)/(double)(resolution)*2*M_PI;
+
+    double R = properties.mRadius;
+    double x = R*cos(theta);
+    double y = R*sin(theta);
+    double z = z1;
+    mesh->mVertices[2*i].Set(x, y, z);
+
+    z = z2;
+    mesh->mVertices[2*i+1].Set(x, y, z);
+  }
+}
+
+//==============================================================================
+void ArrowShape::configureArrow(const Eigen::Vector3d& _tail,
+                                const Eigen::Vector3d& _head,
+                                const Properties& _properties)
+{
+  mTail = _tail;
+  mHead = _head;
+  mProperties = _properties;
+
+  mProperties.mHeadLengthScale =
+      std::max(0.0, std::min(1.0, mProperties.mHeadLengthScale));
+  mProperties.mMinHeadLength = std::max(0.0, mProperties.mMinHeadLength);
+  mProperties.mMaxHeadLength = std::max(0.0, mProperties.mMaxHeadLength);
+  mProperties.mHeadRadiusScale = std::max(1.0, mProperties.mHeadRadiusScale);
+
+  double length = (mTail-mHead).norm();
+
+  double minHeadLength =
+      std::min(mProperties.mMinHeadLength,
+               mProperties.mDoubleArrow? length/2.0 : length);
+  double maxHeadLength =
+      std::min(mProperties.mMaxHeadLength,
+               mProperties.mDoubleArrow? length/2.0 : length);
+
+  double headLength = mProperties.mHeadLengthScale*length;
+  headLength = std::min(maxHeadLength, std::max(minHeadLength, headLength));
+
+  // construct the tail
+  if(mProperties.mDoubleArrow)
+  {
+    constructArrowTip(mMesh->mMeshes[0], headLength, 0, mProperties);
+  }
+  else
+  {
+    constructArrowTip(mMesh->mMeshes[0], 0, 0, mProperties);
+  }
+
+  // construct the main body
+  if(mProperties.mDoubleArrow)
+  {
+    constructArrowBody(mMesh->mMeshes[1], headLength, length-headLength,
+        mProperties);
+  }
+  else
+  {
+    constructArrowBody(mMesh->mMeshes[1], 0, length-headLength, mProperties);
+  }
+
+  // construct the head
+  constructArrowTip(mMesh->mMeshes[2], length-headLength, length, mProperties);
+
+  Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
+  tf.translation() = mTail;
+  Eigen::Vector3d v = mHead - mTail;
+  Eigen::Vector3d z = Eigen::Vector3d::UnitZ();
+
+  if(v.norm() > 0 && v.cross(z).norm() > 0)
+  {
+    v.normalize();
+    Eigen::Vector3d axis = z.cross(v);
+    axis.normalize();
+    tf.rotate(Eigen::AngleAxisd(acos(z.dot(v)), axis));
+  }
+
+  aiNode* node = mMesh->mRootNode;
+  for(size_t i=0; i<4; ++i)
+    for(size_t j=0; j<4; ++j)
+      node->mTransformation[i][j] = tf(i,j);
+}
+
+//==============================================================================
+void ArrowShape::instantiate(size_t resolution)
+{
+  aiNode* node = new aiNode;
+  node->mNumMeshes = 3;
+  node->mMeshes = new unsigned int[3];
+  for(size_t i=0; i<3; ++i)
+    node->mMeshes[i] = i;
+
+  aiScene* scene = new aiScene;
+  scene->mNumMeshes = 3;
+  scene->mMeshes = new aiMesh*[3];
+  scene->mRootNode = node;
+
+  scene->mMaterials = new aiMaterial*[1];
+  scene->mMaterials[0] = new aiMaterial;
+
+  // allocate memory
+  for(size_t i=0; i<3; ++i)
+  {
+    size_t numVertices = (i==0 || i==2)? 2*resolution+1 : 2*resolution;
+
+    aiMesh* mesh = new aiMesh;
+
+    mesh->mNumVertices = numVertices;
+    mesh->mVertices = new aiVector3D[numVertices];
+    mesh->mNormals = new aiVector3D[numVertices];
+    mesh->mColors[0] = new aiColor4D[numVertices];
+
+    size_t numFaces = (i==0 || i==2)? 3*resolution : numVertices;
+    mesh->mNumFaces = numFaces;
+    mesh->mFaces = new aiFace[numFaces];
+    for(size_t j=0; j<numFaces; ++j)
+    {
+      mesh->mFaces[j].mNumIndices = 3;
+      mesh->mFaces[j].mIndices = new unsigned int[3];
+    }
+
+    scene->mMeshes[i] = mesh;
+  }
+
+  // set normals
+  aiMesh* mesh = scene->mMeshes[0];
+  for(size_t i=0; i<resolution; ++i)
+  {
+    mesh->mNormals[2*i].Set(0.0f, 0.0f, 1.0f);
+
+    double theta = (double)(i)/(double)(resolution)*2*M_PI;
+    mesh->mNormals[2*i+1].Set(cos(theta), sin(theta), 0.0f);
+  }
+  mesh->mNormals[mesh->mNumVertices-1].Set(0.0f, 0.0f, -1.0f);
+
+  mesh = scene->mMeshes[1];
+  for(size_t i=0; i<resolution; ++i)
+  {
+    double theta = (double)(i)/(double)(resolution)*2*M_PI;
+    mesh->mNormals[2*i].Set(cos(theta), sin(theta), 0.0f);
+    mesh->mNormals[2*i+1].Set(cos(theta), sin(theta), 0.0f);
+  }
+
+  mesh = scene->mMeshes[2];
+  for(size_t i=0; i<resolution; ++i)
+  {
+    mesh->mNormals[2*i].Set(0.0f, 0.0f, -1.0f);
+
+    double theta = (double)(i)/(double)(resolution)*2*M_PI;
+    mesh->mNormals[2*i+1].Set(cos(theta), sin(theta), 0.0f);
+  }
+  mesh->mNormals[mesh->mNumVertices-1].Set(0.0f, 0.0f, 1.0f);
+
+  // set faces
+  mesh = scene->mMeshes[0];
+  aiFace* face;
+  for(size_t i=0; i<resolution; ++i)
+  {
+    face = &mesh->mFaces[3*i];
+    face->mIndices[0] = 2*i;
+    face->mIndices[1] = 2*i+1;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
+
+    face = &mesh->mFaces[3*i+1];
+    face->mIndices[0] = 2*i;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+2 : 0;
+
+    face = &mesh->mFaces[3*i+2];
+    face->mIndices[0] = 2*i+1;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[2] = 2*resolution;
+  }
+
+  mesh = scene->mMeshes[1];
+  for(size_t i=0; i<resolution; ++i)
+  {
+    face = &mesh->mFaces[2*i];
+    face->mIndices[0] = 2*i;
+    face->mIndices[1] = 2*i+1;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
+
+    face = &mesh->mFaces[2*i+1];
+    face->mIndices[0] = 2*i;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+2 : 0;
+  }
+
+  mesh = scene->mMeshes[2];
+  for(size_t i=0; i<resolution; ++i)
+  {
+    face = &mesh->mFaces[3*i];
+    face->mIndices[0] = 2*i;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[2] = 2*i+1;
+
+    face = &mesh->mFaces[3*i+1];
+    face->mIndices[0] = 2*i;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+2 : 0;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
+
+    face = &mesh->mFaces[3*i+2];
+    face->mIndices[0] = 2*i+1;
+    face->mIndices[1] = 2*resolution;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
+  }
+
+  mMesh = scene;
+
+  setColor(mColor);
+}
+
+} // namespace dynamics
+} // namespace dart
+

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -307,6 +307,7 @@ void ArrowShape::instantiate(size_t resolution)
   aiFace* face;
   for(size_t i=0; i<resolution; ++i)
   {
+    // Back of head
     face = &mesh->mFaces[3*i];
     face->mIndices[0] = 2*i;
     face->mIndices[1] = 2*i+1;
@@ -317,10 +318,11 @@ void ArrowShape::instantiate(size_t resolution)
     face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
     face->mIndices[2] = (i+1 < resolution)? 2*i+2 : 0;
 
+    // Tip
     face = &mesh->mFaces[3*i+2];
     face->mIndices[0] = 2*i+1;
-    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
-    face->mIndices[2] = 2*resolution;
+    face->mIndices[1] = 2*resolution;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
   }
 
   mesh = scene->mMeshes[1];
@@ -328,18 +330,19 @@ void ArrowShape::instantiate(size_t resolution)
   {
     face = &mesh->mFaces[2*i];
     face->mIndices[0] = 2*i;
-    face->mIndices[1] = 2*i+1;
-    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[2] = 2*i+1;
 
     face = &mesh->mFaces[2*i+1];
     face->mIndices[0] = 2*i;
-    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
-    face->mIndices[2] = (i+1 < resolution)? 2*i+2 : 0;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+2 : 0;
+    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
   }
 
   mesh = scene->mMeshes[2];
   for(size_t i=0; i<resolution; ++i)
   {
+    // Back of head
     face = &mesh->mFaces[3*i];
     face->mIndices[0] = 2*i;
     face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
@@ -350,10 +353,11 @@ void ArrowShape::instantiate(size_t resolution)
     face->mIndices[1] = (i+1 < resolution)? 2*i+2 : 0;
     face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
 
+    // Tip
     face = &mesh->mFaces[3*i+2];
     face->mIndices[0] = 2*i+1;
-    face->mIndices[1] = 2*resolution;
-    face->mIndices[2] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[1] = (i+1 < resolution)? 2*i+3 : 1;
+    face->mIndices[2] = 2*resolution;
   }
 
   mMesh = scene;

--- a/dart/dynamics/ArrowShape.h
+++ b/dart/dynamics/ArrowShape.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2015, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Michael X. Grey <mxgrey@gatech.edu>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_ARROWSHAPE_H_
+#define DART_DYNAMICS_ARROWSHAPE_H_
+
+#include "dart/dynamics/MeshShape.h"
+
+namespace dart {
+namespace dynamics {
+
+class ArrowShape : public MeshShape
+{
+public:
+
+  struct Properties
+  {
+    /// _radius affects the thickness of the arrow. _headRadiusScale can be
+    /// [1,INFINITY) and is a multiplier that affects the wideness of the
+    /// beginning of the arrow head. _headLengthScale can be [0,1] and indicates
+    /// what fraction of the arrow length is to be the conical head.
+    /// _minHeadLength will prevent the arrow head from being shorter than the
+    /// given value; _maxHeadLength will prevent it from being longer than the
+    /// given value. Set _minHeadLength and _maxHeadLength to the same value to
+    /// fix the size of the arrow head.
+    Properties(double _radius=0.01, double _headRadiusScale=2.0,
+               double _headLengthScale=0.15,
+               double _minHeadLength=0,  double _maxHeadLength=INFINITY,
+               bool _doubleArrow=false);
+
+    double mRadius;
+    double mHeadRadiusScale;
+    double mHeadLengthScale;
+    double mMinHeadLength;
+    double mMaxHeadLength;
+    bool mDoubleArrow;
+  };
+
+  /// This will produce an arrow that reaches from _tail to _head with the given
+  /// properties.
+  ArrowShape(const Eigen::Vector3d& _tail, const Eigen::Vector3d& _head,
+             const Properties& _properties = Properties(),
+             const Eigen::Vector3d& _color=Eigen::Vector3d(0.5,0.5,1.0),
+             size_t _resolution=10);
+
+  /// Set the positions of the tail and head of the arrow without changing any
+  /// settings
+  void setPositions(const Eigen::Vector3d& _tail, const Eigen::Vector3d& _head);
+
+  /// Get the location of the tail of this arrow
+  const Eigen::Vector3d& getTail() const;
+
+  /// Get the location of the head of this arrow
+  const Eigen::Vector3d& getHead() const;
+
+  /// Set the properties of this arrow
+  void setProperties(const Properties& _properties);
+
+  /// Set the color of this arrow
+  void setColor(const Eigen::Vector3d& _color) override;
+
+  /// Get the properties of this arrow
+  const Properties& getProperties() const;
+
+  void configureArrow(const Eigen::Vector3d& _tail,
+                      const Eigen::Vector3d& _head,
+                      const Properties& _properties);
+
+protected:
+
+  void instantiate(size_t resolution);
+
+  Eigen::Vector3d mTail;
+  Eigen::Vector3d mHead;
+
+  Properties mProperties;
+};
+
+} // namespace dynamics
+} // namespace dart
+
+#endif // DART_DYNAMICS_ARROWSHAPE_H_

--- a/dart/dynamics/MeshShape.h
+++ b/dart/dynamics/MeshShape.h
@@ -93,6 +93,7 @@ private:
   /// \brief
   void _updateBoundingBoxDim();
 
+protected:
   /// \brief
   const aiScene* mMesh;
 

--- a/dart/dynamics/Shape.h
+++ b/dart/dynamics/Shape.h
@@ -73,7 +73,7 @@ public:
   virtual ~Shape();
 
   /// \brief Set color.
-  void setColor(const Eigen::Vector3d& _color);
+  virtual void setColor(const Eigen::Vector3d& _color);
 
   /// \brief Get color.
   const Eigen::Vector3d& getColor() const;


### PR DESCRIPTION
I've created an ArrowShape which is just a specialization of the MeshShape.

This pull request also has constructors and destructors for aiScene, which allows us to delete aiScenes in the destructor of the MeshShape class. The only catch is that there is a ``void* mPrivate`` in the aiScene structure which cannot be properly destructed without some hidden internal assimp data structures. It's probably worth raising an issue with the assimp retainers to understand why certain important constructors and destructors are not included in their basic library.