### PR TITLE
Change dartpy install command to make install-dartpy

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -121,15 +121,16 @@ else
 fi
 
 if [ "$RUN_INSTALL_TEST" = "ON" ]; then
-  # Make sure we can install with no issues
+  # Install C++ package
   make -j$num_threads install
 
   if [ "$BUILD_DARTPY" = "ON" ]; then
-    # Run a python example (experimental)
-    if [ "$BUILD_DARTPY" = "ON" ]; then
-      cd $BUILD_DIR/python/examples/hello_world
-      python3 main.py
-    fi
+    # Install dartpy
+    make -j$num_threads install-dartpy
+
+    # Run a python example
+    cd $BUILD_DIR/python/examples/hello_world
+    python3 main.py
   else
     # Build an example using installed DART
     cd $BUILD_DIR/examples/hello_world

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
   * Fixed TypeError from dartpy.dynamics.Node.getBodyNodePtr(): [#1463](https://github.com/dartsim/dart/pull/1463)
   * Added pybind/eigen.h to DistanceResult.cpp for read/write of eigen types: [#1480](https://github.com/dartsim/dart/pull/1480)
   * Added bindings for adding ShapeFrames to CollisionGroup: [#1490](https://github.com/dartsim/dart/pull/1490)
+  * Changed dartpy install command to make install-dartpy: [#1503](https://github.com/dartsim/dart/pull/1503)
 
 * Build and testing
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,10 +104,6 @@ option(DART_BUILD_DARTPY "Build dartpy (the python binding)" OFF)
 option(DART_FORCE_COLORED_OUTPUT
   "Always produce ANSI-colored output (GNU/Clang only)." OFF)
 
-if(DART_BUILD_DARTPY)
-  set(BUILD_SHARED_LIBS OFF)
-endif()
-
 #===============================================================================
 # Print intro
 #===============================================================================
@@ -301,7 +297,7 @@ add_subdirectory(dart)
 
 set(DART_IN_SOURCE_BUILD TRUE)
 
-if(TARGET dart AND NOT DART_BUILD_DARTPY)
+if(TARGET dart)
 
   # Add a "tests" target to build unit tests.
   enable_testing()
@@ -357,7 +353,7 @@ if (DART_BUILD_DARTPY)
   add_subdirectory(python)
 endif()
 
-if(DART_BUILD_EXTRAS AND NOT DART_BUILD_DARTPY)
+if(DART_BUILD_EXTRAS)
   add_subdirectory(extras)
 endif()
 
@@ -408,12 +404,10 @@ write_basic_config_version_file(
   VERSION ${${PROJECT_NAME_UPPERCASE}_VERSION}
   COMPATIBILITY SameMajorVersion
 )
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${DART_CONFIG_OUT} ${DART_VERSION_OUT}
-    DESTINATION "${CONFIG_INSTALL_DIR}"
-  )
-endif()
+install(
+  FILES ${DART_CONFIG_OUT} ${DART_VERSION_OUT}
+  DESTINATION "${CONFIG_INSTALL_DIR}"
+)
 
 # Generate the DART pkg-config
 set(PC_CONFIG_IN ${CMAKE_SOURCE_DIR}/cmake/dart.pc.in)
@@ -422,41 +416,31 @@ if(DART_VERBOSE)
   message(STATUS ${PC_CONFIG_OUT})
 endif()
 configure_file(${PC_CONFIG_IN} ${PC_CONFIG_OUT} @ONLY)
-if(NOT DART_BUILD_DARTPY)
-  install(FILES ${PC_CONFIG_OUT} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-endif()
+install(FILES ${PC_CONFIG_OUT} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # Install a Catkin 'package.xml' file. This is required by REP-136.
-if(NOT DART_BUILD_DARTPY)
-  install(FILES package.xml DESTINATION
-    ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
-  )
-endif()
+install(FILES package.xml DESTINATION
+  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+)
 
 #===============================================================================
 # Install sample data, examples, and tutorials
 #===============================================================================
 
 # Sample data
-if(NOT DART_BUILD_DARTPY)
-  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data"
-    DESTINATION ${DART_ADDITIONAL_DOCUMENTATION_INSTALL_PATH}
-  )
-endif()
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data"
+  DESTINATION ${DART_ADDITIONAL_DOCUMENTATION_INSTALL_PATH}
+)
 
 # Examples source
-if(NOT DART_BUILD_DARTPY)
-  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/examples"
-    DESTINATION ${DART_ADDITIONAL_DOCUMENTATION_INSTALL_PATH}
-  )
-endif()
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/examples"
+  DESTINATION ${DART_ADDITIONAL_DOCUMENTATION_INSTALL_PATH}
+)
 
 # Tutorials source
-if(NOT DART_BUILD_DARTPY)
-  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/tutorials"
-    DESTINATION ${DART_ADDITIONAL_DOCUMENTATION_INSTALL_PATH}
-  )
-endif()
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/tutorials"
+  DESTINATION ${DART_ADDITIONAL_DOCUMENTATION_INSTALL_PATH}
+)
 
 #===============================================================================
 # Uninstall

