### PR TITLE
Added initial position and initial velocity properties

### DIFF
--- a/dart/dynamics/DegreeOfFreedom.cpp
+++ b/dart/dynamics/DegreeOfFreedom.cpp
@@ -121,12 +121,6 @@ double DegreeOfFreedom::getPosition() const
 }
 
 //==============================================================================
-void DegreeOfFreedom::resetPosition()
-{
-  setPosition(0.0);
-}
-
-//==============================================================================
 void DegreeOfFreedom::setPositionLimits(double _lowerLimit, double _upperLimit)
 {
   setPositionLowerLimit(_lowerLimit);
@@ -172,6 +166,24 @@ double DegreeOfFreedom::getPositionUpperLimit() const
 }
 
 //==============================================================================
+void DegreeOfFreedom::resetPosition()
+{
+  mJoint->resetPosition(mIndexInJoint);
+}
+
+//==============================================================================
+void DegreeOfFreedom::setInitialPosition(double _initial)
+{
+  mJoint->setInitialPosition(mIndexInJoint, _initial);
+}
+
+//==============================================================================
+double DegreeOfFreedom::getInitialPosition() const
+{
+  return mJoint->getInitialPosition(mIndexInJoint);
+}
+
+//==============================================================================
 void DegreeOfFreedom::setVelocity(double _velocity)
 {
   mJoint->setVelocity(mIndexInJoint, _velocity);
@@ -186,7 +198,7 @@ double DegreeOfFreedom::getVelocity() const
 //==============================================================================
 void DegreeOfFreedom::resetVelocity()
 {
-  setVelocity(0.0);
+  mJoint->resetVelocity(mIndexInJoint);
 }
 
 //==============================================================================
@@ -231,6 +243,18 @@ void DegreeOfFreedom::setVelocityUpperLimit(double _limit)
 double DegreeOfFreedom::getVelocityUpperLimit() const
 {
   return mJoint->getVelocityUpperLimit(mIndexInJoint);
+}
+
+//==============================================================================
+void DegreeOfFreedom::setInitialVelocity(double _initial)
+{
+  mJoint->setInitialVelocity(mIndexInJoint, _initial);
+}
+
+//==============================================================================
+double DegreeOfFreedom::getInitialVelocity() const
+{
+  return mJoint->getInitialVelocity(mIndexInJoint);
 }
 
 //==============================================================================

--- a/dart/dynamics/DegreeOfFreedom.h
+++ b/dart/dynamics/DegreeOfFreedom.h
@@ -135,9 +135,6 @@ public:
   /// Get the position of this DegreeOfFreedom
   double getPosition() const;
 
-  /// Set the position of this DegreeOfFreedom to zero
-  void resetPosition();
-
   /// Set the position limits of this DegreeOfFreedom
   void setPositionLimits(double _lowerLimit, double _upperLimit);
 
@@ -159,6 +156,15 @@ public:
   /// Get the upper position limit of this DegreeOfFreedom
   double getPositionUpperLimit() const;
 
+  /// Set the position of this DegreeOfFreedom to zero
+  void resetPosition();
+
+  /// Change the position that resetPosition() will give to this DegreeOfFreedom
+  void setInitialPosition(double _initial);
+
+  /// Get the position that resetPosition() will give to this DegreeOfFreedom
+  double getInitialPosition() const;
+
   /// \}
 
   //----------------------------------------------------------------------------
@@ -170,9 +176,6 @@ public:
 
   /// Get the velocity of this DegreeOfFreedom
   double getVelocity() const;
-
-  /// Set the velocity of this DegreeOfFreedom to zero
-  void resetVelocity();
 
   /// Set the velocity limits of this DegreeOfFreedom
   void setVelocityLimits(double _lowerLimit, double _upperLimit);
@@ -194,6 +197,15 @@ public:
 
   /// Get the upper Velocity limit of this DegreeOfFreedom
   double getVelocityUpperLimit() const;
+
+  /// Set the velocity of this DegreeOfFreedom to zero
+  void resetVelocity();
+
+  /// Change the velocity that resetVelocity() will give to this DegreeOfFreedom
+  void setInitialVelocity(double _initial);
+
+  /// Get the velocity that resetVelocity() will give to this DegreeOfFreedom
+  double getInitialVelocity() const;
 
   /// \}
 

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -64,7 +64,7 @@ Joint::Properties::Properties(const std::string& _name,
     mIsPositionLimited(_isPositionLimited),
     mActuatorType(_actuatorType)
 {
-
+  // Do nothing
 }
 
 //==============================================================================
@@ -316,6 +316,56 @@ size_t Joint::getJointIndexInTree() const
 size_t Joint::getTreeIndex() const
 {
   return mChildBodyNode->getTreeIndex();
+}
+
+//==============================================================================
+bool Joint::checkSanity(bool _printWarnings) const
+{
+  bool sane = true;
+  for(size_t i=0; i < getNumDofs(); ++i)
+  {
+    if(getInitialPosition(i) < getPositionLowerLimit(i)
+       || getPositionUpperLimit(i) < getInitialPosition(i))
+    {
+      if(_printWarnings)
+      {
+        dtwarn << "[Joint::checkSanity] Initial position of index " << i << " ["
+               << getDofName(i) << "] in Joint [" << getName() << "] is "
+               << "outside of its position limits\n"
+               << " -- Initial Position: " << getInitialPosition(i) << "\n"
+               << " -- Limits: [" << getPositionLowerLimit(i) << ", "
+               << getPositionUpperLimit(i) << "]\n";
+      }
+      else
+      {
+        return false;
+      }
+
+      sane = false;
+    }
+
+    if(getInitialVelocity(i) < getVelocityLowerLimit(i)
+       || getVelocityUpperLimit(i) < getInitialVelocity(i))
+    {
+      if(_printWarnings)
+      {
+        dtwarn << "[Joint::checkSanity] Initial velocity of index " << i << " ["
+               << getDofName(i) << "] is Joint [" << getName() << "] is "
+               << "outside of its velocity limits\n"
+               << " -- Initial Velocity: " << getInitialVelocity(i) << "\n"
+               << " -- Limits: [" << getVelocityLowerLimit(i) << ", "
+               << getVelocityUpperLimit(i) << "]\n";
+      }
+      else
+      {
+        return false;
+      }
+
+      sane = false;
+    }
+  }
+
+  return sane;
 }
 
 //==============================================================================

--- a/dart/dynamics/Joint.h
+++ b/dart/dynamics/Joint.h
@@ -503,6 +503,15 @@ public:
   /// \}
 
   //----------------------------------------------------------------------------
+  /// \{ \name Sanity Check
+  //----------------------------------------------------------------------------
+
+  /// Returns false if the initial position or initial velocity are outside of
+  /// limits
+  // TODO: Consider extending this to a more comprehensive sanity check
+  bool checkSanity(bool _printWarnings = true) const;
+
+  //----------------------------------------------------------------------------
   /// \{ \name Velocity change
   //----------------------------------------------------------------------------
 

--- a/dart/dynamics/Joint.h
+++ b/dart/dynamics/Joint.h
@@ -332,9 +332,6 @@ public:
   /// Get the positions of all generalized coordinates in this Joint
   virtual Eigen::VectorXd getPositions() const = 0;
 
-  /// Set the positions of all generalized coordinates in this Joint to zero
-  virtual void resetPositions() = 0;
-
   /// Set lower limit for position
   virtual void setPositionLowerLimit(size_t _index, double _position) = 0;
 
@@ -346,6 +343,27 @@ public:
 
   /// Get upper limit for position
   virtual double getPositionUpperLimit(size_t _index) const = 0;
+
+  /// Set the position of this generalized coordinate to its initial position
+  virtual void resetPosition(size_t _index) = 0;
+
+  /// Set the positions of all generalized coordinates in this Joint to their
+  /// initial positions
+  virtual void resetPositions() = 0;
+
+  /// Change the position that resetPositions() will give to this coordinate
+  virtual void setInitialPosition(size_t _index, double _initial) = 0;
+
+  /// Get the position that resetPosition() will give to this coordinate
+  virtual double getInitialPosition(size_t _index) const = 0;
+
+  /// Change the positions that resetPositions() will give to this Joint's
+  /// coordinates
+  virtual void setInitialPositions(const Eigen::VectorXd& _initial) = 0;
+
+  /// Get the positions that resetPositions() will give to this Joint's
+  /// coordinates
+  virtual Eigen::VectorXd getInitialPositions() const = 0;
 
   /// \}
 
@@ -365,9 +383,6 @@ public:
   /// Get the velocities of all generalized coordinates in this Joint
   virtual Eigen::VectorXd getVelocities() const = 0;
 
-  /// Set the velocities of all generalized coordinates in this Joint to zero
-  virtual void resetVelocities() = 0;
-
   /// Set lower limit for velocity
   virtual void setVelocityLowerLimit(size_t _index, double _velocity) = 0;
 
@@ -379,6 +394,28 @@ public:
 
   /// Get upper limit for velocity
   virtual double getVelocityUpperLimit(size_t _index) const = 0;
+
+  /// Set the velocity of a generalized coordinate in this Joint to its initial
+  /// velocity
+  virtual void resetVelocity(size_t _index) = 0;
+
+  /// Set the velocities of all generalized coordinates in this Joint to their
+  /// initial velocities
+  virtual void resetVelocities() = 0;
+
+  /// Change the velocity that resetVelocity() will give to this coordinate
+  virtual void setInitialVelocity(size_t _index, double _initial) = 0;
+
+  /// Get the velocity that resetVelocity() will give to this coordinate
+  virtual double getInitialVelocity(size_t _index) const = 0;
+
+  /// Change the velocities that resetVelocities() will give to this Joint's
+  /// coordinates
+  virtual void setInitialVelocities(const Eigen::VectorXd& _initial) = 0;
+
+  /// Get the velocities that resetVelocities() will give to this Joint's
+  /// coordinates
+  virtual Eigen::VectorXd getInitialVelocities() const = 0;
 
   /// \}
 

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -71,11 +71,17 @@ public:
     /// Upper limit of position
     Vector mPositionUpperLimits;
 
+    /// Initial positions
+    Vector mInitialPositions;
+
     /// Min value allowed.
     Vector mVelocityLowerLimits;
 
     /// Max value allowed.
     Vector mVelocityUpperLimits;
+
+    /// Initial velocities
+    Vector mInitialVelocities;
 
     /// Min value allowed.
     Vector mAccelerationLowerLimits;
@@ -122,6 +128,9 @@ public:
       const Vector& _restPosition = Vector::Constant(0.0),
       const Vector& _dampingCoefficient = Vector::Constant(0.0),
       const Vector& _coulombFrictions = Vector::Constant(0.0));
+    // TODO(MXG): In version 6.0, we should add mInitialPositions and
+    // mInitialVelocities to the constructor arguments. For now we must wait in
+    // order to avoid breaking the API
 
     /// Copy constructor
     // Note: we only need this because VS2013 lacks full support for std::array
@@ -238,9 +247,6 @@ public:
   Eigen::VectorXd getPositions() const override;
 
   // Documentation inherited
-  void resetPositions() override;
-
-  // Documentation inherited
   void setPositionLowerLimit(size_t _index, double _position) override;
 
   // Documentation inherited
@@ -251,6 +257,24 @@ public:
 
   // Documentation inherited
   double getPositionUpperLimit(size_t _index) const override;
+
+  // Documentation inherited
+  void resetPosition(size_t _index) override;
+
+  // Documentation inherited
+  void resetPositions() override;
+
+  // Documentation inherited
+  void setInitialPosition(size_t _index, double _initial) override;
+
+  // Documentation inherited
+  double getInitialPosition(size_t _index) const override;
+
+  // Documentation inherited
+  void setInitialPositions(const Eigen::VectorXd& _initial) override;
+
+  // Documentation inherited
+  Eigen::VectorXd getInitialPositions() const override;
 
   //----------------------------------------------------------------------------
   // Velocity
@@ -269,9 +293,6 @@ public:
   Eigen::VectorXd getVelocities() const override;
 
   // Documentation inherited
-  void resetVelocities() override;
-
-  // Documentation inherited
   void setVelocityLowerLimit(size_t _index, double _velocity) override;
 
   // Documentation inherited
@@ -282,6 +303,24 @@ public:
 
   // Documentation inherited
   double getVelocityUpperLimit(size_t _index) const override;
+
+  // Documentation inherited
+  void resetVelocity(size_t _index) override;
+
+  // Documentation inherited
+  void resetVelocities() override;
+
+  // Documentation inherited
+  void setInitialVelocity(size_t _index, double _initial) override;
+
+  // Documentation inherited
+  double getInitialVelocity(size_t _index) const override;
+
+  // Documentation inherited
+  void setInitialVelocities(const Eigen::VectorXd& _initial) override;
+
+  // Documentation inherited
+  Eigen::VectorXd getInitialVelocities() const override;
 
   //----------------------------------------------------------------------------
   // Acceleration

--- a/dart/dynamics/SingleDofJoint.cpp
+++ b/dart/dynamics/SingleDofJoint.cpp
@@ -516,7 +516,7 @@ double SingleDofJoint::getInitialPosition(size_t _index) const
 //==============================================================================
 void SingleDofJoint::setInitialPositions(const Eigen::VectorXd& _initial)
 {
-  if( static_cast<size_t>(_initial.size() != getNumDofs()) )
+  if( static_cast<size_t>(_initial.size()) != getNumDofs() )
   {
     SINGLEDOFJOINT_REPORT_DIM_MISMATCH( setInitialPositions, _initial );
     return;

--- a/dart/dynamics/SingleDofJoint.cpp
+++ b/dart/dynamics/SingleDofJoint.cpp
@@ -79,8 +79,10 @@ SingleDofJoint::UniqueProperties::UniqueProperties(
     std::string _dofName)
   : mPositionLowerLimit(_positionLowerLimit),
     mPositionUpperLimit(_positionUpperLimit),
+    mInitialPosition(0.0),
     mVelocityLowerLimit(_velocityLowerLimit),
     mVelocityUpperLimit(_velocityUpperLimit),
+    mInitialVelocity(0.0),
     mAccelerationLowerLimit(_accelerationLowerLimit),
     mAccelerationUpperLimit(_accelerationUpperLimit),
     mForceLowerLimit(_forceLowerLimit),
@@ -124,8 +126,10 @@ void SingleDofJoint::setProperties(const UniqueProperties& _properties)
   setDofName(0, _properties.mDofName, _properties.mPreserveDofName);
   setPositionLowerLimit(0, _properties.mPositionLowerLimit);
   setPositionUpperLimit(0, _properties.mPositionUpperLimit);
+  setInitialPosition(0, _properties.mInitialPosition);
   setVelocityLowerLimit(0, _properties.mVelocityLowerLimit);
   setVelocityUpperLimit(0, _properties.mVelocityUpperLimit);
+  setInitialVelocity(0, _properties.mInitialVelocity);
   setAccelerationLowerLimit(0, _properties.mAccelerationLowerLimit);
   setAccelerationUpperLimit(0, _properties.mAccelerationUpperLimit);
   setForceLowerLimit(0, _properties.mForceLowerLimit);
@@ -420,12 +424,6 @@ Eigen::VectorXd SingleDofJoint::getPositions() const
 }
 
 //==============================================================================
-void SingleDofJoint::resetPositions()
-{
-  setPositionStatic(0.0);
-}
-
-//==============================================================================
 void SingleDofJoint::setPositionLowerLimit(size_t _index, double _position)
 {
   if (_index != 0)
@@ -471,6 +469,66 @@ double SingleDofJoint::getPositionUpperLimit(size_t _index) const
   }
 
   return mSingleDofP.mPositionUpperLimit;
+}
+
+//==============================================================================
+void SingleDofJoint::resetPosition(size_t _index)
+{
+  if (_index != 0)
+  {
+    SINGLEDOFJOINT_REPORT_OUT_OF_RANGE( resetPosition, _index );
+    return;
+  }
+
+  setPositionStatic(mSingleDofP.mInitialPosition);
+}
+
+//==============================================================================
+void SingleDofJoint::resetPositions()
+{
+  setPositionStatic(mSingleDofP.mInitialPosition);
+}
+
+//==============================================================================
+void SingleDofJoint::setInitialPosition(size_t _index, double _initial)
+{
+  if (_index != 0)
+  {
+    SINGLEDOFJOINT_REPORT_OUT_OF_RANGE( setInitialPosition, _index );
+    return;
+  }
+
+  mSingleDofP.mInitialPosition = _initial;
+}
+
+//==============================================================================
+double SingleDofJoint::getInitialPosition(size_t _index) const
+{
+  if (_index != 0)
+  {
+    SINGLEDOFJOINT_REPORT_OUT_OF_RANGE( getInitialPosition, _index );
+    return 0.0;
+  }
+
+  return mSingleDofP.mInitialPosition;
+}
+
+//==============================================================================
+void SingleDofJoint::setInitialPositions(const Eigen::VectorXd& _initial)
+{
+  if( static_cast<size_t>(_initial.size() != getNumDofs()) )
+  {
+    SINGLEDOFJOINT_REPORT_DIM_MISMATCH( setInitialPositions, _initial );
+    return;
+  }
+
+  setInitialPosition(0, _initial[0]);
+}
+
+//==============================================================================
+Eigen::VectorXd SingleDofJoint::getInitialPositions() const
+{
+  return Eigen::Matrix<double, 1, 1>::Constant(mSingleDofP.mInitialPosition);
 }
 
 //==============================================================================
@@ -528,12 +586,6 @@ Eigen::VectorXd SingleDofJoint::getVelocities() const
 }
 
 //==============================================================================
