### PR TITLE
Fix incorrect bullet header inclusion

### DIFF
--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -35,7 +35,7 @@
 
 #include "dart/collision/bullet/BulletCollisionDetector.hpp"
 
-#include <bullet/BulletCollision/Gimpact/btGImpactShape.h>
+#include <BulletCollision/Gimpact/btGImpactShape.h>
 
 #include "dart/common/Console.hpp"
 #include "dart/collision/CollisionObject.hpp"


### PR DESCRIPTION
This may not be problematic if we include the system include directory (e.g., `/usr/include/`) since bullet is usually installed under the directory, but this wouldn't work otherwise.