### PR TITLE
Correct child for a joint

### DIFF
--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -740,7 +740,7 @@ SdfParser::SDFJoint SdfParser::readJoint(tinyxml2::XMLElement* _jointElement,
   SDFJoint newJoint;
   newJoint.parentName = (parent_it == _sdfBodyNodes.end())?
         "" : parent_it->first;
-  newJoint.childName = (parent_it == _sdfBodyNodes.end())?
+  newJoint.childName = (child_it == _sdfBodyNodes.end())?
         "" : child_it->first;
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
Child of a joint was not correctly parsed in SDF files.