### PR TITLE
Fix/py collision obj

### DIFF
--- a/python/dartpy/collision/CollisionObject.cpp
+++ b/python/dartpy/collision/CollisionObject.cpp
@@ -41,10 +41,27 @@ namespace python {
 void CollisionObject(py::module& m)
 {
   ::py::class_<dart::collision::CollisionObject>(m, "CollisionObject")
-      .def(
+    .def(
+        "getCollisionDetector",
+        +[](dart::collision::CollisionObject* self) -> dart::collision::CollisionDetector* {
+            return self->getCollisionDetector();
+        },
+        ::py::return_value_policy::reference_internal)
+    .def(
+        "getShapeFrame",
+        +[](const dart::collision::CollisionObject* self) -> const dart::dynamics::ShapeFrame* {
+            return self->getShapeFrame();
+        },
+        ::py::return_value_policy::reference_internal)
+        .def(
           "getShape",
           +[](const dart::collision::CollisionObject* self)
-              -> dart::dynamics::ConstShapePtr { return self->getShape(); });
+              -> dart::dynamics::ConstShapePtr { return self->getShape(); })
+        .def("getTransform",
+        +[](const dart::collision::CollisionObject* self) -> const Eigen::Isometry3d& {
+            return self->getTransform();
+        },
+        ::py::return_value_policy::reference_internal);
 }
 
 } // namespace python

--- a/python/dartpy/collision/CollisionObject.cpp
+++ b/python/dartpy/collision/CollisionObject.cpp
@@ -41,27 +41,29 @@ namespace python {
 void CollisionObject(py::module& m)
 {
   ::py::class_<dart::collision::CollisionObject>(m, "CollisionObject")
-    .def(
-        "getCollisionDetector",
-        +[](dart::collision::CollisionObject* self) -> dart::collision::CollisionDetector* {
+      .def(
+          "getCollisionDetector",
+          +[](dart::collision::CollisionObject* self)
+              -> dart::collision::CollisionDetector* {
             return self->getCollisionDetector();
-        },
-        ::py::return_value_policy::reference_internal)
-    .def(
-        "getShapeFrame",
-        +[](const dart::collision::CollisionObject* self) -> const dart::dynamics::ShapeFrame* {
+          },
+          ::py::return_value_policy::reference_internal)
+      .def(
+          "getShapeFrame",
+          +[](const dart::collision::CollisionObject* self)
+              -> const dart::dynamics::ShapeFrame* {
             return self->getShapeFrame();
-        },
-        ::py::return_value_policy::reference_internal)
-        .def(
+          },
+          ::py::return_value_policy::reference_internal)
+      .def(
           "getShape",
           +[](const dart::collision::CollisionObject* self)
               -> dart::dynamics::ConstShapePtr { return self->getShape(); })
-        .def("getTransform",
-        +[](const dart::collision::CollisionObject* self) -> const Eigen::Isometry3d& {
-            return self->getTransform();
-        },
-        ::py::return_value_policy::reference_internal);
+      .def(
+          "getTransform",
+          +[](const dart::collision::CollisionObject* self)
+              -> const Eigen::Isometry3d& { return self->getTransform(); },
+          ::py::return_value_policy::reference_internal);
 }
 
 } // namespace python

--- a/python/dartpy/collision/module.cpp
+++ b/python/dartpy/collision/module.cpp
@@ -57,6 +57,8 @@ void CollisionGroup(py::module& sm);
 void FCLCollisionGroup(py::module& sm);
 void DARTCollisionGroup(py::module& sm);
 
+void CollisionObject(py::module& sm);
+
 #if HAVE_BULLET
 void BulletCollisionDetector(py::module& sm);
 void BulletCollisionGroup(py::module& sm);
@@ -89,6 +91,8 @@ void dart_collision(py::module& m)
   CollisionGroup(sm);
   FCLCollisionGroup(sm);
   DARTCollisionGroup(sm);
+
+  CollisionObject(sm);
 
 #if HAVE_BULLET
   BulletCollisionDetector(sm);

--- a/python/dartpy/dynamics/ShapeNode.cpp
+++ b/python/dartpy/dynamics/ShapeNode.cpp
@@ -105,7 +105,20 @@ void ShapeNode(py::module& m)
           "getOffset",
           +[](const dart::dynamics::ShapeNode* self) -> Eigen::Vector3d {
             return self->getOffset();
-          });
+          })
+      .def(
+          "getBodyNodePtr",
+          +[](dart::dynamics::ShapeNode* self) -> dart::dynamics::BodyNode*{
+            return self->getBodyNodePtr().get();
+          },
+          ::py::return_value_policy::reference_internal)
+      .def(
+          "getBodyNodePtr",
+          +[](const dart::dynamics::ShapeNode* self)
+              -> const dart::dynamics::BodyNode* {
+            return self->getBodyNodePtr().get();
+          },
+          ::py::return_value_policy::reference_internal);
 }
 
 } // namespace python

--- a/python/dartpy/dynamics/ShapeNode.cpp
+++ b/python/dartpy/dynamics/ShapeNode.cpp
@@ -32,6 +32,7 @@
 
 #include <dart/dart.hpp>
 #include <pybind11/pybind11.h>
+
 #include "eigen_geometry_pybind.h"
 #include "eigen_pybind.h"
 
@@ -108,7 +109,7 @@ void ShapeNode(py::module& m)
           })
       .def(
           "getBodyNodePtr",
-          +[](dart::dynamics::ShapeNode* self) -> dart::dynamics::BodyNode*{
+          +[](dart::dynamics::ShapeNode* self) -> dart::dynamics::BodyNode* {
             return self->getBodyNodePtr().get();
           },
           ::py::return_value_policy::reference_internal)


### PR DESCRIPTION
Adds Python bindings to get more complete Contact/Collision information, especially to get `BodyNode`s involved in a particular contact via `someContact.collisionObject1.getShapeFrame().getBodyNodePtr()`. The following changes are made

- `CollisionObject`'s methods from C++ were completed
- `CollisionObject` declaration added in `python/dartpy/collision/module.cpp` -> Collision objects can be used now from Python code
- add `getBodyNodePtr()` for `dartpy::dynamics::ShapeNode`. Here, a discussion may be needed. As `getBodyNodePtr()` returns a `dart::dynamics::BodyNodePtr` (not implemented in dartpy yet) the easiest implementation was to return the raw `BodyNode*` using `getBodyNodePtr().get()`. So *reference counting of dart will be wrong here*. Can this become a problem, or is this okay? Should it be implemented via adding `BodyNodePtr` objects as well?

***

**Before creating a pull request**

- [ ] ~~Document new methods and classes~~
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
