### PR TITLE
Add getters for joints/bodies to MetaSkeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,7 @@ message(STATUS "Run 'make' to build all the components")
 message(STATUS "Run 'make tests' to build all the unittests")
 message(STATUS "Run 'make examples' to build all the examples")
 message(STATUS "Run 'make tutorials' to build all the tutorials")
+message(STATUS "Run 'make view_docs' to see the API documentation")
 
 #===============================================================================
 # END

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,17 @@ if(DOXYGEN_FOUND)
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/doxygen
   )
 
+  # Add the "view_docs" target that opens the generated API documentation.
+  if(APPLE)
+    set(OPEN_COMMAND "open")
+  else()
+    set(OPEN_COMMAND "xdg-open")
+  endif()
+
+  add_custom_target(view_docs "${OPEN_COMMAND}" "${DOXYGEN_HTML_INDEX}"
+    DEPENDS "${DOXYGEN_HTML_INDEX}"
+    COMMENT "Opening documentation in a web browser.")
+
 endif()
 
 #===============================================================================

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -95,19 +95,19 @@ public:
   /// Get const BodyNode whose index is _idx
   virtual const BodyNode* getBodyNode(std::size_t _idx) const = 0;
 
-  /// Returns the joint of given name.
+  /// Returns the body node of given name.
   ///
   /// When there are multiple body nodes with the same name, returns the first
-  /// joint, which is implementation dependent, and prints a warning.
+  /// body node, which is implementation dependent, and prints a warning.
   ///
   /// \param[in] name The body node name that want to search.
   /// \return The body node of given name.
   virtual BodyNode* getBodyNode(const std::string& name) = 0;
 
-  /// Returns the joint of given name.
+  /// Returns the body node of given name.
   ///
   /// When there are multiple body nodes with the same name, returns the first
-  /// joint, which is implementation dependent, and prints a warning.
+  /// body node, which is implementation dependent, and prints a warning.
   ///
   /// \param[in] name The body node name that want to search.
   /// \return The body node of given name.

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -97,23 +97,13 @@ public:
 
   /// Returns the BodyNode of given name.
   ///
-  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
-  /// this MetaSkeleton contains BodyNodes from multiple Skeletons. In this
-  /// case, this function returns the first one, which is implementation
-  /// dependent, and prints a warning.
-  ///
-  /// \param[in] name The body node name that want to search.
+  /// \param[in] name The BodyNode name that want to search.
   /// \return The body node of given name.
   virtual BodyNode* getBodyNode(const std::string& name) = 0;
 
   /// Returns the BodyNode of given name.
   ///
-  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
-  /// this MetaSkeleton contains BodyNodes from multiple Skeletons. In this
-  /// case, this function returns the first one, which is implementation
-  /// dependent, and prints a warning.
-  ///
-  /// \param[in] name The body node name that want to search.
+  /// \param[in] name The BodyNode name that want to search.
   /// \return The body node of given name.
   virtual const BodyNode* getBodyNode(const std::string& name) const = 0;
 
@@ -124,21 +114,13 @@ public:
   virtual const std::vector<const BodyNode*>& getBodyNodes() const = 0;
 
   /// Returns all the BodyNodes of given name.
-  ///
-  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
-  /// this MetaSkeleton contains BodyNodes from multiple Skeletons.
-  ///
-  /// \param[in] name The body node name that want to search.
-  /// \return The list of body nodes of given name.
+  /// \param[in] name The BodyNode name that want to search.
+  /// \return The list of BodyNodes of given name.
   virtual std::vector<BodyNode*> getBodyNodes(const std::string& name) = 0;
 
   /// Returns all the BodyNodes of given name.
-  ///
-  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
-  /// this MetaSkeleton contains BodyNodes from multiple Skeletons.
-  ///
-  /// \param[in] name The body node name that want to search.
-  /// \return The list of body nodes of given name.
+  /// \param[in] name The BodyNode name that want to search.
+  /// \return The list of BodyNodes of given name.
   virtual std::vector<const BodyNode*> getBodyNodes(
       const std::string& name) const = 0;
 
@@ -158,23 +140,11 @@ public:
   virtual const Joint* getJoint(std::size_t _idx) const = 0;
 
   /// Returns the Joint of given name.
-  ///
-  /// This MetaSkeleton can contain multiple Joints with the same name when
-  /// this MetaSkeleton contains Joints from multiple Skeletons. In this
-  /// case, this function returns the first one, which is implementation
-  /// dependent, and prints a warning.
-  ///
   /// \param[in] name The joint name that want to search.
   /// \return The joint of given name.
   virtual Joint* getJoint(const std::string& name) = 0;
 
   /// Returns the joint of given name.
-  ///
-  /// This MetaSkeleton can contain multiple Joints with the same name when
-  /// this MetaSkeleton contains Joints from multiple Skeletons. In this
-  /// case, this function returns the first one, which is implementation
-  /// dependent, and prints a warning.
-  ///
   /// \param[in] name The joint name that want to search.
   /// \return The joint of given name.
   virtual const Joint* getJoint(const std::string& name) const = 0;

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -95,11 +95,40 @@ public:
   /// Get const BodyNode whose index is _idx
   virtual const BodyNode* getBodyNode(std::size_t _idx) const = 0;
 
