### PR TITLE
Disable build with pagmo on macOS

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -16,6 +16,6 @@ brew 'libccd'
 brew 'octomap'
 brew 'ode'
 brew 'open-scene-graph'
-brew 'pagmo'
+#brew 'pagmo'  # disabled to reduce the build time
 brew 'tinyxml2'
 brew 'urdfdom'


### PR DESCRIPTION
Building with `pagmo` solver increases the build time that leads to time out for Travis CI's maximum build time (fails all the time because of this). So this PR disables it.

It'd be great to test all the components of DART, but it also has no point if it fails all the time due to the exceeding build time limit.