### PR TITLE
Packaging DART 5.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ project(dart)
 
 set(DART_MAJOR_VERSION "5")
 set(DART_MINOR_VERSION "0")
-set(DART_PATCH_VERSION "0")
+set(DART_PATCH_VERSION "1")
 set(DART_VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}.${DART_PATCH_VERSION}")
 set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")
 set(DART_PKG_EXTERNAL_DEPS "flann, ccd, fcl")

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-### Version 5.0.1 (2015-XX-XX)
+### Version 5.0.1 (2015-07-24)
 
 1. Improved app indexing for bipedStand and atlasSimbicon
     * [Pull request #417](https://github.com/dartsim/dart/pull/417)
@@ -8,6 +8,22 @@
 
 1. Improved CollisionNode's index validity check
     * [Pull request #421](https://github.com/dartsim/dart/pull/421)
+
+1. Standardized warning messages for Joints
+    * [Pull request #425](https://github.com/dartsim/dart/pull/425)
+    * [Pull request #429](https://github.com/dartsim/dart/pull/429)
+
+1. Fixed bug in SDF parser -- correct child for a joint
+    * [Pull request #431](https://github.com/dartsim/dart/pull/431)
+
+1. Fixed SDF parsing for single link model without joint
+    * [Pull request #444](https://github.com/dartsim/dart/pull/444)
+
+1. Added missing virtual destructors to Properties in Entity and [Soft]BodyNode
+    * [Pull request #458](https://github.com/dartsim/dart/pull/458)
+
+1. Limited maximum required version of Assimp less than 3.0~dfsg-4
+    * [Pull request #459](https://github.com/dartsim/dart/pull/459)
 
 ### Version 5.0.0 (2015-06-15)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-### Version 5.0.1 (2015-07-24)
+### Version 5.0.1 (2015-07-28)
 
 1. Improved app indexing for bipedStand and atlasSimbicon
     * [Pull request #417](https://github.com/dartsim/dart/pull/417)
@@ -24,6 +24,9 @@
 
 1. Limited maximum required version of Assimp less than 3.0~dfsg-4
     * [Pull request #459](https://github.com/dartsim/dart/pull/459)
+
+1. Fixed SEGFAULTs in DartLoader
+    * [Pull request #472](https://github.com/dartsim/dart/pull/472)
 
 ### Version 5.0.0 (2015-06-15)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,8 +8,9 @@ dart (5.0.1) unstable; urgency=low
   * Fixed SDF parsing for single link model without joint
   * Added missing virtual destructors to Properties in Entity and [Soft]BodyNode
   * Limited maximum required version of Assimp less than 3.0~dfsg-4
+  * Fixed SEGFAULTs in DartLoader
 
- -- Jeongseok Lee <jslee02@gmail.com>  Fri, 24 Jul 2015 18:00:00 -0500
+ -- Jeongseok Lee <jslee02@gmail.com>  Tue, 28 Jul 2015 03:00:00 -0500
 
 dart (5.0.0) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+dart (5.0.1) unstable; urgency=low
+
+  * Improved app indexing for bipedStand and atlasSimbicon
+  * Added clipping command when it exceeds the limits
+  * Improved CollisionNode's index validity check
+  * Standardized warning messages for Joints
+  * Fixed bug in SDF parser -- correct child for a joint
+  * Fixed SDF parsing for single link model without joint
+  * Added missing virtual destructors to Properties in Entity and [Soft]BodyNode
+  * Limited maximum required version of Assimp less than 3.0~dfsg-4
+
+ -- Jeongseok Lee <jslee02@gmail.com>  Fri, 24 Jul 2015 18:00:00 -0500
+
 dart (5.0.0) unstable; urgency=low
 
   * Fixed aligned memory allocation with Eigen objects


### PR DESCRIPTION
DART 5.0.1 release includes patches for the bugs we found in DART 5.0.0. 

[DART 5.0.1 will be used in Gazebo 6.0](https://bitbucket.org/osrf/gazebo/pull-request/1825/dart-interface-update-for-dart-50/diff).