### PR TITLE
Fix incorrect applying of joint constraint impulses --  Patch for 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: cpp
 os:
   - linux
   - osx
+sudo: required
+dist: trusty
 compiler:
   - gcc
   - clang
@@ -27,3 +29,4 @@ script:
 after_failure:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then '../ci/after_failure_linux.sh' ; fi
   - if [ "$TRAVIS_OS_NAME" = "osx"   ]; then '../ci/after_failure_osx.sh'   ; fi
+

--- a/ci/before_install_linux.sh
+++ b/ci/before_install_linux.sh
@@ -1,61 +1,29 @@
-before_install() {
-  cd /tmp
-
-  # Install nlopt from source since Ubuntu 12.04 does not provide debian package for nlopt
-  curl -o nlopt-2.4.1.tar.gz http://ab-initio.mit.edu/nlopt/nlopt-2.4.1.tar.gz
-  tar -xf nlopt-2.4.1.tar.gz
-  cd nlopt-2.4.1/
-  sh autogen.sh &>/dev/null  # mute the output
-  make CPPFLAGS='-fPIC' && sudo make install &>/dev/null  # mute the output
-}
-
-# Install gcc-4.8 and g++-4.8 for C++11
-sudo apt-get -qq --yes install python-software-properties 
-sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-sudo apt-get -qq update
-sudo apt-get -qq --yes install gcc-4.8 g++-4.8
-sudo apt-get -qq --yes autoremove
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-
-# Install eigen-3.2.1 (for unsupported/Eigen/Splines)
-wget --quiet -O libeigen3-dev_3.2.1-1~precise1_all.deb http://packages.yade-dem.org/precise/libeigen3-dev_3.2.1-1~precise1_all.deb
-sudo dpkg -i libeigen3-dev_3.2.1-1~precise1_all.deb
-
-# Install boost 1.55 compatible with C++11
-wget --quiet -O boost_1_55_0.tar.gz http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz/download
-tar -xzf boost_1_55_0.tar.gz
-cd boost_1_55_0/
-sudo apt-get -qq update
-sudo apt-get -qq install build-essential g++ python-dev autotools-dev libicu-dev build-essential libbz2-dev 
-./bootstrap.sh --prefix=/usr/local &>/dev/null  # mute the output
-n=`cat /proc/cpuinfo | grep "cpu cores" | uniq | awk '{print $NF}'`
-sudo ./b2 --with=all -j $n install &>/dev/null  # mute the output
-sudo sh -c 'echo "/usr/local/lib" >> /etc/ld.so.conf.d/local.conf'
-sudo ldconfig
-
-sudo add-apt-repository --yes ppa:libccd-debs/ppa
-sudo add-apt-repository --yes ppa:fcl-debs/ppa
-sudo add-apt-repository --yes ppa:dartsim/ppa
+sudo apt-add-repository --yes ppa:libccd-debs/ppa
+sudo apt-add-repository --yes ppa:fcl-debs/ppa
+sudo apt-add-repository --yes ppa:dartsim/ppa
 sudo apt-get -qq update
 
 APT_CORE='
 cmake
 libassimp-dev
+libboost-all-dev
 libccd-dev
+libeigen3-dev
 libfcl-dev
 '
 
-APT=$APT_CORE' 
+APT=$APT_CORE'
 freeglut3-dev
 libxi-dev
 libxmu-dev
 libflann-dev
+libnlopt-dev
 coinor-libipopt-dev
 libtinyxml-dev
 libtinyxml2-dev
 liburdfdom-dev
 liburdfdom-headers-dev
+libopenscenegraph-dev
 '
 
 if [ $BUILD_CORE_ONLY = OFF ]; then
@@ -63,6 +31,4 @@ if [ $BUILD_CORE_ONLY = OFF ]; then
 else
   sudo apt-get -qq --yes --force-yes install $APT_CORE
 fi
-
-(before_install)
 

--- a/dart/constraint/JointCoulombFrictionConstraint.cpp
+++ b/dart/constraint/JointCoulombFrictionConstraint.cpp
@@ -200,6 +200,7 @@ void JointCoulombFrictionConstraint::applyUnitImpulse(size_t _index)
       mJoint->setConstraintImpulse(i, 1.0);
       skeleton->updateBiasImpulse(mBodyNode);
       skeleton->updateVelocityChange();
+      mJoint->setConstraintImpulse(i, 0.0);
     }
 
     ++localIndex;
@@ -262,7 +263,8 @@ void JointCoulombFrictionConstraint::applyImpulse(double* _lambda)
     if (mActive[i] == false)
       continue;
 
-    mJoint->setConstraintImpulse(i, _lambda[localIndex]);
+    mJoint->setConstraintImpulse(
+                i, mJoint->getConstraintImpulse(i) + _lambda[localIndex]);
 
     mOldX[i] = _lambda[localIndex];
 

--- a/dart/constraint/JointLimitConstraint.cpp
+++ b/dart/constraint/JointLimitConstraint.cpp
@@ -309,6 +309,7 @@ void JointLimitConstraint::applyUnitImpulse(size_t _index)
       mJoint->setConstraintImpulse(i, 1.0);
       skeleton->updateBiasImpulse(mBodyNode);
       skeleton->updateVelocityChange();
+      mJoint->setConstraintImpulse(i, 0.0);
     }
 
     ++localIndex;
