### PR TITLE
Removed version check for Bullet.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,14 +360,8 @@ else()
 endif()
 
 # BulletCollision
-if(UNIX)
-  pkg_check_modules(BULLET bullet>=2.82 QUIET)
-  if(NOT BULLET_FOUND)
-     pkg_check_modules(BULLET bullet2.82>=2.82 QUIET)
-  endif()
-else()
-  find_package(Bullet COMPONENTS BulletMath BulletCollision QUIET)
-endif()
+find_package(Bullet COMPONENTS BulletMath BulletCollision QUIET)
+
 if(BULLET_FOUND)
   message(STATUS "Looking for BulletCollision - ${BULLET_VERSION} found")
   set(HAVE_BULLET_COLLISION TRUE)


### PR DESCRIPTION
This fixes #625 by removing the test for a Bullet version. This is important because Ubuntu 14.04 ships with Bullet 2.81, which fails the version check for Bullet 2.82 in the current DART `master`.

I would prefer to remove the check entirely, instead of simply lowering to Bullet 2.81, because we have no evidence to believe that the interface will not work on earlier versions of Bullet. We can re-introduce a version check if we find a compelling reason to do so (e.g. DART fails to build against very old versions).

I also removed the logic that uses `pkg-config` on `UNIX` systems. The `find_package` command works fine for me on Linux and was unable to find a justification for these gymnastics in the `git` history.. Does anyone know why this check was introduced?