### PR TITLE
Fixed segmentation fault for null meshes

### DIFF
--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -235,6 +235,9 @@ void ArrowShape::configureArrow(const Eigen::Vector3d& _tail,
   for(size_t i=0; i<4; ++i)
     for(size_t j=0; j<4; ++j)
       node->mTransformation[i][j] = tf(i,j);
+
+  _updateBoundingBoxDim();
+  updateVolume();
 }
 
 //==============================================================================

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -299,6 +299,14 @@ void MeshShape::updateVolume() {
 }
 
 void MeshShape::_updateBoundingBoxDim() {
+
+  if(!mMesh)
+  {
+    mBoundingBox.setMin(Eigen::Vector3d::Zero());
+    mBoundingBox.setMax(Eigen::Vector3d::Zero());
+    return;
+  }
+
   double max_X = -std::numeric_limits<double>::infinity();
   double max_Y = -std::numeric_limits<double>::infinity();
   double max_Z = -std::numeric_limits<double>::infinity();

--- a/dart/dynamics/MeshShape.h
+++ b/dart/dynamics/MeshShape.h
@@ -145,11 +145,9 @@ protected:
   // Documentation inherited.
   void updateVolume() override;
 
-private:
   /// \brief
   void _updateBoundingBoxDim();
 
-protected:
   /// \brief
   const aiScene* mMesh;
 


### PR DESCRIPTION
I found that there is a risk of segmentation fault for meshes that are not immediately initialized. It occurs when the Mesh::_updateBoundingBoxDim function is called. This pull request fixes this issue, and adds some more initialization for ``ArrowShape``.