### PR TITLE
Fixed CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,7 +519,7 @@ endif()
 set(PC_CONFIG_IN ${CMAKE_SOURCE_DIR}/cmake/dart.pc.in)
 set(PC_CONFIG_OUT ${CMAKE_BINARY_DIR}/cmake/dart.pc)
 message(STATUS ${PC_CONFIG_OUT})
-configure_file(${PC_CONFIG_IN} ${PC_CONFIG_OUT} @only)
+configure_file(${PC_CONFIG_IN} ${PC_CONFIG_OUT} @ONLY)
 install(FILES ${PC_CONFIG_OUT} DESTINATION lib/pkgconfig)
 
 # Install a Catkin 'package.xml' file. This is required by REP-136.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,13 @@
 # CMake settings
 #===============================================================================
 cmake_minimum_required(VERSION 2.8.6 FATAL_ERROR)
-cmake_policy(SET CMP0042 NEW)
+
+# Use MACOSX_RPATH by default on OS X. This was added in CMake 2.8.12 and
+# became default in CMake 3.0. Explicitly setting this policy is necessary to
+# suppress a warning in CMake 3.0 and above.
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+endif()
 
 # Disables a warning about a change in Cygwin Cmake
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 # CMake settings
 #===============================================================================
 cmake_minimum_required(VERSION 2.8.6 FATAL_ERROR)
+cmake_policy(SET CMP0042 NEW)
 
 # Disables a warning about a change in Cygwin Cmake
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)


### PR DESCRIPTION
This pull request sets the [`CMP0042` policy](http://www.cmake.org/cmake/help/v3.0/policy/CMP0042.html) in CMake:

> MACOSX_RPATH is enabled by default.
>
> CMake 2.8.12 and newer has support for using `@rpath` in a target’s install name. This was enabled by setting the target property MACOSX_RPATH. The `@rpath` in an install name is a more flexible and powerful mechanism than @executable_path or `@loader_path` for locating shared libraries.
>
> CMake 3.0 and later prefer this property to be ON by default. Projects wanting `@rpath` in a target’s install name may remove any setting of the INSTALL_NAME_DIR and CMAKE_INSTALL_NAME_DIR variables.
>
> This policy was introduced in CMake version 3.0. CMake version 3.0.2 warns when the policy is not set and uses OLD behavior. Use the cmake_policy command to set it to OLD or NEW explicitly.

Setting this explicitly suppresses a warning when building with CMake >= 3.0 on OS X. From what I can tell online, `@rpath` is strictly better than the other options, so it is also a good thing to enable.

I also noticed that CMake was warning about an unused `@only` flag option in `configure_file`. It appears that this flag is case-sensitive, so I changed it to uppercase.