### PR TITLE
Remove GL_ACCUM flag from SimWindow

### DIFF
--- a/dart/gui/GlutWindow.cpp
+++ b/dart/gui/GlutWindow.cpp
@@ -80,8 +80,7 @@ void GlutWindow::initWindow(int _w, int _h, const char* _name) {
   mWinWidth = _w;
   mWinHeight = _h;
 
-  glutInitDisplayMode(GLUT_DEPTH | GLUT_DOUBLE |GLUT_RGBA  | GLUT_STENCIL
-                      | GLUT_ACCUM);
+  glutInitDisplayMode(GLUT_DEPTH | GLUT_DOUBLE | GLUT_RGBA | GLUT_STENCIL);
   glutInitWindowPosition(150, 100);
   glutInitWindowSize(_w, _h);
   mWinIDs.push_back(glutCreateWindow(_name));


### PR DESCRIPTION
This pull request removes the `GL_ACCUM` flag from `SimWindow`. This flag was depcreated in OpenGL 3.1 and is not supported in Parallels VM.

Does anything in `dart::rendering` uses accumulation buffers? If not, can we remove this flag?
