### PR TITLE
Fix cmake syntax mistake

### DIFF
--- a/examples/humanJointLimits/InSourceBuild.cmake
+++ b/examples/humanJointLimits/InSourceBuild.cmake
@@ -16,8 +16,11 @@ if(NOT TinyDNN_FOUND)
   return()
 endif()
 
-find_package(Threads)
-if(NOT Threads_FOUND QUIET)
+find_package(Threads QUIET)
+if(NOT Threads_FOUND)
+  if(DART_VERBOSE)
+    message(STATUS "Failed to find Threads. humanJointLimits is disabled.")
+  endif()
   return()
 endif()
 


### PR DESCRIPTION
A quick fix of CMake syntax error introduced in #1207.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
