### PR TITLE
Port clang warning fix over to 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
 
 * Misc
 
-  * Add World::create(): [#962](https://github.com/dartsim/dart/pull/962)
-  * Suppressed warnings: [#937](https://github.com/dartsim/dart/pull/937)
+  * Added World::create(): [#962](https://github.com/dartsim/dart/pull/962)
+  * Suppressed -Winjected-class-name warnings from Clang 5.0.0: [#964](https://github.com/dartsim/dart/pull/964)
+  * Suppressed -Wdangling-else warnings from GCC 7.2.0: [#937](https://github.com/dartsim/dart/pull/937)
   * Fixed various build issues with Visual Studio: [#956](https://github.com/dartsim/dart/pull/956)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)

--- a/dart/common/detail/CompositeData.hpp
+++ b/dart/common/detail/CompositeData.hpp
@@ -48,12 +48,37 @@ namespace common {
 namespace detail {
 
 //==============================================================================
+// This default template definition will be called when AspectOrComposite is
+// an Aspect.
+template <class AspectOrComposite, bool isAspect>
+struct GetAspectImpl
+{
+  using Type = AspectOrComposite;
+};
+
+//==============================================================================
+// This template specialization will be called when AspectOrComposite is not
+// an Aspect (and is presumably a composite that defines a nested Aspect type).
+template <class AspectOrComposite>
+struct GetAspectImpl<AspectOrComposite, false>
+{
+  // If you get a compiler error that leads you here, then you are trying to
+  // ask for the Aspect of an object that is not associated with any Aspect.
+  // That means it does not define a nested Aspect type (such as how
+  // RevoluteJoint defines the RevoluteJoint::Aspect).
+  //
+  // Whatever function is leading to the error must be given a template type
+  // that either defines a nested type with the name Aspect, or else inherits
+  // from the type dart::common::Aspect.
+  using Type = typename AspectOrComposite::Aspect;
+};
+
+//==============================================================================
 template <class AspectT>
 struct GetAspect
 {
-  using Type = typename std::conditional<
-      std::is_base_of<Aspect, AspectT>::value,
-      AspectT, typename AspectT::Aspect>::type;
+  using Type = typename GetAspectImpl<
+    AspectT, std::is_base_of<Aspect, AspectT>::value>::Type;
 };
 
 //==============================================================================


### PR DESCRIPTION
Same as #963, but targeting `release-6.4`