### PR TITLE
 Make the LCP internal error printout less aggressive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 #### Changes
 
+* Simulation
+
+  * The LCP solver will be less aggressive about printing out unnecessary warnings: [#1238](https://github.com/dartsim/dart/pull/1238)
+
 * Collision Detection
 
   * The BodyNodeCollisionFilter will ignore contacts between immobile bodies: [#1232](https://github.com/dartsim/dart/pull/1232)

--- a/dart/external/odelcpsolver/lcp.cpp
+++ b/dart/external/odelcpsolver/lcp.cpp
@@ -1008,7 +1008,7 @@ void dSolveLCP (int n, dReal *A, dReal *x, dReal *b,
           // We shouldn't be overly aggressive about printing this warning,
           // because sometimes it gets spammed if s is just a tiny bit beneath
           // 0.0.
-          if (s < REAL(-1e-2)) {
+          if (s < REAL(-1e-6)) {
             dMessage (d_ERR_LCP, "LCP internal error, s <= 0 (s=%.4e)",
                       (double)s);
           }

--- a/dart/external/odelcpsolver/lcp.cpp
+++ b/dart/external/odelcpsolver/lcp.cpp
@@ -1004,7 +1004,15 @@ void dSolveLCP (int n, dReal *A, dReal *x, dReal *b,
         // we're going to get stuck in an infinite loop. instead, just cross
         // our fingers and exit with the current solution.
         if (s <= REAL(0.0)) {
-          dMessage (d_ERR_LCP, "LCP internal error, s <= 0 (s=%.4e)",(double)s);
+
+          // We shouldn't be overly aggressive about printing this warning,
+          // because sometimes it gets spammed if s is just a tiny bit beneath
+          // 0.0.
+          if (s < REAL(-1e-2)) {
+            dMessage (d_ERR_LCP, "LCP internal error, s <= 0 (s=%.4e)",
+                      (double)s);
+          }
+
           if (i < n) {
             dSetZero (x+i,n-i);
             dSetZero (w+i,n-i);


### PR DESCRIPTION
A line in the LCP solver may print out excessive warnings over minor imprecision. This causes unnecessary terminal spam that looks like this:

```
ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)

ODE Message 3: LCP internal error, s <= 0 (s=-1.5440e-13)

ODE Message 3: LCP internal error, s <= 0 (s=-6.4683e-13)
```

These messages often print even when nothing is really wrong with the simulation. I've wrapped the printout of this message in an if-statement that should make the LCP solver less aggressive when it comes to printing this out.


***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
