### PR TITLE
Use global namespace resolution in macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   * Added MetaSkeleton::hasBodyNode() and MetaSkeleton::hasJoint(): [#1000](https://github.com/dartsim/dart/pull/1000)
   * Suppressed -Winjected-class-name warnings from Clang 5.0.0: [#964](https://github.com/dartsim/dart/pull/964)
   * Suppressed -Wdangling-else warnings from GCC 7.2.0: [#937](https://github.com/dartsim/dart/pull/937)
+  * Changed console macros to use global namespace resolutions: [#1010](https://github.com/dartsim/dart/pull/1010)
   * Fixed various build issues with Visual Studio: [#956](https://github.com/dartsim/dart/pull/956)
   * Removed TinyXML dependency: [#993](https://github.com/dartsim/dart/pull/993)
 

--- a/dart/common/Console.hpp
+++ b/dart/common/Console.hpp
@@ -37,16 +37,16 @@
 #include <ostream>
 
 /// \brief Output a message
-#define dtmsg (dart::common::colorMsg("Msg", 32))
+#define dtmsg (::dart::common::colorMsg("Msg", 32))
 
 /// \brief Output a debug message
-#define dtdbg (dart::common::colorMsg("Dbg", 36))
+#define dtdbg (::dart::common::colorMsg("Dbg", 36))
 
 /// \brief Output a warning message
-#define dtwarn (dart::common::colorErr("Warning", __FILE__, __LINE__, 33))
+#define dtwarn (::dart::common::colorErr("Warning", __FILE__, __LINE__, 33))
 
 /// \brief Output an error message
-#define dterr (dart::common::colorErr("Error", __FILE__, __LINE__, 31))
+#define dterr (::dart::common::colorErr("Error", __FILE__, __LINE__, 31))
 
 namespace dart {
 namespace common {


### PR DESCRIPTION
to avoid namespace conflicts

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
