### PR TITLE
Removing OpenGL dep from main lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,6 @@ include_directories(SYSTEM ${CCD_INCLUDE_DIRS})
 include_directories(SYSTEM ${FCL_INCLUDE_DIRS})
 include_directories(SYSTEM ${ASSIMP_INCLUDE_DIRS})
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-include_directories(SYSTEM ${OPENGL_INCLUDE_DIR})
-include_directories(SYSTEM ${GLUT_INCLUDE_DIR})
 if(HAVE_BULLET_COLLISION)
   include_directories(SYSTEM ${BULLET_INCLUDE_DIRS})
 endif()
@@ -138,7 +136,6 @@ set(DART_DEPENDENCIES ${CCD_LIBRARIES}
                       ${FCL_LIBRARIES}
                       ${ASSIMP_LIBRARIES}
                       ${Boost_LIBRARIES}
-                      ${OPENGL_LIBRARIES} # TODO(JS): Should be removed once draw functions are removed from classes in dynamics namespace
 )
 
 if(HAVE_BULLET_COLLISION)

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -128,61 +128,57 @@ else()
   message(SEND_ERROR "Please install system boost version ${DART_MIN_BOOST_VERSION} or higher.")
 endif()
 
-if(NOT BUILD_CORE_ONLY)
-
-  # GLUT
-  if(WIN32 AND NOT CYGWIN)
-    set(GLUT_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/include")
-    set(GLUT_LIBRARIES glut32)
+# GLUT
+if(WIN32 AND NOT CYGWIN)
+  set(GLUT_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/include")
+  set(GLUT_LIBRARIES glut32)
+else()
+  find_package(GLUT QUIET)
+  if(GLUT_FOUND)
+    message(STATUS "Looking for GLUT - found")
+    set(GLUT_LIBRARIES ${GLUT_glut_LIBRARY})
   else()
-    find_package(GLUT QUIET)
-    if(GLUT_FOUND)
-      message(STATUS "Looking for GLUT - found")
-      set(GLUT_LIBRARIES ${GLUT_glut_LIBRARY})
-    else()
-      message(SEND_ERROR "Looking for GLUT - NOT found, Please install freeglut3-dev")
-    endif()
+    message(SEND_ERROR "Looking for GLUT - NOT found, Please install freeglut3-dev")
   endif()
+endif()
 
-  # FLANN
-  find_package(FLANN 1.8.4 QUIET)
-  if(FLANN_FOUND)
-    message(STATUS "Looking for FLANN - ${FLANN_VERSION} found")
-  else()
-    message(SEND_ERROR "Looking for FLANN - NOT found, please install libflann-dev (>= 1.8.4)")
-  endif()
+# FLANN
+find_package(FLANN 1.8.4 QUIET)
+if(FLANN_FOUND)
+  message(STATUS "Looking for FLANN - ${FLANN_VERSION} found")
+else()
+  message(SEND_ERROR "Looking for FLANN - NOT found, please install libflann-dev (>= 1.8.4)")
+endif()
 
-  # TINYXML
-  find_package(TINYXML 2.6.2 QUIET)
-  if(TINYXML_FOUND)
-    message(STATUS "Looking for TINYXML - ${TINYXML_VERSION} found")
-  else()
-    message(SEND_ERROR "Looking for TINYXML - NOT found, please install libtinyxml-dev (>= 2.6.2)")
-  endif()
+# TINYXML
+find_package(TINYXML 2.6.2 QUIET)
+if(TINYXML_FOUND)
+  message(STATUS "Looking for TINYXML - ${TINYXML_VERSION} found")
+else()
+  message(SEND_ERROR "Looking for TINYXML - NOT found, please install libtinyxml-dev (>= 2.6.2)")
+endif()
 
-  # TINYXML2
-  find_package(TINYXML2 QUIET)
-  if(TINYXML2_FOUND)
-    message(STATUS "Looking for TINYXML2 - ${TINYXML2_VERSION} found")
-  else()
-    message(SEND_ERROR "Looking for TINYXML2 - NOT found, please install libtinyxml2-dev (>= 1.0.1)")
-  endif()
+# TINYXML2
+find_package(TINYXML2 QUIET)
+if(TINYXML2_FOUND)
+  message(STATUS "Looking for TINYXML2 - ${TINYXML2_VERSION} found")
+else()
+  message(SEND_ERROR "Looking for TINYXML2 - NOT found, please install libtinyxml2-dev (>= 1.0.1)")
+endif()
 
-  # urdfdom
-  find_package(urdfdom QUIET)
-  if(urdfdom_FOUND)
-    message(STATUS "Looking for urdfdom - found")
-  else()
-    message(SEND_ERROR "Looking for urdfdom - NOT found, please install liburdfdom-dev")
-  endif()
-  if(MSVC)
-    set(urdfdom_LIBRARIES optimized urdfdom_sensor      debug urdfdom_sensord
-                          optimized urdfdom_model_state debug urdfdom_model_stated
-                          optimized urdfdom_model       debug urdfdom_modeld
-                          optimized urdfdom_world       debug urdfdom_worldd
-                          optimized console_bridge      debug console_bridged)
-  endif()
-
+# urdfdom
+find_package(urdfdom QUIET)
+if(urdfdom_FOUND)
+  message(STATUS "Looking for urdfdom - found")
+else()
+  message(SEND_ERROR "Looking for urdfdom - NOT found, please install liburdfdom-dev")
+endif()
+if(MSVC)
+  set(urdfdom_LIBRARIES optimized urdfdom_sensor      debug urdfdom_sensord
+                        optimized urdfdom_model_state debug urdfdom_model_stated
+                        optimized urdfdom_model       debug urdfdom_modeld
+                        optimized urdfdom_world       debug urdfdom_worldd
+                        optimized console_bridge      debug console_bridged)
 endif()
 
 #-----------------------

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -17,7 +17,6 @@ add_subdirectory(optimizer)
 add_subdirectory(integration)
 add_subdirectory(lcpsolver)
 add_subdirectory(math)
-add_subdirectory(renderer)
 add_subdirectory(simulation)
 
 # Set header and source files
@@ -32,7 +31,6 @@ set(dart_hdrs
   ${dart_optimizer_hdrs}
   ${dart_collision_hdrs}
   ${dart_constraint_hdrs}
-  ${dart_renderer_hdrs}
   ${dart_simulation_hdrs}
 )
 set(dart_srcs
@@ -44,7 +42,6 @@ set(dart_srcs
   ${dart_optimizer_srcs}
   ${dart_collision_srcs}
   ${dart_constraint_srcs}
-  ${dart_renderer_srcs}
   ${dart_simulation_srcs}
 )
 
@@ -71,6 +68,7 @@ if(FLANN_FOUND)
 endif()
 
 if(GLUT_FOUND)
+  add_subdirectory(renderer)
   add_subdirectory(gui)
 endif()
 

--- a/dart/gui/CMakeLists.txt
+++ b/dart/gui/CMakeLists.txt
@@ -2,6 +2,7 @@
 file(GLOB srcs "*.cpp")
 file(GLOB hdrs "*.h")
 
+include_directories(SYSTEM ${OPENGL_INCLUDE_DIR})
 include_directories(SYSTEM ${GLUT_INCLUDE_DIR})
 
 # Add subdirectories
@@ -9,12 +10,12 @@ if(HAVE_OPENSCENEGRAPH)
   add_subdirectory(osg)
 endif(HAVE_OPENSCENEGRAPH)
 
-set(dart_gui_hdrs ${dart_gui_hdrs} ${hdrs})
-set(dart_gui_srcs ${dart_gui_srcs} ${srcs})
+set(dart_gui_hdrs ${dart_gui_hdrs} ${hdrs} ${dart_renderer_hdrs})
+set(dart_gui_srcs ${dart_gui_srcs} ${srcs} ${dart_renderer_srcs})
 
 # Library
 dart_add_library(dart-gui ${srcs} ${hdrs})
-target_link_libraries(dart-gui dart-utils ${GLUT_LIBRARY})
+target_link_libraries(dart-gui dart-utils ${GLUT_LIBRARY} ${OPENGL_LIBRARIES})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "gui headers" ${hdrs})

--- a/dart/gui/osg/render/CMakeLists.txt
+++ b/dart/gui/osg/render/CMakeLists.txt
@@ -18,7 +18,7 @@ configure_file(
 )
 
 install(
-  FILES ${dart_gui_osg_hdrs} ${CMAKE_CURRENT_BINARY_DIR}/render.h
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/render.h
   DESTINATION include/dart/gui/osg/render
   COMPONENT headers
 )


### PR DESCRIPTION
I removed OpenGL (and renderer) libs/includes from main library (libdart) and moved them to gui library (lib-dart-gui). Also, I minor fix for installing properly the gui-osg include files..