### PR TITLE
Fixing handling of use_parent_model_frame tag in SdfParser (#893)

### DIFF
--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -1268,7 +1268,7 @@ static void readAxisElement(
   Eigen::Vector3d xyz = getValueVector3d(axisElement, "xyz");
   if (useParentModelFrame)
   {
-    xyz = _parentModelFrame * xyz;
+    xyz = _parentModelFrame.rotation() * xyz;
   }
   axis = xyz;
 


### PR DESCRIPTION
Backport #893 from master to release-6.2