### PR TITLE
[dartpy] Add wrapper for convertToPositions() in class BallJoint

### DIFF
--- a/python/dartpy/dynamics/BallJoint.cpp
+++ b/python/dartpy/dynamics/BallJoint.cpp
@@ -97,6 +97,12 @@ void BallJoint(py::module& m)
           },
           ::py::return_value_policy::reference_internal)
       .def_static(
+          "convertToPositions",
+          +[](const Eigen::Matrix3d& _tf) -> Eigen::Vector3d {
+            return dart::dynamics::BallJoint::convertToPositions(_tf);
+          },
+          ::py::arg("tf"))
+      .def_static(
           "convertToTransform",
           +[](const Eigen::Vector3d& _positions) -> Eigen::Isometry3d {
             return dart::dynamics::BallJoint::convertToTransform(_positions);

--- a/python/tests/unit/dynamics/test_joint.py
+++ b/python/tests/unit/dynamics/test_joint.py
@@ -121,5 +121,26 @@ def test_access_to_parent_child_transforms():
     assert np.allclose(childToJointTf.matrix(), storedChildTf.matrix())
 
 
+def test_BallJoint_positions_conversion():
+    assert np.allclose(
+        dart.dynamics.BallJoint.convertToPositions(np.eye(3)),
+        np.zeros((1, 3))
+    )
+    assert np.allclose(
+        dart.dynamics.BallJoint.convertToPositions(
+            np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]])),
+        np.array([0, 0, -np.pi/2])
+    )
+
+    for i in range(30):
+        ballJointPos = np.random.uniform(-np.pi/2, np.pi/2, 3)
+        assert np.allclose(
+            dart.dynamics.BallJoint.convertToPositions(
+                dart.dynamics.BallJoint.convertToRotation(ballJointPos)
+            ),
+            ballJointPos
+        )
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Expose `dartpy.dynamics.BallJoint.convertToPositions()` to dartpy.

***

**Before creating a pull request**

- [ ] ~Document new methods and classes~
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
