### PR TITLE
Added a package.xml file for REP-136 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,11 @@ if(WIN32)
 endif()
 
 #===============================================================================
-# Poject settings
+# Project settings
 #===============================================================================
+#
+# If you change the version, please update the <version> tag in package.xml.
+
 project(dart)
 
 set(DART_MAJOR_VERSION "5")
@@ -79,6 +82,9 @@ endif()
 #===============================================================================
 # Find dependencies
 #===============================================================================
+#
+# If you add a dependency, please add the corresponding rosdep key as a
+# dependency in package.xml.
 
 #------------------------
 # Mandatory dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,9 @@ message(STATUS ${PC_CONFIG_OUT})
 configure_file(${PC_CONFIG_IN} ${PC_CONFIG_OUT} @only)
 install(FILES ${PC_CONFIG_OUT} DESTINATION lib/pkgconfig)
 
+# Install a Catkin 'package.xml' file. This is required by REP-136.
+install(FILES package.xml DESTINATION share/${PROJECT_NAME})
+
 #===============================================================================
 # Add sub-directories
 #===============================================================================

--- a/package.xml
+++ b/package.xml
@@ -5,6 +5,8 @@
   <description>Dynamic Animation and Robotics Toolkit</description>
   <maintainer email="jslee02@gmail.com">Jeongseok Lee</maintainer>
   <license>BSD</license>
+  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
   <depend>assimp</depend>
   <depend>eigen</depend>
   <depend>fcl</depend>
@@ -18,7 +20,6 @@
   <depend>tinyxml2</depend>
   <!-- These are required by REP-136. -->
   <exec_depend>catkin</exec_depend>
-  <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>dart</name>
+  <version>5.0.0</version>
+  <description>Dynamic Animation and Robotics Toolkit</description>
+  <maintainer email="jslee02@gmail.com">Jeongseok Lee</maintainer>
+  <license>BSD</license>
+  <depend>assimp</depend>
+  <depend>eigen</depend>
+  <depend>fcl</depend>
+  <depend>glut</depend>
+  <depend>libccd</depend>
+  <depend>libflann-dev</depend>
+  <depend>liburdfdom-dev</depend>
+  <depend>libxi-dev</depend>
+  <depend>libxmu-dev</depend>
+  <depend>tinyxml</depend>
+  <depend>tinyxml2</depend>
+  <!-- These are required by REP-136. -->
+  <exec_depend>catkin</exec_depend>
+  <buildtool_depend>cmake</buildtool_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -1,9 +1,23 @@
-<?xml version="1.0"?>
+<?xml version="1.0"?> 
 <package format="2">
+  <!-- This is a Catkin package.xml file to optionally support building DART in
+       a Catkin workspace. Catkin is not required to build DART. For more
+       information, see: http://ros.org/reps/rep-0136.html -->
   <name>dart</name>
   <version>5.0.0</version>
-  <description>Dynamic Animation and Robotics Toolkit</description>
+  <description>
+    DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
+    cross-platform, open source library created by the Georgia Tech Graphics
+    Lab and Humanoid Robotics Lab. The library provides data structures and
+    algorithms for kinematic and dynamic applications in robotics and computer
+    animation.
+  </description>
+  <url type="website">http://dartsim.github.io/</url>
+  <url type="repository">https://github.com/dartsim/dart</url>
+  <url type="bugtracker">https://github.com/dartsim/dart/issues</url>
   <maintainer email="jslee02@gmail.com">Jeongseok Lee</maintainer>
+  <author email="karenliu@cc.gatech.edu">C. Karen Liu</author>
+  <author email="mstilman@cc.gatech.edu">Mike Stilman</author>
   <license>BSD</license>
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>


### PR DESCRIPTION
This pull request: (1) [adds a `package.xml`](http://www.ros.org/reps/rep-0136.html#having-a-catkin-package-xml) file for DART and (2) [installs it to `share/dart`](http://www.ros.org/reps/rep-0136.html#installing-a-catkin-package-xml). These are the minimal requirements, from [REP-136](http://www.ros.org/reps/rep-0136.html) to build a third-party package as part of a Catkin workspace.

I am generally not a fan of putting these type of files in  non-ROS packages, so I make this pull request with some trepidation. However, this is very useful if you are developing DART in parallel with ROS packages (e.g. the work I mentioned on `DartLoader`) because: (1) it allows you to easily link against DART without installing it into a system directory, (2) automatically re-builds DART when it is changed, and (3) insures that the DART build is done before building ROS packages that depend on it.

This **doesn't add any dependencies** and these files **have no effect** if you are not building DART in a Catkin workspace. The only visible change is that you will have an extra XML file in `/share/dart`.