### PR TITLE
Allow BoxedLcpConstraintSolver to have secondary LCP solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Dynamics
 
   * Fixed incorrect transpose check in Inertia::verifySpatialTensor(): [#1258](https://github.com/dartsim/dart/pull/1258)
+  * Allowed BoxedLcpConstraintSolver to have a secondary LCP solver: [#1265](https://github.com/dartsim/dart/pull/1265)
 
 * Simulation
 

--- a/dart/collision/CollisionDetector.hpp
+++ b/dart/collision/CollisionDetector.hpp
@@ -76,7 +76,7 @@ public:
 
   /// \brief Create a clone of this CollisionDetector. All the properties will
   /// be copied over, but not collision objects.
-  virtual std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() = 0;
+  virtual std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() const = 0;
 
   /// Return collision detection engine type as a std::string
   virtual const std::string& getType() const = 0;

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -109,7 +109,7 @@ BulletCollisionDetector::~BulletCollisionDetector()
 
 //==============================================================================
 std::shared_ptr<CollisionDetector>
-BulletCollisionDetector::cloneWithoutCollisionObjects()
+BulletCollisionDetector::cloneWithoutCollisionObjects() const
 {
   return BulletCollisionDetector::create();
 }

--- a/dart/collision/bullet/BulletCollisionDetector.hpp
+++ b/dart/collision/bullet/BulletCollisionDetector.hpp
@@ -61,7 +61,8 @@ public:
   virtual ~BulletCollisionDetector();
 
   // Documentation inherited
-  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() override;
+  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() const
+  override;
 
   // Documentation inherited
   const std::string& getType() const override;

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<DARTCollisionDetector> DARTCollisionDetector::create()
 
 //==============================================================================
 std::shared_ptr<CollisionDetector>
-DARTCollisionDetector::cloneWithoutCollisionObjects()
+DARTCollisionDetector::cloneWithoutCollisionObjects() const
 {
   return DARTCollisionDetector::create();
 }

--- a/dart/collision/dart/DARTCollisionDetector.hpp
+++ b/dart/collision/dart/DARTCollisionDetector.hpp
@@ -49,7 +49,8 @@ public:
   static std::shared_ptr<DARTCollisionDetector> create();
 
   // Documentation inherited
-  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() override;
+  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() const
+  override;
 
   // Documentation inherited
   const std::string& getType() const override;

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -667,7 +667,7 @@ FCLCollisionDetector::~FCLCollisionDetector()
 
 //==============================================================================
 std::shared_ptr<CollisionDetector>
-FCLCollisionDetector::cloneWithoutCollisionObjects()
+FCLCollisionDetector::cloneWithoutCollisionObjects() const
 {
   return FCLCollisionDetector::create();
 }

--- a/dart/collision/fcl/FCLCollisionDetector.hpp
+++ b/dart/collision/fcl/FCLCollisionDetector.hpp
@@ -84,7 +84,8 @@ public:
   virtual ~FCLCollisionDetector();
 
   // Documentation inherited
-  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() override;
+  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() const
+  override;
 
   // Documentation inherited
   const std::string& getType() const override;

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -127,7 +127,7 @@ OdeCollisionDetector::~OdeCollisionDetector()
 
 //==============================================================================
 std::shared_ptr<CollisionDetector>
-OdeCollisionDetector::cloneWithoutCollisionObjects()
+OdeCollisionDetector::cloneWithoutCollisionObjects() const
 {
   return OdeCollisionDetector::create();
 }

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -62,7 +62,8 @@ public:
   virtual ~OdeCollisionDetector();
 
   // Documentation inherited
-  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() override;
+  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects() const
+  override;
 
   // Documentation inherited
   const std::string& getType() const override;

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -62,7 +62,7 @@ BoxedLcpConstraintSolver::BoxedLcpConstraintSolver(
 
 //==============================================================================
 BoxedLcpConstraintSolver::BoxedLcpConstraintSolver()
-  : BoxedLcpConstraintSolver(std::make_shared<PgsBoxedLcpSolver>())
+  : BoxedLcpConstraintSolver(std::make_shared<DantzigBoxedLcpSolver>())
 {
   // Do nothing
 }

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -76,6 +76,14 @@ void BoxedLcpConstraintSolver::setBoxedLcpSolver(BoxedLcpSolverPtr lcpSolver)
     return;
   }
 
+  if (lcpSolver == mFallbackBoxedLcpSolver)
+  {
+    dtwarn << "[BoxedLcpConstraintSolver::setBoxedLcpSolver] Attempting to set "
+           << "the primary LCP solver that is identical to the secondary LCP "
+           << "solver, which is redundant. Please use different solvers or set "
+           << "the secondary LCP solver to nullptr.\n";
+  }
+
   mBoxedLcpSolver = std::move(lcpSolver);
 }
 
@@ -89,6 +97,14 @@ ConstBoxedLcpSolverPtr BoxedLcpConstraintSolver::getBoxedLcpSolver() const
 void BoxedLcpConstraintSolver::setFallbackBoxedLcpSolver(
     BoxedLcpSolverPtr lcpSolver)
 {
+  if (lcpSolver == mBoxedLcpSolver)
+  {
+    dtwarn << "[BoxedLcpConstraintSolver::setBoxedLcpSolver] Attempting to set "
+           << "the secondary LCP solver that is identical to the primary LCP "
+           << "solver, which is redundant. Please use different solvers or set "
+           << "the secondary LCP solver to nullptr.\n";
+  }
+
   mFallbackBoxedLcpSolver = std::move(lcpSolver);
 }
 

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -47,27 +47,55 @@ public:
   /// \param[in] timeStep Simulation time step
   /// \param[in] boxedLcpSolver The primary boxed LCP solver. When nullptr is
   /// passed, Dantzig solver will be used.
-  /// \param[in] fallbackBoxedLcpSolver The secondary boxed-LCP solver. When
+  /// \param[in] secondaryBoxedLcpSolver The secondary boxed-LCP solver. When
   /// nullptr is passed, PGS solver will be used. This is to make the default
   /// solver setting to be Dantzig + PGS. In order to disable use of secondary
-  /// solver, call setFallbackBoxedLcpSolver(nullptr) explicitly.
+  /// solver, call setSecondaryBoxedLcpSolver(nullptr) explicitly.
+  ///
+  /// \deprecated Deprecated in DART 6.8. Please use other constructors that
+  /// doesn't take timespte. Timestep should be set by the owner of this solver
+  /// such as dart::simulation::World when the solver added.
+  DART_DEPRECATED(6.8)
   BoxedLcpConstraintSolver(
       double timeStep,
-      BoxedLcpSolverPtr boxedLcpSolver = nullptr,
-      BoxedLcpSolverPtr fallbackBoxedLcpSolver = nullptr);
+      BoxedLcpSolverPtr boxedLcpSolver,
+      BoxedLcpSolverPtr secondaryBoxedLcpSolver);
+
+  /// Constructos with default primary and secondary LCP solvers, which are
+  /// Dantzig and PGS, respectively.
+  BoxedLcpConstraintSolver();
+
+  /// Constructors with specific primary LCP solver.
+  ///
+  /// \param[in] boxedLcpSolver The primary boxed LCP solver. When nullptr is
+  /// passed, which is discouraged, Dantzig solver will be used.
+  BoxedLcpConstraintSolver(BoxedLcpSolverPtr boxedLcpSolver);
+
+  /// Constructs with specific primary and secondary LCP solvers.
+  ///
+  /// \param[in] boxedLcpSolver The primary boxed LCP solver. When nullptr is
+  /// passed, which is discouraged, Dantzig solver will be used.
+  /// \param[in] secondaryBoxedLcpSolver The secondary boxed-LCP solver. Pass
+  /// nullptr to disable using secondary LCP solver.
+  BoxedLcpConstraintSolver(
+      BoxedLcpSolverPtr boxedLcpSolver,
+      BoxedLcpSolverPtr secondaryBoxedLcpSolver);
 
   /// Sets boxed LCP (BLCP) solver
