### PR TITLE
Rename MultiSphereShape to MultiSphereConvexHullShape

### DIFF
--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -53,7 +53,7 @@
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
-#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 
@@ -401,7 +401,7 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
   using dynamics::CapsuleShape;
   using dynamics::ConeShape;
   using dynamics::PlaneShape;
-  using dynamics::MultiSphereShape;
+  using dynamics::MultiSphereConvexHullShape;
   using dynamics::MeshShape;
   using dynamics::SoftMeshShape;
 
@@ -482,11 +482,11 @@ btCollisionShape* BulletCollisionDetector::createBulletCollisionShape(
     bulletCollisionShape = new btStaticPlaneShape(
           convertVector3(normal), offset);
   }
-  else if (shape->is<MultiSphereShape>())
+  else if (shape->is<MultiSphereConvexHullShape>())
   {
-    assert(dynamic_cast<const MultiSphereShape*>(shape.get()));
+    assert(dynamic_cast<const MultiSphereConvexHullShape*>(shape.get()));
 
-    const auto multiSphere = static_cast<const MultiSphereShape*>(shape.get());
+    const auto multiSphere = static_cast<const MultiSphereConvexHullShape*>(shape.get());
     const auto numSpheres = multiSphere->getNumSpheres();
     const auto& spheres = multiSphere->getSpheres();
 

--- a/dart/dynamics/CMakeLists.txt
+++ b/dart/dynamics/CMakeLists.txt
@@ -8,6 +8,8 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "dynamics headers" ${hdrs})
+# TODO: remove below line once the files are completely removed.
+list(REMOVE_ITEM header_names "MultiSphereShape.hpp")
 dart_generate_include_header_list(
   dynamics_headers
   "dart/dynamics/"

--- a/dart/dynamics/MultiSphereConvexHullShape.cpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.cpp
@@ -29,7 +29,7 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 
 #include "dart/common/Console.hpp"
 #include "dart/math/Helpers.hpp"
@@ -39,33 +39,33 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-MultiSphereShape::MultiSphereShape(const Spheres& spheres)
+MultiSphereConvexHullShape::MultiSphereConvexHullShape(const Spheres& spheres)
   : Shape(MULTISPHERE)
 {
   addSpheres(spheres);
 }
 
 //==============================================================================
-MultiSphereShape::~MultiSphereShape()
+MultiSphereConvexHullShape::~MultiSphereConvexHullShape()
 {
   // Do nothing
 }
 
 //==============================================================================
-const std::string& MultiSphereShape::getType() const
+const std::string& MultiSphereConvexHullShape::getType() const
 {
   return getStaticType();
 }
 
 //==============================================================================
-const std::string& MultiSphereShape::getStaticType()
+const std::string& MultiSphereConvexHullShape::getStaticType()
 {
-  static const std::string type("MultiSphereShape");
+  static const std::string type("MultiSphereConvexHullShape");
   return type;
 }
 
 //==============================================================================
-void MultiSphereShape::addSpheres(const MultiSphereShape::Spheres& spheres)
+void MultiSphereConvexHullShape::addSpheres(const MultiSphereConvexHullShape::Spheres& spheres)
 {
   mSpheres.insert(mSpheres.end(), spheres.begin(), spheres.end());
 
@@ -74,7 +74,7 @@ void MultiSphereShape::addSpheres(const MultiSphereShape::Spheres& spheres)
 }
 
 //==============================================================================
-void MultiSphereShape::addSphere(const MultiSphereShape::Sphere& sphere)
+void MultiSphereConvexHullShape::addSphere(const MultiSphereConvexHullShape::Sphere& sphere)
 {
   mSpheres.push_back(sphere);
 
@@ -83,13 +83,13 @@ void MultiSphereShape::addSphere(const MultiSphereShape::Sphere& sphere)
 }
 
 //==============================================================================
-void MultiSphereShape::addSphere(double radius, const Eigen::Vector3d& position)
+void MultiSphereConvexHullShape::addSphere(double radius, const Eigen::Vector3d& position)
 {
   addSphere(std::make_pair(radius, position));
 }
 
 //==============================================================================
-void MultiSphereShape::removeAllSpheres()
+void MultiSphereConvexHullShape::removeAllSpheres()
 {
   mSpheres.clear();
 
@@ -98,32 +98,32 @@ void MultiSphereShape::removeAllSpheres()
 }
 
 //==============================================================================
-std::size_t MultiSphereShape::getNumSpheres() const
+std::size_t MultiSphereConvexHullShape::getNumSpheres() const
 {
   return mSpheres.size();
 }
 
 //==============================================================================
-const MultiSphereShape::Spheres& MultiSphereShape::getSpheres() const
+const MultiSphereConvexHullShape::Spheres& MultiSphereConvexHullShape::getSpheres() const
 {
   return mSpheres;
 }
 
 //==============================================================================
-Eigen::Matrix3d MultiSphereShape::computeInertia(double mass) const
+Eigen::Matrix3d MultiSphereConvexHullShape::computeInertia(double mass) const
 {
   // Use bounding box to represent the mesh
   return BoxShape::computeInertia(mBoundingBox.computeFullExtents(), mass);
 }
 
 //==============================================================================
-void MultiSphereShape::updateVolume()
+void MultiSphereConvexHullShape::updateVolume()
 {
   mVolume = BoxShape::computeVolume(mBoundingBox.computeFullExtents());
 }
 
 //==============================================================================
-void MultiSphereShape::updateBoundingBoxDim()
+void MultiSphereConvexHullShape::updateBoundingBoxDim()
 {
   Eigen::Vector3d min
       = Eigen::Vector3d::Constant(std::numeric_limits<double>::max());

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -101,7 +101,8 @@ private:
 
 };
 
-using MultiSphereShape = MultiSphereConvexHullShape;
+DART_DEPRECATED(6.2)
+typedef MultiSphereConvexHullShape MultiSphereShape;
 
 }  // namespace dynamics
 }  // namespace dart

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016, Humanoid Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016-2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2016-2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_MULTISPHERECONVEXHULLSHAPE_HPP_
+#define DART_DYNAMICS_MULTISPHERECONVEXHULLSHAPE_HPP_
+
+#include <vector>
+
+#include "dart/dynamics/Shape.hpp"
+
+namespace dart {
+namespace dynamics {
+
+/// MultiSphereConvexHullShape represents the convex hull of a collection of spheres.
+class MultiSphereConvexHullShape : public Shape
+{
+public:
+
+  using Sphere = std::pair<double, Eigen::Vector3d>;
+  using Spheres = std::vector<Sphere>;
+
+  /// Constructor.
+  explicit MultiSphereConvexHullShape(const Spheres& spheres);
+
+  /// Destructor.
+  virtual ~MultiSphereConvexHullShape();
+
+  // Documentation inherited.
+  const std::string& getType() const override;
+
+  /// Returns shape type for this class
+  static const std::string& getStaticType();
+
+  /// Add a list of spheres
+  void addSpheres(const Spheres& spheres);
+
+  /// Add a sphere
+  void addSphere(const Sphere& sphere);
+
+  /// Add a sphere
+  void addSphere(double radius, const Eigen::Vector3d& position);
+
+  /// Remove all spheres
+  void removeAllSpheres();
+
+  /// Get the number of spheres
+  std::size_t getNumSpheres() const;
+
+  /// Get the set of spheres
+  const Spheres& getSpheres() const;
+
+  /// Compute the inertia of this MultiSphereConvexHullShape.
+  ///
+  /// \note The return value is an approximated inertia that is the inertia of
+  /// the axis-alinged bounding box of this MultiSphereConvexHullShape.
+  Eigen::Matrix3d computeInertia(double mass) const override;
+
+protected:
+
+  /// Update the volume of this MultiSphereConvexHullShape.
+  ///
+  /// \note The result volume is an approximated volumen that is the volume of
+  /// the axis-alinged bounding box of this MultiSphereConvexHullShape.
+  void updateVolume() override;
+
+private:
+
+  /// Update bounding box (in the local coordinate frame) of the shape.
+  void updateBoundingBoxDim();
+
+  /// Spheres
+  Spheres mSpheres;
+
+};
+
+using MultiSphereShape = MultiSphereConvexHullShape;
+
+}  // namespace dynamics
+}  // namespace dart
+
+#endif  // DART_DYNAMICS_MULTISPHERECONVEXHULLSHAPE_HPP_

