### PR TITLE
Changes to Linkage and Chain Criteria

### DIFF
--- a/dart/dynamics/Chain.h
+++ b/dart/dynamics/Chain.h
@@ -54,7 +54,7 @@ public:
   struct Criteria
   {
     /// Constructor for Chain::Criteria
-    Criteria(BodyNode* _start, BodyNode* _target);
+    Criteria(BodyNode* _start, BodyNode* _target, bool _includeBoth = false);
 
     /// Return a vector of BodyNodes that form a chain
     std::vector<BodyNode*> satisfy() const;
@@ -66,6 +66,11 @@ public:
     /// branching or a FreeJoint along the way
     WeakBodyNodePtr mTarget;
 
+    /// Set this to true if both the start and the target BodyNode should be
+    /// included. Otherwise, whichever is upstream of the other will be left out
+    /// of the chain.
+    bool mIncludeBoth;
+
     /// Convert this Criteria into Linkage::Criteria
     Linkage::Criteria convert() const;
 
@@ -73,13 +78,24 @@ public:
     operator Linkage::Criteria() const;
   };
 
+  /// This enum is used to specify to the create() function that both the start
+  /// and the target BodyNodes should be included in the Chain that gets
+  /// generated.
+  enum IncludeBoth_t { IncludeBoth };
+
   /// Create a Chain given some Chain::Criteria
   static ChainPtr create(const Chain::Criteria& _criteria,
                          const std::string& _name = "Chain");
 
-  /// Create a Chain given a start and a target BodyNode
+  /// Create a Chain given a start and a target BodyNode. Note that whichever
+  /// BodyNode is upstream of the other will be excluded from the Chain.
   static ChainPtr create(BodyNode* _start, BodyNode* _target,
                          const std::string& _name = "Chain");
+
+  /// Create a Chain given a start and a target BodyNode. In this version, both
+  /// BodyNodes will be included in the Chain that gets created.
+  static ChainPtr create(BodyNode* _start, BodyNode* _target,
+                         IncludeBoth_t, const std::string& _name = "Chain");
 
   /// Returns false if this Chain has been broken, or some new Branching has
   /// been added.
@@ -93,6 +109,10 @@ protected:
   /// Alternative constructor for the Chain class
   Chain(BodyNode* _start, BodyNode* _target,
         const std::string& _name = "Chain");
+
+  /// Alternative constructor for the Chain class
+  Chain(BodyNode* _start, BodyNode* _target,
+        IncludeBoth_t, const std::string& _name = "Chain");
 
 };
 

--- a/dart/dynamics/Linkage.cpp
+++ b/dart/dynamics/Linkage.cpp
@@ -71,6 +71,9 @@ std::vector<BodyNode*> Linkage::Criteria::satisfy() const
     // Get the root BodyNode of this BodyNode's tree
     size_t treeIndex = inferStart->getTreeIndex();
     start.mNode = inferStart->getSkeleton()->getRootBodyNode(treeIndex);
+
+    if(EXCLUDE == start.mPolicy)
+      start.mPolicy = INCLUDE;
   }
 
   refreshTerminalMap();

--- a/dart/dynamics/Linkage.cpp
+++ b/dart/dynamics/Linkage.cpp
@@ -58,12 +58,13 @@ std::vector<BodyNode*> Linkage::Criteria::satisfy() const
 
   refreshTerminalMap();
 
-  bns.push_back(mStart.mNode.lock());
+  if(EXCLUDE != mStart.mPolicy)
+    bns.push_back(mStart.mNode.lock());
   expansionPolicy(mStart.mNode.lock(), mStart.mPolicy, bns);
 
   for(size_t i=0; i<mTargets.size(); ++i)
   {
-    expandToTarget(mStart.mNode.lock(), mTargets[i], bns);
+    expandToTarget(mStart, mTargets[i], bns);
   }
 
   // Make sure each BodyNode is only included once
