### PR TITLE
Reset internal force of point mass before every simulation step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [DART 6.10.0 (20XX-XX-XX)](https://github.com/dartsim/dart/milestone/58?closed=1)
 
+* Dynamics
+
+  * Fixed soft body simulation when command input is not resetted: [#1372](https://github.com/dartsim/dart/pull/1372)
+
 * GUI
 
   * Fixed memory leaks from dart::gui::osg::Viewer: [#1349](https://github.com/dartsim/dart/pull/1349)

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -842,7 +842,7 @@ void PointMass::updateBiasForceFD(double _dt, const Eigen::Vector3d& _gravity)
   double kv = mParentSoftBodyNode->getVertexSpringStiffness();
   double ke = mParentSoftBodyNode->getEdgeSpringStiffness();
   double kd = mParentSoftBodyNode->getDampingCoefficient();
-  int nN = getNumConnectedPointMasses();
+  std::size_t nN = getNumConnectedPointMasses();
   mAlpha = state.mForces - (kv + nN * ke) * getPositions()
            - (_dt * (kv + nN * ke) + kd) * getVelocities()
            - getMass() * getPartialAccelerations() - mB;

--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -713,8 +713,16 @@ void SoftBodyNode::updateBiasForce(
 {
   const Eigen::Matrix6d& mI
       = BodyNode::mAspectProperties.mInertia.getSpatialTensor();
-  for (auto& pointMass : mPointMasses)
+  for (PointMass* pointMass : mPointMasses)
+  {
+    // Reset internal forces of point masses before used.
+    //
+    // Once control force for point massis introduced, assign it instead of
+    // always reseting the internal forces to zero.
+    pointMass->resetForces();
+
     pointMass->updateBiasForceFD(_timeStep, _gravity);
+  }
 
   // Gravity force
   if (BodyNode::mAspectProperties.mGravityMode == true)

--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -717,8 +717,8 @@ void SoftBodyNode::updateBiasForce(
   {
     // Reset internal forces of point masses before used.
     //
-    // Once control force for point massis introduced, assign it instead of
-    // always reseting the internal forces to zero.
+    // Once control force for point mass is introduced, assign it to the
+    // internal force instead of always resetting the internal forces to zero.
     pointMass->resetForces();
 
     pointMass->updateBiasForceFD(_timeStep, _gravity);


### PR DESCRIPTION
The soft body simulation behaves unexpectedly when the simulation option is `resetCommand = false`. The root cause was that the internal forces of point masses, which are used for soft body simulation, are not reset to zero in every simulation step. In the rigid body case, this issues doesn't happen because the internal forces are set to the control command. Soft body, however, doesn't have control command API so it keeps the previous value, and this leads to the unexpected behavior.

This PR fixes the issue by always setting the internal forces of point mass to zero regardless of the `resetCommand` option.

Resolves #1370 

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