+  ///
+  /// \param[in] boxedLcpSolver The primary boxed LCP solver. When nullptr is
+  /// passed, Dantzig solver will be used.
   void setBoxedLcpSolver(BoxedLcpSolverPtr lcpSolver);
 
   /// Returns boxed LCP (BLCP) solver
   ConstBoxedLcpSolverPtr getBoxedLcpSolver() const;
 
   /// Sets boxed LCP (BLCP) solver that is used when the primary solver failed
-  void setFallbackBoxedLcpSolver(BoxedLcpSolverPtr lcpSolver);
+  void setSecondaryBoxedLcpSolver(BoxedLcpSolverPtr lcpSolver);
 
   /// Returns boxed LCP (BLCP) solver that is used when the primary solver
   /// failed
-  ConstBoxedLcpSolverPtr getFallbackBoxedLcpSolver() const;
+  ConstBoxedLcpSolverPtr getSecondaryBoxedLcpSolver() const;
 
 protected:
   // Documentation inherited.
@@ -75,9 +103,13 @@ protected:
 
   /// Boxed LCP solver
   BoxedLcpSolverPtr mBoxedLcpSolver;
+  // TODO(JS): Hold as unique_ptr because there is no reason to share. Make this
+  // change in DART 7 because it's API breaking change.
 
   /// Boxed LCP solver to be used when the primary solver failed
