### PR TITLE
Use FCLCollisionDetector by default if version >= 0.4 is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,17 @@ if(FCL_FOUND)
 else()
   if(FCL_VERSION)
     message(SEND_ERROR "Looking for FCL - ${FCL_VERSION} found, ${PROJECT_NAME} requires 0.2.9 or greater.")
+    if("${FCL_VERSION}" VERSION_LESS "0.4.0")
+      message(WARNING
+        "Found FCL version ${FCL_VERSION}, which is older than 0.4.0. FCL"
+        " versions predating 0.4.0 return incorrect contacts for"
+        " primitive-primitive collsions. You should use FCLMeshCollisionDetector"
+        " instead of FCLCollisionDetector if you need accurate contacts."
+      )
+      set(DART_USE_FCLMESHCOLLISIONDETECTOR 1)
+    else()
+      set(DART_USE_FCLMESHCOLLISIONDETECTOR 0)
+    endif()
   else()
     message(SEND_ERROR "Looking for FCL - NOT found, please install libfcl-dev")
   endif()

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -8,6 +8,8 @@
 #define DART_VERSION "@DART_VERSION@"
 #define DART_DESCRIPTION "@DART_PKG_DESC@"
 
+#cmakedefine DART_USE_FCLMESHCOLLISIONDETECTOR 1
+
 #cmakedefine HAVE_NLOPT 1
 #cmakedefine HAVE_IPOPT 1
 #cmakedefine HAVE_SNOPT 1

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -41,11 +41,13 @@
 #include "dart/dynamics/SoftBodyNode.h"
 #include "dart/dynamics/Joint.h"
 #include "dart/dynamics/Skeleton.h"
-#include "dart/collision/fcl_mesh/FCLMeshCollisionDetector.h"
-#include "dart/collision/dart/DARTCollisionDetector.h"
-#ifdef HAVE_BULLET_COLLISION
-  #include "dart/collision/bullet/BulletCollisionDetector.h"
+
+#if DART_USE_FCLMESHCOLLISIONDETECTOR
+  #include "dart/collision/fcl_mesh/FCLMeshCollisionDetector.h"
+#else
+  #include "dart/collision/fcl/FCLCollisionDetector.h"
 #endif
+
 #include "dart/constraint/ConstrainedGroup.h"
 #include "dart/constraint/ContactConstraint.h"
 #include "dart/constraint/SoftContactConstraint.h"
@@ -62,7 +64,11 @@ using namespace dynamics;
 
 //==============================================================================
 ConstraintSolver::ConstraintSolver(double _timeStep)
-  : mCollisionDetector(new collision::FCLMeshCollisionDetector()),
+#if DART_USE_FCLMESHCOLLISIONDETECTOR
+  : mCollisionDetector(new collision::FCLMeshCollisionDetector),
+#else
+  : mCollisionDetector(new collision::FCLCollisionDetector),
+#endif
     mTimeStep(_timeStep),
     mLCPSolver(new DantzigLCPSolver(mTimeStep))
 {


### PR DESCRIPTION
DART currently uses `FCLMeshCollisionDetector` by default because FCL < 0.4 returns incorrect contact points for some primitive-primitive collision checks. This pull request changes the behavior in two ways:

1. Prints a warning about the bug if CMake detects an old version of FCL.
2. Uses `FCLCollisionDetector`, instead of `FCLMeshCollisionDetector`, if a new version if FCL is found.