### PR TITLE
Added alpha channel and Color functions

### DIFF
--- a/apps/simpleFrames/Main.cpp
+++ b/apps/simpleFrames/Main.cpp
@@ -78,10 +78,11 @@ int main(int argc, char* argv[])
   myWorld.addEntity(&A);
 
   SimpleFrame arrow(Frame::World(), "arrow");
-  arrow.addVisualizationShape(new ArrowShape(Eigen::Vector3d(0.1,-0.1, 0.0),
-                                             Eigen::Vector3d(0.1, 0.0, 0.0),
-                                             ArrowShape::Properties(0.002, 1.8),
-                                             Eigen::Vector3d(1.0, 0.5, 0.5)));
+  arrow.addVisualizationShape(
+        new ArrowShape(Eigen::Vector3d(0.1,-0.1, 0.0),
+                       Eigen::Vector3d(0.1, 0.0, 0.0),
+                       ArrowShape::Properties(0.002, 1.8),
+                       Eigen::Vector4d(1.0, 0.5, 0.5, 1.0)));
   myWorld.addEntity(&arrow);
 
   // CAREFUL: For an Entity (or Frame) that gets added to the world to be

--- a/apps/softBodies/Main.cpp
+++ b/apps/softBodies/Main.cpp
@@ -55,6 +55,20 @@ int main(int argc, char* argv[])
           DART_DATA_PATH"skel/softBodies.skel");
   assert(myWorld != NULL);
 
+  for(size_t i=0; i<myWorld->getNumSkeletons(); ++i)
+  {
+    dart::dynamics::Skeleton* skel = myWorld->getSkeleton(i);
+    for(size_t j=0; j<skel->getNumBodyNodes(); ++j)
+    {
+      dart::dynamics::BodyNode* bn = skel->getBodyNode(j);
+      for(size_t k=0; k<bn->getNumVisualizationShapes(); ++k)
+      {
+        dart::dynamics::Shape* vs = bn->getVisualizationShape(k);
+        vs->setColor(dart::Color::Random());
+      }
+    }
+  }
+
   // create a window and link it to the world
   MyWindow window;
   window.setWorld(myWorld);

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -58,7 +58,7 @@ ArrowShape::Properties::Properties(double _radius, double _headRadiusScale,
 ArrowShape::ArrowShape(const Eigen::Vector3d& _tail,
                        const Eigen::Vector3d& _head,
                        const Properties& _properties,
-                       const Eigen::Vector3d& _color,
+                       const Eigen::Vector4d& _color,
                        size_t _resolution)
   : MeshShape(Eigen::Vector3d::Ones(), nullptr),
     mTail(_tail),
@@ -96,7 +96,7 @@ void ArrowShape::setProperties(const Properties& _properties)
 }
 
 //==============================================================================
-void ArrowShape::setColor(const Eigen::Vector3d& _color)
+void ArrowShape::setRGBA(const Eigen::Vector4d& _color)
 {
   mColor = _color;
   for(size_t i=0; i<mMesh->mNumMeshes; ++i)
@@ -104,7 +104,8 @@ void ArrowShape::setColor(const Eigen::Vector3d& _color)
     aiMesh* mesh = mMesh->mMeshes[i];
     for(size_t j=0; j<mesh->mNumVertices; ++j)
     {
-      mesh->mColors[0][j] = aiColor4D(_color.x(), _color.y(), _color.z(), 1.0f);
+      mesh->mColors[0][j] = aiColor4D(_color[0], _color[1],
+                                      _color[2], _color[3]);
     }
   }
 }

--- a/dart/dynamics/ArrowShape.h
+++ b/dart/dynamics/ArrowShape.h
@@ -73,7 +73,7 @@ public:
   /// properties.
   ArrowShape(const Eigen::Vector3d& _tail, const Eigen::Vector3d& _head,
              const Properties& _properties = Properties(),
-             const Eigen::Vector3d& _color=Eigen::Vector3d(0.5,0.5,1.0),
+             const Eigen::Vector4d& _color=Eigen::Vector4d(0.5,0.5,1.0,1.0),
              size_t _resolution=10);
 
   /// Set the positions of the tail and head of the arrow without changing any
@@ -90,7 +90,7 @@ public:
   void setProperties(const Properties& _properties);
 
   /// Set the color of this arrow
-  void setColor(const Eigen::Vector3d& _color) override;
+  void setRGBA(const Eigen::Vector4d& _color) override;
 
   /// Get the properties of this arrow
   const Properties& getProperties() const;

--- a/dart/dynamics/Shape.cpp
+++ b/dart/dynamics/Shape.cpp
@@ -46,7 +46,7 @@ Shape::Shape(ShapeType _type)
   : mBoundingBoxDim(0, 0, 0),
     mVolume(0.0),
     mID(mCounter++),
