### PR TITLE
merge(~) feature for Composite State and Properties

### DIFF
--- a/dart/common/Cloneable.hpp
+++ b/dart/common/Cloneable.hpp
@@ -248,11 +248,27 @@ public:
   /// Map-based move assignment operator
   CloneableMap& operator=(MapType&& otherMap);
 
-  /// Copy the contents of another cloneable map into this one.
-  void copy(const CloneableMap& otherMap);
+  /// Copy the contents of another cloneable map into this one. If merge is set
+  /// to false, then any fields in this map which are not present in the other
+  /// map will be erased; otherwise they will be kept. Setting merge to false
+  /// will make the contents of this map an exact duplicate of the other map.
+  void copy(const CloneableMap& otherMap, bool merge=false);
 
-  /// Copy the contents of a map into this one.
-  void copy(const MapType& otherMap);
+  /// Copy the contents of a map into this one. If merge is set to false, then
+  /// any fields in this map which are not present in the other map will be
+  /// erased; otherwise they will be kept. Setting merge to false will make the
+  /// contents of this map an exact duplicate of the other map.
+  void copy(const MapType& otherMap, bool merge=false);
+
+  /// Merge the contents of another cloneable map into this one. If there are
+  /// any entries which both maps have, then the contents of otherMap will take
+  /// precedence. This is the same as calling copy(otherMap, true).
+  void merge(const CloneableMap& otherMap);
+
+  /// Merge the contents of another map into this one. If there are any entries
+  /// which both maps have, then the contents of otherMap will take precedence.
+  /// This is the same as calling copy(otherMap, true).
+  void merge(const MapType& otherMap);
 
   /// Get the map that is being held
   MapType& getMap();

--- a/dart/common/detail/Cloneable.hpp
+++ b/dart/common/detail/Cloneable.hpp
@@ -426,14 +426,14 @@ CloneableMap<MapType>& CloneableMap<MapType>::operator=(
 
 //==============================================================================
 template <typename MapType>
-void CloneableMap<MapType>::copy(const CloneableMap& otherMap)
+void CloneableMap<MapType>::copy(const CloneableMap& otherMap, bool merge)
 {
-  copy(otherMap.getMap());
+  copy(otherMap.getMap(), merge);
 }
 
 //==============================================================================
 template <typename MapType>
-void CloneableMap<MapType>::copy(const MapType& otherMap)
+void CloneableMap<MapType>::copy(const MapType& otherMap, bool merge)
 {
   typename MapType::iterator receiver = mMap.begin();
   typename MapType::const_iterator sender = otherMap.begin();
@@ -449,34 +449,69 @@ void CloneableMap<MapType>::copy(const MapType& otherMap)
     }
     else if( receiver->first == sender->first )
     {
-      // We should copy the incoming object when possible so we can avoid the
-      // memory allocation overhead of cloning.
-      if(receiver->second)
-        receiver->second->copy(*sender->second);
-      else
-        receiver->second = sender->second->clone();
+      if(sender->second)
+      {
+        // If the sender has an object, we should copy it.
+        if(receiver->second)
+          // We should copy instead of cloning the incoming object when possible
+          // so we can avoid the memory allocation overhead of cloning.
+          receiver->second->copy(*sender->second);
+        else
+          receiver->second = sender->second->clone();
+      }
+      else if(!merge)
+      {
+        // If the sender has no object, we should clear this one.
+        receiver->second = nullptr;
+      }
 
       ++receiver;
       ++sender;
     }
     else if( receiver->first < sender->first )
     {
-      // Clear this entry in the map, because it does not have an analog in the
-      // map that we are copying
-      receiver->second = nullptr;
+      if(!merge)
+      {
+        // Clear this entry in the map, because it does not have an analog in
+        // the map that we are copying
+        receiver->second = nullptr;
+      }
       ++receiver;
     }
     else
     {
-      mMap[sender->first] = sender->second->clone();
+      if(sender->second)
+      {
+        // If receiver has a higher value, then the receiving map does not
+        // contain an entry for this entry of the sending map, and therefore the
+        // entry must be created.
+        mMap[sender->first] = sender->second->clone();
+      }
       ++sender;
     }
   }
 
-  while( mMap.end() != receiver )
+  if(!merge)
   {
-    mMap.erase(receiver++);
+    while( mMap.end() != receiver )
+    {
+      mMap.erase(receiver++);
+    }
   }
+}
+
+//==============================================================================
+template <typename MapType>
+void CloneableMap<MapType>::merge(const CloneableMap& otherMap)
+{
+  copy(otherMap, true);
+}
+
+//==============================================================================
+template <typename MapType>
+void CloneableMap<MapType>::merge(const MapType& otherMap)
+{
+  copy(otherMap, true);
 }
 
 //==============================================================================

--- a/dart/common/detail/CompositeData.hpp
+++ b/dart/common/detail/CompositeData.hpp
@@ -142,6 +142,11 @@ public:
     return static_cast<Data&>(*it.first);
   }
 
+  template <class AspectT>
+  bool has() const
+  {
+    return (get<AspectT>() != nullptr);
+  }
 };
 
 //==============================================================================

--- a/unittests/testAspect.cpp
+++ b/unittests/testAspect.cpp
@@ -702,6 +702,20 @@ TEST(Aspect, StateAndProperties)
   // The constructor arguments should match the type order
   Composite::MakeState<DoubleAspect, IntAspect, CharAspect, FloatAspect>(
         doubleState, intState, charState, floatState);
+
+  // ---- Test copying and merging ----
+  Composite::Properties c_properties_1(properties);
+  EXPECT_FALSE(c_properties_1.has<IntAspect>());
+
+  Composite::Properties c_properties_2;
+  c_properties_2.create<IntAspect>();
+  EXPECT_TRUE(c_properties_2.has<IntAspect>());
+
+  c_properties_2.merge(c_properties_1);
+  EXPECT_TRUE(c_properties_2.has<IntAspect>());
+
+  c_properties_2.copy(c_properties_1);
+  EXPECT_FALSE(c_properties_2.has<IntAspect>());
 }
 
 TEST(Aspect, Construction)


### PR DESCRIPTION
Up until now, ``Composite::State`` and ``Composite::Properties`` has had a ``copy(~)`` function which will do a deep copy making the contents of one instance exactly the same as the contents of another instance.

This PR adds a ``merge`` function which will allow the receiving instance to hang onto any entries it has which are not present in the sending instance. So suppose we have:

```
Composite::Properties receiver, sender;
sender.create<Aspect1>();
receiver.create<Aspect2>();
receiver.merge(sender);
```

Then ``receiver`` will get the ``Aspect1`` contents of ``sender``, but it will also get to keep its own ``Aspect2`` contents. On the other hand if we used ``receiver.copy(sender)`` instead, then ``receiver`` would lose its ``Aspect2`` contents in order to be a perfect duplicate of ``sender``.

I've also added a ``has<Aspect>()`` function for ``Composite::State`` and ``Composite::Properties``.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/708)
<!-- Reviewable:end -->
