### PR TITLE
Update CI scripts to exit immediately on failure

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,15 @@
+#tap 'dartsim/dart' # for ipopt
+ 
+brew 'assimp'
+brew 'boost'
+brew 'bullet'
+brew 'eigen'
+brew 'fcl'
+#brew 'flann'
+#brew 'ipopt'
+brew 'libccd'
+#brew 'nlopt'
+brew 'ode'
+brew 'open-scene-graph'
+brew 'tinyxml2'
+brew 'urdfdom'

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+ 
+set -e
+
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$COMPILER" = "CLANG" ]; then exit; fi
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then 'ci/install_linux.sh' ; fi

--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+ 
+set -e
+
 sudo apt-add-repository --yes ppa:libccd-debs/ppa
 sudo apt-add-repository --yes ppa:fcl-debs/ppa
 sudo apt-add-repository --yes ppa:dartsim/ppa

--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -1,2 +1,6 @@
+#!/usr/bin/env bash
+ 
+set -e
+
 brew update > /dev/null
 brew bundle

--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -1,20 +1,2 @@
-brew tap dartsim/dart # for ipopt
-
 brew update > /dev/null
-
-brew install git
-brew install cmake
-brew install assimp
-brew install fcl
-brew install bullet
-brew install ode
-brew install flann
-brew install boost
-brew install eigen
-brew install tinyxml
-brew install tinyxml2
-brew install libccd
-brew install nlopt
-brew install ipopt
-brew install urdfdom
-brew install open-scene-graph
+brew bundle

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+ 
+set -e
+
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$COMPILER" = "CLANG" ]; then exit; fi
 
 mkdir build && cd build


### PR DESCRIPTION
The current CI tests pass even on test failures (see [this build](https://travis-ci.org/dartsim/dart/jobs/357492491#L2600)).

This PR add `set -e` option so that it exits immediately.

Caveat: By adding `set -e`, Homebrew fails to install some packages (`flann`, `ipopt`, `nlopt`) successfully (e.g., [this](https://travis-ci.org/dartsim/dart/jobs/357492491#L1221)). Those packages are disabled for now, and we will revisit this.

