### PR TITLE
Require Assimp < 3.0~dfsg-4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends: debhelper (>= 9),
                libeigen3-dev,
                libfcl-dev (>= 0.2.7),
                libassimp-dev (>= 3),
+               libassimp-dev (<< 3.0~dfsg-4),
                freeglut3-dev,
                libxi-dev,
                libxmu-dev,
@@ -28,6 +29,7 @@ Depends: ${misc:Depends},
          libdart-core5.0 (= ${binary:Version}),
          libeigen3-dev,
          libassimp-dev (>= 3),
+         libassimp-dev (<< 3.0~dfsg-4),
          libfcl-dev
 Description: Dynamic Animation and Robotics Toolkit, core development files
  DART is a collaborative, cross-platform, open source library created by the


### PR DESCRIPTION
This pull request makes DART depend on the version of Assimp that is missing C++ symbols; see #451 for details. This should stop DART from breaking when Assimp `3.0~dfsg-4` is released on Ubuntu. It would be good if @jslee02 could release a new version of DART with this change to stave off any potential problems.

Next, I will build the Debian packages for the updated version of Assimp and work with @jslee02 to get them in the DART PPA. Once that is done, we can modify the `debian/control` file to depend on `libassimp-dev (>= 3.0~dfsg-4)` and release a version of DART without the custom `aiScene` methods.