### PR TITLE
[dartpy] Fix enabling drag and drop of InteractiveFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
   * Added bindings for background color support in osg viewer: [#1398](https://github.com/dartsim/dart/pull/1398)
   * Added bindings for BallJoint::convertToPositions(): [#1408](https://github.com/dartsim/dart/pull/1408)
   * Fixed typos in Skeleton: [#1392](https://github.com/dartsim/dart/pull/1392)
+  * Fixed enabling drag and drop for InteractiveFrame: [#1432](https://github.com/dartsim/dart/pull/1432)
 
 * Build
 

--- a/python/dartpy/gui/osg/InteractiveFrame.cpp
+++ b/python/dartpy/gui/osg/InteractiveFrame.cpp
@@ -115,7 +115,7 @@ void InteractiveFrame(py::module& m)
                   self->removeAllShapeFrames();
                 });
 
-  ::pybind11::enum_<dart::gui::osg::InteractiveTool::Type>(it, "Type")
+  ::py::enum_<dart::gui::osg::InteractiveTool::Type>(it, "Type")
       .value("LINEAR", dart::gui::osg::InteractiveTool::Type::LINEAR)
       .value("ANGULAR", dart::gui::osg::InteractiveTool::Type::ANGULAR)
       .value("PLANAR", dart::gui::osg::InteractiveTool::Type::PLANAR)

--- a/python/dartpy/gui/osg/Viewer.cpp
+++ b/python/dartpy/gui/osg/Viewer.cpp
@@ -237,101 +237,63 @@ void Viewer(py::module& m)
           })
       .def(
           "enableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::dynamics::Entity* entity) -> dart::gui::osg::DragAndDrop* {
-            return self->enableDragAndDrop(entity);
-          },
-          py::return_value_policy::reference_internal,
-          ::py::arg("entity"))
-      .def(
-          "enableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self, dart::dynamics::SimpleFrame* frame)
-              -> dart::gui::osg::SimpleFrameDnD* {
-            return self->enableDragAndDrop(frame);
-          },
-          py::return_value_policy::reference_internal,
+          ::py::overload_cast<dart::gui::osg::InteractiveFrame*>(
+              &dart::gui::osg::Viewer::enableDragAndDrop),
+          ::py::return_value_policy::reference_internal,
           ::py::arg("frame"))
       .def(
           "enableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::dynamics::SimpleFrame* frame,
-              dart::dynamics::Shape* shape)
-              -> dart::gui::osg::SimpleFrameShapeDnD* {
-            return self->enableDragAndDrop(frame, shape);
-          },
-          py::return_value_policy::reference_internal,
+          ::py::overload_cast<dart::dynamics::SimpleFrame*>(
+              &dart::gui::osg::Viewer::enableDragAndDrop),
+          ::py::return_value_policy::reference_internal,
+          ::py::arg("frame"))
+      .def(
+          "enableDragAndDrop",
+          ::py::overload_cast<
+              dart::dynamics::SimpleFrame*,
+              dart::dynamics::Shape*>(
+              &dart::gui::osg::Viewer::enableDragAndDrop),
+          ::py::return_value_policy::reference_internal,
           ::py::arg("frame"),
           ::py::arg("shape"))
       .def(
           "enableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self, dart::dynamics::BodyNode* bodyNode)
-              -> dart::gui::osg::BodyNodeDnD* {
-            return self->enableDragAndDrop(bodyNode);
-          },
-          py::return_value_policy::reference_internal,
-          ::py::arg("bodyNode"))
-      .def(
-          "enableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::dynamics::BodyNode* bodyNode,
-              bool useExternalIK) -> dart::gui::osg::BodyNodeDnD* {
-            return self->enableDragAndDrop(bodyNode, useExternalIK);
-          },
-          py::return_value_policy::reference_internal,
+          ::py::overload_cast<dart::dynamics::BodyNode*, bool, bool>(
+              &dart::gui::osg::Viewer::enableDragAndDrop),
+          ::py::return_value_policy::reference_internal,
           ::py::arg("bodyNode"),
