### PR TITLE
Fix bug of ContactConstraint with kinematic joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## DART 6
 
+### DART 6.1.2 (2016-XX-XX)
+
+* Dynamics
+
+  * Fixed bug of ContactConstraint with kinematic joints: [#809](https://github.com/dartsim/dart/pull/809)
+
 ### DART 6.1.1 (2016-10-14)
 
 * Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 # If you change the version, please update the <version> tag in package.xml.
 set(DART_MAJOR_VERSION "6")
 set(DART_MINOR_VERSION "1")
-set(DART_PATCH_VERSION "1")
+set(DART_PATCH_VERSION "2")
 set(DART_VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}.${DART_PATCH_VERSION}")
 set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")
 set(DART_PKG_EXTERNAL_DEPS "eigen, ccd, fcl, assimp, boost")

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -738,12 +738,8 @@ void ContactConstraint::getRelVelocity(double* _relVel)
   for (std::size_t i = 0; i < mDim; ++i)
   {
     _relVel[i] = 0.0;
-
-    if (mBodyNode1->isReactive())
-      _relVel[i] -= mJacobians1[i].dot(mBodyNode1->getSpatialVelocity());
-
-    if (mBodyNode2->isReactive())
-      _relVel[i] -= mJacobians2[i].dot(mBodyNode2->getSpatialVelocity());
+    _relVel[i] -= mJacobians1[i].dot(mBodyNode1->getSpatialVelocity());
+    _relVel[i] -= mJacobians2[i].dot(mBodyNode2->getSpatialVelocity());
 
 //    std::cout << "_relVel[i]: " << _relVel[i] << std::endl;
   }

--- a/dart/constraint/SoftContactConstraint.cpp
+++ b/dart/constraint/SoftContactConstraint.cpp
@@ -888,24 +888,14 @@ void SoftContactConstraint::getRelVelocity(double* _vel)
     _vel[i] = 0.0;
 
     if (mPointMass1)
-    {
       _vel[i] -= mJacobians1[i].tail<3>().dot(mPointMass1->getBodyVelocity());
-    }
     else
-    {
-      if (mBodyNode1->isReactive())
-        _vel[i] -= mJacobians1[i].dot(mBodyNode1->getSpatialVelocity());
-    }
+      _vel[i] -= mJacobians1[i].dot(mBodyNode1->getSpatialVelocity());
 
     if (mPointMass2)
-    {
       _vel[i] -= mJacobians2[i].tail<3>().dot(mPointMass2->getBodyVelocity());
-    }
     else
-    {
-      if (mBodyNode2->isReactive())
-        _vel[i] -= mJacobians2[i].dot(mBodyNode2->getSpatialVelocity());
-    }
+      _vel[i] -= mJacobians2[i].dot(mBodyNode2->getSpatialVelocity());
 
 //    std::cout << "_relVel[i + _idx]: " << _relVel[i + _idx] << std::endl;
   }

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dart</name>
-  <version>6.1.1</version>
+  <version>6.1.2</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/unittests/unit/CMakeLists.txt
+++ b/unittests/unit/CMakeLists.txt
@@ -1,4 +1,5 @@
 dart_add_test("unit" test_Aspect)
+dart_add_test("unit" test_ContactConstraint)
 dart_add_test("unit" test_GenericJoints)
 dart_add_test("unit" test_Geometry)
 dart_add_test("unit" test_LocalResourceRetriever)

--- a/unittests/unit/test_ContactConstraint.cpp
+++ b/unittests/unit/test_ContactConstraint.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "TestHelpers.hpp"
+
+#include "dart/common/common.hpp"
+#include "dart/dynamics/dynamics.hpp"
+#include "dart/constraint/constraint.hpp"
+#include "dart/simulation/World.hpp"
+
+using namespace dart;
+
+//==============================================================================
+TEST(ContactConstraint, ContactWithKinematicJoint)
+{
+  auto world = std::make_shared<simulation::World>();
+
+  auto skeleton1 = dynamics::Skeleton::create("skeleton1");
+  auto pair1 = skeleton1->createJointAndBodyNodePair<dynamics::FreeJoint>();
+  auto bodyNode1 = pair1.second;
+  auto joint1 = pair1.first;
+  joint1->setActuatorType(dynamics::Joint::VELOCITY);
+  auto shape1
+      = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d(1.0, 1.0, 1.0));
+  bodyNode1->createShapeNodeWith<
+      VisualAspect, CollisionAspect, DynamicsAspect>(shape1);
+  skeleton1->setPosition(5, 0.0);
+
+  auto skeleton2 = dynamics::Skeleton::create("skeleton2");
+  auto pair2 = skeleton2->createJointAndBodyNodePair<dynamics::FreeJoint>();
+  auto bodyNode2 = pair2.second;
+  auto joint2 = pair2.first;
+  joint2->setActuatorType(dynamics::Joint::FORCE);
+  auto shape2
+      = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d(0.5, 0.5, 0.5));
+  bodyNode2->createShapeNodeWith<
+      VisualAspect, CollisionAspect, DynamicsAspect>(shape2);
+  skeleton2->setPosition(5, 0.75);
+
+  world->addSkeleton(skeleton1);
+  world->addSkeleton(skeleton2);
+
+  for (auto i = 0u; i < 100; ++i)
+  {
+    skeleton1->setCommand(3, 0.1);
+
+    world->step();
+
+    EXPECT_EQ(bodyNode1->getLinearVelocity()[0], 0.1);
+
+    // Need few steps to settle down
+    if (i > 15)
+      EXPECT_NEAR(bodyNode2->getLinearVelocity()[0], 0.1, 1e-6);
+  }
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
`ContactConstraint` ignored the velocity of kinematic body nodes (body nodes with kinematic joints such as VELOCITY, ACCELERATION) in the relative contact velocity computation. This PR fixes the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/809)
<!-- Reviewable:end -->
