### PR TITLE
package.xml: depend on bullet

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <buildtool_depend>cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
   <depend>assimp</depend>
+  <depend>bullet</depend>
   <depend>eigen</depend>
   <depend>fcl</depend>
   <depend>glut</depend>


### PR DESCRIPTION
DART is using bullet for collision detection, but bullet wasn't listed in the package.xml file.