-  BoxedLcpSolverPtr mFallbackBoxedLcpSolver;
+  BoxedLcpSolverPtr mSecondaryBoxedLcpSolver;
+  // TODO(JS): Hold as unique_ptr because there is no reason to share. Make this
+  // change in DART 7 because it's API breaking change.
 
   /// Cache data for boxed LCP formulation
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> mA;

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -43,14 +43,31 @@ class BoxedLcpConstraintSolver : public ConstraintSolver
 {
 public:
   /// Constructor
+  ///
+  /// \param[in] timeStep Simulation time step
+  /// \param[in] boxedLcpSolver The primary boxed LCP solver. When nullptr is
+  /// passed, Dantzig solver will be used.
+  /// \param[in] fallbackBoxedLcpSolver The secondary boxed-LCP solver. When
+  /// nullptr is passed, PGS solver will be used. This is to make the default
+  /// solver setting to be Dantzig + PGS. In order to disable use of secondary
+  /// solver, call setFallbackBoxedLcpSolver(nullptr) explicitly.
   BoxedLcpConstraintSolver(
-      double timeStep, BoxedLcpSolverPtr boxedLcpSolver = nullptr);
+      double timeStep,
+      BoxedLcpSolverPtr boxedLcpSolver = nullptr,
+      BoxedLcpSolverPtr fallbackBoxedLcpSolver = nullptr);
 
   /// Sets boxed LCP (BLCP) solver
   void setBoxedLcpSolver(BoxedLcpSolverPtr lcpSolver);
 
   /// Returns boxed LCP (BLCP) solver
   ConstBoxedLcpSolverPtr getBoxedLcpSolver() const;
+
+  /// Sets boxed LCP (BLCP) solver that is used when the primary solver failed
+  void setFallbackBoxedLcpSolver(BoxedLcpSolverPtr lcpSolver);
+
+  /// Returns boxed LCP (BLCP) solver that is used when the primary solver
+  /// failed
+  ConstBoxedLcpSolverPtr getFallbackBoxedLcpSolver() const;
 
 protected:
   // Documentation inherited.
@@ -59,14 +76,27 @@ protected:
   /// Boxed LCP solver
   BoxedLcpSolverPtr mBoxedLcpSolver;
 
+  /// Boxed LCP solver to be used when the primary solver failed
+  BoxedLcpSolverPtr mFallbackBoxedLcpSolver;
+
   /// Cache data for boxed LCP formulation
   Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> mA;
+
+  /// Cache data for boxed LCP formulation
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+      mABackup;
 
   /// Cache data for boxed LCP formulation
   Eigen::VectorXd mX;
 
   /// Cache data for boxed LCP formulation
+  Eigen::VectorXd mXBackup;
+
+  /// Cache data for boxed LCP formulation
   Eigen::VectorXd mB;
+
+  /// Cache data for boxed LCP formulation
+  Eigen::VectorXd mBBackup;
 
   /// Cache data for boxed LCP formulation
   Eigen::VectorXd mW;
@@ -75,10 +105,19 @@ protected:
   Eigen::VectorXd mLo;
 
   /// Cache data for boxed LCP formulation
+  Eigen::VectorXd mLoBackup;
+
+  /// Cache data for boxed LCP formulation
   Eigen::VectorXd mHi;
 
   /// Cache data for boxed LCP formulation
+  Eigen::VectorXd mHiBackup;
+
+  /// Cache data for boxed LCP formulation
   Eigen::VectorXi mFIndex;
+
+  /// Cache data for boxed LCP formulation
+  Eigen::VectorXi mFIndexBackup;
 
   /// Cache data for boxed LCP formulation
   Eigen::VectorXi mOffset;

