### PR TITLE
Removing the requirement that Aspects are created within Composites

### DIFF
--- a/dart/common/Aspect.cpp
+++ b/dart/common/Aspect.cpp
@@ -69,17 +69,6 @@ const Aspect::Properties* Aspect::getAspectProperties() const
 }
 
 //==============================================================================
-Aspect::Aspect(Composite* composite)
-{
-  if(nullptr == composite)
-  {
-    dterr << "[Aspect::constructor] You are not allowed to construct an Aspect "
-          << "outside of an Composite!\n";
-    assert(false);
-  }
-}
-
-//==============================================================================
 void Aspect::setComposite(Composite* /*newComposite*/)
 {
   // Do nothing

--- a/dart/common/Aspect.hpp
+++ b/dart/common/Aspect.hpp
@@ -95,7 +95,7 @@ public:
   virtual ~Aspect() = default;
 
   /// Clone this Aspect into a new composite
-  virtual std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const = 0;
+  virtual std::unique_ptr<Aspect> cloneAspect() const = 0;
 
   /// Set the State of this Aspect. By default, this does nothing.
   virtual void setAspectState(const State& otherState);
@@ -112,13 +112,6 @@ public:
   virtual const Properties* getAspectProperties() const;
 
 protected:
-
-  /// Constructor
-  ///
-  /// We require the Composite argument in this constructor to make it clear
-  /// to extensions that they must have a Composite argument in their
-  /// constructors.
-  Aspect(Composite* composite);
 
   /// This function will be triggered (1) after the Aspect has been created
   /// [transfer will be false] and (2) after the Aspect has been transferred
@@ -141,7 +134,7 @@ class CompositeTrackingAspect : public Aspect
 public:
 
   /// Default constructor
-  CompositeTrackingAspect(Composite* comp);
+  CompositeTrackingAspect();
 
   /// Get the Composite of this Aspect
   CompositeType* getComposite();
@@ -171,16 +164,16 @@ protected:
 //==============================================================================
 #define DART_COMMON_ASPECT_PROPERTY_CONSTRUCTOR( ClassName, UpdatePropertiesMacro )\
   ClassName (const ClassName &) = delete;\
-  inline ClassName (dart::common::Composite* comp, const PropertiesData& properties = PropertiesData())\
-    : AspectWithVersionedProperties< Base, Derived, PropertiesData, CompositeType, UpdatePropertiesMacro>(comp, properties) { }
+  inline ClassName (const PropertiesData& properties = PropertiesData())\
+    : AspectWithVersionedProperties< Base, Derived, PropertiesData, CompositeType, UpdatePropertiesMacro>(properties) { }
 
 //==============================================================================
 #define DART_COMMON_ASPECT_STATE_PROPERTY_CONSTRUCTORS(ClassName)\
   ClassName (const ClassName &) = delete;\
-  inline ClassName (dart::common::Composite* comp, const StateData& state = StateData(), const PropertiesData& properties = PropertiesData())\
-    : AspectImpl(comp, state, properties) { }\
-  inline ClassName (dart::common::Composite* comp, const PropertiesData& properties, const StateData state = StateData())\
-    : AspectImpl(comp, properties, state) { }
+  inline ClassName (const StateData& state = StateData(), const PropertiesData& properties = PropertiesData())\
+    : AspectImpl(state, properties) { }\
+  inline ClassName (const PropertiesData& properties, const StateData state = StateData())\
+    : AspectImpl(properties, state) { }
 
 //==============================================================================
 #define DART_COMMON_SET_ASPECT_PROPERTY_CUSTOM( Type, Name, Update )\

--- a/dart/common/AspectWithVersion.hpp
+++ b/dart/common/AspectWithVersion.hpp
@@ -98,29 +98,26 @@ public:
 
   /// Construct using a StateData and a PropertiesData instance
   AspectWithStateAndVersionedProperties(
-      common::Composite* comp,
       const StateData& state = StateData(),
       const PropertiesData& properties = PropertiesData())
-    : AspectPropertiesImpl(comp, properties, state)
+    : AspectPropertiesImpl(properties, state)
   {
     // Do nothing
   }
 
   /// Construct using a PropertiesData and a StateData instance
   AspectWithStateAndVersionedProperties(
-      common::Composite* comp,
       const PropertiesData& properties,
       const StateData& state = StateData())
-    : AspectPropertiesImpl(comp, properties, state)
+    : AspectPropertiesImpl(properties, state)
   {
     // Do nothing
   }
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override
+  std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(
-          newComposite, this->getState(), this->getProperties());
+    return make_unique<Derived>(this->getState(), this->getProperties());
   }
 
 };

