### PR TITLE
Add MultiSphereShape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Dynamics
 
   * Added `computeLagrangian()` to `MetaSkeleton` and `BodyNode`: [#746](https://github.com/dartsim/dart/pull/746)
-  * Added new shapes: sphere, capsule, and cone: [#769](https://github.com/dartsim/dart/pull/769), [#745](https://github.com/dartsim/dart/pull/745)
+  * Added new shapes: sphere, capsule, cone, and multi-sphere: [#770](https://github.com/dartsim/dart/pull/770), [#769](https://github.com/dartsim/dart/pull/769), [#745](https://github.com/dartsim/dart/pull/745)
 
 * Planning
 

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -491,8 +491,8 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     const auto numSpheres = multiSphere->getNumSpheres();
     const auto& spheres = multiSphere->getSpheres();
 
-    btVector3 bulletPositions[numSpheres];
-    btScalar bulletRadii[numSpheres];
+    std::vector<btVector3> bulletPositions(numSpheres);
+    std::vector<btScalar> bulletRadii(numSpheres);
 
     for (auto i = 0u; i < numSpheres; ++i)
     {
@@ -500,8 +500,8 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
       bulletPositions[i] = convertVector3(spheres[i].second);
     }
 
-    bulletCollisionShape
-        = new btMultiSphereShape(bulletPositions, bulletRadii, numSpheres);
+    bulletCollisionShape = new btMultiSphereShape(
+          bulletPositions.data(), bulletRadii.data(), numSpheres);
   }
   else if (shape->is<MeshShape>())
   {

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -51,6 +51,7 @@
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/MultiSphereShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 
@@ -401,13 +402,13 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
   using dynamics::CapsuleShape;
   using dynamics::ConeShape;
   using dynamics::PlaneShape;
+  using dynamics::MultiSphereShape;
   using dynamics::MeshShape;
   using dynamics::SoftMeshShape;
 
-  const auto& shapeType = shape->getType();
   btCollisionShape* bulletCollisionShape = nullptr;
 
-  if (SphereShape::getStaticType() == shapeType)
+  if (shape->is<SphereShape>())
   {
     assert(dynamic_cast<const SphereShape*>(shape.get()));
 
@@ -416,7 +417,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
 
     bulletCollisionShape = new btSphereShape(radius);
   }
-  else if (BoxShape::getStaticType() == shapeType)
+  else if (shape->is<BoxShape>())
   {
     assert(dynamic_cast<const BoxShape*>(shape.get()));
 
@@ -425,7 +426,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
 
     bulletCollisionShape = new btBoxShape(convertVector3(size*0.5));
   }
-  else if (EllipsoidShape::getStaticType() == shapeType)
+  else if (shape->is<EllipsoidShape>())
   {
     assert(dynamic_cast<const EllipsoidShape*>(shape.get()));
 
@@ -435,7 +436,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     bulletCollisionShape = createBulletEllipsoidMesh(
           size[0], size[1], size[2]);
   }
-  else if (CylinderShape::getStaticType() == shapeType)
+  else if (shape->is<CylinderShape>())
   {
     assert(dynamic_cast<const CylinderShape*>(shape.get()));
 
@@ -446,7 +447,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
 
     bulletCollisionShape = new btCylinderShapeZ(size);
   }
-  else if (CapsuleShape::getStaticType() == shapeType)
+  else if (shape->is<CapsuleShape>())
   {
     assert(dynamic_cast<const CapsuleShape*>(shape.get()));
 
@@ -456,7 +457,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
 
     bulletCollisionShape = new btCapsuleShapeZ(radius, height);
   }
-  else if (ConeShape::getStaticType() == shapeType)
+  else if (shape->is<ConeShape>())
   {
     assert(dynamic_cast<const ConeShape*>(shape.get()));
 
@@ -471,7 +472,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     // until find better solution even using zero margin is not recommended:
     // https://www.sjbaker.org/wiki/index.php?title=Physics_-_Bullet_Collected_random_advice#Minimum_object_sizes_-_by_Erwin
   }
-  else if (PlaneShape::getStaticType() == shapeType)
+  else if (shape->is<PlaneShape>())
   {
     assert(dynamic_cast<const PlaneShape*>(shape.get()));
 
@@ -482,7 +483,27 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     bulletCollisionShape = new btStaticPlaneShape(
           convertVector3(normal), offset);
   }
-  else if (MeshShape::getStaticType() == shapeType)
+  else if (shape->is<MultiSphereShape>())
+  {
+    assert(dynamic_cast<const MultiSphereShape*>(shape.get()));
+
+    const auto multiSphere = static_cast<const MultiSphereShape*>(shape.get());
+    const auto numSpheres = multiSphere->getNumSpheres();
+    const auto& spheres = multiSphere->getSpheres();
+
+    btVector3 bulletPositions[numSpheres];
+    btScalar bulletRadii[numSpheres];
+
+    for (auto i = 0u; i < numSpheres; ++i)
+    {
+      bulletRadii[i] = static_cast<btScalar>(spheres[i].first);
+      bulletPositions[i] = convertVector3(spheres[i].second);
+    }
+
+    bulletCollisionShape
+        = new btMultiSphereShape(bulletPositions, bulletRadii, numSpheres);
+  }
+  else if (shape->is<MeshShape>())
   {
     assert(dynamic_cast<const MeshShape*>(shape.get()));
 
@@ -493,7 +514,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     bulletCollisionShape = createBulletCollisionShapeFromAssimpScene(
           scale, mesh);
   }
-  else if (SoftMeshShape::getStaticType() == shapeType)
+  else if (shape->is<SoftMeshShape>())
   {
     assert(dynamic_cast<const SoftMeshShape*>(shape.get()));
 
@@ -506,7 +527,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
   {
     dterr << "[BulletCollisionDetector::createBulletCollisionShape] "
           << "Attempting to create an unsupported shape type ["
-          << shapeType << "] Creating a sphere with 0.1 radius "
+          << shape->getType() << "] Creating a sphere with 0.1 radius "
           << "instead.\n";
 
     bulletCollisionShape = new btSphereShape(0.1);

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -43,6 +43,7 @@
 #include "dart/common/LocalResourceRetriever.hpp"
 #include "dart/common/Uri.hpp"
 #include "dart/dynamics/AssimpInputResourceAdaptor.hpp"
+#include "dart/dynamics/BoxShape.hpp"
 
 #if !(ASSIMP_AISCENE_CTOR_DTOR_DEFINED)
 // We define our own constructor and destructor for aiScene, because it seems to
@@ -264,19 +265,11 @@ void MeshShape::setDisplayList(int _index) {
   mDisplayList = _index;
 }
 
-Eigen::Matrix3d MeshShape::computeInertia(double _mass) const {
-  // use bounding box to represent the mesh
-  Eigen::Vector3d bounds = mBoundingBox.computeFullExtents();
-  double l = bounds.x();
-  double h = bounds.y();
-  double w = bounds.z();
-
-  Eigen::Matrix3d inertia = Eigen::Matrix3d::Identity();
-  inertia(0, 0) = _mass / 12.0 * (h * h + w * w);
-  inertia(1, 1) = _mass / 12.0 * (l * l + w * w);
-  inertia(2, 2) = _mass / 12.0 * (l * l + h * h);
-
-  return inertia;
+//==============================================================================
+Eigen::Matrix3d MeshShape::computeInertia(double _mass) const
+{
+  // Use bounding box to represent the mesh
+  return BoxShape::computeInertia(mBoundingBox.computeFullExtents(), _mass);
 }
 
 void MeshShape::updateVolume() {

--- a/dart/dynamics/MultiSphereShape.cpp
+++ b/dart/dynamics/MultiSphereShape.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/MultiSphereShape.hpp"
+
+#include "dart/common/Console.hpp"
+#include "dart/math/Helpers.hpp"
+#include "dart/dynamics/BoxShape.hpp"
+
+namespace dart {
+namespace dynamics {
+
+//==============================================================================
+MultiSphereShape::MultiSphereShape(const Spheres& spheres)
+  : Shape()
+{
+  addSpheres(spheres);
+}
+
+//==============================================================================
+MultiSphereShape::~MultiSphereShape()
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& MultiSphereShape::getType() const
+{
+  return getStaticType();
+}
+
+//==============================================================================
+const std::string& MultiSphereShape::getStaticType()
+{
+  static const std::string type("MultiSphereShape");
+  return type;
+}
+
+//==============================================================================
+void MultiSphereShape::addSpheres(const MultiSphereShape::Spheres& spheres)
+{
+  mSpheres.insert(mSpheres.end(), spheres.begin(), spheres.end());
+
+  updateBoundingBoxDim();
+  updateVolume();
+}
+
+//==============================================================================
+void MultiSphereShape::addSphere(const MultiSphereShape::Sphere& sphere)
+{
+  mSpheres.push_back(sphere);
+
+  updateBoundingBoxDim();
+  updateVolume();
+}
+
+//==============================================================================
+void MultiSphereShape::addSphere(double radius, const Eigen::Vector3d& position)
+{
+  addSphere(std::make_pair(radius, position));
+}
+
+//==============================================================================
+void MultiSphereShape::removeAllSpheres()
+{
+  mSpheres.clear();
+
+  updateBoundingBoxDim();
+  updateVolume();
+}
+
+//==============================================================================
+std::size_t MultiSphereShape::getNumSpheres() const
+{
+  return mSpheres.size();
+}
+
+//==============================================================================
+const MultiSphereShape::Spheres& MultiSphereShape::getSpheres() const
+{
+  return mSpheres;
+}
+
+//==============================================================================
+Eigen::Matrix3d MultiSphereShape::computeInertia(double mass) const
+{
+  // Use bounding box to represent the mesh
+  return BoxShape::computeInertia(mBoundingBox.computeFullExtents(), mass);
+}
+
+//==============================================================================
+void MultiSphereShape::updateVolume()
+{
+  mVolume = BoxShape::computeVolume(mBoundingBox.computeFullExtents());
+}
+
+//==============================================================================
+void MultiSphereShape::updateBoundingBoxDim()
+{
+  Eigen::Vector3d min
+      = Eigen::Vector3d::Constant(std::numeric_limits<double>::max());
+  Eigen::Vector3d max = -min;
+
+  for (const auto& sphere : mSpheres)
+  {
+    const auto& radius = sphere.first;
+    const Eigen::Vector3d& pos = sphere.second;
+    const Eigen::Vector3d extent = Eigen::Vector3d::Constant(radius);
+
+    min = min.cwiseMin(pos - extent);
+    max = max.cwiseMax(pos + extent);
+  }
+
+  mBoundingBox.setMin(min);
+  mBoundingBox.setMax(max);
+}
+
+}  // namespace dynamics
+}  // namespace dart

--- a/dart/dynamics/MultiSphereShape.hpp
+++ b/dart/dynamics/MultiSphereShape.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_MULTISPHERESHAPE_HPP_
+#define DART_DYNAMICS_MULTISPHERESHAPE_HPP_
+
+#include <vector>
+
+#include "dart/dynamics/Shape.hpp"
+
+namespace dart {
+namespace dynamics {
+
+class MultiSphereShape : public Shape
+{
+public:
+
+  using Sphere = std::pair<double, Eigen::Vector3d>;
+  using Spheres = std::vector<Sphere>;
+
+  /// Constructor.
+  explicit MultiSphereShape(const Spheres& spheres);
+
+  /// Destructor.
+  virtual ~MultiSphereShape();
+
+  // Documentation inherited.
+  const std::string& getType() const;
+
+  /// Returns shape type for this class
+  static const std::string& getStaticType();
+
+  /// Add a list of spheres
+  void addSpheres(const Spheres& spheres);
+
+  /// Add a sphere
+  void addSphere(const Sphere& sphere);
+
+  /// Add a sphere
+  void addSphere(double radius, const Eigen::Vector3d& position);
+
+  /// Remove all spheres
+  void removeAllSpheres();
+
+  /// Get the number of spheres
+  std::size_t getNumSpheres() const;
+
+  /// Get the set of spheres
+  const Spheres& getSpheres() const;
+
+  /// Compute the inertia of this MultiSphereShape.
+  ///
+  /// \note The return value is an approximated inertia that is the inertia of
+  /// the axis-alinged bounding box of this MultiSphereShape.
+  Eigen::Matrix3d computeInertia(double mass) const override;
+
+protected:
+
+  /// Update the volume of this MultiSphereShape.
+  ///
+  /// \note The result volume is an approximated volumen that is the volume of
+  /// the axis-alinged bounding box of this MultiSphereShape.
+  void updateVolume() override;
+
+private:
+
+  /// Update bounding box (in the local coordinate frame) of the shape.
+  void updateBoundingBoxDim();
+
+  /// Spheres
+  Spheres mSpheres;
+
+};
+
+}  // namespace dynamics
+}  // namespace dart
+
+#endif  // DART_DYNAMICS_MULTISPHERESHAPE_HPP_

--- a/dart/dynamics/MultiSphereShape.hpp
+++ b/dart/dynamics/MultiSphereShape.hpp
@@ -39,6 +39,7 @@
 namespace dart {
 namespace dynamics {
 
+/// MultiSphereShape represents the convex hull of a collection of spheres.
 class MultiSphereShape : public Shape
 {
 public:

--- a/dart/gui/SimWindow.cpp
+++ b/dart/gui/SimWindow.cpp
@@ -51,6 +51,7 @@
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/MultiSphereShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/LineSegmentShape.hpp"
@@ -405,43 +406,55 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
   using dynamics::CapsuleShape;
   using dynamics::ConeShape;
   using dynamics::PlaneShape;
+  using dynamics::MultiSphereShape;
   using dynamics::MeshShape;
   using dynamics::SoftMeshShape;
   using dynamics::LineSegmentShape;
 
-  const auto& shapeType = shape->getType();
-
-  if (SphereShape::getStaticType() == shapeType)
+  if (shape->is<SphereShape>())
   {
     const auto* sphere = static_cast<const SphereShape*>(shape);
     mRI->drawSphere(sphere->getRadius());
   }
-  else if (BoxShape::getStaticType() == shapeType)
+  else if (shape->is<BoxShape>())
   {
     const auto* box = static_cast<const BoxShape*>(shape);
     mRI->drawCube(box->getSize());
   }
-  else if (EllipsoidShape::getStaticType() == shapeType)
+  else if (shape->is<EllipsoidShape>())
   {
     const auto* ellipsoid = static_cast<const EllipsoidShape*>(shape);
     mRI->drawEllipsoid(ellipsoid->getSize());
   }
-  else if (CylinderShape::getStaticType() == shapeType)
+  else if (shape->is<CylinderShape>())
   {
     const auto* cylinder = static_cast<const CylinderShape*>(shape);
     mRI->drawCylinder(cylinder->getRadius(), cylinder->getHeight());
   }
-  else if (CapsuleShape::getStaticType() == shapeType)
+  else if (shape->is<CapsuleShape>())
   {
     const auto* capsule = static_cast<const CapsuleShape*>(shape);
     mRI->drawCapsule(capsule->getRadius(), capsule->getHeight());
   }
-  else if (ConeShape::getStaticType() == shapeType)
+  else if (shape->is<ConeShape>())
   {
     const auto* cone = static_cast<const ConeShape*>(shape);
     mRI->drawCone(cone->getRadius(), cone->getHeight());
   }
-  else if (MeshShape::getStaticType() == shapeType)
+  else if (shape->is<MultiSphereShape>())
+  {
+    const auto* multiSphere = static_cast<const MultiSphereShape*>(shape);
+    const auto& spheres = multiSphere->getSpheres();
+    for (const auto& sphere : spheres)
+    {
+      glTranslated(sphere.second.x(), sphere.second.y(), sphere.second.z());
+      mRI->drawSphere(sphere.first);
+      glTranslated(-sphere.second.x(), -sphere.second.y(), -sphere.second.z());
+    }
+    // TODO(JS): This is an workaround that draws only spheres rather than the
+    // actual convex hull.
+  }
+  else if (shape->is<MeshShape>())
   {
     const auto& mesh = static_cast<const MeshShape*>(shape);
 
@@ -452,12 +465,12 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
     else
       mRI->drawMesh(mesh->getScale(), mesh->getMesh());
   }
-  else if (SoftMeshShape::getStaticType() == shapeType)
+  else if (shape->is<SoftMeshShape>())
   {
     const auto& softMesh = static_cast<const SoftMeshShape*>(shape);
     mRI->drawSoftMesh(softMesh->getAssimpMesh());
   }
-  else if (LineSegmentShape::getStaticType() == shapeType)
+  else if (shape->is<LineSegmentShape>())
   {
     const auto& lineSegmentShape
         = static_cast<const LineSegmentShape*>(shape);
@@ -467,7 +480,7 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
   else
   {
     dterr << "[SimWindow::drawShape] Attempting to draw an unsupported shape "
-          << "type [" << shapeType << "].\n";
+          << "type [" << shape->getType() << "].\n";
   }
 
   glDisable(GL_COLOR_MATERIAL);

--- a/dart/gui/osg/ShapeFrameNode.cpp
+++ b/dart/gui/osg/ShapeFrameNode.cpp
@@ -43,6 +43,7 @@
 #include "dart/gui/osg/render/CapsuleShapeNode.hpp"
 #include "dart/gui/osg/render/ConeShapeNode.hpp"
 #include "dart/gui/osg/render/PlaneShapeNode.hpp"
+#include "dart/gui/osg/render/MultiSphereShapeNode.hpp"
 #include "dart/gui/osg/render/MeshShapeNode.hpp"
 #include "dart/gui/osg/render/SoftMeshShapeNode.hpp"
 #include "dart/gui/osg/render/LineSegmentShapeNode.hpp"
@@ -58,6 +59,7 @@
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/MultiSphereShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/LineSegmentShape.hpp"
@@ -236,6 +238,15 @@ void ShapeFrameNode::createShapeNode(
         std::dynamic_pointer_cast<PlaneShape>(shape);
     if(ps)
       mShapeNode = new render::PlaneShapeNode(ps, this);
+    else
+      warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
+  }
+  else if(shape->is<MultiSphereShape>())
+  {
+    std::shared_ptr<MultiSphereShape> ms =
+        std::dynamic_pointer_cast<MultiSphereShape>(shape);
+    if(ms)
+      mShapeNode = new render::MultiSphereShapeNode(ms, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }

--- a/dart/gui/osg/render/MultiSphereShapeNode.cpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <osg/Geode>
+#include <osg/ShapeDrawable>
+#include <osg/Light>
+#include <osg/Material>
+
+#include "dart/gui/osg/render/MultiSphereShapeNode.hpp"
+#include "dart/gui/osg/Utils.hpp"
+
+#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/SimpleFrame.hpp"
+
+namespace dart {
+namespace gui {
+namespace osg {
+namespace render {
+
+//==============================================================================
+class MultiSphereShapeGeode : public ShapeNode, public ::osg::Geode
+{
+public:
+
+  MultiSphereShapeGeode(dart::dynamics::MultiSphereShape* shape,
+                        ShapeFrameNode* parentShapeFrame,
+                        MultiSphereShapeNode* parentNode);
+
+  void refresh();
+  void extractData();
+
+protected:
+
+  virtual ~MultiSphereShapeGeode();
+
+  MultiSphereShapeNode* mParentNode;
+  dart::dynamics::MultiSphereShape* mMultiSphereShape;
+  MultiSphereShapeDrawable* mDrawable;
+
+};
+
+//==============================================================================
+class MultiSphereShapeDrawable : public ::osg::ShapeDrawable
+{
+public:
+
+  MultiSphereShapeDrawable(dart::dynamics::MultiSphereShape* shape,
+                           dart::dynamics::VisualAspect* visualAspect,
+                           MultiSphereShapeGeode* parent);
+
+  void refresh(bool firstTime);
+
+protected:
+
+  virtual ~MultiSphereShapeDrawable();
+
+  dart::dynamics::MultiSphereShape* mMultiSphereShape;
+  dart::dynamics::VisualAspect* mVisualAspect;
+  MultiSphereShapeGeode* mParent;
+
+};
+
+//==============================================================================
+MultiSphereShapeNode::MultiSphereShapeNode(
+    std::shared_ptr<dart::dynamics::MultiSphereShape> shape,
+    ShapeFrameNode* parent)
+  : ShapeNode(shape, parent, this),
+    mMultiSphereShape(shape),
+    mGeode(nullptr)
+{
+  extractData(true);
+  setNodeMask(mVisualAspect->isHidden()? 0x0 : ~0x0);
+}
+
+//==============================================================================
+void MultiSphereShapeNode::refresh()
+{
+  mUtilized = true;
+
+  setNodeMask(mVisualAspect->isHidden()? 0x0 : ~0x0);
+
+  if(mShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    return;
+
+  extractData(false);
+}
+
+//==============================================================================
+void MultiSphereShapeNode::extractData(bool /*firstTime*/)
+{
+  if(nullptr == mGeode)
+  {
+    mGeode = new MultiSphereShapeGeode(
+          mMultiSphereShape.get(), mParentShapeFrameNode, this);
+    addChild(mGeode);
+    return;
+  }
+
+  mGeode->refresh();
+}
+
+//==============================================================================
+MultiSphereShapeNode::~MultiSphereShapeNode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+MultiSphereShapeGeode::MultiSphereShapeGeode(
+    dart::dynamics::MultiSphereShape* shape,
+    ShapeFrameNode* parentShapeFrame,
+    MultiSphereShapeNode* parentNode)
+  : ShapeNode(parentNode->getShape(), parentShapeFrame, this),
+    mParentNode(parentNode),
+    mMultiSphereShape(shape),
+    mDrawable(nullptr)
+{
+  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+  extractData();
+}
+
+//==============================================================================
+void MultiSphereShapeGeode::refresh()
+{
+  mUtilized = true;
+
+  extractData();
+}
+
+//==============================================================================
+void MultiSphereShapeGeode::extractData()
+{
+  if(nullptr == mDrawable)
+  {
+    mDrawable = new MultiSphereShapeDrawable(
+          mMultiSphereShape, mVisualAspect, this);
+    addDrawable(mDrawable);
+    return;
+  }
+
+  mDrawable->refresh(false);
+}
+
+//==============================================================================
+MultiSphereShapeGeode::~MultiSphereShapeGeode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+MultiSphereShapeDrawable::MultiSphereShapeDrawable(
+    dart::dynamics::MultiSphereShape* shape,
+    dart::dynamics::VisualAspect* visualAspect,
+    MultiSphereShapeGeode* parent)
+  : mMultiSphereShape(shape),
+    mVisualAspect(visualAspect),
+    mParent(parent)
+{
+  refresh(true);
+}
+
+//==============================================================================
+void MultiSphereShapeDrawable::refresh(bool firstTime)
+{
+  if(mMultiSphereShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    setDataVariance(::osg::Object::STATIC);
+  else
+    setDataVariance(::osg::Object::DYNAMIC);
+
+  if(mMultiSphereShape->checkDataVariance(
+       dart::dynamics::Shape::DYNAMIC_PRIMITIVE)
+     || firstTime)
+  {
+    ::osg::ref_ptr<::osg::CompositeShape> osg_shape = nullptr;
+    osg_shape = new ::osg::CompositeShape();
+
+    const auto& spheres = mMultiSphereShape->getSpheres();
+    for (const auto& sphere : spheres)
+    {
+      ::osg::ref_ptr<::osg::Sphere> osg_sphere = nullptr;
+      osg_sphere = new ::osg::Sphere(
+          ::osg::Vec3(sphere.second.x(), sphere.second.y(), sphere.second.z()),
+          sphere.first);
+      osg_shape->addChild(osg_sphere);
+    }
+
+    setShape(osg_shape);
+    dirtyDisplayList();
+  }
+
+  if(mMultiSphereShape->checkDataVariance(
+       dart::dynamics::Shape::DYNAMIC_COLOR)
+     || firstTime)
+  {
+    setColor(eigToOsgVec4(mVisualAspect->getRGBA()));
+  }
+}
+
+//==============================================================================
+MultiSphereShapeDrawable::~MultiSphereShapeDrawable()
+{
+  // Do nothing
+}
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart

--- a/dart/gui/osg/render/MultiSphereShapeNode.hpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_GUI_OSG_RENDER_MULTISPHERESHAPENODE_HPP_
+#define DART_GUI_OSG_RENDER_MULTISPHERESHAPENODE_HPP_
+
+#include <osg/ShapeDrawable>
+#include <osg/MatrixTransform>
+
+#include "dart/gui/osg/render/ShapeNode.hpp"
+
+namespace dart {
+
+namespace dynamics {
+class MultiSphereShape;
+} // namespace dynamics
+
+namespace gui {
+namespace osg {
+namespace render {
+
+class MultiSphereShapeGeode;
+class MultiSphereShapeDrawable;
+
+class MultiSphereShapeNode : public ShapeNode, public ::osg::MatrixTransform
+{
+public:
+
+  MultiSphereShapeNode(
+      std::shared_ptr<dart::dynamics::MultiSphereShape> shape,
+      ShapeFrameNode* parent);
+
+  void refresh();
+  void extractData(bool firstTime);
+
+protected:
+
+  virtual ~MultiSphereShapeNode();
+
+  std::shared_ptr<dart::dynamics::MultiSphereShape> mMultiSphereShape;
+  MultiSphereShapeGeode* mGeode;
+
+};
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart
+
+#endif // DART_GUI_OSG_RENDER_MULTISPHERESHAPENODE_HPP_

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -57,6 +57,7 @@
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/MultiSphereShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/Joint.hpp"
@@ -1302,6 +1303,23 @@ dynamics::ShapePtr readShape(
              << "plane shape. DART will use 0.0." << std::endl;
       newShape = dynamics::ShapePtr(new dynamics::PlaneShape(normal, 0.0));
     }
+  }
+  else if (hasElement(geometryEle, "multi_sphere"))
+  {
+    tinyxml2::XMLElement* multiSphereEle = getElement(geometryEle, "multi_sphere");
+
+    ElementEnumerator xmlSpheres(multiSphereEle, "sphere");
+    dynamics::MultiSphereShape::Spheres spheres;
+    while (xmlSpheres.next())
+    {
+      const double radius = getValueDouble(xmlSpheres.get(), "radius");
+      const Eigen::Vector3d position
+          = getValueVector3d(xmlSpheres.get(), "position");
+
+      spheres.emplace_back(radius, position);
+    }
+
+    newShape = dynamics::ShapePtr(new dynamics::MultiSphereShape(spheres));
   }
   else if (hasElement(geometryEle, "mesh"))
   {

--- a/data/skel/shapes.skel
+++ b/data/skel/shapes.skel
@@ -238,10 +238,57 @@
             </joint>
         </skeleton>
 
+        <skeleton name="multi sphere skeleton">
+            <body name="multi sphere">
+                <gravity>1</gravity>
+                <transformation>0.8 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <multi_sphere>
+                            <sphere>
+                                <radius>0.05</radius>
+                                <position>-0.075 0.0 0.0</position>
+                            </sphere>
+                            <sphere>
+                                <radius>0.075</radius>
+                                <position>0.075 0.0 0.0</position>
+                            </sphere>
+                        </multi_sphere>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <multi_sphere>
+                            <sphere>
+                                <radius>0.05</radius>
+                                <position>-0.075 0.0 0.0</position>
+                            </sphere>
+                            <sphere>
+                                <radius>0.075</radius>
+                                <position>0.075 0.0 0.0</position>
+                            </sphere>
+                        </multi_sphere>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>multi sphere</child>
+            </joint>
+        </skeleton>
+
         <skeleton name="mesh skeleton">
             <body name="mesh">
                 <gravity>1</gravity>
-                <transformation>0.8 -0.0 0 1 2 3</transformation>
+                <transformation>1.0 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>

--- a/data/skel/test/test_shapes.skel
+++ b/data/skel/test/test_shapes.skel
@@ -238,10 +238,57 @@
             </joint>
         </skeleton>
 
+        <skeleton name="multi sphere skeleton">
+            <body name="multi sphere">
+                <gravity>1</gravity>
+                <transformation>0.8 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <multi_sphere>
+                            <sphere>
+                                <radius>0.05</radius>
+                                <position>-0.075 0.0 0.0</position>
+                            </sphere>
+                            <sphere>
+                                <radius>0.075</radius>
+                                <position>0.075 0.0 0.0</position>
+                            </sphere>
+                        </multi_sphere>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <multi_sphere>
+                            <sphere>
+                                <radius>0.05</radius>
+                                <position>-0.075 0.0 0.0</position>
+                            </sphere>
+                            <sphere>
+                                <radius>0.075</radius>
+                                <position>0.075 0.0 0.0</position>
+                            </sphere>
+                        </multi_sphere>
+                    </geometry>
+                </collision_shape>                                
+            </body>
+            
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>multi sphere</child>
+            </joint>
+        </skeleton>
+
         <skeleton name="mesh skeleton">
             <body name="mesh">
                 <gravity>1</gravity>
-                <transformation>0.8 -0.0 0 1 2 3</transformation>
+                <transformation>1.0 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>
@@ -271,7 +318,7 @@
                 <parent>world</parent>
                 <child>mesh</child>
             </joint>
-        </skeleton> 
+        </skeleton>
 
     </world>
 </skel>

--- a/unittests/testSkelParser.cpp
+++ b/unittests/testSkelParser.cpp
@@ -435,7 +435,7 @@ TEST(SkelParser, Shapes)
   EXPECT_NE(world, nullptr);
 
   const auto numSkels = world->getNumSkeletons();
-  EXPECT_EQ(numSkels, 8);
+  EXPECT_EQ(numSkels, 9);
 
   ShapePtr shape;
   SkeletonPtr skel;
@@ -494,6 +494,19 @@ TEST(SkelParser, Shapes)
   auto coneShape = std::static_pointer_cast<CapsuleShape>(shape);
   EXPECT_EQ(coneShape->getHeight(), 0.1);
   EXPECT_EQ(coneShape->getRadius(), 0.05);
+
+  // MultiSphere
+  skel = world->getSkeleton("multi sphere skeleton");
+  EXPECT_NE(skel, nullptr);
+  shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
+  EXPECT_TRUE(shape->is<MultiSphereShape>());
+  auto multiSphereShape = std::static_pointer_cast<MultiSphereShape>(shape);
+  EXPECT_EQ(multiSphereShape->getNumSpheres(), 2u);
+  const auto& spheres = multiSphereShape->getSpheres();
+  EXPECT_EQ(spheres[0].first, 0.05);
+  EXPECT_EQ(spheres[0].second, Eigen::Vector3d(-0.075, 0.0, 0.0));
+  EXPECT_EQ(spheres[1].first, 0.075);
+  EXPECT_EQ(spheres[1].second, Eigen::Vector3d(+0.075, 0.0, 0.0));
 
   // Mesh
   skel = world->getSkeleton("mesh skeleton");


### PR DESCRIPTION
This pull request adds new shape class `MultiSphereShape` inspired by `bullet`'s `btMultiSphereShape`. A multi-sphere shape is a convex hull of a collection of spheres.

#### Collision Detection
Only BulletCollisionDetector support this shape. 

#### Visualization
Both OpenGL and OSG merely draw the sub-spheres instead of the actual convex hull. This should be addressed in the future.

#### Parsing
This shape is supported by SKEL file format. Here is part of an example skel file that for a `MultiSphereShape` with two sub-spheres:
```xml
<visualization_shape>
    <transformation>0 0 0 0 0 0</transformation>
    <geometry>
        <multi_sphere>
            <sphere>
                <radius>0.05</radius>
                <position>-0.075 0.0 0.0</position>
            </sphere>
            <sphere>
                <radius>0.075</radius>
                <position>0.075 0.0 0.0</position>
            </sphere>
        </multi_sphere>
    </geometry>
    <color>0.6 0.6 0.8</color>
</visualization_shape>
```

This figure shows all the shapes supported by DART (from left: box, sphere, ellipsoid, cylinder, capsule, cone, multi-sphere (two spheres), mesh):
![image](https://cloud.githubusercontent.com/assets/4038467/18811545/5fbd64f6-8281-11e6-8b29-14837045541e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/770)
<!-- Reviewable:end -->
