### PR TITLE
Support colcon workspace with bullet and ode

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,3 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
 {
   "name": "DART",
   "dependencies": ["BULLET_PHYSICS", "ODE"],

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,4 @@
+{
+  "name": "DART",
+  "dependencies": ["BULLET_PHYSICS", "ODE"],
+}


### PR DESCRIPTION
We have been using [colcon](https://colcon.readthedocs.io/en/released/index.html) to build gazebo and ignition packages from source in a workspace, similar to using catkin-tools with a catkin workspace. A cool feature of colcon is that it can automatically identify cmake dependencies based on the cmake project name and build packages in the workspace in the correct order without creating `package.xml` files.

* https://github.com/colcon/colcon-cmake/blob/master/colcon_cmake/package_identification/cmake.py#L132-L135

If a `package.xml` file is present in a package, it will use that instead of the automatic detection, so you can build a mixed workspace of plain cmake and ROS1 or ROS2 packages.

When attempting to use colcon in a workspace with ign-physics, dartsim, bullet, and ODE, it was not properly identifying the dependencies. I believe the following two steps are necessary:

* adding depend tags for `BULLET_PHYSICS` and `ODE` to the dartsim package.xml file
    * https://github.com/bulletphysics/bullet3/blob/master/CMakeLists.txt#L7
    * https://bitbucket.org/odedevs/ode/src/695ba8c6aa4a725b610514725dcb9ea77683236d/CMakeLists.txt#lines-3
* changing the cmake project name and package.xml package name to `DART` to match the generated `DARTConfig.cmake`

I'm not sure if there are cpack / rosdistro / rosdep implications of changing these things, but I think it helps with colcon. Here's a workspace file for testing:

* https://bitbucket.org/osrf/gazebodistro/raw/%20physics_dart_bullet_ode/ign-physics1.yaml

cc @mxgrey @jslee02 @azeey 

***

**Before creating a pull request**

- [X] Document new methods and classes
- [X] Format new code files using `clang-format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
