### PR TITLE
Fix BULLET_INCLUDE_DIRS in DARTConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,13 @@ if(HAVE_BULLET_COLLISION)
 endif()
 include_directories("${CMAKE_BINARY_DIR}")
 
+set(DART_INCLUDE_DIRS
+    "${CMAKE_INSTALL_PREFIX}/include"
+    "${EIGEN3_INCLUDE_DIRS}")
+if(HAVE_BULLET_COLLISION)
+  list(APPEND DART_INCLUDE_DIRS "${BULLET_INCLUDE_DIRS}")
+endif()
+
 #===============================================================================
 # Check for non-case-sensitive filesystems
 #===============================================================================

--- a/cmake/DARTConfig.cmake.in
+++ b/cmake/DARTConfig.cmake.in
@@ -9,10 +9,7 @@
 #===============================================================================
 # DART_INCLUDE_DIRS
 #===============================================================================
-set(DART_INCLUDE_DIRS
-    "@CMAKE_INSTALL_PREFIX@/include"
-    "@EIGEN3_INCLUDE_DIRS@"
-    "@BULLET_INCLUDE_DIRS@")
+set(DART_INCLUDE_DIRS "@DART_INCLUDE_DIRS@")
 
 #===============================================================================
 # DART_LIBRARIES


### PR DESCRIPTION
The fix from #361 doesn't work if bullet package was failed to be found by `find_package()`. When bullet is not found, `BULLET_INCLUDE_DIRS` will be set to `BULLET_INCLUDE_DIRS-NOT-FOUND` rather than blank as we assumed in #361.

Instead, we set `DART_INCLUDE_DIRS` in the top level CMakeList.txt by adding `BULLET_INCLUDE_DIRS` to `DART_INCLUDE_DIRS` only when bullet is found. `DARTConfig.cmake` is then configured using `DART_INCLUDE_DIRS`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/697)
<!-- Reviewable:end -->