--- a/cmake/Components.cmake
+++ b/cmake/Components.cmake
@@ -69,14 +69,12 @@ function(add_component package_name component)
   set(target "${component_prefix}${component}")
   add_custom_target("${target}")
 
-  if(NOT DART_BUILD_DARTPY)
-    install(EXPORT "${target}"
-      FILE "${package_name}_${component}Targets.cmake"
-      DESTINATION "${CONFIG_INSTALL_DIR}"
-      )
-    # TODO(JS): It would be nice if we could check if ${target} has at least one
-    # dependency target.
-  endif()
+  install(EXPORT "${target}"
+    FILE "${package_name}_${component}Targets.cmake"
+    DESTINATION "${CONFIG_INSTALL_DIR}"
+    )
+  # TODO(JS): It would be nice if we could check if ${target} has at least one
+  # dependency target.
 
   set_property(TARGET "${target}" PROPERTY "${component_prefix}COMPONENT" TRUE)
   set_property(TARGET "${target}" PROPERTY "${component_prefix}DEPENDENCIES")
@@ -167,13 +165,11 @@ function(add_component_targets package_name component)
         " are supported.")
     endif()
 
-    if(NOT DART_BUILD_DARTPY)
-      install(TARGETS "${dependency_target}"
-        EXPORT "${target}"
-        ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}"
-        LIBRARY DESTINATION "${LIBRARY_INSTALL_DIR}"
-      )
-    endif()
+    install(TARGETS "${dependency_target}"
+      EXPORT "${target}"
+      ARCHIVE DESTINATION "${LIBRARY_INSTALL_DIR}"
+      LIBRARY DESTINATION "${LIBRARY_INSTALL_DIR}"
+    )
   endforeach()
 
   set_property(TARGET "${target}" APPEND
@@ -219,17 +215,13 @@ function(install_component_exports package_name)
         endif()
       endforeach()
       if(NOT "${find_pkg_path}" STREQUAL "")
-        if(NOT DART_BUILD_DARTPY)
-          install(FILES "${find_pkg_path}" DESTINATION "${CONFIG_INSTALL_DIR}")
-        endif()
+        install(FILES "${find_pkg_path}" DESTINATION "${CONFIG_INSTALL_DIR}")
       endif()
       if("${dart_find_pkg_path}" STREQUAL "")
         message(FATAL_ERROR "Failed to find '${dart_find_pkg_path}'.")
       endif()
       list(APPEND external_dependencies ${dependent_package})
-      if(NOT DART_BUILD_DARTPY)
-        install(FILES "${dart_find_pkg_path}" DESTINATION "${CONFIG_INSTALL_DIR}")
-      endif()
+      install(FILES "${dart_find_pkg_path}" DESTINATION "${CONFIG_INSTALL_DIR}")
     endforeach()
 
     configure_file(
@@ -237,8 +229,6 @@ function(install_component_exports package_name)
       "${output_path}"
       @ONLY)
 
-    if(NOT DART_BUILD_DARTPY)
-      install(FILES "${output_path}" DESTINATION "${CONFIG_INSTALL_DIR}")
-    endif()
+    install(FILES "${output_path}" DESTINATION "${CONFIG_INSTALL_DIR}")
   endforeach()
 endfunction()

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -94,9 +94,7 @@ if(DART_VERBOSE)
   message(STATUS ${DART_CONFIG_HPP_OUT})
 endif()
 configure_file(${DART_CONFIG_HPP_IN} ${DART_CONFIG_HPP_OUT} @ONLY)
-if(NOT DART_BUILD_DARTPY)
-  install(FILES ${DART_CONFIG_HPP_OUT} DESTINATION include/dart)
-endif()
+install(FILES ${DART_CONFIG_HPP_OUT} DESTINATION include/dart)
 
 # Print building component
 get_property(components GLOBAL PROPERTY ${PROJECT_NAME}_COMPONENTS)
@@ -180,8 +178,6 @@ if(MSVC)
   )
 endif()
 
