### PR TITLE
Final step to give dartsim stable status in ROS build farm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * ROS support
 
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031)
+  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031), [#1032](https://github.com/dartsim/dart/pull/1031), [#1033](https://github.com/dartsim/dart/pull/1033)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -31,7 +31,7 @@ if(DART_BUILD_GUI_OSG)
         set(warning_msg "Could NOT find OpenSceneGraph nor OpenThreads")
       endif()
     endif()
-    message(WARNING "${warning_msg} -- we will skip dart-gui-osg\n"
+    message(STATUS "${warning_msg} -- we will skip dart-gui-osg\n"
             "If you believe you do have both OSG and OpenThreads installed, try setting OSG_DIR")
     return()
   endif()


### PR DESCRIPTION
Sorry for all the PR spam, but we're almost there! The last thing the ROS package build farm is complaining about is a cmake warning that we expect to occur. This results in an "unstable" status, which is acceptable, but I'd prefer we make it stable since it's such an easy fix (and this should probably be a status message instead of a warning anyway).

I also updated the changelog to include PR #1032 which I accidentally skipped.