### PR TITLE
Fix Visual Studio 2015 build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,7 +471,7 @@ endif()
 #===============================================================================
 if(MSVC)
   # Visual Studio enables c++11 support by default
-  if(NOT MSVC12)
+  if(NOT MSVC12 AND NOT MSVC14)
     message(FATAL_ERROR "${PROJECT_NAME} requires VS 2013 or greater.")
   endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP4")

--- a/dart/constraint/ConstrainedGroup.h
+++ b/dart/constraint/ConstrainedGroup.h
@@ -49,7 +49,7 @@ class Skeleton;
 
 namespace constraint {
 
-class ConstraintInfo;
+struct ConstraintInfo;
 class ConstraintBase;
 class ConstraintSolver;
 

--- a/dart/dynamics/Skeleton.h
+++ b/dart/dynamics/Skeleton.h
@@ -833,7 +833,7 @@ public:
   friend class EndEffector;
 
 protected:
-  class DataCache;
+  struct DataCache;
 
   /// Constructor called by create()
   Skeleton(const Properties& _properties);

--- a/dart/math/Helpers.h
+++ b/dart/math/Helpers.h
@@ -182,7 +182,7 @@ inline bool isInt(double _x) {
 /// \brief Returns whether _v is a NaN (Not-A-Number) value
 inline bool isNan(double _v) {
 #ifdef _WIN32
-  return _isnan(_v);
+  return _isnan(_v) != 0;
 #else
   return std::isnan(_v);
 #endif

--- a/dart/utils/urdf/urdf_world_parser.cpp
+++ b/dart/utils/urdf/urdf_world_parser.cpp
@@ -39,6 +39,7 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <iostream>
 
 #include <tinyxml.h>
 


### PR DESCRIPTION
This pull request fixes all the build errors that I encountered while trying to build DART with Visual Studio 2015.

CMake would fail to configure if you weren't using exactly Visual Studio 2013, so I added a conditional for 2015 as well.