### PR TITLE
Deprecate custom make_unique in favor of std::make_unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [DART 6.9.0 (20XX-XX-XX)](https://github.com/dartsim/dart/milestone/52?closed=1)
 
+* Common
+
+  * Deprecated custom make_unique in favor of std::make_unique: [#1317](https://github.com/dartsim/dart/pull/1317)
+
 * Collision Detection
 
   * Added raycast query to BulletCollisionDetector: [#1309](https://github.com/dartsim/dart/pull/1309)

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -144,7 +144,7 @@ const std::string& BulletCollisionDetector::getStaticType()
 std::unique_ptr<CollisionGroup>
 BulletCollisionDetector::createCollisionGroup()
 {
-  return common::make_unique<BulletCollisionGroup>(shared_from_this());
+  return std::make_unique<BulletCollisionGroup>(shared_from_this());
 }
 
 //==============================================================================
@@ -491,9 +491,9 @@ BulletCollisionDetector::createBulletCollisionShape(
     const auto sphere = static_cast<const SphereShape*>(shape.get());
     const auto radius = sphere->getRadius();
 
-    auto bulletCollisionShape = common::make_unique<btSphereShape>(radius);
+    auto bulletCollisionShape = std::make_unique<btSphereShape>(radius);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<BoxShape>())
@@ -504,9 +504,9 @@ BulletCollisionDetector::createBulletCollisionShape(
     const Eigen::Vector3d& size = box->getSize();
 
     auto bulletCollisionShape
-        = common::make_unique<btBoxShape>(convertVector3(size*0.5));
+        = std::make_unique<btBoxShape>(convertVector3(size*0.5));
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<EllipsoidShape>())
@@ -519,7 +519,7 @@ BulletCollisionDetector::createBulletCollisionShape(
     auto bulletCollisionShape = createBulletEllipsoidMesh(
           radii[0]*2.0, radii[1]*2.0, radii[2]*2.0);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<CylinderShape>())
@@ -531,9 +531,9 @@ BulletCollisionDetector::createBulletCollisionShape(
     const auto height = cylinder->getHeight();
     const auto size = btVector3(radius, radius, height * 0.5);
 
-    auto bulletCollisionShape = common::make_unique<btCylinderShapeZ>(size);
+    auto bulletCollisionShape = std::make_unique<btCylinderShapeZ>(size);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<CapsuleShape>())
@@ -545,9 +545,9 @@ BulletCollisionDetector::createBulletCollisionShape(
     const auto height = capsule->getHeight();
 
     auto bulletCollisionShape
-        = common::make_unique<btCapsuleShapeZ>(radius, height);
+        = std::make_unique<btCapsuleShapeZ>(radius, height);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<ConeShape>())
@@ -559,14 +559,14 @@ BulletCollisionDetector::createBulletCollisionShape(
     const auto height = cone->getHeight();
 
     auto bulletCollisionShape
-        = common::make_unique<btConeShapeZ>(radius, height);
+        = std::make_unique<btConeShapeZ>(radius, height);
     bulletCollisionShape->setMargin(0.0);
     // TODO(JS): Bullet seems to use constant margin 0.4, however this could be
     // dangerous when the cone is sufficiently small. We use zero margin here
     // until find better solution even using zero margin is not recommended:
     // https://www.sjbaker.org/wiki/index.php?title=Physics_-_Bullet_Collected_random_advice#Minimum_object_sizes_-_by_Erwin
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<PlaneShape>())
@@ -577,10 +577,10 @@ BulletCollisionDetector::createBulletCollisionShape(
     const Eigen::Vector3d normal = plane->getNormal();
     const double offset = plane->getOffset();
 
-    auto bulletCollisionShape = common::make_unique<btStaticPlaneShape>(
+    auto bulletCollisionShape = std::make_unique<btStaticPlaneShape>(
           convertVector3(normal), offset);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<MultiSphereConvexHullShape>())
@@ -601,10 +601,10 @@ BulletCollisionDetector::createBulletCollisionShape(
       bulletPositions[i] = convertVector3(spheres[i].second);
     }
 
-    auto bulletCollisionShape = common::make_unique<btMultiSphereShape>(
+    auto bulletCollisionShape = std::make_unique<btMultiSphereShape>(
           bulletPositions.data(), bulletRadii.data(), numSpheres);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<MeshShape>())
@@ -618,7 +618,7 @@ BulletCollisionDetector::createBulletCollisionShape(
     auto bulletCollisionShape = createBulletCollisionShapeFromAssimpScene(
           scale, mesh);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<SoftMeshShape>())
@@ -630,7 +630,7 @@ BulletCollisionDetector::createBulletCollisionShape(
 
     auto bulletCollisionShape = createBulletCollisionShapeFromAssimpMesh(mesh);
 
-    return common::make_unique<BulletCollisionShape>(
+    return std::make_unique<BulletCollisionShape>(
           std::move(bulletCollisionShape));
   }
   else if (shape->is<HeightmapShapef>())
@@ -650,8 +650,8 @@ BulletCollisionDetector::createBulletCollisionShape(
           << shape->getType() << "]). Creating a sphere with 0.1 radius "
           << "instead.\n";
 
-    return common::make_unique<BulletCollisionShape>(
-          common::make_unique<btSphereShape>(0.1));
+    return std::make_unique<BulletCollisionShape>(
+          std::make_unique<btSphereShape>(0.1));
 
     // take this back in as soon as bullet supports double in heightmaps
     // const auto heightMap = static_cast<const HeightmapShaped*>(shape.get());
@@ -664,8 +664,8 @@ BulletCollisionDetector::createBulletCollisionShape(
           << shape->getType() << "] Creating a sphere with 0.1 radius "
           << "instead.\n";
 
-    return common::make_unique<BulletCollisionShape>(
-          common::make_unique<btSphereShape>(0.1));
+    return std::make_unique<BulletCollisionShape>(
+          std::make_unique<btSphereShape>(0.1));
   }
 }
 
@@ -1037,7 +1037,7 @@ std::unique_ptr<btCollisionShape> createBulletEllipsoidMesh(
     triMesh->addTriangle(vertices[0], vertices[1], vertices[2]);
   }
 
-  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
+  auto gimpactMeshShape = std::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
   return std::move(gimpactMeshShape);
@@ -1066,7 +1066,7 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
     }
   }
 
-  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
+  auto gimpactMeshShape = std::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
   gimpactMeshShape->setUserPointer(triMesh);
 
@@ -1090,7 +1090,7 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpMesh(
     triMesh->addTriangle(vertices[0], vertices[1], vertices[2]);
   }
 
-  auto gimpactMeshShape = common::make_unique<btGImpactMeshShape>(triMesh);
+  auto gimpactMeshShape = std::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
   return std::move(gimpactMeshShape);
@@ -1125,7 +1125,7 @@ createBulletCollisionShapeFromHeightmap(
   // create the height field
   const btVector3 localScaling(scale.x(), scale.y(), scale.z());
   const bool flipQuadEdges = false;
-  auto heightFieldShape = common::make_unique<btHeightfieldTerrainShape>(
+  auto heightFieldShape = std::make_unique<btHeightfieldTerrainShape>(
       heightMap->getWidth(),   // Width of height field
       heightMap->getDepth(),   // Depth of height field
       heights.data(),          // Height values
@@ -1155,7 +1155,7 @@ createBulletCollisionShapeFromHeightmap(
         << max.x() << ", " << max.y() << ", " << max.z() << "}"
         << " (will be translated by z=" << trans.z() << ")" << std::endl;
 
-  return common::make_unique<BulletCollisionShape>(
+  return std::make_unique<BulletCollisionShape>(
       std::move(heightFieldShape), relativeShapeTransform);
 }
 

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -96,7 +96,7 @@ const std::string& DARTCollisionDetector::getStaticType()
 std::unique_ptr<CollisionGroup>
 DARTCollisionDetector::createCollisionGroup()
 {
-  return common::make_unique<DARTCollisionGroup>(shared_from_this());
+  return std::make_unique<DARTCollisionGroup>(shared_from_this());
 }
 
 //==============================================================================

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -689,7 +689,7 @@ const std::string& FCLCollisionDetector::getStaticType()
 std::unique_ptr<CollisionGroup>
 FCLCollisionDetector::createCollisionGroup()
 {
-  return common::make_unique<FCLCollisionGroup>(shared_from_this());
+  return std::make_unique<FCLCollisionGroup>(shared_from_this());
 }
 
 //==============================================================================

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -148,7 +148,7 @@ const std::string& OdeCollisionDetector::getStaticType()
 //==============================================================================
 std::unique_ptr<CollisionGroup> OdeCollisionDetector::createCollisionGroup()
 {
-  return common::make_unique<OdeCollisionGroup>(shared_from_this());
+  return std::make_unique<OdeCollisionGroup>(shared_from_this());
 }
 
 //==============================================================================

--- a/dart/common/AspectWithVersion.hpp
+++ b/dart/common/AspectWithVersion.hpp
@@ -112,7 +112,7 @@ public:
   // Documentation inherited
   std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(this->getState(), this->getProperties());
+    return std::make_unique<Derived>(this->getState(), this->getProperties());
   }
 
 };

--- a/dart/common/EmbeddedAspect.hpp
+++ b/dart/common/EmbeddedAspect.hpp
@@ -361,7 +361,7 @@ public:
   // Documentation inherited
   std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(this->getState(), this->getProperties());
+    return std::make_unique<Derived>(this->getState(), this->getProperties());
   }
 
 };

--- a/dart/common/Memory.hpp
+++ b/dart/common/Memory.hpp
@@ -47,7 +47,9 @@ namespace common {
 template <typename _Tp, typename... _Args>
 std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args);
 
+/// \deprecated Deprecated in 6.9. Use std::make_unique instead.
 template<typename T, typename... Args>
+DART_DEPRECATED(6.9)
 std::unique_ptr<T> make_unique(Args&&... args);
 
 #if EIGEN_VERSION_AT_LEAST(3,2,1) && EIGEN_VERSION_AT_MOST(3,2,8)
@@ -172,7 +174,7 @@ public:                                                                        \
       class_name,                                                              \
       DART_UNIQUE_PTR_CREATOR_NAME,                                            \
       std::unique_ptr,                                                         \
-      ::dart::common::make_unique)
+      ::std::make_unique)
 
 // Define static creator function that returns std::unique_ptr to the object
 // where the constructor is protected
@@ -182,7 +184,7 @@ public:                                                                        \
       class_name,                                                              \
       DART_UNIQUE_PTR_CREATOR_NAME,                                            \
       std::unique_ptr,                                                         \
-      ::dart::common::make_unique)
+      ::std::make_unique)
 
 // Define two static creator functions that returns std::unique_ptr and
 // std::unique_ptr, respectively, to the object

