### PR TITLE
Eigen aligned memory allocator

### DIFF
--- a/dart/constraint/ContactConstraint.h
+++ b/dart/constraint/ContactConstraint.h
@@ -172,10 +172,10 @@ private:
   double mRestitutionCoeff;
 
   /// Local body jacobians for mBodyNode1
-  std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d> > mJacobians1;
+  Eigen::aligned_vector<Eigen::Vector6d> mJacobians1;
 
   /// Local body jacobians for mBodyNode2
-  std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d> > mJacobians2;
+  Eigen::aligned_vector<Eigen::Vector6d> mJacobians2;
 
   ///
   bool mIsFrictionOn;

--- a/dart/constraint/SoftContactConstraint.h
+++ b/dart/constraint/SoftContactConstraint.h
@@ -209,10 +209,10 @@ private:
   double mRestitutionCoeff;
 
   /// Local body jacobians for mBodyNode1
-  std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d> > mJacobians1;
+  Eigen::aligned_vector<Eigen::Vector6d> mJacobians1;
 
   /// Local body jacobians for mBodyNode2
-  std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d> > mJacobians2;
+  Eigen::aligned_vector<Eigen::Vector6d> mJacobians2;
 
   /// Contact normal expressed in body frame of the first body node
   Eigen::Vector3d mBodyDirection1;

--- a/dart/dynamics/BodyNode.h
+++ b/dart/dynamics/BodyNode.h
@@ -123,6 +123,9 @@ public:
         double _frictionCoeff = DART_DEFAULT_FRICTION_COEFF,
         double _restitutionCoeff = DART_DEFAULT_RESTITUTION_COEFF,
         bool _gravityMode = true);
+
+    // To get byte-aligned Eigen vectors
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /// Composition of Entity and BodyNode properties

--- a/dart/dynamics/Frame.h
+++ b/dart/dynamics/Frame.h
@@ -290,6 +290,9 @@ private:
   /// Contains whether or not this is the World Frame
   const bool mAmWorld;
 
+public:
+  // To get byte-aligned Eigen vectors
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 /// The WorldFrame class is a class that is used internally to create the
@@ -326,6 +329,10 @@ private:
 
   /// This is set to a Zero vector and never changes
   const Eigen::Vector6d mZero;
+
+public:
+  // To get byte-aligned Eigen vectors
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 } // namespace dynamics

--- a/dart/dynamics/Inertia.h
+++ b/dart/dynamics/Inertia.h
@@ -123,10 +123,6 @@ public:
   bool verify(bool _printWarnings = true,
               double _tolerance = 1e-8) const;
 
-public:
-  // To get byte-aligned Eigen vectors
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
 protected:
 
   /// Compute the spatial tensor based on the inertial parameters

--- a/dart/dynamics/Inertia.h
+++ b/dart/dynamics/Inertia.h
@@ -123,6 +123,10 @@ public:
   bool verify(bool _printWarnings = true,
               double _tolerance = 1e-8) const;
 
+public:
+  // To get byte-aligned Eigen vectors
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
 protected:
 
   /// Compute the spatial tensor based on the inertial parameters

--- a/dart/dynamics/Inertia.h
+++ b/dart/dynamics/Inertia.h
@@ -142,6 +142,10 @@ protected:
 
   /// Cache for generalized spatial inertia of the Body
   Eigen::Matrix6d mSpatialTensor;
+
+public:
+  // To get byte-aligned Eigen vectors
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 } // namespace dynamics

--- a/dart/dynamics/Joint.h
+++ b/dart/dynamics/Joint.h
@@ -149,6 +149,10 @@ public:
                ActuatorType _actuatorType = DefaultActuatorType);
 
     virtual ~Properties() = default;
