### PR TITLE
Provide setters and getters for WeldJointConstraint::mRelativeTransform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ endif()
 #===============================================================================
 
 # If you change the version, please update the <version> tag in package.xml.
-set(DART_MAJOR_VERSION "6")
-set(DART_MINOR_VERSION "3")
+set(DART_MAJOR_VERSION "7")
+set(DART_MINOR_VERSION "0")
 set(DART_PATCH_VERSION "0")
 set(DART_VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}.${DART_PATCH_VERSION}")
 set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")

--- a/dart/constraint/WeldJointConstraint.cpp
+++ b/dart/constraint/WeldJointConstraint.cpp
@@ -81,8 +81,21 @@ WeldJointConstraint::WeldJointConstraint(dynamics::BodyNode* _body1,
 }
 
 //==============================================================================
+void WeldJointConstraint::setRelativeTransform(const Eigen::Isometry3d& _tf)
+{
+  mRelativeTransform = _tf;
+}
+
+//==============================================================================
+const Eigen::Isometry3d& WeldJointConstraint::getRelativeTransform() const
+{
+  return mRelativeTransform;
+}
+
+//==============================================================================
 WeldJointConstraint::~WeldJointConstraint()
 {
+  // Do nothing
 }
 
 //==============================================================================

--- a/dart/constraint/WeldJointConstraint.hpp
+++ b/dart/constraint/WeldJointConstraint.hpp
@@ -51,6 +51,12 @@ public:
   /// Constructor that takes two bodies
   WeldJointConstraint(dynamics::BodyNode* _body1, dynamics::BodyNode* _body2);
 
+  /// Set the relative transform that this WeldJointConstraint will enforce
+  void setRelativeTransform(const Eigen::Isometry3d& _tf);
+
+  /// Get the relative transform that this WeldJointConstraint will enforce
+  const Eigen::Isometry3d& getRelativeTransform() const;
+
   /// Destructor
   virtual ~WeldJointConstraint();
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dart</name>
-  <version>6.3.0</version>
+  <version>7.0.0</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics


### PR DESCRIPTION
I couldn't find any reason to restrict access to setting `mRelativeTransform`. I also couldn't identify any other data members who would be impacted by changing `mRelativeTransform`, so the setter is just a straightforward copy.

This addresses #903.