### PR TITLE
Rename notifyXUpdate() relevantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Misc
 
+  * Modified the member function names pertain to lazy evaluation to be more relevant to their functionalities: [#833](https://github.com/dartsim/dart/pull/833)
   * Added CMake targets for code formatting using clang-format: [#811](https://github.com/dartsim/dart/pull/811), [#817](https://github.com/dartsim/dart/pull/817)
 
 ### DART 6.1.2 (2016-XX-XX)

--- a/dart/common/Aspect.hpp
+++ b/dart/common/Aspect.hpp
@@ -177,7 +177,7 @@ protected:
 
 //==============================================================================
 #define DART_COMMON_SET_ASPECT_PROPERTY( Type, Name )\
-  DART_COMMON_SET_ASPECT_PROPERTY_CUSTOM( Type, Name, notifyPropertiesUpdate )
+  DART_COMMON_SET_ASPECT_PROPERTY_CUSTOM( Type, Name, notifyPropertiesUpdated )
 
 //==============================================================================
 #define DART_COMMON_GET_ASPECT_PROPERTY( Type, Name )\

--- a/dart/common/detail/AspectWithVersion.hpp
+++ b/dart/common/detail/AspectWithVersion.hpp
@@ -33,6 +33,7 @@
 #define DART_COMMON_DETAIL_ASPECTWITHVERSION_HPP_
 
 #include "dart/common/Aspect.hpp"
+#include "dart/common/Deprecated.hpp"
 #include "dart/common/StlHelpers.hpp"
 
 namespace dart {
@@ -151,7 +152,11 @@ public:
   std::size_t incrementVersion();
 
   /// Call UpdateProperties(this) and incrementVersion()
+  DART_DEPRECATED(6.2)
   void notifyPropertiesUpdate();
+
+  /// Call UpdateProperties(this) and incrementVersion()
+  void notifyPropertiesUpdated();
 
 protected:
 
@@ -286,7 +291,7 @@ void AspectWithVersionedProperties<BaseT, DerivedT, PropertiesData,
 setProperties(const PropertiesData& properties)
 {
   static_cast<PropertiesData&>(mProperties) = properties;
-  this->notifyPropertiesUpdate();
+  this->notifyPropertiesUpdated();
 }
 
 //==============================================================================
@@ -328,6 +333,16 @@ template <class BaseT, class DerivedT, typename PropertiesData,
 void AspectWithVersionedProperties<
     BaseT, DerivedT, PropertiesData,
     CompositeT, updateProperties>::notifyPropertiesUpdate()
+{
+  notifyPropertiesUpdated();
+}
+
+//==============================================================================
+template <class BaseT, class DerivedT, typename PropertiesData,
+          class CompositeT, void (*updateProperties)(DerivedT*)>
+void AspectWithVersionedProperties<
+    BaseT, DerivedT, PropertiesData,
+    CompositeT, updateProperties>::notifyPropertiesUpdated()
 {
   UpdateProperties(static_cast<Derived*>(this));
   this->incrementVersion();

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -63,7 +63,7 @@ ArrowShape::ArrowShape(const Eigen::Vector3d& _tail,
   instantiate(_resolution);
   configureArrow(mTail, mHead, mProperties);
   setColorMode(MeshShape::COLOR_INDEX);
-  notifyColorUpdate(_color);
+  notifyColorUpdated(_color);
 }
 
 //==============================================================================
@@ -92,7 +92,7 @@ void ArrowShape::setProperties(const Properties& _properties)
 }
 
 //==============================================================================
-void ArrowShape::notifyColorUpdate(const Eigen::Vector4d& _color)
+void ArrowShape::notifyColorUpdated(const Eigen::Vector4d& _color)
 {
   for(std::size_t i=0; i<mMesh->mNumMeshes; ++i)
   {

--- a/dart/dynamics/ArrowShape.hpp
+++ b/dart/dynamics/ArrowShape.hpp
@@ -85,7 +85,7 @@ public:
   void setProperties(const Properties& _properties);
 
   /// Set the color of this arrow
-  void notifyColorUpdate(const Eigen::Vector4d& _color) override;
+  void notifyColorUpdated(const Eigen::Vector4d& _color) override;
 
   /// Get the properties of this arrow
   const Properties& getProperties() const;

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -832,23 +832,36 @@ public:
   //----------------------------------------------------------------------------
 
   // Documentation inherited
-  void notifyTransformUpdate() override;
+  void dirtyTransform() override;
 
   // Documentation inherited
-  void notifyVelocityUpdate() override;
+  void dirtyVelocity() override;
 
   // Documentation inherited
-  void notifyAccelerationUpdate() override;
+  void dirtyAcceleration() override;
 
   /// Notify the Skeleton that the tree of this BodyNode needs an articulated
   /// inertia update
+  DART_DEPRECATED(6.2)
   void notifyArticulatedInertiaUpdate();
 
+  /// Notify the Skeleton that the tree of this BodyNode needs an articulated
+  /// inertia update
+  void dirtyArticulatedInertia();
+
   /// Tell the Skeleton that the external forces need to be updated
+  DART_DEPRECATED(6.2)
   void notifyExternalForcesUpdate();
 
+  /// Tell the Skeleton that the external forces need to be updated
+  void dirtyExternalForces();
+
   /// Tell the Skeleton that the coriolis forces need to be update
+  DART_DEPRECATED(6.2)
   void notifyCoriolisUpdate();
+
+  /// Tell the Skeleton that the coriolis forces need to be update
+  void dirtyCoriolisForces();
 
   //----------------------------------------------------------------------------
   // Friendship

--- a/dart/dynamics/EndEffector.cpp
+++ b/dart/dynamics/EndEffector.cpp
@@ -49,7 +49,7 @@ EndEffectorProperties::EndEffectorProperties(const Eigen::Isometry3d& defaultTf)
 void SupportUpdate(Support* support)
 {
   if(EndEffector* ee = support->getComposite())
-    ee->getSkeleton()->notifySupportUpdate(ee->getTreeIndex());
+    ee->getSkeleton()->dirtySupportPolygon(ee->getTreeIndex());
 }
 
 } // namespace detail
@@ -138,16 +138,16 @@ void EndEffector::resetRelativeTransform()
 }
 
 //==============================================================================
-void EndEffector::notifyTransformUpdate()
+void EndEffector::dirtyTransform()
 {
   if(!mNeedTransformUpdate)
   {
     const SkeletonPtr& skel = getSkeleton();
     if(skel)
-      skel->notifySupportUpdate(getTreeIndex());
+      skel->dirtySupportPolygon(getTreeIndex());
   }
 
-  Frame::notifyTransformUpdate();
+  Frame::dirtyTransform();
 }
 
 //==============================================================================

--- a/dart/dynamics/EndEffector.hpp
+++ b/dart/dynamics/EndEffector.hpp
@@ -144,7 +144,7 @@ public:
   //----------------------------------------------------------------------------
 
   // Documentation inherited
-  void notifyTransformUpdate() override;
+  void dirtyTransform() override;
 
   /// \}
 

--- a/dart/dynamics/Entity.cpp
+++ b/dart/dynamics/Entity.cpp
@@ -130,6 +130,12 @@ bool Entity::isFrame() const
 //==============================================================================
 void Entity::notifyTransformUpdate()
 {
+  dirtyTransform();
+}
+
+//==============================================================================
+void Entity::dirtyTransform()
+{
   mNeedTransformUpdate = true;
 
   // The actual transform hasn't updated yet. But when its getter is called,
@@ -146,6 +152,12 @@ bool Entity::needsTransformUpdate() const
 //==============================================================================
 void Entity::notifyVelocityUpdate()
 {
+  dirtyVelocity();
+}
+
+//==============================================================================
+void Entity::dirtyVelocity()
+{
   mNeedVelocityUpdate = true;
 
   // The actual velocity hasn't updated yet. But when its getter is called,
@@ -161,6 +173,12 @@ bool Entity::needsVelocityUpdate() const
 
 //==============================================================================
 void Entity::notifyAccelerationUpdate()
+{
+  dirtyAcceleration();
+}
+
+//==============================================================================
+void Entity::dirtyAcceleration()
 {
   mNeedAccelerationUpdate = true;
 
@@ -242,7 +260,7 @@ void Entity::changeParentFrame(Frame* _newParentFrame)
       mParentFrame->mChildEntities.insert(this);
       mParentFrame->processNewEntity(this);
     }
-    notifyTransformUpdate();
+    dirtyTransform();
   }
 
   if(mParentFrame)

--- a/dart/dynamics/Entity.hpp
+++ b/dart/dynamics/Entity.hpp
@@ -113,20 +113,38 @@ public:
   /// suitable for temporary objects.
   bool isQuiet() const;
 
-  /// Notify this Entity that its parent Frame's pose has changed
+  /// Notify the transformation update of this Entity that its parent Frame's
+  /// pose is needed
+  DART_DEPRECATED(6.2)
   virtual void notifyTransformUpdate();
+
+  /// Notify the transformation update of this Entity that its parent Frame's
+  /// pose is needed
+  virtual void dirtyTransform();
 
   /// Returns true iff a transform update is needed for this Entity
   bool needsTransformUpdate() const;
 
-  /// Notify this Entity that its parent Frame's velocity has changed
+  /// Notify the velocity update of this Entity that its parent Frame's velocity
+  /// is needed
+  DART_DEPRECATED(6.2)
   virtual void notifyVelocityUpdate();
+
+  /// Notify the velocity update of this Entity that its parent Frame's velocity
+  /// is needed
+  virtual void dirtyVelocity();
 
   /// Returns true iff a velocity update is needed for this Entity
   bool needsVelocityUpdate() const;
 
-  /// Notify this Entity that its parent Frame's acceleration has changed
+  /// Notify the acceleration of this Entity that its parent Frame's
+  /// acceleration is needed
+  DART_DEPRECATED(6.2)
   virtual void notifyAccelerationUpdate();
+
+  /// Notify the acceleration of this Entity that its parent Frame's
+  /// acceleration is needed
+  virtual void dirtyAcceleration();
 
   /// Returns true iff an acceleration update is needed for this Entity
   bool needsAccelerationUpdate() const;

--- a/dart/dynamics/Entity.hpp
+++ b/dart/dynamics/Entity.hpp
@@ -173,12 +173,15 @@ protected:
 
   /// Does this Entity need a Transform update
   mutable bool mNeedTransformUpdate;
+  // TODO(JS): Rename this to mIsTransformDirty in DART 7
 
   /// Does this Entity need a Velocity update
   mutable bool mNeedVelocityUpdate;
+  // TODO(JS): Rename this to mIsVelocityDirty in DART 7
 
   /// Does this Entity need an Acceleration update
   mutable bool mNeedAccelerationUpdate;
+  // TODO(JS): Rename this to mIsAccelerationDirty in DART 7
 
   /// Frame changed signal
   FrameChangedSignal mFrameChangedSignal;

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -124,7 +124,7 @@ void EulerJoint::setAxisOrder(EulerJoint::AxisOrder _order, bool _renameDofs)
   if (_renameDofs)
     updateDegreeOfFreedomNames();
 
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   updateRelativeJacobian(true);
   Joint::incrementVersion();
 }

--- a/dart/dynamics/FixedFrame.cpp
+++ b/dart/dynamics/FixedFrame.cpp
@@ -76,7 +76,7 @@ void FixedFrame::setRelativeTransform(const Eigen::Isometry3d& transform)
     return;
 
   mAspectProperties.mRelativeTf = transform;
-  notifyTransformUpdate();
+  dirtyTransform();
   incrementVersion();
 }
 

--- a/dart/dynamics/FixedJacobianNode.cpp
+++ b/dart/dynamics/FixedJacobianNode.cpp
@@ -44,8 +44,8 @@ void FixedJacobianNode::setRelativeTransform(
     return;
 
   FixedFrame::setRelativeTransform(newRelativeTf);
-  notifyJacobianUpdate();
-  notifyJacobianDerivUpdate();
+  dirtyJacobian();
+  dirtyJacobianDeriv();
 }
 
 //==============================================================================

--- a/dart/dynamics/Frame.cpp
+++ b/dart/dynamics/Frame.cpp
@@ -447,9 +447,9 @@ bool Frame::isWorld() const
 }
 
 //==============================================================================
-void Frame::notifyTransformUpdate()
+void Frame::dirtyTransform()
 {
-  notifyVelocityUpdate(); // Global Velocity depends on the Global Transform
+  dirtyVelocity(); // Global Velocity depends on the Global Transform
 
   // Always trigger the signal, in case a new subscriber has registered in the
   // time since the last signal
@@ -462,13 +462,13 @@ void Frame::notifyTransformUpdate()
   mNeedTransformUpdate = true;
 
   for(Entity* entity : mChildEntities)
-    entity->notifyTransformUpdate();
+    entity->dirtyTransform();
 }
 
 //==============================================================================
-void Frame::notifyVelocityUpdate()
+void Frame::dirtyVelocity()
 {
-  notifyAccelerationUpdate(); // Global Acceleration depends on Global Velocity
+  dirtyAcceleration(); // Global Acceleration depends on Global Velocity
 
   // Always trigger the signal, in case a new subscriber has registered in the
   // time since the last signal
@@ -481,11 +481,11 @@ void Frame::notifyVelocityUpdate()
   mNeedVelocityUpdate = true;
 
   for(Entity* entity : mChildEntities)
-    entity->notifyVelocityUpdate();
+    entity->dirtyVelocity();
 }
 
 //==============================================================================
-void Frame::notifyAccelerationUpdate()
+void Frame::dirtyAcceleration()
 {
   // Always trigger the signal, in case a new subscriber has registered in the
   // time since the last signal
@@ -498,7 +498,7 @@ void Frame::notifyAccelerationUpdate()
   mNeedAccelerationUpdate = true;
 
   for(Entity* entity : mChildEntities)
-    entity->notifyAccelerationUpdate();
+    entity->dirtyAcceleration();
 }
 
 //==============================================================================

--- a/dart/dynamics/Frame.hpp
+++ b/dart/dynamics/Frame.hpp
@@ -238,14 +238,16 @@ public:
   /// Returns true if this Frame is the World Frame
   bool isWorld() const;
 
-  /// Notify this Frame and all its children that its pose has changed
-  virtual void notifyTransformUpdate() override;
+  /// Notify the transformation updates of this Frame and all its children are
+  /// needed
+  virtual void dirtyTransform() override;
 
-  /// Notify this Frame and all its children that its velocity has changed
-  virtual void notifyVelocityUpdate() override;
+  /// Notify the velocity updates of this Frame and all its children are needed
+  virtual void dirtyVelocity() override;
 
-  /// Notify this Frame and all its children that its acceleration has changed
-  virtual void notifyAccelerationUpdate() override;
+  /// Notify the acceleration updates of this Frame and all its children are
+  /// needed
+  virtual void dirtyAcceleration() override;
 
 protected:
 

--- a/dart/dynamics/JacobianNode.cpp
+++ b/dart/dynamics/JacobianNode.cpp
@@ -97,6 +97,12 @@ JacobianNode::JacobianNode(BodyNode* bn)
 //==============================================================================
 void JacobianNode::notifyJacobianUpdate()
 {
+  dirtyJacobian();
+}
+
+//==============================================================================
+void JacobianNode::dirtyJacobian()
+{
   // mIsWorldJacobianDirty depends on mIsBodyJacobianDirty, so we only need to
   // check mIsBodyJacobianDirty if we want to terminate.
   if(mIsBodyJacobianDirty)
@@ -106,11 +112,17 @@ void JacobianNode::notifyJacobianUpdate()
   mIsWorldJacobianDirty = true;
 
   for(JacobianNode* child : mChildJacobianNodes)
-    child->notifyJacobianUpdate();
+    child->dirtyJacobian();
 }
 
 //==============================================================================
 void JacobianNode::notifyJacobianDerivUpdate()
+{
+  dirtyJacobianDeriv();
+}
+
+//==============================================================================
+void JacobianNode::dirtyJacobianDeriv()
 {
   // These two flags are independent of each other, so we must check that both
   // are true if we want to terminate early.
@@ -121,7 +133,7 @@ void JacobianNode::notifyJacobianDerivUpdate()
   mIsWorldJacobianClassicDerivDirty = true;
 
   for(JacobianNode* child : mChildJacobianNodes)
-    child->notifyJacobianDerivUpdate();
+    child->dirtyJacobianDeriv();
 }
 
 } // namespace dynamics

