### PR TITLE
Fix building with FCL built without Octomap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 #### Changes
 
-* XXX
+* Build
 
-  * XXX: [#XXXX](https://github.com/dartsim/dart/pull/XXXX)
+  * Fixed building with FCL built without Octomap: [#1292](https://github.com/dartsim/dart/pull/1292)
 
 #### Compilers Tested
 

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -77,13 +77,13 @@
 
 #include <fcl/broadphase/broadphase_dynamic_AABB_tree.h>
 
-#if HAVE_OCTOMAP && defined(FCL_HAVE_OCTOMAP)
+#if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
 #if FCL_VERSION_AT_LEAST(0,6,0)
 #include <fcl/geometry/octree/octree.h>
 #else
 #include <fcl/octree.h>
 #endif // FCL_VERSION_AT_LEAST(0,6,0)
-#endif // HAVE_OCTOMAP && defined(FCL_HAVE_OCTOMAP)
+#endif // HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
 
 #if FCL_VERSION_AT_LEAST(0,5,0)
 #include <memory>
@@ -121,9 +121,9 @@ using Cylinder = ::fcl::Cylinder<double>;
 using Ellipsoid = ::fcl::Ellipsoid<double>;
 using Halfspace = ::fcl::Halfspace<double>;
 using Sphere = ::fcl::Sphere<double>;
-#if HAVE_OCTOMAP && defined(FCL_HAVE_OCTOMAP)
+#if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
 using OcTree = ::fcl::OcTree<double>;
-#endif // HAVE_OCTOMAP && defined(FCL_HAVE_OCTOMAP)
+#endif // HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
 // Collision objects
 using CollisionObject = ::fcl::CollisionObject<double>;
 using CollisionGeometry = ::fcl::CollisionGeometry<double>;
@@ -145,9 +145,9 @@ using Box = ::fcl::Box;
 using Cylinder = ::fcl::Cylinder;
 using Halfspace = ::fcl::Halfspace;
 using Sphere = ::fcl::Sphere;
-#if HAVE_OCTOMAP && defined(FCL_HAVE_OCTOMAP)
+#if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
 using OcTree = ::fcl::OcTree;
-#endif // HAVE_OCTOMAP && defined(FCL_HAVE_OCTOMAP)
+#endif // HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
 // Collision objects
 using CollisionObject = ::fcl::CollisionObject;
 using CollisionGeometry = ::fcl::CollisionGeometry;


### PR DESCRIPTION
This PR fixes #1290 by treating `FCL_HAVE_OCTOMAP` as boolean instead of checking whether it's defined.

***

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
