### PR TITLE
Fix control file for missing urdfdom-dev dep

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### Version 6.0.0 (2015-12-19)
+
+1. Added missing `liburdfdom-dev` dependency in Ubuntu package
+    * [Pull request #574](https://github.com/dartsim/dart/pull/574)
+
 ### Version 5.1.1 (2015-11-06)
 
 1. Add bullet dependency to package.xml
@@ -321,7 +326,7 @@
     * [Pull request #277](https://github.com/dartsim/dart/pull/277)
 1. Added all-inclusive header and namespace headers
     * [Pull request #278](https://github.com/dartsim/dart/pull/278)
-1. Added DegreeOfFreedom class for getting/setting data of individual generalized coordinates 
+1. Added DegreeOfFreedom class for getting/setting data of individual generalized coordinates
     * [Pull request #288](https://github.com/dartsim/dart/pull/288)
 1. Added hybrid dynamics
     * [Pull request #298](https://github.com/dartsim/dart/pull/298)
@@ -474,4 +479,3 @@
 1. Clean-up of the Robot class
 1. Removed Object class
 1. More robust build and installation process on Linux
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 dart (6.0.0) unstable; urgency=medium
 
-  * Added missing 'liburdfdom-dev' dependency on Ubuntu package
+  * Added missing 'liburdfdom-dev' dependency in Ubuntu package
 
 dart (5.1.1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+dart (6.0.0) unstable; urgency=medium
+
+  * Added missing 'liburdfdom-dev' dependency on Ubuntu package
+
 dart (5.1.1) unstable; urgency=medium
 
   * Add bullet dependency to package.xml
@@ -129,7 +133,7 @@ dart (4.3.0) unstable; urgency=low
 
   * Added name manager for efficient name look-up and unique naming
   * Added all-inclusive header and namespace headers
-  * Added DegreeOfFreedom class for getting/setting data of individual generalized coordinates 
+  * Added DegreeOfFreedom class for getting/setting data of individual generalized coordinates
   * Added hybrid dynamics
   * Added joint actuator types
   * Added Coulomb joint friction
@@ -209,4 +213,3 @@ dart (3.0.0) unstable; urgency=low
   * Add "common" namespace
 
  -- Tobias Kunz <tobias@gatech.edu>  Fri, 11 Oct 2013 22:00:00 -0400
- 

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper (>= 9),
                libtinyxml-dev,
                libtinyxml2-dev,
                liburdfdom-dev,
-               libboost-dev (>= 1.54.0.1ubuntu1), 
+               libboost-dev (>= 1.54.0.1ubuntu1),
                libboost-system-dev (>= 1.54.0-4ubuntu3),
                libboost-regex-dev (>= 1.54.0-4ubuntu3),
                libopenthreads-dev,
@@ -71,7 +71,8 @@ Depends: ${misc:Depends},
          libxmu-dev,
          libtinyxml2-dev,
          libopenthreads-dev,
-         libopenscenegraph-dev
+         libopenscenegraph-dev,
+         liburdfdom-dev
 Description: Dynamic Animation and Robotics Toolkit, development files
  DART is a collaborative, cross-platform, open source library created by the
  Georgia Tech Graphics Lab and Humanoid Robotics Lab. The library provides data


### PR DESCRIPTION
Fix for missing `liburdfdom-dev` dependency. See #571.

Should I add something to the changelog?
