### PR TITLE
Use prebuilt Ubuntu Docker images for CIs

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
       COMPILER: gcc
       BUILD_TYPE: Debug
       BUILD_DIR: $(Build.SourcesDirectory)
-      DOCKERFILE: Dockerfile.ubuntu-xenial
+      DOCKER_NAME: dartsim/dart-dev:xenial-v6.10
       BUILD_DARTPY: OFF
     steps:
       - template: .ci/azure-pipelines/docker.yml
@@ -23,7 +23,7 @@ jobs:
       COMPILER: gcc
       BUILD_TYPE: Debug
       BUILD_DIR: $(Build.SourcesDirectory)
-      DOCKERFILE: Dockerfile.ubuntu-bionic
+      DOCKER_NAME: dartsim/dart-dev:bionic-v6.10
       BUILD_DARTPY: OFF
     steps:
       - template: .ci/azure-pipelines/docker.yml
@@ -36,7 +36,7 @@ jobs:
       COMPILER: gcc
       BUILD_TYPE: Debug
       BUILD_DIR: $(Build.SourcesDirectory)
-      DOCKERFILE: Dockerfile.ubuntu-focal
+      DOCKER_NAME: dartsim/dart-dev:focal-v6.10
       BUILD_DARTPY: OFF
     steps:
       - template: .ci/azure-pipelines/docker.yml

--- a/.ci/azure-pipelines/docker.yml
+++ b/.ci/azure-pipelines/docker.yml
@@ -2,11 +2,12 @@ parameters:
   numThreads: 4
 
 steps:
-- script: |
-    docker build -t ${DOCKERFILE,,} -f ".ci/docker/$DOCKERFILE" .;
-    docker run -itd -v $(Build.SourcesDirectory):$(Build.SourcesDirectory) --env-file .ci/docker/env.list --name dart-docker ${DOCKERFILE,,};
-    docker exec dart-docker /bin/sh -c "cd $(Build.SourcesDirectory) && ./.ci/install.sh";
-  displayName: 'Install'
-- script: |
-    docker exec dart-docker /bin/sh -c "cd $(Build.SourcesDirectory) && ./.ci/script.sh -j${{ parameters.numThreads }}";
-  displayName: 'Script'
+  - script: docker pull $DOCKER_NAME
+    displayName: "Pull dev container"
+  - script: |
+      docker run \
+        -v $(Build.SourcesDirectory):$(Build.SourcesDirectory) \
+        --env-file .ci/docker/env.list \
+        $DOCKER_NAME \
+        /bin/sh -c "cd $(Build.SourcesDirectory) && ./.ci/script.sh -j${{ parameters.numThreads }}"
+    displayName: "Build"

--- a/.ci/docker/Dockerfile.ubuntu-bionic
+++ b/.ci/docker/Dockerfile.ubuntu-bionic
@@ -1,1 +1,0 @@
-FROM ubuntu:bionic

--- a/.ci/docker/Dockerfile.ubuntu-focal
+++ b/.ci/docker/Dockerfile.ubuntu-focal
@@ -1,1 +1,0 @@
-FROM ubuntu:focal

--- a/.ci/docker/Dockerfile.ubuntu-groovy
+++ b/.ci/docker/Dockerfile.ubuntu-groovy
@@ -1,1 +1,0 @@
-FROM ubuntu:groovy

--- a/.ci/docker/Dockerfile.ubuntu-trusty
+++ b/.ci/docker/Dockerfile.ubuntu-trusty
@@ -1,1 +1,0 @@
-FROM ubuntu:trusty

--- a/.ci/docker/Dockerfile.ubuntu-xenial
+++ b/.ci/docker/Dockerfile.ubuntu-xenial
@@ -1,1 +1,0 @@
-FROM ubuntu:xenial

--- a/.ci/docker/Dockerfile.ubuntu-xenial-32bit
+++ b/.ci/docker/Dockerfile.ubuntu-xenial-32bit
@@ -1,1 +1,0 @@
-FROM i386/ubuntu:xenial

