### PR TITLE
Update ClangFormat to version 6.0

### DIFF
--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -3,11 +3,6 @@ set -ex
 
 $SUDO apt-get -qq update
 $SUDO apt-get -y install lsb-release software-properties-common
-
-if [ $(lsb_release -sc) = "trusty" ]; then
-  $SUDO apt-add-repository -y ppa:libccd-debs/ppa
-  $SUDO apt-add-repository -y ppa:fcl-debs/ppa
-fi
 $SUDO apt-add-repository -y ppa:dartsim/ppa
 $SUDO apt-get -qq update
 
@@ -44,19 +39,19 @@ $SUDO apt-get -y install \
   liburdfdom-dev \
   liburdfdom-headers-dev \
   libopenscenegraph-dev
-if [ $(lsb_release -sc) = "trusty" ]; then
-  $SUDO apt-get -y install libnlopt-dev
-  $SUDO apt-get -y install clang-format-3.8
-elif [ $(lsb_release -sc) = "xenial" ]; then
+if [ $(lsb_release -sc) = "xenial" ]; then
   $SUDO apt-get -y install libnlopt-dev
   $SUDO apt-get -y install liboctomap-dev libode-dev
-  $SUDO apt-get -y install clang-format-3.8
 elif [ $(lsb_release -sc) = "bionic" ]; then
   $SUDO apt-get -y install libnlopt-dev
   $SUDO apt-get -y install liboctomap-dev libode-dev
+  $SUDO apt-get -y install clang-format-6.0
 elif [ $(lsb_release -sc) = "cosmic" ]; then
   $SUDO apt-get -y install libnlopt-cxx-dev
   $SUDO apt-get -y install liboctomap-dev libode-dev
+else
+  echo -e "$(lsb_release -sc) is not supported."
+  exit 1
 fi
 
 $SUDO apt-get -y install lcov

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -35,7 +35,7 @@ fi
 
 mkdir build && cd build
 
-if [ "$BUILD_NAME" = "TRUSTY_DEBUG" ]; then
+if [ "$BUILD_NAME" = "BIONIC_DEBUG" ]; then
   cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DDART_VERBOSE=ON -DDART_TREAT_WARNINGS_AS_ERRORS=ON -DDART_BUILD_EXTRAS=ON -DDART_CODECOV=ON ..
 else
   cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DDART_VERBOSE=ON -DDART_TREAT_WARNINGS_AS_ERRORS=ON -DDART_BUILD_EXTRAS=ON -DDART_CODECOV=OFF ..
@@ -47,7 +47,7 @@ else
   make -j$num_threads all tests
 fi
 
-if [ "$OS_NAME" = "linux" ] && [ $(lsb_release -sc) = "trusty" ]; then
+if [ "$OS_NAME" = "linux" ] && [ $(lsb_release -sc) = "bionic" ]; then
   make check-format
 fi
 
@@ -67,6 +67,6 @@ cmake ..
 make -j4
 
 # Uploading report to CodeCov
-if [ "$BUILD_NAME" = "TRUSTY_DEBUG" ]; then
+if [ "$BUILD_NAME" = "BIONIC_DEBUG" ]; then
   bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 fi

--- a/.clang-format
+++ b/.clang-format
@@ -42,6 +42,7 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 # Sort headers by main include file (implicit priority 0),
 # then project and private includes, then system headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,6 @@ matrix:
   include:
     - os: linux
       env:
-        - BUILD_NAME=XENIAL_DEBUG
-        - DOCKERFILE="Dockerfile.ubuntu-xenial"
-        - BUILD_TYPE=Debug
-        - COMPILER=GCC
-      services: docker
-    - os: linux
-      env:
         - BUILD_NAME=XENIAL_RELEASE
         - DOCKERFILE="Dockerfile.ubuntu-xenial"
         - BUILD_TYPE=Release
@@ -41,13 +34,6 @@ matrix:
         - BUILD_NAME=BIONIC_RELEASE
         - DOCKERFILE="Dockerfile.ubuntu-bionic"
         - BUILD_TYPE=Release
