### PR TITLE
Chain constructor to not SEGFAULT when passed a nullptr

### DIFF
--- a/dart/dynamics/Chain.cpp
+++ b/dart/dynamics/Chain.cpp
@@ -85,6 +85,9 @@ ChainPtr Chain::create(const Chain::Criteria& _criteria,
 ChainPtr Chain::create(BodyNode* _start, BodyNode* _target,
                        const std::string& _name)
 {
+  if (nullptr == _start || nullptr == _target)
+    return nullptr;
+
   ChainPtr chain(new Chain(_start, _target, _name));
   chain->mPtr = chain;
   return chain;


### PR DESCRIPTION
It's very convenient to write code that looks like this:
```c++
auto chain = Chain::create(skel->getBodyNode("start"), skel->getBodyNode("target"));
if (!chain)
  // error!
```
Unfortunately, this currently SEGFAULTs if either `getBodyNode` returns `nullptr`. The only solution is to do this, which is much more verbose:
```c++
BodyNodePtr start = skel->getBodyNode("start");
BodyNodePtr target = skel->getBodyNode("target");
ChainPtr chain;
if (start && target)
  chain = Chain::create(start, target);
else
  // error!
```

This pull request modifies `Chain::create` to return `nullptr` if either input `BodyNode` is `nullptr`. This enables you to write the first block of code.

**API Question:** Should `Chain::create(~)` interpret `nullptr` in `start` to mean "the world"? This would be necessary, in conjunction with my proposal in #437, to create a chain that includes a link attached to the `World`. This would be consistent with the usage of a `nullptr` parent in DART to refer to the world frame.