### PR TITLE
Use btGImpactMeshShape instead of btConvexTriangleMeshShape

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ project(dart)
 
 set(DART_MAJOR_VERSION "5")
 set(DART_MINOR_VERSION "1")
-set(DART_PATCH_VERSION "2")
+set(DART_PATCH_VERSION "3")
 set(DART_VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}.${DART_PATCH_VERSION}")
 set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")
 set(DART_PKG_EXTERNAL_DEPS "flann, ccd, fcl")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,21 +355,43 @@ else()
   set(HAVE_SHARK FALSE)
 endif()
 
-# BulletCollision
-if(UNIX)
-  pkg_check_modules(BULLET bullet>=2.82 QUIET)
-  if(NOT BULLET_FOUND)
-     pkg_check_modules(BULLET bullet2.82>=2.82 QUIET)
-  endif()
-else()
-  find_package(Bullet COMPONENTS BulletMath BulletCollision QUIET)
-endif()
+# Bullet. Force MODULE mode to use the FindBullet.cmake file distributed with
+# CMake. Otherwise, we may end up using the BulletConfig.cmake file distributed
+# with Bullet, which uses relative paths and may break transitive dependencies.
+find_package(Bullet COMPONENTS BulletMath BulletCollision MODULE QUIET)
+
 if(BULLET_FOUND)
-  message(STATUS "Looking for BulletCollision - ${BULLET_VERSION} found")
+  # Test whether Bullet was built with double precision. If so, we need to
+  # define the BT_USE_DOUBLE_PRECISION pre-processor directive before including
+  # any Bullet headers. This is a workaround for the fact that Bullet does not
+  # add the definition to BULLET_DEFINITIONS or generate a #cmakedefine header.
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_FLAGS "")
+  set(CMAKE_REQUIRED_DEFINITIONS "-DBT_USE_DOUBLE_PRECISION")
+  set(CMAKE_REQUIRED_INCLUDES "${BULLET_INCLUDE_DIRS}")
+  set(CMAKE_REQUIRED_LIBRARIES "${BULLET_LIBRARIES}")
+  check_cxx_source_compiles(
+    "
+    #include <btBulletCollisionCommon.h>
+    int main()
+    {
+      btVector3 v(0., 0., 1.);
+      btStaticPlaneShape planeShape(v, 0.);
+      return 0;
+    }
+    "
+    BT_USE_DOUBLE_PRECISION
+  )
+
+  if(BT_USE_DOUBLE_PRECISION)
+    message(STATUS "Looking for Bullet - found (double precision)")
+  else()
+    message(STATUS "Looking for Bullet - found (single precision)")
+  endif()
+
   set(HAVE_BULLET_COLLISION TRUE)
-  add_definitions(-DHAVE_BULLET_COLLISION)
 else()
