### PR TITLE
Add more occupancy update functions to VoxelGridShape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Dynamics
 
-  * Added VoxelGridShape: [#1076](https://github.com/dartsim/dart/pull/1076)
+  * Added VoxelGridShape: [#1076](https://github.com/dartsim/dart/pull/1076), [#1083](https://github.com/dartsim/dart/pull/1083)
 
 ### [DART 6.5.0 (2018-05-12)](https://github.com/dartsim/dart/milestone/41?closed=1)
 

--- a/dart/dynamics/VoxelGridShape.cpp
+++ b/dart/dynamics/VoxelGridShape.cpp
@@ -43,7 +43,7 @@ namespace dynamics {
 namespace {
 
 //==============================================================================
-octomap::point3d toVector3(const Eigen::Vector3d& point)
+octomap::point3d toPoint3d(const Eigen::Vector3d& point)
 {
   return octomap::point3d(point.x(), point.y(), point.z());
 }
@@ -56,10 +56,10 @@ octomath::Quaternion toQuaternion(const Eigen::Matrix3d& rotation)
 }
 
 //==============================================================================
-octomap::pose6d toPose(const Eigen::Isometry3d& frame)
+octomap::pose6d toPose6d(const Eigen::Isometry3d& frame)
 {
   return octomap::pose6d(
-      toVector3(frame.translation()), toQuaternion(frame.linear()));
+      toPoint3d(frame.translation()), toQuaternion(frame.linear()));
 }
 
 } // namespace
@@ -133,14 +133,14 @@ fcl_shared_ptr<const octomap::OcTree> VoxelGridShape::getOctree() const
 void VoxelGridShape::updateOccupancy(
     const Eigen::Vector3d& point, bool occupied)
 {
-  mOctree->updateNode(toVector3(point), occupied);
+  mOctree->updateNode(toPoint3d(point), occupied);
 }
 
 //==============================================================================
 void VoxelGridShape::updateOccupancy(
     const Eigen::Vector3d& from, const Eigen::Vector3d& to)
 {
-  mOctree->insertRay(toVector3(from), toVector3(to));
+  mOctree->insertRay(toPoint3d(from), toPoint3d(to));
 }
 
 //==============================================================================
@@ -151,12 +151,11 @@ void VoxelGridShape::updateOccupancy(
 {
   if (relativeTo == Frame::World())
   {
-    mOctree->insertPointCloud(pointCloud, toVector3(sensorOrigin));
+    mOctree->insertPointCloud(pointCloud, toPoint3d(sensorOrigin));
   }
   else
   {
-    updateOccupancy(
-        pointCloud, sensorOrigin, relativeTo->getWorldTransform());
+    updateOccupancy(pointCloud, sensorOrigin, relativeTo->getWorldTransform());
   }
 }
 
@@ -167,7 +166,7 @@ void VoxelGridShape::updateOccupancy(
     const Eigen::Isometry3d& relativeTo)
 {
   mOctree->insertPointCloud(
-      pointCloud, toVector3(sensorOrigin), toPose(relativeTo));
+      pointCloud, toPoint3d(sensorOrigin), toPose6d(relativeTo));
 }
 
 //==============================================================================

--- a/dart/dynamics/VoxelGridShape.cpp
+++ b/dart/dynamics/VoxelGridShape.cpp
@@ -147,16 +147,16 @@ void VoxelGridShape::updateOccupancy(
 void VoxelGridShape::updateOccupancy(
     const octomap::Pointcloud& pointCloud,
     const Eigen::Vector3d& sensorOrigin,
-    const Frame* inCoordinatesOf)
+    const Frame* relativeTo)
 {
-  if (inCoordinatesOf == Frame::World())
+  if (relativeTo == Frame::World())
   {
     mOctree->insertPointCloud(pointCloud, toVector3(sensorOrigin));
   }
   else
   {
     updateOccupancy(
-        pointCloud, sensorOrigin, inCoordinatesOf->getWorldTransform());
+        pointCloud, sensorOrigin, relativeTo->getWorldTransform());
   }
 }
 
@@ -164,10 +164,10 @@ void VoxelGridShape::updateOccupancy(
 void VoxelGridShape::updateOccupancy(
     const octomap::Pointcloud& pointCloud,
     const Eigen::Vector3d& sensorOrigin,
-    const Eigen::Isometry3d& inCoordinatesOf)
+    const Eigen::Isometry3d& relativeTo)
 {
   mOctree->insertPointCloud(
-      pointCloud, toVector3(sensorOrigin), toPose(inCoordinatesOf));
+      pointCloud, toVector3(sensorOrigin), toPose(relativeTo));
 }
 
 //==============================================================================

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -39,10 +39,13 @@
 
 #include <octomap/octomap.h>
 #include "dart/collision/fcl/BackwardCompatibility.hpp"
