### PR TITLE
Use docker for Xenial build on Azure

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
     BUILD_DIR: $(Build.SourcesDirectory)
     SUDO: sudo
   steps:
-  - template: .ci/azure-pipelines/native.yml
+  - template: .ci/azure-pipelines/docker.yml
 
 - job: xenial_32bit_gcc_release
   pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Debug
     BUILD_DIR: $(Build.SourcesDirectory)
-    SUDO: sudo
+    DOCKERFILE: Dockerfile.ubuntu-xenial
   steps:
   - template: .ci/azure-pipelines/docker.yml
 


### PR DESCRIPTION
Per https://github.com/Microsoft/azure-pipelines-image-generation/pull/732, Azure uses Boost 1.69 by default, it seems there is no option for choosing the system boost (1.58). For some reason, [DART fails to build with Boost 1.69](https://dev.azure.com/dartsim/dart/_build/results?buildId=492), which should be fixed. In any case, the Xenial build should use the system Boost, so this PR changes to use docker for Xenial build.