--- a/dart/common/ProxyAspect.hpp
+++ b/dart/common/ProxyAspect.hpp
@@ -80,7 +80,7 @@ public:
   // Documentation inherited
   std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<ProxyStateAndPropertiesAspect>();
+    return std::make_unique<ProxyStateAndPropertiesAspect>();
   }
 
 };

--- a/dart/common/detail/AspectWithVersion.hpp
+++ b/dart/common/detail/AspectWithVersion.hpp
@@ -234,7 +234,7 @@ std::unique_ptr<Aspect>
 AspectWithState<BaseT, DerivedT, StateData, CompositeT, updateState>::
     cloneAspect() const
 {
-  return common::make_unique<Derived>(mState);
+  return std::make_unique<Derived>(mState);
 }
 
 //==============================================================================
@@ -312,7 +312,7 @@ AspectWithVersionedProperties<BaseT, DerivedT, PropertiesData,
                              CompositeT, updateProperties>::
 cloneAspect() const
 {
-  return common::make_unique<Derived>(mProperties);
+  return std::make_unique<Derived>(mProperties);
 }
 
 //==============================================================================

--- a/dart/common/detail/Cloneable.hpp
+++ b/dart/common/detail/Cloneable.hpp
@@ -126,7 +126,7 @@ MakeCloneable<Base, Mixin>& MakeCloneable<Base, Mixin>::operator=(
 template <class Base, class Mixin>
 std::unique_ptr<Base> MakeCloneable<Base, Mixin>::clone() const
 {
-  return common::make_unique<MakeCloneable<Base, Mixin>>(*this);
+  return std::make_unique<MakeCloneable<Base, Mixin>>(*this);
 }
 
 //==============================================================================
@@ -142,7 +142,7 @@ template <class Base, class OwnerT, class DataT,
           DataT (*getData)(const OwnerT*)>
 ProxyCloneable<Base, OwnerT, DataT, setData, getData>::ProxyCloneable()
   : mOwner(nullptr),
-    mData(make_unique<Data>())
+    mData(std::make_unique<Data>())
 {
   // Do nothing
 }
@@ -178,7 +178,7 @@ template <typename... Args>
 ProxyCloneable<Base, OwnerT, DataT, setData, getData>::ProxyCloneable(
     Args&&... args)
   : mOwner(nullptr),
-    mData(dart::common::make_unique<Data>(std::forward<Args>(args)...))
+    mData(std::make_unique<Data>(std::forward<Args>(args)...))
 {
   // Do nothing
 }
@@ -265,7 +265,7 @@ void ProxyCloneable<Base, OwnerT, DataT, setData, getData>::set(
     return;
   }
 
-  mData = make_unique<Data>(data);
+  mData = std::make_unique<Data>(data);
 }
 
 //==============================================================================
