### PR TITLE
Update API to support fcl 0.5 and tinyxml 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Collision detection
 
-  * Added support of FCL 0.5.0: [#749](https://github.com/dartsim/dart/pull/749)
+  * Added support of FCL 0.5 and tinyxml2 4.0: [#749](https://github.com/dartsim/dart/pull/749)
   * Added warnings for unsupported shape pairs of DARTCollisionDetector: [#722](https://github.com/dartsim/dart/pull/722)
 
 * Misc improvements and bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Collision detection
 
+  * Added support of FCL 0.5.0: [#749](https://github.com/dartsim/dart/pull/749)
   * Added warnings for unsupported shape pairs of DARTCollisionDetector: [#722](https://github.com/dartsim/dart/pull/722)
 
 * Misc improvements and bug fixes

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -778,11 +778,7 @@ std::unique_ptr<CollisionObject> FCLCollisionDetector::createCollisionObject(
 }
 
 //==============================================================================
-#if FCL_VERSION_AT_LEAST(0,5,0)
-std::shared_ptr<fcl::CollisionGeometry>
-#else
-boost::shared_ptr<fcl::CollisionGeometry>
-#endif
+fcl_shared_ptr<fcl::CollisionGeometry>
 FCLCollisionDetector::claimFCLCollisionGeometry(
     const dynamics::ConstShapePtr& shape)
 {
@@ -805,11 +801,7 @@ FCLCollisionDetector::claimFCLCollisionGeometry(
 }
 
 //==============================================================================
-#if FCL_VERSION_AT_LEAST(0,5,0)
-std::shared_ptr<fcl::CollisionGeometry>
-#else
-boost::shared_ptr<fcl::CollisionGeometry>
-#endif
+fcl_shared_ptr<fcl::CollisionGeometry>
 FCLCollisionDetector::createFCLCollisionGeometry(
     const dynamics::ConstShapePtr& shape,
     FCLCollisionDetector::PrimitiveShape type,
@@ -947,17 +939,9 @@ FCLCollisionDetector::createFCLCollisionGeometry(
   }
 
   if (geom)
-#if FCL_VERSION_AT_LEAST(0,5,0)
-    return std::shared_ptr<fcl::CollisionGeometry>(geom, deleter);
-#else
-    return boost::shared_ptr<fcl::CollisionGeometry>(geom, deleter);
-#endif
+    return fcl_shared_ptr<fcl::CollisionGeometry>(geom, deleter);
   else
-#if FCL_VERSION_AT_LEAST(0,5,0)
-    return std::shared_ptr<fcl::CollisionGeometry>();
-#else
-    return boost::shared_ptr<fcl::CollisionGeometry>();
-#endif
+    return fcl_shared_ptr<fcl::CollisionGeometry>();
 }
 
 //==============================================================================

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -431,8 +431,6 @@ fcl::BVHModel<BV>* createEllipsoid(float _sizeX, float _sizeY, float _sizeZ)
   return model;
 }
 
-#if FCL_MAJOR_MINOR_VERSION_AT_MOST(0,4)
-
 //==============================================================================
 template<class BV>
 fcl::BVHModel<BV>* createCylinder(double _baseRadius, double _topRadius,
@@ -535,8 +533,6 @@ fcl::BVHModel<BV>* createCylinder(double _baseRadius, double _topRadius,
   model->endModel();
   return model;
 }
-
-#endif
 
 //==============================================================================
 template<class BV>
@@ -782,7 +778,11 @@ std::unique_ptr<CollisionObject> FCLCollisionDetector::createCollisionObject(
 }
 
 //==============================================================================
+#if FCL_VERSION_AT_LEAST(0,5,0)
+std::shared_ptr<fcl::CollisionGeometry>
+#else
 boost::shared_ptr<fcl::CollisionGeometry>
+#endif
 FCLCollisionDetector::claimFCLCollisionGeometry(
     const dynamics::ConstShapePtr& shape)
 {
@@ -805,7 +805,11 @@ FCLCollisionDetector::claimFCLCollisionGeometry(
 }
 
 //==============================================================================
+#if FCL_VERSION_AT_LEAST(0,5,0)
+std::shared_ptr<fcl::CollisionGeometry>
+#else
 boost::shared_ptr<fcl::CollisionGeometry>
+#endif
 FCLCollisionDetector::createFCLCollisionGeometry(
     const dynamics::ConstShapePtr& shape,
     FCLCollisionDetector::PrimitiveShape type,
@@ -943,9 +947,17 @@ FCLCollisionDetector::createFCLCollisionGeometry(
   }
 
   if (geom)
+#if FCL_VERSION_AT_LEAST(0,5,0)
+    return std::shared_ptr<fcl::CollisionGeometry>(geom, deleter);
+#else
     return boost::shared_ptr<fcl::CollisionGeometry>(geom, deleter);
+#endif
   else
+#if FCL_VERSION_AT_LEAST(0,5,0)
+    return std::shared_ptr<fcl::CollisionGeometry>();
+#else
     return boost::shared_ptr<fcl::CollisionGeometry>();
+#endif
 }
 
 //==============================================================================

--- a/dart/collision/fcl/FCLCollisionDetector.hpp
+++ b/dart/collision/fcl/FCLCollisionDetector.hpp
@@ -36,6 +36,7 @@
 #include <fcl/collision_object.h>
 #include <boost/weak_ptr.hpp> // This should be removed once we migrate to fcl 0.5
 #include "dart/collision/CollisionDetector.hpp"
+#include "dart/collision/fcl/FCLTypes.hpp"
 
 namespace dart {
 namespace collision {
@@ -130,7 +131,11 @@ protected:
 
   /// Return fcl::CollisionGeometry associated with give Shape. New
   /// fcl::CollisionGeome will be created if it hasn't created yet.
+#if FCL_VERSION_AT_LEAST(0,5,0)
+  std::shared_ptr<fcl::CollisionGeometry> claimFCLCollisionGeometry(
+#else
   boost::shared_ptr<fcl::CollisionGeometry> claimFCLCollisionGeometry(
+#endif
       const dynamics::ConstShapePtr& shape);
 
 protected:
@@ -162,7 +167,11 @@ private:
 
   /// Create fcl::CollisionGeometry with the custom deleter
   /// FCLCollisionGeometryDeleter
+#if FCL_VERSION_AT_LEAST(0,5,0)
+  std::shared_ptr<fcl::CollisionGeometry> createFCLCollisionGeometry(
+#else
   boost::shared_ptr<fcl::CollisionGeometry> createFCLCollisionGeometry(
+#endif
       const dynamics::ConstShapePtr& shape,
       FCLCollisionDetector::PrimitiveShape type,
       const FCLCollisionGeometryDeleter& deleter);
@@ -170,7 +179,11 @@ private:
 private:
 
   using ShapeMap = std::map<dynamics::ConstShapePtr,
-                            boost::weak_ptr<fcl::CollisionGeometry>>;
+#if FCL_VERSION_AT_LEAST(0,5,0)
+                           std::weak_ptr<fcl::CollisionGeometry>>;
+#else
+                           boost::weak_ptr<fcl::CollisionGeometry>>;
+#endif
   // TODO(JS): FCL replaced all the use of boost in version 0.5. Once we migrate
   // to 0.5 or greater, this also should be changed to
   // std::weak_ptr<fcl::CollisionGeometry>

--- a/dart/collision/fcl/FCLCollisionDetector.hpp
+++ b/dart/collision/fcl/FCLCollisionDetector.hpp
@@ -131,11 +131,7 @@ protected:
 
   /// Return fcl::CollisionGeometry associated with give Shape. New
   /// fcl::CollisionGeome will be created if it hasn't created yet.
-#if FCL_VERSION_AT_LEAST(0,5,0)
-  std::shared_ptr<fcl::CollisionGeometry> claimFCLCollisionGeometry(
-#else
-  boost::shared_ptr<fcl::CollisionGeometry> claimFCLCollisionGeometry(
-#endif
+  fcl_shared_ptr<fcl::CollisionGeometry> claimFCLCollisionGeometry(
       const dynamics::ConstShapePtr& shape);
 
 protected:
@@ -167,11 +163,7 @@ private:
 
   /// Create fcl::CollisionGeometry with the custom deleter
   /// FCLCollisionGeometryDeleter
-#if FCL_VERSION_AT_LEAST(0,5,0)
-  std::shared_ptr<fcl::CollisionGeometry> createFCLCollisionGeometry(
-#else
-  boost::shared_ptr<fcl::CollisionGeometry> createFCLCollisionGeometry(
-#endif
+  fcl_shared_ptr<fcl::CollisionGeometry> createFCLCollisionGeometry(
       const dynamics::ConstShapePtr& shape,
       FCLCollisionDetector::PrimitiveShape type,
       const FCLCollisionGeometryDeleter& deleter);
@@ -179,11 +171,7 @@ private:
 private:
 
   using ShapeMap = std::map<dynamics::ConstShapePtr,
-#if FCL_VERSION_AT_LEAST(0,5,0)
-                           std::weak_ptr<fcl::CollisionGeometry>>;
-#else
-                           boost::weak_ptr<fcl::CollisionGeometry>>;
-#endif
+                            fcl_weak_ptr<fcl::CollisionGeometry>>;
   // TODO(JS): FCL replaced all the use of boost in version 0.5. Once we migrate
   // to 0.5 or greater, this also should be changed to
   // std::weak_ptr<fcl::CollisionGeometry>

--- a/dart/collision/fcl/FCLCollisionObject.cpp
+++ b/dart/collision/fcl/FCLCollisionObject.cpp
@@ -63,7 +63,11 @@ const fcl::CollisionObject* FCLCollisionObject::getFCLCollisionObject() const
 FCLCollisionObject::FCLCollisionObject(
     CollisionDetector* collisionDetector,
     const dynamics::ShapeFrame* shapeFrame,
+#if FCL_VERSION_AT_LEAST(0,5,0)
+    const std::shared_ptr<fcl::CollisionGeometry>& fclCollGeom)
+#else
     const boost::shared_ptr<fcl::CollisionGeometry>& fclCollGeom)
+#endif
   : CollisionObject(collisionDetector, shapeFrame),
     mFCLCollisionObjectUserData(new UserData(this)),
     mFCLCollisionObject(new fcl::CollisionObject(fclCollGeom))

--- a/dart/collision/fcl/FCLCollisionObject.cpp
+++ b/dart/collision/fcl/FCLCollisionObject.cpp
@@ -63,11 +63,7 @@ const fcl::CollisionObject* FCLCollisionObject::getFCLCollisionObject() const
 FCLCollisionObject::FCLCollisionObject(
     CollisionDetector* collisionDetector,
     const dynamics::ShapeFrame* shapeFrame,
-#if FCL_VERSION_AT_LEAST(0,5,0)
-    const std::shared_ptr<fcl::CollisionGeometry>& fclCollGeom)
-#else
-    const boost::shared_ptr<fcl::CollisionGeometry>& fclCollGeom)
-#endif
+    const fcl_shared_ptr<fcl::CollisionGeometry>& fclCollGeom)
   : CollisionObject(collisionDetector, shapeFrame),
     mFCLCollisionObjectUserData(new UserData(this)),
     mFCLCollisionObject(new fcl::CollisionObject(fclCollGeom))

--- a/dart/collision/fcl/FCLCollisionObject.hpp
+++ b/dart/collision/fcl/FCLCollisionObject.hpp
@@ -34,6 +34,7 @@
 
 #include <fcl/collision_object.h>
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/collision/fcl/FCLTypes.hpp"
 
 namespace dart {
 namespace collision {
@@ -64,7 +65,11 @@ protected:
   /// Constructor
   FCLCollisionObject(CollisionDetector* collisionDetector,
       const dynamics::ShapeFrame* shapeFrame,
+#if FCL_VERSION_AT_LEAST(0,5,0)
+      const std::shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
+#else
       const boost::shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
+#endif
 
   // Documentation inherited
   void updateEngineData() override;

--- a/dart/collision/fcl/FCLCollisionObject.hpp
+++ b/dart/collision/fcl/FCLCollisionObject.hpp
@@ -65,11 +65,7 @@ protected:
   /// Constructor
   FCLCollisionObject(CollisionDetector* collisionDetector,
       const dynamics::ShapeFrame* shapeFrame,
-#if FCL_VERSION_AT_LEAST(0,5,0)
-      const std::shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
-#else
-      const boost::shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
-#endif
+      const fcl_shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
 
   // Documentation inherited
   void updateEngineData() override;

--- a/dart/collision/fcl/FCLTypes.hpp
+++ b/dart/collision/fcl/FCLTypes.hpp
@@ -46,6 +46,14 @@
   (FCL_MAJOR_VERSION < x || (FCL_MAJOR_VERSION <= x && \
   (FCL_MINOR_VERSION < y || (FCL_MINOR_VERSION <= y))))
 
+#if FCL_VERSION_AT_LEAST(0,5,0)
+template <class T> using fcl_shared_ptr = std::shared_ptr<T>;
+template <class T> using fcl_weak_ptr = std::weak_ptr<T>;
+#else
+template <class T> using fcl_shared_ptr = boost::shared_ptr<T>;
+template <class T> using fcl_weak_ptr = boost::weak_ptr<T>;
+#endif
+
 namespace dart {
 namespace collision {
 

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -726,7 +726,7 @@ bool getAttributeBool(const tinyxml2::XMLElement* element,
   const int result = element->QueryBoolAttribute(attributeName.c_str(),
                                                  &val);
 
-  if (result != tinyxml2::XML_NO_ERROR)
+  if (result != tinyxml2::XML_SUCCESS)
   {
     dtwarn << "[getAttribute] Error in parsing bool type attribute ["
            << attributeName << "] of an element [" << element->Name()
@@ -744,7 +744,7 @@ int getAttributeInt(const tinyxml2::XMLElement* element,
   int val = 0;
   const int result = element->QueryIntAttribute(attributeName.c_str(), &val);
 
-  if (result != tinyxml2::XML_NO_ERROR)
+  if (result != tinyxml2::XML_SUCCESS)
   {
     dtwarn << "[getAttribute] Error in parsing int type attribute ["
            << attributeName << "] of an element [" << element->Name()
@@ -763,7 +763,7 @@ unsigned int getAttributeUInt(const tinyxml2::XMLElement* element,
   const int result = element->QueryUnsignedAttribute(attributeName.c_str(),
                                                      &val);
 
-  if (result != tinyxml2::XML_NO_ERROR)
+  if (result != tinyxml2::XML_SUCCESS)
   {
     dtwarn << "[getAttribute] Error in parsing unsiged int type attribute ["
            << attributeName << "] of an element [" << element->Name()
@@ -782,7 +782,7 @@ float getAttributeFloat(const tinyxml2::XMLElement* element,
   const int result = element->QueryFloatAttribute(attributeName.c_str(),
                                                   &val);
 
-  if (result != tinyxml2::XML_NO_ERROR)
+  if (result != tinyxml2::XML_SUCCESS)
   {
     dtwarn << "[getAttribute] Error in parsing float type attribute ["
            << attributeName << "] of an element [" << element->Name()
@@ -801,7 +801,7 @@ double getAttributeDouble(const tinyxml2::XMLElement* element,
   const int result = element->QueryDoubleAttribute(attributeName.c_str(),
                                                    &val);
 
-  if (result != tinyxml2::XML_NO_ERROR)
+  if (result != tinyxml2::XML_SUCCESS)
   {
     dtwarn << "[getAttribute] Error in parsing double type attribute ["
            << attributeName << "] of an element [" << element->Name()


### PR DESCRIPTION
FCL switched to use the smart pointers of the C++11 standard library since 0.5.0, and removed `XML_NO_ERROR` since 4.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/749)
<!-- Reviewable:end -->