+
+  public:
+    // To get byte-aligned Eigen vectors
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /// Default actuator type

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -225,7 +225,7 @@ void LineSegmentShape::addConnection(size_t _idx1, size_t _idx2)
 void LineSegmentShape::removeConnection(size_t _vertexIdx1, size_t _vertexIdx2)
 {
   // Search through all connections to remove any that match the request
-  std::vector<Eigen::Vector2i>::iterator it = mConnections.begin();
+  Eigen::aligned_vector<Eigen::Vector2i>::iterator it = mConnections.begin();
   while(it != mConnections.end())
   {
     const Eigen::Vector2i c = (*it);
@@ -263,7 +263,8 @@ void LineSegmentShape::removeConnection(size_t _connectionIdx)
 }
 
 //==============================================================================
-const std::vector<Eigen::Vector2i>& LineSegmentShape::getConnections() const
+const Eigen::aligned_vector<Eigen::Vector2i>&
+LineSegmentShape::getConnections() const
 {
   return mConnections;
 }

--- a/dart/dynamics/LineSegmentShape.h
+++ b/dart/dynamics/LineSegmentShape.h
@@ -98,7 +98,7 @@ public:
   void removeConnection(size_t _connectionIdx);
 
   /// Get all the connections
-  const std::vector<Eigen::Vector2i>& getConnections() const;
+  const Eigen::aligned_vector<Eigen::Vector2i>& getConnections() const;
 
   // Documentation inherited
   virtual void draw(renderer::RenderInterface* _ri,
@@ -121,7 +121,7 @@ protected:
   std::vector<Eigen::Vector3d> mVertices;
 
   /// Vector of connections
-  std::vector<Eigen::Vector2i> mConnections;
+  Eigen::aligned_vector<Eigen::Vector2i> mConnections;
 
   /// A dummy vertex that can be returned when an out-of-bounds vertex is
   /// requested

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -108,6 +108,7 @@ public:
     /// The name of the DegreesOfFreedom for this Joint
     std::array<std::string, DOF> mDofNames;
 
+    /// Default constructor
     UniqueProperties(
       const Vector& _positionLowerLimits = Vector::Constant(-DART_DBL_INF),
       const Vector& _positionUpperLimits = Vector::Constant( DART_DBL_INF),
@@ -121,6 +122,11 @@ public:
       const Vector& _restPosition = Vector::Constant(0.0),
       const Vector& _dampingCoefficient = Vector::Constant(0.0),
       const Vector& _coulombFrictions = Vector::Constant(0.0));
+
+    /// Copy constructor
+    // Note: we only need this because VS2013 lacks full support for std::array
+    // Once std::array is properly supported, this should be removed.
+    UniqueProperties(const UniqueProperties& _other);
 
     virtual ~UniqueProperties() = default;
 
@@ -136,6 +142,10 @@ public:
         const UniqueProperties& _multiDofProperties = UniqueProperties());
 
     virtual ~Properties();
+
+  public:
+    // To get byte-aligned Eigen vectors
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   /// Destructor

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -123,6 +123,10 @@ public:
       const Vector& _coulombFrictions = Vector::Constant(0.0));
 
     virtual ~UniqueProperties() = default;
+
+  public:
+    // To get byte-aligned Eigen vectors
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
 
   struct Properties : Joint::Properties, UniqueProperties

--- a/dart/dynamics/ScrewJoint.h
+++ b/dart/dynamics/ScrewJoint.h
@@ -63,6 +63,7 @@ public:
 
     UniqueProperties(const Eigen::Vector3d& _axis = Eigen::Vector3d::UnitZ(),
                      double _pitch = 0.1);
+
     virtual ~UniqueProperties() = default;
   };
 

--- a/dart/dynamics/TranslationalJoint.h
+++ b/dart/dynamics/TranslationalJoint.h
@@ -54,7 +54,8 @@ public:
   struct Properties : MultiDofJoint<3>::Properties
   {
     Properties(const MultiDofJoint<3>::Properties& _properties =
-                                                MultiDofJoint<3>::Properties());
+        MultiDofJoint<3>::Properties());
+
     virtual ~Properties() = default;
   };
 