--- a/dart/constraint/BoxedLcpSolver.hpp
+++ b/dart/constraint/BoxedLcpSolver.hpp
@@ -48,25 +48,48 @@ public:
   /// Returns the type
   virtual const std::string& getType() const = 0;
 
-  /// Get true if this solver and the template parameter (a solver class) are
-  /// the same type. This function is a syntactic sugar, which is identical to:
-  /// \code getType() == ShapeType::getStaticType() \endcode.
+  /// Returns true if this solver and the template parameter (a solver class)
+  /// are the same type. This function is a syntactic sugar, which is identical
+  /// to:
+  /// \code getType() == BoxedLcpSolver::getStaticType() \endcode.
   ///
   /// Example code:
   /// \code
-  /// auto shape = bodyNode->getShapeNode(0)->getShape();
-  /// if (shape->is<BoxShape>())
-  ///   std::cout << "The shape type is box!\n";
+  /// auto lcpSolver = constraintSolver->getBoxedLcpSolver();
+  /// if (shape->is<DantzigBoxedLcpSolver>())
+  ///   std::cout << "The LCP solver type is Dantzig!\n";
   /// \endcode
   ///
   /// \sa getType()
   template <typename BoxedLcpSolverT>
   bool is() const;
 
-  /// Solves constriant impulses for a constrained group
+  /// Solves constriant impulses for a constrained group. The LCP formulation
+  /// setting that this function solve is A*x = b + w where each x[i], w[i]
+  /// satisfies one of
+  ///   (1) x = lo, w >= 0
+  ///   (2) x = hi, w <= 0
+  ///   (3) lo < x < hi, w = 0
+  ///
+  /// \param[in] n Dimension of constraints.
+  /// \param[in] A A term of the LCP formulation.
+  /// \param[in] x x term of the LCP formulation.
+  /// \param[in] b b term of the LCP formulation.
+  /// \param[in] nub Number of the first unbounded constraints.
+  /// \param[in] lo Lower bound of x where it's restricted to be lo <= 0.
+  /// \param[in] hi Upper bound of x where it's enforced to be hi >= 0.
+  /// \param[in] findex Indices to corresponding normal contact constraint. Set
+  /// the index to itself (e.g., findex[k] = k) for normal contacts or
+  /// non-contact constraints. For friction constraint, set the cooresponding
+  /// normal contact constraint.
+  /// \param[in] earlyTermination Set true to return false as soon as the solver
+  /// find the solution doesn't exist. Otherwise, the solver will continue to
+  /// push hard to solve the problem using some hacks.
+  ///
+  /// \return Success.
   // Note: The function signature is ODE specific for now. Consider changing
   // this to Eigen friendly version once own Dantzig LCP solver is available.
-  virtual void solve(
+  virtual bool solve(
       int n,
       double* A,
       double* x,
@@ -74,7 +97,8 @@ public:
       int nub,
       double* lo,
       double* hi,
-      int* findex)
+      int* findex,
+      bool earlyTermination = false)
       = 0;
 
 #ifndef NDEBUG

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -83,7 +83,8 @@ ConstraintSolver::ConstraintSolver()
     mCollisionGroup(mCollisionDetector->createCollisionGroupAsSharedPtr()),
     mCollisionOption(
       collision::CollisionOption(
-        true, 1000u, std::make_shared<collision::BodyNodeCollisionFilter>()))
+        true, 1000u, std::make_shared<collision::BodyNodeCollisionFilter>())),
+    mTimeStep(0.001)
 {
   auto cd = std::static_pointer_cast<collision::FCLCollisionDetector>(
         mCollisionDetector);

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -78,9 +78,20 @@ ConstraintSolver::ConstraintSolver(double timeStep)
 }
 
 //==============================================================================
-ConstraintSolver::~ConstraintSolver()
+ConstraintSolver::ConstraintSolver()
+  : mCollisionDetector(collision::FCLCollisionDetector::create()),
+    mCollisionGroup(mCollisionDetector->createCollisionGroupAsSharedPtr()),
+    mCollisionOption(
+      collision::CollisionOption(
+        true, 1000u, std::make_shared<collision::BodyNodeCollisionFilter>()))
 {
-  // Do nothing
+  auto cd = std::static_pointer_cast<collision::FCLCollisionDetector>(
+        mCollisionDetector);
+
+  cd->setPrimitiveShapeType(collision::FCLCollisionDetector::MESH);
+  // TODO(JS): Consider using FCL's primitive shapes once FCL addresses
+  // incorrect contact point computation.
+  // (see: https://github.com/flexible-collision-library/fcl/issues/106)
 }
 
 //==============================================================================

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -39,6 +39,7 @@
 
 #include "dart/common/Deprecated.hpp"
 #include "dart/constraint/SmartPointer.hpp"
