### PR TITLE
Apply IK solution only when the solver succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 #### Changes
 
+* Kinematics
+
+  * Fixed applying IK solution when the solver failed to solve: [#1266](https://github.com/dartsim/dart/pull/1266)
+
 * Dynamics
 
   * Fixed incorrect transpose check in Inertia::verifySpatialTensor(): [#1258](https://github.com/dartsim/dart/pull/1258)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Kinematics
 
-  * Fixed applying IK solution when the solver failed to solve: [#1266](https://github.com/dartsim/dart/pull/1266)
+  * Added findSolution() and solveAndApply() to InverseKinematics and HierarchicalIk classes and deprecated solve(~) member functions: [#1266](https://github.com/dartsim/dart/pull/1266)
 
 * Dynamics
 

--- a/dart/dynamics/HierarchicalIK.cpp
+++ b/dart/dynamics/HierarchicalIK.cpp
@@ -41,23 +41,46 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-bool HierarchicalIK::solve(bool _applySolution)
+bool HierarchicalIK::solve(bool applySolution)
+{
+  if (applySolution)
+  {
+    return solveAndApply(true);
+  }
+  else
+  {
+    Eigen::VectorXd positions;
+    return findSolution(positions);
+  }
+}
+
+//==============================================================================
+bool HierarchicalIK::solve(Eigen::VectorXd& positions, bool applySolution)
+{
+  if (applySolution)
+    return solveAndApply(positions, true);
+  else
+    return findSolution(positions);
+}
+
+//==============================================================================
+bool HierarchicalIK::findSolution(Eigen::VectorXd& positions)
 {
   if(nullptr == mSolver)
   {
-    dtwarn << "[HierarchicalIK::solve] The Solver for a HierarchicalIK module "
-           << "associated with [" << mSkeleton.lock()->getName() << "] is a "
-           << "nullptr. You must reset the module's Solver before you can use "
-           << "it.\n";
+    dtwarn << "[HierarchicalIK::findSolution] The Solver for a HierarchicalIK "
+           << "module associated with [" << mSkeleton.lock()->getName()
+           << "] is a nullptr. You must reset the module's Solver before you "
+           << "can use it.\n";
     return false;
   }
 
   if(nullptr == mProblem)
   {
-    dtwarn << "[HierarchicalIK::solve] The Problem for a HierarchicalIK module "
-           << "associated with [" << mSkeleton.lock()->getName() << "] is a "
-           << "nullptr. You must reset the module's Problem before you can use "
-           << "it.\n";
+    dtwarn << "[HierarchicalIK::findSolution] The Problem for a HierarchicalIK "
+           << "module associated with [" << mSkeleton.lock()->getName()
+           << "] is a nullptr. You must reset the module's Problem before you "
+           << "can use it.\n";
     return false;
   }
 
@@ -65,8 +88,8 @@ bool HierarchicalIK::solve(bool _applySolution)
 
   if(nullptr == skel)
   {
-    dtwarn << "[HierarchicalIK::solve] Calling a HierarchicalIK module which "
-           << "is associated with a Skeleton that no longer exists.\n";
+    dtwarn << "[HierarchicalIK::findSolution] Calling a HierarchicalIK module "
+           << "which is associated with a Skeleton that no longer exists.\n";
     return false;
   }
 
@@ -95,20 +118,30 @@ bool HierarchicalIK::solve(bool _applySolution)
   const Eigen::VectorXd originalPositions = skel->getPositions();
   const bool wasSolved = mSolver->solve();
 
-  if(wasSolved && _applySolution)
-    setPositions(mProblem->getOptimalSolution());
-  else
-    setPositions(originalPositions);
+  positions = mProblem->getOptimalSolution();
 
+  setPositions(originalPositions);
   skel->setVelocities(originalVelocities);
   return wasSolved;
 }
 
 //==============================================================================
-bool HierarchicalIK::solve(Eigen::VectorXd& positions, bool _applySolution)
+bool HierarchicalIK::solveAndApply(bool allowIncompleteResult)
 {
-  bool wasSolved = solve(_applySolution);
-  positions = mProblem->getOptimalSolution();
+  Eigen::VectorXd solution;
+  const auto wasSolved = findSolution(solution);
+  if (wasSolved || allowIncompleteResult)
+    setPositions(solution);
+  return wasSolved;
+}
+
+//==============================================================================
+bool HierarchicalIK::solveAndApply(
+    Eigen::VectorXd& positions, bool allowIncompleteResult)
+{
+  const auto wasSolved = findSolution(positions);
+  if (wasSolved || allowIncompleteResult)
+    setPositions(positions);
   return wasSolved;
 }
 

--- a/dart/dynamics/HierarchicalIK.hpp
+++ b/dart/dynamics/HierarchicalIK.hpp
@@ -67,9 +67,9 @@ public:
   virtual ~HierarchicalIK() = default;
 
   /// Solve the IK Problem. By default, the Skeleton itself will retain the
-  /// solved joint positions. If you pass in false for _applySolution, then the
-  /// joint positions will be return to their original positions after the
-  /// problem is solved.
+  /// solved joint positions unless it failed to solve. If you pass in false for
+  /// _applySolution, then the joint positions will be return to their original
+  /// positions after the problem is solved.
   bool solve(bool _applySolution = true);
 
   /// Same as solve(bool), but the positions vector will be filled with the

--- a/dart/dynamics/HierarchicalIK.hpp
+++ b/dart/dynamics/HierarchicalIK.hpp
@@ -103,7 +103,7 @@ public:
   /// getting a result close to a solution even if it failed to find the
   /// solution.
   /// \return True if a solution is successfully found
-  bool solveAndApply(bool allowIncompleteResult = false);
+  bool solveAndApply(bool allowIncompleteResult = true);
 
   /// Identical to solveAndApply(bool), but \c position will be filled with the
   /// solved positions.
@@ -119,7 +119,7 @@ public:
   /// solution.
   /// \return True if a solution is successfully found
   bool solveAndApply(
-      Eigen::VectorXd& positions, bool allowIncompleteResult = false);
+      Eigen::VectorXd& positions, bool allowIncompleteResult = true);
 
   /// Clone this HierarchicalIK module
   virtual std::shared_ptr<HierarchicalIK> clone(

--- a/dart/dynamics/HierarchicalIK.hpp
+++ b/dart/dynamics/HierarchicalIK.hpp
@@ -67,14 +67,59 @@ public:
   virtual ~HierarchicalIK() = default;
 
   /// Solve the IK Problem. By default, the Skeleton itself will retain the
-  /// solved joint positions unless it failed to solve. If you pass in false for
-  /// _applySolution, then the joint positions will be return to their original
-  /// positions after the problem is solved.
-  bool solve(bool _applySolution = true);
+  /// solved joint positions. If you pass in false for \c applySolution, then the
+  /// joint positions will be return to their original positions after the
+  /// problem is solved.
+  ///
+  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() instead.
+  DART_DEPRECATED(6.8)
+  bool solve(bool applySolution = true);
 
   /// Same as solve(bool), but the positions vector will be filled with the
   /// solved positions.
-  bool solve(Eigen::VectorXd& positions, bool _applySolution = true);
+  ///
+  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() or
+  /// findSolution() instead.
+  DART_DEPRECATED(6.8)
+  bool solve(Eigen::VectorXd& positions, bool applySolution = true);
+
+  /// Finds a solution of the IK problem without applying the solution.
+  ///
+  /// \param[out] positions The solution of the IK problem. If the solver failed
+  /// to find a solution then it will still set the position with the best
+  /// guess. For example, iterative solvers will fill \c position with the last
+  /// result of the iterations.
+  /// \return True if a solution is successfully found.
+  /// \sa solveAndApply()
+  bool findSolution(Eigen::VectorXd& positions);
+
+  /// Identical to findSolution(), but this function applies the solution when
+  /// the solver successfully found a solution or \c allowIncompleteResult is
+  /// set to true.
+  ///
+  /// \param[in] allowIncompleteResult Allow to apply the solution even when
+  /// the solver failed to find solution. This option would be useful when an
+  /// iterative solver is used because they will often do a decent job of
+  /// getting a result close to a solution even if it failed to find the
+  /// solution.
+  /// \return True if a solution is successfully found
+  bool solveAndApply(bool allowIncompleteResult = false);
+
+  /// Identical to solveAndApply(bool), but \c position will be filled with the
+  /// solved positions.
+  ///
+  /// \param[out] positions The solution of the IK problem. If the solver failed
+  /// to find a solution then it will still set the position with the best
+  /// guess. For example, iterative solvers will fill \c positions with the last
+  /// result of the iterations.
+  /// \param[in] allowIncompleteResult Allow to apply the solution even when
+  /// the solver failed to find solution. This option would be useful when an
+  /// iterative solver is used because they will often do a decent job of
+  /// getting a result close to a solution even if it failed to find the
+  /// solution.
+  /// \return True if a solution is successfully found
+  bool solveAndApply(
+      Eigen::VectorXd& positions, bool allowIncompleteResult = false);
 
   /// Clone this HierarchicalIK module
   virtual std::shared_ptr<HierarchicalIK> clone(

--- a/dart/dynamics/InverseKinematics.cpp
+++ b/dart/dynamics/InverseKinematics.cpp
@@ -92,21 +92,17 @@ bool InverseKinematics::solve(bool _applySolution)
   // Many GradientMethod implementations use Joint::integratePositions, so we
   // need to clear out any velocities that might be in the Skeleton and then
   // reset those velocities later. This has been opened as issue #699.
-  Eigen::VectorXd originalVelocities = skel->getVelocities();
-  for(std::size_t i=0; i < skel->getNumDofs(); ++i)
-    skel->getDof(i)->setVelocity(0.0);
+  const Eigen::VectorXd originalVelocities = skel->getVelocities();
+  skel->resetVelocities();
 
-  if(_applySolution)
-  {
-    bool wasSolved = mSolver->solve();
+  const Eigen::VectorXd originalPositions = getPositions();
+  const bool wasSolved = mSolver->solve();
+
+  if(wasSolved && _applySolution)
     setPositions(mProblem->getOptimalSolution());
-    skel->setVelocities(originalVelocities);
-    return wasSolved;
-  }
+  else
+    setPositions(originalPositions);
 
-  Eigen::VectorXd originalPositions = getPositions();
-  bool wasSolved = mSolver->solve();
-  setPositions(originalPositions);
   skel->setVelocities(originalVelocities);
   return wasSolved;
 }

--- a/dart/dynamics/InverseKinematics.hpp
+++ b/dart/dynamics/InverseKinematics.hpp
@@ -121,9 +121,10 @@ public:
   /// InverseKinematics::getProblem() and then using
   /// Problem::addSeed(Eigen::VectorXd).
   ///
-  /// By default, the Skeleton itself will retain the solved joint positions.
-  /// If you pass in false for _applySolution, then the joint positions will be
-  /// returned to their original positions after the problem is solved.
+  /// By default, the Skeleton itself will retain the solved joint positions
+  /// unless it failed to solve. If you pass in false for _applySolution, then
+  /// the joint positions will be returned to their original positions after the
+  /// problem is solved.
   ///
   /// Calling this function will automatically call Position::setLowerBounds(~)
   /// and Position::setUpperBounds(~) with the lower/upper position bounds of

--- a/dart/dynamics/InverseKinematics.hpp
+++ b/dart/dynamics/InverseKinematics.hpp
@@ -121,21 +121,102 @@ public:
   /// InverseKinematics::getProblem() and then using
   /// Problem::addSeed(Eigen::VectorXd).
   ///
-  /// By default, the Skeleton itself will retain the solved joint positions
-  /// unless it failed to solve. If you pass in false for _applySolution, then
-  /// the joint positions will be returned to their original positions after the
-  /// problem is solved.
+  /// By default, the Skeleton itself will retain the solved joint positions.
+  /// If you pass in false for _applySolution, then the joint positions will be
+  /// returned to their original positions after the problem is solved.
   ///
   /// Calling this function will automatically call Position::setLowerBounds(~)
   /// and Position::setUpperBounds(~) with the lower/upper position bounds of
   /// the corresponding Degrees Of Freedom. Problem::setDimension(~) will be
   /// taken care of automatically, and Problem::setInitialGuess(~) will be
   /// called with the current positions of the Degrees Of Freedom.
-  bool solve(bool _applySolution = true);
+  ///
+  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() instead.
+  DART_DEPRECATED(6.8)
+  bool solve(bool applySolution = true);
 
   /// Same as solve(bool), but the positions vector will be filled with the
   /// solved positions.
-  bool solve(Eigen::VectorXd& positions, bool _applySolution = true);
+  ///
+  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() or
+  /// findSolution() instead.
+  DART_DEPRECATED(6.8)
+  bool solve(Eigen::VectorXd& positions, bool applySolution = true);
+
+  /// Finds a solution of the IK problem without applying the solution.
+  ///
+  /// The initial guess for the IK optimization problem is the current joint
+  /// positions of the target system. If the iterative solver fails to find a
+  /// successive solution, it attempts more to solve the problem with other seed
+  /// configurations or random configurations if enough seed is not provided.
+  ///
+  /// Here is the pseudocode as described above:
+  ///
+  /// \code
+  /// attempts <- 0
+  /// initial_guess <- current_joint_positions
+  /// while attempts <= max_attempts:
+  ///   result <- solve(initial_guess)
+  ///   if result = success:
+  ///     return
+  ///   else:
+  ///     attempts <- attempts + 1
+  ///     if attempts <= num_seed:
+  ///       initial_guess <- seed[attempts - 1]
+  ///     else:
+  ///       initial_guess <- random_configuration  // within the bounds
+  /// \endcode
+  ///
+  /// By default, the max_attempts is 1, but this can be changed by calling
+  /// InverseKinematics::getSolver() and casting the SolverPtr to an
+  /// optimizer::GradientDescentSolver (unless you have changed the Solver type)
+  /// and then calling GradientDescentSolver::setMaxAttempts(std::size_t).
+  ///
+  /// By default, the list of seeds is empty, but they can be added by calling
+  /// InverseKinematics::getProblem() and then using
+  /// Problem::addSeed(Eigen::VectorXd).
+  ///
+  /// Calling this function will automatically call Position::setLowerBounds(~)
+  /// and Position::setUpperBounds(~) with the lower/upper position bounds of
+  /// the corresponding Degrees Of Freedom. Problem::setDimension(~) will be
+  /// taken care of automatically, and Problem::setInitialGuess(~) will be
+  /// called with the current positions of the Degrees Of Freedom.
+  ///
+  /// \param[out] position The solution of the IK problem. If the solver failed
+  /// to find a solution then it will still set the position with the best
+  /// guess. For example, iterative solvers will fill \c positions with the last
+  /// result of the iterations.
+  /// \return True if a solution is successfully found.
+  /// \sa solveAndApply()
+  bool findSolution(Eigen::VectorXd& positions);
+
+  /// Identical to findSolution(), but this function applies the solution when
+  /// the solver successfully found a solution or \c allowIncompleteResult is
+  /// set to true.
+  ///
+  /// \param[in] allowIncompleteResult Allow to apply the solution even when
+  /// the solver failed to find solution. This option would be useful when an
+  /// iterative solver is used because they will often do a decent job of
+  /// getting a result close to a solution even if it failed to find the
+  /// solution.
+  /// \return True if a solution is successfully found
+  bool solveAndApply(bool allowIncompleteResult = false);
+
+  /// Identical to solveAndApply(bool), but \c position will be filled with the
+  /// solved positions.
+  ///
+  /// \param[out] positions The solution of the IK problem. If the solver failed
+  /// to find a solution then it will still set the position with the best
+  /// guess. For example, iterative solvers will fill \c positions with the last
+  /// result of the iterations.
+  /// \param[in] allowIncompleteResult Allow to apply the solution even when
+  /// the solver failed to find solution. This option would be useful when an
+  /// iterative solver is used because they will often do a decent job of
+  /// getting a result close to a solution even if it failed to find the
+  /// solution.
+  /// \return True if a solution is successfully found
+  bool solveAndApply(
+      Eigen::VectorXd& positions, bool allowIncompleteResult = false);
 
   /// Clone this IK module, but targeted at a new Node. Any Functions in the
   /// Problem that inherit InverseKinematics::Function will be adapted to the

--- a/dart/dynamics/InverseKinematics.hpp
+++ b/dart/dynamics/InverseKinematics.hpp
@@ -200,7 +200,7 @@ public:
   /// getting a result close to a solution even if it failed to find the
   /// solution.
   /// \return True if a solution is successfully found
-  bool solveAndApply(bool allowIncompleteResult = false);
+  bool solveAndApply(bool allowIncompleteResult = true);
 
   /// Identical to solveAndApply(bool), but \c position will be filled with the
   /// solved positions.
@@ -216,7 +216,7 @@ public:
   /// solution.
   /// \return True if a solution is successfully found
   bool solveAndApply(
-      Eigen::VectorXd& positions, bool allowIncompleteResult = false);
+      Eigen::VectorXd& positions, bool allowIncompleteResult = true);
 
   /// Clone this IK module, but targeted at a new Node. Any Functions in the
   /// Problem that inherit InverseKinematics::Function will be adapted to the

--- a/dart/gui/osg/DragAndDrop.cpp
+++ b/dart/gui/osg/DragAndDrop.cpp
@@ -797,7 +797,7 @@ void BodyNodeDnD::move()
   if(mUseExternalIK)
   {
     mIK->getSolver()->setNumMaxIterations(10);
-    mIK->solve();
+    mIK->solveAndApply(true);
   }
 }
 

--- a/examples/osgExamples/osgAtlasPuppet/osgAtlasPuppet.cpp
+++ b/examples/osgExamples/osgAtlasPuppet/osgAtlasPuppet.cpp
@@ -232,7 +232,7 @@ public:
       mAtlas->getJoint(0)->setPositions(FreeJoint::convertToPositions(new_tf));
     }
 
-    bool solved = mAtlas->getIK(true)->solve();
+    bool solved = mAtlas->getIK(true)->solveAndApply(true);
 
     if(!solved)
       ++iter;

--- a/examples/osgExamples/osgHuboPuppet/osgHuboPuppet.cpp
+++ b/examples/osgExamples/osgHuboPuppet/osgHuboPuppet.cpp
@@ -813,7 +813,7 @@ public:
       mHubo->getJoint(0)->setPositions(FreeJoint::convertToPositions(new_tf));
     }
 
