### PR TITLE
Fix mixed intrinsic and extrinsic camera parameters in OpenGL projection matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   * Fixed refresh of LineSegmentShapeNode: [#1381](https://github.com/dartsim/dart/pull/1381)
   * Fixed OSG transparent object sorting: [#1414](https://github.com/dartsim/dart/pull/1414)
   * Added modifier key support to ImGuiHandler: [#1436](https://github.com/dartsim/dart/pull/1436)
+  * Fixed mixed intrinsic and extrinsic camera parameters in OpenGL projection matrix: [#1485](https://github.com/dartsim/dart/pull/1485)
 
 * Parser
 
@@ -77,6 +78,10 @@
   * Removed gccfilter: [#1464](https://github.com/dartsim/dart/pull/1464)
   * Allowed to set CMAKE_INSTALL_PREFIX on Windows: [#1478](https://github.com/dartsim/dart/pull/1478)
   * Enforced to use OpenSceneGraph 3.7.0 or greater on macOS Catalina: [#1479](https://github.com/dartsim/dart/pull/1479)
+
+* Documentation
+
+  * Updated tutorial documentation and code to reflect new APIs: [#1481](https://github.com/dartsim/dart/pull/1481)
 
 ### [DART 6.9.2 (2019-08-16)](https://github.com/dartsim/dart/milestone/60?closed=1)
 

--- a/dart/gui/glut/MotionBlurSimWindow.cpp
+++ b/dart/gui/glut/MotionBlurSimWindow.cpp
@@ -101,11 +101,11 @@ void MotionBlurSimWindow::render()
           static_cast<double>(mWinWidth) / static_cast<double>(mWinHeight),
           0.1,
           10.0);
-      gluLookAt(
-          mEye[0], mEye[1], mEye[2], 0.0, 0.0, -1.0, mUp[0], mUp[1], mUp[2]);
 
       glMatrixMode(GL_MODELVIEW);
       glLoadIdentity();
+      gluLookAt(
+          mEye[0], mEye[1], mEye[2], 0.0, 0.0, -1.0, mUp[0], mUp[1], mUp[2]);
       initGL();
 
       mTrackBall.applyGLRotation();
@@ -165,11 +165,11 @@ void MotionBlurSimWindow::render()
         static_cast<double>(mWinWidth) / static_cast<double>(mWinHeight),
         0.1,
         10.0);
-    gluLookAt(
-        mEye[0], mEye[1], mEye[2], 0.0, 0.0, -1.0, mUp[0], mUp[1], mUp[2]);
 
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
+    gluLookAt(
+        mEye[0], mEye[1], mEye[2], 0.0, 0.0, -1.0, mUp[0], mUp[1], mUp[2]);
     initGL();
 
     mTrackBall.applyGLRotation();

--- a/dart/gui/glut/Win3D.cpp
+++ b/dart/gui/glut/Win3D.cpp
@@ -206,10 +206,10 @@ void Win3D::render()
       static_cast<double>(mWinWidth) / static_cast<double>(mWinHeight),
       0.1,
       10.0);
-  gluLookAt(mEye[0], mEye[1], mEye[2], 0.0, 0.0, -1.0, mUp[0], mUp[1], mUp[2]);
 
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
+  gluLookAt(mEye[0], mEye[1], mEye[2], 0.0, 0.0, -1.0, mUp[0], mUp[1], mUp[2]);
   initGL();
 
   mTrackBall.applyGLRotation();


### PR DESCRIPTION
This PR fixes the incorrect projection matrix computation in OpenGL due to the misplaced `gluLookAt()` calls.

Fixes #1484.

***

**Before creating a pull request**

- [x] (N/A) Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] (N/A) Add unit test(s) for this change 
