### PR TITLE
Made osgDart honor DART_BUILD_EXAMPLES

### DIFF
--- a/osgDart/CMakeLists.txt
+++ b/osgDart/CMakeLists.txt
@@ -31,7 +31,10 @@ if(${OPENSCENEGRAPH_FOUND})
   )
 
   add_subdirectory(render)
-  add_subdirectory(examples)
+
+  if(${DART_BUILD_EXAMPLES})
+    add_subdirectory(examples)
+  endif(${DART_BUILD_EXAMPLES})
 
   install(
     FILES ${osgDart_hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osgDart.h


### PR DESCRIPTION
This pull request makes `osgDart` obey the `DART_BUILD_EXAMPLES` variable.