### PR TITLE
Remove const qualifier of ResourceRetriever methods

### DIFF
--- a/dart/common/LocalResourceRetriever.cpp
+++ b/dart/common/LocalResourceRetriever.cpp
@@ -45,7 +45,7 @@ namespace dart {
 namespace common {
 
 //==============================================================================
-bool LocalResourceRetriever::exists(const Uri& _uri) const
+bool LocalResourceRetriever::exists(const Uri& _uri)
 {
   // Open and close the file to check if it exists. It would be more efficient
   // to stat() it, but that is not portable.
@@ -58,7 +58,7 @@ bool LocalResourceRetriever::exists(const Uri& _uri) const
 }
 
 //==============================================================================
-common::ResourcePtr LocalResourceRetriever::retrieve(const Uri& _uri) const
+common::ResourcePtr LocalResourceRetriever::retrieve(const Uri& _uri)
 {
   if(_uri.mScheme.get_value_or("file") != "file")
     return nullptr;

--- a/dart/common/LocalResourceRetriever.h
+++ b/dart/common/LocalResourceRetriever.h
@@ -50,10 +50,10 @@ public:
   virtual ~LocalResourceRetriever() = default;
 
   // Documentation inherited.
-  bool exists(const Uri& _uri) const override;
+  bool exists(const Uri& _uri) override;
 
   // Documentation inherited.
-  ResourcePtr retrieve(const Uri& _uri) const override;
+  ResourcePtr retrieve(const Uri& _uri) override;
 };
 
 using LocalResourceRetrieverPtr = std::shared_ptr<LocalResourceRetriever>;

--- a/dart/common/ResourceRetriever.h
+++ b/dart/common/ResourceRetriever.h
@@ -54,10 +54,16 @@ public:
   virtual ~ResourceRetriever() = default;
 
   /// \brief Return whether the resource specified by a URI exists.
-  virtual bool exists(const Uri& _uri) const = 0;
+  virtual bool exists(const Uri& _uri) = 0;
 
   /// \brief Return the resource specified by a URI or nullptr on failure.
-  virtual ResourcePtr retrieve(const Uri& _uri) const = 0;
+  virtual ResourcePtr retrieve(const Uri& _uri) = 0;
+
+  // We don't const-qualify for exists and retrieve here. Derived classes of
+  // ResourceRetriever will be interacting with external resources that you
+  // don't necessarily have control over so we cannot guarantee that you get the
+  // same result every time with the same input Uri. Indeed, const-qualification
+  // for those functions is pointless.
 };
 
 using ResourceRetrieverPtr = std::shared_ptr<ResourceRetriever>;

--- a/dart/utils/CompositeResourceRetriever.cpp
+++ b/dart/utils/CompositeResourceRetriever.cpp
@@ -74,7 +74,7 @@ bool CompositeResourceRetriever::addSchemaRetriever(
 }
 
 //==============================================================================
-bool CompositeResourceRetriever::exists(const common::Uri& _uri) const
+bool CompositeResourceRetriever::exists(const common::Uri& _uri)
 {
   for(const common::ResourceRetrieverPtr& resourceRetriever
       : getRetrievers(_uri))
@@ -87,7 +87,7 @@ bool CompositeResourceRetriever::exists(const common::Uri& _uri) const
 
 //==============================================================================
 common::ResourcePtr CompositeResourceRetriever::retrieve(
-  const common::Uri& _uri) const
+  const common::Uri& _uri)
 {
   const std::vector<common::ResourceRetrieverPtr> &retrievers
     = getRetrievers(_uri);

--- a/dart/utils/CompositeResourceRetriever.h
+++ b/dart/utils/CompositeResourceRetriever.h
@@ -71,10 +71,10 @@ public:
     const common::ResourceRetrieverPtr& _resourceRetriever);
 
   // Documentation inherited.
-  bool exists(const common::Uri& _uri) const override;
+  bool exists(const common::Uri& _uri) override;
 
   // Documentation inherited.
-  common::ResourcePtr retrieve(const common::Uri& _uri) const override;
+  common::ResourcePtr retrieve(const common::Uri& _uri) override;
 
 private:
   std::vector<common::ResourceRetrieverPtr> getRetrievers(

--- a/dart/utils/PackageResourceRetriever.cpp
+++ b/dart/utils/PackageResourceRetriever.cpp
@@ -71,7 +71,7 @@ void PackageResourceRetriever::addPackageDirectory(
 }
 
 //==============================================================================
-bool PackageResourceRetriever::exists(const common::Uri& _uri) const
+bool PackageResourceRetriever::exists(const common::Uri& _uri)
 {
   std::string packageName, relativePath;
   if (!resolvePackageUri(_uri, packageName, relativePath))
@@ -89,8 +89,7 @@ bool PackageResourceRetriever::exists(const common::Uri& _uri) const
 }
 
 //==============================================================================
-common::ResourcePtr PackageResourceRetriever::retrieve(
-    const common::Uri& _uri) const
+common::ResourcePtr PackageResourceRetriever::retrieve(const common::Uri& _uri)
 {
   std::string packageName, relativePath;
   if (!resolvePackageUri(_uri, packageName, relativePath))

--- a/dart/utils/PackageResourceRetriever.h
+++ b/dart/utils/PackageResourceRetriever.h
@@ -90,10 +90,10 @@ public:
                            const std::string& _packageDirectory);
 
   // Documentation inherited.
-  bool exists(const common::Uri& _uri) const override;
+  bool exists(const common::Uri& _uri) override;
 
   // Documentation inherited.
-  common::ResourcePtr retrieve(const common::Uri& _uri) const override;
+  common::ResourcePtr retrieve(const common::Uri& _uri) override;
 
 private:
   common::ResourceRetrieverPtr mLocalRetriever;

--- a/unittests/TestHelpers.h
+++ b/unittests/TestHelpers.h
@@ -404,41 +404,39 @@ struct TestResource : public dart::common::Resource
 //==============================================================================
 struct PresentResourceRetriever : public dart::common::ResourceRetriever
 {
-  bool exists(const dart::common::Uri& _uri) const override
+  bool exists(const dart::common::Uri& _uri) override
   {
     mExists.push_back(_uri.toString());
     return true;
   }
 
-  dart::common::ResourcePtr retrieve(
-          const dart::common::Uri& _uri) const override
+  dart::common::ResourcePtr retrieve(const dart::common::Uri& _uri) override
   {
     mRetrieve.push_back(_uri.toString());
     return std::make_shared<TestResource>();
   }
 
-  mutable std::vector<std::string> mExists;
-  mutable std::vector<std::string> mRetrieve;
+  std::vector<std::string> mExists;
+  std::vector<std::string> mRetrieve;
 };
 
 //==============================================================================
 struct AbsentResourceRetriever : public dart::common::ResourceRetriever
 {
-  bool exists(const dart::common::Uri& _uri) const override
+  bool exists(const dart::common::Uri& _uri) override
   {
     mExists.push_back(_uri.toString());
     return false;
   }
 
-  dart::common::ResourcePtr retrieve(
-          const dart::common::Uri& _uri) const override
+  dart::common::ResourcePtr retrieve(const dart::common::Uri& _uri) override
   {
     mRetrieve.push_back(_uri.toString());
     return nullptr;
   }
 
-  mutable std::vector<std::string> mExists;
-  mutable std::vector<std::string> mRetrieve;
+  std::vector<std::string> mExists;
+  std::vector<std::string> mRetrieve;
 };
 
 #endif // #ifndef DART_UNITTESTS_TEST_HELPERS_H


### PR DESCRIPTION
This pull request reverts the const-qualification on the ResourceRetriever methods introduced by #517.

Please see #532 for more details.