### PR TITLE
Store path to mesh in MeshShape

### DIFF
--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -129,9 +129,9 @@ aiMaterial::~aiMaterial()
 namespace dart {
 namespace dynamics {
 
-MeshShape::MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh)
+MeshShape::MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh,
+                     const std::string &_path)
   : Shape(MESH),
-    mMesh(_mesh),
     mDisplayList(0),
     mScale(_scale)
 {
@@ -139,9 +139,11 @@ MeshShape::MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh)
   assert(_scale[1] > 0.0);
   assert(_scale[2] > 0.0);
 
-  if(nullptr == mMesh)
-    return;
+  setMesh(_mesh, _path);
 
+  if (nullptr == mMesh) {
+    return;
+  }
   _updateBoundingBoxDim();
   computeVolume();
   initMeshes();
@@ -155,12 +157,20 @@ const aiScene* MeshShape::getMesh() const {
   return mMesh;
 }
 
-void MeshShape::setMesh(const aiScene* _mesh) {
+const std::string &MeshShape::getMeshPath() const
+{
+  return mMeshPath;
+}
+
+void MeshShape::setMesh(const aiScene* _mesh, const std::string &_path) {
   mMesh = _mesh;
 
-  if(nullptr == _mesh)
+  if(nullptr == _mesh) {
+    mMeshPath = "";
     return;
+  }
 
+  mMeshPath = _path;
   _updateBoundingBoxDim();
   computeVolume();
 }

--- a/dart/dynamics/MeshShape.h
+++ b/dart/dynamics/MeshShape.h
@@ -51,7 +51,8 @@ namespace dynamics {
 class MeshShape : public Shape {
 public:
   /// \brief Constructor.
-  MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh);
+  MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh,
+            const std::string &path = std::string());
 
   /// \brief Destructor.
   virtual ~MeshShape();
@@ -60,7 +61,10 @@ public:
   const aiScene* getMesh() const;
 
   /// \brief
-  void setMesh(const aiScene* _mesh);
+  void setMesh(const aiScene* _mesh, const std::string &path = std::string());
+
+  /// \brief Path to the mesh on disk; an empty string if unavailable.
+  const std::string &getMeshPath() const;
 
   /// \brief
   void setScale(const Eigen::Vector3d& _scale);
@@ -96,6 +100,9 @@ private:
 protected:
   /// \brief
   const aiScene* mMesh;
+
+  /// \brief
+  std::string mMeshPath;
 
   /// \brief OpenGL DisplayList id for rendering
   int mDisplayList;

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -552,7 +552,7 @@ dynamics::ShapePtr DartLoader::createShape(const VisualOrCollision* _vizOrCol)
     else
     {
       shape = dynamics::ShapePtr(new dynamics::MeshShape(
-          Eigen::Vector3d(mesh->scale.x, mesh->scale.y, mesh->scale.z), model));
+          Eigen::Vector3d(mesh->scale.x, mesh->scale.y, mesh->scale.z), model, fullPath));
     }
   }
   // Unknown geometry type


### PR DESCRIPTION
This pull request adds a `getMeshPath` method to `MeshShape`. This returns the path to mesh on disk if it is available. If not, it returns an empty string (the default behavior).

This information is necessary to render meshes with non-embedded textures. Assimp references external textures with a path relative to the directory containing the mesh.