### PR TITLE
Split tutorials, examples, and tests into separate targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,21 +615,12 @@ if(NOT BUILD_CORE_ONLY)
     add_subdirectory(osgDart)
   endif(DART_BUILD_OSGDART)
 
+  add_subdirectory(apps EXCLUDE_FROM_ALL)
+  add_subdirectory(tutorials EXCLUDE_FROM_ALL)
+
   # Unit tests
-  if(DART_BUILD_UNITTESTS)
-    enable_testing()
-    add_subdirectory(unittests)
-  endif(DART_BUILD_UNITTESTS)
-
-  # Examples
-  if(DART_BUILD_EXAMPLES)
-    add_subdirectory(apps)
-  endif(DART_BUILD_EXAMPLES)
-
-  if(DART_BUILD_TUTORIALS)
-    add_subdirectory(tutorials)
-  endif()
-
+  enable_testing()
+  add_subdirectory(unittests EXCLUDE_FROM_ALL)
 endif(NOT BUILD_CORE_ONLY)
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,6 @@ else()
   option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 endif()
 option(DART_BUILD_OSGDART "Build osgDart library" ON)
-option(DART_BUILD_EXAMPLES "Build examples" ON)
-option(DART_BUILD_TUTORIALS "Build tutorials" ON)
-option(DART_BUILD_UNITTESTS "Build unit tests" ON)
 option(DART_COVERALLS "Turn on coveralls support" OFF)
 option(DART_COVERALLS_UPLOAD "Upload the generated coveralls json" ON)
 
