### PR TITLE
Minor change: included <memory> from FCLTypes.hpp

### DIFF
--- a/dart/collision/fcl/FCLTypes.hpp
+++ b/dart/collision/fcl/FCLTypes.hpp
@@ -47,6 +47,7 @@
   (FCL_MINOR_VERSION < y || (FCL_MINOR_VERSION <= y))))
 
 #if FCL_VERSION_AT_LEAST(0,5,0)
+#include <memory>
 template <class T> using fcl_shared_ptr = std::shared_ptr<T>;
 template <class T> using fcl_weak_ptr = std::weak_ptr<T>;
 #else


### PR DESCRIPTION
This is only a minuscule update. For compiling with fcl-0.5 needed to include <memory> from FCLTypes.hpp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/772)
<!-- Reviewable:end -->
