### PR TITLE
Add wrapper to get all `BodyNode`s from a `Skeleton`

### DIFF
--- a/python/dartpy/dynamics/ReferentialSkeleton.cpp
+++ b/python/dartpy/dynamics/ReferentialSkeleton.cpp
@@ -85,6 +85,12 @@ void ReferentialSkeleton(py::module& m)
           })
       .def(
           "getBodyNodes",
+          +[](dart::dynamics::ReferentialSkeleton* self)
+              -> const std::vector<dart::dynamics::BodyNode*>& {
+            return self->getBodyNodes();
+          })
+      .def(
+          "getBodyNodes",
           +[](dart::dynamics::ReferentialSkeleton* self,
               const std::string& name)
               -> std::vector<dart::dynamics::BodyNode*> {

--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -388,6 +388,12 @@ void Skeleton(py::module& m)
           py::return_value_policy::reference_internal)
       .def(
           "getBodyNodes",
+          +[](dart::dynamics::Skeleton* self)
+              -> const std::vector<dart::dynamics::BodyNode*>& {
+            return self->getBodyNodes();
+          })
+      .def(
+          "getBodyNodes",
           +[](dart::dynamics::Skeleton* self, const std::string& name)
               -> std::vector<dart::dynamics::BodyNode*> {
             return self->getBodyNodes(name);

--- a/python/tests/unit/dynamics/test_skeleton.py
+++ b/python/tests/unit/dynamics/test_skeleton.py
@@ -15,6 +15,8 @@ def test_basic():
     assert joint1.getType() == 'FreeJoint'
     assert joint1.getName() == 'joint0'
 
+    assert skel.getBodyNodes()[0].getName() == body1.getName()
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Before, it was only possible to access multiple `BodyNode`s by name
***

**Before creating a pull request**

- [ ] ~Document new methods and classes~
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
