### PR TITLE
Update total mass when removing bodies

### DIFF
--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -2216,6 +2216,8 @@ void Skeleton::unregisterBodyNode(BodyNode* _oldBodyNode)
                                      mSoftBodyNodes.end(), soft),
                          mSoftBodyNodes.end());
   }
+
+  updateTotalMass();
 }
 
 //==============================================================================

--- a/unittests/testSkeleton.cpp
+++ b/unittests/testSkeleton.cpp
@@ -1258,7 +1258,7 @@ TEST(Skeleton, Updating)
   J0f = screw->getRelativeJacobian();
   EXPECT_FALSE(equals(J0i, J0f));
 
-  // Regression test for Pull Request #
+  // Regression test for Pull Request #731
   const double originalMass = skeleton->getMass();
   BodyNode* lastBn = skeleton->getBodyNode(skeleton->getNumBodyNodes()-1);
   const double removedMass = lastBn->getMass();

--- a/unittests/testSkeleton.cpp
+++ b/unittests/testSkeleton.cpp
@@ -1257,6 +1257,16 @@ TEST(Skeleton, Updating)
   screw->setPitch(3);
   J0f = screw->getRelativeJacobian();
   EXPECT_FALSE(equals(J0i, J0f));
+
+  // Regression test for Pull Request #
+  const double originalMass = skeleton->getMass();
+  BodyNode* lastBn = skeleton->getBodyNode(skeleton->getNumBodyNodes()-1);
+  const double removedMass = lastBn->getMass();
+  EXPECT_FALSE(removedMass == 0.0);
+  lastBn->remove();
+  const double newMass = skeleton->getMass();
+  EXPECT_FALSE(originalMass == newMass);
+  EXPECT_TRUE(newMass == originalMass - removedMass);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
The total mass of a Skeleton was not getting updated when a body is removed. This fixes the problem and introduces a regression test for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/731)
<!-- Reviewable:end -->
