### PR TITLE
Fix inconsistent frame rate of GlutWindow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ project(dart)
 
 set(DART_MAJOR_VERSION "5")
 set(DART_MINOR_VERSION "1")
-set(DART_PATCH_VERSION "3")
+set(DART_PATCH_VERSION "4")
 set(DART_VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}.${DART_PATCH_VERSION}")
 set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")
 set(DART_PKG_EXTERNAL_DEPS "flann, ccd, fcl")

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
-### Version 5.1.3 (2016-10-14)
+### Version 5.1.4 (2016-10-14)
+
+1. Fixed inconsistent frame rate of GlutWindow
+    * [Pull request #794](https://github.com/dartsim/dart/pull/794)
 
 ### Version 5.1.3 (2016-10-07)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+### Version 5.1.3 (2016-10-14)
+
 ### Version 5.1.3 (2016-10-07)
 
 1. Updated to support Bullet built with double precision (backport of [#660](https://github.com/dartsim/dart/pull/660))

--- a/apps/addDeleteSkels/MyWindow.cpp
+++ b/apps/addDeleteSkels/MyWindow.cpp
@@ -56,10 +56,8 @@ void MyWindow::keyboard(unsigned char _key, int _x, int _y) {
   switch (_key) {
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
-      if (mSimulating) {
+      if (mSimulating)
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'q':  // Spawn a cube
     case 'Q': {  // Spawn a cube

--- a/apps/atlasSimbicon/MyWindow.cpp
+++ b/apps/atlasSimbicon/MyWindow.cpp
@@ -104,18 +104,12 @@ void MyWindow::keyboard(unsigned char _key, int _x, int _y)
   case ' ':  // use space key to play or stop the motion
     mSimulating = !mSimulating;
     if (mSimulating)
-    {
       mPlay = false;
-      glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-    }
     break;
   case 'p':  // playBack
     mPlay = !mPlay;
     if (mPlay)
-    {
       mSimulating = false;
-      glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-    }
     break;
   case '[':  // step backward
     if (!mSimulating)

--- a/apps/bipedStand/MyWindow.cpp
+++ b/apps/bipedStand/MyWindow.cpp
@@ -81,17 +81,13 @@ void MyWindow::keyboard(unsigned char _key, int _x, int _y) {
   switch (_key) {
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
-      if (mSimulating) {
+      if (mSimulating)
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
-      if (mPlay) {
+      if (mPlay)
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating) {

--- a/apps/hybridDynamics/MyWindow.cpp
+++ b/apps/hybridDynamics/MyWindow.cpp
@@ -89,18 +89,12 @@ void MyWindow::keyboard(unsigned char _key, int _x, int _y)
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
       if (mSimulating)
-      {
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
       if (mPlay)
-      {
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating)

--- a/apps/jointConstraints/MyWindow.cpp
+++ b/apps/jointConstraints/MyWindow.cpp
@@ -83,18 +83,12 @@ void MyWindow::keyboard(unsigned char key, int x, int y)
     case ' ': // use space key to play or stop the motion
       mSimulating = !mSimulating;
       if(mSimulating)
-      {
         mPlay = false;
-        glutTimerFunc( mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p': // playBack
       mPlay = !mPlay;
       if (mPlay)
-      {
         mSimulating = false;
-        glutTimerFunc( mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[': // step backward
       if (!mSimulating)

--- a/apps/mixedChain/MyWindow.cpp
+++ b/apps/mixedChain/MyWindow.cpp
@@ -109,18 +109,12 @@ void MyWindow::keyboard(unsigned char key, int x, int y)
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
       if (mSimulating)
-      {
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
       if (mPlay)
-      {
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating)

--- a/apps/rigidCubes/MyWindow.cpp
+++ b/apps/rigidCubes/MyWindow.cpp
@@ -62,17 +62,13 @@ void MyWindow::keyboard(unsigned char _key, int _x, int _y) {
   switch (_key) {
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
-      if (mSimulating) {
+      if (mSimulating)
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
-      if (mPlay) {
+      if (mPlay)
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating) {

--- a/apps/rigidShapes/MyWindow.cpp
+++ b/apps/rigidShapes/MyWindow.cpp
@@ -96,18 +96,12 @@ void MyWindow::keyboard(unsigned char key, int x, int y)
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
       if (mSimulating)
-      {
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
       if (mPlay)
-      {
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating)

--- a/apps/softBodies/MyWindow.cpp
+++ b/apps/softBodies/MyWindow.cpp
@@ -108,18 +108,12 @@ void MyWindow::keyboard(unsigned char key, int x, int y)
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
       if (mSimulating)
-      {
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
       if (mPlay)
-      {
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating)

--- a/apps/vehicle/MyWindow.cpp
+++ b/apps/vehicle/MyWindow.cpp
@@ -80,17 +80,13 @@ void MyWindow::keyboard(unsigned char _key, int _x, int _y) {
   switch (_key) {
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
-      if (mSimulating) {
+      if (mSimulating)
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
-      if (mPlay) {
+      if (mPlay)
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating) {

--- a/dart/gui/GlutWindow.cpp
+++ b/dart/gui/GlutWindow.cpp
@@ -104,6 +104,9 @@ void GlutWindow::initWindow(int _w, int _h, const char* _name) {
 #endif
   // TODO: Disabled use of GL_MULTISAMPLE for Windows. Please see #411 for the
   // detail.
+
+  glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
+  // Note: We book the timer id 0 for the main rendering purpose.
 }
 
 void GlutWindow::reshape(int _w, int _h) {

--- a/dart/gui/GlutWindow.h
+++ b/dart/gui/GlutWindow.h
@@ -53,6 +53,7 @@ public:
   GlutWindow();
   virtual ~GlutWindow();
 
+  /// \warning This function should be called once.
   virtual void initWindow(int _w, int _h, const char* _name);
 
   // callback functions

--- a/dart/gui/SimWindow.cpp
+++ b/dart/gui/SimWindow.cpp
@@ -184,17 +184,13 @@ void SimWindow::keyboard(unsigned char _key, int _x, int _y) {
   switch (_key) {
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
-      if (mSimulating) {
+      if (mSimulating)
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
-      if (mPlay) {
+      if (mPlay)
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case '[':  // step backward
       if (!mSimulating) {

--- a/dart/gui/SoftSimWindow.cpp
+++ b/dart/gui/SoftSimWindow.cpp
@@ -65,18 +65,12 @@ void SoftSimWindow::keyboard(unsigned char key, int x, int y)
     case ' ':  // use space key to play or stop the motion
       mSimulating = !mSimulating;
       if (mSimulating)
-      {
         mPlay = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     case 'p':  // playBack
       mPlay = !mPlay;
       if (mPlay)
-      {
         mSimulating = false;
-        glutTimerFunc(mDisplayTimeout, refreshTimer, 0);
-      }
       break;
     // case '[':  // step backward
     //   if (!mSimulating)

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dart</name>
-  <version>5.1.3</version>
+  <version>5.1.4</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics


### PR DESCRIPTION
SimWindow and the derived classes (e.g., `MyWindow` of apps) call `glutTimerFunc()` when resuming the simulation or replay. However, this leads to calling the callee function passes into `glutTimerFunc()` multiple times because `glutTimerFunc()` adds the callee function instead of resetting. I believe this is why the drawing rate was increased as reported by #729 and #792.

This PR fixes it by calling `glutTimerFunc()` once in `GlutWindow::initWindow()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/794)
<!-- Reviewable:end -->
