### PR TITLE
FindBullet: separate win32 optimized and debug libraries

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -142,7 +142,8 @@ jobs:
   variables:
     VCPKG_INSTALL_ROOT: $(Build.SourcesDirectory)\vcpkg
     VCPKG_ARCH: 'x64-windows'
-    VCPKG_PACKAGES: 'assimp boost-system boost-filesystem bullet3 ccd eigen3 fcl ode'
+    VCPKG_PACKAGES: 'assimp boost-system boost-filesystem ccd eigen3 fcl'
+    VCPKG_OPTIONAL_PACKAGES: 'bullet3 ode'
     BUILD_TOOLSET_VERSION: '142'
     CMAKE_GENERATOR: 'Visual Studio 16 2019'
   steps:
@@ -151,7 +152,7 @@ jobs:
       $(VCPKG_INSTALL_ROOT)\bootstrap-vcpkg.bat
     displayName: 'Install vcpkg'
   - script: |
-      $(VCPKG_INSTALL_ROOT)\vcpkg.exe install --recurse --triplet $(VCPKG_ARCH) $(VCPKG_PACKAGES)
+      $(VCPKG_INSTALL_ROOT)\vcpkg.exe install --recurse --triplet $(VCPKG_ARCH) $(VCPKG_PACKAGES) $(VCPKG_OPTIONAL_PACKAGES)
       $(VCPKG_INSTALL_ROOT)\vcpkg.exe integrate install
     displayName: 'Install dependencies'
   - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -142,7 +142,7 @@ jobs:
   variables:
     VCPKG_INSTALL_ROOT: $(Build.SourcesDirectory)\vcpkg
     VCPKG_ARCH: 'x64-windows'
-    VCPKG_PACKAGES: 'assimp boost-system boost-filesystem ccd eigen3 fcl'
+    VCPKG_PACKAGES: 'assimp boost-system boost-filesystem bullet3 ccd eigen3 fcl ode'
     BUILD_TOOLSET_VERSION: '142'
     CMAKE_GENERATOR: 'Visual Studio 16 2019'
   steps:

--- a/cmake/DARTFindBullet.cmake
+++ b/cmake/DARTFindBullet.cmake
@@ -12,9 +12,19 @@
 find_package(Bullet COMPONENTS BulletMath BulletCollision MODULE QUIET)
 
 if((BULLET_FOUND OR Bullet_FOUND) AND NOT TARGET Bullet)
+  if(WIN32 AND "optimized" IN_LIST BULLET_LIBRARIES
+           AND     "debug" IN_LIST BULLET_LIBRARIES)
+    cmake_parse_arguments(BULLET_INTERFACE_LIBRARIES "" "" "debug;optimized"
+        ${BULLET_LIBRARIES})
+    set(BULLET_INTERFACE_LIBRARIES
+        $<$<CONFIG:Debug>:${BULLET_INTERFACE_LIBRARIES_debug}>
+        $<$<NOT:$<CONFIG:Debug>>:${BULLET_INTERFACE_LIBRARIES_optimized}>)
+  else()
+    set(BULLET_INTERFACE_LIBRARIES ${BULLET_LIBRARIES})
+  endif()
   add_library(Bullet INTERFACE IMPORTED)
   set_target_properties(Bullet PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${BULLET_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES "${BULLET_LIBRARIES}"
+    INTERFACE_LINK_LIBRARIES "${BULLET_INTERFACE_LIBRARIES}"
   )
 endif()


### PR DESCRIPTION
I see a configuration error on windows when trying to build dart with bullet3 installed from `vcpkg`:

~~~
CMake Error at cmake/DARTFindBullet.cmake:16 (set_target_properties):
  Property INTERFACE_LINK_LIBRARIES may not contain link-type keyword
  "optimized".  The INTERFACE_LINK_LIBRARIES property may contain
  configuration-sensitive generator-expressions which may be used to specify
  per-configuration rules.
~~~ 

There are multiple optimized and debug libraries interleaved in the `BULLET_LIBRARIES` parameter, so we can't use the simple approach from https://github.com/dartsim/dart/commit/73ef8c2716b37ad8a1fdd5d1468eb88841408ec2. I've used `cmake_parse_arguments` to separate the `debug` and `optimized` libraries, and I think I set up the generator expressions correctly, but I'm not sure. I've added `bullet3` and `ode` to the list of vcpkg packages to install in azure-pipeline, so CI should confirm if this fix is working.

***

**Before creating a pull request**

- [X] Document new methods and classes
- [X] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
