### PR TITLE
Implement missing implementation in ConstrainedGroup

### DIFF
--- a/dart/constraint/ConstrainedGroup.cpp
+++ b/dart/constraint/ConstrainedGroup.cpp
@@ -100,12 +100,14 @@ void ConstrainedGroup::removeAllConstraints()
 }
 
 //==============================================================================
+#ifndef NDEBUG
 bool ConstrainedGroup::containConstraint(
     const ConstConstraintBasePtr& _constraint) const
 {
   return std::find(mConstraints.begin(), mConstraints.end(), _constraint)
       != mConstraints.end();
 }
+#endif
 
 //==============================================================================
 size_t ConstrainedGroup::getTotalDimension() const

--- a/dart/constraint/ConstrainedGroup.cpp
+++ b/dart/constraint/ConstrainedGroup.cpp
@@ -61,7 +61,7 @@ ConstrainedGroup::~ConstrainedGroup()
 void ConstrainedGroup::addConstraint(const ConstraintBasePtr& _constraint)
 {
   assert(_constraint != nullptr && "Attempted to add nullptr.");
-  assert(containConstraint(_constraint) == false
+  assert(!containConstraint(_constraint)
          && "Attempted to add a duplicate constraint.");
   assert(_constraint->isActive());
 
@@ -105,17 +105,6 @@ bool ConstrainedGroup::containConstraint(
 {
   return std::find(mConstraints.begin(), mConstraints.end(), _constraint)
       != mConstraints.end();
-}
-
-//==============================================================================
-bool ConstrainedGroup::checkAndAddConstraint(
-    const ConstraintBasePtr& _constraint)
-{
-  if (containConstraint(_constraint))
-    return false;
-
-  addConstraint(_constraint);
-  return true;
 }
 
 //==============================================================================

--- a/dart/constraint/ConstrainedGroup.cpp
+++ b/dart/constraint/ConstrainedGroup.cpp
@@ -36,6 +36,7 @@
 
 #include "dart/constraint/ConstrainedGroup.h"
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
@@ -59,9 +60,9 @@ ConstrainedGroup::~ConstrainedGroup()
 //==============================================================================
 void ConstrainedGroup::addConstraint(const ConstraintBasePtr& _constraint)
 {
-  assert(_constraint != nullptr && "Null constraint pointer is now allowed.");
+  assert(_constraint != nullptr && "Attempted to add nullptr.");
   assert(containConstraint(_constraint) == false
-         && "Don't try to add same constraint multiple times into Community.");
+         && "Attempted to add a duplicate constraint.");
   assert(_constraint->isActive());
 
   mConstraints.push_back(_constraint);
@@ -83,9 +84,9 @@ ConstraintBasePtr ConstrainedGroup::getConstraint(size_t _index) const
 //==============================================================================
 void ConstrainedGroup::removeConstraint(const ConstraintBasePtr& _constraint)
 {
-  assert(_constraint != nullptr && "Null constraint pointer is now allowed.");
-  assert(containConstraint(_constraint) == true
-         && "Don't try to remove a constraint not contained in Community.");
+  assert(_constraint != nullptr && "Attempted to add nullptr.");
+  assert(containConstraint(_constraint)
+         && "Attempted to remove not existing constraint.");
 
   mConstraints.erase(
         remove(mConstraints.begin(), mConstraints.end(), _constraint),
@@ -95,15 +96,6 @@ void ConstrainedGroup::removeConstraint(const ConstraintBasePtr& _constraint)
 //==============================================================================
 void ConstrainedGroup::removeAllConstraints()
 {
-//  dtwarn << "ConstrainedGroup::removeAllConstraints(): "
-//         << "Not implemented." << std::endl;
-
-  // TODO(JS): Temporary implementation
-//  for (size_t i = 0; i < mConstraints.size(); ++i)
-//  {
-//    delete mConstraints[i];
-//  }
-
   mConstraints.clear();
 }
 
@@ -111,22 +103,19 @@ void ConstrainedGroup::removeAllConstraints()
 bool ConstrainedGroup::containConstraint(
     const ConstConstraintBasePtr& _constraint) const
 {
-//  std::cout << "CommunityTEST::_containConstraint(): Not implemented."
-//            << std::endl;
-
-  // TODO(MXG): Is there any reason these functions are not implemented yet?
-
-  return false;
+  return std::find(mConstraints.begin(), mConstraints.end(), _constraint)
+      != mConstraints.end();
 }
 
 //==============================================================================
 bool ConstrainedGroup::checkAndAddConstraint(
     const ConstraintBasePtr& _constraint)
 {
-  std::cout << "CommunityTEST::_checkAndAddConstraint(): Not implemented."
-            << std::endl;
+  if (containConstraint(_constraint))
+    return false;
 
-  return false;
+  addConstraint(_constraint);
+  return true;
 }
 
 //==============================================================================

--- a/dart/constraint/ConstrainedGroup.h
+++ b/dart/constraint/ConstrainedGroup.h
@@ -100,11 +100,10 @@ public:
   friend class ConstraintSolver;
 
 private:
+#ifndef NDEBUG
   /// Return true if _constraint is contained
   bool containConstraint(const ConstConstraintBasePtr& _constraint) const;
-
-  /// Return true and add the constraint if _constraint is contained
-  bool checkAndAddConstraint(const ConstraintBasePtr& _constraint);
+#endif
 
   /// List of constraints
   std::vector<ConstraintBasePtr> mConstraints;


### PR DESCRIPTION
This pull request implements a missing implementation in ConstrainedGroup as reported in #584 and removes a private method ConstrainedGroup::checkAndAddConstraint() as it's not being called anywhere. Also, this makes ConstrainedGroup::containConstraint() to be compiled only in debug mode.