### PR TITLE
More robust SDF parsing -- Patch for Release 5.0

### DIFF
--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -259,13 +259,13 @@ dynamics::SkeletonPtr SdfParser::readSkeleton(
 
   // Iterate through the collected properties and construct the Skeleton from
   // the root nodes downward
-  JointMap::iterator it = sdfJoints.begin();
-  BodyMap::const_iterator child;
-  dynamics::BodyNode* parent;
-  while(it != sdfJoints.end())
+  BodyMap::iterator body = sdfBodyNodes.begin();
+  JointMap::const_iterator parentJoint;
+  dynamics::BodyNode* parentBody;
+  while(body != sdfBodyNodes.end())
   {
     NextResult result = getNextJointAndNodePair(
-          it, child, parent, newSkeleton, sdfJoints, sdfBodyNodes);
+          body, parentJoint, parentBody, newSkeleton, sdfBodyNodes, sdfJoints);
 
     if(BREAK == result)
       break;
@@ -275,24 +275,26 @@ dynamics::SkeletonPtr SdfParser::readSkeleton(
     {
       // If a root FreeJoint is needed for the parent of the current joint, then
       // create it
-      BodyMap::const_iterator rootNode = sdfBodyNodes.find(it->second.parentName);
       SDFJoint rootJoint;
       rootJoint.properties =
           Eigen::make_aligned_shared<dynamics::FreeJoint::Properties>(
-            dynamics::Joint::Properties("root", rootNode->second.initTransform));
+            dynamics::Joint::Properties("root", body->second.initTransform));
       rootJoint.type = "free";
 
-      if(!pairCreator(newSkeleton, nullptr, rootJoint, rootNode->second))
+      if(!pairCreator(newSkeleton, nullptr, rootJoint, body->second))
         break;
+
+      sdfBodyNodes.erase(body);
+      body = sdfBodyNodes.begin();
 
       continue;
     }
 
-    if(!pairCreator(newSkeleton, parent, it->second, child->second))
+    if(!pairCreator(newSkeleton, parentBody, parentJoint->second, body->second))
       break;
 
-    sdfJoints.erase(it);
-    it = sdfJoints.begin();
+    sdfBodyNodes.erase(body);
+    body = sdfBodyNodes.begin();
   }
 
   return newSkeleton;
