### PR TITLE
Improve MultiSphereShape rendering

### DIFF
--- a/dart/gui/OpenGLRenderInterface.cpp
+++ b/dart/gui/OpenGLRenderInterface.cpp
@@ -143,11 +143,8 @@ void OpenGLRenderInterface::scale(const Eigen::Vector3d& _scale) {
     glScaled(_scale[0], _scale[1], _scale[2]);
 }
 
-void OpenGLRenderInterface::drawSphere(double radius)
+void OpenGLRenderInterface::drawSphere(double radius, int slices, int stacks)
 {
-  GLint slices = 16;
-  GLint stacks = 16;
-
   // Code taken from glut/lib/glut_shapes.c
   QUAD_OBJ_INIT;
   gluQuadricDrawStyle(quadObj, GLU_FILL);
@@ -155,6 +152,63 @@ void OpenGLRenderInterface::drawSphere(double radius)
   //gluQuadricTexture(quadObj, GL_TRUE);
 
   gluSphere(quadObj, radius, slices, stacks);
+}
+
+void OpenGLRenderInterface::drawMultiSphere(
+    const std::vector<std::pair<double, Eigen::Vector3d>>& spheres,
+    int slices, int stacks)
+{
+  // Draw spheres
+  for (const auto& sphere : spheres)
+  {
+    glPushMatrix();
+    {
+      glTranslated(sphere.second.x(), sphere.second.y(), sphere.second.z());
+      drawSphere(sphere.first, slices, stacks);
+    }
+    glPopMatrix();
+  }
+
+  if (spheres.size() < 2u)
+    return;
+
+  // Draw the cylinder that connects the first and second spheres.
+  //
+  // TODO(JS): This is a workaround. The correct solution would be drawing the
+  // convex hull of the spheres but we don't have a function that computes
+  // convex hull from point cloud.
+  const auto& r0 = spheres[0].first;
+  const auto& r1 = spheres[1].first;
+  const Eigen::Vector3d& p0 = spheres[0].second;
+  const Eigen::Vector3d& p1 = spheres[1].second;
+
+  const auto dist = (p0 - p1).norm();
+
+  if (dist < std::numeric_limits<double>::epsilon())
+    return;
+
+  const Eigen::Vector3d zAxis = (p1 - p0).normalized();
+
+  const auto r0r1 = r0 - r1;
+  const auto theta = std::acos(r0r1/dist);
+  const auto baseRadius = r0*std::sin(theta);
+  const auto topRadius = r1*std::sin(theta);
+  const Eigen::Vector3d baseCenter = p0 + r0*std::cos(theta)*zAxis;
+  const Eigen::Vector3d topCenter = p1 + r1*std::cos(theta)*zAxis;
+  const Eigen::Vector3d center = 0.5*(baseCenter + topCenter);
+  const auto height = (topCenter - baseCenter).norm();
+  const Eigen::AngleAxisd aa(Eigen::Quaterniond().setFromTwoVectors(
+      Eigen::Vector3d::UnitZ(), zAxis));
+
+  glPushMatrix();
+  {
+    glTranslated(center.x(), center.y(), center.z());
+    glRotated(math::toDegree(aa.angle()),
+              aa.axis().x(), aa.axis().y(), aa.axis().z());
+
+    drawOpenCylinder(baseRadius, topRadius, height, slices, stacks);
+  }
+  glPopMatrix();
 }
 
 void OpenGLRenderInterface::drawEllipsoid(const Eigen::Vector3d& _diameters) {
@@ -208,28 +262,49 @@ void OpenGLRenderInterface::drawCube(const Eigen::Vector3d& _size) {
     //glut/lib/glut_shapes.c
 }
 
-void OpenGLRenderInterface::drawCylinder(double _radius, double _height) {
-    glScaled(_radius, _radius, _height);
+//==============================================================================
+void OpenGLRenderInterface::drawOpenCylinder(
+    double baseRadius, double topRadius, double height, int slices, int stacks)
+{
+  glPushMatrix();
 
-    GLdouble radius = 1;
-    GLdouble height = 1;
-    GLint slices = 16;
-    GLint stacks = 16;
+  // Graphics assumes Cylinder is centered at CoM
+  // gluCylinder places base at z = 0 and top at z = height
+  glTranslated(0.0, 0.0, -0.5*height);
 
-    // Graphics assumes Cylinder is centered at CoM
-    // gluCylinder places base at z = 0 and top at z = height
-    glTranslated(0.0, 0.0, -0.5);
+  // Code taken from glut/lib/glut_shapes.c
+  QUAD_OBJ_INIT;
+  gluQuadricDrawStyle(quadObj, GLU_FILL);
+  gluQuadricNormals(quadObj, GLU_SMOOTH);
+  //gluQuadricTexture(quadObj, GL_TRUE);
 
-    // Code taken from glut/lib/glut_shapes.c
-    QUAD_OBJ_INIT;
-    gluQuadricDrawStyle(quadObj, GLU_FILL);
-    gluQuadricNormals(quadObj, GLU_SMOOTH);
-    //gluQuadricTexture(quadObj, GL_TRUE);
+  // glut/lib/glut_shapes.c
+  gluCylinder(quadObj, baseRadius, topRadius, height, slices, stacks);
 
-    gluCylinder(quadObj, radius, radius, height, slices, stacks); //glut/lib/glut_shapes.c
-    gluDisk(quadObj, 0, radius, slices, stacks);
-    glTranslated(0.0,0.0,1.0);
-    gluDisk(quadObj, 0, radius, slices, stacks);
+  glPopMatrix();
+}
+
+//==============================================================================
+void OpenGLRenderInterface::drawCylinder(
+    double radius, double height, int slices, int stacks)
+{
+  drawOpenCylinder(radius, radius, height, slices, stacks);
+
+  glPushMatrix();
+
+  glScaled(radius, radius, height);
+
+  QUAD_OBJ_INIT;
+  gluQuadricDrawStyle(quadObj, GLU_FILL);
+  gluQuadricNormals(quadObj, GLU_SMOOTH);
+  //gluQuadricTexture(quadObj, GL_TRUE);
+
+  glTranslated(0.0, 0.0, 0.5);
+  gluDisk(quadObj, 0, 1, slices, stacks);
+  glTranslated(0.0, 0.0, -1.0);
+  gluDisk(quadObj, 0, 1, slices, stacks);
+
+  glPopMatrix();
 }
 
 //==============================================================================
@@ -318,11 +393,9 @@ void OpenGLRenderInterface::drawCapsule(double radius, double height)
   gluQuadricNormals(quadObj, GLU_SMOOTH);
 
   gluCylinder(quadObj, radius, radius, height, slices, stacks); //glut/lib/glut_shapes.c
-  gluDisk(quadObj, 0, radius, slices, stacks);
-  glTranslated(0.0, 0.0, height);
-  gluDisk(quadObj, 0, radius, slices, stacks);
 
   // Upper hemisphere
+  glTranslated(0.0, 0.0, height);
   drawOpenDome(radius, slices, stacks);
 
   // Lower hemisphere

--- a/dart/gui/OpenGLRenderInterface.hpp
+++ b/dart/gui/OpenGLRenderInterface.hpp
@@ -80,10 +80,12 @@ public:
     void compileList(dynamics::Shape* _shape);
     GLuint compileList(const Eigen::Vector3d& _scale, const aiScene* _mesh);
 
-    void drawSphere(double _radius) override;
+    void drawSphere(double radius, int slices = 16, int stacks = 16) override;
+    void drawMultiSphere(const std::vector<std::pair<double, Eigen::Vector3d>>& spheres, int slices = 16, int stacks = 16) override;
     void drawEllipsoid(const Eigen::Vector3d& _diameters) override;
     void drawCube(const Eigen::Vector3d& _size) override;
-    void drawCylinder(double _radius, double _height) override;
+    void drawOpenCylinder(double baseRadius, double topRadius, double height, int slices = 16, int stacks = 16) override;
+    void drawCylinder(double _radius, double _height, int slices = 16, int stacks = 16) override;
     void drawCapsule(double radius, double height) override;
     void drawCone(double radius, double height) override;
     void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh) override;

--- a/dart/gui/RenderInterface.cpp
+++ b/dart/gui/RenderInterface.cpp
@@ -101,8 +101,13 @@ void RenderInterface::scale(const Eigen::Vector3d& /*_scale*/)
 {
 }
 
-void RenderInterface::drawSphere(double /*_radius*/)
+void RenderInterface::drawSphere(double /*_radius*/, int /*slices*/, int /*stacks*/)
 {
+}
+
+void RenderInterface::drawMultiSphere(const std::vector<std::pair<double, Eigen::Vector3d>>& /*spheres*/, int /*slices*/, int /*stacks*/)
+{
+  // Do nothing
 }
 
 void RenderInterface::drawEllipsoid(const Eigen::Vector3d& /*_size*/)
@@ -136,7 +141,11 @@ void RenderInterface::drawCube(const Eigen::Vector3d& /*_size*/)
 {
 }
 
-void RenderInterface::drawCylinder(double /*_radius*/, double /*_height*/)
+void RenderInterface::drawOpenCylinder(double /*baseRadius*/, double /*topRadius*/, double /*height*/, int /*slices*/, int /*stacks*/)
+{
+}
+
+void RenderInterface::drawCylinder(double /*_radius*/, double /*_height*/, int /*slices*/, int /*stacks*/)
 {
 }
 

--- a/dart/gui/RenderInterface.hpp
+++ b/dart/gui/RenderInterface.hpp
@@ -90,10 +90,12 @@ public:
     virtual void transform(const Eigen::Isometry3d& _transform); //glMultMatrix
     virtual void scale(const Eigen::Vector3d& _scale); //glScale
 
-    virtual void drawSphere(double _radius);
+    virtual void drawSphere(double radius, int slices = 16, int stacks = 16);
+    virtual void drawMultiSphere(const std::vector<std::pair<double, Eigen::Vector3d>>& spheres, int slices = 16, int stacks = 16);
     virtual void drawEllipsoid(const Eigen::Vector3d& _size);
     virtual void drawCube(const Eigen::Vector3d& _size);
-    virtual void drawCylinder(double _radius, double _height);
+    virtual void drawOpenCylinder(double baseRadius, double topRadius, double height, int slices = 16, int stacks = 16);
+    virtual void drawCylinder(double _radius, double _height, int slices = 16, int stacks = 16);
     virtual void drawCapsule(double _radius, double _height);
     virtual void drawCone(double _radius, double _height);
     virtual void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh);

