### PR TITLE
Fix packaging of dart-core/dart libraries

### DIFF
--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -36,6 +36,7 @@ set(dart_core_hdrs
   ${dart_optimizer_hdrs}
   ${dart_collision_hdrs}
   ${dart_constraint_hdrs}
+  ${dart_renderer_hdrs}
   ${dart_simulation_hdrs}
 )
 set(dart_core_srcs
@@ -47,6 +48,7 @@ set(dart_core_srcs
   ${dart_optimizer_srcs}
   ${dart_collision_srcs}
   ${dart_constraint_srcs}
+  ${dart_renderer_srcs}
   ${dart_simulation_srcs}
 )
 if(NOT BUILD_CORE_ONLY)
@@ -54,13 +56,11 @@ if(NOT BUILD_CORE_ONLY)
     dart.h
     ${dart_gui_hdrs}
     ${dart_planning_hdrs}
-    ${dart_renderer_hdrs}
     ${dart_utils_hdrs}
   )
   set(dart_srcs
     ${dart_gui_srcs}
     ${dart_planning_srcs}
-    ${dart_renderer_srcs}
     ${dart_utils_srcs}
   )
 endif()

--- a/debian/libdart-core5-dev.install
+++ b/debian/libdart-core5-dev.install
@@ -7,6 +7,7 @@ usr/include/dart/dynamics/*
 usr/include/dart/integration/*
 usr/include/dart/lcpsolver/*
 usr/include/dart/math/*
+usr/include/dart/optimizer/*
 usr/include/dart/renderer/*
 usr/include/dart/simulation/*
 usr/share/dartcore/DARTCoreConfig.cmake

--- a/debian/libdart5-dev.install
+++ b/debian/libdart5-dev.install
@@ -1,5 +1,4 @@
 usr/include/dart/dart.h
-usr/include/dart/optimizer/*
 usr/include/dart/planning/*
 usr/include/dart/utils/*
 usr/include/dart/gui/*


### PR DESCRIPTION
This pull request fixes incorrect packaging of `dart-core` and `dart`.

`dart-core` library should contain following namespaces:
* common
* math
* integration
* lcpsolver
* dynamics
* optimizer
* collision
* constraint
* renderer
* simulation

and `dart` library should contain following namespaces:
* `dart-core`
* gui
* planning
* utils