-        - COMPILER=GCC
-      services: docker
-    - os: linux
-      env:
-        - BUILD_NAME=COSMIC_DEBUG
-        - DOCKERFILE="Dockerfile.ubuntu-cosmic"
-        - BUILD_TYPE=Debug
         - COMPILER=GCC
       services: docker
     - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,7 @@ endif()
 
 find_program(
   CLANG_FORMAT_EXECUTABLE
-  NAMES clang-format-3.8
+  NAMES clang-format-6.0
 )
 
 get_property(formatting_files GLOBAL PROPERTY DART_FORMAT_FILES)

--- a/dart/common/detail/LockableReference-impl.hpp
+++ b/dart/common/detail/LockableReference-impl.hpp
@@ -42,8 +42,7 @@ namespace common {
 template <typename Lockable>
 SingleLockableReference<Lockable>::SingleLockableReference(
     std::weak_ptr<const void> lockableHolder, Lockable& lockable) noexcept
-    : mLockableHolder(std::move(lockableHolder)),
-      mLockable(lockable)
+  : mLockableHolder(std::move(lockableHolder)), mLockable(lockable)
 {
   // Do nothing
 }

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -160,12 +160,8 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
       }
     }
 
-    assert(
-        isSymmetric(
-            n,
-            mA.data(),
-            mOffset[i],
-            mOffset[i] + constraint->getDimension() - 1));
+    assert(isSymmetric(
+        n, mA.data(), mOffset[i], mOffset[i] + constraint->getDimension() - 1));
 
     constraint->unexcite();
   }

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -68,18 +68,16 @@ ContactConstraint::ContactConstraint(
     collision::Contact& contact, double timeStep)
   : ConstraintBase(),
     mTimeStep(timeStep),
-    mBodyNodeA(
-        const_cast<dynamics::ShapeFrame*>(
-            contact.collisionObject1->getShapeFrame())
-            ->asShapeNode()
-            ->getBodyNodePtr()
-            .get()),
-    mBodyNodeB(
-        const_cast<dynamics::ShapeFrame*>(
-            contact.collisionObject2->getShapeFrame())
-            ->asShapeNode()
-            ->getBodyNodePtr()
-            .get()),
+    mBodyNodeA(const_cast<dynamics::ShapeFrame*>(
+                   contact.collisionObject1->getShapeFrame())
+                   ->asShapeNode()
+                   ->getBodyNodePtr()
+                   .get()),
+    mBodyNodeB(const_cast<dynamics::ShapeFrame*>(
+                   contact.collisionObject2->getShapeFrame())
+                   ->asShapeNode()
+                   ->getBodyNodePtr()
+                   .get()),
     mContact(contact),
     mFirstFrictionalDirection(Eigen::Vector3d::UnitZ()),
     mIsFrictionOn(true),

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
@@ -124,10 +124,10 @@ struct TranslationalJoint2DProperties : GenericJoint<math::R2Space>::Properties,
 };
 
 //==============================================================================
-using TranslationalJoint2DBase
-    = common::EmbedPropertiesOnTopOf<TranslationalJoint2D,
-                                     TranslationalJoint2DUniqueProperties,
-                                     GenericJoint<math::R2Space>>;
+using TranslationalJoint2DBase = common::EmbedPropertiesOnTopOf<
+    TranslationalJoint2D,
+    TranslationalJoint2DUniqueProperties,
+    GenericJoint<math::R2Space>>;
 
 } // namespace detail
 } // namespace dynamics