--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+# TODO(JS): Remove this file once CODECOV and gh-page migrated to the Docker builds
+
 # Sanity checks for required environment variables.
 if [ -z "$BUILD_DARTPY" ]; then
   echo "Info: Environment variable BUILD_DARTPY is unset. Using OFF by default."

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -70,12 +70,7 @@ jobs:
       - name: Pull dev container
         run: docker pull ${{ env.DART_DEV_IMAGE }}:${{ env.DOCKER_TAG }}
       - name: Build
-        run: |
-          docker run \
-            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
-            --env-file ./.ci/docker/env.list \
-            $DOCKER_NAME \
-            /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh"
+        run: ${{ env.UBUNTU_BUILD_CMD }}
 
   groovy_gcc_release:
     name: Ubuntu 20.10 [GCC|Release]

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,97 +13,98 @@ on:
     # Run every day at 02:00
     - cron: "0 2 * * 0-6"
 
+env:
+  # Hosted on: https://hub.docker.com/repository/docker/dartsim/dart-dev
+  DART_DEV_IMAGE: dartsim/dart-dev
+  UBUNTU_BUILD_CMD: |
+    docker run \
+      -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+      --env-file ./.ci/docker/env.list \
+      $DART_DEV_IMAGE:$DOCKER_TAG \
+      /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh"
+
 jobs:
   xenial_gcc_release:
     name: Ubuntu 16.04 [GCC|Release]
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_TAG: xenial-v6.10
+      COMPILER: gcc
+      BUILD_TYPE: Release
+      BUILD_DARTPY: OFF
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Dependencies
-        env:
-          COMPILER: gcc
-          DOCKERFILE: Dockerfile.ubuntu-xenial
-          BUILD_TYPE: Release
-          BUILD_DARTPY: OFF
-        run: |
-          docker build -t "${DOCKERFILE,,}" -f ".ci/docker/$DOCKERFILE" .;
-          docker run -itd -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --env-file ./.ci/docker/env.list --name dart-docker "${DOCKERFILE,,}";
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/install.sh";
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Pull dev container
+        run: docker pull ${{ env.DART_DEV_IMAGE }}:${{ env.DOCKER_TAG }}
       - name: Build
-        run: |
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
+        run: ${{ env.UBUNTU_BUILD_CMD }}
 
   bionic_gcc_release:
     name: Ubuntu 18.04 [GCC|Release]
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_TAG: bionic-v6.10
+      COMPILER: gcc
+      BUILD_TYPE: Release
+      BUILD_DARTPY: ON
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Dependencies
-        env:
-          COMPILER: gcc
-          DOCKERFILE: Dockerfile.ubuntu-bionic
-          BUILD_TYPE: Release
-          BUILD_DARTPY: ON
-        run: |
-          docker build -t "${DOCKERFILE,,}" -f ".ci/docker/$DOCKERFILE" .;
-          docker run -itd -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --env-file ./.ci/docker/env.list --name dart-docker "${DOCKERFILE,,}";
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/install.sh";
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Pull dev container
+        run: docker pull ${{ env.DART_DEV_IMAGE }}:${{ env.DOCKER_TAG }}
       - name: Build
