### PR TITLE
OSG shadows

### DIFF
--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 if(DART_BUILD_GUI_OSG)
 
   find_package(OpenSceneGraph 3.0 QUIET
-    COMPONENTS osg osgViewer osgManipulator osgGA osgDB)
+    COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow)
 
   # It seems that OPENSCENEGRAPH_FOUND will inadvertently get set to true when
   # OpenThreads is found, even if OpenSceneGraph is not installed. This is quite

--- a/dart/gui/osg/Viewer.hpp
+++ b/dart/gui/osg/Viewer.hpp
@@ -301,7 +301,7 @@ public:
   const ::osg::ref_ptr<::osg::Group>& getPhysicsGroup() const;
 
   bool isShadowed() const;
-  void enableShadows(bool _enable = true, ShadowType type = ShadowType::STANDARD_SHADOW_MAP);
+  void enableShadows(bool _enable = true, ShadowType type = ShadowType::SHADOW_MAP);
 
 protected:
 

--- a/dart/gui/osg/Viewer.hpp
+++ b/dart/gui/osg/Viewer.hpp
@@ -117,7 +117,7 @@ public:
 
   /// Constructor for dart::gui::osg::Viewer. This will automatically create the
   /// default event handler.
-  Viewer(const ::osg::Vec4& clearColor = ::osg::Vec4(0.9,0.9,0.9,1.0));
+  Viewer(const ::osg::Vec4& clearColor = ::osg::Vec4(0.9,0.9,0.9,1.0), bool shadowsOn = false);
 
   /// Destructor
   virtual ~Viewer();
@@ -288,6 +288,12 @@ public:
   /// Get the root ::osg::Group of this Viewer
   const ::osg::ref_ptr<::osg::Group>& getRootGroup() const;
 
+  /// Get the physics root ::osg::Group of this Viewer
+  const ::osg::ref_ptr<::osg::Group>& getPhysicsGroup() const;
+
+  bool isShadowed() const;
+  void enableShadows(bool _enable = true);
+
 protected:
 
   friend class SaveScreen;
@@ -318,6 +324,12 @@ protected:
 
   /// The root node of this Viewer
   ::osg::ref_ptr<::osg::Group> mRootGroup;
+
+  /// The DART physics node of this Viewer
+  ::osg::ref_ptr<::osg::Group> mPhysicsGroup;
+
+  /// Whether the shadows are enabled
+  bool mShadowed;
 
   /// The Group Node containing light sources
   ::osg::ref_ptr<::osg::Group> mLightGroup;

--- a/dart/gui/osg/Viewer.hpp
+++ b/dart/gui/osg/Viewer.hpp
@@ -115,9 +115,18 @@ class Viewer : public osgViewer::Viewer, public dart::common::Subject
 {
 public:
 
+  enum ShadowType {
+    SHADOW_MAP = 0,
+    STANDARD_SHADOW_MAP,
+    SOFT_SHADOW_MAP,
+    SHADOW_TEXTURE,
+    SHADOW_VOLUME
+    // TODO: Add more techniques
+  };
+
   /// Constructor for dart::gui::osg::Viewer. This will automatically create the
   /// default event handler.
-  Viewer(const ::osg::Vec4& clearColor = ::osg::Vec4(0.9,0.9,0.9,1.0), bool shadowsOn = false);
+  Viewer(const ::osg::Vec4& clearColor = ::osg::Vec4(0.9,0.9,0.9,1.0), bool shadowsOn = false, ShadowType shadowType = ShadowType::SHADOW_MAP);
 
   /// Destructor
   virtual ~Viewer();
@@ -292,7 +301,7 @@ public:
   const ::osg::ref_ptr<::osg::Group>& getPhysicsGroup() const;
 
   bool isShadowed() const;
-  void enableShadows(bool _enable = true);
+  void enableShadows(bool _enable = true, ShadowType type = ShadowType::STANDARD_SHADOW_MAP);
 
 protected:
 


### PR DESCRIPTION
This is a better version of #976, where:

- I changed the `dart::gui::osg::Viewer` class to be able to enable/disable shadows
- I did not touch the lights (this should be in a separate PR)

There are two issues (one minor and one major):

- For now we select the `mLight1` as the light that casts shadows (because this one is higher in the up direction). I am not an OSG expert and I do not know how to combine multiple lights to produce shadows. I think this is minor as it should mostly be ok. Here's one example:
![hexa_shadow](https://user-images.githubusercontent.com/1283922/35868254-427a14d8-0b5c-11e8-802a-497ad9e62f2c.png)
- The `ImGuiViewer` is not working properly once you enable shadows (either black or distorted views on the ImGui panels). Here's an example:

![image](https://user-images.githubusercontent.com/1283922/36029209-950b7604-0da2-11e8-9e2d-e13c5f6f9c67.png)

I am investigating why this happens and I will try to provide a fix..

@jslee02 let me know what you think..
