### PR TITLE
Fixed bug with renaming Joints and created regression test

### DIFF
--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -130,15 +130,16 @@ const std::string& Joint::setName(const std::string& _name, bool _renameDofs)
   {
     skel->mNameMgrForJoints.removeName(mJointP.mName);
     mJointP.mName = _name;
-    skel->addEntryToJointNameMgr(this);
+
+    skel->addEntryToJointNameMgr(this, _renameDofs);
   }
   else
   {
     mJointP.mName = _name;
-  }
 
-  if (_renameDofs)
-    updateDegreeOfFreedomNames();
+    if (_renameDofs)
+      updateDegreeOfFreedomNames();
+  }
 
   return mJointP.mName;
 }

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -214,11 +214,14 @@ const std::string& Skeleton::addEntryToBodyNodeNameMgr(BodyNode* _newNode)
 }
 
 //==============================================================================
-const std::string& Skeleton::addEntryToJointNameMgr(Joint* _newJoint)
+const std::string& Skeleton::addEntryToJointNameMgr(Joint* _newJoint,
+                                                    bool _updateDofNames)
 {
   _newJoint->mJointP.mName =
       mNameMgrForJoints.issueNewNameAndAdd(_newJoint->getName(), _newJoint);
-  _newJoint->updateDegreeOfFreedomNames();
+
+  if(_updateDofNames)
+    _newJoint->updateDegreeOfFreedomNames();
 
   return _newJoint->mJointP.mName;
 }

--- a/dart/dynamics/Skeleton.h
+++ b/dart/dynamics/Skeleton.h
@@ -981,7 +981,7 @@ protected:
   const std::string& addEntryToBodyNodeNameMgr(BodyNode* _newNode);
 
   /// Add a Joint to to the Joint NameManager
-  const std::string& addEntryToJointNameMgr(Joint* _newJoint);
+  const std::string& addEntryToJointNameMgr(Joint* _newJoint, bool _updateDofNames=true);
 
   /// Add a SoftBodyNode to the SoftBodyNode NameManager
   void addEntryToSoftBodyNodeNameMgr(SoftBodyNode* _newNode);

--- a/unittests/testNameManagement.cpp
+++ b/unittests/testNameManagement.cpp
@@ -347,6 +347,40 @@ TEST(NameManagement, WorldSimpleFrames)
 }
 
 //==============================================================================
+TEST(NameManagement, JointDegreeOfFreedom)
+{
+  SkeletonPtr subtree = Skeleton::create("subtree");
+  EulerJoint::Properties jointProperties;
+  jointProperties.mName = "j_bicep_right";
+  JointPtr joint = subtree->createJointAndBodyNodePair<EulerJoint>(
+        nullptr, jointProperties).first;
+  std::string newName = "j_bicep_right_inverse";
+
+  EXPECT_TRUE( joint->getDof(0)->getName() == "j_bicep_right_x" );
+  EXPECT_TRUE( joint->getDof(1)->getName() == "j_bicep_right_y" );
+  EXPECT_TRUE( joint->getDof(2)->getName() == "j_bicep_right_z" );
+
+  joint->setName(newName, false);
+
+  EXPECT_TRUE( joint->getDof(0)->getName() == "j_bicep_right_x" );
+  EXPECT_TRUE( joint->getDof(1)->getName() == "j_bicep_right_y" );
+  EXPECT_TRUE( joint->getDof(2)->getName() == "j_bicep_right_z" );
+
+  joint->setName(newName, true);
+
+  EXPECT_TRUE( joint->getDof(0)->getName() == "j_bicep_right_inverse_x" );
+  EXPECT_TRUE( joint->getDof(1)->getName() == "j_bicep_right_inverse_y" );
+  EXPECT_TRUE( joint->getDof(2)->getName() == "j_bicep_right_inverse_z" );
+
+  newName = "j_bicep_left";
+  joint->setName(newName, true);
+
+  EXPECT_TRUE( joint->getDof(0)->getName() == "j_bicep_left_x" );
+  EXPECT_TRUE( joint->getDof(1)->getName() == "j_bicep_left_y" );
+  EXPECT_TRUE( joint->getDof(2)->getName() == "j_bicep_left_z" );
+}
+
+//==============================================================================
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
A bug was found where renaming a Joint would always alter the DegreeOfFreedom names, even when the user told them not to be renamed. This pull request fixes that issue and introduces a regression test to prevent it from happening again.