### PR TITLE
Suppress unused variables warnings in release mode

### DIFF
--- a/dart/common/StlHelpers.h
+++ b/dart/common/StlHelpers.h
@@ -42,6 +42,10 @@
 #include <memory>
 #include <vector>
 
+// Macro to suppress -Wunused-parameter and -Wunused-variable warnings in
+// release mode when a variable is only used in assertions.
+#define DART_UNUSED(x) do { (void)(x); } while (0)
+
 namespace dart {
 namespace common {
 

--- a/dart/lcpsolver/ODELCPSolver.cpp
+++ b/dart/lcpsolver/ODELCPSolver.cpp
@@ -38,6 +38,7 @@
 
 #include <cstdio>
 
+#include "dart/common/StlHelpers.h"
 #include "dart/lcpsolver/Lemke.h"
 #include "dart/lcpsolver/lcp.h"
 #include "dart/lcpsolver/misc.h"
@@ -63,6 +64,8 @@ bool ODELCPSolver::Solve(const Eigen::MatrixXd& _A,
     return (err == 0);
   } else {
     assert(_numDir >= 4);
+    DART_UNUSED(_numDir);
+
     double* A, *b, *x, *w, *lo, *hi;
     int n = _A.rows();
 

--- a/dart/optimizer/ipopt/IpoptSolver.cpp
+++ b/dart/optimizer/ipopt/IpoptSolver.cpp
@@ -37,6 +37,7 @@
 #include "dart/optimizer/ipopt/IpoptSolver.h"
 
 #include "dart/common/Console.h"
+#include "dart/common/StlHelpers.h"
 #include "dart/math/Helpers.h"
 #include "dart/optimizer/Function.h"
 #include "dart/optimizer/Problem.h"
@@ -205,6 +206,7 @@ bool DartTNLP::get_bounds_info(Ipopt::Index n,
   assert(static_cast<size_t>(n) == problem->getDimension());
   assert(static_cast<size_t>(m) == problem->getNumEqConstraints()
          + problem->getNumIneqConstraints());
+  DART_UNUSED(m);
 
   // lower and upper bounds
   for (Ipopt::Index i = 0; i < n; i++)
@@ -321,6 +323,7 @@ bool DartTNLP::eval_g(Ipopt::Index _n,
 
   assert(static_cast<size_t>(_m) == problem->getNumEqConstraints()
                                     + problem->getNumIneqConstraints());
+  DART_UNUSED(_m);
 
   // TODO(JS):
   if (_new_x)


### PR DESCRIPTION
Building DART in release mode disables assertions. There are a few parameters in DART that are only used in assertions, so this generates `-Wunused-parameter` warnings. This pull request adds a `DART_UNUSED` that suppresses those warnings. See [this StackOverflow answer](http://stackoverflow.com/a/777359/111426) for more explanation.