### PR TITLE
Improvements to ReferentialSkeleton

### DIFF
--- a/dart/dynamics/Group.cpp
+++ b/dart/dynamics/Group.cpp
@@ -209,7 +209,7 @@ bool Group::removeBodyNode(BodyNode* _bn, bool _warning)
     return false;
   }
 
-  unregisterBodyNode(_bn);
+  unregisterBodyNode(_bn, false);
 
   return true;
 }

--- a/dart/dynamics/Group.cpp
+++ b/dart/dynamics/Group.cpp
@@ -166,7 +166,71 @@ void Group::swapDofIndices(size_t _index1, size_t _index2)
 }
 
 //==============================================================================
-void Group::addBodyNode(BodyNode* _bn, bool _warning)
+bool Group::addComponent(BodyNode* _bn, bool _warning)
+{
+  bool added = false;
+
+  added |= addBodyNode(_bn, false);
+
+  for(size_t i=0; i < _bn->getParentJoint()->getNumDofs(); ++i)
+    added |= addDof(_bn->getParentJoint()->getDof(i), false);
+
+  if(_warning && !added)
+  {
+    dtwarn << "[Group::addComponent] The BodyNode named [" << _bn->getName()
+           << "] (" << _bn << ") and all of its parent DegreesOfFreedom are "
+           << "already in the Group [" << getName() << "] (" << this << ")\n";
+    assert(false);
+  }
+
+  return added;
+}
+
+//==============================================================================
+bool Group::addComponents(const std::vector<BodyNode*>& _bodyNodes,
+                          bool _warning)
+{
+  bool added = false;
+  for(BodyNode* bn : _bodyNodes)
+    added |= addComponent(bn, _warning);
+
+  return added;
+}
+
+//==============================================================================
+bool Group::removeComponent(BodyNode* _bn, bool _warning)
+{
+  bool removed = false;
+
+  removed |= removeBodyNode(_bn, false);
+
+  for(size_t i=0; i < _bn->getParentJoint()->getNumDofs(); ++i)
+    removed |= removeDof(_bn->getParentJoint()->getDof(i), false);
+
+  if(_warning && !removed)
+  {
+    dtwarn << "[Group::removeComponent] The BodyNode named [" << _bn->getName()
+           << "] (" << _bn << ") and its parent DegreesOfFreedom were not in "
+           << "the Group [" << getName() << "] (" << this << ")\n";
+    assert(false);
+  }
+
+  return removed;
+}
+
+//==============================================================================
+bool Group::removeComponents(const std::vector<BodyNode*>& _bodyNodes,
+                             bool _warning)
+{
+  bool removed = false;
+  for(BodyNode* bn : _bodyNodes)
+    removed |= removeComponent(bn, _warning);
+
+  return removed;
+}
+
+//==============================================================================
+bool Group::addBodyNode(BodyNode* _bn, bool _warning)
 {
   if(INVALID_INDEX != getIndexOf(_bn, false))
   {
@@ -176,21 +240,24 @@ void Group::addBodyNode(BodyNode* _bn, bool _warning)
              << "] (" << _bn << ") is already in the Group [" << getName()
              << "] (" << this << ")\n";
       assert(false);
-      return;
     }
 
-    return;
+    return false;
   }
 
   registerBodyNode(_bn);
+  return true;
 }
 
 //==============================================================================
-void Group::addBodyNodes(const std::vector<BodyNode*>& _bodyNodes,
+bool Group::addBodyNodes(const std::vector<BodyNode*>& _bodyNodes,
                          bool _warning)
 {
+  bool added = false;
   for(BodyNode* bn : _bodyNodes)
-    addBodyNode(bn, _warning);
+    added |= addBodyNode(bn, _warning);
+
+  return added;
 }
 
 //==============================================================================
@@ -210,7 +277,6 @@ bool Group::removeBodyNode(BodyNode* _bn, bool _warning)
   }
 
   unregisterBodyNode(_bn, false);
-
   return true;
 }
 
@@ -218,15 +284,15 @@ bool Group::removeBodyNode(BodyNode* _bn, bool _warning)
 bool Group::removeBodyNodes(const std::vector<BodyNode*>& _bodyNodes,
                             bool _warning)
 {
-  bool allGood = true;
+  bool removed = false;
   for(BodyNode* bn : _bodyNodes)
-    allGood &= removeBodyNode(bn, _warning);
+    removed |= removeBodyNode(bn, _warning);
 
-  return allGood;
+  return removed;
 }
 
 //==============================================================================
-void Group::addDof(DegreeOfFreedom* _dof, bool _warning)
+bool Group::addDof(DegreeOfFreedom* _dof, bool _warning)
 {
   if(INVALID_INDEX != getIndexOf(_dof, false))
   {
@@ -236,20 +302,23 @@ void Group::addDof(DegreeOfFreedom* _dof, bool _warning)
              << "] (" << _dof << ") is already in the Group [" << getName()
              << "] (" << this << ")\n";
       assert(false);
-      return;
     }
 
-    return;
+    return false;
   }
 
   registerDegreeOfFreedom(_dof);
+  return true;
 }
 
 //==============================================================================
-void Group::addDofs(const std::vector<DegreeOfFreedom*>& _dofs, bool _warning)
+bool Group::addDofs(const std::vector<DegreeOfFreedom*>& _dofs, bool _warning)
 {
+  bool added = false;
   for(DegreeOfFreedom* dof : _dofs)
-    addDof(dof, _warning);
+    added |= addDof(dof, _warning);
+
+  return added;
 }
 
 //==============================================================================
