### PR TITLE
Updating the constraint namespace to C++11

### DIFF
--- a/apps/atlasSimbicon/Controller.cpp
+++ b/apps/atlasSimbicon/Controller.cpp
@@ -231,7 +231,7 @@ void Controller::harnessPelvis()
     return;
 
   BodyNode* bd = mAtlasRobot->getBodyNode("pelvis");
-  mWeldJointConstraintPelvis = new WeldJointConstraint(bd);
+  mWeldJointConstraintPelvis = std::make_shared<WeldJointConstraint>(bd);
   mConstratinSolver->addConstraint(mWeldJointConstraintPelvis);
   mPelvisHarnessOn = true;
 
@@ -257,7 +257,7 @@ void Controller::harnessLeftFoot()
     return;
 
   BodyNode* bd = mAtlasRobot->getBodyNode("l_foot");
-  mWeldJointConstraintLeftFoot = new WeldJointConstraint(bd);
+  mWeldJointConstraintLeftFoot = std::make_shared<WeldJointConstraint>(bd);
   mLeftFootHarnessOn = true;
 
   dtmsg << "Left foot is harnessed." << std::endl;
@@ -282,7 +282,7 @@ void Controller::harnessRightFoot()
     return;
 
   BodyNode* bd = mAtlasRobot->getBodyNode("r_foot");
-  mWeldJointConstraintRightFoot = new WeldJointConstraint(bd);
+  mWeldJointConstraintRightFoot = std::make_shared<WeldJointConstraint>(bd);
   mRightFootHarnessOn = true;
 
   dtmsg << "Right foot is harnessed." << std::endl;

--- a/apps/atlasSimbicon/Controller.h
+++ b/apps/atlasSimbicon/Controller.h
@@ -172,13 +172,13 @@ private:
   dart::dynamics::BodyNode* _getRightFoot() const;
 
   /// \brief Weld joint constraint for pelvis harnessing
-  dart::constraint::WeldJointConstraint* mWeldJointConstraintPelvis;
+  dart::constraint::WeldJointConstraintPtr mWeldJointConstraintPelvis;
 
   /// \brief Weld joint constraint for left foot harnessing
-  dart::constraint::WeldJointConstraint* mWeldJointConstraintLeftFoot;
+  dart::constraint::WeldJointConstraintPtr mWeldJointConstraintLeftFoot;
 
   /// \brief Weld joint constraint for right foot harnessing
-  dart::constraint::WeldJointConstraint* mWeldJointConstraintRightFoot;
+  dart::constraint::WeldJointConstraintPtr mWeldJointConstraintRightFoot;
 
   /// \brief Initial state of the robot
   Eigen::VectorXd mInitialState;

--- a/apps/jointConstraints/MyWindow.cpp
+++ b/apps/jointConstraints/MyWindow.cpp
@@ -142,7 +142,7 @@ void MyWindow::keyboard(unsigned char key, int x, int y)
       if (mHarnessOn)
       {
         BodyNode* bd = mWorld->getSkeleton(1)->getBodyNode("h_pelvis");
-        mWeldJoint = new WeldJointConstraint(bd);
+        mWeldJoint = std::make_shared<WeldJointConstraint>(bd);
         mWorld->getConstraintSolver()->addConstraint(mWeldJoint);
       }
       else

--- a/apps/jointConstraints/MyWindow.h
+++ b/apps/jointConstraints/MyWindow.h
@@ -72,7 +72,7 @@ public:
 private:
   Eigen::Vector3d mForce;
   Controller* mController;
-  dart::constraint::WeldJointConstraint* mWeldJoint;
+  dart::constraint::WeldJointConstraintPtr mWeldJoint;
   int mImpulseDuration;
   bool mHarnessOn;
 

--- a/apps/rigidLoop/Main.cpp
+++ b/apps/rigidLoop/Main.cpp
@@ -74,7 +74,8 @@ int main(int argc, char* argv[])
   bd2->getVisualizationShape(0)->setColor(Eigen::Vector3d(1.0, 0.0, 0.0));
   Eigen::Vector3d offset(0.0, 0.025, 0.0);
   Eigen::Vector3d jointPos = bd1->getTransform() * offset;
