### PR TITLE
add more hint to Pendulum.cpp, revise the typo error in collision.md

### DIFF
--- a/docs/readthedocs/tutorials/collisions.md
+++ b/docs/readthedocs/tutorials/collisions.md
@@ -575,7 +575,7 @@ And now we can add it to the world without any complaints:
 mWorld->addSkeleton(object);
 ```
 
-### Lesson 3d: Compute collisions
+### Lesson 3c: Compute collisions
 
 Now that we've added the Skeleton to the world, we want to make sure that it
 wasn't actually placed inside of something accidentally. If an object in a 

--- a/tutorials/tutorialMultiPendulum.cpp
+++ b/tutorials/tutorialMultiPendulum.cpp
@@ -107,17 +107,17 @@ public:
       mForceCountDown[index] = default_countdown;
   }
 
-  void changeRestPosition(double)
+  void changeRestPosition(double /*delta*/)
   {
     // Lesson 2a
   }
 
-  void changeStiffness(double)
+  void changeStiffness(double /*delta*/)
   {
     // Lesson 2b
   }
 
-  void changeDamping(double)
+  void changeDamping(double /*delta*/)
   {
     // Lesson 2c
   }


### PR DESCRIPTION
There is some code in lesson 2a of Pendulum:
for(size_t i = 0; i < mPendulum->getNumDofs(); ++i)
{
  DegreeOfFreedom* dof = mPendulum->getDof(i);
  double q0 = dof->getRestPosition() + delta;
  dof->setRestPosition(q0);
}
the variable delta may be the parameter of the functions, but the tutorial don't say where the variable 'delta' comes from.
http://dart.readthedocs.org/en/release-5.1/tutorials/multi-pendulum/#lesson-2a-set-joint-spring-rest-position

User may need read the finished file and get hints.


There is a typo error in collision.md