### PR TITLE
Fixed a CMake typo that was preventing dynamics/detail headers from being installed

### DIFF
--- a/dart/dynamics/CMakeLists.txt
+++ b/dart/dynamics/CMakeLists.txt
@@ -28,7 +28,7 @@ install(
 )
 
 install(
-  FILES ${detail}
+  FILES ${detail_hdrs}
   DESTINATION include/dart/dynamics/detail
   COMPONENT headers
 )


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/706)
<!-- Reviewable:end -->
