### PR TITLE
Packaging 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## DART 6
 
-### DART 6.5.0 (201X-XX-XX)
+### [DART 6.5.0 (2018-05-12)](https://github.com/dartsim/dart/milestone/41?closed=1)
 
 * Common
 
   * Added LockableReference classes: [#1011](https://github.com/dartsim/dart/pull/1011)
+  * Added missing \<vector\> to Memory.hpp: [#1057](https://github.com/dartsim/dart/pull/1057)
 
 * GUI
 

--- a/dart/common/Memory.hpp
+++ b/dart/common/Memory.hpp
@@ -35,6 +35,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "dart/config.hpp"
 #include "dart/common/Deprecated.hpp"


### PR DESCRIPTION
**Summary**
* Include #1057 into 6.5.0 instead of 6.4.1 (decided not to release 6.4.1)
* Update changelog

**PPA builds**
* [trusty](https://launchpad.net/~dartsim/+archive/ubuntu/ppa/+build/14872022)
* [xenial](https://launchpad.net/~dartsim/+archive/ubuntu/ppa/+build/14872024)
* [bionic](https://launchpad.net/~dartsim/+archive/ubuntu/ppa/+build/14872014)