### PR TITLE
Add secondary friction coefficient parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Added joint velocity limit constraint support: [#1407](https://github.com/dartsim/dart/pull/1407)
   * Added type property to constrain classes: [#1415](https://github.com/dartsim/dart/pull/1415)
   * Allowed to set joint rest position out of joint limits: [#1418](https://github.com/dartsim/dart/pull/1418)
+  * Added secondary friction coefficient parameter: [#1424](https://github.com/dartsim/dart/pull/1424)
 
 * GUI
 

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -710,6 +710,27 @@ double ContactConstraint::computeFrictionCoefficient(
 }
 
 //==============================================================================
+double ContactConstraint::computePrimaryFrictionCoefficient(
+    const dynamics::ShapeNode* shapeNode)
+{
+  assert(shapeNode);
+
+  auto dynamicAspect = shapeNode->getDynamicsAspect();
+
+  if (dynamicAspect == nullptr)
+  {
+    dtwarn << "[ContactConstraint] Attempt to extract "
+           << "primary friction coefficient "
+           << "from a ShapeNode that doesn't have DynamicAspect. The default "
+           << "value (" << DART_DEFAULT_FRICTION_COEFF << ") will be used "
+           << "instead.\n";
+    return DART_DEFAULT_FRICTION_COEFF;
+  }
+
+  return dynamicAspect->getPrimaryFrictionCoeff();
+}
+
+//==============================================================================
 double ContactConstraint::computeSecondaryFrictionCoefficient(
     const dynamics::ShapeNode* shapeNode)
 {
@@ -719,7 +740,8 @@ double ContactConstraint::computeSecondaryFrictionCoefficient(
 
   if (dynamicAspect == nullptr)
   {
-    dtwarn << "[ContactConstraint] Attempt to extract friction coefficient "
+    dtwarn << "[ContactConstraint] Attempt to extract "
+           << "secondary friction coefficient "
            << "from a ShapeNode that doesn't have DynamicAspect. The default "
            << "value (" << DART_DEFAULT_FRICTION_COEFF << ") will be used "
            << "instead.\n";

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -115,8 +115,10 @@ ContactConstraint::ContactConstraint(
   // TODO(JS): Assume the frictional coefficient can be changed during
   //           simulation steps.
   // Update mFrictionCoeff
-  const double frictionCoeffA = computeFrictionCoefficient(shapeNodeA);
-  const double frictionCoeffB = computeFrictionCoefficient(shapeNodeB);
+  const double primaryFrictionCoeffA =
+                       computePrimaryFrictionCoefficient(shapeNodeA);
+  const double primaryFrictionCoeffB =
+                       computePrimaryFrictionCoefficient(shapeNodeB);
   const double secondaryFrictionCoeffA =
                        computeSecondaryFrictionCoefficient(shapeNodeA);
   const double secondaryFrictionCoeffB =
@@ -124,10 +126,11 @@ ContactConstraint::ContactConstraint(
 
   // TODO(JS): Consider providing various ways of the combined friction or
   // allowing to override this method by a custom method
-  mFrictionCoeff = std::min(frictionCoeffA, frictionCoeffB);
+  mPrimaryFrictionCoeff =
+      std::min(primaryFrictionCoeffA, primaryFrictionCoeffB);
   mSecondaryFrictionCoeff =
       std::min(secondaryFrictionCoeffA, secondaryFrictionCoeffB);
-  if (mFrictionCoeff > DART_FRICTION_COEFF_THRESHOLD ||
+  if (mPrimaryFrictionCoeff > DART_FRICTION_COEFF_THRESHOLD ||
       mSecondaryFrictionCoeff > DART_FRICTION_COEFF_THRESHOLD)
   {
     mIsFrictionOn = true;
@@ -394,8 +397,8 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
     assert(info->findex[0] == -1);
 
     // Upper and lower bounds of tangential direction-1 impulsive force
-    info->lo[1] = -mFrictionCoeff;
-    info->hi[1] = mFrictionCoeff;
+    info->lo[1] = -mPrimaryFrictionCoeff;
+    info->hi[1] = mPrimaryFrictionCoeff;
     info->findex[1] = 0;
 
     // Upper and lower bounds of tangential direction-2 impulsive force

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -140,6 +140,8 @@ protected:
 
   static double computeFrictionCoefficient(
       const dynamics::ShapeNode* shapeNode);
+  static double computeSecondaryFrictionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
   static double computeRestitutionCoefficient(
       const dynamics::ShapeNode* shapeNode);
 
@@ -173,8 +175,11 @@ private:
   /// First frictional direction
   Eigen::Vector3d mFirstFrictionalDirection;
 
-  /// Coefficient of Friction
+  /// Primary Coefficient of Friction
   double mFrictionCoeff;
+
+  /// Primary Coefficient of Friction
+  double mSecondaryFrictionCoeff;
 
   /// Coefficient of restitution
   double mRestitutionCoeff;

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -178,7 +178,7 @@ private:
   Eigen::Vector3d mFirstFrictionalDirection;
 
   /// Primary Coefficient of Friction
-  double mFrictionCoeff;
+  double mPrimaryFrictionCoeff;
 
   /// Primary Coefficient of Friction
   double mSecondaryFrictionCoeff;

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -140,6 +140,8 @@ protected:
 
   static double computeFrictionCoefficient(
       const dynamics::ShapeNode* shapeNode);
+  static double computePrimaryFrictionCoefficient(
+      const dynamics::ShapeNode* shapeNode);
   static double computeSecondaryFrictionCoefficient(
       const dynamics::ShapeNode* shapeNode);
   static double computeRestitutionCoefficient(

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -55,7 +55,7 @@ CollisionAspectProperties::CollisionAspectProperties(const bool collidable)
 //==============================================================================
 DynamicsAspectProperties::DynamicsAspectProperties(
     const double frictionCoeff, const double restitutionCoeff)
-  : mPrimaryFrictionCoeff(frictionCoeff),
+  : mFrictionCoeff(frictionCoeff),
     mRestitutionCoeff(restitutionCoeff),
     mSecondaryFrictionCoeff(frictionCoeff)
 {
@@ -67,7 +67,7 @@ DynamicsAspectProperties::DynamicsAspectProperties(
     const double primaryFrictionCoeff,
     const double secondaryFrictionCoeff,
     const double restitutionCoeff)
-  : mPrimaryFrictionCoeff(primaryFrictionCoeff),
+  : mFrictionCoeff(primaryFrictionCoeff),
     mRestitutionCoeff(restitutionCoeff),
     mSecondaryFrictionCoeff(secondaryFrictionCoeff)
 {
@@ -189,15 +189,25 @@ DynamicsAspect::DynamicsAspect(const PropertiesData& properties)
 
 void DynamicsAspect::setFrictionCoeff(const double& value)
 {
-  mProperties.mPrimaryFrictionCoeff = value;
+  mProperties.mFrictionCoeff = value;
   mProperties.mSecondaryFrictionCoeff = value;
 }
 
 double DynamicsAspect::getFrictionCoeff() const
 {
   return 0.5 * (
-      mProperties.mPrimaryFrictionCoeff +
+      mProperties.mFrictionCoeff +
       mProperties.mSecondaryFrictionCoeff);
+}
+
+void DynamicsAspect::setPrimaryFrictionCoeff(const double& value)
+{
+  mProperties.mFrictionCoeff = value;
+}
+
+const double& DynamicsAspect::getPrimaryFrictionCoeff() const
+{
+  return mProperties.mFrictionCoeff;
 }
 
 //==============================================================================

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -54,9 +54,19 @@ CollisionAspectProperties::CollisionAspectProperties(const bool collidable)
 
 //==============================================================================
 DynamicsAspectProperties::DynamicsAspectProperties(
+    const double frictionCoeff, const double restitutionCoeff)
+  : mPrimaryFrictionCoeff(frictionCoeff),
+    mRestitutionCoeff(restitutionCoeff),
+    mSecondaryFrictionCoeff(frictionCoeff)
+{
+  // Do nothing
+}
+
+//==============================================================================
+DynamicsAspectProperties::DynamicsAspectProperties(
     const double primaryFrictionCoeff,
-    const double restitutionCoeff,
-    const double secondaryFrictionCoeff)
+    const double secondaryFrictionCoeff,
+    const double restitutionCoeff)
   : mPrimaryFrictionCoeff(primaryFrictionCoeff),
     mRestitutionCoeff(restitutionCoeff),
     mSecondaryFrictionCoeff(secondaryFrictionCoeff)

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -54,9 +54,11 @@ CollisionAspectProperties::CollisionAspectProperties(const bool collidable)
 
 //==============================================================================
 DynamicsAspectProperties::DynamicsAspectProperties(
-    const double frictionCoeff, const double restitutionCoeff,
+    const double primaryFrictionCoeff,
+    const double restitutionCoeff,
     const double secondaryFrictionCoeff)
-  : mFrictionCoeff(frictionCoeff), mRestitutionCoeff(restitutionCoeff),
+  : mPrimaryFrictionCoeff(primaryFrictionCoeff),
+    mRestitutionCoeff(restitutionCoeff),
     mSecondaryFrictionCoeff(secondaryFrictionCoeff)
 {
   // Do nothing
@@ -173,6 +175,19 @@ DynamicsAspect::DynamicsAspect(const PropertiesData& properties)
   : Base(properties)
 {
   // Do nothing
+}
+
+void DynamicsAspect::setFrictionCoeff(const double& value)
+{
+  mProperties.mPrimaryFrictionCoeff = value;
+  mProperties.mSecondaryFrictionCoeff = value;
+}
+
+double DynamicsAspect::getFrictionCoeff() const
+{
+  return 0.5 * (
+      mProperties.mPrimaryFrictionCoeff +
+      mProperties.mSecondaryFrictionCoeff);
 }
 
 //==============================================================================

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -54,8 +54,10 @@ CollisionAspectProperties::CollisionAspectProperties(const bool collidable)
 
 //==============================================================================
 DynamicsAspectProperties::DynamicsAspectProperties(
-    const double frictionCoeff, const double restitutionCoeff)
-  : mFrictionCoeff(frictionCoeff), mRestitutionCoeff(restitutionCoeff)
+    const double frictionCoeff, const double restitutionCoeff,
+    const double secondaryFrictionCoeff)
+  : mFrictionCoeff(frictionCoeff), mRestitutionCoeff(restitutionCoeff),
+    mSecondaryFrictionCoeff(secondaryFrictionCoeff)
 {
   // Do nothing
 }

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -148,9 +148,10 @@ public:
   /// Get average of primary and secondary friction coefficients.
   double getFrictionCoeff() const;
 
-  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, PrimaryFrictionCoeff)
-  // void setPrimaryFrictionCoeff(const double& value);
-  // const double& getPrimaryFrictionCoeff() const;
+  // DART_COMMON_SET_GET_ASPECT_PROPERTY(double, PrimaryFrictionCoeff)
+  void setPrimaryFrictionCoeff(const double& value);
+  const double& getPrimaryFrictionCoeff() const;
+
   DART_COMMON_SET_GET_ASPECT_PROPERTY(double, SecondaryFrictionCoeff)
   // void setSecondaryFrictionCoeff(const double& value);
   // const double& getSecondaryFrictionCoeff() const;

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -151,7 +151,7 @@ public:
   DART_COMMON_SET_GET_ASPECT_PROPERTY(double, PrimaryFrictionCoeff)
   // void setPrimaryFrictionCoeff(const double& value);
   // const double& getPrimaryFrictionCoeff() const;
-  DART_COMMON_SET_GET_ASPECT_PROPERTY( double, SecondaryFrictionCoeff )
+  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, SecondaryFrictionCoeff)
   // void setSecondaryFrictionCoeff(const double& value);
   // const double& getSecondaryFrictionCoeff() const;
   DART_COMMON_SET_GET_ASPECT_PROPERTY(double, RestitutionCoeff)

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -149,6 +149,9 @@ public:
   DART_COMMON_SET_GET_ASPECT_PROPERTY(double, RestitutionCoeff)
   // void setRestitutionCoeff(const double& value);
   // const double& getRestitutionCoeff() const;
+  DART_COMMON_SET_GET_ASPECT_PROPERTY( double, SecondaryFrictionCoeff )
+  // void setSecondaryFrictionCoeff(const double& value);
+  // const double& getSecondaryFrictionCoeff() const;
 };
 
 //==============================================================================

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -143,15 +143,20 @@ public:
 
   DynamicsAspect(const PropertiesData& properties = PropertiesData());
 
-  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, FrictionCoeff)
-  // void setFrictionCoeff(const double& value);
-  // const double& getFrictionCoeff() const;
-  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, RestitutionCoeff)
-  // void setRestitutionCoeff(const double& value);
-  // const double& getRestitutionCoeff() const;
+  /// Set both primary and secondary friction coefficients to the same value.
+  void setFrictionCoeff(const double& value);
+  /// Get average of primary and secondary friction coefficients.
+  double getFrictionCoeff() const;
+
+  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, PrimaryFrictionCoeff)
+  // void setPrimaryFrictionCoeff(const double& value);
+  // const double& getPrimaryFrictionCoeff() const;
   DART_COMMON_SET_GET_ASPECT_PROPERTY( double, SecondaryFrictionCoeff )
   // void setSecondaryFrictionCoeff(const double& value);
   // const double& getSecondaryFrictionCoeff() const;
+  DART_COMMON_SET_GET_ASPECT_PROPERTY(double, RestitutionCoeff)
+  // void setRestitutionCoeff(const double& value);
+  // const double& getRestitutionCoeff() const;
 };
 
 //==============================================================================

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -97,11 +97,15 @@ struct DynamicsAspectProperties
   /// Secondary coefficient of friction
   double mSecondaryFrictionCoeff;
 
-  /// Constructor
+  /// Constructors
+  /// The frictionCoeff argument will be used for both primary and secondary friction
   DynamicsAspectProperties(
-      const double primaryFrictionCoeff = 1.0,
-      const double restitutionCoeff = 0.0,
-      const double secondaryFrictionCoeff = 1.0);
+      const double frictionCoeff = 1.0, const double restitutionCoeff = 0.0);
+
+  DynamicsAspectProperties(
+      const double primaryFrictionCoeff,
+      const double secondaryFrictionCoeff,
+      const double restitutionCoeff);
 
   /// Destructor
   virtual ~DynamicsAspectProperties() = default;

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -89,7 +89,7 @@ struct CollisionAspectProperties
 struct DynamicsAspectProperties
 {
   /// Primary coefficient of friction
-  double mPrimaryFrictionCoeff;
+  double mFrictionCoeff;
 
   /// Coefficient of restitution
   double mRestitutionCoeff;

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -88,15 +88,19 @@ struct CollisionAspectProperties
 
 struct DynamicsAspectProperties
 {
-  /// Coefficient of friction
+  /// Primary coefficient of friction
   double mFrictionCoeff;
 
   /// Coefficient of restitution
   double mRestitutionCoeff;
 
+  /// Secondary coefficient of friction
+  double mSecondaryFrictionCoeff;
+
   /// Constructor
   DynamicsAspectProperties(
-      const double frictionCoeff = 1.0, const double restitutionCoeff = 0.0);
+      const double frictionCoeff = 1.0, const double restitutionCoeff = 0.0,
+      const double secondaryFrictionCoeff = 1.0);
 
   /// Destructor
   virtual ~DynamicsAspectProperties() = default;

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -89,7 +89,7 @@ struct CollisionAspectProperties
 struct DynamicsAspectProperties
 {
   /// Primary coefficient of friction
-  double mFrictionCoeff;
+  double mPrimaryFrictionCoeff;
 
   /// Coefficient of restitution
   double mRestitutionCoeff;
@@ -99,7 +99,8 @@ struct DynamicsAspectProperties
 
   /// Constructor
   DynamicsAspectProperties(
-      const double frictionCoeff = 1.0, const double restitutionCoeff = 0.0,
+      const double primaryFrictionCoeff = 1.0,
+      const double restitutionCoeff = 0.0,
       const double secondaryFrictionCoeff = 1.0);
 
   /// Destructor

--- a/unittests/comprehensive/test_Friction.cpp
+++ b/unittests/comprehensive/test_Friction.cpp
@@ -80,15 +80,18 @@ TEST(Friction, FrictionPerShapeNode)
   skeleton1->setName("Skeleton2");
 
   auto body1 = skeleton1->getRootBodyNode();
-  EXPECT_DOUBLE_EQ(
-      body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 1.0);
+  // default friction values
+  EXPECT_DOUBLE_EQ(1.0,
+      body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
 
   auto body2 = skeleton2->getRootBodyNode();
-  EXPECT_DOUBLE_EQ(
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 1.0);
+  // default friction values
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  // set all friction coeffs to 0.0
   body2->getShapeNode(0)->getDynamicsAspect()->setFrictionCoeff(0.0);
-  EXPECT_DOUBLE_EQ(
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff(), 0.0);
+  EXPECT_DOUBLE_EQ(0.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
 
   // Create a world and add the rigid body
   auto world = simulation::World::create();

--- a/unittests/comprehensive/test_Friction.cpp
+++ b/unittests/comprehensive/test_Friction.cpp
@@ -83,15 +83,43 @@ TEST(Friction, FrictionPerShapeNode)
   // default friction values
   EXPECT_DOUBLE_EQ(1.0,
       body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body1->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body1->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
 
   auto body2 = skeleton2->getRootBodyNode();
   // default friction values
   EXPECT_DOUBLE_EQ(1.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  // test setting primary friction
+  body2->getShapeNode(0)->getDynamicsAspect()->setPrimaryFrictionCoeff(0.5);
+  EXPECT_DOUBLE_EQ(0.75,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.5,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  // test setting secondary friction
+  body2->getShapeNode(0)->getDynamicsAspect()->setSecondaryFrictionCoeff(0.25);
+  EXPECT_DOUBLE_EQ(0.375,
+      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.5,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.25,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
   // set all friction coeffs to 0.0
   body2->getShapeNode(0)->getDynamicsAspect()->setFrictionCoeff(0.0);
   EXPECT_DOUBLE_EQ(0.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
 
   // Create a world and add the rigid body
   auto world = simulation::World::create();


### PR DESCRIPTION
Currently the ContactConstraint uses a friction pyramid with 2 directions, and it uses the same friction coefficient in each direction. We have found it useful in gazebo to be able to specify different values in each direction (anisotropic wheel friction for example). As such, I've added `mSecondaryFrictionCoeff` to the ShapeNode DynamicsAspect and updated the ContactConstraint to use this secondary coefficient. @azeey and I have additional code in his fork that adds parameters for specifying the friction directions and slip parameters, which will be addressed in subsequent pull requests.

[edited] To avoid a behavior change, the `mFrictionCoeff` member variable in the ShapeFrame DynamicsAspect is renamed to `mPrimaryFrictionCoeff` along with its auto-generated get/set functions. The existing auto-generated `getFrictionCoeff` and `setFrictionCoeff` are explicitly implemented such that `setFrictionCoeff` sets both friction parameters and `getFrictionCoeff` returns the average (and also returns `double` instead of `const double &`). I've added test coverage for these new functions. We have test cases in gazebo demonstrating anisotropic friction in case you'd like to add one here in the future.

***

**Before creating a pull request**

- [X] Document new methods and classes
- [X] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [X] Add unit test(s) for this change