-if(NOT DART_BUILD_DARTPY)
-  install(FILES dart.hpp DESTINATION include/dart/ COMPONENT headers)
-endif()
+install(FILES dart.hpp DESTINATION include/dart/ COMPONENT headers)
 
 dart_format_add(${dart_core_headers} ${dart_core_sources})

--- a/dart/collision/CMakeLists.txt
+++ b/dart/collision/CMakeLists.txt
@@ -23,18 +23,16 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/collision.hpp
-    DESTINATION include/dart/collision
-    COMPONENT headers
-  )
-  install(
-    FILES ${detail_hdrs}
-    DESTINATION include/dart/collision/detail
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/collision.hpp
+  DESTINATION include/dart/collision
+  COMPONENT headers
+)
+install(
+  FILES ${detail_hdrs}
+  DESTINATION include/dart/collision/detail
+  COMPONENT headers
+)
 
 # Add subdirectories
 add_subdirectory(dart)

--- a/dart/collision/bullet/CMakeLists.txt
+++ b/dart/collision/bullet/CMakeLists.txt
@@ -71,12 +71,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/bullet.hpp
-    DESTINATION include/dart/collision/bullet
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/bullet.hpp
+  DESTINATION include/dart/collision/bullet
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs} ${detail_hdrs} ${detail_srcs})

--- a/dart/collision/dart/CMakeLists.txt
+++ b/dart/collision/dart/CMakeLists.txt
@@ -13,10 +13,8 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/dart.hpp
-    DESTINATION include/dart/collision/dart
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/dart.hpp
+  DESTINATION include/dart/collision/dart
+  COMPONENT headers
+)

--- a/dart/collision/fcl/CMakeLists.txt
+++ b/dart/collision/fcl/CMakeLists.txt
@@ -13,10 +13,8 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/fcl.hpp
-    DESTINATION include/dart/collision/fcl
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/fcl.hpp
+  DESTINATION include/dart/collision/fcl
+  COMPONENT headers
+)

--- a/dart/collision/ode/CMakeLists.txt
+++ b/dart/collision/ode/CMakeLists.txt
@@ -31,12 +31,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/ode.hpp
-    DESTINATION include/dart/collision/ode
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/ode.hpp
+  DESTINATION include/dart/collision/ode
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs} ${detail_hdrs} ${detail_srcs})

--- a/dart/common/CMakeLists.txt
+++ b/dart/common/CMakeLists.txt
@@ -15,15 +15,13 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/common.hpp
-    DESTINATION include/dart/common
-    COMPONENT headers
-  )
-  install(
-    FILES ${detail_hdrs}
-    DESTINATION include/dart/common/detail
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/common.hpp
+  DESTINATION include/dart/common
+  COMPONENT headers
+)
+install(
+  FILES ${detail_hdrs}
+  DESTINATION include/dart/common/detail
+  COMPONENT headers
+)

