### PR TITLE
Generate namespace headers without requiring *.hpp.in files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Build system
 
-  * Fix compilation warnings for newer versions of compilers: [#1177](https://github.com/dartsim/dart/pull/1177)
+  * Fixed compilation warnings for newer versions of compilers: [#1177](https://github.com/dartsim/dart/pull/1177)
+  * Changed to generate namespace headers without requiring *.hpp.in files: [#1192](https://github.com/dartsim/dart/pull/1192)
 
 * Collision Detection
 
@@ -299,7 +300,7 @@
 
 * Common data structures
 
-  * Added `Node`, `Aspect`, `State`, and `Properties`: [#713](https://github.com/dartsim/dart/pull/713), [#712](https://github.com/dartsim/dart/issues/712), [#708](https://github.com/dartsim/dart/pull/708), [#707](https://github.com/dartsim/dart/pull/707), [#659](https://github.com/dartsim/dart/pull/659), [#649](https://github.com/dartsim/dart/pull/649), [#645](https://github.com/dartsim/dart/issues/645), [#607](https://github.com/dartsim/dart/pull/607), [#598](https://github.com/dartsim/dart/pull/598), [#591](https://github.com/dartsim/dart/pull/591), [#531](https://github.com/dartsim/dart/pull/531) 
+  * Added `Node`, `Aspect`, `State`, and `Properties`: [#713](https://github.com/dartsim/dart/pull/713), [#712](https://github.com/dartsim/dart/issues/712), [#708](https://github.com/dartsim/dart/pull/708), [#707](https://github.com/dartsim/dart/pull/707), [#659](https://github.com/dartsim/dart/pull/659), [#649](https://github.com/dartsim/dart/pull/649), [#645](https://github.com/dartsim/dart/issues/645), [#607](https://github.com/dartsim/dart/pull/607), [#598](https://github.com/dartsim/dart/pull/598), [#591](https://github.com/dartsim/dart/pull/591), [#531](https://github.com/dartsim/dart/pull/531)
   * Added mathematical constants and user-defined literals for radian, degree, and pi: [#669](https://github.com/dartsim/dart/pull/669), [#314](https://github.com/dartsim/dart/issues/314)
   * Added `ShapeFrame` and `ShapeNode`: [#608](https://github.com/dartsim/dart/pull/608)
   * Added `BoundingBox`: [#547](https://github.com/dartsim/dart/pull/547), [#546](https://github.com/dartsim/dart/issues/546)
@@ -402,7 +403,7 @@
 
 ### Version 5.1.6 (2017-08-08)
 
-1. Improved camera movement of OpenGL GUI: smooth zooming and translation 
+1. Improved camera movement of OpenGL GUI: smooth zooming and translation
     * [Pull request #843](https://github.com/dartsim/dart/pull/843)
 
 2. Removed debian meta files from the main DART repository

--- a/cmake/DARTMacros.cmake
+++ b/cmake/DARTMacros.cmake
@@ -43,6 +43,8 @@ macro(dart_get_subdir_list var curdir)
 endmacro()
 
 #===============================================================================
+# DEPRECATED in 6.7 (see #1081)
+#
 # Generate header file list to a cached list.
 # Usage:
 #   dart_generate_include_header_list(_var _target_dir _cacheDesc [headers...])
@@ -55,6 +57,18 @@ macro(dart_generate_include_header_list _var _target_dir _cacheDesc)
       ${_cacheDesc}"_HEADERS"
       "#include \"${_target_dir}${header}\"\n"
     )
+  endforeach()
+endmacro()
+
+#===============================================================================
+# Generate header file.
+# Usage:
+#   dart_generate_include_header_file(file_path target_dir [headers...])
+#===============================================================================
+macro(dart_generate_include_header_file file_path target_dir)
+  file(WRITE ${file_path} "// Automatically generated file by cmake\n\n")
+  foreach(header ${ARGN})
+    file(APPEND ${file_path} "#include \"${target_dir}${header}\"\n")
   endforeach()
 endmacro()
 

--- a/dart/collision/CMakeLists.txt
+++ b/dart/collision/CMakeLists.txt
@@ -16,15 +16,10 @@ set(
   dart/dart.hpp
   fcl/fcl.hpp
 )
-dart_generate_include_header_list(
-  collision_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/collision.hpp"
   "dart/collision/"
-  "collision headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/collision.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/collision.hpp
 )
 
 # Install

--- a/dart/collision/bullet/CMakeLists.txt
+++ b/dart/collision/bullet/CMakeLists.txt
@@ -71,15 +71,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "collision_bullet headers" ${hdrs})
-dart_generate_include_header_list(
-  collision_bullet_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/bullet.hpp"
   "dart/collision/bullet/"
-  "collision_bullet headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/bullet.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/bullet.hpp
 )
 
 # Install

--- a/dart/collision/collision.hpp.in
+++ b/dart/collision/collision.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${collision_headers}

--- a/dart/collision/dart/CMakeLists.txt
+++ b/dart/collision/dart/CMakeLists.txt
@@ -6,15 +6,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "collision_dart headers" ${hdrs})
-dart_generate_include_header_list(
-  collision_dart_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/dart.hpp"
   "dart/collision/dart/"
-  "collision_dart headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/dart.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/dart.hpp
 )
 
 # Install

--- a/dart/collision/fcl/CMakeLists.txt
+++ b/dart/collision/fcl/CMakeLists.txt
@@ -6,15 +6,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "collision_fcl headers" ${hdrs})
-dart_generate_include_header_list(
-  collision_fcl_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/fcl.hpp"
   "dart/collision/fcl/"
-  "collision_fcl headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/fcl.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/fcl.hpp
 )
 
 # Install

--- a/dart/collision/ode/CMakeLists.txt
+++ b/dart/collision/ode/CMakeLists.txt
@@ -31,15 +31,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "collision_ode headers" ${hdrs})
-dart_generate_include_header_list(
-  collision_ode_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/ode.hpp"
   "dart/collision/ode/"
-  "collision_ode headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/ode.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/ode.hpp
 )
 
 # Install

--- a/dart/common/CMakeLists.txt
+++ b/dart/common/CMakeLists.txt
@@ -8,15 +8,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "common headers" ${hdrs})
-dart_generate_include_header_list(
-  common_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/common.hpp"
   "dart/common/"
-  "common headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/common.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/common.hpp
 )
 
 # Install

--- a/dart/common/common.hpp.in
+++ b/dart/common/common.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${common_headers}

--- a/dart/constraint/CMakeLists.txt
+++ b/dart/constraint/CMakeLists.txt
@@ -8,15 +8,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "constraint headers" ${hdrs})
-dart_generate_include_header_list(
-  constraint_headers
-  "dart/constraint/"
-  "constraint headers"
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/constraints.hpp"
+  "dart/constraints/"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/constraint.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/constraint.hpp
 )
 
 # Install

--- a/dart/constraint/CMakeLists.txt
+++ b/dart/constraint/CMakeLists.txt
@@ -9,8 +9,8 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 # Generate header for this namespace
 dart_get_filename_components(header_names "constraint headers" ${hdrs})
 dart_generate_include_header_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/constraints.hpp"
-  "dart/constraints/"
+  "${CMAKE_CURRENT_BINARY_DIR}/constraint.hpp"
+  "dart/constraint/"
   ${header_names}
 )
 

--- a/dart/constraint/constraint.hpp.in
+++ b/dart/constraint/constraint.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${constraint_headers}

--- a/dart/dynamics/CMakeLists.txt
+++ b/dart/dynamics/CMakeLists.txt
@@ -10,15 +10,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 dart_get_filename_components(header_names "dynamics headers" ${hdrs})
 # TODO: remove below line once the files are completely removed.
 list(REMOVE_ITEM header_names "MultiSphereShape.hpp")
-dart_generate_include_header_list(
-  dynamics_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/dynamics.hpp"
   "dart/dynamics/"
-  "dynamics headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/dynamics.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/dynamics.hpp
 )
 
 # Install

--- a/dart/dynamics/dynamics.hpp.in
+++ b/dart/dynamics/dynamics.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${dynamics_headers}

--- a/dart/gui/CMakeLists.txt
+++ b/dart/gui/CMakeLists.txt
@@ -97,15 +97,10 @@ set(
   ${header_names}
   glut/glut.hpp
 )
-dart_generate_include_header_list(
-  gui_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/gui.hpp"
   "dart/gui/"
-  "gui headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/gui.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/gui.hpp
 )
 
 # Install

--- a/dart/gui/glut/CMakeLists.txt
+++ b/dart/gui/glut/CMakeLists.txt
@@ -6,15 +6,10 @@ dart_add_gui_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "gui_glut_headers headers" ${hdrs})
-dart_generate_include_header_list(
-  gui_glut_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/glut.hpp"
   "dart/gui/glut/"
-  "gui_glut_headers headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/glut.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/glut.hpp
 )
 
 # Install

