### PR TITLE
Add ODE collision detector

### DIFF
--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -9,6 +9,7 @@ cmake
 assimp
 fcl
 bullet
+ode
 flann
 boost
 eigen

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,4 +1,4 @@
-if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$COMPILER" = "CLANG" ]; then exit; fi
+if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$COMPILER" = "CLANG" ]; then exit; fi
 
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DDART_VERBOSE=ON -DDART_TREAT_WARNINGS_AS_ERRORS=ON -DDART_COVERALLS=$COVERALLS ..

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -186,7 +186,7 @@ else()
 endif()
 
 # ODE
-find_package(ODE 0.13 QUIET)
+find_package(ODE 0.11 QUIET)
 dart_check_optional_package(ODE "dart-collision-ode" "ode" "0.11")
 if(ODE_FOUND)
   set(HAVE_ODE_COLLISION TRUE)

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -186,7 +186,7 @@ else()
 endif()
 
 # ODE
-find_package(ODE 0.11 QUIET)
+find_package(ODE 0.13 QUIET)
 dart_check_optional_package(ODE "dart-collision-ode" "ode" "0.11")
 if(ODE_FOUND)
   set(HAVE_ODE_COLLISION TRUE)

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -185,6 +185,15 @@ else()
   set(HAVE_BULLET_COLLISION FALSE)
 endif()
 
+# ODE
+find_package(ODE 0.11 QUIET)
+dart_check_optional_package(ODE "dart-collision-ode" "ode" "0.11")
+if(ODE_FOUND)
+  set(HAVE_ODE_COLLISION TRUE)
+else()
+  set(HAVE_ODE_COLLISION FALSE)
+endif()
+
 #--------------------------------
 # Dependencies for dart-planning
 #--------------------------------

--- a/cmake/FindODE.cmake
+++ b/cmake/FindODE.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2015-2016, Humanoid Lab, Georgia Tech Research Corporation
+# Copyright (c) 2015-2017, Graphics Lab, Georgia Tech Research Corporation
+# Copyright (c) 2016-2017, Personal Robotics Lab, Carnegie Mellon University
+# This file is provided under the "BSD-style" License
+
+# Find ODE
+#
+# This sets the following variables:
+# ODE_FOUND
+# ODE_INCLUDE_DIRS
+# ODE_LIBRARIES
+# ODE_VERSION
+
+find_package(PkgConfig QUIET)
+
+# Check to see if pkgconfig is installed.
+pkg_check_modules(PC_ODE ode QUIET)
+
+# Include directories
+find_path(ODE_INCLUDE_DIRS
+    NAMES ode/collision.h
+    HINTS ${PC_ODE_INCLUDEDIR}
+    PATHS "${CMAKE_INSTALL_PREFIX}/include")
+
+# Libraries
+if(MSVC)
+  set(ODE_LIBRARIES optimized ode debug oded)
+else()
+  find_library(ODE_LIBRARIES
+      NAMES ode
+      HINTS ${PC_ODE_LIBDIR})
+endif()
+
+# Version
+set(ODE_VERSION ${PC_ODE_VERSION})
+
+# Set (NAME)_FOUND if all the variables and the version are satisfied.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ODE
+    FAIL_MESSAGE  DEFAULT_MSG
+    REQUIRED_VARS ODE_INCLUDE_DIRS ODE_LIBRARIES
+    VERSION_VAR   ODE_VERSION)
+

