### PR TITLE
Standardized warning messages for MultiDofJoints

### DIFF
--- a/dart/dynamics/detail/MultiDofJoint.h
+++ b/dart/dynamics/detail/MultiDofJoint.h
@@ -38,7 +38,7 @@
 #define DART_DYNAMICS_DETAIL_MULTIDOFJOINT_H_
 
 #define MULTIDOFJOINT_REPORT_DIM_MISMATCH( func, arg )              \
-  dterr << "[MultiDofJoint::" #func "] mismatch beteween size of "  \
+  dterr << "[MultiDofJoint::" #func "] Mismatch beteween size of "  \
         << #arg " [" << arg .size() << "] and the number of "       \
         << "DOFs [" << getNumDofs() << "] for Joint named ["        \
         << getName() << "]\n";                                      \

--- a/dart/dynamics/detail/MultiDofJoint.h
+++ b/dart/dynamics/detail/MultiDofJoint.h
@@ -37,6 +37,19 @@
 #ifndef DART_DYNAMICS_DETAIL_MULTIDOFJOINT_H_
 #define DART_DYNAMICS_DETAIL_MULTIDOFJOINT_H_
 
+#define MULTIDOFJOINT_REPORT_DIM_MISMATCH( func, arg )              \
+  dterr << "[MultiDofJoint::" #func "] mismatch beteween size of "  \
+        << #arg " [" << arg .size() << "] and the number of "       \
+        << "DOFs [" << getNumDofs() << "] for Joint named ["        \
+        << getName() << "]\n";                                      \
+  assert(false);
+
+#define MULTIDOFJOINT_REPORT_OUT_OF_RANGE( func, index )            \
+  dterr << "[MultiDofJoint::" << #func << "] The index [" << index  \
+        << "] is out of range for Joint named [" << getName()       \
+        << "] which has " << getNumDofs() << " DOFs\n";             \
+  assert(false);
+
 //==============================================================================
 template <size_t DOF>
 MultiDofJoint<DOF>::UniqueProperties::UniqueProperties(
@@ -196,9 +209,8 @@ DegreeOfFreedom* MultiDofJoint<DOF>::getDof(size_t _index)
   if (_index < DOF)
     return mDofs[_index];
 
-  dterr << "[MultiDofJoint::getDof] Attempting to access index (" << _index
-        << "). The index must be less than (" << DOF << ")!\n";
-  assert(false);
+  MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getDof, _index);
+
   return nullptr;
 }
 
@@ -209,9 +221,8 @@ const DegreeOfFreedom* MultiDofJoint<DOF>::getDof(size_t _index) const
   if (_index < DOF)
     return mDofs[_index];
 
-  dterr << "[MultiDofJoint::getDof] Attempting to access index (" << _index
-        << "). The index must be less than (" << DOF << ")!\n";
-  assert(false);
+  MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getDof, _index);
+
   return nullptr;
 }
 
@@ -226,6 +237,7 @@ const std::string& MultiDofJoint<DOF>::setDofName(size_t _index,
     dtwarn << "[MultiDofJoint::setDofName] Attempting to set the name of DOF "
            << "index " << _index << ", which is out of bounds. We will set "
            << "the name of DOF index 0 instead\n";
+    assert(false);
     _index = 0;
   }
 