--- a/dart/dynamics/detail/MultiDofJoint.h
+++ b/dart/dynamics/detail/MultiDofJoint.h
@@ -66,7 +66,34 @@ MultiDofJoint<DOF>::UniqueProperties::UniqueProperties(
     mFrictions(_coulombFrictions)
 {
   for (size_t i = 0; i < DOF; ++i)
+  {
     mPreserveDofNames[i] = false;
+    mDofNames[i] = std::string();
+  }
+}
+
+//==============================================================================
+template <size_t DOF>
+MultiDofJoint<DOF>::UniqueProperties::UniqueProperties(
+    const UniqueProperties& _other)
+  : mPositionLowerLimits(_other.mPositionLowerLimits),
+    mPositionUpperLimits(_other.mPositionUpperLimits),
+    mVelocityLowerLimits(_other.mVelocityLowerLimits),
+    mVelocityUpperLimits(_other.mVelocityUpperLimits),
+    mAccelerationLowerLimits(_other.mAccelerationLowerLimits),
+    mAccelerationUpperLimits(_other.mAccelerationUpperLimits),
+    mForceLowerLimits(_other.mForceLowerLimits),
+    mForceUpperLimits(_other.mForceUpperLimits),
+    mSpringStiffnesses(_other.mSpringStiffnesses),
+    mRestPositions(_other.mRestPositions),
+    mDampingCoefficients(_other.mDampingCoefficients),
+    mFrictions(_other.mFrictions)
+{
+  for (size_t i = 0; i < DOF; ++i)
+  {
+    mPreserveDofNames[i] = _other.mPreserveDofNames[i];
+    mDofNames[i] = _other.mDofNames[i];
+  }
 }
 
 //==============================================================================

--- a/dart/math/MathTypes.h
+++ b/dart/math/MathTypes.h
@@ -38,6 +38,8 @@
 #define DART_MATH_MATHTYPES_H_
 
 #include <limits>
+#include <map>
+#include <memory>
 #include <vector>
 
 #include <Eigen/Dense>
@@ -83,7 +85,27 @@ typedef Matrix<double, 6, 6> Matrix6d;
 typedef std::vector<Eigen::Vector3d> EIGEN_V_VEC3D;
 typedef std::vector<std::vector<Eigen::Vector3d > > EIGEN_VV_VEC3D;
 
+template <typename _Tp>
+using aligned_vector = std::vector<_Tp, Eigen::aligned_allocator<_Tp>>;
+
+template <typename _Key, typename _Tp, typename _Compare = std::less<_Key>>
+using aligned_map = std::map<_Key, _Tp, _Compare,
+    Eigen::aligned_allocator<std::pair<const _Key, _Tp>>>;
+
+template<typename _Tp, typename... _Args>
+inline std::shared_ptr<_Tp> make_aligned_shared()
+{
+  return std::make_shared<_Tp>();
 }
+
+template<typename _Tp, typename... _Args>
+inline std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
+{
+  return std::allocate_shared<_Tp>(Eigen::aligned_allocator<_Tp>(),
+                                   std::forward<_Args>(__args)...);
+}
+
+}  // namespace Eigen
 
 namespace dart {
 namespace math {

--- a/dart/math/MathTypes.h
+++ b/dart/math/MathTypes.h
@@ -92,6 +92,8 @@ template <typename _Key, typename _Tp, typename _Compare = std::less<_Key>>
 using aligned_map = std::map<_Key, _Tp, _Compare,
     Eigen::aligned_allocator<std::pair<const _Key, _Tp>>>;
 
+#if EIGEN_VERSION_AT_LEAST(3,2,1)
+
 /// Aligned allocator that is compatible with c++11
 // Ref: https://bitbucket.org/eigen/eigen/commits/f5b7700
 // TODO: Remove this and use Eigen::aligned_allocator once new version of Eigen
@@ -145,6 +147,18 @@ inline std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
   return std::allocate_shared<_Tp>(Eigen::aligned_allocator_cpp11<_Tp_nc>(),
                                    std::forward<_Args>(__args)...);
 }
+
+#else
+
+template <typename _Tp, typename... _Args>
+inline std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
+{
+  typedef typename std::remove_const<_Tp>::type _Tp_nc;
+  return std::allocate_shared<_Tp>(Eigen::aligned_allocator<_Tp_nc>(),
+                                   std::forward<_Args>(__args)...);
+}
+
+#endif
 
 }  // namespace Eigen
 

--- a/dart/math/MathTypes.h
+++ b/dart/math/MathTypes.h
@@ -92,16 +92,57 @@ template <typename _Key, typename _Tp, typename _Compare = std::less<_Key>>
 using aligned_map = std::map<_Key, _Tp, _Compare,
     Eigen::aligned_allocator<std::pair<const _Key, _Tp>>>;
 
-template<typename _Tp, typename... _Args>
-inline std::shared_ptr<_Tp> make_aligned_shared()
+/// Aligned allocator that is compatible with c++11
+// Ref: https://bitbucket.org/eigen/eigen/commits/f5b7700
+// TODO: Remove this and use Eigen::aligned_allocator once new version of Eigen
+// is released with above commit.
+template <class T>
+class aligned_allocator_cpp11 : public std::allocator<T>
 {
-  return std::make_shared<_Tp>();
-}
+public:
+  typedef size_t          size_type;
+  typedef std::ptrdiff_t  difference_type;
+  typedef T*              pointer;
+  typedef const T*        const_pointer;
+  typedef T&              reference;
+  typedef const T&        const_reference;
+  typedef T               value_type;
 
