### PR TITLE
Aligning a map with fixed-size vectorizable Eigen structs in testDynamics

### DIFF
--- a/unittests/testDynamics.cpp
+++ b/unittests/testDynamics.cpp
@@ -839,7 +839,7 @@ void DynamicsTest::testFiniteDifferenceBodyNodeVelocity(
       skeleton->setVelocities(dq);
       skeleton->setAccelerations(ddq);
 
-      std::map<dynamics::BodyNodePtr, Eigen::Isometry3d> Tmap;
+      Eigen::aligned_map<dynamics::BodyNodePtr, Eigen::Isometry3d> Tmap;
       for (auto k = 0u; k < numBodies; ++k)
       {
         auto body  = skeleton->getBodyNode(k);
@@ -1063,9 +1063,9 @@ void testForwardKinematicsSkeleton(const dynamics::SkeletonPtr& skel)
   Eigen::VectorXd dq;
   Eigen::VectorXd ddq;
 
-  std::map<dynamics::BodyNodePtr, Eigen::Isometry3d>  Tmap;
-  std::map<dynamics::BodyNodePtr, Eigen::Vector6d>    Vmap;
-  std::map<dynamics::BodyNodePtr, Eigen::Vector6d>   dVmap;
+  Eigen::aligned_map<dynamics::BodyNodePtr, Eigen::Isometry3d>  Tmap;
+  Eigen::aligned_map<dynamics::BodyNodePtr, Eigen::Vector6d>    Vmap;
+  Eigen::aligned_map<dynamics::BodyNodePtr, Eigen::Vector6d>   dVmap;
 
   for (auto j = 0u; j < numBodies; ++j)
   {


### PR DESCRIPTION
This PR fixes segfaults on 32-bit systems ([trusty](https://launchpadlibrarian.net/221507472/buildlog_ubuntu-trusty-i386.dart_5.1.0.ppa4~trusty_BUILDING.txt.gz), [vivid](https://launchpadlibrarian.net/221507681/buildlog_ubuntu-vivid-i386.dart_5.1.0.ppa4~vivid_BUILDING.txt.gz)).