### PR TITLE
[WIP] Add ResourceRetriever::getFilePath()

### DIFF
--- a/dart/common/LocalResourceRetriever.cpp
+++ b/dart/common/LocalResourceRetriever.cpp
@@ -43,14 +43,7 @@ namespace common {
 //==============================================================================
 bool LocalResourceRetriever::exists(const Uri& _uri)
 {
-  // Open and close the file to check if it exists. It would be more efficient
-  // to stat() it, but that is not portable.
-  if(_uri.mScheme.get_value_or("file") != "file")
-    return false;
-  else if (!_uri.mPath)
-    return false;
-
-  return std::ifstream(_uri.getFilesystemPath(), std::ios::binary).good();
+  return !getFilePath(_uri).empty();
 }
 
 //==============================================================================
@@ -68,6 +61,24 @@ common::ResourcePtr LocalResourceRetriever::retrieve(const Uri& _uri)
     return resource;
   else
     return nullptr;
+}
+
+//==============================================================================
+std::string LocalResourceRetriever::getFilePath(const Uri& uri)
+{
+  // Open and close the file to check if it exists. It would be more efficient
+  // to stat() it, but that is not portable.
+  if(uri.mScheme.get_value_or("file") != "file")
+    return "";
+  else if (!uri.mPath)
+    return "";
+
+  const auto path = uri.getFilesystemPath();
+
+  if (std::ifstream(path, std::ios::binary).good())
+    return path;
+  else
+    return "";
 }
 
 } // namespace common

--- a/dart/common/LocalResourceRetriever.hpp
+++ b/dart/common/LocalResourceRetriever.hpp
@@ -50,6 +50,9 @@ public:
 
   // Documentation inherited.
   ResourcePtr retrieve(const Uri& _uri) override;
+
+  // Documentation inherited.
+  std::string getFilePath(const Uri& uri) override;
 };
 
 using LocalResourceRetrieverPtr = std::shared_ptr<LocalResourceRetriever>;

--- a/dart/common/ResourceRetriever.cpp
+++ b/dart/common/ResourceRetriever.cpp
@@ -53,5 +53,11 @@ std::string ResourceRetriever::readAll(const Uri& uri)
   return resource->readAll();
 }
 
+//==============================================================================
+std::string ResourceRetriever::getFilePath(const Uri& /*uri*/)
+{
+  return "";
+}
+
 } // namespace common
 } // namespace dart

--- a/dart/common/ResourceRetriever.hpp
+++ b/dart/common/ResourceRetriever.hpp
@@ -48,10 +48,10 @@ class ResourceRetriever
 public:
   virtual ~ResourceRetriever() = default;
 
-  /// \brief Return whether the resource specified by a URI exists.
+  /// Returns whether the resource specified by a URI exists.
   virtual bool exists(const Uri& _uri) = 0;
 
-  /// \brief Return the resource specified by a URI or nullptr on failure.
+  /// Returns the resource specified by a URI or nullptr on failure.
   virtual ResourcePtr retrieve(const Uri& _uri) = 0;
 
   /// Reads all data from the resource of uri, and returns it as a string.
@@ -61,11 +61,16 @@ public:
   /// \throw std::runtime_error when failed to read sucessfully.
   virtual std::string readAll(const Uri& uri);
 
-  // We don't const-qualify for exists, retrieve, and readAll here. Derived
-  // classes of ResourceRetriever will be interacting with external resources
-  // that you don't necessarily have control over so we cannot guarantee that
-  // you get the same result every time with the same input Uri. Indeed,
-  // const-qualification for those functions is pointless.
+  /// Returns absolute file path to \c uri; an empty string if unavailable.
+  ///
+  /// This base class returns an empty string by default.
+  virtual std::string getFilePath(const Uri& uri);
+
+  // We don't const-qualify for exists, retrieve, readAll, and getFilePath here.
+  // Derived classes of ResourceRetriever will be interacting with external
+  // resources that you don't necessarily have control over so we cannot
+  // guarantee that you get the same result every time with the same input Uri.
+  // Indeed, const-qualification for those functions is pointless.
 };
 
 using ResourceRetrieverPtr = std::shared_ptr<ResourceRetriever>;

--- a/dart/io/CompositeResourceRetriever.cpp
+++ b/dart/io/CompositeResourceRetriever.cpp
@@ -101,6 +101,19 @@ common::ResourcePtr CompositeResourceRetriever::retrieve(
 }
 
 //==============================================================================
