### PR TITLE
Assign resource retriever when nullptr passed to SdfParser

### DIFF
--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -246,6 +246,9 @@ dynamics::FreeJoint::Properties readFreeJoint(
     const Eigen::Isometry3d& parentModelFrame,
     const std::string& name);
 
+common::ResourceRetrieverPtr getRetriever(
+    const common::ResourceRetrieverPtr& retriever);
+
 } // anonymous namespace
 
 
@@ -259,9 +262,12 @@ simulation::WorldPtr readSdfFile(
 }
 
 //==============================================================================
-simulation::WorldPtr readWorld(const common::Uri& fileUri,
-                               const common::ResourceRetrieverPtr& retriever)
+simulation::WorldPtr readWorld(
+    const common::Uri& fileUri,
+    const common::ResourceRetrieverPtr& nullOrRetriever)
 {
+  const auto retriever = getRetriever(nullOrRetriever);
+
   //--------------------------------------------------------------------------
   // Load xml and create Document
   tinyxml2::XMLDocument _dartFile;
@@ -312,8 +318,11 @@ simulation::WorldPtr readWorld(const common::Uri& fileUri,
 
 //==============================================================================
 dynamics::SkeletonPtr readSkeleton(
-    const common::Uri& fileUri, const common::ResourceRetrieverPtr& retriever)
+    const common::Uri& fileUri,
+    const common::ResourceRetrieverPtr& nullOrRetriever)
 {
+  const auto retriever = getRetriever(nullOrRetriever);
+
   //--------------------------------------------------------------------------
   // Load xml and create Document
   tinyxml2::XMLDocument _dartFile;
@@ -1470,6 +1479,16 @@ dynamics::FreeJoint::Properties readFreeJoint(
     const std::string&)
 {
   return dynamics::FreeJoint::Properties();
+}
+
+//==============================================================================
+common::ResourceRetrieverPtr getRetriever(
+  const common::ResourceRetrieverPtr& retriever)
+{
+  if(retriever)
+    return retriever;
+  else
+    return std::make_shared<common::LocalResourceRetriever>();
 }
 
 } // anonymouse

--- a/unittests/testSdfParser.cpp
+++ b/unittests/testSdfParser.cpp
@@ -76,6 +76,55 @@ TEST(SdfParser, SDFSingleBodyWithoutJoint)
 }
 
 //==============================================================================
+TEST(SdfParser, ParsingSDFFiles)
+{
+  const auto numSteps = 10u;
+
+  // Create a list of sdf files to test with where the sdf files contains World
+  std::vector<std::string> worldFiles;
+  worldFiles.push_back(DART_DATA_PATH"sdf/benchmark.world");
+  worldFiles.push_back(DART_DATA_PATH"sdf/double_pendulum.world");
+  worldFiles.push_back(DART_DATA_PATH"sdf/double_pendulum_with_base.world");
+  worldFiles.push_back(DART_DATA_PATH"sdf/empty.world");
+  worldFiles.push_back(DART_DATA_PATH"sdf/ground.world");
+  worldFiles.push_back(DART_DATA_PATH"sdf/test/single_bodynode_skeleton.world");
+
+  std::vector<WorldPtr> worlds;
+  for (const auto& worldFile : worldFiles)
+    worlds.push_back(SdfParser::readWorld(worldFile));
+
+  for (auto world : worlds)
+  {
+    EXPECT_TRUE(nullptr != world);
+
+    for (auto i = 0u; i < numSteps; ++i)
+      world->step();
+  }
+
+  // Create another list of sdf files to test with where the sdf files contains
+  // Skeleton
+  std::vector<std::string> skeletonFiles;
+  skeletonFiles.push_back(DART_DATA_PATH"sdf/atlas/atlas_v3_no_head.sdf");
+  skeletonFiles.push_back(DART_DATA_PATH"sdf/atlas/atlas_v3_no_head_soft_feet.sdf");
+
+  auto world = std::make_shared<World>();
+  std::vector<SkeletonPtr> skeletons;
+  for (const auto& skeletonFile : skeletonFiles)
+    skeletons.push_back(SdfParser::readSkeleton(skeletonFile));
+
+  for (auto skeleton : skeletons)
+  {
+    EXPECT_TRUE(nullptr != skeleton);
+
+    world->addSkeleton(skeleton);
+    for (auto i = 0u; i < numSteps; ++i)
+      world->step();
+
+    world->removeAllSkeletons();
+  }
+}
+
+//==============================================================================
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This fixes SdfParser fails to load mesh files, which was reported by @sehoonha .