### PR TITLE
Joint rest positions default to zero, even if that is out of their limits

### DIFF
--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -383,6 +383,9 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
     singleDof.mVelocityUpperLimit =  _jt->limits->velocity;
     singleDof.mForceLowerLimit = -_jt->limits->effort;
     singleDof.mForceUpperLimit =  _jt->limits->effort;
+
+    if(_jt->limits->lower > 0 || _jt->limits->upper < 0)
+      singleDof.mRestPosition = (_jt->limits->lower + _jt->limits->upper) / 2.;
   }
 
   if(_jt->dynamics)

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -385,7 +385,19 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
     singleDof.mForceUpperLimit =  _jt->limits->effort;
 
     if(_jt->limits->lower > 0 || _jt->limits->upper < 0)
-      singleDof.mRestPosition = (_jt->limits->lower + _jt->limits->upper) / 2.;
+    {
+      if(std::isfinite(_jt->limits->lower)
+         && std::isfinite(_jt->limits->upper))
+        singleDof.mRestPosition
+          = (_jt->limits->lower + _jt->limits->upper) / 2.;
+      else if(std::isfinite(_jt->limits->lower))
+        singleDof.mRestPosition = _jt->limits->lower;
+      else if(std::isfinite(_jt->limits->upper))
+        singleDof.mRestPosition = _jt->limits->upper;
+
+      // Any other case means that the limits are both +inf, both -inf, or
+      // either is NaN. This should generate a warning elsewhere.
+    }
   }
 
   if(_jt->dynamics)


### PR DESCRIPTION
The default `mRestPosition` defaults to zero. This causes a warning to be printed when a joint is loaded from URDF whose limits do not include the zero value. In that case, this commit defaults the rest position to the center of the joint range (if it is bounded) or one of its endpoints. The logic is a bit convoluted to handle infinite limits.

This pull request fixes the warning. However, even with these changes, the robot is loaded in the invalid zero configuration. My assumption was that `mRestPosition` would also be used to initialize the robot's initial configuration. Is that not the case?

Finally, I am wondering if we should always use this logic to initialize `mRestPosition`, even if zero is a valid value. Thoughts?