--- a/dart/dynamics/JacobianNode.hpp
+++ b/dart/dynamics/JacobianNode.hpp
@@ -263,11 +263,21 @@ public:
 
   /// Notify this BodyNode and all its descendents that their Jacobians need to
   /// be updated.
+  DART_DEPRECATED(6.2)
   void notifyJacobianUpdate();
+
+  /// Notify this BodyNode and all its descendents that their Jacobians need to
+  /// be updated.
+  void dirtyJacobian();
 
   /// Notify this BodyNode and all its descendents that their Jacobian
   /// derivatives need to be updated.
+  DART_DEPRECATED(6.2)
   void notifyJacobianDerivUpdate();
+
+  /// Notify this BodyNode and all its descendents that their Jacobian
+  /// derivatives need to be updated.
+  void dirtyJacobianDeriv();
 
 protected:
 

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -440,7 +440,7 @@ void Joint::setTransformFromParentBodyNode(const Eigen::Isometry3d& _T)
 {
   assert(math::verifyTransform(_T));
   mAspectProperties.mT_ParentBodyToJoint = _T;
-  notifyPositionUpdate();
+  notifyPositionUpdated();
 }
 
 //==============================================================================
@@ -449,7 +449,7 @@ void Joint::setTransformFromChildBodyNode(const Eigen::Isometry3d& _T)
   assert(math::verifyTransform(_T));
   mAspectProperties.mT_ChildBodyToJoint = _T;
   updateRelativeJacobian();