--- a/dart/gui/SimWindow.cpp
+++ b/dart/gui/SimWindow.cpp
@@ -442,15 +442,7 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
   else if (shape->is<MultiSphereShape>())
   {
     const auto* multiSphere = static_cast<const MultiSphereShape*>(shape);
-    const auto& spheres = multiSphere->getSpheres();
-    for (const auto& sphere : spheres)
-    {
-      glTranslated(sphere.second.x(), sphere.second.y(), sphere.second.z());
-      mRI->drawSphere(sphere.first);
-      glTranslated(-sphere.second.x(), -sphere.second.y(), -sphere.second.z());
-    }
-    // TODO(JS): This is an workaround that draws only spheres rather than the
-    // actual convex hull.
+    mRI->drawMultiSphere(multiSphere->getSpheres());
   }
   else if (shape->is<MeshShape>())
   {


### PR DESCRIPTION
Previously, DART only draws the spheres in a `MultiSphereShape` while the actual shape is the convex hull enclosing all the spheres. This PR still doesn't render the convex hull but improves the visualization by drawing the cylinders that connect the pairs of the spheres.

Before:
![image](https://cloud.githubusercontent.com/assets/4038467/24438991/5e2a72c6-1419-11e7-9898-8099ba3f0157.png)


After:
![image](https://cloud.githubusercontent.com/assets/4038467/24438883/96d64628-1418-11e7-9e71-7df90f55e908.png)