-    mColor(0.5, 0.5, 1.0),
+    mColor(0.5, 0.5, 1.0, 1.0),
     mTransform(Eigen::Isometry3d::Identity()),
     mType(_type)
 {
@@ -56,10 +56,31 @@ Shape::~Shape() {
 }
 
 void Shape::setColor(const Eigen::Vector3d& _color) {
-  mColor = _color;
+  setRGB(_color);
 }
 
-const Eigen::Vector3d& Shape::getColor() const {
+void Shape::setColor(const Eigen::Vector4d &_color) {
+  setRGBA(_color);
+}
+
+void Shape::setRGB(const Eigen::Vector3d& _rgb) {
+  mColor << _rgb, mColor[3];
+  setRGBA(mColor);
+}
+
+void Shape::setRGBA(const Eigen::Vector4d& _rgba) {
+  mColor = _rgba;
+}
+
+Eigen::Vector3d Shape::getColor() const {
+  return getRGB();
+}
+
+Eigen::Vector3d Shape::getRGB() const {
+  return Eigen::Vector3d(mColor[0], mColor[1], mColor[2]);
+}
+
+const Eigen::Vector4d& Shape::getRGBA() const {
   return mColor;
 }
 

--- a/dart/dynamics/Shape.h
+++ b/dart/dynamics/Shape.h
@@ -72,11 +72,27 @@ public:
   /// \brief Destructor
   virtual ~Shape();
 
-  /// \brief Set color.
+  /// \brief Set RGB color components (leave alpha alone). Identical to
+  /// setRGB(const Eigen::Vector3d&)
   void setColor(const Eigen::Vector3d& _color);
 
+  /// \brief Set RGBA color components
+  void setColor(const Eigen::Vector4d& _color);
+
+  /// \brief Set RGB color components (leave alpha alone)
+  void setRGB(const Eigen::Vector3d& _rgb);
+
+  /// \brief Set RGBA color components
+  virtual void setRGBA(const Eigen::Vector4d& _rgba);
+
   /// \brief Get color.
-  const Eigen::Vector3d& getColor() const;
+  Eigen::Vector3d getColor() const;
+
+  /// \brief Get RGB color components
+  Eigen::Vector3d getRGB() const;
+
+  /// \brief Get RGBA color components
+  const Eigen::Vector4d& getRGBA() const;
 
   /// \brief Get dimensions of bounding box.
   ///        The dimension will be automatically determined by the sub-classes
@@ -139,7 +155,7 @@ protected:
   int mID;
 
   /// \brief Color for the primitive.
-  Eigen::Vector3d mColor;
+  Eigen::Vector4d mColor;
 
   /// \brief Local geometric transformation of the Shape w.r.t. parent frame.
   Eigen::Isometry3d mTransform;

--- a/dart/math/Helpers.h
+++ b/dart/math/Helpers.h
@@ -255,6 +255,87 @@ inline int castUIntToInt(size_t _x)
 }
 
 }  // namespace math
+
+namespace Color
+{
+
+inline Eigen::Vector4d Red(double alpha)
+{
+  return Eigen::Vector4d(0.9, 0.1, 0.1, alpha);
+}
+
+inline Eigen::Vector3d Red()
+{
+  return Eigen::Vector3d(0.9, 0.1, 0.1);
+}
+
+inline Eigen::Vector4d Green(double alpha)
+{
+  return Eigen::Vector4d(0.1, 0.9, 0.1, alpha);
+}
+
+inline Eigen::Vector3d Green()
+{
+  return Eigen::Vector3d(0.1, 0.9, 0.1);
+}
+
+inline Eigen::Vector4d Blue(double alpha)
+{
+  return Eigen::Vector4d(0.1, 0.1, 0.9, alpha);
+}
+
+inline Eigen::Vector3d Blue()
+{
+  return Eigen::Vector3d(0.1, 0.1, 0.9);
+}
+
+inline Eigen::Vector4d White(double alpha)
+{
+  return Eigen::Vector4d(1.0, 1.0, 1.0, alpha);
+}
+
+inline Eigen::Vector3d White()
+{
+  return Eigen::Vector3d(1.0, 1.0, 1.0);
+}
+
+inline Eigen::Vector4d Black(double alpha)
+{
+  return Eigen::Vector4d(0.05, 0.05, 0.05, alpha);
+}
+
+inline Eigen::Vector3d Black()
+{
+  return Eigen::Vector3d(0.05, 0.05, 0.05);
+}
+
+inline Eigen::Vector4d Gray(double alpha)
+{
+  return Eigen::Vector4d(0.6, 0.6, 0.6, alpha);
+}
+
+inline Eigen::Vector3d Gray()
+{
+  return Eigen::Vector3d(0.6, 0.6, 0.6);
+}
+
+inline Eigen::Vector4d Random(double alpha)
+{
+  return Eigen::Vector4d(math::random(0.0, 1.0),
+                         math::random(0.0, 1.0),
+                         math::random(0.0, 1.0),
+                         alpha);
+}
+
+inline Eigen::Vector3d Random()
+{
+  return Eigen::Vector3d(math::random(0.0, 1.0),
+                         math::random(0.0, 1.0),
+                         math::random(0.0, 1.0));
+}
+
+} // namespace Color
+
 }  // namespace dart
 
 #endif  // DART_MATH_HELPERS_H_


### PR DESCRIPTION
I've added an alpha channel for Shape colors. It turns out the whole OpenGL renderer pipeline was completely ready for an alpha channel, it just wasn't being used.

I also added some Color generating functions. Rather than create a Color class, I simply made a namespace called Color in dart/math/Helpers.h and put some functions in that namespace. I decided to inline all the functions so that end users can just check the header to see what actual color codes are being used for each of the color functions.