--- a/dart/common/Composite.cpp
+++ b/dart/common/Composite.cpp
@@ -283,7 +283,7 @@ void Composite::_set(std::type_index type_idx, const Aspect* aspect)
 {
   if(aspect)
   {
-    mAspectMap[type_idx] = aspect->cloneAspect(this);
+    mAspectMap[type_idx] = aspect->cloneAspect();
     addToComposite(mAspectMap[type_idx].get());
   }
   else

--- a/dart/common/EmbeddedAspect.hpp
+++ b/dart/common/EmbeddedAspect.hpp
@@ -316,63 +316,56 @@ public:
 
   using CompositeType = CompositeT;
 
-  EmbeddedStateAndPropertiesAspect() = delete;
   EmbeddedStateAndPropertiesAspect(
       const EmbeddedStateAndPropertiesAspect&) = delete;
 
   virtual ~EmbeddedStateAndPropertiesAspect() = default;
 
   /// Construct using nothing. The object will remain unaffected.
-  EmbeddedStateAndPropertiesAspect(
-      common::Composite* comp)
-    : AspectPropertiesImpl(comp)
+  EmbeddedStateAndPropertiesAspect()
+    : AspectPropertiesImpl()
   {
     // Do nothing
   }
 
   /// Construct using a State. The object's Properties will remain unaffected.
   EmbeddedStateAndPropertiesAspect(
-      common::Composite* comp,
       const StateData& state)
-    : AspectPropertiesImpl(comp, state)
+    : AspectPropertiesImpl(state)
   {
     // Do nothing
   }
 
   /// Construct using Properties. The object's State will remain unaffected.
   EmbeddedStateAndPropertiesAspect(
-      common::Composite* comp,
       const PropertiesData& properties)
-    : AspectPropertiesImpl(comp, properties)
+    : AspectPropertiesImpl(properties)
   {
     // Do nothing
   }
 
   /// Construct using a State and Properties instance
   EmbeddedStateAndPropertiesAspect(
-      common::Composite* comp,
       const StateData& state,
       const PropertiesData& properties)
-    : AspectPropertiesImpl(comp, properties, state)
+    : AspectPropertiesImpl(properties, state)
   {
     // Do nothing
   }
 
   /// Construct using a Properties and State instance
   EmbeddedStateAndPropertiesAspect(
-      common::Composite* comp,
       const PropertiesData& properties,
       const StateData& state)
-    : AspectPropertiesImpl(comp, properties, state)
+    : AspectPropertiesImpl(properties, state)
   {
     // Do nothing
   }
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override
+  std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(
-          newComposite, this->getState(), this->getProperties());
+    return make_unique<Derived>(this->getState(), this->getProperties());
   }
 
 };

--- a/dart/common/ProxyAspect.hpp
+++ b/dart/common/ProxyAspect.hpp
@@ -82,9 +82,9 @@ public:
   }
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override
+  std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<ProxyStateAndPropertiesAspect>(newComposite);
+    return make_unique<ProxyStateAndPropertiesAspect>();
   }
 
 };

