### PR TITLE
Changing authority of Optional/Required Addons

### DIFF
--- a/dart/common/Addon.h
+++ b/dart/common/Addon.h
@@ -111,19 +111,6 @@ public:
   /// which implies that the Addon has no properties.
   virtual const Properties* getAddonProperties() const;
 
-  /// This function will be called if the user is attempting to delete the Addon
-  /// but not immediately replacing it with another Addon of the same type. The
-  /// incoming argument will point to the AddonManager that had been holding
-  /// this Addon.
-  ///
-  /// If your Addon is mandatory for the AddonManager type that is passed in
-  /// here, then you should perform error handling in this function, and you
-  /// should return false to indicate that the operation is not permitted. If
-  /// you return false, then the Addon will NOT be removed from its Manager.
-  ///
-  /// By default, this simply returns true.
-  virtual bool isOptional(AddonManager* oldManager);
-
 protected:
 
   /// Constructor

--- a/dart/common/AddonManager.h
+++ b/dart/common/AddonManager.h
@@ -38,6 +38,7 @@
 #define DART_COMMON_ADDONMANAGER_H_
 
 #include <map>
+#include <unordered_set>
 #include <typeinfo>
 #include <typeindex>
 
@@ -54,27 +55,8 @@ namespace common {
 /// on average in log(N) time. Most often, a class that accepts Addons will have
 /// certain Addon types that it will need to access frequently, and it would be
 /// beneficial to have constant-time access to those Addon types. To get
-/// constant-time access to specific Addon types, there are FOUR macros that you
-/// should use in your derived class:
-///
-/// DART_ENABLE_ADDON_SPECIALIZATION() must be declared once in the derived
-/// class's definition, under a 'public:' declaration range.
-///
-/// DART_SPECIALIZE_ADDON_INTERNAL( AddonType ) must be declared once for each
-/// AddonType that you want to specialize. It should be placed in the derived
-/// class's definition, under a 'public:' declaration range.
-///
-/// DART_SPECIALIZE_ADDON_EXTERNAL( Derived, AddonType ) must be declared once
-/// for each AddonType that you want to specialize. It should be placed
-/// immediately after the class's definition in the same header file as the
-/// derived class, inside of the same namespace as the derived class. This macro
-/// defines a series of templated functions, so it should go in a header, and
-/// not in a source file.
-///
-/// DART_INSTANTIATE_SPECIALIZED_ADDON( AddonType ) must be declared once for
-/// each AddonType that you want to specialize. It should be placed inside the
-/// constructor of the derived class, preferably before anything else is done
-/// inside the body of the constructor.
+/// constant-time access to specific Addon types, you can use the templated
+/// class SpecializedAddonManager.
 class AddonManager
 {
 public:
@@ -86,9 +68,20 @@ public:
   using Properties = ExtensibleMapHolder<PropertiesMap>;
 
   using AddonMap = std::map< std::type_index, std::unique_ptr<Addon> >;
+  using RequiredAddonSet = std::unordered_set<std::type_index>;
 
   /// Virtual destructor
   virtual ~AddonManager() = default;
+
+  /// Default constructor
+  AddonManager() = default;
+
+  /// It is currently unsafe to copy an AddonManager
+  // TODO(MXG): Consider making this safe by cloning Addons into the new copy
+  AddonManager(const AddonManager&) = delete;
+
+  /// It is currently unsafe to move an AddonManager
+  AddonManager(AddonManager&&) = delete;
 
   /// Check if this AddonManager currently has a certain type of Addon
   template <class T>
@@ -134,6 +127,10 @@ public:
   template <class T>
   static constexpr bool isSpecializedFor();
 
+  /// Check if this Manager requires this specific type of Addon
+  template <class T>
+  bool requires() const;
+
   /// Set the states of the addons in this AddonManager based on the given
   /// AddonManager::State. The states of any Addon types that do not exist
   /// within this manager will be ignored.
@@ -175,6 +172,10 @@ protected:
 
   /// A map that relates the type of Addon to its pointer
   AddonMap mAddonMap;
+
+  /// A set containing type information for Addons which are not allowed to
+  /// leave this manager.
+  RequiredAddonSet mRequiredAddons;
 };
 
 } // namespace common