+#include "dart/constraint/ConstrainedGroup.hpp"
 #include "dart/constraint/ConstraintBase.hpp"
 #include "dart/collision/CollisionDetector.hpp"
 
@@ -56,9 +57,19 @@ class ConstraintSolver
 {
 public:
   /// Constructor
+  ///
+  /// \deprecated Deprecated in DART 6.8. Please use other constructors that
+  /// doesn't take timespte. Timestep should be set by the owner of this solver
+  /// such as dart::simulation::World when the solver added.
+  DART_DEPRECATED(6.8)
   explicit ConstraintSolver(double timeStep);
+
   // TODO(JS): Remove timeStep. The timestep can be set by world when a
   // constraint solver is assigned to a world.
+  // Deprecate
+
+  /// Default constructor
+  ConstraintSolver();
 
   /// Copy constructor
   // TODO: implement copy constructor since this class contains a pointer to
@@ -66,7 +77,7 @@ public:
   ConstraintSolver(const ConstraintSolver& other) = delete;
 
   /// Destructor
-  virtual ~ConstraintSolver();
+  virtual ~ConstraintSolver() = default;
 
   /// Add single skeleton
   void addSkeleton(const dynamics::SkeletonPtr& skeleton);
@@ -114,7 +125,7 @@ public:
   void clearLastCollisionResult();
 
   /// Set time step
-  void setTimeStep(double _timeStep);
+  virtual void setTimeStep(double _timeStep);
 
   /// Get time step
   double getTimeStep() const;

--- a/dart/constraint/DantzigBoxedLcpSolver.cpp
+++ b/dart/constraint/DantzigBoxedLcpSolver.cpp
@@ -51,7 +51,7 @@ const std::string& DantzigBoxedLcpSolver::getStaticType()
 }
 
 //==============================================================================
-void DantzigBoxedLcpSolver::solve(
+bool DantzigBoxedLcpSolver::solve(
     int n,
     double* A,
     double* x,
@@ -59,9 +59,10 @@ void DantzigBoxedLcpSolver::solve(
     int /*nub*/,
     double* lo,
     double* hi,
-    int* findex)
+    int* findex,
+    bool earlyTermination)
 {
-  dSolveLCP(n, A, x, b, nullptr, 0, lo, hi, findex);
+  return dSolveLCP(n, A, x, b, nullptr, 0, lo, hi, findex, earlyTermination);
 }
 
 #ifndef NDEBUG

--- a/dart/constraint/DantzigBoxedLcpSolver.hpp
+++ b/dart/constraint/DantzigBoxedLcpSolver.hpp
@@ -48,7 +48,7 @@ public:
   static const std::string& getStaticType();
 
   // Documentation inherited.
-  void solve(
+  bool solve(
       int n,
       double* A,
       double* x,
@@ -56,7 +56,8 @@ public:
       int nub,
       double* lo,
       double* hi,
-      int* findex) override;
+      int* findex,
+      bool earlyTermination) override;
 
 #ifndef NDEBUG
   // Documentation inherited.

--- a/dart/constraint/PgsBoxedLcpSolver.cpp
+++ b/dart/constraint/PgsBoxedLcpSolver.cpp
@@ -73,7 +73,8 @@ const std::string& PgsBoxedLcpSolver::getStaticType()
   return type;
 }
 