--- a/dart/math/detail/Random-impl.hpp
+++ b/dart/math/detail/Random-impl.hpp
@@ -93,8 +93,8 @@ namespace Eigen {
 namespace internal {
 
 template <typename T>
-struct functor_has_linear_access<dart::math::detail::
-                                     UniformScalarFromMatrixFunctor<T>>
+struct functor_has_linear_access<
+    dart::math::detail::UniformScalarFromMatrixFunctor<T>>
 {
   enum
   {
@@ -103,8 +103,8 @@ struct functor_has_linear_access<dart::math::detail::
 };
 
 template <typename T>
-struct functor_has_linear_access<dart::math::detail::
-                                     UniformScalarFromVectorFunctor<T>>
+struct functor_has_linear_access<
+    dart::math::detail::UniformScalarFromVectorFunctor<T>>
 {
   enum
   {
@@ -177,9 +177,9 @@ struct UniformScalarImpl
 //==============================================================================
 // Floating-point case
 template <typename S>
-struct UniformScalarImpl<S,
-                         typename std::
-                             enable_if<std::is_floating_point<S>::value>::type>
+struct UniformScalarImpl<
+    S,
+    typename std::enable_if<std::is_floating_point<S>::value>::type>
 {
   static S run(S min, S max)
   {
@@ -193,11 +193,10 @@ struct UniformScalarImpl<S,
 //==============================================================================
 // Floating-point case
 template <typename S>
-struct
-    UniformScalarImpl<S,
-                      typename std::
-                          enable_if<is_compatible_to_uniform_int_distribution<S>::
-                                        value>::type>
+struct UniformScalarImpl<
+    S,
+    typename std::enable_if<
+        is_compatible_to_uniform_int_distribution<S>::value>::type>
 {
   static S run(S min, S max)
   {
@@ -218,11 +217,11 @@ struct UniformMatrixImpl
 //==============================================================================
 // Dynamic matrix case
 template <typename Derived>
-struct UniformMatrixImpl<Derived,
-                         typename std::enable_if<!Derived::IsVectorAtCompileTime
-                                                 && Derived::SizeAtCompileTime
-                                                        == Eigen::Dynamic>::
-                             type>
+struct UniformMatrixImpl<
+    Derived,
+    typename std::enable_if<
+        !Derived::IsVectorAtCompileTime
+        && Derived::SizeAtCompileTime == Eigen::Dynamic>::type>
 {
   static typename Derived::PlainObject run(
       const Eigen::MatrixBase<Derived>& min,
@@ -246,11 +245,11 @@ struct UniformMatrixImpl<Derived,
 //==============================================================================
 // Dynamic vector case
 template <typename Derived>
-struct UniformMatrixImpl<Derived,
-                         typename std::enable_if<Derived::IsVectorAtCompileTime
-                                                 && Derived::SizeAtCompileTime
-                                                        == Eigen::Dynamic>::
-                             type>
+struct UniformMatrixImpl<
+    Derived,
+    typename std::enable_if<
+        Derived::IsVectorAtCompileTime
+        && Derived::SizeAtCompileTime == Eigen::Dynamic>::type>
 {
   static typename Derived::PlainObject run(
       const Eigen::MatrixBase<Derived>& min,
@@ -271,11 +270,11 @@ struct UniformMatrixImpl<Derived,
 //==============================================================================
 // Fixed matrix case
 template <typename Derived>
-struct UniformMatrixImpl<Derived,
-                         typename std::enable_if<!Derived::IsVectorAtCompileTime
-                                                 && Derived::SizeAtCompileTime
-                                                        != Eigen::Dynamic>::
-                             type>
+struct UniformMatrixImpl<
+    Derived,
+    typename std::enable_if<
+        !Derived::IsVectorAtCompileTime
+        && Derived::SizeAtCompileTime != Eigen::Dynamic>::type>
 {
   static typename Derived::PlainObject run(
       const Eigen::MatrixBase<Derived>& min,
@@ -296,11 +295,11 @@ struct UniformMatrixImpl<Derived,
 //==============================================================================
 // Fixed vector case
 template <typename Derived>
-struct UniformMatrixImpl<Derived,
-                         typename std::enable_if<Derived::IsVectorAtCompileTime
-                                                 && Derived::SizeAtCompileTime
-                                                        != Eigen::Dynamic>::
-                             type>
+struct UniformMatrixImpl<
+    Derived,
+    typename std::enable_if<
+        Derived::IsVectorAtCompileTime
+        && Derived::SizeAtCompileTime != Eigen::Dynamic>::type>
 {
   static typename Derived::PlainObject run(
       const Eigen::MatrixBase<Derived>& min,
@@ -327,8 +326,9 @@ struct UniformImpl
 
 //==============================================================================
 template <typename T>
-struct UniformImpl<T,
-                   typename std::enable_if<std::is_arithmetic<T>::value>::type>
+struct UniformImpl<
+    T,
+    typename std::enable_if<std::is_arithmetic<T>::value>::type>
 {
   static T run(T min, T max)
   {
@@ -338,8 +338,9 @@ struct UniformImpl<T,
 
 //==============================================================================
 template <typename T>
-struct UniformImpl<T,
-                   typename std::enable_if<is_base_of_matrix<T>::value>::type>
+struct UniformImpl<
+    T,
+    typename std::enable_if<is_base_of_matrix<T>::value>::type>
 {
   static T run(const Eigen::MatrixBase<T>& min, const Eigen::MatrixBase<T>& max)
   {
@@ -357,9 +358,9 @@ struct NormalScalarImpl
 //==============================================================================
 // Floating-point case
 template <typename S>
-struct NormalScalarImpl<S,
-                        typename std::
-                            enable_if<std::is_floating_point<S>::value>::type>
+struct NormalScalarImpl<
+    S,
+    typename std::enable_if<std::is_floating_point<S>::value>::type>
 {
   static S run(S mean, S sigma)
   {
@@ -371,11 +372,10 @@ struct NormalScalarImpl<S,
 //==============================================================================
 // Floating-point case
 template <typename S>
-struct
-    NormalScalarImpl<S,
-                     typename std::
-                         enable_if<is_compatible_to_uniform_int_distribution<S>::
-                                       value>::type>
+struct NormalScalarImpl<
+    S,
+    typename std::enable_if<
+        is_compatible_to_uniform_int_distribution<S>::value>::type>
 {
   static S run(S mean, S sigma)
   {
@@ -396,8 +396,9 @@ struct NormalImpl
 
 //==============================================================================
 template <typename T>
-struct NormalImpl<T,
-                  typename std::enable_if<std::is_arithmetic<T>::value>::type>
+struct NormalImpl<
+    T,
+    typename std::enable_if<std::is_arithmetic<T>::value>::type>
 {
   static T run(T min, T max)
   {
@@ -405,7 +406,7 @@ struct NormalImpl<T,
   }
 };
 
-} // (anonymous) namespace
+} // namespace
 
 //==============================================================================
 template <typename S>

--- a/dart/optimizer/Population.cpp
+++ b/dart/optimizer/Population.cpp
@@ -68,7 +68,7 @@ bool isValidF(const MultiObjectiveProblem& problem, const Eigen::VectorXd& f)
   return true;
 }
 
-} // (anonymous) namespace
+} // namespace
 
 //==============================================================================
 Population::Population(

--- a/examples/osgExamples/osgBoxStacking/osgBoxStacking.cpp
+++ b/examples/osgExamples/osgBoxStacking/osgBoxStacking.cpp
@@ -55,10 +55,10 @@ dynamics::SkeletonPtr createBox(const Eigen::Vector3d& position)
   double boxHeight = 0.5;
   auto boxShape = std::make_shared<dynamics::BoxShape>(
       Eigen::Vector3d(boxWidth, boxDepth, boxHeight));
-  dynamics::ShapeNode* shapeNode
-      = boxBody->createShapeNodeWith<dynamics::VisualAspect,
-                                     dynamics::CollisionAspect,
-                                     dynamics::DynamicsAspect>(boxShape);
+  dynamics::ShapeNode* shapeNode = boxBody->createShapeNodeWith<
+      dynamics::VisualAspect,
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(boxShape);
   shapeNode->getVisualAspect()->setColor(
       dart::math::Random::uniform<Eigen::Vector3d>(0.0, 1.0));
 
@@ -97,10 +97,10 @@ dynamics::SkeletonPtr createFloor()
   double floorHeight = 0.01;
   auto box = std::make_shared<dynamics::BoxShape>(
       Eigen::Vector3d(floorWidth, floorWidth, floorHeight));
-  dynamics::ShapeNode* shapeNode
-      = body->createShapeNodeWith<dynamics::VisualAspect,
-                                  dynamics::CollisionAspect,
-                                  dynamics::DynamicsAspect>(box);
+  dynamics::ShapeNode* shapeNode = body->createShapeNodeWith<
+      dynamics::VisualAspect,
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(box);
   shapeNode->getVisualAspect()->setColor(dart::Color::LightGray());
 
   // Put the body into position


### PR DESCRIPTION
We use a specific version of ClangFormat because different version can format the code differently even with the same configuration. In this PR, we update the ClangFormat version to 6.0. I particularly chose 6.0 because it's the highest version that is available on the Ubuntu distros we support for DART >= 6.8.

***

**Before creating a pull request**

- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