-template<typename _Tp, typename... _Args>
+  template <class U>
+  struct rebind
+  {
+    typedef aligned_allocator_cpp11<U> other;
+  };
+
+  aligned_allocator_cpp11()
+    : std::allocator<T>() {}
+
+  aligned_allocator_cpp11(const aligned_allocator_cpp11& other)
+    : std::allocator<T>(other) {}
+
+  template <class U>
+  aligned_allocator_cpp11(const aligned_allocator_cpp11<U>& other)
+    : std::allocator<T>(other) {}
+
+  ~aligned_allocator_cpp11() {}
+
+  pointer allocate(size_type num, const void* /*hint*/ = 0)
+  {
+    internal::check_size_for_overflow<T>(num);
+    return static_cast<pointer>( internal::aligned_malloc(num * sizeof(T)) );
+  }
+
+  void deallocate(pointer p, size_type /*num*/)
+  {
+    internal::aligned_free(p);
+  }
+};
+
+template <typename _Tp, typename... _Args>
 inline std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
 {
-  return std::allocate_shared<_Tp>(Eigen::aligned_allocator<_Tp>(),
+  typedef typename std::remove_const<_Tp>::type _Tp_nc;
+  return std::allocate_shared<_Tp>(Eigen::aligned_allocator_cpp11<_Tp_nc>(),
                                    std::forward<_Args>(__args)...);
 }
 

--- a/dart/renderer/OpenGLRenderInterface.cpp
+++ b/dart/renderer/OpenGLRenderInterface.cpp
@@ -586,7 +586,7 @@ void OpenGLRenderInterface::draw(dynamics::Shape* _shape) {
 
 void OpenGLRenderInterface::drawLineSegments(
     const std::vector<Eigen::Vector3d>& _vertices,
-    const std::vector<Eigen::Vector2i>& _connections)
+    const Eigen::aligned_vector<Eigen::Vector2i>& _connections)
 {
   glBegin(GL_LINES);
   for(const Eigen::Vector2i& c : _connections)

--- a/dart/renderer/OpenGLRenderInterface.h
+++ b/dart/renderer/OpenGLRenderInterface.h
@@ -98,7 +98,7 @@ public:
     virtual void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh) override;
     virtual void drawList(GLuint index) override;
     virtual void drawLineSegments(const std::vector<Eigen::Vector3d>& _vertices,
-                                  const std::vector<Eigen::Vector2i>& _connections) override;
+                                  const Eigen::aligned_vector<Eigen::Vector2i>& _connections) override;
 
     virtual void setPenColor(const Eigen::Vector4d& _col) override;
     virtual void setPenColor(const Eigen::Vector3d& _col) override;

--- a/dart/renderer/RenderInterface.cpp
+++ b/dart/renderer/RenderInterface.cpp
@@ -140,7 +140,8 @@ void RenderInterface::drawList(unsigned int indeX)
 {
 }
 
-void RenderInterface::drawLineSegments(const std::vector<Eigen::Vector3d>&, const std::vector<Eigen::Vector2i>&)
+void RenderInterface::drawLineSegments(const std::vector<Eigen::Vector3d>&,
+                                       const Eigen::aligned_vector<Eigen::Vector2i>&)
 {
 }
 

--- a/dart/renderer/RenderInterface.h
+++ b/dart/renderer/RenderInterface.h
@@ -43,6 +43,8 @@
 #include <assimp/scene.h>
 #include <Eigen/Dense>
 
+#include "dart/math/MathTypes.h"
+
 namespace dart {
 namespace renderer {
 
@@ -107,7 +109,7 @@ public:
     virtual void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh);
     virtual void drawList(unsigned int index);
     virtual void drawLineSegments(const std::vector<Eigen::Vector3d>& _vertices,
-                                  const std::vector<Eigen::Vector2i>& _connections);
+                                  const Eigen::aligned_vector<Eigen::Vector2i>& _connections);
 
     virtual unsigned int compileDisplayList(const Eigen::Vector3d& _size, const aiScene* _mesh);
 

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -764,8 +764,9 @@ SkelParser::SkelBodyNode SkelParser::readSoftBodyNode(
 
   SkelBodyNode softBodyNode;
   softBodyNode.properties =
-      std::make_shared<dynamics::SoftBodyNode::Properties>(
-        *standardBodyNode.properties, newSoftBodyNode);
+      std::allocate_shared<dynamics::SoftBodyNode::Properties>(
+          Eigen::aligned_allocator<dynamics::SoftBodyNode::Properties>(),
+          *standardBodyNode.properties, newSoftBodyNode);
   softBodyNode.initTransform = standardBodyNode.initTransform;
   softBodyNode.type = "soft";
 
@@ -1499,7 +1500,9 @@ SkelParser::JointPropPtr SkelParser::readRevoluteJoint(
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
         _jointElement, properties, _joint, _name, 1);
 
-  return std::make_shared<dynamics::RevoluteJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::RevoluteJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::RevoluteJoint::Properties>(),
+      properties);
 }
 
 //==============================================================================
@@ -1555,8 +1558,11 @@ SkelParser::JointPropPtr SkelParser::readPrismaticJoint(
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
         _jointElement, properties, _joint, _name, 1);
 
-  return std::make_shared<dynamics::PrismaticJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::PrismaticJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::PrismaticJoint::Properties>(),
+      properties);
 }
+
 //==============================================================================
 SkelParser::JointPropPtr SkelParser::readScrewJoint(
     tinyxml2::XMLElement* _jointElement,
@@ -1617,7 +1623,8 @@ SkelParser::JointPropPtr SkelParser::readScrewJoint(
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
         _jointElement, properties, _joint, _name, 1);
 
-  return std::make_shared<dynamics::ScrewJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::ScrewJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::ScrewJoint::Properties>(), properties);
 }
 
 //==============================================================================
