### PR TITLE
Remove explicit SSE2 compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   if(DART_TREAT_WARNINGS_AS_ERRORS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -msse2 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fPIC")
   execute_process(
     COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
   set(CXX_COMPILER_VERSION ${GCC_VERSION})
@@ -181,7 +181,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # Turn warning "deprecated-declarations" into an warning even if -Werror is
     # specified until we abandon glut.
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
   execute_process(
     COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE CLANG_VERSION)
   set(CXX_COMPILER_VERSION ${CLANG_VERSION})


### PR DESCRIPTION
We add unconditionally the SSE2 compiler flag when using GCC. This is making [non x86 arches to fail](https://buildd.debian.org/status/logs.php?pkg=kido&ver=0.1.0%2Bdfsg-1).

The bug report [comes from Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=833817) and the developers made a couple of good points about it:

 * SSE2 is enable by default if you run 64 bits on x86.
 * We can not assume that i386 supports it since i386 for Debian implies 686 (or greater) and SSE2 was introduced in pentium4.

I think that the impact of removing it is really low.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/760)
<!-- Reviewable:end -->
