### PR TITLE
Add friction direction unit vector and frame parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   * Added type property to constrain classes: [#1415](https://github.com/dartsim/dart/pull/1415)
   * Allowed to set joint rest position out of joint limits: [#1418](https://github.com/dartsim/dart/pull/1418)
   * Added secondary friction coefficient parameter: [#1424](https://github.com/dartsim/dart/pull/1424)
+  * Allowed to set friction direction per ShapeFrame: [#1427](https://github.com/dartsim/dart/pull/1427)
 
 * GUI
 

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -803,7 +803,7 @@ Eigen::Vector3d ContactConstraint::computeWorldFirstFrictionDir(
   }
 
   auto frame = dynamicAspect->getFirstFrictionDirectionFrame();
-  Eigen::Vector3d frictionDir = dynamicAspect->getFirstFrictionDirection();
+  const Eigen::Vector3d& frictionDir = dynamicAspect->getFirstFrictionDirection();
 
   // rotate using custom frame if it is specified
   if (frame)

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -141,7 +141,7 @@ ContactConstraint::ContactConstraint(
     auto frictionDirA = computeWorldFirstFrictionDir(shapeNodeA);
     auto frictionDirB = computeWorldFirstFrictionDir(shapeNodeB);
 
-    // resulting friction direction unit vector
+    // check if the friction direction unit vectors have been set
     bool nonzeroDirA = frictionDirA.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
     bool nonzeroDirB = frictionDirB.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
 

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -797,7 +797,7 @@ Eigen::Vector3d ContactConstraint::computeWorldFirstFrictionDir(
   {
     dtwarn << "[ContactConstraint] Attempt to extract friction direction "
            << "from a ShapeNode that doesn't have DynamicAspect. The default "
-           << "value (" << DART_DEFAULT_FRICTION_DIR << ") will be used "
+           << "value (" << DART_DEFAULT_FRICTION_DIR.transpose() << ") will be used "
            << "instead.\n";
     return DART_DEFAULT_FRICTION_DIR;
   }

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -870,7 +870,7 @@ ContactConstraint::getTangentBasisMatrixODE(const Eigen::Vector3d& n)
 
   // Pick an arbitrary vector to take the cross product of (in this case,
   // Z-axis)
-  Eigen::Vector3d tangent = mFirstFrictionalDirection.cross(n);
+  Eigen::Vector3d tangent = n.cross(mFirstFrictionalDirection);
 
   // TODO(JS): Modify following lines once _updateFirstFrictionalDirection() is
   //           implemented.
@@ -878,16 +878,16 @@ ContactConstraint::getTangentBasisMatrixODE(const Eigen::Vector3d& n)
   // pick another tangent (use X-axis as arbitrary vector)
   if (tangent.squaredNorm() < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED)
   {
-    tangent = Eigen::Vector3d::UnitX().cross(n);
+    tangent = n.cross(Eigen::Vector3d::UnitX());
 
     // Make sure this is not zero length, otherwise normalization will lead to
     // NaN values.
     if (tangent.squaredNorm() < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED)
     {
-      tangent = Eigen::Vector3d::UnitY().cross(n);
+      tangent = n.cross(Eigen::Vector3d::UnitY());
       if (tangent.squaredNorm() < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED)
       {
-        tangent = Eigen::Vector3d::UnitZ().cross(n);
+        tangent = n.cross(Eigen::Vector3d::UnitZ());
 
         // Now tangent shouldn't be zero-length unless the normal is
         // zero-length, which shouldn't the case because ConstraintSolver

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -183,11 +183,6 @@ ContactConstraint::ContactConstraint(
   assert(mBodyNodeB->getSkeleton());
   mIsSelfCollision = (mBodyNodeA->getSkeleton() == mBodyNodeB->getSkeleton());
 
-  const math::Jacobian jacA
-      = mBodyNodeA->getSkeleton()->getJacobian(mBodyNodeA);
-  const math::Jacobian jacB
-      = mBodyNodeB->getSkeleton()->getJacobian(mBodyNodeB);
-
   // Compute local contact Jacobians expressed in body frame
   if (mIsFrictionOn)
   {
@@ -915,8 +910,10 @@ ContactConstraint::getTangentBasisMatrixODE(const Eigen::Vector3d& n)
   // Note: a possible speedup is in place for mNumDir % 2 = 0
   // Each basis and its opposite belong in the matrix, so we iterate half as
   // many times
-  T.col(0) = tangent;
-  T.col(1) = Eigen::Quaterniond(Eigen::AngleAxisd(0.5_pi, n)) * tangent;
+  // The first column is the same as mFirstFrictionalDirection unless
+  // mFirstFrictionalDirection is parallel to the normal
+  T.col(0) = Eigen::Quaterniond(Eigen::AngleAxisd(0.5_pi, n)) * tangent;
+  T.col(1) = tangent;
   return T;
 }
 

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -65,8 +65,7 @@ double ContactConstraint::mConstraintForceMixing = DART_CFM;
 
 constexpr double DART_DEFAULT_FRICTION_COEFF = 1.0;
 constexpr double DART_DEFAULT_RESTITUTION_COEFF = 0.0;
-const Eigen::Vector3d DART_DEFAULT_FRICTION_DIR =
-    Eigen::Vector3d::UnitZ();
+const Eigen::Vector3d DART_DEFAULT_FRICTION_DIR = Eigen::Vector3d::UnitZ();
 
 //==============================================================================
 ContactConstraint::ContactConstraint(
@@ -117,23 +116,23 @@ ContactConstraint::ContactConstraint(
   // TODO(JS): Assume the frictional coefficient can be changed during
   //           simulation steps.
   // Update mFrictionCoeff
-  const double primaryFrictionCoeffA =
-                       computePrimaryFrictionCoefficient(shapeNodeA);
-  const double primaryFrictionCoeffB =
-                       computePrimaryFrictionCoefficient(shapeNodeB);
-  const double secondaryFrictionCoeffA =
-                       computeSecondaryFrictionCoefficient(shapeNodeA);
-  const double secondaryFrictionCoeffB =
-                       computeSecondaryFrictionCoefficient(shapeNodeB);
+  const double primaryFrictionCoeffA
+      = computePrimaryFrictionCoefficient(shapeNodeA);
+  const double primaryFrictionCoeffB
+      = computePrimaryFrictionCoefficient(shapeNodeB);
+  const double secondaryFrictionCoeffA
+      = computeSecondaryFrictionCoefficient(shapeNodeA);
+  const double secondaryFrictionCoeffB
+      = computeSecondaryFrictionCoefficient(shapeNodeB);
 
   // TODO(JS): Consider providing various ways of the combined friction or
   // allowing to override this method by a custom method
-  mPrimaryFrictionCoeff =
-      std::min(primaryFrictionCoeffA, primaryFrictionCoeffB);
-  mSecondaryFrictionCoeff =
-      std::min(secondaryFrictionCoeffA, secondaryFrictionCoeffB);
-  if (mPrimaryFrictionCoeff > DART_FRICTION_COEFF_THRESHOLD ||
-      mSecondaryFrictionCoeff > DART_FRICTION_COEFF_THRESHOLD)
+  mPrimaryFrictionCoeff
+      = std::min(primaryFrictionCoeffA, primaryFrictionCoeffB);
+  mSecondaryFrictionCoeff
+      = std::min(secondaryFrictionCoeffA, secondaryFrictionCoeffB);
+  if (mPrimaryFrictionCoeff > DART_FRICTION_COEFF_THRESHOLD
+      || mSecondaryFrictionCoeff > DART_FRICTION_COEFF_THRESHOLD)
   {
     mIsFrictionOn = true;
 
@@ -142,8 +141,10 @@ ContactConstraint::ContactConstraint(
     auto frictionDirB = computeWorldFirstFrictionDir(shapeNodeB);
 
     // check if the friction direction unit vectors have been set
-    bool nonzeroDirA = frictionDirA.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
-    bool nonzeroDirB = frictionDirB.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
+    bool nonzeroDirA
+        = frictionDirA.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
+    bool nonzeroDirB
+        = frictionDirB.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
 
     // only consider custom friction direction if one has nonzero length
     if (nonzeroDirA || nonzeroDirB)
@@ -797,13 +798,14 @@ Eigen::Vector3d ContactConstraint::computeWorldFirstFrictionDir(
   {
     dtwarn << "[ContactConstraint] Attempt to extract friction direction "
            << "from a ShapeNode that doesn't have DynamicAspect. The default "
-           << "value (" << DART_DEFAULT_FRICTION_DIR.transpose() << ") will be used "
-           << "instead.\n";
+           << "value (" << DART_DEFAULT_FRICTION_DIR.transpose()
+           << ") will be used instead.\n";
     return DART_DEFAULT_FRICTION_DIR;
   }
 
   auto frame = dynamicAspect->getFirstFrictionDirectionFrame();
-  const Eigen::Vector3d& frictionDir = dynamicAspect->getFirstFrictionDirection();
+  const Eigen::Vector3d& frictionDir
+      = dynamicAspect->getFirstFrictionDirection();
 
   // rotate using custom frame if it is specified
   if (frame)

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -579,7 +579,7 @@ void ContactConstraint::applyUnitImpulse(std::size_t index)
       // Both bodies are not reactive
       else
       {
-        // This case should not be happed
+        // This case should not be happened
         assert(0);
       }
     }

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -144,6 +144,8 @@ protected:
       const dynamics::ShapeNode* shapeNode);
   static double computeSecondaryFrictionCoefficient(
       const dynamics::ShapeNode* shapeNode);
+  static Eigen::Vector3d computeWorldFirstFrictionDir(
+      const dynamics::ShapeNode* shapenode);
   static double computeRestitutionCoefficient(
       const dynamics::ShapeNode* shapeNode);
 

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -201,9 +201,8 @@ void DynamicsAspect::setFrictionCoeff(const double& value)
 
 double DynamicsAspect::getFrictionCoeff() const
 {
-  return 0.5 * (
-      mProperties.mFrictionCoeff +
-      mProperties.mSecondaryFrictionCoeff);
+  return 0.5
+         * (mProperties.mFrictionCoeff + mProperties.mSecondaryFrictionCoeff);
 }
 
 void DynamicsAspect::setPrimaryFrictionCoeff(const double& value)

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -57,7 +57,9 @@ DynamicsAspectProperties::DynamicsAspectProperties(
     const double frictionCoeff, const double restitutionCoeff)
   : mFrictionCoeff(frictionCoeff),
     mRestitutionCoeff(restitutionCoeff),
-    mSecondaryFrictionCoeff(frictionCoeff)
+    mSecondaryFrictionCoeff(frictionCoeff),
+    mFirstFrictionDirection(Eigen::Vector3d::Zero()),
+    mFirstFrictionDirectionFrame(nullptr)
 {
   // Do nothing
 }
@@ -66,10 +68,14 @@ DynamicsAspectProperties::DynamicsAspectProperties(
 DynamicsAspectProperties::DynamicsAspectProperties(
     const double primaryFrictionCoeff,
     const double secondaryFrictionCoeff,
-    const double restitutionCoeff)
+    const double restitutionCoeff,
+    const Eigen::Vector3d& firstFrictionDirection,
+    const Frame* firstFrictionDirectionFrame)
   : mFrictionCoeff(primaryFrictionCoeff),
     mRestitutionCoeff(restitutionCoeff),
-    mSecondaryFrictionCoeff(secondaryFrictionCoeff)
+    mSecondaryFrictionCoeff(secondaryFrictionCoeff),
+    mFirstFrictionDirection(firstFrictionDirection),
+    mFirstFrictionDirectionFrame(firstFrictionDirectionFrame)
 {
   // Do nothing
 }
@@ -208,6 +214,18 @@ void DynamicsAspect::setPrimaryFrictionCoeff(const double& value)
 const double& DynamicsAspect::getPrimaryFrictionCoeff() const
 {
   return mProperties.mFrictionCoeff;
+}
+
+//==============================================================================
+void DynamicsAspect::setFirstFrictionDirectionFrame(const Frame* value)
+{
+  mProperties.mFirstFrictionDirectionFrame = value;
+}
+
+//==============================================================================
+const Frame* DynamicsAspect::getFirstFrictionDirectionFrame() const
+{
+  return mProperties.mFirstFrictionDirectionFrame;
 }
 
 //==============================================================================

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -158,6 +158,18 @@ public:
   DART_COMMON_SET_GET_ASPECT_PROPERTY(double, RestitutionCoeff)
   // void setRestitutionCoeff(const double& value);
   // const double& getRestitutionCoeff() const;
+
+  /// Set the frame for interpreting the first friction direction vector.
+  /// The frame pointer defaults to nullptr, which is interpreted as this
+  /// ShapeFrame.
+  void setFirstFrictionDirectionFrame(const Frame* value);
+
+  /// Get the frame for the first friction direction vector.
+  const Frame* getFirstFrictionDirectionFrame() const;
+
+  DART_COMMON_SET_GET_ASPECT_PROPERTY( Eigen::Vector3d, FirstFrictionDirection )
+  // void setFirstFrictionDirection(const Eigen::Vector3d& value);
+  // const Eigen::Vector3d& getFirstFrictionDirection() const;
 };
 
 //==============================================================================

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -167,7 +167,7 @@ public:
   /// Get the frame for the first friction direction vector.
   const Frame* getFirstFrictionDirectionFrame() const;
 
-  DART_COMMON_SET_GET_ASPECT_PROPERTY( Eigen::Vector3d, FirstFrictionDirection )
+  DART_COMMON_SET_GET_ASPECT_PROPERTY(Eigen::Vector3d, FirstFrictionDirection)
   // void setFirstFrictionDirection(const Eigen::Vector3d& value);
   // const Eigen::Vector3d& getFirstFrictionDirection() const;
 };

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -105,7 +105,8 @@ struct DynamicsAspectProperties
   const Frame* mFirstFrictionDirectionFrame;
 
   /// Constructors
-  /// The frictionCoeff argument will be used for both primary and secondary friction
+  /// The frictionCoeff argument will be used for both primary and secondary
+  /// friction
   DynamicsAspectProperties(
       const double frictionCoeff = 1.0, const double restitutionCoeff = 0.0);
 

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -101,6 +101,7 @@ struct DynamicsAspectProperties
   Eigen::Vector3d mFirstFrictionDirection;
 
   /// First friction direction frame
+  /// The first friction direction unit vector is expressed in this frame
   const Frame* mFirstFrictionDirectionFrame;
 
   /// Constructors
@@ -108,6 +109,20 @@ struct DynamicsAspectProperties
   DynamicsAspectProperties(
       const double frictionCoeff = 1.0, const double restitutionCoeff = 0.0);
 
+  /// Set primary and secondary friction and restitution coefficients.
+  /// The first friction direction vector and frame may optionally be set.
+  /// The vector defaults to a zero-vector, which will cause it to be ignored
+  /// and the global friction directions used instead.
+  /// If the vector is set to a non-zero vector, the first friction direction
+  /// for this shape is computed from this vector expressed in the frame
+  /// given by the Frame pointer. THe Frame pointer defaults to nullptr,
+  /// which is interpreted as the body-fixed frame of this Shape.
+  /// Note that if two objects with custom friction directions come into
+  /// contact, only one of the directions can be chosen.
+  /// One approach is to use the first friction direction for the ShapeNode
+  /// with the smaller primary friction coefficient, since that has the
+  /// dominant effect. See the ContactConstraint implementation for
+  /// further details.
   DynamicsAspectProperties(
       const double primaryFrictionCoeff,
       const double secondaryFrictionCoeff,

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -97,6 +97,12 @@ struct DynamicsAspectProperties
   /// Secondary coefficient of friction
   double mSecondaryFrictionCoeff;
 
+  /// First friction direction unit vector
+  Eigen::Vector3d mFirstFrictionDirection;
+
+  /// First friction direction frame
+  const Frame* mFirstFrictionDirectionFrame;
+
   /// Constructors
   /// The frictionCoeff argument will be used for both primary and secondary friction
   DynamicsAspectProperties(
@@ -105,7 +111,9 @@ struct DynamicsAspectProperties
   DynamicsAspectProperties(
       const double primaryFrictionCoeff,
       const double secondaryFrictionCoeff,
-      const double restitutionCoeff);
+      const double restitutionCoeff,
+      const Eigen::Vector3d& firstFrictionDirection = Eigen::Vector3d::Zero(),
+      const Frame* firstFrictionDirectionFrame = nullptr);
 
   /// Destructor
   virtual ~DynamicsAspectProperties() = default;

--- a/unittests/comprehensive/test_Friction.cpp
+++ b/unittests/comprehensive/test_Friction.cpp
@@ -77,7 +77,15 @@ TEST(Friction, FrictionPerShapeNode)
   skeleton1->setName("Skeleton1");
   auto skeleton2
       = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(+0.5, 0, 0));
-  skeleton1->setName("Skeleton2");
+  skeleton2->setName("Skeleton2");
+  auto skeleton3
+      = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(+1.5, 0, 0),
+                  Eigen::Vector3d(0, 0, 0.7853981633974483));
+  skeleton3->setName("Skeleton3");
+  auto skeleton4
+      = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(-1.5, 0, 0),
+                  Eigen::Vector3d(0, 0, 0.7853981633974483));
+  skeleton4->setName("Skeleton4");
 
   auto body1 = skeleton1->getRootBodyNode();
   // default friction values
@@ -121,6 +129,65 @@ TEST(Friction, FrictionPerShapeNode)
   EXPECT_DOUBLE_EQ(0.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
 
+  auto body3 = skeleton3->getRootBodyNode();
+  // default friction values
+  EXPECT_DOUBLE_EQ(1.0,
+      body3->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body3->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body3->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
+  EXPECT_EQ(nullptr,
+      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
+  // this body is rotated by 45 degrees, so set friction direction in body frame along Y axis
+  // so that gravity pushes it in x and y
+  body3->getShapeNode(0)->getDynamicsAspect()->setPrimaryFrictionCoeff(0.0);
+  body3->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirection(Eigen::Vector3d(0, 1, 0));
+  // check friction values
+  EXPECT_DOUBLE_EQ(0.5,
+      body3->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body3->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body3->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
+  EXPECT_EQ(nullptr,
+      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
+
+  auto body4 = skeleton4->getRootBodyNode();
+  // default friction values
+  EXPECT_DOUBLE_EQ(1.0,
+      body4->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body4->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body4->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
+  EXPECT_EQ(nullptr,
+      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
+  // this body is rotated by 45 degrees, but set friction direction according to world frame
+  // so that the body orientation doesn't matter.
+  // thus a diagonal axis is needed to push it in x and y
+  body4->getShapeNode(0)->getDynamicsAspect()->setPrimaryFrictionCoeff(0.0);
+  body4->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirectionFrame(Frame::World());
+  body4->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirection(
+      Eigen::Vector3d(0.5*std::sqrt(2), 0.5*std::sqrt(2), 0));
+  // check friction values
+  EXPECT_DOUBLE_EQ(0.5,
+      body4->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(0.0,
+      body4->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body4->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
+  EXPECT_DOUBLE_EQ(1.0,
+      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
+  EXPECT_EQ(Frame::World(),
+      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
+
   // Create a world and add the rigid body
   auto world = simulation::World::create();
   EXPECT_TRUE(equals(world->getGravity(), ::Eigen::Vector3d(0, 0, -9.81)));
@@ -130,6 +197,8 @@ TEST(Friction, FrictionPerShapeNode)
   world->addSkeleton(createFloor());
   world->addSkeleton(skeleton1);
   world->addSkeleton(skeleton2);
+  world->addSkeleton(skeleton3);
+  world->addSkeleton(skeleton4);
 
   const auto numSteps = 500;
   for (auto i = 0u; i < numSteps; ++i)
@@ -139,13 +208,31 @@ TEST(Friction, FrictionPerShapeNode)
     // Wait until the first box settle-in on the ground
     if (i > 300)
     {
+      const auto x1 = body1->getTransform().translation()[0];
       const auto y1 = body1->getTransform().translation()[1];
+      EXPECT_NEAR(x1, -0.5, 0.00001);
       EXPECT_NEAR(y1, -0.17889, 0.001);
 
-      // The second box still moves even after landed on the ground because its
+      // The second box still moves even after landing on the ground because its
       // friction is zero.
+      const auto x2 = body2->getTransform().translation()[0];
       const auto y2 = body2->getTransform().translation()[1];
+      EXPECT_NEAR(x2, 0.5, 0.00001);
       EXPECT_LE(y2, -0.17889);
+
+      // The third box still moves even after landing on the ground because its
+      // friction is zero along the first friction direction.
+      const auto x3 = body3->getTransform().translation()[0];
+      const auto y3 = body3->getTransform().translation()[1];
+      EXPECT_GE(x3, 1.5249);
+      EXPECT_LE(y3, -0.20382);
+
+      // The fourth box still moves even after landing on the ground because its
+      // friction is zero along the first friction direction.
+      const auto x4 = body4->getTransform().translation()[0];
+      const auto y4 = body4->getTransform().translation()[1];
+      EXPECT_LE(x4, -1.5249);
+      EXPECT_LE(y4, -0.20382);
     }
   }
 }

--- a/unittests/comprehensive/test_Friction.cpp
+++ b/unittests/comprehensive/test_Friction.cpp
@@ -78,115 +78,165 @@ TEST(Friction, FrictionPerShapeNode)
   auto skeleton2
       = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(+0.5, 0, 0));
   skeleton2->setName("Skeleton2");
-  auto skeleton3
-      = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(+1.5, 0, 0),
-                  Eigen::Vector3d(0, 0, 0.7853981633974483));
+  auto skeleton3 = createBox(
+      Eigen::Vector3d(0.3, 0.3, 0.3),
+      Eigen::Vector3d(+1.5, 0, 0),
+      Eigen::Vector3d(0, 0, 0.7853981633974483));
   skeleton3->setName("Skeleton3");
-  auto skeleton4
-      = createBox(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(-1.5, 0, 0),
-                  Eigen::Vector3d(0, 0, 0.7853981633974483));
+  auto skeleton4 = createBox(
+      Eigen::Vector3d(0.3, 0.3, 0.3),
+      Eigen::Vector3d(-1.5, 0, 0),
+      Eigen::Vector3d(0, 0, 0.7853981633974483));
   skeleton4->setName("Skeleton4");
 
   auto body1 = skeleton1->getRootBodyNode();
   // default friction values
-  EXPECT_DOUBLE_EQ(1.0,
-      body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0, body1->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body1->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body1->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
 
   auto body2 = skeleton2->getRootBodyNode();
   // default friction values
-  EXPECT_DOUBLE_EQ(1.0,
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0, body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
   // test setting primary friction
   body2->getShapeNode(0)->getDynamicsAspect()->setPrimaryFrictionCoeff(0.5);
-  EXPECT_DOUBLE_EQ(0.75,
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.5,
+  EXPECT_DOUBLE_EQ(
+      0.75, body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      0.5,
       body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
   // test setting secondary friction
   body2->getShapeNode(0)->getDynamicsAspect()->setSecondaryFrictionCoeff(0.25);
-  EXPECT_DOUBLE_EQ(0.375,
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.5,
+  EXPECT_DOUBLE_EQ(
+      0.375, body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      0.5,
       body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.25,
+  EXPECT_DOUBLE_EQ(
+      0.25,
       body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
   // set all friction coeffs to 0.0
   body2->getShapeNode(0)->getDynamicsAspect()->setFrictionCoeff(0.0);
-  EXPECT_DOUBLE_EQ(0.0,
-      body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.0,
+  EXPECT_DOUBLE_EQ(
+      0.0, body2->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      0.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.0,
+  EXPECT_DOUBLE_EQ(
+      0.0,
       body2->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
 
   auto body3 = skeleton3->getRootBodyNode();
   // default friction values
-  EXPECT_DOUBLE_EQ(1.0,
-      body3->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0, body3->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body3->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body3->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.0,
-      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
-  EXPECT_EQ(nullptr,
-      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
-  // this body is rotated by 45 degrees, so set friction direction in body frame along Y axis
-  // so that gravity pushes it in x and y
+  EXPECT_DOUBLE_EQ(
+      0.0,
+      body3->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirection()
+          .squaredNorm());
+  EXPECT_EQ(
+      nullptr,
+      body3->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirectionFrame());
+  // this body is rotated by 45 degrees, so set friction direction in body frame
+  // along Y axis so that gravity pushes it in x and y
   body3->getShapeNode(0)->getDynamicsAspect()->setPrimaryFrictionCoeff(0.0);
-  body3->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirection(Eigen::Vector3d(0, 1, 0));
+  body3->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirection(
+      Eigen::Vector3d(0, 1, 0));
   // check friction values
-  EXPECT_DOUBLE_EQ(0.5,
-      body3->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.0,
+  EXPECT_DOUBLE_EQ(
+      0.5, body3->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      0.0,
       body3->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body3->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
-      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
-  EXPECT_EQ(nullptr,
-      body3->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
+  EXPECT_DOUBLE_EQ(
+      1.0,
+      body3->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirection()
+          .squaredNorm());
+  EXPECT_EQ(
+      nullptr,
+      body3->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirectionFrame());
 
   auto body4 = skeleton4->getRootBodyNode();
   // default friction values
-  EXPECT_DOUBLE_EQ(1.0,
-      body4->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0, body4->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body4->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body4->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.0,
-      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
-  EXPECT_EQ(nullptr,
-      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
-  // this body is rotated by 45 degrees, but set friction direction according to world frame
-  // so that the body orientation doesn't matter.
-  // thus a diagonal axis is needed to push it in x and y
+  EXPECT_DOUBLE_EQ(
+      0.0,
+      body4->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirection()
+          .squaredNorm());
+  EXPECT_EQ(
+      nullptr,
+      body4->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirectionFrame());
+  // this body is rotated by 45 degrees, but set friction direction according to
+  // world frame so that the body orientation doesn't matter. thus a diagonal
+  // axis is needed to push it in x and y
   body4->getShapeNode(0)->getDynamicsAspect()->setPrimaryFrictionCoeff(0.0);
-  body4->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirectionFrame(Frame::World());
+  body4->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirectionFrame(
+      Frame::World());
   body4->getShapeNode(0)->getDynamicsAspect()->setFirstFrictionDirection(
-      Eigen::Vector3d(0.5*std::sqrt(2), 0.5*std::sqrt(2), 0));
+      Eigen::Vector3d(0.5 * std::sqrt(2), 0.5 * std::sqrt(2), 0));
   // check friction values
-  EXPECT_DOUBLE_EQ(0.5,
-      body4->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
-  EXPECT_DOUBLE_EQ(0.0,
+  EXPECT_DOUBLE_EQ(
+      0.5, body4->getShapeNode(0)->getDynamicsAspect()->getFrictionCoeff());
+  EXPECT_DOUBLE_EQ(
+      0.0,
       body4->getShapeNode(0)->getDynamicsAspect()->getPrimaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
+  EXPECT_DOUBLE_EQ(
+      1.0,
       body4->getShapeNode(0)->getDynamicsAspect()->getSecondaryFrictionCoeff());
-  EXPECT_DOUBLE_EQ(1.0,
-      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirection().squaredNorm());
-  EXPECT_EQ(Frame::World(),
-      body4->getShapeNode(0)->getDynamicsAspect()->getFirstFrictionDirectionFrame());
+  EXPECT_DOUBLE_EQ(
+      1.0,
+      body4->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirection()
+          .squaredNorm());
+  EXPECT_EQ(
+      Frame::World(),
+      body4->getShapeNode(0)
+          ->getDynamicsAspect()
+          ->getFirstFrictionDirectionFrame());
 
   // Create a world and add the rigid body
   auto world = simulation::World::create();


### PR DESCRIPTION
Currently the ContactConstraint uses a friction pyramid with 2 directions. In #1424, we added an additional parameter to allow the friction coefficient to be specified separately in each direction. This pull request allows the friction direction to be specified with a unit vector `FirstFrictionDirection` and pointer to a frame `FirstFrictionDirectionFrame` in which the unit vector is expressed. If `FirstFrictionDirection` is a vector of zeros (which is its default value), it is ignored and the default friction directions are used. If the frame pointer is `nullptr` (which is its default value), the body-fixed frame of that ShapeNode is used.

I've added two bodies to `test_Friction` with friction direction set using the default body-fixed frame and also using the world frame. In these tests, the friction is set to zero along one direction, and the lateral gravity component pushes along a diagonal.

***

**Before creating a pull request**

- [X] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [X] Add unit test(s) for this change