@@ -269,7 +338,6 @@ bool Group::removeDof(DegreeOfFreedom* _dof, bool _warning)
   }
 
   unregisterDegreeOfFreedom(_dof->getChildBodyNode(), _dof->getIndexInJoint());
-
   return true;
 }
 
@@ -277,11 +345,11 @@ bool Group::removeDof(DegreeOfFreedom* _dof, bool _warning)
 bool Group::removeDofs(const std::vector<DegreeOfFreedom*>& _dofs,
                        bool _warning)
 {
-  bool allGood = true;
+  bool removed = false;
   for(DegreeOfFreedom* dof : _dofs)
-    allGood &= removeDof(dof, _warning);
+    removed |= removeDof(dof, _warning);
 
-  return allGood;
+  return removed;
 }
 
 //==============================================================================

--- a/dart/dynamics/Group.h
+++ b/dart/dynamics/Group.h
@@ -118,8 +118,8 @@ public:
   bool addBodyNode(BodyNode* _bn, bool _warning=true);
 
   /// Add a set of BodyNodes to this Group. If _warning is true, you will be
-  /// warned when you attempt to add the same BodyNode twice, and an assertion
-  /// will be thrown.
+  /// warned when you attempt to add a BodyNode that is already in the Group,
+  /// and an assertion will be thrown.
   ///
   /// This function will return false if all of the BodyNodes were already in
   /// the Group.
@@ -141,38 +141,87 @@ public:
   bool removeBodyNodes(const std::vector<BodyNode*>& _bodyNodes,
                        bool _warning=true);
 
-  /// Add a DegreeOfFreedom to this Group. If _warning is true, you will be
+  /// Add a Joint to this Group. If _addDofs is true, it will also add all the
+  /// DegreesOfFreedom of the Joint. If _warning is true, you will be warned
+  /// if the Joint (and all its DOFs if _addDofs is set to true) was already in
+  /// the Group, and an assertion will be thrown.
+  ///
+  /// This function will return false if the Joint (and all its DOFs, if
+  /// _addDofs is true) was already in the Group.
+  bool addJoint(Joint* _joint, bool _addDofs=true, bool _warning=true);
+
+  /// Add a set of Joints to this Group. If _addDofs is true, it will also add
+  /// all the DOFs of each Joint. If _warning is true, you will be warned when
+  /// you attempt to add a Joint that is already in the Group (and all its DOFs
+  /// are in the Group, if _addDofs is set to true), and an assertion will be
+  /// thrown.
+  ///
+  /// This function will return false if all the Joints (and their DOFs if
+  /// _addDofs is set to true) were already in the Group.
+  bool addJoints(const std::vector<Joint*>& _joints, bool _addDofs=true,
+                 bool _warning=true);
+
+  /// Remove a Joint from this Group. If _removeDofs is true, it will also
+  /// remove any DOFs belonging to this Joint. If _warning is true, you will
+  /// be warned if you attempt to remove a Joint which is not in this Group (and
+  /// none of its DOFs are in the Group if _removeDofs is set to true), and an
+  /// assertion will be thrown.
+  ///
+  /// This function will return false if the Joint was not in the Group (and
+  /// neither were any of its DOFs, if _removeDofs is set to true).
+  bool removeJoint(Joint* _joint, bool _removeDofs=true, bool _warning=true);
+
+  /// Remove a set of Joints from this Group. If _removeDofs is true, it will
+  /// also remove any DOFs belonging to any of the Joints. If _warning is true,
+  /// you will be warned if you attempt to remove a Joint which is not in this
+  /// Group (and none of its DOFs are in the Group if _removeDofs is set to
+  /// true), and an assertion will be thrown.
+  ///
+  /// This function will return false if none of the Joints (nor any of their
+  /// DOFs if _removeDofs is set to true) were in the Group.
+  bool removeJoints(const std::vector<Joint*>& _joints, bool _removeDofs=true,
+                    bool _warning=true);
+
+  /// Add a DegreeOfFreedom to this Group. If _addJoint is true, the Joint of
+  /// this DOF will also be added to the Group. If _warning is true, you will be
   /// warned when you attempt to add the same DegreeOfFreedom twice, and an
   /// assertion will be thrown.
   ///
   /// This function will return false if the DegreeOfFreedom was already in the
   /// Group.
-  bool addDof(DegreeOfFreedom* _dof, bool _warning=true);
+  bool addDof(DegreeOfFreedom* _dof, bool _addJoint=true, bool _warning=true);
 
-  /// Add a set of DegreesOfFreedom to this Group. If _warning is true, you will
-  /// be warned when you attempt to add the same DegreeOfFreedom twice, and an
-  /// assertion will be thrown.
+  /// Add a set of DegreesOfFreedom to this Group. If _addJoint is true, the
+  /// Joint of each DOF will also be added to the Group. If _warning is true,
+  /// you will be warned when you attempt to add the same DegreeOfFreedom twice,
+  /// and an assertion will be thrown.
   ///
   /// This function will return false if all of the DegreesOfFreedom was already
   /// in the Group.
-  bool addDofs(const std::vector<DegreeOfFreedom*>& _dofs, bool _warning=true);
+  bool addDofs(const std::vector<DegreeOfFreedom*>& _dofs,
+               bool _addJoint = true, bool _warning=true);
 
-  /// Remove a DegreeOfFreedom from this Group. If _warning is true, you will be
+  /// Remove a DegreeOfFreedom from this Group. If _cleanupJoint is true, the
+  /// Joint of this DOF will be removed, but only if no other DOFs belonging to
+  /// the Joint are remaining in the Group. If _warning is true, you will be
   /// warned when you attempt to remove a DegreeOfFreedom that is not in this
   /// Group, and an assertion will be thrown.
   ///
   /// This function will return false if the DegreeOfFreedom was not in this
   /// Group.
