### PR TITLE
Remove undefined behavior from SkelParser

### DIFF
--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -541,7 +541,12 @@ dynamics::SkeletonPtr SkelParser::readSkeleton(
     order.erase(index->second);
     lookup.erase(index);
     joints.erase(it);
-    it = joints.find(order.begin()->second);
+
+    IndexToJoint::iterator nextJoint = order.begin();
+    if(nextJoint == order.end())
+      break;
+
+    it = joints.find(nextJoint->second);
   }
 
   return newSkeleton;


### PR DESCRIPTION
We were using an iterator without first checking whether it was valid, even though the container will drop down to size 0 by the time the parsing is finished. Now we quit parsing once the container is empty.