### PR TITLE
Added function to retrieve ShapeFrames from CollisionGroups

### DIFF
--- a/dart/collision/CollisionGroup.cpp
+++ b/dart/collision/CollisionGroup.cpp
@@ -155,6 +155,17 @@ std::size_t CollisionGroup::getNumShapeFrames() const
 }
 
 //==============================================================================
+const dynamics::ShapeFrame* CollisionGroup::getShapeFrame(
+    std::size_t index) const
+{
+  assert(index < mShapeFrameMap.size());
+  if(index < mShapeFrameMap.size())
+    return mShapeFrameMap[index].first;
+
+  return nullptr;
+}
+
+//==============================================================================
 bool CollisionGroup::collide(const CollisionOption& option, CollisionResult& result)
 {
   return mCollisionDetector->collide(this, option, result);

--- a/dart/collision/CollisionGroup.hpp
+++ b/dart/collision/CollisionGroup.hpp
@@ -168,6 +168,9 @@ public:
   /// Return number of ShapeFrames added to this CollisionGroup
   std::size_t getNumShapeFrames() const;
 
+  /// Get the ShapeFrame corresponding to the given index
+  const dynamics::ShapeFrame* getShapeFrame(std::size_t index) const;
+
   /// Perform collision detection within this CollisionGroup.
   bool collide(const CollisionOption& option, CollisionResult& result);
 

--- a/unittests/testCollision.cpp
+++ b/unittests/testCollision.cpp
@@ -541,6 +541,19 @@ void testSimpleFrames(const std::shared_ptr<CollisionDetector>& cd)
             + group2->getNumShapeFrames()
             + group3->getNumShapeFrames());
 
+  for(std::size_t i=0; i < group1->getNumShapeFrames(); ++i)
+    EXPECT_EQ(groupAll->getShapeFrame(i), group1->getShapeFrame(i));
+
+  std::size_t start = group1->getNumShapeFrames();
+  std::size_t end = start + group2->getNumShapeFrames();
+  for(std::size_t i=start; i < end; ++i)
+    EXPECT_EQ(groupAll->getShapeFrame(i), group2->getShapeFrame(i-start));
+
+  start = start + group2->getNumShapeFrames();
+  end = start + group3->getNumShapeFrames();
+  for(std::size_t i=start; i < end; ++i)
+    EXPECT_EQ(groupAll->getShapeFrame(i), group3->getShapeFrame(i-start));
+
   collision::CollisionOption option;
   collision::CollisionResult result;
 


### PR DESCRIPTION
I wanted to be able to make deep clones of ``CollisionGroup``s, so I've added the ability to access the ShapeFrames of a ``CollisionGroup``. The deep clone will still need to be done manually by the user for the time being for a variety of reasons, such as:

1. ``ShapeFrame`` ownership is still a complex issue without a decisive solution.

2. The deeply cloned ``CollisionGroup`` will probably need to belong to a different ``CollisionDetector``, since the motive for deep cloning is usually multi-threading, and I can't think of an obvious API for automating this right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/711)
<!-- Reviewable:end -->
