### PR TITLE
Remove list of local source files from generated doxygen documentation

### DIFF
--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -624,7 +624,7 @@ MAX_INITIALIZER_LINES  = 30
 # will mention the files that were used to generate the documentation.
 # The default value is: YES.
 
-SHOW_USED_FILES        = YES
+SHOW_USED_FILES        = NO
 
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page. This
 # will remove the Files entry from the Quick Index and from the Folder Tree View


### PR DESCRIPTION
This pull request removes the list of local source files at the bottom of generated documentation.