### PR TITLE
Made ConstraintSolver obey C++11 ownership conventions

### DIFF
--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -72,7 +72,6 @@ ConstraintSolver::ConstraintSolver(double _timeStep)
 //==============================================================================
 ConstraintSolver::~ConstraintSolver()
 {
-  delete mLCPSolver;
 }
 
 //==============================================================================

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -72,7 +72,6 @@ ConstraintSolver::ConstraintSolver(double _timeStep)
 //==============================================================================
 ConstraintSolver::~ConstraintSolver()
 {
-  delete mCollisionDetector;
   delete mLCPSolver;
 }
 
@@ -239,23 +238,28 @@ double ConstraintSolver::getTimeStep() const
 void ConstraintSolver::setCollisionDetector(
     collision::CollisionDetector* _collisionDetector)
 {
+  setCollisionDetector(
+    std::unique_ptr<collision::CollisionDetector>(_collisionDetector));
+}
+
+//==============================================================================
+void ConstraintSolver::setCollisionDetector(
+  std::unique_ptr<collision::CollisionDetector>&& _collisionDetector)
+{
   assert(_collisionDetector && "Invalid collision detector.");
+
+  // Change the collision detector of the constraint solver to new one
+  mCollisionDetector = std::move(_collisionDetector);
 
   // Add skeletons in the constraint solver to new collision detector
   for (size_t i = 0; i < mSkeletons.size(); ++i)
-    _collisionDetector->addSkeleton(mSkeletons[i]);
-
-  // Release the old collision detector
-  delete mCollisionDetector;
-
-  // Change the collision detector of the constraint solver to new one
-  mCollisionDetector = _collisionDetector;
+    mCollisionDetector->addSkeleton(mSkeletons[i]);
 }
 
 //==============================================================================
 collision::CollisionDetector* ConstraintSolver::getCollisionDetector() const
 {
-  return mCollisionDetector;
+  return mCollisionDetector.get();
 }
 
 //==============================================================================

--- a/dart/constraint/ConstraintSolver.h
+++ b/dart/constraint/ConstraintSolver.h
@@ -41,6 +41,7 @@
 
 #include <Eigen/Dense>
 
+#include "dart/common/Deprecated.h"
 #include "dart/constraint/SmartPointer.h"
 #include "dart/constraint/ConstraintBase.h"
 #include "dart/collision/CollisionDetector.h"
@@ -101,8 +102,15 @@ public:
   /// Get time step
   double getTimeStep() const;
 
-  /// Set collision detector
+  /// Set collision detector. This function acquires ownership of the
+  /// CollisionDetector passed as an argument. This method is deprecated in favor
+  /// of the overload that accepts a std::unique_ptr.
+  DEPRECATED(7.1)
   void setCollisionDetector(collision::CollisionDetector* _collisionDetector);
+
+  /// Set collision detector
+  void setCollisionDetector(
+    std::unique_ptr<collision::CollisionDetector>&& _collisionDetector);
 
   /// Get collision detector
   collision::CollisionDetector* getCollisionDetector() const;
@@ -136,7 +144,7 @@ private:
   bool isSoftContact(const collision::Contact& _contact) const;
 
   /// Collision detector
-  collision::CollisionDetector* mCollisionDetector;
+  std::unique_ptr<collision::CollisionDetector> mCollisionDetector;
 
   /// Time step
   double mTimeStep;

--- a/dart/constraint/ConstraintSolver.h
+++ b/dart/constraint/ConstraintSolver.h
@@ -150,7 +150,7 @@ private:
   double mTimeStep;
 
   /// LCP solver
-  LCPSolver* mLCPSolver;
+  std::unique_ptr<LCPSolver> mLCPSolver;
 
   /// Skeleton list
   std::vector<dynamics::SkeletonPtr> mSkeletons;

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -250,43 +250,32 @@ simulation::WorldPtr SkelParser::readWorld(
     }
 
     // Collision detector
+    std::unique_ptr<collision::CollisionDetector> collision_detector;
+
     if (hasElement(physicsElement, "collision_detector"))
     {
       std::string strCD = getValueString(physicsElement, "collision_detector");
+
       if (strCD == "fcl_mesh")
-      {
-        newWorld->getConstraintSolver()->setCollisionDetector(
-              new collision::FCLMeshCollisionDetector());
-      }
+        collision_detector.reset(new collision::FCLMeshCollisionDetector);
       else if (strCD == "fcl")
-      {
-        newWorld->getConstraintSolver()->setCollisionDetector(
-              new collision::FCLCollisionDetector());
-      }
+        collision_detector.reset(new collision::FCLCollisionDetector);
       else if (strCD == "dart")
-      {
-        newWorld->getConstraintSolver()->setCollisionDetector(
-              new collision::DARTCollisionDetector());
-      }
+        collision_detector.reset(new collision::DARTCollisionDetector);
 #ifdef HAVE_BULLET_COLLISION
       else if (strCD == "bullet")
-      {
-        newWorld->getConstraintSolver()->setCollisionDetector(
-              new collision::BulletCollisionDetector());
-      }
+        collision_detector.reset(new collision::BulletCollisionDetector);
 #endif
       else
-      {
         dtwarn << "Unknown collision detector[" << strCD << "]. "
-               << "Default collision detector[fcl] will be loaded."
-               << std::endl;
-      }
+               << "Default collision detector[fcl_mesh] will be loaded.\n";
     }
-    else
-    {
-      newWorld->getConstraintSolver()->setCollisionDetector(
-            new collision::FCLMeshCollisionDetector());
-    }
+
+    if (!collision_detector)
+      collision_detector.reset(new collision::FCLMeshCollisionDetector);
+
+    newWorld->getConstraintSolver()->setCollisionDetector(
+      std::move(collision_detector));
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
`constraint::ConstraintSolver` takes ownership of the `setCollisionDetector` passed in to `setCollisionDetector`. This is not clear from the API because the function accepts a raw pointer. This leads to a SEGFAULT if you do not expect `ConstraintSolver` to delete your `CollisionDetector`.

I modified `setCollisionDetector` to take an `unique_ptr` to make the ownership transfer explicit. I also switched to storing the `LCPSolver` in a `unique_ptr` to remove the other manual `delete` from the `ConstraintSolver` destructor.