### PR TITLE
Fix aligned for old gcc compilers

### DIFF
--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -150,11 +150,10 @@ if(DART_ENABLE_SIMD)
     # in CMake time, then I would gratefully apply these options differently
     # depending on the architectures.
   elseif(CMAKE_COMPILER_IS_GNUCXX)
-    set(native_flags "-march=native")
+    target_compile_options(dart PUBLIC -march=native)
     if(GCC_VERSION VERSION_GREATER 7.0)
-      set(native_flags "-march=native;-faligned-new")
+      target_compile_options(dart PUBLIC -faligned-new)
     endif()
-    target_compile_options(dart PUBLIC ${native_flags})
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     target_compile_options(dart PUBLIC -march=native -faligned-new)
   endif()

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -150,7 +150,11 @@ if(DART_ENABLE_SIMD)
     # in CMake time, then I would gratefully apply these options differently
     # depending on the architectures.
   elseif(CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(dart PUBLIC -march=native -faligned-new)
+    set(native_flags "-march=native")
+    if(GCC_VERSION VERSION_GREATER 7.0)
+      set(native_flags "-march=native;-faligned-new")
+    endif()
+    target_compile_options(dart PUBLIC ${native_flags})
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     target_compile_options(dart PUBLIC -march=native -faligned-new)
   endif()


### PR DESCRIPTION
Coming back to #1116, because it seems that in some older versions of gcc (e.g., I have 5.4 in my second computer) we get `unrecognized command line argument '-faligned-new'`. This should activate the argument only when required (and doesn't break the compilation). In clang compilers I did not notice the same (I tested with clang 4.0)..