### PR TITLE
correct the right retriever in getRetriever function

### DIFF
--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -2409,8 +2409,7 @@ common::ResourceRetrieverPtr getRetriever(
           "file", std::make_shared<common::LocalResourceRetriever>());
     newRetriever->addSchemaRetriever(
           "dart", DartResourceRetriever::create());
-
-    return DartResourceRetriever::create();
+    return newRetriever;
   }
 }
 


### PR DESCRIPTION
A quick bug fix for file:// URI in SkelParser

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/847)
<!-- Reviewable:end -->
