### PR TITLE
Read joint friction from URDF

### DIFF
--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -1861,7 +1861,7 @@ void readJointDynamicsAndLimit(tinyxml2::XMLElement* _jointElement,
           *proxy.restPosition = val;
         }
 
-        // friction
+        // spring_stiffness
         if (hasElement(dynamicsElement, "spring_stiffness"))
         {
           double val = getValueDouble(dynamicsElement, "spring_stiffness");

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -365,7 +365,10 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
   }
 
   if(_jt->dynamics)
+  {
     singleDof.mDampingCoefficients[0] = _jt->dynamics->damping;
+    singleDof.mFrictions[0] = _jt->dynamics->friction;
+  }
 
   std::pair<dynamics::Joint*, dynamics::BodyNode*> pair;
   switch(_jt->type)

--- a/unittests/unit/test_DartLoader.cpp
+++ b/unittests/unit/test_DartLoader.cpp
@@ -84,3 +84,56 @@ TEST(DartLoader, parseWorld)
   EXPECT_TRUE(nullptr !=
       loader.parseWorld("dart://sample/urdf/test/testWorld.urdf"));
 }
+
+TEST(DartLoader, parseJointProperties)
+{
+  std::string urdfStr =
+    "<robot name=\"testRobot\">                                       "
+    "  <link name=\"link_0\">                                         "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 -0.087\"/>                 "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>                      "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "  </link>                                                        "
+    "  <joint name=\"0_to_1\" type=\"revolute\">                      "
+    "    <parent link=\"link_0\"/>                                    "
+    "    <child link=\"link_1\"/>                                     "
+    "    <limit effort=\"2.5\" lower=\"-3.14159265359\"               "
+    "           upper=\"3.14159265359\" velocity=\"3.00545697193\"/>  "
+    "    <axis xyz=\"0 0 1\"/>                                        "
+    "    <dynamics damping=\"1.2\" friction=\"2.3\"/>                 "
+    "  </joint>                                                       "
+    "  <link name=\"link_1\">                                         "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 -0.087\"/>                 "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>                      "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "  </link>                                                        "
+    "</robot>                                                         ";
+
+  DartLoader loader;
+  auto robot = loader.parseSkeletonString(urdfStr, "");
+  EXPECT_TRUE(nullptr != robot);
+
+  auto joint1 = robot->getJoint(1);
+  EXPECT_TRUE(nullptr != joint1);
+
+  EXPECT_NEAR(joint1->getDampingCoefficient(0), 1.2, 1e-12);
+  EXPECT_NEAR(joint1->getCoulombFriction(0), 2.3, 1e-12);
+}


### PR DESCRIPTION
This PR fixes the URDF parser to read joint friction.

Resolves #890.