### PR TITLE
Improved wording of the cmake warning messages for ASSIMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,9 +170,11 @@ if(ASSIMP_FOUND)
   ASSIMP_AISCENE_CTOR_DTOR_DEFINED)
 
   if(NOT ASSIMP_AISCENE_CTOR_DTOR_DEFINED)
-    message(WARNING "Installed ASSIMP ${ASSIMP_VERSION} is missing symbols "
-            "for constructor or destructor of aiScene. DART will use own "
-            "implementation. Please use ASSIMP that fixed this issue.")
+    message(WARNING "The installed version of ASSIMP (${ASSIMP_VERSION}) is "
+                    "missing symbols for the constructor and/or destructor of "
+                    "aiScene. DART will use its own implementations of these "
+                    "functions. We recommend using a version of ASSIMP that "
+                    "does not have this issue.")
   endif(NOT ASSIMP_AISCENE_CTOR_DTOR_DEFINED)
 
   check_cxx_source_compiles(
@@ -188,9 +190,11 @@ if(ASSIMP_FOUND)
   ASSIMP_AIMATERIAL_CTOR_DTOR_DEFINED)
 
   if(NOT ASSIMP_AIMATERIAL_CTOR_DTOR_DEFINED)
-    message(WARNING "Installed ASSIMP ${ASSIMP_VERSION} is missing symbols "
-            "for constructor or destructor of aiMaterial. DART will use own "
-            "implementation. Please use ASSIMP that fixed this issue.")
+    message(WARNING "The installed version of ASSIMP (${ASSIMP_VERSION}) is "
+                    "missing symbols for the constructor and/or destructor of "
+                    "aiMaterial. DART will use its own implementations of "
+                    "these functions. We recommend using a version of ASSIMP "
+                    "that does not have this issue.")
   endif(NOT ASSIMP_AIMATERIAL_CTOR_DTOR_DEFINED)
 
   unset(CMAKE_REQUIRED_INCLUDES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ if(ASSIMP_FOUND)
                     "missing symbols for the constructor and/or destructor of "
                     "aiScene. DART will use its own implementations of these "
                     "functions. We recommend using a version of ASSIMP that "
-                    "does not have this issue.")
+                    "does not have this issue, once one becomes available.")
   endif(NOT ASSIMP_AISCENE_CTOR_DTOR_DEFINED)
 
   check_cxx_source_compiles(
@@ -194,7 +194,7 @@ if(ASSIMP_FOUND)
                     "missing symbols for the constructor and/or destructor of "
                     "aiMaterial. DART will use its own implementations of "
                     "these functions. We recommend using a version of ASSIMP "
-                    "that does not have this issue.")
+                    "that does not have this issue, once one becomes available.")
   endif(NOT ASSIMP_AIMATERIAL_CTOR_DTOR_DEFINED)
 
   unset(CMAKE_REQUIRED_INCLUDES)


### PR DESCRIPTION
I felt that the wording of the cmake warning messages for ASSIMP might be difficult to understand, so I attempted to improve their clarity a bit.