### PR TITLE
Reduce Travis-CI build log on Mac

### DIFF
--- a/ci/before_install_osx.sh
+++ b/ci/before_install_osx.sh
@@ -1,23 +1,26 @@
 brew tap dartsim/dart
 brew tap homebrew/science
 
-brew update
+brew update > /dev/null
 
-brew install git
-# brew install cmake   # installed cmake-3.0.2
-brew install assimp
-brew install fcl
-brew install bullet
-brew install flann     # 1.8.14
-# brew install boost   # installed boost-1.55.2
-brew install eigen     # 3.2.2
-brew install tinyxml   # 2.6.2
-brew install tinyxml2  # 2.2.0
-brew install libccd    #
-brew install nlopt     # 2.4.2
-brew install ipopt
-brew install ros/deps/urdfdom
-brew install ros/deps/urdfdom_headers
-brew install ros/deps/console_bridge
-brew install ros/deps/gtest
+PACKAGES='
+git
+cmake
+assimp
+fcl
+bullet
+flann
+boost
+eigen
+tinyxml
+tinyxml2
+libccd
+nlopt
+ipopt
+ros/deps/urdfdom
+ros/deps/urdfdom_headers
+ros/deps/console_bridge
+ros/deps/gtest
+'
 
+brew install $PACKAGES | grep -v '%$'


### PR DESCRIPTION
This PR reduces Travis-CI build log on Mac based on the idea of:
* https://github.com/osrf/homebrew-simulation/commit/f3cad8c9ab2639d5981418b96002d02a1d6955ea
* https://github.com/travis-ci/travis-ci/issues/4936