### PR TITLE
Print warning when planning component is being built

### DIFF
--- a/dart/planning/CMakeLists.txt
+++ b/dart/planning/CMakeLists.txt
@@ -7,6 +7,9 @@ dart_check_optional_package(FLANN "dart-planning" "flann" "1.8.4")
 dart_find_package(lz4)
 dart_check_optional_package(lz4 "dart-planning" "lz4")
 
+# Print warning for use of deprecated component
+message(WARNING "The 'planning' component is deprecated and will be removed in DART 7.")
+
 # Search all header and source files
 file(GLOB hdrs "*.hpp")
 file(GLOB srcs "*.cpp")


### PR DESCRIPTION
The planning component is deprecated and will be removed in the next release. This PR adds a warning when the deprecated component is being built.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [x] (N/A) Add unit test(s) for this change
