### PR TITLE
Fix compilation on Ubuntu 18.04, g++8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### DART 7.0.0 (201X-XX-XX)
 
+* Build system
+
+  * Fix compilation warnings for newer versions of compilers: [#1174](https://github.com/dartsim/dart/pull/1174)
+
 * Collision detection
 
   * Added FCL 0.6 support: [#873](https://github.com/dartsim/dart/pull/873)
@@ -17,10 +21,6 @@
 ## DART 6
 
 ### DART 6.7.0 (201X-XX-XX)
-
-* Build system
-
-  * Fix compilation warnings for newer versions of compilers: [#1174](https://github.com/dartsim/dart/pull/1174)
 
 * Dynamics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 ### DART 6.7.0 (201X-XX-XX)
 
+* Build system
+
+  * Fix compilation warnings for newer versions of compilers: [#1174](https://github.com/dartsim/dart/pull/1174)
+
 * Dynamics
 
   * Refactor constraint solver: [#1099](https://github.com/dartsim/dart/pull/1099), [#1101](https://github.com/dartsim/dart/pull/1101)

--- a/dart/external/imgui/CMakeLists.txt
+++ b/dart/external/imgui/CMakeLists.txt
@@ -12,6 +12,10 @@ include_directories(
   PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+  target_compile_options(dart-external-imgui PRIVATE -w)
+endif()
+
 # Component
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})

--- a/dart/gui/osg/DefaultEventHandler.cpp
+++ b/dart/gui/osg/DefaultEventHandler.cpp
@@ -331,7 +331,6 @@ bool DefaultEventHandler::handle(const ::osgGA::GUIEventAdapter& ea,
         {
           mViewer->switchHeadlights(!mViewer->checkHeadlights());
           return true;
-          break;
         }
 
         case ' ':
@@ -344,6 +343,7 @@ bool DefaultEventHandler::handle(const ::osgGA::GUIEventAdapter& ea,
           break;
         }
       }
+      break;
     }
 
     case ::osgGA::GUIEventAdapter::MOVE:


### PR DESCRIPTION
It seems that there are compilation issues with recent versions of GCC (and maybe Clang) when compiling with the setting that warnings are errors, because some new warnings have been introduced.

This PR is a quick and dirty attempt to just make sure dartsim can compile with these new versions. There are two changes:

1. Disable warnings for imgui, which is an external dependency that we've copy/dumped into our codebase. If the warning is something worth fixing, then we should fix it upstream before copying it into here, instead of just fixing it locally.

2. There's a new warning for [implicit fallthroughs](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/) so I've just added a break (which probably should've been there to begin with :sweat_smile:, so good job new warning!)

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
