### PR TITLE
Add option to DartResourceRetriever to search from environment variable DART_DATA_PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ### [DART 6.6.1 (2018-08-04)](https://github.com/dartsim/dart/milestone/46?closed=1)
 
+* Utils
+
+  * Added option to DartResourceRetriever to search from environment variable DART_DATA_PATH: [#1095](https://github.com/dartsim/dart/pull/1095)
+
 * Examples
 
-  * Fix CMakeLists.txt of humanJointLimits: [#1094](https://github.com/dartsim/dart/pull/1094)
+  * Fixed CMakeLists.txt of humanJointLimits: [#1094](https://github.com/dartsim/dart/pull/1094)
 
 ### [DART 6.6.0 (2018-08-02)](https://github.com/dartsim/dart/milestone/44?closed=1)
 
@@ -368,7 +372,7 @@
 1. Improved camera movement of OpenGL GUI: smooth zooming and translation 
     * [Pull request #843](https://github.com/dartsim/dart/pull/843)
 
-1. Removed debian meta files from the main DART repository
+2. Removed debian meta files from the main DART repository
     * [Pull request #853](https://github.com/dartsim/dart/pull/853)
 
 ### Version 5.1.5 (2017-01-20)

--- a/dart/utils/DartResourceRetriever.hpp
+++ b/dart/utils/DartResourceRetriever.hpp
@@ -40,7 +40,6 @@
 namespace dart {
 namespace utils {
 
-///
 /// Retrieve local resources from sample data files given file URI. The scheme
 /// and authority should be "file" and "sample", respectively.
 ///
@@ -54,14 +53,13 @@ namespace utils {
 /// @endcode
 ///
 /// DartResourceRetriever searches files in the following order:
-/// 1) DART_DATA_LOCAL_PATH: path to the data directory in source
-///    (e.g., [DART_SRC_ROOT]/data/).
-/// 2) DART_DATA_GLOBAL_PATH: path to the data directory installed at a system
-///    directory. The location can be varied depending on OS.
-///    (e.g., Linux: /usr/local/share/doc/dart/data/)
-/// where DART_DATA_LOCAL_PATH and DART_DATA_GLOBAL_PATH are defined in
-/// config.hpp that are determined in CMake time.
-///
+/// 1) Preprocessor, DART_DATA_LOCAL_PATH: Path to the data directory in the
+///    source directory (e.g., [DART_SRC_ROOT]/data/).
+/// 2) Preprocessor, DART_DATA_GLOBAL_PATH: Path to the data directory installed
+///    in a system directory. The location can be varied depending on OS
+///    (e.g., Linux: /usr/local/share/doc/dart/data/).
+/// 3) environment variable, DART_DATA_PATH: Path to the data directory
+///    specified by the user.
 class DartResourceRetriever : public common::ResourceRetriever
 {
 public:
@@ -76,7 +74,7 @@ public:
   DartResourceRetriever();
 
   /// Destructor.
-  virtual ~DartResourceRetriever() = default;
+  ~DartResourceRetriever() override = default;
 
   // Documentation inherited.
   bool exists(const common::Uri& uri) override;


### PR DESCRIPTION
This PR adds a fallback option to `DartResourceRetriever` to use an environment variable to search DART data files. The existing preprocessor, `DART_DATA_GLOBAL_PATH`, doesn't work if the package manager uses temporary install directory (e.g., Launchpad PPA and Homebrew).

This should resolve #1091 and https://github.com/dartsim/homebrew-dart/issues/54.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