-  message(STATUS "Looking for BulletCollision - NOT found, please install libbullet-dev")
+  message(STATUS "Looking for Bullet - NOT found, to use BulletCollisionDetector, please install libbullet-dev")
   set(HAVE_BULLET_COLLISION FALSE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,12 +251,14 @@ if(NOT BUILD_CORE_ONLY)
   find_package(FLANN 1.8.4 QUIET)
   if(FLANN_FOUND)
     message(STATUS "Looking for FLANN - ${FLANN_VERSION} found")
+    set(HAVE_FLANN TRUE)
   else()
     if(FLANN_VERSION)
       message(SEND_ERROR "Looking for FLANN - ${FLANN_VERSION} found, ${PROJECT_NAME} requires 1.8.4 or greater.")
     else()
       message(SEND_ERROR "Looking for FLANN - NOT found, please install libflann-dev")
     endif()
+    set(HAVE_FLANN FALSE)
   endif()
 
   # TINYXML
@@ -428,6 +430,7 @@ endif()
 
 if(NOT BUILD_CORE_ONLY)
   set(DART_DEPENDENCIES ${urdfdom_LIBRARIES}
+                        ${FLANN_LIBRARIES}
                         ${TINYXML_LIBRARIES}
                         ${TINYXML2_LIBRARIES}
   )

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ### Version 5.1.3 (201X-XX-XX)
 
+1. Switched to use btGImpactMeshShape instead of btConvexTriangleMeshShape for mesh
+    * [Pull request #764](https://github.com/dartsim/dart/pull/764)
+
 1. Backported [#749](https://github.com/dartsim/dart/pull/749) to DART 5.1
     * [Pull request #759](https://github.com/dartsim/dart/pull/759)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,9 +49,6 @@ install:
 
 # scripts to run before build
 before_build:
-  - cmd: cd C:\projects\dart
-  - cmd: md build
-  - cmd: cd build
   - cmd: if "%platform%"=="Win32" set CMAKE_GENERATOR_NAME=Visual Studio 14 2015
   - cmd: if "%platform%"=="x64"   set CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
   - cmd: if "%platform%"=="Win32" set PROGRAM_FILES_PATH=Program Files (x86)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,10 +52,24 @@ before_build:
   - cmd: cd C:\projects\dart
   - cmd: md build
   - cmd: cd build
-  # We generate project files for Visual Studio 12 because the boost binaries installed on the test server are for Visual Studio 12.
   - cmd: if "%platform%"=="Win32" set CMAKE_GENERATOR_NAME=Visual Studio 14 2015
   - cmd: if "%platform%"=="x64"   set CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
-  - cmd: cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%configuration% -DBUILD_CORE_ONLY="%BUILD_CORE_ONLY%" -DDART_BUILD_EXAMPLES="%BUILD_EXAMPLES%" -DDART_BUILD_TUTORIALS="%BUILD_TUTORIALS%" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS="ON" -Durdfdom_DIR="%urdfdom_DIR%" -Durdfdom_headers_DIR="%urdfdom_headers_DIR%" -DDART_MSVC_DEFAULT_OPTIONS="%MSVC_DEFAULT_OPTIONS%" ..
+  - cmd: if "%platform%"=="Win32" set PROGRAM_FILES_PATH=Program Files (x86)
+  - cmd: if "%platform%"=="x64"   set PROGRAM_FILES_PATH=Program Files
+  - cmd: if not exist "C:\%PROGRAM_FILES_PATH%\flann\include\flann\flann.hpp" (
+            curl -L -o flann-1.9.1.tar.gz https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz &&
+            cmake -E tar zxf flann-1.9.1.tar.gz &&
+            cd flann-1.9.1 &&
+            md build &&
+            cd build &&
+            cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%Configuration% .. &&
+            cmake --build . --target install --config %Configuration% &&
+            cd ..\..
+         ) else (echo Using cached flann)
+  - cmd: cd C:\projects\dart
+  - cmd: md build
+  - cmd: cd build
+  - cmd: cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%configuration% -DBUILD_CORE_ONLY="%BUILD_CORE_ONLY%" -DDART_BUILD_EXAMPLES="%BUILD_EXAMPLES%" -DDART_BUILD_TUTORIALS="%BUILD_TUTORIALS%" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS="ON" -Durdfdom_DIR="%urdfdom_DIR%" -Durdfdom_headers_DIR="%urdfdom_headers_DIR%" -DDART_MSVC_DEFAULT_OPTIONS="%MSVC_DEFAULT_OPTIONS%" -DFLANN_INCLUDE_DIRS="C:\%PROGRAM_FILES_PATH%\flann\include" -DFLANN_LIBRARIES="C:\%PROGRAM_FILES_PATH%\flann\lib\flann_cpp_s.lib" ..
 
 build:
   project: C:\projects\dart\build\dart.sln # path to Visual Studio solution or project

--- a/cmake/FindFLANN.cmake
+++ b/cmake/FindFLANN.cmake
@@ -6,6 +6,7 @@
 # This sets the following variables:
 # FLANN_FOUND
 # FLANN_INCLUDE_DIRS
+# FLANN_LIBRARIES
 # FLANN_VERSION
 
 find_package(PkgConfig QUIET)
@@ -19,6 +20,10 @@ find_path(FLANN_INCLUDE_DIRS
     HINTS ${PC_FLANN_INCLUDEDIR}
     PATHS "${CMAKE_INSTALL_PREFIX}/include")
 
+# Libraries
+find_library(FLANN_LIBRARIES flann_cpp
+    HINTS ${PC_FLANN_LIBDIR})
+
 # Version
 set(FLANN_VERSION ${PC_FLANN_VERSION})
 
@@ -26,6 +31,6 @@ set(FLANN_VERSION ${PC_FLANN_VERSION})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FLANN
     FAIL_MESSAGE  DEFAULT_MSG
-    REQUIRED_VARS FLANN_INCLUDE_DIRS
+    REQUIRED_VARS FLANN_INCLUDE_DIRS FLANN_LIBRARIES
     VERSION_VAR   FLANN_VERSION)
 

--- a/dart/collision/bullet/BulletCollisionNode.cpp
+++ b/dart/collision/bullet/BulletCollisionNode.cpp
@@ -148,8 +148,8 @@ BulletCollisionNode::BulletCollisionNode(dynamics::BodyNode* _bodyNode)
       {
         const dynamics::MeshShape* shapeMesh
             = static_cast<const dynamics::MeshShape*>(shape.get());
-        btConvexTriangleMeshShape* btMesh = _createMesh(shapeMesh->getScale(),
-                                                        shapeMesh->getMesh());
+        btGImpactMeshShape* btMesh = _createMesh(shapeMesh->getScale(),
+                                                 shapeMesh->getMesh());
         btCollisionObject* btCollObj = new btCollisionObject();
 
         // Add user data
@@ -208,7 +208,7 @@ btCollisionObject*BulletCollisionNode::getBulletCollisionObject(int _i)
 }
 
 //==============================================================================
-btConvexTriangleMeshShape* _createMesh(const Eigen::Vector3d& _scale,
+btGImpactMeshShape* _createMesh(const Eigen::Vector3d& _scale,
                                        const aiScene* _mesh)
 {
   btTriangleMesh* btMesh = new btTriangleMesh();
@@ -230,8 +230,8 @@ btConvexTriangleMeshShape* _createMesh(const Eigen::Vector3d& _scale,
     }
   }
 
-  btConvexTriangleMeshShape* btMeshShape =
-      new btConvexTriangleMeshShape(btMesh);
+  btGImpactMeshShape* btMeshShape = new btGImpactMeshShape(btMesh);
+  btMeshShape->updateBound();
 
   return btMeshShape;
 }

--- a/dart/collision/bullet/BulletCollisionNode.h
+++ b/dart/collision/bullet/BulletCollisionNode.h
@@ -41,6 +41,7 @@
 
 #include <assimp/scene.h>
 #include <btBulletCollisionCommon.h>
+#include <bullet/BulletCollision/Gimpact/btGImpactShape.h>
 #include <Eigen/Dense>
 
 #include "dart/dynamics/SmartPointer.h"
@@ -91,8 +92,8 @@ private:
 };
 
 /// @brief Create Bullet mesh from assimp3 mesh
-btConvexTriangleMeshShape* _createMesh(const Eigen::Vector3d& _scale,
-                                       const aiScene* _mesh);
+btGImpactMeshShape* _createMesh(
+    const Eigen::Vector3d& _scale, const aiScene* _mesh);
 
 }  // namespace collision
 }  // namespace dart

