### PR TITLE
Fix SOVERSION to use only MAJOR to match ABI rules

### DIFF
--- a/cmake/DARTMacros.cmake
+++ b/cmake/DARTMacros.cmake
@@ -90,7 +90,7 @@ macro(dart_add_library _name)
   add_library(${_name} ${ARGN})
   set_target_properties(
     ${_name} PROPERTIES
-    SOVERSION "${DART_MAJOR_VERSION}.${DART_MINOR_VERSION}"
+    SOVERSION "${DART_MAJOR_VERSION}"
     VERSION "${DART_VERSION}"
   )
 endmacro()


### PR DESCRIPTION
The SOVERSION is currently coded to MAJOR.MINOR in Dart. If I'm not wrong, Dart follows semantic versioning so ABI is compatible in all minor versions of a major serie . If that is the case, I think that the current SOVERSION should be composed only by the major version.