### PR TITLE
Fix TypeError from dartpy.dynamics.Node.getBodyNodePtr()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
   * Fixed typos in Skeleton: [#1392](https://github.com/dartsim/dart/pull/1392)
   * Fixed enabling drag and drop for InteractiveFrame: [#1432](https://github.com/dartsim/dart/pull/1432)
   * Added bindings for pointcloud and contact retrieval: [#1455](https://github.com/dartsim/dart/pull/1455)
+  * Fixed TypeError from dartpy.dynamics.Node.getBodyNodePtr(): [#1463](https://github.com/dartsim/dart/pull/1463)
 
 * Build and testing
 

--- a/python/dartpy/dynamics/BodyNode.cpp
+++ b/python/dartpy/dynamics/BodyNode.cpp
@@ -35,8 +35,7 @@
 #include <pybind11/stl.h>
 #include "eigen_geometry_pybind.h"
 #include "eigen_pybind.h"
-
-PYBIND11_DECLARE_HOLDER_TYPE(T, dart::dynamics::TemplateBodyNodePtr<T>, true);
+#include "pointers.hpp"
 
 namespace py = pybind11;
 

--- a/python/dartpy/dynamics/Node.cpp
+++ b/python/dartpy/dynamics/Node.cpp
@@ -34,6 +34,7 @@
 #include <pybind11/pybind11.h>
 #include "eigen_geometry_pybind.h"
 #include "eigen_pybind.h"
+#include "pointers.hpp"
 
 namespace py = pybind11;
 

--- a/python/dartpy/dynamics/pointers.hpp
+++ b/python/dartpy/dynamics/pointers.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/dart.hpp>
+#include <pybind11/pybind11.h>
+
+PYBIND11_DECLARE_HOLDER_TYPE(T, dart::dynamics::TemplateBodyNodePtr<T>, true);

--- a/python/tests/unit/dynamics/test_body_node.py
+++ b/python/tests/unit/dynamics/test_body_node.py
@@ -11,6 +11,9 @@ def test_basic():
 
     for i in range(kr5.getNumBodyNodes()):
         body = kr5.getBodyNode(i)
+        bodyPtr = body.getBodyNodePtr()
+        assert body == bodyPtr
+        assert body.getName() == bodyPtr.getName()
         assert np.array_equal(
             np.array(body.getSpatialVelocity()), np.zeros(6)) is True
         shape_nodes = body.getShapeNodes()


### PR DESCRIPTION
`dartpy.dynamics.Node.getBodyNodePtr()` causes TypeError as
```python
>>> b.getBodyNodePtr()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Unable to convert function return value to a Python type! The signature was
	(self: dartpy.dynamics.Node) -> dart::dynamics::TemplateBodyNodePtr<dart::dynamics::BodyNode>
```

This was because `dart::dynamics::TemplateBodyNodePtr<dart::dynamics::BodyNode>` is declared after the `Node` binding. This PR fixes it by declaring the holder type at the top of dynamics submodule.

This PR needs to be merged before #1457.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