-    mHubo->getIK(true)->solve();
+    mHubo->getIK(true)->solveAndApply(true);
   }
 
   bool mAmplifyMovement;

--- a/examples/osgExamples/osgWamIkFast/WamWorld.cpp
+++ b/examples/osgExamples/osgWamIkFast/WamWorld.cpp
@@ -42,5 +42,5 @@ WamWorld::WamWorld(WorldPtr world, SkeletonPtr robot)
 //==============================================================================
 void WamWorld::customPreRefresh()
 {
-  mWam->getIK(true)->solve();
+  mWam->getIK(true)->solveAndApply(true);
 }

--- a/unittests/comprehensive/CMakeLists.txt
+++ b/unittests/comprehensive/CMakeLists.txt
@@ -56,5 +56,6 @@ if(TARGET dart-utils)
 endif()
 
 dart_format_add(
+  test_InverseKinematics.cpp
   test_MultiObjectiveOptimization.cpp
 )

--- a/unittests/comprehensive/test_InverseKinematics.cpp
+++ b/unittests/comprehensive/test_InverseKinematics.cpp
@@ -41,31 +41,44 @@ using namespace Eigen;
 using namespace dart;
 using namespace dart::dynamics;
 
-SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
-                                           Vector3d dim2, TypeOfDOF type2,
-                                           bool finished = true)
+SkeletonPtr createFreeFloatingTwoLinkRobot(
+    Vector3d dim1, Vector3d dim2, TypeOfDOF type2, bool finished = true)
 {
   SkeletonPtr robot = Skeleton::create();
 
   // Create the first link
   BodyNode::Properties node(BodyNode::AspectProperties("link1"));
-  node.mInertia.setLocalCOM(Vector3d(0.0, 0.0, dim1(2)/2.0));
+  node.mInertia.setLocalCOM(Vector3d(0.0, 0.0, dim1(2) / 2.0));
   std::shared_ptr<Shape> shape(new BoxShape(dim1));
 
-  BodyNode* parent_node = robot->createJointAndBodyNodePair<FreeJoint>(nullptr,
-    GenericJoint<SE3Space>::Properties(std::string("joint1")), node).second;
-  parent_node->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
-        shape);
+  BodyNode* parent_node
+      = robot
+            ->createJointAndBodyNodePair<FreeJoint>(
+                nullptr,
+                GenericJoint<SE3Space>::Properties(std::string("joint1")),
+                node)
+            .second;
+  parent_node
+      ->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+          shape);
 
   // Create the second link
   node = BodyNode::Properties(BodyNode::AspectProperties("link2"));