-  notifyPositionUpdate();
+  notifyPositionUpdated();
 }
 
 //==============================================================================
@@ -560,11 +560,17 @@ void Joint::updateArticulatedInertia() const
 //==============================================================================
 void Joint::notifyPositionUpdate()
 {
+  notifyPositionUpdated();
+}
+
+//==============================================================================
+void Joint::notifyPositionUpdated()
+{
   if(mChildBodyNode)
   {
-    mChildBodyNode->notifyTransformUpdate();
-    mChildBodyNode->notifyJacobianUpdate();
-    mChildBodyNode->notifyJacobianDerivUpdate();
+    mChildBodyNode->dirtyTransform();
+    mChildBodyNode->dirtyJacobian();
+    mChildBodyNode->dirtyJacobianDeriv();
   }
 
   mIsRelativeJacobianDirty = true;
@@ -579,7 +585,7 @@ void Joint::notifyPositionUpdate()
   if(skel)
   {
     std::size_t tree = mChildBodyNode->mTreeIndex;
-    skel->notifyArticulatedInertiaUpdate(tree);
+    skel->dirtyArticulatedInertia(tree);
     skel->mTreeCache[tree].mDirty.mExternalForces = true;
     skel->mSkelCache.mDirty.mExternalForces = true;
   }
@@ -588,10 +594,16 @@ void Joint::notifyPositionUpdate()
 //==============================================================================
 void Joint::notifyVelocityUpdate()
 {
+  notifyVelocityUpdated();
+}
+
+//==============================================================================
+void Joint::notifyVelocityUpdated()
+{
   if(mChildBodyNode)
   {
-    mChildBodyNode->notifyVelocityUpdate();
-    mChildBodyNode->notifyJacobianDerivUpdate();
+    mChildBodyNode->dirtyVelocity();
+    mChildBodyNode->dirtyJacobianDeriv();
   }
 
   mIsRelativeJacobianTimeDerivDirty = true;
@@ -603,8 +615,14 @@ void Joint::notifyVelocityUpdate()
 //==============================================================================
 void Joint::notifyAccelerationUpdate()
 {
+  notifyAccelerationUpdated();
+}
+
+//==============================================================================
+void Joint::notifyAccelerationUpdated()
+{
   if(mChildBodyNode)
-    mChildBodyNode->notifyAccelerationUpdate();
+    mChildBodyNode->dirtyAcceleration();
 
   mNeedSpatialAccelerationUpdate = true;
   mNeedPrimaryAccelerationUpdate = true;

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -925,18 +925,22 @@ protected:
   /// True iff this joint's position has changed since the last call to
   /// getRelativeTransform()
   mutable bool mNeedTransformUpdate;
+  // TODO(JS): Rename this to mIsTransformDirty in DART 7
 
   /// True iff this joint's position or velocity has changed since the last call
   /// to getRelativeSpatialVelocity()
   mutable bool mNeedSpatialVelocityUpdate;
+  // TODO(JS): Rename this to mIsSpatialVelocityDirty in DART 7
 
   /// True iff this joint's position, velocity, or acceleration has changed
   /// since the last call to getRelativeSpatialAcceleration()
   mutable bool mNeedSpatialAccelerationUpdate;
+  // TODO(JS): Rename this to mIsSpatialAccelerationDirty in DART 7
 
   /// True iff this joint's position, velocity, or acceleration has changed
   /// since the last call to getRelativePrimaryAcceleration()
   mutable bool mNeedPrimaryAccelerationUpdate;
+  // TODO(JS): Rename this to mIsPrimaryAccelerationDirty in DART 7
 
   /// True iff this joint's relative Jacobian has not been updated since the last
   /// position change

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -634,14 +634,26 @@ public:
   /// \{ \name Update Notifiers
   //----------------------------------------------------------------------------
 
-  /// Notify that a position update is needed
+  /// Notify that a position has updated
+  DART_DEPRECATED(6.2)
   void notifyPositionUpdate();
 
-  /// Notify that a velocity update is needed
+  /// Notify that a position has updated
+  void notifyPositionUpdated();
+
+  /// Notify that a velocity has updated
+  DART_DEPRECATED(6.2)
   void notifyVelocityUpdate();
 
-  /// Notify that an acceleration update is needed
+  /// Notify that a velocity has updated
+  void notifyVelocityUpdated();
+
+  /// Notify that an acceleration has updated
+  DART_DEPRECATED(6.2)
   void notifyAccelerationUpdate();
+
+  /// Notify that an acceleration has updated
+  void notifyAccelerationUpdated();
 
   /// \}
 

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -175,7 +175,7 @@ void MeshShape::update()
 }
 
 //==============================================================================
-void MeshShape::notifyAlphaUpdate(double alpha)
+void MeshShape::notifyAlphaUpdated(double alpha)
 {
   for(std::size_t i=0; i<mMesh->mNumMeshes; ++i)
   {

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -85,7 +85,7 @@ public:
   virtual void update();
 
   // Documentation inherited
-  void notifyAlphaUpdate(double alpha) override;
+  void notifyAlphaUpdated(double alpha) override;
 
   /// \brief
   void setMesh(

--- a/dart/dynamics/PlanarJoint.cpp
+++ b/dart/dynamics/PlanarJoint.cpp
@@ -65,7 +65,7 @@ void PlanarJoint::setProperties(const UniqueProperties& _properties)
 void PlanarJoint::setAspectProperties(const AspectProperties& properties)
 {
   mAspectProperties = properties;
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   updateRelativeJacobian(true);
   Joint::incrementVersion();
 }
@@ -127,7 +127,7 @@ void PlanarJoint::setXYPlane(bool _renameDofs)
 
   if (_renameDofs)
     updateDegreeOfFreedomNames();
-  notifyPositionUpdate();
+  notifyPositionUpdated();
 }
 
 //==============================================================================
@@ -137,7 +137,7 @@ void PlanarJoint::setYZPlane(bool _renameDofs)
 
   if (_renameDofs)
     updateDegreeOfFreedomNames();
-  notifyPositionUpdate();
+  notifyPositionUpdated();
 }
 
 //==============================================================================
@@ -147,7 +147,7 @@ void PlanarJoint::setZXPlane(bool _renameDofs)
 
   if (_renameDofs)
     updateDegreeOfFreedomNames();
-  notifyPositionUpdate();
+  notifyPositionUpdated();
 }
 
 //==============================================================================
@@ -159,7 +159,7 @@ void PlanarJoint::setArbitraryPlane(const Eigen::Vector3d& _transAxis1,
 
   if (_renameDofs)
     updateDegreeOfFreedomNames();
-  notifyPositionUpdate();
+  notifyPositionUpdated();
 }
 
 //==============================================================================

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -170,7 +170,7 @@ PointMass::PointMass(SoftBodyNode* _softBodyNode)
     mNotifier(_softBodyNode->mNotifier)
 {
   assert(mParentSoftBodyNode != nullptr);
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================
@@ -316,7 +316,7 @@ void PointMass::setPosition(std::size_t _index, double _position)
   assert(_index < 3);
 
   getState().mPositions[_index] = _position;
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================
@@ -331,7 +331,7 @@ double PointMass::getPosition(std::size_t _index) const
 void PointMass::setPositions(const Vector3d& _positions)
 {
   getState().mPositions = _positions;
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================
@@ -344,7 +344,7 @@ const Vector3d& PointMass::getPositions() const
 void PointMass::resetPositions()
 {
   getState().mPositions.setZero();
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================
@@ -353,7 +353,7 @@ void PointMass::setVelocity(std::size_t _index, double _velocity)
   assert(_index < 3);
 
   getState().mVelocities[_index] = _velocity;
-  mNotifier->notifyVelocityUpdate();
+  mNotifier->dirtyVelocity();
 }
 
 //==============================================================================
@@ -368,7 +368,7 @@ double PointMass::getVelocity(std::size_t _index) const
 void PointMass::setVelocities(const Vector3d& _velocities)
 {
   getState().mVelocities = _velocities;
-  mNotifier->notifyVelocityUpdate();
+  mNotifier->dirtyVelocity();
 }
 
 //==============================================================================
@@ -381,7 +381,7 @@ const Vector3d& PointMass::getVelocities() const
 void PointMass::resetVelocities()
 {
   getState().mVelocities.setZero();
-  mNotifier->notifyVelocityUpdate();
+  mNotifier->dirtyVelocity();
 }
 
 //==============================================================================
@@ -390,7 +390,7 @@ void PointMass::setAcceleration(std::size_t _index, double _acceleration)
   assert(_index < 3);
 
   getState().mAccelerations[_index] = _acceleration;
-  mNotifier->notifyAccelerationUpdate();
+  mNotifier->dirtyAcceleration();
 }
 
 //==============================================================================
@@ -405,7 +405,7 @@ double PointMass::getAcceleration(std::size_t _index) const
 void PointMass::setAccelerations(const Eigen::Vector3d& _accelerations)
 {
   getState().mAccelerations = _accelerations;
-  mNotifier->notifyAccelerationUpdate();
+  mNotifier->dirtyAcceleration();
 }
 
 //==============================================================================
@@ -426,7 +426,7 @@ const Vector3d& PointMass::getPartialAccelerations() const
 void PointMass::resetAccelerations()
 {
   getState().mAccelerations.setZero();
-  mNotifier->notifyAccelerationUpdate();
+  mNotifier->dirtyAcceleration();
 }
 
 //==============================================================================
@@ -600,7 +600,7 @@ void PointMass::setRestingPosition(const Eigen::Vector3d& _p)
 
   mRest = _p;
   mParentSoftBodyNode->incrementVersion();
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================
@@ -1116,29 +1116,29 @@ void PointMassNotifier::clearAccelerationNotice()
 }
 
 //==============================================================================
-void PointMassNotifier::notifyTransformUpdate()
+void PointMassNotifier::dirtyTransform()
 {
   mNeedTransformUpdate = true;
   mNeedVelocityUpdate = true;
   mNeedPartialAccelerationUpdate = true;
   mNeedAccelerationUpdate = true;
 
-  mParentSoftBodyNode->notifyArticulatedInertiaUpdate();
-  mParentSoftBodyNode->notifyExternalForcesUpdate();
+  mParentSoftBodyNode->dirtyArticulatedInertia();
+  mParentSoftBodyNode->dirtyExternalForces();
 }
 
 //==============================================================================
-void PointMassNotifier::notifyVelocityUpdate()
+void PointMassNotifier::dirtyVelocity()
 {
   mNeedVelocityUpdate = true;
   mNeedPartialAccelerationUpdate = true;
   mNeedAccelerationUpdate = true;
 
-  mParentSoftBodyNode->notifyCoriolisUpdate();
+  mParentSoftBodyNode->dirtyCoriolisForces();
 }
 
 //==============================================================================
-void PointMassNotifier::notifyAccelerationUpdate()
+void PointMassNotifier::dirtyAcceleration()
 {
   mNeedAccelerationUpdate = true;
 }

--- a/dart/dynamics/PointMass.hpp
+++ b/dart/dynamics/PointMass.hpp
@@ -700,6 +700,7 @@ protected:
   std::string mName;
 
   bool mNeedPartialAccelerationUpdate;
+  // TODO(JS): Rename this to mIsPartialAccelerationDirty in DART 7
 
   SoftBodyNode* mParentSoftBodyNode;
 

--- a/dart/dynamics/PointMass.hpp
+++ b/dart/dynamics/PointMass.hpp
@@ -685,9 +685,9 @@ public:
   void clearPartialAccelerationNotice();
   void clearAccelerationNotice();
 
-  void notifyTransformUpdate() override;
-  void notifyVelocityUpdate() override;
-  void notifyAccelerationUpdate() override;
+  void dirtyTransform() override;
+  void dirtyVelocity() override;
+  void dirtyAcceleration() override;
 
   // Documentation inherited
   const std::string& setName(const std::string& _name) override;

--- a/dart/dynamics/PrismaticJoint.cpp
+++ b/dart/dynamics/PrismaticJoint.cpp
@@ -123,7 +123,7 @@ void PrismaticJoint::setAxis(const Eigen::Vector3d& _axis)
     return;
 
   mAspectProperties.mAxis = _axis.normalized();
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   updateRelativeJacobian();
   Joint::incrementVersion();
 }

--- a/dart/dynamics/RevoluteJoint.cpp
+++ b/dart/dynamics/RevoluteJoint.cpp
@@ -124,7 +124,7 @@ void RevoluteJoint::setAxis(const Eigen::Vector3d& _axis)
     return;
 
   mAspectProperties.mAxis = _axis.normalized();
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   updateRelativeJacobian();
   Joint::incrementVersion();
 }

