### PR TITLE
Use make_unique with full namespace

### DIFF
--- a/dart/common/detail/Cloneable.hpp
+++ b/dart/common/detail/Cloneable.hpp
@@ -177,7 +177,7 @@ template <typename... Args>
 ProxyCloneable<Base, OwnerT, DataT, setData, getData>::ProxyCloneable(
     Args&&... args)
   : mOwner(nullptr),
-    mData(make_unique<Data>(std::forward<Args>(args)...))
+    mData(dart::common::make_unique<Data>(std::forward<Args>(args)...))
 {
   // Do nothing
 }
@@ -278,7 +278,7 @@ void ProxyCloneable<Base, OwnerT, DataT, setData, getData>::set(
     return;
   }
 
-  mData = make_unique<Data>(std::move(data));
+  mData = dart::common::make_unique<Data>(std::move(data));
 }
 
 //==============================================================================
@@ -338,7 +338,7 @@ template <class Base, class OwnerT, class DataT,
 std::unique_ptr<Base> ProxyCloneable<
     Base, OwnerT, DataT, setData, getData>::clone() const
 {
-  return make_unique<ProxyCloneable>(get());
+  return dart::common::make_unique<ProxyCloneable>(get());
 }
 
 //==============================================================================


### PR DESCRIPTION
If DART is built with C++14 enabled, `dart::common::make_unique()` conflicts with `std::make_unique` (introduced in C++14). This PR adds the full namespace where it's missing to avoid the confliction.