-  node.mInertia.setLocalCOM(Vector3d(0.0, 0.0, dim2(2)/2.0));
+  node.mInertia.setLocalCOM(Vector3d(0.0, 0.0, dim2(2) / 2.0));
   shape = std::shared_ptr<Shape>(new BoxShape(dim2));
 
   std::pair<Joint*, BodyNode*> pair2 = add1DofJoint(
-        robot, parent_node, node, "joint2", 0.0, -constantsd::pi(), constantsd::pi(), type2);
-  pair2.second->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
-        shape);
+      robot,
+      parent_node,
+      node,
+      "joint2",
+      0.0,
+      -constantsd::pi(),
+      constantsd::pi(),
+      type2);
+  pair2.second
+      ->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+          shape);
 
   Joint* joint = pair2.first;
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
@@ -75,7 +88,7 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
   parent_node = pair2.second;
 
   // If finished, initialize the skeleton
-  if(finished)
+  if (finished)
     addEndEffector(robot, parent_node, dim2);
 
   return robot;
@@ -83,7 +96,7 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 
 #if HAVE_NLOPT
 //==============================================================================
-//TEST(InverseKinematics, FittingTransformation)
+// TEST(InverseKinematics, FittingTransformation)
 //{
 //  const double TOLERANCE = 1e-6;
 //#if BUILD_TYPE_RELEASE
