### PR TITLE
Use urdfdom 0.3.0 for AppVeyor CI tests

### DIFF
--- a/ci/appveyor_install.ps1
+++ b/ci/appveyor_install.ps1
@@ -10,7 +10,7 @@ function InstallPrerequisites($work_dir, $install_dir)
   cd $work_dir
 
   $msi = "dart-prerequisites.msi"
-  $uri = "https://github.com/dartsim/dart-prerequisites-windows/raw/bfb42e9e8271bc99f8b070715bd407cb5988c322/DART%205.0-prerequisites-msvc12-md-32bit.msi"
+  $uri = "https://github.com/dartsim/dart-prerequisites-windows/raw/3e34167fd29fcc870ebed50bf318f3f31f491e6a/DART%205.0-prerequisites-msvc12-md-32bit.msi"
   Invoke-WebRequest $uri -OutFile $msi
 
   $install_command = "msiexec.exe"

--- a/dart/utils/urdf/urdf_world_parser.cpp
+++ b/dart/utils/urdf/urdf_world_parser.cpp
@@ -179,7 +179,7 @@ std::shared_ptr<World> parseWorldURDF(
           TiXmlElement* origin = entity_xml->FirstChildElement("origin");
           if( origin )
           {
-            if( !parsePose( entity.origin, origin ) )
+            if( !urdf::parsePose( entity.origin, origin ) )
             {
               dtwarn << "[ERROR] Missing origin tag for '" << entity.model->getName() << "'\n";
               return world;


### PR DESCRIPTION
The DART prerequisites installer for Windows was updated to use newer version of urdfdom (0.3.0). This PR updates the script for AppVeyor CI to install the updated one. This should resolve the issue of missing `urdf::parsePose` reported by @jturner65.