### PR TITLE
Chimera friendly version

### DIFF
--- a/dart/common/Factory.hpp
+++ b/dart/common/Factory.hpp
@@ -98,6 +98,9 @@ public:
   // (see: https://github.com/dartsim/dart/pull/845)
 
 private:
+  template <typename Derived>
+  static HeldT defaultCreator(Args&&... args);
+
   /// Object creator function map.
   CreatorMap mCreatorMap;
 };

--- a/dart/common/detail/Factory-impl.hpp
+++ b/dart/common/detail/Factory-impl.hpp
@@ -113,11 +113,7 @@ void Factory<KeyT, BaseT, HeldT, Args...>::registerCreator(
 {
   return registerCreator(
       key,
-      [](Args&&... args) -> HeldT
-      {
-        return detail::DefaultCreator<Derived, HeldT, Args...>::run(
-            std::forward<Args>(args)...);
-      }
+      &Factory::defaultCreator<Derived>
   );
 }
 
@@ -176,6 +172,18 @@ HeldT Factory<KeyT, BaseT, HeldT, Args...>::create(
   }
 
   return it->second(std::forward<Args>(args)...);
+}
+
+//==============================================================================
+template <typename KeyT,
+          typename BaseT,
+          typename HeldT,
+          typename... Args>
+template <typename Derived>
+HeldT Factory<KeyT, BaseT, HeldT, Args...>::defaultCreator(Args&&... args)
+{
+  return detail::DefaultCreator<Derived, HeldT, Args...>::run(
+        std::forward<Args>(args)...);
 }
 
 //==============================================================================


### PR DESCRIPTION
We're planning to another python binding package for DART, namely dartpy, that uses chimera to automatically generate the bindings. Unfortunately, chimera has an [issue of using lambda function parameter in a variadic template class](https://github.com/personalrobotics/chimera/issues/148). This PR workaround the issue by replacing the lambda function with a static member function.