### PR TITLE
Wrap IKFast solutions for cyclic joint positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Kinematics
 
   * Added IkFast parameter accessors to IkFast class: [#1396](https://github.com/dartsim/dart/pull/1396)
+  * Changed IkFast to wrap IK solutions into the joint limits for RevoluteJoint: [#1452](https://github.com/dartsim/dart/pull/1452)
 
 * Dynamics
 

--- a/dart/dynamics/IkFast.cpp
+++ b/dart/dynamics/IkFast.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
+#include "dart/dynamics/RevoluteJoint.hpp"
 #include "dart/external/ikfast/ikfast.h"
 
 namespace dart {
@@ -134,14 +135,18 @@ void convertIkSolution(
 
     const auto dofIndex = dofIndices[index];
     const auto* dof = skel->getDof(dofIndex);
+    const auto* joint = dof->getJoint();
 
     auto solutionValue = solutionValues[i];
 
     const auto lb = dof->getPositionLowerLimit();
     const auto ub = dof->getPositionUpperLimit();
 
-    if (dof->isCyclic())
+    if (joint->getType() == RevoluteJoint::getStaticType())
     {
+      // TODO(JS): Apply this to any DegreeOfFreedom whose configuration space
+      // is SO(2).
+
       const auto currentValue = dof->getPosition();
       if (!wrapCyclicSolution(currentValue, lb, ub, solutionValue))
       {

--- a/dart/dynamics/IkFast.cpp
+++ b/dart/dynamics/IkFast.cpp
@@ -132,21 +132,39 @@ void convertIkSolution(
     if (isFreeJoint)
       continue;
 
-    solution.mConfig[index] = solutionValues[i];
-
     const auto dofIndex = dofIndices[index];
+    const auto* dof = skel->getDof(dofIndex);
 
-    if (solutionValues[i] < skel->getDof(dofIndex)->getPositionLowerLimit())
+    auto solutionValue = solutionValues[i];
+
+    const auto lb = dof->getPositionLowerLimit();
+    const auto ub = dof->getPositionUpperLimit();
+
+    if (dof->isCyclic())
     {
-      limitViolated = true;
-      break;
+      const auto currentValue = dof->getPosition();
+      if (!wrapCyclicSolution(currentValue, lb, ub, solutionValue))
+      {
+        limitViolated = true;
+        break;
+      }
+    }
+    else
+    {
+      if (solutionValues[i] < lb)
+      {
+        limitViolated = true;
+        break;
+      }
+
+      if (solutionValues[i] > ub)
+      {
+        limitViolated = true;
+        break;
+      }
     }
 
-    if (solutionValues[i] > skel->getDof(dofIndex)->getPositionUpperLimit())
-    {
-      limitViolated = true;
-      break;
-    }
+    solution.mConfig[index] = solutionValue;
 
     index++;
   }
@@ -440,6 +458,84 @@ Eigen::Isometry3d IkFast::computeFk(const Eigen::VectorXd& parameters)
   Eigen::Isometry3d tf;
   convertTransform(eetrans, eerot, tf);
   return tf;
+}
+
+//==============================================================================
+bool wrapCyclicSolution(
+    double currentValue, double lb, double ub, double& solutionValue)
+{
+  if (lb > ub)
+    return false;
+
+  const auto pi2 = math::constantsd::two_pi();
+
+  if (currentValue < lb)
+  {
+    const auto diff_lb = lb - solutionValue;
+    const auto lb_ceil = solutionValue + std::ceil(diff_lb / pi2) * pi2;
+    assert(lb <= lb_ceil);
+    if (lb_ceil <= ub)
+    {
+      solutionValue = lb_ceil;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  else if (ub < currentValue)
+  {
+    const auto diff_ub = ub - solutionValue;
+    const auto ub_floor = solutionValue + std::floor(diff_ub / pi2) * pi2;
+    assert(ub_floor <= ub);
+    if (lb <= ub_floor)
+    {
+      solutionValue = ub_floor;
+    }
+    else
+    {
+      return false;
+    }
+  }
+  else
+  {
+    const auto diff_curr = currentValue - solutionValue;
+    const auto curr_floor = solutionValue + std::floor(diff_curr / pi2) * pi2;
+    const auto curr_ceil = solutionValue + std::ceil(diff_curr / pi2) * pi2;
+
+    bool found = false;
+
+    if (lb <= curr_floor)
+    {
+      solutionValue = curr_floor;
+      found = true;
+    }
+
+    if (curr_ceil <= ub)
+    {
+      if (found)
+      {
+        if (std::abs(curr_floor - currentValue)
+            > std::abs(curr_ceil - currentValue))
+        {
+          solutionValue = curr_ceil;
+          found = true;
+        }
+      }
+      else
+      {
+        solutionValue = curr_ceil;
+        found = true;
+      }
+    }
+
+    if (!found)
+    {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 } // namespace dynamics

--- a/dart/dynamics/IkFast.hpp
+++ b/dart/dynamics/IkFast.hpp
@@ -254,6 +254,23 @@ private:
   std::array<IkReal, 3> mTargetTranspose;
 };
 
+/// Tries to wrap a single dof IK solution, from IKFast, in the range of joint
+/// limits.
+///
+/// This function shouldn't be used for a non-cyclic DegreeOfFreedom.
+///
+/// If multiple solution are available (when the range is wider than 2*pi),
+/// returns the closest solution to the current joint position.
+///
+/// \param[in] curr The current joint positions before solving IK.
+/// \param[in] lb The lower joint position limit.
+/// \param[in] ub The upper joint position limit.
+/// \param[in,out] sol The IK solution to be wrapped. No assumption that the
+/// value initially in the bounds. This value is only updated if an available
+/// solution is found.
+/// \return True if a solution is found. False, otherwise.
+bool wrapCyclicSolution(double curr, double lb, double ub, double& sol);
+
 } // namespace dynamics
 } // namespace dart
 

--- a/unittests/unit/test_IkFast.cpp
+++ b/unittests/unit/test_IkFast.cpp
@@ -40,6 +40,59 @@
 using namespace dart;
 
 //==============================================================================
+TEST(IkFast, WrapCyclicSolution)
+{
+  const auto pi = math::constantsd::pi();
+
+  double sol;
+
+  // Invalid bounds (lb > ub)
+  EXPECT_FALSE(dynamics::wrapCyclicSolution(0, 10, -10, sol));
+
+  // Current value is in the lmits, but solution is lesser than lower limit.
+  // Expect valid solution that is the cloest to the current value.
+  sol = -3 * pi;
+  EXPECT_TRUE(dynamics::wrapCyclicSolution(-pi / 2, -pi, +pi, sol));
+  EXPECT_DOUBLE_EQ(sol, -pi);
+  sol = -3 * pi;
+  EXPECT_TRUE(
+      dynamics::wrapCyclicSolution(-pi / 2, -(3.0 / 4.0) * pi, +pi, sol));
+  EXPECT_DOUBLE_EQ(sol, +pi);
+  sol = -3 * pi;
+  EXPECT_FALSE(
+      dynamics::wrapCyclicSolution(-pi / 2, -0.9 * pi, +0.9 * pi, sol));
+
+  // Current value is in the lmits, but solution is greater than upper limit.
+  // Expect valid solution that is the cloest to the current value.
+  sol = -3 * pi;
+  EXPECT_TRUE(dynamics::wrapCyclicSolution(+pi / 2, -pi, +pi, sol));
+  EXPECT_DOUBLE_EQ(sol, +pi);
+  sol = -3 * pi;
+  EXPECT_TRUE(
+      dynamics::wrapCyclicSolution(+pi / 2, -pi, +(3.0 / 4.0) * pi, sol));
+  EXPECT_DOUBLE_EQ(sol, -pi);
+  sol = -3 * pi;
+  EXPECT_FALSE(
+      dynamics::wrapCyclicSolution(+pi / 2, -0.9 * pi, +0.9 * pi, sol));
+
+  // Both current value and solution are lesser than lower limit.
+  // Expect least valid solution.
+  sol = -9 * pi;
+  EXPECT_TRUE(dynamics::wrapCyclicSolution(-5 * pi, -4 * pi, +4 * pi, sol));
+  EXPECT_DOUBLE_EQ(sol, -3 * pi);
+  sol = -9 * pi;
+  EXPECT_FALSE(dynamics::wrapCyclicSolution(-5 * pi, -4 * pi, -3.1 * pi, sol));
+
+  // Both current value and solution are greater than upper limit.
+  // Expect greatest valid solution.
+  sol = +9 * pi;
+  EXPECT_TRUE(dynamics::wrapCyclicSolution(+5 * pi, -4 * pi, +4 * pi, sol));
+  EXPECT_DOUBLE_EQ(sol, +3 * pi);
+  sol = +9 * pi;
+  EXPECT_FALSE(dynamics::wrapCyclicSolution(+5 * pi, +3.1 * pi, +4 * pi, sol));
+}
+
+//==============================================================================
 TEST(IkFast, FailedToLoadSharedLibrary)
 {
   auto skel = dynamics::Skeleton::create();


### PR DESCRIPTION
IKFast sometimes returns solutions that are not wrapped within the range of the joint limits, which is regarded as an invalid solution in DART.

This PR fixes the issue by adding logic that tries to wrap IKFast solutions for rotational joints. The idea is to wrap the solution within joint limits. If there is more than one solution (when the joint limit range is wider than 2pi), it returns the closest solution to the current joint position to minimize joint motion.

The logic should be applied to any DegreeOfFreedom whose configuration space is SO(2), but this PR only applies it to RevoluteJoint. This is because the current API doesn't provide for it. `DegreeOfFreedom::isCyclic()` is the closest function to what we want, but it only returns true when the rotational joint has no limits.

This PR partially fix #1449 because it only works for `RevoluteJoint`.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
