### PR TITLE
Fixed find_package(DART) on optimizer components

### DIFF
--- a/dart/optimizer/ipopt/CMakeLists.txt
+++ b/dart/optimizer/ipopt/CMakeLists.txt
@@ -25,4 +25,7 @@ install(
   DESTINATION include/dart/optimizer/ipopt
   COMPONENT headers
 )
-install(TARGETS dart-optimizer-ipopt EXPORT DARTIpoptTargets DESTINATION lib)
+install(TARGETS dart-optimizer-ipopt
+  EXPORT DARTTargets
+  DESTINATION lib
+)

--- a/dart/optimizer/nlopt/CMakeLists.txt
+++ b/dart/optimizer/nlopt/CMakeLists.txt
@@ -25,4 +25,7 @@ install(
   DESTINATION include/dart/optimizer/nlopt
   COMPONENT headers
 )
-install(TARGETS dart-optimizer-nlopt EXPORT DARTNLoptTargets DESTINATION lib)
+install(TARGETS dart-optimizer-nlopt
+  EXPORT DARTTargets
+  DESTINATION lib
+)

--- a/dart/optimizer/snopt/CMakeLists.txt
+++ b/dart/optimizer/snopt/CMakeLists.txt
@@ -25,5 +25,7 @@ install(
   DESTINATION include/dart/optimizer/snopt
   COMPONENT headers
 )
-install(TARGETS dart-optimizer-snopt EXPORT DARTSNOPTTargets DESTINATION lib)
-
+install(TARGETS dart-optimizer-snopt
+  EXPORT DARTTargets
+  DESTINATION lib
+)


### PR DESCRIPTION
Merging #630 uncovered some latent issues in DART's CMake configuration. The optional `dart::optimizer` components (bindings for `nlopt`, `ipopt`, and `snopt`) were not being added to the `DARTTargets` group and, thus, were not included in `DARTTargets.cmake`. This caused finding those components, e.g. via `find_package(DART COMPONENTS nlopt)`, to fail even if they were built.

I thought the same issue would be present with `FCLCollisionDetector` and `BulletCollisionDetector`, but it appears that all of the available collision detectors are being linked into `dart.so`. There is dead code in those `CMakeLists.txt` file that indicates this was not always the case.

I found this surprising because merging all of these into one library seems undesirable. Was this an intentional change?