### PR TITLE
Fix Copy Safety

### DIFF
--- a/dart/dynamics/BodyNode.h
+++ b/dart/dynamics/BodyNode.h
@@ -146,6 +146,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  BodyNode(const BodyNode&) = delete;
+
   /// Destructor
   virtual ~BodyNode();
 

--- a/dart/dynamics/Entity.h
+++ b/dart/dynamics/Entity.h
@@ -103,6 +103,8 @@ public:
   /// Constructor for typical usage
   explicit Entity(Frame* _refFrame, const std::string& _name, bool _quiet);
 
+  Entity(const Entity&) = delete;
+
   /// Destructor
   virtual ~Entity();
 

--- a/dart/dynamics/Frame.h
+++ b/dart/dynamics/Frame.h
@@ -63,6 +63,8 @@ public:
   friend class Entity;
   friend class WorldFrame;
 
+  Frame(const Frame&) = delete;
+
   /// Destructor
   virtual ~Frame();
 

--- a/dart/dynamics/Joint.h
+++ b/dart/dynamics/Joint.h
@@ -159,6 +159,8 @@ public:
   /// Default actuator type
   static const ActuatorType DefaultActuatorType;
 
+  Joint(const Joint&) = delete;
+
   /// Destructor
   virtual ~Joint();
 

--- a/dart/dynamics/MetaSkeleton.h
+++ b/dart/dynamics/MetaSkeleton.h
@@ -70,6 +70,8 @@ public:
                             const std::string& _oldName,
                             const std::string& _newName)>;
 
+  MetaSkeleton(const MetaSkeleton&) = delete;
+
   /// Default destructor
   virtual ~MetaSkeleton() = default;
 

--- a/dart/dynamics/Skeleton.h
+++ b/dart/dynamics/Skeleton.h
@@ -113,6 +113,8 @@ public:
   /// Get the mutex that protects the state of this Skeleton
   std::mutex& getMutex() const;
 
+  Skeleton(const Skeleton&) = delete;
+
   /// Destructor
   virtual ~Skeleton();
 


### PR DESCRIPTION
As pointed out by @mkoval in issue #524, we neglected to delete the copy constructors of various classes that are not copy-safe. This pull request deletes their copy constructors.