--- a/dart/gui/gui.hpp.in
+++ b/dart/gui/gui.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${gui_headers}

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -76,15 +76,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} gui)
 # Generate header for this namespace
 dart_get_filename_components(header_names "gui osg headers" ${hdrs})
 list(APPEND header_names "render/render.hpp")
-dart_generate_include_header_list(
-  gui_osg_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/osg.hpp"
   "dart/gui/osg/"
-  "gui osg headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/osg.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
 )
 
 # Install

--- a/dart/gui/osg/render/CMakeLists.txt
+++ b/dart/gui/osg/render/CMakeLists.txt
@@ -6,15 +6,10 @@ set(dart_gui_osg_hdrs ${dart_gui_osg_hdrs} ${hdrs} PARENT_SCOPE)
 set(dart_gui_osg_srcs ${dart_gui_osg_srcs} ${srcs} PARENT_SCOPE)
 
 dart_get_filename_components(header_names "gui osg render headers" ${hdrs})
-dart_generate_include_header_list(
-  gui_osg_render_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/render.hpp"
   "dart/gui/osg/render/"
-  "gui osg render headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/render.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/render.hpp
 )
 
 # Install

--- a/dart/integration/CMakeLists.txt
+++ b/dart/integration/CMakeLists.txt
@@ -6,15 +6,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "integration headers" ${hdrs})
-dart_generate_include_header_list(
-  integration_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/integration.hpp"
   "dart/integration/"
-  "integration headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/integration.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/integration.hpp
 )
 
 # Install