@@ -313,57 +315,48 @@ bool SdfParser::createPair(dynamics::SkeletonPtr skeleton,
 }
 
 SdfParser::NextResult SdfParser::getNextJointAndNodePair(
-    JointMap::iterator& it,
-    BodyMap::const_iterator& child,
-    dynamics::BodyNode*& parent,
+    BodyMap::iterator& body,
+    JointMap::const_iterator& parentJoint,
+    dynamics::BodyNode*& parentBody,
     const dynamics::SkeletonPtr skeleton,
-    JointMap& sdfJoints,
-    const BodyMap& sdfBodyNodes)
+    BodyMap& sdfBodyNodes,
+    const JointMap& sdfJoints)
 {
-  NextResult result = VALID;
-  const SDFJoint& joint = it->second;
-  parent = skeleton->getBodyNode(joint.parentName);
-  if(nullptr == parent
-     && joint.parentName != "world" && !joint.parentName.empty())
+  parentJoint = sdfJoints.find(body->first);
+  if(parentJoint == sdfJoints.end())
+  {
+    return CREATE_FREEJOINT_ROOT;
+  }
+
+  const std::string& parentBodyName = parentJoint->second.parentName;
+  const std::string& parentJointName = parentJoint->second.properties->mName;
+
+  // Check if the parent Body is created yet
+  parentBody = skeleton->getBodyNode(parentBodyName);
+  if(nullptr == parentBody && parentBodyName != "world"
+     && !parentBodyName.empty())
   {
     // Find the properties of the parent Joint of the current Joint, because it
     // does not seem to be created yet.
-    JointMap::iterator check_parent_joint = sdfJoints.find(joint.parentName);
-    if(check_parent_joint == sdfJoints.end())
-    {
-      BodyMap::const_iterator check_parent_node = sdfBodyNodes.find(joint.parentName);
-      if(check_parent_node == sdfBodyNodes.end())
-      {
-        dterr << "[SdfParser::getNextJointAndNodePair] Could not find Link "
-              << "named [" << joint.parentName << "] requested as parent of "
-              << "Joint [" << joint.properties->mName << "]. We will now quit "
-              << "parsing.\n";
-        return BREAK;
-      }
+    BodyMap::iterator check_parent_body = sdfBodyNodes.find(parentBodyName);
 
-      // If the current Joint has a parent BodyNode but does not have a parent
-      // Joint, then we need to create a FreeJoint for the parent BodyNode.
-      result = CREATE_FREEJOINT_ROOT;
+    if(check_parent_body == sdfBodyNodes.end())
+    {
+      // The Body does not exist in the file
+      dterr << "[SdfParser::getNextJointAndNodePair] Could not find Link "
+            << "named [" << parentBodyName << "] requested as parent of "
+            << "Joint [" << parentJointName << "]. We will now quit "
+            << "parsing.\n";
+      return BREAK;
     }
     else
     {
-      it = check_parent_joint;
+      body = check_parent_body;
       return CONTINUE; // Create the parent before creating the current Joint
     }
   }
 
-  // Find the child node of this Joint, so we can create them together
-  child = sdfBodyNodes.find(joint.childName);
-  if(child == sdfBodyNodes.end())
-  {
-    dterr << "[SdfParser::getNextJointAndNodePair] Could not find Link named ["
-          << joint.childName << "] requested as child of Joint ["
-          << joint.properties->mName << "]. This should not be possible! "
-          << "We will now quit parsing. Please report this bug!\n";
-    return BREAK;
-  }
-
-  return result;
+  return VALID;
 }
 
 dynamics::SkeletonPtr SdfParser::makeSkeleton(

--- a/dart/utils/sdf/SdfParser.h
+++ b/dart/utils/sdf/SdfParser.h
@@ -84,7 +84,10 @@ public:
       std::string type;
     };
 
+    // Maps the name of a BodyNode to its properties
     typedef Eigen::aligned_map<std::string, SDFBodyNode> BodyMap;
+
+    // Maps a child BodyNode to the properties of its parent Joint
     typedef std::map<std::string, SDFJoint> JointMap;
 
     static simulation::WorldPtr readWorld(
@@ -133,13 +136,12 @@ public:
       CREATE_FREEJOINT_ROOT
     };
 
-    static NextResult getNextJointAndNodePair(
-        JointMap::iterator& it,
-        BodyMap::const_iterator& child,
-        dynamics::BodyNode*& parent,
+    static NextResult getNextJointAndNodePair(BodyMap::iterator& body,
+        JointMap::const_iterator& parentJoint,
+        dynamics::BodyNode*& parentBody,
         const dynamics::SkeletonPtr skeleton,
-        JointMap& sdfJoints,
-        const BodyMap& sdfBodyNodes);
+        BodyMap& sdfBodyNodes,
+        const JointMap& sdfJoints);
 
     /// \brief
     static dynamics::SkeletonPtr makeSkeleton(

--- a/data/sdf/test/single_bodynode_skeleton.world
+++ b/data/sdf/test/single_bodynode_skeleton.world
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+  <world name="default">
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <!--include>
+      <uri>model://ground_plane</uri>
+    </include-->
+
+    <physics type="dart">
+      <gravity>0.0 0.0 -9.81</gravity>
+      <real_time_update_rate>0.000000</real_time_update_rate>
+      <max_step_size>0.001000</max_step_size>
+    </physics>
+
+    <model name="skeleton 1">
+      <pose>0 0 0 0 0 0</pose>
+      <link name="link 1">
+        <pose>0 0 0  0 0 0</pose>
+        <self_collide>0</self_collide>
+        <inertial>
+          <pose>0 0 0  0 0 0</pose>
+        </inertial>
+        <visual name="visual 1">
+          <pose>0 0 0  0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+        <collision name="collision 1">
+          <pose>0 0 0  0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.3</length>
+            </cylinder>
+          </geometry>
+        </collision>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/unittests/testParser.cpp
+++ b/unittests/testParser.cpp
@@ -45,6 +45,7 @@
 #include "dart/simulation/World.h"
 #include "dart/simulation/World.h"
 #include "dart/utils/SkelParser.h"
+#include "dart/utils/sdf/SdfParser.h"
 
 using namespace dart;
 using namespace math;
@@ -435,6 +436,30 @@ TEST(Parser, JointDynamicsElements)
   EXPECT_EQ(joint1->getCoulombFriction   (2), 3.0);
   EXPECT_EQ(joint1->getRestPosition      (2), 0.3);
   EXPECT_EQ(joint1->getSpringStiffness   (2), 1.0);
+}
+
+//==============================================================================
+TEST(Parser, SDFSingleBodyWithoutJoint)
+{
+  // Regression test for #444
+  WorldPtr world
+      = SdfParser::readSdfFile(
+          DART_DATA_PATH"/sdf/test/single_bodynode_skeleton.world");
+  EXPECT_TRUE(world != nullptr);
+
+  SkeletonPtr skel = world->getSkeleton(0);
+  EXPECT_TRUE(skel != nullptr);
+  EXPECT_EQ(skel->getNumBodyNodes(), 1);
+  EXPECT_EQ(skel->getNumJoints(), 1);
+
+  BodyNodePtr bodyNode = skel->getBodyNode(0);
+  EXPECT_TRUE(bodyNode != nullptr);
+  EXPECT_EQ(bodyNode->getNumVisualizationShapes(), 1);
+  EXPECT_EQ(bodyNode->getNumCollisionShapes(), 1);
+
+  JointPtr joint = skel->getJoint(0);
+  EXPECT_TRUE(joint != nullptr);
+  EXPECT_EQ(joint->getType(), FreeJoint::getStaticType());
 }
 
 //==============================================================================


### PR DESCRIPTION
The SDF parser currently assumes there is at least one Joint in the model, so it fails to correctly parse a model that has no Joints (i.e. all bodies are root nodes).

This pull request fixes that issue, and should be more robust in general because it iterates through bodies instead of joints when constructing a Skeleton.