### PR TITLE
Remove specifying suffix and prefix of python module

### DIFF
--- a/python/dartpy/CMakeLists.txt
+++ b/python/dartpy/CMakeLists.txt
@@ -75,13 +75,6 @@ if(TARGET dart-collision-ode)
   target_link_libraries(dartpy PUBLIC dart-collision-ode)
 endif()
 
-set_target_properties(dartpy
-  PROPERTIES
-    PREFIX ""
-    SUFFIX ".so"  # python uses '.so' extension even on macOS
-    DEBUG_POSTFIX ""
-)
-
 install(TARGETS dartpy
   LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}"
 )


### PR DESCRIPTION
[They are set by `pybind11_add_module()`](https://github.com/pybind/pybind11/blob/2a5a5ec0a47c245fbf1bb1a8a90b4c3278e01693/tools/pybind11Tools.cmake#L139-L140).

***

**Before creating a pull request**

- [x] Document new methods and classes (N/A)
- [x] Format new code files using `clang-format` (N/A)

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md` (N/A)
- [x] Add unit test(s) for this change (N/A)