+std::string CompositeResourceRetriever::getFilePath(const common::Uri& uri)
+{
+  for (const auto& resourceRetriever : getRetrievers(uri))
+  {
+    const auto path = resourceRetriever->getFilePath(uri);
+    if (!path.empty())
+      return path;
+  }
+
+  return "";
+}
+
+//==============================================================================
 std::vector<common::ResourceRetrieverPtr>
   CompositeResourceRetriever::getRetrievers(const common::Uri& _uri) const
 {

--- a/dart/io/CompositeResourceRetriever.hpp
+++ b/dart/io/CompositeResourceRetriever.hpp
@@ -72,6 +72,9 @@ public:
   // Documentation inherited.
   common::ResourcePtr retrieve(const common::Uri& _uri) override;
 
+  // Documentation inherited.
+  std::string getFilePath(const common::Uri& uri) override;
+
 private:
   std::vector<common::ResourceRetrieverPtr> getRetrievers(
     const common::Uri& _uri) const;

--- a/dart/io/DartResourceRetriever.cpp
+++ b/dart/io/DartResourceRetriever.cpp
@@ -104,6 +104,39 @@ common::ResourcePtr DartResourceRetriever::retrieve(const common::Uri& uri)
 }
 
 //==============================================================================
+std::string DartResourceRetriever::getFilePath(const common::Uri& uri)
+{
+  std::string relativePath;
+  if (!resolveDataUri(uri, relativePath))
+    return "";
+
+  if (uri.mAuthority.get() == "sample")
+  {
+    for (const auto& dataPath : mDataDirectories)
+    {
+      common::Uri fileUri;
+      fileUri.fromPath(dataPath + relativePath);
+
+      const auto path = mLocalRetriever->getFilePath(fileUri);
+
+      // path is empty if the file specified by fileUri doesn't exist.
+      if (!path.empty())
+        return path;
+    }
+  }
+  else
+  {
+    const auto path = mLocalRetriever->getFilePath(uri);
+
+    // path is empty if the file specified by fileUri doesn't exist.
+    if (!path.empty())
+      return path;
+  }
+
+  return "";
+}
+
+//==============================================================================
 void DartResourceRetriever::addDataDirectory(
     const std::string& dataDirectory)
 {

--- a/dart/io/DartResourceRetriever.hpp
+++ b/dart/io/DartResourceRetriever.hpp
@@ -84,6 +84,9 @@ public:
   // Documentation inherited.
   common::ResourcePtr retrieve(const common::Uri& uri) override;
 
+  // Documentation inherited.
+  std::string getFilePath(const common::Uri& uri) override;
+
 private:
 
   void addDataDirectory(const std::string& packageDirectory);

--- a/dart/io/PackageResourceRetriever.cpp
+++ b/dart/io/PackageResourceRetriever.cpp
@@ -69,19 +69,7 @@ void PackageResourceRetriever::addPackageDirectory(
 //==============================================================================
 bool PackageResourceRetriever::exists(const common::Uri& _uri)
 {
-  std::string packageName, relativePath;
-  if (!resolvePackageUri(_uri, packageName, relativePath))
-    return false;
-
-  for(const std::string& packagePath : getPackagePaths(packageName))
-  {
-    common::Uri fileUri;
-    fileUri.fromPath(packagePath + relativePath);
-
-    if (mLocalRetriever->exists(fileUri))
-      return true;
-  }
-  return false;
+  return !getFilePath(_uri).empty();
 }
 
 //==============================================================================
@@ -100,6 +88,28 @@ common::ResourcePtr PackageResourceRetriever::retrieve(const common::Uri& _uri)
       return resource;
   }
   return nullptr;
+}
+
+//==============================================================================
+std::string PackageResourceRetriever::getFilePath(const common::Uri& uri)
+{
+  std::string packageName, relativePath;
+  if (!resolvePackageUri(uri, packageName, relativePath))
+    return "";
+
+  for(const std::string& packagePath : getPackagePaths(packageName))
+  {
+    common::Uri fileUri;
+    fileUri.fromPath(packagePath + relativePath);
+
+    const auto path = mLocalRetriever->getFilePath(fileUri);
+
+    // path is empty if the file specified by fileUri doesn't exist.
+    if (!path.empty())
+      return path;
+  }
+
+  return "";
 }
 
 //==============================================================================

--- a/dart/io/PackageResourceRetriever.hpp
+++ b/dart/io/PackageResourceRetriever.hpp
@@ -91,6 +91,9 @@ public:
   // Documentation inherited.
   common::ResourcePtr retrieve(const common::Uri& _uri) override;
 
+  // Documentation inherited.
+  std::string getFilePath(const common::Uri& uri) override;
+
 private:
   common::ResourceRetrieverPtr mLocalRetriever;
   std::unordered_map<std::string, std::vector<std::string> > mPackageMap;


### PR DESCRIPTION
**Motivation**
In some cases, it is required to extract the (absolute) file path of a URI (if available). For example, `MeshShape` needs to know the path to a mesh file to infer the path to a texture image, which is given as a relative path. Currently, we don't have a public method to get a file path from a URI unless it's a file URI. `PackageResourceRetriever` and `DartResourceRetriever` have similar functionality, but it's not public.

**Proposal**
I propose adding `ResourceRetriever::getFilePath()` that returns the absolute file path specified by a URI or an empty string if unavailable.

***

**Before creating a pull request**

- [x] Document new methods and classes

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
