### PR TITLE
Specify mode for find_package()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 * Build system
 
-  * Fix #1223 for the recursive case: [#1227](https://github.com/dartsim/dart/pull/1227)
+  * Fixed #1223 for the recursive case: [#1227](https://github.com/dartsim/dart/pull/1227)
+  * Specified mode for find_package(): [#1228](https://github.com/dartsim/dart/pull/1228)
 
 ### [DART 6.7.1 (2019-01-15)](https://github.com/dartsim/dart/milestone/49?closed=1)
 

--- a/cmake/DARTFindEigen3.cmake
+++ b/cmake/DARTFindEigen3.cmake
@@ -9,10 +9,10 @@
 # We intentionally don't specify the required Eigen3 version like
 # find_package(Eigen3 3.2.92) because the version file is not provided by
 # upstream until 3.3.1.
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 REQUIRED CONFIG)
 if(EIGEN3_VERSION_STRING VERSION_LESS 3.2.92)  # 3.3~beta1
-  message(FATAL_ERROR "Eigen3 ${EIGEN3_VERSION_STRING} is found but >= 3.2.92
-    (3.3~beta1) is required"
+  message(FATAL_ERROR "Eigen3 ${EIGEN3_VERSION_STRING} is found but >= 3.2.92 "
+    "(3.3~beta1) is required"
   )
 endif()
 

--- a/cmake/DARTFindGLUT.cmake
+++ b/cmake/DARTFindGLUT.cmake
@@ -6,4 +6,4 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(GLUT QUIET CONFIG)
+find_package(GLUT QUIET MODULE)

--- a/cmake/DARTFindGLUT.cmake
+++ b/cmake/DARTFindGLUT.cmake
@@ -6,4 +6,4 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(GLUT QUIET)
+find_package(GLUT QUIET CONFIG)

--- a/cmake/DARTFindIPOPT.cmake
+++ b/cmake/DARTFindIPOPT.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(IPOPT 3.11.9 QUIET)
+find_package(IPOPT 3.11.9 QUIET MODULE)
 
 if(IPOPT_FOUND AND NOT TARGET IPOPT::ipopt)
   add_library(IPOPT::ipopt INTERFACE IMPORTED)

--- a/cmake/DARTFindNLOPT.cmake
+++ b/cmake/DARTFindNLOPT.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(NLOPT 2.4.1 QUIET)
+find_package(NLOPT 2.4.1 QUIET MODULE)
 
 if(NLOPT_FOUND AND NOT TARGET NLOPT::nlopt)
   add_library(NLOPT::nlopt INTERFACE IMPORTED)

--- a/cmake/DARTFindODE.cmake
+++ b/cmake/DARTFindODE.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(ODE 0.13 QUIET)
+find_package(ODE 0.13 QUIET MODULE)
 
 if(ODE_FOUND AND NOT TARGET ODE::ODE)
   add_library(ODE::ODE INTERFACE IMPORTED)

--- a/cmake/DARTFindOpenGL.cmake
+++ b/cmake/DARTFindOpenGL.cmake
@@ -14,7 +14,7 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 OLD)
 endif()
 
-find_package(OpenGL QUIET CONFIG)
+find_package(OpenGL QUIET MODULE)
 
 cmake_policy(POP)
 

--- a/cmake/DARTFindOpenGL.cmake
+++ b/cmake/DARTFindOpenGL.cmake
@@ -14,7 +14,7 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 OLD)
 endif()
 
-find_package(OpenGL QUIET)
+find_package(OpenGL QUIET CONFIG)
 
 cmake_policy(POP)
 

--- a/cmake/DARTFindassimp.cmake
+++ b/cmake/DARTFindassimp.cmake
@@ -6,14 +6,14 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(assimp REQUIRED)
+find_package(assimp REQUIRED MODULE)
 
 # Manually check version because the upstream version compatibility policy
 # doesn't allow different major number while DART is compatible any version
 # greater than or equal to 3.2.
 if(ASSIMP_VERSION VERSION_LESS 3.2)
-  message(STATUS "Found Assimp ${ASSIMP_VERSION}, but Assimp >= 3.2 is
-    required"
+  message(STATUS "Found Assimp ${ASSIMP_VERSION}, but Assimp >= 3.2 is "
+    "required"
   )
 endif()
 

--- a/cmake/DARTFindccd.cmake
+++ b/cmake/DARTFindccd.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(ccd 2.0 REQUIRED)
+find_package(ccd 2.0 REQUIRED MODULE)
 
 # Set target ccd if not set
 # Upstream provides the target since 2.1

--- a/cmake/DARTFindfcl.cmake
+++ b/cmake/DARTFindfcl.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(fcl 0.3.2 REQUIRED)
+find_package(fcl 0.3.2 REQUIRED MODULE)
 
 # Set target fcl if not set
 # Upstream provides the target since 0.5.0 but some package managers don't

--- a/cmake/DARTFindflann.cmake
+++ b/cmake/DARTFindflann.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(flann 1.8.4 QUIET)
+find_package(flann 1.8.4 QUIET MODULE)
 
 if((FLANN_FOUND OR flann_FOUND) AND NOT TARGET flann)
   add_library(flann INTERFACE IMPORTED)

--- a/cmake/DARTFindoctomap.cmake
+++ b/cmake/DARTFindoctomap.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(octomap 1.6.8 QUIET)
+find_package(octomap 1.6.8 QUIET CONFIG CONFIG)
 
 if(octomap_FOUND AND NOT TARGET octomap)
   add_library(octomap INTERFACE IMPORTED)

--- a/cmake/DARTFindoctomap.cmake
+++ b/cmake/DARTFindoctomap.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(octomap 1.6.8 QUIET CONFIG CONFIG)
+find_package(octomap 1.6.8 QUIET CONFIG)
 
 if(octomap_FOUND AND NOT TARGET octomap)
   add_library(octomap INTERFACE IMPORTED)

--- a/cmake/DARTFindpagmo.cmake
+++ b/cmake/DARTFindpagmo.cmake
@@ -6,4 +6,4 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(pagmo QUIET)
+find_package(pagmo QUIET CONFIG)

--- a/cmake/DARTFindtinyxml2.cmake
+++ b/cmake/DARTFindtinyxml2.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(tinyxml2 QUIET)
+find_package(tinyxml2 QUIET MODULE)
 
 if((TINYXML2_FOUND OR tinyxml2_FOUND) AND NOT TARGET tinyxml2::tinyxml2)
   add_library(tinyxml2::tinyxml2 INTERFACE IMPORTED)

--- a/cmake/DARTFindurdfdom.cmake
+++ b/cmake/DARTFindurdfdom.cmake
@@ -6,7 +6,7 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(urdfdom QUIET)
+find_package(urdfdom QUIET CONFIG)
 
 if(urdfdom_FOUND AND NOT TARGET urdfdom)
   add_library(urdfdom INTERFACE IMPORTED)
@@ -15,4 +15,3 @@ if(urdfdom_FOUND AND NOT TARGET urdfdom)
     INTERFACE_LINK_LIBRARIES "${urdfdom_LIBRARIES}"
   )
 endif()
-


### PR DESCRIPTION
There could be a case that `find_package()` is module mode when we intend it to be config mode (by not providing own module file) if the downstream package provides a module file. This PR specifies the mode explicitly to avoid this confusion.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