--- a/dart/dynamics/ScrewJoint.cpp
+++ b/dart/dynamics/ScrewJoint.cpp
@@ -124,7 +124,7 @@ void ScrewJoint::setAxis(const Eigen::Vector3d& _axis)
     return;
 
   mAspectProperties.mAxis = _axis.normalized();
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   updateRelativeJacobian();
   Joint::incrementVersion();
 }
@@ -142,7 +142,7 @@ void ScrewJoint::setPitch(double _pitch)
     return;
 
   mAspectProperties.mPitch = _pitch;
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   updateRelativeJacobian();
   Joint::incrementVersion();
 }

--- a/dart/dynamics/Shape.cpp
+++ b/dart/dynamics/Shape.cpp
@@ -142,13 +142,25 @@ void Shape::refreshData()
 }
 
 //==============================================================================
-void Shape::notifyAlphaUpdate(double /*alpha*/)
+void Shape::notifyAlphaUpdate(double alpha)
+{
+  notifyAlphaUpdated(alpha);
+}
+
+//==============================================================================
+void Shape::notifyAlphaUpdated(double /*alpha*/)
 {
   // Do nothing
 }
 
 //==============================================================================
-void Shape::notifyColorUpdate(const Eigen::Vector4d& /*color*/)
+void Shape::notifyColorUpdate(const Eigen::Vector4d& color)
+{
+  notifyColorUpdated(color);
+}
+
+//==============================================================================
+void Shape::notifyColorUpdated(const Eigen::Vector4d& /*color*/)
 {
   // Do nothing
 }

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -152,10 +152,18 @@ public:
   virtual void refreshData();
 
   /// Notify that the alpha of this shape has updated