--- a/dart/dynamics/MultiSphereShape.hpp
+++ b/dart/dynamics/MultiSphereShape.hpp
@@ -32,76 +32,9 @@
 #ifndef DART_DYNAMICS_MULTISPHERESHAPE_HPP_
 #define DART_DYNAMICS_MULTISPHERESHAPE_HPP_
 
-#include <vector>
+#warning "This header has been deprecated in DART 6.2. "\
+  "Please include MultiSphereConvexHullShape.hpp intead."
 
-#include "dart/dynamics/Shape.hpp"
-
-namespace dart {
-namespace dynamics {
-
-/// MultiSphereShape represents the convex hull of a collection of spheres.
-class MultiSphereShape : public Shape
-{
-public:
-
-  using Sphere = std::pair<double, Eigen::Vector3d>;
-  using Spheres = std::vector<Sphere>;
-
-  /// Constructor.
-  explicit MultiSphereShape(const Spheres& spheres);
-
-  /// Destructor.
-  virtual ~MultiSphereShape();
-
-  // Documentation inherited.
-  const std::string& getType() const override;
-
-  /// Returns shape type for this class
-  static const std::string& getStaticType();
-
-  /// Add a list of spheres
-  void addSpheres(const Spheres& spheres);
-
-  /// Add a sphere
-  void addSphere(const Sphere& sphere);
-
-  /// Add a sphere
-  void addSphere(double radius, const Eigen::Vector3d& position);
-
-  /// Remove all spheres
-  void removeAllSpheres();
-
-  /// Get the number of spheres
-  std::size_t getNumSpheres() const;
-
-  /// Get the set of spheres
-  const Spheres& getSpheres() const;
-
-  /// Compute the inertia of this MultiSphereShape.
-  ///
-  /// \note The return value is an approximated inertia that is the inertia of
-  /// the axis-alinged bounding box of this MultiSphereShape.
-  Eigen::Matrix3d computeInertia(double mass) const override;
-
-protected:
-
-  /// Update the volume of this MultiSphereShape.
-  ///
-  /// \note The result volume is an approximated volumen that is the volume of
-  /// the axis-alinged bounding box of this MultiSphereShape.
-  void updateVolume() override;
-
-private:
-
-  /// Update bounding box (in the local coordinate frame) of the shape.
-  void updateBoundingBoxDim();
-
-  /// Spheres
-  Spheres mSpheres;
-
-};
-
-}  // namespace dynamics
-}  // namespace dart
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 
 #endif  // DART_DYNAMICS_MULTISPHERESHAPE_HPP_