--- a/dart/constraint/CMakeLists.txt
+++ b/dart/constraint/CMakeLists.txt
@@ -15,15 +15,13 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/constraint.hpp
-    DESTINATION include/dart/constraint
-    COMPONENT headers
-  )
-  install(
-    FILES ${detail_hdrs}
-    DESTINATION include/dart/constraint/detail
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/constraint.hpp
+  DESTINATION include/dart/constraint
+  COMPONENT headers
+)
+install(
+  FILES ${detail_hdrs}
+  DESTINATION include/dart/constraint/detail
+  COMPONENT headers
+)

--- a/dart/dynamics/CMakeLists.txt
+++ b/dart/dynamics/CMakeLists.txt
@@ -17,15 +17,13 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/dynamics.hpp
-    DESTINATION include/dart/dynamics
-    COMPONENT headers
-  )
-  install(
-    FILES ${detail_hdrs}
-    DESTINATION include/dart/dynamics/detail
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/dynamics.hpp
+  DESTINATION include/dart/dynamics
+  COMPONENT headers
+)
+install(
+  FILES ${detail_hdrs}
+  DESTINATION include/dart/dynamics/detail
+  COMPONENT headers
+)

--- a/dart/external/ikfast/CMakeLists.txt
+++ b/dart/external/ikfast/CMakeLists.txt
@@ -2,10 +2,8 @@
 file(GLOB hdrs "*.h")
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs}
-    DESTINATION include/dart/external/ikfast
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs}
+  DESTINATION include/dart/external/ikfast
+  COMPONENT headers
+)

--- a/dart/external/imgui/CMakeLists.txt
+++ b/dart/external/imgui/CMakeLists.txt
@@ -28,10 +28,8 @@ add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs}
-    DESTINATION include/dart/external/imgui
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs}
+  DESTINATION include/dart/external/imgui
+  COMPONENT headers
+)

--- a/dart/external/lodepng/CMakeLists.txt
+++ b/dart/external/lodepng/CMakeLists.txt
@@ -16,10 +16,8 @@ add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs}
-    DESTINATION include/dart/external/lodepng
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs}
+  DESTINATION include/dart/external/lodepng
+  COMPONENT headers
+)

--- a/dart/external/odelcpsolver/CMakeLists.txt
+++ b/dart/external/odelcpsolver/CMakeLists.txt
@@ -23,10 +23,8 @@ add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs}
-    DESTINATION include/dart/external/odelcpsolver
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs}
+  DESTINATION include/dart/external/odelcpsolver
+  COMPONENT headers
+)

--- a/dart/gui/CMakeLists.txt
+++ b/dart/gui/CMakeLists.txt
@@ -99,12 +99,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/gui.hpp
-    DESTINATION include/dart/gui
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/gui.hpp
+  DESTINATION include/dart/gui
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs} ${dart_gui_headers} ${dart_gui_sources})

--- a/dart/gui/glut/CMakeLists.txt
+++ b/dart/gui/glut/CMakeLists.txt
@@ -13,10 +13,8 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/glut.hpp
-    DESTINATION include/dart/gui/glut
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/glut.hpp
+  DESTINATION include/dart/gui/glut
+  COMPONENT headers
+)

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -103,12 +103,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
-    DESTINATION include/dart/gui/osg
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
+  DESTINATION include/dart/gui/osg
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs} ${dart_gui_osg_hdrs} ${dart_gui_osg_srcs})

--- a/dart/gui/osg/render/CMakeLists.txt
+++ b/dart/gui/osg/render/CMakeLists.txt
@@ -13,13 +13,11 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/render.hpp
-    DESTINATION include/dart/gui/osg/render
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/render.hpp
+  DESTINATION include/dart/gui/osg/render
+  COMPONENT headers
+)
 
 dart_format_add(
   HeightmapShapeNode.hpp

--- a/dart/integration/CMakeLists.txt
+++ b/dart/integration/CMakeLists.txt
@@ -13,10 +13,8 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/integration.hpp
-    DESTINATION include/dart/integration
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/integration.hpp
+  DESTINATION include/dart/integration
+  COMPONENT headers
+)

