### PR TITLE
Use Brewfile to install depedencies on macOS

### DIFF
--- a/ci/Brewfile
+++ b/ci/Brewfile
@@ -1,0 +1,18 @@
+brew 'git'
+brew 'cmake'
+brew 'assimp'
+brew 'dartsim/dart/fcl'
+brew 'bullet', args: ['--with-double-precision']
+brew 'ode', args: ['--with-libccd', '--with-double-precision']
+brew 'flann'
+brew 'boost'
+brew 'eigen'
+brew 'tinyxml'
+brew 'tinyxml2'
+brew 'libccd'
+brew 'nlopt'
+brew 'dartsim/dart/ipopt'
+brew 'ros/deps/urdfdom'
+brew 'ros/deps/urdfdom_headers'
+brew 'ros/deps/console_bridge'
+brew 'open-scene-graph'

--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -1,20 +1,2 @@
 brew update > /dev/null
-
-brew install git | grep -v '%$'
-brew install cmake | grep -v '%$'
-brew install assimp | grep -v '%$'
-brew install dartsim/dart/fcl | grep -v '%$'
-brew install bullet --with-double-precision | grep -v '%$'
-brew install ode --with-libccd --with-double-precision | grep -v '%$'
-brew install flann | grep -v '%$'
-brew install boost | grep -v '%$'
-brew install eigen | grep -v '%$'
-brew install tinyxml | grep -v '%$'
-brew install tinyxml2 | grep -v '%$'
-brew install libccd | grep -v '%$'
-brew install nlopt | grep -v '%$'
-brew install dartsim/dart/ipopt | grep -v '%$'
-brew install ros/deps/urdfdom | grep -v '%$'
-brew install ros/deps/urdfdom_headers | grep -v '%$'
-brew install ros/deps/console_bridge | grep -v '%$'
-brew install open-scene-graph | grep -v '%$'
+brew bundle --file="$TRAVIS_BUILD_DIR/ci/Brewfile"


### PR DESCRIPTION
[Homebrew will fail when it tries to install or upgrade a pacakge that is already installed the most up-to-date version](https://docs.travis-ci.com/user/reference/osx/#A-note-on-upgrading-packages) like [this](https://travis-ci.org/dartsim/dart/jobs/337454320#L68).

This PR introduces use of `brew bundel` and `Brewfile` as recommended by the [Travis manual](https://docs.travis-ci.com/user/reference/osx/#A-note-on-upgrading-packages).