### PR TITLE
Support IN_LIST operator in DARTConfig.cmake (6.9 backport)

### DIFF
--- a/cmake/DARTConfig.cmake.in
+++ b/cmake/DARTConfig.cmake.in
@@ -10,6 +10,20 @@
 #   dart     - Main target.
 #   dart-<C> - Target for specific component (e.g., dart-collision-bullet).
 
+# Specify CMake minimum required version
+if(NOT CMAKE_MINIMUM_REQUIRED_VERSION)
+  if(MSVC)
+    cmake_minimum_required(VERSION 3.8.0)
+  else()
+    cmake_minimum_required(VERSION 3.5.1)
+  endif()
+else()
+  # Support if() IN_LIST operator
+  if(POLICY CMP0057)
+    cmake_policy(SET CMP0057 NEW)
+  endif()
+endif()
+
 #===============================================================================
 # Helper Function Definitions
 #===============================================================================

--- a/cmake/DARTFindBullet.cmake
+++ b/cmake/DARTFindBullet.cmake
@@ -12,6 +12,7 @@
 find_package(Bullet COMPONENTS BulletMath BulletCollision MODULE QUIET)
 
 if((BULLET_FOUND OR Bullet_FOUND) AND NOT TARGET Bullet)
+  cmake_policy(SET CMP0057 NEW)
   if(WIN32 AND "optimized" IN_LIST BULLET_LIBRARIES
            AND     "debug" IN_LIST BULLET_LIBRARIES)
     cmake_parse_arguments(BULLET_INTERFACE_LIBRARIES "" "" "debug;optimized"

--- a/cmake/DARTFindBullet.cmake
+++ b/cmake/DARTFindBullet.cmake
@@ -12,7 +12,6 @@
 find_package(Bullet COMPONENTS BulletMath BulletCollision MODULE QUIET)
 
 if((BULLET_FOUND OR Bullet_FOUND) AND NOT TARGET Bullet)
-  cmake_policy(SET CMP0057 NEW)
   if(WIN32 AND "optimized" IN_LIST BULLET_LIBRARIES
            AND     "debug" IN_LIST BULLET_LIBRARIES)
     cmake_parse_arguments(BULLET_INTERFACE_LIBRARIES "" "" "debug;optimized"


### PR DESCRIPTION
In DART 6.9.3, the `IN_LIST` keyword in DARTFindBullet caused a configuration error in gazebo10 (see https://github.com/osrf/gazebo/pull/2835). Setting `CMP0057` to new should prevent similar problems in downstream packages.

***

**Before creating a pull request**

- [X] Document new methods and classes
- [X] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