-void PgsBoxedLcpSolver::solve(
+//==============================================================================
+bool PgsBoxedLcpSolver::solve(
     int n,
     double* A,
     double* x,
@@ -81,7 +82,8 @@ void PgsBoxedLcpSolver::solve(
     int nub,
     double* lo,
     double* hi,
-    int* findex)
+    int* findex,
+    bool /*earlyTermination*/)
 {
   const int nskip = dPAD(n);
 
@@ -96,7 +98,7 @@ void PgsBoxedLcpSolver::solve(
     dSolveLDLT(A, mCacheD.data(), b, n, nskip);
     std::memcpy(x, b, n * sizeof(double));
 
-    return;
+    return true;
   }
 
   mCacheOrder.clear();
@@ -161,8 +163,7 @@ void PgsBoxedLcpSolver::solve(
 
   if (possibleToTerminate)
   {
-    // return true;
-    return;
+    return true;
   }
 
   // Normalizing
@@ -240,9 +241,7 @@ void PgsBoxedLcpSolver::solve(
       break;
   }
 
-  // return sentinel; // TODO(JS): Consider providing the result passing
-  // sentinel
-  // in it.
+  return possibleToTerminate;
 }
 
 #ifndef NDEBUG

--- a/dart/constraint/PgsBoxedLcpSolver.hpp
+++ b/dart/constraint/PgsBoxedLcpSolver.hpp
@@ -66,7 +66,7 @@ public:
   static const std::string& getStaticType();
 
   // Documentation inherited.
-  void solve(
+  bool solve(
       int n,
       double* A,
       double* x,
@@ -74,7 +74,8 @@ public:
       int nub,
       double* lo,
       double* hi,
-      int* findex) override;
+      int* findex,
+      bool earlyTermination) override;
 
 #ifndef NDEBUG
   // Documentation inherited.

--- a/dart/external/odelcpsolver/lcp.h
+++ b/dart/external/odelcpsolver/lcp.h
@@ -57,8 +57,8 @@ to be implemented. the first `nub' variables are assumed to have findex < 0.
 #include "dart/external/odelcpsolver/odeconfig.h"
 #include "dart/external/odelcpsolver/common.h"
 
-void dSolveLCP (int n, dReal *A, dReal *x, dReal *b, dReal *w,
-	int nub, dReal *lo, dReal *hi, int *findex);
+bool dSolveLCP (int n, dReal *A, dReal *x, dReal *b, dReal *w,
+  int nub, dReal *lo, dReal *hi, int *findex, bool earlyTermination = false);
 
 size_t dEstimateSolveLCPMemoryReq(int n, bool outer_w_avail);
 

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -542,8 +542,8 @@ void World::setConstraintSolver(constraint::UniqueConstraintSolverPtr solver)
     return;
   }
 
-  assert(mConstraintSolver);
-  solver->setFromOtherConstraintSolver(*mConstraintSolver);
+  if (mConstraintSolver)
+    solver->setFromOtherConstraintSolver(*mConstraintSolver);
 
   mConstraintSolver = std::move(solver);
   mConstraintSolver->setTimeStep(mTimeStep);

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -45,6 +45,7 @@
 #include "dart/common/Console.hpp"
 #include "dart/integration/SemiImplicitEulerIntegrator.hpp"
 #include "dart/dynamics/Skeleton.hpp"
+#include "dart/constraint/ConstrainedGroup.hpp"
 #include "dart/constraint/BoxedLcpConstraintSolver.hpp"
 #include "dart/collision/CollisionGroup.hpp"
 
@@ -66,12 +67,13 @@ World::World(const std::string& _name)
     mTimeStep(0.001),
     mTime(0.0),
     mFrame(0),
-    mConstraintSolver(
-      new constraint::BoxedLcpConstraintSolver(mTimeStep)),
     mRecording(new Recording(mSkeletons)),
     onNameChanged(mNameChangedSignal)
 {
   mIndices.push_back(0);
+
+  auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>();
+  setConstraintSolver(std::move(solver));
 }
 
 //==============================================================================
@@ -131,16 +133,18 @@ WorldPtr World::clone() const
 //==============================================================================
 void World::setTimeStep(double _timeStep)
 {
-  assert(_timeStep > 0.0 && "Invalid timestep.");
+  if (_timeStep <= 0.0)
+  {
+    dtwarn << "[World] Attempting to set negative timestep. Ignoring this "
+           << "request because it can lead to undefined behavior.\n";
+    return;
+  }
 
   mTimeStep = _timeStep;
-//  mConstraintHandler->setTimeStep(_timeStep);
+  assert(mConstraintSolver);
   mConstraintSolver->setTimeStep(_timeStep);
-  for (std::vector<dynamics::SkeletonPtr>::iterator it = mSkeletons.begin();
-       it != mSkeletons.end(); ++it)
-  {
-    (*it)->setTimeStep(_timeStep);
-  }
+  for (auto& skel : mSkeletons)
+    skel->setTimeStep(_timeStep);
 }
 
 //==============================================================================
@@ -542,10 +546,17 @@ void World::setConstraintSolver(constraint::UniqueConstraintSolverPtr solver)
   solver->setFromOtherConstraintSolver(*mConstraintSolver);
 
   mConstraintSolver = std::move(solver);
+  mConstraintSolver->setTimeStep(mTimeStep);
 }
 
 //==============================================================================
-constraint::ConstraintSolver* World::getConstraintSolver() const
+constraint::ConstraintSolver* World::getConstraintSolver()
+{
+  return mConstraintSolver.get();
+}
+
+//==============================================================================
+const constraint::ConstraintSolver* World::getConstraintSolver() const
 {
   return mConstraintSolver.get();
 }

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -242,7 +242,10 @@ public:
   void setConstraintSolver(constraint::UniqueConstraintSolverPtr solver);
 
   /// Get the constraint solver
-  constraint::ConstraintSolver* getConstraintSolver() const;
+  constraint::ConstraintSolver* getConstraintSolver();
+
+  /// Get the constraint solver
+  const constraint::ConstraintSolver* getConstraintSolver() const;
 
   /// Bake simulated current state and store it into mRecording
   void bake();

--- a/examples/osgExamples/osgBoxStacking/osgBoxStacking.cpp
+++ b/examples/osgExamples/osgBoxStacking/osgBoxStacking.cpp
@@ -358,21 +358,21 @@ protected:
       //         mWorld->getTimeStep());
       auto lcpSolver = std::make_shared<constraint::DantzigBoxedLcpSolver>();
       auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>(
-          mWorld->getTimeStep(), lcpSolver);
+          lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else if (solverType == 1)
     {
       auto lcpSolver = std::make_shared<constraint::DantzigBoxedLcpSolver>();
       auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>(
-          mWorld->getTimeStep(), lcpSolver);
+          lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else if (solverType == 2)
     {
       auto lcpSolver = std::make_shared<constraint::PgsBoxedLcpSolver>();
       auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>(
-          mWorld->getTimeStep(), lcpSolver);
+          lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else

--- a/unittests/comprehensive/test_World.cpp
+++ b/unittests/comprehensive/test_World.cpp
@@ -360,7 +360,6 @@ TEST(World, SetNewConstraintSolver)
 
   auto solver1
       = dart::common::make_unique<constraint::BoxedLcpConstraintSolver>(
-          world->getTimeStep(),
           std::make_shared<constraint::DantzigBoxedLcpSolver>());
   EXPECT_TRUE(solver1->getSkeletons().size() == 0);
   EXPECT_TRUE(solver1->getConstraints().size() == 0);
@@ -371,7 +370,6 @@ TEST(World, SetNewConstraintSolver)
 
   auto solver2
       = dart::common::make_unique<constraint::BoxedLcpConstraintSolver>(
-          world->getTimeStep(),
           std::make_shared<constraint::PgsBoxedLcpSolver>());
   EXPECT_TRUE(solver2->getSkeletons().size() == 0);
   EXPECT_TRUE(solver2->getConstraints().size() == 0);

--- a/unittests/regression/CMakeLists.txt
+++ b/unittests/regression/CMakeLists.txt
@@ -7,6 +7,8 @@ if(TARGET dart-utils-urdf)
   dart_add_test("regression" test_Issue838)
   target_link_libraries(test_Issue838 dart-utils-urdf)
 
+  dart_add_test("regression" test_Issue892)
+
   dart_add_test("regression" test_Issue895)
 
   dart_add_test("regression" test_Issue986)
@@ -32,4 +34,4 @@ if(TARGET dart-collision-bullet AND TARGET dart-collision-ode)
 
 endif()
 
-dart_format_add(test_Issue1243.cpp)
+dart_format_add(test_Issue892.cpp test_Issue1243.cpp)

--- a/unittests/regression/test_Issue892.cpp
+++ b/unittests/regression/test_Issue892.cpp
@@ -84,10 +84,10 @@ TEST(Issue892, LCPSolverShouldNotRetrunNanValues)
       EXPECT_TRUE(result.isCollision());
 
       auto angle1 = box1->getRootJoint()->getPosition(0);
-      auto angle2 = box1->getRootJoint()->getPosition(0);
+      auto angle2 = box2->getRootJoint()->getPosition(0);
 
       EXPECT_NEAR(angle1, -0.345858, 0.1);
-      EXPECT_NEAR(angle2, -0.345858, 0.1);
+      EXPECT_NEAR(angle2, +0.345858, 0.1);
     }
   }
 }

--- a/unittests/regression/test_Issue892.cpp
+++ b/unittests/regression/test_Issue892.cpp
@@ -80,9 +80,6 @@ TEST(Issue892, LCPSolverShouldNotRetrunNanValues)
 
     if (i > 1100)
     {
-      const CollisionResult result = world->getLastCollisionResult();
-      EXPECT_TRUE(result.isCollision());
-
       auto angle1 = box1->getRootJoint()->getPosition(0);
       auto angle2 = box2->getRootJoint()->getPosition(0);
 

--- a/unittests/regression/test_Issue892.cpp
+++ b/unittests/regression/test_Issue892.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <TestHelpers.hpp>
+#include <dart/dart.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
+#include <gtest/gtest.h>
+
+using namespace dart::collision;
+using namespace dart::dynamics;
+using namespace dart::simulation;
+
+//==============================================================================
+SkeletonPtr createBox(double offset, double angle, std::string name)
+{
+  SkeletonPtr box = Skeleton::create(name);
+  RevoluteJoint::Properties props;
+  props.mAxis = Eigen::Vector3d::UnitY();
+  props.mT_ParentBodyToJoint.translation() = Eigen::Vector3d(offset, 0.0, 0.0);
+  props.mT_ChildBodyToJoint.translation() = Eigen::Vector3d(0.0, 0.0, -0.4);
+
+  BodyNode* bn
+      = box->createJointAndBodyNodePair<RevoluteJoint>(nullptr, props).second;
+
+  auto shape = std::make_shared<BoxShape>(Eigen::Vector3d(0.2, 0.1, 1.0));
+  bn->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(shape);
+
+  box->getDof(0)->setPosition(-angle);
+
+  return box;
+}
+
+//==============================================================================
+TEST(Issue892, LCPSolverShouldNotRetrunNanValues)
+{
+  // Set more than 1100 steps so that the two boxes are in contact.
+  const auto numSteps = 2000u;
+
+  auto box1 = createBox(+0.4, +0.1, "box0");
+  auto box2 = createBox(-0.4, -0.1, "box1");
+
+  WorldPtr world = World::create();
+  world->addSkeleton(box1);
+  world->addSkeleton(box2);
+
+  for (auto i = 0u; i < numSteps; ++i)
+  {
+    world->step();
+    EXPECT_FALSE(box1->getRootJoint()->getPositions().hasNaN());
+    EXPECT_FALSE(box2->getRootJoint()->getPositions().hasNaN());
+
+    if (i > 1100)
+    {
+      const CollisionResult result = world->getLastCollisionResult();
+      EXPECT_TRUE(result.isCollision());
+
+      auto angle1 = box1->getRootJoint()->getPosition(0);
+      auto angle2 = box1->getRootJoint()->getPosition(0);
+
+      EXPECT_NEAR(angle1, -0.345858, 0.1);
+      EXPECT_NEAR(angle2, -0.345858, 0.1);
+    }
+  }
+}

--- a/unittests/unit/test_ContactConstraint.cpp
+++ b/unittests/unit/test_ContactConstraint.cpp
@@ -47,8 +47,7 @@ void testContactWithKinematicJoint(
 {
   auto world = std::make_shared<simulation::World>();
   world->setConstraintSolver(
-      common::make_unique<constraint::BoxedLcpConstraintSolver>(
-          world->getTimeStep(), lcpSolver));
+      common::make_unique<constraint::BoxedLcpConstraintSolver>(lcpSolver));
 
   auto skeleton1 = dynamics::Skeleton::create("skeleton1");
   auto pair1 = skeleton1->createJointAndBodyNodePair<dynamics::FreeJoint>();


### PR DESCRIPTION
### Problem
Dantzig LCP solver sometimes returns inaccurate solution or even NAN values when the LCP doesn't have a solution. More importantly, `BoxedLCPConstraintSolver` uses the solution without any sanity checks, which easily leads to unstable simulation. This is reported in #892.

### Solution
Let `BoxedLCPConstraintSolver` to use more robust LCP solver such as PGS when it fails to solve with the primary LCP solver. In addition to that, as a final resort, it discards NAN value solution when the secondary LCP solver failed as well.

### Testing
Added the regression test provided by @pchorak. Thanks!

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
