### PR TITLE
Don't use constexpr for vs2013

### DIFF
--- a/dart/math/Helpers.h
+++ b/dart/math/Helpers.h
@@ -66,19 +66,34 @@ inline int delta(int _i, int _j) {
   return 0;
 }
 
+#if defined(_MSC_VER)
+// TODO: Change to constexpr once Visual Studio supports it
+template <typename T> inline
+#else
 template <typename T> inline constexpr
+#endif
 int sign(T x, std::false_type)
 {
   return static_cast<T>(0) < x;
 }
 
+#if defined(_MSC_VER)
+// TODO: Change to constexpr once Visual Studio supports it
+template <typename T> inline
+#else
 template <typename T> inline constexpr
+#endif
 int sign(T x, std::true_type)
 {
   return (static_cast<T>(0) < x) - (x < static_cast<T>(0));
 }
 
+#if defined(_MSC_VER)
+// TODO: Change to constexpr once Visual Studio supports it
+template <typename T> inline
+#else
 template <typename T> inline constexpr
+#endif
 int sign(T x)
 {
   return sign(x, std::is_signed<T>());


### PR DESCRIPTION
[Visual Studio 2013 doesn't support `constexpr` specifier yet](https://msdn.microsoft.com/en-us/library/vstudio/hh567368(v=vs.120).aspx).