-        run: |
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
+        run: ${{ env.UBUNTU_BUILD_CMD }}
 
   focal_gcc_release:
     name: Ubuntu 20.04 [GCC|Release]
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_TAG: focal-v6.10
+      COMPILER: gcc
+      BUILD_TYPE: Release
+      BUILD_DARTPY: ON
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Dependencies
-        env:
-          COMPILER: gcc
-          DOCKERFILE: Dockerfile.ubuntu-focal
-          BUILD_TYPE: Release
-          BUILD_DARTPY: ON
-        run: |
-          docker build -t "${DOCKERFILE,,}" -f ".ci/docker/$DOCKERFILE" .;
-          docker run -itd -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --env-file ./.ci/docker/env.list --name dart-docker "${DOCKERFILE,,}";
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/install.sh";
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Pull dev container
+        run: docker pull ${{ env.DART_DEV_IMAGE }}:${{ env.DOCKER_TAG }}
       - name: Build
         run: |
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
+          docker run \
+            -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+            --env-file ./.ci/docker/env.list \
+            $DOCKER_NAME \
+            /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh"
 
   groovy_gcc_release:
     name: Ubuntu 20.10 [GCC|Release]
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_TAG: groovy-v6.10
+      COMPILER: gcc
+      BUILD_TYPE: Release
+      BUILD_DARTPY: ON
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Dependencies
-        env:
-          COMPILER: gcc
-          DOCKERFILE: Dockerfile.ubuntu-groovy
-          BUILD_TYPE: Release
-          BUILD_DARTPY: ON
-        run: |
-          docker build -t "${DOCKERFILE,,}" -f ".ci/docker/$DOCKERFILE" .;
-          docker run -itd -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --env-file ./.ci/docker/env.list --name dart-docker "${DOCKERFILE,,}";
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/install.sh";
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Pull dev container
+        run: docker pull ${{ env.DART_DEV_IMAGE }}:${{ env.DOCKER_TAG }}
       - name: Build
-        run: |
-          docker exec dart-docker /bin/sh -c "cd $GITHUB_WORKSPACE && ./.ci/script.sh";
+        run: ${{ env.UBUNTU_BUILD_CMD }}
 
   catalina_clang_release:
     name: macOS 10.15 [Clang|Release]
     runs-on: macOS-10.15
+    env:
+      COMPILER: clang
+      BUILD_TYPE: Release
+      BUILD_DARTPY: ON
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Dependencies
-        env:
-          COMPILER: clang
         run: .ci/install.sh
       - name: Build
-        env:
-          COMPILER: clang
-          BUILD_TYPE: Release
-          BUILD_DARTPY: ON
         run: sudo -E .ci/script.sh
 
   windows_2019_msvc:
@@ -114,7 +115,7 @@ jobs:
       VCPKG_ROOT: "C:/dartsim/vcpkg"
       VCPKG_BUILD_TAG: v0.2.0-70f192e
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Dependencies
         shell: cmd
         run: |
@@ -143,7 +144,7 @@ jobs:
       VCPKG_ROOT: "C:/dartsim/vcpkg"
       VCPKG_BUILD_TAG: v0.2.0-70f192e
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Dependencies
         shell: cmd
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,32 +27,34 @@ matrix:
 
     - os: linux
       env:
+        - DOCKER_NAME="dartsim/dart-dev:xenial-32bit-v6.10"
         - BUILD_NAME=XENIAL_32BIT_DEBUG_CODECOV
-        - DOCKERFILE="Dockerfile.ubuntu-xenial-32bit"
         - BUILD_TYPE=Release  # TODO: Tests fail in debug mode
         - COMPILER=gcc
       services: docker
 
     - os: linux
       env:
+        - DOCKER_NAME="dartsim/dart-dev:bionic-v6.10"
         - BUILD_DOCS=ON
-        - DOCKERFILE="Dockerfile.ubuntu-bionic"
         - BUILD_TYPE=Release
         - COMPILER=gcc
       services: docker
 
 install:
-  - if [ -n "$DOCKERFILE" ]; then
-      docker build -t "${DOCKERFILE,,}" -f ".ci/docker/$DOCKERFILE" .;
-      docker run -itd -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR --env-file .ci/docker/env.list --name dart-docker "${DOCKERFILE,,}";
-      docker exec dart-docker /bin/sh -c "cd $TRAVIS_BUILD_DIR && ./.ci/install.sh";
+  - if [ -n "$DOCKER_NAME" ]; then
+      docker pull $DOCKER_NAME;
     else
       sudo -E .ci/install.sh;
     fi
 
 script:
