### PR TITLE
Remove deleted default constructors of AspectWith[StateAnd]VersionedProperties

### DIFF
--- a/dart/common/AspectWithVersion.hpp
+++ b/dart/common/AspectWithVersion.hpp
@@ -88,7 +88,6 @@ public:
       DerivedT, StateDataT, PropertiesDataT, CompositeT,
       updateState, updateProperties>;
 
-  AspectWithStateAndVersionedProperties() = delete;
   AspectWithStateAndVersionedProperties(
       const AspectWithStateAndVersionedProperties&) = delete;
 

--- a/dart/common/detail/AspectWithVersion.hpp
+++ b/dart/common/detail/AspectWithVersion.hpp
@@ -117,7 +117,6 @@ public:
   using AspectImplementation = AspectWithVersionedProperties<
       Base, Derived, PropertiesData, CompositeT, updateProperties>;
 
-  AspectWithVersionedProperties() = delete;
   AspectWithVersionedProperties(const AspectWithVersionedProperties&) = delete;
 
   /// Construct using a PropertiesData instance


### PR DESCRIPTION
The default constructors of `AspectWith[StateAnd]VersionedProperties` are deleted, but the other constructors of them actually allow to create them without parameters because of their default parameter values. This leads to a compilation error of an ambiguous function call when creating them without parameters. This PR removes the delete declarations of the default constructors.