@@ -1684,7 +1691,9 @@ SkelParser::JointPropPtr SkelParser::readUniversalJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 2);
 
-  return std::make_shared<dynamics::UniversalJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::UniversalJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::UniversalJoint::Properties>(),
+      properties);
 }
 
 //==============================================================================
@@ -1715,7 +1724,8 @@ SkelParser::JointPropPtr SkelParser::readBallJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::make_shared<dynamics::BallJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::BallJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::BallJoint::Properties>(), properties);
 }
 
 //==============================================================================
@@ -1768,7 +1778,8 @@ SkelParser::JointPropPtr SkelParser::readEulerJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::make_shared<dynamics::EulerJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::EulerJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::EulerJoint::Properties>(), properties);
 }
 
 //==============================================================================
@@ -1803,7 +1814,9 @@ SkelParser::JointPropPtr SkelParser::readTranslationalJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::make_shared<dynamics::TranslationalJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::TranslationalJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::TranslationalJoint::Properties>(),
+      properties);
 }
 
 //==============================================================================
@@ -1885,7 +1898,9 @@ SkelParser::JointPropPtr SkelParser::readPlanarJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::make_shared<dynamics::PlanarJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::PlanarJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::PlanarJoint::Properties>(),
+      properties);
 }
 
 //==============================================================================
@@ -1916,7 +1931,8 @@ SkelParser::JointPropPtr SkelParser::readFreeJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 6);
 
-  return std::make_shared<dynamics::FreeJoint::Properties>(properties);
+  return std::allocate_shared<dynamics::FreeJoint::Properties>(
+      Eigen::aligned_allocator<dynamics::FreeJoint::Properties>(), properties);
 }
 
 }  // namespace utils

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -516,7 +516,8 @@ dynamics::SkeletonPtr SkelParser::readSkeleton(
       // create it
       BodyMap::const_iterator rootNode = bodyNodes.find(it->second.parentName);
       SkelJoint rootJoint;
-      rootJoint.properties = std::make_shared<dynamics::FreeJoint::Properties>(
+      rootJoint.properties =
+          Eigen::make_aligned_shared<dynamics::FreeJoint::Properties>(
             dynamics::Joint::Properties("root", rootNode->second.initTransform));
       rootJoint.type = "free";
 

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -764,9 +764,9 @@ SkelParser::SkelBodyNode SkelParser::readSoftBodyNode(
 
   SkelBodyNode softBodyNode;
   softBodyNode.properties =
-      std::allocate_shared<dynamics::SoftBodyNode::Properties>(
-          Eigen::aligned_allocator<dynamics::SoftBodyNode::Properties>(),
+      Eigen::make_aligned_shared<dynamics::SoftBodyNode::Properties>(
           *standardBodyNode.properties, newSoftBodyNode);
+
   softBodyNode.initTransform = standardBodyNode.initTransform;
   softBodyNode.type = "soft";
 
@@ -1444,7 +1444,7 @@ SkelParser::JointPropPtr SkelParser::readWeldJoint(
 {
   assert(_jointElement != nullptr);
 
-  return std::make_shared<dynamics::WeldJoint::Properties>();
+  return Eigen::make_aligned_shared<dynamics::WeldJoint::Properties>();
 }
 
 //==============================================================================
@@ -1500,8 +1500,7 @@ SkelParser::JointPropPtr SkelParser::readRevoluteJoint(
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
         _jointElement, properties, _joint, _name, 1);
 
-  return std::allocate_shared<dynamics::RevoluteJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::RevoluteJoint::Properties>(),
+  return Eigen::make_aligned_shared<dynamics::RevoluteJoint::Properties>(
       properties);
 }
 
@@ -1558,8 +1557,7 @@ SkelParser::JointPropPtr SkelParser::readPrismaticJoint(
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
         _jointElement, properties, _joint, _name, 1);
 
-  return std::allocate_shared<dynamics::PrismaticJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::PrismaticJoint::Properties>(),
+  return Eigen::make_aligned_shared<dynamics::PrismaticJoint::Properties>(
       properties);
 }
 
@@ -1623,8 +1621,8 @@ SkelParser::JointPropPtr SkelParser::readScrewJoint(
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
         _jointElement, properties, _joint, _name, 1);
 
-  return std::allocate_shared<dynamics::ScrewJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::ScrewJoint::Properties>(), properties);
+  return Eigen::make_aligned_shared<dynamics::ScrewJoint::Properties>(
+        properties);
 }
 
 //==============================================================================
@@ -1691,8 +1689,7 @@ SkelParser::JointPropPtr SkelParser::readUniversalJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 2);
 
