### PR TITLE
Conform to package.xml format 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Build system
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027) [#1029](https://github.com/dartsim/dart/pull/1029)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Build system
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### DART 6.3.1 (201X-XX-XX)
 
-* Build system
+* ROS support
 
   * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Build system
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027) [#1029](https://github.com/dartsim/dart/pull/1029)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/package.xml
+++ b/package.xml
@@ -25,9 +25,8 @@
   <depend>assimp</depend>
   <depend>bullet</depend>
   <depend>eigen</depend>
-  <depend>fcl</depend>
+  <depend>fcl_catkin</depend>
   <depend>glut</depend>
-  <depend>libccd</depend>
   <depend>libflann-dev</depend>
   <depend>liburdfdom-dev</depend>
   <depend>libxi-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,9 @@
   <depend>tinyxml</depend>
   <depend>tinyxml2</depend>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,8 @@
   <depend>tinyxml</depend>
   <depend>tinyxml2</depend>
 
+  <!-- The following tags are recommended by REP-136 -->
+  <run_depend>catkin</run_depend>
   <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>pkg-config</build_depend>
   <depend>assimp</depend>
   <depend>bullet</depend>
+  <depend>boost</depend>
   <depend>eigen</depend>
   <depend>libfcl-dev</depend>
   <depend>glut</depend>

--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,7 @@
   <depend>assimp</depend>
   <depend>bullet</depend>
   <depend>eigen</depend>
-  <depend>fcl_catkin</depend>
+  <depend>libfcl-dev</depend>
   <depend>glut</depend>
   <depend>libflann-dev</depend>
   <depend>liburdfdom-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,7 @@
   <depend>tinyxml2</depend>
 
   <!-- The following tags are recommended by REP-136 -->
-  <run_depend>catkin</run_depend>
+  <exec_depend>catkin</exec_depend>
   <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
It turns out that the recommendations of REP-136 are only using terminology for format 1 of package.xml, but we want to use format 2. This change should accommodate both needs.