### PR TITLE
Protect dart-gui-osg and check more rigorously for the presence of OSG

### DIFF
--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -8,6 +8,11 @@ if(DART_BUILD_GUI_OSG)
 
   find_package(OpenSceneGraph 3.0 QUIET
     COMPONENTS osg osgViewer osgManipulator osgGA osgDB)
+
+  # It seems that OPENSCENEGRAPH_FOUND will inadvertently get set to true when
+  # OpenThreads is found, even if OpenSceneGraph is not installed. This is quite
+  # possibly a bug in OSG's cmake configuration file. For now, it seems that
+  # requiring OSG_FOUND to be true as well fixes this.
   if(OPENSCENEGRAPH_FOUND AND OSG_FOUND)
     if(DART_VERBOSE)
       message(STATUS "Looking for OpenSceneGraph - ${OPENSCENEGRAPH_VERSION} found")

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -12,7 +12,6 @@ if(DART_BUILD_GUI_OSG)
     if(DART_VERBOSE)
       message(STATUS "Looking for OpenSceneGraph - ${OPENSCENEGRAPH_VERSION} found")
     endif()
-    set(HAVE_OPENSCENEGRAPH TRUE)
   else()
     # dart-gui-osg requires both OSG and OpenThreads. This section attempts to
     # identify which of those are missing from the building machine and offer
@@ -29,65 +28,63 @@ if(DART_BUILD_GUI_OSG)
     endif()
     message(WARNING "${warning_msg} -- we will skip dart-gui-osg\n"
             "If you believe you do have both OSG and OpenThreads installed, try setting OSG_DIR")
-    set(HAVE_OPENSCENEGRAPH FALSE)
+    return()
   endif()
 
 else()
 
   message(STATUS "Skipping OpenSceneGraph (DART_BUILD_GUI_OSG == ${DART_BUILD_GUI_OSG})")
-  set(HAVE_OPENSCENEGRAPH FALSE)
+  return()
 
 endif()
 
-if(HAVE_OPENSCENEGRAPH)
-  # Search all header and source files
-  file(GLOB hdrs "*.hpp")
-  file(GLOB srcs "*.cpp")
+# Search all header and source files
+file(GLOB hdrs "*.hpp")
+file(GLOB srcs "*.cpp")
 
-  set(dart_gui_osg_hdrs ${hdrs})
-  set(dart_gui_osg_srcs ${srcs})
+set(dart_gui_osg_hdrs ${hdrs})
+set(dart_gui_osg_srcs ${srcs})
 
-  add_subdirectory(render)
+add_subdirectory(render)
 
-  # Set local target name
-  set(target_name ${PROJECT_NAME}-gui-osg)
-  set(component_name gui-osg)
+# Set local target name
+set(target_name ${PROJECT_NAME}-gui-osg)
+set(component_name gui-osg)
 
-  # Add target
-  dart_add_library(${target_name} ${hdrs} ${srcs} ${dart_gui_osg_hdrs} ${dart_gui_osg_srcs})
-  target_include_directories(
-    ${target_name} SYSTEM
-    PUBLIC ${OPENSCENEGRAPH_INCLUDE_DIRS}
-  )
-  target_link_libraries(
-    ${target_name}
-    dart-gui
-    ${OPENSCENEGRAPH_LIBRARIES}
-  )
+# Add target
+dart_add_library(${target_name} ${hdrs} ${srcs} ${dart_gui_osg_hdrs} ${dart_gui_osg_srcs})
+target_include_directories(
+  ${target_name} SYSTEM
+  PUBLIC ${OPENSCENEGRAPH_INCLUDE_DIRS}
+)
+target_link_libraries(
+  ${target_name}
+  dart-gui
+  ${OPENSCENEGRAPH_LIBRARIES}
+)
 
-  # Component
-  add_component(${PROJECT_NAME} ${component_name})
-  add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
-  add_component_dependencies(${PROJECT_NAME} ${component_name} gui)
+# Component
+add_component(${PROJECT_NAME} ${component_name})
+add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
+add_component_dependencies(${PROJECT_NAME} ${component_name} gui)
 
-  # Generate header for this namespace
-  dart_get_filename_components(header_names "gui osg headers" ${hdrs})
-  list(APPEND header_names "render/render.hpp")
-  dart_generate_include_header_list(
-    gui_osg_headers
-    "dart/gui/osg/"
-    "gui osg headers"
-    ${header_names}
-  )
-  configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/osg.hpp.in
-    ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
-  )
+# Generate header for this namespace
+dart_get_filename_components(header_names "gui osg headers" ${hdrs})
+list(APPEND header_names "render/render.hpp")
+dart_generate_include_header_list(
+  gui_osg_headers
+  "dart/gui/osg/"
+  "gui osg headers"
+  ${header_names}
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/osg.hpp.in
+  ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
+)
 
