### PR TITLE
Fix for aligned in newer compilers/ubuntu 18.04

### DIFF
--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -146,9 +146,9 @@ if(DART_ENABLE_SIMD)
     # in CMake time, then I would gratefully apply these options differently
     # depending on the architectures.
   elseif(CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(dart PUBLIC -march=native)
+    target_compile_options(dart PUBLIC -march=native -faligned-new)
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(dart PUBLIC -march=native)
+    target_compile_options(dart PUBLIC -march=native -faligned-new)
   endif()
 endif()
 


### PR DESCRIPTION
In a clean (X)Ubuntu 18.04 installation, when compiling with SIMD option (native flags) and gcc (version=7.3.0) or clang (version=6.0.0), some tests (and examples) fail because of segfaults.

The flag `-faligned-new` solves the issue (alternatively, one could enable C++17, but this flag enables just the right feature for the job). This also happened with clang. I do not know (and I cannot test) what happens for Visual Studio, so I left it untouched.

Let me know if you can reproduce the error and if there's another way of making it work.