### PR TITLE
Suppress -Wdangling-else warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * License
 
   * Added Personal Robotics Lab and Open Source Robotics Foundation as contributors: [#929](https://github.com/dartsim/dart/pull/929)
+  
+* Misc
+
+  * Suppressed warnings: [#937](https://github.com/dartsim/dart/pull/937)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -709,7 +709,9 @@ void testSphereSphere(const std::shared_ptr<CollisionDetector>& cd,
     // TODO(JS): BulletCollsionDetector includes a bug related to this.
     // (see #876)
     if (cd->getType() != BulletCollisionDetector::getStaticType())
+    {
       EXPECT_EQ(result.getNumContacts(), 1u);
+    }
     for (auto i = 0u; i < result.getNumContacts(); ++i)
     {
       std::cout << "point: " << result.getContact(i).point.transpose() << std::endl;

--- a/unittests/comprehensive/test_Frames.cpp
+++ b/unittests/comprehensive/test_Frames.cpp
@@ -704,7 +704,9 @@ void test_relative_values(bool spatial_targets, bool spatial_followers)
       randomize_transform(tf, 1, 2*M_PI);
       T->setTransform(tf, F);
       if(i != j)
+      {
         EXPECT_TRUE( equals(T->getTransform(F).matrix(), tf.matrix(), 1e-10));
+      }
     }
   }
 }

--- a/unittests/comprehensive/test_Skeleton.cpp
+++ b/unittests/comprehensive/test_Skeleton.cpp
@@ -147,27 +147,34 @@ TEST(Skeleton, Restructuring)
         BodyNode* bn = skeleton->getBodyNode(name);
         EXPECT_FALSE(bn == nullptr);
         if(bn)
+        {
           EXPECT_TRUE(bn->getName() == name);
+        }
 
         name = skeleton->getBodyNode(j)->getName();
         bn = original->getBodyNode(name);
         EXPECT_FALSE(bn == nullptr);
         if(bn)
+        {
           EXPECT_TRUE(bn->getName() == name);
-
+        }
 
         // Make sure no Joints have been lost or gained in translation
         name = original->getJoint(j)->getName();
         Joint* joint = skeleton->getJoint(name);
         EXPECT_FALSE(joint == nullptr);
         if(joint)
+        {
           EXPECT_TRUE(joint->getName() == name);
+        }
 
         name = skeleton->getJoint(j)->getName();
         joint = original->getJoint(name);
         EXPECT_FALSE(joint == nullptr);
         if(joint)
+        {
           EXPECT_TRUE(joint->getName() == name);
+        }
       }
     }
 
@@ -178,13 +185,17 @@ TEST(Skeleton, Restructuring)
       DegreeOfFreedom* dof = skeleton->getDof(name);
       EXPECT_FALSE(dof == nullptr);
       if(dof)
+      {
         EXPECT_TRUE(dof->getName() == name);
+      }
 
       name = skeleton->getDof(j)->getName();
       dof = original->getDof(name);
       EXPECT_FALSE(dof == nullptr);
       if(dof)
+      {
         EXPECT_TRUE(dof->getName() == name);
+      }
     }
   }
 

--- a/unittests/unit/test_ContactConstraint.cpp
+++ b/unittests/unit/test_ContactConstraint.cpp
@@ -81,6 +81,8 @@ TEST(ContactConstraint, ContactWithKinematicJoint)
 
     // Need few steps to settle down
     if (i > 15)
+    {
       EXPECT_NEAR(bodyNode2->getLinearVelocity()[0], 0.1, 1e-6);
+    }
   }
 }


### PR DESCRIPTION
GCC 7.2.0 prints warnings of `-Wdangling-else`. It seems this is because if-statements with a single line macro is prone to dangling else. This PR suppresses these warnings by adding explicit braces around the single line of the macro.

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
