### PR TITLE
Add pyramid shape support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
-- job: mojav_clang_debug
+- job: catalina_clang_debug
   timeoutInMinutes: 120
   pool:
     vmImage: 'macOS-10.15'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,18 +26,6 @@ jobs:
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
-- job: eoan_gcc_debug
-  timeoutInMinutes: 120
-  pool:
-    vmImage: 'ubuntu-16.04'
-  variables:
-    COMPILER: gcc
-    BUILD_TYPE: Debug
-    BUILD_DIR: $(Build.SourcesDirectory)
-    DOCKERFILE: Dockerfile.ubuntu-eoan
-  steps:
-  - template: .ci/azure-pipelines/docker.yml
-
 - job: focal_gcc_debug
   timeoutInMinutes: 120
   pool:

--- a/.ci/docker/Dockerfile.ubuntu-eoan
+++ b/.ci/docker/Dockerfile.ubuntu-eoan
@@ -1,1 +1,0 @@
-FROM ubuntu:eoan

--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -81,7 +81,8 @@ if [ "$BUILD_DARTPY" = "ON" ]; then
   apt-get install -y --no-install-recommends \
     python3-dev \
     python3-numpy \
-    python3-pip
+    python3-pip \
+    python3-setuptools
   pip3 install pytest -U
 
   if [ $(lsb_release -sc) = "xenial" ] || [ $(lsb_release -sc) = "bionic" ]; then

--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -66,7 +66,7 @@ if [ $(lsb_release -sc) = "xenial" ] || [ $(lsb_release -sc) = "bionic" ]; then
     liboctomap-dev \
     libode-dev \
     clang-format-6.0
-elif [ $(lsb_release -sc) = "eoan" ] || [ $(lsb_release -sc) = "focal" ]; then
+elif [ $(lsb_release -sc) = "focal" ]; then
   apt-get install -y --no-install-recommends \
     libnlopt-cxx-dev \
     liboctomap-dev \
@@ -93,7 +93,7 @@ if [ "$BUILD_DARTPY" = "ON" ]; then
     make -j4
     make install
     cd ../..
-  elif [ $(lsb_release -sc) = "eoan" ] || [ $(lsb_release -sc) = "focal" ]; then
+  elif [ $(lsb_release -sc) = "focal" ]; then
     apt-get -y install pybind11-dev python3 libpython3-dev python3-pytest \
       python3-distutils
   else

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ assignees: ''
 #### Environment
 > Select the following information.
 * DART version: [e.g., master, 6.8.3]
-* OS name and version name(or number): [e.g., Ubuntu 18.04, macOS Mojav, Windows 10]
+* OS name and version name(or number): [e.g., Ubuntu 18.04, macOS Catalina, Windows 10]
 * Compiler name and version number: [e.g., GCC 7.4.0, Clang 3.9.1]
 
 #### Expected Behavior

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -69,43 +69,6 @@ jobs:
       run: |
         docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
 
-  eoan_gcc_release:
-    name: Ubuntu 19.10 [GCC|Release]
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      env:
-        COMPILER: gcc
-        DOCKERFILE: Dockerfile.ubuntu-eoan
-        BUILD_TYPE: Release
-      run: |
-        docker build -t "${DOCKERFILE,,}" -f ".ci/docker/$DOCKERFILE" .;
-        docker run -itd -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --env-file ./.ci/docker/env.list --name dart-docker "${DOCKERFILE,,}";
-        docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/install.sh";
-    - name: Build
-      run: |
-        docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
-
-  eoan_gcc_dartpy_release:
-    name: Ubuntu 19.10 [GCC|dartpy|Release]
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      env:
-        COMPILER: gcc
-        DOCKERFILE: Dockerfile.ubuntu-eoan
-        BUILD_DARTPY: ON
-        BUILD_TYPE: Release
-      run: |
-        docker build -t "${DOCKERFILE,,}" -f ".ci/docker/$DOCKERFILE" .;
-        docker run -itd -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --env-file ./.ci/docker/env.list --name dart-docker "${DOCKERFILE,,}";
-        docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/install.sh";
-    - name: Build
-      run: |
-        docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
-
   focal_gcc_release:
     name: Ubuntu 20.04 [GCC|Release]
     runs-on: ubuntu-18.04

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -106,7 +106,7 @@ jobs:
       run: |
         docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
 
-  mojav_clang_release:
+  catalina_clang_release:
     name: macOS 10.15 [Clang|Release]
     runs-on: macOS-10.15
     steps:
@@ -121,7 +121,7 @@ jobs:
         BUILD_TYPE: Release
       run: sudo -E .ci/script.sh
 
