### PR TITLE
Update package.xml based on catkin documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## DART 6
 
-### [DART 6.3.1 XXXXX]
+### DART 6.3.1 (201X-XX-XX)
 
 * Build system
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## DART 6
 
+### [DART 6.3.1 XXXXX]
+
+* Build system
+
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027)
+
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 
 * Collision detection

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 # If you change the version, please update the <version> tag in package.xml.
 set(DART_MAJOR_VERSION "6")
 set(DART_MINOR_VERSION "3")
-set(DART_PATCH_VERSION "0")
+set(DART_PATCH_VERSION "1")
 set(DART_VERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}.${DART_PATCH_VERSION}")
 set(DART_PKG_DESC "Dynamic Animation and Robotics Toolkit.")
 set(DART_PKG_EXTERNAL_DEPS "eigen, ccd, fcl, assimp, boost")

--- a/package.xml
+++ b/package.xml
@@ -3,24 +3,25 @@
   <!-- This is a Catkin package.xml file to optionally support building DART in
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
-  <name>dart</name>
+  <name>dartsim</name>
   <version>6.3.0</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics
-    Lab and Humanoid Robotics Lab. The library provides data structures and
-    algorithms for kinematic and dynamic applications in robotics and computer
-    animation.
+    Lab and Humanoid Robotics Lab, with ongoing support by the University
+    of Washington Personal Robotics Lab and Open Robotics. DART provides data
+    structures and algorithms for kinematic and dynamic applications in robotics
+    and computer animation.
   </description>
   <url type="website">http://dartsim.github.io/</url>
   <url type="repository">https://github.com/dartsim/dart</url>
   <url type="bugtracker">https://github.com/dartsim/dart/issues</url>
-  <maintainer email="jslee02@gmail.com">Jeongseok Lee</maintainer>
+  <maintainer email="grey@openrobotics.org">Michael X. Grey</maintainer>
+  <author email="jslee02@gmail.com">Jeongseok Lee</maintainer>
   <author email="karenliu@cc.gatech.edu">C. Karen Liu</author>
-  <author email="mstilman@cc.gatech.edu">Mike Stilman</author>
+  <author>Mike Stilman</author>
   <license>BSD</license>
-  <buildtool_depend>cmake</buildtool_depend>
-  <buildtool_depend>pkg-config</buildtool_depend>
+  <build_depend>pkg-config</build_depend>
   <depend>assimp</depend>
   <depend>bullet</depend>
   <depend>eigen</depend>
@@ -33,9 +34,7 @@
   <depend>libxmu-dev</depend>
   <depend>tinyxml</depend>
   <depend>tinyxml2</depend>
-  <!-- These are required by REP-136. -->
-  <exec_depend>catkin</exec_depend>
-  <export>
-    <build_type>cmake</build_type>
-  </export>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
 </package>

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <url type="repository">https://github.com/dartsim/dart</url>
   <url type="bugtracker">https://github.com/dartsim/dart/issues</url>
   <maintainer email="grey@openrobotics.org">Michael X. Grey</maintainer>
-  <author email="jslee02@gmail.com">Jeongseok Lee</maintainer>
+  <author email="jslee02@gmail.com">Jeongseok Lee</author>
   <author email="karenliu@cc.gatech.edu">C. Karen Liu</author>
   <author>Mike Stilman</author>
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.3.0</version>
+  <version>6.3.1</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics


### PR DESCRIPTION
This updates the package.xml to (I think) more closely adhere to the documentation [here](http://wiki.ros.org/catkin/package.xml). If anyone has more experience writing package.xml files, please critique this.

I named myself as the maintainer so that if ROS users/maintainers have issues with the package, they'll direct issues to me first. I'll go ahead and take responsibility for that, since I'm surrounded by coworkers who are experts at ROS package management.

I'm not totally clear on whether it would be better to put this in 6.3 or 6.4. I'm thinking we can do a 6.3.1 release after merging this and make that the first DART release into ROS. If anyone dislikes that idea, please do say something, since I'm new to this process.