### PR TITLE
install_osx: try removing sudo from brew commands

### DIFF
--- a/.ci/install_osx.sh
+++ b/.ci/install_osx.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-sudo -u $(logname) brew update > /dev/null
-sudo -u $(logname) brew bundle || sudo -u $(logname) brew bundle
+brew update > /dev/null
+brew bundle || brew bundle
 
 pip3 install -U pytest


### PR DESCRIPTION
The osx CI is failing in #1424 complaining about running as root:

~~~
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
~~~

So I've removed the `sudo` calls from the install_osx script and CI is now passing.

***

**Before creating a pull request**

- [X] Document new methods and classes
- [X] Format new code files using `clang-format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