--- a/dart/lcpsolver/CMakeLists.txt
+++ b/dart/lcpsolver/CMakeLists.txt
@@ -13,10 +13,8 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/lcpsolver.hpp
-    DESTINATION include/dart/lcpsolver
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/lcpsolver.hpp
+  DESTINATION include/dart/lcpsolver
+  COMPONENT headers
+)

--- a/dart/math/CMakeLists.txt
+++ b/dart/math/CMakeLists.txt
@@ -15,15 +15,13 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/math.hpp
-    DESTINATION include/dart/math
-    COMPONENT headers
-  )
-  install(
-    FILES ${detail_hdrs}
-    DESTINATION include/dart/math/detail
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/math.hpp
+  DESTINATION include/dart/math
+  COMPONENT headers
+)
+install(
+  FILES ${detail_hdrs}
+  DESTINATION include/dart/math/detail
+  COMPONENT headers
+)

--- a/dart/optimizer/CMakeLists.txt
+++ b/dart/optimizer/CMakeLists.txt
@@ -13,13 +13,11 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/optimizer.hpp
-    DESTINATION include/dart/optimizer
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/optimizer.hpp
+  DESTINATION include/dart/optimizer
+  COMPONENT headers
+)
 
 # Add subdirectories (components)
 add_subdirectory(ipopt)

--- a/dart/optimizer/ipopt/CMakeLists.txt
+++ b/dart/optimizer/ipopt/CMakeLists.txt
@@ -29,12 +29,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/ipopt.hpp
-    DESTINATION include/dart/optimizer/ipopt
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/ipopt.hpp
+  DESTINATION include/dart/optimizer/ipopt
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs})

--- a/dart/optimizer/nlopt/CMakeLists.txt
+++ b/dart/optimizer/nlopt/CMakeLists.txt
@@ -29,12 +29,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/nlopt.hpp
-    DESTINATION include/dart/optimizer/nlopt
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/nlopt.hpp
+  DESTINATION include/dart/optimizer/nlopt
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs})

--- a/dart/optimizer/pagmo/CMakeLists.txt
+++ b/dart/optimizer/pagmo/CMakeLists.txt
@@ -45,12 +45,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/pagmo.hpp
-    DESTINATION include/dart/optimizer/pagmo
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/pagmo.hpp
+  DESTINATION include/dart/optimizer/pagmo
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs})

--- a/dart/optimizer/snopt/CMakeLists.txt
+++ b/dart/optimizer/snopt/CMakeLists.txt
@@ -18,16 +18,14 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/snopt.h
-    DESTINATION include/dart/optimizer/snopt
-    COMPONENT headers
-  )
-  install(TARGETS dart-optimizer-snopt
-    EXPORT DARTTargets
-    DESTINATION lib
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/snopt.h
+  DESTINATION include/dart/optimizer/snopt
+  COMPONENT headers
+)
+install(TARGETS dart-optimizer-snopt
+  EXPORT DARTTargets
+  DESTINATION lib
+)
 
 dart_format_add(${hdrs} ${srcs})

--- a/dart/planning/CMakeLists.txt
+++ b/dart/planning/CMakeLists.txt
@@ -37,12 +37,10 @@ dart_generate_include_header_file(
 )
 
 ## Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/planning.hpp
-    DESTINATION include/dart/planning
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/planning.hpp
+  DESTINATION include/dart/planning
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs})

--- a/dart/simulation/CMakeLists.txt
+++ b/dart/simulation/CMakeLists.txt
@@ -15,15 +15,13 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/simulation.hpp
-    DESTINATION include/dart/simulation
-    COMPONENT headers
-  )
-  install(
-    FILES ${detail_hdrs}
-    DESTINATION include/dart/simulation/detail
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/simulation.hpp
+  DESTINATION include/dart/simulation
+  COMPONENT headers
+)
+install(
+  FILES ${detail_hdrs}
+  DESTINATION include/dart/simulation/detail
+  COMPONENT headers
+)

