### PR TITLE
Fix compatibility with clang-cl

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -204,3 +204,34 @@ jobs:
           -DDART_MSVC_DEFAULT_OPTIONS=ON ^
           -DDART_VERBOSE=ON
         cmake --build . --target ALL_BUILD -- /maxcpucount:4
+        
+  windows_2019_clang_cl:
+    name: Windows (clang-cl) [Release]
+    runs-on: windows-2019
+    env:
+      COMPILER: gcc
+      BUILD_TYPE: Release
+      RUN_TESTS: OFF
+      VCPKG_ROOT: 'C:/dartsim/vcpkg'
+      VCPKG_BUILD_TAG: v0.1.1
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      shell: cmd
+      run: |
+        mkdir -p C:/dartsim
+        choco install -y wget
+        wget https://github.com/dartsim/vcpkg-build/releases/download/%VCPKG_BUILD_TAG%/vcpkg-dartsim-dependencies.zip
+        unzip vcpkg-dartsim-dependencies.zip -d C:/dartsim
+    - name: Build
+      shell: cmd
+      run: |
+        mkdir build
+        cd build
+        cmake .. -G "Visual Studio 16 2019" -A x64 -Wno-dev ^
+          -T ClangCl ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake" ^
+          -DDART_MSVC_DEFAULT_OPTIONS=ON ^
+          -DDART_VERBOSE=ON
+        cmake --build . --target ALL_BUILD

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -209,7 +209,7 @@ jobs:
     name: Windows (clang-cl) [Release]
     runs-on: windows-2019
     env:
-      COMPILER: gcc
+      COMPILER: clang
       BUILD_TYPE: Release
       RUN_TESTS: OFF
       VCPKG_ROOT: 'C:/dartsim/vcpkg'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if(MSVC)
 
   # Visual Studio enables C++14 support by default
   set(msvc_required_version 1920)
-  if(MSVC_VERSION VERSION_LESS ${msvc_required_version})
+  if(MSVC_VERSION VERSION_LESS ${msvc_required_version} AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
     message(FATAL_ERROR "Visual Studio ${MSVC_VERSION} is detected, but "
       "${PROJECT_NAME_UPPERCASE} requires ${msvc_required_version} or greater."
     )

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(external)
 # Enable multi-threaded compilation.
 # We do this here and not in the root folder since the examples and the
 # tutorials do not have enough source files to benefit from this.
-if(MSVC)
+if(MSVC AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif()
 


### PR DESCRIPTION
clang-cl is the Visual Studio-compatible version of clang (https://clang.llvm.org/docs/MSVCCompatibility.html).
This PR: 
* Enables compilation of DART even for VS < 2019 if Clang is used (as clang-cl can be perfectly C++14 compatible even if the used MSVC version is not)
* Avoid to pass the /MP option to clang-cl that does not support it
* Adds a GitHub Actions job to compile DART with clang-cl (using in particular the ClangCl toolset shipped with MSVC)