### PR TITLE
Remove outdated code in World.hpp

### DIFF
--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -106,9 +106,6 @@ public:
 
   /// Create a clone of this World. All Skeletons and SimpleFrames that are held
   /// by this World will be copied over.
-  ///
-  /// Note that the states of the Skeletons will not be transferred over to this
-  /// clone [TODO: copy the states as well]
   std::shared_ptr<World> clone() const;
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
State copy on skeleton clone was resolved by https://github.com/dartsim/dart/pull/691. Thanks to @brianhou for finding this.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
