### PR TITLE
CMake: Add DART_SKIP_<dep> advanced options

### DIFF
--- a/cmake/DARTMacros.cmake
+++ b/cmake/DARTMacros.cmake
@@ -127,7 +127,9 @@ endfunction()
 
 #===============================================================================
 macro(dart_check_optional_package variable component dependency)
-  if(${${variable}_FOUND})
+  option(DART_SKIP_${variable} "If ON, do not use ${variable} even if it is found." OFF)
+  mark_as_advanced(DART_SKIP_${variable})
+  if(${${variable}_FOUND} AND NOT ${DART_SKIP_${variable}})
     set(HAVE_${variable} TRUE CACHE BOOL "Check if ${variable} found." FORCE)
     if(DART_VERBOSE)
       message(STATUS "Looking for ${dependency} - version ${${variable}_VERSION}"
@@ -135,12 +137,17 @@ macro(dart_check_optional_package variable component dependency)
     endif()
   else()
     set(HAVE_${variable} FALSE CACHE BOOL "Check if ${variable} found." FORCE)
-    if(ARGV3) # version
-      message(WARNING "Looking for ${dependency} - NOT found, to use"
-                      " ${component}, please install ${dependency} (>= ${ARGV3})")
-    else()
-      message(WARNING "Looking for ${dependency} - NOT found, to use"
-                      " ${component}, please install ${dependency}")
+    if(NOT ${${variable}_FOUND})
+      if(ARGV3) # version
+        message(WARNING "Looking for ${dependency} - NOT found, to use"
+                        " ${component}, please install ${dependency} (>= ${ARGV3})")
+      else()
+        message(WARNING "Looking for ${dependency} - NOT found, to use"
+                        " ${component}, please install ${dependency}")
+      endif()
+    elseif(${DART_SKIP_${variable}} AND DART_VERBOSE)
+      message(STATUS "Not using ${dependency} - version ${${variable}_VERSION}"
+                     " even if found because DART_SKIP_${variable} is ON.")
     endif()
     return()
   endif()


### PR DESCRIPTION
Add DART_SKIP_<dep> option to permit to specify that a dependency should not used even if it is found in the system.

This is useful in package managers such as vcpkg to ensure that, for a given set of enabled features, the same version of the library is build, independently from which dependency are actually installed in the system. A mpre extended rationale is provided in https://github.com/ignitionrobotics/ign-cmake/issues/63 .