--- a/dart/collision/CMakeLists.txt
+++ b/dart/collision/CMakeLists.txt
@@ -42,6 +42,9 @@ install(
 # Add subdirectories
 add_subdirectory(dart)
 add_subdirectory(fcl)
+if(HAVE_ODE_COLLISION)
+  add_subdirectory(ode)
+endif()
 if(HAVE_BULLET_COLLISION)
   add_subdirectory(bullet)
 endif()

--- a/dart/collision/CollisionDetector.cpp
+++ b/dart/collision/CollisionDetector.cpp
@@ -51,7 +51,7 @@ CollisionDetector::createCollisionGroupAsSharedPtr()
 
 //==============================================================================
 std::shared_ptr<CollisionObject> CollisionDetector::claimCollisionObject(
-    const dynamics::ShapeFrame* shapeFrame)
+    const dynamics::ShapeFrame* shapeFrame, const CollisionGroup* group)
 {
   if (!mCollisionObjectManager)
     mCollisionObjectManager.reset(new ManagerForUnsharableCollisionObjects(this));
@@ -140,7 +140,8 @@ CollisionDetector::ManagerForSharableCollisionObjects::claimCollisionObject(
 {
   const auto search = mCollisionObjectMap.find(shapeFrame);
 
-  if (mCollisionObjectMap.end() != search)
+  const auto found = mCollisionObjectMap.end() != search;
+  if (found)
   {
     const auto& collObj = search->second;
     assert(collObj.lock());

--- a/dart/collision/CollisionDetector.cpp
+++ b/dart/collision/CollisionDetector.cpp
@@ -51,7 +51,7 @@ CollisionDetector::createCollisionGroupAsSharedPtr()
 
 //==============================================================================
 std::shared_ptr<CollisionObject> CollisionDetector::claimCollisionObject(
-    const dynamics::ShapeFrame* shapeFrame, const CollisionGroup* group)
+    const dynamics::ShapeFrame* shapeFrame)
 {
   if (!mCollisionObjectManager)
     mCollisionObjectManager.reset(new ManagerForUnsharableCollisionObjects(this));

--- a/dart/collision/CollisionDetector.hpp
+++ b/dart/collision/CollisionDetector.hpp
@@ -154,7 +154,7 @@ protected:
   /// Claim CollisionObject associated with shapeFrame. New CollisionObject
   /// will be created if it hasn't created yet for shapeFrame.
   std::shared_ptr<CollisionObject> claimCollisionObject(
-      const dynamics::ShapeFrame* shapeFrame);
+      const dynamics::ShapeFrame* shapeFrame, const CollisionGroup* group);
 
   /// Create CollisionObject
   virtual std::unique_ptr<CollisionObject> createCollisionObject(

--- a/dart/collision/CollisionDetector.hpp
+++ b/dart/collision/CollisionDetector.hpp
@@ -154,7 +154,7 @@ protected:
   /// Claim CollisionObject associated with shapeFrame. New CollisionObject
   /// will be created if it hasn't created yet for shapeFrame.
   std::shared_ptr<CollisionObject> claimCollisionObject(
-      const dynamics::ShapeFrame* shapeFrame, const CollisionGroup* group);
+      const dynamics::ShapeFrame* shapeFrame);
 
   /// Create CollisionObject
   virtual std::unique_ptr<CollisionObject> createCollisionObject(

--- a/dart/collision/CollisionGroup.cpp
+++ b/dart/collision/CollisionGroup.cpp
@@ -69,7 +69,7 @@ void CollisionGroup::addShapeFrame(const dynamics::ShapeFrame* shapeFrame)
   if (hasShapeFrame(shapeFrame))
     return;
 
-  auto collObj = mCollisionDetector->claimCollisionObject(shapeFrame);
+  auto collObj = mCollisionDetector->claimCollisionObject(shapeFrame, this);
 
   addCollisionObjectToEngine(collObj.get());
 

--- a/dart/collision/CollisionGroup.cpp
+++ b/dart/collision/CollisionGroup.cpp
@@ -69,7 +69,7 @@ void CollisionGroup::addShapeFrame(const dynamics::ShapeFrame* shapeFrame)
   if (hasShapeFrame(shapeFrame))
     return;
 
-  auto collObj = mCollisionDetector->claimCollisionObject(shapeFrame, this);
+  auto collObj = mCollisionDetector->claimCollisionObject(shapeFrame);
 
   addCollisionObjectToEngine(collObj.get());
 

--- a/dart/collision/bullet/BulletCollisionObject.cpp
+++ b/dart/collision/bullet/BulletCollisionObject.cpp
@@ -38,13 +38,6 @@ namespace dart {
 namespace collision {
 
 //==============================================================================
-BulletCollisionObject::UserData::UserData(CollisionObject* collisionObject)
-  : collisionObject(collisionObject)
-{
-  // Do nothing
-}
-
-//==============================================================================
 btCollisionObject* BulletCollisionObject::getBulletCollisionObject()
 {
   return mBulletCollisionObject.get();
@@ -62,11 +55,10 @@ BulletCollisionObject::BulletCollisionObject(
     const dynamics::ShapeFrame* shapeFrame,
     btCollisionShape* bulletCollisionShape)
   : CollisionObject(collisionDetector, shapeFrame),
-    mBulletCollisionObjectUserData(new UserData(this)),
     mBulletCollisionObject(new btCollisionObject())
 {
   mBulletCollisionObject->setCollisionShape(bulletCollisionShape);
-  mBulletCollisionObject->setUserPointer(mBulletCollisionObjectUserData.get());
+  mBulletCollisionObject->setUserPointer(this);
 }
 
 //==============================================================================

--- a/dart/collision/bullet/BulletCollisionObject.hpp
+++ b/dart/collision/bullet/BulletCollisionObject.hpp
@@ -48,13 +48,6 @@ class BulletCollisionObject : public CollisionObject
 {
 public:
 
-  struct UserData
-  {
-    CollisionObject* collisionObject;
-
-    UserData(CollisionObject* collisionObject);
-  };
-
   friend class BulletCollisionDetector;
 
   /// Return Bullet collision object
@@ -74,9 +67,6 @@ protected:
   void updateEngineData() override;
 
 protected:
-
-  /// Bullet collision geometry user data
-  std::unique_ptr<UserData> mBulletCollisionObjectUserData;
 
   /// Bullet collision object
   std::unique_ptr<btCollisionObject> mBulletCollisionObject;

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -74,7 +74,7 @@ bool distanceCallback(
     void* cdata,
     fcl::FCL_REAL& dist);
 
-void postProcessFCL(
+void reportContacts(
     const fcl::CollisionResult& fclResult,
     fcl::CollisionObject* o1,
     fcl::CollisionObject* o2,
@@ -1120,7 +1120,7 @@ bool collisionCallback(
     }
     else
     {
-      postProcessFCL(fclResult, o1, o2, option, *result);
+      reportContacts(fclResult, o1, o2, option, *result);
     }
 
     // Check satisfaction of the stopping conditions
@@ -1286,7 +1286,7 @@ void markColinearPoints(
 }
 
 //==============================================================================
-void postProcessFCL(
+void reportContacts(
     const fcl::CollisionResult& fclResult,
     fcl::CollisionObject* o1,
     fcl::CollisionObject* o2,

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -1088,15 +1088,8 @@ bool collisionCallback(
   // Filtering
   if (filter)
   {
-    auto userData1
-        = static_cast<FCLCollisionObject::UserData*>(o1->getUserData());
-    auto userData2
-        = static_cast<FCLCollisionObject::UserData*>(o2->getUserData());
-    assert(userData1);
-    assert(userData2);
-
-    auto collisionObject1 = userData1->mCollisionObject;
-    auto collisionObject2 = userData2->mCollisionObject;
+    auto collisionObject1 = static_cast<FCLCollisionObject*>(o1->getUserData());
+    auto collisionObject2 = static_cast<FCLCollisionObject*>(o2->getUserData());
     assert(collisionObject1);
     assert(collisionObject2);
 
@@ -1164,15 +1157,8 @@ bool distanceCallback(
   // Filtering
   if (filter)
   {
-    auto userData1
-        = static_cast<FCLCollisionObject::UserData*>(o1->getUserData());
-    auto userData2
-        = static_cast<FCLCollisionObject::UserData*>(o2->getUserData());
-    assert(userData1);
-    assert(userData2);
-
-    auto collisionObject1 = userData1->mCollisionObject;
-    auto collisionObject2 = userData2->mCollisionObject;
+    auto collisionObject1 = static_cast<FCLCollisionObject*>(o1->getUserData());
+    auto collisionObject2 = static_cast<FCLCollisionObject*>(o2->getUserData());
     assert(collisionObject1);
     assert(collisionObject2);
 
@@ -1358,19 +1344,12 @@ void postProcessDART(
   {
     const auto& c = fclResult.getContact(i);
 
-    auto userData1
-        = static_cast<FCLCollisionObject::UserData*>(o1->getUserData());
-    auto userData2
-        = static_cast<FCLCollisionObject::UserData*>(o2->getUserData());
-    assert(userData1);
-    assert(userData2);
-
     // for each pair of intersecting triangles, we create two contact points
     Contact pair1;
     Contact pair2;
 
-    pair1.collisionObject1 = userData1->mCollisionObject;
-    pair1.collisionObject2 = userData2->mCollisionObject;
+    pair1.collisionObject1 = static_cast<FCLCollisionObject*>(o1->getUserData());
+    pair1.collisionObject2 = static_cast<FCLCollisionObject*>(o2->getUserData());
 
     if (option.enableContact)
     {
@@ -1460,17 +1439,10 @@ void interpreteDistanceResult(
   result.minDistance
       = std::max(fclResult.min_distance, option.distanceLowerBound);
 
-  const auto* userData1
-      = static_cast<FCLCollisionObject::UserData*>(o1->getUserData());
-  const auto* userData2
-      = static_cast<FCLCollisionObject::UserData*>(o2->getUserData());
-  assert(userData1);
-  assert(userData2);
-  assert(userData1->mCollisionObject);
-  assert(userData2->mCollisionObject);
-
-  result.shapeFrame1 = userData1->mCollisionObject->getShapeFrame();
-  result.shapeFrame2 = userData2->mCollisionObject->getShapeFrame();
+  result.shapeFrame1
+      = static_cast<FCLCollisionObject*>(o1->getUserData())->getShapeFrame();
+  result.shapeFrame2
+      = static_cast<FCLCollisionObject*>(o2->getUserData())->getShapeFrame();
 
   if (option.enableNearestPoints)
   {
@@ -1629,14 +1601,8 @@ Contact convertContact(const fcl::Contact& fclContact,
 {
   Contact contact;
 
-  auto userData1
-      = static_cast<FCLCollisionObject::UserData*>(o1->getUserData());
-  auto userData2
-      = static_cast<FCLCollisionObject::UserData*>(o2->getUserData());
-  assert(userData1);
-  assert(userData2);
-  contact.collisionObject1 = userData1->mCollisionObject;
-  contact.collisionObject2 = userData2->mCollisionObject;
+  contact.collisionObject1 = static_cast<FCLCollisionObject*>(o1->getUserData());
+  contact.collisionObject2 = static_cast<FCLCollisionObject*>(o2->getUserData());
 
   if (option.enableContact)
   {

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -74,7 +74,7 @@ bool distanceCallback(
     void* cdata,
     fcl::FCL_REAL& dist);
 
-void reportContacts(
+void postProcessFCL(
     const fcl::CollisionResult& fclResult,
     fcl::CollisionObject* o1,
     fcl::CollisionObject* o2,
@@ -1120,7 +1120,7 @@ bool collisionCallback(
     }
     else
     {
-      reportContacts(fclResult, o1, o2, option, *result);
+      postProcessFCL(fclResult, o1, o2, option, *result);
     }
 
     // Check satisfaction of the stopping conditions
@@ -1286,7 +1286,7 @@ void markColinearPoints(
 }
 
 //==============================================================================
-void reportContacts(
+void postProcessFCL(
     const fcl::CollisionResult& fclResult,
     fcl::CollisionObject* o1,
     fcl::CollisionObject* o2,

--- a/dart/collision/fcl/FCLCollisionDetector.hpp
+++ b/dart/collision/fcl/FCLCollisionDetector.hpp
@@ -34,7 +34,6 @@
 
 #include <vector>
 #include <fcl/collision_object.h>
-#include <boost/weak_ptr.hpp> // This should be removed once we migrate to fcl 0.5
 #include "dart/collision/CollisionDetector.hpp"
 #include "dart/collision/fcl/FCLTypes.hpp"
 
@@ -185,9 +184,6 @@ private:
 
   using ShapeMap = std::map<dynamics::ConstShapePtr,
                             fcl_weak_ptr<fcl::CollisionGeometry>>;
-  // TODO(JS): FCL replaced all the use of boost in version 0.5. Once we migrate
-  // to 0.5 or greater, this also should be changed to
-  // std::weak_ptr<fcl::CollisionGeometry>
 
   ShapeMap mShapeMap;
 

--- a/dart/collision/fcl/FCLCollisionObject.cpp
+++ b/dart/collision/fcl/FCLCollisionObject.cpp
@@ -41,7 +41,7 @@ namespace dart {
 namespace collision {
 
 //==============================================================================
-FCLCollisionObject::UserData::UserData(CollisionObject* collisionObject)
+FCLCollisionObject::UserData::UserData(FCLCollisionObject* collisionObject)
   : mCollisionObject(collisionObject)
 {
   // Do nothing

--- a/dart/collision/fcl/FCLCollisionObject.cpp
+++ b/dart/collision/fcl/FCLCollisionObject.cpp
@@ -41,13 +41,6 @@ namespace dart {
 namespace collision {
 
 //==============================================================================
-FCLCollisionObject::UserData::UserData(FCLCollisionObject* collisionObject)
-  : mCollisionObject(collisionObject)
-{
-  // Do nothing
-}
-
-//==============================================================================
 fcl::CollisionObject* FCLCollisionObject::getFCLCollisionObject()
 {
   return mFCLCollisionObject.get();
@@ -65,10 +58,9 @@ FCLCollisionObject::FCLCollisionObject(
     const dynamics::ShapeFrame* shapeFrame,
     const fcl_shared_ptr<fcl::CollisionGeometry>& fclCollGeom)
   : CollisionObject(collisionDetector, shapeFrame),
-    mFCLCollisionObjectUserData(new UserData(this)),
     mFCLCollisionObject(new fcl::CollisionObject(fclCollGeom))
 {
-  mFCLCollisionObject->setUserData(mFCLCollisionObjectUserData.get());
+  mFCLCollisionObject->setUserData(this);
 }
 
 //==============================================================================

--- a/dart/collision/fcl/FCLCollisionObject.hpp
+++ b/dart/collision/fcl/FCLCollisionObject.hpp
@@ -45,13 +45,6 @@ public:
 
   friend class FCLCollisionDetector;
 
-  struct UserData
-  {
-    FCLCollisionObject* mCollisionObject;
-
-    UserData(FCLCollisionObject* collisionObject);
-  };
-
   /// Return FCL collision object
   fcl::CollisionObject* getFCLCollisionObject();
 
@@ -69,9 +62,6 @@ protected:
   void updateEngineData() override;
 
 protected:
-
-  /// FCL collision geometry user data
-  std::unique_ptr<UserData> mFCLCollisionObjectUserData;
 
   /// FCL collision object
   std::unique_ptr<fcl::CollisionObject> mFCLCollisionObject;

--- a/dart/collision/fcl/FCLTypes.hpp
+++ b/dart/collision/fcl/FCLTypes.hpp
@@ -51,6 +51,7 @@
 template <class T> using fcl_shared_ptr = std::shared_ptr<T>;
 template <class T> using fcl_weak_ptr = std::weak_ptr<T>;
 #else
+#include <boost/weak_ptr.hpp>
 template <class T> using fcl_shared_ptr = boost::shared_ptr<T>;
 template <class T> using fcl_weak_ptr = boost::weak_ptr<T>;
 #endif

--- a/dart/collision/ode/CMakeLists.txt
+++ b/dart/collision/ode/CMakeLists.txt
@@ -1,13 +1,15 @@
 # Search all header and source files
 file(GLOB hdrs "*.hpp")
 file(GLOB srcs "*.cpp")
+file(GLOB detail_hdrs "detail/*.hpp")
+file(GLOB detail_srcs "detail/*.cpp")
 
 # Set local target name
 set(target_name ${PROJECT_NAME}-collision-ode)
 set(component_name collision-ode)
 
 # Add target
-dart_add_library(${target_name} ${hdrs} ${srcs})
+dart_add_library(${target_name} ${hdrs} ${srcs} ${detail_hdrs} ${detail_srcs})
 target_include_directories(
   ${target_name} SYSTEM
   PUBLIC ${ODE_INCLUDE_DIRS}
@@ -24,7 +26,7 @@ add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
 
 # Coverage test
-dart_coveralls_add(${hdrs} ${srcs})
+dart_coveralls_add(${hdrs} ${srcs} ${detail_hdrs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "collision_ode headers" ${hdrs})

--- a/dart/collision/ode/CMakeLists.txt
+++ b/dart/collision/ode/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Search all header and source files
+file(GLOB hdrs "*.hpp")
+file(GLOB srcs "*.cpp")
+
+# Set local target name
+set(target_name ${PROJECT_NAME}-collision-ode)
+set(component_name collision-ode)
+
+# Add target
+dart_add_library(${target_name} ${hdrs} ${srcs})
+target_include_directories(
+  ${target_name} SYSTEM
+  PUBLIC ${ODE_INCLUDE_DIRS}
+)
+target_link_libraries(
+  ${target_name}
+  dart
+  ${ODE_LIBRARIES}
+)
+
+# Component
+add_component(${PROJECT_NAME} ${component_name})
+add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
+add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
+
+# Coverage test
+dart_coveralls_add(${hdrs} ${srcs})
+
+# Generate header for this namespace
+dart_get_filename_components(header_names "collision_ode headers" ${hdrs})
+dart_generate_include_header_list(
+  collision_ode_headers
+  "dart/collision/ode/"
+  "collision_ode headers"
+  ${header_names}
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/ode.hpp.in
+  ${CMAKE_CURRENT_BINARY_DIR}/ode.hpp
+)
+
+# Install
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/ode.hpp
+  DESTINATION include/dart/collision/ode
+  COMPONENT headers
+)

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -270,43 +270,6 @@ void CollisionCallback(void* data, dGeomID o1, dGeomID o2)
 }
 
 //==============================================================================
-void fillArrays(const aiScene* mesh)
-{
-
-}
-
-//==============================================================================
-void createMesh(const aiScene* mesh, float scaleX, float scaleY, float scaleZ)
-{
-  assert(mesh);
-
-  auto odeTriMeshData = dGeomTriMeshDataCreate();
-
-  // Create FCL mesh from Assimp mesh
-
-  for (auto i = 0u; i < mesh->mNumMeshes; i++)
-  {
-    for (auto j = 0u; j < mesh->mMeshes[i]->mNumFaces; j++)
-    {
-//      fcl::Vec3f vertices[3];
-      for (std::size_t k = 0; k < 3; k++)
-      {
-//        mesh->mMeshes[i]->mVertices;
-        const aiVector3D& vertex
-            = mesh->mMeshes[i]->mVertices[
-              mesh->mMeshes[i]->mFaces[j].mIndices[k]];
-//        vertices[k] = fcl::Vec3f(vertex.x * scaleX,
-//                                 vertex.y * scaleY,
-//                                 vertex.z * scaleZ);
-      }
-//      model->addTriangle(vertices[0], vertices[1], vertices[2]);
-    }
-  }
-
-//  dGeomTriMeshDataBuildDouble(odeTriMeshData);
-}
-
-//==============================================================================
 void reportContacts(
     int numContacts,
     dContactGeom* contactGeoms,

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -296,7 +296,7 @@ dGeomID OdeCollisionDetector::createOdeCollisionGeometry(
 
     // TODO(JS): transform the normal and offset according to the transform
     // of the parent body.
-    odeGeomId = dCreatePlane(0, normal.x(), normal.y(), normal.z(), -0.375);
+    odeGeomId = dCreatePlane(0, normal.x(), normal.y(), normal.z(), offset);
   }
   //else if (MeshShape::getStaticType() == shapeType)
   //{

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/ode/OdeCollisionDetector.hpp"
+
+#include <ode/ode.h>
+
+#include "dart/dynamics/SphereShape.hpp"
+#include "dart/dynamics/BoxShape.hpp"
+#include "dart/dynamics/EllipsoidShape.hpp"
+#include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/CapsuleShape.hpp"
+#include "dart/dynamics/ConeShape.hpp"
+#include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/MeshShape.hpp"
+#include "dart/dynamics/SoftMeshShape.hpp"
+#include "dart/collision/CollisionFilter.hpp"
+#include "dart/collision/ode/OdeTypes.hpp"
+#include "dart/collision/ode/OdeCollisionGroup.hpp"
+#include "dart/collision/ode/OdeCollisionObject.hpp"
+
+namespace dart {
+namespace collision {
+
+namespace {
+
+void CollisionCallback(void *data, dGeomID o1, dGeomID o2);
+
+void reportContacts(int numContacts,
+    dContactGeom* contactGeoms,
+    OdeCollisionObject* b1,
+    OdeCollisionObject* b2,
+    const CollisionOption& option,
+    CollisionResult& result);
+
+Contact convertContact(
+    const dContactGeom& fclContact,
+    OdeCollisionObject* b1,
+    OdeCollisionObject* b2,
+    const CollisionOption& option);
+
+struct OdeCollisionCallbackData
+{
+  dContactGeom* contactGeoms;
+
+  /// Collision option of DART
+  const CollisionOption& option;
+
+  /// Collision result of DART
+  CollisionResult* result;
+
+  /// Whether the collision iteration can stop
+  bool done;
+
+  int numContacts;
+
+  OdeCollisionCallbackData(
+      const CollisionOption& option,
+      CollisionResult* result)
+    : option(option),
+      result(result),
+      done(false),
+      numContacts(0)
+  {
+    // Do nothing
+  }
+};
+
+} // anonymous namespace
+
+//==============================================================================
+std::shared_ptr<OdeCollisionDetector> OdeCollisionDetector::create()
+{
+  return std::shared_ptr<OdeCollisionDetector>(
+        new OdeCollisionDetector());
+}
+
+//==============================================================================
+OdeCollisionDetector::~OdeCollisionDetector()
+{
+
+}
+
+//==============================================================================
+std::shared_ptr<CollisionDetector>
+OdeCollisionDetector::cloneWithoutCollisionObjects()
+{
+
+}
+
+//==============================================================================
+const std::string& OdeCollisionDetector::getType() const
+{
+
+}
+
+//==============================================================================
+const std::string& OdeCollisionDetector::getStaticType()
+{
+
+}
+
+//==============================================================================
+std::unique_ptr<CollisionGroup> OdeCollisionDetector::createCollisionGroup()
+{
+  return common::make_unique<OdeCollisionGroup>(shared_from_this());
+}
+
+//==============================================================================
+bool OdeCollisionDetector::collide(
+    CollisionGroup* group,
+    const CollisionOption& option,
+    CollisionResult* result)
+{
+  auto odeGroup = static_cast<OdeCollisionGroup*>(group);
+  odeGroup->updateEngineData();
+
+  OdeCollisionCallbackData data(option, result);
+  data.contactGeoms = contactCollisions;
+
+  // Do collision detection; this will add contacts to the contact group
+  dSpaceCollide(odeGroup->getOdeSpaceId(), &data, CollisionCallback);
+
+  return data.numContacts > 0;
+}
+
+//==============================================================================
+bool OdeCollisionDetector::collide(
+    CollisionGroup* group1,
+    CollisionGroup* group2,
+    const CollisionOption& option,
+    CollisionResult* result)
+{
+  // TODO(JS): not implemented
+  return false;
+}
+
+//==============================================================================
+double OdeCollisionDetector::distance(
+    CollisionGroup* group, const DistanceOption& option, DistanceResult* result)
+{
+  // TODO(JS): not implemented
+  return -1.0;
+}
+
+//==============================================================================
+double OdeCollisionDetector::distance(
+    CollisionGroup* group1,
+    CollisionGroup* group2,
+    const DistanceOption& option,
+    DistanceResult* result)
+{
+  // TODO(JS): not implemented
+  return -1.0;
+}
+
+//==============================================================================
+OdeCollisionDetector::OdeCollisionDetector()
+{
+  //mCollisionObjectManager.reset(new ManagerForSharableCollisionObjects(this));
+
+  // Collision detection init
+  dInitODE2(0);
+
+  dAllocateODEDataForThread(dAllocateMaskAll);
+
+  mWorldId = dWorldCreate();
+  // TODO(JS): destroy world at the destructor of this class
+}
+
+//==============================================================================
+std::unique_ptr<CollisionObject> OdeCollisionDetector::createCollisionObject(
+    const dynamics::ShapeFrame* shapeFrame)
+{
+  auto odeCollGeom = claimOdeCollisionGeometry(shapeFrame->getShape());
+
+  return std::unique_ptr<OdeCollisionObject>(
+        new OdeCollisionObject(this, shapeFrame, odeCollGeom));
+}
+
+//==============================================================================
+dGeomID OdeCollisionDetector::claimOdeCollisionGeometry(
+    const dynamics::ConstShapePtr& shape)
+{
+  // TODO(JS): ODE create unique geom per CollisionObject. remove this function.
+
+//  const auto search = mShapeMap.find(shape);
+
+//  const auto found = (search != mShapeMap.end());
+//  if (found)
+//  {
+//    const auto& odeGeomId = search->second;
+//    // TODO(JS): check if the geom is valid
+
+//    return odeGeomId;
+//  }
+
+  auto newOdeGeomId = createOdeCollisionGeometry(shape);
+//  mShapeMap[shape] = newOdeGeomId;
+
+  return newOdeGeomId;
+}
+
+//==============================================================================
+dWorldID OdeCollisionDetector::getWorldId() const
+{
+  return mWorldId;
+}
+
+//==============================================================================
+dGeomID OdeCollisionDetector::createOdeCollisionGeometry(
+    const dynamics::ConstShapePtr& shape)
+{
+  using dynamics::Shape;
+  using dynamics::SphereShape;
+  using dynamics::BoxShape;
+  using dynamics::EllipsoidShape;
+  using dynamics::CylinderShape;
+  using dynamics::PlaneShape;
+  using dynamics::MeshShape;
+  using dynamics::SoftMeshShape;
+
+  dGeomID odeGeomId = nullptr;
+  const auto& shapeType = shape->getType();
+
+  if (shape->is<SphereShape>())
+  {
+    const auto sphere = static_cast<const SphereShape*>(shape.get());
+    const auto radius = sphere->getRadius();
+
+    odeGeomId = dCreateSphere(0, radius);
+  }
+  else if (BoxShape::getStaticType() == shapeType)
+  {
+    const auto box = static_cast<const BoxShape*>(shape.get());
+    const Eigen::Vector3d& size = box->getSize();
+
+    odeGeomId = dCreateBox(0, size.x(), size.y(), size.z());
+  }
+  //else if (EllipsoidShape::getStaticType() == shapeType)
+  //{
+  //  auto ellipsoid = static_cast<const EllipsoidShape*>(shape.get());
+  //  const Eigen::Vector3d& radii = ellipsoid->getRadii();
+  //
+  //  odeGeomId = dCreateEllipsoid(0, size.x(), size.y(), size.z());
+  //
+  //}
+  // TODO(JS): ODE doesn't support ellipsoid
+  else if (CylinderShape::getStaticType() == shapeType)
+  {
+    const auto cylinder = static_cast<const CylinderShape*>(shape.get());
+    const auto radius = cylinder->getRadius();
+    const auto height = cylinder->getHeight();
+
+    odeGeomId = dCreateCylinder(0, radius, height);
+  }
+  else if (PlaneShape::getStaticType() == shapeType)
+  {
+    const auto plane = static_cast<const PlaneShape*>(shape.get());
+    const Eigen::Vector3d normal = plane->getNormal();
+    const double offset = plane->getOffset();
+
+    odeGeomId = dCreatePlane(0, normal.x(), normal.y(), normal.z(), offset);
+  }
+  //else if (MeshShape::getStaticType() == shapeType)
+  //{
+  //  auto shapeMesh = static_cast<const MeshShape*>(shape.get());
+  //  const Eigen::Vector3d& scale = shapeMesh->getScale();
+  //  auto aiScene = shapeMesh->getMesh();
+  //
+  //  odeGeomId = dCreateTriMesh(0, ...);
+  //}
+  // TODO(SJ): not implemented
+  //else if (SoftMeshShape::getStaticType() == shapeType)
+  //{
+  //  auto softMeshShape = static_cast<const SoftMeshShape*>(shape.get());
+  //  auto aiMesh = softMeshShape->getAssimpMesh();
+  //
+  //}
+  // TODO(SJ): not implemented
+  else
+  {
+    dterr << "[FCLCollisionDetector::createFCLCollisionGeometry] "
+          << "Attempting to create an unsupported shape type ["
+          << shapeType << "]. Creating a sphere with 0.1 radius "
+          << "instead.\n";
+
+    odeGeomId = dCreateSphere(0, 0.1);
+  }
+
+  return odeGeomId;
+}
+
+namespace {
+
+//==============================================================================
+void CollisionCallback(void* data, dGeomID o1, dGeomID o2)
+{
+  assert(dGeomGetBody(o1));
+  assert(dGeomGetBody(o2));
+
+  assert(!dGeomIsSpace(o1));
+  assert(!dGeomIsSpace(o2));
+
+  auto cdData = static_cast<OdeCollisionCallbackData*>(data);
+
+  if (cdData->done)
+    return;
+
+  auto b1 = dGeomGetBody(o1);
+  auto b2 = dGeomGetBody(o2);
+
+        auto& odeResult   = cdData->contactGeoms;
+        auto* result      = cdData->result;
+  const auto& option      = cdData->option;
+  const auto& filter      = option.collisionFilter;
+
+  auto bdData1 = dBodyGetData(b1);
+  auto bdData2 = dBodyGetData(b2);
+
+  auto userData1 = static_cast<OdeCollisionObject::UserData*>(bdData1);
+  auto userData2 = static_cast<OdeCollisionObject::UserData*>(bdData2);
+  assert(userData1);
+  assert(userData2);
+
+  auto collObj1 = userData1->mCollisionObject;
+  auto collObj2 = userData2->mCollisionObject;
+  assert(collObj1);
+  assert(collObj2);
+
+  if (filter && !filter->needCollision(collObj2, collObj1))
+      return;
+
+  // Perform narrow-phase collision detection
+  auto numc = dCollide(
+      o1, o2, MAX_COLLIDE_RETURNS, odeResult, sizeof(odeResult[0]));
+
+  cdData->numContacts = numc;
+
+  if (result)
+    reportContacts(numc, odeResult, collObj1, collObj2, option, *result);
+}
+
+//==============================================================================
+void reportContacts(
+    int numContacts,
+    dContactGeom* contactGeoms,
+    OdeCollisionObject* b1,
+    OdeCollisionObject* b2,
+    const CollisionOption& option,
+    CollisionResult& result)
+{
+  if (0u == numContacts)
+    return;
+
+  // For binary check, return after adding the first contact point to the result
+  // without the checkings of repeatidity and co-linearity.
+  if (1u == option.maxNumContacts)
+  {
+    result.addContact(convertContact(contactGeoms[0], b1, b2, option));
+
+    return;
+  }
+
+  for (auto i = 0; i < numContacts; ++i)
+  {
+    result.addContact(convertContact(contactGeoms[i], b1, b2, option));
+
+    if (result.getNumContacts() >= option.maxNumContacts)
+      return;
+  }
+}
+
+//==============================================================================
+Contact convertContact(
+    const dContactGeom& odeContact,
+    OdeCollisionObject* b1,
+    OdeCollisionObject* b2,
+    const CollisionOption& option)
+{
+  Contact contact;
+
+  contact.collisionObject1 = b1;
+  contact.collisionObject2 = b2;
+
+  if (option.enableContact)
+  {
+    contact.point = OdeTypes::convertVector3(odeContact.pos);
+    contact.normal = -OdeTypes::convertVector3(odeContact.normal);
+    contact.penetrationDepth = odeContact.depth;
+  }
+
+  return contact;
+}
+
+} // anonymous namespace
+
+} // namespace collision
+} // namespace dart

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -98,9 +98,7 @@ protected:
   std::unique_ptr<CollisionObject> createCollisionObject(
       const dynamics::ShapeFrame* shapeFrame) override;
 
-  dGeomID claimOdeCollisionGeometry(const dynamics::ConstShapePtr& shape);
-
-  dWorldID getWorldId() const;
+  dWorldID getOdeWorldId() const;
 
 protected:
 

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -40,11 +40,16 @@
 namespace dart {
 namespace collision {
 
+namespace detail {
+class OdeGeom;
+}
+
 class OdeCollisionDetector : public CollisionDetector
 {
 public:
 
   friend class OdeCollisionObject;
+  friend class detail::OdeGeom;
 
   static std::shared_ptr<OdeCollisionDetector> create();
 
@@ -110,11 +115,8 @@ private:
 
 private:
 
-  using ShapeMap = std::map<dynamics::ConstShapePtr, dGeomID>;
-
-  ShapeMap mShapeMap;
-
   dContactGeom contactCollisions[MAX_COLLIDE_RETURNS];
+  // TODO(JS)
 
 };
 

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -40,16 +40,17 @@
 namespace dart {
 namespace collision {
 
-namespace detail {
-class OdeGeom;
-}
-
+/// OdeCollisionDetector wraps the ODE collision detector.
+///
+/// The supported collision shape types are sphere, box, capsule, cylinder,
+/// plane, and trimesh.
+///
+/// ODE additionally supports ray and heightfiled, but DART doesn't support them
+/// yet.
 class OdeCollisionDetector : public CollisionDetector
 {
 public:
-
   friend class OdeCollisionObject;
-  friend class detail::OdeGeom;
 
   static std::shared_ptr<OdeCollisionDetector> create();
 
@@ -81,13 +82,13 @@ public:
       const CollisionOption& option = CollisionOption(false, 1u, nullptr),
       CollisionResult* result = nullptr) override;
 
-  // Documentation inherited
+  /// \warning Not implemented yet.
   double distance(
       CollisionGroup* group,
       const DistanceOption& option = DistanceOption(false, 0.0, nullptr),
       DistanceResult* result = nullptr) override;
 
-  // Documentation inherited
+  /// \warning Not implemented yet.
   double distance(
       CollisionGroup* group1,
       CollisionGroup* group2,
@@ -95,7 +96,6 @@ public:
       DistanceResult* result = nullptr) override;
 
 protected:
-
   /// Constructor
   OdeCollisionDetector();
 
@@ -106,7 +106,6 @@ protected:
   dWorldID getOdeWorldId() const;
 
 protected:
-
   /// Top-level world for all bodies
   dWorldID mWorldId;
 
@@ -114,9 +113,7 @@ private:
   dGeomID createOdeCollisionGeometry(const dynamics::ConstShapePtr& shape);
 
 private:
-
   dContactGeom contactCollisions[MAX_COLLIDE_RETURNS];
-
 };
 
 }  // namespace collision

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_ODE_ODECOLLISIONDETECTOR_HPP_
+#define DART_COLLISION_ODE_ODECOLLISIONDETECTOR_HPP_
+
+#include <ode/ode.h>
+
+#include "dart/collision/CollisionDetector.hpp"
+
+#define MAX_COLLIDE_RETURNS 250
+
+namespace dart {
+namespace collision {
+
+class OdeCollisionDetector : public CollisionDetector
+{
+public:
+
+  friend class OdeCollisionObject;
+
+  static std::shared_ptr<OdeCollisionDetector> create();
+
+  /// Constructor
+  virtual ~OdeCollisionDetector();
+
+  // Documentation inherited
+  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() override;
+
+  // Documentation inherited
+  const std::string& getType() const override;
+
+  /// Get collision detector type for this class
+  static const std::string& getStaticType();
+
+  // Documentation inherited
+  std::unique_ptr<CollisionGroup> createCollisionGroup() override;
+
+  // Documentation inherited
+  bool collide(
+      CollisionGroup* group,
+      const CollisionOption& option = CollisionOption(false, 1u, nullptr),
+      CollisionResult* result = nullptr) override;
+
+  // Documentation inherited
+  bool collide(
+      CollisionGroup* group1,
+      CollisionGroup* group2,
+      const CollisionOption& option = CollisionOption(false, 1u, nullptr),
+      CollisionResult* result = nullptr) override;
+
+  // Documentation inherited
+  double distance(
+      CollisionGroup* group,
+      const DistanceOption& option = DistanceOption(false, 0.0, nullptr),
+      DistanceResult* result = nullptr) override;
+
+  // Documentation inherited
+  double distance(
+      CollisionGroup* group1,
+      CollisionGroup* group2,
+      const DistanceOption& option = DistanceOption(false, 0.0, nullptr),
+      DistanceResult* result = nullptr) override;
+
+protected:
+
+  /// Constructor
+  OdeCollisionDetector();
+
+  // Documentation inherited
+  std::unique_ptr<CollisionObject> createCollisionObject(
+      const dynamics::ShapeFrame* shapeFrame) override;
+
+  dGeomID claimOdeCollisionGeometry(const dynamics::ConstShapePtr& shape);
+
+  dWorldID getWorldId() const;
+
+protected:
+
+  /// Top-level world for all bodies
+  dWorldID mWorldId;
+
+private:
+  dGeomID createOdeCollisionGeometry(const dynamics::ConstShapePtr& shape);
+
+private:
+
+  using ShapeMap = std::map<dynamics::ConstShapePtr, dGeomID>;
+
+  ShapeMap mShapeMap;
+
+  dContactGeom contactCollisions[MAX_COLLIDE_RETURNS];
+
+};
+
+}  // namespace collision
+}  // namespace dart
+
+#endif  // DART_COLLISION_ODE_ODECOLLISIONDETECTOR_HPP_

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -116,7 +116,6 @@ private:
 private:
 
   dContactGeom contactCollisions[MAX_COLLIDE_RETURNS];
-  // TODO(JS)
 
 };
 

--- a/dart/collision/ode/OdeCollisionGroup.cpp
+++ b/dart/collision/ode/OdeCollisionGroup.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/ode/OdeCollisionGroup.hpp"
+
+#include "dart/collision/ode/OdeCollisionObject.hpp"
+
+namespace dart {
+namespace collision {
+
+//==============================================================================
+OdeCollisionGroup::OdeCollisionGroup(
+    const CollisionDetectorPtr& collisionDetector)
+  : CollisionGroup(collisionDetector)
+{
+  mSpaceId = dHashSpaceCreate(0);
+  dHashSpaceSetLevels(mSpaceId, -2, 8);
+
+  mContactGroupId = dJointGroupCreate(0);
+}
+
+//==============================================================================
+void OdeCollisionGroup::initializeEngineData()
+{
+}
+
+//==============================================================================
+void OdeCollisionGroup::addCollisionObjectToEngine(CollisionObject* object)
+{
+  auto casted = static_cast<OdeCollisionObject*>(object);
+  auto geomId = casted->getGeomId();
+  dSpaceAdd(mSpaceId, geomId);
+
+  initializeEngineData();
+}
+
+//==============================================================================
+void OdeCollisionGroup::addCollisionObjectsToEngine(
+    const std::vector<CollisionObject*>& collObjects)
+{
+  for (auto collObj : collObjects)
+  {
+    auto casted = static_cast<OdeCollisionObject*>(collObj);
+
+  }
+
+  initializeEngineData();
+}
+
+//==============================================================================
+void OdeCollisionGroup::removeCollisionObjectFromEngine(CollisionObject* object)
+{
+  auto casted = static_cast<OdeCollisionObject*>(object);
+
+
+  initializeEngineData();
+}
+
+//==============================================================================
+void OdeCollisionGroup::removeAllCollisionObjectsFromEngine()
+{
+
+  initializeEngineData();
+}
+
+//==============================================================================
+void OdeCollisionGroup::updateCollisionGroupEngineData()
+{
+}
+
+//==============================================================================
+dSpaceID OdeCollisionGroup::getOdeSpaceId() const
+{
+  return mSpaceId;
+}
+
+}  // namespace collision
+}  // namespace dart

--- a/dart/collision/ode/OdeCollisionGroup.cpp
+++ b/dart/collision/ode/OdeCollisionGroup.cpp
@@ -55,7 +55,7 @@ void OdeCollisionGroup::initializeEngineData()
 void OdeCollisionGroup::addCollisionObjectToEngine(CollisionObject* object)
 {
   auto casted = static_cast<OdeCollisionObject*>(object);
-  auto geomId = casted->getGeomId();
+  auto geomId = casted->getOdeGeomId();
   dSpaceAdd(mSpaceId, geomId);
 
   initializeEngineData();
@@ -68,7 +68,8 @@ void OdeCollisionGroup::addCollisionObjectsToEngine(
   for (auto collObj : collObjects)
   {
     auto casted = static_cast<OdeCollisionObject*>(collObj);
-
+    auto geomId = casted->getOdeGeomId();
+    dSpaceAdd(mSpaceId, geomId);
   }
 
   initializeEngineData();

--- a/dart/collision/ode/OdeCollisionGroup.hpp
+++ b/dart/collision/ode/OdeCollisionGroup.hpp
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Graphics Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Personal Robotics Lab, Carnegie Mellon University
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:
@@ -29,56 +28,64 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
-#define DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
+#ifndef DART_COLLISION_ODE_ODECOLLISIONGROUP_HPP_
+#define DART_COLLISION_ODE_ODECOLLISIONGROUP_HPP_
 
-#include <fcl/collision_object.h>
-#include "dart/collision/CollisionObject.hpp"
-#include "dart/collision/fcl/FCLTypes.hpp"
+#include <ode/ode.h>
+
+#include "dart/collision/CollisionGroup.hpp"
 
 namespace dart {
 namespace collision {
 
-class FCLCollisionObject : public CollisionObject
+class OdeCollisionGroup : public CollisionGroup
 {
 public:
 
-  friend class FCLCollisionDetector;
-
-  struct UserData
-  {
-    FCLCollisionObject* mCollisionObject;
-
-    UserData(FCLCollisionObject* collisionObject);
-  };
-
-  /// Return FCL collision object
-  fcl::CollisionObject* getFCLCollisionObject();
-
-  /// Return FCL collision object
-  const fcl::CollisionObject* getFCLCollisionObject() const;
-
-protected:
+  friend class OdeCollisionDetector;
 
   /// Constructor
-  FCLCollisionObject(CollisionDetector* collisionDetector,
-      const dynamics::ShapeFrame* shapeFrame,
-      const fcl_shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
+  OdeCollisionGroup(const CollisionDetectorPtr& collisionDetector);
 
-  // Documentation inherited
-  void updateEngineData() override;
+  /// Destructor
+  virtual ~OdeCollisionGroup() = default;
 
 protected:
 
-  /// FCL collision geometry user data
-  std::unique_ptr<UserData> mFCLCollisionObjectUserData;
+  using CollisionGroup::updateEngineData;
 
-  /// FCL collision object
-  std::unique_ptr<fcl::CollisionObject> mFCLCollisionObject;
+  // Documentation inherited
+  void initializeEngineData() override;
+
+  // Documentation inherited
+  void addCollisionObjectToEngine(CollisionObject* object) override;
+
+  // Documentation inherited
+  void addCollisionObjectsToEngine(
+      const std::vector<CollisionObject*>& collObjects) override;
+
+  // Documentation inherited
+  void removeCollisionObjectFromEngine(CollisionObject* object) override;
+
+  // Documentation inherited
+  void removeAllCollisionObjectsFromEngine() override;
+
+  // Documentation inherited
+  void updateCollisionGroupEngineData() override;
+
+  dSpaceID getOdeSpaceId() const;
+
+protected:
+
+  /// Top-level space for all sub-spaces/collisions
+  dSpaceID mSpaceId;
+
+  /// Collision attributes
+  dJointGroupID mContactGroupId;
 
 };
 
 }  // namespace collision
 }  // namespace dart
 
-#endif  // DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
+#endif  // DART_COLLISION_ODE_ODECOLLISIONGROUP_HPP_

--- a/dart/collision/ode/OdeCollisionGroup.hpp
+++ b/dart/collision/ode/OdeCollisionGroup.hpp
@@ -41,17 +41,15 @@ namespace collision {
 class OdeCollisionGroup : public CollisionGroup
 {
 public:
-
   friend class OdeCollisionDetector;
 
   /// Constructor
   OdeCollisionGroup(const CollisionDetectorPtr& collisionDetector);
 
   /// Destructor
-  virtual ~OdeCollisionGroup() = default;
+  virtual ~OdeCollisionGroup();
 
 protected:
-
   using CollisionGroup::updateEngineData;
 
   // Documentation inherited
@@ -73,16 +71,12 @@ protected:
   // Documentation inherited
   void updateCollisionGroupEngineData() override;
 
+  /// Returns ODE space id associated with this collision group
   dSpaceID getOdeSpaceId() const;
 
 protected:
-
   /// Top-level space for all sub-spaces/collisions
   dSpaceID mSpaceId;
-
-  /// Collision attributes
-  dJointGroupID mContactGroupId;
-
 };
 
 }  // namespace collision

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -154,12 +154,6 @@ detail::OdeGeom* createOdeGeom(
 
     geom = new detail::OdeBox(collObj, size);
   }
-  //else if (shape->is<EllipsoidShape>())
-  //{
-  //  auto ellipsoid = static_cast<const EllipsoidShape*>(shape.get());
-  //  const Eigen::Vector3d& radii = ellipsoid->getRadii();
-  //}
-  // TODO(JS): ODE doesn't support ellipsoid
   else if (shape->is<CapsuleShape>())
   {
     const auto capsule = static_cast<const CapsuleShape*>(shape);
@@ -192,13 +186,6 @@ detail::OdeGeom* createOdeGeom(
 
     geom = new detail::OdeMesh(collObj, aiScene, scale);
   }
-  // TODO(SJ): not implemented
-  //else if (SoftMeshShape::getStaticType() == shapeType)
-  //{
-  //  auto softMeshShape = static_cast<const SoftMeshShape*>(shape);
-  //  auto aiMesh = softMeshShape->getAssimpMesh();
-  //}
-  // TODO(SJ): not implemented
   else
   {
     dterr << "[OdeCollisionDetector] Attempting to create an unsupported shape "
@@ -207,7 +194,10 @@ detail::OdeGeom* createOdeGeom(
 
     geom = new detail::OdeSphere(collObj, 0.01);
   }
+  // TODO(JS): not implemented for EllipsoidShape, ConeShape, MultiSphereShape,
+  // and SoftMeshShape.
 
+  assert(geom);
   const auto geomId = geom->getOdeGeomId();
   dGeomSetData(geomId, collObj);
 

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/ode/OdeCollisionObject.hpp"
+
+namespace dart {
+namespace collision {
+
+//==============================================================================
+OdeCollisionObject::UserData::UserData(OdeCollisionObject* collisionObject)
+  : mCollisionObject(collisionObject)
+{
+  // Do nothing
+}
+
+//==============================================================================
+OdeCollisionObject::~OdeCollisionObject()
+{
+  if (mBodyId)
+    dBodyDestroy(mBodyId);
+  mBodyId = nullptr;
+
+  if (mGeomId)
+    dGeomDestroy(mGeomId);
+  mGeomId = nullptr;
+}
+
+//==============================================================================
+OdeCollisionObject::OdeCollisionObject(
+    OdeCollisionDetector* collisionDetector,
+    const dynamics::ShapeFrame* shapeFrame,
+    dGeomID odeCollGeom)
+  : CollisionObject(collisionDetector, shapeFrame),
+    mOdeCollisionObjectUserData(new UserData(this)),
+    mGeomId(odeCollGeom)
+{
+  mBodyId = dBodyCreate(collisionDetector->getWorldId());
+  dGeomSetBody(mGeomId, mBodyId);
+
+  dBodySetData(mBodyId, mOdeCollisionObjectUserData.get());
+}
+
+//==============================================================================
+void OdeCollisionObject::updateEngineData()
+{
+  const Eigen::Isometry3d& tf = getTransform();
+  const Eigen::Vector3d pos = tf.translation();
+  const Eigen::Quaterniond rot(tf.linear());
+
+  dQuaternion quat;
+  quat[0] = rot.w();
+  quat[1] = rot.x();
+  quat[2] = rot.y();
+  quat[3] = rot.z();
+
+  dGeomSetOffsetPosition(mGeomId, pos.x(), pos.y(), pos.z());
+  dGeomSetOffsetRotation(mGeomId, quat);
+}
+
+//==============================================================================
+dBodyID OdeCollisionObject::getBodyId() const
+{
+  return mBodyId;
+}
+
+//==============================================================================
+dGeomID OdeCollisionObject::getGeomId() const
+{
+  return mGeomId;
+}
+
+}  // namespace collision
+}  // namespace dart

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -74,6 +74,8 @@ protected:
   dGeomID mGeomId;
 
   /// ODE body id associated with this object
+  ///
+  /// If the ODE geom type is immobile, this is nullptr.
   dBodyID mBodyId;
 };
 

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -66,16 +66,16 @@ protected:
   // Documentation inherited
   void updateEngineData() override;
 
-  dBodyID getBodyId() const;
-  dGeomID getGeomId() const;
+  dBodyID getOdeBodyId() const;
+  dGeomID getOdeGeomId() const;
 
 protected:
 
   /// ODE collision geometry user data
   std::unique_ptr<UserData> mOdeCollisionObjectUserData;
 
-  dBodyID mBodyId;
   dGeomID mGeomId;
+  dBodyID mBodyId;
 
 };
 

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -42,21 +42,15 @@ namespace collision {
 class OdeCollisionObject : public CollisionObject
 {
 public:
-
   friend class OdeCollisionDetector;
   friend class OdeCollisionGroup;
 
-  struct UserData
-  {
-    OdeCollisionObject* mCollisionObject;
+  struct GeomUserData;
 
-    UserData(OdeCollisionObject* collisionObject);
-  };
-
+  /// Destructor
   virtual ~OdeCollisionObject();
 
 protected:
-
   /// Constructor
   OdeCollisionObject(
       OdeCollisionDetector* collisionDetector,
@@ -66,17 +60,32 @@ protected:
   // Documentation inherited
   void updateEngineData() override;
 
-  dBodyID getOdeBodyId() const;
+  /// Returns the ODE geom id associated to this object
   dGeomID getOdeGeomId() const;
 
+  /// Returns the ODE body id associated to this object
+  dBodyID getOdeBodyId() const;
+
 protected:
-
   /// ODE collision geometry user data
-  std::unique_ptr<UserData> mOdeCollisionObjectUserData;
+  std::unique_ptr<GeomUserData> mOdeCollisionObjectUserData;
 
+  /// ODE geom id associated with this object
   dGeomID mGeomId;
-  dBodyID mBodyId;
 
+  /// ODE body id associated with this object
+  dBodyID mBodyId;
+};
+
+/// OdeCollisionObject::GeomUserData to be embedded to ODE geom.
+struct OdeCollisionObject::GeomUserData
+{
+  /// Collision object that will be stored in the ODE geom. This is necessary
+  /// to know which collision object is associated with the ODE geom.
+  OdeCollisionObject* mCollisionObject;
+
+  /// Constructor
+  GeomUserData(OdeCollisionObject* collisionObject);
 };
 
 } // namespace collision

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -45,8 +45,6 @@ public:
   friend class OdeCollisionDetector;
   friend class OdeCollisionGroup;
 
-  struct GeomUserData;
-
   /// Destructor
   virtual ~OdeCollisionObject();
 
@@ -54,40 +52,28 @@ protected:
   /// Constructor
   OdeCollisionObject(
       OdeCollisionDetector* collisionDetector,
-      const dynamics::ShapeFrame* shapeFrame,
-      dGeomID odeCollGeom);
+      const dynamics::ShapeFrame* shapeFrame);
 
   // Documentation inherited
   void updateEngineData() override;
 
-  /// Returns the ODE geom id associated to this object
-  dGeomID getOdeGeomId() const;
-
   /// Returns the ODE body id associated to this object
   dBodyID getOdeBodyId() const;
 
-protected:
-  /// ODE collision geometry user data
-  std::unique_ptr<GeomUserData> mOdeCollisionObjectUserData;
+  /// Returns the ODE body id associated to this object
+  dGeomID getOdeGeomId() const;
 
-  /// ODE geom id associated with this object
-  dGeomID mGeomId;
+protected:
+  /// ODE geom
+  std::unique_ptr<detail::OdeGeom> mOdeGeom;
 
   /// ODE body id associated with this object
   ///
   /// If the ODE geom type is immobile, this is nullptr.
   dBodyID mBodyId;
-};
 
-/// OdeCollisionObject::GeomUserData to be embedded to ODE geom.
-struct OdeCollisionObject::GeomUserData
-{
-  /// Collision object that will be stored in the ODE geom. This is necessary
-  /// to know which collision object is associated with the ODE geom.
-  OdeCollisionObject* mCollisionObject;
+private:
 
-  /// Constructor
-  GeomUserData(OdeCollisionObject* collisionObject);
 };
 
 } // namespace collision

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Graphics Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Personal Robotics Lab, Carnegie Mellon University
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:
@@ -29,56 +28,58 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
-#define DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
+#ifndef DART_COLLISION_ODE_ODECOLLISIONOBJECT_HPP_
+#define DART_COLLISION_ODE_ODECOLLISIONOBJECT_HPP_
 
-#include <fcl/collision_object.h>
+#include <ode/ode.h>
+
 #include "dart/collision/CollisionObject.hpp"
-#include "dart/collision/fcl/FCLTypes.hpp"
+#include "dart/collision/ode/OdeCollisionDetector.hpp"
 
 namespace dart {
 namespace collision {
 
-class FCLCollisionObject : public CollisionObject
+class OdeCollisionObject : public CollisionObject
 {
 public:
 
-  friend class FCLCollisionDetector;
+  friend class OdeCollisionDetector;
+  friend class OdeCollisionGroup;
 
   struct UserData
   {
-    FCLCollisionObject* mCollisionObject;
+    OdeCollisionObject* mCollisionObject;
 
-    UserData(FCLCollisionObject* collisionObject);
+    UserData(OdeCollisionObject* collisionObject);
   };
 
-  /// Return FCL collision object
-  fcl::CollisionObject* getFCLCollisionObject();
-
-  /// Return FCL collision object
-  const fcl::CollisionObject* getFCLCollisionObject() const;
+  virtual ~OdeCollisionObject();
 
 protected:
 
   /// Constructor
-  FCLCollisionObject(CollisionDetector* collisionDetector,
+  OdeCollisionObject(
+      OdeCollisionDetector* collisionDetector,
       const dynamics::ShapeFrame* shapeFrame,
-      const fcl_shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
+      dGeomID odeCollGeom);
 
   // Documentation inherited
   void updateEngineData() override;
 
+  dBodyID getBodyId() const;
+  dGeomID getGeomId() const;
+
 protected:
 
-  /// FCL collision geometry user data
-  std::unique_ptr<UserData> mFCLCollisionObjectUserData;
+  /// ODE collision geometry user data
+  std::unique_ptr<UserData> mOdeCollisionObjectUserData;
 
-  /// FCL collision object
-  std::unique_ptr<fcl::CollisionObject> mFCLCollisionObject;
+  dBodyID mBodyId;
+  dGeomID mGeomId;
 
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
+#endif  // DART_COLLISION_ODE_ODECOLLISIONOBJECT_HPP_

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -39,6 +39,10 @@
 namespace dart {
 namespace collision {
 
+namespace detail {
+class OdeGeom;
+} // namespace detail
+
 class OdeCollisionObject : public CollisionObject
 {
 public:
@@ -71,9 +75,6 @@ protected:
   ///
   /// If the ODE geom type is immobile, this is nullptr.
   dBodyID mBodyId;
-
-private:
-
 };
 
 } // namespace collision

--- a/dart/collision/ode/OdeTypes.cpp
+++ b/dart/collision/ode/OdeTypes.cpp
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Graphics Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Personal Robotics Lab, Carnegie Mellon University
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:
@@ -29,56 +28,16 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
-#define DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
-
-#include <fcl/collision_object.h>
-#include "dart/collision/CollisionObject.hpp"
-#include "dart/collision/fcl/FCLTypes.hpp"
+#include "dart/collision/ode/OdeTypes.hpp"
 
 namespace dart {
 namespace collision {
 
-class FCLCollisionObject : public CollisionObject
+//==============================================================================
+Eigen::Vector3d OdeTypes::convertVector3(const dVector3& vec)
 {
-public:
-
-  friend class FCLCollisionDetector;
-
-  struct UserData
-  {
-    FCLCollisionObject* mCollisionObject;
-
-    UserData(FCLCollisionObject* collisionObject);
-  };
-
-  /// Return FCL collision object
-  fcl::CollisionObject* getFCLCollisionObject();
-
-  /// Return FCL collision object
-  const fcl::CollisionObject* getFCLCollisionObject() const;
-
-protected:
-
-  /// Constructor
-  FCLCollisionObject(CollisionDetector* collisionDetector,
-      const dynamics::ShapeFrame* shapeFrame,
-      const fcl_shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
-
-  // Documentation inherited
-  void updateEngineData() override;
-
-protected:
-
-  /// FCL collision geometry user data
-  std::unique_ptr<UserData> mFCLCollisionObjectUserData;
-
-  /// FCL collision object
-  std::unique_ptr<fcl::CollisionObject> mFCLCollisionObject;
-
-};
+  return Eigen::Vector3d(vec[0], vec[1], vec[2]);
+}
 
 }  // namespace collision
 }  // namespace dart
-
-#endif  // DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_

--- a/dart/collision/ode/OdeTypes.hpp
+++ b/dart/collision/ode/OdeTypes.hpp
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Graphics Lab, Georgia Tech Research Corporation
- * Copyright (c) 2016-2017, Personal Robotics Lab, Carnegie Mellon University
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:
@@ -29,56 +28,22 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
-#define DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
+#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
+#define DART_COLLISION_ODE_ODETYPES_HPP_
 
-#include <fcl/collision_object.h>
-#include "dart/collision/CollisionObject.hpp"
-#include "dart/collision/fcl/FCLTypes.hpp"
+#include <Eigen/Eigen>
+#include <ode/ode.h>
 
 namespace dart {
 namespace collision {
 
-class FCLCollisionObject : public CollisionObject
+class OdeTypes
 {
 public:
-
-  friend class FCLCollisionDetector;
-
-  struct UserData
-  {
-    FCLCollisionObject* mCollisionObject;
-
-    UserData(FCLCollisionObject* collisionObject);
-  };
-
-  /// Return FCL collision object
-  fcl::CollisionObject* getFCLCollisionObject();
-
-  /// Return FCL collision object
-  const fcl::CollisionObject* getFCLCollisionObject() const;
-
-protected:
-
-  /// Constructor
-  FCLCollisionObject(CollisionDetector* collisionDetector,
-      const dynamics::ShapeFrame* shapeFrame,
-      const fcl_shared_ptr<fcl::CollisionGeometry>& fclCollGeom);
-
-  // Documentation inherited
-  void updateEngineData() override;
-
-protected:
-
-  /// FCL collision geometry user data
-  std::unique_ptr<UserData> mFCLCollisionObjectUserData;
-
-  /// FCL collision object
-  std::unique_ptr<fcl::CollisionObject> mFCLCollisionObject;
-
+  static Eigen::Vector3d convertVector3(const dVector3& vec);
 };
 
 }  // namespace collision
 }  // namespace dart
 
-#endif  // DART_COLLISION_FCL_FCLCOLLISIONOBJECT_HPP_
+#endif  // DART_COLLISION_ODE_ODETYPES_HPP_

--- a/dart/collision/ode/OdeTypes.hpp
+++ b/dart/collision/ode/OdeTypes.hpp
@@ -41,7 +41,6 @@ class OdeTypes
 {
 public:
   static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
 };
 
 }  // namespace collision

--- a/dart/collision/ode/detail/OdeBox.cpp
+++ b/dart/collision/ode/detail/OdeBox.cpp
@@ -28,23 +28,27 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#include "dart/collision/ode/detail/OdeBox.hpp"
 
-#include <Eigen/Eigen>
-#include <ode/ode.h>
+#include "dart/dynamics/BoxShape.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+//==============================================================================
+OdeBox::OdeBox(const OdeCollisionObject* parent, const Eigen::Vector3d& size)
+  : OdeGeom(parent)
 {
-public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
-};
+  mGeomId = dCreateBox(0, size.x(), size.y(), size.z());
+}
 
-}  // namespace collision
-}  // namespace dart
+//==============================================================================
+OdeBox::~OdeBox()
+{
+  dGeomDestroy(mGeomId);
+}
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+} // namespace detail
+} // namespace collision
+} // namespace dart

--- a/dart/collision/ode/detail/OdeBox.hpp
+++ b/dart/collision/ode/detail/OdeBox.hpp
@@ -28,23 +28,29 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#ifndef DART_COLLISION_ODE_DETAIL_ODEBOX_HPP_
+#define DART_COLLISION_ODE_DETAIL_ODEBOX_HPP_
 
-#include <Eigen/Eigen>
 #include <ode/ode.h>
+
+#include "dart/collision/ode/detail/OdeGeom.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+class OdeBox : public OdeGeom
 {
 public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
+  /// Constructor
+  OdeBox(const OdeCollisionObject* parent, const Eigen::Vector3d& size);
+
+  /// Destructor
+  virtual ~OdeBox();
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace detail
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+#endif  // DART_COLLISION_ODE_DETAIL_ODEBOX_HPP_

--- a/dart/collision/ode/detail/OdeCapsule.cpp
+++ b/dart/collision/ode/detail/OdeCapsule.cpp
@@ -28,23 +28,28 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#include "dart/collision/ode/detail/OdeCapsule.hpp"
 
-#include <Eigen/Eigen>
-#include <ode/ode.h>
+#include "dart/dynamics/CapsuleShape.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+//==============================================================================
+OdeCapsule::OdeCapsule(
+    const OdeCollisionObject* parent, double radius, double height)
+  : OdeGeom(parent)
 {
-public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
-};
+  mGeomId = dCreateCylinder(0, radius, height);
+}
 
-}  // namespace collision
-}  // namespace dart
+//==============================================================================
+OdeCapsule::~OdeCapsule()
+{
+  dGeomDestroy(mGeomId);
+}
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+} // namespace detail
+} // namespace collision
+} // namespace dart

--- a/dart/collision/ode/detail/OdeCapsule.cpp
+++ b/dart/collision/ode/detail/OdeCapsule.cpp
@@ -41,7 +41,7 @@ OdeCapsule::OdeCapsule(
     const OdeCollisionObject* parent, double radius, double height)
   : OdeGeom(parent)
 {
-  mGeomId = dCreateCylinder(0, radius, height);
+  mGeomId = dCreateCapsule(0, radius, height);
 }
 
 //==============================================================================

--- a/dart/collision/ode/detail/OdeCapsule.hpp
+++ b/dart/collision/ode/detail/OdeCapsule.hpp
@@ -28,23 +28,30 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#ifndef DART_COLLISION_ODE_DETAIL_ODECAPSULE_HPP_
+#define DART_COLLISION_ODE_DETAIL_ODECAPSULE_HPP_
 
-#include <Eigen/Eigen>
 #include <ode/ode.h>
+
+#include "dart/collision/ode/detail/OdeGeom.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+class OdeCapsule : public OdeGeom
 {
 public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
+  /// Constructor
+  OdeCapsule(
+    const OdeCollisionObject* parent, double radius, double height);
+
+  /// Destructor
+  virtual ~OdeCapsule();
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace detail
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+#endif  // DART_COLLISION_ODE_DETAIL_ODECAPSULE_HPP_

--- a/dart/collision/ode/detail/OdeCylinder.cpp
+++ b/dart/collision/ode/detail/OdeCylinder.cpp
@@ -28,23 +28,28 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#include "dart/collision/ode/detail/OdeCylinder.hpp"
 
-#include <Eigen/Eigen>
-#include <ode/ode.h>
+#include "dart/dynamics/CylinderShape.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+//==============================================================================
+OdeCylinder::OdeCylinder(
+    const OdeCollisionObject* parent, double radius, double height)
+  : OdeGeom(parent)
 {
-public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
-};
+  mGeomId = dCreateCylinder(0, radius, height);
+}
 
-}  // namespace collision
-}  // namespace dart
+//==============================================================================
+OdeCylinder::~OdeCylinder()
+{
+  dGeomDestroy(mGeomId);
+}
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+} // namespace detail
+} // namespace collision
+} // namespace dart

--- a/dart/collision/ode/detail/OdeCylinder.hpp
+++ b/dart/collision/ode/detail/OdeCylinder.hpp
@@ -28,23 +28,30 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#ifndef DART_COLLISION_ODE_DETAIL_ODECYLINDER_HPP_
+#define DART_COLLISION_ODE_DETAIL_ODECYLINDER_HPP_
 
-#include <Eigen/Eigen>
 #include <ode/ode.h>
+
+#include "dart/collision/ode/detail/OdeGeom.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+class OdeCylinder : public OdeGeom
 {
 public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
+  /// Constructor
+  OdeCylinder(
+      const OdeCollisionObject* parent, double radius, double height);
+
+  /// Destructor
+  virtual ~OdeCylinder();
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace detail
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+#endif  // DART_COLLISION_ODE_DETAIL_ODECYLINDER_HPP_

--- a/dart/collision/ode/detail/OdeGeom.cpp
+++ b/dart/collision/ode/detail/OdeGeom.cpp
@@ -28,23 +28,52 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#include "dart/collision/ode/detail/OdeGeom.hpp"
 
-#include <Eigen/Eigen>
-#include <ode/ode.h>
+#include "dart/dynamics/PlaneShape.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+//==============================================================================
+OdeGeom::OdeGeom(const OdeCollisionObject* collObj)
+  : mParentCollisionObject(collObj),
+    mGeomId(nullptr) // will be set by concrete geom classes
 {
-public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
-};
+  // Do nothing
+}
 
-}  // namespace collision
-}  // namespace dart
+//==============================================================================
+OdeGeom::~OdeGeom()
+{
+  // Do nothing
+}
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+//==============================================================================
+const OdeCollisionObject* OdeGeom::getParentCollisionObject() const
+{
+  return mParentCollisionObject;
+}
+
+//==============================================================================
+void OdeGeom::updateEngineData()
+{
+  // Do nothing
+}
+
+//==============================================================================
+dGeomID OdeGeom::getOdeGeomId() const
+{
+  return mGeomId;
+}
+
+//==============================================================================
+bool OdeGeom::isPlaceable() const
+{
+  return true;
+}
+
+} // namespace detail
+} // namespace collision
+} // namespace dart

--- a/dart/collision/ode/detail/OdeGeom.hpp
+++ b/dart/collision/ode/detail/OdeGeom.hpp
@@ -28,23 +28,54 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#ifndef DART_COLLISION_ODE_DETAIL_ODEGEOM_HPP_
+#define DART_COLLISION_ODE_DETAIL_ODEGEOM_HPP_
 
-#include <Eigen/Eigen>
 #include <ode/ode.h>
+
+#include "dart/collision/ode/OdeCollisionObject.hpp"
+#include "dart/collision/ode/OdeCollisionDetector.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+class OdeGeom
 {
 public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
+  struct GeomUserData;
+
+  /// Constructor.
+  OdeGeom(const OdeCollisionObject* collObj);
+
+  /// Destructor.
+  virtual ~OdeGeom();
+
+  /// Returns the parent collision object.
+  const OdeCollisionObject* getParentCollisionObject() const;
+
+  // Documentation inherited.
+  virtual void updateEngineData();
+
+  /// Returns the ODE geom ID associated to this object.
+  dGeomID getOdeGeomId() const;
+
+  /// Returns true if the ODE geom is placeable.
+  virtual bool isPlaceable() const;
+
+protected:
+  /// Parent collision object
+  const OdeCollisionObject* mParentCollisionObject;
+
+  /// ODE geom ID associated with this object.
+  ///
+  /// This geom ID should be set by the concrete classes such as OdeBox and
+  /// OdeSphere.
+  dGeomID mGeomId;
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace detail
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+#endif  // DART_COLLISION_ODE_DETAIL_ODEGEOM_HPP_

--- a/dart/collision/ode/detail/OdeMesh.cpp
+++ b/dart/collision/ode/detail/OdeMesh.cpp
@@ -28,23 +28,47 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#include "dart/collision/ode/detail/OdeMesh.hpp"
 
-#include <Eigen/Eigen>
-#include <ode/ode.h>
+#include "dart/dynamics/MeshShape.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+//==============================================================================
+OdeMesh::OdeMesh(
+    const OdeCollisionObject* parent,
+    const aiScene* scene,
+    const Eigen::Vector3d& scale)
+  : OdeGeom(parent)
 {
-public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
-};
+  // fill array
 
-}  // namespace collision
-}  // namespace dart
+//  mGeomId = dCreateBox(0, size.x(), size.y(), size.z());
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+}
+
+//==============================================================================
+void fillArrays(float* mVertices, int* mIndices)
+{
+  
+}
+
+//==============================================================================
+OdeMesh::~OdeMesh()
+{
+  delete[] mVertices;
+  delete[] mIndices;
+
+  dGeomDestroy(mGeomId);
+}
+
+//==============================================================================
+void OdeMesh::updateEngineData()
+{
+}
+
+} // namespace detail
+} // namespace collision
+} // namespace dart

--- a/dart/collision/ode/detail/OdeMesh.hpp
+++ b/dart/collision/ode/detail/OdeMesh.hpp
@@ -28,23 +28,43 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#ifndef DART_COLLISION_ODE_DETAIL_ODEMESH_HPP_
+#define DART_COLLISION_ODE_DETAIL_ODEMESH_HPP_
 
-#include <Eigen/Eigen>
 #include <ode/ode.h>
+#include <assimp/scene.h>
+
+#include "dart/collision/ode/detail/OdeGeom.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+class OdeMesh : public OdeGeom
 {
 public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
+  /// Constructor
+  OdeMesh(
+    const OdeCollisionObject* parent,
+    const aiScene* scene,
+    const Eigen::Vector3d& scale = Eigen::Vector3d::Ones());
+
+  /// Destructor
+  virtual ~OdeMesh();
+
+  // Documentation inherited
+  void updateEngineData() override;
+
+private:
+  /// Array of vertex values.
+  float* mVertices;
+
+  /// Array of index values.
+  int* mIndices;
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace detail
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+#endif  // DART_COLLISION_ODE_DETAIL_ODEMESH_HPP_

--- a/dart/collision/ode/detail/OdeMesh.hpp
+++ b/dart/collision/ode/detail/OdeMesh.hpp
@@ -56,11 +56,22 @@ public:
   void updateEngineData() override;
 
 private:
+  void fillArrays(
+      const aiScene* scene,
+      const Eigen::Vector3d& scale = Eigen::Vector3d::Ones());
+
+private:
   /// Array of vertex values.
-  float* mVertices;
+  std::vector<double> mVertices;
+
+  /// Array of normals values.
+  std::vector<double> mNormals;
 
   /// Array of index values.
-  int* mIndices;
+  std::vector<int> mIndices;
+
+  /// ODE trimesh data.
+  dTriMeshDataID mOdeTriMeshDataId;
 };
 
 } // namespace detail

--- a/dart/collision/ode/detail/OdePlane.hpp
+++ b/dart/collision/ode/detail/OdePlane.hpp
@@ -28,23 +28,35 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#ifndef DART_COLLISION_ODE_DETAIL_ODEPLANE_HPP_
+#define DART_COLLISION_ODE_DETAIL_ODEPLANE_HPP_
 
-#include <Eigen/Eigen>
 #include <ode/ode.h>
+
+#include "dart/collision/ode/detail/OdeGeom.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+class OdePlane : public OdeGeom
 {
 public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
+  /// Constructor
+  OdePlane(
+    const OdeCollisionObject* parent,
+    const Eigen::Vector3d& normal,
+    double offset);
+
+  /// Destructor
+  virtual ~OdePlane();
+
+  // Documentation inherited.
+  void updateEngineData() override;
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace detail
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+#endif  // DART_COLLISION_ODE_DETAIL_ODEPLANE_HPP_

--- a/dart/collision/ode/detail/OdeSphere.cpp
+++ b/dart/collision/ode/detail/OdeSphere.cpp
@@ -28,23 +28,27 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#include "dart/collision/ode/detail/OdeSphere.hpp"
 
-#include <Eigen/Eigen>
-#include <ode/ode.h>
+#include "dart/dynamics/SphereShape.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+//==============================================================================
+OdeSphere::OdeSphere(const OdeCollisionObject* parent, double radius)
+  : OdeGeom(parent)
 {
-public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
-};
+  mGeomId = dCreateSphere(0, radius);
+}
 
-}  // namespace collision
-}  // namespace dart
+//==============================================================================
+OdeSphere::~OdeSphere()
+{
+  dGeomDestroy(mGeomId);
+}
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+} // namespace detail
+} // namespace collision
+} // namespace dart

--- a/dart/collision/ode/detail/OdeSphere.hpp
+++ b/dart/collision/ode/detail/OdeSphere.hpp
@@ -28,23 +28,29 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_ODETYPES_HPP_
-#define DART_COLLISION_ODE_ODETYPES_HPP_
+#ifndef DART_COLLISION_ODE_DETAIL_ODESPHERE_HPP_
+#define DART_COLLISION_ODE_DETAIL_ODESPHERE_HPP_
 
-#include <Eigen/Eigen>
 #include <ode/ode.h>
+
+#include "dart/collision/ode/detail/OdeGeom.hpp"
 
 namespace dart {
 namespace collision {
+namespace detail {
 
-class OdeTypes
+class OdeSphere : public OdeGeom
 {
 public:
-  static Eigen::Vector3d convertVector3(const dVector3& vec);
-  static void convertMatrix3(dMatrix3 out, const Eigen::Matrix3d& in);
+  /// Constructor
+  OdeSphere(const OdeCollisionObject* parent, double radius);
+
+  /// Destructor
+  virtual ~OdeSphere();
 };
 
-}  // namespace collision
-}  // namespace dart
+} // namespace detail
+} // namespace collision
+} // namespace dart
 
-#endif  // DART_COLLISION_ODE_ODETYPES_HPP_
+#endif  // DART_COLLISION_ODE_DETAIL_ODESPHERE_HPP_

--- a/dart/collision/ode/ode.hpp.in
+++ b/dart/collision/ode/ode.hpp.in
@@ -1,0 +1,3 @@
+// Automatically generated file by cmake
+
+${collision_ode_headers}

--- a/dart/config.hpp.in
+++ b/dart/config.hpp.in
@@ -65,6 +65,7 @@
 #cmakedefine01 HAVE_IPOPT
 #cmakedefine01 HAVE_SNOPT
 #cmakedefine01 HAVE_BULLET_COLLISION
+#cmakedefine01 HAVE_ODE_COLLISION
 #cmakedefine01 HAVE_FLANN
 
 #cmakedefine01 DART_ENABLE_SIMD

--- a/dart/external/odelcpsolver/common.h
+++ b/dart/external/odelcpsolver/common.h
@@ -25,8 +25,8 @@
 
 #include <math.h>
 
-#include "odeconfig.h"
-#include "error.h"
+#include "dart/external/odelcpsolver/odeconfig.h"
+#include "dart/external/odelcpsolver/error.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/dart/external/odelcpsolver/error.cpp
+++ b/dart/external/odelcpsolver/error.cpp
@@ -20,8 +20,8 @@
  *                                                                       *
  *************************************************************************/
 
-#include "odeconfig.h"
-#include "error.h"
+#include "dart/external/odelcpsolver/odeconfig.h"
+#include "dart/external/odelcpsolver/error.h"
 
 
 

--- a/dart/external/odelcpsolver/error.h
+++ b/dart/external/odelcpsolver/error.h
@@ -25,7 +25,7 @@
 #ifndef _ODE_ERROR_H_
 #define _ODE_ERROR_H_
 
-#include "odeconfig.h"
+#include "dart/external/odelcpsolver/odeconfig.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/dart/external/odelcpsolver/fastdot.cpp
+++ b/dart/external/odelcpsolver/fastdot.cpp
@@ -22,7 +22,7 @@
 
 /* generated code, do not edit. */
 
-#include "matrix.h"
+#include "dart/external/odelcpsolver/matrix.h"
 
 
 dReal _dDot (const dReal *a, const dReal *b, int n)

--- a/dart/external/odelcpsolver/fastldlt.cpp
+++ b/dart/external/odelcpsolver/fastldlt.cpp
@@ -22,7 +22,7 @@
 
 /* generated code, do not edit. */
 
-#include "matrix.h"
+#include "dart/external/odelcpsolver/matrix.h"
 
 /* solve L*X=B, with B containing 1 right hand sides.
  * L is an n*n lower triangular matrix with ones on the diagonal.

--- a/dart/external/odelcpsolver/fastlsolve.cpp
+++ b/dart/external/odelcpsolver/fastlsolve.cpp
@@ -22,7 +22,7 @@
 
 /* generated code, do not edit. */
 
-#include "matrix.h"
+#include "dart/external/odelcpsolver/matrix.h"
 
 /* solve L*X=B, with B containing 1 right hand sides.
  * L is an n*n lower triangular matrix with ones on the diagonal.

--- a/dart/external/odelcpsolver/fastltsolve.cpp
+++ b/dart/external/odelcpsolver/fastltsolve.cpp
@@ -22,7 +22,7 @@
 
 /* generated code, do not edit. */
 
-#include "matrix.h"
+#include "dart/external/odelcpsolver/matrix.h"
 
 /* solve L^T * x=b, with b containing 1 right hand side.
  * L is an n*n lower triangular matrix with ones on the diagonal.

--- a/dart/external/odelcpsolver/lcp.cpp
+++ b/dart/external/odelcpsolver/lcp.cpp
@@ -108,10 +108,10 @@ rows/columns and manipulate C.
 
 */
 
-#include "odeconfig.h"
-#include "lcp.h"
-#include "matrix.h"
-#include "misc.h"
+#include "dart/external/odelcpsolver/odeconfig.h"
+#include "dart/external/odelcpsolver/lcp.h"
+#include "dart/external/odelcpsolver/matrix.h"
+#include "dart/external/odelcpsolver/misc.h"
 
 //***************************************************************************
 // code generation parameters

--- a/dart/external/odelcpsolver/lcp.h
+++ b/dart/external/odelcpsolver/lcp.h
@@ -54,8 +54,8 @@ to be implemented. the first `nub' variables are assumed to have findex < 0.
 #include <stdio.h>
 #include <cassert>
 
-#include "odeconfig.h"
-#include "common.h"
+#include "dart/external/odelcpsolver/odeconfig.h"
+#include "dart/external/odelcpsolver/common.h"
 
 void dSolveLCP (int n, dReal *A, dReal *x, dReal *b, dReal *w,
 	int nub, dReal *lo, dReal *hi, int *findex);

--- a/dart/external/odelcpsolver/matrix.cpp
+++ b/dart/external/odelcpsolver/matrix.cpp
@@ -27,8 +27,8 @@
   #include <malloc.h>
 #endif
 
-#include "common.h"
-#include "matrix.h"
+#include "dart/external/odelcpsolver/common.h"
+#include "dart/external/odelcpsolver/matrix.h"
 
 #ifndef EFFICIENT_ALIGNMENT
 #define EFFICIENT_ALIGNMENT 16

--- a/dart/external/odelcpsolver/matrix.h
+++ b/dart/external/odelcpsolver/matrix.h
@@ -25,7 +25,7 @@
 #ifndef _ODE_MATRIX_H_
 #define _ODE_MATRIX_H_
 
-#include "common.h"
+#include "dart/external/odelcpsolver/common.h"
 
 
 #ifdef __cplusplus

--- a/dart/external/odelcpsolver/misc.cpp
+++ b/dart/external/odelcpsolver/misc.cpp
@@ -20,9 +20,9 @@
  *                                                                       *
  *************************************************************************/
 
-#include "odeconfig.h"
-#include "misc.h"
-#include "matrix.h"
+#include "dart/external/odelcpsolver/odeconfig.h"
+#include "dart/external/odelcpsolver/misc.h"
+#include "dart/external/odelcpsolver/matrix.h"
 
 //****************************************************************************
 // random numbers

--- a/dart/external/odelcpsolver/misc.h
+++ b/dart/external/odelcpsolver/misc.h
@@ -25,7 +25,7 @@
 #ifndef _ODE_MISC_H_
 #define _ODE_MISC_H_
 
-#include "common.h"
+#include "dart/external/odelcpsolver/common.h"
 
 
 #ifdef __cplusplus

--- a/dart/utils/CMakeLists.txt
+++ b/dart/utils/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(
 )
 target_link_libraries(
   ${target_name}
+  dart-collision-ode
   dart-collision-bullet
   ${TINYXML_LIBRARIES}
   ${TINYXML2_LIBRARIES}
@@ -38,7 +39,7 @@ target_link_libraries(
 # Component
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
-add_component_dependencies(${PROJECT_NAME} ${component_name} collision-bullet)
+add_component_dependencies(${PROJECT_NAME} ${component_name} collision-ode collision-bullet)
 
 # Coverage test
 dart_coveralls_add(${hdrs} ${srcs} ${dart_utils_headers} ${dart_utils_sources})

--- a/dart/utils/CMakeLists.txt
+++ b/dart/utils/CMakeLists.txt
@@ -30,7 +30,6 @@ target_include_directories(
 )
 target_link_libraries(
   ${target_name}
-  dart-collision-ode
   dart-collision-bullet
   ${TINYXML_LIBRARIES}
   ${TINYXML2_LIBRARIES}
@@ -39,7 +38,7 @@ target_link_libraries(
 # Component
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
-add_component_dependencies(${PROJECT_NAME} ${component_name} collision-ode collision-bullet)
+add_component_dependencies(${PROJECT_NAME} ${component_name} collision-bullet)
 
 # Coverage test
 dart_coveralls_add(${hdrs} ${srcs} ${dart_utils_headers} ${dart_utils_sources})

--- a/unittests/comprehensive/CMakeLists.txt
+++ b/unittests/comprehensive/CMakeLists.txt
@@ -17,6 +17,9 @@ if(TARGET dart-utils)
 
   dart_add_test("comprehensive" test_Collision)
   target_link_libraries(test_Collision dart-utils)
+  if(TARGET dart-collision-ode)
+    target_link_libraries(test_Collision dart-collision-ode)
+  endif()
 
   dart_add_test("comprehensive" test_Dynamics)
   target_link_libraries(test_Dynamics dart-utils)

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -772,6 +772,10 @@ void testBoxBox(const std::shared_ptr<CollisionDetector>& cd,
   collision::CollisionOption option;
   collision::CollisionResult result;
 
+  result.clear();
+  EXPECT_TRUE(group1->collide(group2.get(), option, &result));
+
+  result.clear();
   EXPECT_TRUE(groupAll->collide(option, &result));
 
   Eigen::Vector3d min = Eigen::Vector3d(-0.25, 0.25, 0.0);

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -822,10 +822,10 @@ void testBoxBox(const std::shared_ptr<CollisionDetector>& cd,
 //==============================================================================
 TEST_F(COLLISION, BoxBox)
 {
-  //auto fcl_mesh_dart = FCLCollisionDetector::create();
-  //fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
-  //fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
-  //testBoxBox(fcl_mesh_dart);
+  auto fcl_mesh_dart = FCLCollisionDetector::create();
+  fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
+  fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
+  testBoxBox(fcl_mesh_dart);
 
   // auto fcl_prim_fcl = FCLCollisionDetector::create();
   // fcl_prim_fcl->setPrimitiveShapeType(FCLCollisionDetector::MESH);
@@ -847,13 +847,13 @@ TEST_F(COLLISION, BoxBox)
   testBoxBox(ode);
 #endif
 
-//#if HAVE_BULLET_COLLISION
-//  auto bullet = BulletCollisionDetector::create();
-//  testBoxBox(bullet);
-//#endif
+#if HAVE_BULLET_COLLISION
+  auto bullet = BulletCollisionDetector::create();
+  testBoxBox(bullet);
+#endif
 
-//  auto dart = DARTCollisionDetector::create();
-//  testBoxBox(dart);
+  auto dart = DARTCollisionDetector::create();
+  testBoxBox(dart);
 }
 
 //==============================================================================
@@ -953,10 +953,10 @@ void testCylinderCylinder(const std::shared_ptr<CollisionDetector>& cd)
 //==============================================================================
 TEST_F(COLLISION, testCylinderCylinder)
 {
-  // auto fcl_mesh_dart = FCLCollisionDetector::create();
-  // fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
-  // fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
-  // testCylinderCylinder(fcl_mesh_dart);
+  auto fcl_mesh_dart = FCLCollisionDetector::create();
+  fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
+  fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
+  testCylinderCylinder(fcl_mesh_dart);
 
   // auto fcl_prim_fcl = FCLCollisionDetector::create();
   // fcl_prim_fcl->setPrimitiveShapeType(FCLCollisionDetector::MESH);
@@ -1016,7 +1016,7 @@ void testCapsuleCapsule(const std::shared_ptr<CollisionDetector>& cd)
 
   result.clear();
   simpleFrame1->setTranslation(Eigen::Vector3d::Zero());
-  simpleFrame2->setTranslation(Eigen::Vector3d(0.75, 0.0, 0.0));
+  simpleFrame2->setTranslation(Eigen::Vector3d(0.74, 0.0, 0.0));
   EXPECT_TRUE(group->collide(option, &result));
   EXPECT_TRUE(result.getNumContacts() >= 1u);
 }

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -799,10 +799,10 @@ void testBoxBox(const std::shared_ptr<CollisionDetector>& cd,
 //==============================================================================
 TEST_F(COLLISION, BoxBox)
 {
-  auto fcl_mesh_dart = FCLCollisionDetector::create();
-  fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
-  fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
-  testBoxBox(fcl_mesh_dart);
+  //auto fcl_mesh_dart = FCLCollisionDetector::create();
+  //fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
+  //fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
+  //testBoxBox(fcl_mesh_dart);
 
   // auto fcl_prim_fcl = FCLCollisionDetector::create();
   // fcl_prim_fcl->setPrimitiveShapeType(FCLCollisionDetector::MESH);
@@ -820,17 +820,17 @@ TEST_F(COLLISION, BoxBox)
   // testBoxBox(fcl_mesh_fcl);
 
 #if HAVE_ODE_COLLISION
-//  auto ode = OdeCollisionDetector::create();
-//  testBoxBox(ode);
+  auto ode = OdeCollisionDetector::create();
+  testBoxBox(ode);
 #endif
 
-#if HAVE_BULLET_COLLISION
-  auto bullet = BulletCollisionDetector::create();
-  testBoxBox(bullet);
-#endif
+//#if HAVE_BULLET_COLLISION
+//  auto bullet = BulletCollisionDetector::create();
+//  testBoxBox(bullet);
+//#endif
 
-  auto dart = DARTCollisionDetector::create();
-  testBoxBox(dart);
+//  auto dart = DARTCollisionDetector::create();
+//  testBoxBox(dart);
 }
 
 //==============================================================================
@@ -891,6 +891,77 @@ void testOptions(const std::shared_ptr<CollisionDetector>& cd)
   EXPECT_FALSE(group->collide(option, &result));
   EXPECT_EQ(result.getNumContacts(), 0u);
   EXPECT_FALSE(result.isCollision());
+}
+
+//==============================================================================
+void testCylinderCylinder(const std::shared_ptr<CollisionDetector>& cd)
+{
+  auto simpleFrame1 = SimpleFrame::createShared(Frame::World());
+  auto simpleFrame2 = SimpleFrame::createShared(Frame::World());
+
+  auto shape1 = std::make_shared<CapsuleShape>(1.0, 1.0);
+  auto shape2 = std::make_shared<CapsuleShape>(0.5, 1.0);
+
+  simpleFrame1->setShape(shape1);
+  simpleFrame2->setShape(shape2);
+
+  auto group = cd->createCollisionGroup(simpleFrame1.get(), simpleFrame2.get());
+
+  EXPECT_EQ(group->getNumShapeFrames(), 2u);
+
+  collision::CollisionOption option;
+  option.enableContact = true;
+
+  collision::CollisionResult result;
+
+  result.clear();
+  simpleFrame1->setTranslation(Eigen::Vector3d::Zero());
+  simpleFrame2->setTranslation(Eigen::Vector3d(2.0, 0.0, 0.0));
+  EXPECT_FALSE(group->collide(option, &result));
+  EXPECT_TRUE(result.getNumContacts() == 0u);
+
+  result.clear();
+  simpleFrame1->setTranslation(Eigen::Vector3d::Zero());
+  simpleFrame2->setTranslation(Eigen::Vector3d(0.75, 0.0, 0.0));
+  EXPECT_TRUE(group->collide(option, &result));
+  EXPECT_TRUE(result.getNumContacts() >= 1u);
+}
+
+//==============================================================================
+TEST_F(COLLISION, testCylinderCylinder)
+{
+  // auto fcl_mesh_dart = FCLCollisionDetector::create();
+  // fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
+  // fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
+  // testCylinderCylinder(fcl_mesh_dart);
+
+  // auto fcl_prim_fcl = FCLCollisionDetector::create();
+  // fcl_prim_fcl->setPrimitiveShapeType(FCLCollisionDetector::MESH);
+  // fcl_prim_fcl->setContactPointComputationMethod(FCLCollisionDetector::FCL);
+  // testCylinderCylinder(fcl_prim_fcl);
+
+  // auto fcl_mesh_fcl = FCLCollisionDetector::create();
+  // fcl_mesh_fcl->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+  // fcl_mesh_fcl->setContactPointComputationMethod(FCLCollisionDetector::DART);
+  // testCylinderCylinder(fcl_mesh_fcl);
+
+  // auto fcl_mesh_fcl = FCLCollisionDetector::create();
+  // fcl_mesh_fcl->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+  // fcl_mesh_fcl->setContactPointComputationMethod(FCLCollisionDetector::FCL);
+  // testCylinderCylinder(fcl_mesh_fcl);
+
+#if HAVE_ODE_COLLISION
+  auto ode = OdeCollisionDetector::create();
+  testCylinderCylinder(ode);
+#endif
+
+#if HAVE_BULLET_COLLISION
+  auto bullet = BulletCollisionDetector::create();
+  testCylinderCylinder(bullet);
+#endif
+
+  // auto dart = DARTCollisionDetector::create();
+  // testCylinderCylinder(dart);
 }
 
 //==============================================================================

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -706,7 +706,7 @@ void testSphereSphere(const std::shared_ptr<CollisionDetector>& cd,
   {
     EXPECT_TRUE(group->collide(option, &result));
     EXPECT_EQ(result.getNumContacts(), 1u);
-    for (auto i = 0; i < result.getNumContacts(); ++i)
+    for (auto i = 0u; i < result.getNumContacts(); ++i)
     {
       std::cout << "point: " << result.getContact(i).point.transpose() << std::endl;
     }


### PR DESCRIPTION
This PR adds the ODE collision detector support to DART.

The supported shape types are sphere, box, capsule, cylinder plane, and mesh; and the unsupported types are ellipsoid, cone, multi-sphere, and soft mesh.

The ODE collision detector only supports collision detection queries but not distance queries.

The ODE collision detector is only enabled when ODE 0.11 or later is installed on the system.
