### PR TITLE
Fix handling of submeshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## DART 6
 
+### [DART 6.8.5 (2019-05-25)](https://github.com/dartsim/dart/milestone/57?closed=1)
+
+* Collision
+
+  * Fixed handling of submeshes in ODE collision detector: [#1336](https://github.com/dartsim/dart/pull/1336)
+
 ### [DART 6.8.4 (2019-05-03)](https://github.com/dartsim/dart/milestone/56?closed=1)
 
 #### Changes

--- a/dart/collision/ode/detail/OdeMesh.cpp
+++ b/dart/collision/ode/detail/OdeMesh.cpp
@@ -58,7 +58,7 @@ OdeMesh::OdeMesh(
       mOdeTriMeshDataId,
       mVertices.data(),
       3*sizeof(double),
-      static_cast<int>(mVertices.size()),
+      static_cast<int>(mVertices.size()/3),
       mIndices.data(),
       static_cast<int>(mIndices.size()),
       3*sizeof(int),
@@ -110,6 +110,7 @@ void OdeMesh::fillArrays(const aiScene* scene, const Eigen::Vector3d& scale)
 
   auto vertexIndex = 0u;
   auto indexIndex = 0u;
+  auto offset = 0u;
   for (auto i = 0u; i < scene->mNumMeshes; ++i)
   {
     const auto mesh = scene->mMeshes[i];
@@ -128,10 +129,12 @@ void OdeMesh::fillArrays(const aiScene* scene, const Eigen::Vector3d& scale)
 
     for (auto j = 0u; j < mesh->mNumFaces; ++j)
     {
-      mIndices[indexIndex++] = mesh->mFaces[j].mIndices[0];
-      mIndices[indexIndex++] = mesh->mFaces[j].mIndices[1];
-      mIndices[indexIndex++] = mesh->mFaces[j].mIndices[2];
+      mIndices[indexIndex++] = mesh->mFaces[j].mIndices[0] + offset;
+      mIndices[indexIndex++] = mesh->mFaces[j].mIndices[1] + offset;
+      mIndices[indexIndex++] = mesh->mFaces[j].mIndices[2] + offset;
     }
+
+    offset += mesh->mNumVertices;
   }
 }
 


### PR DESCRIPTION
Meshes with multiple submeshes are not handled properly when using ODE as the collision detector. This is because the indices for each submesh start from 0 in Assimp, but the input to ODE requires the vertices and indices of all submeshes to be merged.

The issue can manifest itself in various ways, but the simplest example I came up with is to create a plane and a box in one mesh and have a sphere fall onto the plane.

**Before**
![dart_before_fix](https://user-images.githubusercontent.com/206116/58362094-f12d2400-7e58-11e9-933c-63c0e537136e.gif)

**After**
![dart_after_fix](https://user-images.githubusercontent.com/206116/58362088-e2df0800-7e58-11e9-97c6-ef040f854912.gif)

I have attached the mesh for reference
[plane_with_box.zip](https://github.com/dartsim/dart/files/3218953/plane_with_box.zip)
