### PR TITLE
Added missing override specifiers on draw() methods

### DIFF
--- a/dart/dynamics/BoxShape.h
+++ b/dart/dynamics/BoxShape.h
@@ -60,7 +60,7 @@ public:
   // Documentation inherited.
   void draw(renderer::RenderInterface* _ri = nullptr,
             const Eigen::Vector4d& _col = Eigen::Vector4d::Ones(),
-            bool _default = true) const;
+            bool _default = true) const override;
 
   /// \brief Compute volume from given properties
   static double computeVolume(const Eigen::Vector3d& size);

--- a/dart/dynamics/CylinderShape.h
+++ b/dart/dynamics/CylinderShape.h
@@ -65,7 +65,7 @@ public:
   // Documentation inherited.
   void draw(renderer::RenderInterface* _ri = nullptr,
             const Eigen::Vector4d& _color = Eigen::Vector4d::Ones(),
-            bool _useDefaultColor = true) const;
+            bool _useDefaultColor = true) const override;
 
   /// \brief Compute volume from given properties
   static double computeVolume(double radius, double height);

--- a/dart/dynamics/EllipsoidShape.h
+++ b/dart/dynamics/EllipsoidShape.h
@@ -60,7 +60,7 @@ public:
   // Documentation inherited.
   void draw(renderer::RenderInterface* _ri = nullptr,
             const Eigen::Vector4d& _col = Eigen::Vector4d::Ones(),
-            bool _useDefaultColor = true) const;
+            bool _useDefaultColor = true) const override;
 
   /// \brief Compute volume from given properties
   static double computeVolume(const Eigen::Vector3d& size);

--- a/dart/dynamics/PlaneShape.h
+++ b/dart/dynamics/PlaneShape.h
@@ -56,7 +56,7 @@ public:
   // TODO(JS): Not implemented yet
   void draw(renderer::RenderInterface* _ri = nullptr,
             const Eigen::Vector4d& _col = Eigen::Vector4d::Ones(),
-            bool _default = true) const;
+            bool _default = true) const override;
 
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;

--- a/dart/dynamics/SoftMeshShape.h
+++ b/dart/dynamics/SoftMeshShape.h
@@ -72,7 +72,7 @@ public:
   virtual void draw(
       renderer::RenderInterface* _ri      = nullptr,
       const Eigen::Vector4d&     _col     = Eigen::Vector4d::Ones(),
-      bool                       _default = true) const;
+      bool                       _default = true) const override;
 
 protected:
   // Documentation inherited.


### PR DESCRIPTION
This fixes a bunch of `-Winconsistent-missing-override` warnings in Clang 3.7.