### PR TITLE
Suppress warnings in Function.cpp

### DIFF
--- a/dart/common/Deprecated.h
+++ b/dart/common/Deprecated.h
@@ -34,6 +34,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/config.h"
+
 #ifndef DART_COMMON_DEPRECATED_H_
 #define DART_COMMON_DEPRECATED_H_
 
@@ -52,6 +54,48 @@
 #else
   #define DEPRECATED(version) ()
   #define FORCEINLINE
+#endif
+
+// We define two convenient macros that can be used to suppress
+// deprecated-warnings for a specific code block rather than a whole project.
+// This macros would be useful when you need to call deprecated function for
+// some reason (e.g., for backward compatibility) but don't want warnings.
+//
+// Example code:
+//
+// deprecated_function()  // warning
+//
+// DART_SUPPRESS_DEPRECATED_BEGIN
+// deprecated_function()  // okay, no warning
+// DART_SUPPRESS_DEPRECATED_END
+//
+#if defined (DART_COMPILER_GCC)
+
+  #define DART_SUPPRESS_DEPRECATED_BEGIN                            \
+    _Pragma("GCC diagnostic push")                                  \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+
+  #define DART_SUPPRESS_DEPRECATED_END \
+    _Pragma("GCC diagnostic pop")
+
+#elif defined (DART_COMPILER_CLANG)
+
+  #define DART_SUPPRESS_DEPRECATED_BEGIN                              \
+    _Pragma("clang diagnostic push")                                  \
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+
+  #define DART_SUPPRESS_DEPRECATED_END \
+    _Pragma("clang diagnostic pop")
+
+#elif defined (DART_COMPILER_MSVC)
+
+  #define DART_SUPPRESS_DEPRECATED_BEGIN \
+    __pragma(warning(push))              \
+    __pragma(warning(disable:4996))
+
+  #define DART_SUPPRESS_DEPRECATED_END \
+    __pragma(warning(pop))
+
 #endif
 
 #endif  // DART_COMMON_DEPRECATED_H_

--- a/dart/config.h.in
+++ b/dart/config.h.in
@@ -28,6 +28,15 @@
   (DART_MAJOR_VERSION < x || (DART_MAJOR_VERSION <= x && \
   (DART_MINOR_VERSION < y || (DART_MINOR_VERSION <= y))))
 
+// Detect the compiler
+#if defined(__clang__)
+  #define DART_COMPILER_CLANG
+#elif defined(__GNUC__) || defined(__GNUG__)
+  #define DART_COMPILER_GCC
+#elif defined(_MSC_VER)
+  #define DART_COMPILER_MSVC
+#endif
+
 #cmakedefine BUILD_TYPE_DEBUG 1
 #cmakedefine BUILD_TYPE_RELEASE 1
 #cmakedefine BUILD_TYPE_RELWITHDEBINFO 1

--- a/dart/optimizer/Function.cpp
+++ b/dart/optimizer/Function.cpp
@@ -37,7 +37,6 @@
 
 #include "dart/optimizer/Function.h"
 
-#include "dart/config.h"
 #include "dart/common/Console.h"
 
 namespace dart {
@@ -86,28 +85,9 @@ double Function::eval(const Eigen::VectorXd& _x)
   // deprecated-warnings until then (see #544).
   Eigen::Map<const Eigen::VectorXd> temp(_x.data(), _x.size());
 
-#if defined (DART_COMPILER_GCC)
-
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  DART_SUPPRESS_DEPRECATED_BEGIN
   return eval(temp);
-  #pragma GCC diagnostic pop
-
-#elif defined (DART_COMPILER_CLANG)
-
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  return eval(temp);
-  #pragma clang diagnostic pop
-
-#elif defined (DART_COMPILER_MSVC)
-
-  #pragma warning( push )
-  #pragma warning( disable : 4996 )
-  return eval(temp);
-  #pragma warning( pop )
-
-#endif
+  DART_SUPPRESS_DEPRECATED_END
 }
 
 //==============================================================================
@@ -129,28 +109,9 @@ void Function::evalGradient(const Eigen::VectorXd& _x,
   // deprecated-warnings until then (see #544).
   Eigen::Map<const Eigen::VectorXd> temp(_x.data(), _x.size());
 
-#if defined (DART_COMPILER_GCC)
-
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  DART_SUPPRESS_DEPRECATED_BEGIN
   evalGradient(temp, _grad);
-  #pragma GCC diagnostic pop
-
-#elif defined (DART_COMPILER_CLANG)
-
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  evalGradient(temp, _grad);
-  #pragma clang diagnostic pop
-
-#elif defined (DART_COMPILER_MSVC)
-
-  #pragma warning( push )
-  #pragma warning( disable : 4996 )
-  evalGradient(temp, _grad);
-  #pragma warning( pop )
-
-#endif
+  DART_SUPPRESS_DEPRECATED_END
 }
 
 //==============================================================================

--- a/dart/optimizer/Function.cpp
+++ b/dart/optimizer/Function.cpp
@@ -37,6 +37,7 @@
 
 #include "dart/optimizer/Function.h"
 
+#include "dart/config.h"
 #include "dart/common/Console.h"
 
 namespace dart {
@@ -81,9 +82,32 @@ double Function::eval(Eigen::Map<const Eigen::VectorXd>& _x)
 double Function::eval(const Eigen::VectorXd& _x)
 {
   // TODO(MXG): This is for backwards compatibility. This function should be
-  // made pure abstract with the next major version-up
+  // made pure abstract with the next major version-up. We suppress the
+  // deprecated-warnings until then (see #544).
   Eigen::Map<const Eigen::VectorXd> temp(_x.data(), _x.size());
+
+#if defined (DART_COMPILER_GCC)
+
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return eval(temp);
+  #pragma GCC diagnostic pop
+
+#elif defined (DART_COMPILER_CLANG)
+
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  return eval(temp);
+  #pragma clang diagnostic pop
+
+#elif defined (DART_COMPILER_MSVC)
+
+  #pragma warning( push )
+  #pragma warning( disable : 4996 )
+  return eval(temp);
+  #pragma warning( pop )
+
+#endif
 }
 
 //==============================================================================
@@ -101,9 +125,32 @@ void Function::evalGradient(Eigen::Map<const Eigen::VectorXd>& _x,
 void Function::evalGradient(const Eigen::VectorXd& _x,
                             Eigen::Map<Eigen::VectorXd> _grad)
 {
-  // TODO(MXG): This is for backwards compatibility
+  // TODO(MXG): This is for backwards compatibility. We suppress the
+  // deprecated-warnings until then (see #544).
   Eigen::Map<const Eigen::VectorXd> temp(_x.data(), _x.size());
+
+#if defined (DART_COMPILER_GCC)
+
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   evalGradient(temp, _grad);
+  #pragma GCC diagnostic pop
+
+#elif defined (DART_COMPILER_CLANG)
+
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  evalGradient(temp, _grad);
+  #pragma clang diagnostic pop
+
+#elif defined (DART_COMPILER_MSVC)
+
+  #pragma warning( push )
+  #pragma warning( disable : 4996 )
+  evalGradient(temp, _grad);
+  #pragma warning( pop )
+
+#endif
 }
 
 //==============================================================================


### PR DESCRIPTION
For backward compatibility, we have to call deprecated functions in Function.cpp, but the compilers complain for these calls. This pull request suppresses the warnings only for those calls. See also #544.

Note that the suppression code couldn't be made as macros. It needs to use compiler dependent #pragma directives but directives is not allowed to be declared in macros.