### PR TITLE
Fix MSVC linking for assimp and fcl

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -183,7 +183,7 @@ jobs:
       BUILD_TYPE: Release
       RUN_TESTS: OFF
       VCPKG_ROOT: 'C:/dartsim/vcpkg'
-      VCPKG_BUILD_TAG: v0.1.1
+      VCPKG_BUILD_TAG: v0.2.0-70f192e
     steps:
     - uses: actions/checkout@v1
     - name: Install Dependencies

--- a/cmake/Findassimp.cmake
+++ b/cmake/Findassimp.cmake
@@ -26,7 +26,10 @@ find_path(ASSIMP_INCLUDE_DIRS assimp/scene.h
 
 # Libraries
 if(MSVC)
-  set(ASSIMP_LIBRARIES "assimp$<$<CONFIG:Debug>:d>")
+  find_package(assimp QUIET CONFIG)
+  if(TARGET assimp::assimp)
+    set(ASSIMP_LIBRARIES "assimp::assimp")
+  endif()
 else()
   find_library(ASSIMP_LIBRARIES
       NAMES assimp
@@ -34,7 +37,9 @@ else()
 endif()
 
 # Version
-set(ASSIMP_VERSION ${PC_ASSIMP_VERSION})
+if(PC_ASSIMP_VERSION)
+  set(ASSIMP_VERSION ${PC_ASSIMP_VERSION})
+endif()
 
 # Set (NAME)_FOUND if all the variables and the version are satisfied.
 include(FindPackageHandleStandardArgs)

--- a/cmake/Findfcl.cmake
+++ b/cmake/Findfcl.cmake
@@ -28,7 +28,10 @@ find_path(FCL_INCLUDE_DIRS
 
 # Libraries
 if(MSVC)
-  set(FCL_LIBRARIES "fcl$<$<CONFIG:Debug>:d>")
+  find_package(fcl QUIET CONFIG)
+  if(TARGET fcl)
+    set(FCL_LIBRARIES fcl)
+  endif()
 else()
   # Give explicit precedence to ${PC_FCL_LIBDIR}
   find_library(FCL_LIBRARIES

--- a/cmake/Findfcl.cmake
+++ b/cmake/Findfcl.cmake
@@ -47,7 +47,9 @@ else()
 endif()
 
 # Version
-set(FCL_VERSION ${PC_FCL_VERSION})
+if(PC_FCL_VERSION)
+  set(FCL_VERSION ${PC_FCL_VERSION})
+endif()
 
 # Set (NAME)_FOUND if all the variables and the version are satisfied.
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
This PR fixes the linking of tests that use fcl and assimp on MSVC, hopefully fixing the problems reported in https://github.com/ignitionrobotics/ign-physics/issues/87#issuecomment-705155086 .

As the existing code is working well in CI for non-MSVC platforms, and as support for CMake imported targets can vary depending on the platform (for example, `assimp::assimp` is basically broken in Ubuntu 20.04 apt packages: https://bugs.launchpad.net/ubuntu/+source/assimp/+bug/1882427 and https://github.com/robotology/idyntree/issues/693), to minimize the possible regressions I just used the imported targets for fcl and assimp when using MSVC.

 