@@ -544,9 +541,6 @@ message(STATUS "BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 message(STATUS "ENABLE_OPENMP    : ${ENABLE_OPENMP}")
 message(STATUS "Build core only  : ${BUILD_CORE_ONLY}")
 message(STATUS "Build osgDart    : ${DART_BUILD_OSGDART}")
-message(STATUS "Build examples   : ${DART_BUILD_EXAMPLES}")
-message(STATUS "Build tutorials  : ${DART_BUILD_TUTORIALS}")
-message(STATUS "Build unit tests : ${DART_BUILD_UNITTESTS}")
 message(STATUS "Install path     : ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "CXX_FLAGS        : ${CMAKE_CXX_FLAGS}")
 if(${CMAKE_BUILD_TYPE_UPPERCASE} STREQUAL "RELEASE")
@@ -605,12 +599,32 @@ install(FILES ${PC_CONFIG_OUT} DESTINATION lib/pkgconfig)
 install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 
 #===============================================================================
+# Helper Functions
+#===============================================================================
+
+set_property(GLOBAL PROPERTY DART_EXAMPLES)
+set_property(GLOBAL PROPERTY DART_TUTORIALS)
+set_property(GLOBAL PROPERTY DART_UNITTESTS)
+
+function(dart_add_example target_name)
+  set_property(GLOBAL APPEND PROPERTY DART_EXAMPLES "${target_name}")
+endfunction(dart_add_example)
+
+function(dart_add_tutorial target_name)
+  set_property(GLOBAL APPEND PROPERTY DART_TUTORIALS "${target_name}")
+endfunction(dart_add_tutorial)
+
+function(dart_add_unittest target_name)
+  set_property(GLOBAL APPEND PROPERTY DART_UNITTESTS "${target_name}")
+endfunction(dart_add_unittest)
+
+#===============================================================================
 # Add sub-directories
 #===============================================================================
+
 add_subdirectory(dart)
 
 if(NOT BUILD_CORE_ONLY)
-
   if(DART_BUILD_OSGDART)
     add_subdirectory(osgDart)
   endif(DART_BUILD_OSGDART)
@@ -618,10 +632,40 @@ if(NOT BUILD_CORE_ONLY)
   add_subdirectory(apps EXCLUDE_FROM_ALL)
   add_subdirectory(tutorials EXCLUDE_FROM_ALL)
 
-  # Unit tests
-  enable_testing()
-  add_subdirectory(unittests EXCLUDE_FROM_ALL)
+  # Add a "tutorials" target to build tutorials.
+  get_property(tutorials GLOBAL PROPERTY DART_TUTORIALS)
+  add_custom_target(tutorials DEPENDS ${tutorials})
+
+  message(STATUS "")
+  message(STATUS "[ Tutorials ]")
+  foreach(tutorial ${tutorials})
+    message(STATUS "Adding tutorial: ${tutorial}")
+  endforeach(tutorial ${tutorials})
+
+  # Add an "examples" target to build examples.
+  get_property(examples GLOBAL PROPERTY DART_EXAMPLES)
+  add_custom_target(examples DEPENDS ${examples})
+
+  message(STATUS "")
+  message(STATUS "[ Examples ]")
+
+  foreach(example ${examples})
+    message(STATUS "Adding example: ${example}")
+  endforeach(example ${examples})
 endif(NOT BUILD_CORE_ONLY)
+
+# Add a "tests" target to build unit tests.
+enable_testing()
+add_subdirectory(unittests EXCLUDE_FROM_ALL)
+
+get_property(unittests GLOBAL PROPERTY DART_UNITTESTS)
+add_custom_target(tests DEPENDS ${unittests})
+
+message(STATUS "")
+message(STATUS "[ Unit Tests ]")
+foreach(unittest ${unittests})
+  message(STATUS "Adding test: ${unittest}")
+endforeach(unittest ${unittests})
 
 #===============================================================================
 # Export targets

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,16 +1,12 @@
 # A list of applications
 set_property(DIRECTORY PROPERTY FOLDER Apps)
 
-message(STATUS "")
-message(STATUS "[ Applications ]")
-
 # Automatically identify all directories in the apps folder
 file(GLOB children RELATIVE ${CMAKE_CURRENT_LIST_DIR} "*")
 set(directories "")
 foreach(child ${children})
   if(IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/${child}")
     if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${child}/CMakeLists.txt")
-      message(STATUS "Adding application: " ${child})
       list(APPEND directories ${child})
     endif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${child}/CMakeLists.txt")
   endif(IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/${child}")
@@ -19,14 +15,5 @@ endforeach(child)
 # List of all the subdirectories to include
 foreach(APPDIR ${directories})
   add_subdirectory(${APPDIR})
-  if(WIN32)
-    if(TARGET ${APPTARGET})
-      set_target_properties(${APPTARGET} PROPERTIES FOLDER Apps
-          #EXCLUDE_FROM_DEFAULT_BUILD ON
-          )
-      set_target_properties(${APPTARGET} PROPERTIES STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
-    endif(TARGET ${APPTARGET})
-  endif(WIN32)
+  dart_add_example(${APPDIR})
 endforeach(APPDIR)
-
-add_custom_target(examples DEPENDS ${directories})

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -28,3 +28,5 @@ foreach(APPDIR ${directories})
     endif(TARGET ${APPTARGET})
   endif(WIN32)
 endforeach(APPDIR)
+
+add_custom_target(examples DEPENDS ${directories})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,6 @@ environment:
   MSVC_DEFAULT_OPTIONS: ON
   BOOST_ROOT: C:\Libraries\boost_1_59_0
   BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib32-msvc-14.0
-  BUILD_EXAMPLES: OFF  # don't build examples to not exceed allowed build time (40 min)
-  BUILD_TUTORIALS: OFF  # don't build tutorials to not exceed allowed build time (40 min)
   matrix:
   - BUILD_CORE_ONLY: ON
   - BUILD_CORE_ONLY: OFF
@@ -55,7 +53,7 @@ before_build:
   # We generate project files for Visual Studio 12 because the boost binaries installed on the test server are for Visual Studio 12.
   - cmd: if "%platform%"=="Win32" set CMAKE_GENERATOR_NAME=Visual Studio 14 2015
   - cmd: if "%platform%"=="x64"   set CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
-  - cmd: cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%configuration% -DBUILD_CORE_ONLY="%BUILD_CORE_ONLY%" -DDART_BUILD_EXAMPLES="%BUILD_EXAMPLES%" -DDART_BUILD_TUTORIALS="%BUILD_TUTORIALS%" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS="ON" -Durdfdom_DIR="%urdfdom_DIR%" -Durdfdom_headers_DIR="%urdfdom_headers_DIR%" -DDART_MSVC_DEFAULT_OPTIONS="%MSVC_DEFAULT_OPTIONS%" ..
+  - cmd: cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%configuration% -DBUILD_CORE_ONLY="%BUILD_CORE_ONLY%" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS="ON" -Durdfdom_DIR="%urdfdom_DIR%" -Durdfdom_headers_DIR="%urdfdom_headers_DIR%" -DDART_MSVC_DEFAULT_OPTIONS="%MSVC_DEFAULT_OPTIONS%" ..
 
 build:
   project: C:\projects\dart\build\dart.sln # path to Visual Studio solution or project

--- a/ci/script_linux.sh
+++ b/ci/script_linux.sh
@@ -1,7 +1,7 @@
 make
 if [ $COVERALLS = ON ]; then make coveralls; fi
 sudo ldconfig --verbose # So the test executeables can detect libtinyxml2
-if [ $BUILD_CORE_ONLY = OFF ]; then make all test tests; fi
+if [ $BUILD_CORE_ONLY = OFF ]; then make all tutorials examples tests test; fi
 # cd tools/
 # ./code_check.sh
 # ./abi_check.sh 4.1.0  # Check with DART 4.1.0

--- a/ci/script_linux.sh
+++ b/ci/script_linux.sh
@@ -1,7 +1,7 @@
 make
 if [ $COVERALLS = ON ]; then make coveralls; fi
 sudo ldconfig --verbose # So the test executeables can detect libtinyxml2
-if [ $BUILD_CORE_ONLY = OFF ]; then make test; fi
+if [ $BUILD_CORE_ONLY = OFF ]; then make all test tests; fi
 # cd tools/
 # ./code_check.sh
 # ./abi_check.sh 4.1.0  # Check with DART 4.1.0

--- a/ci/script_osx.sh
+++ b/ci/script_osx.sh
@@ -1,5 +1,5 @@
 make
-if [ $BUILD_CORE_ONLY = OFF ]; then make all tests test; fi
+if [ $BUILD_CORE_ONLY = OFF ]; then make all tutorials examples tests test; fi
 # cd tools/
 # ./code_check.sh
 # ./abi_check.sh 4.1.0  # Check with DART 4.1.0

--- a/ci/script_osx.sh
+++ b/ci/script_osx.sh
@@ -1,5 +1,5 @@
 make
-if [ $BUILD_CORE_ONLY = OFF ]; then make test; fi
+if [ $BUILD_CORE_ONLY = OFF ]; then make all tests test; fi
 # cd tools/
 # ./code_check.sh
 # ./abi_check.sh 4.1.0  # Check with DART 4.1.0

--- a/osgDart/CMakeLists.txt
+++ b/osgDart/CMakeLists.txt
@@ -32,9 +32,7 @@ if(${OPENSCENEGRAPH_FOUND})
 
   add_subdirectory(render)
 
-  if(${DART_BUILD_EXAMPLES})
-    add_subdirectory(examples)
-  endif(${DART_BUILD_EXAMPLES})
+  add_subdirectory(examples EXCLUDE_FROM_ALL)
 
   install(
     FILES ${osgDart_hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osgDart.h

--- a/osgDart/examples/CMakeLists.txt
+++ b/osgDart/examples/CMakeLists.txt
@@ -1,14 +1,11 @@
 file(GLOB osgdart_examples_src "*.cpp")
 list(SORT osgdart_examples_src)
 
-message(STATUS "")
-message(STATUS "[ osgDart Examples ]")
-
 foreach(example ${osgdart_examples_src})
-
   get_filename_component(example_base ${example} NAME_WE)
-  message(STATUS "Adding example: " ${example_base})
+
   add_executable(${example_base} ${example})
   target_link_libraries(${example_base} dart osgDart ${OPENSCENEGRAPH_LIBRARIES})
 
+  dart_add_example(${example_base})
 endforeach(example)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -1,16 +1,11 @@
 file(GLOB tutorials_src "*.cpp")
 list(SORT tutorials_src)
 
-message(STATUS "")
-message(STATUS "[ Tutorials ]")
-
 foreach(tutorial ${tutorials_src})
   get_filename_component(tutorial_base ${tutorial} NAME_WE)
-  list(APPEND all_tutorials ${tutorial_base})
 
-  message(STATUS "Adding tutorial: ${tutorial_base}")
   add_executable(${tutorial_base} ${tutorial})
   target_link_libraries(${tutorial_base} dart)
-endforeach(tutorial)
 
-add_custom_target(tutorials DEPENDS ${all_tutorials})
+  dart_add_tutorial(${tutorial_base})
+endforeach(tutorial)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -6,7 +6,11 @@ message(STATUS "[ Tutorials ]")
 
 foreach(tutorial ${tutorials_src})
   get_filename_component(tutorial_base ${tutorial} NAME_WE)
+  list(APPEND all_tutorials ${tutorial_base})
+
   message(STATUS "Adding tutorial: ${tutorial_base}")
   add_executable(${tutorial_base} ${tutorial})
   target_link_libraries(${tutorial_base} dart)
 endforeach(tutorial)
+
+add_custom_target(tutorials DEPENDS ${all_tutorials})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -61,11 +61,13 @@ message(STATUS "")
 message(STATUS "[ Unit tests ]")
 file(GLOB tests "test*.cpp")
 foreach(test ${tests})
-
   # Get the name (i.e. bla.cpp => bla)
   get_filename_component(base ${test} NAME_WE)
+  list(APPEND all_tests ${base})
+
   link_directories(${DARTExt_LIBRARY_DIRS})
   add_executable(${base} ${test})
+
   if(MSVC)
     target_link_libraries(${base} dart optimized gtest debug gtestd)
   else()
@@ -80,8 +82,8 @@ foreach(test ${tests})
     add_test(${base} ${CMAKE_BINARY_DIR}/bin/tests/${base})
     message(STATUS "Adding test: " ${base})
   endif(NOT contains)
-
 endforeach(test)
+
 
 if(HAVE_IPOPT)
   target_link_libraries(testOptimizer dart-optimizer-ipopt ${IPOPT_LIBRARIES})
@@ -94,3 +96,5 @@ endif(HAVE_NLOPT)
 if(HAVE_SNOPT)
   target_link_libraries(testOptimizer dart-optimizer-snopt)
 endif(HAVE_SNOPT)
+
+add_custom_target(tests DEPENDS ${all_tests})

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -57,8 +57,6 @@ endif()
 set_target_properties(gtest PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 # Compile each test file
-message(STATUS "")
-message(STATUS "[ Unit tests ]")
 file(GLOB tests "test*.cpp")
 foreach(test ${tests})
   # Get the name (i.e. bla.cpp => bla)
@@ -67,6 +65,7 @@ foreach(test ${tests})
 
   link_directories(${DARTExt_LIBRARY_DIRS})
   add_executable(${base} ${test})
+  dart_add_unittest(${base})
 
   if(MSVC)
     target_link_libraries(${base} dart optimized gtest debug gtestd)
@@ -80,7 +79,6 @@ foreach(test ${tests})
   list_contains(contains ${base} ${dontTest})
   if(NOT contains)
     add_test(${base} ${CMAKE_BINARY_DIR}/bin/tests/${base})
-    message(STATUS "Adding test: " ${base})
   endif(NOT contains)
 endforeach(test)
 
@@ -96,5 +94,3 @@ endif(HAVE_NLOPT)
 if(HAVE_SNOPT)
   target_link_libraries(testOptimizer dart-optimizer-snopt)
 endif(HAVE_SNOPT)
-
-add_custom_target(tests DEPENDS ${all_tests})


### PR DESCRIPTION
This pull request replaces the `DART_BUILD_UNITTESTS`, `DART_BUILD_EXAMPLES` and `DART_BUILD_TUTORIALS` CMake flags the `tests`, `examples`, and `tutorials` targets. These features are no longer built by default unless the user explicitly passes the corresponding target(s) to `make`. 

The key advantage of this approach is that targets are specified at *build time*, whereas CMake flags are specified at *configure time*. These features are optional and take a long time to build, so I prefer having them disabled by default. It's currently awkward to do this because changing these settings requires re-running CMake with new `-D` flags and, possibly, deleting your `CMakeCache.txt` file.

With the new paradigm, this is as simple as running `make` during development and passing the `tests`, `examples`, or `tutorials` target when you want to try re-building that code. Note that you can still run `make all tests examples tutorials` to build everything at once.

I am not sure what @jslee02 and @mxgrey think of this change, so this pull request is mostly intended to start a discussion.