### PR TITLE
Delete copy constructors for non-copyable classes (round 2) -- Patch for 5.1

### DIFF
--- a/dart/dynamics/DegreeOfFreedom.h
+++ b/dart/dynamics/DegreeOfFreedom.h
@@ -64,6 +64,8 @@ public:
   template<size_t> friend class MultiDofJoint;
   friend class Skeleton;
 
+  DegreeOfFreedom(const DegreeOfFreedom&) = delete;
+
   /// Change the name of this DegreeOfFreedom
   ///
   /// The _preserveName argument will be passed to the preserveName(bool)

--- a/dart/dynamics/EulerJoint.h
+++ b/dart/dynamics/EulerJoint.h
@@ -81,6 +81,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  EulerJoint(const EulerJoint&) = delete;
+
   /// Destructor
   virtual ~EulerJoint();
 

--- a/dart/dynamics/FreeJoint.h
+++ b/dart/dynamics/FreeJoint.h
@@ -61,6 +61,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  FreeJoint(const FreeJoint&) = delete;
+
   /// Destructor
   virtual ~FreeJoint();
 

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -62,6 +62,8 @@ public:
 
   typedef Eigen::Matrix<double, DOF, 1> Vector;
 
+  MultiDofJoint(const MultiDofJoint&) = delete;
+
   struct UniqueProperties
   {
     /// Lower limit of position

--- a/dart/dynamics/PlanarJoint.h
+++ b/dart/dynamics/PlanarJoint.h
@@ -121,6 +121,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  PlanarJoint(const PlanarJoint&) = delete;
+
   /// Destructor
   virtual ~PlanarJoint();
 

--- a/dart/dynamics/PrismaticJoint.h
+++ b/dart/dynamics/PrismaticJoint.h
@@ -72,6 +72,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  PrismaticJoint(const PrismaticJoint&) = delete;
+
   /// Destructor
   virtual ~PrismaticJoint();
 

--- a/dart/dynamics/RevoluteJoint.h
+++ b/dart/dynamics/RevoluteJoint.h
@@ -74,6 +74,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  RevoluteJoint(const RevoluteJoint&) = delete;
+
   /// Destructor
   virtual ~RevoluteJoint();
 

--- a/dart/dynamics/ScrewJoint.h
+++ b/dart/dynamics/ScrewJoint.h
@@ -78,6 +78,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  ScrewJoint(const ScrewJoint&) = delete;
+
   /// Destructor
   virtual ~ScrewJoint();
 

--- a/dart/dynamics/TranslationalJoint.h
+++ b/dart/dynamics/TranslationalJoint.h
@@ -59,6 +59,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  TranslationalJoint(const TranslationalJoint&) = delete;
+
   /// Destructor
   virtual ~TranslationalJoint();
 

--- a/dart/dynamics/UniversalJoint.h
+++ b/dart/dynamics/UniversalJoint.h
@@ -73,6 +73,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  UniversalJoint(const UniversalJoint&) = delete;
+
   /// Destructor
   virtual ~UniversalJoint();
 

--- a/dart/dynamics/WeldJoint.h
+++ b/dart/dynamics/WeldJoint.h
@@ -59,6 +59,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  WeldJoint(const WeldJoint&) = delete;
+
   /// Destructor
   virtual ~WeldJoint();
 

--- a/dart/dynamics/ZeroDofJoint.h
+++ b/dart/dynamics/ZeroDofJoint.h
@@ -58,6 +58,8 @@ public:
     virtual ~Properties() = default;
   };
 
+  ZeroDofJoint(const ZeroDofJoint&) = delete;
+
   /// Destructor
   virtual ~ZeroDofJoint();
 


### PR DESCRIPTION
Some invalid copy constructors were neglected with the last pull request, so this pull request deletes more of them.