### PR TITLE
Use Codecov for online code coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ install:
 script:
   - 'ci/script.sh'
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 after_failure: 
   - cat Testing/Temporary/LastTest.log
   - cat Testing/Temporary/LastTestsFailed.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DART: Dynamic Animation and Robotics Toolkit
-[![Build Status](https://travis-ci.org/dartsim/dart.png?branch=master)](https://travis-ci.org/dartsim/dart) [![Build status](https://ci.appveyor.com/api/projects/status/6rta8olo95bpu84r/branch/master?svg=true)](https://ci.appveyor.com/project/jslee02/dart/branch/master) [![Coverage Status](https://coveralls.io/repos/github/dartsim/dart/badge.svg?branch=master)](https://coveralls.io/github/dartsim/dart?branch=master)
+[![Build Status](https://travis-ci.org/dartsim/dart.png?branch=master)](https://travis-ci.org/dartsim/dart) [![Build status](https://ci.appveyor.com/api/projects/status/6rta8olo95bpu84r/branch/master?svg=true)](https://ci.appveyor.com/project/jslee02/dart/branch/master) [![codecov](https://codecov.io/gh/dartsim/dart/branch/master/graph/badge.svg)](https://codecov.io/gh/dartsim/dart)
 
 Visit the [DART website](http://dartsim.github.io/) for more information
 * [Gallery](http://dartsim.github.io/gallery.html)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
Coveralls and Codecov are all promising coverage reporting services, but it seems [the layout of Codecov](https://codecov.io/gh/dartsim/dart/branch/codecov) looks more organized and intuitive to me comparing to [Coveralls'](https://coveralls.io/github/dartsim/dart?branch=master).

We could use Codecov with this minimal changes of this PR since they both work based on `gcov` but uploading to different services. There are some CMake scripts could be cleaned up, but I'd like to save it for future PRs.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/806)

<!-- Reviewable:end -->
