### PR TITLE
Fix for #734

### DIFF
--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -220,9 +220,6 @@ void MeshShape::setMesh(
   }
 
   mResourceRetriever = _resourceRetriever;
-
-  _updateBoundingBoxDim();
-  updateVolume();
 }
 
 void MeshShape::setScale(const Eigen::Vector3d& _scale) {
@@ -230,8 +227,8 @@ void MeshShape::setScale(const Eigen::Vector3d& _scale) {
   assert(_scale[1] > 0.0);
   assert(_scale[2] > 0.0);
   mScale = _scale;
-  updateVolume();
   _updateBoundingBoxDim();
+  updateVolume();
 }
 
 const Eigen::Vector3d& MeshShape::getScale() const {

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -220,6 +220,9 @@ void MeshShape::setMesh(
   }
 
   mResourceRetriever = _resourceRetriever;
+
+  _updateBoundingBoxDim();
+  updateVolume();
 }
 
 void MeshShape::setScale(const Eigen::Vector3d& _scale) {


### PR DESCRIPTION
This is a fix to #734. In short:

- There's a small bug in `setScale` method of `MeshShape`; i.e., `_updateBoundingBoxDim` needs to be called before `updateVolume`
- The calls to `updateVolume` and `_updateBoundingBoxDim` in the `setMesh` method are not needed.
