### PR TITLE
Fix finding manually installed OpenSceneGraph for CMake < 3.12

### DIFF
--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -6,8 +6,18 @@ endif()
 # OpenSceneGraph
 if(DART_BUILD_GUI_OSG)
 
+  if (CMAKE_VERSION VERSION_LESS 3.12)
+    get_property(old_find_library_use_lib64_paths GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
+    set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+  endif()
+
   find_package(OpenSceneGraph 3.0 QUIET
-    COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow)
+    COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow
+  )
+
+  if (CMAKE_VERSION VERSION_LESS 3.12)
+    set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS ${old_find_library_use_lib64_paths})
+  endif()
 
   # It seems that OPENSCENEGRAPH_FOUND will inadvertently get set to true when
   # OpenThreads is found, even if OpenSceneGraph is not installed. This is quite


### PR DESCRIPTION
### Problem
OSG installs its binaries in `<install_prefix>/lib<arch>`, which is not searchable by CMake < 3.12.

### Solution
Explicily set CMake to find lib64 paths by setting `FIND_LIBRARY_USE_LIB64_PATHS` as `TRUE` as suggestted [here](https://github.com/openscenegraph/OpenSceneGraph/pull/660#issuecomment-441502412).

### Note

This is tangential to #1262.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
