### PR TITLE
Fix typos in wrappers of dartpy Skeletons

### DIFF
--- a/python/dartpy/dynamics/MetaSkeleton.cpp
+++ b/python/dartpy/dynamics/MetaSkeleton.cpp
@@ -1201,7 +1201,7 @@ void MetaSkeleton(py::module& m)
       .def(
           "getGravityForces",
           +[](dart::dynamics::MetaSkeleton* self) -> const Eigen::VectorXd& {
-            return self->getCoriolisForces();
+            return self->getGravityForces();
           })
       .def(
           "getCoriolisAndGravityForces",
@@ -1211,7 +1211,7 @@ void MetaSkeleton(py::module& m)
       .def(
           "getExternalForces",
           +[](dart::dynamics::MetaSkeleton* self) -> const Eigen::VectorXd& {
-            return self->getCoriolisAndGravityForces();
+            return self->getExternalForces();
           })
       .def(
           "getConstraintForces",

--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -1060,12 +1060,12 @@ void Skeleton(py::module& m)
           "getGravityForces",
           +[](dart::dynamics::Skeleton* self,
               std::size_t treeIndex) -> const Eigen::VectorXd& {
-            return self->getCoriolisForces(treeIndex);
+            return self->getGravityForces(treeIndex);
           })
       .def(
           "getGravityForces",
           +[](dart::dynamics::Skeleton* self) -> const Eigen::VectorXd& {
-            return self->getCoriolisForces();
+            return self->getGravityForces();
           })
       .def(
           "getCoriolisAndGravityForces",
@@ -1082,12 +1082,12 @@ void Skeleton(py::module& m)
           "getExternalForces",
           +[](dart::dynamics::Skeleton* self,
               std::size_t treeIndex) -> const Eigen::VectorXd& {
-            return self->getCoriolisAndGravityForces(treeIndex);
+            return self->getExternalForces(treeIndex);
           })
       .def(
           "getExternalForces",
           +[](dart::dynamics::Skeleton* self) -> const Eigen::VectorXd& {
-            return self->getCoriolisAndGravityForces();
+            return self->getExternalForces();
           })
       .def(
           "getConstraintForces",


### PR DESCRIPTION
`getGravityForces()` and `getExternalForces()` are fixed in
`dartpy.dynamics.MetaSkeleton` and `dartpy.dynamics.Skeleton`.
The wrong functions were called.

***

**Before creating a pull request**

- [ ] ~Document new methods and classes~
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
