### PR TITLE
Fixing package name of FCL and removing libccd in package.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Build system
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027) [#1029](https://github.com/dartsim/dart/pull/1029)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/package.xml
+++ b/package.xml
@@ -25,9 +25,8 @@
   <depend>assimp</depend>
   <depend>bullet</depend>
   <depend>eigen</depend>
-  <depend>fcl</depend>
+  <depend>fcl_catkin</depend>
   <depend>glut</depend>
-  <depend>libccd</depend>
   <depend>libflann-dev</depend>
   <depend>liburdfdom-dev</depend>
   <depend>libxi-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,7 @@
   <depend>assimp</depend>
   <depend>bullet</depend>
   <depend>eigen</depend>
-  <depend>fcl_catkin</depend>
+  <depend>libfcl-dev</depend>
   <depend>glut</depend>
   <depend>libflann-dev</depend>
   <depend>liburdfdom-dev</depend>


### PR DESCRIPTION
After running some experiments with the ROS release tools, it seems they expect the package name for fcl to be `libfcl-dev`, and `libccd` doesn't seem to be recognized as a package (but we only depend on it transitively through `libfcl`, so it shouldn't matter).

This version of the package.xml seemed to work with `bloom-release`.