### PR TITLE
fixed issue #804 - Rendering white lines with nvidia driver

### DIFF
--- a/dart/gui/Win3D.cpp
+++ b/dart/gui/Win3D.cpp
@@ -224,7 +224,6 @@ void Win3D::initGL() {
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glHint(GL_POLYGON_SMOOTH_HINT, GL_NICEST);
-  glEnable(GL_POLYGON_SMOOTH);
   glShadeModel(GL_SMOOTH);
   glPolygonMode(GL_FRONT, GL_FILL);
 }


### PR DESCRIPTION
The non-osg display shows strange white lines with an nvidia driver.
The fix is based on this proposal
http://gamedev.stackexchange.com/questions/31941/opengl-behaviour-depending-on-the-graphics-card
that I found by googling around... I tested this with GTX1080 and NVidia
driver version 367.48 on debian linux. The strange white lines disappeared.

Compared to the rendering result as shown in issue #804, the new rendering is as espected. See:

![non-osg-fixed](https://cloud.githubusercontent.com/assets/1280457/19658376/0372f0f8-9a28-11e6-9ca2-5db57856dc26.JPG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/805)
<!-- Reviewable:end -->
