### PR TITLE
Replace not operator with !

### DIFF
--- a/dart/constraint/JointLimitConstraint.cpp
+++ b/dart/constraint/JointLimitConstraint.cpp
@@ -364,8 +364,8 @@ void JointLimitConstraint::applyUnitImpulse(std::size_t index)
   std::size_t dof = mJoint->getNumDofs();
   for (std::size_t i = 0; i < dof; ++i)
   {
-    if (not mIsPositionLimitViolated[static_cast<int>(i)]
-        && not mIsVelocityLimitViolated[static_cast<int>(i)])
+    if (!mIsPositionLimitViolated[static_cast<int>(i)]
+        && !mIsVelocityLimitViolated[static_cast<int>(i)])
     {
       continue;
     }
@@ -394,8 +394,8 @@ void JointLimitConstraint::getVelocityChange(double* delVel, bool withCfm)
   std::size_t dof = mJoint->getNumDofs();
   for (std::size_t i = 0; i < dof; ++i)
   {
-    if (not mIsPositionLimitViolated[static_cast<int>(i)]
-        && not mIsVelocityLimitViolated[static_cast<int>(i)])
+    if (!mIsPositionLimitViolated[static_cast<int>(i)]
+        && !mIsVelocityLimitViolated[static_cast<int>(i)])
     {
       continue;
     }
@@ -438,8 +438,8 @@ void JointLimitConstraint::applyImpulse(double* lambda)
   std::size_t dof = mJoint->getNumDofs();
   for (std::size_t i = 0; i < dof; ++i)
   {
-    if (not mIsPositionLimitViolated[static_cast<int>(i)]
-        && not mIsVelocityLimitViolated[static_cast<int>(i)])
+    if (!mIsPositionLimitViolated[static_cast<int>(i)]
+        && !mIsVelocityLimitViolated[static_cast<int>(i)])
     {
       continue;
     }

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -986,7 +986,7 @@ bool copyNode(tinyxml2::XMLNode* destParent, const tinyxml2::XMLNode& src)
   for (const tinyxml2::XMLNode* node = src.FirstChild(); node != nullptr;
        node = node->NextSibling())
   {
-    if (not copyNode(copy, *node))
+    if (!copyNode(copy, *node))
     {
       return false;
     }
@@ -1001,7 +1001,7 @@ bool copyChildNodes(tinyxml2::XMLNode* destParent, const tinyxml2::XMLNode& src)
   for (const tinyxml2::XMLNode* node = src.FirstChild(); node != nullptr;
        node = node->NextSibling())
   {
-    if (not copyNode(destParent, *node))
+    if (!copyNode(destParent, *node))
     {
       return false;
     }

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -61,7 +61,7 @@ dynamics::BodyNode::Properties createBodyProperties(
   dynamics::BodyNode::Properties bodyProps;
 
   // Name
-  if (not mjcfBody.getName().empty())
+  if (!mjcfBody.getName().empty())
   {
     bodyProps.mName = mjcfBody.getName();
   }
@@ -92,7 +92,7 @@ void createJointCommonProperties(
     const detail::Joint& mjcfJoint)
 {
   // Name
-  if (not mjcfJoint.getName().empty())
+  if (!mjcfJoint.getName().empty())
   {
     props.mName = mjcfJoint.getName();
   }
@@ -629,12 +629,12 @@ bool populateSkeletonRecurse(
   assert(joint != nullptr);
 
   // Create ShapeNodes for the current BodyNode
-  if (not createShapeNodes(bodyNode, mjcfBody, mjcfAsset))
+  if (!createShapeNodes(bodyNode, mjcfBody, mjcfAsset))
     return false;
 
   for (auto i = 0u; i < mjcfBody.getNumChildBodies(); ++i)
   {
-    if (not populateSkeletonRecurse(
+    if (!populateSkeletonRecurse(
             skel, bodyNode, mjcfBody.getChildBody(i), mjcfAsset))
     {
       return false;
@@ -652,7 +652,7 @@ dynamics::SkeletonPtr createSkeleton(
 
   const bool success
       = populateSkeletonRecurse(skel, nullptr, mjcfBody, mjcfAsset);
-  if (not success)
+  if (!success)
   {
     const std::string bodyName
         = mjcfBody.getName().empty() ? "(noname)" : mjcfBody.getName();
@@ -716,7 +716,7 @@ simulation::WorldPtr createWorld(
     std::tie(joint, body)
         = skel->createJointAndBodyNodePair<dynamics::WeldJoint>();
 
-    if (not mjcfGeom.getName().empty())
+    if (!mjcfGeom.getName().empty())
     {
       skel->setName(options.mGeomSkeletonNamePrefix + mjcfGeom.getName());
     }
@@ -754,7 +754,7 @@ simulation::WorldPtr createWorld(
     std::tie(joint, body)
         = skel->createJointAndBodyNodePair<dynamics::WeldJoint>();
 
-    if (not mjcfSite.getName().empty())
+    if (!mjcfSite.getName().empty())
     {
       skel->setName(options.mSiteSkeletonNamePrefix + mjcfSite.getName());
     }
@@ -818,7 +818,7 @@ simulation::WorldPtr readWorld(const common::Uri& uri, const Options& options)
 {
   auto mujoco = detail::MujocoModel();
   const detail::Errors errors = mujoco.read(uri, options.mRetriever);
-  if (not errors.empty())
+  if (!errors.empty())
   {
     dterr << "[MjcfParser] Failed to parse MJCF file for the following "
              "reason(s):\n";
@@ -848,7 +848,7 @@ simulation::WorldPtr readWorld(const common::Uri& uri, const Options& options)
     // Body2
     dynamics::BodyNode* body2 = nullptr;
     const std::string& bodyName2 = weld.getBody2();
-    if (not bodyName2.empty())
+    if (!bodyName2.empty())
     {
       body2 = getUniqueBodyOrNull(*world, bodyName2);
       if (body2 == nullptr)

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -208,7 +208,7 @@ Errors Body::compile(const Compiler& compiler)
       }
     }
 
-    if (not mGeoms.empty())
+    if (!mGeoms.empty())
     {
       mInertial = computeInertialFromGeoms(mGeoms, compiler);
     }

--- a/dart/utils/mjcf/detail/BodyAttributes.cpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.cpp
@@ -117,7 +117,7 @@ Errors appendBodyAttributes(
   // user
   if (hasAttribute(element, "user"))
   {
-    if (not size)
+    if (!size)
     {
       errors.emplace_back(
           ErrorCode::ATTRIBUTE_INVALID,

--- a/dart/utils/mjcf/detail/Default.cpp
+++ b/dart/utils/mjcf/detail/Default.cpp
@@ -191,7 +191,7 @@ Errors Defaults::read(tinyxml2::XMLElement* element, const Default* parent)
 
   auto newDefault = Default();
   const Errors defaultErrors = newDefault.read(element, parent);
-  if (not defaultErrors.empty())
+  if (!defaultErrors.empty())
   {
     errors.insert(errors.end(), defaultErrors.begin(), defaultErrors.end());
     return errors;
@@ -203,7 +203,7 @@ Errors Defaults::read(tinyxml2::XMLElement* element, const Default* parent)
   while (defaultElements.next())
   {
     const Errors defaultErrors = read(defaultElements.get(), &newDefault);
-    if (not defaultErrors.empty())
+    if (!defaultErrors.empty())
     {
       errors.insert(errors.end(), defaultErrors.begin(), defaultErrors.end());
       return errors;

--- a/dart/utils/mjcf/detail/Geom.cpp
+++ b/dart/utils/mjcf/detail/Geom.cpp
@@ -94,7 +94,7 @@ Errors Geom::read(
 static bool canUseFromTo(
     GeomType type, const common::optional<Eigen::Vector6d>& fromto)
 {
-  if (not fromto)
+  if (!fromto)
     return false;
 
   switch (type)

--- a/dart/utils/mjcf/detail/Inertial.cpp
+++ b/dart/utils/mjcf/detail/Inertial.cpp
@@ -54,7 +54,7 @@ Errors Inertial::read(tinyxml2::XMLElement* element)
   }
 
   // (required) pos
-  if (not hasAttribute(element, "pos"))
+  if (!hasAttribute(element, "pos"))
   {
     errors.emplace_back(
         ErrorCode::ATTRIBUTE_MISSING,
@@ -103,7 +103,7 @@ Errors Inertial::read(tinyxml2::XMLElement* element)
   }
 
   // (required) mass
-  if (not hasAttribute(element, "mass"))
+  if (!hasAttribute(element, "mass"))
   {
     errors.emplace_back(
         ErrorCode::ATTRIBUTE_MISSING,
@@ -129,7 +129,7 @@ Errors Inertial::read(tinyxml2::XMLElement* element)
   else
   {
     // If diaginertia is omitted, the next attribute becomes required.
-    if (not hasAttribute(element, "fullinertia"))
+    if (!hasAttribute(element, "fullinertia"))
     {
       errors.emplace_back(
           ErrorCode::ATTRIBUTE_MISSING,

--- a/dart/utils/mjcf/detail/Mesh.cpp
+++ b/dart/utils/mjcf/detail/Mesh.cpp
@@ -151,7 +151,7 @@ const Eigen::Vector3d& Mesh::getScale() const
 //==============================================================================
 dynamics::MeshShapePtr Mesh::getMeshShape() const
 {
-  if (not mMeshShape && not mTriedToParse)
+  if (!mMeshShape && !mTriedToParse)
   {
     mMeshShape = createMeshShape();
     mTriedToParse = true;

--- a/dart/utils/mjcf/detail/MujocoModel.cpp
+++ b/dart/utils/mjcf/detail/MujocoModel.cpp
@@ -195,7 +195,7 @@ Errors MujocoModel::read(
   }
 
   tinyxml2::XMLDocument mjcfDoc;
-  if (not readXmlFile(mjcfDoc, uri, retriever))
+  if (!readXmlFile(mjcfDoc, uri, retriever))
   {
     errors.emplace_back(
         ErrorCode::FILE_READ, "Failed to load '" + uri.toString() + "'.");

--- a/dart/utils/mjcf/detail/Site.cpp
+++ b/dart/utils/mjcf/detail/Site.cpp
@@ -180,7 +180,7 @@ Errors Site::read(tinyxml2::XMLElement* element)
 static bool canUseFromTo(
     GeomType type, const common::optional<Eigen::Vector6d>& fromto)
 {
-  if (not fromto)
+  if (!fromto)
     return false;
 
   switch (type)

--- a/dart/utils/mjcf/detail/Utils.cpp
+++ b/dart/utils/mjcf/detail/Utils.cpp
@@ -57,7 +57,7 @@ Errors checkOrientationValidity(const tinyxml2::XMLElement* element)
 
   if (hasAttribute(element, "axisangle"))
   {
-    if (not orientationTypes.empty())
+    if (!orientationTypes.empty())
       orientationTypes += ", ";
     orientationTypes += "axisangle";
     ++numOrientationTypes;
@@ -65,7 +65,7 @@ Errors checkOrientationValidity(const tinyxml2::XMLElement* element)
 
   if (hasAttribute(element, "euler"))
   {
-    if (not orientationTypes.empty())
+    if (!orientationTypes.empty())
       orientationTypes += ", ";
     orientationTypes += "euler";
     ++numOrientationTypes;
@@ -73,7 +73,7 @@ Errors checkOrientationValidity(const tinyxml2::XMLElement* element)
 
   if (hasAttribute(element, "xyaxes"))
   {
-    if (not orientationTypes.empty())
+    if (!orientationTypes.empty())
       orientationTypes += ", ";
     orientationTypes += "xyaxes";
     ++numOrientationTypes;
@@ -81,7 +81,7 @@ Errors checkOrientationValidity(const tinyxml2::XMLElement* element)
 
   if (hasAttribute(element, "zaxis"))
   {
-    if (not orientationTypes.empty())
+    if (!orientationTypes.empty())
       orientationTypes += ", ";
     orientationTypes += "zaxis";
     ++numOrientationTypes;
@@ -187,7 +187,7 @@ Errors handleInclude(
     const common::Uri mjcfUri
         = common::Uri::createFromRelativeUri(baseUri, fileAttribute);
     tinyxml2::XMLDocument mjcfDoc;
-    if (not readXmlFile(mjcfDoc, mjcfUri, retriever))
+    if (!readXmlFile(mjcfDoc, mjcfUri, retriever))
     {
       errors.emplace_back(
           ErrorCode::FILE_READ, "Failed to load '" + mjcfUri.toString() + "'.");
@@ -203,7 +203,7 @@ Errors handleInclude(
     }
 
     const bool copyResult = copyChildNodes(element, *mujocoElement);
-    if (not copyResult)
+    if (!copyResult)
     {
       errors.push_back(
           Error(ErrorCode::FILE_READ, "Failed to handle <include>"));

--- a/dart/utils/mjcf/detail/Weld.cpp
+++ b/dart/utils/mjcf/detail/Weld.cpp
@@ -136,7 +136,7 @@ Errors Weld::read(tinyxml2::XMLElement* element, const Defaults& defaults)
   {
     mBody2 = *mAttributes.mBody2;
   }
-  if (not mAttributes.mRelPose.tail<4>().isApprox(Eigen::Vector4d::Zero()))
+  if (!mAttributes.mRelPose.tail<4>().isApprox(Eigen::Vector4d::Zero()))
   {
     mRelativeTransfrom = Eigen::Isometry3d::Identity();
     Eigen::Quaterniond quat;

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -739,7 +739,7 @@ bool DartLoader::createShapeNodes(
     {
       auto shapeNode
           = bodyNode->createShapeNodeWith<dynamics::VisualAspect>(shape);
-      if (not visual->name.empty())
+      if (!visual->name.empty())
         shapeNode->setName(visual->name);
       shapeNode->setRelativeTransform(toEigen(visual->origin));
       setMaterial(model, shapeNode->getVisualAspect(), visual.get());
@@ -761,7 +761,7 @@ bool DartLoader::createShapeNodes(
       auto shapeNode = bodyNode->createShapeNodeWith<
           dynamics::CollisionAspect,
           dynamics::DynamicsAspect>(shape);
-      if (not collision->name.empty())
+      if (!collision->name.empty())
         shapeNode->setName(collision->name);
       shapeNode->setRelativeTransform(toEigen(collision->origin));
     }

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -2626,7 +2626,7 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
     if (line.count('"', 0, commentpos) -
         line.count('\\"', 0, commentpos)) % 2 == 0:   # not in quotes
       # Allow one space for new scopes, two spaces otherwise:
-      if (not Match(r'^\s*{ //', line) and
+      if (!Match(r'^\s*{ //', line) and
           ((commentpos >= 1 and
             line[commentpos-1] not in string.whitespace) or
            (commentpos >= 2 and
@@ -2905,7 +2905,7 @@ def CheckSectionSpacing(filename, clean_lines, class_info, linenum, error):
     # Also ignores cases where the previous line ends with a backslash as can be
     # common when defining classes in C macros.
     prev_line = clean_lines.lines[linenum - 1]
-    if (not IsBlankLine(prev_line) and
+    if (!IsBlankLine(prev_line) and
         not Search(r'\b(class|struct)\b', prev_line) and
         not Search(r'\\$', prev_line)):
       # Try a bit harder to find the beginning of the class.  This is to
@@ -3383,7 +3383,7 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
   #
   # The "$Id:...$" comment may also get very long without it being the
   # developers fault.
-  if (not line.startswith('#include') and not is_header_guard and
+  if (!line.startswith('#include') and not is_header_guard and
       not Match(r'^\s*//.*http(s?)://\S*$', line) and
       not Match(r'^// \$Id:.*#[0-9]+ \$$', line)):
     line_width = GetLineWidth(line)


### PR DESCRIPTION
`not` operator isn't compatible in some build environments. No reason to use the _alternative_ operators.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format new code files using `clang-format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