--- a/dart/config.h.in
+++ b/dart/config.h.in
@@ -54,4 +54,8 @@
 #cmakedefine ASSIMP_AISCENE_CTOR_DTOR_DEFINED 1
 #cmakedefine ASSIMP_AIMATERIAL_CTOR_DTOR_DEFINED 1
 
+// Workaround for the fact that Bullet does not add the definition to
+// BULLET_DEFINITIONS or generate a #cmakedefine header.
+#cmakedefine BT_USE_DOUBLE_PRECISION
+
 #endif // #ifndef DART_CONFIG_H_

--- a/dart/config.h.in
+++ b/dart/config.h.in
@@ -46,6 +46,7 @@
 #cmakedefine HAVE_IPOPT 1
 #cmakedefine HAVE_SNOPT 1
 #cmakedefine HAVE_BULLET_COLLISION 1
+#cmakedefine HAVE_FLANN 1
 
 #define DART_ROOT_PATH "@CMAKE_SOURCE_DIR@/"
 #define DART_DATA_PATH "@CMAKE_SOURCE_DIR@/data/"

--- a/data/skel/shapes.skel
+++ b/data/skel/shapes.skel
@@ -20,7 +20,7 @@
                     <color>0.95 0.95 0.95</color>
                 </visualization_shape>
                 <collision_shape>
-                    <transformation>0 0 0 0 0 0</transformation>
+                    <transformation>0 -0.005 0 0 0 0</transformation>
                     <geometry>
                         <box>
                             <size>10 0.01 10</size>

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -84,11 +84,11 @@ foreach(test ${tests})
 endforeach(test)
 
 if(HAVE_IPOPT)
-  target_link_libraries(testOptimizer dart-optimizer-ipopt ${IPOPT_LIBRARIES})
+  target_link_libraries(testOptimizer dart-optimizer-ipopt)
 endif(HAVE_IPOPT)
 
 if(HAVE_NLOPT)
-  target_link_libraries(testOptimizer dart-optimizer-nlopt ${NLOPT_LIBRARIES})
+  target_link_libraries(testOptimizer dart-optimizer-nlopt)
 endif(HAVE_NLOPT)
 
 if(HAVE_SNOPT)

--- a/unittests/testNearestNeighbor.cpp
+++ b/unittests/testNearestNeighbor.cpp
@@ -7,11 +7,15 @@
 
 #include <iostream>
 #include <gtest/gtest.h>
-#include <flann/flann.hpp>
 #include <Eigen/Core>
+#include <dart/dart.h>
+#if HAVE_FLANN
+#include <flann/flann.hpp>
+#endif // HAVE_FLANN
 #include "TestHelpers.h"
 
 /* ********************************************************************************************* */
+#if HAVE_FLANN
 TEST(NEAREST_NEIGHBOR, 2D) {
 
     // Build the index with the first node
@@ -44,6 +48,7 @@ TEST(NEAREST_NEIGHBOR, 2D) {
     bool equality = equals(Vector2d(point[0], point[1]), p3, 1e-3);
     EXPECT_TRUE(equality);
 }
+#endif // HAVE_FLANN
 
 /* ********************************************************************************************* */
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This pull request switches to use `btConvexTriangleMeshShape` instead of `btGImpactMeshShape` for mesh shapes to support not only convex but also concave meshes.

Related issue: #762

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/764)
<!-- Reviewable:end -->
