### PR TITLE
Update DART versions in examples and tutorials

### DIFF
--- a/examples/addDeleteSkels/CMakeLists.txt
+++ b/examples/addDeleteSkels/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(addDeleteSkels)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/atlasSimbicon/CMakeLists.txt
+++ b/examples/atlasSimbicon/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(atlasSimbicon)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/bipedStand/CMakeLists.txt
+++ b/examples/bipedStand/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(bipedStand)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/hardcodedDesign/CMakeLists.txt
+++ b/examples/hardcodedDesign/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(hardcodedDesign)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/hybridDynamics/CMakeLists.txt
+++ b/examples/hybridDynamics/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(hybridDynamics)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/jointConstraints/CMakeLists.txt
+++ b/examples/jointConstraints/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(jointConstraints)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/mixedChain/CMakeLists.txt
+++ b/examples/mixedChain/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(mixedChain)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/operationalSpaceControl/CMakeLists.txt
+++ b/examples/operationalSpaceControl/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(operationalSpaceControl)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgAtlasPuppet/CMakeLists.txt
+++ b/examples/osgExamples/osgAtlasPuppet/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgAtlasPuppet)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgAtlasSimbicon/CMakeLists.txt
+++ b/examples/osgExamples/osgAtlasSimbicon/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgAtlasSimbicon)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgDragAndDrop/CMakeLists.txt
+++ b/examples/osgExamples/osgDragAndDrop/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgDragAndDrop)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgEmpty/CMakeLists.txt
+++ b/examples/osgExamples/osgEmpty/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgEmpty)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgHuboPuppet/CMakeLists.txt
+++ b/examples/osgExamples/osgHuboPuppet/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgHubuPuppet)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgImGui/CMakeLists.txt
+++ b/examples/osgExamples/osgImGui/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgImGui)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgOperationalSpaceControl/CMakeLists.txt
+++ b/examples/osgExamples/osgOperationalSpaceControl/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgOperationalSpaceControl)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgSoftBodies/CMakeLists.txt
+++ b/examples/osgExamples/osgSoftBodies/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgSoftBodies)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/osgExamples/osgTinkertoy/CMakeLists.txt
+++ b/examples/osgExamples/osgTinkertoy/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(osgTinkertoy)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui-osg CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/rigidChain/CMakeLists.txt
+++ b/examples/rigidChain/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(rigidChain)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/rigidLoop/CMakeLists.txt
+++ b/examples/rigidLoop/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(rigidLoop)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/rigidShapes/CMakeLists.txt
+++ b/examples/rigidShapes/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(rigidShapes)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/simpleFrames/CMakeLists.txt
+++ b/examples/simpleFrames/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(simpleFrames)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/softBodies/CMakeLists.txt
+++ b/examples/softBodies/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(softBodies)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/speedTest/CMakeLists.txt
+++ b/examples/speedTest/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(speedTest)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/examples/vehicle/CMakeLists.txt
+++ b/examples/vehicle/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(vehicle)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialBiped-Finished/CMakeLists.txt
+++ b/tutorials/tutorialBiped-Finished/CMakeLists.txt
@@ -5,9 +5,14 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-project(tutorialBiped-Finished)
+get_filename_component(tutorial_name ${CMAKE_CURRENT_LIST_DIR} NAME)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+project(${tutorial_name})
+
+find_package(DART 6.6.0 REQUIRED
+  COMPONENTS collision-bullet utils-urdf gui
+  CONFIG
+)
 
 add_compile_options(-std=c++11)
 
@@ -17,4 +22,3 @@ file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${PROJECT_NAME} ${srcs})
 
 target_link_libraries(${PROJECT_NAME} ${DART_LIBRARIES})
-

--- a/tutorials/tutorialBiped-Finished/CMakeLists.txt
+++ b/tutorials/tutorialBiped-Finished/CMakeLists.txt
@@ -5,9 +5,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-get_filename_component(tutorial_name ${CMAKE_CURRENT_LIST_DIR} NAME)
-
-project(${tutorial_name})
+project(tutorialBiped-Finished)
 
 find_package(DART 6.6.0 REQUIRED
   COMPONENTS collision-bullet utils-urdf gui

--- a/tutorials/tutorialBiped-Finished/InSourceBuild.cmake
+++ b/tutorials/tutorialBiped-Finished/InSourceBuild.cmake
@@ -9,7 +9,9 @@ endif()
 file(GLOB srcs "*.cpp" "*.hpp")
 
 add_executable(${tutorial_name} ${srcs})
-target_link_libraries(${tutorial_name} dart dart-utils-urdf dart-gui)
+target_link_libraries(${tutorial_name}
+  dart dart-collision-bullet dart-utils-urdf dart-gui
+)
 set_target_properties(${tutorial_name}
   PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/tutorials/tutorialBiped/CMakeLists.txt
+++ b/tutorials/tutorialBiped/CMakeLists.txt
@@ -5,9 +5,14 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-project(tutorialBiped)
+get_filename_component(tutorial_name ${CMAKE_CURRENT_LIST_DIR} NAME)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+project(${tutorial_name})
+
+find_package(DART 6.6.0 REQUIRED
+  COMPONENTS collision-bullet utils-urdf gui
+  CONFIG
+)
 
 add_compile_options(-std=c++11)
 
@@ -17,4 +22,3 @@ file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${PROJECT_NAME} ${srcs})
 
 target_link_libraries(${PROJECT_NAME} ${DART_LIBRARIES})
-

--- a/tutorials/tutorialBiped/InSourceBuild.cmake
+++ b/tutorials/tutorialBiped/InSourceBuild.cmake
@@ -9,7 +9,9 @@ endif()
 file(GLOB srcs "*.cpp" "*.hpp")
 
 add_executable(${tutorial_name} ${srcs})
-target_link_libraries(${tutorial_name} dart dart-utils-urdf dart-gui)
+target_link_libraries(${tutorial_name}
+  dart dart-collision-bullet dart-utils-urdf dart-gui
+)
 set_target_properties(${tutorial_name}
   PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/tutorials/tutorialCollisions-Finished/CMakeLists.txt
+++ b/tutorials/tutorialCollisions-Finished/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(tutorialCollisions-Finished)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialCollisions/CMakeLists.txt
+++ b/tutorials/tutorialCollisions/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(tutorialCollisions)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialDominoes-Finished/CMakeLists.txt
+++ b/tutorials/tutorialDominoes-Finished/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(tutorialDominoes-Finished)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialDominoes/CMakeLists.txt
+++ b/tutorials/tutorialDominoes/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(tutorialDominoes)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialMultiPendulum-Finished/CMakeLists.txt
+++ b/tutorials/tutorialMultiPendulum-Finished/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(tutorialMultiPendulum-Finished)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 

--- a/tutorials/tutorialMultiPendulum/CMakeLists.txt
+++ b/tutorials/tutorialMultiPendulum/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(tutorialMultiPendulum)
 
-find_package(DART 6.5.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
+find_package(DART 6.6.0 REQUIRED COMPONENTS utils-urdf gui CONFIG)
 
 add_compile_options(-std=c++11)
 


### PR DESCRIPTION
Additionally, this PR fixes #1079 by adding missing `collision-bullet` dependency to `tutorialBiped[-Finished]` tutorial.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
