### PR TITLE
Added missing target_link_libraries to osgDart

### DIFF
--- a/osgDart/CMakeLists.txt
+++ b/osgDart/CMakeLists.txt
@@ -12,6 +12,10 @@ if(${OPENSCENEGRAPH_FOUND})
   file(GLOB osgDart_hdrs "*.h")
 
   dart_add_library(osgDart ${osgDart_srcs} ${osgDart_hdrs})
+  target_link_libraries(osgDart
+    dart-core
+    ${OPENSCENEGRAPH_LIBRARIES}
+  )
 
   dart_get_filename_components(header_names "osgDart headers" ${osgDart_hdrs})
   list(APPEND header_names "render/render.h")


### PR DESCRIPTION
I needed to add these to get `osgDart` to build on OS X.

*Note:* This is a pull request into the `grey/osg` branch, not `master`.