### PR TITLE
BoxedLcpConstraintSolver: API compatible with 6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 #### Changes
 
-* XXX
+* Dynamics
 
-  * XXX: [#XXXX](https://github.com/dartsim/dart/pull/XXXX)
+  * Fixed BoxedLcpConstraintSolver is not API compatible with 6.7: [#1291](https://github.com/dartsim/dart/pull/1291)
 
 #### Compilers Tested
 

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -58,8 +58,8 @@ public:
   DART_DEPRECATED(6.8)
   BoxedLcpConstraintSolver(
       double timeStep,
-      BoxedLcpSolverPtr boxedLcpSolver,
-      BoxedLcpSolverPtr secondaryBoxedLcpSolver);
+      BoxedLcpSolverPtr boxedLcpSolver = nullptr,
+      BoxedLcpSolverPtr secondaryBoxedLcpSolver = nullptr);
 
   /// Constructos with default primary and secondary LCP solvers, which are
   /// Dantzig and PGS, respectively.


### PR DESCRIPTION
Fixes #1288 by adding default values to solver arguments.

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
