### PR TITLE
Use CONFIG mode to find DART in examples and tutorials

### DIFF
--- a/examples/addDeleteSkels/CMakeLists.txt
+++ b/examples/addDeleteSkels/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(addDeleteSkels)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/atlasSimbicon/CMakeLists.txt
+++ b/examples/atlasSimbicon/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(atlasSimbicon)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/bipedStand/CMakeLists.txt
+++ b/examples/bipedStand/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(bipedStand)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/hardcodedDesign/CMakeLists.txt
+++ b/examples/hardcodedDesign/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(hardcodedDesign)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/hybridDynamics/CMakeLists.txt
+++ b/examples/hybridDynamics/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(hybridDynamics)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/jointConstraints/CMakeLists.txt
+++ b/examples/jointConstraints/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(jointConstraints)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/mixedChain/CMakeLists.txt
+++ b/examples/mixedChain/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(mixedChain)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/operationalSpaceControl/CMakeLists.txt
+++ b/examples/operationalSpaceControl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(operationalSpaceControl)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgAtlasPuppet/CMakeLists.txt
+++ b/examples/osgExamples/osgAtlasPuppet/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgAtlasPuppet)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgAtlasSimbicon/CMakeLists.txt
+++ b/examples/osgExamples/osgAtlasSimbicon/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgAtlasSimbicon)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgDragAndDrop/CMakeLists.txt
+++ b/examples/osgExamples/osgDragAndDrop/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgDragAndDrop)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgEmpty/CMakeLists.txt
+++ b/examples/osgExamples/osgEmpty/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgEmpty)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgHuboPuppet/CMakeLists.txt
+++ b/examples/osgExamples/osgHuboPuppet/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgHubuPuppet)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgImGui/CMakeLists.txt
+++ b/examples/osgExamples/osgImGui/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgImGui)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgOperationalSpaceControl/CMakeLists.txt
+++ b/examples/osgExamples/osgOperationalSpaceControl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgOperationalSpaceControl)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgSoftBodies/CMakeLists.txt
+++ b/examples/osgExamples/osgSoftBodies/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgSoftBodies)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgTinkertoy/CMakeLists.txt
+++ b/examples/osgExamples/osgTinkertoy/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(osgTinkertoy)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui-osg)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/rigidChain/CMakeLists.txt
+++ b/examples/rigidChain/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(rigidChain)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/rigidCubes/CMakeLists.txt
+++ b/examples/rigidCubes/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(rigidCubes)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/rigidLoop/CMakeLists.txt
+++ b/examples/rigidLoop/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(rigidLoop)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/rigidShapes/CMakeLists.txt
+++ b/examples/rigidShapes/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(rigidShapes)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/simpleFrames/CMakeLists.txt
+++ b/examples/simpleFrames/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(simpleFrames)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/softBodies/CMakeLists.txt
+++ b/examples/softBodies/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(softBodies)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/speedTest/CMakeLists.txt
+++ b/examples/speedTest/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(speedTest)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/vehicle/CMakeLists.txt
+++ b/examples/vehicle/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(vehicle)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialBiped-Finished/CMakeLists.txt
+++ b/tutorials/tutorialBiped-Finished/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialBiped-Finished)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialBiped/CMakeLists.txt
+++ b/tutorials/tutorialBiped/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialBiped)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialCollisions-Finished/CMakeLists.txt
+++ b/tutorials/tutorialCollisions-Finished/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialCollisions-Finished)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialCollisions/CMakeLists.txt
+++ b/tutorials/tutorialCollisions/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialCollisions)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialDominoes-Finished/CMakeLists.txt
+++ b/tutorials/tutorialDominoes-Finished/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialDominoes-Finished)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialDominoes/CMakeLists.txt
+++ b/tutorials/tutorialDominoes/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialDominoes)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialMultiPendulum-Finished/CMakeLists.txt
+++ b/tutorials/tutorialMultiPendulum-Finished/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialMultiPendulum-Finished)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialMultiPendulum/CMakeLists.txt
+++ b/tutorials/tutorialMultiPendulum/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(tutorialMultiPendulum)
 
-find_package(DART 6.1.1 REQUIRED COMPONENTS utils-urdf gui)
+find_package(DART 6.2.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 


### PR DESCRIPTION
`find_package(DART)` uses [`FindDart.cmake`](https://github.com/Kitware/CMake/blob/master/Modules/FindDart.cmake) of the [DART programming language](https://www.dartlang.org/) by default. This PR changes the DART examples and tutorials to use `CONFIG` mode instead to find our DART using [`DARTConfig.cmake`](https://github.com/dartsim/dart/blob/master/cmake/DARTConfig.cmake.in).

This PR resolves #888.