+#include "dart/dynamics/Frame.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
 namespace dynamics {
+
+class Frame;
 
 /// VoxelGridShape represents a probabilistic 3D occupancy voxel grid.
 class VoxelGridShape : public Shape
@@ -82,10 +85,35 @@ public:
   /// \param[in] occupied True if the location was measured occupied.
   void updateOccupancy(const Eigen::Vector3d& point, bool occupied = true);
 
-  /// Integrates a point cloud sensor measurement.
+  /// Inserts a ray between \c from and \c to into the voxel grid.
+  ///
+  /// \param from Origin of sensor in global coordinates.
+  /// \param to Endpoint of measurement in global coordinates.
+  void updateOccupancy(const Eigen::Vector3d& from, const Eigen::Vector3d& to);
+
+  /// Integrates a 3D ray cloud sensor measurement.
+  ///
+  /// \param[in] pointCloud Point cloud relative to frame. Points represent the
+  /// end points of the rays from the sensor origin.
+  /// \param[in] sensorOrigin Origin of sensor relative to frame.
+  /// \param[in] inCoordinatesOf Reference frame, determines transform to be
+  /// applied to point cloud and sensor origin.
   void updateOccupancy(
       const octomap::Pointcloud& pointCloud,
-      const octomap::point3d& sensorOrigin);
+      const Eigen::Vector3d& sensorOrigin,
+      const Frame* inCoordinatesOf = Frame::World());
+
+  /// Integrates a 3D ray cloud sensor measurement.
+  ///
+  /// \param[in] pointCloud Point cloud relative to frame. Points represent the
+  /// end points of the rays from the sensor origin.
+  /// \param[in] sensorOrigin Origin of sensor relative to frame.
+  /// \param[in] inCoordinatesOf Reference frame, determines transform to be
+  /// applied to point cloud and sensor origin.
+  void updateOccupancy(
+      const octomap::Pointcloud& pointCloud,
+      const Eigen::Vector3d& sensorOrigin,
+      const Eigen::Isometry3d& inCoordinatesOf);
 
   /// Returns occupancy probability of a node that contains \c point.
   double getOccupancy(const Eigen::Vector3d& point) const;

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -102,10 +102,10 @@ public:
   /// Note that the probability is computed by both of the current probability
   /// and the new sensor measurement.
   ///
-  /// The voxels of the end points of rays will increase the probability because
-  /// that's where the ray hit an object. On the other hand, the voxels that the
-  /// rays pass through will decreases the probabilities because it mean there
-  /// are no objects where the rays passed.
+  /// The voxels where the ray endpoints are located will increase the
+  /// probabilities because that’s where the rays hit objects. On the other
+  /// hand, the voxels that the rays pass through will decrease the
+  /// probabilities because it means there are no objects.
   ///
   /// \param[in] pointCloud Point cloud relative to frame. Points represent the
   /// end points of the rays from the sensor origin.
@@ -122,10 +122,10 @@ public:
   /// Note that the probability is computed by both of the current probability
   /// and the new sensor measurement.
   ///
