### PR TITLE
Added missing 'override' keywords

### DIFF
--- a/dart/dynamics/InverseKinematics.h
+++ b/dart/dynamics/InverseKinematics.h
@@ -315,10 +315,10 @@ public:
     virtual ~TaskSpaceRegion() = default;
 
     // Documentation inherited
-    virtual std::unique_ptr<ErrorMethod> clone(InverseKinematics* _newIK) const;
+    std::unique_ptr<ErrorMethod> clone(InverseKinematics* _newIK) const override;
 
     // Documentation inherited
-    virtual Eigen::Vector6d computeError() override;
+    Eigen::Vector6d computeError() override;
 
     /// Setting this to true (which is default) will tell it to compute the
     /// error based on the center of the Task Space Region instead of the edge
@@ -446,12 +446,12 @@ public:
     virtual ~JacobianDLS() = default;
 
     // Documentation inherited
-    virtual std::unique_ptr<GradientMethod> clone(
-        InverseKinematics* _newIK) const;
+    std::unique_ptr<GradientMethod> clone(
+        InverseKinematics* _newIK) const override;
 
     // Documentation inherited
-    virtual void computeGradient(const Eigen::Vector6d& _error,
-                                 Eigen::VectorXd& _grad) override;
+    void computeGradient(const Eigen::Vector6d& _error,
+                         Eigen::VectorXd& _grad) override;
 
     /// Set the damping coefficient. A higher damping coefficient will smooth
     /// out behavior around singularities but will also result in less precision
@@ -484,12 +484,12 @@ public:
     virtual ~JacobianTranspose() = default;
 
     // Documentation inherited
-    virtual std::unique_ptr<GradientMethod> clone(
-        InverseKinematics* _newIK) const;
+    std::unique_ptr<GradientMethod> clone(
+        InverseKinematics* _newIK) const override;
 
     // Documentation inherited
-    virtual void computeGradient(const Eigen::Vector6d& _error,
-                                 Eigen::VectorXd& _grad) override;
+    void computeGradient(const Eigen::Vector6d& _error,
+                         Eigen::VectorXd& _grad) override;
   };
 
   /// If this IK module is set to active, then it will be utilized by any

--- a/dart/dynamics/MeshShape.h
+++ b/dart/dynamics/MeshShape.h
@@ -85,7 +85,7 @@ public:
   virtual void update();
 
   // Documentation inherited
-  virtual void setAlpha(double _alpha) override;
+  void setAlpha(double _alpha) override;
 
   /// \brief
   void setMesh(
@@ -129,7 +129,7 @@ public:
   // Documentation inherited.
   void draw(renderer::RenderInterface* _ri = nullptr,
             const Eigen::Vector4d& _col = Eigen::Vector4d::Ones(),
-            bool _default = true) const;
+            bool _default = true) const override;
 
   /// \brief
   static const aiScene* loadMesh(const std::string& _fileName);
@@ -139,11 +139,11 @@ public:
     const std::string& _uri, const common::ResourceRetrieverPtr& _retriever);
 
   // Documentation inherited.
-  virtual Eigen::Matrix3d computeInertia(double _mass) const;
+  Eigen::Matrix3d computeInertia(double _mass) const override;
 
 protected:
   // Documentation inherited.
-  virtual void computeVolume();
+  void computeVolume() override;
 
 private:
   /// \brief

--- a/dart/optimizer/nlopt/NloptSolver.h
+++ b/dart/optimizer/nlopt/NloptSolver.h
@@ -64,16 +64,16 @@ public:
   virtual ~NloptSolver();
 
   // Documentation inherited
-  virtual bool solve();
+  bool solve() override;
 
   // Documentation inherited
   Eigen::VectorXd getLastConfiguration() const;
 
   // Documentation inherited
-  virtual std::string getType() const override;
+  std::string getType() const override;
 
   // Documentation inherited
-  virtual std::shared_ptr<Solver> clone() const override;
+  std::shared_ptr<Solver> clone() const override;
 
   /// Copy the Properties of another NloptSolver
   void copy(const NloptSolver& _other);


### PR DESCRIPTION
This pull request adds several missing `override` keywords that produce warnings in clang 3.7. I also removed a few `virtual` keywords on functions methods that are flagged as `override`. [The `virtual` keyword has no effect if you're overriding a `virtual` function](http://stackoverflow.com/a/29760395/111426), so this is not necessary. It also seems to be the style used in the majority of DART.