### PR TITLE
Bugfix/urdfparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   * Added FOV API to OSG viewer: [#1048](https://github.com/dartsim/dart/pull/1048)
 
+* Parsers
+
+  * Fixed incorrect parsing of continuous joints specified in URDF [#1064](https://github.com/dartsim/dart/pull/1064)
+
 * Simulation
 
   * Added World::hasSkeleton(): [#1050](https://github.com/dartsim/dart/pull/1050)

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -377,8 +377,8 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
     case urdf::Joint::CONTINUOUS:
     {
       // We overwrite joint position limits to negative/positive infinities
-      // for "continuous" joint. The URDF parser, by default, either reads the
-      // limits, if specified for this joint, or sets them to 0.
+      // for "continuous" joint. The URDF parser, by default, either reads
+      // the limits, if specified for this joint, or sets them to 0.
       singleDof.mPositionLowerLimits[0] = -math::constantsd::inf();
       singleDof.mPositionUpperLimits[0] = math::constantsd::inf();
     }

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -374,8 +374,12 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
   std::pair<dynamics::Joint*, dynamics::BodyNode*> pair;
   switch(_jt->type)
   {
-    case urdf::Joint::REVOLUTE:
     case urdf::Joint::CONTINUOUS:
+    {
+      singleDof.mPositionLowerLimits[0] = -math::constantsd::inf();
+      singleDof.mPositionUpperLimits[0] = math::constantsd::inf();
+    }
+    case urdf::Joint::REVOLUTE:
     {
       dynamics::RevoluteJoint::Properties properties(
             dynamics::GenericJoint<math::R1Space>::Properties(basicProperties, singleDof),

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -376,6 +376,9 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
   {
     case urdf::Joint::CONTINUOUS:
     {
+      // We overwrite joint position limits to negative/positive infinities
+      // for "continuous" joint. The URDF parser, by default, either reads the
+      // limits, if specified for this joint, or sets them to 0.
       singleDof.mPositionLowerLimits[0] = -math::constantsd::inf();
       singleDof.mPositionUpperLimits[0] = math::constantsd::inf();
     }

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -381,6 +381,16 @@ dynamics::BodyNode* DartLoader::createDartJointAndNode(
       // the limits, if specified for this joint, or sets them to 0.
       singleDof.mPositionLowerLimits[0] = -math::constantsd::inf();
       singleDof.mPositionUpperLimits[0] = math::constantsd::inf();
+
+      // This joint is still revolute but with no joint limits
+      dynamics::RevoluteJoint::Properties properties(
+            dynamics::GenericJoint<math::R1Space>::Properties(basicProperties, singleDof),
+            toEigen(_jt->axis));
+
+      pair = _skeleton->createJointAndBodyNodePair<dynamics::RevoluteJoint>(
+            _parent, properties, _body);
+
+      break;
     }
     case urdf::Joint::REVOLUTE:
     {

--- a/unittests/unit/test_DartLoader.cpp
+++ b/unittests/unit/test_DartLoader.cpp
@@ -138,3 +138,57 @@ TEST(DartLoader, parseJointProperties)
   EXPECT_NEAR(joint1->getDampingCoefficient(0), 1.2, 1e-12);
   EXPECT_NEAR(joint1->getCoulombFriction(0), 2.3, 1e-12);
 }
+
+TEST(DartLoader, parseJointPropertiesIncorrectly)
+{
+  std::string urdfStr =
+    "<robot name=\"testRobot\">                                       "
+    "  <link name=\"link_0\">                                         "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 -0.087\"/>                 "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>                      "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "  </link>                                                        "
+    "  <joint name=\"0_to_1\" type=\"continuous\">                    "
+    "    <parent link=\"link_0\"/>                                    "
+    "    <child link=\"link_1\"/>                                     "
+    "    <limit effort=\"2.5\" velocity=\"3.00545697193\"/>           "
+    "    <axis xyz=\"0 0 1\"/>                                        "
+    "    <dynamics damping=\"1.2\" friction=\"2.3\"/>                 "
+    "  </joint>                                                       "
+    "  <link name=\"link_1\">                                         "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 -0.087\"/>                 "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>                      "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "  </link>                                                        "
+    "</robot>                                                         ";
+
+  DartLoader loader;
+  auto robot = loader.parseSkeletonString(urdfStr, "");
+  EXPECT_TRUE(nullptr != robot);
+
+  auto joint1 = robot->getJoint(1);
+  // Bug: Should be +/-inf.
+  EXPECT_NEAR(joint1->getPositionLowerLimit(0), 0.0, 1e-12);
+  EXPECT_NEAR(joint1->getPositionUpperLimit(0), 0.0, 1e-12);
+  // Bug: Should return true.
+  EXPECT_FALSE(joint1->isCyclic(0));
+}
+

--- a/unittests/unit/test_DartLoader.cpp
+++ b/unittests/unit/test_DartLoader.cpp
@@ -139,7 +139,7 @@ TEST(DartLoader, parseJointProperties)
   EXPECT_NEAR(joint1->getCoulombFriction(0), 2.3, 1e-12);
 }
 
-TEST(DartLoader, parseJointPropertiesIncorrectly)
+TEST(DartLoader, parseJointPropertiesCorrectly)
 {
   std::string urdfStr =
     "<robot name=\"testRobot\">                                       "
@@ -185,10 +185,8 @@ TEST(DartLoader, parseJointPropertiesIncorrectly)
   EXPECT_TRUE(nullptr != robot);
 
   auto joint1 = robot->getJoint(1);
-  // Bug: Should be +/-inf.
-  EXPECT_NEAR(joint1->getPositionLowerLimit(0), 0.0, 1e-12);
-  EXPECT_NEAR(joint1->getPositionUpperLimit(0), 0.0, 1e-12);
-  // Bug: Should return true.
-  EXPECT_FALSE(joint1->isCyclic(0));
+  EXPECT_DOUBLE_EQ(joint1->getPositionLowerLimit(0), -dart::math::constantsd::inf());
+  EXPECT_DOUBLE_EQ(joint1->getPositionUpperLimit(0), dart::math::constantsd::inf());
+  EXPECT_TRUE(joint1->isCyclic(0));
 }
 

--- a/unittests/unit/test_DartLoader.cpp
+++ b/unittests/unit/test_DartLoader.cpp
@@ -126,6 +126,27 @@ TEST(DartLoader, parseJointProperties)
     "      </geometry>                                                "
     "    </visual>                                                    "
     "  </link>                                                        "
+    "  <joint name=\"1_to_2\" type=\"continuous\">                    "
+    "    <parent link=\"link_1\"/>                                    "
+    "    <child link=\"link_2\"/>                                     "
+    "    <limit effort=\"2.5\" velocity=\"3.00545697193\"/>           "
+    "    <axis xyz=\"0 0 1\"/>                                        "
+    "    <dynamics damping=\"1.2\" friction=\"2.3\"/>                 "
+    "  </joint>                                                       "
+    "  <link name=\"link_2\">                                         "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 -0.087\"/>                 "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "    <visual>                                                     "
+    "      <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>                      "
+    "      <geometry>                                                 "
+    "        <box size=\"1 1 1\"/>                                    "
+    "      </geometry>                                                "
+    "    </visual>                                                    "
+    "  </link>                                                        "
     "</robot>                                                         ";
 
   DartLoader loader;
@@ -134,59 +155,11 @@ TEST(DartLoader, parseJointProperties)
 
   auto joint1 = robot->getJoint(1);
   EXPECT_TRUE(nullptr != joint1);
-
   EXPECT_NEAR(joint1->getDampingCoefficient(0), 1.2, 1e-12);
   EXPECT_NEAR(joint1->getCoulombFriction(0), 2.3, 1e-12);
+
+  auto joint2 = robot->getJoint(2);
+  EXPECT_DOUBLE_EQ(joint2->getPositionLowerLimit(0), -dart::math::constantsd::inf());
+  EXPECT_DOUBLE_EQ(joint2->getPositionUpperLimit(0), dart::math::constantsd::inf());
+  EXPECT_TRUE(joint2->isCyclic(0));
 }
-
-TEST(DartLoader, parseJointPropertiesCorrectly)
-{
-  std::string urdfStr =
-    "<robot name=\"testRobot\">                                       "
-    "  <link name=\"link_0\">                                         "
-    "    <visual>                                                     "
-    "      <origin rpy=\"0 0 0\" xyz=\"0 0 -0.087\"/>                 "
-    "      <geometry>                                                 "
-    "        <box size=\"1 1 1\"/>                                    "
-    "      </geometry>                                                "
-    "    </visual>                                                    "
-    "    <visual>                                                     "
-    "      <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>                      "
-    "      <geometry>                                                 "
-    "        <box size=\"1 1 1\"/>                                    "
-    "      </geometry>                                                "
-    "    </visual>                                                    "
-    "  </link>                                                        "
-    "  <joint name=\"0_to_1\" type=\"continuous\">                    "
-    "    <parent link=\"link_0\"/>                                    "
-    "    <child link=\"link_1\"/>                                     "
-    "    <limit effort=\"2.5\" velocity=\"3.00545697193\"/>           "
-    "    <axis xyz=\"0 0 1\"/>                                        "
-    "    <dynamics damping=\"1.2\" friction=\"2.3\"/>                 "
-    "  </joint>                                                       "
-    "  <link name=\"link_1\">                                         "
-    "    <visual>                                                     "
-    "      <origin rpy=\"0 0 0\" xyz=\"0 0 -0.087\"/>                 "
-    "      <geometry>                                                 "
-    "        <box size=\"1 1 1\"/>                                    "
-    "      </geometry>                                                "
-    "    </visual>                                                    "
-    "    <visual>                                                     "
-    "      <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>                      "
-    "      <geometry>                                                 "
-    "        <box size=\"1 1 1\"/>                                    "
-    "      </geometry>                                                "
-    "    </visual>                                                    "
-    "  </link>                                                        "
-    "</robot>                                                         ";
-
-  DartLoader loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
-  EXPECT_TRUE(nullptr != robot);
-
-  auto joint1 = robot->getJoint(1);
-  EXPECT_DOUBLE_EQ(joint1->getPositionLowerLimit(0), -dart::math::constantsd::inf());
-  EXPECT_DOUBLE_EQ(joint1->getPositionUpperLimit(0), dart::math::constantsd::inf());
-  EXPECT_TRUE(joint1->isCyclic(0));
-}
-


### PR DESCRIPTION
Continuous Joints have been previously parsed with joint limits set to 0 resulting in incorrect behavior of the joint and relevant functions [For instance, `isCyclic()`].

This PR corrects the parsing for these joints by setting the joint limits to negative/positive infinity.

To show the behavior:
Commit 456cca0 has a test to show that current implementation has a bug.
Commit 5eff95d provides a fix.
Commit 9d8d316 has the test to show the fix works.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
