### PR TITLE
Avoid collision checking between objects from the same body node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,5 @@ after_success:
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 
 after_failure: 
-  - cat Testing/Temporary/LastTest.log
-  - cat Testing/Temporary/LastTestsFailed.log
-
+  - cat build/Testing/Temporary/LastTest.log
+  - cat build/Testing/Temporary/LastTestsFailed.log

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -55,6 +55,9 @@ bool BodyNodeCollisionFilter::needCollision(
   auto bodyNode1 = shapeNode1->getBodyNodePtr();
   auto bodyNode2 = shapeNode2->getBodyNodePtr();
 
+  if (bodyNode1 == bodyNode2)
+    return false;
+
   if (!bodyNode1->isCollidable() || !bodyNode2->isCollidable())
     return false;
 

--- a/unittests/regression/CMakeLists.txt
+++ b/unittests/regression/CMakeLists.txt
@@ -5,4 +5,6 @@ if(TARGET dart-utils-urdf)
   dart_add_test("regression" test_Issue838)
   target_link_libraries(test_Issue838 dart-utils-urdf)
 
+  dart_add_test("regression" test_Issue895)
+
 endif()

--- a/unittests/regression/test_Issue895.cpp
+++ b/unittests/regression/test_Issue895.cpp
@@ -38,7 +38,8 @@ TEST(Issue895, BodyNodeSelfCollision)
 {
   const dart::dynamics::SkeletonPtr skel = dart::dynamics::Skeleton::create();
   dart::dynamics::BodyNode* bn =
-      skel->createJointAndBodyNodePair<FreeJoint>().second;;
+      skel->createJointAndBodyNodePair<FreeJoint>().second;
+  skel->enableSelfCollisionCheck();
 
   dart::dynamics::BoxShapePtr box =
       std::make_shared<dart::dynamics::BoxShape>(Eigen::Vector3d::Ones());
@@ -49,15 +50,16 @@ TEST(Issue895, BodyNodeSelfCollision)
   bn->createShapeNodeWith<CollisionAspect>(box)->setRelativeTranslation(
         Eigen::Vector3d(0.5, 0.5, 0.0));
 
-  dart::collision::CollisionDetectorPtr detector =
-      dart::collision::FCLCollisionDetector::create();
+  dart::simulation::WorldPtr world =
+      std::make_shared<dart::simulation::World>();
 
-  dart::collision::CollisionGroupPtr group =
-      detector->createCollisionGroupAsSharedPtr();
+  world->addSkeleton(skel);
 
-  group->addShapeFramesOf(bn);
+  world->step();
+  const dart::collision::CollisionResult result =
+      world->getLastCollisionResult();
 
-  EXPECT_FALSE(group->collide());
+  EXPECT_EQ(result.getNumContacts(), 0u);
 }
 
 //==============================================================================

--- a/unittests/regression/test_Issue895.cpp
+++ b/unittests/regression/test_Issue895.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <TestHelpers.hpp>
+#include <dart/dart.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
+
+//==============================================================================
+TEST(Issue895, BodyNodeSelfCollision)
+{
+  const dart::dynamics::SkeletonPtr skel = dart::dynamics::Skeleton::create();
+  dart::dynamics::BodyNode* bn =
+      skel->createJointAndBodyNodePair<FreeJoint>().second;;
+
+  dart::dynamics::BoxShapePtr box =
+      std::make_shared<dart::dynamics::BoxShape>(Eigen::Vector3d::Ones());
+
+  // Create two ShapeNodes on one BodyNode where the ShapeNodes will always be
+  // in collision
+  bn->createShapeNodeWith<CollisionAspect>(box);
+  bn->createShapeNodeWith<CollisionAspect>(box)->setRelativeTranslation(
+        Eigen::Vector3d(0.5, 0.5, 0.0));
+
+  dart::collision::CollisionDetectorPtr detector =
+      dart::collision::FCLCollisionDetector::create();
+
+  dart::collision::CollisionGroupPtr group =
+      detector->createCollisionGroupAsSharedPtr();
+
+  group->addShapeFramesOf(bn);
+
+  EXPECT_FALSE(group->collide());
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
I noticed that if I create multiple collision objects for a single link in Gazebo while using DART physics, they are collision checked against each other even though they are part of the same link (body node). The proposed change to `CollisionFilter::needCollision` prevents collision checking between shapes attached to the same body node.

See [collisions.world](https://github.com/dartsim/dart/files/1163781/collisions.world.txt) for an example in Gazebo. It contains a model with two links and self-collisions enabled. The top link consists of two flush collision meshes. Without the change, contacts points (blue dots) are detected between the flush meshes.
![before](https://user-images.githubusercontent.com/5615894/28440399-f1f395ec-6d5a-11e7-94e4-1c225e8c8603.jpg)

With the change, no such contacts are detected.
![after](https://user-images.githubusercontent.com/5615894/28440459-3b345f5c-6d5b-11e7-913b-e83a9af5015b.jpg)