### PR TITLE
Add CapsuleShape and ConeShape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Dynamics
 
   * Added `computeLagrangian()` to `MetaSkeleton` and `BodyNode`: [#746](https://github.com/dartsim/dart/pull/746)
-  * Added `SphereShape`: [#745](https://github.com/dartsim/dart/pull/745)
+  * Added new shapes: sphere, capsule, and cone: [#769](https://github.com/dartsim/dart/pull/769), [#745](https://github.com/dartsim/dart/pull/745)
 
 * Planning
 

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -465,6 +465,10 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     const auto height = cone->getHeight();
 
     bulletCollisionShape = new btConeShapeZ(radius, height);
+    bulletCollisionShape->setMargin(0.0);
+    // TODO(JS): Bullet seems to use constant margin 0.4, however this could be
+    // dangerous when the cone is sufficiently small. We use zero margin here
+    // until find better solution.
   }
   else if (PlaneShape::getStaticType() == shapeType)
   {

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -468,7 +468,8 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     bulletCollisionShape->setMargin(0.0);
     // TODO(JS): Bullet seems to use constant margin 0.4, however this could be
     // dangerous when the cone is sufficiently small. We use zero margin here
-    // until find better solution.
+    // until find better solution even using zero margin is not recommended:
+    // https://www.sjbaker.org/wiki/index.php?title=Physics_-_Bullet_Collected_random_advice#Minimum_object_sizes_-_by_Erwin
   }
   else if (PlaneShape::getStaticType() == shapeType)
   {

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -48,6 +48,8 @@
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/CapsuleShape.hpp"
+#include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
@@ -396,6 +398,8 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
   using dynamics::BoxShape;
   using dynamics::EllipsoidShape;
   using dynamics::CylinderShape;
+  using dynamics::CapsuleShape;
+  using dynamics::ConeShape;
   using dynamics::PlaneShape;
   using dynamics::MeshShape;
   using dynamics::SoftMeshShape;
@@ -441,6 +445,26 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     const auto size = btVector3(radius, radius, height * 0.5);
 
     bulletCollisionShape = new btCylinderShapeZ(size);
+  }
+  else if (CapsuleShape::getStaticType() == shapeType)
+  {
+    assert(dynamic_cast<const CapsuleShape*>(shape.get()));
+
+    const auto capsule = static_cast<const CapsuleShape*>(shape.get());
+    const auto radius = capsule->getRadius();
+    const auto height = capsule->getHeight();
+
+    bulletCollisionShape = new btCapsuleShapeZ(radius, height);
+  }
+  else if (ConeShape::getStaticType() == shapeType)
+  {
+    assert(dynamic_cast<const ConeShape*>(shape.get()));
+
+    const auto cone = static_cast<const ConeShape*>(shape.get());
+    const auto radius = cone->getRadius();
+    const auto height = cone->getHeight();
+
+    bulletCollisionShape = new btConeShapeZ(radius, height);
   }
   else if (PlaneShape::getStaticType() == shapeType)
   {

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -927,7 +927,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
   {
     dterr << "[FCLCollisionDetector::createFCLCollisionGeometry] "
           << "Attempting to create an unsupported shape type ["
-          << shapeType << "] Creating a sphere with 0.1 radius "
+          << shapeType << "]. Creating a sphere with 0.1 radius "
           << "instead.\n";
 
     geom = createEllipsoid<fcl::OBBRSS>(0.1, 0.1, 0.1);

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -36,7 +36,7 @@ namespace dart {
 namespace dynamics {
 
 BoxShape::BoxShape(const Eigen::Vector3d& _size)
-  : Shape(BOX),
+  : Shape(),
     mSize(_size) {
   assert(_size[0] > 0.0);
   assert(_size[1] > 0.0);

--- a/dart/dynamics/CapsuleShape.hpp
+++ b/dart/dynamics/CapsuleShape.hpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_CAPSULESHAPE_HPP_
+#define DART_DYNAMICS_CAPSULESHAPE_HPP_
+
+#include "dart/dynamics/Shape.hpp"
+
+namespace dart {
+namespace dynamics {
+
+/// CapsuleShape represents a three-dimensional geometric shape consisting of a
+/// cylinder with hemispherical ends.
+class CapsuleShape : public Shape
+{
+public:
+
+  /// Constructor.
+  /// \param[in] radius Radius of the capsule.
+  /// \param[in] height Height of the cylindrical part.
+  CapsuleShape(double radius, double height);
+
+  // Documentation inherited.
+  const std::string& getType() const override;
+
+  /// Get shape type string for this shape.
+  static const std::string& getStaticType();
+
+  /// Get the radius of the capsule.
+  double getRadius() const;
+
+  /// Set the radius of the capsule.
+  void setRadius(double radius);
+
+  /// Get the height of the cylindrical part.
+  double getHeight() const;
+
+  /// Set the height of the cylindrical part.
+  void setHeight(double height);
+
+  /// Compute volume from given properties.
+  /// \param[in] radius Radius of the capsule.
+  /// \param[in] height Height of the cylindrical part.
+  static double computeVolume(double radius, double height);
+
+  /// Compute moments of inertia of a capsule
+  /// \param[in] radius Radius of the capsule.
+  /// \param[in] height Height of the cylindrical part.
+  static Eigen::Matrix3d computeInertia(
+      double radius, double height, double mass);
+
+  // Documentation inherited.
+  Eigen::Matrix3d computeInertia(double mass) const override;
+
+protected:
+
+  // Documentation inherited.
+  void updateVolume() override;
+
+private:
+
+  /// Update bounding box (in the local coordinate frame) of the shape.
+  void updateBoundingBoxDim();
+
+  /// Radius of the capsule.
+  double mRadius;
+
+  /// Height of the cylindrical part.
+  double mHeight;
+
+};
+
+}  // namespace dynamics
+}  // namespace dart
+
+#endif  // DART_DYNAMICS_CAPSULESHAPE_HPP_

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -109,7 +109,7 @@ Eigen::Matrix3d ConeShape::computeInertia(
   const auto radius2 = radius*radius;
   const auto height2 = height*height;
 
-  const auto Ixx = (3.0/20.0)*mass*(radius2 + 4.0*height2);
+  const auto Ixx = (3.0/20.0)*mass*(radius2 + (2.0/3.0)*height2);
   const auto Izz = (3.0/10.0)*mass*radius2;
 
   return Eigen::Vector3d(Ixx, Ixx, Izz).asDiagonal();

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013-2016, Graphics Lab, Georgia Tech Research Corporation
- * Copyright (c) 2013-2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
  * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
  * All rights reserved.
  *
@@ -29,94 +29,111 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/ConeShape.hpp"
 
 #include <cmath>
 #include "dart/math/Helpers.hpp"
+#include "dart/dynamics/SphereShape.hpp"
+#include "dart/dynamics/CylinderShape.hpp"
 
 namespace dart {
 namespace dynamics {
 
-CylinderShape::CylinderShape(double _radius, double _height)
+//==============================================================================
+ConeShape::ConeShape(double radius, double height)
   : Shape(),
-    mRadius(_radius),
-    mHeight(_height) {
-  assert(0.0 < _radius);
-  assert(0.0 < _height);
-  _updateBoundingBoxDim();
+    mRadius(radius),
+    mHeight(height)
+{
+  assert(0.0 < radius);
+  assert(0.0 < height);
+  updateBoundingBoxDim();
   updateVolume();
 }
 
 //==============================================================================
-const std::string& CylinderShape::getType() const
+const std::string& ConeShape::getType() const
 {
   return getStaticType();
 }
 
 //==============================================================================
-const std::string& CylinderShape::getStaticType()
+const std::string& ConeShape::getStaticType()
 {
-  static const std::string type("CylinderShape");
+  static const std::string type("ConeShape");
   return type;
 }
 
-double CylinderShape::getRadius() const {
+//==============================================================================
+double ConeShape::getRadius() const
+{
   return mRadius;
 }
 
-void CylinderShape::setRadius(double _radius) {
-  assert(0.0 < _radius);
-  mRadius = _radius;
-  _updateBoundingBoxDim();
+//==============================================================================
+void ConeShape::setRadius(double radius)
+{
+  assert(0.0 < radius);
+  mRadius = radius;
+  updateBoundingBoxDim();
   updateVolume();
 }
 
-double CylinderShape::getHeight() const {
+//==============================================================================
+double ConeShape::getHeight() const
+{
   return mHeight;
 }
 
-void CylinderShape::setHeight(double _height) {
-  assert(0.0 < _height);
-  mHeight = _height;
-  _updateBoundingBoxDim();
+//==============================================================================
+void ConeShape::setHeight(double height)
+{
+  assert(0.0 < height);
+  mHeight = height;
+  updateBoundingBoxDim();
   updateVolume();
 }
 
 //==============================================================================
-double CylinderShape::computeVolume(double radius, double height)
+double ConeShape::computeVolume(double radius, double height)
 {
-  return math::constantsd::pi() * std::pow(radius, 2) * height;
+  return (1.0/3.0) * math::constantsd::pi() * std::pow(radius, 2) * height;
 }
 
 //==============================================================================
-Eigen::Matrix3d CylinderShape::computeInertia(
+Eigen::Matrix3d ConeShape::computeInertia(
     double radius, double height, double mass)
 {
-  Eigen::Matrix3d inertia = Eigen::Matrix3d::Zero();
+  // Reference: https://en.wikipedia.org/wiki/List_of_moments_of_inertia
 
-  inertia(0, 0) = mass * (3.0 * std::pow(radius, 2) + std::pow(height, 2))
-      / 12.0;
-  inertia(1, 1) = inertia(0, 0);
-  inertia(2, 2) = 0.5 * mass * radius * radius;
+  const auto radius2 = radius*radius;
+  const auto height2 = height*height;
 
-  return inertia;
+  const auto Ixx = (3.0/20.0)*mass*(radius2 + 4.0*height2);
+  const auto Izz = (3.0/10.0)*mass*radius2;
+
+  return Eigen::Vector3d(Ixx, Ixx, Izz).asDiagonal();
 }
 
 //==============================================================================
-void CylinderShape::updateVolume()
+void ConeShape::updateVolume()
 {
   mVolume = computeVolume(mRadius, mHeight);
 }
 
 //==============================================================================
-Eigen::Matrix3d CylinderShape::computeInertia(double mass) const
+Eigen::Matrix3d ConeShape::computeInertia(double mass) const
 {
   return computeInertia(mRadius, mHeight, mass);
 }
 
-void CylinderShape::_updateBoundingBoxDim() {
-  mBoundingBox.setMin(Eigen::Vector3d(-mRadius, -mRadius, -mHeight * 0.5));
-  mBoundingBox.setMax(Eigen::Vector3d(mRadius, mRadius, mHeight * 0.5));
+//==============================================================================
+void ConeShape::updateBoundingBoxDim()
+{
+  const Eigen::Vector3d corner(mRadius, mRadius, mRadius + 0.5*mHeight);
+
+  mBoundingBox.setMin(-corner);
+  mBoundingBox.setMax(corner);
 }
 
 }  // namespace dynamics

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_CONESHAPE_HPP_
+#define DART_DYNAMICS_CONESHAPE_HPP_
+
+#include "dart/dynamics/Shape.hpp"
+
+namespace dart {
+namespace dynamics {
+
+/// ConeShape represents a three-dimensional geometric shape that tapers
+/// smoothly from a flat circular base to a point called the apex or vertex.
+class ConeShape : public Shape
+{
+public:
+
+  /// Constructor.
+  /// \param[in] radius Radius of the circular base.
+  /// \param[in] height Lateral height of the cone.
+  ConeShape(double radius, double height);
+
+  // Documentation inherited.
+  const std::string& getType() const override;
+
+  /// Get shape type string for this shape.
+  static const std::string& getStaticType();
+
+  /// Get the radius of the circular base.
+  double getRadius() const;
+
+  /// Set the radius of the circular base.
+  void setRadius(double radius);
+
+  /// Get the lateral height of the cone.
+  double getHeight() const;
+
+  /// Set the lateral height of the cone.
+  void setHeight(double height);
+
+  /// Compute volume from given properties.
+  /// \param[in] radius Radius of the circular base.
+  /// \param[in] height Lateral height of the cone.
+  static double computeVolume(double radius, double height);
+
+  /// Compute moments of inertia of a cone.
+  /// \param[in] radius Radius of the circular base.
+  /// \param[in] height Lateral height of the cone.
+  /// \param[in] mass The mass of the cone.
+  static Eigen::Matrix3d computeInertia(
+      double radius, double height, double mass);
+
+  // Documentation inherited.
+  Eigen::Matrix3d computeInertia(double mass) const override;
+
+protected:
+
+  // Documentation inherited.
+  void updateVolume() override;
+
+private:
+
+  /// Update bounding box (in the local coordinate frame) of the shape.
+  void updateBoundingBoxDim();
+
+  /// Radius of the circular base.
+  double mRadius;
+
+  /// Height of the cylindrical part.
+  double mHeight;
+
+};
+
+}  // namespace dynamics
+}  // namespace dart
+
+#endif  // DART_DYNAMICS_CONESHAPE_HPP_

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -71,7 +71,9 @@ public:
   /// \param[in] height Lateral height of the cone.
   static double computeVolume(double radius, double height);
 
-  /// Compute moments of inertia of a cone.
+  /// Compute moments of inertia of a cone at the center of geometric center
+  /// (half of the z-axis segment between the tip and the center of the base
+  /// disk).
   /// \param[in] radius Radius of the circular base.
   /// \param[in] height Lateral height of the cone.
   /// \param[in] mass The mass of the cone.

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -37,7 +37,7 @@ namespace dart {
 namespace dynamics {
 
 EllipsoidShape::EllipsoidShape(const Eigen::Vector3d& _size)
-  : Shape(ELLIPSOID) {
+  : Shape() {
   setSize(_size);
 }
 

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -38,7 +38,7 @@ namespace dynamics {
 
 //==============================================================================
 LineSegmentShape::LineSegmentShape(float _thickness)
-  : Shape(LINE_SEGMENT),
+  : Shape(),
     mThickness(_thickness),
     mDummyVertex(Eigen::Vector3d::Zero())
 {
@@ -58,7 +58,7 @@ LineSegmentShape::LineSegmentShape(float _thickness)
 LineSegmentShape::LineSegmentShape(const Eigen::Vector3d& _v1,
                                    const Eigen::Vector3d& _v2,
                                    float _thickness)
-  : Shape(LINE_SEGMENT),
+  : Shape(),
     mThickness(_thickness)
 {
   if (_thickness <= 0.0f)

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -128,7 +128,7 @@ namespace dynamics {
 MeshShape::MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh,
                      const std::string& _path,
                      const common::ResourceRetrieverPtr& _resourceRetriever)
-  : Shape(MESH),
+  : Shape(),
     mResourceRetriever(_resourceRetriever),
     mDisplayList(0),
     mColorMode(MATERIAL_COLOR),

--- a/dart/dynamics/Shape.cpp
+++ b/dart/dynamics/Shape.cpp
@@ -31,18 +31,31 @@
 
 #include "dart/dynamics/Shape.hpp"
 
+#include "dart/common/Console.hpp"
+
 #define PRIMITIVE_MAGIC_NUMBER 1000
 
 namespace dart {
 namespace dynamics {
+
 //==============================================================================
-Shape::Shape(ShapeType _type)
+Shape::Shape(ShapeType /*_type*/)
   : mBoundingBox(),
     mVolume(0.0),
     mID(mCounter++),
-    mVariance(STATIC),
-    mType(_type)
+    mVariance(STATIC)
 {
+  // Do nothing
+}
+
+//==============================================================================
+Shape::Shape()
+  : mBoundingBox(),
+    mVolume(0.0),
+    mID(mCounter++),
+    mVariance(STATIC)
+{
+  // Do nothing
 }
 
 //==============================================================================
@@ -55,6 +68,18 @@ Shape::~Shape()
 const math::BoundingBox& Shape::getBoundingBox() const
 {
     return mBoundingBox;
+}
+
+//==============================================================================
+Eigen::Matrix3d Shape::computeInertiaFromDensity(double density) const
+{
+  return computeInertiaFromMass(density * getVolume());
+}
+
+//==============================================================================
+Eigen::Matrix3d Shape::computeInertiaFromMass(double mass) const
+{
+  return computeInertia(mass);
 }
 
 //==============================================================================
@@ -72,7 +97,12 @@ int Shape::getID() const
 //==============================================================================
 Shape::ShapeType Shape::getShapeType() const
 {
-  return mType;
+  dtwarn << "[Shape::getShapeType] This function is deprecated since DART 6.1 "
+         << "with Shape::ShapeType, and this won't work as expected. Please "
+         << "consider using Shape::getType() or [ShapeClass]::getStaticType() "
+         << "instead for the type checking.\n";
+
+  return static_cast<ShapeType>(0);
 }
 
 //==============================================================================

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -83,7 +83,23 @@ public:
   virtual ~Shape();
 
   /// Returns a string representing the shape type
+  /// \sa is()
   virtual const std::string& getType() const = 0;
+
+  /// Get true if the types of this Shape and the template parameter (a shape
+  /// class) are identical. This function is a syntactic sugar, which is
+  /// identical to: (getType() == ShapeType::getStaticType()).
+  ///
+  /// Example code:
+  /// \code
+  /// auto shape = bodyNode->getShapeNode(0)->getShape();
+  /// if (shape->is<BoxShape>())
+  ///   std::cout << "The shape type is box!\n";
+  /// \endcode
+  ///
+  /// \sa getType()
+  template <typename ShapeType>
+  bool is() const;
 
   /// \brief Get the bounding box of the shape in its local coordinate frame.
   ///        The dimension will be automatically determined by the sub-classes
@@ -161,5 +177,7 @@ protected:
 
 }  // namespace dynamics
 }  // namespace dart
+
+#include "dart/dynamics/detail/Shape.hpp"
 
 #endif  // DART_DYNAMICS_SHAPE_HPP_

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -73,7 +73,11 @@ public:
   };
 
   /// \brief Constructor
+  DART_DEPRECATED(6.1)
   explicit Shape(ShapeType _type);
+
+  /// \brief Constructor
+  Shape();
 
   /// \brief Destructor
   virtual ~Shape();
@@ -152,12 +156,6 @@ protected:
 
   /// \brief
   static int mCounter;
-
-private:
-
-  /// \deprecated Deprecated in 6.1. Please use getType() instead.
-  /// \brief Type of primitive shpae
-  ShapeType mType;
 
 };
 

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -98,7 +98,7 @@ public:
   /// \endcode
   ///
   /// \sa getType()
-  template <typename ShapeType>
+  template <typename ShapeT>
   bool is() const;
 
   /// \brief Get the bounding box of the shape in its local coordinate frame.

--- a/dart/dynamics/SoftMeshShape.cpp
+++ b/dart/dynamics/SoftMeshShape.cpp
@@ -40,7 +40,7 @@ namespace dart {
 namespace dynamics {
 
 SoftMeshShape::SoftMeshShape(SoftBodyNode* _softBodyNode)
-  : Shape(SOFT_MESH),
+  : Shape(),
     mSoftBodyNode(_softBodyNode),
     mAssimpMesh(nullptr)
 {

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -38,7 +38,7 @@ namespace dynamics {
 
 //==============================================================================
 SphereShape::SphereShape(double radius)
-  : Shape(SPHERE)
+  : Shape()
 {
   setRadius(radius);
 }

--- a/dart/dynamics/detail/Shape.hpp
+++ b/dart/dynamics/detail/Shape.hpp
@@ -37,10 +37,10 @@
 namespace dart {
 namespace dynamics {
 
-template <typename ShapeType>
+template <typename ShapeT>
 bool Shape::is() const
 {
-  return getType() == ShapeType::getStaticType();
+  return getType() == ShapeT::getStaticType();
 }
 
 }  // namespace dynamics

--- a/dart/dynamics/detail/Shape.hpp
+++ b/dart/dynamics/detail/Shape.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_DETAIL_SHAPE_HPP_
+#define DART_DYNAMICS_DETAIL_SHAPE_HPP_
+
+#include "dart/dynamics/Shape.hpp"
+
+namespace dart {
+namespace dynamics {
+
+template <typename ShapeType>
+bool Shape::is() const
+{
+  return getType() == ShapeType::getStaticType();
+}
+
+}  // namespace dynamics
+}  // namespace dart
+
+#endif  // DART_DYNAMICS_DETAIL_SHAPE_HPP_

--- a/dart/gui/OpenGLRenderInterface.cpp
+++ b/dart/gui/OpenGLRenderInterface.cpp
@@ -232,6 +232,18 @@ void OpenGLRenderInterface::drawCylinder(double _radius, double _height) {
     gluDisk(quadObj, 0, radius, slices, stacks);
 }
 
+//==============================================================================
+void OpenGLRenderInterface::drawCapsule(double /*_radius*/, double /*_height*/)
+{
+  // TODO(JS): Not implemented yet
+}
+
+//==============================================================================
+void OpenGLRenderInterface::drawCone(double /*_radius*/, double /*_height*/)
+{
+  // TODO(JS): Not implemented yet
+}
+
 void OpenGLRenderInterface::color4_to_float4(const aiColor4D *c, float f[4])
 {
     f[0] = c->r;

--- a/dart/gui/OpenGLRenderInterface.cpp
+++ b/dart/gui/OpenGLRenderInterface.cpp
@@ -233,15 +233,121 @@ void OpenGLRenderInterface::drawCylinder(double _radius, double _height) {
 }
 
 //==============================================================================
-void OpenGLRenderInterface::drawCapsule(double /*_radius*/, double /*_height*/)
+static void drawOpenDome(double radius, int slices, int stacks)
 {
-  // TODO(JS): Not implemented yet
+  // (2pi/Stacks)
+  const auto pi = dart::math::constants<double>::pi();
+  const auto drho = pi / stacks / 2.0;
+  const auto dtheta = 2.0 * pi / slices;
+
+  const auto rho = drho;
+  const auto srho = std::sin(rho);
+  const auto crho = std::cos(rho);
+
+  // Many sources of OpenGL sphere drawing code uses a triangle fan
+  // for the caps of the sphere. This however introduces texturing
+  // artifacts at the poles on some OpenGL implementations
+  glBegin(GL_TRIANGLE_FAN);
+  glNormal3d(0.0, 0.0, radius);
+  glVertex3d(0.0, 0.0, radius);
+  for (int j = 0; j <= slices; ++j)
+  {
+    const auto theta = (j == slices) ? 0.0 : j * dtheta;
+    const auto stheta = -std::sin(theta);
+    const auto ctheta = std::cos(theta);
+
+    const auto x = srho * stheta;
+    const auto y = srho * ctheta;
+    const auto z = crho;
+
+    glNormal3d(x, y, z);
+    glVertex3d(x * radius, y * radius, z * radius);
+  }
+  glEnd();
+
+  for (int i = 1; i < stacks; ++i)
+  {
+    const auto rho = i * drho;
+    const auto srho = std::sin(rho);
+    const auto crho = std::cos(rho);
+    const auto srhodrho = std::sin(rho + drho);
+    const auto crhodrho = std::cos(rho + drho);
+
+    // Many sources of OpenGL sphere drawing code uses a triangle fan
+    // for the caps of the sphere. This however introduces texturing
+    // artifacts at the poles on some OpenGL implementations
+    glBegin(GL_TRIANGLE_STRIP);
+
+    for (int j = 0; j <= slices; ++j)
+    {
+      const auto theta = (j == slices) ? 0.0 : j * dtheta;
+      const auto stheta = -std::sin(theta);
+      const auto ctheta = std::cos(theta);
+
+      auto x = srho * stheta;
+      auto y = srho * ctheta;
+      auto z = crho;
+
+      glNormal3d(x, y, z);
+      glVertex3d(x * radius, y * radius, z * radius);
+
+      x = srhodrho * stheta;
+      y = srhodrho * ctheta;
+      z = crhodrho;
+
+      glNormal3d(x, y, z);
+      glVertex3d(x * radius, y * radius, z * radius);
+    }
+    glEnd();
+  }
 }
 
 //==============================================================================
-void OpenGLRenderInterface::drawCone(double /*_radius*/, double /*_height*/)
+void OpenGLRenderInterface::drawCapsule(double radius, double height)
 {
-  // TODO(JS): Not implemented yet
+  GLint slices = 16;
+  GLint stacks = 16;
+
+  // Graphics assumes Cylinder is centered at CoM
+  // gluCylinder places base at z = 0 and top at z = height
+  glTranslated(0.0, 0.0, -0.5*height);
+
+  // Code taken from glut/lib/glut_shapes.c
+  QUAD_OBJ_INIT;
+  gluQuadricDrawStyle(quadObj, GLU_FILL);
+  gluQuadricNormals(quadObj, GLU_SMOOTH);
+
+  gluCylinder(quadObj, radius, radius, height, slices, stacks); //glut/lib/glut_shapes.c
+  gluDisk(quadObj, 0, radius, slices, stacks);
+  glTranslated(0.0, 0.0, height);
+  gluDisk(quadObj, 0, radius, slices, stacks);
+
+  // Upper hemisphere
+  drawOpenDome(radius, slices, stacks);
+
+  // Lower hemisphere
+  glTranslated(0.0, 0.0, -height);
+  glRotated(180.0, 0.0, 1.0, 0.0);
+  drawOpenDome(radius, slices, stacks);
+}
+
+//==============================================================================
+void OpenGLRenderInterface::drawCone(double radius, double height)
+{
+  GLint slices = 16;
+  GLint stacks = 16;
+
+  // Graphics assumes Cylinder is centered at CoM
+  // gluCylinder places base at z = 0 and top at z = height
+  glTranslated(0.0, 0.0, -0.5*height);
+
+  // Code taken from glut/lib/glut_shapes.c
+  QUAD_OBJ_INIT;
+  gluQuadricDrawStyle(quadObj, GLU_FILL);
+  gluQuadricNormals(quadObj, GLU_SMOOTH);
+
+  gluCylinder(quadObj, radius, 0.0, height, slices, stacks); //glut/lib/glut_shapes.c
+  gluDisk(quadObj, 0, radius, slices, stacks);
 }
 
 void OpenGLRenderInterface::color4_to_float4(const aiColor4D *c, float f[4])

--- a/dart/gui/OpenGLRenderInterface.hpp
+++ b/dart/gui/OpenGLRenderInterface.hpp
@@ -84,6 +84,8 @@ public:
     void drawEllipsoid(const Eigen::Vector3d& _size) override;
     void drawCube(const Eigen::Vector3d& _size) override;
     void drawCylinder(double _radius, double _height) override;
+    void drawCapsule(double radius, double height) override;
+    void drawCone(double radius, double height) override;
     void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh) override;
     void drawSoftMesh(const aiMesh* mesh) override;
     void drawList(GLuint index) override;

--- a/dart/gui/RenderInterface.cpp
+++ b/dart/gui/RenderInterface.cpp
@@ -140,6 +140,14 @@ void RenderInterface::drawCylinder(double /*_radius*/, double /*_height*/)
 {
 }
 
+void RenderInterface::drawCapsule(double /*_radius*/, double /*_height*/)
+{
+}
+
+void RenderInterface::drawCone(double /*_radius*/, double /*_height*/)
+{
+}
+
 void RenderInterface::setPenColor(const Eigen::Vector4d& /*_col*/)
 {
 }

--- a/dart/gui/RenderInterface.hpp
+++ b/dart/gui/RenderInterface.hpp
@@ -94,6 +94,8 @@ public:
     virtual void drawEllipsoid(const Eigen::Vector3d& _size);
     virtual void drawCube(const Eigen::Vector3d& _size);
     virtual void drawCylinder(double _radius, double _height);
+    virtual void drawCapsule(double _radius, double _height);
+    virtual void drawCone(double _radius, double _height);
     virtual void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh);
     virtual void drawSoftMesh(const aiMesh* mesh);
     virtual void drawList(unsigned int index);

--- a/dart/gui/SimWindow.cpp
+++ b/dart/gui/SimWindow.cpp
@@ -48,6 +48,8 @@
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/CapsuleShape.hpp"
+#include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
@@ -400,6 +402,8 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
   using dynamics::BoxShape;
   using dynamics::EllipsoidShape;
   using dynamics::CylinderShape;
+  using dynamics::CapsuleShape;
+  using dynamics::ConeShape;
   using dynamics::PlaneShape;
   using dynamics::MeshShape;
   using dynamics::SoftMeshShape;
@@ -426,6 +430,16 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
   {
     const auto* cylinder = static_cast<const CylinderShape*>(shape);
     mRI->drawCylinder(cylinder->getRadius(), cylinder->getHeight());
+  }
+  else if (CapsuleShape::getStaticType() == shapeType)
+  {
+    const auto* capsule = static_cast<const CapsuleShape*>(shape);
+    mRI->drawCapsule(capsule->getRadius(), capsule->getHeight());
+  }
+  else if (ConeShape::getStaticType() == shapeType)
+  {
+    const auto* cone = static_cast<const ConeShape*>(shape);
+    mRI->drawCone(cone->getRadius(), cone->getHeight());
   }
   else if (MeshShape::getStaticType() == shapeType)
   {

--- a/dart/gui/osg/ShapeFrameNode.cpp
+++ b/dart/gui/osg/ShapeFrameNode.cpp
@@ -40,6 +40,8 @@
 #include "dart/gui/osg/render/BoxShapeNode.hpp"
 #include "dart/gui/osg/render/EllipsoidShapeNode.hpp"
 #include "dart/gui/osg/render/CylinderShapeNode.hpp"
+#include "dart/gui/osg/render/CapsuleShapeNode.hpp"
+#include "dart/gui/osg/render/ConeShapeNode.hpp"
 #include "dart/gui/osg/render/PlaneShapeNode.hpp"
 #include "dart/gui/osg/render/MeshShapeNode.hpp"
 #include "dart/gui/osg/render/SoftMeshShapeNode.hpp"
@@ -53,6 +55,8 @@
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/CapsuleShape.hpp"
+#include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
@@ -205,6 +209,24 @@ void ShapeFrameNode::createShapeNode(
         std::dynamic_pointer_cast<CylinderShape>(shape);
     if(cs)
       mShapeNode = new render::CylinderShapeNode(cs, this);
+    else
+      warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
+  }
+  else if(CapsuleShape::getStaticType() == shapeType)
+  {
+    std::shared_ptr<CapsuleShape> cs =
+        std::dynamic_pointer_cast<CapsuleShape>(shape);
+    if(cs)
+      mShapeNode = new render::CapsuleShapeNode(cs, this);
+    else
+      warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
+  }
+  else if(ConeShape::getStaticType() == shapeType)
+  {
+    std::shared_ptr<ConeShape> cs =
+        std::dynamic_pointer_cast<ConeShape>(shape);
+    if(cs)
+      mShapeNode = new render::ConeShapeNode(cs, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }

--- a/dart/gui/osg/render/CapsuleShapeNode.cpp
+++ b/dart/gui/osg/render/CapsuleShapeNode.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <osg/Geode>
+#include <osg/ShapeDrawable>
+
+#include "dart/gui/osg/render/CapsuleShapeNode.hpp"
+#include "dart/gui/osg/Utils.hpp"
+
+#include "dart/dynamics/CapsuleShape.hpp"
+#include "dart/dynamics/SimpleFrame.hpp"
+
+namespace dart {
+namespace gui {
+namespace osg {
+namespace render {
+
+//==============================================================================
+class CapsuleShapeGeode : public ShapeNode, public ::osg::Geode
+{
+public:
+
+  CapsuleShapeGeode(dart::dynamics::CapsuleShape* shape,
+                    ShapeFrameNode* parent,
+                    CapsuleShapeNode* parentNode);
+
+  void refresh();
+  void extractData();
+
+protected:
+
+  virtual ~CapsuleShapeGeode();
+
+  dart::dynamics::CapsuleShape* mCapsuleShape;
+  CapsuleShapeDrawable* mDrawable;
+
+};
+
+//==============================================================================
+class CapsuleShapeDrawable : public ::osg::ShapeDrawable
+{
+public:
+
+  CapsuleShapeDrawable(dart::dynamics::CapsuleShape* shape,
+                       dart::dynamics::VisualAspect* visualAspect,
+                       CapsuleShapeGeode* parent);
+
+  void refresh(bool firstTime);
+
+protected:
+
+  virtual ~CapsuleShapeDrawable();
+
+  dart::dynamics::CapsuleShape* mCapsuleShape;
+  dart::dynamics::VisualAspect* mVisualAspect;
+
+  CapsuleShapeGeode* mParent;
+
+};
+
+//==============================================================================
+CapsuleShapeNode::CapsuleShapeNode(
+    std::shared_ptr<dart::dynamics::CapsuleShape> shape,
+    ShapeFrameNode* parent)
+  : ShapeNode(shape, parent, this),
+    mCapsuleShape(shape),
+    mGeode(nullptr)
+{
+  extractData(true);
+  setNodeMask(mVisualAspect->isHidden()? 0x0 : ~0x0);
+}
+
+//==============================================================================
+void CapsuleShapeNode::refresh()
+{
+  mUtilized = true;
+
+  setNodeMask(mVisualAspect->isHidden()? 0x0 : ~0x0);
+
+  if(mShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    return;
+
+  extractData(false);
+}
+
+//==============================================================================
+void CapsuleShapeNode::extractData(bool /*firstTime*/)
+{
+  if(nullptr == mGeode)
+  {
+    mGeode = new CapsuleShapeGeode(mCapsuleShape.get(), mParentShapeFrameNode, this);
+    addChild(mGeode);
+    return;
+  }
+
+  mGeode->refresh();
+}
+
+//==============================================================================
+CapsuleShapeNode::~CapsuleShapeNode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+CapsuleShapeGeode::CapsuleShapeGeode(
+    dart::dynamics::CapsuleShape* shape,
+    ShapeFrameNode* parent,
+    CapsuleShapeNode* parentNode)
+  : ShapeNode(parentNode->getShape(), parent, this),
+    mCapsuleShape(shape),
+    mDrawable(nullptr)
+{
+  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+  extractData();
+}
+
+//==============================================================================
+void CapsuleShapeGeode::refresh()
+{
+  mUtilized = true;
+
+  extractData();
+}
+
+//==============================================================================
+void CapsuleShapeGeode::extractData()
+{
+  if(nullptr == mDrawable)
+  {
+    mDrawable = new CapsuleShapeDrawable(mCapsuleShape, mVisualAspect, this);
+    addDrawable(mDrawable);
+    return;
+  }
+
+  mDrawable->refresh(false);
+}
+
+//==============================================================================
+CapsuleShapeGeode::~CapsuleShapeGeode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+CapsuleShapeDrawable::CapsuleShapeDrawable(
+    dart::dynamics::CapsuleShape* shape,
+    dart::dynamics::VisualAspect* visualAspect,
+    CapsuleShapeGeode* parent)
+  : mCapsuleShape(shape),
+    mVisualAspect(visualAspect),
+    mParent(parent)
+{
+  refresh(true);
+}
+
+//==============================================================================
+void CapsuleShapeDrawable::refresh(bool firstTime)
+{
+  if(mCapsuleShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    setDataVariance(::osg::Object::STATIC);
+  else
+    setDataVariance(::osg::Object::DYNAMIC);
+
+  if(mCapsuleShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_PRIMITIVE)
+     || firstTime)
+  {
+    double R = mCapsuleShape->getRadius();
+    double h = mCapsuleShape->getHeight();
+    ::osg::ref_ptr<::osg::Capsule> osg_shape =
+        new ::osg::Capsule(::osg::Vec3(0,0,0), R, h);
+    setShape(osg_shape);
+    dirtyDisplayList();
+  }
+
+  if(mCapsuleShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
+     || firstTime)
+  {
+    setColor(eigToOsgVec4(mVisualAspect->getRGBA()));
+  }
+}
+
+//==============================================================================
+CapsuleShapeDrawable::~CapsuleShapeDrawable()
+{
+  // Do nothing
+}
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart

--- a/dart/gui/osg/render/CapsuleShapeNode.hpp
+++ b/dart/gui/osg/render/CapsuleShapeNode.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_GUI_OSG_RENDER_CAPSULESHAPENODE_HPP_
+#define DART_GUI_OSG_RENDER_CAPSULESHAPENODE_HPP_
+
+#include <osg/MatrixTransform>
+
+#include "dart/gui/osg/render/ShapeNode.hpp"
+
+namespace dart {
+
+namespace dynamics {
+class CapsuleShape;
+} // namespace dynamics
+
+namespace gui {
+namespace osg {
+namespace render {
+
+class CapsuleShapeGeode;
+class CapsuleShapeDrawable;
+
+class CapsuleShapeNode : public ShapeNode, public ::osg::Group
+{
+public:
+
+  CapsuleShapeNode(std::shared_ptr<dart::dynamics::CapsuleShape> shape,
+                   ShapeFrameNode* parent);
+
+  void refresh();
+  void extractData(bool firstTime);
+
+protected:
+
+  virtual ~CapsuleShapeNode();
+
+  std::shared_ptr<dart::dynamics::CapsuleShape> mCapsuleShape;
+  CapsuleShapeGeode* mGeode;
+
+};
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart
+
+#endif // DART_GUI_OSG_RENDER_CAPSULESHAPENODE_HPP_

--- a/dart/gui/osg/render/ConeShapeNode.cpp
+++ b/dart/gui/osg/render/ConeShapeNode.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <osg/Geode>
+#include <osg/ShapeDrawable>
+
+#include "dart/gui/osg/render/ConeShapeNode.hpp"
+#include "dart/gui/osg/Utils.hpp"
+
+#include "dart/dynamics/ConeShape.hpp"
+#include "dart/dynamics/SimpleFrame.hpp"
+
+namespace dart {
+namespace gui {
+namespace osg {
+namespace render {
+
+//==============================================================================
+class ConeShapeGeode : public ShapeNode, public ::osg::Geode
+{
+public:
+
+  ConeShapeGeode(dart::dynamics::ConeShape* shape,
+                 ShapeFrameNode* parent,
+                 ConeShapeNode* parentNode);
+
+  void refresh();
+  void extractData();
+
+protected:
+
+  virtual ~ConeShapeGeode();
+
+  dart::dynamics::ConeShape* mConeShape;
+  ConeShapeDrawable* mDrawable;
+
+};
+
+//==============================================================================
+class ConeShapeDrawable : public ::osg::ShapeDrawable
+{
+public:
+
+  ConeShapeDrawable(dart::dynamics::ConeShape* shape,
+                    dart::dynamics::VisualAspect* visualAspect,
+                    ConeShapeGeode* parent);
+
+  void refresh(bool firstTime);
+
+protected:
+
+  virtual ~ConeShapeDrawable();
+
+  dart::dynamics::ConeShape* mConeShape;
+  dart::dynamics::VisualAspect* mVisualAspect;
+
+  ConeShapeGeode* mParent;
+
+};
+
+//==============================================================================
+ConeShapeNode::ConeShapeNode(
+    std::shared_ptr<dart::dynamics::ConeShape> shape,
+    ShapeFrameNode* parent)
+  : ShapeNode(shape, parent, this),
+    mConeShape(shape),
+    mGeode(nullptr)
+{
+  extractData(true);
+  setNodeMask(mVisualAspect->isHidden()? 0x0 : ~0x0);
+}
+
+//==============================================================================
+void ConeShapeNode::refresh()
+{
+  mUtilized = true;
+
+  setNodeMask(mVisualAspect->isHidden()? 0x0 : ~0x0);
+
+  if(mShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    return;
+
+  extractData(false);
+}
+
+//==============================================================================
+void ConeShapeNode::extractData(bool /*firstTime*/)
+{
+  if(nullptr == mGeode)
+  {
+    mGeode = new ConeShapeGeode(mConeShape.get(), mParentShapeFrameNode, this);
+    addChild(mGeode);
+    return;
+  }
+
+  mGeode->refresh();
+}
+
+//==============================================================================
+ConeShapeNode::~ConeShapeNode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+ConeShapeGeode::ConeShapeGeode(
+    dart::dynamics::ConeShape* shape,
+    ShapeFrameNode* parent,
+    ConeShapeNode* parentNode)
+  : ShapeNode(parentNode->getShape(), parent, this),
+    mConeShape(shape),
+    mDrawable(nullptr)
+{
+  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+  extractData();
+}
+
+//==============================================================================
+void ConeShapeGeode::refresh()
+{
+  mUtilized = true;
+
+  extractData();
+}
+
+//==============================================================================
+void ConeShapeGeode::extractData()
+{
+  if(nullptr == mDrawable)
+  {
+    mDrawable = new ConeShapeDrawable(mConeShape, mVisualAspect, this);
+    addDrawable(mDrawable);
+    return;
+  }
+
+  mDrawable->refresh(false);
+}
+
+//==============================================================================
+ConeShapeGeode::~ConeShapeGeode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+ConeShapeDrawable::ConeShapeDrawable(
+    dart::dynamics::ConeShape* shape,
+    dart::dynamics::VisualAspect* visualAspect,
+    ConeShapeGeode* parent)
+  : mConeShape(shape),
+    mVisualAspect(visualAspect),
+    mParent(parent)
+{
+  refresh(true);
+}
+
+//==============================================================================
+void ConeShapeDrawable::refresh(bool firstTime)
+{
+  if(mConeShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    setDataVariance(::osg::Object::STATIC);
+  else
+    setDataVariance(::osg::Object::DYNAMIC);
+
+  if(mConeShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_PRIMITIVE)
+     || firstTime)
+  {
+    double R = mConeShape->getRadius();
+    double h = mConeShape->getHeight();
+    ::osg::ref_ptr<::osg::Cone> osg_shape =
+        new ::osg::Cone(::osg::Vec3(0,0,0), R, h);
+    setShape(osg_shape);
+    dirtyDisplayList();
+  }
+
+  if(mConeShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
+     || firstTime)
+  {
+    setColor(eigToOsgVec4(mVisualAspect->getRGBA()));
+  }
+}
+
+//==============================================================================
+ConeShapeDrawable::~ConeShapeDrawable()
+{
+  // Do nothing
+}
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart

--- a/dart/gui/osg/render/ConeShapeNode.hpp
+++ b/dart/gui/osg/render/ConeShapeNode.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_GUI_OSG_RENDER_CONESHAPENODE_HPP_
+#define DART_GUI_OSG_RENDER_CONESHAPENODE_HPP_
+
+#include <osg/MatrixTransform>
+
+#include "dart/gui/osg/render/ShapeNode.hpp"
+
+namespace dart {
+
+namespace dynamics {
+class ConeShape;
+} // namespace dynamics
+
+namespace gui {
+namespace osg {
+namespace render {
+
+class ConeShapeGeode;
+class ConeShapeDrawable;
+
+class ConeShapeNode : public ShapeNode, public ::osg::Group
+{
+public:
+
+  ConeShapeNode(std::shared_ptr<dart::dynamics::ConeShape> shape,
+                    ShapeFrameNode* parent);
+
+  void refresh();
+  void extractData(bool firstTime);
+
+protected:
+
+  virtual ~ConeShapeNode();
+
+  std::shared_ptr<dart::dynamics::ConeShape> mConeShape;
+  ConeShapeGeode* mGeode;
+
+};
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart
+
+#endif // DART_GUI_OSG_RENDER_CONESHAPENODE_HPP_

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -53,6 +53,8 @@
 #include "dart/dynamics/SphereShape.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/CapsuleShape.hpp"
+#include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
@@ -1267,6 +1269,20 @@ dynamics::ShapePtr readShape(
     double                radius       = getValueDouble(cylinderEle, "radius");
     double                height       = getValueDouble(cylinderEle, "height");
     newShape = dynamics::ShapePtr(new dynamics::CylinderShape(radius, height));
+  }
+  else if (hasElement(geometryEle, "capsule"))
+  {
+    tinyxml2::XMLElement* capsuleEle   = getElement(geometryEle, "capsule");
+    double                radius       = getValueDouble(capsuleEle, "radius");
+    double                height       = getValueDouble(capsuleEle, "height");
+    newShape = dynamics::ShapePtr(new dynamics::CapsuleShape(radius, height));
+  }
+  else if (hasElement(geometryEle, "cone"))
+  {
+    tinyxml2::XMLElement* coneEle      = getElement(geometryEle, "cone");
+    double                radius       = getValueDouble(coneEle, "radius");
+    double                height       = getValueDouble(coneEle, "height");
+    newShape = dynamics::ShapePtr(new dynamics::ConeShape(radius, height));
   }
   else if (hasElement(geometryEle, "plane"))
   {

--- a/data/skel/shapes.skel
+++ b/data/skel/shapes.skel
@@ -4,7 +4,7 @@
         <physics>
             <time_step>0.001</time_step>
             <gravity>0 -9.81 0</gravity>
-            <collision_detector>fcl</collision_detector>
+            <collision_detector>bullet</collision_detector>
         </physics>
         
         <skeleton name="ground skeleton">
@@ -168,8 +168,8 @@
             </joint>
         </skeleton>
 
-        <skeleton name="mesh skeleton">
-            <body name="mesh">
+        <skeleton name="capsule skeleton">
+            <body name="capsule">
                 <gravity>1</gravity>
                 <transformation>0.4 -0.0 0 1 2 3</transformation>
                 <inertia>
@@ -179,8 +179,78 @@
                 <visualization_shape>
                     <transformation>0 0 0 0 0 0</transformation>
                     <geometry>
+                        <capsule>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </capsule>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <capsule>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </capsule>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>capsule</child>
+            </joint>
+        </skeleton>
+
+        <skeleton name="cone skeleton">
+            <body name="cone">
+                <gravity>1</gravity>
+                <transformation>0.6 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <cone>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </cone>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <cone>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </cone>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>cone</child>
+            </joint>
+        </skeleton>
+
+        <skeleton name="mesh skeleton">
+            <body name="mesh">
+                <gravity>1</gravity>
+                <transformation>0.8 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
                         <mesh>
-                            <file_name>../obj/BoxSmall.obj</file_name>
+                            <file_name>../obj/foot.obj</file_name>
                             <scale>1.0 1.0 1.0</scale>
                         </mesh>
                     </geometry>
@@ -190,7 +260,7 @@
                     <transformation>0 0 0 0 0 0</transformation>
                     <geometry>
                         <mesh>
-                            <file_name>../obj/BoxSmall.obj</file_name>
+                            <file_name>../obj/foot.obj</file_name>
                             <scale>1.0 1.0 1.0</scale>
                         </mesh>
                     </geometry>
@@ -201,7 +271,7 @@
                 <parent>world</parent>
                 <child>mesh</child>
             </joint>
-        </skeleton> 
+        </skeleton>
 
     </world>
 </skel>

--- a/data/skel/test/test_shapes.skel
+++ b/data/skel/test/test_shapes.skel
@@ -250,7 +250,7 @@
                     <transformation>0 0 0 0 0 0</transformation>
                     <geometry>
                         <mesh>
-                            <file_name>../../obj/BoxSmall.obj</file_name>
+                            <file_name>../../obj/foot.obj</file_name>
                             <scale>1.0 1.0 1.0</scale>
                         </mesh>
                     </geometry>
@@ -260,7 +260,7 @@
                     <transformation>0 0 0 0 0 0</transformation>
                     <geometry>
                         <mesh>
-                            <file_name>../../obj/BoxSmall.obj</file_name>
+                            <file_name>../../obj/foot.obj</file_name>
                             <scale>1.0 1.0 1.0</scale>
                         </mesh>
                     </geometry>

--- a/data/skel/test/test_shapes.skel
+++ b/data/skel/test/test_shapes.skel
@@ -1,0 +1,277 @@
+<?xml version="1.0" ?>
+<skel version="1.0">
+    <world name="world 1">
+        <physics>
+            <time_step>0.001</time_step>
+            <gravity>0 -9.81 0</gravity>
+            <collision_detector>bullet</collision_detector>
+        </physics>
+        
+        <skeleton name="ground skeleton">
+            <body name="ground">
+                <transformation>0 -0.375 0 0 0 0</transformation>
+                <visualization_shape>
+                    <transformation>0 -0.005 0 0 0 0</transformation>
+                    <geometry>
+                        <box>
+                            <size>10 0.01 10</size>
+                        </box>
+                    </geometry>
+                    <color>0.95 0.95 0.95</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 -0.005 0 0 0 0</transformation>
+                    <geometry>
+                        <box>
+                            <size>10 0.01 10</size>
+                        </box>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            <joint type="weld" name="joint 1">
+                <parent>world</parent>
+                <child>ground</child>
+            </joint>
+        </skeleton> 
+        
+        <skeleton name="box skeleton">
+            <body name="box">
+                <gravity>1</gravity>
+                <transformation>-0.4 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <box>
+                            <size>0.1 0.05 0.1</size>
+                        </box>
+                    </geometry>
+                    <color>0.8 0.3 0.3</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <box>
+                            <size>0.1 0.05 0.1</size>
+                        </box>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>box</child>
+            </joint>
+        </skeleton>
+        
+        <skeleton name="sphere skeleton">
+            <body name="sphere">
+                <gravity>1</gravity>
+                <transformation>-0.2 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <sphere>
+                            <radius>0.05</radius>
+                        </sphere>
+                    </geometry>
+                    <color>0.3 0.8 0.3</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <sphere>
+                            <radius>0.05</radius>
+                        </sphere>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>sphere</child>
+            </joint>
+        </skeleton>
+        
+        <skeleton name="ellipsoid skeleton">
+            <body name="ellipsoid">
+                <gravity>1</gravity>
+                <transformation>-0.0 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <ellipsoid>
+                            <size>0.05 0.10 0.15</size>
+                        </ellipsoid>
+                    </geometry>
+                    <color>0.8 0.8 0.4</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <ellipsoid>
+                            <size>0.05 0.10 0.15</size>
+                        </ellipsoid>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>ellipsoid</child>
+            </joint>
+        </skeleton>
+
+        <skeleton name="cylinder skeleton">
+            <body name="cylinder">
+                <gravity>1</gravity>
+                <transformation>0.2 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <cylinder>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </cylinder>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <cylinder>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </cylinder>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>cylinder</child>
+            </joint>
+        </skeleton>
+
+        <skeleton name="capsule skeleton">
+            <body name="capsule">
+                <gravity>1</gravity>
+                <transformation>0.4 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <capsule>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </capsule>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <capsule>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </capsule>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>capsule</child>
+            </joint>
+        </skeleton>
+
+        <skeleton name="cone skeleton">
+            <body name="cone">
+                <gravity>1</gravity>
+                <transformation>0.6 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <cone>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </cone>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <cone>
+                            <height>0.1</height>
+                            <radius>0.05</radius>
+                        </cone>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>cone</child>
+            </joint>
+        </skeleton>
+
+        <skeleton name="mesh skeleton">
+            <body name="mesh">
+                <gravity>1</gravity>
+                <transformation>0.8 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <mesh>
+                            <file_name>../../obj/BoxSmall.obj</file_name>
+                            <scale>1.0 1.0 1.0</scale>
+                        </mesh>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <mesh>
+                            <file_name>../../obj/BoxSmall.obj</file_name>
+                            <scale>1.0 1.0 1.0</scale>
+                        </mesh>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>mesh</child>
+            </joint>
+        </skeleton> 
+
+    </world>
+</skel>

--- a/unittests/testSkelParser.cpp
+++ b/unittests/testSkelParser.cpp
@@ -33,14 +33,8 @@
 #include <gtest/gtest.h>
 #include "TestHelpers.hpp"
 
-#include "dart/dynamics/SoftBodyNode.hpp"
-#include "dart/dynamics/RevoluteJoint.hpp"
-#include "dart/dynamics/PlanarJoint.hpp"
-#include "dart/dynamics/Skeleton.hpp"
-#include "dart/simulation/World.hpp"
-#include "dart/simulation/World.hpp"
-#include "dart/utils/XmlHelpers.hpp"
-#include "dart/utils/SkelParser.hpp"
+#include "dart/dart.hpp"
+#include "dart/utils/utils.hpp"
 
 using namespace dart;
 using namespace math;
@@ -431,6 +425,79 @@ TEST(SkelParser, JointDynamicsElements)
   EXPECT_EQ(joint1->getCoulombFriction   (2), 3.0);
   EXPECT_EQ(joint1->getRestPosition      (2), 0.3);
   EXPECT_EQ(joint1->getSpringStiffness   (2), 1.0);
+}
+
+//==============================================================================
+TEST(SkelParser, Shapes)
+{
+  WorldPtr world
+      = SkelParser::readWorld(DART_DATA_PATH"/skel/test/test_shapes.skel");
+  EXPECT_NE(world, nullptr);
+
+  const auto numSkels = world->getNumSkeletons();
+  EXPECT_EQ(numSkels, 8);
+
+  ShapePtr shape;
+  SkeletonPtr skel;
+
+  // Ground (box)
+  skel = world->getSkeleton("ground skeleton");
+  EXPECT_NE(skel, nullptr);
+
+  // Box
+  skel = world->getSkeleton("box skeleton");
+  EXPECT_NE(skel, nullptr);
+  shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
+  EXPECT_EQ(shape->getType(), BoxShape::getStaticType());
+  auto boxShape = std::static_pointer_cast<BoxShape>(shape);
+  EXPECT_EQ(boxShape->getSize(), Eigen::Vector3d(0.1, 0.05, 0.1));
+
+  // Sphere
+  skel = world->getSkeleton("sphere skeleton");
+  EXPECT_NE(skel, nullptr);
+  shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
+  EXPECT_EQ(shape->getType(), SphereShape::getStaticType());
+  auto sphereShape = std::static_pointer_cast<SphereShape>(shape);
+  EXPECT_EQ(sphereShape->getRadius(), 0.05);
+
+  // Ellipsoid
+  skel = world->getSkeleton("ellipsoid skeleton");
+  EXPECT_NE(skel, nullptr);
+  shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
+  EXPECT_EQ(shape->getType(), EllipsoidShape::getStaticType());
+  auto ellipsoidShape = std::static_pointer_cast<EllipsoidShape>(shape);
+  EXPECT_EQ(ellipsoidShape->getSize(), Eigen::Vector3d(0.05, 0.10, 0.15));
+
+  // Cylinder
+  skel = world->getSkeleton("cylinder skeleton");
+  EXPECT_NE(skel, nullptr);
+  shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
+  EXPECT_EQ(shape->getType(), CylinderShape::getStaticType());
+  auto cylinderShape = std::static_pointer_cast<CylinderShape>(shape);
+  EXPECT_EQ(cylinderShape->getHeight(), 0.1);
+  EXPECT_EQ(cylinderShape->getRadius(), 0.05);
+
+  // Capsule
+  skel = world->getSkeleton("capsule skeleton");
+  EXPECT_NE(skel, nullptr);
+  shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
+  EXPECT_EQ(shape->getType(), CapsuleShape::getStaticType());
+  auto capsuleShape = std::static_pointer_cast<CapsuleShape>(shape);
+  EXPECT_EQ(capsuleShape->getHeight(), 0.1);
+  EXPECT_EQ(capsuleShape->getRadius(), 0.05);
+
+  // Cone
+  skel = world->getSkeleton("cone skeleton");
+  EXPECT_NE(skel, nullptr);
+  shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
+  EXPECT_EQ(shape->getType(), ConeShape::getStaticType());
+  auto coneShape = std::static_pointer_cast<CapsuleShape>(shape);
+  EXPECT_EQ(coneShape->getHeight(), 0.1);
+  EXPECT_EQ(coneShape->getRadius(), 0.05);
+
+  // Mesh
+  skel = world->getSkeleton("mesh skeleton");
+  EXPECT_NE(skel, nullptr);
 }
 
 //==============================================================================

--- a/unittests/testSkelParser.cpp
+++ b/unittests/testSkelParser.cpp
@@ -448,7 +448,7 @@ TEST(SkelParser, Shapes)
   skel = world->getSkeleton("box skeleton");
   EXPECT_NE(skel, nullptr);
   shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
-  EXPECT_EQ(shape->getType(), BoxShape::getStaticType());
+  EXPECT_TRUE(shape->is<BoxShape>());
   auto boxShape = std::static_pointer_cast<BoxShape>(shape);
   EXPECT_EQ(boxShape->getSize(), Eigen::Vector3d(0.1, 0.05, 0.1));
 
@@ -456,7 +456,7 @@ TEST(SkelParser, Shapes)
   skel = world->getSkeleton("sphere skeleton");
   EXPECT_NE(skel, nullptr);
   shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
-  EXPECT_EQ(shape->getType(), SphereShape::getStaticType());
+  EXPECT_TRUE(shape->is<SphereShape>());
   auto sphereShape = std::static_pointer_cast<SphereShape>(shape);
   EXPECT_EQ(sphereShape->getRadius(), 0.05);
 
@@ -464,7 +464,7 @@ TEST(SkelParser, Shapes)
   skel = world->getSkeleton("ellipsoid skeleton");
   EXPECT_NE(skel, nullptr);
   shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
-  EXPECT_EQ(shape->getType(), EllipsoidShape::getStaticType());
+  EXPECT_TRUE(shape->is<EllipsoidShape>());
   auto ellipsoidShape = std::static_pointer_cast<EllipsoidShape>(shape);
   EXPECT_EQ(ellipsoidShape->getSize(), Eigen::Vector3d(0.05, 0.10, 0.15));
 
@@ -472,7 +472,7 @@ TEST(SkelParser, Shapes)
   skel = world->getSkeleton("cylinder skeleton");
   EXPECT_NE(skel, nullptr);
   shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
-  EXPECT_EQ(shape->getType(), CylinderShape::getStaticType());
+  EXPECT_TRUE(shape->is<CylinderShape>());
   auto cylinderShape = std::static_pointer_cast<CylinderShape>(shape);
   EXPECT_EQ(cylinderShape->getHeight(), 0.1);
   EXPECT_EQ(cylinderShape->getRadius(), 0.05);
@@ -481,7 +481,7 @@ TEST(SkelParser, Shapes)
   skel = world->getSkeleton("capsule skeleton");
   EXPECT_NE(skel, nullptr);
   shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
-  EXPECT_EQ(shape->getType(), CapsuleShape::getStaticType());
+  EXPECT_TRUE(shape->is<CapsuleShape>());
   auto capsuleShape = std::static_pointer_cast<CapsuleShape>(shape);
   EXPECT_EQ(capsuleShape->getHeight(), 0.1);
   EXPECT_EQ(capsuleShape->getRadius(), 0.05);
@@ -490,7 +490,7 @@ TEST(SkelParser, Shapes)
   skel = world->getSkeleton("cone skeleton");
   EXPECT_NE(skel, nullptr);
   shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
-  EXPECT_EQ(shape->getType(), ConeShape::getStaticType());
+  EXPECT_TRUE(shape->is<ConeShape>());
   auto coneShape = std::static_pointer_cast<CapsuleShape>(shape);
   EXPECT_EQ(coneShape->getHeight(), 0.1);
   EXPECT_EQ(coneShape->getRadius(), 0.05);


### PR DESCRIPTION
This pull request adds two new shape classes: `CapsuleShape` and `ConeShape`. Currently, only BulletCollisionDetector support the shapes. Both of OpenGL and OSG based renderers display the shapes. Also, these shapes can be parsed from SKEL file format. Here is part of an example skel file that contains the new shapes:
```xml
<visualization_shape>
    <geometry>
        <capsule>
            <height>0.1</height>
            <radius>0.05</radius>
        </capsule>
    </geometry>
</visualization_shape>

<visualization_shape>
    <geometry>
        <cone>
            <height>0.1</height>
            <radius>0.05</radius>
        </cone>
    </geometry>
</visualization_shape>
```

Additional changes: A syntactic sugar function `Shape::is<SHAPE_TYPE>()` is added that enables us to check the shape type from a `Shape` pointer in more convenient way. Here is a short example code:
```cpp
auto shape = bodyNode->getShapeNode(0)->getShape();
if (shape->is<BoxShape>())
  std::cout << "The shape type is box!\n";
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/769)
<!-- Reviewable:end -->