-void SingleDofJoint::resetVelocities()
-{
-  setVelocityStatic(0.0);
-}
-
-//==============================================================================
 void SingleDofJoint::setVelocityLowerLimit(size_t _index, double _velocity)
 {
   if (_index != 0)
@@ -579,6 +631,66 @@ double SingleDofJoint::getVelocityUpperLimit(size_t _index) const
   }
 
   return mSingleDofP.mVelocityUpperLimit;
+}
+
+//==============================================================================
+void SingleDofJoint::resetVelocity(size_t _index)
+{
+  if (_index != 0)
+  {
+    SINGLEDOFJOINT_REPORT_OUT_OF_RANGE( resetVelocity, _index );
+    return;
+  }
+
+  setVelocityStatic(mSingleDofP.mInitialVelocity);
+}
+
+//==============================================================================
+void SingleDofJoint::resetVelocities()
+{
+  setVelocityStatic(mSingleDofP.mInitialVelocity);
+}
+
+//==============================================================================
+void SingleDofJoint::setInitialVelocity(size_t _index, double _initial)
+{
+  if (_index != 0)
+  {
+    SINGLEDOFJOINT_REPORT_OUT_OF_RANGE( setInitialVelocity, _index );
+    return;
+  }
+
+  mSingleDofP.mInitialVelocity = _initial;
+}
+
+//==============================================================================
+double SingleDofJoint::getInitialVelocity(size_t _index) const
+{
+  if (_index != 0)
+  {
+    SINGLEDOFJOINT_REPORT_OUT_OF_RANGE( getInitialVelocity, _index );
+    return 0.0;
+  }
+
+  return mSingleDofP.mInitialVelocity;
+}
+
+//==============================================================================
+void SingleDofJoint::setInitialVelocities(const Eigen::VectorXd& _initial)
+{
+  if( static_cast<size_t>(_initial.size()) != getNumDofs() )
+  {
+    SINGLEDOFJOINT_REPORT_DIM_MISMATCH( setInitialVelocities, _initial );
+    return;
+  }
+
+  setInitialVelocity(0, _initial[0]);
+}
+
+//==============================================================================
+Eigen::VectorXd SingleDofJoint::getInitialVelocities() const
+{
+  return Eigen::Matrix<double, 1, 1>::Constant(mSingleDofP.mInitialVelocity);
 }
 
 //==============================================================================