@@ -253,10 +265,8 @@ void MultiDofJoint<DOF>::preserveDofName(size_t _index, bool _preserve)
 {
   if (DOF <= _index)
   {
-    dtwarn << "[MultiDofJoint::preserveDofName] Attempting to preserve the "
-           << "name of DOF index " << _index << ", which is out of bounds. We "
-           << "will preserve the name of DOF index 0 instead\n";
-    _index = 0;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(preserveDofName, _index);
+    return;
   }
 
   mMultiDofP.mPreserveDofNames[_index] = _preserve;
@@ -269,9 +279,10 @@ bool MultiDofJoint<DOF>::isDofNamePreserved(size_t _index) const
   if(DOF <= _index)
   {
     dtwarn << "[MultiDofJoint::isDofNamePreserved] Requesting whether DOF "
-           << "index " << _index << " is preserved, but this is out of bounds "
-           << "(max " << DOF-1 << "). We will return the result of DOF index 0 "
-           << "instead\n";
+           << "index [" << _index << "] in Joint [" << getName()
+           << "] is preserved, but this is out of bounds (max " << DOF-1
+           << "). We will return the result of DOF index 0 instead\n";
+    assert(false);
     _index = 0;
   }
 
@@ -284,9 +295,10 @@ const std::string& MultiDofJoint<DOF>::getDofName(size_t _index) const
 {
   if(DOF <= _index)
   {
-    dterr << "[MultiDofJoint::getDofName] Requested name of DOF index "
-          << _index << ", but that is out of bounds (max " << DOF-1 << "). "
-          << "Returning name of DOF 0\n";
+    dterr << "[MultiDofJoint::getDofName] Requested name of DOF index ["
+          << _index << "] in Joint [" << getName() << "], but that is out of "
+          << "bounds (max " << DOF-1 << "). Returning name of DOF 0\n";
+    assert(false);
     return mMultiDofP.mDofNames[0];
   }
 
@@ -321,9 +333,7 @@ size_t MultiDofJoint<DOF>::getIndexInTree(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::getIndexInTree] index (" << _index
-          << ") out of range. Must be less than " << getNumDofs() << "!\n";
-    assert(false);
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getIndexInTree, _index);
     return 0;
   }
 
@@ -336,9 +346,7 @@ void MultiDofJoint<DOF>::setCommand(size_t _index, double _command)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::setCommand]: index[" << _index << "] out of range"
-          << std::endl;
-    return;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setCommand, _index);
   }
 
   switch (mJointP.mActuatorType)
@@ -386,8 +394,7 @@ double MultiDofJoint<DOF>::getCommand(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::getCommand]: index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getCommand, _index);
     return 0.0;
   }
 
@@ -400,9 +407,7 @@ void MultiDofJoint<DOF>::setCommands(const Eigen::VectorXd& _commands)
 {
   if (static_cast<size_t>(_commands.size()) != getNumDofs())
   {
-    dterr << "[MultiDofJoint::setCommands]: commands's size["
-          << _commands.size() << "] is different with the dof ["
-          << getNumDofs() << "]" << std::endl;
+    MULTIDOFJOINT_REPORT_DIM_MISMATCH(setCommands, _commands);
     return;
   }
 
@@ -465,7 +470,7 @@ void MultiDofJoint<DOF>::setPosition(size_t _index, double _position)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setPosition index[" << _index << "] out of range" << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setPosition, _index);
     return;
   }
 
@@ -480,7 +485,7 @@ double MultiDofJoint<DOF>::getPosition(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setPosition index[" << _index << "] out of range" << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getPosition, _index);
     return 0.0;
   }
 
@@ -493,8 +498,7 @@ void MultiDofJoint<DOF>::setPositions(const Eigen::VectorXd& _positions)
 {
   if (static_cast<size_t>(_positions.size()) != getNumDofs())
   {
-    dterr << "setPositions positions's size[" << _positions.size()
-          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
+    MULTIDOFJOINT_REPORT_DIM_MISMATCH(setPositions, _positions);
     return;
   }
 
@@ -521,8 +525,7 @@ void MultiDofJoint<DOF>::setPositionLowerLimit(size_t _index, double _position)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setPositionLowerLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setPositionLowerLimit, _index);
     return;
   }
 
@@ -535,8 +538,7 @@ double MultiDofJoint<DOF>::getPositionLowerLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getPositionLowerLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getPositionLowerLimit, _index);
     return 0.0;
   }
 
@@ -549,8 +551,7 @@ void MultiDofJoint<DOF>::setPositionUpperLimit(size_t _index, double _position)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setPositionUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setPositionUpperLimit, _index);
     return;
   }
 
