### PR TITLE
Differences of generalized coordinates

### DIFF
--- a/dart/dynamics/BallJoint.h
+++ b/dart/dynamics/BallJoint.h
@@ -72,7 +72,21 @@ public:
   /// Convert a BallJoint-style position vector into a rotation matrix
   static Eigen::Matrix3d convertToRotation(const Eigen::Vector3d& _positions);
 
+  // Documentation inherited
+  void setPositionsStatic(const Eigen::Vector3d& _positions) override;
+
+  // Documentation inherited
+  Eigen::Vector3d getPositionDifferencesStatic(
+      const Eigen::Vector3d& _q0, const Eigen::Vector3d& _q1) const override;
+
+  // Documentation inherited
+  Eigen::Matrix<double, 6, 3> getLocalJacobianStatic(
+      const Eigen::Vector3d& _positions) const override;
+
 protected:
+
+  using MultiDofJoint::getLocalJacobianStatic;
+
   // Documentation inherited
   virtual void integratePositions(double _dt);
 

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -116,6 +116,114 @@ Eigen::Matrix3d EulerJoint::convertToRotation(const Eigen::Vector3d& _positions)
 }
 
 //==============================================================================
+Eigen::Matrix<double, 6, 3> EulerJoint::getLocalJacobianStatic(
+    const Eigen::Vector3d& _positions) const
+{
+  Eigen::Matrix<double, 6, 3> J;
+
+  // double q0 = _positions[0];
+  const double q1 = _positions[1];
+  const double q2 = _positions[2];
+
+  // double c0 = cos(q0);
+  double c1 = cos(q1);
+  double c2 = cos(q2);
+
+  // double s0 = sin(q0);
+  double s1 = sin(q1);
+  double s2 = sin(q2);
+
+  Eigen::Vector6d J0 = Eigen::Vector6d::Zero();
+  Eigen::Vector6d J1 = Eigen::Vector6d::Zero();
+  Eigen::Vector6d J2 = Eigen::Vector6d::Zero();
+
+  switch (mAxisOrder)
+  {
+    case AO_XYZ:
+    {
+      //------------------------------------------------------------------------
+      // S = [    c1*c2, s2,  0
+      //       -(c1*s2), c2,  0
+      //             s1,  0,  1
+      //              0,  0,  0
+      //              0,  0,  0
+      //              0,  0,  0 ];
+      //------------------------------------------------------------------------
+      J0 << c1*c2, -(c1*s2),  s1, 0.0, 0.0, 0.0;
+      J1 <<    s2,       c2, 0.0, 0.0, 0.0, 0.0;
+      J2 <<   0.0,      0.0, 1.0, 0.0, 0.0, 0.0;
+
+#ifndef NDEBUG
+      if (fabs(getPositionsStatic()[1]) == DART_PI * 0.5)
+        std::cout << "Singular configuration in ZYX-euler joint ["
+                  << mName << "]. ("
+                  << _positions[0] << ", "
+                  << _positions[1] << ", "
+                  << _positions[2] << ")"
+                  << std::endl;
+#endif
+
+      break;
+    }
+    case AO_ZYX:
+    {
+      //------------------------------------------------------------------------
+      // S = [   -s1,    0,   1
+      //       s2*c1,   c2,   0
+      //       c1*c2,  -s2,   0
+      //           0,    0,   0
+      //           0,    0,   0
+      //           0,    0,   0 ];
+      //------------------------------------------------------------------------
+      J0 << -s1, s2*c1, c1*c2, 0.0, 0.0, 0.0;
+      J1 << 0.0,    c2,   -s2, 0.0, 0.0, 0.0;
+      J2 << 1.0,   0.0,   0.0, 0.0, 0.0, 0.0;
+
+#ifndef NDEBUG
+      if (fabs(_positions[1]) == DART_PI * 0.5)
+        std::cout << "Singular configuration in ZYX-euler joint ["
+                  << mName << "]. ("
+                  << _positions[0] << ", "
+                  << _positions[1] << ", "
+                  << _positions[2] << ")"
+                  << std::endl;
+#endif
+
+      break;
+    }
+    default:
+    {
+      dterr << "Undefined Euler axis order\n";
+      break;
+    }
+  }
+
+  J.col(0) = math::AdT(mT_ChildBodyToJoint, J0);
+  J.col(1) = math::AdT(mT_ChildBodyToJoint, J1);
+  J.col(2) = math::AdT(mT_ChildBodyToJoint, J2);
+
+  assert(!math::isNan(J));
+
+#ifndef NDEBUG
+  Eigen::MatrixXd JTJ = J.transpose() * J;
+  Eigen::FullPivLU<Eigen::MatrixXd> luJTJ(JTJ);
+  //    Eigen::FullPivLU<Eigen::MatrixXd> luS(mS);
+  double det = luJTJ.determinant();
+  if (det < 1e-5)
+  {
+    std::cout << "ill-conditioned Jacobian in joint [" << mName << "]."
+              << " The determinant of the Jacobian is (" << det << ")."
+              << std::endl;
+    std::cout << "rank is (" << luJTJ.rank() << ")." << std::endl;
+    std::cout << "det is (" << luJTJ.determinant() << ")." << std::endl;
+    //        std::cout << "mS: \n" << mS << std::endl;
+  }
+#endif
+
+  return J;
+}
+
+//==============================================================================
 void EulerJoint::updateDegreeOfFreedomNames()
 {
   std::vector<std::string> affixes;
@@ -158,105 +266,7 @@ void EulerJoint::updateLocalTransform() const
 //==============================================================================
 void EulerJoint::updateLocalJacobian(bool) const
 {
-  // double q0 = mPositions[0];
-  const Eigen::Vector3d& positions = getPositionsStatic();
-  double q1 = positions[1];
-  double q2 = positions[2];
-
-  // double c0 = cos(q0);
-  double c1 = cos(q1);
-  double c2 = cos(q2);
-
-  // double s0 = sin(q0);
-  double s1 = sin(q1);
-  double s2 = sin(q2);
-
-  Eigen::Vector6d J0 = Eigen::Vector6d::Zero();
-  Eigen::Vector6d J1 = Eigen::Vector6d::Zero();
-  Eigen::Vector6d J2 = Eigen::Vector6d::Zero();
-
-  switch (mAxisOrder)
-  {
-    case AO_XYZ:
-    {
-      //------------------------------------------------------------------------
-      // S = [    c1*c2, s2,  0
-      //       -(c1*s2), c2,  0
-      //             s1,  0,  1
-      //              0,  0,  0
-      //              0,  0,  0
-      //              0,  0,  0 ];
-      //------------------------------------------------------------------------
-      J0 << c1*c2, -(c1*s2),  s1, 0.0, 0.0, 0.0;
-      J1 <<    s2,       c2, 0.0, 0.0, 0.0, 0.0;
-      J2 <<   0.0,      0.0, 1.0, 0.0, 0.0, 0.0;
-
-#ifndef NDEBUG
-      if (fabs(getPositionsStatic()[1]) == DART_PI * 0.5)
-        std::cout << "Singular configuration in ZYX-euler joint ["
-                  << mName << "]. ("
-                  << positions[0] << ", "
-                  << positions[1] << ", "
-                  << positions[2] << ")"
-                  << std::endl;
-#endif
-
-      break;
-    }
-    case AO_ZYX:
-    {
-      //------------------------------------------------------------------------
-      // S = [   -s1,    0,   1
-      //       s2*c1,   c2,   0
-      //       c1*c2,  -s2,   0
-      //           0,    0,   0
-      //           0,    0,   0
-      //           0,    0,   0 ];
-      //------------------------------------------------------------------------
-      J0 << -s1, s2*c1, c1*c2, 0.0, 0.0, 0.0;
-      J1 << 0.0,    c2,   -s2, 0.0, 0.0, 0.0;
-      J2 << 1.0,   0.0,   0.0, 0.0, 0.0, 0.0;
-
-#ifndef NDEBUG
-      if (fabs(positions[1]) == DART_PI * 0.5)
-        std::cout << "Singular configuration in ZYX-euler joint ["
-                  << mName << "]. ("
-                  << positions[0] << ", "
-                  << positions[1] << ", "
-                  << positions[2] << ")"
-                  << std::endl;
-#endif
-
-      break;
-    }
-    default:
-    {
-      dterr << "Undefined Euler axis order\n";
-      break;
-    }
-  }
-
-  mJacobian.col(0) = math::AdT(mT_ChildBodyToJoint, J0);
-  mJacobian.col(1) = math::AdT(mT_ChildBodyToJoint, J1);
-  mJacobian.col(2) = math::AdT(mT_ChildBodyToJoint, J2);
-
-  assert(!math::isNan(mJacobian));
-
-#ifndef NDEBUG
-  Eigen::MatrixXd JTJ = mJacobian.transpose() * mJacobian;
-  Eigen::FullPivLU<Eigen::MatrixXd> luJTJ(JTJ);
-  //    Eigen::FullPivLU<Eigen::MatrixXd> luS(mS);
-  double det = luJTJ.determinant();
-  if (det < 1e-5)
-  {
-    std::cout << "ill-conditioned Jacobian in joint [" << mName << "]."
-              << " The determinant of the Jacobian is (" << det << ")."
-              << std::endl;
-    std::cout << "rank is (" << luJTJ.rank() << ")." << std::endl;
-    std::cout << "det is (" << luJTJ.determinant() << ")." << std::endl;
-    //        std::cout << "mS: \n" << mS << std::endl;
-  }
-#endif
+  mJacobian = getLocalJacobianStatic(getPositionsStatic());
 }
 
 //==============================================================================

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -117,7 +117,14 @@ public:
 
   Eigen::Matrix3d convertToRotation(const Eigen::Vector3d& _positions) const;
 
+  // Documentation inherited
+  Eigen::Matrix<double, 6, 3> getLocalJacobianStatic(
+      const Eigen::Vector3d& _positions) const override;
+
 protected:
+
+  using MultiDofJoint::getLocalJacobianStatic;
+
   /// Set the names of this joint's DegreesOfFreedom. Used during construction
   /// and when axis order is changed.
   virtual void updateDegreeOfFreedomNames();

--- a/dart/dynamics/FreeJoint.h
+++ b/dart/dynamics/FreeJoint.h
@@ -67,7 +67,21 @@ public:
   /// Convert a FreeJoint-style 6D vector into a transform
   static Eigen::Isometry3d convertToTransform(const Eigen::Vector6d& _positions);
 
+  // Documentation inherited
+  void setPositionsStatic(const Eigen::Vector6d& _positions) override;
+
+  // Documentation inherited
+  Eigen::Matrix6d getLocalJacobianStatic(
+      const Eigen::Vector6d& _positions) const override;
+
+  // Documentation inherited
+  Eigen::Vector6d getPositionDifferencesStatic(
+      const Eigen::Vector6d& _q0, const Eigen::Vector6d& _q1) const override;
+
 protected:
+
+  using MultiDofJoint::getLocalJacobianStatic;
+
   // Documentation inherited
   virtual void integratePositions(double _dt);
 

--- a/dart/dynamics/Joint.h
+++ b/dart/dynamics/Joint.h
@@ -410,7 +410,7 @@ public:
   /// \}
 
   //----------------------------------------------------------------------------
-  /// \{ \name Integration
+  /// \{ \name Integration and finite difference
   //----------------------------------------------------------------------------
 
   /// Integrate positions using Euler method
@@ -418,6 +418,11 @@ public:
 
   /// Integrate velocities using Euler method
   virtual void integrateVelocities(double _dt) = 0;
+
+  /// Return the difference of two generalized coordinates which are measured in
+  /// the configuration space of this Skeleton.
+  virtual Eigen::VectorXd getPositionsDifference(
+      const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const = 0;
 
   /// \}
 
@@ -486,6 +491,11 @@ public:
   /// Get generalized Jacobian from parent body node to child body node
   /// w.r.t. local generalized coordinate
   virtual const math::Jacobian getLocalJacobian() const = 0;
+
+  /// Get generalized Jacobian from parent body node to child body node
+  /// w.r.t. local generalized coordinate
+  virtual math::Jacobian getLocalJacobian(
+      const Eigen::VectorXd& _positions) const = 0;
 
   /// Get time derivative of generalized Jacobian from parent body node
   /// to child body node w.r.t. local generalized coordinate

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -211,7 +211,7 @@ public:
   // code.
 
   /// Fixed-size version of setPositions()
-  void setPositionsStatic(const Eigen::Matrix<double, DOF, 1>& _positions);
+  virtual void setPositionsStatic(const Eigen::Matrix<double, DOF, 1>& _positions);
 
   /// Fixed-size version of getPositions()
   const Eigen::Matrix<double, DOF, 1>& getPositionsStatic() const;
@@ -286,7 +286,7 @@ public:
   virtual void resetConstraintImpulses();
 
   //----------------------------------------------------------------------------
-  // Integration
+  // Integration and finite difference
   //----------------------------------------------------------------------------
 
   // Documentation inherited
@@ -294,6 +294,15 @@ public:
 
   // Documentation inherited
   virtual void integrateVelocities(double _dt);
+
+  // Documentation inherited
+  Eigen::VectorXd getPositionsDifference(
+      const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const override;
+
+  /// Fixed-size version of getPositionsDifference()
+  virtual Eigen::Matrix<double, DOF, 1> getPositionDifferencesStatic(
+      const Eigen::Matrix<double, DOF, 1>& _q0,
+      const Eigen::Matrix<double, DOF, 1>& _q1) const;
 
   //----------------------------------------------------------------------------
   /// \{ \name Passive forces - spring, viscous friction, Coulomb friction
@@ -343,6 +352,14 @@ protected:
 
   /// Fixed-size version of getLocalJacobian()
   const Eigen::Matrix<double, 6, DOF>& getLocalJacobianStatic() const;
+
+  // Documentation inherited
+  math::Jacobian getLocalJacobian(
+      const Eigen::VectorXd& _positions) const override;
+
+  /// Fixed-size version of getLocalJacobian()
+  virtual Eigen::Matrix<double, 6, DOF> getLocalJacobianStatic(
+      const Eigen::Matrix<double, DOF, 1>& _positions) const = 0;
 
   // Documentation inherited
   const math::Jacobian getLocalJacobianTimeDeriv() const override;
@@ -1506,6 +1523,32 @@ void MultiDofJoint<DOF>::integrateVelocities(double _dt)
 
 //==============================================================================
 template <size_t DOF>
+Eigen::VectorXd MultiDofJoint<DOF>::getPositionsDifference(
+    const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const
+{
+  if (static_cast<size_t>(_q0.size()) != getNumDofs()
+      || static_cast<size_t>(_q1.size()) != getNumDofs())
+  {
+    dterr << "MultiDofJoint::getPositionsDifference: q0's size[" << _q0.size()
+          << "] or q1's size[" << _q1.size() << "is different with the dof ["
+          << getNumDofs() << "]." << std::endl;
+    return Eigen::VectorXd::Zero(getNumDofs());
+  }
+
+  return getPositionDifferencesStatic(_q0, _q1);
+}
+
+//==============================================================================
+template <size_t DOF>
+Eigen::Matrix<double, DOF, 1> MultiDofJoint<DOF>::getPositionDifferencesStatic(
+    const Eigen::Matrix<double, DOF, 1>& _q0,
+    const Eigen::Matrix<double, DOF, 1>& _q1) const
+{
+  return _q1 - _q0;
+}
+
+//==============================================================================
+template <size_t DOF>
 void MultiDofJoint<DOF>::setSpringStiffness(size_t _index, double _k)
 {
   if (_index >= getNumDofs())
@@ -1657,12 +1700,7 @@ Eigen::Vector6d MultiDofJoint<DOF>::getBodyConstraintWrench() const
 template <size_t DOF>
 const math::Jacobian MultiDofJoint<DOF>::getLocalJacobian() const
 {
-  if(mIsLocalJacobianDirty)
-  {
-    updateLocalJacobian(false);
-    mIsLocalJacobianDirty = false;
-  }
-  return mJacobian;
+  return getLocalJacobianStatic();
 }
 
 //==============================================================================
@@ -1676,6 +1714,14 @@ MultiDofJoint<DOF>::getLocalJacobianStatic() const
     mIsLocalJacobianDirty = false;
   }
   return mJacobian;
+}
+
+//==============================================================================
+template <size_t DOF>
+math::Jacobian MultiDofJoint<DOF>::getLocalJacobian(
+    const Eigen::VectorXd& _positions) const
+{
+  return getLocalJacobianStatic(_positions);
 }
 
 //==============================================================================

--- a/dart/dynamics/PlanarJoint.h
+++ b/dart/dynamics/PlanarJoint.h
@@ -103,7 +103,14 @@ public:
   /// Return second translational axis
   const Eigen::Vector3d& getTranslationalAxis2() const;
 
+  // Documentation inherited
+  Eigen::Matrix<double, 6, 3> getLocalJacobianStatic(
+      const Eigen::Vector3d& _positions) const override;
+
 protected:
+
+  using MultiDofJoint::getLocalJacobianStatic;
+
   /// Set the names of this joint's DegreesOfFreedom. Used during construction
   /// and when the Plane type is changed.
   virtual void updateDegreeOfFreedomNames();

--- a/dart/dynamics/SingleDofJoint.cpp
+++ b/dart/dynamics/SingleDofJoint.cpp
@@ -746,6 +746,30 @@ void SingleDofJoint::integrateVelocities(double _dt)
 }
 
 //==============================================================================
+Eigen::VectorXd SingleDofJoint::getPositionsDifference(
+    const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const
+{
+  if (static_cast<size_t>(_q0.size()) != getNumDofs()
+      || static_cast<size_t>(_q1.size()) != getNumDofs())
+  {
+    dterr << "SingleDofJoint::getPositionsDifference: q0's size[" << _q0.size()
+          << "] or q1's size[" << _q1.size() << "is different with the dof ["
+          << getNumDofs() << "]." << std::endl;
+    return Eigen::Matrix<double, 1, 1>::Zero();
+  }
+
+  return Eigen::Matrix<double, 1, 1>::Constant(
+        getPositionDifferenceStatic(_q0[0], _q1[0]));
+}
+
+//==============================================================================
+double SingleDofJoint::getPositionDifferenceStatic(double _q0,
+                                                    double _q1) const
+{
+  return _q1 - _q0;
+}
+
+//==============================================================================
 void SingleDofJoint::setSpringStiffness(size_t _index, double _k)
 {
   if (_index != 0)
@@ -913,12 +937,7 @@ Eigen::Vector6d SingleDofJoint::getBodyConstraintWrench() const
 //==============================================================================
 const math::Jacobian SingleDofJoint::getLocalJacobian() const
 {
-  if(mIsLocalJacobianDirty)
-  {
-    updateLocalJacobian(false);
-    mIsLocalJacobianDirty = false;
-  }
-  return mJacobian;
+  return getLocalJacobianStatic();
 }
 
 //==============================================================================
@@ -930,6 +949,14 @@ const Eigen::Vector6d& SingleDofJoint::getLocalJacobianStatic() const
     mIsLocalJacobianDirty = false;
   }
   return mJacobian;
+}
+
+//==============================================================================
+math::Jacobian SingleDofJoint::getLocalJacobian(
+    const Eigen::VectorXd& /*_positions*/) const
+{
+  // The Jacobian is always constant w.r.t. the generalized coordinates.
+  return getLocalJacobianStatic();
 }
 
 //==============================================================================

--- a/dart/dynamics/SingleDofJoint.h
+++ b/dart/dynamics/SingleDofJoint.h
@@ -277,7 +277,7 @@ public:
   virtual void resetConstraintImpulses();
 
   //----------------------------------------------------------------------------
-  // Integration
+  // Integration and finite difference
   //----------------------------------------------------------------------------
 
   // Documentation inherited
@@ -285,6 +285,13 @@ public:
 
   // Documentation inherited
   virtual void integrateVelocities(double _dt);
+
+  // Documentation inherited
+  Eigen::VectorXd getPositionsDifference(
+      const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const override;
+
+  /// Fixed-size version of getPositionsDifference()
+  double getPositionDifferenceStatic(double _q0, double _q1) const;
 
   //----------------------------------------------------------------------------
   /// \{ \name Passive forces - spring, viscous friction, Coulomb friction
@@ -347,6 +354,10 @@ protected:
 
   /// Fixed-size version of getLocalJacobian()
   const Eigen::Vector6d& getLocalJacobianStatic() const;
+
+  // Documentation inherited
+  math::Jacobian getLocalJacobian(
+      const Eigen::VectorXd& _positions) const override;
 
   // Documentation inherited
   const math::Jacobian getLocalJacobianTimeDeriv() const override;

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -1160,6 +1160,55 @@ void Skeleton::integrateVelocities(double _dt)
 }
 
 //==============================================================================
+Eigen::VectorXd Skeleton::getPositionDifferences(
+    const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const
+{
+  if (static_cast<size_t>(_q0.size()) != getNumDofs()
+      || static_cast<size_t>(_q1.size()) != getNumDofs())
+  {
+    dterr << "Skeleton::getPositionsDifference: q0's size[" << _q0.size()
+          << "] or q1's size[" << _q1.size() << "is different with the dof ["
+          << getNumDofs() << "]." << std::endl;
+    return Eigen::VectorXd::Zero(getNumDofs());
+  }
+
+  Eigen::VectorXd dq(getNumDofs());
+
+  for (const auto& bodyNode : mBodyNodes)
+  {
+    const Joint* joint = bodyNode->getParentJoint();
+    const size_t dof   = joint->getNumDofs();
+
+    if (dof)
+    {
+      size_t index = joint->getDof(0)->getIndexInSkeleton();
+      const Eigen::VectorXd& q0Seg = _q0.segment(index, dof);
+      const Eigen::VectorXd& q1Seg = _q1.segment(index, dof);
+      dq.segment(index, dof) = joint->getPositionsDifference(q0Seg, q1Seg);
+    }
+  }
+
+  return dq;
+}
+
+//==============================================================================
+Eigen::VectorXd Skeleton::getVelocityDifferences(
+    const Eigen::VectorXd& _dq0, const Eigen::VectorXd& _dq1) const
+{
+  if (static_cast<size_t>(_dq0.size()) != getNumDofs()
+      || static_cast<size_t>(_dq1.size()) != getNumDofs())
+  {
+    dterr << "Skeleton::getPositionsDifference: dq0's size[" << _dq0.size()
+          << "] or dq1's size[" << _dq1.size() << "is different with the dof ["
+          << getNumDofs() << "]." << std::endl;
+    return Eigen::VectorXd::Zero(getNumDofs());
+  }
+
+  // All the tangent spaces of Joint's configuration spaces are vector spaces.
+  return _dq1 - _dq0;
+}
+
+//==============================================================================
 void Skeleton::computeForwardKinematics(bool _updateTransforms,
                                         bool _updateVels,
                                         bool _updateAccs)

--- a/dart/dynamics/Skeleton.h
+++ b/dart/dynamics/Skeleton.h
@@ -426,7 +426,7 @@ public:
   Eigen::VectorXd getJointConstraintImpulses() const;
 
   //----------------------------------------------------------------------------
-  // Integration
+  // Integration and finite difference
   //----------------------------------------------------------------------------
 
   // Documentation inherited
@@ -434,6 +434,16 @@ public:
 
   // Documentation inherited
   void integrateVelocities(double _dt);
+
+  /// Return the difference of two generalized positions which are measured in
+  /// the configuration space of this Skeleton.
+  Eigen::VectorXd getPositionDifferences(
+      const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const;
+
+  /// Return the difference of two generalized velocities or accelerations which
+  /// are measured in the tangent space at the identity.
+  Eigen::VectorXd getVelocityDifferences(
+      const Eigen::VectorXd& _dq0, const Eigen::VectorXd& _dq1) const;
 
   //----------------------------------------------------------------------------
   // State

--- a/dart/dynamics/TranslationalJoint.cpp
+++ b/dart/dynamics/TranslationalJoint.cpp
@@ -58,6 +58,14 @@ TranslationalJoint::~TranslationalJoint()
 }
 
 //==============================================================================
+Eigen::Matrix<double, 6, 3> TranslationalJoint::getLocalJacobianStatic(
+    const Eigen::Vector3d& /*_positions*/) const
+{
+  // The Jacobian is always constant w.r.t. the generalized coordinates.
+  return getLocalJacobianStatic();
+}
+
+//==============================================================================
 void TranslationalJoint::updateDegreeOfFreedomNames()
 {
   if(!mDofs[0]->isNamePreserved())
@@ -82,22 +90,13 @@ void TranslationalJoint::updateLocalTransform() const
 //==============================================================================
 void TranslationalJoint::updateLocalJacobian(bool _mandatory) const
 {
-  if(_mandatory)
+  if (_mandatory)
   {
-    Eigen::Vector6d J0;
-    Eigen::Vector6d J1;
-    Eigen::Vector6d J2;
-
-    J0 << 0, 0, 0, 1, 0, 0;
-    J1 << 0, 0, 0, 0, 1, 0;
-    J2 << 0, 0, 0, 0, 0, 1;
-
-    mJacobian.col(0) = math::AdT(mT_ChildBodyToJoint, J0);
-    mJacobian.col(1) = math::AdT(mT_ChildBodyToJoint, J1);
-    mJacobian.col(2) = math::AdT(mT_ChildBodyToJoint, J2);
+    mJacobian.bottomRows<3>() = mT_ChildBodyToJoint.linear();
 
     // Verification
-    assert(!math::isNan(mJacobian));
+    assert(mJacobian.topRows<3>() == Eigen::Matrix3d::Zero());
+    assert(!math::isNan(mJacobian.bottomRows<3>()));
   }
 }
 

--- a/dart/dynamics/TranslationalJoint.h
+++ b/dart/dynamics/TranslationalJoint.h
@@ -54,7 +54,14 @@ public:
   /// Destructor
   virtual ~TranslationalJoint();
 
+  // Documentation inherited
+  Eigen::Matrix<double, 6, 3> getLocalJacobianStatic(
+      const Eigen::Vector3d& _positions) const override;
+
 protected:
+
+  using MultiDofJoint::getLocalJacobianStatic;
+
   // Documentation inherited
   virtual void updateDegreeOfFreedomNames();
 
@@ -62,7 +69,7 @@ protected:
   virtual void updateLocalTransform() const;
 
   // Documentation inherited
-  virtual void updateLocalJacobian(bool _mandatory=true) const;
+  virtual void updateLocalJacobian(bool _mandatory = true) const;
 
   // Documentation inherited
   virtual void updateLocalJacobianTimeDeriv() const;

--- a/dart/dynamics/UniversalJoint.cpp
+++ b/dart/dynamics/UniversalJoint.cpp
@@ -89,6 +89,20 @@ const Eigen::Vector3d& UniversalJoint::getAxis2() const
 }
 
 //==============================================================================
+Eigen::Matrix<double, 6, 2> UniversalJoint::getLocalJacobianStatic(
+    const Eigen::Vector2d& _positions) const
+{
+  Eigen::Matrix<double, 6, 2> J;
+  J.col(0) = math::AdTAngular(
+               mT_ChildBodyToJoint
+               * math::expAngular(-mAxis[1] * _positions[1]),
+                                  mAxis[0]);
+  J.col(1) = math::AdTAngular(mT_ChildBodyToJoint, mAxis[1]);
+  assert(!math::isNan(J));
+  return J;
+}
+
+//==============================================================================
 void UniversalJoint::updateDegreeOfFreedomNames()
 {
   if(!mDofs[0]->isNamePreserved())
@@ -111,12 +125,7 @@ void UniversalJoint::updateLocalTransform() const
 //==============================================================================
 void UniversalJoint::updateLocalJacobian(bool) const
 {
-  mJacobian.col(0) = math::AdTAngular(
-                       mT_ChildBodyToJoint
-                       * math::expAngular(-mAxis[1] * getPositionsStatic()[1]),
-                                          mAxis[0]);
-  mJacobian.col(1) = math::AdTAngular(mT_ChildBodyToJoint, mAxis[1]);
-  assert(!math::isNan(mJacobian));
+  mJacobian = getLocalJacobianStatic(getPositionsStatic());
 }
 
 //==============================================================================

--- a/dart/dynamics/UniversalJoint.h
+++ b/dart/dynamics/UniversalJoint.h
@@ -70,7 +70,14 @@ public:
   ///
   const Eigen::Vector3d& getAxis2() const;
 
+  // Documentation inherited
+  Eigen::Matrix<double, 6, 2> getLocalJacobianStatic(
+      const Eigen::Vector2d& _positions) const override;
+
 protected:
+
+  using MultiDofJoint::getLocalJacobianStatic;
+
   // Documentation inherited
   virtual void updateDegreeOfFreedomNames();
 

--- a/dart/dynamics/ZeroDofJoint.cpp
+++ b/dart/dynamics/ZeroDofJoint.cpp
@@ -395,7 +395,15 @@ void ZeroDofJoint::integratePositions(double _dt)
 //==============================================================================
 void ZeroDofJoint::integrateVelocities(double _dt)
 {
-    // Do nothing
+  // Do nothing
+}
+
+//==============================================================================
+Eigen::VectorXd ZeroDofJoint::getPositionsDifference(
+    const Eigen::VectorXd& /*_q0*/,
+    const Eigen::VectorXd& /*_q1*/) const
+{
+  return Eigen::VectorXd::Zero(0);
 }
 
 //==============================================================================
@@ -467,6 +475,13 @@ Eigen::Vector6d ZeroDofJoint::getBodyConstraintWrench() const
 
 //==============================================================================
 const math::Jacobian ZeroDofJoint::getLocalJacobian() const
+{
+  return Eigen::Matrix<double, 6, 0>();
+}
+
+//==============================================================================
+math::Jacobian ZeroDofJoint::getLocalJacobian(
+    const Eigen::VectorXd& /*_positions*/) const
 {
   return Eigen::Matrix<double, 6, 0>();
 }

--- a/dart/dynamics/ZeroDofJoint.h
+++ b/dart/dynamics/ZeroDofJoint.h
@@ -250,7 +250,7 @@ public:
   virtual void resetConstraintImpulses();
 
   //----------------------------------------------------------------------------
-  // Integration
+  // Integration and finite difference
   //----------------------------------------------------------------------------
 
   // Documentation inherited
@@ -258,6 +258,10 @@ public:
 
   // Documentation inherited
   virtual void integrateVelocities(double _dt);
+
+  // Documentation inherited
+  Eigen::VectorXd getPositionsDifference(
+      const Eigen::VectorXd& _q0, const Eigen::VectorXd& _q1) const override;
 
   //----------------------------------------------------------------------------
   /// \{ \name Passive forces - spring, viscous friction, Coulomb friction
@@ -308,6 +312,10 @@ protected:
 
   // Documentation inherited
   virtual const math::Jacobian getLocalJacobian() const override;
+
+  // Documentation inherited
+  math::Jacobian getLocalJacobian(
+      const Eigen::VectorXd& _positions) const override;
 
   // Documentation inherited
   virtual const math::Jacobian getLocalJacobianTimeDeriv() const override;

--- a/unittests/testDynamics.cpp
+++ b/unittests/testDynamics.cpp
@@ -80,9 +80,13 @@ public:
   // difference.
   void testJacobians(const std::string& _fileName);
 
+  // Compare velocities and accelerations with actual vaules and approximates
+  // using finite differece method.
+  void testFiniteDifferenceGeneralizedCoordinates(const std::string& _fileName);
+
   // Compare accelerations computed by recursive method, Jacobian, and finite
   // difference.
-  void testFiniteDifference(const std::string& _fileName);
+  void testFiniteDifferenceBodyNodeAcceleration(const std::string& _fileName);
 
   // Compare dynamics terms in equations of motion such as mass matrix, mass
   // inverse matrix, Coriolis force vector, gravity force vector, and external
@@ -653,7 +657,111 @@ void DynamicsTest::testJacobians(const std::string& _fileName)
 }
 
 //==============================================================================
-void DynamicsTest::testFiniteDifference(const std::string& _fileName)
+void DynamicsTest::testFiniteDifferenceGeneralizedCoordinates(
+    const std::string& _fileName)
+{
+  using namespace std;
+  using namespace Eigen;
+  using namespace dart;
+  using namespace math;
+  using namespace dynamics;
+  using namespace simulation;
+  using namespace utils;
+
+  //----------------------------- Settings -------------------------------------
+#ifndef NDEBUG  // Debug mode
+  int nRandomItr = 2;
+#else
+  int nRandomItr = 10;
+#endif
+  double qLB   = -0.5 * DART_PI;
+  double qUB   =  0.5 * DART_PI;
+  double dqLB  = -0.3 * DART_PI;
+  double dqUB  =  0.3 * DART_PI;
+  double ddqLB = -0.1 * DART_PI;
+  double ddqUB =  0.1 * DART_PI;
+  Vector3d gravity(0.0, -9.81, 0.0);
+  double timeStep = 1e-3;
+
+  // load skeleton
+  World* world = SkelParser::readWorld(_fileName);
+  assert(world != NULL);
+  world->setGravity(gravity);
+  world->setTimeStep(timeStep);
+
+  //------------------------------ Tests ---------------------------------------
+  for (size_t i = 0; i < world->getNumSkeletons(); ++i)
+  {
+    Skeleton* skeleton = world->getSkeleton(i);
+    assert(skeleton != NULL);
+    int dof = skeleton->getNumDofs();
+
+    for (int j = 0; j < nRandomItr; ++j)
+    {
+      // Generate a random state and ddq
+      VectorXd q0   = VectorXd(dof);
+      VectorXd dq0  = VectorXd(dof);
+      VectorXd ddq0 = VectorXd(dof);
+      for (int k = 0; k < dof; ++k)
+      {
+        q0[k]   = math::random(qLB,   qUB);
+        dq0[k]  = math::random(dqLB,  dqUB);
+        ddq0[k] = math::random(ddqLB, ddqUB);
+      }
+
+      skeleton->setPositions(q0);
+      skeleton->setVelocities(dq0);
+      skeleton->setAccelerations(ddq0);
+
+      skeleton->integratePositions(timeStep);
+      VectorXd q1 = skeleton->getPositions();
+      skeleton->integrateVelocities(timeStep);
+      VectorXd dq1 = skeleton->getVelocities();
+
+      skeleton->integratePositions(timeStep);
+      VectorXd q2 = skeleton->getPositions();
+      skeleton->integrateVelocities(timeStep);
+      VectorXd dq2 = skeleton->getVelocities();
+
+      VectorXd dq0FD = (q1 - q0) / timeStep;
+      VectorXd dq1FD = (q2 - q1) / timeStep;
+      VectorXd ddqFD1 = (dq1FD - dq0FD) / timeStep;
+      VectorXd ddqFD2 = (dq2 - dq1) / timeStep;
+
+      EXPECT_TRUE(equals(dq0, dq0FD));
+      EXPECT_TRUE(equals(dq1, dq1FD));
+      EXPECT_TRUE(equals(ddq0, ddqFD1));
+      EXPECT_TRUE(equals(ddq0, ddqFD2));
+
+      if (!equals(dq0FD, dq0))
+      {
+        std::cout << "dq0  : " << dq0.transpose() << std::endl;
+        std::cout << "dq0FD: " << dq0FD.transpose() << std::endl;
+      }
+      if (!equals(dq1, dq1FD))
+      {
+        std::cout << "dq1  : " << dq1.transpose() << std::endl;
+        std::cout << "dq1FD: " << dq1FD.transpose() << std::endl;
+      }
+      if (!equals(ddq0, ddqFD1))
+      {
+        std::cout << "ddq0  : " << ddq0.transpose() << std::endl;
+        std::cout << "ddqFD1: " << ddqFD1.transpose() << std::endl;
+      }
+      if (!equals(ddq0, ddqFD2))
+      {
+        std::cout << "ddq0  : " << ddq0.transpose() << std::endl;
+        std::cout << "ddqFD2: " << ddqFD2.transpose() << std::endl;
+      }
+    }
+  }
+
+  delete world;
+}
+
+//==============================================================================
+void DynamicsTest::testFiniteDifferenceBodyNodeAcceleration(
+    const std::string& _fileName)
 {
   using namespace std;
   using namespace Eigen;
@@ -703,10 +811,6 @@ void DynamicsTest::testFiniteDifference(const std::string& _fileName)
         q[k]   = math::random(qLB,   qUB);
         dq[k]  = math::random(dqLB,  dqUB);
         ddq[k] = math::random(ddqLB, ddqUB);
-
-//        q[k]   = 0.0;
-//        dq[k]  = 0.0;
-//        ddq[k] = 0.0;
       }
 
       VectorXd qNext  =  q +  dq * timeStep;
@@ -1546,7 +1650,8 @@ TEST_F(DynamicsTest, testFiniteDifference)
 #ifndef NDEBUG
     dtdbg << getList()[i] << std::endl;
 #endif
-    testFiniteDifference(getList()[i]);
+    testFiniteDifferenceGeneralizedCoordinates(getList()[i]);
+    testFiniteDifferenceBodyNodeAcceleration(getList()[i]);
   }
 }
 

--- a/unittests/testDynamics.cpp
+++ b/unittests/testDynamics.cpp
@@ -723,10 +723,10 @@ void DynamicsTest::testFiniteDifferenceGeneralizedCoordinates(
       skeleton->integrateVelocities(timeStep);
       VectorXd dq2 = skeleton->getVelocities();
 
-      VectorXd dq0FD = (q1 - q0) / timeStep;
-      VectorXd dq1FD = (q2 - q1) / timeStep;
-      VectorXd ddqFD1 = (dq1FD - dq0FD) / timeStep;
-      VectorXd ddqFD2 = (dq2 - dq1) / timeStep;
+      VectorXd dq0FD = skeleton->getPositionDifferences(q0, q1) / timeStep;
+      VectorXd dq1FD = skeleton->getPositionDifferences(q1, q2) / timeStep;
+      VectorXd ddqFD1 = skeleton->getVelocityDifferences(dq0FD, dq1FD) / timeStep;
+      VectorXd ddqFD2 = skeleton->getVelocityDifferences(dq1, dq2) / timeStep;
 
       EXPECT_TRUE(equals(dq0, dq0FD));
       EXPECT_TRUE(equals(dq1, dq1FD));


### PR DESCRIPTION
This pull request provides useful API for computing generalized velocity or acceleration using finite difference method. Previously, the finite differences for BallJoint and FreeJoint required special treatment that might not be straightforward.

Example code (when the root Joint is FreeJoint or BallJoint):
```cpp
// time step and recorded generalized positions
double h = mWorld->getTimeStep();
Eigen::VectorXd q0 = mWorld->getRecording()->getConfig(49, 0);
Eigen::VectorXd q1 = mWorld->getRecording()->getConfig(50, 0);
Eigen::VectorXd q2 = mWorld->getRecording()->getConfig(51, 0);

// Old API
Eigen::VectorXd q_old = skeleton->getPositions();

skeleton->setPositions(q0);
Eigen::MatrixXd Jw0 = skeleton->getJoint(0)->getLocalJacobian().topLeftCorner<3,3>();
Eigen::VectorXd dq0 = (q1 - q0) / h; 
Eigen::Vector3d dq0_root = Jw0.inverse() * math::logMap(dart::math::expMapRot(-q0.head<3>()) * math::expMapRot(q1.head<3>())) / h;
dq0.head(3) = dq0_root;

skeleton->setPositions(q1);
Eigen::MatrixXd Jw1 = skeleton->getJoint(0)->getLocalJacobian().topLeftCorner<3,3>();
Eigen::VectorXd dq1 = (q2 - q1) / h; 
Eigen::Vector3d qd1_root = Jw1.inverse() * math::logMap(dart::math::expMapRot(-q.head<3>()) * math::expMapRot(postq.head(3))) / h;
dq1.head(3) = rootRotation;

Eigen::VectorXd ddq = (dq1 - dq0) / h;

skeleton->setPositions(q_old);

// New API
Eigen::VectorXd dq0 = skeleton->getPositionDifferences(q0, q1) / h;
Eigen::VectorXd dq1 = skeleton->getPositionDifferences(q1, q2) / h;
Eigen::VectorXd ddq = skeleton->getVelocityDifferences(dq0, dq1) / h;
```

Also, getting differences from a Skeleton with new generalized coordinates does not affect on the Skeleton's generalized coordinates so that we don't need to backup.

Resolves #290.
