### PR TITLE
Windows compile fix: Be more specific about which AspectWithState to use

### DIFF
--- a/dart/common/AspectWithVersion.hpp
+++ b/dart/common/AspectWithVersion.hpp
@@ -91,7 +91,7 @@ public:
   constexpr static void (*UpdateProperties)(Derived*) = updateProperties;
 
   using AspectStateImpl
-      = AspectWithState<Derived, StateData, CompositeType, updateState>;
+      = common::AspectWithState<Derived, StateData, CompositeType, updateState>;
 
   using AspectPropertiesImpl = detail::AspectWithVersionedProperties<
       AspectStateImpl,


### PR DESCRIPTION
*Note: There are other errors that still need to be resolved before* `/permissive-` *is no longer needed on Windows*.

Using DART (master) in a project on Windows yields the following compile error:

```
2>C:\...\include\dart/common/AspectWithVersion.hpp(94): error C2974: 'dart::common::detail::AspectWithState': invalid template argument for 'CompositeT', type expected
2>  C:\...\include\dart/common/detail/AspectWithVersion.hpp(53): note: see declaration of 'dart::common::detail::AspectWithState'
2>  C:\...\include\dart/dynamics/EndEffector.hpp(57): note: see reference to class template instantiation 'dart::common::AspectWithStateAndVersionedProperties<dart::dynamics::Support,dart::dynamics::detail::SupportStateData,dart::dynamics::detail::SupportPropertiesData,dart::dynamics::EndEffector,dart::dynamics::detail::SupportUpdate,dart::dynamics::detail::SupportUpdate>' being compiled
2>C:\...\include\dart/common/AspectWithVersion.hpp(94): error C2976: 'dart::common::detail::AspectWithState': too few template arguments
2>  C:\...\include\dart/common/detail/AspectWithVersion.hpp(53): note: see declaration of 'dart::common::detail::AspectWithState'   
```

This is the same error mentioned in #753.

`dart\common\AspectWithVersion.hpp` has two symbols for `AspectWithState`. The first is 

`dart::common::detail::AspectWithState` defined by include: 

`#include "dart\common\detail\AspectWithVersion.hpp"`. This takes 5 template arguments.

The second symbol is defined after the above `#include` as 

```
template <
    class DerivedT,
    typename StateDataT,
    class CompositeT = Composite,
    void (*updateState)(DerivedT*) = &detail::NoOp<DerivedT*> >
using AspectWithState = detail::AspectWithState<
    CompositeTrackingAspect<CompositeT>,
    DerivedT,
    StateDataT,
    CompositeT,
    updateState>;
```
This version takes 4 template arguments.


The problem is with the following line, Windows is using the first definition of `AspectWithState`, which is the incorrect version that requires 5 template arguments:

```
using AspectStateImpl
      = AspectWithState<Derived, StateData, CompositeType, updateState>;
```

Adding `common::` as I've done in the PR distinguishes `dart::common::AspectWithState` from `dart::common::detail::AspectWithState`.

Note: This has already been worked around on Windows by compiling with `/permissive-`, but I think this would still be a good addition to the codebase to make it more robust. Also there are other compile errors that occur without `/permissive-` that I haven't resolved yet.


***

**Before creating a pull request**

- [X] Document new methods and classes
- [X] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