-  # Install
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
-    DESTINATION include/dart/gui/osg
-    COMPONENT headers
-  )
-endif()
+# Install
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
+  DESTINATION include/dart/gui/osg
+  COMPONENT headers
+)

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -8,7 +8,7 @@ if(DART_BUILD_GUI_OSG)
 
   find_package(OpenSceneGraph 3.0 QUIET
     COMPONENTS osg osgViewer osgManipulator osgGA osgDB)
-  if(OPENSCENEGRAPH_FOUND)
+  if(OPENSCENEGRAPH_FOUND AND OSG_FOUND)
     if(DART_VERBOSE)
       message(STATUS "Looking for OpenSceneGraph - ${OPENSCENEGRAPH_VERSION} found")
     endif()
@@ -39,53 +39,55 @@ else()
 
 endif()
 
-# Search all header and source files
-file(GLOB hdrs "*.hpp")
-file(GLOB srcs "*.cpp")
+if(HAVE_OPENSCENEGRAPH)
+  # Search all header and source files
+  file(GLOB hdrs "*.hpp")
+  file(GLOB srcs "*.cpp")
 
-set(dart_gui_osg_hdrs ${hdrs})
-set(dart_gui_osg_srcs ${srcs})
+  set(dart_gui_osg_hdrs ${hdrs})
+  set(dart_gui_osg_srcs ${srcs})
 
-add_subdirectory(render)
+  add_subdirectory(render)
 
-# Set local target name
-set(target_name ${PROJECT_NAME}-gui-osg)
-set(component_name gui-osg)
+  # Set local target name
+  set(target_name ${PROJECT_NAME}-gui-osg)
+  set(component_name gui-osg)
 
-# Add target
-dart_add_library(${target_name} ${hdrs} ${srcs} ${dart_gui_osg_hdrs} ${dart_gui_osg_srcs})
-target_include_directories(
-  ${target_name} SYSTEM
-  PUBLIC ${OPENSCENEGRAPH_INCLUDE_DIRS}
-)
-target_link_libraries(
-  ${target_name}
-  dart-gui
-  ${OPENSCENEGRAPH_LIBRARIES}
-)
+  # Add target
+  dart_add_library(${target_name} ${hdrs} ${srcs} ${dart_gui_osg_hdrs} ${dart_gui_osg_srcs})
+  target_include_directories(
+    ${target_name} SYSTEM
+    PUBLIC ${OPENSCENEGRAPH_INCLUDE_DIRS}
+  )
+  target_link_libraries(
+    ${target_name}
+    dart-gui
+    ${OPENSCENEGRAPH_LIBRARIES}
+  )
 
-# Component
-add_component(${PROJECT_NAME} ${component_name})
-add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
-add_component_dependencies(${PROJECT_NAME} ${component_name} gui)
+  # Component
+  add_component(${PROJECT_NAME} ${component_name})
+  add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
+  add_component_dependencies(${PROJECT_NAME} ${component_name} gui)
 
-# Generate header for this namespace
-dart_get_filename_components(header_names "gui osg headers" ${hdrs})
-list(APPEND header_names "render/render.hpp")
-dart_generate_include_header_list(
-  gui_osg_headers
-  "dart/gui/osg/"
-  "gui osg headers"
-  ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/osg.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
-)
+  # Generate header for this namespace
+  dart_get_filename_components(header_names "gui osg headers" ${hdrs})
+  list(APPEND header_names "render/render.hpp")
+  dart_generate_include_header_list(
+    gui_osg_headers
+    "dart/gui/osg/"
+    "gui osg headers"
+    ${header_names}
+  )
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/osg.hpp.in
+    ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
+  )
 
-# Install
-install(
-  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
-  DESTINATION include/dart/gui/osg
-  COMPONENT headers
-)
+  # Install
+  install(
+    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
+    DESTINATION include/dart/gui/osg
+    COMPONENT headers
+  )
+endif()


### PR DESCRIPTION
This PR has two related (but independent) purposes:

1. Prevent `dart-gui-osg` from being built when OSG is not detected. ~~This is done by wrapping the second half of `dart/gui/osg/CMakeLists.txt` in an if-block.~~ This is done by returning immediately if OpenSceneGraph cmake variables cannot be found. This was not needed in the past because the call to `add_subdirectory(osg)` used to be wrapped in an if-statement.

2. More rigorously check whether OSG exists. In the process of fixing this, I discovered that the version of `FindOpenSceneGraph.cmake` that is provided with `cmake-3.5` will set `OPENSCENEGRAPH_FOUND` to true if it finds libopen**threads**, even if libopen**scenegraph** isn't actually installed. I believe this is a bug on the part of either CMake or OpenSceneGraph, because this behavior contradicts the variable's description provided by `FindOpenSceneGraph.cmake`, but I found a workaround by checking both `OPENSCENEGRAPH_FOUND` and `OSG_FOUND`. The latter seems to correctly return false when OpenSceneGraph is not available.

Note that the vast majority of the diff is due to white space from indenting the content inside the if-statement.