### PR TITLE
Added a mutex to Skeleton.

### DIFF
--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -106,6 +106,12 @@ ConstSkeletonPtr Skeleton::getPtr() const
 }
 
 //==============================================================================
+std::mutex& Skeleton::getMutex() const
+{
+  return mMutex;
+}
+
+//==============================================================================
 Skeleton::~Skeleton()
 {
   for (BodyNode* bn : mSkelCache.mBodyNodes)

--- a/dart/dynamics/Skeleton.h
+++ b/dart/dynamics/Skeleton.h
@@ -38,6 +38,7 @@
 #ifndef DART_DYNAMICS_SKELETON_H_
 #define DART_DYNAMICS_SKELETON_H_
 
+#include <mutex>
 #include "dart/common/NameManager.h"
 #include "dart/dynamics/MetaSkeleton.h"
 #include "dart/dynamics/SmartPointer.h"
@@ -105,6 +106,9 @@ public:
 
   /// Get the shared_ptr that manages this Skeleton
   ConstSkeletonPtr getPtr() const;
+
+  /// Get the mutex that protects the state of this Skeleton
+  std::mutex& getMutex() const;
 
   /// Destructor
   virtual ~Skeleton();
@@ -968,6 +972,8 @@ protected:
   // TODO(JS): Better naming
   /// Flag for status of impulse testing.
   bool mIsImpulseApplied;
+
+  mutable std::mutex mMutex;
 
 public:
   //--------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds an `std::mutex` to `Skeleton`. Most of the methods on `Skeleton` are not thread safe, so using some kind of mutex is necessary in a multi-threaded application. It's useful to attach the mutex to `Skeleton` so you don't have to manually pass one around to every function that operates on it.