### PR TITLE
Revive Shape::getShapeType() for backward compatibility

### DIFF
--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -36,7 +36,7 @@ namespace dart {
 namespace dynamics {
 
 BoxShape::BoxShape(const Eigen::Vector3d& _size)
-  : Shape(),
+  : Shape(BOX),
     mSize(_size) {
   assert(_size[0] > 0.0);
   assert(_size[1] > 0.0);

--- a/dart/dynamics/BoxShape.hpp
+++ b/dart/dynamics/BoxShape.hpp
@@ -46,7 +46,7 @@ public:
   virtual ~BoxShape();
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/CapsuleShape.cpp
+++ b/dart/dynamics/CapsuleShape.cpp
@@ -41,7 +41,7 @@ namespace dynamics {
 
 //==============================================================================
 CapsuleShape::CapsuleShape(double radius, double height)
-  : Shape(),
+  : Shape(CAPSULE),
     mRadius(radius),
     mHeight(height)
 {

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -41,7 +41,7 @@ namespace dynamics {
 
 //==============================================================================
 ConeShape::ConeShape(double radius, double height)
-  : Shape(),
+  : Shape(CONE),
     mRadius(radius),
     mHeight(height)
 {

--- a/dart/dynamics/CylinderShape.cpp
+++ b/dart/dynamics/CylinderShape.cpp
@@ -38,7 +38,7 @@ namespace dart {
 namespace dynamics {
 
 CylinderShape::CylinderShape(double _radius, double _height)
-  : Shape(),
+  : Shape(CYLINDER),
     mRadius(_radius),
     mHeight(_height) {
   assert(0.0 < _radius);

--- a/dart/dynamics/CylinderShape.hpp
+++ b/dart/dynamics/CylinderShape.hpp
@@ -46,7 +46,7 @@ public:
   CylinderShape(double _radius, double _height);
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -37,7 +37,7 @@ namespace dart {
 namespace dynamics {
 
 EllipsoidShape::EllipsoidShape(const Eigen::Vector3d& _size)
-  : Shape() {
+  : Shape(ELLIPSOID) {
   setSize(_size);
 }
 

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -46,7 +46,7 @@ public:
   virtual ~EllipsoidShape();
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -38,7 +38,7 @@ namespace dynamics {
 
 //==============================================================================
 LineSegmentShape::LineSegmentShape(float _thickness)
-  : Shape(),
+  : Shape(LINE_SEGMENT),
     mThickness(_thickness),
     mDummyVertex(Eigen::Vector3d::Zero())
 {

--- a/dart/dynamics/LineSegmentShape.hpp
+++ b/dart/dynamics/LineSegmentShape.hpp
@@ -52,7 +52,7 @@ public:
                    float _thickness = 1.0f);
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -129,7 +129,7 @@ namespace dynamics {
 MeshShape::MeshShape(const Eigen::Vector3d& _scale, const aiScene* _mesh,
                      const std::string& _path,
                      const common::ResourceRetrieverPtr& _resourceRetriever)
-  : Shape(),
+  : Shape(MESH),
     mResourceRetriever(_resourceRetriever),
     mDisplayList(0),
     mColorMode(MATERIAL_COLOR),

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -70,7 +70,7 @@ public:
   virtual ~MeshShape();
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/MultiSphereShape.cpp
+++ b/dart/dynamics/MultiSphereShape.cpp
@@ -40,7 +40,7 @@ namespace dynamics {
 
 //==============================================================================
 MultiSphereShape::MultiSphereShape(const Spheres& spheres)
-  : Shape()
+  : Shape(MULTISPHERE)
 {
   addSpheres(spheres);
 }

--- a/dart/dynamics/MultiSphereShape.hpp
+++ b/dart/dynamics/MultiSphereShape.hpp
@@ -54,7 +54,7 @@ public:
   virtual ~MultiSphereShape();
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/PlaneShape.cpp
+++ b/dart/dynamics/PlaneShape.cpp
@@ -36,7 +36,7 @@ namespace dynamics {
 
 //==============================================================================
 PlaneShape::PlaneShape(const Eigen::Vector3d& _normal, double _offset)
-  : Shape(),
+  : Shape(PLANE),
     mNormal(_normal.normalized()),
     mOffset(_offset)
 {

--- a/dart/dynamics/PlaneShape.hpp
+++ b/dart/dynamics/PlaneShape.hpp
@@ -48,7 +48,7 @@ public:
   PlaneShape(const Eigen::Vector3d& _normal, const Eigen::Vector3d& _point);
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/Shape.cpp
+++ b/dart/dynamics/Shape.cpp
@@ -39,11 +39,12 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-Shape::Shape(ShapeType /*_type*/)
+Shape::Shape(ShapeType type)
   : mBoundingBox(),
     mVolume(0.0),
     mID(mCounter++),
-    mVariance(STATIC)
+    mVariance(STATIC),
+    mType(type)
 {
   // Do nothing
 }
@@ -53,7 +54,8 @@ Shape::Shape()
   : mBoundingBox(),
     mVolume(0.0),
     mID(mCounter++),
-    mVariance(STATIC)
+    mVariance(STATIC),
+    mType(UNSUPPORTED)
 {
   // Do nothing
 }
@@ -97,12 +99,7 @@ int Shape::getID() const
 //==============================================================================
 Shape::ShapeType Shape::getShapeType() const
 {
-  dtwarn << "[Shape::getShapeType] This function is deprecated since DART 6.1 "
-         << "with Shape::ShapeType, and this won't work as expected. Please "
-         << "consider using Shape::getType() or [ShapeClass]::getStaticType() "
-         << "instead for the type checking.\n";
-
-  return static_cast<ShapeType>(0);
+  return mType;
 }
 
 //==============================================================================

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -54,10 +54,14 @@ public:
     BOX,
     ELLIPSOID,
     CYLINDER,
+    CAPSULE,
+    CONE,
     PLANE,
+    MULTISPHERE,
     MESH,
     SOFT_MESH,
-    LINE_SEGMENT
+    LINE_SEGMENT,
+    UNSUPPORTED
   };
 
   /// DataVariance can be used by renderers to determine whether it should
@@ -73,7 +77,7 @@ public:
   };
 
   /// \brief Constructor
-  DART_DEPRECATED(6.1)
+  /// \deprecated Deprecated in 6.1. Please use getType() instead.
   explicit Shape(ShapeType _type);
 
   /// \brief Constructor
@@ -172,6 +176,10 @@ protected:
 
   /// \brief
   static int mCounter;
+
+  /// \deprecated Deprecated in 6.1. Please use getType() instead.
+  /// Type of primitive shpae.
+  ShapeType mType;
 
 };
 

--- a/dart/dynamics/SoftMeshShape.cpp
+++ b/dart/dynamics/SoftMeshShape.cpp
@@ -40,7 +40,7 @@ namespace dart {
 namespace dynamics {
 
 SoftMeshShape::SoftMeshShape(SoftBodyNode* _softBodyNode)
-  : Shape(),
+  : Shape(SOFT_MESH),
     mSoftBodyNode(_softBodyNode),
     mAssimpMesh(nullptr)
 {

--- a/dart/dynamics/SoftMeshShape.hpp
+++ b/dart/dynamics/SoftMeshShape.hpp
@@ -55,7 +55,7 @@ public:
   virtual ~SoftMeshShape();
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -38,7 +38,7 @@ namespace dynamics {
 
 //==============================================================================
 SphereShape::SphereShape(double radius)
-  : Shape()
+  : Shape(SPHERE)
 {
   setRadius(radius);
 }

--- a/dart/dynamics/SphereShape.hpp
+++ b/dart/dynamics/SphereShape.hpp
@@ -47,7 +47,7 @@ public:
   virtual ~SphereShape();
 
   // Documentation inherited.
-  const std::string& getType() const;
+  const std::string& getType() const override;
 
   /// Returns shape type for this class
   static const std::string& getStaticType();


### PR DESCRIPTION
This pull request revives `Shape::getShapeType()` for backward compatibility that was malfunctioned in #769.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/779)
<!-- Reviewable:end -->
