### PR TITLE
Fix linking error of FLANN on Ubuntu Disco

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -50,6 +50,18 @@ jobs:
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
+- job: ubuntu_disco_gcc_release
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  variables:
+    OS_NAME: linux
+    COMPILER: gcc
+    BUILD_TYPE: Release
+    BUILD_DIR: $(Build.SourcesDirectory)
+    DOCKERFILE: Dockerfile.ubuntu-disco
+  steps:
+  - template: .ci/azure-pipelines/docker.yml
+
 - job: macos_high_seirra_clang_debug
   pool:
     vmImage: 'macOS 10.13'

--- a/.ci/docker/Dockerfile.ubuntu-disco
+++ b/.ci/docker/Dockerfile.ubuntu-disco
@@ -1,0 +1,1 @@
+FROM ubuntu:disco

--- a/cmake/DARTFindlz4.cmake
+++ b/cmake/DARTFindlz4.cmake
@@ -1,0 +1,9 @@
+# Copyright (c) 2011-2019, The DART development contributors
+# All rights reserved.
+#
+# The list of contributors can be found at:
+#   https://github.com/dartsim/dart/blob/master/LICENSE
+#
+# This file is provided under the "BSD-style" License
+
+find_package(lz4 QUIET)

--- a/cmake/Findlz4.cmake
+++ b/cmake/Findlz4.cmake
@@ -1,0 +1,51 @@
+# Copyright (c) 2011-2019, The DART development contributors
+# All rights reserved.
+#
+# The list of contributors can be found at:
+#   https://github.com/dartsim/dart/blob/master/LICENSE
+#
+# This file is provided under the "BSD-style" License
+
+# Find lz4
+#
+# This sets the following variables:
+#   lz4_FOUND
+#   lz4_INCLUDE_DIRS
+#   lz4_LIBRARIES
+#   lz4_VERSION
+#
+# and the following targets:
+#   lz4
+
+find_package(PkgConfig QUIET)
+
+# Check to see if pkgconfig is installed.
+pkg_check_modules(PC_lz4 lz4 QUIET)
+
+# Include directories
+find_path(lz4_INCLUDE_DIRS
+    NAMES lz4.h
+    HINTS ${PC_lz4_INCLUDEDIR}
+    PATHS "${CMAKE_INSTALL_PREFIX}/include")
+
+# Libraries
+find_library(lz4_LIBRARIES lz4
+    HINTS ${PC_lz4_LIBDIR})
+
+# Version
+set(lz4_VERSION ${PC_lz4_VERSION})
+
+# Set (NAME)_FOUND if all the variables and the version are satisfied.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(lz4
+    FAIL_MESSAGE  DEFAULT_MSG
+    REQUIRED_VARS lz4_INCLUDE_DIRS lz4_LIBRARIES
+    VERSION_VAR   lz4_VERSION)
+
+if(lz4_FOUND AND NOT TARGET lz4)
+  add_library(lz4 INTERFACE IMPORTED)
+  set_target_properties(lz4 PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${lz4_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${lz4_LIBRARIES}"
+  )
+endif()

--- a/dart/planning/CMakeLists.txt
+++ b/dart/planning/CMakeLists.txt
@@ -2,6 +2,11 @@
 dart_find_package(flann)
 dart_check_optional_package(FLANN "dart-planning" "flann" "1.8.4")
 
+# Add lz4 dependency explicitly. lz4 is a dependency of flann, but it's not
+# added to flann as the dependency.
+dart_find_package(lz4)
+dart_check_optional_package(lz4 "dart-planning" "lz4")
+
 # Search all header and source files
 file(GLOB hdrs "*.hpp")
 file(GLOB srcs "*.cpp")
@@ -12,13 +17,13 @@ set(component_name planning)
 
 # Add target
 dart_add_library(${target_name} ${hdrs} ${srcs})
-target_link_libraries(${target_name} PUBLIC dart flann)
+target_link_libraries(${target_name} PUBLIC dart flann lz4)
 
 # Component
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 add_component_dependencies(${PROJECT_NAME} ${component_name} dart)
-add_component_dependency_packages(${PROJECT_NAME} ${component_name} flann)
+add_component_dependency_packages(${PROJECT_NAME} ${component_name} flann lz4)
 
 ## Generate header for this namespace
 dart_get_filename_components(header_names "planning headers" ${hdrs})


### PR DESCRIPTION
FLANN requires `lz4` to be linked, but it's not explicitly linked by the upstream.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
