### PR TITLE
Added definitions for constexpr static members (see #603)

### DIFF
--- a/dart/math/ConfigurationSpace.cpp
+++ b/dart/math/ConfigurationSpace.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/math/ConfigurationSpace.hpp"
+
+namespace dart {
+namespace math {
+
+//==============================================================================
+//
+// These namespace-level definitions are required to enable ODR-use of static
+// constexpr member variables.
+//
+// See this StackOverflow answer: http://stackoverflow.com/a/14396189/111426
+//
+constexpr std::size_t SO3Space::NumDofs;
+constexpr int SO3Space::NumDofsEigen;
+
+//==============================================================================
+//
+// These namespace-level definitions are required to enable ODR-use of static
+// constexpr member variables.
+//
+// See this StackOverflow answer: http://stackoverflow.com/a/14396189/111426
+//
+constexpr std::size_t SE3Space::NumDofs;
+constexpr int SE3Space::NumDofsEigen;
+
+} // namespace math
+} // namespace dart

--- a/dart/math/ConfigurationSpace.hpp
+++ b/dart/math/ConfigurationSpace.hpp
@@ -55,6 +55,18 @@ struct RealVectorSpace
   using JacobianMatrix = Eigen::Matrix<double, 6, NumDofs>;
 };
 
+//==============================================================================
+//
+// These namespace-level definitions are required to enable ODR-use of static
+// constexpr member variables.
+//
+// See this StackOverflow answer: http://stackoverflow.com/a/14396189/111426
+//
+template <std::size_t Dimension>
+constexpr std::size_t RealVectorSpace<Dimension>::NumDofs;
+template <std::size_t Dimension>
+constexpr int RealVectorSpace<Dimension>::NumDofsEigen;
+
 using NullSpace = RealVectorSpace<0u>;
 using R1Space = RealVectorSpace<1u>;
 using R2Space = RealVectorSpace<2u>;
@@ -91,7 +103,6 @@ struct SE3Space
 };
 
 struct MapsToManifoldPoint {};
-
 
 //==============================================================================
 template <typename SpaceT>


### PR DESCRIPTION
This PR adds definitions for constexpr static members for ODR-use like we did in #603.