--- a/dart/integration/integration.hpp.in
+++ b/dart/integration/integration.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${integration_headers}

--- a/dart/lcpsolver/CMakeLists.txt
+++ b/dart/lcpsolver/CMakeLists.txt
@@ -6,15 +6,10 @@ dart_add_core_sources(${srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "lcpsolver headers" ${hdrs})
-dart_generate_include_header_list(
-  lcpsolver_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/lcpsolver.hpp"
   "dart/lcpsolver/"
-  "lcpsolver headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/lcpsolver.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/lcpsolver.hpp
 )
 
 # Install

--- a/dart/lcpsolver/lcpsolver.hpp.in
+++ b/dart/lcpsolver/lcpsolver.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${lcpsolver_headers}

--- a/dart/math/CMakeLists.txt
+++ b/dart/math/CMakeLists.txt
@@ -8,15 +8,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "math headers" ${hdrs})
-dart_generate_include_header_list(
-  math_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/math.hpp"
   "dart/math/"
-  "math headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/math.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/math.hpp
 )
 
 # Install

--- a/dart/math/math.hpp.in
+++ b/dart/math/math.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${math_headers}

--- a/dart/optimizer/CMakeLists.txt
+++ b/dart/optimizer/CMakeLists.txt
@@ -6,15 +6,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "optimizer headers" ${hdrs})
-dart_generate_include_header_list(
-  optimizer_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/optimizer.hpp"
   "dart/optimizer/"
-  "optimizer headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/optimizer.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/optimizer.hpp
 )
 
 # Install

--- a/dart/optimizer/ipopt/CMakeLists.txt
+++ b/dart/optimizer/ipopt/CMakeLists.txt
@@ -22,15 +22,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "optimizer_ipopt headers" ${hdrs})
-dart_generate_include_header_list(
-  optimizer_ipopt_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/ipopt.hpp"
   "dart/optimizer/ipopt/"
-  "optimizer_ipopt headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/ipopt.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/ipopt.hpp
 )
 
 # Install

--- a/dart/optimizer/nlopt/CMakeLists.txt
+++ b/dart/optimizer/nlopt/CMakeLists.txt
@@ -22,15 +22,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "optimizer_nlopt headers" ${hdrs})
-dart_generate_include_header_list(
-  optimizer_nlopt_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/nlopt.hpp"
   "dart/optimizer/nlopt/"
-  "optimizer_nlopt headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/nlopt.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/nlopt.hpp
 )
 
 # Install

