### PR TITLE
Merge 4.3.6 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,11 @@
+## DART 6
+
 ### Version 6.0.0 (2015-12-19)
 
 1. Added missing `liburdfdom-dev` dependency in Ubuntu package
     * [Pull request #574](https://github.com/dartsim/dart/pull/574)
+
+## DART 5
 
 ### Version 5.1.1 (2015-11-06)
 
@@ -300,6 +304,19 @@
 1. Added specification of minimum dependency version
     * [Pull request #306](https://github.com/dartsim/dart/pull/306)
 
+## DART 4
+
+### Version 4.3.6 (2016-04-16)
+
+1. Fixed duplicate entries in Skeleton::mBodyNodes causing segfault in destructor
+    * [Issue #671](https://github.com/dartsim/dart/issues/671)
+    * [Pull request #672](https://github.com/dartsim/dart/pull/672)
+
+### Version 4.3.5 (2016-01-09)
+
+1. Fixed incorrect applying of joint constraint impulses (backported from 6.0.0)
+    * [Pull request #578](https://github.com/dartsim/dart/pull/578)
+
 ### Version 4.3.4 (2015-01-24)
 
 1. Fixed build issue with gtest on Mac
@@ -424,6 +441,8 @@
   * [Issue #122](https://github.com/dartsim/dart/issues/122)
   * [Pull request #168](https://github.com/dartsim/dart/pull/168)
 
+## DART 3
+
 ### Version 3.0 (2013-11-04)
 
 1. Removed Transformation classes. Their functionality is now included in joint classes.
@@ -433,6 +452,8 @@
 1. A lot of function and variable renames
 1. Added constraint namespace
 1. Added "common" namespace
+
+## DART 2
 
 ### Version 2.6 (2013-09-07)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -107,6 +107,18 @@ dart (5.0.0) unstable; urgency=low
 
  -- Jeongseok Lee <jslee02@gmail.com>  Mon, 15 Jun 2015 23:40:00 -0500
 
+dart4 (4.3.6) unstable; urgency=medium
+
+  * Fixed duplicate entries in Skeleton::mBodyNodes causing segfault in destructor
+
+ -- Jeongseok Lee <jslee02@gmail.com>  Sat, 16 Apr 2016 12:00:00 -0500
+
+dart4 (4.3.5) unstable; urgency=medium
+
+  * Fixed incorrect applying of joint constraint impulses (backported from 6.0.0)
+
+ -- Jeongseok Lee <jslee02@gmail.com>  Sat, 9 Jan 2015 12:00:00 -0500
+
 dart (4.3.4) unstable; urgency=low
 
   * Fixed build issue with gtest on Mac

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-dart (6.0.0) unstable; urgency=medium
+dart6 (6.0.0) unstable; urgency=medium
 
   * Added missing 'liburdfdom-dev' dependency in Ubuntu package
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: dart
+Source: dart6
 Priority: extra
 Maintainer: Jeongseok Lee <jslee02@gmail.com>
 Build-Depends: debhelper (>= 9),


### PR DESCRIPTION
All the invalid changes for DART 6.0 are ignored.