### PR TITLE
Bring back declaration of urdf::parsePose

### DIFF
--- a/dart/utils/urdf/urdf_world_parser.cpp
+++ b/dart/utils/urdf/urdf_world_parser.cpp
@@ -51,6 +51,12 @@
 
 const bool debug = false;
 
+namespace urdf {
+
+bool parsePose(urdf::Pose &pose, TiXmlElement* xml);
+
+} // namespace urdf
+
 namespace dart {
 namespace utils {
 namespace urdf_parsing {


### PR DESCRIPTION
It seems that the Windows versions of the urdfdom headers are not declaring the function ``urdf::parsePose``, as reported by @jturner65 and as seen in the Appveyor CI tests.

This pull request brings back the declaration.