--- a/dart/common/detail/Aspect.hpp
+++ b/dart/common/detail/Aspect.hpp
@@ -47,9 +47,8 @@ namespace common {
 
 //==============================================================================
 template <class CompositeType>
-CompositeTrackingAspect<CompositeType>::CompositeTrackingAspect(Composite* comp)
-  : Aspect(comp),
-    mComposite(nullptr) // This will be set later when the Composite calls setComposite
+CompositeTrackingAspect<CompositeType>::CompositeTrackingAspect()
+  : mComposite(nullptr) // This will be set later when the Composite calls setComposite
 {
   // Do nothing
 }
@@ -82,15 +81,9 @@ void CompositeTrackingAspect<CompositeType>::setComposite(Composite* newComposit
   assert(nullptr == mComposite);
 
   mComposite = dynamic_cast<CompositeType*>(newComposite);
-  if(nullptr == mComposite)
-  {
-    dterr << "[" << typeid(*this).name() << "::setComposite] Attempting to use a "
-          << "[" << typeid(newComposite).name() << "] type composite, but this "
-          << "Aspect is only designed to be attached to a ["
-          << typeid(CompositeType).name() << "] type composite. This may cause "
-          << "undefined behavior!\n";
-    assert(false);
-  }
+  // Note: Derived classes should be responsible for handling the case in which
+  // the new composite type does not match the expected type. We should not
+  // assume here that it is an error.
 }
 
 //==============================================================================

--- a/dart/common/detail/AspectWithVersion.hpp
+++ b/dart/common/detail/AspectWithVersion.hpp
@@ -64,17 +64,16 @@ public:
   using AspectImplementation = AspectWithState<
       Base, Derived, StateData, CompositeT, updateState>;
 
-  AspectWithState() = delete;
   AspectWithState(const AspectWithState&) = delete;
 
   /// Construct using a StateData instance
-  AspectWithState(Composite* comp, const StateData& state = StateData());
+  AspectWithState(const StateData& state = StateData());
 
   /// Construct this Aspect and pass args into the constructor of the Base class
   template <typename... BaseArgs>
-  AspectWithState(Composite* comp, const StateData& state,
+  AspectWithState(const StateData& state,
                  BaseArgs&&... args)
-    : Base(comp, std::forward<BaseArgs>(args)...),
+    : Base(std::forward<BaseArgs>(args)...),
       mState(state)
   {
     // Do nothing
@@ -93,8 +92,7 @@ public:
   const State& getState() const;
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(
-      Composite* newComposite) const override;
+  std::unique_ptr<Aspect> cloneAspect() const override;
 
 protected:
 
@@ -127,13 +125,13 @@ public:
 
   /// Construct using a PropertiesData instance
   AspectWithVersionedProperties(
-      Composite* comp, const PropertiesData& properties = PropertiesData());
+      const PropertiesData& properties = PropertiesData());
 
   /// Construct this Aspect and pass args into the constructor of the Base class
   template <typename... BaseArgs>
   AspectWithVersionedProperties(
-      Composite* comp, const PropertiesData& properties, BaseArgs&&... args)
-    : Base(comp, std::forward<BaseArgs>(args)...),
+      const PropertiesData& properties, BaseArgs&&... args)
+    : Base(std::forward<BaseArgs>(args)...),
       mProperties(properties)
   {
     // Do nothing
@@ -152,8 +150,7 @@ public:
   const Properties& getProperties() const;
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(
-      Composite* newComposite) const override;
+  std::unique_ptr<Aspect> cloneAspect() const override;
 
   /// Increment the version of this Aspect and its Composite
   std::size_t incrementVersion();
@@ -185,8 +182,8 @@ constexpr void (*AspectWithState<
 template <class BaseT, class DerivedT, typename StateDataT,
           class CompositeT, void (*updateState)(DerivedT*)>
 AspectWithState<BaseT, DerivedT, StateDataT, CompositeT, updateState>::
-AspectWithState(Composite* comp, const StateDataT& state)
-  : BaseT(comp),
+AspectWithState(const StateDataT& state)
+  : BaseT(),
     mState(state)
 {
   // Do nothing
@@ -235,9 +232,9 @@ template <class BaseT, class DerivedT, typename StateData,
           class CompositeT, void (*updateState)(DerivedT*)>
 std::unique_ptr<Aspect>
 AspectWithState<BaseT, DerivedT, StateData, CompositeT, updateState>::
-    cloneAspect(Composite* newComposite) const
+    cloneAspect() const
 {
-  return common::make_unique<Derived>(newComposite, mState);
+  return common::make_unique<Derived>(mState);
 }
 
 //==============================================================================
@@ -258,9 +255,8 @@ template <class BaseT, class DerivedT, typename PropertiesDataT,
           class CompositeT, void (*updateProperties)(DerivedT*)>
 AspectWithVersionedProperties<BaseT, DerivedT, PropertiesDataT,
                              CompositeT, updateProperties>::
-AspectWithVersionedProperties(
-    Composite* comp, const PropertiesData& properties)
-  : BaseT(comp),
+AspectWithVersionedProperties(const PropertiesData& properties)
+  : BaseT(),
     mProperties(properties)
 {
   // Do nothing
@@ -314,9 +310,9 @@ template <class BaseT, class DerivedT, typename PropertiesData,
 std::unique_ptr<Aspect>
 AspectWithVersionedProperties<BaseT, DerivedT, PropertiesData,
                              CompositeT, updateProperties>::
-cloneAspect(Composite* newComposite) const
+cloneAspect() const
 {
-  return common::make_unique<Derived>(newComposite, mProperties);
+  return common::make_unique<Derived>(mProperties);
 }
 
 //==============================================================================

--- a/dart/common/detail/Composite.hpp
+++ b/dart/common/detail/Composite.hpp
@@ -94,7 +94,7 @@ void Composite::set(std::unique_ptr<T>&& aspect)
 template <class T, typename ...Args>
 T* Composite::createAspect(Args&&... args)
 {
-  T* aspect = new T(this, std::forward<Args>(args)...);
+  T* aspect = new T(std::forward<Args>(args)...);
   mAspectMap[typeid(T)] = std::unique_ptr<T>(aspect);
   addToComposite(aspect);
 

--- a/dart/common/detail/EmbeddedAspect.hpp
+++ b/dart/common/detail/EmbeddedAspect.hpp
@@ -92,7 +92,6 @@ public:
 
   enum DelegateTag { Delegate };
 
-  EmbeddedStateAspect() = delete;
   EmbeddedStateAspect(const EmbeddedStateAspect&) = delete;
 
   virtual ~EmbeddedStateAspect() = default;
@@ -107,8 +106,8 @@ public:
   };
 
   /// Construct this Aspect without affecting the State.
-  EmbeddedStateAspect(Composite* comp)
-    : Base(comp)
+  EmbeddedStateAspect()
+    : Base()
   {
     // Do nothing
   }
@@ -130,10 +129,10 @@ public:
   // these constraints, I would gladly replace this implementation. -(MXG)
   template <typename T, typename... RemainingArgs>
   EmbeddedStateAspect(
-      Composite* comp, const T& arg1,
+      const T& arg1,
       RemainingArgs&&... remainingArgs)
     : EmbeddedStateAspect(
-        Delegate, comp,
+        Delegate,
         static_cast<const typename ConvertIfState<T>::type&>(arg1),
         std::forward<RemainingArgs>(remainingArgs)...)
   {
@@ -187,9 +186,9 @@ public:
   }
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override
+  std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(newComposite, this->getState());
+    return make_unique<Derived>(this->getState());
   }
 
 protected:
@@ -198,9 +197,9 @@ protected:
   /// arguments into the constructor of the Base class.
   template <typename... RemainingArgs>
   EmbeddedStateAspect(
-      DelegateTag, Composite* comp, const StateData& state,
+      DelegateTag, const StateData& state,
       RemainingArgs&&... remainingArgs)
-    : Base(comp, std::forward<RemainingArgs>(remainingArgs)...),
+    : Base(std::forward<RemainingArgs>(remainingArgs)...),
       mTemporaryState(make_unique<State>(state))
   {
     // Do nothing
@@ -210,8 +209,8 @@ protected:
   /// arguments into the constructor of the Base class.
   template <typename... BaseArgs>
   EmbeddedStateAspect(
-      DelegateTag, Composite* comp, BaseArgs&&... args)
-    : Base(comp, std::forward<BaseArgs>(args)...)
+      DelegateTag, BaseArgs&&... args)
+    : Base(std::forward<BaseArgs>(args)...)
   {
     // Do nothing
   }
@@ -266,7 +265,6 @@ public:
   constexpr static void (*SetEmbeddedProperties)(Derived*, const Properties&) = setEmbeddedProperties;
   constexpr static const Properties& (*GetEmbeddedProperties)(const Derived*) = getEmbeddedProperties;
 
-  EmbeddedPropertiesAspect() = delete;
   EmbeddedPropertiesAspect(const EmbeddedPropertiesAspect&) = delete;
 
   virtual ~EmbeddedPropertiesAspect() = default;
@@ -281,8 +279,8 @@ public:
   };
 
   /// Construct this Aspect without affecting the Properties.
-  EmbeddedPropertiesAspect(Composite* comp)
-    : Base(comp)
+  EmbeddedPropertiesAspect()
+    : Base()
   {
     // Do nothing
   }
@@ -304,10 +302,10 @@ public:
   // these constraints, I would gladly replace this implementation. -(MXG)
   template <typename T, typename... RemainingArgs>
   EmbeddedPropertiesAspect(
-      Composite* comp, const T& arg1,
+      const T& arg1,
       RemainingArgs&&... remainingArgs)
     : EmbeddedPropertiesAspect(
-        Delegate, comp,
+        Delegate,
         static_cast<const typename ConvertIfProperties<T>::type&>(arg1),
         std::forward<RemainingArgs>(remainingArgs)...)
   {
@@ -360,9 +358,9 @@ public:
     return *mTemporaryProperties;
   }
 
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override
+  std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(newComposite, this->getProperties());
+    return make_unique<Derived>(this->getProperties());
   }
 
 protected:
@@ -371,9 +369,9 @@ protected:
   /// arguments into the constructor of the Base class.
   template <typename... RemainingArgs>
   EmbeddedPropertiesAspect(
-      DelegateTag, Composite* comp, const PropertiesData& properties,
+      DelegateTag, const PropertiesData& properties,
       RemainingArgs&&... remainingArgs)
-    : Base(comp, std::forward<RemainingArgs>(remainingArgs)...),
+    : Base(std::forward<RemainingArgs>(remainingArgs)...),
       mTemporaryProperties(make_unique<Properties>(properties))
   {
     // Do nothing
@@ -383,8 +381,8 @@ protected:
   /// arguments into the constructor of the Base class.
   template <typename... BaseArgs>
   EmbeddedPropertiesAspect(
-      DelegateTag, Composite* comp, BaseArgs&&... args)
-    : Base(comp, std::forward<BaseArgs>(args)...)
+      DelegateTag, BaseArgs&&... args)
+    : Base(std::forward<BaseArgs>(args)...)
   {
     // Do nothing
   }

--- a/dart/common/detail/ProxyAspect.hpp
+++ b/dart/common/detail/ProxyAspect.hpp
@@ -57,9 +57,9 @@ public:
 
   /// General constructor
   template <typename... Args>
-  ProxyStateAspect(Composite* comp, Args&&... args)
-    : Base(comp, std::forward<Args>(args)...),
-      mProxyState(dynamic_cast<CompositeType*>(comp))
+  ProxyStateAspect(Args&&... args)
+    : Base(std::forward<Args>(args)...),
+      mProxyState()
   {
     // Do nothing
   }
@@ -77,9 +77,9 @@ public:
   }
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override
+  std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<ProxyStateAspect>(newComposite);
+    return make_unique<ProxyStateAspect>();
   }
 
 protected:
@@ -126,9 +126,9 @@ public:
 
   /// General constructor
   template <typename... Args>
-  ProxyPropertiesAspect(Composite* comp, Args&&... args)
-    : Base(comp, std::forward<Args>(args)...),
-      mProxyProperties(dynamic_cast<CompositeType*>(this))
+  ProxyPropertiesAspect(Args&&... args)
+    : Base(std::forward<Args>(args)...),
+      mProxyProperties()
   {
     // Do nothing
   }
@@ -146,9 +146,9 @@ public:
   }
 
   // Documentation inherited
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override
+  std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<ProxyPropertiesAspect>(newComposite);
+    return make_unique<ProxyPropertiesAspect>();
   }
 
 protected:

--- a/dart/common/detail/SpecializedForAspect.hpp
+++ b/dart/common/detail/SpecializedForAspect.hpp
@@ -210,7 +210,7 @@ void SpecializedForAspect<SpecAspect>::_set(
 
   if(aspect)
   {
-    mSpecAspectIterator->second = aspect->cloneAspect(this);
+    mSpecAspectIterator->second = aspect->cloneAspect();
     addToComposite(mSpecAspectIterator->second.get());
   }
   else
@@ -258,7 +258,7 @@ SpecAspect* SpecializedForAspect<SpecAspect>::_createAspect(
   usedSpecializedAspectAccess = true;
 #endif // DART_UNITTEST_SPECIALIZED_ASPECT_ACCESS
 
-  SpecAspect* aspect = new SpecAspect(this, std::forward<Args>(args)...);
+  SpecAspect* aspect = new SpecAspect(std::forward<Args>(args)...);
   mSpecAspectIterator->second = std::unique_ptr<SpecAspect>(aspect);
   addToComposite(aspect);
 

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -79,9 +79,8 @@ ShapeFrameProperties::ShapeFrameProperties(const ShapePtr& shape)
 } // namespace detail
 
 //==============================================================================
-VisualAspect::VisualAspect(common::Composite* comp,
-                         const PropertiesData& properties)
-  : VisualAspect::BaseClass(comp, properties)
+VisualAspect::VisualAspect(const PropertiesData& properties)
+  : VisualAspect::BaseClass(properties)
 {
   // Do nothing
 }
@@ -165,9 +164,8 @@ bool VisualAspect::isHidden() const
 
 //==============================================================================
 CollisionAspect::CollisionAspect(
-    common::Composite* comp,
     const PropertiesData& properties)
-  : AspectImplementation(comp, properties)
+  : AspectImplementation(properties)
 {
   // Do nothing
 }
@@ -180,9 +178,8 @@ bool CollisionAspect::isCollidable() const
 
 //==============================================================================
 DynamicsAspect::DynamicsAspect(
-    common::Composite* comp,
     const PropertiesData& properties)
-  : BaseClass(comp, properties)
+  : BaseClass(properties)
 {
   // Do nothing
 }

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -63,8 +63,7 @@ public:
       VisualAspect, detail::VisualAspectProperties, ShapeFrame>;
 
   /// Constructor
-  VisualAspect(common::Composite* comp,
-              const PropertiesData& properties = PropertiesData());
+  VisualAspect(const PropertiesData& properties = PropertiesData());
 
   VisualAspect(const VisualAspect&) = delete;
 
@@ -125,8 +124,7 @@ class CollisionAspect final :
 public:
 
   CollisionAspect(const CollisionAspect &) = delete;
-  CollisionAspect(dart::common::Composite* comp,
-                      const PropertiesData& properties = PropertiesData());
+  CollisionAspect(const PropertiesData& properties = PropertiesData());
 
   DART_COMMON_SET_GET_ASPECT_PROPERTY( bool, Collidable )
   // void setCollidable(const bool& value);
@@ -151,8 +149,7 @@ public:
 
   DynamicsAspect(const DynamicsAspect&) = delete;
 
-  DynamicsAspect(dart::common::Composite* comp,
-                const PropertiesData& properties = PropertiesData());
+  DynamicsAspect(const PropertiesData& properties = PropertiesData());
 
   DART_COMMON_SET_GET_ASPECT_PROPERTY( double, FrictionCoeff )
   // void setFrictionCoeff(const double& value);

--- a/unittests/testAspect.cpp
+++ b/unittests/testAspect.cpp
@@ -228,8 +228,8 @@ class StateAspectTest : public dart::common::AspectWithState<
 {
 public:
 
-  StateAspectTest(Composite* mgr, const StateData& state = StateData())
-    : dart::common::AspectWithState<StateAspectTest, dart::common::Empty>(mgr, state)
+  StateAspectTest(const StateData& state = StateData())
+    : dart::common::AspectWithState<StateAspectTest, dart::common::Empty>(state)
   {
 
   }
@@ -246,15 +246,15 @@ class GenericAspect : public Aspect, public Subject
 {
 public:
 
-  GenericAspect(Composite* composite)
-    : Aspect(composite)
+  GenericAspect()
+    : Aspect()
   {
     // Do nothing
   }
 
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override final
+  std::unique_ptr<Aspect> cloneAspect() const override final
   {
-    return dart::common::make_unique<GenericAspect>(newComposite);
+    return dart::common::make_unique<GenericAspect>();
   }
 
 };
@@ -263,15 +263,15 @@ class SpecializedAspect : public Aspect, public Subject
 {
 public:
 
-  SpecializedAspect(Composite* composite)
-    : Aspect(composite)
+  SpecializedAspect()
+    : Aspect()
   {
     // Do nothing
   }
 
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override final
+  std::unique_ptr<Aspect> cloneAspect() const override final
   {
-    return dart::common::make_unique<SpecializedAspect>(newComposite);
+    return dart::common::make_unique<SpecializedAspect>();
   }
 };
 
@@ -294,35 +294,35 @@ public:
   using State = Aspect::MakeState<Data>;
   using Properties = Aspect::MakeProperties<Data>;
 
-  StatefulAspect(Composite* mgr)
-    : Aspect(mgr)
+  StatefulAspect()
+    : Aspect()
   {
     // Do nothing
   }
 
-  StatefulAspect(Composite* mgr, const StatefulAspect& other)
-    : Aspect(mgr),
+  StatefulAspect(const StatefulAspect& other)
+    : Aspect(),
       mState(other.mState), mProperties(other.mProperties)
   {
     // Do nothing
   }
 
-  StatefulAspect(Composite* mgr, const T& state)
-    : Aspect(mgr), mState(state)
+  StatefulAspect(const T& state)
+    : Aspect(), mState(state)
   {
     // Do nothing
   }
 
-  StatefulAspect(Composite* mgr, const T& state, const T& properties)
-    : Aspect(mgr),
+  StatefulAspect(const T& state, const T& properties)
+    : Aspect(),
       mState(state), mProperties(properties)
   {
     // Do nothing
   }
 
-  std::unique_ptr<Aspect> cloneAspect(Composite* newComposite) const override final
+  std::unique_ptr<Aspect> cloneAspect() const override final
   {
-    return dart::common::make_unique<StatefulAspect>(newComposite, *this);
+    return dart::common::make_unique<StatefulAspect>(*this);
   }
 
   void setAspectState(const Aspect::State& otherState) override


### PR DESCRIPTION
This addresses #712 and lifts the arbitrary requirement that every ``Aspect`` be created within a ``Composite``.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/713)
<!-- Reviewable:end -->