+  /// Returns the joint of given name.
+  ///
+  /// When there are multiple body nodes with the same name, returns the first
+  /// joint, which is implementation dependent, and prints a warning.
+  ///
+  /// \param[in] name The body node name that want to search.
+  /// \return The body node of given name.
+  virtual BodyNode* getBodyNode(const std::string& name) = 0;
+
+  /// Returns the joint of given name.
+  ///
+  /// When there are multiple body nodes with the same name, returns the first
+  /// joint, which is implementation dependent, and prints a warning.
+  ///
+  /// \param[in] name The body node name that want to search.
+  /// \return The body node of given name.
+  virtual const BodyNode* getBodyNode(const std::string& name) const = 0;
+
   /// Get all the BodyNodes that are held by this MetaSkeleton
   virtual const std::vector<BodyNode*>& getBodyNodes() = 0;
 
   /// Get all the BodyNodes that are held by this MetaSkeleton
   virtual const std::vector<const BodyNode*>& getBodyNodes() const = 0;
+
+  /// Returns all the body nodes of given name.
+  /// \param[in] name The body node name that want to search.
+  /// \return The list of body nodes of given name.
+  virtual std::vector<BodyNode*> getBodyNodes(const std::string& name) = 0;
+
+  /// Returns all the body nodes of given name.
+  /// \param[in] name The body node name that want to search.
+  /// \return The list of body nodes of given name.
+  virtual std::vector<const BodyNode*> getBodyNodes(
+      const std::string& name) const = 0;
 
   /// Get the index of a specific BodyNode within this ReferentialSkeleton.
   /// Returns INVALID_INDEX if it is not held in this ReferentialSkeleton.
@@ -115,6 +144,41 @@ public:
 
   /// Get const Joint whose index is _idx
   virtual const Joint* getJoint(std::size_t _idx) const = 0;
+
+  /// Returns the joint of given name.
+  ///
+  /// When there are multiple joints with the same name, returns the first
+  /// joint, which is implementation dependent, and prints a warning.
+  ///
+  /// \param[in] name The joint name that want to search.
+  /// \return The joint of given name.
+  virtual Joint* getJoint(const std::string& name) = 0;
+
+  /// Returns the joint of given name.
+  ///
+  /// When there are multiple joints with the same name, returns the first
+  /// joint, which is implementation dependent, and prints a warning.
+  ///
+  /// \param[in] name The joint name that want to search.
+  /// \return The joint of given name.
+  virtual const Joint* getJoint(const std::string& name) const = 0;
+
+  /// Returns all the joints that are held by this MetaSkeleton.
+  virtual std::vector<Joint*> getJoints() = 0;
+
+  /// Returns all the joints that are held by this MetaSkeleton.
+  virtual std::vector<const Joint*> getJoints() const = 0;
+
+  /// Returns all the joint of given name.
+  /// \param[in] name The joint name that want to search.
+  /// \return The list of joints of given name.
+  virtual std::vector<Joint*> getJoints(const std::string& name) = 0;
+
+  /// Returns all the joint of given name.
+  /// \param[in] name The joint name that want to search.
+  /// \return The list of joints of given name.
+  virtual std::vector<const Joint*> getJoints(
+      const std::string& name) const = 0;
 
   /// Get the index of a specific Joint within this ReferentialSkeleton. Returns
   /// INVALID_INDEX if it is not held in this ReferentialSkeleton.

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -95,19 +95,23 @@ public:
   /// Get const BodyNode whose index is _idx
   virtual const BodyNode* getBodyNode(std::size_t _idx) const = 0;
 
-  /// Returns the body node of given name.
+  /// Returns the BodyNode of given name.
   ///
-  /// When there are multiple body nodes with the same name, returns the first
-  /// body node, which is implementation dependent, and prints a warning.
+  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
+  /// this MetaSkeleton contains BodyNodes from multiple Skeletons. In this
+  /// case, this function returns the first one, which is implementation
+  /// dependent, and prints a warning.
   ///
   /// \param[in] name The body node name that want to search.
   /// \return The body node of given name.
   virtual BodyNode* getBodyNode(const std::string& name) = 0;
 
-  /// Returns the body node of given name.
+  /// Returns the BodyNode of given name.
   ///
-  /// When there are multiple body nodes with the same name, returns the first
-  /// body node, which is implementation dependent, and prints a warning.
+  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
+  /// this MetaSkeleton contains BodyNodes from multiple Skeletons. In this
+  /// case, this function returns the first one, which is implementation
+  /// dependent, and prints a warning.
   ///
   /// \param[in] name The body node name that want to search.
   /// \return The body node of given name.
@@ -119,12 +123,20 @@ public:
   /// Get all the BodyNodes that are held by this MetaSkeleton
   virtual const std::vector<const BodyNode*>& getBodyNodes() const = 0;
 
-  /// Returns all the body nodes of given name.
+  /// Returns all the BodyNodes of given name.
+  ///
+  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
+  /// this MetaSkeleton contains BodyNodes from multiple Skeletons.
+  ///
   /// \param[in] name The body node name that want to search.
   /// \return The list of body nodes of given name.
   virtual std::vector<BodyNode*> getBodyNodes(const std::string& name) = 0;
 
