### PR TITLE
Prepend DART_ to DEPRECATED and FORCEINLINE macros to avoid name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Misc improvements and bug fixes
 
+  * Renamed `DEPRECATED` and `FORCEINLINE` to `DART_DEPRECATED` and `DART_FORCEINLINE` to avoid name conflicts: [#742](https://github.com/dartsim/dart/pull/742)
   * Updated copyright: added CMU to copyright holder, moved individual contributors to CONTRIBUTING.md: [#723](https://github.com/dartsim/dart/pull/723)
 
 ### DART 6.0.0 (2016-05-10)

--- a/dart/common/Deprecated.hpp
+++ b/dart/common/Deprecated.hpp
@@ -41,14 +41,14 @@
 //==============================================================================
 
 #if defined(__GNUC__) || defined(__clang__)
-  #define DEPRECATED(version) __attribute__ ((deprecated))
-  #define FORCEINLINE __attribute__((always_inline))
+  #define DART_DEPRECATED(version) __attribute__ ((deprecated))
+  #define DART_FORCEINLINE __attribute__((always_inline))
 #elif defined(_MSC_VER)
-  #define DEPRECATED(version) __declspec(deprecated)
-  #define FORCEINLINE __forceinline
+  #define DART_DEPRECATED(version) __declspec(deprecated)
+  #define DART_FORCEINLINE __DART_FORCEINLINE
 #else
-  #define DEPRECATED(version) ()
-  #define FORCEINLINE
+  #define DART_DEPRECATED(version) ()
+  #define DART_FORCEINLINE
 #endif
 
 // We define two convenient macros that can be used to suppress

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -101,7 +101,7 @@ public:
   /// Set collision detector. This function acquires ownership of the
   /// CollisionDetector passed as an argument. This method is deprecated in
   /// favor of the overload that accepts a std::shared_ptr.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void setCollisionDetector(collision::CollisionDetector* collisionDetector);
 
   /// Set collision detector

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -706,12 +706,12 @@ public:
   /// this status is set by the constraint solver during dynamics simulation but
   /// not by collision detector.
   /// \param[in] True if this body node is colliding.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void setColliding(bool _isColliding);
 
   /// Return whether this body node is set to be colliding with other objects.
   /// \return True if this body node is colliding.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   bool isColliding();
 
   /// Add applying linear Cartesian forces to this node
@@ -1030,7 +1030,7 @@ protected:
   static std::size_t msBodyNodeCount;
 
   /// Whether the node is currently in collision with another node.
-  /// \deprecated DEPRECATED(6.0) See #670 for more detail.
+  /// \deprecated DART_DEPRECATED(6.0) See #670 for more detail.
   bool mIsColliding;
 
   //--------------------------------------------------------------------------

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -539,31 +539,31 @@ public:
   //----------------------------------------------------------------------------
 
   /// Deprecated. Use getRelativeTransform() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const Eigen::Isometry3d& getLocalTransform() const;
 
   /// Deprecated. Use getLocalSpatialVelocity() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const Eigen::Vector6d& getLocalSpatialVelocity() const;
 
   /// Deprecated. Use getLocalSpatialAcceleration() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const Eigen::Vector6d& getLocalSpatialAcceleration() const;
 
   /// Deprecated. Use getLocalPrimaryAcceleration() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const Eigen::Vector6d& getLocalPrimaryAcceleration() const;
 
   /// Deprecated. Use getRelativeJacobian() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const math::Jacobian getLocalJacobian() const;
 
   /// Deprecated. Use getRelativeJacobian() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   math::Jacobian getLocalJacobian(const Eigen::VectorXd& positions) const;
 
   /// Deprecated. Use getRelativeJacobianTimeDeriv() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const math::Jacobian getLocalJacobianTimeDeriv() const;
 
   /// Get transform of the child BodyNode relative to the parent BodyNode
@@ -680,27 +680,27 @@ protected:
   //----------------------------------------------------------------------------
 
   /// Deprecated. Use updateRelativeTransform() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void updateLocalTransform() const;
 
   /// Deprecated. Use updateRelativeSpatialVelocity() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void updateLocalSpatialVelocity() const;
 
   /// Deprecated. Use updateRelativeSpatialAcceleration() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void updateLocalSpatialAcceleration() const;
 
   /// Deprecated. Use updateRelativePrimaryAcceleration() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void updateLocalPrimaryAcceleration() const;
 
   /// Deprecated. Use updateRelativeJacobian() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void updateLocalJacobian(bool mandatory = true) const;
 
   /// Deprecated. Use updateRelativeJacobianTimeDeriv() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void updateLocalJacobianTimeDeriv() const;
 
   /// Update transform of the child BodyNode relative to the parent BodyNode

--- a/dart/dynamics/Marker.hpp
+++ b/dart/dynamics/Marker.hpp
@@ -70,13 +70,13 @@ public:
   /// Get the BodyNode this Marker belongs to
   ///
   /// Deprecated: Use getBodyNodePtr() instead
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   BodyNode* getBodyNode();
 
   /// Get the (const) BodyNode this Marker belongs to
   ///
   /// Deprecated: Use getBodyNodePtr() instead
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const BodyNode* getBodyNode() const;
 
   /// Get position of this marker in the parent body node coordinates

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -653,7 +653,7 @@ public:
   virtual double getPotentialEnergy() const = 0;
 
   /// Clear collision flags of the BodyNodes in this MetaSkeleton
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   virtual void clearCollidingBodies() = 0;
 
   /// \}

--- a/dart/dynamics/ReferentialSkeleton.hpp
+++ b/dart/dynamics/ReferentialSkeleton.hpp
@@ -269,7 +269,7 @@ public:
   double getPotentialEnergy() const override;
 
   // Documentation inherited
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void clearCollidingBodies() override;
 
   /// \}

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -208,7 +208,7 @@ public:
   void setProperties(const AspectProperties& properties);
 
   /// Get the Properties of this Skeleton
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   const AspectProperties& getSkeletonProperties() const;
 
   /// Set the AspectProperties of this Skeleton
@@ -222,11 +222,11 @@ public:
 
   /// Deprecated. Please use enableSelfCollisionCheck() and
   /// setAdjacentBodyCheck() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void enableSelfCollision(bool enableAdjacentBodyCheck = false);
 
   /// Deprecated. Please use disableSelfCollisionCheck() instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void disableSelfCollision();
 
   /// Set whether to check self-collision.
@@ -826,7 +826,7 @@ public:
   double getPotentialEnergy() const override;
 
   // Documentation inherited
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   void clearCollidingBodies() override;
 
   /// \}

--- a/dart/gui/SimWindow.hpp
+++ b/dart/gui/SimWindow.hpp
@@ -67,10 +67,10 @@ public:
 
   virtual void drawSkeletons() const;
 
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   virtual void drawSkels();
 
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   virtual void drawEntities();
 
   /// \brief

--- a/dart/math/Geometry.hpp
+++ b/dart/math/Geometry.hpp
@@ -432,7 +432,7 @@ Eigen::Isometry3d computeTransform(const Eigen::Vector3d& axis,
                                    AxisType axisType = AxisType::AXIS_X);
 
 /// Generate frame given origin and z-axis
-DEPRECATED(6.0)
+DART_DEPRECATED(6.0)
 Eigen::Isometry3d getFrameOriginAxisZ(const Eigen::Vector3d& _origin,
                                       const Eigen::Vector3d& _axisZ);
 

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -172,7 +172,7 @@ public:
   //--------------------------------------------------------------------------
 
   /// Deprecated. Please use checkCollision(~) instead.
-  DEPRECATED(6.0)
+  DART_DEPRECATED(6.0)
   bool checkCollision(bool checkAllCollisions);
 
   /// Perform collision checking with 'option' over all the feasible collision

--- a/dart/utils/XmlHelpers.hpp
+++ b/dart/utils/XmlHelpers.hpp
@@ -105,11 +105,11 @@ tinyxml2::XMLElement* getElement(tinyxml2::XMLElement* parentElement,
 bool hasAttribute(const tinyxml2::XMLElement* element, const char* const name);
 
 // Please use getAttributeString() instead.
-DEPRECATED(6.0)
+DART_DEPRECATED(6.0)
 std::string getAttribute(tinyxml2::XMLElement* element, const char* const name);
 
 // Please use getAttributeDouble() instead.
-DEPRECATED(6.0)
+DART_DEPRECATED(6.0)
 void getAttribute(tinyxml2::XMLElement* element, const char* const name, double* d);
 
 std::string     getAttributeString  (const tinyxml2::XMLElement* element, const std::string& attributeName);

--- a/dart/utils/sdf/SdfParser.hpp
+++ b/dart/utils/sdf/SdfParser.hpp
@@ -42,7 +42,7 @@ namespace utils {
 
 namespace SdfParser {
 
-DEPRECATED(6.0)
+DART_DEPRECATED(6.0)
 simulation::WorldPtr readSdfFile(
     const common::Uri& fileUri,
     const common::ResourceRetrieverPtr& retriever = nullptr);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/742)
<!-- Reviewable:end -->
