### PR TITLE
Don't use material if the material index is -1 in OpenGLRenderInterface

### DIFF
--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -132,7 +132,7 @@ namespace dart {
 namespace dynamics {
 
 MeshShape::MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh,
-                     const std::string &_path,
+                     const std::string& _path,
                      const common::ResourceRetrieverPtr& _resourceRetriever)
   : Shape(MESH),
     mResourceRetriever(_resourceRetriever),
@@ -183,7 +183,7 @@ const std::string &MeshShape::getMeshPath() const
 }
 
 void MeshShape::setMesh(
-  const aiScene* _mesh, const std::string &_path,
+  const aiScene* _mesh, const std::string& _path,
   const common::ResourceRetrieverPtr& _resourceRetriever)
 {
   mMesh = _mesh;

--- a/dart/renderer/OpenGLRenderInterface.cpp
+++ b/dart/renderer/OpenGLRenderInterface.cpp
@@ -345,7 +345,8 @@ void OpenGLRenderInterface::recursiveRender(const struct aiScene *sc, const stru
         const struct aiMesh* mesh = sc->mMeshes[nd->mMeshes[n]];
 
         glPushAttrib(GL_POLYGON_BIT | GL_LIGHTING_BIT);  // for applyMaterial()
-        applyMaterial(sc->mMaterials[mesh->mMaterialIndex]);
+        if(mesh->mMaterialIndex != (unsigned int)(-1)) // -1 is being used by us to indicate no material
+            applyMaterial(sc->mMaterials[mesh->mMaterialIndex]);
 
         if(mesh->mNormals == nullptr) {
             glDisable(GL_LIGHTING);


### PR DESCRIPTION
It seems [we started to set the material index to -1 to indicate no material](https://github.com/dartsim/dart/commit/6b0266cfad6aad4cdc40befdf8d5994479a78491#diff-ed1bdc3b52a7df5f3d58c16da27962e4R262). This is correctly handled by osgDart but it was not applied to OpenGLRenderInterface. This should fix segfault of simpleFrames app.