### PR TITLE
Fix compilation errors and warnings on Windows

### DIFF
--- a/dart/config.h.in
+++ b/dart/config.h.in
@@ -41,4 +41,13 @@
 #define DART_ROOT_PATH "@CMAKE_SOURCE_DIR@/"
 #define DART_DATA_PATH "@CMAKE_SOURCE_DIR@/data/"
 
+// Visual Studio does not have std::nextafter() under std namespace, and the
+// function name is different.
+#if defined(_MSC_VER)
+namespace std {
+template <typename T>
+T nextafter(T x, T y) { return _nextafter(x, y); }
+}
+#endif
+
 #endif // #ifndef DART_CONFIG_H_

--- a/dart/config.h.in
+++ b/dart/config.h.in
@@ -41,13 +41,4 @@
 #define DART_ROOT_PATH "@CMAKE_SOURCE_DIR@/"
 #define DART_DATA_PATH "@CMAKE_SOURCE_DIR@/data/"
 
-// Visual Studio does not have std::nextafter() under std namespace, and the
-// function name is different.
-#if defined(_MSC_VER)
-namespace std {
-template <typename T>
-T nextafter(T x, T y) { return _nextafter(x, y); }
-}
-#endif
-
 #endif // #ifndef DART_CONFIG_H_

--- a/dart/lcpsolver/common.h
+++ b/dart/lcpsolver/common.h
@@ -167,10 +167,6 @@ typedef dReal dQuaternion[4];
 #define dCopySign(a,b) ((dReal)copysignf(a,b)) /* copy value sign */
 #define dNextAfter(x, y) nextafterf(x, y) /* next value after */
 
-#if defined(_ODE__NEXTAFTERF_REQUIRED)
-float _nextafterf(float x, float y);
-#endif
-
 #ifdef HAVE___ISNANF
 #define dIsNan(x) (__isnanf(x))
 #elif defined(HAVE__ISNANF)
@@ -205,8 +201,6 @@ float _nextafterf(float x, float y);
 #define dCeil(x) ceil(x)
 #define dCopySign(a,b) (copysign((a),(b)))
 #define dNextAfter(x, y) nextafter(x, y)
-
-#undef _ODE__NEXTAFTERF_REQUIRED
 
 #ifdef HAVE___ISNAN
 #define dIsNan(x) (__isnan(x))

--- a/dart/lcpsolver/odeconfig.h
+++ b/dart/lcpsolver/odeconfig.h
@@ -55,18 +55,6 @@
   typedef unsigned char   uint8;
 #endif
 
-/* Visual C does not define these functions */
-#if defined(_MSC_VER)
-  #define copysignf(x, y) ((float)_copysign(x, y))
-  #define copysign(x, y) _copysign(x, y)
-  #define nextafterf(x, y) _nextafterf(x, y)
-  #define nextafter(x, y) _nextafter(x, y)
-  #if !defined(_WIN64)
-    #define _ODE__NEXTAFTERF_REQUIRED
-  #endif
-#endif
-
-
 
 /* Define the dInfinity macro */
 #ifdef INFINITY

--- a/tutorials/tutorialBiped-Finished.cpp
+++ b/tutorials/tutorialBiped-Finished.cpp
@@ -309,7 +309,7 @@ SkeletonPtr loadBiped()
 
   // Set joint limits
   for(size_t i = 0; i < biped->getNumJoints(); ++i)
-    biped->getJoint(i)->setPositionLimited(true);
+    biped->getJoint(i)->setPositionLimitEnforced(true);
   
   // Enable self collision check but ignore adjacent bodies
   biped->enableSelfCollision();

--- a/tutorials/tutorialCollisions-Finished.cpp
+++ b/tutorials/tutorialCollisions-Finished.cpp
@@ -33,9 +33,9 @@
  *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *   POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <random>
 #include "dart/dart.h"
-#include <random>
 
 const double default_shape_density = 1000; // kg/m^3
 const double default_shape_height  = 0.1;  // m

--- a/tutorials/tutorialCollisions.cpp
+++ b/tutorials/tutorialCollisions.cpp
@@ -33,9 +33,9 @@
  *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *   POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <random>
 #include "dart/dart.h"
-#include <random>
 
 const double default_shape_density = 1000; // kg/m^3
 const double default_shape_height  = 0.1;  // m


### PR DESCRIPTION
This PR:
* removes macros for some c99 library functions in odeconfig.h
  * The macros was required since old Visual Studio does not support those functions; they have similar implementation in Visual Studio but they are not in std namespace and have slightly different names
  * Visual Studio 2013 and after support those functions and now these macros cause compilation errors because of the namespace issue. For example, std::nextafter(~) will be modified by the macro to std::_nextafter(~) but _nextafter(~) is not in std namespace.
* removes use of deprecated function
* removes duplicated header inclusion

Note that AppVeyor CI build test wouldn't pass since #488 has not addressed yet.