### PR TITLE
Fix refresh of LineSegmentShapeNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Fixed memory leaks from dart::gui::osg::Viewer: [#1349](https://github.com/dartsim/dart/pull/1349)
   * Added point rendering mode to PointCloudShape: [#1351](https://github.com/dartsim/dart/pull/1351), [#1355](https://github.com/dartsim/dart/pull/1355)
   * Updated ImGui to 1.71: [#1362](https://github.com/dartsim/dart/pull/1362)
+  * Fixed refresh of LineSegmentShapeNode: [#1381](https://github.com/dartsim/dart/pull/1381)
 
 * dartpy
 

--- a/dart/gui/osg/render/LineSegmentShapeNode.cpp
+++ b/dart/gui/osg/render/LineSegmentShapeNode.cpp
@@ -84,6 +84,7 @@ protected:
 
   ::osg::ref_ptr<::osg::Vec3Array> mVertices;
   ::osg::ref_ptr<::osg::Vec4Array> mColors;
+  ::osg::ref_ptr<::osg::DrawElementsUInt> mElements;
 };
 
 //==============================================================================
@@ -187,8 +188,10 @@ LineSegmentShapeDrawable::LineSegmentShapeDrawable(
   : mLineSegmentShape(shape),
     mVisualAspect(visualAspect),
     mVertices(new ::osg::Vec3Array),
-    mColors(new ::osg::Vec4Array)
+    mColors(new ::osg::Vec4Array),
+    mElements(new ::osg::DrawElementsUInt(::osg::PrimitiveSet::LINES))
 {
+  addPrimitiveSet(mElements);
   refresh(true);
 }
 
@@ -207,18 +210,16 @@ void LineSegmentShapeDrawable::refresh(bool firstTime)
     const common::aligned_vector<Eigen::Vector2i>& connections
         = mLineSegmentShape->getConnections();
 
-    ::osg::ref_ptr<::osg::DrawElementsUInt> elements
-        = new ::osg::DrawElementsUInt(::osg::PrimitiveSet::LINES);
-    elements->reserve(2 * connections.size());
+    mElements->resize(2 * connections.size());
 
     for (std::size_t i = 0; i < connections.size(); ++i)
     {
       const Eigen::Vector2i& c = connections[i];
-      elements->push_back(c[0]);
-      elements->push_back(c[1]);
+      mElements->push_back(static_cast<unsigned int>(c[0]));
+      mElements->push_back(static_cast<unsigned int>(c[1]));
     }
 
-    addPrimitiveSet(elements);
+    setPrimitiveSet(0, mElements);
   }
 
   if (mLineSegmentShape->checkDataVariance(

--- a/dart/gui/osg/render/LineSegmentShapeNode.cpp
+++ b/dart/gui/osg/render/LineSegmentShapeNode.cpp
@@ -210,7 +210,8 @@ void LineSegmentShapeDrawable::refresh(bool firstTime)
     const common::aligned_vector<Eigen::Vector2i>& connections
         = mLineSegmentShape->getConnections();
 
-    mElements->resize(2 * connections.size());
+    mElements->clear();
+    mElements->reserve(2 * connections.size());
 
     for (std::size_t i = 0; i < connections.size(); ++i)
     {


### PR DESCRIPTION
`LineSegmentShapeNode` keeps adding new line segments instead of refreshing with new line. See the details in #1380 and [this post](https://dartsim.discourse.group/t/setting-datavariance-dynamic-causes-simulation-to-slow-and-then-stop/95).

Resolves #1380.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
