### PR TITLE
New setTransform function for SimpleFrame

### DIFF
--- a/dart/dynamics/SimpleFrame.cpp
+++ b/dart/dynamics/SimpleFrame.cpp
@@ -34,8 +34,9 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "dart/dynamics/SimpleFrame.h"
+#include "dart/common/Console.h"
 #include "dart/math/Geometry.h"
+#include "dart/dynamics/SimpleFrame.h"
 
 namespace dart {
 namespace dynamics {
@@ -64,6 +65,14 @@ void SimpleFrame::setRelativeTransform(
 {
   mRelativeTf = _newRelTransform;
   notifyTransformUpdate();
+}
+
+//==============================================================================
+void SimpleFrame::setTransform(const Eigen::Isometry3d& _newTransform,
+                               const Frame* _withRespectTo)
+{
+  setRelativeTransform(
+        _withRespectTo->getTransform(getParentFrame()) * _newTransform);
 }
 
 //==============================================================================

--- a/dart/dynamics/SimpleFrame.h
+++ b/dart/dynamics/SimpleFrame.h
@@ -70,6 +70,12 @@ public:
   /// Set the relative transform of this SimpleFrame
   void setRelativeTransform(const Eigen::Isometry3d& _newRelTransform);
 
+  /// Set the transform of this SimpleFrame so that its transform with respect
+  /// to Frame _withRespectTo is equal to _newTransform. Note that the parent
+  /// Frame of this SimpleFrame will not be changed.
+  void setTransform(const Eigen::Isometry3d& _newTransform,
+                    const Frame* _withRespectTo);
+
   // Documentation inherited
   const Eigen::Isometry3d& getRelativeTransform() const;
 

--- a/unittests/testFrames.cpp
+++ b/unittests/testFrames.cpp
@@ -696,6 +696,21 @@ void test_relative_values(bool spatial_targets, bool spatial_followers)
       check_offset_computations(targets, followers, T, F, tolerance);
     }
   }
+
+  // Test SimpleFrame::setTransform()
+  for(size_t i=0; i<followers.size(); ++i)
+  {
+    for(size_t j=0; j<followers.size(); ++j)
+    {
+      SimpleFrame* F = followers[i];
+      SimpleFrame* T = followers[j];
+      Eigen::Isometry3d tf;
+      randomize_transform(tf, 1, 2*M_PI);
+      T->setTransform(tf, F);
+      if(i != j)
+        EXPECT_TRUE( equals(T->getTransform(F).matrix(), tf.matrix(), 1e-10));
+    }
+  }
 }
 
 // Test different combinations of using spatial and classical derivative terms


### PR DESCRIPTION
This pull request adds a new function to the API that allows the user to set the transform of a SimpleFrame such that it has a specified transform with respect to some other Frame. The parent Frame of the SimpleFrame remains unchanged.