### PR TITLE
Fix compilation warnings and build error

### DIFF
--- a/apps/atlasSimbicon/State.cpp
+++ b/apps/atlasSimbicon/State.cpp
@@ -648,7 +648,7 @@ double State::getDerivativeGain(int _idx) const
 //==============================================================================
 void State::setFeedbackSagitalCOMDistance(size_t _index, double _val)
 {
-  assert(_index <= mSagitalCd.size() && "Invalid index.");
+  assert(static_cast<int>(_index) <= mSagitalCd.size() && "Invalid index.");
 
   mSagitalCd[_index] = _val;
 }
@@ -656,7 +656,7 @@ void State::setFeedbackSagitalCOMDistance(size_t _index, double _val)
 //==============================================================================
 void State::setFeedbackSagitalCOMVelocity(size_t _index, double _val)
 {
-  assert(_index <= mSagitalCv.size() && "Invalid index.");
+  assert(static_cast<int>(_index) <= mSagitalCv.size() && "Invalid index.");
 
   mSagitalCv[_index] = _val;
 }
@@ -664,7 +664,7 @@ void State::setFeedbackSagitalCOMVelocity(size_t _index, double _val)
 //==============================================================================
 void State::setFeedbackCoronalCOMDistance(size_t _index, double _val)
 {
-  assert(_index <= mCoronalCd.size() && "Invalid index.");
+  assert(static_cast<int>(_index) <= mCoronalCd.size() && "Invalid index.");
 
   mCoronalCd[_index] = _val;
 }
@@ -672,7 +672,7 @@ void State::setFeedbackCoronalCOMDistance(size_t _index, double _val)
 //==============================================================================
 void State::setFeedbackCoronalCOMVelocity(size_t _index, double _val)
 {
-  assert(_index <= mCoronalCv.size() && "Invalid index.");
+  assert(static_cast<int>(_index) <= mCoronalCv.size() && "Invalid index.");
 
   mCoronalCv[_index] = _val;
 }

--- a/dart/collision/bullet/BulletTypes.h
+++ b/dart/collision/bullet/BulletTypes.h
@@ -43,14 +43,6 @@
 namespace dart {
 namespace collision {
 
-#if !defined(__APPLE__) && BT_BULLET_VERSION < 283
-/// Dummy inline function to suppress unused-variable warning from bullet
-inline int btGetInfinityMask()
-{
-  return btInfinityMask;
-}
-#endif
-
 /// @brief Convert Bullet vector3 type to Eigen vector3 type
 Eigen::Vector3d convertVector3(const btVector3& _vec);
 

--- a/unittests/testSdfParser.cpp
+++ b/unittests/testSdfParser.cpp
@@ -62,13 +62,13 @@ TEST(SdfParser, SDFSingleBodyWithoutJoint)
 
   SkeletonPtr skel = world->getSkeleton(0);
   EXPECT_TRUE(skel != nullptr);
-  EXPECT_EQ(skel->getNumBodyNodes(), 1);
-  EXPECT_EQ(skel->getNumJoints(), 1);
+  EXPECT_EQ(skel->getNumBodyNodes(), 1u);
+  EXPECT_EQ(skel->getNumJoints(), 1u);
 
   BodyNodePtr bodyNode = skel->getBodyNode(0);
   EXPECT_TRUE(bodyNode != nullptr);
-  EXPECT_EQ(bodyNode->getNumVisualizationShapes(), 1);
-  EXPECT_EQ(bodyNode->getNumCollisionShapes(), 1);
+  EXPECT_EQ(bodyNode->getNumVisualizationShapes(), 1u);
+  EXPECT_EQ(bodyNode->getNumCollisionShapes(), 1u);
 
   JointPtr joint = skel->getJoint(0);
   EXPECT_TRUE(joint != nullptr);


### PR DESCRIPTION
This pull request fixes:
* signed/unsigned mismatch warnings in atlasSimbicon app and testSdfParser
* build error reported by #418.

The unused-variable-warnings from bullet are now suppressed by [adding SYSTEM flag to include_directories](https://github.com/dartsim/dart/pull/435) instead of [problematic dummy functions](https://github.com/dartsim/dart/commit/3e7565870bb5c135b49ee6ba931ecb03c49e7448).