@@ -107,7 +120,8 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 ////  Joint* joint1 = body1->getParentJoint();
 //  Joint* joint2 = body2->getParentJoint();
 
-//  //------------------------- Free joint test ----------------------------------
+//  //------------------------- Free joint test
+//  ----------------------------------
 //  // The parent joint of body1 is free joint so body1 should be able to
 //  // transform to arbitrary tramsformation.
 //  for (std::size_t i = 0; i < numRandomTests; ++i)
@@ -125,7 +139,8 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 //    robot->setConfigs(oldConfig, true, false, false);
 //  }
 
-//  //----------------------- Revolute joint test ---------------------------------
+//  //----------------------- Revolute joint test
+//  ---------------------------------
 //  // The parent joint of body2 is revolute joint so body2 can rotate along the
 //  // axis of the revolute joint.
 //  for (std::size_t i = 0; i < numRandomTests; ++i)
@@ -154,8 +169,8 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 //                0.0, TOLERANCE);
 //  }
 
-//  //---------------- Revolute joint test with joint limit ----------------------
-//  for (std::size_t i = 0; i < numRandomTests; ++i)
+//  //---------------- Revolute joint test with joint limit
+//  ---------------------- for (std::size_t i = 0; i < numRandomTests; ++i)
 //  {
 //    // Set joint limit
 //    joint2->setPositionLowerLimit(0, DART_RADIAN *  0.0);