@@ -281,7 +281,7 @@ void ProxyCloneable<Base, OwnerT, DataT, setData, getData>::set(
     return;
   }
 
-  mData = dart::common::make_unique<Data>(std::move(data));
+  mData = std::make_unique<Data>(std::move(data));
 }
 
 //==============================================================================
@@ -341,7 +341,7 @@ template <class Base, class OwnerT, class DataT,
 std::unique_ptr<Base> ProxyCloneable<
     Base, OwnerT, DataT, setData, getData>::clone() const
 {
-  return dart::common::make_unique<ProxyCloneable>(get());
+  return std::make_unique<ProxyCloneable>(get());
 }
 
 //==============================================================================
@@ -566,7 +566,7 @@ std::unique_ptr< CloneableVector<T> > CloneableVector<T>::clone() const
   for(const T& entry : mVector)
     clonedVector.push_back(entry->clone());
 
-  return common::make_unique< CloneableVector<T> >( std::move(clonedVector) );
+  return std::make_unique< CloneableVector<T> >( std::move(clonedVector) );
 }
 
 //==============================================================================

--- a/dart/common/detail/CompositeData.hpp
+++ b/dart/common/detail/CompositeData.hpp
@@ -123,7 +123,7 @@ public:
     using DataType = typename GetData<Aspect>::Type;
 
     std::unique_ptr<DataType>& data = this->mMap[typeid(AspectType)]
