### PR TITLE
Remove use of boost::filesystem in public APIs

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,5 +29,5 @@ jobs:
         OS_NAME: linux
         COMPILER: gcc
         BUILD_TYPE: Release
-        RUN_TESTS: OFF
+        RUN_TESTS: ON
       run: '.ci/script.sh'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [DART 6.10.0 (20XX-XX-XX)](https://github.com/dartsim/dart/milestone/58?closed=1)
 
+* Common
+
+  * Removed use of boost::filesystem in public APIs: [#1417](https://github.com/dartsim/dart/pull/1417)
+
 * Kinematics
 
   * Added IkFast parameter accessors to IkFast class: [#1396](https://github.com/dartsim/dart/pull/1396)

--- a/dart/common/SharedLibrary.cpp
+++ b/dart/common/SharedLibrary.cpp
@@ -59,16 +59,30 @@ namespace common {
 std::shared_ptr<SharedLibrary> SharedLibrary::create(
     const boost::filesystem::path& path)
 {
+  return create(path.string());
+}
+
+//==============================================================================
+std::shared_ptr<SharedLibrary> SharedLibrary::create(const std::string& path)
+{
   return detail::SharedLibraryManager::getSingleton().load(path);
 }
 
 //==============================================================================
 SharedLibrary::SharedLibrary(
     ProtectedConstructionTag, const boost::filesystem::path& canonicalPath)
-  : mCanonicalPath(canonicalPath), mInstance(nullptr)
+  : SharedLibrary(ProtectedConstruction, canonicalPath.string())
+{
+  // Do nothing
+}
+
+//==============================================================================
+SharedLibrary::SharedLibrary(
+    ProtectedConstructionTag, const std::string& canonicalPath)
+  : mCanonicalPath(canonicalPath), mPath(canonicalPath), mInstance(nullptr)
 {
   mInstance
-      = static_cast<DYNLIB_HANDLE>(DYNLIB_LOAD(canonicalPath.string().c_str()));
+      = static_cast<DYNLIB_HANDLE>(DYNLIB_LOAD(canonicalPath.c_str()));
 
   if (!mInstance)
   {
@@ -86,7 +100,7 @@ SharedLibrary::~SharedLibrary()
   if (DYNLIB_UNLOAD(mInstance))
   {
     dterr << "[SharedLibrary::~SharedLibrary] Failed to unload library '"
-          << mCanonicalPath << "': " << getLastError() << "\n";
+          << mPath << "': " << getLastError() << "\n";
   }
 }
 
@@ -94,6 +108,12 @@ SharedLibrary::~SharedLibrary()
 const boost::filesystem::path& SharedLibrary::getCanonicalPath() const
 {
   return mCanonicalPath;
+}
+
+//==============================================================================
+const std::string& SharedLibrary::path() const
+{
+  return mPath;
 }
 
 //==============================================================================

--- a/dart/common/SharedLibrary.cpp
+++ b/dart/common/SharedLibrary.cpp
@@ -81,8 +81,7 @@ SharedLibrary::SharedLibrary(
     ProtectedConstructionTag, const std::string& canonicalPath)
   : mCanonicalPath(canonicalPath), mPath(canonicalPath), mInstance(nullptr)
 {
-  mInstance
-      = static_cast<DYNLIB_HANDLE>(DYNLIB_LOAD(canonicalPath.c_str()));
+  mInstance = static_cast<DYNLIB_HANDLE>(DYNLIB_LOAD(canonicalPath.c_str()));
 
   if (!mInstance)
   {

--- a/dart/common/SharedLibrary.hpp
+++ b/dart/common/SharedLibrary.hpp
@@ -35,8 +35,11 @@
 
 #include <memory>
 #include <string>
+
 #include <boost/filesystem.hpp>
+
 #include "dart/common/Platform.hpp"
+#include "dart/common/Deprecated.hpp"
 
 #if DART_OS_LINUX
 
@@ -108,8 +111,24 @@ public:
   /// "/path/../to/yourfile".
   /// \return Pointer to the created SharedLibrary upon success in loading.
   /// Otherwise, returns nullptr.
+  /// \deprecated Deprecated in 6.10. Please use create(const std::string&)
+  /// instead.
+  DART_DEPRECATED(6.10)
   static std::shared_ptr<SharedLibrary> create(
       const boost::filesystem::path& path);
+
+  /// Creates a SharedLibrary from a path to the shared library.
+  ///
+  /// \note SharedLibrary should be always created from this create function.
+  /// \param[in] path The path to the shared library. The path can be a relative
+  /// path or an absolute path. If the path doens't exist this function returns
+  /// nullptr. If the path exist, the path will be stored as the canonical path
+  /// where a canonical path is an absolute path that has no elements which are
+  /// symbolic links, and no dot or dot dot elements such as
+  /// "/path/../to/yourfile".
+  /// \return Pointer to the created SharedLibrary upon success in loading.
+  /// Otherwise, returns nullptr.
+  static std::shared_ptr<SharedLibrary> create(const std::string& path);
 
   /// Constructs from a path to the shared library.
   ///
@@ -122,14 +141,33 @@ public:
   /// \param[in] path The canonical path to the shared library.
   /// \return Pointer to the created SharedLibrary upon success in loading.
   /// Otherwise, returns nullptr.
+  /// \deprecated Deprecated in 6.10. Please use
+  /// SharedLibrary(ProtectedConstructionTag, const std::string&) instead.
+  DART_DEPRECATED(6.10)
   explicit SharedLibrary(
       ProtectedConstructionTag, const boost::filesystem::path& path);
+
+  /// Constructs from a path to the shared library.
+  ///
+  /// This constructor is only called by detail::SharedLibraryManager.
+  /// ProtectedConstructionTag is necessary to enforce creating SharedLibrary
+  /// using std::make_shared.
+  ///
+  /// \note Please use create() to contruct SharedLibrary instead of this
+  /// constructor.
+  /// \param[in] path The canonical path to the shared library.
+  /// \return Pointer to the created SharedLibrary upon success in loading.
+  /// Otherwise, returns nullptr.
+  explicit SharedLibrary(ProtectedConstructionTag, const std::string& path);
 
   /// Destructor.
   virtual ~SharedLibrary();
 
   /// Returns the path to the shared library file.
   const boost::filesystem::path& getCanonicalPath() const;
+
+  /// Returns the path to the shared library file.
+  const std::string& path() const;
 
   /// Returns true if the shared library loading was successful.
   bool isValid() const;
@@ -148,6 +186,12 @@ protected:
   /// path that has no elements which are symbolic links, and no dot or dot dot
   /// elements such as "/path/../to/yourfile".
   boost::filesystem::path mCanonicalPath;
+  // TODO(JS): Remove in DART 7.
+
+  /// Canonical path to the shared library where a canonical path is an absolute
+  /// path that has no elements which are symbolic links, and no dot or dot dot
+  /// elements such as "/path/../to/yourfile".
+  std::string mPath;
 
   /// Handle to the loaded library.
   DYNLIB_HANDLE mInstance;

--- a/dart/common/SharedLibrary.hpp
+++ b/dart/common/SharedLibrary.hpp
@@ -38,8 +38,8 @@
 
 #include <boost/filesystem.hpp>
 
-#include "dart/common/Platform.hpp"
 #include "dart/common/Deprecated.hpp"
+#include "dart/common/Platform.hpp"
 
 #if DART_OS_LINUX
 

--- a/dart/common/detail/SharedLibraryManager.cpp
+++ b/dart/common/detail/SharedLibraryManager.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/common/detail/SharedLibraryManager.hpp"
 
+#include <fstream>
+
 #include "dart/common/Console.hpp"
 #include "dart/common/SharedLibrary.hpp"
 
@@ -43,8 +45,15 @@ namespace detail {
 std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
     const boost::filesystem::path& path)
 {
+  return load(path.string());
+}
+
+//==============================================================================
+std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
+    const std::string& path)
+{
   // Check if the given path exits
-  const bool exists = boost::filesystem::exists(path);
+  const bool exists = std::ifstream(path).good();
   if (!exists)
   {
     dtwarn << "[SharedLibraryManager::load] Failed to load the shared library '"
@@ -53,11 +62,11 @@ std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
   }
 
   // Convert the given path to the canonical path
-  const auto canonicalPath = boost::filesystem::canonical(path);
+  const auto canonicalPath = boost::filesystem::canonical(path).string();
 
-  const auto iter = mLibraries.find(canonicalPath);
+  const auto iter = mSharedLibraries.find(canonicalPath);
 
-  const auto found = iter != mLibraries.end();
+  const auto found = iter != mSharedLibraries.end();
   if (found)
   {
     auto lib = iter->second.lock();
@@ -68,7 +77,7 @@ std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
     if (lib)
       return lib;
     else
-      mLibraries.erase(iter);
+      mSharedLibraries.erase(iter);
   }
 
   const auto newLib = std::make_shared<SharedLibrary>(
@@ -77,7 +86,7 @@ std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
   if (!newLib->isValid())
     return nullptr;
 
-  mLibraries[canonicalPath] = newLib;
+  mSharedLibraries[canonicalPath] = newLib;
   assert(canonicalPath == newLib->getCanonicalPath());
 
   return newLib;

--- a/dart/common/detail/SharedLibraryManager.hpp
+++ b/dart/common/detail/SharedLibraryManager.hpp
@@ -34,11 +34,14 @@
 #define DART_COMMON_DETAIL_SHAREDLIBRARYMANAGER_HPP_
 
 #include <memory>
+#include <string>
 #include <unordered_map>
-#include <boost/filesystem.hpp>
-#include "dart/common/Singleton.hpp"
 
+#include <boost/filesystem.hpp>
 #include <boost/functional/hash.hpp>
+
+#include "dart/common/Deprecated.hpp"
+#include "dart/common/Singleton.hpp"
 
 namespace std {
 
@@ -71,7 +74,20 @@ public:
   /// Windows).
   /// \return Pointer to the shared library upon success. Otherwise, returns
   /// nullptr.
+  /// \deprecated Deprecated in 6.10. Please use load(const std::string&)
+  /// instead.
+  DART_DEPRECATED(6.10)
   std::shared_ptr<SharedLibrary> load(const boost::filesystem::path& path);
+
+  /// Loads the shared library with the specified path.
+  ///
+  /// \param[in] path The path to the shared library. If the path doesn't
+  /// include the extension, this function will use the best guess depending on
+  /// the OS (e.g., '.so' for Linux, '.dylib' for macOS, and '.dll' for
+  /// Windows).
+  /// \return Pointer to the shared library upon success. Otherwise, returns
+  /// nullptr.
+  std::shared_ptr<SharedLibrary> load(const std::string& path);
 
 protected:
   friend class Singleton<SharedLibraryManager>;
@@ -80,6 +96,11 @@ protected:
   /// Map from library path to the library instances.
   std::unordered_map<boost::filesystem::path, std::weak_ptr<SharedLibrary>>
       mLibraries;
+  // TODO(JS): Remove this in DART 7.
+
+  /// Map from library path to the library instances.
+  std::unordered_map<std::string, std::weak_ptr<SharedLibrary>>
+      mSharedLibraries;
 };
 
 } // namespace detail


### PR DESCRIPTION


***

**Before creating a pull request**

- [ ] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
