### PR TITLE
Add option for parsing root joint type without world link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Dynamics
 
-  * Fixex friction and restitution of individual shapes in a body: [#1369](https://github.com/dartsim/dart/pull/1369)
+  * Fixed friction and restitution of individual shapes in a body: [#1369](https://github.com/dartsim/dart/pull/1369)
   * Fixed soft body simulation when command input is not resetted: [#1372](https://github.com/dartsim/dart/pull/1372)
 
 * GUI
@@ -18,6 +18,7 @@
 
   * Allowed parsing SDF up to version 1.6: [#1385](https://github.com/dartsim/dart/pull/1385)
   * Fixed SDF parser not creating dynamics aspect for collision shape: [#1386](https://github.com/dartsim/dart/pull/1386)
+  * Added root joint parsing option in URDF parser: [#1399](https://github.com/dartsim/dart/pull/1399)
 
 * dartpy
 

--- a/dart/dynamics/SharedLibraryIkFast.cpp
+++ b/dart/dynamics/SharedLibraryIkFast.cpp
@@ -56,8 +56,8 @@ bool loadFunction(
 
   if (!symbol)
   {
-    dterr << "Failed to load the symbol '" << symbolName
-          << "' from the file '" << fileName << "'.\n";
+    dterr << "Failed to load the symbol '" << symbolName << "' from the file '"
+          << fileName << "'.\n";
     return false;
   }
 

--- a/dart/utils/urdf/DartLoader.hpp
+++ b/dart/utils/urdf/DartLoader.hpp
@@ -76,6 +76,13 @@ namespace utils {
 class DartLoader
 {
 public:
+  enum Flags
+  {
+    NONE = 0,
+    FIXED_BASE_LINK = 1 << 1,
+    DEFAULT = NONE,
+  };
+
   /// Constructor with the default ResourceRetriever.
   DartLoader();
 
@@ -104,24 +111,28 @@ public:
   /// Parse a file to produce a Skeleton
   dynamics::SkeletonPtr parseSkeleton(
       const common::Uri& _uri,
-      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr);
+      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr,
+      unsigned int flags = DEFAULT);
 
   /// Parse a text string to produce a Skeleton
   dynamics::SkeletonPtr parseSkeletonString(
       const std::string& _urdfString,
       const common::Uri& _baseUri,
-      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr);
+      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr,
+      unsigned int flags = DEFAULT);
 
   /// Parse a file to produce a World
   dart::simulation::WorldPtr parseWorld(
       const common::Uri& _uri,
-      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr);
+      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr,
+      unsigned int flags = DEFAULT);
 
   /// Parse a text string to produce a World
   dart::simulation::WorldPtr parseWorldString(
       const std::string& _urdfString,
       const common::Uri& _baseUri,
-      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr);
+      const common::ResourceRetrieverPtr& _resourceRetriever = nullptr,
+      unsigned int flags = DEFAULT);
 
 private:
   typedef std::shared_ptr<dynamics::BodyNode::Properties> BodyPropPtr;
@@ -131,7 +142,8 @@ private:
   static dart::dynamics::SkeletonPtr modelInterfaceToSkeleton(
       const urdf::ModelInterface* model,
       const common::Uri& baseUri,
-      const common::ResourceRetrieverPtr& resourceRetriever);
+      const common::ResourceRetrieverPtr& resourceRetriever,
+      unsigned int flags);
 
   static bool createSkeletonRecursive(
       const urdf::ModelInterface* model,
@@ -139,7 +151,8 @@ private:
       const urdf::Link* lk,
       dynamics::BodyNode* parent,
       const common::Uri& baseUri,
-      const common::ResourceRetrieverPtr& _resourceRetriever);
+      const common::ResourceRetrieverPtr& _resourceRetriever,
+      unsigned int flags);
 
   static bool addMimicJointsRecursive(
       const urdf::ModelInterface* model,
@@ -157,8 +170,7 @@ private:
       const dynamics::BodyNode::Properties& _body,
       dynamics::BodyNode* _parent,
       dynamics::SkeletonPtr _skeleton,
-      const common::Uri& _baseUri,
-      const common::ResourceRetrieverPtr& _resourceRetriever);
+      unsigned int flgas);
 
   static bool createDartNodeProperties(
       const urdf::Link* _lk,

--- a/dart/utils/urdf/DartLoader.hpp
+++ b/dart/utils/urdf/DartLoader.hpp
@@ -76,10 +76,16 @@ namespace utils {
 class DartLoader
 {
 public:
+  /// Flags for specifying URDF file parsing policies.
   enum Flags
   {
     NONE = 0,
+
+    /// Parser the root link's joint type to be "fixed" joint when not
+    /// specified.
     FIXED_BASE_LINK = 1 << 1,
+
+    /// The default flgas
     DEFAULT = NONE,
   };
 


### PR DESCRIPTION
The root joint type cannot be specified when the URDF doesn't contain "world" link. In that case, the URDF parser in DART assumes the root joint type as "free" joint, but some user could expect it to be "fixed" joint.

This PR makes that behavior configurable using flags.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
