### PR TITLE
Install fcl using the full formulae name

### DIFF
--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -14,7 +14,7 @@ boost
 eigen
 tinyxml
 tinyxml2
-libccd
+homebrew/science/libccd
 nlopt
 ipopt
 ros/deps/urdfdom

--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -7,7 +7,7 @@ PACKAGES='
 git
 cmake
 assimp
-fcl
+dartsim/dart/fcl
 bullet --with-double-precision
 ode --with-libccd --with-double-precision
 flann

--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -1,4 +1,3 @@
-brew tap dartsim/dart
 brew tap homebrew/science
 
 brew update > /dev/null


### PR DESCRIPTION
I haven't figured out the actual reason, but it seems tapping `dartsim/dart` isn't working and it causes the CI test failure on macOC. This PR changes the script to install `fcl` using its full formula path so that it doesn't require tapping.

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md` (N/A)
- [x] Add unit test(s) for this change (N/A)