-  /// Returns all the body nodes of given name.
+  /// Returns all the BodyNodes of given name.
+  ///
+  /// This MetaSkeleton can contain multiple BodyNodes with the same name when
+  /// this MetaSkeleton contains BodyNodes from multiple Skeletons.
+  ///
   /// \param[in] name The body node name that want to search.
   /// \return The list of body nodes of given name.
   virtual std::vector<const BodyNode*> getBodyNodes(
@@ -145,10 +157,12 @@ public:
   /// Get const Joint whose index is _idx
   virtual const Joint* getJoint(std::size_t _idx) const = 0;
 
-  /// Returns the joint of given name.
+  /// Returns the Joint of given name.
   ///
-  /// When there are multiple joints with the same name, returns the first
-  /// joint, which is implementation dependent, and prints a warning.
+  /// This MetaSkeleton can contain multiple Joints with the same name when
+  /// this MetaSkeleton contains Joints from multiple Skeletons. In this
+  /// case, this function returns the first one, which is implementation
+  /// dependent, and prints a warning.
   ///
   /// \param[in] name The joint name that want to search.
   /// \return The joint of given name.
@@ -156,8 +170,10 @@ public:
 
   /// Returns the joint of given name.
   ///
-  /// When there are multiple joints with the same name, returns the first
-  /// joint, which is implementation dependent, and prints a warning.
+  /// This MetaSkeleton can contain multiple Joints with the same name when
+  /// this MetaSkeleton contains Joints from multiple Skeletons. In this
+  /// case, this function returns the first one, which is implementation
+  /// dependent, and prints a warning.
   ///
   /// \param[in] name The joint name that want to search.
   /// \return The joint of given name.
@@ -169,12 +185,20 @@ public:
   /// Returns all the joints that are held by this MetaSkeleton.
   virtual std::vector<const Joint*> getJoints() const = 0;
 
-  /// Returns all the joint of given name.
+  /// Returns all the Joint of given name.
+  ///
+  /// This MetaSkeleton can contain multiple Joints with the same name when
+  /// this MetaSkeleton contains Joints from multiple Skeletons.
+  ///
   /// \param[in] name The joint name that want to search.
   /// \return The list of joints of given name.
   virtual std::vector<Joint*> getJoints(const std::string& name) = 0;
 
-  /// Returns all the joint of given name.
+  /// Returns all the Joint of given name.
+  ///
+  /// This MetaSkeleton can contain multiple Joints with the same name when
+  /// this MetaSkeleton contains Joints from multiple Skeletons.
+  ///
   /// \param[in] name The joint name that want to search.
   /// \return The list of joints of given name.
   virtual std::vector<const Joint*> getJoints(

--- a/dart/dynamics/ReferentialSkeleton.cpp
+++ b/dart/dynamics/ReferentialSkeleton.cpp
@@ -77,6 +77,30 @@ const BodyNode* ReferentialSkeleton::getBodyNode(std::size_t _idx) const
 }
 
 //==============================================================================
+BodyNode* ReferentialSkeleton::getBodyNode(const std::string& name)
+{
+  auto result = std::find_if(
+      mBodyNodes.begin(),
+      mBodyNodes.end(),
+      [&](const BodyNodePtr& joint)
+      {
+        return (joint->getName() == name);
+      });
+  const auto found = result != mBodyNodes.end();
+
+  if (found)
+    return *result;
+  else
+    return nullptr;
+}
+
+//==============================================================================
+const BodyNode* ReferentialSkeleton::getBodyNode(const std::string& name) const
+{
+  return const_cast<ReferentialSkeleton*>(this)->getBodyNode(name);
+}
+
+//==============================================================================
 template <class T1, class T2>
 static std::vector<T2>& convertVector(const std::vector<T1>& t1_vec,
                                       std::vector<T2>& t2_vec)
@@ -101,6 +125,36 @@ const std::vector<const BodyNode*>& ReferentialSkeleton::getBodyNodes() const
 {
   return convertVector<BodyNodePtr, const BodyNode*>(
         mBodyNodes, mRawConstBodyNodes);
+}
+
+//==============================================================================
+std::vector<BodyNode*> ReferentialSkeleton::getBodyNodes(
+    const std::string& name)
+{
+  std::vector<BodyNode*> bodyNodes;
+
+  for (const auto& bodyNode : mBodyNodes)
+  {
+    if (bodyNode->getName() == name)
+      bodyNodes.push_back(bodyNode.get());
+  }
+
+  return bodyNodes;
+}
+
+//==============================================================================
+std::vector<const BodyNode*> ReferentialSkeleton::getBodyNodes(
+    const std::string& name) const
+{
+  std::vector<const BodyNode*> bodyNodes;
+
+  for (const auto& bodyNode : mBodyNodes)
+  {
+    if (bodyNode->getName() == name)
+      bodyNodes.push_back(bodyNode.get());
+  }
+
+  return bodyNodes;
 }
 
 //==============================================================================
@@ -151,6 +205,81 @@ Joint* ReferentialSkeleton::getJoint(std::size_t _idx)
 const Joint* ReferentialSkeleton::getJoint(std::size_t _idx) const
 {
   return common::getVectorObjectIfAvailable<JointPtr>(_idx, mJoints);
+}
+
+//==============================================================================
+Joint* ReferentialSkeleton::getJoint(const std::string& name)
+{
+  auto result = std::find_if(
+      mJoints.begin(),
+      mJoints.end(),
+      [&](const JointPtr& joint)
+      {
+        return (joint->getName() == name);
+      });
+  const auto found = result != mJoints.end();
+
+  if (found)
+    return *result;
+  else
+    return nullptr;
+}
+
+//==============================================================================
+const Joint* ReferentialSkeleton::getJoint(const std::string& name) const
+{
+  return const_cast<ReferentialSkeleton*>(this)->getJoint(name);
+}
+
+//==============================================================================
+std::vector<Joint*> ReferentialSkeleton::getJoints()
+{
+  std::vector<Joint*> joints;
+  joints.reserve(mJoints.size());
+  for (const auto& joint : mJoints)
+    joints.emplace_back(joint.get());
+
+  return joints;
+}
+
+//==============================================================================
+std::vector<const Joint*> ReferentialSkeleton::getJoints() const
+{
+  std::vector<const Joint*> joints;
+  joints.reserve(mJoints.size());
+  for (const auto& joint : mJoints)
+    joints.emplace_back(joint.get());
+
+  return joints;
+}
+
+//==============================================================================
+std::vector<Joint*> ReferentialSkeleton::getJoints(const std::string& name)
+{
+  std::vector<Joint*> joints;
+
+  for (const auto& joint : mJoints)
+  {
+    if (joint->getName() == name)
+      joints.push_back(joint.get());
+  }
+
+  return joints;
+}
+
+//==============================================================================
+std::vector<const Joint*> ReferentialSkeleton::getJoints(
+    const std::string& name) const
+{
+  std::vector<const Joint*> joints;
+
+  for (const auto& joint : mJoints)
+  {
+    if (joint->getName() == name)
+      joints.push_back(joint.get());
+  }
+
+  return joints;
 }
 
 //==============================================================================

--- a/dart/dynamics/ReferentialSkeleton.cpp
+++ b/dart/dynamics/ReferentialSkeleton.cpp
@@ -79,19 +79,28 @@ const BodyNode* ReferentialSkeleton::getBodyNode(std::size_t _idx) const
 //==============================================================================
 BodyNode* ReferentialSkeleton::getBodyNode(const std::string& name)
 {
-  auto result = std::find_if(
-      mBodyNodes.begin(),
-      mBodyNodes.end(),
-      [&](const BodyNodePtr& joint)
-      {
-        return (joint->getName() == name);
-      });
-  const auto found = result != mBodyNodes.end();
+  BodyNode* bodyNodeFound = nullptr;
 
-  if (found)
-    return *result;
-  else
-    return nullptr;
+  for (const auto& bodyNode : mBodyNodes)
+  {
+    if (bodyNode->getName() == name)
+    {
+      if (!bodyNodeFound)
+      {
+        bodyNodeFound = bodyNode.get();
+      }
+      else
+      {
+        dtwarn << "[ReferentialSkeleton] This ReferentialSkeleton contains "
+               << "more than one body node with name '" << name
+               << "'. Returning the first body node found.\n";
+
+        return bodyNodeFound;
+      }
+    }
+  }
+
+  return bodyNodeFound;
 }
 
 //==============================================================================
@@ -210,19 +219,28 @@ const Joint* ReferentialSkeleton::getJoint(std::size_t _idx) const
 //==============================================================================
 Joint* ReferentialSkeleton::getJoint(const std::string& name)
 {
-  auto result = std::find_if(
-      mJoints.begin(),
-      mJoints.end(),
-      [&](const JointPtr& joint)
-      {
-        return (joint->getName() == name);
-      });
-  const auto found = result != mJoints.end();
+  Joint* jointFound = nullptr;
 
-  if (found)
-    return *result;
-  else
-    return nullptr;
+  for (const auto& joint : mJoints)
+  {
+    if (joint->getName() == name)
+    {
+      if (!jointFound)
+      {
+        jointFound = joint.get();
+      }
+      else
+      {
+        dtwarn << "[ReferentialSkeleton] This ReferentialSkeleton contains "
+               << "more than one joint with name '" << name << "'. Returning "
+               << "the first joint found.\n";
+
+        return jointFound;
+      }
+    }
+  }
+
+  return jointFound;
 }
 
 //==============================================================================

--- a/dart/dynamics/ReferentialSkeleton.hpp
+++ b/dart/dynamics/ReferentialSkeleton.hpp
@@ -79,10 +79,23 @@ public:
   const BodyNode* getBodyNode(std::size_t _idx) const override;
 
   // Documentation inherited
+  BodyNode* getBodyNode(const std::string& name) override;
+
+  // Documentation inherited
+  const BodyNode* getBodyNode(const std::string& name) const override;
+
+  // Documentation inherited
   const std::vector<BodyNode*>& getBodyNodes() override;
 
   // Documentation inherited
   const std::vector<const BodyNode*>& getBodyNodes() const override;
+
+  // Documentation inherited
+  std::vector<BodyNode*> getBodyNodes(const std::string& name) override;
+
+  // Documentation inherited
+  std::vector<const BodyNode*> getBodyNodes(
+      const std::string& name) const override;
 
   // Documentation inherited
   std::size_t getIndexOf(const BodyNode* _bn, bool _warning=true) const override;
@@ -95,6 +108,24 @@ public:
 
   // Documentation inherited
   const Joint* getJoint(std::size_t _idx) const override;
+
+  // Documentation inherited
+  Joint* getJoint(const std::string& name) override;
+
+  // Documentation inherited
+  const Joint* getJoint(const std::string& name) const override;
+
+  // Documentation inherited
+  std::vector<Joint*> getJoints() override;
+
+  // Documentation inherited
+  std::vector<const Joint*> getJoints() const override;
+
+  // Documentation inherited
+  std::vector<Joint*> getJoints(const std::string& name) override;
+
+  // Documentation inherited
+  std::vector<const Joint*> getJoints(const std::string& name) const override;
 
   // Documentation inherited
   std::size_t getIndexOf(const Joint* _joint, bool _warning=true) const override;

--- a/dart/dynamics/ReferentialSkeleton.hpp
+++ b/dart/dynamics/ReferentialSkeleton.hpp
@@ -78,10 +78,20 @@ public:
   // Documentation inherited
   const BodyNode* getBodyNode(std::size_t _idx) const override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  ///
+  /// \note This ReferentialSkeleton can contain multiple BodyNodes with the
+  /// same name when this ReferentialSkeleton contains BodyNodes from multiple
+  /// Skeletons. In this case, this function returns the first one, which is
+  /// implementation dependent, and prints a warning.
   BodyNode* getBodyNode(const std::string& name) override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  ///
+  /// \note This ReferentialSkeleton can contain multiple BodyNodes with the
+  /// same name when this ReferentialSkeleton contains BodyNodes from multiple
+  /// Skeletons. In this case, this function returns the first one, which is
+  /// implementation dependent, and prints a warning.
   const BodyNode* getBodyNode(const std::string& name) const override;
 
   // Documentation inherited

--- a/dart/dynamics/ReferentialSkeleton.hpp
+++ b/dart/dynamics/ReferentialSkeleton.hpp
@@ -78,18 +78,18 @@ public:
   // Documentation inherited
   const BodyNode* getBodyNode(std::size_t _idx) const override;
 
-  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  /// \copydoc MetaSkeleton::getBodyNode(const std::string&).
   ///
-  /// \note This ReferentialSkeleton can contain multiple BodyNodes with the
-  /// same name when this ReferentialSkeleton contains BodyNodes from multiple
+  /// \note ReferentialSkeleton can contain multiple BodyNodes with the same
+  /// name when this ReferentialSkeleton contains BodyNodes from multiple
   /// Skeletons. In this case, this function returns the first one, which is
   /// implementation dependent, and prints a warning.
   BodyNode* getBodyNode(const std::string& name) override;
 
-  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  /// \copydoc MetaSkeleton::getBodyNode(const std::string&).
   ///
-  /// \note This ReferentialSkeleton can contain multiple BodyNodes with the
-  /// same name when this ReferentialSkeleton contains BodyNodes from multiple
+  /// \note ReferentialSkeleton can contain multiple BodyNodes with the same
+  /// name when this ReferentialSkeleton contains BodyNodes from multiple
   /// Skeletons. In this case, this function returns the first one, which is
   /// implementation dependent, and prints a warning.
   const BodyNode* getBodyNode(const std::string& name) const override;
@@ -100,10 +100,16 @@ public:
   // Documentation inherited
   const std::vector<const BodyNode*>& getBodyNodes() const override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  ///
+  /// \note ReferentialSkeleton can contain multiple BodyNodes with the same
+  /// name when ReferentialSkeleton contains BodyNodes from multiple Skeletons.
   std::vector<BodyNode*> getBodyNodes(const std::string& name) override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  ///
+  /// \note ReferentialSkeleton can contain multiple BodyNodes with the same
+  /// name when ReferentialSkeleton contains BodyNodes from multiple Skeletons.
   std::vector<const BodyNode*> getBodyNodes(
       const std::string& name) const override;
 
@@ -119,10 +125,20 @@ public:
   // Documentation inherited
   const Joint* getJoint(std::size_t _idx) const override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getJoint(const std::string&).
+  ///
+  /// \note ReferentialSkeleton can contain multiple Joints with the same
+  /// name when this ReferentialSkeleton contains Joints from multiple
+  /// Skeletons. In this case, this function returns the first one, which is
+  /// implementation dependent, and prints a warning.
   Joint* getJoint(const std::string& name) override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getJoint(const std::string&).
+  ///
+  /// \note ReferentialSkeleton can contain multiple Joints with the same
+  /// name when this ReferentialSkeleton contains Joints from multiple
+  /// Skeletons. In this case, this function returns the first one, which is
+  /// implementation dependent, and prints a warning.
   const Joint* getJoint(const std::string& name) const override;
 
   // Documentation inherited
@@ -131,10 +147,16 @@ public:
   // Documentation inherited
   std::vector<const Joint*> getJoints() const override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getJoints(const std::string&).
+  ///
+  /// \note ReferentialSkeleton can contain multiple Joints with the same
+  /// name when ReferentialSkeleton contains Joints from multiple Skeletons.
   std::vector<Joint*> getJoints(const std::string& name) override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getJoints(const std::string&).
+  ///
+  /// \note ReferentialSkeleton can contain multiple Joints with the same
+  /// name when ReferentialSkeleton contains Joints from multiple Skeletons.
   std::vector<const Joint*> getJoints(const std::string& name) const override;
 
   // Documentation inherited

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -890,6 +890,19 @@ const std::vector<const BodyNode*>& Skeleton::getBodyNodes() const
 }
 
 //==============================================================================
