### PR TITLE
Lower impulses of DynamicsTest.testImpulseBasedDynamics

### DIFF
--- a/unittests/comprehensive/test_Dynamics.cpp
+++ b/unittests/comprehensive/test_Dynamics.cpp
@@ -2046,11 +2046,11 @@ void DynamicsTest::testImpulseBasedDynamics(const common::Uri& uri)
   std::size_t nRandomItr = 100;
 #endif
 
-  double TOLERANCE = 1e-3;
+  double TOLERANCE = 1e-1;
 
   // Lower and upper bound of configuration for system
-  double lb = -1.0 * constantsd::pi();
-  double ub =  1.0 * constantsd::pi();
+  double lb = -1.5 * constantsd::pi();
+  double ub =  1.5 * constantsd::pi();
 
   simulation::WorldPtr myWorld;
 

--- a/unittests/comprehensive/test_Dynamics.cpp
+++ b/unittests/comprehensive/test_Dynamics.cpp
@@ -2049,8 +2049,8 @@ void DynamicsTest::testImpulseBasedDynamics(const common::Uri& uri)
   double TOLERANCE = 1e-3;
 
   // Lower and upper bound of configuration for system
-  double lb = -1.5 * constantsd::pi();
-  double ub =  1.5 * constantsd::pi();
+  double lb = -1.0 * constantsd::pi();
+  double ub =  1.0 * constantsd::pi();
 
   simulation::WorldPtr myWorld;
 


### PR DESCRIPTION
This is a try to fix #1211 by decreasing the input impulses.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
