### PR TITLE
[dartpy] Remove static create() functions in favor of custom custructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 * Examples and Tutorials
 
-  * Updated examples directory to make dart::gui::osg more accessible: [#1305](https://github.com/dartsim/dart/pull/1305)
+  * Updated examples directory to make dart::gui::osg more accessible: [#1324](https://github.com/dartsim/dart/pull/1324)
 
 * dartpy
 
@@ -39,6 +39,7 @@
   * Added ReferentialSkeleton, Linkage, and Chain: [#1321](https://github.com/dartsim/dart/pull/1321)
   * Enabled WorldNode classes to overload virtual functions in Python: [#1322](https://github.com/dartsim/dart/pull/1322)
   * Added JacobianNode and operational space controller example: [#1323](https://github.com/dartsim/dart/pull/1323)
+  * Removed static create() functions in favor of custom constructors: [#1323](https://github.com/dartsim/dart/pull/1323)
 
 ### [DART 6.8.4 (2019-05-03)](https://github.com/dartsim/dart/milestone/56?closed=1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 * Examples and Tutorials
 
-  * Updated examples directory to make dart::gui::osg more accessible: [#1324](https://github.com/dartsim/dart/pull/1324)
+  * Updated examples directory to make dart::gui::osg more accessible: [#1305](https://github.com/dartsim/dart/pull/1305)
 
 * dartpy
 
@@ -39,7 +39,7 @@
   * Added ReferentialSkeleton, Linkage, and Chain: [#1321](https://github.com/dartsim/dart/pull/1321)
   * Enabled WorldNode classes to overload virtual functions in Python: [#1322](https://github.com/dartsim/dart/pull/1322)
   * Added JacobianNode and operational space controller example: [#1323](https://github.com/dartsim/dart/pull/1323)
-  * Removed static create() functions in favor of custom constructors: [#1323](https://github.com/dartsim/dart/pull/1323)
+  * Removed static create() functions in favor of custom constructors: [#1324](https://github.com/dartsim/dart/pull/1324)
 
 ### [DART 6.8.4 (2019-05-03)](https://github.com/dartsim/dart/milestone/56?closed=1)
 

--- a/dart/gui/osg/Viewer.cpp
+++ b/dart/gui/osg/Viewer.cpp
@@ -70,13 +70,11 @@ public:
 
     if(mViewer->mRecording || mViewer->mScreenCapture)
     {
-      int x, y;
-      unsigned int width, height;
-      ::osg::ref_ptr<::osg::Viewport> vp = mCamera->getViewport();
-      x = vp->x();
-      y = vp->y();
-      width = vp->width();
-      height = vp->height();
+      ::osg::ref_ptr<const ::osg::Viewport> vp = mCamera->getViewport();
+      const int x = static_cast<int>(vp->x());
+      const int y = static_cast<int>(vp->y());
+      const int width = static_cast<int>(vp->width());
+      const int height = static_cast<int>(vp->height());
 
       mImage->readPixels(x, y, width, height, GL_RGB, GL_UNSIGNED_BYTE);
     }
@@ -87,7 +85,8 @@ public:
       {
         std::stringstream str;
         str << mViewer->mImageDirectory << "/" << mViewer->mImagePrefix
-            << std::setfill('0') << std::setw(mViewer->mImageDigits)
+            << std::setfill('0')
+            << std::setw(static_cast<int>(mViewer->mImageDigits))
             << mViewer->mImageSequenceNum << std::setw(0) << ".png";
 
         if(::osgDB::writeImageFile(*mImage, str.str()))

--- a/python/dartpy/dynamics/Chain.cpp
+++ b/python/dartpy/dynamics/Chain.cpp
@@ -82,20 +82,6 @@ void Chain(pybind11::module& m)
           ::pybind11::init(
               +[](dart::dynamics::BodyNode* start,
                   dart::dynamics::BodyNode* target,
-                  dart::dynamics::Chain::IncludeUpstreamParentJointTag)
-                  -> dart::dynamics::ChainPtr {
-                return dart::dynamics::Chain::create(
-                    start,
-                    target,
-                    dart::dynamics::Chain::IncludeUpstreamParentJoint);
-              }),
-          ::pybind11::arg("start"),
-          ::pybind11::arg("target"),
-          ::pybind11::arg("includeUpstreamParentJoint"))
-      .def(
-          ::pybind11::init(
-              +[](dart::dynamics::BodyNode* start,
-                  dart::dynamics::BodyNode* target,
                   bool includeUpstreamParentJoint) -> dart::dynamics::ChainPtr {
                 if (includeUpstreamParentJoint)
                   return dart::dynamics::Chain::create(
@@ -108,22 +94,6 @@ void Chain(pybind11::module& m)
           ::pybind11::arg("start"),
           ::pybind11::arg("target"),
           ::pybind11::arg("includeUpstreamParentJoint"))
-      .def(
-          ::pybind11::init(
-              +[](dart::dynamics::BodyNode* start,
-                  dart::dynamics::BodyNode* target,
-                  dart::dynamics::Chain::IncludeUpstreamParentJointTag,
-                  const std::string& name) -> dart::dynamics::ChainPtr {
-                return dart::dynamics::Chain::create(
-                    start,
-                    target,
-                    dart::dynamics::Chain::IncludeUpstreamParentJoint,
-                    name);
-              }),
-          ::pybind11::arg("start"),
-          ::pybind11::arg("target"),
-          ::pybind11::arg("includeUpstreamParentJoint"),
-          ::pybind11::arg("name"))
       .def(
           ::pybind11::init(
               +[](dart::dynamics::BodyNode* start,
@@ -165,16 +135,6 @@ void Chain(pybind11::module& m)
       .def("isStillChain", +[](const dart::dynamics::Chain* self) -> bool {
         return self->isStillChain();
       });
-
-  auto attr = m.attr("Chain");
-
-  ::pybind11::enum_<dart::dynamics::Chain::IncludeUpstreamParentJointTag>(
-      attr, "IncludeUpstreamParentJointTag")
-      .value(
-          "IncludeUpstreamParentJoint",
-          dart::dynamics::Chain::IncludeUpstreamParentJointTag::
-              IncludeUpstreamParentJoint)
-      .export_values();
 
   ::pybind11::class_<dart::dynamics::Chain::Criteria>(m, "ChainCriteria")
       .def(

--- a/python/dartpy/dynamics/Chain.cpp
+++ b/python/dartpy/dynamics/Chain.cpp
@@ -45,6 +45,64 @@ void Chain(pybind11::module& m)
       dart::dynamics::Linkage,
       std::shared_ptr<dart::dynamics::Chain>>(m, "Chain")
       .def(
+          ::pybind11::init(
+              +[](const dart::dynamics::Chain::Criteria& criteria)
+                  -> dart::dynamics::ChainPtr {
+                return dart::dynamics::Chain::create(criteria);
+              }),
+          ::pybind11::arg("criteria"))
+      .def(
+          ::pybind11::init(
+              +[](const dart::dynamics::Chain::Criteria& criteria,
+                  const std::string& name) -> dart::dynamics::ChainPtr {
+                return dart::dynamics::Chain::create(criteria, name);
+              }),
+          ::pybind11::arg("criteria"),
+          ::pybind11::arg("name"))
+      .def(
+          ::pybind11::init(
+              +[](dart::dynamics::BodyNode* start,
+                  dart::dynamics::BodyNode* target)
+                  -> dart::dynamics::ChainPtr {
+                return dart::dynamics::Chain::create(start, target);
+              }),
+          ::pybind11::arg("start"),
+          ::pybind11::arg("target"))
+      .def(
+          ::pybind11::init(
+              +[](dart::dynamics::BodyNode* start,
+                  dart::dynamics::BodyNode* target,
+                  const std::string& name) -> dart::dynamics::ChainPtr {
+                return dart::dynamics::Chain::create(start, target, name);
+              }),
+          ::pybind11::arg("start"),
+          ::pybind11::arg("target"),
+          ::pybind11::arg("name"))
+      .def(
+          ::pybind11::init(
+              +[](dart::dynamics::BodyNode* start,
+                  dart::dynamics::BodyNode* target,
+                  dart::dynamics::Chain::IncludeUpstreamParentJointTag _arg2_)
+                  -> dart::dynamics::ChainPtr {
+                return dart::dynamics::Chain::create(start, target, _arg2_);
+              }),
+          ::pybind11::arg("start"),
+          ::pybind11::arg("target"),
+          ::pybind11::arg("arg2_"))
+      .def(
+          ::pybind11::init(
+              +[](dart::dynamics::BodyNode* start,
+                  dart::dynamics::BodyNode* target,
+                  dart::dynamics::Chain::IncludeUpstreamParentJointTag _arg2_,
+                  const std::string& name) -> dart::dynamics::ChainPtr {
+                return dart::dynamics::Chain::create(
+                    start, target, _arg2_, name);
+              }),
+          ::pybind11::arg("start"),
+          ::pybind11::arg("target"),
+          ::pybind11::arg("arg2_"),
+          ::pybind11::arg("name"))
+      .def(
           "cloneChain",
           +[](const dart::dynamics::Chain* self) -> dart::dynamics::ChainPtr {
             return self->cloneChain();
@@ -67,63 +125,7 @@ void Chain(pybind11::module& m)
           "isStillChain",
           +[](const dart::dynamics::Chain* self) -> bool {
             return self->isStillChain();
-          })
-      .def_static(
-          "create",
-          +[](const dart::dynamics::Chain::Criteria& criteria)
-              -> dart::dynamics::ChainPtr {
-            return dart::dynamics::Chain::create(criteria);
-          },
-          ::pybind11::arg("criteria"))
-      .def_static(
-          "create",
-          +[](const dart::dynamics::Chain::Criteria& criteria,
-              const std::string& name) -> dart::dynamics::ChainPtr {
-            return dart::dynamics::Chain::create(criteria, name);
-          },
-          ::pybind11::arg("criteria"),
-          ::pybind11::arg("name"))
-      .def_static(
-          "create",
-          +[](dart::dynamics::BodyNode* start,
-              dart::dynamics::BodyNode* target) -> dart::dynamics::ChainPtr {
-            return dart::dynamics::Chain::create(start, target);
-          },
-          ::pybind11::arg("start"),
-          ::pybind11::arg("target"))
-      .def_static(
-          "create",
-          +[](dart::dynamics::BodyNode* start,
-              dart::dynamics::BodyNode* target,
-              const std::string& name) -> dart::dynamics::ChainPtr {
-            return dart::dynamics::Chain::create(start, target, name);
-          },
-          ::pybind11::arg("start"),
-          ::pybind11::arg("target"),
-          ::pybind11::arg("name"))
-      .def_static(
-          "create",
-          +[](dart::dynamics::BodyNode* start,
-              dart::dynamics::BodyNode* target,
-              dart::dynamics::Chain::IncludeUpstreamParentJointTag _arg2_)
-              -> dart::dynamics::ChainPtr {
-            return dart::dynamics::Chain::create(start, target, _arg2_);
-          },
-          ::pybind11::arg("start"),
-          ::pybind11::arg("target"),
-          ::pybind11::arg("arg2_"))
-      .def_static(
-          "create",
-          +[](dart::dynamics::BodyNode* start,
-              dart::dynamics::BodyNode* target,
-              dart::dynamics::Chain::IncludeUpstreamParentJointTag _arg2_,
-              const std::string& name) -> dart::dynamics::ChainPtr {
-            return dart::dynamics::Chain::create(start, target, _arg2_, name);
-          },
-          ::pybind11::arg("start"),
-          ::pybind11::arg("target"),
-          ::pybind11::arg("arg2_"),
-          ::pybind11::arg("name"));
+          });
 
   auto attr = m.attr("Chain");
 

--- a/python/dartpy/dynamics/Chain.cpp
+++ b/python/dartpy/dynamics/Chain.cpp
@@ -82,25 +82,66 @@ void Chain(pybind11::module& m)
           ::pybind11::init(
               +[](dart::dynamics::BodyNode* start,
                   dart::dynamics::BodyNode* target,
-                  dart::dynamics::Chain::IncludeUpstreamParentJointTag _arg2_)
+                  dart::dynamics::Chain::IncludeUpstreamParentJointTag)
                   -> dart::dynamics::ChainPtr {
-                return dart::dynamics::Chain::create(start, target, _arg2_);
+                return dart::dynamics::Chain::create(
+                    start,
+                    target,
+                    dart::dynamics::Chain::IncludeUpstreamParentJoint);
               }),
           ::pybind11::arg("start"),
           ::pybind11::arg("target"),
-          ::pybind11::arg("arg2_"))
+          ::pybind11::arg("includeUpstreamParentJoint"))
       .def(
           ::pybind11::init(
               +[](dart::dynamics::BodyNode* start,
                   dart::dynamics::BodyNode* target,
-                  dart::dynamics::Chain::IncludeUpstreamParentJointTag _arg2_,
-                  const std::string& name) -> dart::dynamics::ChainPtr {
-                return dart::dynamics::Chain::create(
-                    start, target, _arg2_, name);
+                  bool includeUpstreamParentJoint) -> dart::dynamics::ChainPtr {
+                if (includeUpstreamParentJoint)
+                  return dart::dynamics::Chain::create(
+                      start,
+                      target,
+                      dart::dynamics::Chain::IncludeUpstreamParentJoint);
+                else
+                  return dart::dynamics::Chain::create(start, target);
               }),
           ::pybind11::arg("start"),
           ::pybind11::arg("target"),
-          ::pybind11::arg("arg2_"),
+          ::pybind11::arg("includeUpstreamParentJoint"))
+      .def(
+          ::pybind11::init(
+              +[](dart::dynamics::BodyNode* start,
+                  dart::dynamics::BodyNode* target,
+                  dart::dynamics::Chain::IncludeUpstreamParentJointTag,
+                  const std::string& name) -> dart::dynamics::ChainPtr {
+                return dart::dynamics::Chain::create(
+                    start,
+                    target,
+                    dart::dynamics::Chain::IncludeUpstreamParentJoint,
+                    name);
+              }),
+          ::pybind11::arg("start"),
+          ::pybind11::arg("target"),
+          ::pybind11::arg("includeUpstreamParentJoint"),
+          ::pybind11::arg("name"))
+      .def(
+          ::pybind11::init(
+              +[](dart::dynamics::BodyNode* start,
+                  dart::dynamics::BodyNode* target,
+                  bool includeUpstreamParentJoint,
+                  const std::string& name) -> dart::dynamics::ChainPtr {
+                if (includeUpstreamParentJoint)
+                  return dart::dynamics::Chain::create(
+                      start,
+                      target,
+                      dart::dynamics::Chain::IncludeUpstreamParentJoint,
+                      name);
+                else
+                  return dart::dynamics::Chain::create(start, target, name);
+              }),
+          ::pybind11::arg("start"),
+          ::pybind11::arg("target"),
+          ::pybind11::arg("includeUpstreamParentJoint"),
           ::pybind11::arg("name"))
       .def(
           "cloneChain",
@@ -121,11 +162,9 @@ void Chain(pybind11::module& m)
             return self->cloneMetaSkeleton(cloneName);
           },
           ::pybind11::arg("cloneName"))
-      .def(
-          "isStillChain",
-          +[](const dart::dynamics::Chain* self) -> bool {
-            return self->isStillChain();
-          });
+      .def("isStillChain", +[](const dart::dynamics::Chain* self) -> bool {
+        return self->isStillChain();
+      });
 
   auto attr = m.attr("Chain");
 

--- a/python/dartpy/dynamics/Linkage.cpp
+++ b/python/dartpy/dynamics/Linkage.cpp
@@ -45,6 +45,21 @@ void Linkage(pybind11::module& m)
       dart::dynamics::ReferentialSkeleton,
       std::shared_ptr<dart::dynamics::Linkage>>(m, "Linkage")
       .def(
+          ::pybind11::init(
+              +[](const dart::dynamics::Linkage::Criteria& criteria)
+                  -> dart::dynamics::LinkagePtr {
+                return dart::dynamics::Linkage::create(criteria);
+              }),
+          ::pybind11::arg("criteria"))
+      .def(
+          ::pybind11::init(
+              +[](const dart::dynamics::Linkage::Criteria& criteria,
+                  const std::string& name) -> dart::dynamics::LinkagePtr {
+                return dart::dynamics::Linkage::create(criteria, name);
+              }),
+          ::pybind11::arg("criteria"),
+          ::pybind11::arg("name"))
+      .def(
           "cloneLinkage",
           +[](const dart::dynamics::Linkage* self)
               -> dart::dynamics::LinkagePtr { return self->cloneLinkage(); })
@@ -72,22 +87,7 @@ void Linkage(pybind11::module& m)
           +[](dart::dynamics::Linkage* self) { self->reassemble(); })
       .def(
           "satisfyCriteria",
-          +[](dart::dynamics::Linkage* self) { self->satisfyCriteria(); })
-      .def_static(
-          "create",
-          +[](const dart::dynamics::Linkage::Criteria& criteria)
-              -> dart::dynamics::LinkagePtr {
-            return dart::dynamics::Linkage::create(criteria);
-          },
-          ::pybind11::arg("criteria"))
-      .def_static(
-          "create",
-          +[](const dart::dynamics::Linkage::Criteria& criteria,
-              const std::string& name) -> dart::dynamics::LinkagePtr {
-            return dart::dynamics::Linkage::create(criteria, name);
-          },
-          ::pybind11::arg("criteria"),
-          ::pybind11::arg("name"));
+          +[](dart::dynamics::Linkage* self) { self->satisfyCriteria(); });
 
   ::pybind11::class_<dart::dynamics::Linkage::Criteria>(m, "LinkageCriteria")
       .def(

--- a/python/dartpy/dynamics/Linkage.cpp
+++ b/python/dartpy/dynamics/Linkage.cpp
@@ -85,9 +85,9 @@ void Linkage(pybind11::module& m)
       .def(
           "reassemble",
           +[](dart::dynamics::Linkage* self) { self->reassemble(); })
-      .def(
-          "satisfyCriteria",
-          +[](dart::dynamics::Linkage* self) { self->satisfyCriteria(); });
+      .def("satisfyCriteria", +[](dart::dynamics::Linkage* self) {
+        self->satisfyCriteria();
+      });
 
   ::pybind11::class_<dart::dynamics::Linkage::Criteria>(m, "LinkageCriteria")
       .def(

--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -45,6 +45,22 @@ void Skeleton(pybind11::module& m)
       dart::dynamics::Skeleton,
       dart::dynamics::MetaSkeleton,
       std::shared_ptr<dart::dynamics::Skeleton>>(m, "Skeleton")
+      .def(::pybind11::init(+[]() -> dart::dynamics::SkeletonPtr {
+        return dart::dynamics::Skeleton::create();
+      }))
+      .def(
+          ::pybind11::init(
+              +[](const std::string& _name) -> dart::dynamics::SkeletonPtr {
+                return dart::dynamics::Skeleton::create(_name);
+              }),
+          ::pybind11::arg("name"))
+      .def(
+          ::pybind11::init(
+              +[](const dart::dynamics::Skeleton::AspectPropertiesData&
+                      properties) -> dart::dynamics::SkeletonPtr {
+                return dart::dynamics::Skeleton::create(properties);
+              }),
+          ::pybind11::arg("properties"))
       .def(
           "getPtr",
           +[](dart::dynamics::Skeleton* self) -> dart::dynamics::SkeletonPtr {
@@ -1211,23 +1227,6 @@ void Skeleton(pybind11::module& m)
           "resetUnion",
           +[](dart::dynamics::Skeleton* self)
               -> void { return self->resetUnion(); })
-      .def_static(
-          "create",
-          +[]() -> dart::dynamics::
-                    SkeletonPtr { return dart::dynamics::Skeleton::create(); })
-      .def_static(
-          "create",
-          +[](const std::string& _name) -> dart::dynamics::SkeletonPtr {
-            return dart::dynamics::Skeleton::create(_name);
-          },
-          ::pybind11::arg("name"))
-      .def_static(
-          "create",
-          +[](const dart::dynamics::Skeleton::AspectPropertiesData& properties)
-              -> dart::dynamics::SkeletonPtr {
-            return dart::dynamics::Skeleton::create(properties);
-          },
-          ::pybind11::arg("properties"))
       .def_readwrite(
           "mUnionRootSkeleton", &dart::dynamics::Skeleton::mUnionRootSkeleton)
       .def_readwrite("mUnionSize", &dart::dynamics::Skeleton::mUnionSize)

--- a/python/dartpy/simulation/World.cpp
+++ b/python/dartpy/simulation/World.cpp
@@ -46,6 +46,13 @@ void World(pybind11::module& m)
       std::shared_ptr<dart::simulation::World>>(m, "World")
       .def(::pybind11::init<>())
       .def(::pybind11::init<const std::string&>(), ::pybind11::arg("name"))
+      .def(::pybind11::init(+[]() -> dart::simulation::WorldPtr {
+        return dart::simulation::World::create();
+      }))
+      .def(::pybind11::init(
+          +[](const std::string& name) -> dart::simulation::WorldPtr {
+            return dart::simulation::World::create(name);
+          }))
       .def(
           "clone",
           +[](const dart::simulation::World* self)
@@ -229,18 +236,6 @@ void World(pybind11::module& m)
       .def(
           "bake",
           +[](dart::simulation::World* self) -> void { return self->bake(); })
-      .def_static(
-          "create",
-          +[]() -> std::shared_ptr<dart::simulation::World> {
-            return dart::simulation::World::create();
-          })
-      .def_static(
-          "create",
-          +[](const std::string& name)
-              -> std::shared_ptr<dart::simulation::World> {
-            return dart::simulation::World::create(name);
-          },
-          ::pybind11::arg("name"))
       .def_readonly("onNameChanged", &dart::simulation::World::onNameChanged);
 }
 

--- a/python/examples/hello_world/main.py
+++ b/python/examples/hello_world/main.py
@@ -2,7 +2,7 @@ import dartpy as dart
 
 
 def main():
-    world = dart.simulation.World.create()
+    world = dart.simulation.World()
 
     urdfParser = dart.utils.DartLoader()
     kr5 = urdfParser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")

--- a/python/examples/hello_world_gui/main.py
+++ b/python/examples/hello_world_gui/main.py
@@ -28,7 +28,7 @@ class HelloWorldNode(dart.gui.osg.RealTimeWorldNode):
 
 
 def main():
-    world = dart.simulation.World.create()
+    world = dart.simulation.World()
 
     urdfParser = dart.utils.DartLoader()
     kr5 = urdfParser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")

--- a/python/examples/operational_space_control/main.py
+++ b/python/examples/operational_space_control/main.py
@@ -44,7 +44,7 @@ class HelloWorldNode(dart.gui.osg.RealTimeWorldNode):
 
 
 def main():
-    world = dart.simulation.World.create()
+    world = dart.simulation.World()
 
     urdfParser = dart.utils.DartLoader()
     kr5 = urdfParser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")

--- a/python/tests/unit/dynamics/test_meta_skeleton.py
+++ b/python/tests/unit/dynamics/test_meta_skeleton.py
@@ -17,11 +17,13 @@ def test_basic():
     elbow = kr5.getBodyNode('elbow')
     assert elbow is not None
 
-    chain = dart.dynamics.Chain(shoulder, elbow, 'midchain')
-    assert chain is not None
+    chain1 = dart.dynamics.Chain(shoulder, elbow, False, 'midchain')
+    assert chain1 is not None
+    assert chain1.getNumBodyNodes() is 2
 
-    print(chain.getNumBodyNodes())
-    assert chain.getNumBodyNodes() is 2
+    chain2 = dart.dynamics.Chain(shoulder, elbow, True, 'midchain')
+    assert chain2 is not None
+    assert chain2.getNumBodyNodes() is 3
 
     assert len(kr5.getPositions()) is not 0
     assert kr5.getNumJoints() is not 0

--- a/python/tests/unit/dynamics/test_meta_skeleton.py
+++ b/python/tests/unit/dynamics/test_meta_skeleton.py
@@ -17,7 +17,7 @@ def test_basic():
     elbow = kr5.getBodyNode('elbow')
     assert elbow is not None
 
-    chain = dart.dynamics.Chain.create(shoulder, elbow, 'midchain')
+    chain = dart.dynamics.Chain(shoulder, elbow, 'midchain')
     assert chain is not None
 
     print(chain.getNumBodyNodes())

--- a/python/tests/unit/simulation/test_world.py
+++ b/python/tests/unit/simulation/test_world.py
@@ -4,7 +4,7 @@ from dartpy.simulation import World
 
 
 def test_empty_world():
-    world = World.create()
+    world = World('my world')
     assert world.getNumSkeletons() is 0
     assert world.getNumSimpleFrames() is 0
 


### PR DESCRIPTION
API changes:
```python
import dartpy as dart

# Before
world = dart.simulation.World.create()
skel = dart.dynamics.Skeleton.create()
world.addSkeleton(skel)
chain = dart.dynamics.Chain(shoulder, elbow, dart.dynamics.Chain.IncludeUpstreamParentJointTag.IncludeUpstreamParentJoint)

# After
world = dart.simulation.World()
skel = dart.dynamics.Skeleton()
world.addSkeleton(skel)
chain = dart.dynamics.Chain(shoulder, elbow, True)  # or chain = dart.dynamics.Chain(shoulder, elbow, includeUpstreamParentJoint=True)
```

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