--- a/dart/dynamics/SingleDofJoint.h
+++ b/dart/dynamics/SingleDofJoint.h
@@ -61,11 +61,17 @@ public:
     /// Upper limit of position
     double mPositionUpperLimit;
 
+    /// Initial position
+    double mInitialPosition;
+
     /// Lower limit of velocity
     double mVelocityLowerLimit;
 
     /// Upper limit of velocity
     double mVelocityUpperLimit;
+
+    /// Initial velocity
+    double mInitialVelocity;
 
     /// Lower limit of acceleration
     double mAccelerationLowerLimit;
@@ -112,6 +118,9 @@ public:
                      double _coulombFriction = 0.0,
                      bool _preserveDofName = false,
                      std::string _dofName = "");
+    // TODO(MXG): In version 6.0, we should add mInitialPosition and
+    // mInitialVelocity to the constructor arguments. For now we must wait in
+    // order to avoid breaking the API
 
     virtual ~UniqueProperties() = default;
   };
@@ -213,9 +222,6 @@ public:
   Eigen::VectorXd getPositions() const override;
 
   // Documentation inherited
-  void resetPositions() override;
-
-  // Documentation inherited
   void setPositionLowerLimit(size_t _index, double _position) override;
 
   // Documentation inherited
@@ -226,6 +232,24 @@ public:
 
   // Documentation inherited
   double getPositionUpperLimit(size_t _index) const override;