-  BallJointConstraint *cl = new BallJointConstraint( bd1, bd2, jointPos);
+  BallJointConstraintPtr cl =
+      std::make_shared<BallJointConstraint>( bd1, bd2, jointPos);
   //WeldJointConstraint *cl = new WeldJointConstraint(bd1, bd2);
   myWorld->getConstraintSolver()->addConstraint(cl);
 

--- a/dart/common/SmartPointer.h
+++ b/dart/common/SmartPointer.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Michael X. Grey <mxgrey@gatech.edu>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COMMON_SMARTPOINTER_H_
+#define DART_COMMON_SMARTPOINTER_H_
+
+#include <memory>
+
+// -- Standard shared/weak pointers --
+// Define a typedef for const and non-const version of shared_ptr and weak_ptr
+// for the class X
+#define DART_COMMON_MAKE_SHARED_WEAK( X )\
+  class X ;\
+  typedef std::shared_ptr< X >       X ## Ptr;\
+  typedef std::shared_ptr< const X > Const ## X ## Ptr;\
+  typedef std::weak_ptr< X >         Weak ## X ## Ptr;\
+  typedef std::weak_ptr< const X >   WeakConst ## X ## Ptr;
+
+#endif // DART_COMMON_SMARTPOINTER_H_

--- a/dart/constraint/ConstrainedGroup.cpp
+++ b/dart/constraint/ConstrainedGroup.cpp
@@ -57,7 +57,7 @@ ConstrainedGroup::~ConstrainedGroup()
 }
 
 //==============================================================================
