### PR TITLE
Multisample anti-aliasing

### DIFF
--- a/dart/gui/GlutWindow.cpp
+++ b/dart/gui/GlutWindow.cpp
@@ -80,8 +80,8 @@ void GlutWindow::initWindow(int _w, int _h, const char* _name) {
   mWinWidth = _w;
   mWinHeight = _h;
 
-  glutInitDisplayMode(GLUT_DEPTH | GLUT_DOUBLE |GLUT_RGBA  | GLUT_STENCIL
-                      | GLUT_ACCUM);
+  glutInitDisplayMode(GLUT_DEPTH | GLUT_DOUBLE | GLUT_RGBA | GLUT_STENCIL
+                      | GLUT_MULTISAMPLE);
   glutInitWindowPosition(150, 100);
   glutInitWindowSize(_w, _h);
   mWinIDs.push_back(glutCreateWindow(_name));
@@ -99,6 +99,8 @@ void GlutWindow::initWindow(int _w, int _h, const char* _name) {
   mRI->initialize();
   // glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
   // glutTimerFunc(mDisplayTimeout, runTimer, 0);
+
+  glDisable(GL_MULTISAMPLE);
 }
 
 void GlutWindow::reshape(int _w, int _h) {

--- a/dart/gui/GlutWindow.cpp
+++ b/dart/gui/GlutWindow.cpp
@@ -80,8 +80,7 @@ void GlutWindow::initWindow(int _w, int _h, const char* _name) {
   mWinWidth = _w;
   mWinHeight = _h;
 
-  glutInitDisplayMode(GLUT_DEPTH | GLUT_DOUBLE | GLUT_RGBA | GLUT_STENCIL
-                      | GLUT_MULTISAMPLE);
+  glutInitDisplayMode(GLUT_DEPTH | GLUT_DOUBLE | GLUT_RGBA | GLUT_MULTISAMPLE);
   glutInitWindowPosition(150, 100);
   glutInitWindowSize(_w, _h);
   mWinIDs.push_back(glutCreateWindow(_name));

--- a/dart/gui/Win3D.cpp
+++ b/dart/gui/Win3D.cpp
@@ -176,7 +176,7 @@ void Win3D::render() {
 
   mTrackBall.applyGLRotation();
 
-  // Drwa origin indicator
+  // Draw world origin indicator
   if (!mCapture)
   {
     glEnable(GL_DEPTH_TEST);
@@ -210,7 +210,7 @@ void Win3D::render() {
   initLights();
   draw();
 
-  // Trackball indicator
+  // Draw trackball indicator
   if (mRotate && !mCapture)
     mTrackBall.draw(mWinWidth, mWinHeight);
 

--- a/dart/gui/Win3D.cpp
+++ b/dart/gui/Win3D.cpp
@@ -96,6 +96,10 @@ void Win3D::keyboard(unsigned char _key, int _x, int _y) {
     case 'c':
     case 'C':  // screen capture
       mCapture = !mCapture;
+      if (mCapture)
+        glEnable(GL_MULTISAMPLE);
+      else
+        glDisable(GL_MULTISAMPLE);
       break;
     case 27:  // ESC
       exit(0);
@@ -159,13 +163,6 @@ void Win3D::drag(int _x, int _y) {
 }
 
 void Win3D::render() {
-  if (mCapture) {
-    capturing();
-    glutSwapBuffers();
-    screenshot();
-    return;
-  }
-
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
   gluPerspective(mPersp,
@@ -179,39 +176,48 @@ void Win3D::render() {
 
   mTrackBall.applyGLRotation();
 
-  glEnable(GL_DEPTH_TEST);
-  glDisable(GL_TEXTURE_2D);
-  glDisable(GL_LIGHTING);
-  glLineWidth(2.0);
-  if (mRotate || mTranslate || mZooming) {
-    glColor3f(1.0f, 0.0f, 0.0f);
-    glBegin(GL_LINES);
-    glVertex3f(-0.1f, 0.0f, -0.0f);
-    glVertex3f(0.15f, 0.0f, -0.0f);
-    glEnd();
+  // Drwa origin indicator
+  if (!mCapture)
+  {
+    glEnable(GL_DEPTH_TEST);
+    glDisable(GL_TEXTURE_2D);
+    glDisable(GL_LIGHTING);
+    glLineWidth(2.0);
+    if (mRotate || mTranslate || mZooming) {
+      glColor3f(1.0f, 0.0f, 0.0f);
+      glBegin(GL_LINES);
+      glVertex3f(-0.1f, 0.0f, -0.0f);
+      glVertex3f(0.15f, 0.0f, -0.0f);
+      glEnd();
 
-    glColor3f(0.0f, 1.0f, 0.0f);
-    glBegin(GL_LINES);
-    glVertex3f(0.0f, -0.1f, 0.0f);
-    glVertex3f(0.0f, 0.15f, 0.0f);
-    glEnd();
+      glColor3f(0.0f, 1.0f, 0.0f);
+      glBegin(GL_LINES);
+      glVertex3f(0.0f, -0.1f, 0.0f);
+      glVertex3f(0.0f, 0.15f, 0.0f);
+      glEnd();
 
-    glColor3f(0.0f, 0.0f, 1.0f);
-    glBegin(GL_LINES);
-    glVertex3f(0.0f, 0.0f, -0.1f);
-    glVertex3f(0.0f, 0.0f, 0.15f);
-    glEnd();
+      glColor3f(0.0f, 0.0f, 1.0f);
+      glBegin(GL_LINES);
+      glVertex3f(0.0f, 0.0f, -0.1f);
+      glVertex3f(0.0f, 0.0f, 0.15f);
+      glEnd();
+    }
   }
+
   glScalef(mZoom, mZoom, mZoom);
   glTranslatef(mTrans[0]*0.001, mTrans[1]*0.001, mTrans[2]*0.001);
 
   initLights();
   draw();
 
-  if (mRotate)
+  // Trackball indicator
+  if (mRotate && !mCapture)
     mTrackBall.draw(mWinWidth, mWinHeight);
 
   glutSwapBuffers();
+
+  if (mCapture)
+    screenshot();
 }
 
 void Win3D::initGL() {
@@ -261,6 +267,7 @@ void Win3D::initLights() {
   glEnable(GL_NORMALIZE);
 }
 
+// Remove once deprecated function, capturing(), is removed
 void accFrustum(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top,
                 GLdouble nearPlane, GLdouble farPlane,
                 GLdouble pixdx, GLdouble pixdy, GLdouble eyedx, GLdouble eyedy,
@@ -285,6 +292,7 @@ void accFrustum(GLdouble left, GLdouble right, GLdouble bottom, GLdouble top,
   glTranslatef(-eyedx, -eyedy, 0.0);
 }
 
+// Remove once deprecated function, capturing(), is removed
 void accPerspective(GLdouble fovy, GLdouble aspect,
                     GLdouble nearPlane, GLdouble farPlane,
                     GLdouble pixdx, GLdouble pixdy,

--- a/dart/gui/Win3D.h
+++ b/dart/gui/Win3D.h
@@ -39,6 +39,7 @@
 
 #include <Eigen/Eigen>
 
+#include "dart/common/Deprecated.h"
 #include "dart/gui/GlutWindow.h"
 #include "dart/gui/Trackball.h"
 
@@ -57,6 +58,7 @@ public:
   virtual void click(int _button, int _state, int _x, int _y);
   virtual void drag(int _x, int _y);
 
+  DEPRECATED(5.0)
   virtual void capturing();
   virtual void initGL();
   virtual void initLights();


### PR DESCRIPTION
This pull request replaces our own multisample anti-aliasing implementation with [the built-in method in OpenGL](https://www.opengl.org/wiki/Multisampling#Rendering_with_Multisampling), and removes the use of accumulation buffer, which is [deprecated in OpenGL 3.0](https://www.opengl.org/wiki/History_of_OpenGL#Deprecation_Model).

Also, `GLUT_STENCIL` flag is removed since it's not used anywhere.