@@ -563,8 +564,7 @@ double MultiDofJoint<DOF>::getPositionUpperLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getPositionUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getPositionUpperLimit, _index);
     return 0.0;
   }
 
@@ -577,7 +577,7 @@ void MultiDofJoint<DOF>::setVelocity(size_t _index, double _velocity)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setVelocity index[" << _index << "] out of range" << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setVelocity, _index);
     return;
   }
 
@@ -598,7 +598,7 @@ double MultiDofJoint<DOF>::getVelocity(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getVelocity index[" << _index << "] out of range" << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getVelocity, _index);
     return 0.0;
   }
 
@@ -611,8 +611,7 @@ void MultiDofJoint<DOF>::setVelocities(const Eigen::VectorXd& _velocities)
 {
   if (static_cast<size_t>(_velocities.size()) != getNumDofs())
   {
-    dterr << "setVelocities velocities's size[" << _velocities.size()
-          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
+    MULTIDOFJOINT_REPORT_DIM_MISMATCH(setVelocities, _velocities);
     return;
   }
 
@@ -645,8 +644,7 @@ void MultiDofJoint<DOF>::setVelocityLowerLimit(size_t _index, double _velocity)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setVelocityLowerLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( setVelocityLowerLimit, _index );
     return;
   }
 
@@ -659,8 +657,7 @@ double MultiDofJoint<DOF>::getVelocityLowerLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getVelocityLowerLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( getVelocityLowerLimit, _index);
     return 0.0;
   }
 
@@ -673,8 +670,7 @@ void MultiDofJoint<DOF>::setVelocityUpperLimit(size_t _index, double _velocity)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setVelocityUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( setVelocityUpperLimit, _index );
     return;
   }
 
@@ -687,8 +683,7 @@ double MultiDofJoint<DOF>::getVelocityUpperLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getVelocityUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( getVelocityUpperLimit, _index );
     return 0.0;
   }
 
@@ -701,8 +696,7 @@ void MultiDofJoint<DOF>::setAcceleration(size_t _index, double _acceleration)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setAcceleration index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( setAcceleration, _index );
     return;
   }
 
@@ -723,8 +717,7 @@ double MultiDofJoint<DOF>::getAcceleration(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getAcceleration index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( getAcceleration, _index );
     return 0.0;
   }
 
@@ -737,8 +730,7 @@ void MultiDofJoint<DOF>::setAccelerations(const Eigen::VectorXd& _accelerations)
 {
   if (static_cast<size_t>(_accelerations.size()) != getNumDofs())
   {
-    dterr << "setAccelerations accelerations's size[" << _accelerations.size()
-          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
+    MULTIDOFJOINT_REPORT_DIM_MISMATCH( setAccelerations, _accelerations );
     return;
   }
 
@@ -772,8 +764,7 @@ void MultiDofJoint<DOF>::setAccelerationLowerLimit(size_t _index,
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setAccelerationLowerLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setAccelerationLowerLimit, _index);
     return;
   }
 
@@ -786,8 +777,7 @@ double MultiDofJoint<DOF>::getAccelerationLowerLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getAccelerationLowerLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getAccelerationLowerLimit, _index);
     return 0.0;
   }
 
@@ -801,8 +791,7 @@ void MultiDofJoint<DOF>::setAccelerationUpperLimit(size_t _index,
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setAccelerationUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setAccelerationUpperLimit, _index)
     return;
   }
 
@@ -815,8 +804,7 @@ double MultiDofJoint<DOF>::getAccelerationUpperLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getAccelerationUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getAccelerationUpperLimit, _index);
     return 0.0;
   }
 
@@ -877,7 +865,7 @@ void MultiDofJoint<DOF>::setForce(size_t _index, double _force)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setForce index[" << _index << "] out of range" << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setForce, _index);
     return;
   }
 
@@ -896,7 +884,7 @@ double MultiDofJoint<DOF>::getForce(size_t _index)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getForce index[" << _index << "] out of range" << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getForce, _index);
     return 0.0;
   }
 
