### PR TITLE
Add default constructor to RayHit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Collision
 
-  * Added default constructors to RayHit and RaycastResult: [#1345](https://github.com/dartsim/dart/pull/1345)
+  * Added default constructor to RayHit: [#1345](https://github.com/dartsim/dart/pull/1345)
 
 * dartpy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [DART 6.9.1 (2019-XX-XX)](https://github.com/dartsim/dart/milestone/59?closed=1)
 
+* Collision
+
+  * Added default constructors to RayHit and RaycastResult: [#1345](https://github.com/dartsim/dart/pull/1345)
+
 * dartpy
 
   * Updated build scripts for uploading dartpy to PyPI: [#1341](https://github.com/dartsim/dart/pull/1341)

--- a/dart/collision/RaycastResult.cpp
+++ b/dart/collision/RaycastResult.cpp
@@ -36,7 +36,17 @@ namespace dart {
 namespace collision {
 
 //==============================================================================
-RaycastResult::RaycastResult()
+RayHit::RayHit()
+  : mCollisionObject(nullptr),
+    mPoint(Eigen::Vector3d::Zero()),
+    mFraction(0.0),
+    mNormal(Eigen::Vector3d::Zero())
+{
+  // Do nothing
+}
+
+//==============================================================================
+RaycastResult::RaycastResult() : mRayHits(false)
 {
   // Do nothing
 }

--- a/dart/collision/RaycastResult.hpp
+++ b/dart/collision/RaycastResult.hpp
@@ -46,30 +46,31 @@ struct RayHit
   /// The collision object the ray hit
   const CollisionObject* mCollisionObject;
 
-  /// The normal at the hit point in the world coordinates
-  Eigen::Vector3d mNormal;
-
   /// The hit point in the world coordinates
   Eigen::Vector3d mPoint;
 
   /// The fraction from "from" point to "to" point
   double mFraction;
+
+  /// The normal at the hit point in the world coordinates
+  Eigen::Vector3d mNormal;
+
+  /// Constructor
+  RayHit();
 };
 
 struct RaycastResult
 {
-  /// Constructor
-  RaycastResult();
-
   /// Clear the result
   void clear();
 
   /// Returns true if there is a hit
   bool hasHit() const;
 
-  bool mHasHit;
-
   std::vector<RayHit> mRayHits;
+
+  /// Constructor
+  RaycastResult();
 };
 
 } // namespace collision

--- a/unittests/comprehensive/test_Raycast.cpp
+++ b/unittests/comprehensive/test_Raycast.cpp
@@ -41,6 +41,23 @@
 using namespace dart;
 
 //==============================================================================
+TEST(Raycast, RayHitDefaultConstructor)
+{
+  RayHit rayHit;
+  EXPECT_TRUE(equals(rayHit.mNormal, Eigen::Vector3d::Zero().eval()));
+  EXPECT_TRUE(equals(rayHit.mPoint, Eigen::Vector3d::Zero().eval()));
+  EXPECT_DOUBLE_EQ(rayHit.mFraction, 0);
+}
+
+//==============================================================================
+TEST(Raycast, RaycastResultDefaultConstructor)
+{
+  RaycastResult result;
+  EXPECT_FALSE(result.hasHit());
+  EXPECT_TRUE(result.mRayHits.empty());
+}
+
+//==============================================================================
 void testBasicInterface(const std::shared_ptr<CollisionDetector>& cd)
 {
   if (cd->getType() != collision::BulletCollisionDetector::getStaticType())
@@ -115,7 +132,7 @@ void testBasicInterface(const std::shared_ptr<CollisionDetector>& cd)
 }
 
 //==============================================================================
-TEST(Distance, testBasicInterface)
+TEST(Raycast, testBasicInterface)
 {
   auto fcl = FCLCollisionDetector::create();
   testBasicInterface(fcl);
@@ -199,7 +216,7 @@ void testOptions(const std::shared_ptr<CollisionDetector>& cd)
 }
 
 //==============================================================================
-TEST(Distance, testOptions)
+TEST(Raycast, testOptions)
 {
   auto fcl = FCLCollisionDetector::create();
   testOptions(fcl);


### PR DESCRIPTION
Necessary to initialize the members. Also, `RayHit.mHasHit` is removed since it's not used.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
