### PR TITLE
Fix dereferencing a dangling pointer in WorldNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Added heightmap support to OSG renderer: [#1293](https://github.com/dartsim/dart/pull/1293)
   * Improved voxel grid and point cloud rendering performance: [#1294](https://github.com/dartsim/dart/pull/1294)
   * Fixed incorrect alpha value update of InteractiveFrame: [#1297](https://github.com/dartsim/dart/pull/1297)
+  * Fixed dereferencing a dangling pointer in WorldNode: [#1311](https://github.com/dartsim/dart/pull/1311)
 
 * Examples and Tutorials
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ coverage:
   ignore:
     - "unittests"
     - "dart/external"
+    - "dart/gui"
 
 comment:
   layout: "diff, flags, files"

--- a/dart/gui/osg/ShapeFrameNode.cpp
+++ b/dart/gui/osg/ShapeFrameNode.cpp
@@ -94,14 +94,31 @@ ShapeFrameNode::ShapeFrameNode(
 }
 
 //==============================================================================
-dart::dynamics::ShapeFrame* ShapeFrameNode::getShapeFrame()
+dart::dynamics::ShapeFrame* ShapeFrameNode::getShapeFrame(bool checkUtilization)
 {
+  if (!mUtilized && checkUtilization)
+  {
+    dtwarn << "[ShapeFrameNode] Attempting to access ShapeFrame of unused "
+           << "ShapeFrameNode. This can be dangerous because unused "
+           << "ShapeFrameNode implies that it's possible that the ShapeFrame "
+           << "already got deleted.\n";
+  }
+
   return mShapeFrame;
 }
 
 //==============================================================================
-const dart::dynamics::ShapeFrame* ShapeFrameNode::getShapeFrame() const
+const dart::dynamics::ShapeFrame* ShapeFrameNode::getShapeFrame(
+    bool checkUtilization) const
 {
+  if (!mUtilized && checkUtilization)
+  {
+    dtwarn << "[ShapeFrameNode] Attempting to access ShapeFrame of unused "
+           << "ShapeFrameNode. This can be dangerous because unused "
+           << "ShapeFrameNode implies that it's possible that the ShapeFrame "
+           << "already got deleted.\n";
+  }
+
   return mShapeFrame;
 }
 

--- a/dart/gui/osg/ShapeFrameNode.hpp
+++ b/dart/gui/osg/ShapeFrameNode.hpp
@@ -67,10 +67,10 @@ public:
                  WorldNode* worldNode);
 
   /// Pointer to the ShapeFrame associated with this ShapeFrameNode
-  dart::dynamics::ShapeFrame* getShapeFrame();
+  dart::dynamics::ShapeFrame* getShapeFrame(bool checkUtilization = false);
 
   /// Pointer to the ShapeFrame associated with this ShapeFrameNode
-  const dart::dynamics::ShapeFrame* getShapeFrame() const;
+  const dart::dynamics::ShapeFrame* getShapeFrame(bool checkUtilization = false) const;
 
   WorldNode* getWorldNode();
 

--- a/dart/gui/osg/WorldNode.cpp
+++ b/dart/gui/osg/WorldNode.cpp
@@ -218,11 +218,8 @@ void WorldNode::clearUnusedNodes()
   {
     NodeMap::iterator it = mFrameToNode.find(frame);
     ShapeFrameNode* node = it->second;
-    if(!node->getShapeFrame() || !node->getShapeFrame()->hasVisualAspect() || !node->getShapeFrame()->getVisualAspect(true)->getShadowed()) {
-      mNormalGroup->removeChild(node);
-    }
-    else
-      mShadowedGroup->removeChild(node);
+    mNormalGroup->removeChild(node);
+    mShadowedGroup->removeChild(node);
     mFrameToNode.erase(it);
   }
 }
@@ -289,6 +286,8 @@ void WorldNode::refreshShapeFrameNode(dart::dynamics::Frame* frame)
     if(!node)
       return;
 
+    node->refresh(true);
+
     // update the group that ShapeFrameNode should be
     if((!node->getShapeFrame()->hasVisualAspect() || !node->getShapeFrame()->getVisualAspect(true)->getShadowed()) && node->getParent(0) != mNormalGroup) {
       mShadowedGroup->removeChild(node);
@@ -299,7 +298,6 @@ void WorldNode::refreshShapeFrameNode(dart::dynamics::Frame* frame)
       mShadowedGroup->addChild(node);
     }
 
-    node->refresh(true);
     return;
   }
 

--- a/dart/gui/osg/WorldNode.hpp
+++ b/dart/gui/osg/WorldNode.hpp
@@ -173,7 +173,8 @@ protected:
 
   void refreshShapeFrameNode(dart::dynamics::Frame* frame);
 
-  using NodeMap = std::unordered_map<dart::dynamics::Frame*, ShapeFrameNode*>;
+  using NodeMap = std::unordered_map<
+      dart::dynamics::Frame*, ::osg::ref_ptr<ShapeFrameNode>>;
 
   /// Map from Frame pointers to FrameNode pointers
   NodeMap mFrameToNode;


### PR DESCRIPTION
~~In `clearUnusedNodes()`, if an unused node doesn't have any holders that have the ownership, it becomes dangling pointers since `WorldNode` holds nodes as raw pointers.~~

In `clearUnusedNodes()`, an unused node is possible to hold a dangling pointer to `ShapeFrame`. This can happen because `ShapeFrameNode` doesn't have the ownership of `ShapeFrame`. This leads to dereferencing a dangling pointer in the logic of checking whether the node is shadowed or not. 

This PR changes the behavior of the node deletion logic to remove the access to the internal `ShapeFrame` pointer. Instead, it now unconditionally removes the node from both of shadowed group and unshadowed group. I believe this is safe because OSG will ignore the attempt of removing a non-existing node in the group.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
