### PR TITLE
Add deprecated and force-inline definitions for clang

### DIFF
--- a/dart/common/Deprecated.h
+++ b/dart/common/Deprecated.h
@@ -43,7 +43,7 @@
 // version up.
 //==============================================================================
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
   #define DEPRECATED(version) __attribute__ ((deprecated))
   #define FORCEINLINE __attribute__((always_inline))
 #elif defined(_MSC_VER)


### PR DESCRIPTION
resolves #379.