+std::vector<BodyNode*> Skeleton::getBodyNodes(const std::string& name)
+{
+  return {getBodyNode(name)};
+}
+
+//==============================================================================
+std::vector<const BodyNode*> Skeleton::getBodyNodes(
+    const std::string& name) const
+{
+  return {getBodyNode(name)};
+}
+
+//==============================================================================
 template <class ObjectT, std::size_t (ObjectT::*getIndexInSkeleton)() const>
 static std::size_t templatedGetIndexOf(const Skeleton* _skel, const ObjectT* _obj,
                                   const std::string& _type, bool _warning)
@@ -975,15 +988,55 @@ const Joint* Skeleton::getJoint(std::size_t _idx) const
 }
 
 //==============================================================================
-Joint* Skeleton::getJoint(const std::string& _name)
+Joint* Skeleton::getJoint(const std::string& name)
 {
-  return mNameMgrForJoints.getObject(_name);
+  return mNameMgrForJoints.getObject(name);
 }
 
 //==============================================================================
-const Joint* Skeleton::getJoint(const std::string& _name) const
+const Joint* Skeleton::getJoint(const std::string& name) const
 {
-  return mNameMgrForJoints.getObject(_name);
+  return mNameMgrForJoints.getObject(name);
+}
+
+//==============================================================================
+std::vector<Joint*> Skeleton::getJoints()
+{
+  const auto& bodyNodes = getBodyNodes();
+
+  std::vector<Joint*> joints;
+  joints.reserve(bodyNodes.size());
+  for (const auto& bodyNode : bodyNodes)
+    joints.emplace_back(bodyNode->getParentJoint());
+
+  return joints;
+}
+
+//==============================================================================
+std::vector<const Joint*> Skeleton::getJoints() const
+{
+  const auto& bodyNodes = getBodyNodes();
+
+  std::vector<const Joint*> joints;
+  joints.reserve(bodyNodes.size());
+  for (const auto& bodyNode : bodyNodes)
+    joints.emplace_back(bodyNode->getParentJoint());
+
+  return joints;
+}
+
+//==============================================================================
+std::vector<Joint*> Skeleton::getJoints(const std::string& name)
+{
+  // Joint names in a skeleton are guaranteed to be unique.
+  return {getJoint(name)};
+}
+
+//==============================================================================
+std::vector<const Joint*> Skeleton::getJoints(const std::string& name) const
+{
+  // Joint names in a skeleton are guaranteed to be unique.
+  return {getJoint(name)};
 }
 
 //==============================================================================

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -892,14 +892,24 @@ const std::vector<const BodyNode*>& Skeleton::getBodyNodes() const
 //==============================================================================
 std::vector<BodyNode*> Skeleton::getBodyNodes(const std::string& name)
 {
-  return {getBodyNode(name)};
+  auto bodyNode = getBodyNode(name);
+
+  if (bodyNode)
+    return {bodyNode};
+  else
+    return std::vector<BodyNode*>();
 }
 
 //==============================================================================
 std::vector<const BodyNode*> Skeleton::getBodyNodes(
     const std::string& name) const
 {
-  return {getBodyNode(name)};
+  const auto bodyNode = getBodyNode(name);
+
+  if (bodyNode)
+    return {bodyNode};
+  else
+    return std::vector<const BodyNode*>();
 }
 
 //==============================================================================
