### PR TITLE
Add World::hasSkeleton()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   * Added FOV API to OSG viewer: [#1048](https://github.com/dartsim/dart/pull/1048)
 
+* Simulation
+
+  * Added World::hasSkeleton(): [#1050](https://github.com/dartsim/dart/pull/1050)
+
 ### [DART 6.4.0 (2018-03-26)](https://github.com/dartsim/dart/milestone/39?closed=1)
 
 * Common

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -392,6 +392,13 @@ std::set<dynamics::SkeletonPtr> World::removeAllSkeletons()
 }
 
 //==============================================================================
+bool World::hasSkeleton(const dynamics::SkeletonPtr& skeleton)
+{
+  return std::find(mSkeletons.begin(), mSkeletons.end(), skeleton)
+      != mSkeletons.end();
+}
+
+//==============================================================================
 int World::getIndex(int _index) const
 {
   return mIndices[_index];

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -392,7 +392,7 @@ std::set<dynamics::SkeletonPtr> World::removeAllSkeletons()
 }
 
 //==============================================================================
-bool World::hasSkeleton(const dynamics::SkeletonPtr& skeleton)
+bool World::hasSkeleton(const dynamics::ConstSkeletonPtr& skeleton) const
 {
   return std::find(mSkeletons.begin(), mSkeletons.end(), skeleton)
       != mSkeletons.end();

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -149,6 +149,9 @@ public:
   /// pointers to them, in case you want to recycle them
   std::set<dynamics::SkeletonPtr> removeAllSkeletons();
 
+  /// Returns wether this World contains a Skeleton.
+  bool hasSkeleton(const dynamics::SkeletonPtr& skeleton);
+
   /// Get the dof index for the indexed skeleton
   int getIndex(int _index) const;
 

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -150,7 +150,7 @@ public:
   std::set<dynamics::SkeletonPtr> removeAllSkeletons();
 
   /// Returns wether this World contains a Skeleton.
-  bool hasSkeleton(const dynamics::SkeletonPtr& skeleton);
+  bool hasSkeleton(const dynamics::ConstSkeletonPtr& skeleton) const;
 
   /// Get the dof index for the indexed skeleton
   int getIndex(int _index) const;

--- a/unittests/comprehensive/test_World.cpp
+++ b/unittests/comprehensive/test_World.cpp
@@ -95,9 +95,16 @@ TEST(World, AddingAndRemovingSkeletons)
   for (int i = 0; i < nSteps; ++i)
       world->step();
 
+  EXPECT_FALSE(world->hasSkeleton(skeleton1));
+  EXPECT_FALSE(world->hasSkeleton(skeleton2));
+  EXPECT_FALSE(world->hasSkeleton(skeleton3));
+  EXPECT_FALSE(world->hasSkeleton(skeleton4));
+
   // Add skeleton1, skeleton2
   world->addSkeleton(skeleton1);
+  EXPECT_TRUE(world->hasSkeleton(skeleton1));
   world->addSkeleton(skeleton2);
+  EXPECT_TRUE(world->hasSkeleton(skeleton2));
   EXPECT_TRUE(world->getNumSkeletons() == 2);
   for (int i = 0; i < nSteps; ++i)
       world->step();
@@ -119,7 +126,9 @@ TEST(World, AddingAndRemovingSkeletons)
 
   // Add skeleton3, skeleton4
   world->addSkeleton(skeleton3);
+  EXPECT_TRUE(world->hasSkeleton(skeleton3));
   world->addSkeleton(skeleton4);
+  EXPECT_TRUE(world->hasSkeleton(skeleton4));
   EXPECT_TRUE(world->getNumSkeletons() == 3);
   for (int i = 0; i < nSteps; ++i)
       world->step();


### PR DESCRIPTION
`World::hasSkeleton` takes `Skeleton` as a shared pointer since `Skeleton` is enforced to be created as a shared pointer by calling `Skeleton::create()`.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