-  return std::allocate_shared<dynamics::UniversalJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::UniversalJoint::Properties>(),
+  return Eigen::make_aligned_shared<dynamics::UniversalJoint::Properties>(
       properties);
 }
 
@@ -1724,8 +1721,8 @@ SkelParser::JointPropPtr SkelParser::readBallJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::allocate_shared<dynamics::BallJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::BallJoint::Properties>(), properties);
+  return Eigen::make_aligned_shared<dynamics::BallJoint::Properties>(
+      properties);
 }
 
 //==============================================================================
@@ -1778,8 +1775,8 @@ SkelParser::JointPropPtr SkelParser::readEulerJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::allocate_shared<dynamics::EulerJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::EulerJoint::Properties>(), properties);
+  return Eigen::make_aligned_shared<dynamics::EulerJoint::Properties>(
+      properties);
 }
 
 //==============================================================================
@@ -1814,8 +1811,7 @@ SkelParser::JointPropPtr SkelParser::readTranslationalJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::allocate_shared<dynamics::TranslationalJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::TranslationalJoint::Properties>(),
+  return Eigen::make_aligned_shared<dynamics::TranslationalJoint::Properties>(
       properties);
 }
 
@@ -1898,8 +1894,7 @@ SkelParser::JointPropPtr SkelParser::readPlanarJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
 
-  return std::allocate_shared<dynamics::PlanarJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::PlanarJoint::Properties>(),
+  return Eigen::make_aligned_shared<dynamics::PlanarJoint::Properties>(
       properties);
 }
 
@@ -1931,8 +1926,8 @@ SkelParser::JointPropPtr SkelParser::readFreeJoint(
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 6);
 
-  return std::allocate_shared<dynamics::FreeJoint::Properties>(
-      Eigen::aligned_allocator<dynamics::FreeJoint::Properties>(), properties);
+  return Eigen::make_aligned_shared<dynamics::FreeJoint::Properties>(
+      properties);
 }
 
 }  // namespace utils

--- a/dart/utils/SkelParser.h
+++ b/dart/utils/SkelParser.h
@@ -107,9 +107,7 @@ public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
   // first: BodyNode name | second: BodyNode information
-  typedef std::map<std::string, SkelBodyNode, std::less<std::string>,
-                   Eigen::aligned_allocator<std::pair<std::string,
-                   SkelBodyNode>>> BodyMap;
+  typedef Eigen::aligned_map<std::string, SkelBodyNode> BodyMap;
 
   typedef std::shared_ptr<dynamics::Joint::Properties> JointPropPtr;
   struct SkelJoint

--- a/dart/utils/SkelParser.h
+++ b/dart/utils/SkelParser.h
@@ -107,7 +107,9 @@ public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
   // first: BodyNode name | second: BodyNode information