@@ -1028,15 +1038,23 @@ std::vector<const Joint*> Skeleton::getJoints() const
 //==============================================================================
 std::vector<Joint*> Skeleton::getJoints(const std::string& name)
 {
-  // Joint names in a skeleton are guaranteed to be unique.
-  return {getJoint(name)};
+  auto joint = getJoint(name);
+
+  if (joint)
+    return {joint};
+  else
+    return std::vector<Joint*>();
 }
 
 //==============================================================================
 std::vector<const Joint*> Skeleton::getJoints(const std::string& name) const
 {
-  // Joint names in a skeleton are guaranteed to be unique.
-  return {getJoint(name)};
+  const auto joint = getJoint(name);
+
+  if (joint)
+    return {joint};
+  else
+    return std::vector<const Joint*>();
 }
 
 //==============================================================================

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -381,10 +381,16 @@ public:
   // Documentation inherited
   const std::vector<const BodyNode*>& getBodyNodes() const override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  ///
+  /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
+  /// So this function returns a single BodyNode.
   std::vector<BodyNode*> getBodyNodes(const std::string& name) override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
+  ///
+  /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
+  /// So this function returns a single BodyNode.
   std::vector<const BodyNode*> getBodyNodes(
       const std::string& name) const override;
 
@@ -418,10 +424,16 @@ public:
   // Documentation inherited
   std::vector<const Joint*> getJoints() const override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getJoints(const std::string&).
