### PR TITLE
Enable compiler optimization by using 'final' keyword for Jacobian functions

### DIFF
--- a/dart/dynamics/BodyNode.h
+++ b/dart/dynamics/BodyNode.h
@@ -636,14 +636,14 @@ public:
 
   /// Return the generalized Jacobian targeting the origin of this BodyNode. The
   /// Jacobian is expressed in the Frame of this BodyNode.
-  const math::Jacobian& getJacobian() const override;
+  const math::Jacobian& getJacobian() const override final;
 
   // Prevent the inherited getJacobian functions from being shadowed
   using TemplatedJacobianNode<BodyNode>::getJacobian;
 
   /// Return the generalized Jacobian targeting the origin of this BodyNode. The
   /// Jacobian is expressed in the World Frame.
-  const math::Jacobian& getWorldJacobian() const;
+  const math::Jacobian& getWorldJacobian() const override final;
 
   // Prevent the inherited getWorldJacobian functions from being shadowed
   using TemplatedJacobianNode<BodyNode>::getWorldJacobian;
@@ -656,7 +656,7 @@ public:
   /// spatial vectors. If you are using classical linear and angular
   /// acceleration vectors, then use getJacobianClassicDeriv(),
   /// getLinearJacobianDeriv(), or getAngularJacobianDeriv() instead.
-  const math::Jacobian& getJacobianSpatialDeriv() const override;
+  const math::Jacobian& getJacobianSpatialDeriv() const override final;
 
   // Prevent the inherited getJacobianSpatialDeriv functions from being shadowed
   using TemplatedJacobianNode<BodyNode>::getJacobianSpatialDeriv;
@@ -668,7 +668,7 @@ public:
   /// NOTE: Since this is a classical time derivative, it should be used with
   /// classical linear and angular vectors. If you are using spatial vectors,
   /// use getJacobianSpatialDeriv() instead.
-  const math::Jacobian& getJacobianClassicDeriv() const override;
+  const math::Jacobian& getJacobianClassicDeriv() const override final;
 
   // Prevent the inherited getJacobianClassicDeriv functions from being shadowed
   using TemplatedJacobianNode<BodyNode>::getJacobianClassicDeriv;

--- a/dart/dynamics/EndEffector.h
+++ b/dart/dynamics/EndEffector.h
@@ -227,25 +227,25 @@ public:
   //----------------------------------------------------------------------------
 
   // Documentation inherited
-  const math::Jacobian& getJacobian() const override;
+  const math::Jacobian& getJacobian() const override final;
 
   // Prevent the inherited getJacobian functions from being shadowed
   using TemplatedJacobianNode<EndEffector>::getJacobian;
 
   // Documentation inherited
-  const math::Jacobian& getWorldJacobian() const override;
+  const math::Jacobian& getWorldJacobian() const override final;
 
   // Prevent the inherited getWorldJacobian functions from being shadowed
   using TemplatedJacobianNode<EndEffector>::getWorldJacobian;
 
   // Documentation inherited
-  const math::Jacobian& getJacobianSpatialDeriv() const override;
+  const math::Jacobian& getJacobianSpatialDeriv() const override final;
 
   // Prevent the inherited getJacobianSpatialDeriv functions from being shadowed
   using TemplatedJacobianNode<EndEffector>::getJacobianSpatialDeriv;
 
   // Documentation inherited
-  const math::Jacobian& getJacobianClassicDeriv() const override;
+  const math::Jacobian& getJacobianClassicDeriv() const override final;
 
   // Prevent the inherited getJacobianClassicDeriv functions from being shadowed
   using TemplatedJacobianNode<EndEffector>::getJacobianClassicDeriv;


### PR DESCRIPTION
We can devirtualize the Jacobian function calls for ``BodyNode`` and ``EndEffector`` by using the ``final`` keyword on their Jacobian function implementations.