-void ConstrainedGroup::addConstraint(ConstraintBase* _constraint)
+void ConstrainedGroup::addConstraint(const ConstraintBasePtr& _constraint)
 {
   assert(_constraint != nullptr && "Null constraint pointer is now allowed.");
   assert(containConstraint(_constraint) == false
@@ -74,14 +74,14 @@ size_t ConstrainedGroup::getNumConstraints() const
 }
 
 //==============================================================================
-ConstraintBase* ConstrainedGroup::getConstraint(size_t _index) const
+ConstraintBasePtr ConstrainedGroup::getConstraint(size_t _index) const
 {
   assert(_index < mConstraints.size());
   return mConstraints[_index];
 }
 
 //==============================================================================
-void ConstrainedGroup::removeConstraint(ConstraintBase* _constraint)
+void ConstrainedGroup::removeConstraint(const ConstraintBasePtr& _constraint)
 {
   assert(_constraint != nullptr && "Null constraint pointer is now allowed.");
   assert(containConstraint(_constraint) == true
@@ -108,16 +108,20 @@ void ConstrainedGroup::removeAllConstraints()
 }
 
 //==============================================================================
-bool ConstrainedGroup::containConstraint(ConstraintBase* _constraint) const
+bool ConstrainedGroup::containConstraint(
+    const ConstConstraintBasePtr& _constraint) const
 {
 //  std::cout << "CommunityTEST::_containConstraint(): Not implemented."
 //            << std::endl;
+
+  // TODO(MXG): Is there any reason these functions are not implemented yet?
 
   return false;
 }
 
 //==============================================================================
-bool ConstrainedGroup::checkAndAddConstraint(ConstraintBase* _constraint)
+bool ConstrainedGroup::checkAndAddConstraint(
+    const ConstraintBasePtr& _constraint)
 {
   std::cout << "CommunityTEST::_checkAndAddConstraint(): Not implemented."
             << std::endl;

--- a/dart/constraint/ConstrainedGroup.h
+++ b/dart/constraint/ConstrainedGroup.h
@@ -41,6 +41,8 @@
 #include <memory>
 #include <Eigen/Dense>
 
+#include "dart/constraint/SmartPointer.h"
+
 namespace dart {
 
 namespace dynamics {
@@ -74,16 +76,16 @@ public:
   //----------------------------------------------------------------------------
 
   /// Add constraint
-  void addConstraint(ConstraintBase* _constraint);
+  void addConstraint(const ConstraintBasePtr& _constraint);
 
   /// Return number of constraints in this constrained group
   size_t getNumConstraints() const;
 
   /// Return a constraint
-  ConstraintBase* getConstraint(size_t _index) const;
+  ConstraintBasePtr getConstraint(size_t _index) const;
 
   /// Remove constraint
-  void removeConstraint(ConstraintBase* _constraint);
+  void removeConstraint(const ConstraintBasePtr& _constraint);
 
   /// Remove all constraints
   void removeAllConstraints();
@@ -99,13 +101,13 @@ public:
 
 private:
   /// Return true if _constraint is contained
-  bool containConstraint(ConstraintBase* _constraint) const;
+  bool containConstraint(const ConstConstraintBasePtr& _constraint) const;
 
   /// Return true and add the constraint if _constraint is contained
-  bool checkAndAddConstraint(ConstraintBase* _constraint);
+  bool checkAndAddConstraint(const ConstraintBasePtr& _constraint);
 
   /// List of constraints
-  std::vector<ConstraintBase*> mConstraints;
+  std::vector<ConstraintBasePtr> mConstraints;
 
   ///
   std::shared_ptr<dynamics::Skeleton> mRootSkeleton;

--- a/dart/constraint/ConstraintSolver.h
+++ b/dart/constraint/ConstraintSolver.h
@@ -41,6 +41,7 @@
 
 #include <Eigen/Dense>
 
+#include "dart/constraint/SmartPointer.h"
 #include "dart/constraint/ConstraintBase.h"
 #include "dart/collision/CollisionDetector.h"
 
@@ -51,17 +52,6 @@ class Skeleton;
 }  // namespace dynamics
 
 namespace constraint {
-
-class ConstrainedGroup;
-class ConstraintBase;
-class ClosedLoopConstraint;
-class ContactConstraint;
-class SoftContactConstraint;
-class JointLimitConstraint;
-class ServoMotorConstraint;
-class JointCoulombFrictionConstraint;
-class JointConstraint;
-class LCPSolver;
 
 // TODO:
 //   - RootSkeleton concept
@@ -97,10 +87,10 @@ public:
   void removeAllSkeletons();
 
   /// Add a constraint
-  void addConstraint(ConstraintBase* _constraint);
+  void addConstraint(const ConstraintBasePtr& _constraint);
 
   /// Remove a constraint
-  void removeConstraint(ConstraintBase* _constraint);
+  void removeConstraint(const ConstraintBasePtr& _constraint);
 
   /// Remove all constraints
   void removeAllConstraints();
@@ -128,10 +118,10 @@ private:
   bool checkAndAddSkeleton(const dynamics::SkeletonPtr& _skeleton);
 
   /// Check if the constraint is contained in this solver
-  bool containConstraint(const ConstraintBase* _constraint) const;
+  bool containConstraint(const ConstConstraintBasePtr& _constraint) const;
 
   /// Add constraint if the constraint is not contained in this solver
-  bool checkAndAddConstraint(ConstraintBase* _constraint);
+  bool checkAndAddConstraint(const ConstraintBasePtr& _constraint);
 
   /// Update constraints
   void updateConstraints();
@@ -158,25 +148,25 @@ private:
   std::vector<dynamics::SkeletonPtr> mSkeletons;
 
   /// Contact constraints those are automatically created
-  std::vector<ContactConstraint*> mContactConstraints;
+  std::vector<ContactConstraintPtr> mContactConstraints;
 
   /// Soft contact constraints those are automatically created
-  std::vector<SoftContactConstraint*> mSoftContactConstraints;
+  std::vector<SoftContactConstraintPtr> mSoftContactConstraints;
 
   /// Joint limit constraints those are automatically created
-  std::vector<JointLimitConstraint*> mJointLimitConstraints;
+  std::vector<JointLimitConstraintPtr> mJointLimitConstraints;
 
   /// Servo motor constraints those are automatically created
-  std::vector<ServoMotorConstraint*> mServoMotorConstraints;
+  std::vector<ServoMotorConstraintPtr> mServoMotorConstraints;
 
   /// Joint Coulomb friction constraints those are automatically created
-  std::vector<JointCoulombFrictionConstraint*> mJointCoulombFrictionConstraints;
+  std::vector<JointCoulombFrictionConstraintPtr> mJointCoulombFrictionConstraints;
 
   /// Constraints that manually added
-  std::vector<ConstraintBase*> mManualConstraints;
+  std::vector<ConstraintBasePtr> mManualConstraints;
 
   /// Active constraints
-  std::vector<ConstraintBase*> mActiveConstraints;
+  std::vector<ConstraintBasePtr> mActiveConstraints;
 
   /// Constraint group list
   std::vector<ConstrainedGroup> mConstrainedGroups;

--- a/dart/constraint/DantzigLCPSolver.cpp
+++ b/dart/constraint/DantzigLCPSolver.cpp
@@ -92,7 +92,7 @@ void DantzigLCPSolver::solve(ConstrainedGroup* _group)
 //  std::cout << "offset[" << 0 << "]: " << offset[0] << std::endl;
   for (size_t i = 1; i < numConstraints; ++i)
   {
-    ConstraintBase* constraint = _group->getConstraint(i - 1);
+    const ConstraintBasePtr& constraint = _group->getConstraint(i - 1);
     assert(constraint->getDimension() > 0);
     offset[i] = offset[i - 1] + constraint->getDimension();
 //    std::cout << "offset[" << i << "]: " << offset[i] << std::endl;
@@ -101,10 +101,9 @@ void DantzigLCPSolver::solve(ConstrainedGroup* _group)
   // For each constraint
   ConstraintInfo constInfo;
   constInfo.invTimeStep = 1.0 / mTimeStep;
-  ConstraintBase* constraint;
   for (size_t i = 0; i < numConstraints; ++i)
   {
-    constraint = _group->getConstraint(i);
+    const ConstraintBasePtr& constraint = _group->getConstraint(i);
 
     constInfo.x      = x      + offset[i];
     constInfo.lo     = lo     + offset[i];
@@ -173,7 +172,7 @@ void DantzigLCPSolver::solve(ConstrainedGroup* _group)
   // Apply constraint impulses
   for (size_t i = 0; i < numConstraints; ++i)
   {
-    constraint = _group->getConstraint(i);
+    const ConstraintBasePtr& constraint = _group->getConstraint(i);
     constraint->applyImpulse(x + offset[i]);
     constraint->excite();
   }

--- a/dart/constraint/PGSLCPSolver.cpp
+++ b/dart/constraint/PGSLCPSolver.cpp
@@ -92,7 +92,7 @@ void PGSLCPSolver::solve(ConstrainedGroup* _group)
   //  std::cout << "offset[" << 0 << "]: " << offset[0] << std::endl;
   for (size_t i = 1; i < numConstraints; ++i)
   {
-    ConstraintBase* constraint = _group->getConstraint(i - 1);
+    const ConstraintBasePtr&  constraint = _group->getConstraint(i - 1);
     assert(constraint->getDimension() > 0);
     offset[i] = offset[i - 1] + constraint->getDimension();
     //    std::cout << "offset[" << i << "]: " << offset[i] << std::endl;
@@ -101,10 +101,9 @@ void PGSLCPSolver::solve(ConstrainedGroup* _group)
   // For each constraint
   ConstraintInfo constInfo;
   constInfo.invTimeStep = 1.0 / mTimeStep;
-  ConstraintBase* constraint;
   for (size_t i = 0; i < numConstraints; ++i)
   {
-    constraint = _group->getConstraint(i);
+    const ConstraintBasePtr& constraint = _group->getConstraint(i);
 
     constInfo.x      = x      + offset[i];
     constInfo.lo     = lo     + offset[i];
@@ -176,7 +175,7 @@ void PGSLCPSolver::solve(ConstrainedGroup* _group)
   // Apply constraint impulses
   for (size_t i = 0; i < numConstraints; ++i)
   {
-    constraint = _group->getConstraint(i);
+    const ConstraintBasePtr& constraint = _group->getConstraint(i);
     constraint->applyImpulse(x + offset[i]);
     constraint->excite();
   }

--- a/dart/constraint/SmartPointer.h
+++ b/dart/constraint/SmartPointer.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016, Georgia Tech Research Corporation
+ * All rights reserved.
+ *
+ * Author(s): Michael X. Grey <mxgrey@gatech.edu>
+ *
+ * Georgia Tech Graphics Lab and Humanoid Robotics Lab
+ *
+ * Directed by Prof. C. Karen Liu and Prof. Mike Stilman
+ * <karenliu@cc.gatech.edu> <mstilman@cc.gatech.edu>
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES) LOSS OF
+ *   USE, DATA, OR PROFITS) OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_CONSTRAINT_SMARTPOINTER_H_
+#define DART_CONSTRAINT_SMARTPOINTER_H_
+
+#include "dart/common/SmartPointer.h"
+
+namespace dart {
+namespace constraint {
+
+DART_COMMON_MAKE_SHARED_WEAK(ConstrainedGroup)
+DART_COMMON_MAKE_SHARED_WEAK(ConstraintBase)
+DART_COMMON_MAKE_SHARED_WEAK(ClosedLoopConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(ContactConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(SoftContactConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(JointLimitConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(ServoMotorConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(JointCoulombFrictionConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(JointConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(LCPSolver)
+
+DART_COMMON_MAKE_SHARED_WEAK(BallJointConstraint)
+DART_COMMON_MAKE_SHARED_WEAK(WeldJointConstraint)
+
+DART_COMMON_MAKE_SHARED_WEAK(BalanceConstraint)
+
+} // namespace constraint
+} // namespace dart
+
+#endif // DART_CONSTRAINT_SMARTPOINTER_H_

--- a/dart/dynamics/SmartPointer.h
+++ b/dart/dynamics/SmartPointer.h
@@ -37,6 +37,7 @@
 #ifndef DART_DYNAMICS_SMARTPOINTER_H_
 #define DART_DYNAMICS_SMARTPOINTER_H_
 
+#include "dart/common/SmartPointer.h"
 #include "dart/dynamics/detail/BodyNodePtr.h"
 #include "dart/dynamics/detail/JointPtr.h"
 #include "dart/dynamics/detail/DegreeOfFreedomPtr.h"
@@ -52,22 +53,12 @@
 namespace dart {
 namespace dynamics {
 
-// -- Standard shared/weak pointers --
-// Define a typedef for const and non-const version of shared_ptr and weak_ptr
-// for the class X
-#define DART_DYNAMICS_MAKE_SHARED_WEAK( X )                 \
-  class X ;                                                 \
-  typedef std::shared_ptr< X >      X ## Ptr;               \
-  typedef std::shared_ptr< const X > Const ## X ## Ptr;     \
-  typedef std::weak_ptr< X >        Weak ## X ## Ptr;       \
-  typedef std::weak_ptr< const X >   WeakConst ## X ## Ptr;
-
-DART_DYNAMICS_MAKE_SHARED_WEAK(SimpleFrame)
+DART_COMMON_MAKE_SHARED_WEAK(SimpleFrame)
 
 //-----------------------------------------------------------------------------
 // Skeleton Smart Pointers
 //-----------------------------------------------------------------------------
-DART_DYNAMICS_MAKE_SHARED_WEAK(Skeleton)
+DART_COMMON_MAKE_SHARED_WEAK(Skeleton)
 // These pointers will take the form of:
 // std::shared_ptr<Skeleton>        --> SkeletonPtr
 // std::shared_ptr<const Skeleton>  --> ConstSkeletonPtr
@@ -75,29 +66,29 @@ DART_DYNAMICS_MAKE_SHARED_WEAK(Skeleton)
 // std::weak_ptr<const Skeleton>    --> WeakConstSkeletonPtr
 
 // MetaSkeleton smart pointers
-DART_DYNAMICS_MAKE_SHARED_WEAK(MetaSkeleton)
+DART_COMMON_MAKE_SHARED_WEAK(MetaSkeleton)
 
 // ReferentialSkeleton smart pointers
-DART_DYNAMICS_MAKE_SHARED_WEAK(ReferentialSkeleton)
+DART_COMMON_MAKE_SHARED_WEAK(ReferentialSkeleton)
 
-DART_DYNAMICS_MAKE_SHARED_WEAK(Group)
-DART_DYNAMICS_MAKE_SHARED_WEAK(Linkage)
-DART_DYNAMICS_MAKE_SHARED_WEAK(Branch)
-DART_DYNAMICS_MAKE_SHARED_WEAK(Chain)
+DART_COMMON_MAKE_SHARED_WEAK(Group)
+DART_COMMON_MAKE_SHARED_WEAK(Linkage)
+DART_COMMON_MAKE_SHARED_WEAK(Branch)
+DART_COMMON_MAKE_SHARED_WEAK(Chain)
 
 
 //-----------------------------------------------------------------------------
 // Shape Smart Pointers
 //-----------------------------------------------------------------------------
-DART_DYNAMICS_MAKE_SHARED_WEAK(Shape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(ArrowShape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(BoxShape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(CylinderShape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(EllipsoidShape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(LineSegmentShape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(MeshShape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(PlaneShape)
-DART_DYNAMICS_MAKE_SHARED_WEAK(SoftMeshShape)
+DART_COMMON_MAKE_SHARED_WEAK(Shape)
+DART_COMMON_MAKE_SHARED_WEAK(ArrowShape)
+DART_COMMON_MAKE_SHARED_WEAK(BoxShape)
+DART_COMMON_MAKE_SHARED_WEAK(CylinderShape)
+DART_COMMON_MAKE_SHARED_WEAK(EllipsoidShape)
+DART_COMMON_MAKE_SHARED_WEAK(LineSegmentShape)
+DART_COMMON_MAKE_SHARED_WEAK(MeshShape)
+DART_COMMON_MAKE_SHARED_WEAK(PlaneShape)
+DART_COMMON_MAKE_SHARED_WEAK(SoftMeshShape)
 
 
 //-----------------------------------------------------------------------------

--- a/docs/readthedocs/tutorials/collisions.md
+++ b/docs/readthedocs/tutorials/collisions.md
@@ -820,7 +820,7 @@ tail BodyNode.
 Now we have everything we need to construct the constraint:
 
 ```cpp
-auto constraint = new dart::constraint::BallJointConstraint(
+auto constraint = std::make_shared<dart::constraint::BallJointConstraint>(
       head, tail, offset);
 ```
 

--- a/docs/readthedocs/tutorials/multi-pendulum.md
+++ b/docs/readthedocs/tutorials/multi-pendulum.md
@@ -364,7 +364,8 @@ Eigen::Vector3d location =
 Now we can create the BallJointConstraint:
 
 ```cpp
-mBallConstraint = new dart::constraint::BallJointConstraint(tip, location);
+mBallConstraint =
+    std::make_shared<dart::constraint::BallJointConstraint>(tip, location);
 ```
 
 And then add it to the world:
@@ -378,12 +379,10 @@ Now we also want to be able to remove this constraint. In the function
 
 ```cpp
 mWorld->getConstraintSolver()->removeConstraint(mBallConstraint);
-delete mBallConstraint;
 mBallConstraint = nullptr;
 ```
 
-Currently DART does not use smart pointers for dynamic constraints, so they
-need to be explicitly deleted. This may be revised in a later version of DART.
+Setting mBallConstraint to a nullptr will allow its smart pointer to delete it.
 
 **Now you are ready to run the demo!**
 

--- a/tutorials/tutorialCollisions-Finished.cpp
+++ b/tutorials/tutorialCollisions-Finished.cpp
@@ -291,7 +291,7 @@ protected:
     // Compute the offset where the JointConstraint should be located
     Eigen::Vector3d offset = Eigen::Vector3d(0, 0, default_shape_height / 2.0);
     offset = tail->getWorldTransform() * offset;
-    auto constraint = new dart::constraint::BallJointConstraint(
+    auto constraint = std::make_shared<dart::constraint::BallJointConstraint>(
           head, tail, offset);
 
     mWorld->getConstraintSolver()->addConstraint(constraint);
@@ -304,13 +304,14 @@ protected:
   {
     for(size_t i=0; i<mJointConstraints.size(); ++i)
     {
-      dart::constraint::JointConstraint* constraint = mJointConstraints[i];
+      const dart::constraint::JointConstraintPtr& constraint =
+          mJointConstraints[i];
+
       if(constraint->getBodyNode1()->getSkeleton() == skel
          || constraint->getBodyNode2()->getSkeleton() == skel)
       {
         mWorld->getConstraintSolver()->removeConstraint(constraint);
         mJointConstraints.erase(mJointConstraints.begin()+i);
-        delete constraint;
         break; // There should only be one constraint per skeleton
       }
     }
@@ -328,7 +329,7 @@ protected:
 
   /// History of the active JointConstraints so that we can properly delete them
   /// when a Skeleton gets removed
-  std::vector<dart::constraint::JointConstraint*> mJointConstraints;
+  std::vector<dart::constraint::JointConstraintPtr> mJointConstraints;
 
   /// A blueprint Skeleton that we will use to spawn balls
   SkeletonPtr mOriginalBall;

--- a/tutorials/tutorialCollisions.cpp
+++ b/tutorials/tutorialCollisions.cpp
@@ -224,13 +224,14 @@ protected:
   {
     for(size_t i=0; i<mJointConstraints.size(); ++i)
     {
-      dart::constraint::JointConstraint* constraint = mJointConstraints[i];
+      const dart::constraint::JointConstraintPtr& constraint =
+          mJointConstraints[i];
+
       if(constraint->getBodyNode1()->getSkeleton() == skel
          || constraint->getBodyNode2()->getSkeleton() == skel)
       {
         mWorld->getConstraintSolver()->removeConstraint(constraint);
         mJointConstraints.erase(mJointConstraints.begin()+i);
-        delete constraint;
         break; // There should only be one constraint per skeleton
       }
     }
@@ -248,7 +249,7 @@ protected:
 
   /// History of the active JointConstraints so that we can properly delete them
   /// when a Skeleton gets removed
-  std::vector<dart::constraint::JointConstraint*> mJointConstraints;
+  std::vector<dart::constraint::JointConstraintPtr> mJointConstraints;
 
   /// A blueprint Skeleton that we will use to spawn balls
   SkeletonPtr mOriginalBall;

--- a/tutorials/tutorialMultiPendulum-Finished.cpp
+++ b/tutorials/tutorialMultiPendulum-Finished.cpp
@@ -160,7 +160,8 @@ public:
     // Attach the last link to the world
     Eigen::Vector3d location =
         tip->getTransform() * Eigen::Vector3d(0.0, 0.0, default_height);
-    mBallConstraint = new dart::constraint::BallJointConstraint(tip, location);
+    mBallConstraint =
+        std::make_shared<dart::constraint::BallJointConstraint>(tip, location);
     mWorld->getConstraintSolver()->addConstraint(mBallConstraint);
   }
 
@@ -168,7 +169,6 @@ public:
   void removeConstraint()
   {
     mWorld->getConstraintSolver()->removeConstraint(mBallConstraint);
-    delete mBallConstraint;
     mBallConstraint = nullptr;
   }
 
@@ -331,7 +331,7 @@ protected:
   SkeletonPtr mPendulum;
 
   /// Pointer to the ball constraint that we will be turning on and off
-  dart::constraint::BallJointConstraint* mBallConstraint;
+  dart::constraint::BallJointConstraintPtr mBallConstraint;
 
   /// Number of iterations before clearing a force entry
   std::vector<int> mForceCountDown;


### PR DESCRIPTION
This change is motivated by issue #583 where it was found that the ``ConstraintSolver`` class is leaking memory. Frequent deletion and creation of ``World`` objects can dramatically exacerbate the issue. By updating to use C++11 smart pointers, we should be able to eliminate these leaks.