-  bool removeDof(DegreeOfFreedom* _dof, bool _warning=true);
+  bool removeDof(DegreeOfFreedom* _dof, bool _cleanupJoint=true,
+                 bool _warning=true);
 
-  /// Remove a set of DegreesOfFreedom from this Group. If _warning is true, you
-  /// will be warned when you attempt to remove a DegreeOfFreedom that is not
-  /// in this Group, and an assertion will be thrown.
+  /// Remove a set of DegreesOfFreedom from this Group. If _cleanupJoint is
+  /// true, the Joint of this DOF will be removed, but only if no other DOFs
+  /// belonging to the Joint are remaining in the Group. If _warning is true,
+  /// you will be warned when you attempt to remove a DegreeOfFreedom that is
+  /// not in this Group, and an assertion will be thrown.
   ///
   /// This function will return false if none of the DegreesOfFreedom were in
   /// this Group.
   bool removeDofs(const std::vector<DegreeOfFreedom*>& _dofs,
-                  bool _warning=true);
+                  bool _cleanupJoint=true, bool _warning=true);
 
 protected:
   /// Default constructor

--- a/dart/dynamics/Group.h
+++ b/dart/dynamics/Group.h
@@ -46,21 +46,25 @@ class Group : public ReferentialSkeleton
 {
 public:
 
-  /// Create a Group out of a set of BodyNodes. If _includeDofs is true, then
-  /// the parent DegreesOfFreedom of each BodyNode will also be added to the
-  /// Group.
+  /// Create a Group out of a set of BodyNodes. If _includeJoints is true, the
+  /// parent Joint of each BodyNode will also be added to the Group. If
+  /// _includeDofs is true, then the parent DegreesOfFreedom of each BodyNode
+  /// will also be added to the Group.
   static GroupPtr create(
       const std::string& _name = "Group",
       const std::vector<BodyNode*>& _bodyNodes = std::vector<BodyNode*>(),
+      bool _includeJoints = true,
       bool _includeDofs = true);
 
   /// Create a Group out of a set of DegreesOfFreedom. If _includeBodyNodes is
   /// true, then the child BodyNode of each DegreeOfFreedom will also be added
-  /// to the Group.
+  /// to the Group. If _includeJoints is true, then the Joint of each
+  /// DegreeOfFreedom will also be added to the Group.
   static GroupPtr create(
       const std::string& _name,
       const std::vector<DegreeOfFreedom*>& _dofs,
-      bool _includeBodyNodes = true);
+      bool _includeBodyNodes = true,
+      bool _includeJoints = true);
 
   /// Create a Group that mimics the given MetaSkeleton
   static GroupPtr create(
@@ -227,12 +231,14 @@ protected:
   /// Default constructor
   Group(const std::string& _name,
         const std::vector<BodyNode*>& _bodyNodes,
+        bool _includeJoints,
         bool _includeDofs);
 
   /// Alternative constructor
   Group(const std::string& _name,
         const std::vector<DegreeOfFreedom*>& _dofs,
-        bool _includeBodyNodes);
+        bool _includeBodyNodes,
+        bool _includeJoints);
 
   /// MetaSkeleton-based constructor
   Group(const std::string& _name,

--- a/dart/dynamics/Group.h
+++ b/dart/dynamics/Group.h
@@ -46,15 +46,26 @@ class Group : public ReferentialSkeleton
 {
 public:
 
-  /// Create a Group out of a set of BodyNodes
+  /// Create a Group out of a set of BodyNodes. If _includeDofs is true, then
+  /// the parent DegreesOfFreedom of each BodyNode will also be added to the
+  /// Group.
   static GroupPtr create(
       const std::string& _name = "Group",
-      const std::vector<BodyNode*>& _bodyNodes = std::vector<BodyNode*>());
+      const std::vector<BodyNode*>& _bodyNodes = std::vector<BodyNode*>(),
+      bool _includeDofs = true);
 
-  /// Create a Group out of a set of DegreesOfFreedom
+  /// Create a Group out of a set of DegreesOfFreedom. If _includeBodyNodes is
+  /// true, then the child BodyNode of each DegreeOfFreedom will also be added
+  /// to the Group.
   static GroupPtr create(
       const std::string& _name,
-      const std::vector<DegreeOfFreedom*>& _dofs);
+      const std::vector<DegreeOfFreedom*>& _dofs,
+      bool _includeBodyNodes = true);
+
+  /// Create a Group that mimics the given MetaSkeleton
+  static GroupPtr create(
+      const std::string& _name,
+      const MetaSkeletonPtr& _metaSkeleton);
 
   /// Destructor
   virtual ~Group() = default;
@@ -165,12 +176,18 @@ public:
 
 protected:
   /// Default constructor
-  Group(const std::string& _name = "Group",
-        const std::vector<BodyNode*>& _bodyNodes = std::vector<BodyNode*>());
+  Group(const std::string& _name,
+        const std::vector<BodyNode*>& _bodyNodes,
+        bool _includeDofs);
 
   /// Alternative constructor
   Group(const std::string& _name,
-        const std::vector<DegreeOfFreedom*>& _dofs);
+        const std::vector<DegreeOfFreedom*>& _dofs,
+        bool _includeBodyNodes);
+
+  /// MetaSkeleton-based constructor
+  Group(const std::string& _name,
+        const MetaSkeletonPtr& _metaSkeleton);
 };
 
 } // dynamics