--- a/dart/optimizer/optimizer.hpp.in
+++ b/dart/optimizer/optimizer.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${optimizer_headers}

--- a/dart/optimizer/pagmo/CMakeLists.txt
+++ b/dart/optimizer/pagmo/CMakeLists.txt
@@ -35,15 +35,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "optimizer_pagmo headers" ${hdrs})
-dart_generate_include_header_list(
-  optimizer_pagmo_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/pagmo.hpp"
   "dart/optimizer/pagmo/"
-  "optimizer_pagmo headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/pagmo.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/pagmo.hpp
 )
 
 # Install

--- a/dart/optimizer/snopt/CMakeLists.txt
+++ b/dart/optimizer/snopt/CMakeLists.txt
@@ -11,15 +11,10 @@ target_link_libraries(dart-optimizer-snopt dart)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "optimizer_snopt headers" ${hdrs})
-dart_generate_include_header_list(
-  optimizer_snopt_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/snopt.hpp"
   "dart/optimizer/snopt/"
-  "optimizer_snopt headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/snopt.h.in
-  ${CMAKE_CURRENT_BINARY_DIR}/snopt.h
 )
 
 # Install

--- a/dart/planning/CMakeLists.txt
+++ b/dart/planning/CMakeLists.txt
@@ -29,15 +29,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
 
 ## Generate header for this namespace
 dart_get_filename_components(header_names "planning headers" ${hdrs})
-dart_generate_include_header_list(
-  planning_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/planning.hpp"
   "dart/planning/"
-  "planning headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/planning.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/planning.hpp
 )
 
 ## Install

--- a/dart/planning/planning.hpp.in
+++ b/dart/planning/planning.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${planning_headers}

--- a/dart/simulation/CMakeLists.txt
+++ b/dart/simulation/CMakeLists.txt
@@ -8,15 +8,10 @@ dart_add_core_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "simulation headers" ${hdrs})
-dart_generate_include_header_list(
-  simulation_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/simulation.hpp"
   "dart/simulation/"
-  "simulation headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/simulation.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/simulation.hpp
 )
 
 # Install

--- a/dart/simulation/simulation.hpp.in
+++ b/dart/simulation/simulation.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${simulation_headers}

--- a/dart/utils/CMakeLists.txt
+++ b/dart/utils/CMakeLists.txt
@@ -52,15 +52,10 @@ set(
   ${header_names}
   sdf/sdf.hpp
 )
-dart_generate_include_header_list(
-  utils_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/utils.hpp"
   "dart/utils/"
-  "utils headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/utils.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/utils.hpp
 )
 
 # Install

--- a/dart/utils/sdf/CMakeLists.txt
+++ b/dart/utils/sdf/CMakeLists.txt
@@ -7,15 +7,10 @@ dart_add_utils_headers(${srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "utils_sdf headers" ${hdrs})
-dart_generate_include_header_list(
-  utils_sdf_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/sdf.hpp"
   "dart/utils/sdf/"
-  "utils_sdf headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/sdf.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/sdf.hpp
 )
 
 # Install

--- a/dart/utils/urdf/CMakeLists.txt
+++ b/dart/utils/urdf/CMakeLists.txt
@@ -64,15 +64,10 @@ add_component_dependencies(${PROJECT_NAME} ${component_name} utils)
 dart_get_filename_components(header_names "utils_urdf headers" ${hdrs})
 # TODO: remove below line once the files are completely removed.
 list(REMOVE_ITEM header_names "URDFTypes.hpp")
-dart_generate_include_header_list(
-  utils_urdf_headers
+dart_generate_include_header_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/urdf.hpp"
   "dart/utils/urdf/"
-  "utils_urdf headers"
   ${header_names}
-)
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/urdf.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/urdf.hpp
 )
 
 # Install

--- a/dart/utils/utils.hpp.in
+++ b/dart/utils/utils.hpp.in
@@ -1,3 +1,0 @@
-// Automatically generated file by cmake
-
-${utils_headers}


### PR DESCRIPTION
This PR simplifies the process of generating namespace headers by not requiring `*.hpp.in` files. This also resolves #1081.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
