### PR TITLE
Added virtual destructors to joint properties.

### DIFF
--- a/dart/dynamics/BallJoint.h
+++ b/dart/dynamics/BallJoint.h
@@ -55,6 +55,7 @@ public:
   {
     Properties(const MultiDofJoint<3>::Properties& _properties =
                                                 MultiDofJoint<3>::Properties());
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -65,6 +65,8 @@ public:
 
     /// Constructor
     UniqueProperties(AxisOrder _axisOrder = AO_XYZ);
+
+    virtual ~UniqueProperties() = default;
   };
 
   struct Properties : MultiDofJoint<3>::Properties, EulerJoint::UniqueProperties
@@ -75,6 +77,8 @@ public:
                                                 MultiDofJoint<3>::Properties(),
         const EulerJoint::UniqueProperties& _eulerJointProperties =
                                                 EulerJoint::UniqueProperties());
+
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/FreeJoint.h
+++ b/dart/dynamics/FreeJoint.h
@@ -57,6 +57,8 @@ public:
   {
     Properties(const MultiDofJoint<6>::Properties& _properties =
                                                 MultiDofJoint<6>::Properties());
+
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/Joint.h
+++ b/dart/dynamics/Joint.h
@@ -145,6 +145,8 @@ public:
                                    Eigen::Isometry3d::Identity(),
                bool _isPositionLimited = false,
                ActuatorType _actuatorType = DefaultActuatorType);
+
+    virtual ~Properties() = default;
   };
 
   /// Default actuator type
@@ -911,6 +913,8 @@ class TemplateJointPtr
 public:
 
   template<class, class> friend class TemplateJointPtr;
+
+  typedef JointT element_type;
 
   /// Default constructor
   TemplateJointPtr() = default;

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -121,6 +121,8 @@ public:
       const Vector& _restPosition = Vector::Constant(0.0),
       const Vector& _dampingCoefficient = Vector::Constant(0.0),
       const Vector& _coulombFrictions = Vector::Constant(0.0));
+
+    virtual ~UniqueProperties() = default;
   };
 
   struct Properties : Joint::Properties, UniqueProperties
@@ -128,6 +130,8 @@ public:
     Properties(
         const Joint::Properties& _jointProperties = Joint::Properties(),
         const UniqueProperties& _multiDofProperties = UniqueProperties());
+
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/PlanarJoint.h
+++ b/dart/dynamics/PlanarJoint.h
@@ -95,6 +95,8 @@ public:
     UniqueProperties(const Eigen::Vector3d& _transAxis1,
                      const Eigen::Vector3d& _transAxis2);
 
+    virtual ~UniqueProperties() = default;
+
     /// Set plane type as XY-plane
     void setXYPlane();
 
@@ -115,6 +117,8 @@ public:
                                               MultiDofJoint<3>::Properties(),
                const PlanarJoint::UniqueProperties& _planarProperties =
                                               PlanarJoint::UniqueProperties());
+
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/PrismaticJoint.h
+++ b/dart/dynamics/PrismaticJoint.h
@@ -58,6 +58,7 @@ public:
     Eigen::Vector3d mAxis;
 
     UniqueProperties(const Eigen::Vector3d& _axis = Eigen::Vector3d::UnitZ());
+    virtual ~UniqueProperties() = default;
   };
 
   struct Properties : SingleDofJoint::Properties,
@@ -68,6 +69,7 @@ public:
                                             SingleDofJoint::Properties(),
         const PrismaticJoint::UniqueProperties& _prismaticProperties =
                                             PrismaticJoint::UniqueProperties());
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/RevoluteJoint.h
+++ b/dart/dynamics/RevoluteJoint.h
@@ -58,6 +58,8 @@ public:
     Eigen::Vector3d mAxis;
 
     UniqueProperties(const Eigen::Vector3d& _axis = Eigen::Vector3d::UnitZ());
+
+    virtual ~UniqueProperties() = default;
   };
 
   struct Properties : SingleDofJoint::Properties,
@@ -68,6 +70,8 @@ public:
                                             SingleDofJoint::Properties(),
         const RevoluteJoint::UniqueProperties& _revoluteProperties =
                                             RevoluteJoint::UniqueProperties());
+
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/ScrewJoint.h
+++ b/dart/dynamics/ScrewJoint.h
@@ -63,6 +63,7 @@ public:
 
     UniqueProperties(const Eigen::Vector3d& _axis = Eigen::Vector3d::UnitZ(),
                      double _pitch = 0.1);
+    virtual ~UniqueProperties() = default;
   };
 
   struct Properties : SingleDofJoint::Properties,
@@ -73,6 +74,7 @@ public:
                                               SingleDofJoint::Properties(),
         const ScrewJoint::UniqueProperties& _screwProperties =
                                               ScrewJoint::UniqueProperties());
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/SingleDofJoint.h
+++ b/dart/dynamics/SingleDofJoint.h
@@ -112,6 +112,8 @@ public:
                      double _coulombFriction = 0.0,
                      bool _preserveDofName = false,
                      std::string _dofName = "");
+
+    virtual ~UniqueProperties() = default;
   };
 
   struct Properties : Joint::Properties, UniqueProperties
@@ -119,6 +121,8 @@ public:
     Properties(
         const Joint::Properties& _jointProperties = Joint::Properties(),
         const UniqueProperties& _singleDofProperties = UniqueProperties());
+
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/TranslationalJoint.h
+++ b/dart/dynamics/TranslationalJoint.h
@@ -55,6 +55,7 @@ public:
   {
     Properties(const MultiDofJoint<3>::Properties& _properties =
                                                 MultiDofJoint<3>::Properties());
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/UniversalJoint.h
+++ b/dart/dynamics/UniversalJoint.h
@@ -59,6 +59,8 @@ public:
 
     UniqueProperties(const Eigen::Vector3d& _axis1 = Eigen::Vector3d::UnitX(),
                      const Eigen::Vector3d& _axis2 = Eigen::Vector3d::UnitY());
+
+    virtual ~UniqueProperties() = default;
   };
 
   struct Properties : MultiDofJoint<2>::Properties,
@@ -68,6 +70,7 @@ public:
                                             MultiDofJoint<2>::Properties(),
                const UniversalJoint::UniqueProperties& _universalProperties =
                                             UniversalJoint::UniqueProperties());
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/WeldJoint.h
+++ b/dart/dynamics/WeldJoint.h
@@ -56,6 +56,7 @@ public:
   struct Properties : ZeroDofJoint::Properties
   {
     Properties(const Joint::Properties& _properties = Joint::Properties());
+    virtual ~Properties() = default;
   };
 
   /// Constructor

--- a/dart/dynamics/ZeroDofJoint.h
+++ b/dart/dynamics/ZeroDofJoint.h
@@ -55,6 +55,7 @@ public:
   struct Properties : Joint::Properties
   {
     Properties(const Joint::Properties& _properties = Joint::Properties());
+    virtual ~Properties() = default;
   };
 
   /// Constructor


### PR DESCRIPTION
This pull request adds default virtual constructors to all joint `Properties` classes. These classes are polymorphic, so this is generally a good idea from a safety perspective. This is also necessary for RTTI to work on these classes (which we need to create Python bindings).