+
+  // Documentation inherited
+  void resetPosition(size_t _index) override;
+
+  // Documentation inherited
+  void resetPositions() override;
+
+  // Documentation inherited
+  void setInitialPosition(size_t _index, double _initial) override;
+
+  // Documentation inherited
+  double getInitialPosition(size_t _index) const override;
+
+  // Documentation inherited
+  void setInitialPositions(const Eigen::VectorXd& _initial) override;
+
+  // Documentation inherited
+  Eigen::VectorXd getInitialPositions() const override;
 
   //----------------------------------------------------------------------------
   // Velocity
@@ -244,9 +268,6 @@ public:
   Eigen::VectorXd getVelocities() const override;
 
   // Documentation inherited
-  void resetVelocities() override;
-
-  // Documentation inherited
   void setVelocityLowerLimit(size_t _index, double _velocity) override;
 
   // Documentation inherited
@@ -257,6 +278,24 @@ public:
 
   // Documentation inherited
   double getVelocityUpperLimit(size_t _index) const override;
+
+  // Documentation inherited
+  void resetVelocity(size_t _index) override;
+
+  // Documentation inherited
+  void resetVelocities() override;
+
+  // Documentation inherited
+  void setInitialVelocity(size_t _index, double _initial) override;
+
+  // Documentation inherited
+  double getInitialVelocity(size_t _index) const override;
+
+  // Documentation inherited
+  void setInitialVelocities(const Eigen::VectorXd& _initial) override;
+
+  // Documentation inherited
+  Eigen::VectorXd getInitialVelocities() const override;
 
   //----------------------------------------------------------------------------
   // Acceleration

--- a/dart/dynamics/ZeroDofJoint.cpp
+++ b/dart/dynamics/ZeroDofJoint.cpp
@@ -192,12 +192,6 @@ Eigen::VectorXd ZeroDofJoint::getPositions() const
 }
 
 //==============================================================================
-void ZeroDofJoint::resetPositions()
-{
-  // Do nothing
-}
-
-//==============================================================================
 void ZeroDofJoint::setPositionLowerLimit(size_t _index, double _position)
 {
   // Do nothing
@@ -219,6 +213,42 @@ void ZeroDofJoint::setPositionUpperLimit(size_t _index, double _position)
 double ZeroDofJoint::getPositionUpperLimit(size_t _index) const
 {
   return 0.0;
+}
+
+//==============================================================================
+void ZeroDofJoint::resetPosition(size_t _index)
+{
+  // Do nothing
+}
+
+//==============================================================================
+void ZeroDofJoint::resetPositions()
+{
+  // Do nothing
+}
+
+//==============================================================================
+void ZeroDofJoint::setInitialPosition(size_t _index, double _initial)
+{
+  // Do nothing
+}
+
+//==============================================================================
+double ZeroDofJoint::getInitialPosition(size_t _index) const
+{
+  return 0.0;
+}
+
+//==============================================================================
+void ZeroDofJoint::setInitialPositions(const Eigen::VectorXd& _initial)
+{
+  // Do nothing
+}
+
+//==============================================================================
+Eigen::VectorXd ZeroDofJoint::getInitialPositions() const
+{
+  return Eigen::VectorXd();
 }
 
 //==============================================================================
@@ -247,12 +277,6 @@ Eigen::VectorXd ZeroDofJoint::getVelocities() const
 }
 
 //==============================================================================
