### PR TITLE
Import dependency targets when loading DARTConfig.cmake

### DIFF
--- a/cmake/DARTFindurdfdom.cmake
+++ b/cmake/DARTFindurdfdom.cmake
@@ -1,0 +1,24 @@
+# Copyright (c) 2011-2018, The DART development contributors
+# All rights reserved.
+#
+# The list of contributors can be found at:
+#   https://github.com/dartsim/dart/blob/master/LICENSE
+#
+# This file is provided under the "BSD-style" License
+
+find_package(urdfdom QUIET)
+if(urdfdom_FOUND)
+  if(DART_VERBOSE)
+    message(STATUS "Looking for urdfdom - ${urdfdom_headers_VERSION} found")
+  endif()
+else()
+  message(STATUS "Looking for urdfdom - NOT found, please install liburdfdom-dev")
+  return()
+endif()
+if(MSVC)
+  set(urdfdom_LIBRARIES optimized urdfdom_sensor      debug urdfdom_sensord
+                        optimized urdfdom_model_state debug urdfdom_model_stated
+                        optimized urdfdom_model       debug urdfdom_modeld
+                        optimized urdfdom_world       debug urdfdom_worldd
+                        optimized console_bridge      debug console_bridged)
+endif()

--- a/cmake/DARTFindurdfdom.cmake
+++ b/cmake/DARTFindurdfdom.cmake
@@ -7,18 +7,3 @@
 # This file is provided under the "BSD-style" License
 
 find_package(urdfdom QUIET)
-if(urdfdom_FOUND)
-  if(DART_VERBOSE)
-    message(STATUS "Looking for urdfdom - ${urdfdom_headers_VERSION} found")
-  endif()
-else()
-  message(STATUS "Looking for urdfdom - NOT found, please install liburdfdom-dev")
-  return()
-endif()
-if(MSVC)
-  set(urdfdom_LIBRARIES optimized urdfdom_sensor      debug urdfdom_sensord
-                        optimized urdfdom_model_state debug urdfdom_model_stated
-                        optimized urdfdom_model       debug urdfdom_modeld
-                        optimized urdfdom_world       debug urdfdom_worldd
-                        optimized console_bridge      debug console_bridged)
-endif()

--- a/cmake/DARTMacros.cmake
+++ b/cmake/DARTMacros.cmake
@@ -77,6 +77,15 @@ endmacro()
 # Usage:
 #   dart_add_library(_libname source1 [source2 ...])
 #===============================================================================
+function(dart_find_package _name)
+  include(DARTFind${_name})
+endfunction()
+
+#===============================================================================
+# Add library and set target properties
+# Usage:
+#   dart_add_library(_libname source1 [source2 ...])
+#===============================================================================
 macro(dart_add_library _name)
   add_library(${_name} ${ARGN})
   set_target_properties(

--- a/cmake/DARTMacros.cmake
+++ b/cmake/DARTMacros.cmake
@@ -77,9 +77,9 @@ endmacro()
 # Usage:
 #   dart_add_library(_libname source1 [source2 ...])
 #===============================================================================
-function(dart_find_package _name)
+macro(dart_find_package _name)
   include(DARTFind${_name})
-endfunction()
+endmacro()
 
 #===============================================================================
 # Add library and set target properties

--- a/dart/utils/urdf/CMakeLists.txt
+++ b/dart/utils/urdf/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 add_component_dependencies(${PROJECT_NAME} ${component_name} utils)
-add_component_dependent_packages(${PROJECT_NAME} ${component_name} urdfdom)
+add_component_dependency_packages(${PROJECT_NAME} ${component_name} urdfdom)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "utils_urdf headers" ${hdrs})

--- a/dart/utils/urdf/CMakeLists.txt
+++ b/dart/utils/urdf/CMakeLists.txt
@@ -1,20 +1,5 @@
 # Dependency checks
-find_package(urdfdom QUIET)
-if(urdfdom_FOUND)
-  if(DART_VERBOSE)
-    message(STATUS "Looking for urdfdom - ${urdfdom_headers_VERSION} found")
-  endif()
-else()
-  message(STATUS "Looking for urdfdom - NOT found, please install liburdfdom-dev")
-  return()
-endif()
-if(MSVC)
-  set(urdfdom_LIBRARIES optimized urdfdom_sensor      debug urdfdom_sensord
-                        optimized urdfdom_model_state debug urdfdom_model_stated
-                        optimized urdfdom_model       debug urdfdom_modeld
-                        optimized urdfdom_world       debug urdfdom_worldd
-                        optimized console_bridge      debug console_bridged)
-endif()
+dart_find_package(urdfdom)
 
 # Search all header and source files
 file(GLOB hdrs "*.hpp")
@@ -59,6 +44,7 @@ target_link_libraries(
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 add_component_dependencies(${PROJECT_NAME} ${component_name} utils)
+add_component_dependent_packages(${PROJECT_NAME} ${component_name} urdfdom)
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "utils_urdf headers" ${hdrs})

--- a/dart/utils/urdf/CMakeLists.txt
+++ b/dart/utils/urdf/CMakeLists.txt
@@ -1,5 +1,20 @@
 # Dependency checks
 dart_find_package(urdfdom)
+if(urdfdom_FOUND)
+  if(DART_VERBOSE)
+    message(STATUS "Looking for urdfdom - ${urdfdom_headers_VERSION} found")
+  endif()
+else()
+  message(STATUS "Looking for urdfdom - NOT found, please install liburdfdom-dev")
+  return()
+endif()
+if(MSVC)
+  set(urdfdom_LIBRARIES optimized urdfdom_sensor      debug urdfdom_sensord
+                        optimized urdfdom_model_state debug urdfdom_model_stated
+                        optimized urdfdom_model       debug urdfdom_modeld
+                        optimized urdfdom_world       debug urdfdom_worldd
+                        optimized console_bridge      debug console_bridged)
+endif()
 
 # Search all header and source files
 file(GLOB hdrs "*.hpp")

--- a/examples/humanJointLimits/InSourceBuild.cmake
+++ b/examples/humanJointLimits/InSourceBuild.cmake
@@ -16,8 +16,11 @@ if(NOT TinyDNN_FOUND)
   return()
 endif()
 
-find_package(Threads)
-if(NOT Threads_FOUND QUIET)
+find_package(Threads QUIET)
+if(NOT Threads_FOUND)
+  if(DART_VERBOSE)
+    message(STATUS "Failed to find Threads. humanJointLimits is disabled.")
+  endif()
   return()
 endif()
 


### PR DESCRIPTION
Currently, the transitive dependencies of DART are propagated by using CMake variables. For example, all the dependency libraries are stored in `DART_LIBRARIES`, which will be defined by loading `DARTConfig.cmake` through calling `find_package(DART)` in a downstream project. 

However, this approach can fail to load the dependency. The items in `DART_LIBRARIES` can be either of the path to a library file or a target. Path items work fine (as long as the path is correct), but not targets because the downstream project don't know how to import the target only from the target name. This PR fixes it by letting `DARTConfig.cmake` loading the dependency targets by calling `find_packages()` for them. This approach should work as long as all the upstream dependencies loading relevant targets subsequently.

In this PR, the new change is only applied for loading `urdfdom` to quickly fix #1200, but this should be applied to all other transitive dependencies in future PRs.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