-        = make_unique<Data>(std::forward<Args>(args)...);
+        = std::make_unique<Data>(std::forward<Args>(args)...);
     return static_cast<Data&>(*data);
   }
 
@@ -158,7 +158,7 @@ public:
 
     const bool exists = !it.second;
     if(!exists)
-      it.first = make_unique<Data>(std::forward<Args>(args)...);
+      it.first = std::make_unique<Data>(std::forward<Args>(args)...);
 
     return static_cast<Data&>(*it.first);
   }

--- a/dart/common/detail/EmbeddedAspect.hpp
+++ b/dart/common/detail/EmbeddedAspect.hpp
@@ -152,7 +152,7 @@ public:
 
     // If the correct type of Composite is not available, we store this on the
     // heap until this Aspect is moved.
-    mTemporaryState = make_unique<State>(state);
+    mTemporaryState = std::make_unique<State>(state);
   }
 
   // Documentation inherited
@@ -184,7 +184,7 @@ public:
   // Documentation inherited
   std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(this->getState());
+    return std::make_unique<Derived>(this->getState());
   }
 
 protected:
@@ -196,7 +196,7 @@ protected:
       DelegateTag, const StateData& state,
       RemainingArgs&&... remainingArgs)
     : Base(std::forward<RemainingArgs>(remainingArgs)...),
-      mTemporaryState(make_unique<State>(state))
+      mTemporaryState(std::make_unique<State>(state))
   {
     // Do nothing
   }
@@ -226,7 +226,7 @@ protected:
   /// Save the embedded State of this Composite before we remove the Aspect
   void loseComposite(Composite* oldComposite) override
   {
-    mTemporaryState = make_unique<State>(
+    mTemporaryState = std::make_unique<State>(
           GetEmbeddedState(static_cast<const Derived*>(this)));
     Base::loseComposite(oldComposite);
   }
@@ -325,7 +325,7 @@ public:
 
     // If the correct type of Composite is not available, we store this on the
     // heap until this Aspect is moved.
-    mTemporaryProperties = make_unique<Properties>(properties);
+    mTemporaryProperties = std::make_unique<Properties>(properties);
   }
 
   // Documentation inherited
@@ -356,7 +356,7 @@ public:
 
   std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<Derived>(this->getProperties());
+    return std::make_unique<Derived>(this->getProperties());
   }
 
 protected:
@@ -368,7 +368,7 @@ protected:
       DelegateTag, const PropertiesData& properties,
       RemainingArgs&&... remainingArgs)
     : Base(std::forward<RemainingArgs>(remainingArgs)...),
-      mTemporaryProperties(make_unique<Properties>(properties))
+      mTemporaryProperties(std::make_unique<Properties>(properties))
   {
     // Do nothing
   }