--- a/dart/common/AddonManager.h
+++ b/dart/common/AddonManager.h
@@ -56,7 +56,7 @@ namespace common {
 /// certain Addon types that it will need to access frequently, and it would be
 /// beneficial to have constant-time access to those Addon types. To get
 /// constant-time access to specific Addon types, you can use the templated
-/// class SpecializedAddonManager.
+/// class SpecializedForAddon.
 class AddonManager
 {
 public:

--- a/dart/common/AddonManagerJoiner.h
+++ b/dart/common/AddonManagerJoiner.h
@@ -52,9 +52,9 @@ template <class Base1>
 class AddonManagerJoiner<Base1> : public Base1 { };
 
 /// AddonManagerJoiner allows classes that inherit from various
-/// SpecializedAddonManager types to be inherited by a single derived class.
+/// SpecializedForAddon types to be inherited by a single derived class.
 /// This class solves the diamond-of-death problem for multiple
-/// SpecializedAddonManager inheritance.
+/// SpecializedForAddon inheritance.
 template <class Base1, class Base2>
 class AddonManagerJoiner<Base1, Base2> : public Base1, public Base2
 {

--- a/dart/common/RequiresAddon.h
+++ b/dart/common/RequiresAddon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Georgia Tech Research Corporation
  * All rights reserved.
  *
  * Author(s): Michael X. Grey <mxgrey@gatech.edu>
@@ -34,74 +34,44 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_DYNAMICS_DETAIL_EULERJOINTPROPERTIES_H_
-#define DART_DYNAMICS_DETAIL_EULERJOINTPROPERTIES_H_
+#ifndef DART_COMMON_REQUIRESADDON_H_
+#define DART_COMMON_REQUIRESADDON_H_
 
-#include <string>
-
-#include "dart/dynamics/MultiDofJoint.h"
-#include "dart/dynamics/Addon.h"
+#include "dart/common/SpecializedAddonManager.h"
 
 namespace dart {
-namespace dynamics {
-
-class EulerJoint;
-
-namespace detail {
+namespace common {
 
 //==============================================================================
-/// Axis order
-enum class AxisOrder : int
-{
-  ZYX = 0,
-  XYZ = 1
-};
+/// RequiresAddon allows classes that inherit AddonManager to know which Addons
+/// are required for their operation. This guarantees that there is no way for
+/// a required Addon do not get unexpectedly removed from their manager.
+///
+/// Required Addons are also automatically specialized for.
+template <class... OtherRequiredAddons>
+class RequiresAddon { };
 
 //==============================================================================
-struct EulerJointUniqueProperties
-{
-  /// Euler angle order
-  AxisOrder mAxisOrder;
-
-  /// Constructor
-  EulerJointUniqueProperties(AxisOrder _axisOrder = AxisOrder::XYZ);
-
-  virtual ~EulerJointUniqueProperties() = default;
-};
-
-//==============================================================================
-struct EulerJointProperties :
-    MultiDofJoint<3>::Properties,
-    EulerJointUniqueProperties
-{
-  /// Composed constructor
-  EulerJointProperties(
-      const MultiDofJoint<3>::Properties& _multiDofProperties =
-          MultiDofJoint<3>::Properties(),
-      const EulerJointUniqueProperties& _eulerJointProperties =
-          EulerJointUniqueProperties());
-
-  virtual ~EulerJointProperties() = default;
-};
-
-//==============================================================================
-class EulerJointAddon final :
-    public AddonWithProtectedPropertiesInSkeleton<
-        EulerJointAddon, EulerJointUniqueProperties, EulerJoint,
-        detail::JointPropertyUpdate<EulerJointAddon> >
+template <class ReqAddon>
+class RequiresAddon<ReqAddon> : public virtual SpecializedAddonManager<ReqAddon>
 {
 public:
-  DART_DYNAMICS_JOINT_ADDON_CONSTRUCTOR( EulerJointAddon )
-  DART_DYNAMICS_SET_GET_ADDON_PROPERTY( AxisOrder, AxisOrder )
+
+  /// Default constructor. This is where the base AddonManager is informed that
+  /// the Addon type is required.
+  RequiresAddon();
+
 };
 
 //==============================================================================
-using EulerJointBase = common::AddonManagerJoiner<
-    MultiDofJoint<3>, common::RequiresAddon<EulerJointAddon> >;
+template <class ReqAddon1, class... OtherReqAddons>
+class RequiresAddon<ReqAddon1, OtherReqAddons...> :
+    public AddonManagerJoiner< Virtual< RequiresAddon<ReqAddon1> >,
+                               Virtual< RequiresAddon<OtherReqAddons...> > > { };
 
-} // namespace detail
-} // namespace dynamics
+} // namespace common
 } // namespace dart
 
+#include "dart/common/detail/RequiresAddon.h"
 
-#endif // DART_DYNAMICS_DETAIL_EULERJOINTPROPERTIES_H_
+#endif // DART_COMMON_REQUIRESADDON_H_

--- a/dart/common/RequiresAddon.h
+++ b/dart/common/RequiresAddon.h
@@ -37,7 +37,7 @@
 #ifndef DART_COMMON_REQUIRESADDON_H_
 #define DART_COMMON_REQUIRESADDON_H_
 
-#include "dart/common/SpecializedAddonManager.h"
+#include "dart/common/SpecializedForAddon.h"
 
 namespace dart {
 namespace common {
@@ -53,7 +53,7 @@ class RequiresAddon { };
 
 //==============================================================================
 template <class ReqAddon>
-class RequiresAddon<ReqAddon> : public virtual SpecializedAddonManager<ReqAddon>
+class RequiresAddon<ReqAddon> : public virtual SpecializedForAddon<ReqAddon>
 {
 public:
 

--- a/dart/common/SpecializedForAddon.h
+++ b/dart/common/SpecializedForAddon.h
@@ -46,18 +46,18 @@ namespace common {
 
 /// Declaration of the variadic template
 template <class... OtherSpecAddons>
-class SpecializedAddonManager { };
+class SpecializedForAddon { };
 
 //==============================================================================
-/// SpecializedAddonManager allows classes that inherit AddonManager to have
+/// SpecializedForAddon allows classes that inherit AddonManager to have
 /// constant-time access to a specific type of Addon
 template <class SpecAddon>
-class SpecializedAddonManager<SpecAddon> : public virtual AddonManager
+class SpecializedForAddon<SpecAddon> : public virtual AddonManager
 {
 public:
 
   /// Default Constructor
-  SpecializedAddonManager();
+  SpecializedForAddon();
 
   /// Check if this AddonManager currently has a certain type of Addon
   template <class T>
@@ -173,23 +173,23 @@ protected:
   /// Return true
   static constexpr bool _isSpecializedFor(type<SpecAddon>);
 
-  /// Iterator that points to the Addon of this SpecializedAddonManager
+  /// Iterator that points to the Addon of this SpecializedForAddon
   AddonManager::AddonMap::iterator mSpecAddonIterator;
 
 };
 
 //==============================================================================
-/// This is the variadic version of the SpecializedAddonManager class which
+/// This is the variadic version of the SpecializedForAddon class which
 /// allows you to include arbitrarily many specialized types in the
 /// specialization.
 template <class SpecAddon1, class... OtherSpecAddons>
-class SpecializedAddonManager<SpecAddon1, OtherSpecAddons...> :
-    public AddonManagerJoiner< Virtual< SpecializedAddonManager<SpecAddon1> >,
-                               Virtual< SpecializedAddonManager<OtherSpecAddons...> > > { };
+class SpecializedForAddon<SpecAddon1, OtherSpecAddons...> :
+    public AddonManagerJoiner< Virtual< SpecializedForAddon<SpecAddon1> >,
+                               Virtual< SpecializedForAddon<OtherSpecAddons...> > > { };
 
 } // namespace common
 } // namespace dart
 
-#include "dart/common/detail/SpecializedAddonManager.h"
+#include "dart/common/detail/SpecializedForAddon.h"
 
 #endif // DART_COMMON_SPECIALIZEDADDONMANAGER_H_

--- a/dart/common/detail/RequiresAddon.h
+++ b/dart/common/detail/RequiresAddon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Georgia Tech Research Corporation
  * All rights reserved.
  *
  * Author(s): Michael X. Grey <mxgrey@gatech.edu>
@@ -34,56 +34,22 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cassert>
-#include <string>
-#include <iostream>
+#ifndef DART_COMMON_DETAIL_REQUIRESADDON_H_
+#define DART_COMMON_DETAIL_REQUIRESADDON_H_
 
-#include "dart/common/Addon.h"
-#include "dart/common/Console.h"
+#include "dart/common/RequiresAddon.h"
 
 namespace dart {
 namespace common {
 
 //==============================================================================
-void Addon::setAddonState(const State& /*otherState*/)
+template <class ReqAddon>
+RequiresAddon<ReqAddon>::RequiresAddon()
 {
-  // Do nothing
-}
-
-//==============================================================================
-const Addon::State* Addon::getAddonState() const
-{
-  return nullptr;
-}
-
-//==============================================================================
-void Addon::setAddonProperties(const Properties& /*someProperties*/)
-{
-  // Do nothing
-}
-
-//==============================================================================
-const Addon::Properties* Addon::getAddonProperties() const
-{
-  return nullptr;
-}
-
-//==============================================================================
-Addon::Addon(AddonManager* manager)
-{
-  if(nullptr == manager)
-  {
-    dterr << "[Addon::constructor] You are not allowed to construct an Addon "
-          << "outside of an AddonManager!\n";
-    assert(false);
-  }
-}
-
-//==============================================================================
-void Addon::setManager(AddonManager* /*newManager*/, bool /*transfer*/)
-{
-  // Do nothing
+  AddonManager::mRequiredAddons.insert(typeid(ReqAddon));
 }
 
 } // namespace common
 } // namespace dart
+
+#endif // DART_COMMON_DETAIL_REQUIRESADDON_H_

--- a/dart/common/detail/SpecializedAddonManager.h
+++ b/dart/common/detail/SpecializedAddonManager.h
@@ -280,7 +280,7 @@ void SpecializedAddonManager<SpecAddon>::_erase(type<SpecAddon>)
   usedSpecializedAddonAccess = true;
 #endif // DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
 
-  DART_COMMON_CHECK_ILLEGAL_ADDON_ERASE(erase, mSpecAddonIterator, DART_BLANK);
+  DART_COMMON_CHECK_ILLEGAL_ADDON_ERASE(erase, SpecAddon, DART_BLANK);
   mSpecAddonIterator->second = nullptr;
 }
 
@@ -301,7 +301,7 @@ std::unique_ptr<SpecAddon> SpecializedAddonManager<SpecAddon>::_release(
   usedSpecializedAddonAccess = true;
 #endif // DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
 
-  DART_COMMON_CHECK_ILLEGAL_ADDON_ERASE(release, mSpecAddonIterator, nullptr);
+  DART_COMMON_CHECK_ILLEGAL_ADDON_ERASE(release, SpecAddon, nullptr);
   std::unique_ptr<SpecAddon> extraction(
         static_cast<SpecAddon*>(mSpecAddonIterator->second.release()));
 

--- a/dart/common/detail/SpecializedForAddon.h
+++ b/dart/common/detail/SpecializedForAddon.h
@@ -37,7 +37,7 @@
 #ifndef DART_COMMON_DETAIL_SPECIALIZEDADDONMANAGER_H_
 #define DART_COMMON_DETAIL_SPECIALIZEDADDONMANAGER_H_
 
-#include "dart/common/SpecializedAddonManager.h"
+#include "dart/common/SpecializedForAddon.h"
 
 // This preprocessor token should only be used by the unittest that is
 // responsible for checking that the specialized routines are being used to
@@ -51,7 +51,7 @@ namespace common {
 
 //==============================================================================
 template <class SpecAddon>
-SpecializedAddonManager<SpecAddon>::SpecializedAddonManager()
+SpecializedForAddon<SpecAddon>::SpecializedForAddon()
 {
   mAddonMap[typeid( SpecAddon )] = nullptr;
   mSpecAddonIterator = mAddonMap.find(typeid( SpecAddon ));
@@ -60,7 +60,7 @@ SpecializedAddonManager<SpecAddon>::SpecializedAddonManager()
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-bool SpecializedAddonManager<SpecAddon>::has() const
+bool SpecializedForAddon<SpecAddon>::has() const
 {
   return _has(type<T>());
 }
@@ -68,7 +68,7 @@ bool SpecializedAddonManager<SpecAddon>::has() const
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-T* SpecializedAddonManager<SpecAddon>::get()
+T* SpecializedForAddon<SpecAddon>::get()
 {
   return _get(type<T>());
 }
@@ -76,7 +76,7 @@ T* SpecializedAddonManager<SpecAddon>::get()
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-const T* SpecializedAddonManager<SpecAddon>::get() const
+const T* SpecializedForAddon<SpecAddon>::get() const
 {
   return _get(type<T>());
 }
@@ -84,7 +84,7 @@ const T* SpecializedAddonManager<SpecAddon>::get() const
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-void SpecializedAddonManager<SpecAddon>::set(const T* addon)
+void SpecializedForAddon<SpecAddon>::set(const T* addon)
 {
   _set(type<T>(), addon);
 }
@@ -92,7 +92,7 @@ void SpecializedAddonManager<SpecAddon>::set(const T* addon)
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-void SpecializedAddonManager<SpecAddon>::set(std::unique_ptr<T>&& addon)
+void SpecializedForAddon<SpecAddon>::set(std::unique_ptr<T>&& addon)
 {
   _set(type<T>(), std::move(addon));
 }
@@ -100,7 +100,7 @@ void SpecializedAddonManager<SpecAddon>::set(std::unique_ptr<T>&& addon)
 //==============================================================================
 template <class SpecAddon>
 template <class T, typename ...Args>
-T* SpecializedAddonManager<SpecAddon>::create(Args&&... args)
+T* SpecializedForAddon<SpecAddon>::create(Args&&... args)
 {
   return _create(type<T>(), std::forward<Args>(args)...);
 }
@@ -108,7 +108,7 @@ T* SpecializedAddonManager<SpecAddon>::create(Args&&... args)
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-void SpecializedAddonManager<SpecAddon>::erase()
+void SpecializedForAddon<SpecAddon>::erase()
 {
   _erase(type<T>());
 }
@@ -116,7 +116,7 @@ void SpecializedAddonManager<SpecAddon>::erase()
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-std::unique_ptr<T> SpecializedAddonManager<SpecAddon>::release()
+std::unique_ptr<T> SpecializedForAddon<SpecAddon>::release()
 {
   return _release(type<T>());
 }
@@ -124,7 +124,7 @@ std::unique_ptr<T> SpecializedAddonManager<SpecAddon>::release()
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-constexpr bool SpecializedAddonManager<SpecAddon>::isSpecializedFor()
+constexpr bool SpecializedForAddon<SpecAddon>::isSpecializedFor()
 {
   return _isSpecializedFor(type<T>());
 }
@@ -132,7 +132,7 @@ constexpr bool SpecializedAddonManager<SpecAddon>::isSpecializedFor()
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-bool SpecializedAddonManager<SpecAddon>::_has(type<T>) const
+bool SpecializedForAddon<SpecAddon>::_has(type<T>) const
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
   usedSpecializedAddonAccess = true;
@@ -143,7 +143,7 @@ bool SpecializedAddonManager<SpecAddon>::_has(type<T>) const
 
 //==============================================================================
 template <class SpecAddon>
-bool SpecializedAddonManager<SpecAddon>::_has(type<SpecAddon>) const
+bool SpecializedForAddon<SpecAddon>::_has(type<SpecAddon>) const
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
   usedSpecializedAddonAccess = true;
@@ -155,14 +155,14 @@ bool SpecializedAddonManager<SpecAddon>::_has(type<SpecAddon>) const
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-T* SpecializedAddonManager<SpecAddon>::_get(type<T>)
+T* SpecializedForAddon<SpecAddon>::_get(type<T>)
 {
   return AddonManager::get<T>();
 }
 
 //==============================================================================
 template <class SpecAddon>
-SpecAddon* SpecializedAddonManager<SpecAddon>::_get(type<SpecAddon>)
+SpecAddon* SpecializedForAddon<SpecAddon>::_get(type<SpecAddon>)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
   usedSpecializedAddonAccess = true;
@@ -174,14 +174,14 @@ SpecAddon* SpecializedAddonManager<SpecAddon>::_get(type<SpecAddon>)
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-const T* SpecializedAddonManager<SpecAddon>::_get(type<T>) const
+const T* SpecializedForAddon<SpecAddon>::_get(type<T>) const
 {
   return AddonManager::get<T>();
 }
 
 //==============================================================================
 template <class SpecAddon>
-const SpecAddon* SpecializedAddonManager<SpecAddon>::_get(type<SpecAddon>) const
+const SpecAddon* SpecializedForAddon<SpecAddon>::_get(type<SpecAddon>) const
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
   usedSpecializedAddonAccess = true;
@@ -193,14 +193,14 @@ const SpecAddon* SpecializedAddonManager<SpecAddon>::_get(type<SpecAddon>) const
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-void SpecializedAddonManager<SpecAddon>::_set(type<T>, const T* addon)
+void SpecializedForAddon<SpecAddon>::_set(type<T>, const T* addon)
 {
   AddonManager::set<T>(addon);
 }
 
 //==============================================================================
 template <class SpecAddon>
-void SpecializedAddonManager<SpecAddon>::_set(
+void SpecializedForAddon<SpecAddon>::_set(
     type<SpecAddon>, const SpecAddon* addon)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
@@ -221,14 +221,14 @@ void SpecializedAddonManager<SpecAddon>::_set(
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-void SpecializedAddonManager<SpecAddon>::_set(type<T>, std::unique_ptr<T>&& addon)
+void SpecializedForAddon<SpecAddon>::_set(type<T>, std::unique_ptr<T>&& addon)
 {
   AddonManager::set<T>(std::move(addon));
 }
 
 //==============================================================================
 template <class SpecAddon>
-void SpecializedAddonManager<SpecAddon>::_set(
+void SpecializedForAddon<SpecAddon>::_set(
     type<SpecAddon>, std::unique_ptr<SpecAddon>&& addon)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
@@ -242,7 +242,7 @@ void SpecializedAddonManager<SpecAddon>::_set(
 //==============================================================================
 template <class SpecAddon>
 template <class T, typename ...Args>
-T* SpecializedAddonManager<SpecAddon>::_create(type<T>, Args&&... args)
+T* SpecializedForAddon<SpecAddon>::_create(type<T>, Args&&... args)
 {
   return AddonManager::create<T>(std::forward<Args>(args)...);
 }
@@ -250,7 +250,7 @@ T* SpecializedAddonManager<SpecAddon>::_create(type<T>, Args&&... args)
 //==============================================================================
 template <class SpecAddon>
 template <typename ...Args>
-SpecAddon* SpecializedAddonManager<SpecAddon>::_create(
+SpecAddon* SpecializedForAddon<SpecAddon>::_create(
     type<SpecAddon>, Args&&... args)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
@@ -267,14 +267,14 @@ SpecAddon* SpecializedAddonManager<SpecAddon>::_create(
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-void SpecializedAddonManager<SpecAddon>::_erase(type<T>)
+void SpecializedForAddon<SpecAddon>::_erase(type<T>)
 {
   AddonManager::erase<T>();
 }
 
 //==============================================================================
 template <class SpecAddon>
-void SpecializedAddonManager<SpecAddon>::_erase(type<SpecAddon>)
+void SpecializedForAddon<SpecAddon>::_erase(type<SpecAddon>)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
   usedSpecializedAddonAccess = true;
@@ -287,14 +287,14 @@ void SpecializedAddonManager<SpecAddon>::_erase(type<SpecAddon>)
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-std::unique_ptr<T> SpecializedAddonManager<SpecAddon>::_release(type<T>)
+std::unique_ptr<T> SpecializedForAddon<SpecAddon>::_release(type<T>)
 {
   return AddonManager::release<T>();
 }
 
 //==============================================================================
 template <class SpecAddon>
-std::unique_ptr<SpecAddon> SpecializedAddonManager<SpecAddon>::_release(
+std::unique_ptr<SpecAddon> SpecializedForAddon<SpecAddon>::_release(
     type<SpecAddon>)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_ADDON_ACCESS
@@ -311,14 +311,14 @@ std::unique_ptr<SpecAddon> SpecializedAddonManager<SpecAddon>::_release(
 //==============================================================================
 template <class SpecAddon>
 template <class T>
-constexpr bool SpecializedAddonManager<SpecAddon>::_isSpecializedFor(type<T>)
+constexpr bool SpecializedForAddon<SpecAddon>::_isSpecializedFor(type<T>)
 {
   return false;
 }
 
 //==============================================================================
 template <class SpecAddon>
-constexpr bool SpecializedAddonManager<SpecAddon>::_isSpecializedFor(type<SpecAddon>)
+constexpr bool SpecializedForAddon<SpecAddon>::_isSpecializedFor(type<SpecAddon>)
 {
   return true;
 }

--- a/dart/dynamics/Addon.h
+++ b/dart/dynamics/Addon.h
@@ -310,52 +310,6 @@ protected:
 #define DART_DYNAMICS_SET_GET_MULTIDOF_ADDON( SingleType, VectorType, SingleName )\
   DART_DYNAMICS_IRREGULAR_SET_GET_MULTIDOF_ADDON( SingleType, VectorType, SingleName, SingleName ## s )
 
-//==============================================================================
-#define DETAIL_DART_ADDON_PROPERTIES_UPDATE( AddonName, GetAddon )\
-  AddonName :: UpdateProperties( GetAddon () );\
-  GetAddon ()->incrementSkeletonVersion();
-
-//==============================================================================
-#define DETAIL_DART_ADDON_STATE_PROPERTIES_UPDATE( AddonName, GetAddon )\
-  AddonName :: UpdateState( GetAddon () );\
-  DETAIL_DART_ADDON_PROPERTIES_UPDATE( AddonName, GetAddon );
-
-//==============================================================================
-// Used for Addons that have Properties (but no State) inside of a Skeleton
-#define DART_DYNAMICS_SKEL_PROPERTIES_ADDON_INLINE( AddonName )\
-  DETAIL_DART_SPECIALIZED_ADDON_INLINE( AddonName,\
-      DETAIL_DART_ADDON_PROPERTIES_UPDATE( AddonName, get ## AddonName ) )
-
-//==============================================================================
-// Used for Addons that have both State and Properties inside of a Skeleton
-#define DART_DYNAMICS_SKEL_ADDON_INLINE( AddonName )\
-  DETAIL_DART_SPECIALIZED_ADDON_INLINE( AddonName,\
-      DETAIL_DART_ADDON_STATE_PROPERTIES_UPDATE( AddonName, get ## AddonName ) )
-
-//==============================================================================
-// Used for edge cases, such as nested template classes, that have Properties
-// (but no State) inside of a Skeleton
-#define DART_DYNAMICS_IRREGULAR_SKEL_PROPERTIES_ADDON_INLINE( TypeName, HomogenizedName )\
-  DETAIL_DART_IRREGULAR_SPECIALIZED_ADDON_INLINE( TypeName, HomogenizedName,\
-    DETAIL_DART_ADDON_PROPERTIES_UPDATE( TypeName, get ## HomogenizedName ) )
-
-//==============================================================================
-// Used for edge cases, such as nested template classes, that have both State
-// and Properties inside of a Skeleton
-#define DART_DYNAMICS_IRREGULAR_SKEL_ADDON_INLINE( TypeName, HomogenizedName )\
-  DETAIL_DART_IRREGULAR_SPECIALIZED_ADDON_INLINE( TypeName, HomogenizedName,\
-    DETAIL_DART_ADDON_STATE_PROPERTIES_UPDATE( TypeName, get ## HomogenizedName ) )
-
-//==============================================================================
-// Used for nested-class Addons that have Properties (but no State) inside of a Skeleton
-#define DART_DYNAMICS_NESTED_SKEL_PROPERTIES_ADDON_INLINE( ParentName, AddonName )\
-  DART_DYNAMICS_IRREGULAR_SKEL_PROPERTIES_ADDON_INLINE( ParentName :: AddonName, ParentName ## AddonName )
-
-//==============================================================================
-// Used for nested-class Addons that have both State and Properties inside of a Skeleton
-#define DART_DYNAMICS_NESTED_SKEL_ADDON_INLINE( ParentName, AddonName )\
-  DART_DYNAMICS_IRREGULAR_SKEL_ADDON_INLINE( ParentName :: AddonName, ParentName ## AddonName )
-
 #include "dart/dynamics/Skeleton.h"
 #include "dart/dynamics/detail/Addon.h"
 

--- a/dart/dynamics/Addon.h
+++ b/dart/dynamics/Addon.h
@@ -50,8 +50,7 @@ namespace dynamics {
 /// Node class). This will increment the version count any time the
 /// Addon::setProperties function is called.
 template <class BaseT, typename PropertiesDataT, class ManagerT = Node,
-          void (*updateProperties)(BaseT*) = common::detail::NoOp<BaseT*>,
-          bool OptionalT = true>
+          void (*updateProperties)(BaseT*) = common::detail::NoOp<BaseT*> >
 class AddonWithProtectedPropertiesInSkeleton : public common::Addon
 {
 public:
@@ -61,10 +60,9 @@ public:
   using ManagerType = ManagerT;
   using Properties = common::Addon::PropertiesMixer<PropertiesData>;
   constexpr static void (*UpdateProperties)(Base*) = updateProperties;
-  constexpr static bool Optional = OptionalT;
 
   using Implementation = AddonWithProtectedPropertiesInSkeleton<
-      BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>;
+      BaseT, PropertiesDataT, ManagerT, updateProperties>;
 
   AddonWithProtectedPropertiesInSkeleton() = delete;
   AddonWithProtectedPropertiesInSkeleton(
@@ -90,9 +88,6 @@ public:
 
   /// Get the Properties of this Addon
   const Properties& getProperties() const;
-
-  // Documentation inherited
-  bool isOptional(common::AddonManager* oldManager) override final;
 
   /// Get the Skeleton that this Addon is embedded in
   SkeletonPtr getSkeleton();
@@ -131,8 +126,7 @@ protected:
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT = Node,
           void (*updateState)(BaseT*) = &common::detail::NoOp<BaseT*>,
-          void (*updateProperties)(BaseT*) = updateState,
-          bool OptionalT = true>
+          void (*updateProperties)(BaseT*) = updateState>
 class AddonWithProtectedStateAndPropertiesInSkeleton : public common::Addon
 {
 public:
@@ -145,7 +139,6 @@ public:
   using Properties = common::Addon::PropertiesMixer<PropertiesData>;
   constexpr static void (*UpdateState)(Base*) = updateState;
   constexpr static void (*UpdateProperties)(Base*) = updateProperties;
-  constexpr static bool Optional = OptionalT;
 
   AddonWithProtectedStateAndPropertiesInSkeleton() = delete;
   AddonWithProtectedStateAndPropertiesInSkeleton(
@@ -191,9 +184,6 @@ public:
   /// Get the Properties of this Addon
   const Properties& getProperties() const;
 
-  // Documentation inherited
-  bool isOptional(common::AddonManager* oldManager) override final;
-
   /// Get the Skeleton that this Addon is embedded in
   SkeletonPtr getSkeleton();
 
@@ -232,7 +222,7 @@ protected:
 #define DART_DYNAMICS_ADDON_PROPERTY_CONSTRUCTOR( ClassName, UpdatePropertiesMacro )\
   ClassName (const ClassName &) = delete;\
   inline ClassName (dart::common::AddonManager* mgr, const PropertiesData& properties)\
-    : AddonWithProtectedPropertiesInSkeleton< Base, PropertiesData, ManagerType, UpdatePropertiesMacro, Optional>(mgr, properties) { }
+    : AddonWithProtectedPropertiesInSkeleton< Base, PropertiesData, ManagerType, UpdatePropertiesMacro>(mgr, properties) { }
 
 //==============================================================================
 #define DART_DYNAMICS_JOINT_ADDON_CONSTRUCTOR( ClassName )\
@@ -242,9 +232,9 @@ protected:
 #define DART_DYNAMICS_ADDON_STATE_PROPERTY_CONSTRUCTORS( ClassName, UpdateStateMacro, UpdatePropertiesMacro )\
   ClassName (const ClassName &) = delete;\
   inline ClassName (dart::common::AddonManager* mgr, const StateData& state = StateData(), const PropertiesData& properties = PropertiesData())\
-    : AddonWithProtectedStateAndPropertiesInSkeleton< Base, StateData, PropertiesData, ManagerType, UpdateStateMacro, UpdatePropertiesMacro, Optional >(mgr, state, properties) { }\
+    : AddonWithProtectedStateAndPropertiesInSkeleton< Base, StateData, PropertiesData, ManagerType, UpdateStateMacro, UpdatePropertiesMacro >(mgr, state, properties) { }\
   inline ClassName (dart::common::AddonManager* mgr, const PropertiesData& properties, const StateData state = StateData())\
-    : AddonWithProtectedStateAndPropertiesInSkeleton< Base, StateData, PropertiesData, ManagerType, UpdateStateMacro, UpdatePropertiesMacro, Optional >(mgr, properties, state) { }
+    : AddonWithProtectedStateAndPropertiesInSkeleton< Base, StateData, PropertiesData, ManagerType, UpdateStateMacro, UpdatePropertiesMacro >(mgr, properties, state) { }
 
 //==============================================================================
 #define DART_DYNAMICS_SET_ADDON_PROPERTY_CUSTOM( Type, Name, Update )\

--- a/dart/dynamics/BodyNode.h
+++ b/dart/dynamics/BodyNode.h
@@ -84,7 +84,7 @@ class Marker;
 /// BodyNode of the BodyNode.
 class BodyNode :
     public virtual common::AddonManager,
-    public virtual SpecializedNodeManagerForBodyNode<EndEffector>,
+    public virtual BodyNodeSpecializedFor<EndEffector>,
     public SkeletonRefCountingBase,
     public TemplatedJacobianNode<BodyNode>
 {

--- a/dart/dynamics/EndEffector.h
+++ b/dart/dynamics/EndEffector.h
@@ -40,7 +40,7 @@
 #include "dart/dynamics/FixedFrame.h"
 #include "dart/dynamics/TemplatedJacobianNode.h"
 #include "dart/dynamics/Addon.h"
-#include "dart/common/SpecializedAddonManager.h"
+#include "dart/common/SpecializedForAddon.h"
 
 namespace dart {
 namespace dynamics {
@@ -98,7 +98,7 @@ public:
 };
 
 class EndEffector final :
-    public virtual common::SpecializedAddonManager<Support>,
+    public virtual common::SpecializedForAddon<Support>,
     public FixedFrame,
     public AccessoryNode<EndEffector>,
     public TemplatedJacobianNode<EndEffector>

--- a/dart/dynamics/MultiDofJoint.h
+++ b/dart/dynamics/MultiDofJoint.h
@@ -47,7 +47,7 @@
 #include "dart/dynamics/Joint.h"
 #include "dart/dynamics/Skeleton.h"
 #include "dart/dynamics/DegreeOfFreedom.h"
-#include "dart/common/SpecializedAddonManager.h"
+#include "dart/common/RequiresAddon.h"
 #include "dart/dynamics/detail/MultiDofJointProperties.h"
 
 namespace dart {
@@ -60,7 +60,7 @@ class Skeleton;
 template<size_t DOF>
 class MultiDofJoint :
     public Joint,
-    public virtual common::SpecializedAddonManager< detail::MultiDofJointAddon<DOF> >
+    public virtual common::RequiresAddon< detail::MultiDofJointAddon<DOF> >
 {
 public:
 

--- a/dart/dynamics/SingleDofJoint.cpp
+++ b/dart/dynamics/SingleDofJoint.cpp
@@ -1145,7 +1145,7 @@ double SingleDofJoint::getPotentialEnergy() const
 
 //==============================================================================
 SingleDofJoint::SingleDofJoint(const Properties& _properties)
-  : Joint(_properties),
+  : detail::SingleDofJointBase(_properties, common::NoArg),
     mDof(createDofPointer(0)),
     mCommand(0.0),
     mPosition(0.0),

--- a/dart/dynamics/SingleDofJoint.h
+++ b/dart/dynamics/SingleDofJoint.h
@@ -40,7 +40,6 @@
 #include <string>
 
 #include "dart/dynamics/Joint.h"
-#include "dart/common/SpecializedAddonManager.h"
 #include "dart/dynamics/detail/SingleDofJointProperties.h"
 
 namespace dart {
@@ -51,7 +50,7 @@ class Skeleton;
 class DegreeOfFreedom;
 
 /// class SingleDofJoint
-class SingleDofJoint : public Joint
+class SingleDofJoint : public detail::SingleDofJointBase
 {
 public:
 

--- a/dart/dynamics/Skeleton.h
+++ b/dart/dynamics/Skeleton.h
@@ -58,7 +58,7 @@ namespace dynamics {
 /// class Skeleton
 class Skeleton :  public virtual common::AddonManager,
                   public MetaSkeleton,
-                  public virtual SpecializedNodeManagerForSkeleton<EndEffector>
+                  public virtual SkeletonSpecializedFor<EndEffector>
 {
 public:
 

--- a/dart/dynamics/SpecializedNodeManager.h
+++ b/dart/dynamics/SpecializedNodeManager.h
@@ -50,19 +50,19 @@ class Skeleton;
 //==============================================================================
 /// Declaration of the variadic template
 template <class... OtherSpecNodes>
-class SpecializedNodeManagerForBodyNode { };
+class BodyNodeSpecializedFor { };
 
 //==============================================================================
-/// SpecializedNodeManagerForBodyNode allows classes that inherit BodyNode to
+/// BodyNodeSpecializedFor allows classes that inherit BodyNode to
 /// have constant-time access to a specific type of Node
 template <class SpecNode>
-class SpecializedNodeManagerForBodyNode<SpecNode> :
+class BodyNodeSpecializedFor<SpecNode> :
     public virtual detail::BasicNodeManagerForBodyNode
 {
 public:
 
   /// Default constructor
-  SpecializedNodeManagerForBodyNode();
+  BodyNodeSpecializedFor();
 
   /// Get the number of Nodes corresponding to the specified type
   template <class NodeType>
@@ -109,35 +109,35 @@ protected:
 };
 
 //==============================================================================
-/// This is the variadic version of the SpecializedNodeManagerForBodyNode class
+/// This is the variadic version of the BodyNodeSpecializedFor class
 /// which allows you to include arbitrarily many specialized types in the
 /// specialization.
 template <class SpecNode1, class... OtherSpecNodes>
-class SpecializedNodeManagerForBodyNode<SpecNode1, OtherSpecNodes...> :
+class BodyNodeSpecializedFor<SpecNode1, OtherSpecNodes...> :
     public NodeManagerJoinerForBodyNode<
-      common::Virtual< SpecializedNodeManagerForBodyNode<SpecNode1> >,
-      common::Virtual< SpecializedNodeManagerForBodyNode<OtherSpecNodes...> > > { };
+      common::Virtual< BodyNodeSpecializedFor<SpecNode1> >,
+      common::Virtual< BodyNodeSpecializedFor<OtherSpecNodes...> > > { };
 
 //==============================================================================
 /// Declaration of the variadic template
 template <class... OtherSpecNodes>
-class SpecializedNodeManagerForSkeleton { };
+class SkeletonSpecializedFor { };
 
 //==============================================================================
-/// SpecializedNodeManagerForSkeleton allows classes that inherit Skeleton to
+/// SkeletonSpecializedForNode allows classes that inherit Skeleton to
 /// have constant-time access to a specific type of Node
 template <class SpecNode>
-class SpecializedNodeManagerForSkeleton<SpecNode> :
+class SkeletonSpecializedFor<SpecNode> :
     public virtual detail::BasicNodeManagerForSkeleton,
-    public virtual SpecializedNodeManagerForBodyNode<SpecNode>
+    public virtual BodyNodeSpecializedFor<SpecNode>
 {
 public:
 
-  using SpecializedNodeManagerForBodyNode<SpecNode>::getNode;
-  using SpecializedNodeManagerForBodyNode<SpecNode>::getNumNodes;
-  using SpecializedNodeManagerForBodyNode<SpecNode>::isSpecializedForNode;
+  using BodyNodeSpecializedFor<SpecNode>::getNode;
+  using BodyNodeSpecializedFor<SpecNode>::getNumNodes;
+  using BodyNodeSpecializedFor<SpecNode>::isSpecializedForNode;
 
-  SpecializedNodeManagerForSkeleton();
+  SkeletonSpecializedFor();
 
   /// Get the number of Nodes of the specified type that are in the treeIndexth
   /// tree of this Skeleton
@@ -196,14 +196,14 @@ protected:
 };
 
 //==============================================================================
-/// This is the variadic version of the SpecializedNodeManagerForSkeleton class
+/// This is the variadic version of the SkeletonSpecializedForNode class
 /// which allows you to include arbitrarily many specialized types in the
 /// specialization.
 template <class SpecNode1, class... OtherSpecNodes>
-class SpecializedNodeManagerForSkeleton<SpecNode1, OtherSpecNodes...> :
+class SkeletonSpecializedFor<SpecNode1, OtherSpecNodes...> :
     public NodeManagerJoinerForSkeleton<
-      common::Virtual< SpecializedNodeManagerForSkeleton<SpecNode1> >,
-      common::Virtual< SpecializedNodeManagerForSkeleton<OtherSpecNodes...> > > { };
+      common::Virtual< SkeletonSpecializedFor<SpecNode1> >,
+      common::Virtual< SkeletonSpecializedFor<OtherSpecNodes...> > > { };
 
 } // namespace dynamics
 } // namespace dart

--- a/dart/dynamics/detail/Addon.h
+++ b/dart/dynamics/detail/Addon.h
@@ -44,9 +44,9 @@ namespace dynamics {
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 AddonWithProtectedPropertiesInSkeleton(
     common::AddonManager* mgr, const PropertiesData& properties)
   : Addon(mgr),
@@ -59,9 +59,9 @@ AddonWithProtectedPropertiesInSkeleton(
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 std::unique_ptr<common::Addon> AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 cloneAddon(common::AddonManager* newManager) const
 {
   DART_COMMON_CAST_NEW_MANAGER_TYPE_AND_RETURN_NULL_IF_BAD(
@@ -71,9 +71,9 @@ cloneAddon(common::AddonManager* newManager) const
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 void AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 setAddonProperties(const Addon::Properties& someProperties)
 {
   setProperties(static_cast<const Properties&>(someProperties));
@@ -81,9 +81,9 @@ setAddonProperties(const Addon::Properties& someProperties)
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 const common::Addon::Properties* AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 getAddonProperties() const
 {
   return &mProperties;
@@ -91,9 +91,9 @@ getAddonProperties() const
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 void AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 setProperties(const PropertiesData& properties)
 {
   static_cast<PropertiesData&>(mProperties) = properties;
@@ -104,9 +104,9 @@ setProperties(const PropertiesData& properties)
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 auto AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 getProperties() const -> const Properties&
 {
   return mProperties;
@@ -114,24 +114,9 @@ getProperties() const -> const Properties&
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
-bool AddonWithProtectedPropertiesInSkeleton<
-  BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
-isOptional(common::AddonManager* oldManager)
-{
-  if(Optional)
-    return true;
-
-  // If the Addon is not optional, we should check whether the Manager type is
-  // the kind that this Addon belongs to.
-  return (nullptr == dynamic_cast<ManagerType*>(oldManager));
-}
-
-//==============================================================================
-template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 SkeletonPtr AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::getSkeleton()
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::getSkeleton()
 {
   if(mManager)
     return mManager->getSkeleton();
@@ -141,9 +126,9 @@ SkeletonPtr AddonWithProtectedPropertiesInSkeleton<
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 ConstSkeletonPtr AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::getSkeleton() const
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::getSkeleton() const
 {
   if(mManager)
     return mManager->getSkeleton();
@@ -153,27 +138,27 @@ ConstSkeletonPtr AddonWithProtectedPropertiesInSkeleton<
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 ManagerT* AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::getManager()
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::getManager()
 {
   return mManager;
 }
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 const ManagerT* AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::getManager() const
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::getManager() const
 {
   return mManager;
 }
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 void AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 incrementSkeletonVersion()
 {
   if(const SkeletonPtr& skel = getSkeleton())
@@ -182,9 +167,9 @@ incrementSkeletonVersion()
 
 //==============================================================================
 template <class BaseT, typename PropertiesDataT,
-          class ManagerT, void (*updateProperties)(BaseT*), bool OptionalT>
+          class ManagerT, void (*updateProperties)(BaseT*)>
 void AddonWithProtectedPropertiesInSkeleton<
-    BaseT, PropertiesDataT, ManagerT, updateProperties, OptionalT>::
+    BaseT, PropertiesDataT, ManagerT, updateProperties>::
 setManager(common::AddonManager* newManager, bool /*transfer*/)
 {
   DART_COMMON_CAST_NEW_MANAGER_TYPE(
@@ -201,10 +186,10 @@ setManager(common::AddonManager* newManager, bool /*transfer*/)
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 AddonWithProtectedStateAndPropertiesInSkeleton(
     common::AddonManager* mgr,
     const StateData& state,
@@ -221,10 +206,10 @@ AddonWithProtectedStateAndPropertiesInSkeleton(
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 AddonWithProtectedStateAndPropertiesInSkeleton(
     common::AddonManager* mgr,
     const PropertiesData& properties,
@@ -241,10 +226,10 @@ AddonWithProtectedStateAndPropertiesInSkeleton(
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 std::unique_ptr<common::Addon> AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 cloneAddon(common::AddonManager* newManager) const
 {
   DART_COMMON_CAST_NEW_MANAGER_TYPE_AND_RETURN_NULL_IF_BAD(
@@ -255,10 +240,10 @@ cloneAddon(common::AddonManager* newManager) const
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 void AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 setAddonState(const Addon::State& otherState)
 {
   setState(static_cast<const State&>(otherState));
@@ -267,10 +252,10 @@ setAddonState(const Addon::State& otherState)
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 const common::Addon::State* AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getAddonState() const
 {
   return &mState;
@@ -279,10 +264,10 @@ getAddonState() const
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 void AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 setState(const StateData& state)
 {
   static_cast<StateData&>(mState) = state;
@@ -292,10 +277,10 @@ setState(const StateData& state)
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 auto AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getState() const -> const State&
 {
   return mState;
@@ -304,10 +289,10 @@ getState() const -> const State&
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 void AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 setAddonProperties(const Addon::Properties& properties)
 {
   setProperties(static_cast<const Properties&>(properties));
@@ -316,10 +301,10 @@ setAddonProperties(const Addon::Properties& properties)
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 const common::Addon::Properties* AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getAddonProperties() const
 {
   return &mProperties;
@@ -328,10 +313,10 @@ getAddonProperties() const
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 void AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 setProperties(const PropertiesData& properties)
 {
   static_cast<PropertiesData&>(mProperties) = properties;
@@ -343,10 +328,10 @@ setProperties(const PropertiesData& properties)
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 auto AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getProperties() const -> const Properties&
 {
   return mProperties;
@@ -355,27 +340,10 @@ getProperties() const -> const Properties&
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
-bool AddonWithProtectedStateAndPropertiesInSkeleton<
-    BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
-isOptional(common::AddonManager* oldManager)
-{
-  if(Optional)
-    return true;
-
-  // If the Addon is not optional, we should check whether the Manager type is
-  // the kind that this Addon belongs to.
-  return (nullptr == dynamic_cast<ManagerType*>(oldManager));
-}
-
-//==============================================================================
-template <class BaseT, typename StateDataT, typename PropertiesDataT,
-          class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 SkeletonPtr AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getSkeleton()
 {
   if(mManager)
@@ -387,10 +355,10 @@ getSkeleton()
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 ConstSkeletonPtr AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getSkeleton() const
 {
   if(mManager)
@@ -402,10 +370,10 @@ getSkeleton() const
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 ManagerT* AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getManager()
 {
   return mManager;
@@ -414,10 +382,10 @@ getManager()
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 const ManagerT* AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 getManager() const
 {
   return mManager;
@@ -426,10 +394,10 @@ getManager() const
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 void AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 incrementSkeletonVersion()
 {
   if(const SkeletonPtr& skel = getSkeleton())
@@ -439,10 +407,10 @@ incrementSkeletonVersion()
 //==============================================================================
 template <class BaseT, typename StateDataT, typename PropertiesDataT,
           class ManagerT, void (*updateState)(BaseT*),
-          void (*updateProperties)(BaseT*), bool OptionalT>
+          void (*updateProperties)(BaseT*)>
 void AddonWithProtectedStateAndPropertiesInSkeleton<
     BaseT, StateDataT, PropertiesDataT,
-    ManagerT, updateState, updateProperties, OptionalT>::
+    ManagerT, updateState, updateProperties>::
 setManager(common::AddonManager* newManager, bool /*transfer*/)
 {
   DART_COMMON_CAST_NEW_MANAGER_TYPE(

--- a/dart/dynamics/detail/MultiDofJointProperties.h
+++ b/dart/dynamics/detail/MultiDofJointProperties.h
@@ -159,7 +159,7 @@ template <size_t DOF>
 class MultiDofJointAddon final :
     public AddonWithProtectedPropertiesInSkeleton<
         MultiDofJointAddon<DOF>, MultiDofJointUniqueProperties<DOF>, MultiDofJoint<DOF>,
-        common::detail::NoOp<MultiDofJointAddon<DOF>*>, false >
+        common::detail::NoOp<MultiDofJointAddon<DOF>*> >
 {
 public:
   MultiDofJointAddon(const MultiDofJointAddon&) = delete;
@@ -287,8 +287,8 @@ MultiDofJointAddon<DOF>::MultiDofJointAddon(
         typename MultiDofJointAddon<DOF>::Base,
         typename MultiDofJointAddon<DOF>::PropertiesData,
         typename MultiDofJointAddon<DOF>::ManagerType,
-        &common::detail::NoOp<typename MultiDofJointAddon<DOF>::Base*>,
-        MultiDofJointAddon<DOF>::Optional>(mgr, properties)
+        &common::detail::NoOp<typename MultiDofJointAddon<DOF>::Base*> >(
+      mgr, properties)
 {
   // Do nothing
 }

--- a/dart/dynamics/detail/PlanarJointProperties.h
+++ b/dart/dynamics/detail/PlanarJointProperties.h
@@ -127,7 +127,7 @@ struct PlanarJointProperties :
 class PlanarJointAddon final :
     public AddonWithProtectedPropertiesInSkeleton<
         PlanarJointAddon, PlanarJointUniqueProperties, PlanarJoint,
-        detail::JointPropertyUpdate<PlanarJointAddon>, false >
+        detail::JointPropertyUpdate<PlanarJointAddon> >
 {
 public:
   DART_DYNAMICS_JOINT_ADDON_CONSTRUCTOR( PlanarJointAddon )
@@ -146,7 +146,7 @@ public:
 
 //==============================================================================
 using PlanarJointBase = common::AddonManagerJoiner<
-    MultiDofJoint<3>, common::SpecializedAddonManager<PlanarJointAddon> >;
+    MultiDofJoint<3>, common::RequiresAddon<PlanarJointAddon> >;
 
 } // namespace detail
 } // namespace dynamics

--- a/dart/dynamics/detail/PrismaticJointProperties.h
+++ b/dart/dynamics/detail/PrismaticJointProperties.h
@@ -80,7 +80,7 @@ struct PrismaticJointProperties :
 class PrismaticJointAddon final :
     public AddonWithProtectedPropertiesInSkeleton<
         PrismaticJointAddon, PrismaticJointUniqueProperties, PrismaticJoint,
-        detail::JointPropertyUpdate<PrismaticJointAddon>, false >
+        detail::JointPropertyUpdate<PrismaticJointAddon> >
 {
 public:
   DART_DYNAMICS_JOINT_ADDON_CONSTRUCTOR( PrismaticJointAddon )
@@ -91,7 +91,7 @@ public:
 
 //==============================================================================
 using PrismaticJointBase = common::AddonManagerJoiner<
-    SingleDofJoint, common::SpecializedAddonManager<PrismaticJointAddon> >;
+    SingleDofJoint, common::RequiresAddon<PrismaticJointAddon> >;
 
 } // namespace detail
 } // namespace dynamics

--- a/dart/dynamics/detail/RevoluteJointProperties.h
+++ b/dart/dynamics/detail/RevoluteJointProperties.h
@@ -80,7 +80,7 @@ struct RevoluteJointProperties :
 class RevoluteJointAddon final :
     public AddonWithProtectedPropertiesInSkeleton<
         RevoluteJointAddon, RevoluteJointUniqueProperties, RevoluteJoint,
-        detail::JointPropertyUpdate<RevoluteJointAddon>, false >
+        detail::JointPropertyUpdate<RevoluteJointAddon> >
 {
 public:
   DART_DYNAMICS_JOINT_ADDON_CONSTRUCTOR( RevoluteJointAddon )
@@ -91,7 +91,7 @@ public:
 
 //==============================================================================
 using RevoluteJointBase = common::AddonManagerJoiner<
-    SingleDofJoint, common::SpecializedAddonManager<RevoluteJointAddon> >;
+    SingleDofJoint, common::RequiresAddon<RevoluteJointAddon> >;
 
 } // namespace detail
 

--- a/dart/dynamics/detail/ScrewJointProperties.h
+++ b/dart/dynamics/detail/ScrewJointProperties.h
@@ -84,7 +84,7 @@ struct ScrewJointProperties : SingleDofJoint::Properties,
 class ScrewJointAddon final :
     public AddonWithProtectedPropertiesInSkeleton<
         ScrewJointAddon, ScrewJointUniqueProperties, ScrewJoint,
-        detail::JointPropertyUpdate<ScrewJointAddon>, false >
+        detail::JointPropertyUpdate<ScrewJointAddon> >
 {
 public:
   DART_DYNAMICS_JOINT_ADDON_CONSTRUCTOR( ScrewJointAddon )
@@ -97,7 +97,7 @@ public:
 
 //==============================================================================
 using ScrewJointBase = common::AddonManagerJoiner<
-    SingleDofJoint, common::SpecializedAddonManager<ScrewJointAddon> >;
+    SingleDofJoint, common::RequiresAddon<ScrewJointAddon> >;
 
 } // namespace detail
 } // namespace dynamics

--- a/dart/dynamics/detail/SingleDofJointProperties.h
+++ b/dart/dynamics/detail/SingleDofJointProperties.h
@@ -37,6 +37,8 @@
 #ifndef DART_DYNAMICS_DETAIL_SINGLEDOFJOINTPROPERTIES_H_
 #define DART_DYNAMICS_DETAIL_SINGLEDOFJOINTPROPERTIES_H_
 
+#include "dart/common/RequiresAddon.h"
+
 #include "dart/dynamics/Addon.h"
 #include "dart/dynamics/Joint.h"
 
@@ -137,7 +139,7 @@ struct SingleDofJointProperties :
 class SingleDofJointAddon final :
     public AddonWithProtectedPropertiesInSkeleton<
         SingleDofJointAddon, SingleDofJointUniqueProperties,
-        SingleDofJoint, common::detail::NoOp, false>
+        SingleDofJoint, common::detail::NoOp>
 {
 public:
   DART_DYNAMICS_ADDON_PROPERTY_CONSTRUCTOR( SingleDofJointAddon, &common::detail::NoOp )
@@ -164,6 +166,10 @@ public:
 
   friend class dart::dynamics::SingleDofJoint;
 };
+
+//==============================================================================
+using SingleDofJointBase = common::AddonManagerJoiner<
+    Joint, common::RequiresAddon<SingleDofJointAddon> >;
 
 } // namespace detail
 } // namespace dynamics

--- a/dart/dynamics/detail/SpecializedNodeManager.h
+++ b/dart/dynamics/detail/SpecializedNodeManager.h
@@ -51,7 +51,7 @@ bool usedSpecializedNodeAccess;
 
 //==============================================================================
 template <class SpecNode>
-SpecializedNodeManagerForBodyNode<SpecNode>::SpecializedNodeManagerForBodyNode()
+BodyNodeSpecializedFor<SpecNode>::BodyNodeSpecializedFor()
 {
   mNodeMap[typeid( SpecNode )] = std::vector<Node*>();
   mSpecNodeIterator = mNodeMap.find(typeid( SpecNode ));
@@ -60,7 +60,7 @@ SpecializedNodeManagerForBodyNode<SpecNode>::SpecializedNodeManagerForBodyNode()
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-size_t SpecializedNodeManagerForBodyNode<SpecNode>::getNumNodes() const
+size_t BodyNodeSpecializedFor<SpecNode>::getNumNodes() const
 {
   return _getNumNodes(type<NodeType>());
 }
@@ -68,7 +68,7 @@ size_t SpecializedNodeManagerForBodyNode<SpecNode>::getNumNodes() const
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-NodeType* SpecializedNodeManagerForBodyNode<SpecNode>::getNode(size_t index)
+NodeType* BodyNodeSpecializedFor<SpecNode>::getNode(size_t index)
 {
   return _getNode(type<NodeType>(), index);
 }
@@ -76,16 +76,16 @@ NodeType* SpecializedNodeManagerForBodyNode<SpecNode>::getNode(size_t index)
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-const NodeType* SpecializedNodeManagerForBodyNode<SpecNode>::getNode(size_t index) const
+const NodeType* BodyNodeSpecializedFor<SpecNode>::getNode(size_t index) const
 {
-  return const_cast<SpecializedNodeManagerForBodyNode<SpecNode>*>(this)->
+  return const_cast<BodyNodeSpecializedFor<SpecNode>*>(this)->
       _getNode(type<NodeType>(), index);
 }
 
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-constexpr bool SpecializedNodeManagerForBodyNode<SpecNode>::isSpecializedForNode()
+constexpr bool BodyNodeSpecializedFor<SpecNode>::isSpecializedForNode()
 {
   return _isSpecializedForNode(type<NodeType>());
 }
@@ -93,14 +93,14 @@ constexpr bool SpecializedNodeManagerForBodyNode<SpecNode>::isSpecializedForNode
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-size_t SpecializedNodeManagerForBodyNode<SpecNode>::_getNumNodes(type<NodeType>) const
+size_t BodyNodeSpecializedFor<SpecNode>::_getNumNodes(type<NodeType>) const
 {
   return detail::BasicNodeManagerForBodyNode::getNumNodes<NodeType>();
 }
 
 //==============================================================================
 template <class SpecNode>
-size_t SpecializedNodeManagerForBodyNode<SpecNode>::_getNumNodes(type<SpecNode>) const
+size_t BodyNodeSpecializedFor<SpecNode>::_getNumNodes(type<SpecNode>) const
 {
 #ifdef DART_UNITTEST_SPECIALIZED_NODE_ACCESS
   usedSpecializedNodeAccess = true;
@@ -112,14 +112,14 @@ size_t SpecializedNodeManagerForBodyNode<SpecNode>::_getNumNodes(type<SpecNode>)
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-NodeType* SpecializedNodeManagerForBodyNode<SpecNode>::_getNode(type<NodeType>, size_t index)
+NodeType* BodyNodeSpecializedFor<SpecNode>::_getNode(type<NodeType>, size_t index)
 {
   return detail::BasicNodeManagerForBodyNode::getNode<NodeType>(index);
 }
 
 //==============================================================================
 template <class SpecNode>
-SpecNode* SpecializedNodeManagerForBodyNode<SpecNode>::_getNode(type<SpecNode>, size_t index)
+SpecNode* BodyNodeSpecializedFor<SpecNode>::_getNode(type<SpecNode>, size_t index)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_NODE_ACCESS
   usedSpecializedNodeAccess = true;
@@ -132,21 +132,21 @@ SpecNode* SpecializedNodeManagerForBodyNode<SpecNode>::_getNode(type<SpecNode>, 
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-constexpr bool SpecializedNodeManagerForBodyNode<SpecNode>::_isSpecializedForNode(type<NodeType>)
+constexpr bool BodyNodeSpecializedFor<SpecNode>::_isSpecializedForNode(type<NodeType>)
 {
   return false;
 }
 
 //==============================================================================
 template <class SpecNode>
-constexpr bool SpecializedNodeManagerForBodyNode<SpecNode>::_isSpecializedForNode(type<SpecNode>)
+constexpr bool BodyNodeSpecializedFor<SpecNode>::_isSpecializedForNode(type<SpecNode>)
 {
   return true;
 }
 
 //==============================================================================
 template <class SpecNode>
-SpecializedNodeManagerForSkeleton<SpecNode>::SpecializedNodeManagerForSkeleton()
+SkeletonSpecializedFor<SpecNode>::SkeletonSpecializedFor()
 {
   mSpecializedTreeNodes[typeid( SpecNode )] = &mTreeSpecNodeIterators;
 
@@ -157,7 +157,7 @@ SpecializedNodeManagerForSkeleton<SpecNode>::SpecializedNodeManagerForSkeleton()
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-size_t SpecializedNodeManagerForSkeleton<SpecNode>::getNumNodes(
+size_t SkeletonSpecializedFor<SpecNode>::getNumNodes(
     size_t treeIndex) const
 {
   return _getNumNodes(type<NodeType>(), treeIndex);
@@ -166,7 +166,7 @@ size_t SpecializedNodeManagerForSkeleton<SpecNode>::getNumNodes(
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::getNode(
+NodeType* SkeletonSpecializedFor<SpecNode>::getNode(
     size_t treeIndex, size_t nodeIndex)
 {
   return _getNode(type<NodeType>(), treeIndex, nodeIndex);
@@ -175,17 +175,17 @@ NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::getNode(
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-const NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::getNode(
+const NodeType* SkeletonSpecializedFor<SpecNode>::getNode(
     size_t treeIndex, size_t nodeIndex) const
 {
-  return const_cast<SpecializedNodeManagerForSkeleton<SpecNode>*>(this)->
+  return const_cast<SkeletonSpecializedFor<SpecNode>*>(this)->
         _getNode(type<NodeType>(), treeIndex, nodeIndex);
 }
 
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::getNode(
+NodeType* SkeletonSpecializedFor<SpecNode>::getNode(
     const std::string& name)
 {
   return _getNode(type<NodeType>(), name);
@@ -194,17 +194,17 @@ NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::getNode(
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-const NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::getNode(
+const NodeType* SkeletonSpecializedFor<SpecNode>::getNode(
     const std::string& name) const
 {
-  return const_cast<SpecializedNodeManagerForSkeleton<SpecNode>*>(this)->
+  return const_cast<SkeletonSpecializedFor<SpecNode>*>(this)->
         _getNode(type<NodeType>(), name);
 }
 
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-size_t SpecializedNodeManagerForSkeleton<SpecNode>::_getNumNodes(
+size_t SkeletonSpecializedFor<SpecNode>::_getNumNodes(
     type<NodeType>, size_t treeIndex) const
 {
   return detail::BasicNodeManagerForSkeleton::getNumNodes<NodeType>(treeIndex);
@@ -212,7 +212,7 @@ size_t SpecializedNodeManagerForSkeleton<SpecNode>::_getNumNodes(
 
 //==============================================================================
 template <class SpecNode>
-size_t SpecializedNodeManagerForSkeleton<SpecNode>::_getNumNodes(
+size_t SkeletonSpecializedFor<SpecNode>::_getNumNodes(
     type<SpecNode>, size_t treeIndex) const
 {
 #ifdef DART_UNITTEST_SPECIALIZED_NODE_ACCESS
@@ -234,7 +234,7 @@ size_t SpecializedNodeManagerForSkeleton<SpecNode>::_getNumNodes(
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::_getNode(
+NodeType* SkeletonSpecializedFor<SpecNode>::_getNode(
     type<NodeType>, size_t treeIndex, size_t nodeIndex)
 {
   return detail::BasicNodeManagerForSkeleton::getNode<NodeType>(
@@ -243,7 +243,7 @@ NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::_getNode(
 
 //==============================================================================
 template <class SpecNode>
-SpecNode* SpecializedNodeManagerForSkeleton<SpecNode>::_getNode(
+SpecNode* SkeletonSpecializedFor<SpecNode>::_getNode(
     type<SpecNode>, size_t treeIndex, size_t nodeIndex)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_NODE_ACCESS
@@ -277,7 +277,7 @@ SpecNode* SpecializedNodeManagerForSkeleton<SpecNode>::_getNode(
 //==============================================================================
 template <class SpecNode>
 template <class NodeType>
-NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::_getNode(
+NodeType* SkeletonSpecializedFor<SpecNode>::_getNode(
     type<NodeType>, const std::string& name)
 {
   return detail::BasicNodeManagerForSkeleton::getNode<NodeType>(name);
@@ -285,7 +285,7 @@ NodeType* SpecializedNodeManagerForSkeleton<SpecNode>::_getNode(
 
 //==============================================================================
 template <class SpecNode>
-SpecNode* SpecializedNodeManagerForSkeleton<SpecNode>::_getNode(
+SpecNode* SkeletonSpecializedFor<SpecNode>::_getNode(
     type<SpecNode>, const std::string& name)
 {
 #ifdef DART_UNITTEST_SPECIALIZED_NODE_ACCESS

--- a/dart/dynamics/detail/UniversalJointProperties.h
+++ b/dart/dynamics/detail/UniversalJointProperties.h
@@ -81,7 +81,7 @@ struct UniversalJointProperties :
 class UniversalJointAddon final :
     public AddonWithProtectedPropertiesInSkeleton<
         UniversalJointAddon, UniversalJointUniqueProperties, UniversalJoint,
-        detail::JointPropertyUpdate<UniversalJointAddon>, false >
+        detail::JointPropertyUpdate<UniversalJointAddon> >
 {
 public:
   DART_DYNAMICS_JOINT_ADDON_CONSTRUCTOR( UniversalJointAddon )
@@ -93,7 +93,7 @@ public:
 
 //==============================================================================
 using UniversalJointBase = common::AddonManagerJoiner<
-    MultiDofJoint<2>, common::SpecializedAddonManager<UniversalJointAddon> >;
+    MultiDofJoint<2>, common::RequiresAddon<UniversalJointAddon> >;
 
 } // namespace detail
 } // namespace dynamics

--- a/unittests/testAddon.cpp
+++ b/unittests/testAddon.cpp
@@ -46,7 +46,7 @@
 #include "dart/common/Subject.h"
 #include "dart/common/sub_ptr.h"
 #include "dart/common/AddonManager.h"
-#include "dart/common/SpecializedAddonManager.h"
+#include "dart/common/SpecializedForAddon.h"
 
 #include "dart/dynamics/EulerJoint.h"
 
@@ -204,7 +204,7 @@ typedef StatefulAddon<float>  FloatAddon;
 typedef StatefulAddon<char>   CharAddon;
 typedef StatefulAddon<int>    IntAddon;
 
-class CustomSpecializedManager : public SpecializedAddonManager<SpecializedAddon> { };
+class CustomSpecializedManager : public SpecializedForAddon<SpecializedAddon> { };
 
 TEST(Addon, Generic)
 {

--- a/unittests/testAddon.cpp
+++ b/unittests/testAddon.cpp
@@ -48,6 +48,8 @@
 #include "dart/common/AddonManager.h"
 #include "dart/common/SpecializedAddonManager.h"
 
+#include "dart/dynamics/EulerJoint.h"
+
 using namespace dart::common;
 
 class GenericAddon : public Addon, public Subject
@@ -500,6 +502,55 @@ TEST(Addon, Construction)
   double p = dart::math::random(0, 100);
   mgr.create<DoubleAddon>(dart::math::random(0, 100), p);
   EXPECT_EQ(mgr.get<DoubleAddon>()->mProperties.val, p);
+}
+
+TEST(Addon, Joints)
+{
+  usedSpecializedAddonAccess = false;
+
+  dart::dynamics::SkeletonPtr skel = Skeleton::create();
+
+  dart::dynamics::EulerJoint* euler =
+      skel->createJointAndBodyNodePair<dart::dynamics::EulerJoint>().first;
+  euler->getMultiDofJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+  euler->getEulerJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+
+  dart::dynamics::PlanarJoint* planar =
+      skel->createJointAndBodyNodePair<dart::dynamics::PlanarJoint>().first;
+  planar->getMultiDofJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+  planar->getPlanarJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+
+  dart::dynamics::PrismaticJoint* prismatic =
+      skel->createJointAndBodyNodePair<dart::dynamics::PrismaticJoint>().first;
+  prismatic->getSingleDofJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+  prismatic->getPrismaticJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+
+  dart::dynamics::RevoluteJoint* revolute =
+      skel->createJointAndBodyNodePair<dart::dynamics::RevoluteJoint>().first;
+  revolute->getSingleDofJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+  revolute->getRevoluteJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+
+  dart::dynamics::ScrewJoint* screw =
+      skel->createJointAndBodyNodePair<dart::dynamics::ScrewJoint>().first;
+  screw->getSingleDofJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+  screw->getScrewJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+
+  dart::dynamics::UniversalJoint* universal =
+      skel->createJointAndBodyNodePair<dart::dynamics::UniversalJoint>().first;
+  universal->getMultiDofJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
+  universal->getUniversalJointAddon();
+  EXPECT_TRUE(usedSpecializedAddonAccess); usedSpecializedAddonAccess = false;
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
In the current implementation of "optionality" for Addons, it is an Addon that decides for itself whether it is optional for a given Manager type. This is semantically backwards, since the Manager owns the Addon and should therefore have authority over whether the Addon is considered optional or required.

This pull request reverses this relationship. Now a Manager can specify which Addons are required for it in a similar fashion to how Addons can be specialized for it. In fact, declaring an Addon as "required" will also automatically specialize the Addon for that Manager.