--- a/dart/dynamics/Group.h
+++ b/dart/dynamics/Group.h
@@ -65,60 +65,100 @@ public:
   /// Swap the index of DegreeOfFreedom _index1 with _index2
   void swapDofIndices(size_t _index1, size_t _index2);
 
+  /// Add a BodyNode and its parent DegreesOfFreedom to this Group. If _warning
+  /// is true, you will be warned when the BodyNode and all its DegreesOfFreedom
+  /// were already in the Group, and an assertion will be thrown.
+  ///
+  /// This function will return false if the BodyNode and all its
+  /// DegreesOfFreedom were already in the Group.
+  bool addComponent(BodyNode* _bn, bool _warning=true);
+
+  /// Add set of BodyNodes and their parent DegreesOfFreedom to this Group. If
+  /// _warning is true, you will be warned when an entire component was already
+  /// in the Group, and an assertion will be thrown.
+  ///
+  /// This function will return false if all of the components in the set were
+  /// already in this Group.
+  bool addComponents(const std::vector<BodyNode*>& _bodyNodes,
+                      bool _warning=true);
+
+  /// Remove a BodyNode and its parent DegreesOfFreedom from this Group. If
+  /// _warning is true, you will be warned if this Group does not have the
+  /// BodyNode or any of its DegreesOfFreedom, and an assertion will be thrown.
+  ///
+  /// This function will return false if the Group did not include the BodyNode
+  /// or any of its parent DegreesOfFreedom.
+  bool removeComponent(BodyNode* _bn, bool _warning=true);
+
+  /// Remove a set of BodyNodes and their parent DegreesOfFreedom from this
+  /// Group. If _warning is true, you will be warned if any of the components
+  /// were completely missing from this Group, and an assertion will be thrown.
+  ///
+  /// This function will return false if none of the components in this set were
+  /// in the Group.
+  bool removeComponents(const std::vector<BodyNode*>& _bodyNodes,
+                        bool _warning=true);
+
   /// Add a BodyNode to this Group. If _warning is true, you will be warned when
-  /// you attempt to add the same BodyNode twice, and assertion will be thrown.
-  void addBodyNode(BodyNode* _bn, bool _warning=true);
+  /// you attempt to add the same BodyNode twice, and an assertion will be
+  /// thrown.
+  ///
+  /// This function will return false if the BodyNode was already in the Group.
+  bool addBodyNode(BodyNode* _bn, bool _warning=true);
 
   /// Add a set of BodyNodes to this Group. If _warning is true, you will be
   /// warned when you attempt to add the same BodyNode twice, and an assertion
   /// will be thrown.