@@ -909,8 +897,7 @@ void MultiDofJoint<DOF>::setForces(const Eigen::VectorXd& _forces)
 {
   if (static_cast<size_t>(_forces.size()) != getNumDofs())
   {
-    dterr << "setForces forces's size[" << _forces.size()
-          << "] is different with the dof [" << getNumDofs() << "]" << std::endl;
+    MULTIDOFJOINT_REPORT_DIM_MISMATCH(setForces, _forces);
     return;
   }
 
@@ -949,8 +936,7 @@ void MultiDofJoint<DOF>::setForceLowerLimit(size_t _index, double _force)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setForceLowerLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setForceLowerLimit, _index);
     return;
   }
 
@@ -963,7 +949,7 @@ double MultiDofJoint<DOF>::getForceLowerLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getForceMin index[" << _index << "] out of range" << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getForceLowerLimit, _index);
     return 0.0;
   }
 
@@ -976,8 +962,7 @@ void MultiDofJoint<DOF>::setForceUpperLimit(size_t _index, double _force)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setForceUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setForceUpperLimit, _index);
     return;
   }
 
@@ -990,8 +975,7 @@ double MultiDofJoint<DOF>::getForceUpperLimit(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getForceUpperLimit index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getForceUpperLimit, _index);
     return 0.0;
   }
 
@@ -1005,8 +989,7 @@ void MultiDofJoint<DOF>::setVelocityChange(size_t _index,
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setVelocityChange index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setVelocityChange, _index);
     return;
   }
 
@@ -1019,8 +1002,7 @@ double MultiDofJoint<DOF>::getVelocityChange(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getVelocityChange index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getVelocityChange, _index);
     return 0.0;
   }
 
@@ -1040,8 +1022,7 @@ void MultiDofJoint<DOF>::setConstraintImpulse(size_t _index, double _impulse)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "setConstraintImpulse index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setConstraintImpulse, _index);
     return;
   }
 
@@ -1054,8 +1035,7 @@ double MultiDofJoint<DOF>::getConstraintImpulse(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "getConstraintImpulse index[" << _index << "] out of range"
-          << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getConstraintImpulse, _index);
     return 0.0;
   }
 
@@ -1092,8 +1072,8 @@ Eigen::VectorXd MultiDofJoint<DOF>::getPositionDifferences(
       || static_cast<size_t>(_q2.size()) != getNumDofs())
   {
     dterr << "MultiDofJoint::getPositionsDifference: q1's size[" << _q1.size()
-          << "] or q2's size[" << _q2.size() << "is different with the dof ["
-          << getNumDofs() << "]." << std::endl;
+          << "] or q2's size[" << _q2.size() << "is different than the dof ["
+          << getNumDofs() << "] for Joint [" << getName() << "]\n";
     return Eigen::VectorXd::Zero(getNumDofs());
   }
 
@@ -1114,8 +1094,7 @@ void MultiDofJoint<DOF>::setSpringStiffness(size_t _index, double _k)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::setSpringStiffness()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setSpringStiffness, _index);
     return;
   }
 
@@ -1130,8 +1109,7 @@ double MultiDofJoint<DOF>::getSpringStiffness(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::getSpringStiffness()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getSpringStiffness, _index);
     return 0.0;
   }
 
@@ -1144,19 +1122,18 @@ void MultiDofJoint<DOF>::setRestPosition(size_t _index, double _q0)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::setRestPosition()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setRestPosition, _index);
     return;
   }
 
   if (mMultiDofP.mPositionLowerLimits[_index] > _q0
       || mMultiDofP.mPositionUpperLimits[_index] < _q0)
   {
-    dterr << "Rest position of joint[" << getName() << "], " << _q0
-          << ", is out of the limit range["
+    dterr << "Rest position of joint [" << getName() << "], " << _q0
+          << ", is out of the limit range ["
           << mMultiDofP.mPositionLowerLimits[_index] << ", "
-          << mMultiDofP.mPositionUpperLimits[_index] << "] in index[" << _index
-          << "].\n";
+          << mMultiDofP.mPositionUpperLimits[_index] << "] in index [" << _index
+          << "] of Joint [" << getName() << "]\n";
     return;
   }
 