@@ -121,21 +122,24 @@ void Linkage::Criteria::expansionPolicy(
     Linkage::Criteria::ExpansionPolicy _policy,
     std::vector<BodyNode*>& _bns) const
 {
-  // If the _start is a terminal, we quit before expanding
-  std::unordered_map<BodyNode*, bool>::const_iterator check_start =
-      mMapOfTerminals.find(_start);
-  if( check_start != mMapOfTerminals.end() )
+  if(EXCLUDE != _policy)
   {
-    bool inclusive = check_start->second;
-    if(inclusive)
-      _bns.push_back(_start);
-    return;
+    // If the _start is a terminal, we quit before expanding
+    std::unordered_map<BodyNode*, bool>::const_iterator check_start =
+        mMapOfTerminals.find(_start);
+    if( check_start != mMapOfTerminals.end() )
+    {
+      bool inclusive = check_start->second;
+      if(inclusive)
+        _bns.push_back(_start);
+      return;
+    }
   }
 
   if(DOWNSTREAM == _policy)
-    expandDownstream(_start, _bns);
+    expandDownstream(_start, _bns, EXCLUDE != _policy);
   else if(UPSTREAM == _policy)
-    expandUpstream(_start, _bns);
+    expandUpstream(_start, _bns, EXCLUDE != _policy);
 }
 
 //==============================================================================