-  typedef std::map<std::string, SkelBodyNode> BodyMap;
+  typedef std::map<std::string, SkelBodyNode, std::less<std::string>,
+                   Eigen::aligned_allocator<std::pair<std::string,
+                   SkelBodyNode>>> BodyMap;
 
   typedef std::shared_ptr<dynamics::Joint::Properties> JointPropPtr;
   struct SkelJoint

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -277,7 +277,8 @@ dynamics::SkeletonPtr SdfParser::readSkeleton(
       // create it
       BodyMap::const_iterator rootNode = sdfBodyNodes.find(it->second.parentName);
       SDFJoint rootJoint;
-      rootJoint.properties = std::make_shared<dynamics::FreeJoint::Properties>(
+      rootJoint.properties =
+          Eigen::make_aligned_shared<dynamics::FreeJoint::Properties>(
             dynamics::Joint::Properties("root", rootNode->second.initTransform));
       rootJoint.type = "free";
 
@@ -549,7 +550,7 @@ SdfParser::SDFBodyNode SdfParser::readBodyNode(
 
   SDFBodyNode sdfBodyNode;
   sdfBodyNode.properties =
-      std::make_shared<dynamics::BodyNode::Properties>(properties);
+      Eigen::make_aligned_shared<dynamics::BodyNode::Properties>(properties);
   sdfBodyNode.initTransform = initTransform;
 
   return sdfBodyNode;
@@ -762,19 +763,24 @@ SdfParser::SDFJoint SdfParser::readJoint(tinyxml2::XMLElement* _jointElement,
       (childWorld * childToJoint).inverse() * _skeletonFrame;
 
   if (type == std::string("prismatic"))
-    newJoint.properties = std::make_shared<dynamics::PrismaticJoint::Properties>(
+    newJoint.properties =
+        Eigen::make_aligned_shared<dynamics::PrismaticJoint::Properties>(
           readPrismaticJoint(_jointElement, parentModelFrame, name));
   if (type == std::string("revolute"))
-    newJoint.properties = std::make_shared<dynamics::RevoluteJoint::Properties>(
+    newJoint.properties =
+        Eigen::make_aligned_shared<dynamics::RevoluteJoint::Properties>(
           readRevoluteJoint(_jointElement, parentModelFrame, name));
   if (type == std::string("screw"))
-    newJoint.properties = std::make_shared<dynamics::ScrewJoint::Properties>(
+    newJoint.properties =
+        Eigen::make_aligned_shared<dynamics::ScrewJoint::Properties>(
           readScrewJoint(_jointElement, parentModelFrame, name));
   if (type == std::string("revolute2"))
-    newJoint.properties = std::make_shared<dynamics::UniversalJoint::Properties>(
+    newJoint.properties =
+        Eigen::make_aligned_shared<dynamics::UniversalJoint::Properties>(
           readUniversalJoint(_jointElement, parentModelFrame, name));
   if (type == std::string("ball"))
-    newJoint.properties = std::make_shared<dynamics::BallJoint::Properties>(
+    newJoint.properties =
+        Eigen::make_aligned_shared<dynamics::BallJoint::Properties>(
           readBallJoint(_jointElement, parentModelFrame, name));
 
   newJoint.type = type;

--- a/dart/utils/sdf/SdfParser.h
+++ b/dart/utils/sdf/SdfParser.h
@@ -84,7 +84,7 @@ public:
       std::string type;
     };
 
-    typedef std::map<std::string, SDFBodyNode> BodyMap;
+    typedef Eigen::aligned_map<std::string, SDFBodyNode> BodyMap;
     typedef std::map<std::string, SDFJoint> JointMap;
 
     static simulation::WorldPtr readWorld(

--- a/dart/utils/sdf/SoftSdfParser.cpp
+++ b/dart/utils/sdf/SoftSdfParser.cpp
@@ -217,7 +217,8 @@ SdfParser::SDFBodyNode SoftSdfParser::readSoftBodyNode(
   }
 
   SDFBodyNode sdfBodyNode;
-  sdfBodyNode.properties = std::make_shared<dynamics::SoftBodyNode::Properties>(
+  sdfBodyNode.properties =
+      Eigen::make_aligned_shared<dynamics::SoftBodyNode::Properties>(
         *standardProperties, softProperties);
   sdfBodyNode.initTransform = standardSDF.initTransform;
   sdfBodyNode.type = "soft";

--- a/unittests/testFrames.cpp
+++ b/unittests/testFrames.cpp
@@ -64,9 +64,7 @@ void randomize_transform(Eigen::Isometry3d& tf,
     tf.rotate(Eigen::AngleAxisd(theta.norm(), theta.normalized()));
 }
 
-void randomize_transforms(
-    std::vector<Eigen::Isometry3d,
-                Eigen::aligned_allocator<Eigen::Isometry3d>>& tfs)
+void randomize_transforms(Eigen::aligned_vector<Eigen::Isometry3d>& tfs)
 {
   for(size_t i=0; i<tfs.size(); ++i)
   {
@@ -151,8 +149,7 @@ TEST(FRAMES, FORWARD_KINEMATICS_CHAIN)
                       Eigen::Isometry3d::Identity().matrix(),
                       tolerance));
 
-  std::vector<Eigen::Isometry3d, Eigen::aligned_allocator<Eigen::Isometry3d>>
-      tfs;
+  Eigen::aligned_vector<Eigen::Isometry3d> tfs;
   tfs.resize(frames.size(), Eigen::Isometry3d::Identity());
 
   randomize_transforms(tfs);
@@ -196,10 +193,8 @@ TEST(FRAMES, FORWARD_KINEMATICS_CHAIN)
 
   // Basic forward spatial velocity propagation
   { // The brackets are to allow reusing variable names
-    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
-        v_rels(frames.size());
-    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
-        v_total(frames.size());
+    Eigen::aligned_vector<Eigen::Vector6d> v_rels(frames.size());
+    Eigen::aligned_vector<Eigen::Vector6d> v_total(frames.size());
 
     for(size_t i=0; i<frames.size(); ++i)
     {
@@ -271,15 +266,11 @@ TEST(FRAMES, FORWARD_KINEMATICS_CHAIN)
 
   // Basic forward spatial acceleration propagation
   {
-    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
-        v_rels(frames.size());
-    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
-        a_rels(frames.size());
+    Eigen::aligned_vector<Eigen::Vector6d> v_rels(frames.size());
+    Eigen::aligned_vector<Eigen::Vector6d> a_rels(frames.size());
 
-    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
-        v_total(frames.size());
-    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
-        a_total(frames.size());
+    Eigen::aligned_vector<Eigen::Vector6d> v_total(frames.size());
+    Eigen::aligned_vector<Eigen::Vector6d> a_total(frames.size());
 
 
     for(size_t i=0; i<frames.size(); ++i)

--- a/unittests/testFrames.cpp
+++ b/unittests/testFrames.cpp
@@ -64,7 +64,9 @@ void randomize_transform(Eigen::Isometry3d& tf,
     tf.rotate(Eigen::AngleAxisd(theta.norm(), theta.normalized()));
 }
 
-void randomize_transforms(std::vector<Eigen::Isometry3d>& tfs)
+void randomize_transforms(
+    std::vector<Eigen::Isometry3d,
+                Eigen::aligned_allocator<Eigen::Isometry3d>>& tfs)
 {
   for(size_t i=0; i<tfs.size(); ++i)
   {
@@ -149,7 +151,8 @@ TEST(FRAMES, FORWARD_KINEMATICS_CHAIN)
                       Eigen::Isometry3d::Identity().matrix(),
                       tolerance));
 
-  std::vector<Eigen::Isometry3d> tfs;
+  std::vector<Eigen::Isometry3d, Eigen::aligned_allocator<Eigen::Isometry3d>>
+      tfs;
   tfs.resize(frames.size(), Eigen::Isometry3d::Identity());
 
   randomize_transforms(tfs);
@@ -193,8 +196,10 @@ TEST(FRAMES, FORWARD_KINEMATICS_CHAIN)
 
   // Basic forward spatial velocity propagation
   { // The brackets are to allow reusing variable names
-    std::vector<Eigen::Vector6d> v_rels(frames.size());
-    std::vector<Eigen::Vector6d> v_total(frames.size());
+    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
+        v_rels(frames.size());
+    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
+        v_total(frames.size());
 
     for(size_t i=0; i<frames.size(); ++i)
     {
@@ -266,11 +271,16 @@ TEST(FRAMES, FORWARD_KINEMATICS_CHAIN)
 
   // Basic forward spatial acceleration propagation
   {
-    std::vector<Eigen::Vector6d> v_rels(frames.size());
-    std::vector<Eigen::Vector6d> a_rels(frames.size());
+    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
+        v_rels(frames.size());
+    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
+        a_rels(frames.size());
 
-    std::vector<Eigen::Vector6d> v_total(frames.size());
-    std::vector<Eigen::Vector6d> a_total(frames.size());
+    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
+        v_total(frames.size());
+    std::vector<Eigen::Vector6d, Eigen::aligned_allocator<Eigen::Vector6d>>
+        a_total(frames.size());
+
 
     for(size_t i=0; i<frames.size(); ++i)
     {

--- a/unittests/testJoints.cpp
+++ b/unittests/testJoints.cpp
@@ -580,8 +580,10 @@ TEST_F(JOINTS, CONVENIENCE_FUNCTIONS)
     // -- collect everything so we can cycle through the tests
     std::vector<Joint*> joints;
     std::vector<BodyNode*> bns;
-    std::vector<Eigen::Isometry3d> desired_tfs;
-    std::vector<Eigen::Isometry3d> actual_tfs;
+    std::vector<Eigen::Isometry3d, Eigen::aligned_allocator<Eigen::Isometry3d>>
+        desired_tfs;
+    std::vector<Eigen::Isometry3d, Eigen::aligned_allocator<Eigen::Isometry3d>>
+        actual_tfs;
 
     joints.push_back(freejoint);
     bns.push_back(freejoint_bn);

--- a/unittests/testJoints.cpp
+++ b/unittests/testJoints.cpp
@@ -580,10 +580,8 @@ TEST_F(JOINTS, CONVENIENCE_FUNCTIONS)
     // -- collect everything so we can cycle through the tests
     std::vector<Joint*> joints;
     std::vector<BodyNode*> bns;
-    std::vector<Eigen::Isometry3d, Eigen::aligned_allocator<Eigen::Isometry3d>>
-        desired_tfs;
-    std::vector<Eigen::Isometry3d, Eigen::aligned_allocator<Eigen::Isometry3d>>
-        actual_tfs;
+    Eigen::aligned_vector<Eigen::Isometry3d> desired_tfs;
+    Eigen::aligned_vector<Eigen::Isometry3d> actual_tfs;
 
     joints.push_back(freejoint);
     bns.push_back(freejoint_bn);


### PR DESCRIPTION
This pull request resolves [memory alignment issues with Eigen objects](http://eigen.tuxfamily.org/dox/group__DenseMatrixManipulation__Alignement.html) in DART.

Also, some helper types and functions are defined for convenience such as ```Eigen::aligned_vector``` and ```Eigen::make_aligned_shared()```. One thing I'm not sure is the namespace and names of them. ```dart::aligned_vector``` or ```dart::aligned::vector``` are alternatives I can imagine. Any thought on this?

Related issues: #413 