@@ -399,7 +399,7 @@ protected:
   /// Save the embedded Properties of this Composite before we remove the Aspect
   void loseComposite(Composite* oldComposite) override
   {
-    mTemporaryProperties = make_unique<Properties>(
+    mTemporaryProperties = std::make_unique<Properties>(
           GetEmbeddedProperties(static_cast<Derived*>(this)));
     Base::loseComposite(oldComposite);
   }

--- a/dart/common/detail/Factory-impl.hpp
+++ b/dart/common/detail/Factory-impl.hpp
@@ -61,7 +61,7 @@ struct DefaultCreator<T, std::unique_ptr<T>, Args...>
 {
   static std::unique_ptr<T> run(Args&&... args)
   {
-    return dart::common::make_unique<T>(std::forward<Args>(args)...);
+    return std::make_unique<T>(std::forward<Args>(args)...);
   }
 };
 

--- a/dart/common/detail/Memory-impl.hpp
+++ b/dart/common/detail/Memory-impl.hpp
@@ -50,7 +50,7 @@ namespace common {
 template <typename _Tp, typename... _Args>
 std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
 {
-  typedef typename std::remove_const<_Tp>::type _Tp_nc;
+  using _Tp_nc = typename std::remove_const<_Tp>::type;
 
 #if EIGEN_VERSION_AT_LEAST(3,2,1) && EIGEN_VERSION_AT_MOST(3,2,8)
   return std::allocate_shared<_Tp>(detail::aligned_allocator_cpp11<_Tp_nc>(),
@@ -65,11 +65,8 @@ std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
 template<typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args)
 {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+  return std::make_unique<T>(std::forward<Args>(args)...);
 }
-// TODO(JS): This is a stopgap solution as it was omitted from C++11 as "partly
-// an oversight". This can be replaced by std::make_unique<T> of the standard
-// library when we migrate to using C++14.
 
 } // namespace common
 } // namespace dart

--- a/dart/common/detail/ProxyAspect.hpp
+++ b/dart/common/detail/ProxyAspect.hpp
@@ -75,7 +75,7 @@ public:
   // Documentation inherited
   std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<ProxyStateAspect>();
+    return std::make_unique<ProxyStateAspect>();
   }
 
 protected:
@@ -144,7 +144,7 @@ public:
   // Documentation inherited
   std::unique_ptr<Aspect> cloneAspect() const override
   {
-    return make_unique<ProxyPropertiesAspect>();
+    return std::make_unique<ProxyPropertiesAspect>();
   }
 
 protected:

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -69,7 +69,7 @@ static void extractDataFromNodeTypeMap(
 
     std::unique_ptr<VectorType>& data = it->second;
     if(!data)
-      data = common::make_unique<VectorType>();
+      data = std::make_unique<VectorType>();
 
     data->getVector().resize(nodes.size());
 

--- a/dart/dynamics/InverseKinematics.cpp
+++ b/dart/dynamics/InverseKinematics.cpp
@@ -467,7 +467,7 @@ InverseKinematics::TaskSpaceRegion::TaskSpaceRegion(
 std::unique_ptr<InverseKinematics::ErrorMethod>
 InverseKinematics::TaskSpaceRegion::clone(InverseKinematics* _newIK) const
 {
-  return common::make_unique<TaskSpaceRegion>(
+  return std::make_unique<TaskSpaceRegion>(
       _newIK, getTaskSpaceRegionProperties());
 }
 
@@ -816,7 +816,7 @@ InverseKinematics::JacobianDLS::JacobianDLS(
 std::unique_ptr<InverseKinematics::GradientMethod>
 InverseKinematics::JacobianDLS::clone(InverseKinematics* _newIK) const
 {
-  return common::make_unique<JacobianDLS>(_newIK, getJacobianDLSProperties());
+  return std::make_unique<JacobianDLS>(_newIK, getJacobianDLSProperties());
 }
 
 //==============================================================================
@@ -875,7 +875,7 @@ InverseKinematics::JacobianTranspose::JacobianTranspose(
 std::unique_ptr<InverseKinematics::GradientMethod>
 InverseKinematics::JacobianTranspose::clone(InverseKinematics* _newIK) const
 {
-  return common::make_unique<JacobianTranspose>(
+  return std::make_unique<JacobianTranspose>(
       _newIK, getGradientMethodProperties());
 }
 

--- a/dart/dynamics/ReferentialSkeleton.cpp
+++ b/dart/dynamics/ReferentialSkeleton.cpp
@@ -45,7 +45,7 @@ namespace dynamics {
 std::unique_ptr<common::LockableReference>
 ReferentialSkeleton::getLockableReference() const
 {
-  return common::make_unique<
+  return std::make_unique<
       common::MultiLockableReference<std::mutex>>(
           mPtr, mSkeletonMutexes.begin(), mSkeletonMutexes.end());
 }

--- a/dart/dynamics/SharedLibraryIkFast.cpp
+++ b/dart/dynamics/SharedLibraryIkFast.cpp
@@ -131,7 +131,7 @@ SharedLibraryIkFast::SharedLibraryIkFast(InverseKinematics* ik,
 auto SharedLibraryIkFast::clone(InverseKinematics* newIK) const
     -> std::unique_ptr<GradientMethod>
 {
-  return dart::common::make_unique<SharedLibraryIkFast>(
+  return std::make_unique<SharedLibraryIkFast>(
       newIK,
       mFilePath,
       mDofs,

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -384,7 +384,7 @@ std::mutex& Skeleton::getMutex() const
 //==============================================================================
 std::unique_ptr<common::LockableReference> Skeleton::getLockableReference() const
 {
-  return common::make_unique<common::SingleLockableReference<std::mutex>>(
+  return std::make_unique<common::SingleLockableReference<std::mutex>>(
       mPtr, mMutex);
 }
 

--- a/dart/dynamics/SoftMeshShape.cpp
+++ b/dart/dynamics/SoftMeshShape.cpp
@@ -109,7 +109,7 @@ void SoftMeshShape::_buildMesh()
   int nFaces    = mSoftBodyNode->getNumFaces();
 
   // Create new aiMesh
-  mAssimpMesh = common::make_unique<aiMesh>();
+  mAssimpMesh = std::make_unique<aiMesh>();
 
   // Set vertices and normals
   mAssimpMesh->mNumVertices = nVertices;

--- a/dart/dynamics/detail/CompositeNode.hpp
+++ b/dart/dynamics/detail/CompositeNode.hpp
@@ -49,7 +49,7 @@ void CompositeStateNode<Base>::setNodeState(const Node::State& otherState)
 template <class Base>
 std::unique_ptr<Node::State> CompositeStateNode<Base>::getNodeState() const
 {
-  return common::make_unique<State>(common::Composite::getCompositeState());
+  return std::make_unique<State>(common::Composite::getCompositeState());
 }
 
 //==============================================================================
@@ -74,7 +74,7 @@ template <class Base>
 std::unique_ptr<Node::Properties>
 CompositePropertiesNode<Base>::getNodeProperties() const
 {
-  return common::make_unique<Properties>(
+  return std::make_unique<Properties>(
         common::Composite::getCompositeProperties());
 }
 

--- a/dart/gui/osg/InteractiveFrame.cpp
+++ b/dart/gui/osg/InteractiveFrame.cpp
@@ -111,7 +111,7 @@ dart::dynamics::SimpleFrame* InteractiveTool::addShapeFrame(
     const dart::dynamics::ShapePtr& shape)
 {
   mSimpleFrames.push_back(
-      dart::common::make_unique<dart::dynamics::SimpleFrame>(this));
+      std::make_unique<dart::dynamics::SimpleFrame>(this));
 
   auto shapeFrame = mSimpleFrames.back().get();
   shapeFrame->setShape(shape);
@@ -227,7 +227,7 @@ dart::dynamics::SimpleFrame* InteractiveFrame::addShapeFrame(
     const dart::dynamics::ShapePtr& shape)
 {
   mSimpleFrames.push_back(
-      dart::common::make_unique<dart::dynamics::SimpleFrame>(this));
+      std::make_unique<dart::dynamics::SimpleFrame>(this));
 
   auto shapeFrame = mSimpleFrames.back().get();
   shapeFrame->setShape(shape);

--- a/dart/optimizer/nlopt/NloptSolver.cpp
+++ b/dart/optimizer/nlopt/NloptSolver.cpp
@@ -97,7 +97,7 @@ bool NloptSolver::solve()
      || mOpt->get_dimension() != dimension
      || mOpt->get_algorithm() != mAlg)
   {
-    mOpt = common::make_unique<nlopt::opt>(mAlg, dimension);
+    mOpt = std::make_unique<nlopt::opt>(mAlg, dimension);
   }
   else
   {

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -72,7 +72,7 @@ World::World(const std::string& _name)
 {
   mIndices.push_back(0);
 
-  auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>();
+  auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>();
   setConstraintSolver(std::move(solver));
 }
 

--- a/examples/box_stacking/main.cpp
+++ b/examples/box_stacking/main.cpp
@@ -354,24 +354,24 @@ protected:
     {
       // auto solver
       //     =
-      //     common::make_unique<constraint::SequentialImpulseConstraintSolver>(
+      //     std::make_unique<constraint::SequentialImpulseConstraintSolver>(
       //         mWorld->getTimeStep());
       auto lcpSolver = std::make_shared<constraint::DantzigBoxedLcpSolver>();
-      auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>(
+      auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>(
           lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else if (solverType == 1)
     {
       auto lcpSolver = std::make_shared<constraint::DantzigBoxedLcpSolver>();
-      auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>(
+      auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>(
           lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else if (solverType == 2)
     {
       auto lcpSolver = std::make_shared<constraint::PgsBoxedLcpSolver>();
-      auto solver = common::make_unique<constraint::BoxedLcpConstraintSolver>(
+      auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>(
           lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }

--- a/examples/box_stacking/main.cpp
+++ b/examples/box_stacking/main.cpp
@@ -357,22 +357,22 @@ protected:
       //     std::make_unique<constraint::SequentialImpulseConstraintSolver>(
       //         mWorld->getTimeStep());
       auto lcpSolver = std::make_shared<constraint::DantzigBoxedLcpSolver>();
-      auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>(
-          lcpSolver);
+      auto solver
+          = std::make_unique<constraint::BoxedLcpConstraintSolver>(lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else if (solverType == 1)
     {
       auto lcpSolver = std::make_shared<constraint::DantzigBoxedLcpSolver>();
-      auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>(
-          lcpSolver);
+      auto solver
+          = std::make_unique<constraint::BoxedLcpConstraintSolver>(lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else if (solverType == 2)
     {
       auto lcpSolver = std::make_shared<constraint::PgsBoxedLcpSolver>();
-      auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>(
-          lcpSolver);
+      auto solver
+          = std::make_unique<constraint::BoxedLcpConstraintSolver>(lcpSolver);
       mWorld->setConstraintSolver(std::move(solver));
     }
     else

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -189,7 +189,7 @@ public:
   std::unique_ptr<GradientMethod> clone(
       InverseKinematics* _newIK) const override
   {
-    return dart::common::make_unique<HuboArmIK>(
+    return std::make_unique<HuboArmIK>(
         _newIK, mBaseLinkName, getAnalyticalProperties());
   }
 
@@ -481,7 +481,7 @@ public:
   std::unique_ptr<GradientMethod> clone(
       InverseKinematics* _newIK) const override
   {
-    return dart::common::make_unique<HuboLegIK>(
+    return std::make_unique<HuboLegIK>(
         _newIK, mBaseLinkName, getAnalyticalProperties());
   }
 

--- a/tutorials/tutorial_biped/main.cpp
+++ b/tutorials/tutorial_biped/main.cpp
@@ -151,8 +151,7 @@ public:
   {
     setWorld(world);
 
-    mController
-        = std::make_unique<Controller>(mWorld->getSkeleton("biped"));
+    mController = std::make_unique<Controller>(mWorld->getSkeleton("biped"));
   }
 
   /// Handle keyboard input

--- a/tutorials/tutorial_biped/main.cpp
+++ b/tutorials/tutorial_biped/main.cpp
@@ -152,7 +152,7 @@ public:
     setWorld(world);
 
     mController
-        = dart::common::make_unique<Controller>(mWorld->getSkeleton("biped"));
+        = std::make_unique<Controller>(mWorld->getSkeleton("biped"));
   }
 
   /// Handle keyboard input

--- a/tutorials/tutorial_biped_finished/main.cpp
+++ b/tutorials/tutorial_biped_finished/main.cpp
@@ -220,8 +220,7 @@ public:
   {
     setWorld(world);
 
-    mController
-        = std::make_unique<Controller>(mWorld->getSkeleton("biped"));
+    mController = std::make_unique<Controller>(mWorld->getSkeleton("biped"));
   }
 
   /// Handle keyboard input

--- a/tutorials/tutorial_biped_finished/main.cpp
+++ b/tutorials/tutorial_biped_finished/main.cpp
@@ -221,7 +221,7 @@ public:
     setWorld(world);
 
     mController
-        = dart::common::make_unique<Controller>(mWorld->getSkeleton("biped"));
+        = std::make_unique<Controller>(mWorld->getSkeleton("biped"));
   }
 
   /// Handle keyboard input

--- a/tutorials/tutorial_dominoes/main.cpp
+++ b/tutorials/tutorial_dominoes/main.cpp
@@ -141,7 +141,7 @@ public:
     mFirstDomino = world->getSkeleton("domino");
     mFloor = world->getSkeleton("floor");
 
-    mController = dart::common::make_unique<Controller>(
+    mController = std::make_unique<Controller>(
         world->getSkeleton("manipulator"), mFirstDomino);
   }
 

--- a/tutorials/tutorial_dominoes_finished/main.cpp
+++ b/tutorials/tutorial_dominoes_finished/main.cpp
@@ -233,7 +233,7 @@ public:
     mFirstDomino = world->getSkeleton("domino");
     mFloor = world->getSkeleton("floor");
 
-    mController = dart::common::make_unique<Controller>(
+    mController = std::make_unique<Controller>(
         world->getSkeleton("manipulator"), mFirstDomino);
   }
 

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -1361,7 +1361,7 @@ void testCreateCollisionGroups(const std::shared_ptr<CollisionDetector>& cd)
   EXPECT_TRUE(shapeNodeGroup1->collide(shapeNodeGroup2.get()));
 
   // Regression test for #666
-  auto world = common::make_unique<World>();
+  auto world = std::make_unique<World>();
   world->getConstraintSolver()->setCollisionDetector(cd);
   world->addSkeleton(boxSkeleton1);
   world->addSkeleton(boxSkeleton2);

--- a/unittests/comprehensive/test_World.cpp
+++ b/unittests/comprehensive/test_World.cpp
@@ -359,7 +359,7 @@ TEST(World, SetNewConstraintSolver)
   EXPECT_TRUE(world->getConstraintSolver()->getConstraints().size() == 1);
 
   auto solver1
-      = dart::common::make_unique<constraint::BoxedLcpConstraintSolver>(
+      = std::make_unique<constraint::BoxedLcpConstraintSolver>(
           std::make_shared<constraint::DantzigBoxedLcpSolver>());
   EXPECT_TRUE(solver1->getSkeletons().size() == 0);
   EXPECT_TRUE(solver1->getConstraints().size() == 0);
@@ -369,7 +369,7 @@ TEST(World, SetNewConstraintSolver)
   EXPECT_TRUE(world->getConstraintSolver()->getConstraints().size() == 1);
 
   auto solver2
-      = dart::common::make_unique<constraint::BoxedLcpConstraintSolver>(
+      = std::make_unique<constraint::BoxedLcpConstraintSolver>(
           std::make_shared<constraint::PgsBoxedLcpSolver>());
   EXPECT_TRUE(solver2->getSkeletons().size() == 0);
   EXPECT_TRUE(solver2->getConstraints().size() == 0);

--- a/unittests/unit/SharedLibraryWamIkFast.cpp
+++ b/unittests/unit/SharedLibraryWamIkFast.cpp
@@ -14919,7 +14919,7 @@ SharedLibraryWamIkFast::SharedLibraryWamIkFast(
 std::unique_ptr<dart::dynamics::InverseKinematics::GradientMethod>
 SharedLibraryWamIkFast::clone(dart::dynamics::InverseKinematics* newIK) const
 {
-  return dart::common::make_unique<SharedLibraryWamIkFast>(
+  return std::make_unique<SharedLibraryWamIkFast>(
       newIK, mDofs, mFreeDofs, getMethodName(), getAnalyticalProperties());
 }
 

--- a/unittests/unit/test_Aspect.cpp
+++ b/unittests/unit/test_Aspect.cpp
@@ -250,7 +250,7 @@ public:
 
   std::unique_ptr<Aspect> cloneAspect() const override final
   {
-    return dart::common::make_unique<GenericAspect>();
+    return std::make_unique<GenericAspect>();
   }
 
 };
@@ -267,7 +267,7 @@ public:
 
   std::unique_ptr<Aspect> cloneAspect() const override final
   {
-    return dart::common::make_unique<SpecializedAspect>();
+    return std::make_unique<SpecializedAspect>();
   }
 };
 
@@ -318,7 +318,7 @@ public:
 
   std::unique_ptr<Aspect> cloneAspect() const override final
   {
-    return dart::common::make_unique<StatefulAspect>(*this);
+    return std::make_unique<StatefulAspect>(*this);
   }
 
   void setAspectState(const Aspect::State& otherState) override

--- a/unittests/unit/test_ContactConstraint.cpp
+++ b/unittests/unit/test_ContactConstraint.cpp
@@ -47,7 +47,7 @@ void testContactWithKinematicJoint(
 {
   auto world = std::make_shared<simulation::World>();
   world->setConstraintSolver(
-      common::make_unique<constraint::BoxedLcpConstraintSolver>(lcpSolver));
+      std::make_unique<constraint::BoxedLcpConstraintSolver>(lcpSolver));
 
   auto skeleton1 = dynamics::Skeleton::create("skeleton1");
   auto pair1 = skeleton1->createJointAndBodyNodePair<dynamics::FreeJoint>();


### PR DESCRIPTION
As we migrated to C++14, the custom `make_unique` is deprecated in favor of `std::make_unique`.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