-  /// The voxels of the end points of rays will increase the probability because
-  /// that's where the ray hit an object. On the other hand, the voxels that the
-  /// rays pass through will decreases the probabilities because it mean there
-  /// are no objects where the rays passed.
+  /// The voxels where the ray endpoints are located will increase the
+  /// probabilities because that’s where the rays hit objects. On the other
+  /// hand, the voxels that the rays pass through will decrease the
+  /// probabilities because it means there are no objects.
   ///
   /// \param[in] pointCloud Point cloud relative to frame. Points represent the
   /// end points of the rays from the sensor origin.

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -100,7 +100,7 @@ public:
   /// applied to point cloud and sensor origin.
   void updateOccupancy(
       const octomap::Pointcloud& pointCloud,
-      const Eigen::Vector3d& sensorOrigin,
+      const Eigen::Vector3d& sensorOrigin = Eigen::Vector3d::Zero(),
       const Frame* inCoordinatesOf = Frame::World());
 
   /// Integrates a 3D ray cloud sensor measurement.

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -45,8 +45,6 @@
 namespace dart {
 namespace dynamics {
 
-class Frame;
-
 /// VoxelGridShape represents a probabilistic 3D occupancy voxel grid.
 class VoxelGridShape : public Shape
 {
@@ -77,43 +75,67 @@ public:
   /// Returns octree.
   fcl_shared_ptr<const octomap::OcTree> getOctree() const;
 
-  /// Integrates a sensor measurement at \c point. The occupancy probability of
-  /// a node that contains \c point will be updated based on the value of
-  /// \c occupied; true will increase while false will decrease.
+  /// Updates the occupancy probability of the voxels where \c point is located.
+  ///
+  /// Note that the probability is computed by both of the current probability
+  /// and the new sensor measurement.
   ///
   /// \param[in] point Location of the sensor measurement.
   /// \param[in] occupied True if the location was measured occupied.
   void updateOccupancy(const Eigen::Vector3d& point, bool occupied = true);
 
-  /// Inserts a ray between \c from and \c to into the voxel grid.
+  /// Updates the occupancy probability of the voxels given sensor measurement,
+  /// which is a single ray.
+  ///
+  /// Note that the probability is computed by both of the current probability
+  /// and the new sensor measurement.
+  ///
+  /// If you have a ray cloud, then using updateOccupancy(PointClout, ...) is
+  /// more efficient.
   ///
   /// \param from Origin of sensor in global coordinates.
   /// \param to Endpoint of measurement in global coordinates.
   void updateOccupancy(const Eigen::Vector3d& from, const Eigen::Vector3d& to);
 
-  /// Integrates a 3D ray cloud sensor measurement.
+  /// Updates the occupancy probability of the voxels given sensor measurement.
+  ///
+  /// Note that the probability is computed by both of the current probability
+  /// and the new sensor measurement.
+  ///
+  /// The voxels of the end points of rays will increase the probability because
+  /// that's where the ray hit an object. On the other hand, the voxles that the
+  /// rays pass through will decreases the probabilities because it mean there
+  /// are no objects where the rays passed.
   ///
   /// \param[in] pointCloud Point cloud relative to frame. Points represent the
   /// end points of the rays from the sensor origin.
   /// \param[in] sensorOrigin Origin of sensor relative to frame.
-  /// \param[in] inCoordinatesOf Reference frame, determines transform to be
+  /// \param[in] relativeTo Reference frame, determines transform to be
   /// applied to point cloud and sensor origin.
   void updateOccupancy(
       const octomap::Pointcloud& pointCloud,
       const Eigen::Vector3d& sensorOrigin = Eigen::Vector3d::Zero(),
-      const Frame* inCoordinatesOf = Frame::World());
+      const Frame* relativeTo = Frame::World());
 
-  /// Integrates a 3D ray cloud sensor measurement.
+  /// Updates the occupancy probability of the voxels given sensor measurement.
+  ///
+  /// Note that the probability is computed by both of the current probability
+  /// and the new sensor measurement.
+  ///
+  /// The voxels of the end points of rays will increase the probability because
+  /// that's where the ray hit an object. On the other hand, the voxles that the
+  /// rays pass through will decreases the probabilities because it mean there
+  /// are no objects where the rays passed.
   ///
   /// \param[in] pointCloud Point cloud relative to frame. Points represent the
   /// end points of the rays from the sensor origin.
   /// \param[in] sensorOrigin Origin of sensor relative to frame.
-  /// \param[in] inCoordinatesOf Reference frame, determines transform to be
+  /// \param[in] relativeTo Reference frame, determines transform to be
   /// applied to point cloud and sensor origin.
   void updateOccupancy(
       const octomap::Pointcloud& pointCloud,
       const Eigen::Vector3d& sensorOrigin,
-      const Eigen::Isometry3d& inCoordinatesOf);
+      const Eigen::Isometry3d& relativeTo);
 
   /// Returns occupancy probability of a node that contains \c point.
   double getOccupancy(const Eigen::Vector3d& point) const;

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -103,7 +103,7 @@ public:
   /// and the new sensor measurement.
   ///
   /// The voxels of the end points of rays will increase the probability because
-  /// that's where the ray hit an object. On the other hand, the voxles that the
+  /// that's where the ray hit an object. On the other hand, the voxels that the
   /// rays pass through will decreases the probabilities because it mean there
   /// are no objects where the rays passed.
   ///
@@ -123,7 +123,7 @@ public:
   /// and the new sensor measurement.
   ///
   /// The voxels of the end points of rays will increase the probability because
-  /// that's where the ray hit an object. On the other hand, the voxles that the
+  /// that's where the ray hit an object. On the other hand, the voxels that the
   /// rays pass through will decreases the probabilities because it mean there
   /// are no objects where the rays passed.
   ///


### PR DESCRIPTION
This PR adds more occupancy update functions that can specify reference frame of the sensor origin and the point cloud.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
