### PR TITLE
Fix const correctness of BodyNode::getMomentOfInertia()

### DIFF
--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -317,8 +317,9 @@ void BodyNode::setMomentOfInertia(double _Ixx, double _Iyy, double _Izz,
 }
 
 //==============================================================================
-void BodyNode::getMomentOfInertia(double& _Ixx, double& _Iyy, double& _Izz,
-                                  double& _Ixy, double& _Ixz, double& _Iyz)
+void BodyNode::getMomentOfInertia(
+    double& _Ixx, double& _Iyy, double& _Izz,
+    double& _Ixy, double& _Ixz, double& _Iyz) const
 {
   _Ixx = mBodyP.mInertia.getParameter(Inertia::I_XX);
   _Iyy = mBodyP.mInertia.getParameter(Inertia::I_YY);

--- a/dart/dynamics/BodyNode.h
+++ b/dart/dynamics/BodyNode.h
@@ -204,7 +204,7 @@ public:
   /// Return moment of inertia defined around the center of mass
   void getMomentOfInertia(
       double& _Ixx, double& _Iyy, double& _Izz,
-      double& _Ixy, double& _Ixz, double& _Iyz);
+      double& _Ixy, double& _Ixz, double& _Iyz) const;
 
   /// Return spatial inertia
   const Eigen::Matrix6d& getSpatialInertia() const;


### PR DESCRIPTION
This pull request fixes const correctness of `BodyNode::getMomentOfInertia()` as reported in #540.