-          ::py::arg("useExternalIK"))
+          ::py::arg_v("useExternalIK", true),
+          ::py::arg_v("useWholeBody", false))
       .def(
           "enableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::dynamics::BodyNode* bodyNode,
-              bool useExternalIK,
-              bool useWholeBody) -> dart::gui::osg::BodyNodeDnD* {
-            return self->enableDragAndDrop(
-                bodyNode, useExternalIK, useWholeBody);
-          },
-          py::return_value_policy::reference_internal,
-          ::py::arg("bodyNode"),
-          ::py::arg("useExternalIK"),
-          ::py::arg("useWholeBody"))
-      .def(
-          "enableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::gui::osg::InteractiveFrame* frame)
-              -> dart::gui::osg::InteractiveFrameDnD* {
-            return self->enableDragAndDrop(frame);
-          },
-          py::return_value_policy::reference_internal,
-          ::py::arg("frame"))
+          ::py::overload_cast<dart::dynamics::Entity*>(
+              &dart::gui::osg::Viewer::enableDragAndDrop),
+          ::py::return_value_policy::reference_internal,
+          ::py::arg("entity"))
       .def(
           "disableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self, dart::gui::osg::DragAndDrop* _dnd)
-              -> bool { return self->disableDragAndDrop(_dnd); },
+          ::py::overload_cast<dart::gui::osg::InteractiveFrameDnD*>(
+              &dart::gui::osg::Viewer::disableDragAndDrop),
           ::py::arg("dnd"))
       .def(
           "disableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::gui::osg::SimpleFrameDnD* _dnd) -> bool {
-            return self->disableDragAndDrop(_dnd);
-          },
+          ::py::overload_cast<dart::gui::osg::SimpleFrameDnD*>(
+              &dart::gui::osg::Viewer::disableDragAndDrop),
           ::py::arg("dnd"))
       .def(
           "disableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::gui::osg::SimpleFrameShapeDnD* _dnd) -> bool {
-            return self->disableDragAndDrop(_dnd);
-          },
+          ::py::overload_cast<dart::gui::osg::SimpleFrameShapeDnD*>(
+              &dart::gui::osg::Viewer::disableDragAndDrop),
           ::py::arg("dnd"))
       .def(
           "disableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self,
-              dart::gui::osg::InteractiveFrameDnD* _dnd) -> bool {
-            return self->disableDragAndDrop(_dnd);
-          },
+          ::py::overload_cast<dart::gui::osg::BodyNodeDnD*>(
+              &dart::gui::osg::Viewer::disableDragAndDrop),
           ::py::arg("dnd"))
       .def(
           "disableDragAndDrop",
-          +[](dart::gui::osg::Viewer* self, dart::gui::osg::BodyNodeDnD* _dnd)
-              -> bool { return self->disableDragAndDrop(_dnd); },
+          ::py::overload_cast<dart::gui::osg::DragAndDrop*>(
+              &dart::gui::osg::Viewer::disableDragAndDrop),
           ::py::arg("dnd"))
       .def(
           "getInstructions",
@@ -383,7 +345,7 @@ void Viewer(py::module& m)
 
             self->setCameraManipulator(self->getCameraManipulator());
           });
-}
+} // namespace python
 
 } // namespace python
 } // namespace dart

--- a/python/examples/drag_and_drop/main.py
+++ b/python/examples/drag_and_drop/main.py
@@ -29,14 +29,14 @@ def main():
     y_marker = dart.dynamics.SimpleFrame(dart.dynamics.Frame.World(), 'Y', tf)
     y_shape = dart.dynamics.BoxShape([0.2, 0.2, 0.2])
     y_marker.setShape(y_shape)
-    y_marker.getVisualAspect(True).setColor([0.0, 0.9, 0.0])
+    y_marker.getVisualAspect(True).setColor([0, 0.9, 0])
     world.addSimpleFrame(y_marker)
 
-    tf.set_translation([0.0, 0.0, 8.0])
+    tf.set_translation([0, 0, 8])
     z_marker = dart.dynamics.SimpleFrame(dart.dynamics.Frame.World(), 'Z', tf)
     z_shape = dart.dynamics.BoxShape([0.2, 0.2, 0.2])
     z_marker.setShape(z_shape)
-    z_marker.getVisualAspect(True).setColor([0.0, 0.0, 0.9])
+    z_marker.getVisualAspect(True).setColor([0, 0, 0.9])
     world.addSimpleFrame(z_marker)
 
     node = dart.gui.osg.WorldNode(world)
@@ -48,6 +48,7 @@ def main():
 
     viewer.addInstructionText("\nCtrl + Left-click: Rotate the box\n")
     print(viewer.getInstructions())
+    print(dart.__file__)
 
     viewer.setUpViewInWindow(0, 0, 640, 480)
     viewer.setCameraHomePosition([20, 17, 17], [0, 0, 0], [0, 0, 1])

--- a/python/examples/drag_and_drop/main.py
+++ b/python/examples/drag_and_drop/main.py
@@ -48,7 +48,6 @@ def main():
 
     viewer.addInstructionText("\nCtrl + Left-click: Rotate the box\n")
     print(viewer.getInstructions())
-    print(dart.__file__)
 
     viewer.setUpViewInWindow(0, 0, 640, 480)
     viewer.setCameraHomePosition([20, 17, 17], [0, 0, 0], [0, 0, 1])


### PR DESCRIPTION
Enabling drag and drop for InteractiveFrame currently doesn't work as expected because of the order of Python bindings for `dart::gui::osg::Viewer::enableDragAndDrop(...)`. [pybind11 calls earlier-defined overloads](https://pybind11.readthedocs.io/en/stable/advanced/functions.html#overload-resolution-order). For `InteractiveFrame` case, `enableDragAndDrop(Entity*)` is called instead of `enableDragAndDrop(InteractiveFrame*)` because `enableDragAndDrop(Entity*)` is defined in prior to the other (and it's compatible since `Entity` is a base of `InteractiveFrame`). To prevent this, this PR defines `enableDragAndDrop(InteractiveFrame*)` (and other functions overloaded for derived classes of `Entity`) before `enableDragAndDrop(Entity*)`.

![dartpy_drag_and_drop](https://user-images.githubusercontent.com/4038467/73114369-b4756900-3ece-11ea-88ee-87bac58e3aa7.gif)

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
