### PR TITLE
Support urdfdom_headers 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
   * Fixed incorrect linking to flann library: [#761](https://github.com/dartsim/dart/pull/761)
 
+* Parsers
+
+  * Added support of urdfdom_headers 1.0: [#766](https://github.com/dartsim/dart/pull/766)
+
 * Misc improvements and bug fixes
 
   * Made building with SIMD optional: [#765](https://github.com/dartsim/dart/pull/765), [#760](https://github.com/dartsim/dart/pull/760)

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -239,7 +239,7 @@ endif()
 # urdfdom
 find_package(urdfdom QUIET)
 if(urdfdom_FOUND)
-  message(STATUS "Looking for urdfdom - found")
+  message(STATUS "Looking for urdfdom - ${urdfdom_headers_VERSION} found")
 else()
   message(STATUS "Looking for urdfdom - NOT found, please install liburdfdom-dev")
 endif()

--- a/dart/config.hpp.in
+++ b/dart/config.hpp.in
@@ -28,6 +28,18 @@
   (DART_MAJOR_VERSION < x || (DART_MAJOR_VERSION <= x && \
   (DART_MINOR_VERSION < y || (DART_MINOR_VERSION <= y))))
 
+/* urdfdom_headers Version number */
+// We define the version numbers of urdfdom_headers here since it doesn't expose
+// the version numbers itself in source level.
+#define URDFDOM_HEADERS_MAJOR_VERSION @urdfdom_headers_VERSION_MAJOR@
+#define URDFDOM_HEADERS_MINOR_VERSION @urdfdom_headers_VERSION_MINOR@
+#define URDFDOM_HEADERS_PATCH_VERSION @urdfdom_headers_VERSION_PATCH@
+
+#define URDFDOM_HEADERS_VERSION_AT_LEAST(x,y,z) \
+  (URDFDOM_HEADERS_MAJOR_VERSION > x || (URDFDOM_HEADERS_MAJOR_VERSION >= x && \
+  (URDFDOM_HEADERS_MINOR_VERSION > y || (URDFDOM_HEADERS_MINOR_VERSION >= y && \
+  URDFDOM_HEADERS_PATCH_VERSION >= z))))
+
 // Detect the compiler
 #if defined(__clang__)
   #define DART_COMPILER_CLANG

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -52,12 +52,13 @@
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/simulation/World.hpp"
+#include "dart/utils/urdf/URDFTypes.hpp"
 #include "dart/utils/urdf/urdf_world_parser.hpp"
-
-using ModelInterfacePtr = boost::shared_ptr<urdf::ModelInterface>;
 
 namespace dart {
 namespace utils {
+
+using ModelInterfacePtr = urdf_shared_ptr<urdf::ModelInterface>;
 
 DartLoader::DartLoader()
   : mLocalRetriever(new common::LocalResourceRetriever),

--- a/dart/utils/urdf/URDFTypes.hpp
+++ b/dart/utils/urdf/URDFTypes.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_UTILS_URDF_URDFTYPES_HPP_
+#define DART_UTILS_URDF_URDFTYPES_HPP_
+
+#include "dart/config.hpp"
+
+#if URDFDOM_HEADERS_VERSION_AT_LEAST(1,0,0)
+#include <memory>
+#else
+#include "boost/shared_ptr.hpp"
+#include "boost/weak_ptr.hpp"
+#endif
+
+namespace dart {
+namespace utils {
+
+#if URDFDOM_HEADERS_VERSION_AT_LEAST(1,0,0)
+template <class T> using urdf_shared_ptr = std::shared_ptr<T>;
+template <class T> using urdf_weak_ptr = std::weak_ptr<T>;
+#else
+template <class T> using urdf_shared_ptr = boost::shared_ptr<T>;
+template <class T> using urdf_weak_ptr = boost::weak_ptr<T>;
+#endif
+
+} // namespace utils
+} // namespace dart
+
+#endif // DART_UTILS_URDF_TYPES_HPP_

--- a/dart/utils/urdf/URDFTypes.hpp
+++ b/dart/utils/urdf/URDFTypes.hpp
@@ -45,14 +45,14 @@ namespace dart {
 namespace utils {
 
 #if URDFDOM_HEADERS_VERSION_AT_LEAST(1,0,0)
-template <class T> using urdf_shared_ptr = std::shared_ptr<T>;
-template <class T> using urdf_weak_ptr = std::weak_ptr<T>;
+template <typename T> using urdf_shared_ptr = std::shared_ptr<T>;
+template <typename T> using urdf_weak_ptr = std::weak_ptr<T>;
 #else
-template <class T> using urdf_shared_ptr = boost::shared_ptr<T>;
-template <class T> using urdf_weak_ptr = boost::weak_ptr<T>;
+template <typename T> using urdf_shared_ptr = boost::shared_ptr<T>;
+template <typename T> using urdf_weak_ptr = boost::weak_ptr<T>;
 #endif
 
 } // namespace utils
 } // namespace dart
 
-#endif // DART_UTILS_URDF_TYPES_HPP_
+#endif // DART_UTILS_URDF_URDFTYPES_HPP_

--- a/dart/utils/urdf/urdf_world_parser.hpp
+++ b/dart/utils/urdf/urdf_world_parser.hpp
@@ -46,6 +46,7 @@
 
 #include "dart/common/Uri.hpp"
 #include "dart/common/ResourceRetriever.hpp"
+#include "dart/utils/urdf/URDFTypes.hpp"
 
 namespace dart {
 namespace utils {
@@ -62,7 +63,7 @@ public:
   /// Copy over a standard urdfEntity
   Entity(const urdf::Entity& urdfEntity);
 
-  boost::shared_ptr<urdf::ModelInterface> model;
+  urdf_shared_ptr<urdf::ModelInterface> model;
   urdf::Pose origin;
   urdf::Twist twist;
 


### PR DESCRIPTION
`urdfdom_headers` 1.0 [is released](https://github.com/ros/urdfdom_headers/releases/tag/1.0.0) with API changes. The major change was replacing `boost` with C++11, which is a relatively small change.

This pull request adds support of `urdfdom_headers` 1.0 using different type aliasings depending on the `urdfdom_headers` versions.

This should fix [the build failures on Ubuntu `yakkety`](https://launchpadlibrarian.net/281296686/buildlog_ubuntu-yakkety-amd64.dart6_6.0.0-0~1541-daily~ubuntu16.10.1_BUILDING.txt.gz). 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/766)
<!-- Reviewable:end -->
