### PR TITLE
Fix not defining boost targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
   * Changed to use GNUInstallDirs for install paths: [#1241](https://github.com/dartsim/dart/pull/1241)
   * Fixed not failing for missing required dependencies: [#1250](https://github.com/dartsim/dart/pull/1250)
+  * Fixed not defining boost targets: [#1254](https://github.com/dartsim/dart/pull/1254)
 
 ### [DART 6.7.3 (2019-02-19)](https://github.com/dartsim/dart/milestone/51?closed=1)
 

--- a/cmake/DARTFindBoost.cmake
+++ b/cmake/DARTFindBoost.cmake
@@ -23,3 +23,27 @@ if(DART_VERBOSE)
 else()
   find_package(Boost ${DART_MIN_BOOST_VERSION} QUIET REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 endif()
+
+if(NOT MSVC)
+  if(NOT TARGET Boost::regex)
+    add_library(Boost::regex INTERFACE IMPORTED)
+    set_target_properties(Boost::regex PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES “${Boost_INCLUDE_DIRS}”
+      INTERFACE_LINK_LIBRARIES “${Boost_REGEX_LIBRARY}”
+    )
+  endif()
+endif()
+if(NOT TARGET Boost::system)
+  add_library(Boost::system INTERFACE IMPORTED)
+  set_target_properties(Boost::system PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES “${Boost_INCLUDE_DIRS}”
+    INTERFACE_LINK_LIBRARIES “${Boost_SYSTEM_LIBRARY}”
+  )
+endif()
+if(NOT TARGET Boost::filesystem)
+  add_library(Boost::filesystem INTERFACE IMPORTED)
+  set_target_properties(Boost::filesystem PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES “${Boost_INCLUDE_DIRS}”
+    INTERFACE_LINK_LIBRARIES “${Boost_FILESYSTEM_LIBRARY}”
+  )
+endif()


### PR DESCRIPTION
This allows us to use the boost targets even when the default `FindBoost.cmake` doesn't define imported boost targets.

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)
- [x] Format new code files using `clang-format` (N/A)

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
