### PR TITLE
Install numpy using pip3 instead of Homebrew

### DIFF
--- a/.ci/install_osx.sh
+++ b/.ci/install_osx.sh
@@ -4,4 +4,4 @@ set -ex
 brew update > /dev/null
 brew bundle || brew bundle
 
-pip3 install -U pytest
+pip3 install -U numpy pytest

--- a/Brewfile
+++ b/Brewfile
@@ -20,4 +20,3 @@ brew 'urdfdom'
 
 # dartpy dependencies
 brew 'pybind11'
-brew 'numpy'


### PR DESCRIPTION
This should fix the CI error on macOS.