--- a/dart/gui/SimWindow.cpp
+++ b/dart/gui/SimWindow.cpp
@@ -51,7 +51,7 @@
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
-#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/LineSegmentShape.hpp"
@@ -404,7 +404,7 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
   using dynamics::CapsuleShape;
   using dynamics::ConeShape;
   using dynamics::PlaneShape;
-  using dynamics::MultiSphereShape;
+  using dynamics::MultiSphereConvexHullShape;
   using dynamics::MeshShape;
   using dynamics::SoftMeshShape;
   using dynamics::LineSegmentShape;
@@ -439,9 +439,9 @@ void SimWindow::drawShape(const dynamics::Shape* shape,
     const auto* cone = static_cast<const ConeShape*>(shape);
     mRI->drawCone(cone->getRadius(), cone->getHeight());
   }
-  else if (shape->is<MultiSphereShape>())
+  else if (shape->is<MultiSphereConvexHullShape>())
   {
-    const auto* multiSphere = static_cast<const MultiSphereShape*>(shape);
+    const auto* multiSphere = static_cast<const MultiSphereConvexHullShape*>(shape);
     mRI->drawMultiSphere(multiSphere->getSpheres());
   }
   else if (shape->is<MeshShape>())

--- a/dart/gui/osg/ShapeFrameNode.cpp
+++ b/dart/gui/osg/ShapeFrameNode.cpp
@@ -59,7 +59,7 @@
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
-#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/LineSegmentShape.hpp"
@@ -248,10 +248,10 @@ void ShapeFrameNode::createShapeNode(
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }
-  else if(shape->is<MultiSphereShape>())
+  else if(shape->is<MultiSphereConvexHullShape>())
   {
-    std::shared_ptr<MultiSphereShape> ms =
-        std::dynamic_pointer_cast<MultiSphereShape>(shape);
+    std::shared_ptr<MultiSphereConvexHullShape> ms =
+        std::dynamic_pointer_cast<MultiSphereConvexHullShape>(shape);
     if(ms)
       mRenderShapeNode = new render::MultiSphereShapeNode(ms, this);
     else

--- a/dart/gui/osg/render/MultiSphereShapeNode.cpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.cpp
@@ -37,7 +37,7 @@
 #include "dart/gui/osg/render/MultiSphereShapeNode.hpp"
 #include "dart/gui/osg/Utils.hpp"
 
-#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 
 namespace dart {
@@ -50,7 +50,7 @@ class MultiSphereShapeGeode : public ShapeNode, public ::osg::Geode
 {
 public:
 
-  MultiSphereShapeGeode(dart::dynamics::MultiSphereShape* shape,
+  MultiSphereShapeGeode(dart::dynamics::MultiSphereConvexHullShape* shape,
                         ShapeFrameNode* parentShapeFrame,
                         MultiSphereShapeNode* parentNode);
 
@@ -62,7 +62,7 @@ protected:
   virtual ~MultiSphereShapeGeode();
 
   MultiSphereShapeNode* mParentNode;
-  dart::dynamics::MultiSphereShape* mMultiSphereShape;
+  dart::dynamics::MultiSphereConvexHullShape* mMultiSphereShape;
   MultiSphereShapeDrawable* mDrawable;
 
 };
@@ -72,7 +72,7 @@ class MultiSphereShapeDrawable : public ::osg::ShapeDrawable
 {
 public:
 
-  MultiSphereShapeDrawable(dart::dynamics::MultiSphereShape* shape,
+  MultiSphereShapeDrawable(dart::dynamics::MultiSphereConvexHullShape* shape,
                            dart::dynamics::VisualAspect* visualAspect,
                            MultiSphereShapeGeode* parent);
 
@@ -82,7 +82,7 @@ protected:
 
   virtual ~MultiSphereShapeDrawable();
 
-  dart::dynamics::MultiSphereShape* mMultiSphereShape;
+  dart::dynamics::MultiSphereConvexHullShape* mMultiSphereShape;
   dart::dynamics::VisualAspect* mVisualAspect;
   MultiSphereShapeGeode* mParent;
 
@@ -90,7 +90,7 @@ protected:
 
 //==============================================================================
 MultiSphereShapeNode::MultiSphereShapeNode(
-    std::shared_ptr<dart::dynamics::MultiSphereShape> shape,
+    std::shared_ptr<dart::dynamics::MultiSphereConvexHullShape> shape,
     ShapeFrameNode* parent)
   : ShapeNode(shape, parent, this),
     mMultiSphereShape(shape),
@@ -135,7 +135,7 @@ MultiSphereShapeNode::~MultiSphereShapeNode()
 
 //==============================================================================
 MultiSphereShapeGeode::MultiSphereShapeGeode(
-    dart::dynamics::MultiSphereShape* shape,
+    dart::dynamics::MultiSphereConvexHullShape* shape,
     ShapeFrameNode* parentShapeFrame,
     MultiSphereShapeNode* parentNode)
   : ShapeNode(parentNode->getShape(), parentShapeFrame, this),
@@ -177,7 +177,7 @@ MultiSphereShapeGeode::~MultiSphereShapeGeode()
 
 //==============================================================================
 MultiSphereShapeDrawable::MultiSphereShapeDrawable(
-    dart::dynamics::MultiSphereShape* shape,
+    dart::dynamics::MultiSphereConvexHullShape* shape,
     dart::dynamics::VisualAspect* visualAspect,
     MultiSphereShapeGeode* parent)
   : mMultiSphereShape(shape),

--- a/dart/gui/osg/render/MultiSphereShapeNode.hpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.hpp
@@ -40,7 +40,7 @@
 namespace dart {
 
 namespace dynamics {
-class MultiSphereShape;
+class MultiSphereConvexHullShape;
 } // namespace dynamics
 
 namespace gui {
@@ -55,7 +55,7 @@ class MultiSphereShapeNode : public ShapeNode, public ::osg::MatrixTransform
 public:
 
   MultiSphereShapeNode(
-      std::shared_ptr<dart::dynamics::MultiSphereShape> shape,
+      std::shared_ptr<dart::dynamics::MultiSphereConvexHullShape> shape,
       ShapeFrameNode* parent);
 
   void refresh();
@@ -65,7 +65,7 @@ protected:
 
   virtual ~MultiSphereShapeNode();
 
-  std::shared_ptr<dart::dynamics::MultiSphereShape> mMultiSphereShape;
+  std::shared_ptr<dart::dynamics::MultiSphereConvexHullShape> mMultiSphereShape;
   MultiSphereShapeGeode* mGeode;
 
 };

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -57,7 +57,7 @@
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
-#include "dart/dynamics/MultiSphereShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/Joint.hpp"
@@ -1311,7 +1311,7 @@ dynamics::ShapePtr readShape(
     tinyxml2::XMLElement* multiSphereEle = getElement(geometryEle, "multi_sphere");
 
     ElementEnumerator xmlSpheres(multiSphereEle, "sphere");
-    dynamics::MultiSphereShape::Spheres spheres;
+    dynamics::MultiSphereConvexHullShape::Spheres spheres;
     while (xmlSpheres.next())
     {
       const double radius = getValueDouble(xmlSpheres.get(), "radius");
@@ -1321,7 +1321,7 @@ dynamics::ShapePtr readShape(
       spheres.emplace_back(radius, position);
     }
 
-    newShape = dynamics::ShapePtr(new dynamics::MultiSphereShape(spheres));
+    newShape = dynamics::ShapePtr(new dynamics::MultiSphereConvexHullShape(spheres));
   }
   else if (hasElement(geometryEle, "mesh"))
   {

--- a/unittests/unit/test_SkelParser.cpp
+++ b/unittests/unit/test_SkelParser.cpp
@@ -512,8 +512,8 @@ TEST(SkelParser, Shapes)
   skel = world->getSkeleton("multi sphere skeleton");
   EXPECT_NE(skel, nullptr);
   shape = skel->getBodyNode(0)->getShapeNode(0)->getShape();
-  EXPECT_TRUE(shape->is<MultiSphereShape>());
-  auto multiSphereShape = std::static_pointer_cast<MultiSphereShape>(shape);
+  EXPECT_TRUE(shape->is<MultiSphereConvexHullShape>());
+  auto multiSphereShape = std::static_pointer_cast<MultiSphereConvexHullShape>(shape);
   EXPECT_EQ(multiSphereShape->getNumSpheres(), 2u);
   const auto& spheres = multiSphereShape->getSpheres();
   EXPECT_EQ(spheres[0].first, 0.05);


### PR DESCRIPTION
This PR renames `MultiSphereShape` to `MultiSphereConvexHullShape` as suggested in this [comment](https://github.com/dartsim/dart/pull/862#issuecomment-290128731).