### PR TITLE
Fixed DantzigLCPSolver when getTotalDimension = 0

### DIFF
--- a/dart/constraint/DantzigLCPSolver.cpp
+++ b/dart/constraint/DantzigLCPSolver.cpp
@@ -69,7 +69,7 @@ void DantzigLCPSolver::solve(ConstrainedGroup* _group)
   size_t n = _group->getTotalDimension();
 
   // If there is no constraint, then just return.
-  if (n == 0)
+  if (0u == n)
     return;
 
   int nSkip = dPAD(n);

--- a/dart/constraint/DantzigLCPSolver.cpp
+++ b/dart/constraint/DantzigLCPSolver.cpp
@@ -63,13 +63,15 @@ DantzigLCPSolver::~DantzigLCPSolver()
 //==============================================================================
 void DantzigLCPSolver::solve(ConstrainedGroup* _group)
 {
-  // If there is no constraint, then just return true.
-  size_t numConstraints = _group->getNumConstraints();
-  if (numConstraints == 0)
-    return;
 
   // Build LCP terms by aggregating them from constraints
+  size_t numConstraints = _group->getNumConstraints();
   size_t n = _group->getTotalDimension();
+
+  // If there is no constraint, then just return.
+  if (n == 0)
+    return;
+
   int nSkip = dPAD(n);
   double* A = new double[n * nSkip];
   double* x = new double[n];


### PR DESCRIPTION
The code previously checked for `getNumConstraints() == 0`, but not `getTotalDimension() == 0`. This caused the LCP solver to access invalid memory if constraints were present, but all constraints had `getDimension() == 0`. I ran into this using a `ServoJointConstraint` in a completely empty environment.

Thanks @jslee02 for helping me debug this.