--- a/dart/utils/CMakeLists.txt
+++ b/dart/utils/CMakeLists.txt
@@ -77,13 +77,11 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/utils.hpp
-    DESTINATION include/dart/utils
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/utils.hpp
+  DESTINATION include/dart/utils
+  COMPONENT headers
+)
 
 # Add subdirectories (components)
 add_subdirectory(urdf)

--- a/dart/utils/mjcf/CMakeLists.txt
+++ b/dart/utils/mjcf/CMakeLists.txt
@@ -16,10 +16,8 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/mjcf.hpp
-    DESTINATION include/dart/utils/mjcf
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/mjcf.hpp
+  DESTINATION include/dart/utils/mjcf
+  COMPONENT headers
+)

--- a/dart/utils/sdf/CMakeLists.txt
+++ b/dart/utils/sdf/CMakeLists.txt
@@ -14,10 +14,8 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/sdf.hpp
-    DESTINATION include/dart/utils/sdf
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/sdf.hpp
+  DESTINATION include/dart/utils/sdf
+  COMPONENT headers
+)

--- a/dart/utils/urdf/CMakeLists.txt
+++ b/dart/utils/urdf/CMakeLists.txt
@@ -38,11 +38,9 @@ configure_file(
   ${DART_UTILS_BACKWARDCOMPATIBILITY_HPP_OUT}
   @ONLY
 )
-if(NOT DART_BUILD_DARTPY)
-  install(FILES ${DART_UTILS_BACKWARDCOMPATIBILITY_HPP_OUT}
-    DESTINATION include/dart/utils/urdf
-  )
-endif()
+install(FILES ${DART_UTILS_BACKWARDCOMPATIBILITY_HPP_OUT}
+  DESTINATION include/dart/utils/urdf
+)
 
 # Add target
 dart_add_library(${target_name} ${hdrs} ${srcs})
@@ -65,12 +63,10 @@ dart_generate_include_header_file(
 )
 
 # Install
-if(NOT DART_BUILD_DARTPY)
-  install(
-    FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/urdf.hpp
-    DESTINATION include/dart/utils/urdf
-    COMPONENT headers
-  )
-endif()
+install(
+  FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/urdf.hpp
+  DESTINATION include/dart/utils/urdf
+  COMPONENT headers
+)
 
 dart_format_add(${hdrs} ${srcs})

--- a/python/dartpy/CMakeLists.txt
+++ b/python/dartpy/CMakeLists.txt
@@ -9,6 +9,9 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
   OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+if(NOT IS_ABSOLUTE PYTHON_SITE_PACKAGES)