@@ -370,7 +371,8 @@ void JointLimitConstraint::applyImpulse(double* _lambda)
     if (mActive[i] == false)
       continue;
 
-    mJoint->setConstraintImpulse(i, _lambda[localIndex]);
+    mJoint->setConstraintImpulse(
+                i, mJoint->getConstraintImpulse(i) + _lambda[localIndex]);
 
     mOldX[i] = _lambda[localIndex];
 

--- a/unittests/testJoints.cpp
+++ b/unittests/testJoints.cpp
@@ -625,6 +625,118 @@ TEST_F(JOINTS, JOINT_COULOMB_FRICTION)
 }
 
 //==============================================================================
+TEST_F(JOINTS, JOINT_COULOMB_FRICTION_AND_POSITION_LIMIT)
+{
+  const double timeStep = 1e-3;
+  const double tol = 1e-2;
+
+  simulation::WorldPtr myWorld
+      = utils::SkelParser::readWorld(
+        DART_DATA_PATH"/skel/test/joint_friction_test.skel");
+  EXPECT_TRUE(myWorld != nullptr);
+
+  myWorld->setGravity(Eigen::Vector3d(0.0, 0.0, 0.0));
+  myWorld->setTimeStep(timeStep);
+
+  dynamics::SkeletonPtr pendulum = myWorld->getSkeleton("double_pendulum");
+  EXPECT_TRUE(pendulum != nullptr);
+  pendulum->disableSelfCollision();
+
+  dynamics::Joint* joint0 = pendulum->getJoint("joint0");
+  dynamics::Joint* joint1 = pendulum->getJoint("joint1");
+
+  EXPECT_TRUE(joint0 != nullptr);
+  EXPECT_TRUE(joint1 != nullptr);
+
+  double frictionForce  = 5.0;
+
+  joint0->setPositionLimitEnforced(true);
+  joint1->setPositionLimitEnforced(true);
+
+  const double ll = -DART_PI/12.0; // -15 degree
+  const double ul = +DART_PI/12.0; // +15 degree
+
+  size_t dof0 = joint0->getNumDofs();
+  for (size_t i = 0; i < dof0; ++i)
+  {
+    joint0->setPosition(i, 0.0);
+    joint0->setPosition(i, 0.0);
+    joint0->setPositionLowerLimit(i, ll);
+    joint0->setPositionUpperLimit(i, ul);
+  }
+
+  size_t dof1 = joint1->getNumDofs();
+  for (size_t i = 0; i < dof1; ++i)
+  {
+    joint1->setPosition(i, 0.0);
+    joint1->setPosition(i, 0.0);
+    joint1->setPositionLowerLimit(i, ll);
+    joint1->setPositionUpperLimit(i, ul);
+  }
+
+  joint0->setCoulombFriction(0, frictionForce);
+  joint1->setCoulombFriction(0, frictionForce);
+
+  EXPECT_EQ(joint0->getCoulombFriction(0), frictionForce);
+  EXPECT_EQ(joint1->getCoulombFriction(0), frictionForce);
+
+#ifndef NDEBUG // Debug mode
+  double simTime = 0.2;
+#else
+  double simTime = 2.0;
+#endif // ------- Debug mode
+  int nSteps = simTime / timeStep;
+
+  // First two seconds rotating in positive direction with higher control forces
+  // than the friction forces
+  for (int i = 0; i < nSteps; i++)
+  {
+    joint0->setForce(0, 100.0);
+    joint1->setForce(0, 100.0);
+    myWorld->step();
+
+    double jointPos0 = joint0->getPosition(0);
+    double jointPos1 = joint1->getPosition(0);
+
+    double jointVel0 = joint0->getVelocity(0);
+    double jointVel1 = joint1->getVelocity(0);
+
+    EXPECT_GE(std::abs(jointVel0), 0.0);
+    EXPECT_GE(std::abs(jointVel1), 0.0);
+
+    EXPECT_GE(jointPos0, ll - tol);
+    EXPECT_LE(jointPos0, ul + tol);
+
+    EXPECT_GE(jointPos1, ll - tol);
+    EXPECT_LE(jointPos1, ul + tol);
+  }
+
+  // Another two seconds rotating in negative direction with higher control
+  // forces than the friction forces
+  for (int i = 0; i < nSteps; i++)
+  {
+    joint0->setForce(0, -100.0);
+    joint1->setForce(0, -100.0);
+    myWorld->step();
+
+    double jointPos0 = joint0->getPosition(0);
+    double jointPos1 = joint1->getPosition(0);
+
+    double jointVel0 = joint0->getVelocity(0);
+    double jointVel1 = joint1->getVelocity(0);
+
+    EXPECT_GE(std::abs(jointVel0), 0.0);
+    EXPECT_GE(std::abs(jointVel1), 0.0);
+
+    EXPECT_GE(jointPos0, ll - tol);
+    EXPECT_LE(jointPos0, ul + tol);
+
+    EXPECT_GE(jointPos1, ll - tol);
+    EXPECT_LE(jointPos1, ul + tol);
+  }
+}
+
+//==============================================================================
 template<int N>
 Eigen::Matrix<double,N,1> random_vec(double limit=100)
 {


### PR DESCRIPTION
This pull request fixes #317 for DART 5.1 as fixed in #566 for DART 6.0.