### PR TITLE
Better robustness and package handling for URDF parsing

### DIFF
--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -271,7 +271,8 @@ const aiScene* MeshShape::loadMesh(const std::string& _fileName) {
                                    NULL, propertyStore);
   if(!scene)
     dtwarn << "[MeshShape] Assimp could not load file: '" << _fileName << "'. "
-           << "This will likely result in a segmentation fault." << std::endl;
+           << "This will likely result in a segmentation fault "
+           << "if you attempt to use the nullptr we return." << std::endl;
   aiReleasePropertyStore(propertyStore);
 
   // Assimp rotates collada files such that the up-axis (specified in the

--- a/dart/utils/urdf/DartLoader.h
+++ b/dart/utils/urdf/DartLoader.h
@@ -38,22 +38,53 @@ namespace utils {
 class DartLoader {
   
 public:
-    dynamics::Skeleton* parseSkeleton(std::string _urdfFileName);
-    simulation::World* parseWorld(std::string _urdfFileName);
-    void setPackageDirectory(const std::string& _urdfPackageDirectory);
+
+    /// Specify the directory of a ROS package. In your URDF files, you may see
+    /// strings with a package URI pattern such as:
+    ///
+    /// "package://my_robot/meshes/mesh_for_my_robot.stl"
+    ///  \______/  \______/\___________________________/
+    ///      |        |                 |
+    ///   package  package   file path with respect to
+    ///   keyword   name       the package directory
+    ///
+    /// For us to successfully parse a URDF, we need to be told what the path
+    /// to the package directory is, using addPackageDirectory(). In this case,
+    /// suppose the path to the my_robot package is /path/to/my_robot. Then you
+    /// should use addPackageDirectory("my_robot", "/path/to/my_robot").
+    /// Altogether, this implies that a file named
+    /// "/path/to/my_robot/meshes/mesh_for_my_robot.stl" exists. Whatever you
+    /// specify as the package directory will end up replacing the 'package
+    /// keyword' and 'package name' components of the URI string.
+    void addPackageDirectory(const std::string& _packageName,
+                             const std::string& _packageDirectory);
+
+    /// Parse a file to produce a Skeleton
+    dynamics::Skeleton* parseSkeleton(const std::string& _urdfFileName);
+
+    /// Parse a text string to produce a Skeleton
+    dynamics::Skeleton* parseSkeletonString(const std::string& _urdfString,
+                                            const std::string& _urdfFileDirectory);
+
+    /// Parse a file to produce a World
+    simulation::World* parseWorld(const std::string& _urdfFileName);
+
+    /// Parse a text string to produce a World
+    simulation::World* parseWorldString(const std::string& _urdfString,
+                                        const std::string& _urdfFileDirectory);
 
 private:
-    std::string getFullFilePath(const std::string& _filename, const std::string& _rootToSkelPath) const;
+    std::string getFullFilePath(const std::string& _filename) const;
     void parseWorldToEntityPaths(const std::string& _xml_string);
 
-    dynamics::Skeleton* modelInterfaceToSkeleton(const urdf::ModelInterface* _model, std::string _rootToSkelPath = "");
-    void createSkeletonRecursive(dynamics::Skeleton* _skel, const urdf::Link* _lk, dynamics::BodyNode* _parent, std::string _rootToSkelPath);
+    dynamics::Skeleton* modelInterfaceToSkeleton(const urdf::ModelInterface* _model);
+    void createSkeletonRecursive(dynamics::Skeleton* _skel, const urdf::Link* _lk, dynamics::BodyNode* _parent);
 
     template <class VisualOrCollision>
-    dynamics::Shape* createShape(const VisualOrCollision* _vizOrCol, std::string  _rootToSkelPath);
+    dynamics::Shape* createShape(const VisualOrCollision* _vizOrCol);
 
     dynamics::Joint* createDartJoint(const urdf::Joint* _jt);
-    dynamics::BodyNode* createDartNode(const urdf::Link* _lk, std::string _rootToSkelPath = NULL);
+    dynamics::BodyNode* createDartNode(const urdf::Link* _lk);
 
     Eigen::Isometry3d toEigen(const urdf::Pose& _pose);
     Eigen::Vector3d toEigen(const urdf::Vector3& _vector);
@@ -61,7 +92,9 @@ private:
 
     std::map<std::string, std::string> mWorld_To_Entity_Paths;
 
-    std::string mPackageDirectory;
+    std::map<std::string, std::string> mPackageDirectories;
+    std::string mRootToSkelPath;
+    std::string mRootToWorldPath;
 };
 
 }

--- a/dart/utils/urdf/urdf_world_parser.cpp
+++ b/dart/utils/urdf/urdf_world_parser.cpp
@@ -47,129 +47,147 @@
 #include <urdf_world/world.h>
 #include <urdf_model/pose.h>
 