-  void addBodyNodes(const std::vector<BodyNode*>& _bodyNodes,
+  ///
+  /// This function will return false if all of the BodyNodes were already in
+  /// the Group.
+  bool addBodyNodes(const std::vector<BodyNode*>& _bodyNodes,
                     bool _warning=true);
 
-  /// Remove a BodyNode from this Group. Note: All DegreesOfFreedom belonging to
-  /// this BodyNode will also be removed. If _warning is true, you will be
-  /// warned when you attempt to remove BodyNode that is not in this Group, and
-  /// an assertion will be thrown.
+  /// Remove a BodyNode from this Group. If _warning is true, you will be warned
+  /// when you attempt to remove a BodyNode that is not in this Group, and an
+  /// assertion will be thrown.
   ///
-  /// The function will return false if the BodyNode was not already in this
-  /// Group.
+  /// The function will return false if the BodyNode was not in this Group.
   bool removeBodyNode(BodyNode* _bn, bool _warning=true);
 
-  /// Remove a set of BodyNodes from this Group. Note: All DegreesOfFreedom
-  /// belonging to each BodyNode will also be removed. If _warning is true, you
-  /// will be warned when you attempt to remove a BodyNode that is not in this
-  /// Group, and an assertion will be thrown.
+  /// Remove a set of BodyNodes from this Group. If _warning is true, you will
+  /// be warned when you attempt to remove a BodyNode that is not in this Group,
+  /// and an assertion will be thrown.
   ///
-  /// The function will return false if one of the BodyNodes was not already in
-  /// this Group.
+  /// The function will return false if none of the BodyNodes were in this Group.
   bool removeBodyNodes(const std::vector<BodyNode*>& _bodyNodes,
                        bool _warning=true);
 
-  /// Add a DegreeOfFreedom to this Group. Note: The BodyNode of this
-  /// DegreeOfFreedom will also be added. If _warning is true, you will be
+  /// Add a DegreeOfFreedom to this Group. If _warning is true, you will be
   /// warned when you attempt to add the same DegreeOfFreedom twice, and an
   /// assertion will be thrown.
-  void addDof(DegreeOfFreedom* _dof, bool _warning=true);
+  ///
+  /// This function will return false if the DegreeOfFreedom was already in the
+  /// Group.
+  bool addDof(DegreeOfFreedom* _dof, bool _warning=true);
 
-  /// Add a set of DegreesOfFreedom to this Group. Note: The BodyNodes of these
-  /// DegreesOfFreedom will also be added. If _warning is true, you will be
-  /// warned when you attempt to add the same DegreeOfFreedom twice, and an
+  /// Add a set of DegreesOfFreedom to this Group. If _warning is true, you will
+  /// be warned when you attempt to add the same DegreeOfFreedom twice, and an
   /// assertion will be thrown.
-  void addDofs(const std::vector<DegreeOfFreedom*>& _dofs, bool _warning=true);
+  ///
+  /// This function will return false if all of the DegreesOfFreedom was already
+  /// in the Group.
+  bool addDofs(const std::vector<DegreeOfFreedom*>& _dofs, bool _warning=true);
 
   /// Remove a DegreeOfFreedom from this Group. If _warning is true, you will be
   /// warned when you attempt to remove a DegreeOfFreedom that is not in this
   /// Group, and an assertion will be thrown.
   ///
-  /// This function will return false if the DegreeOfFreedom was not already in
-  /// this Group.
+  /// This function will return false if the DegreeOfFreedom was not in this
+  /// Group.
   bool removeDof(DegreeOfFreedom* _dof, bool _warning=true);
 
   /// Remove a set of DegreesOfFreedom from this Group. If _warning is true, you
   /// will be warned when you attempt to remove a DegreeOfFreedom that is not
   /// in this Group, and an assertion will be thrown.
   ///
-  /// This function will return false if the DegreeOfFreedom was not alraedy in
+  /// This function will return false if none of the DegreesOfFreedom were in
   /// this Group.
   bool removeDofs(const std::vector<DegreeOfFreedom*>& _dofs,
                   bool _warning=true);

--- a/dart/dynamics/Linkage.cpp
+++ b/dart/dynamics/Linkage.cpp
@@ -517,11 +517,11 @@ void Linkage::satisfyCriteria()
 {
   std::vector<BodyNode*> bns = mCriteria.satisfy();
   while(getNumBodyNodes() > 0)
-    unregisterBodyNode(mBodyNodes.back());
+    unregisterComponent(mBodyNodes.back());
 
   for(BodyNode* bn : bns)
   {
-    registerBodyNode(bn);
+    registerComponent(bn);
   }
 
   update();

--- a/dart/dynamics/ReferentialSkeleton.cpp
+++ b/dart/dynamics/ReferentialSkeleton.cpp
@@ -955,13 +955,44 @@ math::LinearJacobian ReferentialSkeleton::getCOMLinearJacobianDeriv(
 }
 
 //==============================================================================
-void ReferentialSkeleton::registerBodyNode(BodyNode* _bn)
+void ReferentialSkeleton::registerComponent(BodyNode* _bn)
 {
+  registerBodyNode(_bn);
+
   size_t nDofs = _bn->getParentJoint()->getNumDofs();
   for(size_t i=0; i < nDofs; ++i)
-  {
     registerDegreeOfFreedom(_bn->getParentJoint()->getDof(i));
+}
+
+//==============================================================================
+void ReferentialSkeleton::registerBodyNode(BodyNode* _bn)
+{
+  std::unordered_map<const BodyNode*, IndexMap>::iterator it =
+      mIndexMap.find(_bn);
+
+  if( it == mIndexMap.end() )
+  {
+    // Create an index map entry for this BodyNode, and only add the BodyNode's
+    // index to it.
+    IndexMap indexing;
+
+    mBodyNodes.push_back(_bn);
+    indexing.mBodyNodeIndex = mBodyNodes.size()-1;
+
+    mIndexMap[_bn] = indexing;
   }
+  else
+  {
+    IndexMap& indexing = it->second;
+
+    if(INVALID_INDEX == indexing.mBodyNodeIndex)
+    {
+      mBodyNodes.push_back(_bn);
+      indexing.mBodyNodeIndex = mBodyNodes.size()-1;
+    }
+  }
+
+  updateCaches();
 }
 
 //==============================================================================
@@ -975,9 +1006,9 @@ void ReferentialSkeleton::registerDegreeOfFreedom(DegreeOfFreedom* _dof)
 
   if( it == mIndexMap.end() )
   {
+    // Create an index map entry for this DegreeOfFreedom, and only add the
+    // DegreeOfFreedom's index to it
     IndexMap indexing;
-    mBodyNodes.push_back(bn);
-    indexing.mBodyNodeIndex = mBodyNodes.size()-1;
 
     indexing.mDofIndices.resize(localIndex+1, INVALID_INDEX);
     mDofs.push_back(_dof);
@@ -988,17 +1019,29 @@ void ReferentialSkeleton::registerDegreeOfFreedom(DegreeOfFreedom* _dof)
   else
   {
     IndexMap& indexing = it->second;
+
     if(indexing.mDofIndices.size() < localIndex+1)
       indexing.mDofIndices.resize(localIndex+1, INVALID_INDEX);
-    mDofs.push_back(_dof);
-    indexing.mDofIndices[localIndex] = mDofs.size()-1;
+
+    if(INVALID_INDEX == indexing.mDofIndices[localIndex])
+    {
+      mDofs.push_back(_dof);
+      indexing.mDofIndices[localIndex] = mDofs.size()-1;
+    }
   }
 
   updateCaches();
 }
 
 //==============================================================================
-void ReferentialSkeleton::unregisterBodyNode(BodyNode* _bn)
+void ReferentialSkeleton::unregisterComponent(BodyNode* _bn)
+{
+  unregisterBodyNode(_bn, true);
+}
+
+//==============================================================================
+void ReferentialSkeleton::unregisterBodyNode(
+    BodyNode* _bn, bool _unregisterDofs)
 {
   if(nullptr == _bn)
   {
@@ -1022,27 +1065,37 @@ void ReferentialSkeleton::unregisterBodyNode(BodyNode* _bn)
     return;
   }
 
-  const IndexMap& indexing = it->second;
-
-  for(size_t i=0; i<indexing.mDofIndices.size(); ++i)
-  {
-    if(indexing.mDofIndices[i] != INVALID_INDEX)
-      unregisterDegreeOfFreedom(_bn, i, false);
-  }
-
+  IndexMap& indexing = it->second;
   size_t bnIndex = indexing.mBodyNodeIndex;
-  mBodyNodes.erase(mBodyNodes.begin() + indexing.mBodyNodeIndex);
-  for(size_t i = bnIndex; i < mBodyNodes.size(); ++i)
+  mBodyNodes.erase(mBodyNodes.begin() + bnIndex);
+  indexing.mBodyNodeIndex = INVALID_INDEX;
+
+  for(size_t i=bnIndex; i < mBodyNodes.size(); ++i)
   {
-    IndexMap& indexing = mIndexMap[mBodyNodes[i]];
-    indexing.mBodyNodeIndex = i;
+    // Re-index all the BodyNodes in this ReferentialSkeleton which came after
+    // the one that was removed.
+    IndexMap& alteredIndexing = mIndexMap[mBodyNodes[i]];
+    alteredIndexing.mBodyNodeIndex = i;
   }
-  mIndexMap.erase(it);
+
+  if(_unregisterDofs)
+  {
+    for(size_t i=0; i < indexing.mDofIndices.size(); ++i)
+    {
+      if(indexing.mDofIndices[i] != INVALID_INDEX)
+        unregisterDegreeOfFreedom(_bn, i);
+    }
+  }
+
+  if(indexing.isExpired())
+    mIndexMap.erase(it);
+
+  updateCaches();
 }
 
 //==============================================================================
 void ReferentialSkeleton::unregisterDegreeOfFreedom(
-    BodyNode* _bn, size_t _localIndex, bool removeBnIfEmpty)
+    BodyNode* _bn, size_t _localIndex)
 {
   if(nullptr == _bn)
   {
@@ -1061,10 +1114,10 @@ void ReferentialSkeleton::unregisterDegreeOfFreedom(
       it->second.mDofIndices[_localIndex] == INVALID_INDEX)
   {
     dterr << "[ReferentialSkeleton::unregisterDegreeOfFreedom] Attempting to "
-          << "unregister a DegreeOfFreedom from a BodyNode named ["
-          << _bn->getName() << "] (" << _bn << ") that is not currently in the "
-          << "ReferentialSkeleton! This is most likely a bug. Please report "
-          << "this!\n";
+          << "unregister DegreeOfFreedom #" << _localIndex << " of a BodyNode "
+          << "named [" << _bn->getName() << "] (" << _bn << "), but it is not "
+          << "currently in the ReferentialSkeleton! This is most likely a bug. "
+          << "Please report this!\n";
     assert(false);
     return;
   }
@@ -1075,27 +1128,15 @@ void ReferentialSkeleton::unregisterDegreeOfFreedom(
 
   for(size_t i = dofIndex; i < mDofs.size(); ++i)
   {
+    // Re-index all the DOFs in this ReferentialSkeleton which came after the
+    // DOF that was removed.
     DegreeOfFreedomPtr dof = mDofs[i];
     IndexMap& indexing = mIndexMap[dof.getBodyNodePtr()];
     indexing.mDofIndices[dof.getLocalIndex()] = i;
   }
 
-  if(removeBnIfEmpty)
-  {
-    const std::vector<size_t>& dofIndices = it->second.mDofIndices;
-    bool removeBn = true;
-    for(size_t i=0; i<dofIndices.size(); ++i)
-    {
-      if(dofIndices[i] != INVALID_INDEX)
-      {
-        removeBn = false;
-        break;
-      }
-    }
-
-    if(removeBn)
-      unregisterBodyNode(_bn);
-  }
+  if(it->second.isExpired())
+    mIndexMap.erase(it);
 
   updateCaches();
 }
@@ -1140,6 +1181,28 @@ void ReferentialSkeleton::updateCaches()
   mCg       = Eigen::VectorXd::Zero(nDofs);
   mFext     = Eigen::VectorXd::Zero(nDofs);
   mFc       = Eigen::VectorXd::Zero(nDofs);
+}
+
+//==============================================================================
+ReferentialSkeleton::IndexMap::IndexMap()
+  : mBodyNodeIndex(INVALID_INDEX)
+{
+  // Do nothing
+}
+
+//==============================================================================
+bool ReferentialSkeleton::IndexMap::isExpired() const
+{
+  if(mBodyNodeIndex != INVALID_INDEX)
+    return false;
+
+  for(size_t i=0; i < mDofIndices.size(); ++i)
+  {
+    if(mDofIndices[i] != INVALID_INDEX)
+      return false;
+  }
+
+  return true;
 }
 
 } // namespace dynamics

--- a/dart/dynamics/ReferentialSkeleton.h
+++ b/dart/dynamics/ReferentialSkeleton.h
@@ -331,9 +331,13 @@ protected:
   /// to this ReferentialSkeleton. This can only be used by derived classes.
   void registerComponent(BodyNode* _bn);
 
-  /// Add a BodyNode to this ReferentialSkeleton, ignoring its DegreesOfFreedom.
-  /// This can only be used by derived classes.
+  /// Add a BodyNode to this ReferentialSkeleton, ignoring its Joint and
+  /// DegreesOfFreedom. This can only be used by derived classes.
   void registerBodyNode(BodyNode* _bn);
+
+  /// Add a Joint to this Referential Skeleton, ignoring its DegreesOfFreedom.
+  /// This can only be used by derived classes.
+  void registerJoint(Joint* _joint);
 
   /// Add a DegreeOfFreedom to this ReferentialSkeleton. This can only be used
   /// by derived classes.
@@ -346,6 +350,10 @@ protected:
   /// Remove a BodyNode from this ReferentialSkeleton, ignoring its parent
   /// DegreesOfFreedom. This can only be used by derived classes.
   void unregisterBodyNode(BodyNode* _bn, bool _unregisterDofs);
+
+  /// Remove a Joint from this ReferentialSkeleton. This can only be used by
+  /// derived classes.
+  void unregisterJoint(BodyNode* _child);
 
   /// Remove a DegreeOfFreedom from this ReferentialSkeleton. This can only be
   /// used by derived classes.
@@ -365,10 +373,14 @@ protected:
     /// Index of the BodyNode
     size_t mBodyNodeIndex;
 
-    /// Indices of the DegreesOfFreedom
+    /// Index of the parent Joint
+    size_t mJointIndex;
+
+    /// Indices of the parent DegreesOfFreedom
     std::vector<size_t> mDofIndices;
 
-    /// Default constructor. Initializes mBodyNodeIndex to INVALID_INDEX
+    /// Default constructor. Initializes mBodyNodeIndex and mJointIndex to
+    /// INVALID_INDEX
     IndexMap();
 
     /// Returns true if nothing in this entry is mapping to a valid index any
@@ -388,6 +400,9 @@ protected:
 
   /// Raw const BodyNode pointers. This vector is used for the MetaSkeleton API
   mutable std::vector<const BodyNode*> mRawConstBodyNodes;
+
+  /// Joints that this ReferentialSkeleton references
+  std::vector<JointPtr> mJoints;
 
   /// DegreesOfFreedom that this ReferentialSkeleton references
   std::vector<DegreeOfFreedomPtr> mDofs;

--- a/dart/dynamics/ReferentialSkeleton.h
+++ b/dart/dynamics/ReferentialSkeleton.h
@@ -327,21 +327,29 @@ protected:
   /// of ReferentialSkeleton.
   ReferentialSkeleton() = default;
 
-  /// Add a BodyNode to this ReferentialSkeleton. Only usable by derived classes
+  /// Add a BodyNode, along with its parent Joint and parent DegreesOfFreedom
+  /// to this ReferentialSkeleton. This can only be used by derived classes.
+  void registerComponent(BodyNode* _bn);
+
+  /// Add a BodyNode to this ReferentialSkeleton, ignoring its DegreesOfFreedom.
+  /// This can only be used by derived classes.
   void registerBodyNode(BodyNode* _bn);
 
-  /// Add a DegreeOfFreedom to this ReferentialSkeleton. Only usable by
-  /// derived classes.
+  /// Add a DegreeOfFreedom to this ReferentialSkeleton. This can only be used
+  /// by derived classes.
   void registerDegreeOfFreedom(DegreeOfFreedom* _dof);
 
-  /// Completely remove a BodyNode from this ReferentialSkeleton. Only usable
-  /// by derived classes
-  void unregisterBodyNode(BodyNode* _bn);
+  /// Completely remove a BodyNode and its parent DegreesOfFreedom from this
+  /// ReferentialSkeleton. This can only be used by derived classes.
+  void unregisterComponent(BodyNode* _bn);
 
-  /// Remove a DegreeOfFreedom from this ReferentialSkeleton. Only usable by
-  /// derived classes.
-  void unregisterDegreeOfFreedom(BodyNode* _bn, size_t _localIndex,
-                                 bool removeBnIfEmpty = true);
+  /// Remove a BodyNode from this ReferentialSkeleton, ignoring its parent
+  /// DegreesOfFreedom. This can only be used by derived classes.
+  void unregisterBodyNode(BodyNode* _bn, bool _unregisterDofs);
+
+  /// Remove a DegreeOfFreedom from this ReferentialSkeleton. This can only be
+  /// used by derived classes.
+  void unregisterDegreeOfFreedom(BodyNode* _bn, size_t _localIndex);
 
   /// Update the caches to match any changes to the structure of this
   /// ReferentialSkeleton
@@ -359,6 +367,13 @@ protected:
 
     /// Indices of the DegreesOfFreedom
     std::vector<size_t> mDofIndices;
+
+    /// Default constructor. Initializes mBodyNodeIndex to INVALID_INDEX
+    IndexMap();
+
+    /// Returns true if nothing in this entry is mapping to a valid index any
+    /// longer.
+    bool isExpired() const;
   };
 
   /// Name of this ReferentialSkeleton

--- a/dart/dynamics/detail/JointPtr.h
+++ b/dart/dynamics/detail/JointPtr.h
@@ -106,6 +106,12 @@ public:
     return mBodyNodePtr->getParentJoint();
   }
 