@@ -199,12 +203,13 @@ void stepToParent(std::vector<Recording>& _recorder,
 
 //==============================================================================
 void Linkage::Criteria::expandDownstream(
-    BodyNode* _start, std::vector<BodyNode*>& _bns) const
+    BodyNode* _start, std::vector<BodyNode*>& _bns, bool _includeStart) const
 {
   std::vector<Recording> recorder;
   recorder.reserve(_start->getSkeleton()->getNumBodyNodes());
 
-  _bns.push_back(_start);
+  if(_includeStart)
+    _bns.push_back(_start);
   recorder.push_back(Recording(_start, 0));
 
   while(recorder.size() > 0)
@@ -225,12 +230,13 @@ void Linkage::Criteria::expandDownstream(
 
 //==============================================================================
 void Linkage::Criteria::expandUpstream(
-    BodyNode* _start, std::vector<BodyNode*>& _bns) const
+    BodyNode* _start, std::vector<BodyNode*>& _bns, bool _includeStart) const
 {
   std::vector<Recording> recorder;
   recorder.reserve(_start->getSkeleton()->getNumBodyNodes());
 
-  _bns.push_back(_start);
+  if(_includeStart)
+    _bns.push_back(_start);
   recorder.push_back(Recording(_start, -1));
 
   while(recorder.size() > 0)
@@ -294,28 +300,43 @@ void Linkage::Criteria::expandUpstream(
 
 //==============================================================================
 void Linkage::Criteria::expandToTarget(
-    BodyNode* _start,
+    const Linkage::Criteria::Target& _start,
     const Linkage::Criteria::Target& _target,
     std::vector<BodyNode*>& _bns) const
 {
+  BodyNode* start_bn = _start.mNode.lock();
   BodyNode* target_bn = _target.mNode.lock();
   std::vector<BodyNode*> newBns;
-  newBns.reserve(target_bn->getSkeleton()->getNumBodyNodes());
+  newBns.reserve(start_bn->getSkeleton()->getNumBodyNodes());
 
-  if(target_bn == nullptr || _start->descendsFrom(target_bn))
+  if(target_bn == nullptr || start_bn->descendsFrom(target_bn))
   {
-    newBns = climbToTarget(_start, target_bn);
+    newBns = climbToTarget(start_bn, target_bn);
     trimBodyNodes(newBns, _target.mChain, true);
   }
-  else if(target_bn->descendsFrom(_start))
+  else if(target_bn->descendsFrom(start_bn))
   {
-    newBns = climbToTarget(target_bn, _start);
+    newBns = climbToTarget(target_bn, start_bn);
     std::reverse(newBns.begin(), newBns.end());
     trimBodyNodes(newBns, _target.mChain, false);
   }
   else
   {
-    newBns = climbToCommonRoot(_start, target_bn, _target.mChain);
+    newBns = climbToCommonRoot(_start, _target, _target.mChain);
+  }
+
+  // Remove the start BodyNode if it's supposed to be excluded
+  if(EXCLUDE == _start.mPolicy &&
+     newBns.size() > 0 && newBns.front() == start_bn)
+  {
+    newBns.erase(newBns.begin());
+  }
+
+  // Remove the target BodyNode if it's supposed to be excluded
+  if(EXCLUDE == _target.mPolicy &&
+     newBns.size() > 0 && newBns.back() == target_bn)
+  {
+    newBns.pop_back();
   }
 
   // If we have successfully reached the target, expand from there
@@ -347,18 +368,21 @@ std::vector<BodyNode*> Linkage::Criteria::climbToTarget(
 
 //==============================================================================
 std::vector<BodyNode*> Linkage::Criteria::climbToCommonRoot(
-    BodyNode* _start, BodyNode* _target, bool _chain) const
+    const Target& _start, const Target& _target,
+    bool _chain) const
 {
-  BodyNode* root = _start->getParentBodyNode();
+  BodyNode* start_bn = _start.mNode.lock();
+  BodyNode* target_bn = _target.mNode.lock();
+  BodyNode* root = start_bn->getParentBodyNode();
   while(root != nullptr)
   {
-    if(_target->descendsFrom(root))
+    if(target_bn->descendsFrom(root))
       break;
 
     root = root->getParentBodyNode();
   }
 
-  std::vector<BodyNode*> bnStart = climbToTarget(_start, root);
+  std::vector<BodyNode*> bnStart = climbToTarget(start_bn, root);
   trimBodyNodes(bnStart, _chain, true);
 
   if(root != nullptr && bnStart.back() != root)
@@ -367,7 +391,7 @@ std::vector<BodyNode*> Linkage::Criteria::climbToCommonRoot(
     return bnStart;
   }
 
-  std::vector<BodyNode*> bnTarget = climbToTarget(_target, root);
+  std::vector<BodyNode*> bnTarget = climbToTarget(target_bn, root);
   std::reverse(bnTarget.begin(), bnTarget.end());
   trimBodyNodes(bnTarget, _chain, false);
 

--- a/dart/dynamics/Linkage.h
+++ b/dart/dynamics/Linkage.h
@@ -64,9 +64,10 @@ public:
     /// The ExpansionPolicy indicates how the collection of BodyNodes should
     /// expand from the starting BodyNode (mStart)
     enum ExpansionPolicy {
-      NEUTRAL = 0,  ///< Do not expand. Only include the BodyNodes needed to reach the target
-      DOWNSTREAM,   ///< Expand downstream, toward the leaves of the tree
-      UPSTREAM      ///< Expand upstream, toward the root of the tree
+      INCLUDE = 0,  ///< Do not expand from the target. Include everything up to the target and then stop.
+      EXCLUDE,      ///< Do not expand from the target. Include everything up to the target, but NOT the target, and then stop.
+      DOWNSTREAM,   ///< Include the target, and then expand downstream, toward the leaves of the tree.
+      UPSTREAM      ///< Include the target, and then expand upstream, toward the root of the tree.
     };
 
     /// Return a vector of BodyNodes that satisfy the parameters of the Criteria
@@ -78,7 +79,7 @@ public:
     {
       /// Default constructor for Target
       Target(BodyNode* _target = nullptr,
-             ExpansionPolicy _policy = NEUTRAL,
+             ExpansionPolicy _policy = INCLUDE,
              bool _chain = false);
 
       /// The Linkage will expand from the starting BodyNode up to this node
@@ -139,22 +140,23 @@ public:
                          std::vector<BodyNode*>& _bns) const;
 
     /// Expand downstream
-    void expandDownstream(BodyNode* _start, std::vector<BodyNode*>& _bns) const;
+    void expandDownstream(BodyNode* _start, std::vector<BodyNode*>& _bns,
+                          bool _includeStart) const;
 
     /// Expand upstream
-    void expandUpstream(BodyNode* _start, std::vector<BodyNode*>& _bns) const;
+    void expandUpstream(BodyNode* _start, std::vector<BodyNode*>& _bns,
+                        bool _includeStart) const;
 
     /// Construct a path from start to target
-    void expandToTarget(BodyNode* _start, const Target& _target,
+    void expandToTarget(const Target& _start, const Target& _target,
                         std::vector<BodyNode*>& _bns) const;
 
     /// Expand upwards from the _start BodyNode to the _target BodyNode
-    std::vector<BodyNode*> climbToTarget(
-        BodyNode* _start, BodyNode* _target) const;
+    std::vector<BodyNode*> climbToTarget(BodyNode* _start, BodyNode* _target) const;
 
     /// Expand upwards from both BodyNodes to a common root
     std::vector<BodyNode*> climbToCommonRoot(
-        BodyNode* _start, BodyNode* _target, bool _chain) const;
+        const Target& _start, const Target& _target, bool _chain) const;
 
     /// Crawl through the list and cut it off anywhere that the criteria is
     /// violated

--- a/unittests/testSkeleton.cpp
+++ b/unittests/testSkeleton.cpp
@@ -740,9 +740,9 @@ void checkForBodyNodes(
   EXPECT_TRUE(contains);
   if(!contains)
   {
-    dtwarn << "The ReferentialSkeleton [" << refSkel->getName() << "] does NOT "
-           << "contain the BodyNode [" << name << "] of the Skeleton ["
-           << skel->getName() << "]\n";
+    dtmsg << "The ReferentialSkeleton [" << refSkel->getName() << "] does NOT "
+          << "contain the BodyNode [" << name << "] of the Skeleton ["
+          << skel->getName() << "]\n";
   }
 
   ++count;
@@ -760,7 +760,16 @@ size_t checkForBodyNodes(
   checkForBodyNodes(count, refSkel, skel, args...);
 
   if(checkCount)
-    EXPECT_TRUE(count == refSkel->getNumBodyNodes());
+  {
+    bool countValid = (count == refSkel->getNumBodyNodes());
+    EXPECT_TRUE(countValid);
+    if(!countValid)
+    {
+      dtmsg << "The number of BodyNodes checked for [" << count << "] "
+            << "does not equal the number [" << refSkel->getNumBodyNodes()
+            << "] in the ReferentialSkeleton [" << refSkel->getName() << "]\n";
+    }
+  }
 
   return count;
 }
@@ -776,7 +785,7 @@ TEST(Skeleton, Linkage)
 
   ChainPtr midchain = Chain::create(skel->getBodyNode("c1b3"),
                  skel->getBodyNode("c3b4"), "midchain");
-  checkForBodyNodes(midchain, skel, true, "c1b3", "c3b1", "c3b2", "c3b3");
+  checkForBodyNodes(midchain, skel, true, "c3b1", "c3b2", "c3b3");
 
   Linkage::Criteria criteria;
   criteria.mStart = skel->getBodyNode("c5b2");
@@ -817,8 +826,12 @@ TEST(Skeleton, Linkage)
   EXPECT_TRUE( count == combinedSkelBases->getNumBodyNodes() );
 
   ChainPtr downstreamFreeJoint = Chain::create(skel->getBodyNode("c1b1"),
-                            skel->getBodyNode("c1b3"), "downstreamFreeJoint");
+      skel->getBodyNode("c1b3"), Chain::IncludeBoth, "downstreamFreeJoint");
   checkForBodyNodes(downstreamFreeJoint, skel, true, "c1b1");
+
+  ChainPtr emptyChain = Chain::create(skel->getBodyNode("c1b1"),
+      skel->getBodyNode("c1b3"), "emptyChain");
+  checkForBodyNodes(emptyChain, skel, true);
 
   ChainPtr upstreamFreeJoint = Chain::create(skel->getBodyNode("c1b3"),
                           skel->getBodyNode("c1b1"), "upstreamFreeJoint");

--- a/unittests/testSkeleton.cpp
+++ b/unittests/testSkeleton.cpp
@@ -833,6 +833,10 @@ TEST(Skeleton, Linkage)
       skel->getBodyNode("c1b3"), "emptyChain");
   checkForBodyNodes(emptyChain, skel, true);
 
+  ChainPtr chainFromNull = Chain::create(nullptr, skel->getBodyNode("c1b2"),
+                                         "chainFromNull");
+  checkForBodyNodes(chainFromNull, skel, true, "c1b1");
+
   ChainPtr upstreamFreeJoint = Chain::create(skel->getBodyNode("c1b3"),
                           skel->getBodyNode("c1b1"), "upstreamFreeJoint");
   checkForBodyNodes(upstreamFreeJoint, skel, true, "c1b3", "c1b2");


### PR DESCRIPTION
This pull request addresses issue #437 and replaces pull request #440.

The changes are as follows:

* You can now tell specify in your Linkage Criteria that a start or a target BodyNode should be *excluded* from the Linkage.
* The new default behavior for Chains is that whichever BodyNode is upstream of the other will be excluded from the Chain
* An alternative constructor is available for Chains which allows the user to request that both the start and the target BodyNodes should be included, regardless of which is upstream
* Linkage and Chain criteria now allow you to specify a nullptr starting BodyNode, which will be treated as if it represents the World