@@ -167,9 +182,9 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 
 //    // Get desiredT2 by rotating the revolute joint with random angle out of
 //    // the joint limit range
-//    joint2->setPosition(0, math::random(DART_RADIAN * 15.5, constantsd::pi()));
-//    robot->setConfigs(robot->getPositions(), true, false, false);
-//    Isometry3d desiredT2 = body2->getWorldTransform();
+//    joint2->setPosition(0, math::random(DART_RADIAN * 15.5,
+//    constantsd::pi())); robot->setConfigs(robot->getPositions(), true, false,
+//    false); Isometry3d desiredT2 = body2->getWorldTransform();
 
 //    // Transform body2 to the original transofrmation and check if it is done
 //    // well
@@ -197,7 +212,7 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 //}
 
 //==============================================================================
-//TEST(InverseKinematics, FittingVelocity)
+// TEST(InverseKinematics, FittingVelocity)
 //{
 //  const double TOLERANCE = 1e-4;
 //#if BUILD_TYPE_RELEASE
@@ -219,7 +234,8 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 //  Joint* joint1 = body1->getParentJoint();
 ////  Joint* joint2 = body2->getParentJoint();
 
-//  //------------------------- Free joint test ----------------------------------
+//  //------------------------- Free joint test
+//  ----------------------------------
 //  // The parent joint of body1 is free joint so body1 should be able to
 //  // transform to arbitrary tramsformation.
 //  for (std::size_t i = 0; i < numRandomTests; ++i)
