### PR TITLE
Added get/setLCPSolver functions to ConstraintSolver

### DIFF
--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -243,7 +243,7 @@ void ConstraintSolver::setCollisionDetector(
 
 //==============================================================================
 void ConstraintSolver::setCollisionDetector(
-  std::unique_ptr<collision::CollisionDetector>&& _collisionDetector)
+  std::unique_ptr<collision::CollisionDetector> _collisionDetector)
 {
   assert(_collisionDetector && "Invalid collision detector.");
 

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -262,6 +262,20 @@ collision::CollisionDetector* ConstraintSolver::getCollisionDetector() const
 }
 
 //==============================================================================
+void ConstraintSolver::setLCPSolver(std::unique_ptr<LCPSolver> _lcpSolver)
+{
+  assert(_lcpSolver && "Invalid LCP solver.");
+
+  mLCPSolver = std::move(_lcpSolver);
+}
+
+//==============================================================================
+LCPSolver* ConstraintSolver::getLCPSolver() const
+{
+  return mLCPSolver.get();
+}
+
+//==============================================================================
 void ConstraintSolver::solve()
 {
   for (size_t i = 0; i < mSkeletons.size(); ++i)

--- a/dart/constraint/ConstraintSolver.h
+++ b/dart/constraint/ConstraintSolver.h
@@ -110,7 +110,7 @@ public:
 
   /// Set collision detector
   void setCollisionDetector(
-    std::unique_ptr<collision::CollisionDetector>&& _collisionDetector);
+    std::unique_ptr<collision::CollisionDetector> _collisionDetector);
 
   /// Get collision detector
   collision::CollisionDetector* getCollisionDetector() const;

--- a/dart/constraint/ConstraintSolver.h
+++ b/dart/constraint/ConstraintSolver.h
@@ -115,6 +115,12 @@ public:
   /// Get collision detector
   collision::CollisionDetector* getCollisionDetector() const;
 
+  /// Set LCP solver
+  void setLCPSolver(std::unique_ptr<LCPSolver> _lcpSolver);
+
+  /// Get LCP solver
+  LCPSolver* getLCPSolver() const;
+
   /// Solve constraint impulses and apply them to the skeletons
   void solve();
 


### PR DESCRIPTION
There is currently no way to use anything other than the default LCP solver in `ConstraintSolver`. This pull request adds functions that parallel the `get/setCollisionDetector` for the `LCPSolver`.