+  DART_DEPRECATED(6.2)
   virtual void notifyAlphaUpdate(double alpha);
 
+  /// Notify that the alpha of this shape has updated
+  virtual void notifyAlphaUpdated(double alpha);
+
   /// Notify that the color (rgba) of this shape has updated
+  DART_DEPRECATED(6.2)
   virtual void notifyColorUpdate(const Eigen::Vector4d& color);
+
+  /// Notify that the color (rgba) of this shape has updated
+  virtual void notifyColorUpdated(const Eigen::Vector4d& color);
 
 protected:
 

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -85,9 +85,9 @@ void VisualAspect::setRGBA(const Eigen::Vector4d& color)
 {
   mProperties.mRGBA = color;
 
-  notifyPropertiesUpdate();
+  notifyPropertiesUpdated();
 
-  mComposite->getShape()->notifyColorUpdate(color);
+  mComposite->getShape()->notifyColorUpdated(color);
 }
 
 //==============================================================================
@@ -116,9 +116,9 @@ void VisualAspect::setAlpha(const double alpha)
 {
   mProperties.mRGBA[3] = alpha;
 
-  notifyPropertiesUpdate();
+  notifyPropertiesUpdated();
 
-  mComposite->getShape()->notifyAlphaUpdate(alpha);
+  mComposite->getShape()->notifyAlphaUpdated(alpha);
 }
 
 //==============================================================================