@@ -1169,8 +1146,7 @@ double MultiDofJoint<DOF>::getRestPosition(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::getRestPosition()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getRestPosition, _index);
     return 0.0;
   }
 
@@ -1183,8 +1159,7 @@ void MultiDofJoint<DOF>::setDampingCoefficient(size_t _index, double _d)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::setDampingCoefficient()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setDampingCoefficient, _index);
     return;
   }
 
@@ -1200,8 +1175,7 @@ double MultiDofJoint<DOF>::getDampingCoefficient(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::getDampingCoefficient()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getDampingCoefficient, _index);
     return 0.0;
   }
 
@@ -1214,8 +1188,7 @@ void MultiDofJoint<DOF>::setCoulombFriction(size_t _index, double _friction)
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::setFriction()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setCoulombFriction, _index);
     return;
   }
 
@@ -1230,8 +1203,7 @@ double MultiDofJoint<DOF>::getCoulombFriction(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::getFriction()]: index[" << _index
-          << "] out of range." << std::endl;
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getCoulombFriction, _index);
     return 0.0;
   }
 

--- a/dart/dynamics/detail/MultiDofJoint.h
+++ b/dart/dynamics/detail/MultiDofJoint.h
@@ -41,13 +41,13 @@
   dterr << "[MultiDofJoint::" #func "] Mismatch beteween size of "  \
         << #arg " [" << arg .size() << "] and the number of "       \
         << "DOFs [" << getNumDofs() << "] for Joint named ["        \
-        << getName() << "]\n";                                      \
+        << getName() << "].\n";                                      \
   assert(false);
 
 #define MULTIDOFJOINT_REPORT_OUT_OF_RANGE( func, index )            \
   dterr << "[MultiDofJoint::" << #func << "] The index [" << index  \
         << "] is out of range for Joint named [" << getName()       \
-        << "] which has " << getNumDofs() << " DOFs\n";             \
+        << "] which has " << getNumDofs() << " DOFs.\n";             \
   assert(false);
 
 //==============================================================================
@@ -235,8 +235,8 @@ const std::string& MultiDofJoint<DOF>::setDofName(size_t _index,
   if(DOF <= _index)
   {
     dtwarn << "[MultiDofJoint::setDofName] Attempting to set the name of DOF "
-           << "index " << _index << ", which is out of bounds. We will set "
-           << "the name of DOF index 0 instead\n";
+           << "index " << _index << ", which is out of bounds for the Joint ["
+           << getName() << "]. We will set the name of DOF index 0 instead.\n";
     assert(false);
     _index = 0;
   }
@@ -281,7 +281,7 @@ bool MultiDofJoint<DOF>::isDofNamePreserved(size_t _index) const
     dtwarn << "[MultiDofJoint::isDofNamePreserved] Requesting whether DOF "
            << "index [" << _index << "] in Joint [" << getName()
            << "] is preserved, but this is out of bounds (max " << DOF-1
-           << "). We will return the result of DOF index 0 instead\n";
+           << "). We will return the result of DOF index 0 instead.\n";
     assert(false);
     _index = 0;
   }
@@ -297,7 +297,7 @@ const std::string& MultiDofJoint<DOF>::getDofName(size_t _index) const
   {
     dterr << "[MultiDofJoint::getDofName] Requested name of DOF index ["
           << _index << "] in Joint [" << getName() << "], but that is out of "
-          << "bounds (max " << DOF-1 << "). Returning name of DOF 0\n";
+          << "bounds (max " << DOF-1 << "). Returning name of DOF 0.\n";
     assert(false);
     return mMultiDofP.mDofNames[0];
   }
