### PR TITLE
Remove warning of ImGuiViewer + OSG shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Added heightmap support to OSG renderer: [#1293](https://github.com/dartsim/dart/pull/1293)
   * Improved voxel grid and point cloud rendering performance: [#1294](https://github.com/dartsim/dart/pull/1294)
   * Fixed incorrect alpha value update of InteractiveFrame: [#1297](https://github.com/dartsim/dart/pull/1297)
+  * Removed warning of ImGuiViewer + OSG shadow: [#1312](https://github.com/dartsim/dart/pull/1312)
 
 * Examples and Tutorials
 

--- a/dart/gui/osg/WorldNode.cpp
+++ b/dart/gui/osg/WorldNode.cpp
@@ -39,7 +39,6 @@
 
 #include "dart/gui/osg/WorldNode.hpp"
 #include "dart/gui/osg/ShapeFrameNode.hpp"
-#include "dart/gui/osg/ImGuiViewer.hpp"
 
 #include "dart/simulation/World.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -329,33 +328,33 @@ bool WorldNode::isShadowed() const
 }
 
 //==============================================================================
-void WorldNode::setShadowTechnique(::osg::ref_ptr<osgShadow::ShadowTechnique> shadowTechnique) {
-  if(!shadowTechnique) {
+void WorldNode::setShadowTechnique(::osg::ref_ptr<osgShadow::ShadowTechnique> shadowTechnique)
+{
+  if(!shadowTechnique)
+  {
     mShadowed = false;
-    static_cast<osgShadow::ShadowedScene*>(mShadowedGroup.get())->setShadowTechnique(nullptr);
+    mShadowedGroup->setShadowTechnique(nullptr);
   }
-  else {
-    ImGuiViewer* viewer = mViewer ? dynamic_cast<ImGuiViewer*>(mViewer) : nullptr;
-    if(viewer)
-      dtwarn << "[WorldNode] You are enabling shadows inside an ImGuiViewer. "
-             << "The ImGui windows may not render properly.\n";
+  else
+  {
     mShadowed = true;
-    static_cast<osgShadow::ShadowedScene*>(mShadowedGroup.get())->setShadowTechnique(shadowTechnique.get());
+    mShadowedGroup->setShadowTechnique(shadowTechnique);
   }
 }
 
 //==============================================================================
-::osg::ref_ptr<osgShadow::ShadowTechnique> WorldNode::getShadowTechnique() const {
+::osg::ref_ptr<osgShadow::ShadowTechnique> WorldNode::getShadowTechnique() const
+{
   if(!mShadowed)
     return nullptr;
-  return static_cast<osgShadow::ShadowedScene*>(mShadowedGroup.get())->getShadowTechnique();
+  return mShadowedGroup->getShadowTechnique();
 }
 
 //==============================================================================
 ::osg::ref_ptr<osgShadow::ShadowTechnique> WorldNode::createDefaultShadowTechnique(const Viewer* viewer) {
   ::osg::ref_ptr<osgShadow::ShadowMap> sm = new osgShadow::ShadowMap;
   // increase the resolution of default shadow texture for higher quality
-  int mapres = std::pow(2, 13);
+  auto mapres = static_cast<short>(std::pow(2, 13));
   sm->setTextureSize(::osg::Vec2s(mapres,mapres));
   // we are using Light1 because this is the highest one (on up direction)
   sm->setLight(viewer->getLightSource(0));

--- a/dart/gui/osg/WorldNode.cpp
+++ b/dart/gui/osg/WorldNode.cpp
@@ -351,7 +351,10 @@ void WorldNode::setShadowTechnique(::osg::ref_ptr<osgShadow::ShadowTechnique> sh
 }
 
 //==============================================================================
-::osg::ref_ptr<osgShadow::ShadowTechnique> WorldNode::createDefaultShadowTechnique(const Viewer* viewer) {
+::osg::ref_ptr<osgShadow::ShadowTechnique> WorldNode::createDefaultShadowTechnique(const Viewer* viewer)
+{
+  assert(viewer);
+
   ::osg::ref_ptr<osgShadow::ShadowMap> sm = new osgShadow::ShadowMap;
   // increase the resolution of default shadow texture for higher quality
   auto mapres = static_cast<short>(std::pow(2, 13));

--- a/dart/gui/osg/WorldNode.hpp
+++ b/dart/gui/osg/WorldNode.hpp
@@ -194,7 +194,7 @@ protected:
   ::osg::ref_ptr<::osg::Group> mNormalGroup;
 
   /// OSG group for shadowed objects
-  ::osg::ref_ptr<::osg::Group> mShadowedGroup;
+  ::osg::ref_ptr<::osgShadow::ShadowedScene> mShadowedGroup;
 
   /// Whether the shadows are enabled
   bool mShadowed;

--- a/dart/gui/osg/WorldNode.hpp
+++ b/dart/gui/osg/WorldNode.hpp
@@ -173,7 +173,8 @@ protected:
 
   void refreshShapeFrameNode(dart::dynamics::Frame* frame);
 
-  using NodeMap = std::unordered_map<dart::dynamics::Frame*, ShapeFrameNode*>;
+  using NodeMap = std::unordered_map<
+      dart::dynamics::Frame*, ::osg::ref_ptr<ShapeFrameNode>>;
 
   /// Map from Frame pointers to FrameNode pointers
   NodeMap mFrameToNode;

--- a/examples/atlas_simbicon/AtlasSimbiconEventHandler.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconEventHandler.hpp
@@ -48,7 +48,7 @@ public:
       const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter&) override;
 
 protected:
-  AtlasSimbiconWorldNode* mNode;
+  ::osg::ref_ptr<AtlasSimbiconWorldNode> mNode;
 };
 
 #endif // DART_EXAMPLE_OSG_OSGATLASSIMBICON_ATLASSIMBICONEVENTHANDLER_HPP_

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
@@ -60,7 +60,7 @@ AtlasSimbiconWidget::AtlasSimbiconWidget(
 void AtlasSimbiconWidget::render()
 {
   ImGui::SetNextWindowPos(ImVec2(10, 20));
-  ImGui::SetNextWindowSize(ImVec2(360, 340));
+  ImGui::SetNextWindowSize(ImVec2(360, 400));
   ImGui::SetNextWindowBgAlpha(0.5f);
   if (!ImGui::Begin(
           "Atlas Control",
@@ -130,8 +130,20 @@ void AtlasSimbiconWidget::render()
 
     // Headlights
     mGuiHeadlights = mViewer->checkHeadlights();
-    ImGui::Checkbox("Headlights On/Off", &mGuiHeadlights);
-    mViewer->switchHeadlights(mGuiHeadlights);
+    if (ImGui::Checkbox("Headlights On/Off", &mGuiHeadlights))
+    {
+      mViewer->switchHeadlights(mGuiHeadlights);
+    }
+
+    // Shadow
+    mShadow = mNode->isShadowed();
+    if (ImGui::Checkbox("Shadow On/Off", &mShadow))
+    {
+      if (mShadow)
+        mNode->showShadow();
+      else
+        mNode->hideShadow();
+    }
   }
 
   if (ImGui::CollapsingHeader(

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
@@ -59,13 +59,15 @@ protected:
 
   ::osg::ref_ptr<dart::gui::osg::ImGuiViewer> mViewer;
 
-  AtlasSimbiconWorldNode* mNode;
+  ::osg::ref_ptr<AtlasSimbiconWorldNode> mNode;
 
   float mGuiGravityAcc;
 
   float mGravityAcc;
 
   bool mGuiHeadlights;
+
+  bool mShadow;
 
   /// Control mode value for GUI
   int mGuiControlMode;

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
@@ -121,8 +121,8 @@ void AtlasSimbiconWorldNode::showShadow()
       = dart::gui::osg::WorldNode::createDefaultShadowTechnique(mViewer);
   if (auto sm = dynamic_cast<::osgShadow::ShadowMap*>(shadow.get()))
   {
-    auto mapres = static_cast<short>(std::pow(2, 12));
-    sm->setTextureSize(::osg::Vec2s(mapres, mapres));
+    auto mapResolution = static_cast<short>(std::pow(2, 12));
+    sm->setTextureSize(::osg::Vec2s(mapResolution, mapResolution));
   }
 
   setShadowTechnique(shadow);

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
@@ -32,6 +32,8 @@
 
 #include "AtlasSimbiconWorldNode.hpp"
 
+#include <osgShadow/ShadowMap>
+
 //==============================================================================
 AtlasSimbiconWorldNode::AtlasSimbiconWorldNode(
     const dart::simulation::WorldPtr& world,
@@ -110,4 +112,24 @@ void AtlasSimbiconWorldNode::switchToShortStrideWalking()
 void AtlasSimbiconWorldNode::switchToNoControl()
 {
   mController->changeStateMachine("standing", mWorld->getTime());
+}
+
+//==============================================================================
+void AtlasSimbiconWorldNode::showShadow()
+{
+  auto shadow
+      = dart::gui::osg::WorldNode::createDefaultShadowTechnique(mViewer);
+  if (auto sm = dynamic_cast<::osgShadow::ShadowMap*>(shadow.get()))
+  {
+    auto mapres = static_cast<short>(std::pow(2, 12));
+    sm->setTextureSize(::osg::Vec2s(mapres, mapres));
+  }
+
+  setShadowTechnique(shadow);
+}
+
+//==============================================================================
+void AtlasSimbiconWorldNode::hideShadow()
+{
+  setShadowTechnique(nullptr);
 }

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.hpp
@@ -61,6 +61,9 @@ public:
   void switchToShortStrideWalking();
   void switchToNoControl();
 
+  void showShadow();
+  void hideShadow();
+
 protected:
   std::unique_ptr<Controller> mController;
   Eigen::Vector3d mExternalForce;

--- a/examples/atlas_simbicon/main.cpp
+++ b/examples/atlas_simbicon/main.cpp
@@ -69,7 +69,7 @@ int main()
 
   // Add control widget for atlas
   viewer->getImGuiHandler()->addWidget(
-      std::make_shared<AtlasSimbiconWidget>(viewer, node.get()));
+      std::make_shared<AtlasSimbiconWidget>(viewer, node));
 
   // Pass in the custom event handler
   viewer->addEventHandler(new AtlasSimbiconEventHandler(node));

--- a/examples/atlas_simbicon/main.cpp
+++ b/examples/atlas_simbicon/main.cpp
@@ -67,6 +67,9 @@ int main()
       = new dart::gui::osg::ImGuiViewer();
   viewer->addWorldNode(node);
 
+  // Enable shadow
+  node->showShadow();
+
   // Add control widget for atlas
   viewer->getImGuiHandler()->addWidget(
       std::make_shared<AtlasSimbiconWidget>(viewer, node));


### PR DESCRIPTION
The incompatibility issue of ImGuiViewer + OSG shadow found in https://github.com/dartsim/dart/pull/978 was fixed in https://github.com/dartsim/dart/pull/1274. Particularly, these two blocks ([1](https://github.com/dartsim/dart/blob/731267caef5abf8651f663be2adb974b17735392/dart/external/imgui/imgui_impl_opengl2.cpp#L100-L106), [2](https://github.com/dartsim/dart/blob/731267caef5abf8651f663be2adb974b17735392/dart/external/imgui/imgui_impl_opengl2.cpp#L182-L188)) resolved the issue.

![image](https://user-images.githubusercontent.com/4038467/57467796-09d1f300-7238-11e9-8525-851de667ce51.png)

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
