### PR TITLE
Typo error in Tutorial Collisions.md

### DIFF
--- a/docs/readthedocs/tutorials/collisions.md
+++ b/docs/readthedocs/tutorials/collisions.md
@@ -575,7 +575,7 @@ And now we can add it to the world without any complaints:
 mWorld->addSkeleton(object);
 ```
 
-### Lesson 3d: Compute collisions
+### Lesson 3c: Compute collisions
 
 Now that we've added the Skeleton to the world, we want to make sure that it
 wasn't actually placed inside of something accidentally. If an object in a 

--- a/docs/readthedocs/tutorials/multi-pendulum.md
+++ b/docs/readthedocs/tutorials/multi-pendulum.md
@@ -256,13 +256,13 @@ Find the function named ``changeRestPosition`` in the ``MyWindow`` class. This
 function will be called whenever the user presses the 'q' or 'a' button. We want
 those buttons to curl and uncurl the rest positions for the pendulum. To start,
 we'll go through all the generalized coordinates and change their rest positions
-by ``delta``:
+by ``delta_rest_position``:
 
 ```cpp
 for(size_t i = 0; i < mPendulum->getNumDofs(); ++i)
 {
   DegreeOfFreedom* dof = mPendulum->getDof(i);
-  double q0 = dof->getRestPosition() + delta;
+  double q0 = dof->getRestPosition() + delta_rest_position;
 
   dof->setRestPosition(q0);
 }
@@ -298,7 +298,7 @@ spring stiffness. We can change the spring stiffness as follows:
 for(size_t i = 0; i < mPendulum->getNumDofs(); ++i)
 {
   DegreeOfFreedom* dof = mPendulum->getDof(i);
-  double stiffness = dof->getSpringStiffness() + delta;
+  double stiffness = dof->getSpringStiffness() + delta_stiffness;
   dof->setSpringStiffness(stiffness);
 }
 ```
@@ -326,7 +326,7 @@ The API for getting and setting the damping is just like the API for stiffness:
 for(size_t i = 0; i < mPendulum->getNumDofs(); ++i)
 {
   DegreeOfFreedom* dof = mPendulum->getDof(i);
-  double damping = dof->getDampingCoefficient() + delta;
+  double damping = dof->getDampingCoefficient() + delta_damping;
   if(damping < 0.0)
     damping = 0.0;
   dof->setDampingCoefficient(damping);

--- a/docs/readthedocs/tutorials/multi-pendulum.md
+++ b/docs/readthedocs/tutorials/multi-pendulum.md
@@ -256,13 +256,13 @@ Find the function named ``changeRestPosition`` in the ``MyWindow`` class. This
 function will be called whenever the user presses the 'q' or 'a' button. We want
 those buttons to curl and uncurl the rest positions for the pendulum. To start,
 we'll go through all the generalized coordinates and change their rest positions
-by ``delta_rest_position``:
+by ``delta``:
 
 ```cpp
 for(size_t i = 0; i < mPendulum->getNumDofs(); ++i)
 {
   DegreeOfFreedom* dof = mPendulum->getDof(i);
-  double q0 = dof->getRestPosition() + delta_rest_position;
+  double q0 = dof->getRestPosition() + delta;
 
   dof->setRestPosition(q0);
 }
@@ -298,7 +298,7 @@ spring stiffness. We can change the spring stiffness as follows:
 for(size_t i = 0; i < mPendulum->getNumDofs(); ++i)
 {
   DegreeOfFreedom* dof = mPendulum->getDof(i);
-  double stiffness = dof->getSpringStiffness() + delta_stiffness;
+  double stiffness = dof->getSpringStiffness() + delta;
   dof->setSpringStiffness(stiffness);
 }
 ```
@@ -326,7 +326,7 @@ The API for getting and setting the damping is just like the API for stiffness:
 for(size_t i = 0; i < mPendulum->getNumDofs(); ++i)
 {
   DegreeOfFreedom* dof = mPendulum->getDof(i);
-  double damping = dof->getDampingCoefficient() + delta_damping;
+  double damping = dof->getDampingCoefficient() + delta;
   if(damping < 0.0)
     damping = 0.0;
   dof->setDampingCoefficient(damping);


### PR DESCRIPTION
There is two Lesson 3d in the tutorial.

one of they must be 3c.