@@ -248,3 +264,95 @@ SkeletonPtr createFreeFloatingTwoLinkRobot(Vector3d dim1,
 //  }
 //}
 #endif
+
+//==============================================================================
+TEST(InverseKinematics, SolveForFreeJoint)
+{
+  // Very simple test of InverseKinematics module, applied to a FreeJoint to
+  // ensure that the target is reachable
+
+  SkeletonPtr skel = Skeleton::create();
+  skel->createJointAndBodyNodePair<FreeJoint>();
+
+  std::shared_ptr<InverseKinematics> ik = skel->getBodyNode(0)->getIK(true);
+
+  Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
+  tf.translation() = Eigen::Vector3d(0.0, 0.0, 0.8);
+  tf.rotate(Eigen::AngleAxisd(M_PI / 8, Eigen::Vector3d(0, 1, 0)));
+  ik->getTarget()->setTransform(tf);
+
+  ik->getErrorMethod().setBounds(
+      Eigen::Vector6d::Constant(-1e-8), Eigen::Vector6d::Constant(1e-8));
+
+  ik->getSolver()->setNumMaxIterations(100);
+
+  EXPECT_FALSE(equals(
+      ik->getTarget()->getTransform().matrix(),
+      skel->getBodyNode(0)->getTransform().matrix(),
+      1e-1));
+
+  EXPECT_TRUE(ik->getSolver()->solve());
+
+  EXPECT_TRUE(equals(
+      ik->getTarget()->getTransform().matrix(),
+      skel->getBodyNode(0)->getTransform().matrix(),
+      1e-8));
+}
+
+//==============================================================================
+class FailingSolver : public optimizer::Solver
+{
+public:
+  FailingSolver(double constant) : mConstant(constant)
+  {
+    // Do nothing
+  }
+
+  bool solve() override
+  {
+    std::shared_ptr<optimizer::Problem> problem = mProperties.mProblem;
+    if (nullptr == problem)
+    {
+      dtwarn << "[FailingSolver::solve] Attempting to solve a nullptr "
+             << "problem! We will return false.\n";
+      return false;
+    }
+
+    const auto dim = problem->getDimension();
+    const Eigen::VectorXd wrongSolution
+        = Eigen::VectorXd::Constant(static_cast<int>(dim), mConstant);
+    problem->setOptimalSolution(wrongSolution);
+
+    return false;
+  }
+
+  std::string getType() const override
+  {
+    return "FailingSolver";
+  }
+
+  std::shared_ptr<Solver> clone() const override
+  {
+    return std::make_shared<FailingSolver>(mConstant);
+  }
+
+protected:
+  double mConstant;
+};
+
+//==============================================================================
+TEST(InverseKinematics, DoNotApplySolutionOnFailure)
+{
+  SkeletonPtr skel = Skeleton::create();
+  skel->createJointAndBodyNodePair<FreeJoint>();
+
+  std::shared_ptr<InverseKinematics> ik = skel->getBodyNode(0)->getIK(true);
+  ik->setSolver(std::make_shared<FailingSolver>(10));
+  ik->getTarget()->setTransform(Eigen::Isometry3d::Identity());
+
+  const auto dofs = static_cast<int>(skel->getNumDofs());
+  skel->resetPositions();
+
+  EXPECT_FALSE(ik->solve(false));
+  EXPECT_TRUE(equals(skel->getPositions(), Eigen::VectorXd::Zero(dofs).eval()));
+}

--- a/unittests/comprehensive/test_InverseKinematics.cpp
+++ b/unittests/comprehensive/test_InverseKinematics.cpp
@@ -41,230 +41,6 @@ using namespace Eigen;
 using namespace dart;
 using namespace dart::dynamics;
 
-SkeletonPtr createFreeFloatingTwoLinkRobot(
-    Vector3d dim1, Vector3d dim2, TypeOfDOF type2, bool finished = true)
-{
-  SkeletonPtr robot = Skeleton::create();
-
-  // Create the first link
-  BodyNode::Properties node(BodyNode::AspectProperties("link1"));
-  node.mInertia.setLocalCOM(Vector3d(0.0, 0.0, dim1(2) / 2.0));
-  std::shared_ptr<Shape> shape(new BoxShape(dim1));
-
-  BodyNode* parent_node
-      = robot
-            ->createJointAndBodyNodePair<FreeJoint>(
-                nullptr,
-                GenericJoint<SE3Space>::Properties(std::string("joint1")),
-                node)
-            .second;
-  parent_node
-      ->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
-          shape);
-
-  // Create the second link
-  node = BodyNode::Properties(BodyNode::AspectProperties("link2"));
-  node.mInertia.setLocalCOM(Vector3d(0.0, 0.0, dim2(2) / 2.0));
-  shape = std::shared_ptr<Shape>(new BoxShape(dim2));
-
-  std::pair<Joint*, BodyNode*> pair2 = add1DofJoint(
-      robot,
-      parent_node,
-      node,
-      "joint2",
-      0.0,
-      -constantsd::pi(),
-      constantsd::pi(),
-      type2);
-  pair2.second
-      ->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
-          shape);
-
-  Joint* joint = pair2.first;
-  Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
-  T.translate(Eigen::Vector3d(0.0, 0.0, dim1(2)));
-  joint->setTransformFromParentBodyNode(T);
-
-  parent_node = pair2.second;
-
-  // If finished, initialize the skeleton
-  if (finished)
-    addEndEffector(robot, parent_node, dim2);
-
-  return robot;
-}
-
-#if HAVE_NLOPT
-//==============================================================================
-// TEST(InverseKinematics, FittingTransformation)
-//{
-//  const double TOLERANCE = 1e-6;
-//#if BUILD_TYPE_RELEASE
-//  const std::size_t numRandomTests = 100;
-//#else
-//  const std::size_t numRandomTests = 10;
-//#endif
-
-//  // Create two link robot
-//  const double l1 = 1.5;
-//  const double l2 = 1.0;
-//  SkeletonPtr robot = createFreeFloatingTwoLinkRobot(
-//                      Vector3d(0.3, 0.3, l1),
-//                      Vector3d(0.3, 0.3, l2), DOF_ROLL);
-//  std::size_t dof = robot->getNumDofs();
-//  VectorXd oldConfig = robot->getPositions();
-
-//  BodyNode* body1 = robot->getBodyNode(0);
-//  BodyNode* body2 = robot->getBodyNode(1);
-
-////  Joint* joint1 = body1->getParentJoint();
-//  Joint* joint2 = body2->getParentJoint();
-
-//  //------------------------- Free joint test
-//  ----------------------------------
-//  // The parent joint of body1 is free joint so body1 should be able to
-//  // transform to arbitrary tramsformation.
-//  for (std::size_t i = 0; i < numRandomTests; ++i)
-//  {
-//    // Get desiredT2 by transforming body1 to arbitrary transformation
-//    Isometry3d desiredT1 = math::expMap(Vector6d::Random());
-//    body1->fitWorldTransform(desiredT1);
-
-//    // Check
-//    Isometry3d newT1 = body1->getWorldTransform();
-//    EXPECT_NEAR(math::logMap(newT1.inverse() * desiredT1).norm(),
-//                0.0, TOLERANCE);
-
-//    // Set to initial configuration
-//    robot->setConfigs(oldConfig, true, false, false);
-//  }
-
-//  //----------------------- Revolute joint test
-//  ---------------------------------
-//  // The parent joint of body2 is revolute joint so body2 can rotate along the
-//  // axis of the revolute joint.
-//  for (std::size_t i = 0; i < numRandomTests; ++i)
-//  {
-//    // Store the original transformation and joint angle
-//    Isometry3d oldT2 = body2->getWorldTransform();
-//    VectorXd oldQ2 = joint2->getPositions();
-
-//    // Get desiredT2 by rotating the revolute joint with random angle
-//    joint2->setConfigs(VectorXd::Random(1), true, false, false);
-//    Isometry3d desiredT2 = body2->getWorldTransform();
-
-//    // Transform body2 to the original transofrmation and check if it is done
-//    // well
-//    joint2->setConfigs(oldQ2, true, false, false);
-//    EXPECT_NEAR(
-//          math::logMap(oldT2.inverse() * body2->getWorldTransform()).norm(),
-//          0.0, TOLERANCE);
-
-//    // Try to find optimal joint angle
-//    body2->fitWorldTransform(desiredT2);
-
-//    // Check
-//    Isometry3d newT2 = body2->getWorldTransform();
-//    EXPECT_NEAR(math::logMap(newT2.inverse() * desiredT2).norm(),
-//                0.0, TOLERANCE);
-//  }
-
-//  //---------------- Revolute joint test with joint limit
-//  ---------------------- for (std::size_t i = 0; i < numRandomTests; ++i)
-//  {
-//    // Set joint limit
-//    joint2->setPositionLowerLimit(0, DART_RADIAN *  0.0);
-//    joint2->setPositionUpperLimit(0, DART_RADIAN * 15.0);
-
-//    // Store the original transformation and joint angle
-//    Isometry3d oldT2 = body2->getWorldTransform();
-//    VectorXd oldQ2 = joint2->getPositions();
-
-//    // Get desiredT2 by rotating the revolute joint with random angle out of
-//    // the joint limit range
-//    joint2->setPosition(0, math::random(DART_RADIAN * 15.5,
-//    constantsd::pi())); robot->setConfigs(robot->getPositions(), true, false,
-//    false); Isometry3d desiredT2 = body2->getWorldTransform();
-
-//    // Transform body2 to the original transofrmation and check if it is done
-//    // well
-//    joint2->setConfigs(oldQ2, true, false, false);
-//    EXPECT_NEAR(
-//          math::logMap(oldT2.inverse() * body2->getWorldTransform()).norm(),
-//          0.0, TOLERANCE);
-
-//    // Try to find optimal joint angle without joint limit constraint
-//    body2->fitWorldTransform(desiredT2, BodyNode::IKP_PARENT_JOINT, false);
-
-//    // Check if the optimal body2 transformation is reached to the desired one
-//    Isometry3d newT2 = body2->getWorldTransform();
-//    EXPECT_NEAR(math::logMap(newT2.inverse() * desiredT2).norm(),
-//                0.0, TOLERANCE);
-
-//    // Try to find optimal joint angle with joint limit constraint
-//    body2->fitWorldTransform(desiredT2, BodyNode::IKP_PARENT_JOINT, true);
-
-//    // Check if the optimal joint anlge is in the range
-//    double newQ2 = joint2->getPosition(0);
-//    EXPECT_GE(newQ2, DART_RADIAN *  0.0);
-//    EXPECT_LE(newQ2, DART_RADIAN * 15.0);
-//  }
-//}
-
-//==============================================================================
-// TEST(InverseKinematics, FittingVelocity)
-//{
-//  const double TOLERANCE = 1e-4;
-//#if BUILD_TYPE_RELEASE
-//  const std::size_t numRandomTests = 100;
-//#else
-//  const std::size_t numRandomTests = 10;
-//#endif
-
-//  // Create two link robot
-//  const double l1 = 1.5;
-//  const double l2 = 1.0;
-//  SkeletonPtr robot = createFreeFloatingTwoLinkRobot(
-//                      Vector3d(0.3, 0.3, l1),
-//                      Vector3d(0.3, 0.3, l2), DOF_ROLL);
-
-//  BodyNode* body1 = robot->getBodyNode(0);
-////  BodyNode* body2 = robot->getBodyNode(1);
-
-//  Joint* joint1 = body1->getParentJoint();
-////  Joint* joint2 = body2->getParentJoint();
-
-//  //------------------------- Free joint test
-//  ----------------------------------
-//  // The parent joint of body1 is free joint so body1 should be able to
-//  // transform to arbitrary tramsformation.
-//  for (std::size_t i = 0; i < numRandomTests; ++i)
-//  {
-//    // Test for linear velocity
-//    Vector3d desiredVel = Vector3d::Random();
-//    body1->fitWorldLinearVel(desiredVel);
-//    Vector3d fittedLinVel = body1->getWorldLinearVelocity();
-//    Vector3d fittedAngVel = body1->getWorldAngularVelocity();
-//    Vector3d diff = fittedLinVel - desiredVel;
-//    EXPECT_NEAR(diff.dot(diff), 0.0, TOLERANCE);
-//    EXPECT_NEAR(fittedAngVel.dot(fittedAngVel), 0.0, TOLERANCE);
-//    joint1->setGenVels(Vector6d::Zero(), true, true);
-//    robot->setState(robot->getState(), true, true, false);
-
-//    // Test for angular velocity
-//    desiredVel = Vector3d::Random();
-//    body1->fitWorldAngularVel(desiredVel);
-//    fittedLinVel = body1->getWorldLinearVelocity();
-//    fittedAngVel = body1->getWorldAngularVelocity();
-//    diff = fittedAngVel - desiredVel;
-//    EXPECT_NEAR(fittedLinVel.dot(fittedLinVel), 0.0, TOLERANCE);
-//    EXPECT_NEAR(diff.dot(diff), 0.0, TOLERANCE);
-//    joint1->setGenVels(Vector6d::Zero(), true, true);
-//    robot->setState(robot->getState(), true, true, false);
-//  }
-//}
-#endif
-
 //==============================================================================
 TEST(InverseKinematics, SolveForFreeJoint)
 {
@@ -307,6 +83,8 @@ public:
   {
     // Do nothing
   }
+
+  ~FailingSolver() override = default;
 
   bool solve() override
   {
@@ -353,6 +131,10 @@ TEST(InverseKinematics, DoNotApplySolutionOnFailure)
   const auto dofs = static_cast<int>(skel->getNumDofs());
   skel->resetPositions();
 
-  EXPECT_FALSE(ik->solve(false));
+  EXPECT_FALSE(ik->solveAndApply(false));
   EXPECT_TRUE(equals(skel->getPositions(), Eigen::VectorXd::Zero(dofs).eval()));
+
+  EXPECT_FALSE(ik->solveAndApply(true));
+  EXPECT_FALSE(
+      equals(skel->getPositions(), Eigen::VectorXd::Zero(dofs).eval()));
 }

--- a/unittests/unit/test_Optimizer.cpp
+++ b/unittests/unit/test_Optimizer.cpp
@@ -214,36 +214,6 @@ TEST(Optimizer, BasicSnopt)
 #endif
 
 //==============================================================================
-TEST(Optimizer, InverseKinematics)
-{
-  // Very simple test of InverseKinematics module, applied to a FreeJoint to
-  // ensure that the target is reachable
-
-  SkeletonPtr skel = Skeleton::create();
-  skel->createJointAndBodyNodePair<FreeJoint>();
-
-  std::shared_ptr<InverseKinematics> ik = skel->getBodyNode(0)->getIK(true);
-
-  Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
-  tf.translation() = Eigen::Vector3d(0.0, 0.0, 0.8);
-  tf.rotate(Eigen::AngleAxisd(M_PI/8, Eigen::Vector3d(0, 1, 0)));
-  ik->getTarget()->setTransform(tf);
-
-  ik->getErrorMethod().setBounds(Eigen::Vector6d::Constant(-1e-8),
-                                Eigen::Vector6d::Constant( 1e-8));
-
-  ik->getSolver()->setNumMaxIterations(100);
-
-  EXPECT_FALSE(equals(ik->getTarget()->getTransform().matrix(),
-                      skel->getBodyNode(0)->getTransform().matrix(), 1e-1));
-
-  EXPECT_TRUE(ik->getSolver()->solve());
-
-  EXPECT_TRUE(equals(ik->getTarget()->getTransform().matrix(),
-                     skel->getBodyNode(0)->getTransform().matrix(), 1e-8));
-}
-
-//==============================================================================
 bool compareStringAndFile(const std::string& content,
                           const std::string& fileName)
 {


### PR DESCRIPTION
### Problem
IK solvers apply solution even when the solver failed to solve.

### Solution
Apply solution only on success.

### Testing
Added a simple unit test that checks if IK solver changes joint values when the solver failed.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