+  set(PYTHON_SITE_PACKAGES "${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_PACKAGES}")
+endif()
 if(NOT PythonInterp_FOUND)
   message(WARNING "DART_BUILD_DARTPY is ON, but failed to find PythonInterp. "
     "Disabling dartpy."
@@ -38,17 +41,20 @@ endif()
 file(GLOB_RECURSE dartpy_headers "*.h" "*.hpp")
 file(GLOB_RECURSE dartpy_sources "*.cpp")
 
+# Python binding module name
+set(pybind_module dartpy)
+
 # Build a Python extension module:
 # pybind11_add_module(<name> [MODULE | SHARED] [EXCLUDE_FROM_ALL]
 #                     [NO_EXTRAS] [SYSTEM] [THIN_LTO] source1 [source2 ...])
 #
-pybind11_add_module(dartpy
+pybind11_add_module(${pybind_module}
   MODULE
   ${dartpy_headers}
   ${dartpy_sources}
 )
 
-target_include_directories(dartpy
+target_include_directories(${pybind_module}
   SYSTEM PUBLIC
     ${PYTHON_INCLUDE_DIRS}
     ${pybind11_INCLUDE_DIRS}
@@ -56,7 +62,7 @@ target_include_directories(dartpy
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(dartpy
+target_link_libraries(${pybind_module}
   PUBLIC
     dart
     dart-utils
@@ -66,17 +72,32 @@ target_link_libraries(dartpy
     ${PYTHON_LIBRARIES}
 )
 if(TARGET dart-optimizer-nlopt)
-  target_link_libraries(dartpy PUBLIC dart-optimizer-nlopt)
+  target_link_libraries(${pybind_module} PUBLIC dart-optimizer-nlopt)
 endif()
 if(TARGET dart-collision-bullet)
-  target_link_libraries(dartpy PUBLIC dart-collision-bullet)
+  target_link_libraries(${pybind_module} PUBLIC dart-collision-bullet)
 endif()
 if(TARGET dart-collision-ode)
-  target_link_libraries(dartpy PUBLIC dart-collision-ode)
+  target_link_libraries(${pybind_module} PUBLIC dart-collision-ode)
 endif()
 
-install(TARGETS dartpy
-  LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}"
+# Get the path to the bind module
+set(PYBIND_MODULE $<TARGET_FILE:${pybind_module}>)
+
+# Custom target to install (copy) the bind module. This target may require
+# `sudo` if the destination is a system directory.
+set(install_comment "Installing ${pybind_module}...")
+if(BUILD_SHARED_LIBS)
+  string(CONCAT install_comment
+    "${install_comment}\n"
+    "NOTE: ${pybind_module} is built against the DART's shared libraries. "
+    "Install the shared libraries to be able to import ${pybind_module}."
+  )
+endif()
+add_custom_target(install-${pybind_module}
+  COMMENT "${install_comment}"
+  COMMAND ${CMAKE_COMMAND} -E copy ${PYBIND_MODULE} ${PYTHON_SITE_PACKAGES}
+  DEPENDS ${install_dartpy_deps}
 )
 
 list(REMOVE_ITEM dartpy_headers


### PR DESCRIPTION
Previously, DART provided two build modes, which is controlled by `DART_BUILD_DARTPY`: (1) build for the C++ package (as either shared or static libraries) or (2) build for the Python package (i.e. `dartpy`) enforcing to build the C++ libraries as static libraries. When installing the package, (1) installs the C++ headers and shared/static libraries while (b) only the binding module (i.e., `dartpy.so`). So we had to configure and build the package to build for both the C++ package and Python package.

However, there is a use case that requires to build `dartpy` against the shared libraries or/and build both the C++ and Python libraries without reconfiguring the package. This PR (i) removes the enforcement of static library build for `dartpy` and (ii) allows us to build `dartpy` without reconfiguring. For (ii), we still need to set `DART_BUILD_DARTPY` as `ON` though.

In short, here is the old behavior:

```shell
cmake .. -DDART_BUILD_DARTPY=OFF -DBUILD_SHARED_LIBS=ON   # to build as C++ package
make && make install                                      # build the shared libraries (`libdart.so`) and install them with the C++ headers

cmake .. -DDART_BUILD_DARTPY=OFF -DBUILD_SHARED_LIBS=OFF  # to build as C++ package
make && make install                                      # build the shared libraries (`libdart.a`) and install them with the C++ headers

rm -rf *                          # clean up the build directory

cmake .. -DDART_BUILD_DARTPY=ON   # to build as Python package
make dartpy                       # build the static libraries (`libdart.a`) and Python binding (`dartpy.so`)
                                  # BUILD_SHARED_LIBS is ignored
make install                      # install only `dartpy.so`
```

and the following is the new behavior:

```shell
cmake .. -DDART_BUILD_DARTPY=ON -DBUILD_SHARED_LIBS=ON
make && make install                # build the shared libraries (`libdart.so`) and install them with the C++ headers
make dartpy && make install-dartpy  # build the Python binding (`dartpy.so`) against the shared libraries (the shared library should be installed)

cmake .. -DDART_BUILD_DARTPY=ON -DBUILD_SHARED_LIBS=OFF
make && make install                # build the shared libraries (`libdart.so`) and install them with the C++ headers
make dartpy && make install-dartpy  # build the Python binding (`dartpy.so`) against the static libraries

cmake .. -DDART_BUILD_DARTPY=OFF
make && make install                # build the shared libraries (`libdart.so`) and install them with the C++ headers
make dartpy && make install-dartpy  # no such targets
```
***

**Before creating a pull request**

- [x] Document new methods and classes

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