+  ///
+  /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
+  /// So this function returns a single Joint.
   std::vector<Joint*> getJoints(const std::string& name) override;
 
-  // Documentation inherited
+  /// \copydoc MetaSkeleton::getJoints(const std::string&).
+  ///
+  /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
+  /// So this function returns a single Joint.
   std::vector<const Joint*> getJoints(const std::string& name) const override;
 
   // Documentation inherited

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -363,10 +363,10 @@ public:
   /// Get const SoftBodyNode whose index is _idx
   const SoftBodyNode* getSoftBodyNode(std::size_t _idx) const;
 
-  /// Get body node whose name is _name
+  // Documentation inherited
   BodyNode* getBodyNode(const std::string& name) override;
 
-  /// Get const body node whose name is _name
+  // Documentation inherited
   const BodyNode* getBodyNode(const std::string& name) const override;
 
   /// Get soft body node whose name is _name
@@ -384,13 +384,15 @@ public:
   /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
   ///
   /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
-  /// So this function returns a single BodyNode.
+  /// So this function returns the single BodyNode of the given name if it
+  /// exists.
   std::vector<BodyNode*> getBodyNodes(const std::string& name) override;
 
   /// \copydoc MetaSkeleton::getBodyNodes(const std::string&).
   ///
   /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
-  /// So this function returns a single BodyNode.
+  /// So this function returns the single BodyNode of the given name if it
+  /// exists.
   std::vector<const BodyNode*> getBodyNodes(
       const std::string& name) const override;
 
@@ -427,13 +429,13 @@ public:
   /// \copydoc MetaSkeleton::getJoints(const std::string&).
   ///
   /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
-  /// So this function returns a single Joint.
+  /// So this function returns the single Joint of the given name if it exists.
   std::vector<Joint*> getJoints(const std::string& name) override;
 
   /// \copydoc MetaSkeleton::getJoints(const std::string&).
   ///
   /// \note Skeleton always guarantees name uniqueness for BodyNodes and Joints.
