### PR TITLE
Enforce to use OSG 3.7.0 or greater on macOS Catalina

### DIFF
--- a/.ci/install_osx.sh
+++ b/.ci/install_osx.sh
@@ -3,5 +3,6 @@ set -ex
 
 brew update > /dev/null
 brew bundle || brew bundle
+brew install open-scene-graph --HEAD  # install master branch until 3.7.0 is released
 
 pip3 install -U numpy pytest

--- a/Brewfile
+++ b/Brewfile
@@ -13,7 +13,7 @@ brew 'libccd'
 brew 'nlopt'
 brew 'octomap'
 brew 'ode'
-brew 'open-scene-graph'
+#brew 'open-scene-graph'  # disabled until 3.7.0 is released
 #brew 'pagmo'  # disabled to reduce the build time
 brew 'tinyxml2'
 brew 'urdfdom'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
   * Updated Findfcl.cmake to support FCL 0.6: [#1441](https://github.com/dartsim/dart/pull/1441)
   * Added gtest macros for Eigen object comparisons: [#1443](https://github.com/dartsim/dart/pull/1443)
   * Removed gccfilter: [#1464](https://github.com/dartsim/dart/pull/1464)
+  * Allowed to set CMAKE_INSTALL_PREFIX on Windows: [#1478](https://github.com/dartsim/dart/pull/1478)
+  * Enforced to use OpenSceneGraph 3.7.0 or greater on macOS Catalina: [#1479](https://github.com/dartsim/dart/pull/1479)
 
 ### [DART 6.9.2 (2019-08-16)](https://github.com/dartsim/dart/milestone/60?closed=1)
 

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -5,6 +5,18 @@ set(component_name gui-osg)
 # Dependency checks
 dart_check_dependent_target(${target_name} dart-gui)
 
+# Minimum required OSG version
+set(min_osg_version 3.0.0)
+# OpenSceneGraph 3.6.5 or less are not compatible with macOS 10.15 (Catalina) or greater
+# See:
+#   - https://github.com/openscenegraph/OpenSceneGraph/issues/926
+#   - https://github.com/dartsim/dart/issues/1439
+if(APPLE)
+  if(NOT ${CMAKE_SYSTEM_VERSION} VERSION_LESS 19)
+    set(min_osg_version 3.7.0)
+  endif()
+endif()
+
 # OpenSceneGraph
 if(DART_BUILD_GUI_OSG)
 
@@ -13,7 +25,7 @@ if(DART_BUILD_GUI_OSG)
     set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
   endif()
 
-  find_package(OpenSceneGraph 3.0 QUIET
+  find_package(OpenSceneGraph ${min_osg_version} QUIET
     COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow
   )
 

--- a/examples/speed_test/main.cpp
+++ b/examples/speed_test/main.cpp
@@ -164,7 +164,7 @@ void print_results(const std::vector<double>& result)
       result.begin(),
       result.end(),
       diff.begin(),
-      std::bind2nd(std::minus<double>(), mean));
+      std::bind(std::minus<double>(), mean, std::placeholders::_1));
   double stddev = std::sqrt(
       std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0)
       / result.size());


### PR DESCRIPTION
OpenSceneGraph 3.6.5 or less are not compatible with macOS 10.15 (Catalina) or greater (https://github.com/openscenegraph/OpenSceneGraph/issues/926, https://github.com/dartsim/dart/issues/1439). This PR increases the required minimum OSG version for macOS Catalina to 3.7.0 that includes the [fix](https://github.com/openscenegraph/OpenSceneGraph/pull/944).

Resolves #1439

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change (N/A)
