### PR TITLE
Fixes for Issues #838 and #676

### DIFF
--- a/dart/gui/osg/ShapeFrameNode.cpp
+++ b/dart/gui/osg/ShapeFrameNode.cpp
@@ -75,7 +75,7 @@ ShapeFrameNode::ShapeFrameNode(
     WorldNode* _worldNode)
   : mShapeFrame(_frame),
     mWorldNode(_worldNode),
-    mShapeNode(nullptr),
+    mRenderShapeNode(nullptr),
     mUtilized(false)
 {
   refresh();
@@ -120,8 +120,15 @@ void ShapeFrameNode::refresh(bool shortCircuitIfUtilized)
   // TODO(JS): Maybe the data varicance information should be in ShapeFrame and
   // checked here.
 
-  if(shape)
+  if(shape && mShapeFrame->getVisualAspect())
+  {
     refreshShapeNode(shape);
+  }
+  else if(mRenderShapeNode)
+  {
+    removeChild(mRenderShapeNode->getNode());
+    mRenderShapeNode = nullptr;
+  }
 }
 
 //==============================================================================
@@ -146,9 +153,9 @@ ShapeFrameNode::~ShapeFrameNode()
 void ShapeFrameNode::refreshShapeNode(
     const std::shared_ptr<dart::dynamics::Shape>& shape)
 {
-  if(mShapeNode && mShapeNode->getShape() == shape)
+  if(mRenderShapeNode && mRenderShapeNode->getShape() == shape)
   {
-    mShapeNode->refresh();
+    mRenderShapeNode->refresh();
     return;
   }
 
@@ -171,10 +178,10 @@ void ShapeFrameNode::createShapeNode(
     const std::shared_ptr<dart::dynamics::Shape>& shape)
 {
   using namespace dart::dynamics;
-  if(mShapeNode)
-    removeChild(mShapeNode->getNode());
+  if(mRenderShapeNode)
+    removeChild(mRenderShapeNode->getNode());
 
-  mShapeNode = nullptr;
+  mRenderShapeNode = nullptr;
 
   const auto& shapeType = shape->getType();
 
@@ -183,7 +190,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<SphereShape> es =
         std::dynamic_pointer_cast<SphereShape>(shape);
     if(es)
-      mShapeNode = new render::SphereShapeNode(es, this);
+      mRenderShapeNode = new render::SphereShapeNode(es, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -192,7 +199,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<BoxShape> bs =
         std::dynamic_pointer_cast<BoxShape>(shape);
     if(bs)
-      mShapeNode = new render::BoxShapeNode(bs, this);
+      mRenderShapeNode = new render::BoxShapeNode(bs, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -201,7 +208,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<EllipsoidShape> es =
         std::dynamic_pointer_cast<EllipsoidShape>(shape);
     if(es)
-      mShapeNode = new render::EllipsoidShapeNode(es, this);
+      mRenderShapeNode = new render::EllipsoidShapeNode(es, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -210,7 +217,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<CylinderShape> cs =
         std::dynamic_pointer_cast<CylinderShape>(shape);
     if(cs)
-      mShapeNode = new render::CylinderShapeNode(cs, this);
+      mRenderShapeNode = new render::CylinderShapeNode(cs, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -219,7 +226,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<CapsuleShape> cs =
         std::dynamic_pointer_cast<CapsuleShape>(shape);
     if(cs)
-      mShapeNode = new render::CapsuleShapeNode(cs, this);
+      mRenderShapeNode = new render::CapsuleShapeNode(cs, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -228,7 +235,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<ConeShape> cs =
         std::dynamic_pointer_cast<ConeShape>(shape);
     if(cs)
-      mShapeNode = new render::ConeShapeNode(cs, this);
+      mRenderShapeNode = new render::ConeShapeNode(cs, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -237,7 +244,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<PlaneShape> ps =
         std::dynamic_pointer_cast<PlaneShape>(shape);
     if(ps)
-      mShapeNode = new render::PlaneShapeNode(ps, this);
+      mRenderShapeNode = new render::PlaneShapeNode(ps, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -246,7 +253,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<MultiSphereShape> ms =
         std::dynamic_pointer_cast<MultiSphereShape>(shape);
     if(ms)
-      mShapeNode = new render::MultiSphereShapeNode(ms, this);
+      mRenderShapeNode = new render::MultiSphereShapeNode(ms, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -255,7 +262,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<MeshShape> ms =
         std::dynamic_pointer_cast<MeshShape>(shape);
     if(ms)
-      mShapeNode = new render::MeshShapeNode(ms, this);
+      mRenderShapeNode = new render::MeshShapeNode(ms, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -264,7 +271,7 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<SoftMeshShape> sms =
         std::dynamic_pointer_cast<SoftMeshShape>(shape);
     if(sms)
-      mShapeNode = new render::SoftMeshShapeNode(sms, this);
+      mRenderShapeNode = new render::SoftMeshShapeNode(sms, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
@@ -273,19 +280,19 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<LineSegmentShape> lss =
         std::dynamic_pointer_cast<LineSegmentShape>(shape);
     if(lss)
-      mShapeNode = new render::LineSegmentShapeNode(lss, this);
+      mRenderShapeNode = new render::LineSegmentShapeNode(lss, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
   else
   {
-    mShapeNode = new render::WarningShapeNode(shape, this);
+    mRenderShapeNode = new render::WarningShapeNode(shape, this);
   }
 
-  if(nullptr == mShapeNode)
+  if(nullptr == mRenderShapeNode)
     return;
 
-  addChild(mShapeNode->getNode());
+  addChild(mRenderShapeNode->getNode());
 }
 
 } // namespace osg

--- a/dart/gui/osg/ShapeFrameNode.hpp
+++ b/dart/gui/osg/ShapeFrameNode.hpp
@@ -99,7 +99,7 @@ protected:
   /// Pointer to the WorldNode that this ShapeFrameNode belongs to
   WorldNode* mWorldNode;
 
-  render::ShapeNode* mShapeNode;
+  render::ShapeNode* mRenderShapeNode;
 
   /// True iff this ShapeFrameNode has been utilized on the latest update.
   /// If it has not, that is an indication that it is no longer being

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -541,6 +541,8 @@ void MeshShapeGeometry::extractData(bool firstTime)
     if(mNormals->size() != mAiMesh->mNumVertices)
       mNormals->resize(mAiMesh->mNumVertices);
 
+    const Eigen::Vector3d s = mMeshShape->getScale();
+
     for(std::size_t i=0; i<mAiMesh->mNumVertices; ++i)
     {
       const aiVector3D& v = mAiMesh->mVertices[i];
@@ -549,7 +551,7 @@ void MeshShapeGeometry::extractData(bool firstTime)
       if(mAiMesh->mNormals)
       {
         const aiVector3D& n = mAiMesh->mNormals[i];
-        (*mNormals)[i] = ::osg::Vec3(n.x, n.y, n.z);
+        (*mNormals)[i] = ::osg::Vec3(n.x*s[0], n.y*s[1], n.z*s[2]);
       }
       // TODO(MXG): Consider computing normals for meshes that don't come with
       // normal data per vertex

--- a/dart/gui/osg/render/ShapeNode.cpp
+++ b/dart/gui/osg/render/ShapeNode.cpp
@@ -47,7 +47,8 @@ ShapeNode::ShapeNode(std::shared_ptr<dart::dynamics::Shape> shape,
     mUtilized(true)
 {
   mShapeFrame = mParentShapeFrameNode->getShapeFrame();
-  mVisualAspect = mShapeFrame->getVisualAspect(true);
+  mVisualAspect = mShapeFrame->getVisualAspect();
+  assert(mVisualAspect);
 }
 
 //==============================================================================

--- a/dart/utils/urdf/DartLoader.hpp
+++ b/dart/utils/urdf/DartLoader.hpp
@@ -131,6 +131,7 @@ private:
       const common::ResourceRetrieverPtr& _resourceRetriever);
 
     static bool createSkeletonRecursive(
+      const urdf::ModelInterface* model,
       dynamics::SkeletonPtr _skel,
       const urdf::Link* _lk,
       dynamics::BodyNode* _parent,
@@ -157,6 +158,7 @@ private:
       const common::ResourceRetrieverPtr& _resourceRetriever);
 
     static bool createShapeNodes(
+      const urdf::ModelInterface* model,
       const urdf::Link* lk,
       dynamics::BodyNode* bodyNode,
       const common::Uri& baseUri,

--- a/data/urdf/test/issue838.urdf
+++ b/data/urdf/test/issue838.urdf
@@ -12,26 +12,12 @@
     <color rgba="1 1 0 1"/>
   </material>
 
-  <link name="base_link">
+  <link name="link_0">
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <mass value="10.0"/>
       <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
     </inertial>
-  </link>
-  <joint name="base_link_arm_base" type="fixed">
-    <parent link="base_link"/>
-    <child link="arm_base"/>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-  </joint>
-  <link name="arm_base"/>
-  <joint name="arm_base_arm_0" type="fixed">
-    <parent link="arm_base"/>
-    <child link="arm_0"/>
-    <origin xyz="0 0 0"/>
-  </joint>
-  <link name="arm_0">
-    <!-- L54-30-S500 -->
     <visual>
       <origin rpy="0 0 0" xyz="0 0 -0.087"/>
       <geometry>
@@ -47,55 +33,41 @@
       <material name="Blue"/>
     </visual>
   </link>
-  <joint name="arm_0_1" type="revolute">
-    <parent link="arm_0"/>
-    <child link="arm_1"/>
+  <joint name="0_to_1" type="fixed">
+    <parent link="link_0"/>
+    <child link="link_1"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+  </joint>
+  <link name="link_1">
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 -0.087"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Red"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Red"/>
+    </visual>
+  </link>
+  <joint name="1_to_2" type="revolute">
+    <parent link="link_1"/>
+    <child link="link_2"/>
     <limit effort="2.5" lower="-3.14159265359" upper="3.14159265359" velocity="3.00545697193"/>
     <origin rpy="0 0 0" xyz="0 0 0"/>
     <axis xyz="0 0 1"/>
   </joint>
-  <link name="arm_1">
+  <link name="link_2">
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <mass value="0.855"/>
       <inertia ixx="0.001449225" ixy="0" ixz="0" iyy="0.00041553" iyz="0" izz="0.001449225"/>
     </inertial>
     <visual>
-      <origin xyz="0 -0.066 0"/>
-      <geometry>
-        <box size="1 1 1"/>
-      </geometry>
-      <material name="Red"/>
-    </visual>
-    <visual>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="1 1 1"/>
-      </geometry>
-      <material name="Red"/>
-    </visual>
-  </link>
-  <joint name="arm_1_2" type="revolute">
-    <parent link="arm_1"/>
-    <child link="arm_2"/>
-    <limit effort="44.7" lower="-1.80159265359" upper="1.79840734641" velocity="3.46622389446"/>
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-    <axis xyz="0 0 1"/>
-  </joint>
-  <link name="arm_2">
-    <visual>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <box size="1 1 1"/>
-      </geometry>
-      <material name="Green"/>
-    </visual>
-    <inertial>
-      <origin rpy="0 0 0" xyz="0.141 0 0"/>
-      <mass value="0.2484"/>
-      <inertia ixx="6.624e-05" ixy="0" ixz="0" iyy="0.0007038" iyz="0" izz="0.0007038"/>
-    </inertial>
-    <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
         <box size="1 1 1"/>
@@ -110,4 +82,5 @@
       <material name="Yellow"/>
     </visual>
   </link>
+  
 </robot>

--- a/data/urdf/test/issue838.urdf
+++ b/data/urdf/test/issue838.urdf
@@ -1,0 +1,113 @@
+<?xml version="1.0" ?>
+
+<robot name="issue838">
+  <!-- end of arm links/joints -->
+  <material name="Blue">
+    <color rgba="0 0 0.8 1"/>
+  </material>
+  <material name="Red">
+    <color rgba="1 0 0 1"/>
+  </material>
+  <material name="Yellow">
+    <color rgba="1 1 0 1"/>
+  </material>
+
+  <link name="base_link">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="10.0"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+  </link>
+  <joint name="base_link_arm_base" type="fixed">
+    <parent link="base_link"/>
+    <child link="arm_base"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+  </joint>
+  <link name="arm_base"/>
+  <joint name="arm_base_arm_0" type="fixed">
+    <parent link="arm_base"/>
+    <child link="arm_0"/>
+    <origin xyz="0 0 0"/>
+  </joint>
+  <link name="arm_0">
+    <!-- L54-30-S500 -->
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 -0.087"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Blue"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Blue"/>
+    </visual>
+  </link>
+  <joint name="arm_0_1" type="revolute">
+    <parent link="arm_0"/>
+    <child link="arm_1"/>
+    <limit effort="2.5" lower="-3.14159265359" upper="3.14159265359" velocity="3.00545697193"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <axis xyz="0 0 1"/>
+  </joint>
+  <link name="arm_1">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.855"/>
+      <inertia ixx="0.001449225" ixy="0" ixz="0" iyy="0.00041553" iyz="0" izz="0.001449225"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 -0.066 0"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Red"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Red"/>
+    </visual>
+  </link>
+  <joint name="arm_1_2" type="revolute">
+    <parent link="arm_1"/>
+    <child link="arm_2"/>
+    <limit effort="44.7" lower="-1.80159265359" upper="1.79840734641" velocity="3.46622389446"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <axis xyz="0 0 1"/>
+  </joint>
+  <link name="arm_2">
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Green"/>
+    </visual>
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.141 0 0"/>
+      <mass value="0.2484"/>
+      <inertia ixx="6.624e-05" ixy="0" ixz="0" iyy="0.0007038" iyz="0" izz="0.0007038"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Yellow"/>
+    </visual>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="1 1 1"/>
+      </geometry>
+      <material name="Yellow"/>
+    </visual>
+  </link>
+</robot>

--- a/data/urdf/test/issue838.urdf
+++ b/data/urdf/test/issue838.urdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <robot name="issue838">
-  <!-- end of arm links/joints -->
+
   <material name="Blue">
     <color rgba="0 0 0.8 1"/>
   </material>

--- a/examples/osgExamples/osgEmpty/osgEmpty.cpp
+++ b/examples/osgExamples/osgEmpty/osgEmpty.cpp
@@ -31,7 +31,6 @@
 
 #include <dart/dart.hpp>
 #include <dart/gui/osg/osg.hpp>
-#include <dart/utils/urdf/DartLoader.hpp>
 
 //==============================================================================
 class CustomWorldNode : public dart::gui::osg::WorldNode

--- a/examples/osgExamples/osgEmpty/osgEmpty.cpp
+++ b/examples/osgExamples/osgEmpty/osgEmpty.cpp
@@ -31,6 +31,7 @@
 
 #include <dart/dart.hpp>
 #include <dart/gui/osg/osg.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
 
 //==============================================================================
 class CustomWorldNode : public dart::gui::osg::WorldNode

--- a/unittests/regression/CMakeLists.txt
+++ b/unittests/regression/CMakeLists.txt
@@ -1,1 +1,8 @@
 dart_add_test("regression" test_Issue000Template test_Issue000Template.cpp)
+
+if(TARGET dart-utils-urdf)
+
+  dart_add_test("regression" test_Issue838)
+  target_link_libraries(test_Issue838 dart-utils-urdf)
+
+endif()

--- a/unittests/regression/test_Issue838.cpp
+++ b/unittests/regression/test_Issue838.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <TestHelpers.hpp>
+#include <dart/dart.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
+
+//==============================================================================
+TEST(Issue838, MaterialParsing)
+{
+  dart::utils::DartLoader loader;
+  dart::dynamics::SkeletonPtr skeleton =
+      loader.parseSkeleton("dart://sample/urdf/test/testWorld.urdf");
+  EXPECT_TRUE(nullptr != skeleton);
+
+  std::vector<Eigen::Vector4d> colors = {
+    Eigen::Vector4d(0.0, 0.0, 0.8, 1.0),
+    Eigen::Vector4d(1.0, 0.0, 0.0, 1.0),
+    Eigen::Vector4d(1.0, 1.0, 0.0, 1.0)
+  };
+
+  EXPECT_EQ(colors.size(), skeleton->getNumBodyNodes());
+
+  for(size_t i=0; i < skeleton->getNumBodyNodes(); ++i)
+  {
+    const Eigen::Vector4d c = colors[i];
+    const dart::dynamics::BodyNode* bn = skeleton->getBodyNode(i);
+    for(size_t j=0; j < bn->getNumShapeNodes(); ++j)
+    {
+      const dart::dynamics::ShapeNode* sn = bn->getShapeNode(j);
+      EXPECT_TRUE(equals(sn->getVisualAspect()->getRGBA(), c));
+    }
+  }
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittests/regression/test_Issue838.cpp
+++ b/unittests/regression/test_Issue838.cpp
@@ -38,14 +38,13 @@ TEST(Issue838, MaterialParsing)
 {
   dart::utils::DartLoader loader;
   dart::dynamics::SkeletonPtr skeleton =
-      loader.parseSkeleton("dart://sample/urdf/test/testWorld.urdf");
+      loader.parseSkeleton("dart://sample/urdf/test/issue838.urdf");
   EXPECT_TRUE(nullptr != skeleton);
 
-  std::vector<Eigen::Vector4d> colors = {
-    Eigen::Vector4d(0.0, 0.0, 0.8, 1.0),
-    Eigen::Vector4d(1.0, 0.0, 0.0, 1.0),
-    Eigen::Vector4d(1.0, 1.0, 0.0, 1.0)
-  };
+  std::vector<Eigen::Vector4d> colors;
+  colors.push_back(Eigen::Vector4d(0.0, 0.0, 0.8, 1.0));
+  colors.push_back(Eigen::Vector4d(1.0, 0.0, 0.0, 1.0));
+  colors.push_back(Eigen::Vector4d(1.0, 1.0, 0.0, 1.0));
 
   EXPECT_EQ(colors.size(), skeleton->getNumBodyNodes());
 


### PR DESCRIPTION
This pull request fixes the issues brought to light in issues #838 and #676. There are three specific bugs being fixed here:

1. urdfdom has some strange behavior where it treats the first entry in ``Link::visual_array`` differently from the rest with respect to its material information. If a material for a visual is defined globally in the urdf file, the first entry in ``Link::visual_array`` will be correctly linked to it, but none of the other entries will. This issue is discussed in more detail [here](https://github.com/dartsim/dart/issues/838#issuecomment-284209519). This pull request fixes the issue on DART's end with a bit of post-processing.

2. When the ``MeshShape::mScale`` is anything other than Eigen::Vector3d::One(), the normal vectors that are used in the OSG extension also get scaled, which produces incorrect coloring results. This pull request counteracts the scaling to make the coloring normal.

3. It was reported back in #676 that collision shapes were unintentionally getting rendered in OSG. While working on the other issues, I realized a solution to that problem, and it is also in this pull request.

There is a regression test for problem (1). Issues (2) and (3) are visual problems, so I can't think of a straightforward way to regression test them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dartsim/dart/851)
<!-- Reviewable:end -->
