### PR TITLE
Add blacklist to BodyNodeCollisionFilter

### DIFF
--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -129,16 +129,10 @@ void BodyNodeCollisionFilter::removeBodyNodePairFromBlackList(
   if (foundLeft)
   {
     auto& associatedRights = resultLeft->second;
+    associatedRights.erase(bodyNodeGreater);
 
-    const auto resultRight = associatedRights.find(bodyNodeGreater);
-    const bool foundRight = (resultRight != associatedRights.end());
-    if (foundRight)
-    {
-      associatedRights.erase(bodyNodeGreater);
-
-      if (associatedRights.empty())
-        mBlackList.erase(resultLeft);
-    }
+    if (associatedRights.empty())
+      mBlackList.erase(resultLeft);
   }
 }
 

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -101,13 +101,13 @@ void BodyNodeCollisionFilter::addBodyNodePairToBlackList(
   // Call insert in case an entry for bodyNodeLess doesn't exist. If it doesn't
   // exist, it will be initialized with an empty set. If it does already exist,
   // we will just get an iterator to the existing entry.
-  const auto it_less = mBlackList.insert(
-        std::make_pair(bodyNodeLess,
-                       std::set<const dynamics::BodyNode*>())).first;
+  const auto itLess = mBlackList.insert(
+      std::make_pair(bodyNodeLess,
+                     std::unordered_set<const dynamics::BodyNode*>())).first;
 
   // Insert bodyNodeGreater into the set corresponding to bodyNodeLess. If the
   // pair already existed, this will do nothing.
-  it_less->second.insert(bodyNodeGreater);
+  itLess->second.insert(bodyNodeGreater);
 }
 
 //==============================================================================

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -149,21 +149,13 @@ bool BodyNodeCollisionFilter::ignoresCollision(
   auto shapeNode1 = object1->getShapeFrame()->asShapeNode();
   auto shapeNode2 = object2->getShapeFrame()->asShapeNode();
 
-  if (!shapeNode1)
-  {
-    dterr << "[BodyNodeCollisionFilter::ignoresCollision] Inappropriate "
-          << "collision filter is used for shapeNode1. This collision filter "
-          << "shouldn't be for non-ShapeNodes.\n";
-    assert(false);
-  }
-
-  if (!shapeNode2)
-  {
-    dterr << "[BodyNodeCollisionFilter::ignoresCollision] Inappropriate "
-          << "collision filter is used for shapeNode2. This collision filter "
-          << "shouldn't be for non-ShapeNodes.\n";
-    assert(false);
-  }
+  // We don't filter out for non-ShapeNode because this class shouldn't have the
+  // authority to make decisions about filtering any ShapeFrames that aren't
+  // attached to a BodyNode. So here we just return false. In order to decide
+  // whether the non-ShapeNode should be ignored, please use other collision
+  // filters.
+  if (!shapeNode1 || !shapeNode2)
+    return false;
 
   auto bodyNode1 = shapeNode1->getBodyNodePtr();
   auto bodyNode2 = shapeNode2->getBodyNodePtr();

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -153,9 +153,21 @@ bool BodyNodeCollisionFilter::ignoresCollision(
   auto shapeNode1 = object1->getShapeFrame()->asShapeNode();
   auto shapeNode2 = object2->getShapeFrame()->asShapeNode();
 
-  if (!shapeNode1 || !shapeNode2)
-    return false;
-  // We assume that non-ShapeNodes are always being checked for collisions.
+  if (!shapeNode1)
+  {
+    dterr << "[BodyNodeCollisionFilter::ignoresCollision] Inappropriate "
+          << "collision filter is used for shapeNode1. This collision filter "
+          << "shouldn't be for non-ShapeNodes.\n";
+    assert(false);
+  }
+
+  if (!shapeNode2)
+  {
+    dterr << "[BodyNodeCollisionFilter::ignoresCollision] Inappropriate "
+          << "collision filter is used for shapeNode2. This collision filter "
+          << "shouldn't be for non-ShapeNodes.\n";
+    assert(false);
+  }
 
   auto bodyNode1 = shapeNode1->getBodyNodePtr();
   auto bodyNode2 = shapeNode2->getBodyNodePtr();

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -47,12 +47,8 @@ bool CollisionFilter::needCollision(
 //==============================================================================
 void CompositeCollisionFilter::addCollisionFilter(const CollisionFilter* filter)
 {
+  // nullptr is not an allowed filter
   if (!filter)
-    return;
-
-  const auto result = std::find(mFilters.begin(), mFilters.end(), filter);
-  const bool found = (result != mFilters.end());
-  if (found)
     return;
 
   mFilters.insert(filter);

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -99,22 +99,16 @@ void BodyNodeCollisionFilter::addBodyNodePairToBlackList(
   if (bodyNodeLess > bodyNodeGreater)
     std::swap(bodyNodeLess, bodyNodeGreater);
 
-  // Add the pair only when it doesn't already exist
-  const auto resultLeft = mBlackList.find(bodyNodeLess);
-  const bool foundLeft = (resultLeft != mBlackList.end());
-  if (!foundLeft)
-  {
-    mBlackList[bodyNodeLess] = {bodyNodeGreater};
-  }
-  else
-  {
-    auto& key = resultLeft->second;
+  // Call insert in case an entry for bodyNodeLess doesn't exist. If it doesn't
+  // exist, it will be initialized with an empty set. If it does already exist,
+  // we will just get an iterator to the existing entry.
+  const auto it_less = mBlackList.insert(
+        std::make_pair(bodyNodeLess,
+                       std::set<const dynamics::BodyNode*>())).first;
 
-    const auto resultRight = key.find(bodyNodeGreater);
-    const bool foundRight = (resultRight != key.end());
-    if (!foundRight)
-      key.insert(bodyNodeGreater);
-  }
+  // Insert bodyNodeGreater into the set corresponding to bodyNodeLess. If the
+  // pair already existed, this will do nothing.
+  it_less->second.insert(bodyNodeGreater);
 }
 
 //==============================================================================

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -228,10 +228,10 @@ bool BodyNodeCollisionFilter::hasBodyNodePairInBlacklist(
   const bool foundLeft = (resultLeft != mBlackList.end());
   if (foundLeft)
   {
-    auto& key = resultLeft->second;
+    auto& associatedRights = resultLeft->second;
 
-    const auto resultRight = key.find(bodyNodeGreater);
-    const bool foundRight = (resultRight != key.end());
+    const auto resultRight = associatedRights.find(bodyNodeGreater);
+    const bool foundRight = (resultRight != associatedRights.end());
     if (foundRight)
       return true;
   }

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -56,7 +56,7 @@ void CompositeCollisionFilter::addCollisionFilter(const CollisionFilter* filter)
 
 //==============================================================================
 void CompositeCollisionFilter::removeCollisionFilter(
-    const CollisionFilter* filter)
+const CollisionFilter* filter)
 {
   mFilters.erase(filter);
 }
@@ -73,8 +73,7 @@ bool CompositeCollisionFilter::ignoresCollision(
 {
   for (const auto* filter : mFilters)
   {
-    const bool collisionIgnored = filter->ignoresCollision(object1, object2);
-    if (collisionIgnored)
+    if (filter->ignoresCollision(object1, object2))
       return true;
   }
 

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -45,7 +45,7 @@ bool CollisionFilter::needCollision(
 }
 
 //==============================================================================
-void CompositeCollisionFilter::addCollisionFilter(CollisionFilter* filter)
+void CompositeCollisionFilter::addCollisionFilter(const CollisionFilter* filter)
 {
   if (!filter)
     return;
@@ -55,15 +55,14 @@ void CompositeCollisionFilter::addCollisionFilter(CollisionFilter* filter)
   if (found)
     return;
 
-  mFilters.push_back(filter);
+  mFilters.insert(filter);
 }
 
 //==============================================================================
 void CompositeCollisionFilter::removeCollisionFilter(
     const CollisionFilter* filter)
 {
-  mFilters.erase(
-        std::remove(mFilters.begin(), mFilters.end(), filter), mFilters.end());
+  mFilters.erase(filter);
 }
 
 //==============================================================================

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -186,7 +186,7 @@ bool BodyNodeCollisionFilter::ignoresCollision(
     }
   }
 
-  if (existsBodyNodePairInBlacklist(bodyNode1, bodyNode2))
+  if (hasBodyNodePairInBlacklist(bodyNode1, bodyNode2))
     return true;
 
   return false;
@@ -208,7 +208,7 @@ bool BodyNodeCollisionFilter::areAdjacentBodies(
 }
 
 //==============================================================================
-bool BodyNodeCollisionFilter::existsBodyNodePairInBlacklist(
+bool BodyNodeCollisionFilter::hasBodyNodePairInBlacklist(
     const dynamics::BodyNode* bodyNode1,
     const dynamics::BodyNode* bodyNode2) const
 {

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -162,7 +162,7 @@ bool BodyNodeCollisionFilter::needsCollisionCheck(
 
   if (!shapeNode1 || !shapeNode2)
     return true;
-  // We assume that non-ShapeNode is always being checked collision.
+  // We assume that non-ShapeNodes are always being checked for collisions.
 
   auto bodyNode1 = shapeNode1->getBodyNodePtr();
   auto bodyNode2 = shapeNode2->getBodyNodePtr();

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -128,15 +128,15 @@ void BodyNodeCollisionFilter::removeBodyNodePairFromBlackList(
   const bool foundLeft = (resultLeft != mBlackList.end());
   if (foundLeft)
   {
-    auto& key = resultLeft->second;
+    auto& associatedRights = resultLeft->second;
 
-    const auto resultRight = key.find(bodyNodeGreater);
-    const bool foundRight = (resultRight != key.end());
+    const auto resultRight = associatedRights.find(bodyNodeGreater);
+    const bool foundRight = (resultRight != associatedRights.end());
     if (foundRight)
     {
-      key.erase(bodyNodeGreater);
+      associatedRights.erase(bodyNodeGreater);
 
-      if (key.empty())
+      if (associatedRights.empty())
         mBlackList.erase(resultLeft);
     }
   }

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -116,7 +116,7 @@ private:
                          const dynamics::BodyNode* bodyNode2) const;
 
   /// Returns true if the BodyNode pair is in the blacklist.
-  bool existsBodyNodePairInBlacklist(
+  bool hasBodyNodePairInBlacklist(
       const dynamics::BodyNode* bodyNode1,
       const dynamics::BodyNode* bodyNode2) const;
 

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -32,7 +32,6 @@
 #ifndef DART_COLLISION_COLLISIONFILTER_HPP_
 #define DART_COLLISION_COLLISIONFILTER_HPP_
 
-#include <set>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -32,9 +32,6 @@
 #ifndef DART_COLLISION_COLLISIONFILTER_HPP_
 #define DART_COLLISION_COLLISIONFILTER_HPP_
 
-#include <unordered_map>
-#include <unordered_set>
-
 #include "dart/common/Deprecated.hpp"
 #include "dart/collision/detail/UnorderedPairs.hpp"
 

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -36,6 +36,7 @@
 #include <unordered_set>
 
 #include "dart/common/Deprecated.hpp"
+#include "dart/collision/detail/UnorderedPairs.hpp"
 
 namespace dart {
 
@@ -114,18 +115,8 @@ private:
   bool areAdjacentBodies(const dynamics::BodyNode* bodyNode1,
                          const dynamics::BodyNode* bodyNode2) const;
 
-  /// Returns true if the BodyNode pair is in the blacklist.
-  bool hasBodyNodePairInBlacklist(
-      const dynamics::BodyNode* bodyNode1,
-      const dynamics::BodyNode* bodyNode2) const;
-
-  /// List of pairs to be excluded in the collision detection.
-  ///
-  /// Each pair is stored so that the key of the std::unordered_map always has
-  /// a value less than every element in the set that is associated with it.
-  std::unordered_map<
-      const dynamics::BodyNode*,
-      std::unordered_set<const dynamics::BodyNode*>> mBlackList;
+  /// List of pairs to be ignored in the collision detection.
+  detail::UnorderedPairs<dynamics::BodyNode> mBodyNodeBlackList;
 };
 
 } // namespace collision

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -34,7 +34,7 @@
 
 #include <set>
 #include <unordered_map>
-#include <vector>
+#include <unordered_set>
 
 #include "dart/common/Deprecated.hpp"
 
@@ -70,7 +70,7 @@ class CompositeCollisionFilter : public CollisionFilter
 {
 public:
   /// Adds a collision filter to this CompositeCollisionFilter.
-  void addCollisionFilter(CollisionFilter* filter);
+  void addCollisionFilter(const CollisionFilter* filter);
 
   /// Removes a collision filter from this CompositeCollisionFilter.
   void removeCollisionFilter(const CollisionFilter* filter);
@@ -85,7 +85,7 @@ public:
 
 protected:
   /// Collision filters
-  std::vector<CollisionFilter*> mFilters;
+  std::unordered_set<const CollisionFilter*> mFilters;
 };
 
 class BodyNodeCollisionFilter : public CollisionFilter

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -53,14 +53,16 @@ class CollisionFilter
 public:
   /// Returns true if the given two CollisionObjects should be checked by the
   /// collision detector, false otherwise.
-  /// \deprecated Deprecated in 6.3.0. Please use needsCollisionCheck instead.
+  /// \deprecated Deprecated in 6.3.0. Please use ignoreCollision instead. Note
+  /// that ignoreCollision returns logically opposite to what needCollision
+  /// returns.
   DART_DEPRECATED(6.3)
   bool needCollision(
       const CollisionObject* object1, const CollisionObject* object2) const;
 
   /// Returns true if the given two CollisionObjects should be checked by the
   /// collision detector, false otherwise.
-  virtual bool needsCollisionCheck(
+  virtual bool ignoresCollision(
       const CollisionObject* object1, const CollisionObject* object2) const = 0;
 };
 
@@ -77,7 +79,7 @@ public:
   void removeAllCollisionFilters();
 
   // Documentation inherited
-  bool needsCollisionCheck(
+  bool ignoresCollision(
       const CollisionObject* object1,
       const CollisionObject* object2) const override;
 
@@ -103,7 +105,7 @@ public:
   void removeAllBodyNodePairsFromBlackList();
 
   // Documentation inherited
-  bool needsCollisionCheck(
+  bool ignoresCollision(
       const CollisionObject* object1,
       const CollisionObject* object2) const override;
 

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -126,7 +126,7 @@ private:
   /// a value less than every element in the set that is associated with it.
   std::unordered_map<
       const dynamics::BodyNode*,
-      std::set<const dynamics::BodyNode*>> mBlackList;
+      std::unordered_set<const dynamics::BodyNode*>> mBlackList;
 };
 
 } // namespace collision

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -120,9 +120,8 @@ private:
 
   /// List of pairs to be excluded in the collision detection.
   ///
-  /// Each pair is stored as which the key of the std::unordered_map is not
-  /// always greater than any of elements of the associated value that is a
-  /// std::set.
+  /// Each pair is stored so that the key of the std::unordered_map always has
+  /// a value less than every element in the set that is associated with it.
   std::unordered_map<
       const dynamics::BodyNode*,
       std::set<const dynamics::BodyNode*>> mBlackList;

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -195,7 +195,7 @@ void filterOutCollisions(btCollisionWorld* world)
     const auto collObj0 = static_cast<BulletCollisionObject*>(userPtr0);
     const auto collObj1 = static_cast<BulletCollisionObject*>(userPtr1);
 
-    if (!filter->needsCollisionCheck(collObj0, collObj1))
+    if (filter->ignoresCollision(collObj0, collObj1))
       manifoldsToRelease.push_back(contactManifold);
   }
 

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -195,7 +195,7 @@ void filterOutCollisions(btCollisionWorld* world)
     const auto collObj0 = static_cast<BulletCollisionObject*>(userPtr0);
     const auto collObj1 = static_cast<BulletCollisionObject*>(userPtr1);
 
-    if (!filter->needCollision(collObj0, collObj1))
+    if (!filter->needsCollisionCheck(collObj0, collObj1))
       manifoldsToRelease.push_back(contactManifold);
   }
 

--- a/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
+++ b/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
@@ -78,7 +78,7 @@ bool BulletCollisionDispatcher::needsCollision(
   const auto collObj1
       = static_cast<BulletCollisionObject*>(body1->getUserPointer());
 
-  if (mFilter && !mFilter->needCollision(collObj0, collObj1))
+  if (mFilter && !mFilter->needsCollisionCheck(collObj0, collObj1))
     return false;
 
   return btCollisionDispatcher::needsCollision(body0, body1);

--- a/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
+++ b/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
@@ -78,7 +78,7 @@ bool BulletCollisionDispatcher::needsCollision(
   const auto collObj1
       = static_cast<BulletCollisionObject*>(body1->getUserPointer());
 
-  if (mFilter && !mFilter->needsCollisionCheck(collObj0, collObj1))
+  if (mFilter && mFilter->ignoresCollision(collObj0, collObj1))
     return false;
 
   return btCollisionDispatcher::needsCollision(body0, body1);

--- a/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
+++ b/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
@@ -75,7 +75,7 @@ bool BulletOverlapFilterCallback::needBroadphaseCollision(
     const auto collObj0 = static_cast<BulletCollisionObject*>(userPtr0);
     const auto collObj1 = static_cast<BulletCollisionObject*>(userPtr1);
 
-    return filter->needsCollisionCheck(collObj0, collObj1);
+    return !filter->ignoresCollision(collObj0, collObj1);
   }
 
   return collide;

--- a/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
+++ b/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
@@ -75,7 +75,7 @@ bool BulletOverlapFilterCallback::needBroadphaseCollision(
     const auto collObj0 = static_cast<BulletCollisionObject*>(userPtr0);
     const auto collObj1 = static_cast<BulletCollisionObject*>(userPtr1);
 
-    return filter->needCollision(collObj0, collObj1);
+    return filter->needsCollisionCheck(collObj0, collObj1);
   }
 
   return collide;

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -145,7 +145,7 @@ bool DARTCollisionDetector::collide(
     {
       auto* collObj2 = objects[j];
 
-      if (filter && !filter->needCollision(collObj1, collObj2))
+      if (filter && !filter->needsCollisionCheck(collObj1, collObj2))
         continue;
 
       collisionFound = checkPair(collObj1, collObj2, option, result);
@@ -207,7 +207,7 @@ bool DARTCollisionDetector::collide(
     {
       auto* collObj2 = objects2[j];
 
-      if (filter && !filter->needCollision(collObj1, collObj2))
+      if (filter && !filter->needsCollisionCheck(collObj1, collObj2))
         continue;
 
       collisionFound = checkPair(collObj1, collObj2, option, result);

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -145,7 +145,7 @@ bool DARTCollisionDetector::collide(
     {
       auto* collObj2 = objects[j];
 
-      if (filter && !filter->needsCollisionCheck(collObj1, collObj2))
+      if (filter && filter->ignoresCollision(collObj1, collObj2))
         continue;
 
       collisionFound = checkPair(collObj1, collObj2, option, result);
@@ -207,7 +207,7 @@ bool DARTCollisionDetector::collide(
     {
       auto* collObj2 = objects2[j];
 
-      if (filter && !filter->needsCollisionCheck(collObj1, collObj2))
+      if (filter && filter->ignoresCollision(collObj1, collObj2))
         continue;
 
       collisionFound = checkPair(collObj1, collObj2, option, result);

--- a/dart/collision/detail/UnorderedPairs.hpp
+++ b/dart/collision/detail/UnorderedPairs.hpp
@@ -42,19 +42,21 @@ template <class T>
 class UnorderedPairs
 {
 public:
-  /// Add a pair to this container.
+  /// Adds a pair to this container.
   void addPair(const T* left, const T* right);
 
-  /// Remove a pair from this container.
+  /// Removes a pair from this container.
   void removePair(const T* left, const T* right);
 
-  /// Remove all the pairs from this container.
+  /// Removes all the pairs from this container.
   void removeAllPairs();
 
   /// Returns true if this container contains the pair.
   bool contains(const T* left, const T* right) const;
 
 private:
+  /// The actual container to store pairs.
+  ///
   /// Each pair is stored so that the key of the std::unordered_map always has
   /// a value less than every element in the std::unordered_set that is
   /// associated with it.

--- a/dart/collision/detail/UnorderedPairs.hpp
+++ b/dart/collision/detail/UnorderedPairs.hpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2017, Graphics Lab, Georgia Tech Research Corporation
+ * Copyright (c) 2017, Personal Robotics Lab, Carnegie Mellon University
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_DETAIL_UNORDEREDPAIRS_HPP_
+#define DART_COLLISION_DETAIL_UNORDEREDPAIRS_HPP_
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace dart {
+namespace collision {
+namespace detail {
+
+template <class T>
+class UnorderedPairs
+{
+public:
+  /// Add a pair to this container.
+  void addPair(const T* left, const T* right);
+
+  /// Remove a pair from this container.
+  void removePair(const T* left, const T* right);
+
+  /// Remove all the pairs from this container.
+  void removeAllPairs();
+
+  /// Returns true if this container contains the pair.
+  bool contains(const T* left, const T* right) const;
+
+private:
+  /// Each pair is stored so that the key of the std::unordered_map always has
+  /// a value less than every element in the std::unordered_set that is
+  /// associated with it.
+  std::unordered_map<const T*, std::unordered_set<const T*>> mList;
+};
+
+//==============================================================================
+template <class T>
+void UnorderedPairs<T>::addPair(const T* left, const T* right)
+{
+  if (!left || !right)
+    return;
+
+  const auto* less = left;
+  const auto* greater = right;
+
+  if (less > greater)
+    std::swap(less, greater);
+
+  // Call insert in case an entry for bodyNodeLess doesn't exist. If it doesn't
+  // exist, it will be initialized with an empty set. If it does already exist,
+  // we will just get an iterator to the existing entry.
+  const auto itLess = mList.insert(
+      std::make_pair(less, std::unordered_set<const T*>())).first;
+
+  // Insert bodyNodeGreater into the set corresponding to bodyNodeLess. If the
+  // pair already existed, this will do nothing.
+  itLess->second.insert(greater);
+}
+
+//==============================================================================
+template<class T>
+void UnorderedPairs<T>::removePair(const T* left, const T* right)
+{
+  if (!left || !right)
+    return;
+
+  const auto* bodyNodeLess = left;
+  const auto* bodyNodeGreater = right;
+
+  if (bodyNodeLess > bodyNodeGreater)
+    std::swap(bodyNodeLess, bodyNodeGreater);
+
+  // Remove the pair only when it already exists
+  const auto resultLeft = mList.find(bodyNodeLess);
+  const bool foundLeft = (resultLeft != mList.end());
+  if (foundLeft)
+  {
+    auto& associatedRights = resultLeft->second;
+    associatedRights.erase(bodyNodeGreater);
+
+    if (associatedRights.empty())
+      mList.erase(resultLeft);
+  }
+}
+
+//==============================================================================
+template<class T>
+void UnorderedPairs<T>::removeAllPairs()
+{
+  mList.clear();
+}
+
+//==============================================================================
+template<class T>
+bool UnorderedPairs<T>::contains(const T* left, const T* right) const
+{
+  const auto* less = left;
+  const auto* greater = right;
+
+  if (less > greater)
+    std::swap(less, greater);
+
+  const auto resultLeft = mList.find(less);
+  const bool foundLeft = (resultLeft != mList.end());
+  if (foundLeft)
+  {
+    auto& associatedRights = resultLeft->second;
+
+    const auto resultRight = associatedRights.find(greater);
+    const bool foundRight = (resultRight != associatedRights.end());
+    if (foundRight)
+      return true;
+  }
+
+  return false;
+}
+
+} // namespace detail
+} // namespace collision
+} // namespace dart
+
+#endif // DART_COLLISION_DETAIL_UNORDEREDPAIRS_HPP_

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -1099,7 +1099,7 @@ bool collisionCallback(
     assert(collisionObject1);
     assert(collisionObject2);
 
-    if (!filter->needsCollisionCheck(collisionObject2, collisionObject1))
+    if (filter->ignoresCollision(collisionObject2, collisionObject1))
       return collData->done;
   }
 

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -1099,7 +1099,7 @@ bool collisionCallback(
     assert(collisionObject1);
     assert(collisionObject2);
 
-    if (!filter->needCollision(collisionObject2, collisionObject1))
+    if (!filter->needsCollisionCheck(collisionObject2, collisionObject1))
       return collData->done;
   }
 

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -267,7 +267,7 @@ void CollisionCallback(void* data, dGeomID o1, dGeomID o2)
   assert(collObj1);
   assert(collObj2);
 
-  if (filter && !filter->needsCollisionCheck(collObj1, collObj2))
+  if (filter && filter->ignoresCollision(collObj1, collObj2))
       return;
 
   // Perform narrow-phase collision detection

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -267,7 +267,7 @@ void CollisionCallback(void* data, dGeomID o1, dGeomID o2)
   assert(collObj1);
   assert(collObj2);
 
-  if (filter && !filter->needCollision(collObj1, collObj2))
+  if (filter && !filter->needsCollisionCheck(collObj1, collObj2))
       return;
 
   // Perform narrow-phase collision detection

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -260,6 +260,18 @@ collision::ConstCollisionGroupPtr ConstraintSolver::getCollisionGroup() const
 }
 
 //==============================================================================
+collision::CollisionOption& ConstraintSolver::getCollisionOption()
+{
+  return mCollisionOption;
+}
+
+//==============================================================================
+const collision::CollisionOption& ConstraintSolver::getCollisionOption() const
+{
+  return mCollisionOption;
+}
+
+//==============================================================================
 collision::CollisionResult& ConstraintSolver::getLastCollisionResult()
 {
   return mCollisionResult;

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -50,9 +50,6 @@ class ShapeNodeCollisionObject;
 
 namespace constraint {
 
-// TODO:
-//   - RootSkeleton concept
-
 /// ConstraintSolver manages constraints and computes constraint impulses
 class ConstraintSolver
 {
@@ -124,6 +121,14 @@ public:
   /// Return (const) collision group of collision objects that are added to this
   /// ConstraintSolver
   collision::ConstCollisionGroupPtr getCollisionGroup() const;
+
+  /// Returns collision option that is used for collision checkings in this
+  /// ConstraintSolver to generate contact constraints.
+  collision::CollisionOption& getCollisionOption();
+
+  /// Returns collision option that is used for collision checkings in this
+  /// ConstraintSolver to generate contact constraints.
+  const collision::CollisionOption& getCollisionOption() const;
 
   /// Return the last collision checking result
   collision::CollisionResult& getLastCollisionResult();

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -1158,12 +1158,19 @@ void testFilter(const std::shared_ptr<CollisionDetector>& cd)
   auto* body1 = pair1.second;
   body1->createShapeNodeWith<VisualAspect, CollisionAspect>(shape);
 
-  // Create a collision group from the skeleton
-  auto group = cd->createCollisionGroup(skel.get());
+  // Create a world and add the created skeleton
+  auto world = std::make_shared<simulation::World>();
+  world->addSkeleton(skel);
+
+  // Get the constraint solver from the world
+  auto constraintSolver = world->getConstraintSolver();
+
+  // Get the collision group from the constraint solver
+  auto group = constraintSolver->getCollisionGroup();
   EXPECT_EQ(group->getNumShapeFrames(), 2u);
 
   // Default collision filter for Skeleton
-  CollisionOption option;
+  auto& option = constraintSolver->getCollisionOption();
   auto bodyNodeFilter = std::make_shared<BodyNodeCollisionFilter>();
   option.collisionFilter = bodyNodeFilter;
 

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -1164,7 +1164,8 @@ void testFilter(const std::shared_ptr<CollisionDetector>& cd)
 
   // Default collision filter for Skeleton
   CollisionOption option;
-  option.collisionFilter = std::make_shared<BodyNodeCollisionFilter>();
+  auto bodyNodeFilter = std::make_shared<BodyNodeCollisionFilter>();
+  option.collisionFilter = bodyNodeFilter;
 
   skel->enableSelfCollisionCheck();
   skel->enableAdjacentBodyCheck();
@@ -1192,6 +1193,11 @@ void testFilter(const std::shared_ptr<CollisionDetector>& cd)
   EXPECT_FALSE(skel->isEnabledSelfCollisionCheck());
   EXPECT_FALSE(skel->isEnabledAdjacentBodyCheck());
   EXPECT_TRUE(group->collide());
+  EXPECT_FALSE(group->collide(option));
+
+  skel->enableSelfCollisionCheck();
+  skel->enableAdjacentBodyCheck();
+  bodyNodeFilter->addBodyNodePairToBlackList(body0, body1);
   EXPECT_FALSE(group->collide(option));
 }
 

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -1195,10 +1195,17 @@ void testFilter(const std::shared_ptr<CollisionDetector>& cd)
   EXPECT_TRUE(group->collide());
   EXPECT_FALSE(group->collide(option));
 
+  // Test blacklist
   skel->enableSelfCollisionCheck();
   skel->enableAdjacentBodyCheck();
   bodyNodeFilter->addBodyNodePairToBlackList(body0, body1);
   EXPECT_FALSE(group->collide(option));
+  bodyNodeFilter->removeBodyNodePairFromBlackList(body0, body1);
+  EXPECT_TRUE(group->collide(option));
+  bodyNodeFilter->addBodyNodePairToBlackList(body0, body1);
+  EXPECT_FALSE(group->collide(option));
+  bodyNodeFilter->removeAllBodyNodePairsFromBlackList();
+  EXPECT_TRUE(group->collide(option));
 }
 
 //==============================================================================

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -1160,10 +1160,9 @@ void testFilter(const std::shared_ptr<CollisionDetector>& cd)
 
   // Create a world and add the created skeleton
   auto world = std::make_shared<simulation::World>();
-  world->addSkeleton(skel);
-
-  // Get the constraint solver from the world
   auto constraintSolver = world->getConstraintSolver();
+  constraintSolver->setCollisionDetector(cd);
+  world->addSkeleton(skel);
 
   // Get the collision group from the constraint solver
   auto group = constraintSolver->getCollisionGroup();


### PR DESCRIPTION
This pull request enables us to enable/disable collision checking for specific pairs of body nodes by maintaining a blacklist in `BodyNodeCollisionFilter`. Also, `ConstraintSolver::getCollisionOption()` is added to enable to modify the collision filter through it as:
```cpp
auto collisionOption = world->getConstraintSolver()->getCollisionOption();
auto collisionFilter = collisionOption.getCollisionFilter();
collisionFilter->addBodyNodePairToBlackList(body0, body1);
```

Minor changes:
* Add `CompositeCollisionFilter` class to enable to use more than two collision filters by composing them in this class
* Rename `CollisionFilter::needCollision(...)` to `CollisionFilter::needsCollisionCheck(...)`