### PR TITLE
Reverting PlaneShape constructor taking normal and point parameters

### DIFF
--- a/dart/dynamics/PlaneShape.cpp
+++ b/dart/dynamics/PlaneShape.cpp
@@ -119,6 +119,22 @@ double PlaneShape::getOffset() const
 }
 
 //==============================================================================
+void PlaneShape::setNormalAndOffset(const Eigen::Vector3d& _normal,
+                                    double _offset)
+{
+  setNormal(_normal);
+  setOffset(_offset);
+}
+
+//==============================================================================
+void PlaneShape::setNormalAndPoint(const Eigen::Vector3d& _normal,
+                                   const Eigen::Vector3d& _point)
+{
+  setNormal(_normal);
+  setOffset(mNormal.dot(_point));
+}
+
+//==============================================================================
 double PlaneShape::computeDistance(const Eigen::Vector3d& _point) const
 {
   return std::fabs(computeSignedDistance(_point));

--- a/dart/dynamics/PlaneShape.h
+++ b/dart/dynamics/PlaneShape.h
@@ -51,7 +51,6 @@ public:
   PlaneShape(const Eigen::Vector3d& _normal, double _offset);
 
   /// Constructor
-  DEPRECATED(4.3)
   PlaneShape(const Eigen::Vector3d& _normal, const Eigen::Vector3d& _point);
 
   // Documentation inherited.
@@ -74,6 +73,13 @@ public:
 
   /// Get plane offset
   double getOffset() const;
+
+  /// Set plane normal and offset
+  void setNormalAndOffset(const Eigen::Vector3d& _normal, double _offset);
+
+  /// Set plane normal and point
+  void setNormalAndPoint(const Eigen::Vector3d& _normal,
+                         const Eigen::Vector3d& _point);
 
   /// Compute distance between the plane and the given point
   double computeDistance(const Eigen::Vector3d& _point) const;


### PR DESCRIPTION
Revert deprecation of PlaneShape constructor that takes normal and point parameters based on the discussion in #373. Also add setNormalAndOffset and setNormalAndPoint.
