### PR TITLE
Fix unused error variable

### DIFF
--- a/dart/external/lodepng/lodepng.cpp
+++ b/dart/external/lodepng/lodepng.cpp
@@ -5216,7 +5216,6 @@ static unsigned filter(unsigned char* out, const unsigned char* in, unsigned w, 
   size_t bytewidth = (bpp + 7) / 8;
   const unsigned char* prevline = 0;
   unsigned x, y;
-  unsigned error = 0;
   LodePNGFilterStrategy strategy = settings->filter_strategy;
 
   /*
@@ -5261,48 +5260,45 @@ static unsigned filter(unsigned char* out, const unsigned char* in, unsigned w, 
       attempt[type] = (unsigned char*)lodepng_malloc(linebytes);
       if(!attempt[type]) return 83; /*alloc fail*/
     }
-
-    if(!error)
+      
+    for(y = 0; y != h; ++y)
     {
-      for(y = 0; y != h; ++y)
+      /*try the 5 filter types*/
+      for(type = 0; type != 5; ++type)
       {
-        /*try the 5 filter types*/
-        for(type = 0; type != 5; ++type)
+        filterScanline(attempt[type], &in[y * linebytes], prevline, linebytes, bytewidth, type);
+
+        /*calculate the sum of the result*/
+        sum[type] = 0;
+        if(type == 0)
         {
-          filterScanline(attempt[type], &in[y * linebytes], prevline, linebytes, bytewidth, type);
-
-          /*calculate the sum of the result*/
-          sum[type] = 0;
-          if(type == 0)
+          for(x = 0; x != linebytes; ++x) sum[type] += (unsigned char)(attempt[type][x]);
+        }
+        else
+        {
+          for(x = 0; x != linebytes; ++x)
           {
-            for(x = 0; x != linebytes; ++x) sum[type] += (unsigned char)(attempt[type][x]);
-          }
-          else
-          {
-            for(x = 0; x != linebytes; ++x)
-            {
-              /*For differences, each byte should be treated as signed, values above 127 are negative
-              (converted to signed char). Filtertype 0 isn't a difference though, so use unsigned there.
-              This means filtertype 0 is almost never chosen, but that is justified.*/
-              unsigned char s = attempt[type][x];
-              sum[type] += s < 128 ? s : (255U - s);
-            }
-          }
-
-          /*check if this is smallest sum (or if type == 0 it's the first case so always store the values)*/
-          if(type == 0 || sum[type] < smallest)
-          {
-            bestType = type;
-            smallest = sum[type];
+            /*For differences, each byte should be treated as signed, values above 127 are negative
+            (converted to signed char). Filtertype 0 isn't a difference though, so use unsigned there.
+            This means filtertype 0 is almost never chosen, but that is justified.*/
+            unsigned char s = attempt[type][x];
+            sum[type] += s < 128 ? s : (255U - s);
           }
         }
 
-        prevline = &in[y * linebytes];
-
-        /*now fill the out values*/
-        out[y * (linebytes + 1)] = bestType; /*the first byte of a scanline will be the filter type*/
-        for(x = 0; x != linebytes; ++x) out[y * (linebytes + 1) + 1 + x] = attempt[bestType][x];
+        /*check if this is smallest sum (or if type == 0 it's the first case so always store the values)*/
+        if(type == 0 || sum[type] < smallest)
+        {
+          bestType = type;
+          smallest = sum[type];
+        }
       }
+
+      prevline = &in[y * linebytes];
+
+      /*now fill the out values*/
+      out[y * (linebytes + 1)] = bestType; /*the first byte of a scanline will be the filter type*/
+      for(x = 0; x != linebytes; ++x) out[y * (linebytes + 1) + 1 + x] = attempt[bestType][x];
     }
 
     for(type = 0; type != 5; ++type) lodepng_free(attempt[type]);
@@ -5417,7 +5413,7 @@ static unsigned filter(unsigned char* out, const unsigned char* in, unsigned w, 
   }
   else return 88; /* unknown filter strategy */
 
-  return error;
+  return 0;
 }
 
 static void addPaddingBits(unsigned char* out, const unsigned char* in,


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:
dart/dart/external/lodepng/lodepng.cpp	5265	warn	V547 Expression '!error' is always true.

The variable `unsigned error = 0;` was initialised but never used. In this function errors was realised as a return code, f.e.:
if(bpp == 0) return 31;
So variable `error` is not deeded here.