### PR TITLE
Avoid using an undefined cmake macro/function "build_error"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## DART 6
 
-### DART 6.3.1 (2018-03-14)
+### DART 6.3.1 (2018-XX-XX)
+
+* Build system
+
+  * Remove an undefined cmake macro/function: [#1036](https://github.com/dartsim/dart/pull/1036)
 
 * ROS support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## DART 6
 
-### DART 6.3.1 (2018-XX-XX)
+### DART 6.3.1 (2018-03-21)
 
 * Build system
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ elseif("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "RELWITHDEBINFO")
 elseif("${CMAKE_BUILD_TYPE_UPPERCASE}" STREQUAL "MINSIZEREL")
   set(BUILD_TYPE_MINSIZEREL TRUE)
 else()
-  build_error("CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} unknown. Valid options are: Debug | Release | RelWithDebInfo | MinSizeRel")
+  message(STATUS "CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} unknown. Valid options are: Debug | Release | RelWithDebInfo | MinSizeRel")
 endif()
 
 #===============================================================================


### PR DESCRIPTION
This has been causing trouble in the ROS Build Farm, because the build farm passes the argument `-DCMAKE_BUILD_TYPE=None` to cmake.

I think in general we should consider a redesign (mostly a simplification) of how we handle build types, but I'll open a separate issue for that.