### PR TITLE
Disable octomap support on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### [DART 6.8.1 (2019-XX-XX)](https://github.com/dartsim/dart/milestone/53?closed=1)
 
-* XXX
+#### Changes
 
-  * XXX: [#XXXX](https://github.com/dartsim/dart/pull/XXXX)
+* Build System
+
+  * Disabled octomap support on macOS: [#1284](https://github.com/dartsim/dart/pull/1284)
 
 #### Compilers Tested
 

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -98,6 +98,13 @@ if(MSVC)
       "'https://github.com/OctoMap/octomap/pull/213' "
       "is resolved.")
   set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
+elseif(APPLE)
+  # Supporting Octomap on Windows is disabled for the following issue:
+  # https://github.com/OctoMap/octomap/pull/213
+  message(WARNING "Octomap ${octomap_VERSION} is found, but Octomap "
+      "is not supported on macOS until "
+      "'https://github.com/dartsim/dart/issues/1078' is resolved.")
+  set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
 else()
   if(OCTOMAP_FOUND OR octomap_FOUND)
     if(NOT DEFINED octomap_VERSION)
@@ -106,16 +113,9 @@ else()
           "please install octomap with version information"
       )
     else()
-      if(NOT octomap_VERSION VERSION_LESS 1.9.0)
-        message(WARNING "Octomap ${octomap_VERSION} is found, but Octomap 1.9.0 or "
-            "greater is not supported yet. Please see "
-            "'https://github.com/dartsim/dart/issues/1078' for the details")
-        set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
-      else()
-        set(HAVE_OCTOMAP TRUE CACHE BOOL "Check if octomap found." FORCE)
-        if(DART_VERBOSE)
-          message(STATUS "Looking for octomap - version ${octomap_VERSION} found")
-        endif()
+      set(HAVE_OCTOMAP TRUE CACHE BOOL "Check if octomap found." FORCE)
+      if(DART_VERBOSE)
+        message(STATUS "Looking for octomap - version ${octomap_VERSION} found")
       endif()
     endif()
   else()


### PR DESCRIPTION
For some unknow reasons, Homebrew FCL package + octomap fails in collision checking for octomap. This PR disable octomap support only macOS for now.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