+  /// Get the BodyNode that this JointPtr is tied to
+  TemplateBodyNodePtr<BodyNodeT> getBodyNodePtr() const
+  {
+    return mBodyNodePtr;
+  }
+
   /// Set the Joint for this JointPtr
   void set(JointT* _ptr)
   {

--- a/unittests/testSkeleton.cpp
+++ b/unittests/testSkeleton.cpp
@@ -977,6 +977,73 @@ TEST(Skeleton, Linkage)
   checkLinkageJointConsistency(terminatedUpstream);
 }
 
+TEST(Skeleton, Group)
+{
+  SkeletonPtr skel = constructLinkageTestSkeleton();
+
+  // Make twice as many BodyNodes in the Skeleton
+  SkeletonPtr skel2 = constructLinkageTestSkeleton();
+  skel2->getRootBodyNode()->moveTo(skel, nullptr);
+
+  // Test nullptr construction
+  GroupPtr nullGroup = Group::create("null_group", nullptr);
+  EXPECT_EQ(nullGroup->getNumBodyNodes(), 0u);
+  EXPECT_EQ(nullGroup->getNumJoints(), 0u);
+  EXPECT_EQ(nullGroup->getNumDofs(), 0u);
+
+  // Test conversion from Skeleton
+  GroupPtr skel1Group = Group::create("skel1_group", skel);
+  EXPECT_EQ(skel1Group->getNumBodyNodes(), skel->getNumBodyNodes());
+  EXPECT_EQ(skel1Group->getNumJoints(), skel->getNumJoints());
+  EXPECT_EQ(skel1Group->getNumDofs(), skel->getNumDofs());
+
+  for(size_t i=0; i < skel1Group->getNumBodyNodes(); ++i)
+    EXPECT_EQ(skel1Group->getBodyNode(i), skel->getBodyNode(i));
+
+  for(size_t i=0; i < skel1Group->getNumJoints(); ++i)
+    EXPECT_EQ(skel1Group->getJoint(i), skel->getJoint(i));
+
+  for(size_t i=0; i < skel1Group->getNumDofs(); ++i)
+    EXPECT_EQ(skel1Group->getDof(i), skel->getDof(i));
+
+  // Test arbitrary Groups by plucking random BodyNodes, Joints, and
+  // DegreesOfFreedom from a Skeleton.
+  GroupPtr group = Group::create();
+  std::vector<BodyNode*> bodyNodes;
+  std::vector<Joint*> joints;
+  std::vector<DegreeOfFreedom*> dofs;
+  for(size_t i=0; i < 2*skel->getNumBodyNodes(); ++i)
+  {
+    size_t randomIndex = floor(random(0, skel->getNumBodyNodes()));
+    BodyNode* bn = skel->getBodyNode(randomIndex);
+    if(group->addBodyNode(bn, false))
+      bodyNodes.push_back(bn);
+
+    randomIndex = floor(random(0, skel->getNumJoints()));
+    Joint* joint = skel->getJoint(randomIndex);
+    if(group->addJoint(joint, false, false))
+      joints.push_back(joint);
+
+    randomIndex = floor(random(0, skel->getNumDofs()));
+    DegreeOfFreedom* dof = skel->getDof(randomIndex);
+    if(group->addDof(dof, false, false))
+      dofs.push_back(dof);
+  }
+
+  EXPECT_EQ(group->getNumBodyNodes(), bodyNodes.size());
+  EXPECT_EQ(group->getNumJoints(), joints.size());
+  EXPECT_EQ(group->getNumDofs(), dofs.size());
+
+  for(size_t i=0; i < group->getNumBodyNodes(); ++i)
+    EXPECT_EQ(group->getBodyNode(i), bodyNodes[i]);
+
+  for(size_t i=0; i < group->getNumJoints(); ++i)
+    EXPECT_EQ(group->getJoint(i), joints[i]);
+
+  for(size_t i=0; i < group->getNumDofs(); ++i)
+    EXPECT_EQ(group->getDof(i), dofs[i]);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/unittests/testSkeleton.cpp
+++ b/unittests/testSkeleton.cpp
@@ -623,6 +623,23 @@ TEST(Skeleton, NodePersistence)
   }
 }
 