-  mojav_clang_dartpy_release:
+  catalina_clang_dartpy_release:
     name: macOS 10.15 [Clang|dartpy|Release]
     runs-on: macOS-10.15
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
   * Added ConeShape support for FCLCollisionDetector: [#1447](https://github.com/dartsim/dart/pull/1447)
   * Fixed segfault from raycast when no ray hit: [#1461](https://github.com/dartsim/dart/pull/1461)
+  * Added PyramidShape class: [#1466](https://github.com/dartsim/dart/pull/1466)
 
 * Kinematics
 

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -122,7 +122,6 @@ namespace fcl {
 using Vector3 = ::fcl::Vector3<double>;
 using Matrix3 = ::fcl::Matrix3<double>;
 using Transform3 = ::fcl::Transform3<double>;
-using Triangle = ::fcl::Triangle<double>;
 // Geometric primitives
 using Box = ::fcl::Box<double>;
 using Cylinder = ::fcl::Cylinder<double>;
@@ -149,7 +148,6 @@ using Contact = ::fcl::Contact<double>;
 using Vector3 = ::fcl::Vec3f;
 using Matrix3 = ::fcl::Matrix3f;
 using Transform3 = ::fcl::Transform3f;
-using Triangle = ::fcl::Triangle;
 // Geometric primitives
 using Box = ::fcl::Box;
 using Cylinder = ::fcl::Cylinder;

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -122,6 +122,7 @@ namespace fcl {
 using Vector3 = ::fcl::Vector3<double>;
 using Matrix3 = ::fcl::Matrix3<double>;
 using Transform3 = ::fcl::Transform3<double>;
+using Triangle = ::fcl::Triangle<double>;
 // Geometric primitives
 using Box = ::fcl::Box<double>;
 using Cylinder = ::fcl::Cylinder<double>;
@@ -148,6 +149,7 @@ using Contact = ::fcl::Contact<double>;
 using Vector3 = ::fcl::Vec3f;
 using Matrix3 = ::fcl::Matrix3f;
 using Transform3 = ::fcl::Transform3f;
+using Triangle = ::fcl::Triangle;
 // Geometric primitives
 using Box = ::fcl::Box;
 using Cylinder = ::fcl::Cylinder;

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -509,11 +509,19 @@ template <typename BV>
   const double front = -d / 2;
   const double back = d / 2;
 
+#if FCL_VERSION_AT_LEAST(0, 6, 0)
+  points[0] << 0, 0, hTop;
+  points[1] << right, back, hBottom;
+  points[2] << left, back, hBottom;
+  points[3] << left, front, hBottom;
+  points[4] << right, front, hBottom;
+#else
   points[0].setValue(0, 0, hTop);
   points[1].setValue(right, back, hBottom);
   points[2].setValue(left, back, hBottom);
   points[3].setValue(left, front, hBottom);
   points[4].setValue(right, front, hBottom);
+#endif
 
   faces[0].set(0, 1, 2);
   faces[1].set(0, 2, 3);
@@ -524,7 +532,11 @@ template <typename BV>
 
   for (unsigned int i = 0; i < points.size(); ++i)
   {
+#if FCL_VERSION_AT_LEAST(0, 6, 0)
+    points[i] = pose * points[i];
+#else
     points[i] = pose.transform(points[i]);
+#endif
   }
 
   model->beginModel();

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -496,7 +496,7 @@ template <typename BV>
   ::fcl::BVHModel<BV>* model = new ::fcl::BVHModel<BV>;
 
   std::vector<fcl::Vector3> points(5);
-  std::vector<fcl::Triangle> faces(6);
+  std::vector<::fcl::Triangle> faces(6);
 
   const double w = shape.getBaseWidth();
   const double d = shape.getBaseDepth();

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -102,7 +102,7 @@ void BoxedLcpConstraintSolver::setBoxedLcpSolver(BoxedLcpSolverPtr lcpSolver)
   if (!lcpSolver)
   {
     dtwarn << "[BoxedLcpConstraintSolver::setBoxedLcpSolver] "
-           << "nullptr for boxed LCP solver is not allowed.";
+           << "nullptr for boxed LCP solver is not allowed.\n";
     return;
   }
 

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -75,7 +75,7 @@ double PyramidShape::getBaseWidth() const
 //==============================================================================
 void PyramidShape::setBaseWidth(double width)
 {
-  assert(0.0 < radius);
+  assert(0.0 < width);
   mBaseWidth = width;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -92,7 +92,7 @@ double PyramidShape::getBaseDepth() const
 //==============================================================================
 void PyramidShape::setBaseDepth(double depth)
 {
-  assert(0.0 < radius);
+  assert(0.0 < depth);
   mBaseDepth = depth;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/PyramidShape.hpp"
+
+#include <cmath>
+#include "dart/common/Console.hpp"
+#include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/SphereShape.hpp"
+#include "dart/math/Helpers.hpp"
+
+namespace dart {
+namespace dynamics {
+
+//==============================================================================
+PyramidShape::PyramidShape(double baseWidth, double baseDepth, double height)
+  : Shape(PYRAMID),
+    mBaseWidth(baseWidth),
+    mBaseDepth(baseDepth),
+    mHeight(height)
+{
+  assert(0.0 < baseWidth);
+  assert(0.0 < baseDepth);
+  assert(0.0 < height);
+}
+
+//==============================================================================
+const std::string& PyramidShape::getType() const
+{
+  return getStaticType();
+}
+
+//==============================================================================
+const std::string& PyramidShape::getStaticType()
+{
+  static const std::string type("PyramidShape");
+  return type;
+}
+
+//==============================================================================
+double PyramidShape::getBaseWidth() const
+{
+  return mBaseWidth;
+}
+
+//==============================================================================
+void PyramidShape::setBaseWidth(double width)
+{
+  assert(0.0 < radius);
+  mBaseWidth = width;
+  mIsBoundingBoxDirty = true;
+  mIsVolumeDirty = true;
+
+  incrementVersion();
+}
+
+//==============================================================================
+double PyramidShape::getBaseDepth() const
+{
+  return mBaseDepth;
+}
+
+//==============================================================================
+void PyramidShape::setBaseDepth(double depth)
+{
+  assert(0.0 < radius);
+  mBaseDepth = depth;
+  mIsBoundingBoxDirty = true;
+  mIsVolumeDirty = true;
+
+  incrementVersion();
+}
+
+//==============================================================================
+double PyramidShape::getHeight() const
+{
+  return mHeight;
+}
+
+//==============================================================================
+void PyramidShape::setHeight(double height)
+{
+  assert(0.0 < height);
+  mHeight = height;
+  mIsBoundingBoxDirty = true;
+  mIsVolumeDirty = true;
+
+  incrementVersion();
+}
+
+//==============================================================================
+double PyramidShape::computeVolume(
+    double baseWidth, double baseDepth, double height)
+{
+  return (1.0 / 3.0) * baseWidth * baseDepth * height;
+}
+
+//==============================================================================
+void PyramidShape::updateBoundingBox() const
+{
+  const Eigen::Vector3d corner(
+      0.5 * mBaseWidth, 0.5 * mBaseDepth, 0.5 * mHeight);
+
+  mBoundingBox.setMin(-corner);
+  mBoundingBox.setMax(corner);
+
+  mIsBoundingBoxDirty = false;
+}
+
+//==============================================================================
+void PyramidShape::updateVolume() const
+{
+  mVolume = computeVolume(mBaseWidth, mBaseDepth, mHeight);
+  mIsVolumeDirty = false;
+}
+
+//==============================================================================
+Eigen::Matrix3d PyramidShape::computeInertia(double /*mass*/) const
+{
+  // TODO(JS): Not implemented
+  dterr << "[PyramidShape] Moment of inertia computation is not implemented. "
+        << "Returning identity.\n";
+
+  return Eigen::Matrix3d::Identity();
+}
+
+} // namespace dynamics
+} // namespace dart

--- a/dart/dynamics/PyramidShape.hpp
+++ b/dart/dynamics/PyramidShape.hpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_PYRAMIDSHAPE_HPP_
+#define DART_DYNAMICS_PYRAMIDSHAPE_HPP_
+
+#include "dart/dynamics/Shape.hpp"
+
+namespace dart {
+namespace dynamics {
+
+/// PyramidShape represents a polyhedron formed by connecting a rectangular base
+/// and a point (apex) where each base edge and apex form a triangle.
+///
+/// The origin of the reference frame is at the center of a rectangular that
+/// intersect the pyramid and is parallel to the base. The line from the origin
+/// to the apex is aligned with the Z-axis while the lateral and the
+/// longitudinal lengths of the base are aligned with the X-axis and Y-axis,
+/// respectively.
+class PyramidShape : public Shape
+{
+public:
+  /// Constructor.
+  ///
+  /// \param[in] baseWidth Lateral length (along X-axis) of the rectangular
+  /// base.
+  /// \param[in] baseDepth Longitudinal length (along Y-axis) of the rectangular
+  /// base.
+  /// \param[in] height Perpendicular height from the base to the apex.
+  PyramidShape(double baseWidth, double baseDepth, double height);
+
+  // Documentation inherited.
+  const std::string& getType() const override;
+
+  /// Returns shape type string for this shape.
+  static const std::string& getStaticType();
+
+  /// Returns the lateral length (algon X-axis) of the base.
+  double getBaseWidth() const;
+
+  /// Sets the lateral length (algon X-axis) of the base.
+  void setBaseWidth(double width);
+
+  /// Returns the longitudinal length (algon Y-axis) of the base.
+  double getBaseDepth() const;
+
+  /// Sets the longitudinal length (algon Y-axis) of the base.
+  void setBaseDepth(double depth);
+
+  /// Returns the perpendicular height from the base to the apex.
+  double getHeight() const;
+
+  /// Returns the Perpendicular height from the base to the apex.
+  void setHeight(double height);
+
+  /// Computes the volume given properties.
+  ///
+  /// \param[in] baseWidth Lateral length (along X-axis) of the rectangular
+  /// base.
+  /// \param[in] baseDepth Longitudinal length (along Y-axis) of the rectangular
+  /// base.
+  /// \param[in] height Perpendicular height from the base to the apex.
+  static double computeVolume(
+      double baseWidth, double baseDepth, double height);
+
+  // Documentation inherited.
+  Eigen::Matrix3d computeInertia(double mass) const override;
+
+protected:
+  // Documentation inherited.
+  void updateBoundingBox() const override;
+
+  // Documentation inherited.
+  void updateVolume() const override;
+
+private:
+  /// Lateral length (algon X-axis) of the base.
+  double mBaseWidth;
+
+  /// Longitudinal length (algon Y-axis) of the base.
+  double mBaseDepth;
+
+  /// Perpendicular height from the base to the apex.
+  double mHeight;
+};
+
+} // namespace dynamics
+} // namespace dart
+
+#endif // DART_DYNAMICS_PYRAMIDSHAPE_HPP_

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -63,6 +63,8 @@ public:
     CYLINDER,
     CAPSULE,
     CONE,
+    PYRAMID,
+    RECTANGULAR_PYRAMID,
     PLANE,
     MULTISPHERE,
     MESH,

--- a/dart/gui/OpenGLRenderInterface.cpp
+++ b/dart/gui/OpenGLRenderInterface.cpp
@@ -473,6 +473,62 @@ void OpenGLRenderInterface::drawCone(double radius, double height)
   gluDisk(quadObj, 0, radius, slices, stacks);
 }
 
+//==============================================================================
+Eigen::Vector3d computeNormal(
+    const Eigen::Vector3d& v1,
+    const Eigen::Vector3d& v2,
+    const Eigen::Vector3d& v3)
+{
+  return (v1 - v2).cross(v2 - v3).normalized();
+}
+
+//==============================================================================
+void OpenGLRenderInterface::drawPyramid(
+    double baseWidth, double baseDepth, double height)
+{
+  const double w = baseWidth;
+  const double d = baseDepth;
+  const double h = height;
+
+  const double hTop = h / 2;
+  const double hBottom = -hTop;
+  const double left = -w / 2;
+  const double right = w / 2;
+  const double front = -d / 2;
+  const double back = d / 2;
+
+  std::vector<Eigen::Vector3d> points(5);
+  std::vector<Eigen::Vector3i> faces(6);
+
+  points[0] << 0, 0, hTop;
+  points[1] << right, back, hBottom;
+  points[2] << left, back, hBottom;
+  points[3] << left, front, hBottom;
+  points[4] << right, front, hBottom;
+
+  faces[0] << 0, 1, 2;
+  faces[1] << 0, 2, 3;
+  faces[2] << 0, 3, 4;
+  faces[3] << 0, 4, 1;
+  faces[4] << 1, 3, 2;
+  faces[5] << 1, 4, 3;
+
+  glBegin(GL_TRIANGLES);
+  for (const auto& face : faces)
+  {
+    const auto& p1 = points[static_cast<size_t>(face[0])];
+    const auto& p2 = points[static_cast<size_t>(face[1])];
+    const auto& p3 = points[static_cast<size_t>(face[2])];
+    const Eigen::Vector3d n = computeNormal(p1, p2, p3);
+
+    glNormal3dv(n.data());
+    glVertex3dv(p1.data());
+    glVertex3dv(p2.data());
+    glVertex3dv(p3.data());
+  }
+  glEnd();
+}
+
 void OpenGLRenderInterface::color4_to_float4(const aiColor4D* c, float f[4])
 {
   f[0] = c->r;

--- a/dart/gui/OpenGLRenderInterface.hpp
+++ b/dart/gui/OpenGLRenderInterface.hpp
@@ -116,6 +116,7 @@ public:
       int stacks = 16) override;
   void drawCapsule(double radius, double height) override;
   void drawCone(double radius, double height) override;
+  void drawPyramid(double baseWidth, double baseDepth, double height) override;
   void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh) override;
   void drawSoftMesh(const aiMesh* mesh) override;
   void drawList(GLuint index) override;

--- a/dart/gui/RenderInterface.cpp
+++ b/dart/gui/RenderInterface.cpp
@@ -176,6 +176,11 @@ void RenderInterface::drawCone(double /*_radius*/, double /*_height*/)
 {
 }
 
+void RenderInterface::drawPyramid(
+    double /*baseWidth*/, double /*baseDepth*/, double /*height*/)
+{
+}
+
 void RenderInterface::setPenColor(const Eigen::Vector4d& /*_col*/)
 {
 }

--- a/dart/gui/RenderInterface.hpp
+++ b/dart/gui/RenderInterface.hpp
@@ -122,6 +122,7 @@ public:
       double _radius, double _height, int slices = 16, int stacks = 16);
   virtual void drawCapsule(double _radius, double _height);
   virtual void drawCone(double _radius, double _height);
+  virtual void drawPyramid(double baseWidth, double baseDepth, double height);
   virtual void drawMesh(const Eigen::Vector3d& _scale, const aiScene* _mesh);
   virtual void drawSoftMesh(const aiMesh* mesh);
   virtual void drawList(unsigned int index);

--- a/dart/gui/glut/SimWindow.cpp
+++ b/dart/gui/glut/SimWindow.cpp
@@ -54,6 +54,7 @@
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/PyramidShape.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/dynamics/SoftBodyNode.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
@@ -438,6 +439,7 @@ void SimWindow::drawShape(
   using dynamics::MeshShape;
   using dynamics::MultiSphereConvexHullShape;
   using dynamics::PlaneShape;
+  using dynamics::PyramidShape;
   using dynamics::Shape;
   using dynamics::SoftMeshShape;
   using dynamics::SphereShape;
@@ -471,6 +473,12 @@ void SimWindow::drawShape(
   {
     const auto* cone = static_cast<const ConeShape*>(shape);
     mRI->drawCone(cone->getRadius(), cone->getHeight());
+  }
+  else if (shape->is<PyramidShape>())
+  {
+    const auto* pyramid = static_cast<const PyramidShape*>(shape);
+    mRI->drawPyramid(
+        pyramid->getBaseWidth(), pyramid->getBaseDepth(), pyramid->getHeight());
   }
   else if (shape->is<MultiSphereConvexHullShape>())
   {

--- a/dart/gui/osg/ShapeFrameNode.cpp
+++ b/dart/gui/osg/ShapeFrameNode.cpp
@@ -46,6 +46,7 @@
 #include "dart/gui/osg/render/MultiSphereShapeNode.hpp"
 #include "dart/gui/osg/render/PlaneShapeNode.hpp"
 #include "dart/gui/osg/render/PointCloudShapeNode.hpp"
+#include "dart/gui/osg/render/PyramidShapeNode.hpp"
 #include "dart/gui/osg/render/ShapeNode.hpp"
 #include "dart/gui/osg/render/SoftMeshShapeNode.hpp"
 #include "dart/gui/osg/render/SphereShapeNode.hpp"
@@ -67,6 +68,7 @@
 #include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
 #include "dart/dynamics/PointCloudShape.hpp"
+#include "dart/dynamics/PyramidShape.hpp"
 #include "dart/dynamics/ShapeFrame.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
@@ -261,6 +263,15 @@ void ShapeFrameNode::createShapeNode(
     std::shared_ptr<ConeShape> cs = std::dynamic_pointer_cast<ConeShape>(shape);
     if (cs)
       mRenderShapeNode = new render::ConeShapeNode(cs, this);
+    else
+      warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
+  }
+  else if (PyramidShape::getStaticType() == shapeType)
+  {
+    std::shared_ptr<PyramidShape> cs
+        = std::dynamic_pointer_cast<PyramidShape>(shape);
+    if (cs)
+      mRenderShapeNode = new render::PyramidShapeNode(cs, this);
     else
       warnAboutUnsuccessfulCast(shapeType, mShapeFrame->getName());
   }

--- a/dart/gui/osg/render/PyramidShapeNode.cpp
+++ b/dart/gui/osg/render/PyramidShapeNode.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <array>
+
 #include <osg/CullFace>
 #include <osg/Geode>
 #include <osg/Geometry>

--- a/dart/gui/osg/render/PyramidShapeNode.cpp
+++ b/dart/gui/osg/render/PyramidShapeNode.cpp
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <osg/CullFace>
+#include <osg/Geode>
+#include <osg/Geometry>
+#include <osg/LineWidth>
+#include <osg/ShapeDrawable>
+
+#include "dart/gui/osg/ShapeFrameNode.hpp"
+#include "dart/gui/osg/Utils.hpp"
+#include "dart/gui/osg/render/PyramidShapeNode.hpp"
+
+#include "dart/dynamics/PyramidShape.hpp"
+#include "dart/dynamics/SimpleFrame.hpp"
+
+namespace dart {
+namespace gui {
+namespace osg {
+namespace render {
+
+class PyramidShapeGeode : public ShapeNode, public ::osg::Geode
+{
+public:
+  PyramidShapeGeode(
+      std::shared_ptr<dart::dynamics::PyramidShape> shape,
+      ShapeFrameNode* parent);
+
+  void refresh();
+  void extractData(bool firstTime);
+
+protected:
+  virtual ~PyramidShapeGeode();
+
+  std::shared_ptr<dart::dynamics::PyramidShape> mPyramidShape;
+  PyramidShapeDrawable* mDrawable;
+
+  ::osg::ref_ptr<::osg::LineWidth> mLineWidth;
+};
+
+//==============================================================================
+class PyramidShapeDrawable : public ::osg::Geometry
+{
+public:
+  PyramidShapeDrawable(
+      dart::dynamics::PyramidShape* shape,
+      dart::dynamics::VisualAspect* visualAspect);
+
+  void refresh(bool firstTime);
+
+protected:
+  virtual ~PyramidShapeDrawable();
+
+  dart::dynamics::PyramidShape* mPyramidShape;
+  dart::dynamics::VisualAspect* mVisualAspect;
+
+  ::osg::ref_ptr<::osg::Vec3Array> mVertices;
+  ::osg::ref_ptr<::osg::Vec3Array> mNormals;
+  ::osg::ref_ptr<::osg::Vec4Array> mColors;
+  std::array<::osg::ref_ptr<::osg::DrawElementsUInt>, 6> mElements;
+};
+
+//==============================================================================
+PyramidShapeNode::PyramidShapeNode(
+    std::shared_ptr<dart::dynamics::PyramidShape> shape, ShapeFrameNode* parent)
+  : ShapeNode(shape, parent, this), mPyramidShape(shape), mGeode(nullptr)
+{
+  mNode = this;
+  extractData(true);
+  setNodeMask(mVisualAspect->isHidden() ? 0x0 : ~0x0);
+}
+
+//==============================================================================
+void PyramidShapeNode::refresh()
+{
+  mUtilized = true;
+
+  setNodeMask(mVisualAspect->isHidden() ? 0x0 : ~0x0);
+
+  if (mShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    return;
+
+  extractData(false);
+}
+
+//==============================================================================
+void PyramidShapeNode::extractData(bool /*firstTime*/)
+{
+  if (nullptr == mGeode)
+  {
+    mGeode = new PyramidShapeGeode(mPyramidShape, mParentShapeFrameNode);
+    addChild(mGeode);
+    return;
+  }
+
+  mGeode->refresh();
+}
+
+//==============================================================================
+PyramidShapeNode::~PyramidShapeNode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+PyramidShapeGeode::PyramidShapeGeode(
+    std::shared_ptr<dart::dynamics::PyramidShape> shape, ShapeFrameNode* parent)
+  : ShapeNode(shape, parent, this),
+    mPyramidShape(shape),
+    mDrawable(nullptr),
+    mLineWidth(new ::osg::LineWidth)
+{
+  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+  getOrCreateStateSet()->setAttributeAndModes(
+      new ::osg::CullFace(::osg::CullFace::BACK));
+  getOrCreateStateSet()->setMode(GL_LIGHTING, ::osg::StateAttribute::ON);
+  extractData(true);
+}
+
+//==============================================================================
+void PyramidShapeGeode::refresh()
+{
+  mUtilized = true;
+
+  extractData(false);
+}
+
+//==============================================================================
+void PyramidShapeGeode::extractData(bool /*firstTime*/)
+{
+  if (nullptr == mDrawable)
+  {
+    mDrawable = new PyramidShapeDrawable(mPyramidShape.get(), mVisualAspect);
+    addDrawable(mDrawable);
+    return;
+  }
+
+  mDrawable->refresh(false);
+}
+
+//==============================================================================
+PyramidShapeGeode::~PyramidShapeGeode()
+{
+  // Do nothing
+}
+
+//==============================================================================
+PyramidShapeDrawable::PyramidShapeDrawable(
+    dart::dynamics::PyramidShape* shape,
+    dart::dynamics::VisualAspect* visualAspect)
+  : mPyramidShape(shape),
+    mVisualAspect(visualAspect),
+    mVertices(new ::osg::Vec3Array),
+    mNormals(new ::osg::Vec3Array),
+    mColors(new ::osg::Vec4Array)
+{
+  for (auto& e : mElements)
+  {
+    e = new ::osg::DrawElementsUInt(::osg::PrimitiveSet::TRIANGLES);
+    addPrimitiveSet(e);
+  }
+  refresh(true);
+}
+
+//==============================================================================
+void PyramidShapeDrawable::refresh(bool firstTime)
+{
+  if (mPyramidShape->getDataVariance() == dart::dynamics::Shape::STATIC)
+    setDataVariance(::osg::Object::STATIC);
+  else
+    setDataVariance(::osg::Object::DYNAMIC);
+
+  if (firstTime)
+  {
+    for (auto& e : mElements)
+      e->resize(3);
+
+    // Side triangle 1
+    mElements[0]->at(0) = 0;
+    mElements[0]->at(1) = 1;
+    mElements[0]->at(2) = 2;
+
+    // Side triangle 2
+    mElements[1]->at(0) = 0;
+    mElements[1]->at(1) = 2;
+    mElements[1]->at(2) = 3;
+
+    // Side triangle 3
+    mElements[2]->at(0) = 0;
+    mElements[2]->at(1) = 3;
+    mElements[2]->at(2) = 4;
+
+    // Side triangle 4
+    mElements[3]->at(0) = 0;
+    mElements[3]->at(1) = 4;
+    mElements[3]->at(2) = 1;
+
+    // Base triangle 1
+    mElements[4]->at(0) = 1;
+    mElements[4]->at(1) = 3;
+    mElements[4]->at(2) = 2;
+
+    // Base triangle 2
+    mElements[5]->at(0) = 1;
+    mElements[5]->at(1) = 4;
+    mElements[5]->at(2) = 3;
+
+    setPrimitiveSet(0, mElements[0]);
+    setPrimitiveSet(1, mElements[1]);
+    setPrimitiveSet(2, mElements[2]);
+    setPrimitiveSet(3, mElements[3]);
+    setPrimitiveSet(4, mElements[4]);
+    setPrimitiveSet(5, mElements[5]);
+  }
+
+  if (mPyramidShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_VERTICES)
+      || firstTime)
+  {
+    const float w = static_cast<float>(mPyramidShape->getBaseWidth());
+    const float d = static_cast<float>(mPyramidShape->getBaseDepth());
+    const float h = static_cast<float>(mPyramidShape->getBaseWidth());
+
+    const float hTop = h / 2;
+    const float hBottom = -hTop;
+    const float left = -w / 2;
+    const float right = w / 2;
+    const float front = -d / 2;
+    const float back = d / 2;
+
+    mVertices->resize(5);
+    mVertices->at(0).set(0, 0, hTop);
+    mVertices->at(1).set(right, back, hBottom);
+    mVertices->at(2).set(left, back, hBottom);
+    mVertices->at(3).set(left, front, hBottom);
+    mVertices->at(4).set(right, front, hBottom);
+    setVertexArray(mVertices);
+
+    mNormals->clear();
+    mNormals->reserve(mElements.size()); // 6
+    for (const auto& e : mElements)
+    {
+      const auto& v1 = mVertices->at(e->at(0));
+      const auto& v2 = mVertices->at(e->at(1));
+      const auto& v3 = mVertices->at(e->at(2));
+      ::osg::Vec3 n = (v1 - v2) ^ (v2 - v3);
+      n.normalize();
+
+      mNormals->push_back(n);
+    }
+    setNormalArray(mNormals, ::osg::Array::BIND_PER_PRIMITIVE_SET);
+  }
+
+  if (mPyramidShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
+      || firstTime)
+  {
+    if (mColors->size() != 1)
+      mColors->resize(1);
+
+    (*mColors)[0] = eigToOsgVec4d(mVisualAspect->getRGBA());
+
+    setColorArray(mColors, ::osg::Array::BIND_OVERALL);
+  }
+}
+
+//==============================================================================
+PyramidShapeDrawable::~PyramidShapeDrawable()
+{
+  // Do nothing
+}
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart

--- a/dart/gui/osg/render/PyramidShapeNode.hpp
+++ b/dart/gui/osg/render/PyramidShapeNode.hpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-2019, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_GUI_OSG_RENDER_PYRAMIDSHAPENODE_HPP_
+#define DART_GUI_OSG_RENDER_PYRAMIDSHAPENODE_HPP_
+
+#include <osg/MatrixTransform>
+
+#include "dart/gui/osg/render/ShapeNode.hpp"
+
+namespace dart {
+
+namespace dynamics {
+class PyramidShape;
+} // namespace dynamics
+
+namespace gui {
+namespace osg {
+namespace render {
+
+class PyramidShapeGeode;
+class PyramidShapeDrawable;
+
+class PyramidShapeNode : public ShapeNode, public ::osg::Group
+{
+public:
+  PyramidShapeNode(
+      std::shared_ptr<dart::dynamics::PyramidShape> shape,
+      ShapeFrameNode* parent);
+
+  void refresh();
+  void extractData(bool firstTime);
+
+protected:
+  virtual ~PyramidShapeNode();
+
+  std::shared_ptr<dart::dynamics::PyramidShape> mPyramidShape;
+  PyramidShapeGeode* mGeode;
+};
+
+} // namespace render
+} // namespace osg
+} // namespace gui
+} // namespace dart
+
+#endif // DART_GUI_OSG_RENDER_PYRAMIDSHAPENODE_HPP_

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -61,6 +61,7 @@
 #include "dart/dynamics/PlanarJoint.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
 #include "dart/dynamics/PrismaticJoint.hpp"
+#include "dart/dynamics/PyramidShape.hpp"
 #include "dart/dynamics/RevoluteJoint.hpp"
 #include "dart/dynamics/ScrewJoint.hpp"
 #include "dart/dynamics/ShapeNode.hpp"
@@ -1340,6 +1341,15 @@ dynamics::ShapePtr readShape(
     double radius = getValueDouble(coneEle, "radius");
     double height = getValueDouble(coneEle, "height");
     newShape = dynamics::ShapePtr(new dynamics::ConeShape(radius, height));
+  }
+  else if (hasElement(geometryEle, "pyramid"))
+  {
+    tinyxml2::XMLElement* coneEle = getElement(geometryEle, "pyramid");
+    double base_width = getValueDouble(coneEle, "base_width");
+    double base_depth = getValueDouble(coneEle, "base_depth");
+    double height = getValueDouble(coneEle, "height");
+    newShape = dynamics::ShapePtr(
+        new dynamics::PyramidShape(base_width, base_depth, height));
   }
   else if (hasElement(geometryEle, "plane"))
   {

--- a/data/skel/shapes.skel
+++ b/data/skel/shapes.skel
@@ -37,7 +37,7 @@
         <skeleton name="box skeleton">
             <body name="box">
                 <gravity>1</gravity>
-                <transformation>-0.4 -0.0 0 1 2 3</transformation>
+                <transformation>-0.6 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>
@@ -70,7 +70,7 @@
         <skeleton name="sphere skeleton">
             <body name="sphere">
                 <gravity>1</gravity>
-                <transformation>-0.2 -0.0 0 1 2 3</transformation>
+                <transformation>-0.4 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>
@@ -103,7 +103,7 @@
         <skeleton name="ellipsoid skeleton">
             <body name="ellipsoid">
                 <gravity>1</gravity>
-                <transformation>-0.0 -0.0 0 1 2 3</transformation>
+                <transformation>-0.2 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>
@@ -136,7 +136,7 @@
         <skeleton name="cylinder skeleton">
             <body name="cylinder">
                 <gravity>1</gravity>
-                <transformation>0.2 -0.0 0 1 2 3</transformation>
+                <transformation>0.0 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>
@@ -171,7 +171,7 @@
         <skeleton name="capsule skeleton">
             <body name="capsule">
                 <gravity>1</gravity>
-                <transformation>0.4 -0.0 0 1 2 3</transformation>
+                <transformation>0.2 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>
@@ -206,7 +206,7 @@
         <skeleton name="cone skeleton">
             <body name="cone">
                 <gravity>1</gravity>
-                <transformation>0.6 -0.0 0 1 2 3</transformation>
+                <transformation>0.4 -0.0 0 1 2 3</transformation>
                 <inertia>
                     <mass>1</mass>
                     <offset>0 0 0</offset>
@@ -235,6 +235,52 @@
             <joint type="free" name="joint 1">
                 <parent>world</parent>
                 <child>cone</child>
+            </joint>
+        </skeleton>
+
+        <skeleton name="pyramid skeleton">
+            <body name="pyramid">
+                <gravity>1</gravity>
+                <transformation>0.6 -0.0 0 1 2 3</transformation>
+                <inertia>
+                    <mass>1</mass>
+                    <offset>0 0 0</offset>
+                    <!-- MOI is not correct -->
+                    <moment_of_inertia>
+                        <ixx>0.01</ixx>
+                        <iyy>0.01</iyy>
+                        <izz>0.01</izz>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyz>0</iyz>
+                    </moment_of_inertia>
+                </inertia>
+                <visualization_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <pyramid>
+                            <base_width>0.05</base_width>
+                            <base_depth>0.1</base_depth>
+                            <height>0.1</height>
+                        </pyramid>
+                    </geometry>
+                    <color>0.6 0.6 0.8</color>
+                </visualization_shape>
+                <collision_shape>
+                    <transformation>0 0 0 0 0 0</transformation>
+                    <geometry>
+                        <pyramid>
+                            <base_width>0.05</base_width>
+                            <base_depth>0.1</base_depth>
+                            <height>0.1</height>
+                        </pyramid>
+                    </geometry>
+                </collision_shape>
+            </body>
+
+            <joint type="free" name="joint 1">
+                <parent>world</parent>
+                <child>pyramid</child>
             </joint>
         </skeleton>
 


### PR DESCRIPTION
This PR adds the pyramid shape that has a square base. Currently, only FCL supports the shape for collision detection. Like other primitive shapes, the pyramid shape is converted to equivalent mesh with minimal numbers of vertices and faces. Both GLUT and OSG renderer can render the pyramid shape.

The moments of inertia for the pyramid shape is not implemented in this PR.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