@@ -318,9 +318,7 @@ size_t MultiDofJoint<DOF>::getIndexInSkeleton(size_t _index) const
 {
   if (_index >= getNumDofs())
   {
-    dterr << "[MultiDofJoint::getIndexInSkeleton] index (" << _index
-          << ") out of range. Must be less than " << getNumDofs() << "!\n";
-    assert(false);
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getIndexInSkeleton, _index);
     return 0;
   }
 
@@ -358,7 +356,7 @@ void MultiDofJoint<DOF>::setCommand(size_t _index, double _command)
       break;
     case PASSIVE:
       dtwarn << "[MultiDofJoint::setCommand] Attempting to set command for "
-             << "PASSIVE joint." << std::endl;
+             << "PASSIVE joint [" << getName() << "].\n";
       mCommands[_index] = _command;
       break;
     case SERVO:
@@ -379,7 +377,7 @@ void MultiDofJoint<DOF>::setCommand(size_t _index, double _command)
       break;
     case LOCKED:
       dtwarn << "[MultiDofJoint::setCommand] Attempting to set command for "
-             << "LOCKED joint." << std::endl;
+             << "LOCKED joint [" << getName() << "].\n";
       mCommands[_index] = _command;
       break;
     default:
@@ -420,7 +418,7 @@ void MultiDofJoint<DOF>::setCommands(const Eigen::VectorXd& _commands)
       break;
     case PASSIVE:
       dtwarn << "[MultiDofJoint::setCommands] Attempting to set command for "
-             << "PASSIVE joint." << std::endl;
+             << "PASSIVE joint [" << getName() << "].\n";
       mCommands = _commands;
       break;
     case SERVO:
@@ -441,7 +439,7 @@ void MultiDofJoint<DOF>::setCommands(const Eigen::VectorXd& _commands)
       break;
     case LOCKED:
       dtwarn << "[MultiDofJoint::setCommands] Attempting to set command for "
-             << "LOCKED joint." << std::endl;
+             << "LOCKED joint [" << getName() << "].\n";
       mCommands = _commands;
       break;
     default:
@@ -1071,9 +1069,9 @@ Eigen::VectorXd MultiDofJoint<DOF>::getPositionDifferences(
   if (static_cast<size_t>(_q1.size()) != getNumDofs()
       || static_cast<size_t>(_q2.size()) != getNumDofs())
   {
-    dterr << "MultiDofJoint::getPositionsDifference: q1's size[" << _q1.size()
-          << "] or q2's size[" << _q2.size() << "is different than the dof ["
-          << getNumDofs() << "] for Joint [" << getName() << "]\n";
+    dterr << "MultiDofJoint::getPositionsDifference: q1's size [" << _q1.size()
+          << "] or q2's size [" << _q2.size() << "] is different than the dof ["
+          << getNumDofs() << "] for Joint [" << getName() << "].\n";
     return Eigen::VectorXd::Zero(getNumDofs());
   }
 
@@ -1129,11 +1127,11 @@ void MultiDofJoint<DOF>::setRestPosition(size_t _index, double _q0)
   if (mMultiDofP.mPositionLowerLimits[_index] > _q0
       || mMultiDofP.mPositionUpperLimits[_index] < _q0)
   {
-    dterr << "Rest position of joint [" << getName() << "], " << _q0
-          << ", is out of the limit range ["
+    dterr << "[MultiDofJoint::setRestPosition] Value of _q0 [" << _q0
+          << "], is out of the limit range ["
           << mMultiDofP.mPositionLowerLimits[_index] << ", "
-          << mMultiDofP.mPositionUpperLimits[_index] << "] in index [" << _index
-          << "] of Joint [" << getName() << "]\n";
+          << mMultiDofP.mPositionUpperLimits[_index] << "] for index ["
+          << _index << "] of Joint [" << getName() << "].\n";
     return;
   }
 


### PR DESCRIPTION
There was a lot of inconsistency among the format of warning messages for MultiDofJoint functions, even though the warnings they were giving were basically identical: indexing issues. This pull request standardizes (most of) them with two macros.