### PR TITLE
Add ConeShape support for FCLCollisionDetector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   * Removed use of boost::filesystem in public APIs: [#1417](https://github.com/dartsim/dart/pull/1417)
 
+* Collision
+
+  * Add ConeShape support for FCLCollisionDetector: [#1447](https://github.com/dartsim/dart/pull/1447)
+
 * Kinematics
 
   * Added IkFast parameter accessors to IkFast class: [#1396](https://github.com/dartsim/dart/pull/1396)

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -70,6 +70,7 @@
 
 #  include <fcl/BV/OBBRSS.h>
 #  include <fcl/BVH/BVH_model.h>
+#  include <fcl/shape/geometric_shape_to_BVH_model.h>
 #  include <fcl/collision.h>
 #  include <fcl/collision_data.h>
 #  include <fcl/collision_object.h>
@@ -124,6 +125,7 @@ using Transform3 = ::fcl::Transform3<double>;
 // Geometric primitives
 using Box = ::fcl::Box<double>;
 using Cylinder = ::fcl::Cylinder<double>;
+using Cone = ::fcl::Cone<double>;
 using Ellipsoid = ::fcl::Ellipsoid<double>;
 using Halfspace = ::fcl::Halfspace<double>;
 using Sphere = ::fcl::Sphere<double>;
@@ -149,6 +151,7 @@ using Transform3 = ::fcl::Transform3f;
 // Geometric primitives
 using Box = ::fcl::Box;
 using Cylinder = ::fcl::Cylinder;
+using Cone = ::fcl::Cone;
 using Halfspace = ::fcl::Halfspace;
 using Sphere = ::fcl::Sphere;
 #  if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP

--- a/data/skel/shapes.skel
+++ b/data/skel/shapes.skel
@@ -6,7 +6,7 @@
             <gravity>0 -9.81 0</gravity>
             <collision_detector>bullet</collision_detector>
         </physics>
-        
+
         <skeleton name="ground skeleton">
             <body name="ground">
                 <transformation>0 -0.375 0 0 0 0</transformation>
@@ -26,14 +26,14 @@
                             <size>10 0.01 10</size>
                         </box>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
             <joint type="weld" name="joint 1">
                 <parent>world</parent>
                 <child>ground</child>
             </joint>
-        </skeleton> 
-        
+        </skeleton>
+
         <skeleton name="box skeleton">
             <body name="box">
                 <gravity>1</gravity>
@@ -58,15 +58,15 @@
                             <size>0.1 0.05 0.1</size>
                         </box>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>box</child>
             </joint>
         </skeleton>
-        
+
         <skeleton name="sphere skeleton">
             <body name="sphere">
                 <gravity>1</gravity>
@@ -91,15 +91,15 @@
                             <radius>0.05</radius>
                         </sphere>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>sphere</child>
             </joint>
         </skeleton>
-        
+
         <skeleton name="ellipsoid skeleton">
             <body name="ellipsoid">
                 <gravity>1</gravity>
@@ -124,9 +124,9 @@
                             <size>0.05 0.10 0.15</size>
                         </ellipsoid>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>ellipsoid</child>
@@ -159,9 +159,9 @@
                             <radius>0.05</radius>
                         </cylinder>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>cylinder</child>
@@ -194,9 +194,9 @@
                             <radius>0.05</radius>
                         </capsule>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>capsule</child>
@@ -229,9 +229,9 @@
                             <radius>0.05</radius>
                         </cone>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>cone</child>
@@ -276,9 +276,9 @@
                             </sphere>
                         </multi_sphere>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>multi sphere</child>
@@ -311,9 +311,9 @@
                             <scale>1.0 1.0 1.0</scale>
                         </mesh>
                     </geometry>
-                </collision_shape>                                
+                </collision_shape>
             </body>
-            
+
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>mesh</child>

--- a/unittests/comprehensive/test_Collision.cpp
+++ b/unittests/comprehensive/test_Collision.cpp
@@ -801,6 +801,77 @@ TEST_F(Collision, testCylinderCylinder)
 }
 
 //==============================================================================
+void testConeCone(const std::shared_ptr<CollisionDetector>& cd)
+{
+  auto simpleFrame1 = SimpleFrame::createShared(Frame::World());
+  auto simpleFrame2 = SimpleFrame::createShared(Frame::World());
+
+  auto shape1 = std::make_shared<ConeShape>(1.0, 1.0);
+  auto shape2 = std::make_shared<ConeShape>(0.5, 1.0);
+
+  simpleFrame1->setShape(shape1);
+  simpleFrame2->setShape(shape2);
+
+  auto group = cd->createCollisionGroup(simpleFrame1.get(), simpleFrame2.get());
+
+  EXPECT_EQ(group->getNumShapeFrames(), 2u);
+
+  collision::CollisionOption option;
+  option.enableContact = true;
+
+  collision::CollisionResult result;
+
+  result.clear();
+  simpleFrame1->setTranslation(Eigen::Vector3d::Zero());
+  simpleFrame2->setTranslation(Eigen::Vector3d(2.0, 0.0, 0.0));
+  EXPECT_FALSE(group->collide(option, &result));
+  EXPECT_TRUE(result.getNumContacts() == 0u);
+
+  result.clear();
+  simpleFrame1->setTranslation(Eigen::Vector3d::Zero());
+  simpleFrame2->setTranslation(Eigen::Vector3d(0.75, 0.0, 0.0));
+  EXPECT_TRUE(group->collide(option, &result));
+  EXPECT_TRUE(result.getNumContacts() >= 1u);
+}
+
+//==============================================================================
+TEST_F(Collision, testConeCone)
+{
+  auto fcl_mesh_dart = FCLCollisionDetector::create();
+  fcl_mesh_dart->setPrimitiveShapeType(FCLCollisionDetector::MESH);
+  fcl_mesh_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
+  testCylinderCylinder(fcl_mesh_dart);
+
+  auto fcl_mesh_fcl = FCLCollisionDetector::create();
+  fcl_mesh_fcl->setPrimitiveShapeType(FCLCollisionDetector::MESH);
+  fcl_mesh_fcl->setContactPointComputationMethod(FCLCollisionDetector::FCL);
+  testCylinderCylinder(fcl_mesh_fcl);
+
+  auto fcl_prim_dart = FCLCollisionDetector::create();
+  fcl_prim_dart->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+  fcl_prim_dart->setContactPointComputationMethod(FCLCollisionDetector::DART);
+  testCylinderCylinder(fcl_prim_dart);
+
+  auto fcl_prim_fcl = FCLCollisionDetector::create();
+  fcl_prim_fcl->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+  fcl_prim_fcl->setContactPointComputationMethod(FCLCollisionDetector::FCL);
+  testCylinderCylinder(fcl_prim_fcl);
+
+#if HAVE_ODE
+  auto ode = OdeCollisionDetector::create();
+  testCylinderCylinder(ode);
+#endif
+
+#if HAVE_BULLET
+  auto bullet = BulletCollisionDetector::create();
+  testCylinderCylinder(bullet);
+#endif
+
+  // auto dart = DARTCollisionDetector::create();
+  // testCylinderCylinder(dart);
+}
+
+//==============================================================================
 void testCapsuleCapsule(const std::shared_ptr<CollisionDetector>& cd)
 {
   auto simpleFrame1 = SimpleFrame::createShared(Frame::World());


### PR DESCRIPTION
The sphere was used for ConeShape when FCLCollisionDetector is used. This PR changed to use mesh for ConeShape as other shapes in FCLCollisionDetector.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
