### PR TITLE
Fix not copying constraints in setting new constraint solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Simulation
 
   * The LCP solver will be less aggressive about printing out unnecessary warnings: [#1238](https://github.com/dartsim/dart/pull/1238)
+  * Fixed not copying constraints in World::setConstraintSolver(): [#1260](https://github.com/dartsim/dart/pull/1260)
 
 * Collision Detection
 

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -166,6 +166,23 @@ void ConstraintSolver::addConstraint(const ConstraintBasePtr& constraint)
 }
 
 //==============================================================================
+const std::vector<ConstraintBasePtr>& ConstraintSolver::getConstraints()
+{
+  return mManualConstraints;
+}
+
+//==============================================================================
+std::vector<ConstConstraintBasePtr> ConstraintSolver::getConstraints() const
+{
+  std::vector<ConstConstraintBasePtr> constraints;
+  constraints.reserve(mManualConstraints.size());
+  for (auto constraint : mManualConstraints)
+    constraints.push_back(constraint);
+
+  return constraints;
+}
+
+//==============================================================================
 void ConstraintSolver::removeConstraint(const ConstraintBasePtr& constraint)
 {
   assert(constraint);

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -330,6 +330,17 @@ DART_SUPPRESS_DEPRECATED_END
 }
 
 //==============================================================================
+void ConstraintSolver::setFromOtherConstraintSolver(
+    const ConstraintSolver& other)
+{
+  removeAllSkeletons();
+  mManualConstraints.clear();
+
+  addSkeletons(other.getSkeletons());
+  mManualConstraints = other.mManualConstraints;
+}
+
+//==============================================================================
 bool ConstraintSolver::containSkeleton(const ConstSkeletonPtr& _skeleton) const
 {
   assert(_skeleton != nullptr && "Not allowed to insert null pointer skeleton.");

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -166,23 +166,6 @@ void ConstraintSolver::addConstraint(const ConstraintBasePtr& constraint)
 }
 
 //==============================================================================
-const std::vector<ConstraintBasePtr>& ConstraintSolver::getConstraints()
-{
-  return mManualConstraints;
-}
-
-//==============================================================================
-std::vector<ConstConstraintBasePtr> ConstraintSolver::getConstraints() const
-{
-  std::vector<ConstConstraintBasePtr> constraints;
-  constraints.reserve(mManualConstraints.size());
-  for (auto constraint : mManualConstraints)
-    constraints.push_back(constraint);
-
-  return constraints;
-}
-
-//==============================================================================
 void ConstraintSolver::removeConstraint(const ConstraintBasePtr& constraint)
 {
   assert(constraint);
@@ -203,6 +186,44 @@ void ConstraintSolver::removeConstraint(const ConstraintBasePtr& constraint)
 void ConstraintSolver::removeAllConstraints()
 {
   mManualConstraints.clear();
+}
+
+//==============================================================================
+std::size_t ConstraintSolver::getNumConstraints() const
+{
+  return mManualConstraints.size();
+}
+
+//==============================================================================
+ConstraintBasePtr ConstraintSolver::getConstraint(std::size_t index)
+{
+  return mManualConstraints[index];
+}
+
+//==============================================================================
+ConstConstraintBasePtr ConstraintSolver::getConstraint(std::size_t index) const
+{
+  return mManualConstraints[index];
+}
+
+//==============================================================================
+std::vector<ConstraintBasePtr> ConstraintSolver::getConstraints()
+{
+  // Return a copy of constraint list not to expose the implementation detail
+  // that the constraint pointers are held in a vector, in case we want to
+  // change this implementation in the future.
+  return mManualConstraints;
+}
+
+//==============================================================================
+std::vector<ConstConstraintBasePtr> ConstraintSolver::getConstraints() const
+{
+  std::vector<ConstConstraintBasePtr> constraints;
+  constraints.reserve(mManualConstraints.size());
+  for (auto constraint : mManualConstraints)
+    constraints.push_back(constraint);
+
+  return constraints;
 }
 
 //==============================================================================

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -153,6 +153,10 @@ public:
   /// Solve constraint impulses and apply them to the skeletons
   void solve();
 
+  /// Sets this constraint solver using other constraint solver. All the
+  /// properties and registered skeletons and constraints will be copied over.
+  virtual void setFromOtherConstraintSolver(const ConstraintSolver& other);
+
 protected:
   // TODO(JS): Docstring
   virtual void solveConstrainedGroup(ConstrainedGroup& group) = 0;

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -89,17 +89,26 @@ public:
   /// Add a constraint
   void addConstraint(const ConstraintBasePtr& constraint);
 
-  /// Returns all the constraints added to this ConstraintSolver.
-  const std::vector<constraint::ConstraintBasePtr>& getConstraints();
-
-  /// Returns all the constraints added to this ConstraintSolver.
-  std::vector<constraint::ConstConstraintBasePtr> getConstraints() const;
-
   /// Remove a constraint
   void removeConstraint(const ConstraintBasePtr& constraint);
 
   /// Remove all constraints
   void removeAllConstraints();
+
+  /// Returns the number of constraints that was manually added to this ConstraintSolver.
+  std::size_t getNumConstraints() const;
+
+  /// Returns a constraint by index.
+  constraint::ConstraintBasePtr getConstraint(std::size_t index);
+
+  /// Returns a constraint by index.
+  constraint::ConstConstraintBasePtr getConstraint(std::size_t index) const;
+
+  /// Returns all the constraints added to this ConstraintSolver.
+  std::vector<constraint::ConstraintBasePtr> getConstraints();
+
+  /// Returns all the constraints added to this ConstraintSolver.
+  std::vector<constraint::ConstConstraintBasePtr> getConstraints() const;
 
   /// Clears the last collision result
   void clearLastCollisionResult();

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -89,6 +89,12 @@ public:
   /// Add a constraint
   void addConstraint(const ConstraintBasePtr& constraint);
 
+  /// Returns all the constraints added to this ConstraintSolver.
+  const std::vector<constraint::ConstraintBasePtr>& getConstraints();
+
+  /// Returns all the constraints added to this ConstraintSolver.
+  std::vector<constraint::ConstConstraintBasePtr> getConstraints() const;
+
   /// Remove a constraint
   void removeConstraint(const ConstraintBasePtr& constraint);
 

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -538,8 +538,8 @@ void World::setConstraintSolver(constraint::UniqueConstraintSolverPtr solver)
     return;
   }
 
-  solver->removeAllSkeletons();
-  solver->addSkeletons(mConstraintSolver->getSkeletons());
+  assert(mConstraintSolver);
+  solver->setFromOtherConstraintSolver(*mConstraintSolver);
 
   mConstraintSolver = std::move(solver);
 }

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -236,6 +236,9 @@ public:
   //--------------------------------------------------------------------------
 
   /// Sets the constraint solver
+  ///
+  /// Note that the internal properties of \c solver will be overwritten by this
+  /// World.
   void setConstraintSolver(constraint::UniqueConstraintSolverPtr solver);
 
   /// Get the constraint solver

--- a/unittests/comprehensive/test_World.cpp
+++ b/unittests/comprehensive/test_World.cpp
@@ -323,7 +323,7 @@ simulation::WorldPtr createWorld()
   // Create and initialize the world
   simulation::WorldPtr world
     = utils::SkelParser::readWorld("dart://sample/skel/chain.skel");
-  assert(myWorld != nullptr);
+  assert(world != nullptr);
 
   // Create and initialize the world
   world->setGravity(Eigen::Vector3d(0.0, -9.81, 0.0));


### PR DESCRIPTION
### Motivation
`World::setConstraint()` doesn't copy constraints.

### Solution
Introduce `ConstraintSolver::setFromOtherConstraintSolver()` to properly copy skeletons and contraints from existing constraint solver. This is to let `ConstraintSolver` handle the copy instead of the caller (e.g., `World`).

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