-  /// So this function returns a single Joint.
+  /// So this function returns the single Joint of the given name if it exists.
   std::vector<const Joint*> getJoints(const std::string& name) const override;
 
   // Documentation inherited

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -364,10 +364,10 @@ public:
   const SoftBodyNode* getSoftBodyNode(std::size_t _idx) const;
 
   /// Get body node whose name is _name
-  BodyNode* getBodyNode(const std::string& _name);
+  BodyNode* getBodyNode(const std::string& name) override;
 
   /// Get const body node whose name is _name
-  const BodyNode* getBodyNode(const std::string& _name) const;
+  const BodyNode* getBodyNode(const std::string& name) const override;
 
   /// Get soft body node whose name is _name
   SoftBodyNode* getSoftBodyNode(const std::string& _name);
@@ -380,6 +380,13 @@ public:
 
   // Documentation inherited
   const std::vector<const BodyNode*>& getBodyNodes() const override;
+
+  // Documentation inherited
+  std::vector<BodyNode*> getBodyNodes(const std::string& name) override;
+
+  // Documentation inherited
+  std::vector<const BodyNode*> getBodyNodes(
+      const std::string& name) const override;
 
   // Documentation inherited
   std::size_t getIndexOf(const BodyNode* _bn, bool _warning=true) const override;
@@ -399,11 +406,23 @@ public:
   // Documentation inherited
   const Joint* getJoint(std::size_t _idx) const override;
 
-  /// Get Joint whose name is _name
-  Joint* getJoint(const std::string& _name);
+  // Documentation inherited
+  Joint* getJoint(const std::string& name) override;
 
-  /// Get const Joint whose name is _name
-  const Joint* getJoint(const std::string& _name) const;
+  // Documentation inherited
+  const Joint* getJoint(const std::string& name) const override;
+
+  // Documentation inherited
+  std::vector<Joint*> getJoints() override;
+
+  // Documentation inherited
+  std::vector<const Joint*> getJoints() const override;
+
+  // Documentation inherited
+  std::vector<Joint*> getJoints(const std::string& name) override;
+
+  // Documentation inherited
+  std::vector<const Joint*> getJoints(const std::string& name) const override;
 
   // Documentation inherited
   std::size_t getIndexOf(const Joint* _joint, bool _warning=true) const override;

--- a/unittests/comprehensive/test_Skeleton.cpp
+++ b/unittests/comprehensive/test_Skeleton.cpp
@@ -1290,7 +1290,7 @@ TEST(Skeleton, Updating)
 }
 
 //==============================================================================
