### PR TITLE
Enable octomap support on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 * Build
 
   * Fixed compiler warnings from GCC 9.1: [#1366](https://github.com/dartsim/dart/pull/1366)
-  * Replace M_PI with dart::math::constantsd::pi(): [#1367](https://github.com/dartsim/dart/pull/1367)
+  * Replaced M_PI with dart::math::constantsd::pi(): [#1367](https://github.com/dartsim/dart/pull/1367)
+  * Enabled octomap support on macOS: [#1078](https://github.com/dartsim/dart/pull/1078)
 
 ### [DART 6.9.1 (2019-06-06)](https://github.com/dartsim/dart/milestone/59?closed=1)
 

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -98,13 +98,6 @@ if(MSVC)
       "'https://github.com/OctoMap/octomap/pull/213' "
       "is resolved.")
   set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
-elseif(APPLE)
-  # Supporting Octomap on Windows is disabled for the following issue:
-  # https://github.com/OctoMap/octomap/pull/213
-  message(WARNING "Octomap ${octomap_VERSION} is found, but Octomap "
-      "is not supported on macOS until "
-      "'https://github.com/dartsim/dart/issues/1078' is resolved.")
-  set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
 else()
   if(OCTOMAP_FOUND OR octomap_FOUND)
     if(NOT DEFINED octomap_VERSION)


### PR DESCRIPTION
Recent the Homebrew bottles for octomap and fcl seems to work on macOS.

Resolves https://github.com/dartsim/dart/issues/1078

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
