### PR TITLE
Extend createShapeNode to accept more types of arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Added lazy evaluation for shape's volume and bounding-box computation: [#959](https://github.com/dartsim/dart/pull/959)
   * Added IkFast support as analytic IK solver: [#887](https://github.com/dartsim/dart/pull/887)
   * Fixed NaN values caused by zero-length normals in ContactConstraint: [#881](https://github.com/dartsim/dart/pull/881)
+  * Extended BodyNode::createShapeNode() to accept more types of arguments: [#986](https://github.com/dartsim/dart/pull/986)
 
 * Collision detection
 

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -880,26 +880,6 @@ const Joint* BodyNode::getChildJoint(std::size_t _index) const
 DART_BAKE_SPECIALIZED_NODE_DEFINITIONS( BodyNode, ShapeNode )
 
 //==============================================================================
-ShapeNode* BodyNode::createShapeNode(const ShapePtr& shape)
-{
-  ShapeNode::BasicProperties properties;
-  properties.mShape = shape;
-
-  return createShapeNode(properties, true);
-}
-
-//==============================================================================
-ShapeNode* BodyNode::createShapeNode(const ShapePtr& shape,
-                                     const std::string& name)
-{
-  ShapeNode::BasicProperties properties;
-  properties.mShape = shape;
-  properties.mName = name;
-
-  return createShapeNode(properties, false);
-}
-
-//==============================================================================
 const std::vector<ShapeNode*> BodyNode::getShapeNodes()
 {
   const auto numShapeNodes = getNumShapeNodes();

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -900,12 +900,6 @@ ShapeNode* BodyNode::createShapeNode(const ShapePtr& shape,
 }
 
 //==============================================================================
-ShapeNode* BodyNode::createShapeNode(const ShapePtr& shape, const char* name)
-{
-  return createShapeNode(shape, std::string(name));
-}
-
-//==============================================================================
 const std::vector<ShapeNode*> BodyNode::getShapeNodes()
 {
   const auto numShapeNodes = getNumShapeNodes();

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -546,12 +546,21 @@ public:
   /// <BodyNodeName>_ShapeNode_<#>.
   ShapeNode* createShapeNode(const ShapePtr& shape);
 
-  /// Create an ShapeNode with the specified name
+  /// Same as createShapeNode(const ShapePtr&), but this accepts pointers to
+  /// arbitrary Shape types.
+  template <class ShapeType>
+  ShapeNode* createShapeNode(const std::shared_ptr<ShapeType>& shape);
+
+  /// Create a ShapeNode with the specified name
   ShapeNode* createShapeNode(
       const ShapePtr& shape, const std::string& name);
 
-  /// Create an ShapeNode with the specified name
-  ShapeNode* createShapeNode(const ShapePtr& shape, const char* name);
+  /// Same as createShapeNode(const ShapePtr&, const std::string&), but this
+  /// accepts pointers to arbitrary Shape types, and can accept string literals.
+  template <class ShapeType, class StringType>
+  ShapeNode* createShapeNode(
+      const std::shared_ptr<ShapeType>& shape,
+      const StringType& name);
 
   /// Return the list of ShapeNodes
   const std::vector<ShapeNode*> getShapeNodes();

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -544,23 +544,14 @@ public:
 
   /// Create a ShapeNode with an automatically assigned name:
   /// <BodyNodeName>_ShapeNode_<#>.
-  ShapeNode* createShapeNode(const ShapePtr& shape);
-
-  /// Same as createShapeNode(const ShapePtr&), but this accepts pointers to
-  /// arbitrary Shape types.
   template <class ShapeType>
   ShapeNode* createShapeNode(const std::shared_ptr<ShapeType>& shape);
 
   /// Create a ShapeNode with the specified name
-  ShapeNode* createShapeNode(
-      const ShapePtr& shape, const std::string& name);
-
-  /// Same as createShapeNode(const ShapePtr&, const std::string&), but this
-  /// accepts pointers to arbitrary Shape types, and can accept string literals.
   template <class ShapeType, class StringType>
   ShapeNode* createShapeNode(
       const std::shared_ptr<ShapeType>& shape,
-      const StringType& name);
+      StringType&& name);
 
   /// Return the list of ShapeNodes
   const std::vector<ShapeNode*> getShapeNodes();

--- a/dart/dynamics/detail/BodyNode.hpp
+++ b/dart/dynamics/detail/BodyNode.hpp
@@ -157,17 +157,23 @@ ShapeNode* BodyNode::createShapeNode(ShapeNodeProperties properties,
 template <class ShapeType>
 ShapeNode* BodyNode::createShapeNode(const std::shared_ptr<ShapeType>& shape)
 {
-  return createShapeNode(static_cast<ShapePtr>(shape));
+  ShapeNode::BasicProperties properties;
+  properties.mShape = shape;
+
+  return createShapeNode(properties, true);
 }
 
 //==============================================================================
 template <class ShapeType, class StringType>
 ShapeNode* BodyNode::createShapeNode(
     const std::shared_ptr<ShapeType>& shape,
-    const StringType& name)
+    StringType&& name)
 {
-  return createShapeNode(static_cast<ShapePtr>(shape),
-                         static_cast<std::string>(name));
+  ShapeNode::BasicProperties properties;
+  properties.mShape = shape;
+  properties.mName = std::forward<StringType>(name);
+
+  return createShapeNode(properties, false);
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/BodyNode.hpp
+++ b/dart/dynamics/detail/BodyNode.hpp
@@ -154,6 +154,23 @@ ShapeNode* BodyNode::createShapeNode(ShapeNodeProperties properties,
 }
 
 //==============================================================================
+template <class ShapeType>
+ShapeNode* BodyNode::createShapeNode(const std::shared_ptr<ShapeType>& shape)
+{
+  return createShapeNode(static_cast<ShapePtr>(shape));
+}
+
+//==============================================================================
+template <class ShapeType, class StringType>
+ShapeNode* BodyNode::createShapeNode(
+    const std::shared_ptr<ShapeType>& shape,
+    const StringType& name)
+{
+  return createShapeNode(static_cast<ShapePtr>(shape),
+                         static_cast<std::string>(name));
+}
+
+//==============================================================================
 template <class... Aspects>
 ShapeNode* BodyNode::createShapeNodeWith(const ShapePtr& shape)
 {

--- a/unittests/regression/CMakeLists.txt
+++ b/unittests/regression/CMakeLists.txt
@@ -7,4 +7,6 @@ if(TARGET dart-utils-urdf)
 
   dart_add_test("regression" test_Issue895)
 
+  dart_add_test("regression" test_IssueXXX)
+
 endif()

--- a/unittests/regression/CMakeLists.txt
+++ b/unittests/regression/CMakeLists.txt
@@ -7,6 +7,6 @@ if(TARGET dart-utils-urdf)
 
   dart_add_test("regression" test_Issue895)
 
-  dart_add_test("regression" test_IssueXXX)
+  dart_add_test("regression" test_Issue986)
 
 endif()

--- a/unittests/regression/test_Issue986.cpp
+++ b/unittests/regression/test_Issue986.cpp
@@ -36,7 +36,7 @@
 #include <dart/utils/urdf/DartLoader.hpp>
 
 //==============================================================================
-TEST(IssueXXX, CreateShapeNodeShouldCompile)
+TEST(Issue986, CreateShapeNodeShouldCompile)
 {
   const auto skel = dart::dynamics::Skeleton::create();
   auto* bn = skel->createJointAndBodyNodePair<FreeJoint>().second;

--- a/unittests/regression/test_IssueXXX.cpp
+++ b/unittests/regression/test_IssueXXX.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2017, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+#include <TestHelpers.hpp>
+#include <dart/dart.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
+
+//==============================================================================
+TEST(IssueXXX, CreateShapeNodeShouldCompile)
+{
+  const auto skel = dart::dynamics::Skeleton::create();
+  auto* bn = skel->createJointAndBodyNodePair<FreeJoint>().second;
+  auto sphere = std::make_shared<dart::dynamics::SphereShape>(1.0);
+  bn->createShapeNode(sphere);
+
+  auto world = dart::simulation::World::create();
+  world->addSkeleton(skel);
+}

--- a/unittests/regression/test_IssueXXX.cpp
+++ b/unittests/regression/test_IssueXXX.cpp
@@ -40,8 +40,19 @@ TEST(IssueXXX, CreateShapeNodeShouldCompile)
 {
   const auto skel = dart::dynamics::Skeleton::create();
   auto* bn = skel->createJointAndBodyNodePair<FreeJoint>().second;
-  auto sphere = std::make_shared<dart::dynamics::SphereShape>(1.0);
+  const auto sphere = std::make_shared<dart::dynamics::SphereShape>(1.0);
+
   bn->createShapeNode(sphere);
+  bn->createShapeNode(sphere, "custom name");
+
+  const dart::dynamics::ShapePtr generic =
+      std::make_shared<dart::dynamics::SphereShape>(1.0);
+
+  bn->createShapeNode(generic);
+  bn->createShapeNode(generic, "another name");
+
+  bn->createShapeNode(sphere, std::string("passing a string"));
+  bn->createShapeNode(generic, std::string("passing another string"));
 
   auto world = dart::simulation::World::create();
   world->addSkeleton(skel);


### PR DESCRIPTION
GCC 7.2.0/Clang Apple LLVM 9.0.0 fail to build `createShapeNode()` with errors as follows:
```
BodyNode.hpp:149:16: error: ‘class std::shared_ptr<dart::dynamics::SphereShape>’ has no member named ‘mName’
     properties.mName = getName()+"_ShapeNode_"
```

Travis also reports the [same error](https://travis-ci.org/dartsim/dart/jobs/341632273#L2118-L2120).