### PR TITLE
Fix incorrect transpose check in Inertia::verifySpatialTensor()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Dynamics
 
-  * Fix incorrect transpose check in Inertia::verifySpatialTensor(): [#1258](https://github.com/dartsim/dart/pull/1258)
+  * Fixed incorrect transpose check in Inertia::verifySpatialTensor(): [#1258](https://github.com/dartsim/dart/pull/1258)
 
 * Simulation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 #### Changes
 
+* Dynamics
+
+  * Fix incorrect transpose check in Inertia::verifySpatialTensor(): [#1258](https://github.com/dartsim/dart/pull/1258)
+
 * Simulation
 
   * The LCP solver will be less aggressive about printing out unnecessary warnings: [#1238](https://github.com/dartsim/dart/pull/1238)

--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -356,8 +356,8 @@ bool Inertia::verifySpatialTensor(const Eigen::Matrix6d& _spatial,
       std::size_t i1 = i;
       std::size_t j1 = j+3;
 
-      std::size_t i2 = i+3;
-      std::size_t j2 = j;
+      std::size_t i2 = j1;
+      std::size_t j2 = i1;
 
       if(std::abs(_spatial(i1,j1) - _spatial(i2,j2)) > _tolerance)
       {

--- a/dart/math/detail/Random-impl.hpp
+++ b/dart/math/detail/Random-impl.hpp
@@ -406,7 +406,7 @@ struct NormalImpl<
   }
 };
 
-} // detail namespace
+} // namespace detail
 
 //==============================================================================
 template <typename S>

--- a/unittests/unit/CMakeLists.txt
+++ b/unittests/unit/CMakeLists.txt
@@ -4,6 +4,7 @@ dart_add_test("unit" test_ContactConstraint)
 dart_add_test("unit" test_Factory)
 dart_add_test("unit" test_GenericJoints)
 dart_add_test("unit" test_Geometry)
+dart_add_test("unit" test_Inertia)
 dart_add_test("unit" test_Lemke)
 dart_add_test("unit" test_LocalResourceRetriever)
 dart_add_test("unit" test_Math)
@@ -80,3 +81,5 @@ foreach(collision_engine
   endif()
 
 endforeach()
+
+dart_format_add(test_Inertia.cpp)

--- a/unittests/unit/test_Inertia.cpp
+++ b/unittests/unit/test_Inertia.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/Inertia.hpp>
+#include <dart/math/Random.hpp>
+#include <gtest/gtest.h>
+#include "TestHelpers.hpp"
+
+using namespace dart;
+
+//==============================================================================
+TEST(Inertia, Verification)
+{
+  const int numIter = 10;
+
+  for (int i = 0; i < numIter; ++i)
+  {
+    const auto mass = math::Random::uniform<double>(0.1, 10.0);
+    const auto com = math::Random::uniform<Eigen::Vector3d>(-5, 5);
+    const auto i_xx = math::Random::uniform<double>(0.1, 1);
+    const auto i_yy = math::Random::uniform<double>(0.1, 1);
+    const auto i_zz = math::Random::uniform<double>(0.1, 1);
+    const auto i_xy = math::Random::uniform<double>(-1, 1);
+    const auto i_xz = math::Random::uniform<double>(-1, 1);
+    const auto i_yz = math::Random::uniform<double>(-1, 1);
+
+    const dynamics::Inertia inertia(
+        mass, com[0], com[1], com[2], i_xx, i_yy, i_zz, i_xy, i_xz, i_yz);
+
+    EXPECT_TRUE(inertia.verify());
+  }
+}


### PR DESCRIPTION
[The last check of `Inertia::verifySpatialTensor()`](https://github.com/dartsim/dart/blame/a94c9d09938c3cc5f6a463d6e8747d6a78357b15/dart/dynamics/Inertia.cpp#L352-L375) doesn't correctly test the transpose relationship of the top-right block and the bottom-left block.

Resolves #1257 

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
