### PR TITLE
Fix compilation warnings with GCC 9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   * Added findSolution and solveAndApply to InverseKinematics: [#1358](https://github.com/dartsim/dart/pull/1358)
   * Added InteractiveFrame and ImGui APIs: [#1359](https://github.com/dartsim/dart/pull/1359)
 
+* Build
+
+  * Fixed compiler warnings from GCC 9.1: [#1366](https://github.com/dartsim/dart/pull/1366)
+
 ### [DART 6.9.1 (2019-06-06)](https://github.com/dartsim/dart/milestone/59?closed=1)
 
 * Collision

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -948,7 +948,7 @@ std::unique_ptr<btCollisionShape> createBulletEllipsoidMesh(
   auto gimpactMeshShape = std::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
-  return std::move(gimpactMeshShape);
+  return gimpactMeshShape;
 }
 
 //==============================================================================
@@ -978,7 +978,7 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
   gimpactMeshShape->updateBound();
   gimpactMeshShape->setUserPointer(triMesh);
 
-  return std::move(gimpactMeshShape);
+  return gimpactMeshShape;
 }
 
 //==============================================================================
@@ -1001,7 +1001,7 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpMesh(
   auto gimpactMeshShape = std::make_unique<btGImpactMeshShape>(triMesh);
   gimpactMeshShape->updateBound();
 
-  return std::move(gimpactMeshShape);
+  return gimpactMeshShape;
 }
 
 //==============================================================================

--- a/dart/common/detail/sub_ptr.hpp
+++ b/dart/common/detail/sub_ptr.hpp
@@ -54,6 +54,13 @@ sub_ptr<T>::sub_ptr(T* _ptr) : mT(nullptr), mSubjectBase(nullptr)
 
 //==============================================================================
 template <class T>
+sub_ptr<T>::sub_ptr(const sub_ptr& other)
+{
+  set(other.get());
+}
+
+//==============================================================================
+template <class T>
 sub_ptr<T>& sub_ptr<T>::operator=(const sub_ptr<T>& _sp)
 {
   set(_sp.get());

--- a/dart/common/detail/sub_ptr.hpp
+++ b/dart/common/detail/sub_ptr.hpp
@@ -54,7 +54,7 @@ sub_ptr<T>::sub_ptr(T* _ptr) : mT(nullptr), mSubjectBase(nullptr)
 
 //==============================================================================
 template <class T>
-sub_ptr<T>::sub_ptr(const sub_ptr& other)
+sub_ptr<T>::sub_ptr(const sub_ptr& other) : mT(nullptr), mSubjectBase(nullptr)
 {
   set(other.get());
 }

--- a/dart/common/sub_ptr.hpp
+++ b/dart/common/sub_ptr.hpp
@@ -53,6 +53,9 @@ public:
   /// constructor.
   sub_ptr(T* _ptr);
 
+  /// User defined copy constructor
+  sub_ptr(const sub_ptr& other);
+
   /// Change the Subject of this sub_ptr
   sub_ptr& operator=(const sub_ptr& _sp);
 

--- a/dart/dynamics/detail/BodyNodePtr.hpp
+++ b/dart/dynamics/detail/BodyNodePtr.hpp
@@ -141,6 +141,13 @@ public:
     set(nullptr);
   }
 
+  /// User defined assignment operator
+  TemplateBodyNodePtr& operator=(const TemplateBodyNodePtr& bnp)
+  {
+    set(bnp.get());
+    return *this;
+  }
+
   /// Change the BodyNode that this BodyNodePtr references
   template <class OtherBodyNodeT>
   TemplateBodyNodePtr& operator=(

--- a/dart/dynamics/detail/GenericJointAspect.hpp
+++ b/dart/dynamics/detail/GenericJointAspect.hpp
@@ -173,6 +173,12 @@ struct GenericJointUniqueProperties
 
   virtual ~GenericJointUniqueProperties() = default;
 
+  /// Copy assignment operator
+  // Note: we only need this because VS2013 lacks full support for std::array
+  // Once std::array is properly supported, this should be removed.
+  GenericJointUniqueProperties& operator=(
+      const GenericJointUniqueProperties& other);
+
 public:
   // To get byte-aligned Eigen vectors
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -288,6 +294,38 @@ GenericJointUniqueProperties<ConfigSpaceT>::GenericJointUniqueProperties(
     mPreserveDofNames[i] = _other.mPreserveDofNames[i];
     mDofNames[i] = _other.mDofNames[i];
   }
+}
+
+//==============================================================================
+template <class ConfigSpaceT>
+GenericJointUniqueProperties<ConfigSpaceT>&
+GenericJointUniqueProperties<ConfigSpaceT>::operator=(
+    const GenericJointUniqueProperties& other)
+{
+  if (this != &other)
+  {
+    mPositionLowerLimits = other.mPositionLowerLimits;
+    mPositionUpperLimits = other.mPositionUpperLimits;
+    mInitialPositions = other.mInitialPositions;
+    mVelocityLowerLimits = other.mVelocityLowerLimits;
+    mVelocityUpperLimits = other.mVelocityUpperLimits;
+    mInitialVelocities = other.mInitialVelocities;
+    mAccelerationLowerLimits = other.mAccelerationLowerLimits;
+    mAccelerationUpperLimits = other.mAccelerationUpperLimits;
+    mForceLowerLimits = other.mForceLowerLimits;
+    mForceUpperLimits = other.mForceUpperLimits;
+    mSpringStiffnesses = other.mSpringStiffnesses;
+    mRestPositions = other.mRestPositions;
+    mDampingCoefficients = other.mDampingCoefficients;
+    mFrictions = other.mFrictions;
+
+    for (auto i = 0u; i < NumDofs; ++i)
+    {
+      mPreserveDofNames[i] = other.mPreserveDofNames[i];
+      mDofNames[i] = other.mDofNames[i];
+    }
+  }
+  return *this;
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/PlanarJointAspect.cpp
+++ b/dart/dynamics/detail/PlanarJointAspect.cpp
@@ -85,6 +85,32 @@ PlanarJointUniqueProperties::PlanarJointUniqueProperties(
 }
 
 //==============================================================================
+PlanarJointUniqueProperties& PlanarJointUniqueProperties::operator=(
+    const PlanarJointUniqueProperties& other)
+{
+  if (this != &other)
+  {
+    switch (other.mPlaneType)
+    {
+      case PlaneType::ARBITRARY:
+        setArbitraryPlane(other.mTransAxis1, other.mTransAxis2);
+        break;
+      case PlaneType::XY:
+        setXYPlane();
+        break;
+      case PlaneType::YZ:
+        setYZPlane();
+        break;
+      case PlaneType::ZX:
+        setZXPlane();
+        break;
+    }
+  }
+
+  return *this;
+}
+
+//==============================================================================
 void PlanarJointUniqueProperties::setXYPlane()
 {
   mPlaneType = PlaneType::XY;

--- a/dart/dynamics/detail/PlanarJointAspect.hpp
+++ b/dart/dynamics/detail/PlanarJointAspect.hpp
@@ -90,6 +90,10 @@ struct PlanarJointUniqueProperties
 
   virtual ~PlanarJointUniqueProperties() = default;
 
+  /// Assignment operator
+  PlanarJointUniqueProperties& operator=(
+      const PlanarJointUniqueProperties& other);
+
   /// Set plane type as XY-plane
   void setXYPlane();
 

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
@@ -93,6 +93,32 @@ TranslationalJoint2DUniqueProperties::TranslationalJoint2DUniqueProperties(
 }
 
 //==============================================================================
+TranslationalJoint2DUniqueProperties& TranslationalJoint2DUniqueProperties::
+operator=(const TranslationalJoint2DUniqueProperties& other)
+{
+  if (this != &other)
+  {
+    switch (other.mPlaneType)
+    {
+      case PlaneType::ARBITRARY:
+        setArbitraryPlane(other.mTransAxes);
+        break;
+      case PlaneType::XY:
+        setXYPlane();
+        break;
+      case PlaneType::YZ:
+        setYZPlane();
+        break;
+      case PlaneType::ZX:
+        setZXPlane();
+        break;
+    }
+  }
+
+  return *this;
+}
+
+//==============================================================================
 void TranslationalJoint2DUniqueProperties::setXYPlane()
 {
   mPlaneType = PlaneType::XY;

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
@@ -72,6 +72,10 @@ public:
 
   virtual ~TranslationalJoint2DUniqueProperties() = default;
 
+  /// Assignment operator
+  TranslationalJoint2DUniqueProperties& operator=(
+      const TranslationalJoint2DUniqueProperties& other);
+
   /// Sets plane type as XY-plane
   void setXYPlane();
 

--- a/dart/utils/VskParser.cpp
+++ b/dart/utils/VskParser.cpp
@@ -1028,7 +1028,7 @@ common::ResourceRetrieverPtr getRetriever(
     newRetriever->addSchemaRetriever(
           "dart", DartResourceRetriever::create());
 
-    return std::move(newRetriever);
+    return newRetriever;
   }
 }
 

--- a/examples/heightmap/main.cpp
+++ b/examples/heightmap/main.cpp
@@ -68,7 +68,7 @@ dynamics::ShapePtr createHeightmapShape(
   terrainShape->setScale(scale);
   terrainShape->setHeightField(data);
 
-  return std::move(terrainShape);
+  return terrainShape;
 }
 
 template <typename S>


### PR DESCRIPTION
* Fix redundant use of `std::move()` in return statement
* Obey the rule of three when the custom copy constructor is defined

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