-  - if [ -n "$DOCKERFILE" ]; then
-      docker exec dart-docker /bin/sh -c "cd $TRAVIS_BUILD_DIR && ./.ci/script.sh";
+  - if [ -n "$DOCKER_NAME" ]; then
+      docker run "$DOCKER_NAME"
+      docker run \
+          -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR \
+          --env-file .ci/docker/env.list \
+          "$DOCKER_NAME" /bin/sh -c "cd $TRAVIS_BUILD_DIR && ./.ci/script.sh";
     else
       sudo -E .ci/script.sh;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ script:
       docker run \
           -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR \
           --env-file .ci/docker/env.list \
-          "$DOCKER_NAME" /bin/sh -c "cd $TRAVIS_BUILD_DIR && ./.ci/script.sh";
+          $DOCKER_NAME \
+          /bin/sh -c "cd $TRAVIS_BUILD_DIR && ./.ci/script.sh";
     else
       sudo -E .ci/script.sh;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - os: linux
       env:
         - BUILD_NAME=BIONIC_RELEASE_DOCS
-        - DOCKER_NAME=dartsim/dart-dev:bionic-v6.10
+        - DOCKER_NAME=dartsim/dart-dev:bionic-docs
         - BUILD_TYPE=Release
         - COMPILER=gcc
         - BUILD_DOCS=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,18 +27,19 @@ matrix:
 
     - os: linux
       env:
+        - BUILD_NAME=XENIAL_32BIT_RELEASE
         - DOCKER_NAME=dartsim/dart-dev:xenial-32bit-v6.10
-        - BUILD_NAME=XENIAL_32BIT_DEBUG_CODECOV
         - BUILD_TYPE=Release  # TODO: Tests fail in debug mode
         - COMPILER=gcc
       services: docker
 
     - os: linux
       env:
+        - BUILD_NAME=BIONIC_RELEASE_DOCS
         - DOCKER_NAME=dartsim/dart-dev:bionic-v6.10
-        - BUILD_DOCS=ON
         - BUILD_TYPE=Release
         - COMPILER=gcc
+        - BUILD_DOCS=ON
       services: docker
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ install:
 
 script:
   - if [ -n "$DOCKER_NAME" ]; then
-      docker run "$DOCKER_NAME"
       docker run \
           -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR \
           --env-file .ci/docker/env.list \

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
 
     - os: linux
       env:
-        - DOCKER_NAME="dartsim/dart-dev:xenial-32bit-v6.10"
+        - DOCKER_NAME=dartsim/dart-dev:xenial-32bit-v6.10
         - BUILD_NAME=XENIAL_32BIT_DEBUG_CODECOV
         - BUILD_TYPE=Release  # TODO: Tests fail in debug mode
         - COMPILER=gcc
@@ -35,7 +35,7 @@ matrix:
 
     - os: linux
       env:
-        - DOCKER_NAME="dartsim/dart-dev:bionic-v6.10"
+        - DOCKER_NAME=dartsim/dart-dev:bionic-v6.10
         - BUILD_DOCS=ON
         - BUILD_TYPE=Release
         - COMPILER=gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,7 @@ install:
 
 script:
   - if [ -n "$DOCKER_NAME" ]; then
-      docker run \
-          -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR \
-          --env-file .ci/docker/env.list \
-          $DOCKER_NAME \
-          /bin/sh -c "cd $TRAVIS_BUILD_DIR && ./.ci/script.sh";
+      docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR --env-file .ci/docker/env.list $DOCKER_NAME /bin/sh -c "cd $TRAVIS_BUILD_DIR && ./.ci/script.sh";
     else
       sudo -E .ci/script.sh;
     fi


### PR DESCRIPTION
The Docker images are hosted on https://hub.docker.com/repository/docker/dartsim/dart-dev, and the source code repo is https://github.com/dartsim/dart-ci-docker-containers