-void ZeroDofJoint::resetVelocities()
-{
-  // Do nothing
-}
-
-//==============================================================================
 void ZeroDofJoint::setVelocityLowerLimit(size_t _index, double _velocity)
 {
   // Do nothing
@@ -274,6 +298,42 @@ void ZeroDofJoint::setVelocityUpperLimit(size_t _index, double _velocity)
 double ZeroDofJoint::getVelocityUpperLimit(size_t _index) const
 {
   return 0.0;
+}
+
+//==============================================================================
+void ZeroDofJoint::resetVelocity(size_t _index)
+{
+  // Do nothing
+}
+
+//==============================================================================
+void ZeroDofJoint::resetVelocities()
+{
+  // Do nothing
+}
+
+//==============================================================================
+void ZeroDofJoint::setInitialVelocity(size_t _index, double _initial)
+{
+  // Do nothing
+}
+
+//==============================================================================
+double ZeroDofJoint::getInitialVelocity(size_t _index) const
+{
+  return 0.0;
+}
+
+//==============================================================================
+void ZeroDofJoint::setInitialVelocities(const Eigen::VectorXd& _initial)
+{
+  // Do nothing
+}
+
+//==============================================================================
+Eigen::VectorXd ZeroDofJoint::getInitialVelocities() const
+{
+  return Eigen::VectorXd();
 }
 
 //==============================================================================

--- a/dart/dynamics/ZeroDofJoint.h
+++ b/dart/dynamics/ZeroDofJoint.h
@@ -130,9 +130,6 @@ public:
   virtual Eigen::VectorXd getPositions() const override;
 
   // Documentation inherited
-  virtual void resetPositions() override;
-
-  // Documentation inherited
   virtual void setPositionLowerLimit(size_t _index, double _position) override;
 
   // Documentation inherited
@@ -143,6 +140,24 @@ public:
 
   // Documentation inherited
   virtual double getPositionUpperLimit(size_t _index) const override;
+
+  // Documentation inherited
+  virtual void resetPosition(size_t _index) override;
+
+  // Documentation inherited
+  virtual void resetPositions() override;
+
+  // Documentation inherited
+  virtual void setInitialPosition(size_t _index, double _initial) override;
+
+  // Documentation inherited
+  virtual double getInitialPosition(size_t _index) const override;
+
+  // Documentation inherited
+  virtual void setInitialPositions(const Eigen::VectorXd& _initial) override;
+
+  // Documentation inherited
+  virtual Eigen::VectorXd getInitialPositions() const override;
 
   //----------------------------------------------------------------------------
   // Velocity
@@ -161,9 +176,6 @@ public:
   virtual Eigen::VectorXd getVelocities() const override;
 
   // Documentation inherited
-  virtual void resetVelocities() override;
-
-  // Documentation inherited
   virtual void setVelocityLowerLimit(size_t _index, double _velocity) override;
 
   // Documentation inherited
@@ -174,6 +186,24 @@ public:
 
   // Documentation inherited
   virtual double getVelocityUpperLimit(size_t _index) const override;
+
+  // Documentation inherited
+  virtual void resetVelocity(size_t _index) override;
+
+  // Documentation inherited
+  virtual void resetVelocities() override;
+
+  // Documentation inherited
+  virtual void setInitialVelocity(size_t _index, double _initial) override;
+
+  // Documentation inherited
+  virtual double getInitialVelocity(size_t _index) const override;
+
+  // Documentation inherited
+  virtual void setInitialVelocities(const Eigen::VectorXd& _initial) override;
+
+  // Documentation inherited
+  virtual Eigen::VectorXd getInitialVelocities() const override;
 
   //----------------------------------------------------------------------------
   // Acceleration

--- a/dart/dynamics/detail/MultiDofJoint.h
+++ b/dart/dynamics/detail/MultiDofJoint.h
@@ -72,8 +72,10 @@ MultiDofJoint<DOF>::UniqueProperties::UniqueProperties(
     const Vector& _coulombFrictions)
   : mPositionLowerLimits(_positionLowerLimits),
     mPositionUpperLimits(_positionUpperLimits),
+    mInitialPositions(Vector::Zero()),
     mVelocityLowerLimits(_velocityLowerLimits),
     mVelocityUpperLimits(_velocityUpperLimits),
+    mInitialVelocities(Vector::Zero()),
     mAccelerationLowerLimits(_accelerationLowerLimits),
     mAccelerationUpperLimits(_accelerationUpperLimits),
     mForceLowerLimits(_forceLowerLimits),
@@ -96,8 +98,10 @@ MultiDofJoint<DOF>::UniqueProperties::UniqueProperties(
     const UniqueProperties& _other)
   : mPositionLowerLimits(_other.mPositionLowerLimits),
     mPositionUpperLimits(_other.mPositionUpperLimits),
+    mInitialPositions(_other.mInitialPositions),
     mVelocityLowerLimits(_other.mVelocityLowerLimits),
     mVelocityUpperLimits(_other.mVelocityUpperLimits),
+    mInitialVelocities(_other.mInitialVelocities),
     mAccelerationLowerLimits(_other.mAccelerationLowerLimits),
     mAccelerationUpperLimits(_other.mAccelerationUpperLimits),
     mForceLowerLimits(_other.mForceLowerLimits),
@@ -157,8 +161,10 @@ void MultiDofJoint<DOF>::setProperties(const UniqueProperties& _properties)
     setDofName(i, _properties.mDofNames[i], _properties.mPreserveDofNames[i]);
     setPositionLowerLimit(i, _properties.mPositionLowerLimits[i]);
     setPositionUpperLimit(i, _properties.mPositionUpperLimits[i]);
+    setInitialPosition(i, _properties.mInitialPositions[i]);
     setVelocityLowerLimit(i, _properties.mVelocityLowerLimits[i]);
     setVelocityUpperLimit(i, _properties.mVelocityUpperLimits[i]);
+    setInitialVelocity(i, _properties.mInitialVelocities[i]);
     setAccelerationLowerLimit(i, _properties.mAccelerationLowerLimits[i]);
     setAccelerationUpperLimit(i, _properties.mAccelerationUpperLimits[i]);
     setForceLowerLimit(i, _properties.mForceLowerLimits[i]);
@@ -529,13 +535,6 @@ Eigen::VectorXd MultiDofJoint<DOF>::getPositions() const
 
 //==============================================================================
 template <size_t DOF>
-void MultiDofJoint<DOF>::resetPositions()
-{
-  setPositionsStatic(Eigen::Matrix<double, DOF, 1>::Zero());
-}
-
-//==============================================================================
-template <size_t DOF>
 void MultiDofJoint<DOF>::setPositionLowerLimit(size_t _index, double _position)
 {
   if (_index >= getNumDofs())
@@ -571,6 +570,72 @@ void MultiDofJoint<DOF>::setPositionUpperLimit(size_t _index, double _position)
   }
 
   mMultiDofP.mPositionUpperLimits[_index] = _position;
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::resetPosition(size_t _index)
+{
+  if (_index >= getNumDofs())
+  {
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(resetPosition, _index);
+    return;
+  }
+
+  setPosition(_index, mMultiDofP.mInitialPositions[_index]);
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::resetPositions()
+{
+  setPositionsStatic(mMultiDofP.mInitialPositions);
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::setInitialPosition(size_t _index, double _initial)
+{
+  if (_index >= getNumDofs())
+  {
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(setInitialPosition, _index);
+    return;
+  }
+
+  mMultiDofP.mInitialPositions[_index] = _initial;
+}
+
+//==============================================================================
+template <size_t DOF>
+double MultiDofJoint<DOF>::getInitialPosition(size_t _index) const
+{
+  if (_index >= getNumDofs())
+  {
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE(getInitialPosition, _index);
+    return 0.0;
+  }
+
+  return mMultiDofP.mInitialPositions[_index];
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::setInitialPositions(const Eigen::VectorXd& _initial)
+{
+  if ( static_cast<size_t>(_initial.size()) != getNumDofs() )
+  {
+    MULTIDOFJOINT_REPORT_DIM_MISMATCH(setInitialPositions, _initial);
+    return;
+  }
+
+  mMultiDofP.mInitialPositions = _initial;
+}
+
+//==============================================================================
+template <size_t DOF>
+Eigen::VectorXd MultiDofJoint<DOF>::getInitialPositions() const
+{
+  return mMultiDofP.mInitialPositions;
 }
 
 //==============================================================================
@@ -648,13 +713,6 @@ Eigen::VectorXd MultiDofJoint<DOF>::getVelocities() const
 
 //==============================================================================
 template <size_t DOF>
-void MultiDofJoint<DOF>::resetVelocities()
-{
-  setVelocitiesStatic(Eigen::Matrix<double, DOF, 1>::Zero());
-}
-
-//==============================================================================
-template <size_t DOF>
 void MultiDofJoint<DOF>::setVelocityLowerLimit(size_t _index, double _velocity)
 {
   if (_index >= getNumDofs())
@@ -703,6 +761,72 @@ double MultiDofJoint<DOF>::getVelocityUpperLimit(size_t _index) const
   }
 
   return mMultiDofP.mVelocityUpperLimits[_index];
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::resetVelocity(size_t _index)
+{
+  if (_index >= getNumDofs())
+  {
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( resetVelocity, _index );
+    return;
+  }
+
+  setVelocity(_index, mMultiDofP.mInitialVelocities[_index]);
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::resetVelocities()
+{
+  setVelocitiesStatic(mMultiDofP.mInitialVelocities);
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::setInitialVelocity(size_t _index, double _initial)
+{
+  if (_index >= getNumDofs())
+  {
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( setInitialVelocity, _index );
+    return;
+  }
+
+  mMultiDofP.mInitialVelocities[_index] = _initial;
+}
+
+//==============================================================================
+template <size_t DOF>
+double MultiDofJoint<DOF>::getInitialVelocity(size_t _index) const
+{
+  if (_index >= getNumDofs())
+  {
+    MULTIDOFJOINT_REPORT_OUT_OF_RANGE( getInitialVelocity, _index );
+    return 0.0;
+  }
+
+  return mMultiDofP.mInitialVelocities[_index];
+}
+
+//==============================================================================
+template <size_t DOF>
+void MultiDofJoint<DOF>::setInitialVelocities(const Eigen::VectorXd& _initial)
+{
+  if ( static_cast<size_t>(_initial.size()) != getNumDofs() )
+  {
+    MULTIDOFJOINT_REPORT_DIM_MISMATCH( setInitialVelocities, _initial );
+    return;
+  }
+
+  mMultiDofP.mInitialVelocities = _initial;
+}
+
+//==============================================================================
+template <size_t DOF>
+Eigen::VectorXd MultiDofJoint<DOF>::getInitialVelocities() const
+{
+  return mMultiDofP.mInitialVelocities;
 }
 
 //==============================================================================

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -543,6 +543,9 @@ dynamics::SkeletonPtr SkelParser::readSkeleton(
     it = joints.find(nextJoint->second);
   }
 
+  newSkeleton->resetPositions();
+  newSkeleton->resetVelocities();
+
   return newSkeleton;
 }
 
@@ -1136,11 +1139,11 @@ struct DofProxy
 
       lowerPosition(&properties.mPositionLowerLimit),
       upperPosition(&properties.mPositionUpperLimit),
-      initalPosition(&joint.position.data()[0]),
+      initalPosition(&properties.mInitialPosition),
 
       lowerVelocity(&properties.mVelocityLowerLimit),
       upperVelocity(&properties.mVelocityUpperLimit),
-      initialVelocity(&joint.velocity.data()[0]),
+      initialVelocity(&properties.mInitialVelocity),
 
       lowerAcceleration(&properties.mAccelerationLowerLimit),
       upperAcceleration(&properties.mAccelerationUpperLimit),
@@ -1175,11 +1178,11 @@ struct DofProxy
 
       lowerPosition(&properties.mPositionLowerLimits.data()[index]),
       upperPosition(&properties.mPositionUpperLimits.data()[index]),
-      initalPosition(&joint.position.data()[index]),
+      initalPosition(&properties.mInitialPositions.data()[index]),
 
       lowerVelocity(&properties.mVelocityLowerLimits.data()[index]),
       upperVelocity(&properties.mVelocityUpperLimits.data()[index]),
-      initialVelocity(&joint.velocity.data()[index]),
+      initialVelocity(&properties.mInitialVelocities.data()[index]),
 
       lowerAcceleration(&properties.mAccelerationLowerLimits.data()[index]),
       upperAcceleration(&properties.mAccelerationUpperLimits.data()[index]),
@@ -1491,6 +1494,7 @@ SkelParser::JointPropPtr SkelParser::readRevoluteJoint(
     Eigen::VectorXd ipos = Eigen::VectorXd(1);
     ipos << init_pos;
     _joint.position = ipos;
+    properties.mInitialPosition = ipos[0];
   }
 
   //--------------------------------------------------------------------------
@@ -1501,6 +1505,7 @@ SkelParser::JointPropPtr SkelParser::readRevoluteJoint(
     Eigen::VectorXd ivel = Eigen::VectorXd(1);
     ivel << init_vel;
     _joint.velocity = ivel;
+    properties.mInitialVelocity = ivel[0];
   }
 
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
@@ -1548,6 +1553,7 @@ SkelParser::JointPropPtr SkelParser::readPrismaticJoint(
     Eigen::VectorXd ipos = Eigen::VectorXd(1);
     ipos << init_pos;
     _joint.position = ipos;
+    properties.mInitialPosition = ipos[0];
   }
 
   //--------------------------------------------------------------------------
@@ -1558,6 +1564,7 @@ SkelParser::JointPropPtr SkelParser::readPrismaticJoint(
     Eigen::VectorXd ivel = Eigen::VectorXd(1);
     ivel << init_vel;
     _joint.velocity = ivel;
+    properties.mInitialVelocity = ivel[0];
   }
 
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
@@ -1612,6 +1619,7 @@ SkelParser::JointPropPtr SkelParser::readScrewJoint(
     Eigen::VectorXd ipos = Eigen::VectorXd(1);
     ipos << init_pos;
     _joint.position = ipos;
+    properties.mInitialPosition = ipos[0];
   }
 
   //--------------------------------------------------------------------------
@@ -1622,6 +1630,7 @@ SkelParser::JointPropPtr SkelParser::readScrewJoint(
     Eigen::VectorXd ivel = Eigen::VectorXd(1);
     ivel << init_vel;
     _joint.velocity = ivel;
+    properties.mInitialVelocity = ivel[0];
   }
 
   readAllDegreesOfFreedom<dynamics::SingleDofJoint::Properties>(
@@ -1683,6 +1692,7 @@ SkelParser::JointPropPtr SkelParser::readUniversalJoint(
   {
     Eigen::Vector2d init_pos = getValueVector2d(_jointElement, "init_pos");
     _joint.position = init_pos;
+    properties.mInitialPositions = init_pos;
   }
 
   //--------------------------------------------------------------------------
@@ -1691,6 +1701,7 @@ SkelParser::JointPropPtr SkelParser::readUniversalJoint(
   {
     Eigen::Vector2d init_vel = getValueVector2d(_jointElement, "init_vel");
     _joint.velocity = init_vel;
+    properties.mInitialVelocities = init_vel;
   }
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 2);
@@ -1715,6 +1726,7 @@ SkelParser::JointPropPtr SkelParser::readBallJoint(
   {
     Eigen::Vector3d init_pos = getValueVector3d(_jointElement, "init_pos");
     _joint.position = init_pos;
+    properties.mInitialPositions = init_pos;
   }
 
   //--------------------------------------------------------------------------
@@ -1723,6 +1735,7 @@ SkelParser::JointPropPtr SkelParser::readBallJoint(
   {
     Eigen::Vector3d init_vel = getValueVector3d(_jointElement, "init_vel");
     _joint.velocity = init_vel;
+    properties.mInitialVelocities = init_vel;
   }
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
@@ -1769,6 +1782,7 @@ SkelParser::JointPropPtr SkelParser::readEulerJoint(
   {
     Eigen::Vector3d init_pos = getValueVector3d(_jointElement, "init_pos");
     _joint.position = init_pos;
+    properties.mInitialPositions = init_pos;
   }
 
   //--------------------------------------------------------------------------
@@ -1777,6 +1791,7 @@ SkelParser::JointPropPtr SkelParser::readEulerJoint(
   {
     Eigen::Vector3d init_vel = getValueVector3d(_jointElement, "init_vel");
     _joint.velocity = init_vel;
+    properties.mInitialVelocities = init_vel;
   }
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
@@ -1805,6 +1820,7 @@ SkelParser::JointPropPtr SkelParser::readTranslationalJoint(
   {
     Eigen::Vector3d init_pos = getValueVector3d(_jointElement, "init_pos");
     _joint.position = init_pos;
+    properties.mInitialPositions = init_pos;
   }
 
   //--------------------------------------------------------------------------
@@ -1813,6 +1829,7 @@ SkelParser::JointPropPtr SkelParser::readTranslationalJoint(
   {
     Eigen::Vector3d init_vel = getValueVector3d(_jointElement, "init_vel");
     _joint.velocity = init_vel;
+    properties.mInitialVelocities = init_vel;
   }
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
@@ -1888,6 +1905,7 @@ SkelParser::JointPropPtr SkelParser::readPlanarJoint(
   {
     Eigen::Vector3d init_pos = getValueVector3d(_jointElement, "init_pos");
     _joint.position = init_pos;
+    properties.mInitialPositions = init_pos;
   }
 
   //--------------------------------------------------------------------------
@@ -1896,6 +1914,7 @@ SkelParser::JointPropPtr SkelParser::readPlanarJoint(
   {
     Eigen::Vector3d init_vel = getValueVector3d(_jointElement, "init_vel");
     _joint.velocity = init_vel;
+    properties.mInitialVelocities = init_vel;
   }
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 3);
@@ -1920,6 +1939,7 @@ SkelParser::JointPropPtr SkelParser::readFreeJoint(
   {
     Eigen::Vector6d init_pos = getValueVector6d(_jointElement, "init_pos");
     _joint.position = init_pos;
+    properties.mInitialPositions = init_pos;
   }
 
   //--------------------------------------------------------------------------
@@ -1928,6 +1948,7 @@ SkelParser::JointPropPtr SkelParser::readFreeJoint(
   {
     Eigen::Vector6d init_vel = getValueVector6d(_jointElement, "init_vel");
     _joint.velocity = init_vel;
+    properties.mInitialVelocities = init_vel;
   }
 
   readAllDegreesOfFreedom(_jointElement, properties, _joint, _name, 6);

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -297,6 +297,9 @@ dynamics::SkeletonPtr SdfParser::readSkeleton(
     body = sdfBodyNodes.begin();
   }
 
+  // Set positions to their initial values
+  newSkeleton->resetPositions();
+
   return newSkeleton;
 }
 
@@ -799,7 +802,8 @@ static void reportMissingElement(const std::string& functionName,
 static void readAxisElement(
     tinyxml2::XMLElement* axisElement,
     const Eigen::Isometry3d& _parentModelFrame,
-    Eigen::Vector3d& axis, double& lower, double& upper, double& damping)
+    Eigen::Vector3d& axis, double& lower, double& upper, double& initial,
+    double& damping)
 {
   // use_parent_model_frame
   bool useParentModelFrame = false;
@@ -845,6 +849,20 @@ static void readAxisElement(
       upper = getValueDouble(limitElement, "upper");
     }
   }
+
+  // If the zero position is out of our limits, we should change the initial
+  // position instead of assuming zero
+  if( 0.0 < lower || upper < 0.0 )
+  {
+    if( std::isfinite(lower) && std::isfinite(upper) )
+      initial = (lower + upper) / 2.0;
+    else if( std::isfinite(lower) )
+      initial = lower;
+    else if( std::isfinite(upper) )
+      initial = upper;
+
+    // Any other case means the limits are both +inf, both -inf, or one is a NaN
+  }
 }
 
 dart::dynamics::WeldJoint::Properties SdfParser::readWeldJoint(
@@ -877,6 +895,7 @@ dynamics::RevoluteJoint::Properties SdfParser::readRevoluteJoint(
                     newRevoluteJoint.mAxis,
                     newRevoluteJoint.mPositionLowerLimit,
                     newRevoluteJoint.mPositionUpperLimit,
+                    newRevoluteJoint.mInitialPosition,
                     newRevoluteJoint.mDampingCoefficient);
   }
   else
@@ -907,6 +926,7 @@ dynamics::PrismaticJoint::Properties SdfParser::readPrismaticJoint(
                     newPrismaticJoint.mAxis,
                     newPrismaticJoint.mPositionLowerLimit,
                     newPrismaticJoint.mPositionUpperLimit,
+                    newPrismaticJoint.mInitialPosition,
                     newPrismaticJoint.mDampingCoefficient);
   }
   else
@@ -937,6 +957,7 @@ dynamics::ScrewJoint::Properties SdfParser::readScrewJoint(
                     newScrewJoint.mAxis,
                     newScrewJoint.mPositionLowerLimit,
                     newScrewJoint.mPositionUpperLimit,
+                    newScrewJoint.mInitialPosition,
                     newScrewJoint.mDampingCoefficient);
   }
   else
@@ -974,6 +995,7 @@ dynamics::UniversalJoint::Properties SdfParser::readUniversalJoint(
                     newUniversalJoint.mAxis[0],
                     newUniversalJoint.mPositionLowerLimits[0],
                     newUniversalJoint.mPositionUpperLimits[0],
+                    newUniversalJoint.mInitialPositions[0],
                     newUniversalJoint.mDampingCoefficients[0]);
   }
   else
@@ -992,6 +1014,7 @@ dynamics::UniversalJoint::Properties SdfParser::readUniversalJoint(
                     newUniversalJoint.mAxis[1],
                     newUniversalJoint.mPositionLowerLimits[1],
                     newUniversalJoint.mPositionUpperLimits[1],
+                    newUniversalJoint.mInitialPositions[1],
                     newUniversalJoint.mDampingCoefficients[1]);
   }
   else

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -383,6 +383,23 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
     singleDof.mVelocityUpperLimit =  _jt->limits->velocity;
     singleDof.mForceLowerLimit = -_jt->limits->effort;
     singleDof.mForceUpperLimit =  _jt->limits->effort;
+
+    // If the zero position is out of our limits, we should change the initial
+    // position instead of assuming zero.
+    if(_jt->limits->lower > 0 || _jt->limits->upper < 0)
+    {
+      if(std::isfinite(_jt->limits->lower)
+         && std::isfinite(_jt->limits->upper))
+        singleDof.mInitialPosition =
+            (_jt->limits->lower + _jt->limits->upper) / 2.0;
+      else if(std::isfinite(_jt->limits->lower))
+        singleDof.mInitialPosition = _jt->limits->lower;
+      else if(std::isfinite(_jt->limits->upper))
+        singleDof.mInitialPosition = _jt->limits->upper;
+
+      // Any other case means that the limits are both +inf, both -inf, or
+      // either of them is NaN. This should generate warnings elsewhere.
+    }
   }
 
   if(_jt->dynamics)

--- a/unittests/testParser.cpp
+++ b/unittests/testParser.cpp
@@ -237,6 +237,10 @@ TEST(Parser, PlanarJoint)
   EXPECT_EQ(planarJoint4->getRotationalAxis(), Eigen::Vector3d::UnitZ());
 
   EXPECT_EQ(planarJoint1->getPositions(), Eigen::Vector3d(1, 2, 3));
+  std::cout << "positions (" << planarJoint1->getPositions().size()
+            << "): " << planarJoint1->getPositions().transpose() << std::endl;
+  std::cout << "initial positions: (" << planarJoint1->getInitialPositions().size()
+            << "): " << planarJoint1->getInitialPositions().transpose() << std::endl;
   EXPECT_EQ(planarJoint2->getPositions(), Eigen::Vector3d(1, 2, 3));
   EXPECT_EQ(planarJoint3->getPositions(), Eigen::Vector3d(1, 2, 3));
   EXPECT_EQ(planarJoint4->getPositions(), Eigen::Vector3d(1, 2, 3));

--- a/unittests/testParser.cpp
+++ b/unittests/testParser.cpp
@@ -237,10 +237,6 @@ TEST(Parser, PlanarJoint)
   EXPECT_EQ(planarJoint4->getRotationalAxis(), Eigen::Vector3d::UnitZ());
 
   EXPECT_EQ(planarJoint1->getPositions(), Eigen::Vector3d(1, 2, 3));
-  std::cout << "positions (" << planarJoint1->getPositions().size()
-            << "): " << planarJoint1->getPositions().transpose() << std::endl;
-  std::cout << "initial positions: (" << planarJoint1->getInitialPositions().size()
-            << "): " << planarJoint1->getInitialPositions().transpose() << std::endl;
   EXPECT_EQ(planarJoint2->getPositions(), Eigen::Vector3d(1, 2, 3));
   EXPECT_EQ(planarJoint3->getPositions(), Eigen::Vector3d(1, 2, 3));
   EXPECT_EQ(planarJoint4->getPositions(), Eigen::Vector3d(1, 2, 3));


### PR DESCRIPTION
There are now properties that can be given to the joints of a robot for initial position and initial velocity. Calling the ``resetPosition`` and ``resetVelocity`` functions will set the joint to its initial position and velocity respectively, instead of zeroing them out. By default, these properties are zero.

The SkelParser will set these properties based on the initial positions and velocities given in the ``.skel`` file. However, neither the URDF nor the SDF parsers support this, because I could not find a relevant tag in either of those formats.