### PR TITLE
Fix Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 version: "{build}"
 
 # Operating system (build VM template)
-# os: Windows Server 2012 R2
+os: Previous Windows Server 2012 R2  # using previous worker images since default worker has problem installing DART-Prerequisites.msi
 
 # build platform, i.e. Win32 (instead of x86), x64, Any CPU. This setting is optional.
 platform: 


### PR DESCRIPTION
There was [build environment update of Appveyor](http://www.appveyor.com/blog/2015/06/23/new-oss-build-environment-and-xamarin-support) but it causes [a problem installing DART-Prerequisites.msi](). Use [previous worker images](http://www.appveyor.com/updates/2015/06/20) until it's resolved.