+TEST(Skeleton, ZeroDofJointInReferential)
+{
+  // This is a regression test which makes sure that the BodyNodes of
+  // ZeroDofJoints will be correctly included in linkages.
+  SkeletonPtr skel = Skeleton::create();
+
+  BodyNode* bn = skel->createJointAndBodyNodePair<RevoluteJoint>().second;
+  BodyNode* zeroDof1 = skel->createJointAndBodyNodePair<WeldJoint>(bn).second;
+  bn = skel->createJointAndBodyNodePair<PrismaticJoint>(zeroDof1).second;
+  BodyNode* zeroDof2 = skel->createJointAndBodyNodePair<WeldJoint>(bn).second;
+
+  BranchPtr branch = Branch::create(skel->getBodyNode(0));
+  EXPECT_EQ(branch->getNumBodyNodes(), skel->getNumBodyNodes());
+  EXPECT_FALSE(branch->getIndexOf(zeroDof1) == INVALID_INDEX);
+  EXPECT_FALSE(branch->getIndexOf(zeroDof2) == INVALID_INDEX);
+}
+
 TEST(Skeleton, Referential)
 {
   std::vector<SkeletonPtr> skeletons = getSkeletons();


### PR DESCRIPTION
This pull request is in response to issues #548 and #556. This fixes the issue where BodyNodes with zero-dof parent Joints will be left out of ReferentialSkeletons, and it allows users to add and remove BodyNodes and DegreesOfFreedom from Groups freely (i.e. without any coupling between BodyNodes and their parent DegreesOfFreedom).

However, in the current implementation there is still a 1-to-1 correspondence between BodyNodes and Joints, even though BodyNodes are decoupled from DegreesOfFreedom. What this means is that ``ReferentialSkeleton::getJoint(i)`` is always equivalent to ``ReferentialSkeleton::getBodyNode(i)->getParentJoint()``. This is despite the fact that there is no coupling between ``ReferentialSkeleton::getBodyNode(~)`` and ``ReferentialSkeleton::getDof(~)``.

So I before this pull request can be considered finished, I'd like to pose the question: Should ``getBodyNode(~)`` be decoupled from ``getJoint(~)`` for ``ReferentialSkeleton``s, or is the current setup okay as it is?

I should also note that this pull request introduces a few changes to the behavior of the API of the ``Group`` class as a consequence of the decoupling. I hope that this does not result in any headaches for the existing users of ``Group``.