### PR TITLE
Adding setter and getter for WeldJointConstraint::mRelativeTransform

### DIFF
--- a/dart/constraint/WeldJointConstraint.cpp
+++ b/dart/constraint/WeldJointConstraint.cpp
@@ -81,8 +81,21 @@ WeldJointConstraint::WeldJointConstraint(dynamics::BodyNode* _body1,
 }
 
 //==============================================================================
+void WeldJointConstraint::setRelativeTransform(const Eigen::Isometry3d& _tf)
+{
+  mRelativeTransform = _tf;
+}
+
+//==============================================================================
+const Eigen::Isometry3d& WeldJointConstraint::getRelativeTransform() const
+{
+  return mRelativeTransform;
+}
+
+//==============================================================================
 WeldJointConstraint::~WeldJointConstraint()
 {
+  // Do nothing
 }
 
 //==============================================================================

--- a/dart/constraint/WeldJointConstraint.hpp
+++ b/dart/constraint/WeldJointConstraint.hpp
@@ -51,6 +51,12 @@ public:
   /// Constructor that takes two bodies
   WeldJointConstraint(dynamics::BodyNode* _body1, dynamics::BodyNode* _body2);
 
+  /// Set the relative transform that this WeldJointConstraint will enforce
+  void setRelativeTransform(const Eigen::Isometry3d& _tf);
+
+  /// Get the relative transform that this WeldJointConstraint will enforce
+  const Eigen::Isometry3d& getRelativeTransform() const;
+
   /// Destructor
   virtual ~WeldJointConstraint();
 


### PR DESCRIPTION
I couldn't find any reason to restrict access to setting mRelativeTransform. I also couldn't identify any other data members who would be impacted by changing mRelativeTransform, so the setter is just a straightforward copy.

This addresses #903.