### PR TITLE
Don't force CMAKE_INSTALL_PREFIX on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ initialize_component_helpers(${PROJECT_NAME})
 
 # System install paths on Windows
 if(WIN32)
-  set(CMAKE_INSTALL_PREFIX "C:/Golems" CACHE PATH "Install prefix" FORCE)
+  set(CMAKE_INSTALL_PREFIX "C:/Golems" CACHE PATH "Install prefix")
 endif()
 
 #===============================================================================


### PR DESCRIPTION
Fixes #1477.

Without this change, it ignores `CMAKE_INSTALL_PREFIX` values specified by the user and always installs to `C:/Golems`.