### PR TITLE
Add shape type and color options to PointCloudShape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * Fixed incorrect alpha value update of InteractiveFrame: [#1297](https://github.com/dartsim/dart/pull/1297)
   * Fixed dereferencing a dangling pointer in WorldNode: [#1311](https://github.com/dartsim/dart/pull/1311)
   * Removed warning of ImGuiViewer + OSG shadow: [#1312](https://github.com/dartsim/dart/pull/1312)
+  * Added shape type and color options to PointCloudShape: [#1314](https://github.com/dartsim/dart/pull/1314)
 
 * Examples and Tutorials
 

--- a/dart/dynamics/PointCloudShape.cpp
+++ b/dart/dynamics/PointCloudShape.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/dynamics/PointCloudShape.hpp"
 
+#include "dart/common/Console.hpp"
+
 namespace dart {
 namespace dynamics {
 
@@ -51,7 +53,10 @@ Eigen::Vector3d toVector3d(const octomap::point3d& point)
 
 //==============================================================================
 PointCloudShape::PointCloudShape(double visualSize)
-  : Shape(), mVisualSize(visualSize)
+  : Shape(),
+    mPointShapeType(BOX),
+    mColorMode(USE_SHAPE_COLOR),
+    mVisualSize(visualSize)
 {
   // Do nothing
 }
@@ -143,9 +148,82 @@ void PointCloudShape::removeAllPoints()
 }
 
 //==============================================================================
+void PointCloudShape::setPointShapeType(PointCloudShape::PointShapeType type)
+{
+  if (mPointShapeType == type)
+    return;
+
+  mPointShapeType = type;
+  incrementVersion();
+}
+
+//==============================================================================
+PointCloudShape::PointShapeType PointCloudShape::getPointShapeType() const
+{
+  return mPointShapeType;
+}
+
+//==============================================================================
+void PointCloudShape::setColorMode(PointCloudShape::ColorMode mode)
+{
+  mColorMode = mode;
+}
+
+//==============================================================================
+PointCloudShape::ColorMode PointCloudShape::getColorMode() const
+{
+  return mColorMode;
+}
+
+//==============================================================================
+void PointCloudShape::setOverallColor(const Eigen::Vector4d& color)
+{
+  mColors.resize(1);
+  mColors[0] = color;
+}
+
+//==============================================================================
+Eigen::Vector4d PointCloudShape::getOverallColor() const
+{
+  if (mColors.empty())
+  {
+    dtwarn << "[PointCloudShape] Attempt to get the overall color when the "
+           << "color array is empty. Returning (RGBA: [0.5, 0.5, 0.5, 0.5]) "
+           << "color\n";
+    return Eigen::Vector4d(0.5, 0.5, 0.5, 0.5);
+  }
+
+  if (mColors.size() > 1)
+  {
+    dtwarn << "[PointCloudShape] Attempting to get the overal color when the "
+           << "color array contains more than one color. This is potentially "
+           << "an error. Returning the first color in the color array.\n";
+  }
+
+  return mColors[0];
+}
+
+//==============================================================================
+void PointCloudShape::setColors(
+    const std::vector<
+        Eigen::Vector4d,
+        Eigen::aligned_allocator<Eigen::Vector4d> >& colors)
+{
+  mColors = colors;
+}
+
+//==============================================================================
+const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d> >&
+PointCloudShape::getColors() const
+{
+  return mColors;
+}
+
+//==============================================================================
 void PointCloudShape::setVisualSize(double size)
 {
   mVisualSize = size;
+  incrementVersion();
 }
 
 //==============================================================================

--- a/dart/dynamics/PointCloudShape.hpp
+++ b/dart/dynamics/PointCloudShape.hpp
@@ -46,6 +46,20 @@ namespace dynamics {
 class PointCloudShape : public Shape
 {
 public:
+  enum ColorMode
+  {
+    BIND_OVERALL = 0, ///< Use one color for all the points
+    BIND_PER_POINT,   ///< Use one color per point
+    USE_SHAPE_COLOR,  ///< Use the color specified by the ShapeAspect
+  };
+
+  enum PointShapeType
+  {
+    BOX = 0,          ///< 3D volumetric box
+    BILLBOARD_QUAD,   ///< 2D square always facing the screen
+    BILLBOARD_CIRCLE, ///< 2D circle always facing the screen
+  };
+
   /// Constructor
   ///
   /// \param[in] visualSize The size of cube that represents each point.
@@ -89,8 +103,40 @@ public:
   /// Returns the number of points.
   std::size_t getNumPoints() const;
 
-  /// Remove all the points.
+  /// Removes all the points.
   void removeAllPoints();
+
+  /// Sets the point shape type.
+  void setPointShapeType(PointShapeType type);
+
+  /// Returns the point shape type.
+  PointShapeType getPointShapeType() const;
+
+  /// Sets the color mode.
+  void setColorMode(ColorMode mode);
+
+  /// Returns the color mode.
+  ColorMode getColorMode() const;
+
+  /// Sets the overall color.
+  ///
+  /// This function resizes the colors to one.
+  void setOverallColor(const Eigen::Vector4d& color);
+
+  /// Returns the overall color.
+  Eigen::Vector4d getOverallColor() const;
+
+  /// Sets the point cloud colors.
+  ///
+  /// The count of colors should be the same with points. It's undefined
+  /// behavior, otherwise.
+  void setColors(const std::vector<
+                 Eigen::Vector4d,
+                 Eigen::aligned_allocator<Eigen::Vector4d>>& colors);
+
+  /// Returns the point cloud colors.
+  const std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>&
+  getColors() const;
 
   /// Sets size of visual object that represents each point.
   void setVisualSize(double size);
@@ -110,6 +156,16 @@ protected:
 
   /// List of points
   std::vector<Eigen::Vector3d> mPoints;
+
+  /// The point shape type.
+  PointShapeType mPointShapeType;
+
+  /// The color mode
+  ColorMode mColorMode;
+
+  /// List of colors
+  std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>
+      mColors;
 
   /// The size of visual object that represents each point.
   double mVisualSize;

--- a/dart/gui/osg/render/PointCloudShapeNode.hpp
+++ b/dart/gui/osg/render/PointCloudShapeNode.hpp
@@ -33,8 +33,10 @@
 #ifndef DART_GUI_OSG_RENDER_POINTCLOUDSHAPENODE_HPP_
 #define DART_GUI_OSG_RENDER_POINTCLOUDSHAPENODE_HPP_
 
+#include <Eigen/Dense>
 #include <osg/MatrixTransform>
 
+#include "dart/dynamics/PointCloudShape.hpp"
 #include "dart/gui/osg/render/ShapeNode.hpp"
 
 namespace dart {
@@ -48,6 +50,8 @@ namespace osg {
 namespace render {
 
 class PointCloudShapeGeode;
+class PointCloudShapeBillboardGeode;
+class PointNode;
 
 class PointCloudShapeNode : public ShapeNode, public ::osg::Group
 {
@@ -59,12 +63,17 @@ public:
   void refresh() override;
   void extractData(bool firstTime);
 
+  ::osg::ref_ptr<PointNode> createPointNode(
+      const Eigen::Vector3d& point, double size, const Eigen::Vector4d& color);
+
 protected:
   virtual ~PointCloudShapeNode() override;
 
   std::shared_ptr<dart::dynamics::PointCloudShape> mPointCloudShape;
-  PointCloudShapeGeode* mGeode;
+  std::vector<::osg::ref_ptr<PointNode>> mPointNodes;
   std::size_t mPointCloudVersion;
+
+  dynamics::PointCloudShape::PointShapeType mPointShapeType;
 };
 
 } // namespace render

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -48,22 +48,42 @@ static const std::string& robotName = "KR5";
 class PointCloudWorld : public gui::osg::WorldNode
 {
 public:
+  enum PointSamplingMode
+  {
+    SAMPLE_ON_ROBOT = 0,
+    SAMPLE_IN_BOX = 1,
+  };
+
   explicit PointCloudWorld(
       simulation::WorldPtr world, dynamics::SkeletonPtr robot)
-    : gui::osg::WorldNode(std::move(world)), mRobot(std::move(robot))
+    : gui::osg::WorldNode(std::move(world)),
+      mSampleingMode(SAMPLE_ON_ROBOT),
+      mRobot(std::move(robot))
   {
     auto pointCloudFrame = mWorld->getSimpleFrame("point cloud");
     auto voxelGridFrame = mWorld->getSimpleFrame("voxel");
 
     mPointCloudShape = std::dynamic_pointer_cast<dynamics::PointCloudShape>(
         pointCloudFrame->getShape());
+    mPointCloudShape->setColorMode(dynamics::PointCloudShape::BIND_PER_POINT);
     mVoxelGridShape = std::dynamic_pointer_cast<dynamics::VoxelGridShape>(
         voxelGridFrame->getShape());
 
     mPointCloudVisualAspect = pointCloudFrame->getVisualAspect();
     mVoxelGridVisualAspect = voxelGridFrame->getVisualAspect();
+    mVoxelGridVisualAspect->hide();
 
     assert(mVoxelGridShape);
+  }
+
+  void setPointSamplingMode(PointSamplingMode mode)
+  {
+    mSampleingMode = mode;
+  }
+
+  PointSamplingMode getPointSamplingMode() const
+  {
+    return mSampleingMode;
   }
 
   // Triggered at the beginning of each simulation step
@@ -81,7 +101,20 @@ public:
     mRobot->setPositions(pos);
 
     // Generate point cloud from robot meshes
-    auto pointCloud = generatePointCloud(500);
+    octomap::Pointcloud pointCloud;
+    auto numPoints = 500u;
+    switch (mSampleingMode)
+    {
+      case SAMPLE_ON_ROBOT:
+        pointCloud = generatePointCloudOnRobot(numPoints);
+        break;
+      case SAMPLE_IN_BOX:
+        pointCloud = generatePointCloudInBox(
+            numPoints,
+            Eigen::Vector3d::Constant(-0.5),
+            Eigen::Vector3d::Constant(0.5));
+        break;
+    }
 
     // Update sensor position
     static double time = 0.0;
@@ -99,6 +132,11 @@ public:
 
     // Update point cloud
     mPointCloudShape->setPoints(pointCloud);
+
+    // Update point cloud colors
+    auto colors = generatePointCloudColors(pointCloud);
+    assert(pointCloud.size() == colors.size());
+    mPointCloudShape->setColors(colors);
 
     // Update voxel
     mVoxelGridShape->updateOccupancy(pointCloud, sensorPos);
@@ -124,10 +162,21 @@ public:
     return mUpdate;
   }
 
+  std::shared_ptr<dynamics::PointCloudShape> getPointCloudShape()
+  {
+    return mPointCloudShape;
+  }
+
+  std::shared_ptr<const dynamics::PointCloudShape> getPointCloudShape() const
+  {
+    return mPointCloudShape;
+  }
+
 protected:
-  octomap::Pointcloud generatePointCloud(std::size_t numPoints)
+  octomap::Pointcloud generatePointCloudOnRobot(std::size_t numPoints)
   {
     octomap::Pointcloud pointCloud;
+    pointCloud.reserve(numPoints);
 
     const auto numBodies = mRobot->getNumBodyNodes();
     assert(numBodies > 0);
@@ -179,6 +228,60 @@ protected:
         return pointCloud;
     }
   }
+
+  octomap::Pointcloud generatePointCloudInBox(
+      std::size_t numPoints,
+      const Eigen::Vector3d& min = Eigen::Vector3d::Constant(-0.5),
+      const Eigen::Vector3d& max = Eigen::Vector3d::Constant(0.5))
+  {
+    octomap::Pointcloud pointCloud;
+    pointCloud.reserve(numPoints);
+
+    for (auto i = 0u; i < numPoints; ++i)
+    {
+      const Eigen::Vector3d point = math::Random::uniform(min, max);
+      pointCloud.push_back(
+          static_cast<float>(point.x()),
+          static_cast<float>(point.y()),
+          static_cast<float>(point.z()));
+    }
+
+    return pointCloud;
+  }
+
+  std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>
+  generatePointCloudColors(const octomap::Pointcloud& pointCloud)
+  {
+    const auto& points = mPointCloudShape->getPoints();
+    double minZ = std::numeric_limits<double>::max();
+    double maxZ = std::numeric_limits<double>::min();
+    for (const auto& point : points)
+    {
+      minZ = std::min(minZ, point.z());
+      maxZ = std::max(maxZ, point.z());
+    }
+    double diffZ
+        = std::max(std::abs(maxZ - minZ), std::numeric_limits<double>::min());
+
+    std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>>
+        colors;
+    colors.reserve(pointCloud.size());
+    for (const auto& point : pointCloud)
+    {
+      float r
+          = (point.z() - static_cast<float>(minZ)) / static_cast<float>(diffZ);
+      float g = 0.0f;
+      float b = 1.f - r;
+      r = math::clip(r, 0.1f, 0.9f);
+      g = math::clip(g, 0.1f, 0.9f);
+      b = math::clip(b, 0.1f, 0.9f);
+      colors.emplace_back(Eigen::Vector4f(r, g, b, 0.75).cast<double>());
+    }
+
+    return colors;
+  }
+
+  PointSamplingMode mSampleingMode;
 
   SkeletonPtr mRobot;
 
@@ -265,13 +368,21 @@ public:
       }
 
       int robotUpdate = mNode->getUpdate() ? 0 : 1;
-      if (ImGui::RadioButton("Run Robot Updating", &robotUpdate, 0)
-          && mNode->getUpdate())
+      if (ImGui::RadioButton("Run Robot Updating", &robotUpdate, 0))
         mNode->setUpdate(true);
       ImGui::SameLine();
-      if (ImGui::RadioButton("Stop Robot Updating", &robotUpdate, 1)
-          && mNode->getUpdate())
+      if (ImGui::RadioButton("Stop Robot Updating", &robotUpdate, 1))
         mNode->setUpdate(false);
+
+      int samplingMode
+          = mNode->getPointSamplingMode() == PointCloudWorld::SAMPLE_ON_ROBOT
+                ? 0
+                : 1;
+      if (ImGui::RadioButton("Sample on robot", &samplingMode, 0))
+        mNode->setPointSamplingMode(PointCloudWorld::SAMPLE_ON_ROBOT);
+      ImGui::SameLine();
+      if (ImGui::RadioButton("Sample in box", &samplingMode, 1))
+        mNode->setPointSamplingMode(PointCloudWorld::SAMPLE_IN_BOX);
     }
 
     if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen))
@@ -287,6 +398,41 @@ public:
             mNode->getPointCloudVisualAspect()->hide();
         }
 
+        auto pointCloudShape = mNode->getPointCloudShape();
+        int pointShapeType;
+        if (pointCloudShape->getPointShapeType()
+            == dynamics::PointCloudShape::BOX)
+        {
+          pointShapeType = 0;
+        }
+        else if (
+            pointCloudShape->getPointShapeType()
+            == dynamics::PointCloudShape::BILLBOARD_QUAD)
+        {
+          pointShapeType = 1;
+        }
+        else if (
+            pointCloudShape->getPointShapeType()
+            == dynamics::PointCloudShape::BILLBOARD_CIRCLE)
+        {
+          pointShapeType = 2;
+        }
+
+        if (ImGui::RadioButton("Box", &pointShapeType, 0))
+        {
+          pointCloudShape->setPointShapeType(dynamics::PointCloudShape::BOX);
+        }
+        else if (ImGui::RadioButton("Billboard Quad", &pointShapeType, 1))
+        {
+          pointCloudShape->setPointShapeType(
+              dynamics::PointCloudShape::BILLBOARD_QUAD);
+        }
+        else if (ImGui::RadioButton("Billboard Circe", &pointShapeType, 2))
+        {
+          pointCloudShape->setPointShapeType(
+              dynamics::PointCloudShape::BILLBOARD_CIRCLE);
+        }
+
         bool vgShow = !mNode->getVoxelGridVisualAspect()->isHidden();
         if (ImGui::Checkbox("Voxel Grid", &vgShow))
         {
@@ -294,6 +440,14 @@ public:
             mNode->getVoxelGridVisualAspect()->show();
           else
             mNode->getVoxelGridVisualAspect()->hide();
+        }
+
+        float visualSize = static_cast<float>(pointCloudShape->getVisualSize());
+        if (ImGui::InputFloat("Visual Size", &visualSize, 0.01f, 0.02f, "%.2f"))
+        {
+          if (visualSize < 0.01f)
+            visualSize = 0.01f;
+          pointCloudShape->setVisualSize(static_cast<double>(visualSize));
         }
       }
 
@@ -420,8 +574,8 @@ public:
 
 protected:
   osg::ref_ptr<dart::gui::osg::ImGuiViewer> mViewer;
-  PointCloudWorld* mNode;
-  ::osg::ref_ptr<gui::osg::GridVisual> mGrid;
+  osg::ref_ptr<PointCloudWorld> mNode;
+  osg::ref_ptr<gui::osg::GridVisual> mGrid;
 };
 
 dynamics::SkeletonPtr createRobot(const std::string& name)
@@ -533,7 +687,7 @@ int main()
 
   // Add control widget for atlas
   viewer->getImGuiHandler()->addWidget(
-      std::make_shared<PointCloudWidget>(viewer, node.get(), grid));
+      std::make_shared<PointCloudWidget>(viewer, node, grid));
 
   viewer->addAttachment(grid);
 


### PR DESCRIPTION
This PR enables `PointCloudShape` to specify the color and the shape type.

![image](https://user-images.githubusercontent.com/4038467/57668425-1d74b500-75bc-11e9-9021-3c4179ad3ce7.png)
![image](https://user-images.githubusercontent.com/4038467/57668436-282f4a00-75bc-11e9-9b9d-d869e36fd950.png)
![image](https://user-images.githubusercontent.com/4038467/57668445-31b8b200-75bc-11e9-9590-1891d876cbe0.png)


***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
