### PR TITLE
JOSS Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Visit the [DART website](http://dartsim.github.io/) for more information
 * [API Documentation](http://dartsim.github.io/dart/v6.3.0/)
 * Python bindings: [PyDart2](https://github.com/sehoonha/pydart2), [dartpy](https://github.com/personalrobotics/dartpy) (experimental)
 * OpenAI Gym with DART support: [DartEnv](https://github.com/DartEnv/dart-env)
+* If you use DART in an academic publication, please consider citing this [JOSS Paper](https://doi.org/10.21105/joss.00500).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DART: Dynamic Animation and Robotics Toolkit
-[![Build Status](https://travis-ci.org/dartsim/dart.png?branch=master)](https://travis-ci.org/dartsim/dart) [![Build status](https://ci.appveyor.com/api/projects/status/6rta8olo95bpu84r/branch/master?svg=true)](https://ci.appveyor.com/project/jslee02/dart/branch/master) [![codecov](https://codecov.io/gh/dartsim/dart/branch/master/graph/badge.svg)](https://codecov.io/gh/dartsim/dart)
+[![Build Status](https://travis-ci.org/dartsim/dart.png?branch=master)](https://travis-ci.org/dartsim/dart) [![Build status](https://ci.appveyor.com/api/projects/status/6rta8olo95bpu84r/branch/master?svg=true)](https://ci.appveyor.com/project/jslee02/dart/branch/master) [![codecov](https://codecov.io/gh/dartsim/dart/branch/master/graph/badge.svg)](https://codecov.io/gh/dartsim/dart) [![DOI](http://joss.theoj.org/papers/10.21105/joss.00500/status.svg)](https://doi.org/10.21105/joss.00500)
 
 Visit the [DART website](http://dartsim.github.io/) for more information
 * [Gallery](http://dartsim.github.io/gallery.html)

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Visit the [DART website](http://dartsim.github.io/) for more information
 * [API Documentation](http://dartsim.github.io/dart/v6.3.0/)
 * Python bindings: [PyDart2](https://github.com/sehoonha/pydart2), [dartpy](https://github.com/personalrobotics/dartpy) (experimental)
 * OpenAI Gym with DART support: [DartEnv](https://github.com/DartEnv/dart-env)
-* If you use DART in an academic publication, please consider citing this [JOSS Paper](https://doi.org/10.21105/joss.00500). [[BibTeX](https://www.doi2bib.org/bib/10.21105%2Fjoss.00500)]
+* If you use DART in an academic publication, please consider citing this [JOSS Paper](https://doi.org/10.21105/joss.00500). [[BibTeX](https://gist.github.com/jslee02/998b8809e3ae1b7aef6ef04dd2ad5e27)]

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Visit the [DART website](http://dartsim.github.io/) for more information
 * [API Documentation](http://dartsim.github.io/dart/v6.3.0/)
 * Python bindings: [PyDart2](https://github.com/sehoonha/pydart2), [dartpy](https://github.com/personalrobotics/dartpy) (experimental)
 * OpenAI Gym with DART support: [DartEnv](https://github.com/DartEnv/dart-env)
-* If you use DART in an academic publication, please consider citing this [JOSS Paper](https://doi.org/10.21105/joss.00500).
+* If you use DART in an academic publication, please consider citing this [JOSS Paper](https://doi.org/10.21105/joss.00500). [[BibTeX](https://www.doi2bib.org/bib/10.21105%2Fjoss.00500)]


### PR DESCRIPTION
Happy to announce that DART has been accepted to [JOSS](http://joss.theoj.org/)!  :tada: 
Here is the paper webpage: [![DOI](http://joss.theoj.org/papers/10.21105/joss.00500/status.svg)](https://doi.org/10.21105/joss.00500)

This PR adds the JOSS Paper badge to `README.md`.