--- a/dart/dynamics/ShapeNode.cpp
+++ b/dart/dynamics/ShapeNode.cpp
@@ -81,8 +81,8 @@ void ShapeNode::setRelativeTransform(const Eigen::Isometry3d& transform)
   const Eigen::Isometry3d oldTransform = getRelativeTransform();
 
   FixedFrame::setRelativeTransform(transform);
-  notifyJacobianUpdate();
-  notifyJacobianDerivUpdate();
+  dirtyJacobian();
+  dirtyJacobianDeriv();
 
   mRelativeTransformUpdatedSignal.raise(
         this, oldTransform, getRelativeTransform());

--- a/dart/dynamics/SimpleFrame.cpp
+++ b/dart/dynamics/SimpleFrame.cpp
@@ -159,21 +159,21 @@ void SimpleFrame::setRelativeTransform(
     const Eigen::Isometry3d& _newRelTransform)
 {
   mRelativeTf = _newRelTransform;
-  notifyTransformUpdate();
+  dirtyTransform();
 }
 
 //==============================================================================
 void SimpleFrame::setRelativeTranslation(const Eigen::Vector3d& _newTranslation)
 {
   mRelativeTf.translation() = _newTranslation;
-  notifyTransformUpdate();
+  dirtyTransform();
 }
 
 //==============================================================================
 void SimpleFrame::setRelativeRotation(const Eigen::Matrix3d& _newRotation)
 {
   mRelativeTf.linear() = _newRotation;
-  notifyTransformUpdate();
+  dirtyTransform();
 }
 
 //==============================================================================
