### PR TITLE
Fixed SEGFAULTs in DartLoader

### DIFF
--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -273,9 +273,11 @@ const aiScene* MeshShape::loadMesh(const std::string& _fileName) {
                                    aiProcess_OptimizeMeshes,
                                    nullptr, propertyStore);
   if(!scene)
-    dtwarn << "[MeshShape] Assimp could not load file: '" << _fileName << "'. "
-           << "This will likely result in a segmentation fault "
-           << "if you attempt to use the nullptr we return." << std::endl;
+  {
+    dtwarn << "[MeshShape::loadMesh] Assimp could not load file: '"
+           << _fileName << "'.\n";
+    return nullptr;
+  }
   aiReleasePropertyStore(propertyStore);
 
   // Assimp rotates collada files such that the up-axis (specified in the

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -332,7 +332,7 @@ bool DartLoader::createSkeletonRecursive(
   if(!node)
     return false;
   
-  for(unsigned int i = 0; i < _lk->child_links.size(); ++i)
+  for(size_t i = 0; i < _lk->child_links.size(); ++i)
   {
       if (!createSkeletonRecursive(_skel, _lk->child_links[i].get(), node))
         return false;
@@ -490,7 +490,7 @@ bool DartLoader::createDartNodeProperties(
   }
 
   // Set visual information
-  for(unsigned int i = 0; i < _lk->visual_array.size(); i++)
+  for(size_t i = 0; i < _lk->visual_array.size(); i++)
   {
     if(dynamics::ShapePtr shape = createShape(_lk->visual_array[i].get()))
       node->mVizShapes.push_back(shape);
@@ -499,7 +499,7 @@ bool DartLoader::createDartNodeProperties(
   }
 
   // Set collision information
-  for(unsigned int i = 0; i < _lk->collision_array.size(); i++) {
+  for(size_t i = 0; i < _lk->collision_array.size(); i++) {
     if(dynamics::ShapePtr shape = createShape(_lk->collision_array[i].get()))
       node->mColShapes.push_back(shape);
     else

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -550,28 +550,25 @@ dynamics::ShapePtr DartLoader::createShape(const VisualOrCollision* _vizOrCol)
   {
     std::string fullPath = getFullFilePath(mesh->filename);
     if (fullPath.empty())
+    {
+      dtwarn << "[DartLoader::createShape] Skipping URDF mesh with empty"
+                " filename. We are returning a nullptr.\n";
       return nullptr;
+    }
 
     const aiScene* model = dynamics::MeshShape::loadMesh( fullPath );
-    
     if(!model)
-    {
-      dtwarn << "[DartLoader::createShape] Assimp could not load a model from "
-             << "the file '" << fullPath << "'\n";
-      return nullptr;
-    }
-    else
-    {
-      shape = dynamics::ShapePtr(new dynamics::MeshShape(
-          Eigen::Vector3d(mesh->scale.x, mesh->scale.y, mesh->scale.z), model, fullPath));
-    }
+      return nullptr; // MeshShape::loadMesh logs a warning
+
+    shape = dynamics::ShapePtr(new dynamics::MeshShape(
+      Eigen::Vector3d(mesh->scale.x, mesh->scale.y, mesh->scale.z), model, fullPath));
   }
   // Unknown geometry type
   else
   {
-    dtwarn << "[DartLoader::createShape] Unknown urdf Shape type "
-           << "(we only know of Sphere, Box, Cylinder, and Mesh). "
-           << "We are returning a nullptr." << std::endl;
+    dtwarn << "[DartLoader::createShape] Unknown URDF shape type"
+              " (we only know of Sphere, Box, Cylinder, and Mesh)."
+              " We are returning a nullptr.\n";
     return nullptr;
   }
 

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -310,7 +310,7 @@ dynamics::SkeletonPtr DartLoader::modelInterfaceToSkeleton(const urdf::ModelInte
 
   for(size_t i = 0; i < root->child_links.size(); i++)
   {
-    if (!createSkeletonRecursive(skeleton, root->child_links[i].get(), *rootNode))
+    if (!createSkeletonRecursive(skeleton, root->child_links[i].get(), rootNode))
       return nullptr;
 
   }
@@ -321,20 +321,20 @@ dynamics::SkeletonPtr DartLoader::modelInterfaceToSkeleton(const urdf::ModelInte
 bool DartLoader::createSkeletonRecursive(
     dynamics::SkeletonPtr _skel,
     const urdf::Link* _lk,
-    dynamics::BodyNode& _parentNode)
+    dynamics::BodyNode* _parentNode)
 {
   dynamics::BodyNode::Properties properties;
   if (!createDartNodeProperties(_lk, &properties))
     return false;
 
   dynamics::BodyNode* node = createDartJointAndNode(
-        _lk->parent_joint.get(), properties, &_parentNode, _skel);
+        _lk->parent_joint.get(), properties, _parentNode, _skel);
   if(!node)
     return false;
   
   for(size_t i = 0; i < _lk->child_links.size(); ++i)
   {
-      if (!createSkeletonRecursive(_skel, _lk->child_links[i].get(), *node))
+      if (!createSkeletonRecursive(_skel, _lk->child_links[i].get(), node))
         return false;
   }
   return true;

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -310,7 +310,7 @@ dynamics::SkeletonPtr DartLoader::modelInterfaceToSkeleton(const urdf::ModelInte
 
   for(size_t i = 0; i < root->child_links.size(); i++)
   {
-    if (!createSkeletonRecursive(skeleton, root->child_links[i].get(), rootNode))
+    if (!createSkeletonRecursive(skeleton, root->child_links[i].get(), *rootNode))
       return nullptr;
 
   }
@@ -321,20 +321,20 @@ dynamics::SkeletonPtr DartLoader::modelInterfaceToSkeleton(const urdf::ModelInte
 bool DartLoader::createSkeletonRecursive(
     dynamics::SkeletonPtr _skel,
     const urdf::Link* _lk,
-    dynamics::BodyNode* _parentNode)
+    dynamics::BodyNode& _parentNode)
 {
   dynamics::BodyNode::Properties properties;
   if (!createDartNodeProperties(_lk, &properties))
     return false;
 
   dynamics::BodyNode* node = createDartJointAndNode(
-        _lk->parent_joint.get(), properties, _parentNode, _skel);
+        _lk->parent_joint.get(), properties, &_parentNode, _skel);
   if(!node)
     return false;
   
   for(size_t i = 0; i < _lk->child_links.size(); ++i)
   {
-      if (!createSkeletonRecursive(_skel, _lk->child_links[i].get(), node))
+      if (!createSkeletonRecursive(_skel, _lk->child_links[i].get(), *node))
         return false;
   }
   return true;

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -281,7 +281,7 @@ dynamics::SkeletonPtr DartLoader::modelInterfaceToSkeleton(const urdf::ModelInte
     {
       root = root->child_links[0].get();
       dynamics::BodyNode::Properties rootProperties;
-      if (!createDartNodeProperties(root, &rootProperties))
+      if (!createDartNodeProperties(root, rootProperties))
         return nullptr;
 
       rootNode = createDartJointAndNode(
@@ -296,7 +296,7 @@ dynamics::SkeletonPtr DartLoader::modelInterfaceToSkeleton(const urdf::ModelInte
   else
   {
     dynamics::BodyNode::Properties rootProperties;
-    if (!createDartNodeProperties(root, &rootProperties))
+    if (!createDartNodeProperties(root, rootProperties))
       return nullptr;
 
     std::pair<dynamics::Joint*, dynamics::BodyNode*> pair =
@@ -324,7 +324,7 @@ bool DartLoader::createSkeletonRecursive(
     dynamics::BodyNode* _parentNode)
 {
   dynamics::BodyNode::Properties properties;
-  if (!createDartNodeProperties(_lk, &properties))
+  if (!createDartNodeProperties(_lk, properties))
     return false;
 
   dynamics::BodyNode* node = createDartJointAndNode(
@@ -467,15 +467,15 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
  * @function createDartNode
  */
 bool DartLoader::createDartNodeProperties(
-    const urdf::Link* _lk, dynamics::BodyNode::Properties *node)
+    const urdf::Link* _lk, dynamics::BodyNode::Properties &node)
 {
-  node->mName = _lk->name;
+  node.mName = _lk->name;
   
   // Load Inertial information
   if(_lk->inertial) {
     urdf::Pose origin = _lk->inertial->origin;
-    node->mInertia.setLocalCOM(toEigen(origin.position));
-    node->mInertia.setMass(_lk->inertial->mass);
+    node.mInertia.setLocalCOM(toEigen(origin.position));
+    node.mInertia.setMass(_lk->inertial->mass);
 
     Eigen::Matrix3d J;
     J << _lk->inertial->ixx, _lk->inertial->ixy, _lk->inertial->ixz,
@@ -485,7 +485,7 @@ bool DartLoader::createDartNodeProperties(
                                          origin.rotation.y, origin.rotation.z));
     J = R * J * R.transpose();
 
-    node->mInertia.setMoment(J(0,0), J(1,1), J(2,2),
+    node.mInertia.setMoment(J(0,0), J(1,1), J(2,2),
                             J(0,1), J(0,2), J(1,2));
   }
 
@@ -493,7 +493,7 @@ bool DartLoader::createDartNodeProperties(
   for(size_t i = 0; i < _lk->visual_array.size(); i++)
   {
     if(dynamics::ShapePtr shape = createShape(_lk->visual_array[i].get()))
-      node->mVizShapes.push_back(shape);
+      node.mVizShapes.push_back(shape);
     else
       return false;
   }
@@ -501,7 +501,7 @@ bool DartLoader::createDartNodeProperties(
   // Set collision information
   for(size_t i = 0; i < _lk->collision_array.size(); i++) {
     if(dynamics::ShapePtr shape = createShape(_lk->collision_array[i].get()))
-      node->mColShapes.push_back(shape);
+      node.mColShapes.push_back(shape);
     else
       return false;
   }

--- a/dart/utils/urdf/DartLoader.h
+++ b/dart/utils/urdf/DartLoader.h
@@ -92,7 +92,7 @@ private:
     void parseWorldToEntityPaths(const std::string& _xml_string);
 
     dart::dynamics::SkeletonPtr modelInterfaceToSkeleton(const urdf::ModelInterface* _model);
-    bool createSkeletonRecursive(dynamics::SkeletonPtr _skel, const urdf::Link* _lk, dynamics::BodyNode* _parent);
+    bool createSkeletonRecursive(dynamics::SkeletonPtr _skel, const urdf::Link* _lk, dynamics::BodyNode& _parent);
 
     template <class VisualOrCollision>
     dynamics::ShapePtr createShape(const VisualOrCollision* _vizOrCol);

--- a/dart/utils/urdf/DartLoader.h
+++ b/dart/utils/urdf/DartLoader.h
@@ -92,7 +92,7 @@ private:
     void parseWorldToEntityPaths(const std::string& _xml_string);
 
     dart::dynamics::SkeletonPtr modelInterfaceToSkeleton(const urdf::ModelInterface* _model);
-    bool createSkeletonRecursive(dynamics::SkeletonPtr _skel, const urdf::Link* _lk, dynamics::BodyNode& _parent);
+    bool createSkeletonRecursive(dynamics::SkeletonPtr _skel, const urdf::Link* _lk, dynamics::BodyNode* _parent);
 
     template <class VisualOrCollision>
     dynamics::ShapePtr createShape(const VisualOrCollision* _vizOrCol);

--- a/dart/utils/urdf/DartLoader.h
+++ b/dart/utils/urdf/DartLoader.h
@@ -92,7 +92,7 @@ private:
     void parseWorldToEntityPaths(const std::string& _xml_string);
 
     dart::dynamics::SkeletonPtr modelInterfaceToSkeleton(const urdf::ModelInterface* _model);
-    void createSkeletonRecursive(dynamics::SkeletonPtr _skel, const urdf::Link* _lk, dynamics::BodyNode* _parent);
+    bool createSkeletonRecursive(dynamics::SkeletonPtr _skel, const urdf::Link* _lk, dynamics::BodyNode* _parent);
 
     template <class VisualOrCollision>
     dynamics::ShapePtr createShape(const VisualOrCollision* _vizOrCol);
@@ -103,8 +103,8 @@ private:
         dynamics::BodyNode* _parent,
         dynamics::SkeletonPtr _skeleton);
 
-    dynamics::BodyNode::Properties createDartNodeProperties(
-        const urdf::Link* _lk);
+    bool createDartNodeProperties(
+        const urdf::Link* _lk, dynamics::BodyNode::Properties *properties);
 
     Eigen::Isometry3d toEigen(const urdf::Pose& _pose);
     Eigen::Vector3d toEigen(const urdf::Vector3& _vector);

--- a/dart/utils/urdf/DartLoader.h
+++ b/dart/utils/urdf/DartLoader.h
@@ -104,7 +104,7 @@ private:
         dynamics::SkeletonPtr _skeleton);
 
     bool createDartNodeProperties(
-        const urdf::Link* _lk, dynamics::BodyNode::Properties *properties);
+        const urdf::Link* _lk, dynamics::BodyNode::Properties &properties);
 
     Eigen::Isometry3d toEigen(const urdf::Pose& _pose);
     Eigen::Vector3d toEigen(const urdf::Vector3& _vector);

--- a/data/urdf/test/invalid.urdf
+++ b/data/urdf/test/invalid.urdf
@@ -1,0 +1,1 @@
+This is not a valid URDF file.

--- a/data/urdf/test/invalid_mesh.stl
+++ b/data/urdf/test/invalid_mesh.stl
@@ -1,0 +1,1 @@
+This is not a valid STL file.

--- a/data/urdf/test/invalid_mesh.urdf
+++ b/data/urdf/test/invalid_mesh.urdf
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<robot name="invalid_mesh">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="invalid_mesh.stl"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/data/urdf/test/missing_mesh.urdf
+++ b/data/urdf/test/missing_mesh.urdf
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<robot name="multipleshapes">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="this_file_does_not_exist.stl"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/data/urdf/test/missing_package.urdf
+++ b/data/urdf/test/missing_package.urdf
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<robot name="missing_package">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="package://missing_package/foo.stl"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/data/urdf/test/primitive_geometry.urdf
+++ b/data/urdf/test/primitive_geometry.urdf
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="primitive_geometry">
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <sphere radius="1"/>
+        <cylinder radius="1" length="1"/>
+        <box size="1 1 1"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/unittests/testDartLoader.cpp
+++ b/unittests/testDartLoader.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Michael Koval <mkoval@cs.cmu.edu>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <gtest/gtest.h>
+#include "dart/utils/urdf/DartLoader.h"
+
+using dart::utils::DartLoader;
+
+TEST(DartLoader, parseSkeleton_NonExistantPathReturnsNull)
+{
+  DartLoader loader;
+  EXPECT_EQ(nullptr,
+    loader.parseSkeleton(DART_DATA_PATH"skel/test/does_not_exist.urdf"));
+}
+
+TEST(DartLoader, parseSkeleton_InvalidUrdfReturnsNull)
+{
+  DartLoader loader;
+  EXPECT_EQ(nullptr,
+    loader.parseSkeleton(DART_DATA_PATH"urdf/test/invalid.urdf"));
+}
+
+TEST(DartLoader, parseSkeleton_MissingMeshReturnsNull)
+{
+  DartLoader loader;
+  EXPECT_EQ(nullptr,
+    loader.parseSkeleton(DART_DATA_PATH"urdf/test/missing_mesh.urdf"));
+}
+
+TEST(DartLoader, parseSkeleton_InvalidMeshReturnsNull)
+{
+  DartLoader loader;
+  EXPECT_EQ(nullptr,
+    loader.parseSkeleton(DART_DATA_PATH"urdf/test/invalid_mesh.urdf"));
+}
+
+TEST(DartLoader, parseSkeleton_MissingPackageReturnsNull)
+{
+  DartLoader loader;
+  EXPECT_EQ(nullptr,
+    loader.parseSkeleton(DART_DATA_PATH"urdf/test/missing_package.urdf"));
+}
+
+TEST(DartLoader, parseSkeleton_LoadsPrimitiveGeometry)
+{
+  DartLoader loader;
+  EXPECT_TRUE(nullptr !=
+    loader.parseSkeleton(DART_DATA_PATH"urdf/test/primitive_geometry.urdf"));
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittests/testSdfParser.cpp
+++ b/unittests/testSdfParser.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2013-2015, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Jeongseok Lee <jslee02@gmail.com>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <gtest/gtest.h>
+#include "TestHelpers.h"
+
+#include "dart/dynamics/SoftBodyNode.h"
+#include "dart/dynamics/RevoluteJoint.h"
+#include "dart/dynamics/PlanarJoint.h"
+#include "dart/dynamics/Skeleton.h"
+#include "dart/simulation/World.h"
+#include "dart/utils/sdf/SdfParser.h"
+
+using namespace dart;
+using namespace math;
+using namespace dynamics;
+using namespace simulation;
+using namespace utils;
+
+//==============================================================================
+TEST(SdfParser, SDFSingleBodyWithoutJoint)
+{
+  // Regression test for #444
+  WorldPtr world
+      = SdfParser::readSdfFile(
+          DART_DATA_PATH"/sdf/test/single_bodynode_skeleton.world");
+  EXPECT_TRUE(world != nullptr);
+
+  SkeletonPtr skel = world->getSkeleton(0);
+  EXPECT_TRUE(skel != nullptr);
+  EXPECT_EQ(skel->getNumBodyNodes(), 1);
+  EXPECT_EQ(skel->getNumJoints(), 1);
+
+  BodyNodePtr bodyNode = skel->getBodyNode(0);
+  EXPECT_TRUE(bodyNode != nullptr);
+  EXPECT_EQ(bodyNode->getNumVisualizationShapes(), 1);
+  EXPECT_EQ(bodyNode->getNumCollisionShapes(), 1);
+
+  JointPtr joint = skel->getJoint(0);
+  EXPECT_TRUE(joint != nullptr);
+  EXPECT_EQ(joint->getType(), FreeJoint::getStaticType());
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittests/testSkelParser.cpp
+++ b/unittests/testSkelParser.cpp
@@ -53,7 +53,7 @@ using namespace simulation;
 using namespace utils;
 
 //==============================================================================
-TEST(Parser, DataStructure)
+TEST(SkelParser, DataStructure)
 {
   bool              valBool       = true;
   int               valInt        = -3;
@@ -97,7 +97,7 @@ TEST(Parser, DataStructure)
 }
 
 //==============================================================================
-TEST(Parser, EmptyWorld)
+TEST(SkelParser, EmptyWorld)
 {
   WorldPtr world = SkelParser::readWorld(DART_DATA_PATH"skel/test/empty.skel");
 
@@ -114,7 +114,7 @@ TEST(Parser, EmptyWorld)
 }
 
 //==============================================================================
-TEST(Parser, SinglePendulum)
+TEST(SkelParser, SinglePendulum)
 {
   WorldPtr world = SkelParser::readWorld(
                    DART_DATA_PATH"skel/test/single_pendulum.skel");
@@ -134,7 +134,7 @@ TEST(Parser, SinglePendulum)
 }
 
 //==============================================================================
-TEST(Parser, SerialChain)
+TEST(SkelParser, SerialChain)
 {
   WorldPtr world = SkelParser::readWorld(
                    DART_DATA_PATH"skel/test/serial_chain_ball_joint.skel");
@@ -154,7 +154,7 @@ TEST(Parser, SerialChain)
 }
 
 //==============================================================================
-TEST(Parser, RigidAndSoftBodies)
+TEST(SkelParser, RigidAndSoftBodies)
 {
   using namespace dart;
   using namespace math;
@@ -179,7 +179,7 @@ TEST(Parser, RigidAndSoftBodies)
 }
 
 //==============================================================================
-TEST(Parser, PlanarJoint)
+TEST(SkelParser, PlanarJoint)
 {
   using namespace dart;
   using namespace math;
@@ -328,7 +328,7 @@ TEST(SKEL_PARSER, JointActuatorType)
   EXPECT_EQ(joint4->getActuatorType(), Joint::VELOCITY);}
 
 //==============================================================================
-TEST(Parser, DofAttributes)
+TEST(SkelParser, DofAttributes)
 {
   WorldPtr world = SkelParser::readWorld(
                    DART_DATA_PATH"/skel/test/dof_attribute_test.skel");
@@ -405,7 +405,7 @@ TEST(Parser, DofAttributes)
 }
 
 //==============================================================================
-TEST(Parser, JointDynamicsElements)
+TEST(SkelParser, JointDynamicsElements)
 {
   WorldPtr world
       = SkelParser::readWorld(

--- a/unittests/testSkelParser.cpp
+++ b/unittests/testSkelParser.cpp
@@ -45,7 +45,6 @@
 #include "dart/simulation/World.h"
 #include "dart/simulation/World.h"
 #include "dart/utils/SkelParser.h"
-#include "dart/utils/sdf/SdfParser.h"
 
 using namespace dart;
 using namespace math;
@@ -436,30 +435,6 @@ TEST(Parser, JointDynamicsElements)
   EXPECT_EQ(joint1->getCoulombFriction   (2), 3.0);
   EXPECT_EQ(joint1->getRestPosition      (2), 0.3);
   EXPECT_EQ(joint1->getSpringStiffness   (2), 1.0);
-}
-
-//==============================================================================
-TEST(Parser, SDFSingleBodyWithoutJoint)
-{
-  // Regression test for #444
-  WorldPtr world
-      = SdfParser::readSdfFile(
-          DART_DATA_PATH"/sdf/test/single_bodynode_skeleton.world");
-  EXPECT_TRUE(world != nullptr);
-
-  SkeletonPtr skel = world->getSkeleton(0);
-  EXPECT_TRUE(skel != nullptr);
-  EXPECT_EQ(skel->getNumBodyNodes(), 1);
-  EXPECT_EQ(skel->getNumJoints(), 1);
-
-  BodyNodePtr bodyNode = skel->getBodyNode(0);
-  EXPECT_TRUE(bodyNode != nullptr);
-  EXPECT_EQ(bodyNode->getNumVisualizationShapes(), 1);
-  EXPECT_EQ(bodyNode->getNumCollisionShapes(), 1);
-
-  JointPtr joint = skel->getJoint(0);
-  EXPECT_TRUE(joint != nullptr);
-  EXPECT_EQ(joint->getType(), FreeJoint::getStaticType());
 }
 
 //==============================================================================


### PR DESCRIPTION
DartLoader currently SEGFAULTs if it fails loading a mesh and, possibly, in a few other situations. This pull request adds error-handling logic that prints a `dterr` message and returns `nullptr` in that case.