### PR TITLE
Fixed the range check in getRootBodyNode.

### DIFF
--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -379,7 +379,7 @@ static T getVectorObjectIfAvailable(size_t _idx, const std::vector<T>& _vec)
 //==============================================================================
 BodyNode* Skeleton::getRootBodyNode(size_t _treeIdx)
 {
-  if( mTreeCache.size() <= _treeIdx)
+  if( mTreeCache.size() > _treeIdx)
     return mTreeCache[_treeIdx].mBodyNodes[0];
 
   if(mTreeCache.size() == 0)


### PR DESCRIPTION
This pull request fixes a bug in the range check in `Skeleton::getRootBodyNode`. The condition was inverted, which made it impossible to call this function.