@@ -212,7 +212,7 @@ void SimpleFrame::setRelativeSpatialVelocity(
     const Eigen::Vector6d& _newSpatialVelocity)
 {
   mRelativeVelocity = _newSpatialVelocity;
-  notifyVelocityUpdate();
+  dirtyVelocity();
 }
 
 //==============================================================================
@@ -237,7 +237,7 @@ void SimpleFrame::setRelativeSpatialAcceleration(
     const Eigen::Vector6d &_newSpatialAcceleration)
 {
   mRelativeAcceleration = _newSpatialAcceleration;
-  notifyAccelerationUpdate();
+  dirtyAcceleration();
 }
 
 //==============================================================================

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -719,7 +719,7 @@ void Skeleton::setTimeStep(double _timeStep)
   mAspectProperties.mTimeStep = _timeStep;
 
   for(std::size_t i=0; i<mTreeCache.size(); ++i)
-    notifyArticulatedInertiaUpdate(i);
+    dirtyArticulatedInertia(i);
 }
 
 //==============================================================================
@@ -734,7 +734,7 @@ void Skeleton::setGravity(const Eigen::Vector3d& _gravity)
   mAspectProperties.mGravity = _gravity;
   SET_ALL_FLAGS(mGravityForces);
   SET_ALL_FLAGS(mCoriolisAndGravityForces);
-  ON_ALL_TREES(notifySupportUpdate);
+  ON_ALL_TREES(dirtySupportPolygon);
 }
 
 //==============================================================================
@@ -2557,7 +2557,7 @@ void Skeleton::updateCacheDimensions(std::size_t _treeIdx)
   updateCacheDimensions(mTreeCache[_treeIdx]);
   updateCacheDimensions(mSkelCache);
 
-  notifyArticulatedInertiaUpdate(_treeIdx);
+  dirtyArticulatedInertia(_treeIdx);
 }
 
 //==============================================================================