+#include "dart/common/Console.h"
+
 const bool debug = false;
 
 namespace urdf{
 
-  // Implemented in urdf_parser/src/pose.cpp, for some reason nobody thought of putting it in the header
-  bool parsePose(Pose &pose, TiXmlElement* xml);
-  
-  /**
-   * @function parseWorldURDF
-   */
-  World* parseWorldURDF(const std::string& _xml_string, std::string _root_to_world_path) {
-    
-    World* world = new World();
-    TiXmlDocument xml_doc;
-    xml_doc.Parse( _xml_string.c_str() );
-    TiXmlElement *world_xml = xml_doc.FirstChildElement("world");
-    if( !world_xml ) {
-      printf ( "[parseWorldURDF] ERROR: Could not find a <world> element in XML, exiting and not loading! \n" );
-      return NULL;
-    }
-    
-    // Get world name
-    const char *name = world_xml->Attribute("name");
-    if(!name) {
-      printf ("[parseWorldURDF] ERROR: World does not have a name specified. Exiting and not loading! \n");
-      return NULL;
-    }
-    world->name = std::string(name);
-    if(debug) std::cout<< "World name: "<< world->name << std::endl;
-    
-    
-    // Get all include filenames
-    int count = 0;
-    std::map<std::string, std::string> includedFiles;
+// Implemented in urdf_parser/src/pose.cpp, for some reason nobody thought of putting it in the header
+bool parsePose(Pose &pose, TiXmlElement* xml);
 
-    for( TiXmlElement* include_xml = world_xml->FirstChildElement("include");
-	 include_xml; include_xml = include_xml->NextSiblingElement("include") ) {
-      count++;
-      const char *filename = include_xml->Attribute("filename");
-      const char *model_name = include_xml->Attribute("model_name");
-      std::string string_filename( filename );
-      std::string string_model_name( model_name );
-      includedFiles[string_model_name] = string_filename;
-      if(debug) std::cout<<"Include: Model name: "<<  model_name <<" filename: "<< filename <<std::endl;
-    }
-    if(debug) std::cout<<"Found "<<count<<" include filenames "<<std::endl;
-    
-    // Get all entities
-    count = 0;
-    for( TiXmlElement* entity_xml = world_xml->FirstChildElement("entity");
-	 entity_xml; entity_xml = entity_xml->NextSiblingElement("entity") ) {
-      count++;
-      Entity entity;
-      try {
+/**
+ * @function parseWorldURDF
+ */
+World* parseWorldURDF(const std::string& _xml_string, std::string _root_to_world_path) {
 
-	const char* entity_model = entity_xml->Attribute("model");
-	std::string string_entity_model( entity_model );
-	
-	// Find the model
-	if( includedFiles.find( string_entity_model ) == includedFiles.end() ) {
-	  std::cout<<"[parseWorldURDF] ERROR: I cannot find the model you want to use, did you write the name right? Exiting and not loading! \n"<<std::endl;
-	  return NULL;
-	} 
-	else {
-	  std::string fileName = includedFiles.find( string_entity_model )->second;
-	  std::string fileFullName = _root_to_world_path;
-	  fileFullName.append( fileName );
-	  if(debug) std::cout<< "Entity full filename: "<< fileFullName << std::endl;
-	  
-	  // Parse model
-	  std::string xml_model_string;
-	  std::fstream xml_file( fileFullName.c_str(), std::fstream::in );
-	  while( xml_file.good() ) {
-	    std::string line;
-	    std::getline( xml_file, line );
-	    xml_model_string += (line + "\n");
-	  }
-	  xml_file.close();
-	  entity.model = parseURDF( xml_model_string );
+  World* world = new World;
+  TiXmlDocument xml_doc;
+  xml_doc.Parse( _xml_string.c_str() );
+  TiXmlElement *world_xml = xml_doc.FirstChildElement("world");
+  if( !world_xml )
+  {
+    dtwarn << "[parseWorldURDF] ERROR: Could not find a <world> element in XML, exiting and not loading! \n";
+    delete world;
+    return nullptr;
+  }
 
-	  if( !entity.model ) {
-	    std::cout<< "[parseWorldURDF] Model in "<<fileFullName<<" not found. Exiting and not loading!" <<std::endl;
-	    return NULL;
-	  }
-	  else {
-	    // Parse location
-	    TiXmlElement *o = entity_xml->FirstChildElement("origin");
-	    if( o ) {
-	      if( !parsePose( entity.origin, o ) ) {
-		printf ("[ERROR] Write the pose for your entity! \n");
-		return world;
-	      }
-	    }
-	    
-	    // If name is defined
-	    const char* entity_name = entity_xml->Attribute("name");
-	    if( entity_name ) {
-	      std::string string_entity_name( entity_name );
-	      entity.model->name_ = string_entity_name;	
-	    }
-	    
-	    // Store in world
-	    world->models.push_back( entity );
-	  }
-	  
-	} // end of include read
-	
-	
+  // Get world name
+  const char *name = world_xml->Attribute("name");
+  if(!name)
+  {
+    dtwarn << "[parseWorldURDF] ERROR: World does not have a name tag specified. Exiting and not loading! \n";
+    delete world;
+    return nullptr;
+  }
+  world->name = std::string(name);
+  if(debug) std::cout<< "World name: "<< world->name << std::endl;
+
+
+  // Get all include filenames
+  int count = 0;
+  std::map<std::string, std::string> includedFiles;
+
+  for( TiXmlElement* include_xml = world_xml->FirstChildElement("include");
+       include_xml != nullptr;
+       include_xml = include_xml->NextSiblingElement("include") )
+  {
+    ++count;
+    const char *filename = include_xml->Attribute("filename");
+    const char *model_name = include_xml->Attribute("model_name");
+    std::string string_filename( filename );
+    std::string string_model_name( model_name );
+    includedFiles[string_model_name] = string_filename;
+    if(debug) std::cout<< "Include: Model name: " <<  model_name << " filename: " << filename <<std::endl;
+  }
+  if(debug) std::cout<<"Found "<< count <<" include filenames "<<std::endl;
+
+  // Get all entities
+  count = 0;
+  for( TiXmlElement* entity_xml = world_xml->FirstChildElement("entity");
+       entity_xml != nullptr;
+       entity_xml = entity_xml->NextSiblingElement("entity") )
+  {
+    count++;
+    Entity entity;
+    try
+    {
+      const char* entity_model = entity_xml->Attribute("model");
+      std::string string_entity_model( entity_model );
+
+      // Find the model
+      if( includedFiles.find( string_entity_model ) == includedFiles.end() )
+      {
+        dtwarn << "[parseWorldURDF] ERROR: I cannot find the model you want to use, did you provide the correct name? Exiting and not loading! \n"<<std::endl;
+        delete world;
+        return nullptr;
       }
-      catch( ParseError &e ) {
-	if(debug) printf ("Entity xml not initialized correctly \n");
-	//entity->reset();
-	//world->reset();
-	return world;
-      }
-      
-    } // end for
-    if(debug) printf ("Found %d entities \n", count);
-    
-    return world;
-    
-  }	
-  
+      else
+      {
+        std::string fileName = includedFiles.find( string_entity_model )->second;
+        std::string fileFullName = _root_to_world_path;
+        fileFullName.append( fileName );
+        if(debug) std::cout<< "Entity full filename: "<< fileFullName << std::endl;
 
+        // Parse model
+        std::string xml_model_string;
+        std::fstream xml_file( fileFullName.c_str(), std::fstream::in );
+        while( xml_file.good() )
+        {
+          std::string line;
+          std::getline( xml_file, line );
+          xml_model_string += (line + "\n");
+        }
+        xml_file.close();
+        entity.model = parseURDF( xml_model_string );
+
+        if( !entity.model )
+        {
+          dtwarn << "[parseWorldURDF] Model in " << fileFullName
+                 << " not found. Exiting and not loading!\n";
+          delete world;
+          return nullptr;
+        }
+        else
+        {
+          // Parse location
+          TiXmlElement* origin = entity_xml->FirstChildElement("origin");
+          if( origin )
+          {
+            if( !parsePose( entity.origin, origin ) )
+            {
+              dtwarn << "[ERROR] Missing origin tag for '" << entity.model->getName() << "'\n";
+              return world;
+            }
+          }
+
+          // If name is defined
+          const char* entity_name = entity_xml->Attribute("name");
+          if( entity_name )
+          {
+            std::string string_entity_name( entity_name );
+            entity.model->name_ = string_entity_name;
+          }
+
+          // Store in world
+          world->models.push_back( entity );
+        }
+      } // end of include read
+
+
+    }
+    catch( ParseError& e )
+    {
+      if(debug) std::cout << "Entity xml not initialized correctly \n";
+      //entity->reset();
+      //world->reset();
+      return world;
+    }
+
+  } // end for
+  if(debug) std::cout << "Found " << count << " entities \n";
+
+  return world;
+}
 
 } // end namespace


### PR DESCRIPTION
I made changes to the URDF parser so that it can handle package names and directories correctly (thanks @ehuang3 for the info), and while I was at it, I found that the parser was rife with poor error handling (including memory leaks and poorly explained exits) and screwy formatting, so I fixed some of that as well.

Now the URDF parsing can handle arbitrarily many different packages (instead of assuming that all resources will be in the same package), but it still depends on the user to specify the paths to the package directories.

I also added the ability to parse raw xml strings instead of only allowing xml files.

Note that there was a necessary API change in order to support multiple packages. This will not affect any users who were not using URDFs with ROS packages in the first place.