-TEST(Skeleton, GetJoint)
+TEST(Skeleton, GetJointsAndBodyNodes)
 {
   auto skelA = Skeleton::create();
   auto skelB = Skeleton::create();
@@ -1347,6 +1347,25 @@ TEST(Skeleton, GetJoint)
   jointB1->setName("joint1");
   jointB2->setName("joint2");
 
+  EXPECT_TRUE(bodyNodeA0 == skelA->getBodyNode(bodyNodeA0->getName()));
+  EXPECT_TRUE(bodyNodeA1 == skelA->getBodyNode(bodyNodeA1->getName()));
+  EXPECT_TRUE(bodyNodeA2 == skelA->getBodyNode(bodyNodeA2->getName()));
+
+  EXPECT_TRUE(bodyNodeB0 == skelB->getBodyNode(bodyNodeB0->getName()));
+  EXPECT_TRUE(bodyNodeB1 == skelB->getBodyNode(bodyNodeB1->getName()));
+  EXPECT_TRUE(bodyNodeB2 == skelB->getBodyNode(bodyNodeB2->getName()));
+
+  EXPECT_TRUE(skelA->getBodyNodes("wrong name").empty());
+  EXPECT_TRUE(skelB->getBodyNodes("wrong name").empty());
+
+  EXPECT_TRUE(skelA->getBodyNodes(bodyNodeA0->getName()).size() == 1u);
+  EXPECT_TRUE(skelA->getBodyNodes(bodyNodeA1->getName()).size() == 1u);
+  EXPECT_TRUE(skelA->getBodyNodes(bodyNodeA2->getName()).size() == 1u);
+
+  EXPECT_TRUE(skelB->getBodyNodes(bodyNodeB0->getName()).size() == 1u);
+  EXPECT_TRUE(skelB->getBodyNodes(bodyNodeB1->getName()).size() == 1u);
+  EXPECT_TRUE(skelB->getBodyNodes(bodyNodeB2->getName()).size() == 1u);
+
   EXPECT_TRUE(jointA0 == skelA->getJoint(jointA0->getName()));
   EXPECT_TRUE(jointA1 == skelA->getJoint(jointA1->getName()));
   EXPECT_TRUE(jointA2 == skelA->getJoint(jointA2->getName()));
@@ -1354,6 +1373,9 @@ TEST(Skeleton, GetJoint)
   EXPECT_TRUE(jointB0 == skelB->getJoint(jointB0->getName()));
   EXPECT_TRUE(jointB1 == skelB->getJoint(jointB1->getName()));
   EXPECT_TRUE(jointB2 == skelB->getJoint(jointB2->getName()));
+
+  EXPECT_TRUE(skelA->getJoints("wrong name").empty());
+  EXPECT_TRUE(skelB->getJoints("wrong name").empty());
 
   EXPECT_TRUE(skelA->getJoints(jointA0->getName()).size() == 1u);
   EXPECT_TRUE(skelA->getJoints(jointA1->getName()).size() == 1u);
@@ -1368,6 +1390,8 @@ TEST(Skeleton, GetJoint)
   group->addBodyNode(bodyNodeB0);
   group->addJoint(jointA0);
   group->addJoint(jointB0);
+  EXPECT_TRUE(group->getJoints("wrong name").empty());
+  EXPECT_TRUE(group->getBodyNodes("wrong name").empty());
   EXPECT_TRUE(group->getBodyNode("bodyNode0") == bodyNodeA0
               || group->getBodyNode("bodyNode0") == bodyNodeB0);
   EXPECT_TRUE(group->getJoint("joint0") == jointA0

--- a/unittests/comprehensive/test_Skeleton.cpp
+++ b/unittests/comprehensive/test_Skeleton.cpp
@@ -1288,3 +1288,94 @@ TEST(Skeleton, Updating)
   EXPECT_FALSE(originalMass == newMass);
   EXPECT_TRUE(newMass == originalMass - removedMass);
 }
+
+//==============================================================================
+TEST(Skeleton, GetJoint)
+{
+  auto skelA = Skeleton::create();
+  auto skelB = Skeleton::create();
+
+  BodyNode* bodyNodeA0;
+  BodyNode* bodyNodeA1;
+  BodyNode* bodyNodeA2;
+
+  BodyNode* bodyNodeB0;
+  BodyNode* bodyNodeB1;
+  BodyNode* bodyNodeB2;
+
+  Joint* jointA0;
+  Joint* jointA1;
+  Joint* jointA2;
+
+  Joint* jointB0;
+  Joint* jointB1;
+  Joint* jointB2;
+
+  std::tie(jointA0, bodyNodeA0)
+      = skelA->createJointAndBodyNodePair<FreeJoint>();
+  std::tie(jointA1, bodyNodeA1)
+      = skelA->createJointAndBodyNodePair<FreeJoint>(bodyNodeA0);
+  std::tie(jointA2, bodyNodeA2)
+      = skelA->createJointAndBodyNodePair<FreeJoint>(bodyNodeA1);
+
+  std::tie(jointB0, bodyNodeB0)
+      = skelB->createJointAndBodyNodePair<FreeJoint>();
+  std::tie(jointB1, bodyNodeB1)
+      = skelB->createJointAndBodyNodePair<FreeJoint>(bodyNodeB0);
+  std::tie(jointB2, bodyNodeB2)
+      = skelB->createJointAndBodyNodePair<FreeJoint>(bodyNodeB1);
+
+  EXPECT_TRUE(skelA->getNumBodyNodes() == 3u);
+  EXPECT_TRUE(skelB->getNumBodyNodes() == 3u);
+
+  EXPECT_TRUE(skelA->getJoints().size() == 3u);
+  EXPECT_TRUE(skelB->getJoints().size() == 3u);
+
+  bodyNodeA0->setName("bodyNode0");
+  bodyNodeA1->setName("bodyNode1");
+  bodyNodeA2->setName("bodyNode2");
+
+  bodyNodeB0->setName("bodyNode0");
+  bodyNodeB1->setName("bodyNode1");
+  bodyNodeB2->setName("bodyNode2");
+
+  jointA0->setName("joint0");
+  jointA1->setName("joint1");
+  jointA2->setName("joint2");
+
+  jointB0->setName("joint0");
+  jointB1->setName("joint1");
+  jointB2->setName("joint2");
+
+  EXPECT_TRUE(jointA0 == skelA->getJoint(jointA0->getName()));
+  EXPECT_TRUE(jointA1 == skelA->getJoint(jointA1->getName()));
+  EXPECT_TRUE(jointA2 == skelA->getJoint(jointA2->getName()));
+
+  EXPECT_TRUE(jointB0 == skelB->getJoint(jointB0->getName()));
+  EXPECT_TRUE(jointB1 == skelB->getJoint(jointB1->getName()));
+  EXPECT_TRUE(jointB2 == skelB->getJoint(jointB2->getName()));
+
+  EXPECT_TRUE(skelA->getJoints(jointA0->getName()).size() == 1u);
+  EXPECT_TRUE(skelA->getJoints(jointA1->getName()).size() == 1u);
+  EXPECT_TRUE(skelA->getJoints(jointA2->getName()).size() == 1u);
+
+  EXPECT_TRUE(skelB->getJoints(jointB0->getName()).size() == 1u);
+  EXPECT_TRUE(skelB->getJoints(jointB1->getName()).size() == 1u);
+  EXPECT_TRUE(skelB->getJoints(jointB2->getName()).size() == 1u);
+
+  auto group = Group::create();
+  group->addBodyNode(bodyNodeA0);
+  group->addBodyNode(bodyNodeB0);
+  group->addJoint(jointA0);
+  group->addJoint(jointB0);
+  EXPECT_TRUE(group->getBodyNode("bodyNode0") == bodyNodeA0
+              || group->getBodyNode("bodyNode0") == bodyNodeB0);
+  EXPECT_TRUE(group->getJoint("joint0") == jointA0
+              || group->getJoint("joint0") == jointB0);
+  EXPECT_EQ(group->getBodyNodes("bodyNode0").size(), 2u);
+  EXPECT_EQ(group->getBodyNodes("bodyNode1").size(), 0u);
+  EXPECT_EQ(group->getBodyNodes("bodyNode2").size(), 0u);
+  EXPECT_EQ(group->getJoints("joint0").size(), 2u);
+  EXPECT_EQ(group->getJoints("joint1").size(), 0u);
+  EXPECT_EQ(group->getJoints("joint2").size(), 0u);
+}


### PR DESCRIPTION
The newly added APIs are just syntactic sugar to get the joints and body nodes with a name. Probably, some of the implementation are not that efficient.