### PR TITLE
Fix friction and restitution of individual shapes in a body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [DART 6.10.0 (20XX-XX-XX)](https://github.com/dartsim/dart/milestone/58?closed=1)
 
+* Dynamics
+
+  * Fix friction and restitution of individual shapes in a body: [#1369](https://github.com/dartsim/dart/pull/1369)
+
 * GUI
 
   * Fixed memory leaks from dart::gui::osg::Viewer: [#1349](https://github.com/dartsim/dart/pull/1349)

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -132,6 +132,11 @@ protected:
   // Documentation inherited
   bool isActive() const override;
 
+  static double computeFrictionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
+  static double computeRestitutionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
+
 private:
   using TangentBasisMatrix = Eigen::Matrix<double, 3, 2>;
 

--- a/dart/constraint/SoftContactConstraint.hpp
+++ b/dart/constraint/SoftContactConstraint.hpp
@@ -139,6 +139,11 @@ protected:
   // Documentation inherited
   bool isActive() const override;
 
+  static double computeFrictionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
+  static double computeRestitutionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
+
 private:
   /// Get change in relative velocity at contact point due to external impulse
   /// \param[out] _vel Change in relative velocity at contact point of the two

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -240,6 +240,22 @@ BodyNodeAspectProperties::BodyNodeAspectProperties(
   // Do nothing
 }
 
+//==============================================================================
+BodyNodeAspectProperties::BodyNodeAspectProperties(
+    const std::string& name,
+    const Inertia& inertia,
+    bool isCollidable,
+    bool gravityMode)
+  : mName(name),
+    mInertia(inertia),
+    mIsCollidable(isCollidable),
+    mFrictionCoeff(DART_DEFAULT_FRICTION_COEFF),
+    mRestitutionCoeff(DART_DEFAULT_RESTITUTION_COEFF),
+    mGravityMode(gravityMode)
+{
+  // Do nothing
+}
+
 } // namespace detail
 
 //==============================================================================
@@ -326,8 +342,10 @@ void BodyNode::setAspectProperties(const AspectProperties& properties)
   setName(properties.mName);
   setInertia(properties.mInertia);
   setGravityMode(properties.mGravityMode);
+  DART_SUPPRESS_DEPRECATED_BEGIN
   setFrictionCoeff(properties.mFrictionCoeff);
   setRestitutionCoeff(properties.mRestitutionCoeff);
+  DART_SUPPRESS_DEPRECATED_END
 }
 
 //==============================================================================
@@ -648,6 +666,15 @@ Eigen::Vector6d BodyNode::getCOMSpatialAcceleration(
 //==============================================================================
 void BodyNode::setFrictionCoeff(double _coeff)
 {
+  // Below code block is to set the friction coefficients of all the current
+  // dynamics aspects of this BodyNode as a stopgap solution. However, this
+  // won't help for new ShapeNodes that get added later.
+  auto shapeNodes = getShapeNodesWith<DynamicsAspect>();
+  for (auto& shapeNode : shapeNodes) {
+    auto* dynamicsAspect = shapeNode->getDynamicsAspect();
+    dynamicsAspect->setFrictionCoeff(_coeff);
+  }
+
   if (mAspectProperties.mFrictionCoeff == _coeff)
     return;
 
@@ -667,6 +694,15 @@ double BodyNode::getFrictionCoeff() const
 //==============================================================================
 void BodyNode::setRestitutionCoeff(double _coeff)
 {
+  // Below code block is to set the restitution coefficients of all the current
+  // dynamics aspects of this BodyNode as a stopgap solution. However, this
+  // won't help for new ShapeNodes that get added later.
+  auto shapeNodes = getShapeNodesWith<DynamicsAspect>();
+  for (auto& shapeNode : shapeNodes) {
+    auto* dynamicsAspect = shapeNode->getDynamicsAspect();
+    dynamicsAspect->setFrictionCoeff(_coeff);
+  }
+
   if (_coeff == mAspectProperties.mRestitutionCoeff)
     return;
 

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -670,7 +670,8 @@ void BodyNode::setFrictionCoeff(double _coeff)
   // dynamics aspects of this BodyNode as a stopgap solution. However, this
   // won't help for new ShapeNodes that get added later.
   auto shapeNodes = getShapeNodesWith<DynamicsAspect>();
-  for (auto& shapeNode : shapeNodes) {
+  for (auto& shapeNode : shapeNodes)
+  {
     auto* dynamicsAspect = shapeNode->getDynamicsAspect();
     dynamicsAspect->setFrictionCoeff(_coeff);
   }
@@ -698,7 +699,8 @@ void BodyNode::setRestitutionCoeff(double _coeff)
   // dynamics aspects of this BodyNode as a stopgap solution. However, this
   // won't help for new ShapeNodes that get added later.
   auto shapeNodes = getShapeNodesWith<DynamicsAspect>();
-  for (auto& shapeNode : shapeNodes) {
+  for (auto& shapeNode : shapeNodes)
+  {
     auto* dynamicsAspect = shapeNode->getDynamicsAspect();
     dynamicsAspect->setFrictionCoeff(_coeff);
   }

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -254,15 +254,31 @@ public:
       const Frame* _relativeTo, const Frame* _inCoordinatesOf) const;
 
   /// Set coefficient of friction in range of [0, ~]
+  /// \deprecated Deprecated since DART 6.10. Please set the friction
+  /// coefficient per ShapeNode of the BodyNode. This will be removed in the
+  /// next major release.
+  DART_DEPRECATED(6.10)
   void setFrictionCoeff(double _coeff);
 
   /// Return frictional coefficient.
+  /// \deprecated Deprecated since DART 6.10. Please set the friction
+  /// coefficient per ShapeNode of the BodyNode. This will be removed in the
+  /// next major release.
+  DART_DEPRECATED(6.10)
   double getFrictionCoeff() const;
 
   /// Set coefficient of restitution in range of [0, 1]
+  /// \deprecated Deprecated since DART 6.10. Please set the restitution
+  /// coefficient per ShapeNode of the BodyNode. This will be removed in the
+  /// next major release.
+  DART_DEPRECATED(6.10)
   void setRestitutionCoeff(double _coeff);
 
   /// Return coefficient of restitution
+  /// \deprecated Deprecated since DART 6.10. Please set the restitution
+  /// coefficient per ShapeNode of the BodyNode. This will be removed in the
+  /// next major release.
+  DART_DEPRECATED(6.10)
   double getRestitutionCoeff() const;
 
   //--------------------------------------------------------------------------

--- a/dart/dynamics/detail/BodyNodeAspect.hpp
+++ b/dart/dynamics/detail/BodyNodeAspect.hpp
@@ -76,6 +76,9 @@ struct BodyNodeAspectProperties
   bool mIsCollidable;
 
   /// Coefficient of friction
+  /// \deprecated Deprecated since DART 6.10. Please set the friction
+  /// coefficient per ShapeNode of the BodyNode. This will be removed in the
+  /// next major release.
   double mFrictionCoeff;
 
   /// Coefficient of restitution
@@ -85,13 +88,21 @@ struct BodyNodeAspectProperties
   bool mGravityMode;
 
   /// Constructor
+  DART_DEPRECATED(6.10)
+  BodyNodeAspectProperties(
+      const std::string& name,
+      const Inertia& _inertia,
+      bool _isCollidable,
+      double _frictionCoeff,
+      double _restitutionCoeff,
+      bool _gravityMode);
+
+  /// Constructor
   BodyNodeAspectProperties(
       const std::string& name = "BodyNode",
-      const Inertia& _inertia = Inertia(),
-      bool _isCollidable = true,
-      double _frictionCoeff = DART_DEFAULT_FRICTION_COEFF,
-      double _restitutionCoeff = DART_DEFAULT_RESTITUTION_COEFF,
-      bool _gravityMode = true);
+      const Inertia& inertia = Inertia(),
+      bool isCollidable = true,
+      bool gravityMode = true);
 
   virtual ~BodyNodeAspectProperties() = default;
 };

--- a/dart/dynamics/detail/BodyNodeAspect.hpp
+++ b/dart/dynamics/detail/BodyNodeAspect.hpp
@@ -82,12 +82,18 @@ struct BodyNodeAspectProperties
   double mFrictionCoeff;
 
   /// Coefficient of restitution
+  /// \deprecated Deprecated since DART 6.10. Please set the restitution
+  /// coefficient per ShapeNode of the BodyNode. This will be removed in the
+  /// next major release.
   double mRestitutionCoeff;
 
   /// Gravity will be applied if true
   bool mGravityMode;
 
   /// Constructor
+  /// \deprecated Deprecated since DART 6.10 because the friction and
+  /// restitution properties shouldn't be included in this constructor since
+  /// they are deprecated.
   DART_DEPRECATED(6.10)
   BodyNodeAspectProperties(
       const std::string& name,

--- a/python/dartpy/collision/BulletCollisionDetector.cpp
+++ b/python/dartpy/collision/BulletCollisionDetector.cpp
@@ -34,8 +34,8 @@
 
 #if HAVE_BULLET
 
-#include <dart/collision/bullet/bullet.hpp>
-#include <pybind11/pybind11.h>
+#  include <dart/collision/bullet/bullet.hpp>
+#  include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 

--- a/python/dartpy/collision/BulletCollisionGroup.cpp
+++ b/python/dartpy/collision/BulletCollisionGroup.cpp
@@ -34,8 +34,8 @@
 
 #if HAVE_BULLET
 
-#include <dart/collision/bullet/bullet.hpp>
-#include <pybind11/pybind11.h>
+#  include <dart/collision/bullet/bullet.hpp>
+#  include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 

--- a/python/dartpy/collision/OdeCollisionDetector.cpp
+++ b/python/dartpy/collision/OdeCollisionDetector.cpp
@@ -34,8 +34,8 @@
 
 #if HAVE_ODE
 
-#include <dart/collision/ode/ode.hpp>
-#include <pybind11/pybind11.h>
+#  include <dart/collision/ode/ode.hpp>
+#  include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 

--- a/python/dartpy/collision/OdeCollisionGroup.cpp
+++ b/python/dartpy/collision/OdeCollisionGroup.cpp
@@ -34,8 +34,8 @@
 
 #if HAVE_ODE
 
-#include <dart/collision/ode/ode.hpp>
-#include <pybind11/pybind11.h>
+#  include <dart/collision/ode/ode.hpp>
+#  include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 

--- a/python/dartpy/dynamics/BodyNode.cpp
+++ b/python/dartpy/dynamics/BodyNode.cpp
@@ -104,36 +104,10 @@ void BodyNode(py::module& m)
               const std::string&,
               const dart::dynamics::Inertia&,
               bool,
-              double>(),
-          ::py::arg("name"),
-          ::py::arg("inertia"),
-          ::py::arg("isCollidable"),
-          ::py::arg("frictionCoeff"))
-      .def(
-          ::py::init<
-              const std::string&,
-              const dart::dynamics::Inertia&,
-              bool,
-              double,
-              double>(),
-          ::py::arg("name"),
-          ::py::arg("inertia"),
-          ::py::arg("isCollidable"),
-          ::py::arg("frictionCoeff"),
-          ::py::arg("restitutionCoeff"))
-      .def(
-          ::py::init<
-              const std::string&,
-              const dart::dynamics::Inertia&,
-              bool,
-              double,
-              double,
               bool>(),
           ::py::arg("name"),
           ::py::arg("inertia"),
           ::py::arg("isCollidable"),
-          ::py::arg("frictionCoeff"),
-          ::py::arg("restitutionCoeff"),
           ::py::arg("gravityMode"))
       .def_readwrite(
           "mName", &dart::dynamics::detail::BodyNodeAspectProperties::mName)
@@ -143,12 +117,6 @@ void BodyNode(py::module& m)
       .def_readwrite(
           "mIsCollidable",
           &dart::dynamics::detail::BodyNodeAspectProperties::mIsCollidable)
-      .def_readwrite(
-          "mFrictionCoeff",
-          &dart::dynamics::detail::BodyNodeAspectProperties::mFrictionCoeff)
-      .def_readwrite(
-          "mRestitutionCoeff",
-          &dart::dynamics::detail::BodyNodeAspectProperties::mRestitutionCoeff)
       .def_readwrite(
           "mGravityMode",
           &dart::dynamics::detail::BodyNodeAspectProperties::mGravityMode);
@@ -753,28 +721,6 @@ void BodyNode(py::module& m)
           },
           ::py::arg("relativeTo"),
           ::py::arg("inCoordinatesOf"))
-      .def(
-          "setFrictionCoeff",
-          +[](dart::dynamics::BodyNode* self, double _coeff) {
-            self->setFrictionCoeff(_coeff);
-          },
-          ::py::arg("coeff"))
-      .def(
-          "getFrictionCoeff",
-          +[](const dart::dynamics::BodyNode* self) -> double {
-            return self->getFrictionCoeff();
-          })
-      .def(
-          "setRestitutionCoeff",
-          +[](dart::dynamics::BodyNode* self, double _coeff) {
-            self->setRestitutionCoeff(_coeff);
-          },
-          ::py::arg("coeff"))
-      .def(
-          "getRestitutionCoeff",
-          +[](const dart::dynamics::BodyNode* self) -> double {
-            return self->getRestitutionCoeff();
-          })
       .def(
           "getIndexInSkeleton",
           +[](const dart::dynamics::BodyNode* self) -> std::size_t {

--- a/python/dartpy/optimizer/NloptSolver.cpp
+++ b/python/dartpy/optimizer/NloptSolver.cpp
@@ -33,18 +33,18 @@
 #include <dart/config.hpp>
 #if HAVE_NLOPT
 
-#include <dart/dart.hpp>
-#include <dart/optimizer/nlopt/nlopt.hpp>
-#include <pybind11/pybind11.h>
-#include "eigen_pybind.h"
+#  include <dart/dart.hpp>
+#  include <dart/optimizer/nlopt/nlopt.hpp>
+#  include <pybind11/pybind11.h>
+#  include "eigen_pybind.h"
 
 namespace py = pybind11;
 
 namespace dart {
 namespace python {
 
-#define DARTPY_DEFINE_ALGORITHM(alg_name)                                      \
-  .value(#alg_name, dart::optimizer::NloptSolver::Algorithm::alg_name)
+#  define DARTPY_DEFINE_ALGORITHM(alg_name)                                    \
+    .value(#alg_name, dart::optimizer::NloptSolver::Algorithm::alg_name)
 
 void NloptSolver(py::module& m)
 {

--- a/tutorials/tutorial_collisions/main.cpp
+++ b/tutorials/tutorial_collisions/main.cpp
@@ -458,7 +458,7 @@ SkeletonPtr createWall()
       (default_wall_height - default_wall_thickness) / 2.0);
   bn->getParentJoint()->setTransformFromParentBodyNode(tf);
 
-  bn->setRestitutionCoeff(0.2);
+  shapeNode->getDynamicsAspect()->setRestitutionCoeff(0.2);
 
   return wall;
 }

--- a/tutorials/tutorial_collisions_finished/main.cpp
+++ b/tutorials/tutorial_collisions_finished/main.cpp
@@ -392,7 +392,9 @@ BodyNode* addRigidBody(
         default_shape_height * Eigen::Vector3d::Ones());
   }
 
-  bn->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(shape);
+  auto shapeNode
+      = bn->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+          shape);
 
   // Setup the inertia for the body
   Inertia inertia;
@@ -402,7 +404,7 @@ BodyNode* addRigidBody(
   bn->setInertia(inertia);
 
   // Set the coefficient of restitution to make the body more bouncy
-  bn->setRestitutionCoeff(default_restitution);
+  shapeNode->getDynamicsAspect()->setRestitutionCoeff(default_restitution);
 
   // Set damping to make the simulation more stable
   if (parent)
@@ -657,7 +659,7 @@ SkeletonPtr createWall()
       (default_wall_height - default_wall_thickness) / 2.0);
   bn->getParentJoint()->setTransformFromParentBodyNode(tf);
 
-  bn->setRestitutionCoeff(0.2);
+  shapeNode->getDynamicsAspect()->setRestitutionCoeff(0.2);
 
   return wall;
 }

--- a/unittests/comprehensive/CMakeLists.txt
+++ b/unittests/comprehensive/CMakeLists.txt
@@ -3,6 +3,7 @@ dart_add_test("comprehensive" test_Common)
 dart_add_test("comprehensive" test_Concurrency)
 dart_add_test("comprehensive" test_Constraint)
 dart_add_test("comprehensive" test_Frames)
+dart_add_test("comprehensive" test_Friction)
 dart_add_test("comprehensive" test_InverseKinematics)
 dart_add_test("comprehensive" test_NameManagement)
 

--- a/unittests/comprehensive/test_Friction.cpp
+++ b/unittests/comprehensive/test_Friction.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "dart/dynamics/SimpleFrame.hpp"
+#include "dart/math/Helpers.hpp"
+#include "dart/math/Random.hpp"
+
+#include "TestHelpers.hpp"
+
+using namespace dart;
+using namespace dynamics;
+
+//==============================================================================
+dynamics::SkeletonPtr createFloor()
+{
+  auto floor = dynamics::Skeleton::create("floor");
+
+  // Give the floor a body
+  auto body
+      = floor->createJointAndBodyNodePair<dynamics::WeldJoint>(nullptr).second;
+
+  // Give the body a shape
+  double floorWidth = 10.0;
+  double floorHeight = 0.01;
+  auto box = std::make_shared<dynamics::BoxShape>(
+      Eigen::Vector3d(floorWidth, floorWidth, floorHeight));
+  auto* shapeNode = body->createShapeNodeWith<
+      dynamics::VisualAspect,
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(box);
+  shapeNode->getVisualAspect()->setColor(dart::Color::LightGray());
+
+  // Put the body into position
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(0.0, 0.0, -0.5 - floorHeight / 2.0);
+  body->getParentJoint()->setTransformFromParentBodyNode(tf);
+
+  return floor;
+}
+
+//==============================================================================
+TEST(Friction, FrictionPerShapeNode)
+{
+  auto skeleton1
+      = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(-0.5, 0, 0));
+  skeleton1->setName("Skeleton1");
+  auto skeleton2
+      = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(+0.5, 0, 0));
+  skeleton1->setName("Skeleton2");
+
+  auto body1 = skeleton1->getRootBodyNode();
+  EXPECT_DOUBLE_EQ(
+      body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 1.0);
+
+  auto body2 = skeleton2->getRootBodyNode();
+  EXPECT_DOUBLE_EQ(
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 1.0);
+  body2->getShapeNode(0)->getDynamicsAspect()->setFrictionCoeff(0.0);
+  EXPECT_DOUBLE_EQ(
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 0.0);
+
+  // Create a world and add the rigid body
+  auto world = simulation::World::create();
+  EXPECT_TRUE(equals(world->getGravity(), ::Eigen::Vector3d(0, 0, -9.81)));
+  world->setGravity(Eigen::Vector3d(0.0, -5.0, -9.81));
+  EXPECT_TRUE(equals(world->getGravity(), ::Eigen::Vector3d(0.0, -5.0, -9.81)));
+
+  world->addSkeleton(createFloor());
+  world->addSkeleton(skeleton1);
+  world->addSkeleton(skeleton2);
+
+  const auto numSteps = 500;
+  for (auto i = 0u; i < numSteps; ++i)
+  {
+    world->step();
+
+    // Wait until the first box settle-in on the ground
+    if (i > 300)
+    {
+      const auto y1 = body1->getTransform().translation()[1];
+      EXPECT_NEAR(y1, -0.17889, 0.001);
+
+      // The second box still moves even after landed on the ground because its
+      // friction is zero.
+      const auto y2 = body2->getTransform().translation()[1];
+      EXPECT_LE(y2, -0.17889);
+    }
+  }
+}

--- a/unittests/regression/test_Issue1184.cpp
+++ b/unittests/regression/test_Issue1184.cpp
@@ -45,7 +45,6 @@
 //==============================================================================
 TEST(Issue1184, Accuracy)
 {
-
   struct ShapeInfo
   {
     dart::dynamics::ShapePtr shape;
@@ -117,7 +116,8 @@ TEST(Issue1184, Accuracy)
           object->getBodyNode(0)
               ->createShapeNodeWith<
                   dart::dynamics::VisualAspect,
-                  dart::dynamics::CollisionAspect>(objectShape);
+                  dart::dynamics::CollisionAspect,
+                  dart::dynamics::DynamicsAspect>(objectShape);
 
           world->addSkeleton(object);
 
@@ -126,7 +126,8 @@ TEST(Issue1184, Accuracy)
           ground->createJointAndBodyNodePair<dart::dynamics::WeldJoint>()
               .second->createShapeNodeWith<
                   dart::dynamics::VisualAspect,
-                  dart::dynamics::CollisionAspect>(groundInfo.shape);
+                  dart::dynamics::CollisionAspect,
+                  dart::dynamics::DynamicsAspect>(groundInfo.shape);
 
           Eigen::Isometry3d tf_ground = Eigen::Isometry3d::Identity();
           tf_ground.translate(groundInfo.offset * Eigen::Vector3d::UnitZ());


### PR DESCRIPTION
`DynamicAspect` was introduced to allow to set different dynamics properties (including friction and restitution properties) per shape in a `BodyNode` for setting the dynamic properties of individual shapes in a `BodyNode`. However, the constraint solver still uses the dynamics properties stored in `BodyNode`.

This PR deprecates the friction and restitution property related APIs in `BodyNode` and change the constraint solver to use the dynamics properties in `DynamicAspect`.

Resolves #200.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