@@ -3492,6 +3492,12 @@ void Skeleton::clearInternalForces()
 //==============================================================================
 void Skeleton::notifyArticulatedInertiaUpdate(std::size_t _treeIdx)
 {
+  dirtyArticulatedInertia(_treeIdx);
+}
+
+//==============================================================================
+void Skeleton::dirtyArticulatedInertia(std::size_t _treeIdx)
+{
   SET_FLAG(_treeIdx, mArticulatedInertia);
   SET_FLAG(_treeIdx, mMassMatrix);
   SET_FLAG(_treeIdx, mAugMassMatrix);
@@ -3504,6 +3510,12 @@ void Skeleton::notifyArticulatedInertiaUpdate(std::size_t _treeIdx)
 
 //==============================================================================
 void Skeleton::notifySupportUpdate(std::size_t _treeIdx)
+{
+  dirtySupportPolygon(_treeIdx);
+}
+
+//==============================================================================
+void Skeleton::dirtySupportPolygon(std::size_t _treeIdx)
 {
   SET_FLAG(_treeIdx, mSupport);
 }

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -814,10 +814,19 @@ public:
 
   /// Notify that the articulated inertia and everything that depends on it
   /// needs to be updated
+  DART_DEPRECATED(6.2)
   void notifyArticulatedInertiaUpdate(std::size_t _treeIdx);
 
+  /// Notify that the articulated inertia and everything that depends on it
+  /// needs to be updated
+  void dirtyArticulatedInertia(std::size_t _treeIdx);
+
   /// Notify that the support polygon of a tree needs to be updated
+  DART_DEPRECATED(6.2)
   void notifySupportUpdate(std::size_t _treeIdx);
+
+  /// Notify that the support polygon of a tree needs to be updated
+  void dirtySupportPolygon(std::size_t _treeIdx);
 
   // Documentation inherited
   double computeKineticEnergy() const override;

--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -160,7 +160,7 @@ void SoftBodyNode::setAspectState(const AspectState& state)
     return;
 
   mAspectState = state;
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================
@@ -259,7 +259,7 @@ SoftBodyNode::SoftBodyNode(BodyNode* _parentBodyNode,
   // called on this BodyNode, but that happens after construction is finished.
   mAspectProperties = _properties;
   configurePointMasses(softNode);
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================
@@ -335,7 +335,7 @@ void SoftBodyNode::configurePointMasses(ShapeNode* softNode)
   }
 
   incrementVersion();
-  mNotifier->notifyTransformUpdate();
+  mNotifier->dirtyTransform();
 }
 
 //==============================================================================

--- a/dart/dynamics/UniversalJoint.cpp
+++ b/dart/dynamics/UniversalJoint.cpp
@@ -121,7 +121,7 @@ bool UniversalJoint::isCyclic(std::size_t _index) const
 void UniversalJoint::setAxis1(const Eigen::Vector3d& _axis)
 {
   mAspectProperties.mAxis[0] = _axis;
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   Joint::incrementVersion();
 }
 
@@ -129,7 +129,7 @@ void UniversalJoint::setAxis1(const Eigen::Vector3d& _axis)
 void UniversalJoint::setAxis2(const Eigen::Vector3d& _axis)
 {
   mAspectProperties.mAxis[1] = _axis;
-  Joint::notifyPositionUpdate();
+  Joint::notifyPositionUpdated();
   Joint::incrementVersion();
 }
 

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -477,7 +477,7 @@ void GenericJoint<ConfigSpaceT>::setPosition(size_t index, double position)
 
   // Note: It would not make much sense to use setPositionsStatic() here
   this->mAspectState.mPositions[index] = position;
-  this->notifyPositionUpdate();
+  this->notifyPositionUpdated();
 }
 
 //==============================================================================
@@ -658,7 +658,7 @@ void GenericJoint<ConfigSpaceT>::setPositionsStatic(const Vector& positions)
     return;
 
   this->mAspectState.mPositions = positions;
-  this->notifyPositionUpdate();
+  this->notifyPositionUpdated();
 }
 
 //==============================================================================
@@ -678,7 +678,7 @@ void GenericJoint<ConfigSpaceT>::setVelocitiesStatic(
     return;
 
   this->mAspectState.mVelocities = velocities;
-  this->notifyVelocityUpdate();
+  this->notifyVelocityUpdated();
 }
 
 //==============================================================================
@@ -697,7 +697,7 @@ void GenericJoint<ConfigSpaceT>::setAccelerationsStatic(const Vector& accels)
     return;
 
   this->mAspectState.mAccelerations = accels;
-  this->notifyAccelerationUpdate();
+  this->notifyAccelerationUpdated();
 }
 
 //==============================================================================
@@ -723,7 +723,7 @@ void GenericJoint<ConfigSpaceT>::setVelocity(size_t index, double velocity)
 
   // Note: It would not make much sense to use setVelocitiesStatic() here
   this->mAspectState.mVelocities[index] = velocity;
-  this->notifyVelocityUpdate();
+  this->notifyVelocityUpdated();
 
   if (Joint::mAspectProperties.mActuatorType == Joint::VELOCITY)
     this->mAspectState.mCommands[index] = this->getVelocitiesStatic()[index];
@@ -905,7 +905,7 @@ void GenericJoint<ConfigSpaceT>::setAcceleration(
 
   // Note: It would not make much sense to use setAccelerationsStatic() here
   this->mAspectState.mAccelerations[index] = acceleration;
-  this->notifyAccelerationUpdate();
+  this->notifyAccelerationUpdated();
 
   if (Joint::mAspectProperties.mActuatorType == Joint::ACCELERATION)
     this->mAspectState.mCommands[index] = this->getAccelerationsStatic()[index];


### PR DESCRIPTION
This PR renames the member functions of lazy evaluation mechanics properly as suggested in #816.

#814 will be addressed in the next major release since it introduces API breaks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/833)
<!-- Reviewable:end -->
