### PR TITLE
More fixes for package.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Build system
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027) [#1029](https://github.com/dartsim/dart/pull/1029)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Build system
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### DART 6.3.1 (201X-XX-XX)
 
-* Build system
+* ROS support
 
   * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Build system
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027) [#1029](https://github.com/dartsim/dart/pull/1029)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/package.xml
+++ b/package.xml
@@ -25,9 +25,8 @@
   <depend>assimp</depend>
   <depend>bullet</depend>
   <depend>eigen</depend>
-  <depend>fcl</depend>
+  <depend>fcl_catkin</depend>
   <depend>glut</depend>
-  <depend>libccd</depend>
   <depend>libflann-dev</depend>
   <depend>liburdfdom-dev</depend>
   <depend>libxi-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,9 @@
   <depend>tinyxml</depend>
   <depend>tinyxml2</depend>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,8 @@
   <depend>tinyxml</depend>
   <depend>tinyxml2</depend>
 
+  <!-- The following tags are recommended by REP-136 -->
+  <run_depend>catkin</run_depend>
   <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>pkg-config</build_depend>
   <depend>assimp</depend>
   <depend>bullet</depend>
+  <depend>boost</depend>
   <depend>eigen</depend>
   <depend>libfcl-dev</depend>
   <depend>glut</depend>

--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,7 @@
   <depend>assimp</depend>
   <depend>bullet</depend>
   <depend>eigen</depend>
-  <depend>fcl_catkin</depend>
+  <depend>libfcl-dev</depend>
   <depend>glut</depend>
   <depend>libflann-dev</depend>
   <depend>liburdfdom-dev</depend>


### PR DESCRIPTION
Since DART does not depend on catkin in order to configure and build, we can specify that it's build type is cmake instead of catkin. This prevents catkin from complaining about the project not being a catkin package.

This brings us back to conforming to REP-136, which I had naively erased, since I wasn't aware of the nuances between a "catkin package" and a "third-party package" (dartsim is considered the latter).

This also adds a boost dependency that was missing.