### PR TITLE
[dynamics]: deep copy shapes

### DIFF
--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -55,6 +55,9 @@ ArrowShape::Properties::Properties(
 }
 
 //==============================================================================
+ArrowShape::ArrowShape() : MeshShape(Eigen::Vector3d::Ones(), nullptr) {}
+
+//==============================================================================
 ArrowShape::ArrowShape(
     const Eigen::Vector3d& _tail,
     const Eigen::Vector3d& _head,
@@ -254,9 +257,9 @@ void ArrowShape::configureArrow(
 }
 
 //==============================================================================
-ShapePtr ArrowShape::copy() const
+ShapePtr ArrowShape::clone() const
 {
-  aiScene* new_scene = copyMesh();
+  aiScene* new_scene = cloneMesh();
   auto new_shape = std::make_shared<ArrowShape>();
 
   new_shape->mTail = mTail;

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -254,6 +254,29 @@ void ArrowShape::configureArrow(
 }
 
 //==============================================================================
+ShapePtr ArrowShape::copy() const
+{
+  aiScene* new_scene = copyMesh();
+  auto new_shape = std::make_shared<ArrowShape>();
+
+  new_shape->mTail = mTail;
+  new_shape->mHead = mHead;
+  new_shape->mProperties = mProperties;
+
+  new_shape->mMesh = new_scene;
+  new_shape->mMeshUri = mMeshUri;
+  new_shape->mMeshPath = mMeshPath;
+  new_shape->mResourceRetriever = mResourceRetriever;
+  new_shape->mDisplayList = mDisplayList;
+  new_shape->mScale = mScale;
+  new_shape->mColorMode = mColorMode;
+  new_shape->mAlphaMode = mAlphaMode;
+  new_shape->mColorIndex = mColorIndex;
+
+  return new_shape;
+}
+
+//==============================================================================
 void ArrowShape::instantiate(std::size_t resolution)
 {
   aiNode* node = new aiNode;

--- a/dart/dynamics/ArrowShape.hpp
+++ b/dart/dynamics/ArrowShape.hpp
@@ -67,6 +67,9 @@ public:
     bool mDoubleArrow;
   };
 
+  // Empty constructor (for copying)
+  ArrowShape() : MeshShape(Eigen::Vector3d::Ones(), nullptr) {}
+
   /// This will produce an arrow that reaches from _tail to _head with the given
   /// properties.
   ArrowShape(
@@ -99,6 +102,9 @@ public:
       const Eigen::Vector3d& _tail,
       const Eigen::Vector3d& _head,
       const Properties& _properties);
+
+  // Documentation inherited.
+  ShapePtr copy() const override;
 
 protected:
   void instantiate(std::size_t resolution);

--- a/dart/dynamics/ArrowShape.hpp
+++ b/dart/dynamics/ArrowShape.hpp
@@ -67,8 +67,8 @@ public:
     bool mDoubleArrow;
   };
 
-  // Empty constructor (for copying)
-  ArrowShape() : MeshShape(Eigen::Vector3d::Ones(), nullptr) {}
+  /// Empty constructor (for copying)
+  ArrowShape();
 
   /// This will produce an arrow that reaches from _tail to _head with the given
   /// properties.
@@ -104,7 +104,7 @@ public:
       const Properties& _properties);
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   void instantiate(std::size_t resolution);

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -109,6 +109,12 @@ Eigen::Matrix3d BoxShape::computeInertia(double mass) const
 }
 
 //==============================================================================
+ShapePtr BoxShape::copy() const
+{
+  return std::make_shared<BoxShape>(mSize);
+}
+
+//==============================================================================
 void BoxShape::updateBoundingBox() const
 {
   mBoundingBox.setMin(-mSize * 0.5);

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -109,7 +109,7 @@ Eigen::Matrix3d BoxShape::computeInertia(double mass) const
 }
 
 //==============================================================================
-ShapePtr BoxShape::copy() const
+ShapePtr BoxShape::clone() const
 {
   return std::make_shared<BoxShape>(mSize);
 }

--- a/dart/dynamics/BoxShape.hpp
+++ b/dart/dynamics/BoxShape.hpp
@@ -70,7 +70,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/BoxShape.hpp
+++ b/dart/dynamics/BoxShape.hpp
@@ -69,6 +69,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/CapsuleShape.cpp
+++ b/dart/dynamics/CapsuleShape.cpp
@@ -133,6 +133,12 @@ Eigen::Matrix3d CapsuleShape::computeInertia(
 }
 
 //==============================================================================
+ShapePtr CapsuleShape::copy() const
+{
+  return std::make_shared<CapsuleShape>(mRadius, mHeight);
+}
+
+//==============================================================================
 void CapsuleShape::updateBoundingBox() const
 {
   const Eigen::Vector3d corner(mRadius, mRadius, mRadius + 0.5 * mHeight);

--- a/dart/dynamics/CapsuleShape.cpp
+++ b/dart/dynamics/CapsuleShape.cpp
@@ -133,7 +133,7 @@ Eigen::Matrix3d CapsuleShape::computeInertia(
 }
 
 //==============================================================================
-ShapePtr CapsuleShape::copy() const
+ShapePtr CapsuleShape::clone() const
 {
   return std::make_shared<CapsuleShape>(mRadius, mHeight);
 }

--- a/dart/dynamics/CapsuleShape.hpp
+++ b/dart/dynamics/CapsuleShape.hpp
@@ -81,6 +81,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/CapsuleShape.hpp
+++ b/dart/dynamics/CapsuleShape.hpp
@@ -82,7 +82,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -118,6 +118,12 @@ Eigen::Matrix3d ConeShape::computeInertia(
 }
 
 //==============================================================================
+ShapePtr ConeShape::copy() const
+{
+  return std::make_shared<ConeShape>(mRadius, mHeight);
+}
+
+//==============================================================================
 void ConeShape::updateBoundingBox() const
 {
   const Eigen::Vector3d corner(mRadius, mRadius, mRadius + 0.5 * mHeight);

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -118,7 +118,7 @@ Eigen::Matrix3d ConeShape::computeInertia(
 }
 
 //==============================================================================
-ShapePtr ConeShape::copy() const
+ShapePtr ConeShape::clone() const
 {
   return std::make_shared<ConeShape>(mRadius, mHeight);
 }

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -83,6 +83,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -84,7 +84,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/CylinderShape.cpp
+++ b/dart/dynamics/CylinderShape.cpp
@@ -115,6 +115,12 @@ Eigen::Matrix3d CylinderShape::computeInertia(
 }
 
 //==============================================================================
+ShapePtr CylinderShape::copy() const
+{
+  return std::make_shared<CylinderShape>(mRadius, mHeight);
+}
+
+//==============================================================================
 void CylinderShape::updateBoundingBox() const
 {
   mBoundingBox.setMin(Eigen::Vector3d(-mRadius, -mRadius, -mHeight * 0.5));

--- a/dart/dynamics/CylinderShape.cpp
+++ b/dart/dynamics/CylinderShape.cpp
@@ -115,7 +115,7 @@ Eigen::Matrix3d CylinderShape::computeInertia(
 }
 
 //==============================================================================
-ShapePtr CylinderShape::copy() const
+ShapePtr CylinderShape::clone() const
 {
   return std::make_shared<CylinderShape>(mRadius, mHeight);
 }

--- a/dart/dynamics/CylinderShape.hpp
+++ b/dart/dynamics/CylinderShape.hpp
@@ -73,7 +73,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/CylinderShape.hpp
+++ b/dart/dynamics/CylinderShape.hpp
@@ -72,6 +72,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -140,7 +140,7 @@ Eigen::Matrix3d EllipsoidShape::computeInertia(
 }
 
 //==============================================================================
-ShapePtr EllipsoidShape::copy() const
+ShapePtr EllipsoidShape::clone() const
 {
   return std::make_shared<EllipsoidShape>(mDiameters);
 }

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -140,6 +140,12 @@ Eigen::Matrix3d EllipsoidShape::computeInertia(
 }
 
 //==============================================================================
+ShapePtr EllipsoidShape::copy() const
+{
+  return std::make_shared<EllipsoidShape>(mDiameters);
+}
+
+//==============================================================================
 Eigen::Matrix3d EllipsoidShape::computeInertia(double mass) const
 {
   return computeInertia(mDiameters, mass);

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -92,7 +92,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
   /// \brief True if all the radii are exactly eqaul.
   bool isSphere(void) const;

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -91,6 +91,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
   /// \brief True if all the radii are exactly eqaul.
   bool isSphere(void) const;
 

--- a/dart/dynamics/HeightmapShape.hpp
+++ b/dart/dynamics/HeightmapShape.hpp
@@ -149,6 +149,9 @@ public:
   /// Set the color of this arrow
   void notifyColorUpdated(const Eigen::Vector4d& color) override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/HeightmapShape.hpp
+++ b/dart/dynamics/HeightmapShape.hpp
@@ -150,7 +150,7 @@ public:
   void notifyColorUpdated(const Eigen::Vector4d& color) override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -361,7 +361,7 @@ Eigen::Matrix3d LineSegmentShape::computeInertia(double _mass) const
 }
 
 //==============================================================================
-ShapePtr LineSegmentShape::copy() const
+ShapePtr LineSegmentShape::clone() const
 {
   auto new_shape = std::make_shared<LineSegmentShape>(mThickness);
   new_shape->mVertices = mVertices;

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -361,6 +361,16 @@ Eigen::Matrix3d LineSegmentShape::computeInertia(double _mass) const
 }
 
 //==============================================================================
+ShapePtr LineSegmentShape::copy() const
+{
+  auto new_shape = std::make_shared<LineSegmentShape>(mThickness);
+  new_shape->mVertices = mVertices;
+  new_shape->mConnections = mConnections;
+
+  return new_shape;
+}
+
+//==============================================================================
 void LineSegmentShape::updateBoundingBox() const
 {
   if (mVertices.empty())

--- a/dart/dynamics/LineSegmentShape.hpp
+++ b/dart/dynamics/LineSegmentShape.hpp
@@ -108,6 +108,9 @@ public:
   /// will be evenly distributed across all lines.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
   // TODO(MXG): Consider supporting colors-per-vertex
 
 protected:

--- a/dart/dynamics/LineSegmentShape.hpp
+++ b/dart/dynamics/LineSegmentShape.hpp
@@ -109,7 +109,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
   // TODO(MXG): Consider supporting colors-per-vertex
 

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -38,6 +38,7 @@
 #include <assimp/Importer.hpp>
 #include <assimp/cimport.h>
 #include <assimp/postprocess.h>
+#include <assimp/version.h>
 
 #include "dart/common/Console.hpp"
 #include "dart/common/LocalResourceRetriever.hpp"
@@ -426,7 +427,8 @@ aiScene* MeshShape::copyMesh() const
     strcpy(new_scene->mTextures[i]->achFormatHint, mMesh->mTextures[i]->achFormatHint);
     new_scene->mTextures[i]->mHeight = mMesh->mTextures[i]->mHeight;
     new_scene->mTextures[i]->mWidth = mMesh->mTextures[i]->mWidth;
-    new_scene->mTextures[i]->mFilename = mMesh->mTextures[i]->mFilename;
+    if (aiGetVersionMajor() > 4)
+      new_scene->mTextures[i]->mFilename = mMesh->mTextures[i]->mFilename;
     unsigned int size = new_scene->mTextures[i]->mWidth;
     if (new_scene->mTextures[i]->mHeight > 0)
       size *= new_scene->mTextures[i]->mHeight;

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/dynamics/MeshShape.hpp"
 
+#include <iostream>
+
 #include <limits>
 #include <string>
 
@@ -308,6 +310,21 @@ Eigen::Matrix3d MeshShape::computeInertia(double _mass) const
 }
 
 //==============================================================================
+ShapePtr MeshShape::copy() const
+{
+  aiScene* new_scene = copyMesh();
+
+  auto new_shape = std::make_shared<MeshShape>(mScale, new_scene, mMeshUri, mResourceRetriever);
+  new_shape->mMeshPath = mMeshPath;
+  new_shape->mDisplayList = mDisplayList;
+  new_shape->mColorMode = mColorMode;
+  new_shape->mAlphaMode = mAlphaMode;
+  new_shape->mColorIndex = mColorIndex;
+
+  return new_shape;
+}
+
+//==============================================================================
 void MeshShape::updateBoundingBox() const
 {
   if (!mMesh)
@@ -357,6 +374,152 @@ void MeshShape::updateVolume() const
   const Eigen::Vector3d bounds = getBoundingBox().computeFullExtents();
   mVolume = bounds.x() * bounds.y() * bounds.z();
   mIsVolumeDirty = false;
+}
+
+//==============================================================================
+aiScene* MeshShape::copyMesh() const
+{
+  // Create new assimp mesh
+  aiScene* new_scene = new aiScene();
+  // Copy basic data
+  new_scene->mNumAnimations = 0; // we do not care about animations // new_scene->mNumAnimations = mMesh->mNumAnimations;
+  new_scene->mNumCameras = 0; // we do not care about cameras // new_scene->mNumCameras = mMesh->mNumCameras;
+  new_scene->mNumLights = 0; // we do not care about lights // new_scene->mNumLights = mMesh->mNumLights;
+  new_scene->mNumMaterials = mMesh->mNumMaterials;
+  new_scene->mNumMeshes = mMesh->mNumMeshes;
+  new_scene->mNumTextures = mMesh->mNumTextures;
+  new_scene->mFlags = mMesh->mFlags;
+  // Initialize empty structs
+  new_scene->mAnimations = nullptr;
+  new_scene->mCameras = nullptr;
+  new_scene->mLights = nullptr;
+
+  // Copy materials
+  new_scene->mMaterials = new aiMaterial*[new_scene->mNumMaterials];
+  for (unsigned int i = 0; i < new_scene->mNumMaterials; i++)
+  {
+    new_scene->mMaterials[i] = new aiMaterial();
+    new_scene->mMaterials[i]->mNumAllocated = mMesh->mMaterials[i]->mNumAllocated;
+    new_scene->mMaterials[i]->mNumProperties = mMesh->mMaterials[i]->mNumProperties;
+
+    new_scene->mMaterials[i]->mProperties = new aiMaterialProperty*[new_scene->mMaterials[i]->mNumProperties];
+
+    for (unsigned int j = 0; j < new_scene->mMaterials[i]->mNumProperties; j++)
+    {
+      new_scene->mMaterials[i]->mProperties[j] = new aiMaterialProperty();
+      auto& prop = new_scene->mMaterials[i]->mProperties[j];
+      auto& other = mMesh->mMaterials[i]->mProperties[j];
+
+      prop->mKey = other->mKey;
+      prop->mSemantic = other->mSemantic;
+      prop->mIndex = other->mIndex;
+      prop->mDataLength = other->mDataLength;
+      prop->mType = other->mType;
+      prop->mData = new char[prop->mDataLength];
+      memcpy(prop->mData, other->mData, prop->mDataLength);
+    }
+  }
+
+  // Copy meshes
+  new_scene->mMeshes = new aiMesh*[new_scene->mNumMeshes];
+  for (unsigned int i = 0; i < new_scene->mNumMeshes; i++)
+  {
+    new_scene->mMeshes[i] = new aiMesh();
+    auto& mesh = new_scene->mMeshes[i];
+    auto& other = mMesh->mMeshes[i];
+    // Empty - we do not care about animation meshes or bones
+    mesh->mAnimMeshes = nullptr;
+    mesh->mBones = nullptr;
+    mesh->mNumAnimMeshes = 0;
+    mesh->mNumBones = 0;
+    // Basic info
+    mesh->mMaterialIndex = other->mMaterialIndex;
+    mesh->mName = other->mName;
+    mesh->mNumFaces = other->mNumFaces;
+    memcpy(&mesh->mNumUVComponents[0], &other->mNumUVComponents[0], AI_MAX_NUMBER_OF_TEXTURECOORDS * sizeof(unsigned int));
+    mesh->mNumVertices = other->mNumVertices;
+    mesh->mPrimitiveTypes = other->mPrimitiveTypes;
+
+    if (mesh->mNumVertices > 0) {
+      // Copy verticies
+      mesh->mVertices = new aiVector3D[mesh->mNumVertices];
+      memcpy(mesh->mVertices, other->mVertices, mesh->mNumVertices * sizeof(aiVector3D));
+
+      // Copy normals
+      mesh->mNormals = new aiVector3D[mesh->mNumVertices];
+      memcpy(mesh->mNormals, other->mNormals, mesh->mNumVertices * sizeof(aiVector3D));
+
+      // Copy faces
+      mesh->mFaces = new aiFace[mesh->mNumFaces];
+      for (unsigned int a = 0; a < mesh->mNumFaces; a++)
+      {
+        mesh->mFaces[a].mNumIndices = other->mFaces[a].mNumIndices;
+        mesh->mFaces[a].mIndices = new unsigned int[mesh->mFaces[a].mNumIndices];
+        memcpy(mesh->mFaces[a].mIndices, other->mFaces[a].mIndices, mesh->mFaces[a].mNumIndices * sizeof(unsigned int));
+      }
+
+      // Copy tangents
+      if (other->mTangents)
+      {
+        mesh->mTangents = new aiVector3D[mesh->mNumVertices];
+        memcpy(mesh->mTangents, other->mTangents, mesh->mNumVertices * sizeof(aiVector3D));
+      }
+      // Copy bi-tangents
+      if (other->mBitangents)
+      {
+        mesh->mBitangents = new aiVector3D[mesh->mNumVertices];
+        memcpy(mesh->mBitangents, other->mBitangents, mesh->mNumVertices * sizeof(aiVector3D));
+      }
+
+      // Copy color sets
+      for (unsigned int a = 0; a < AI_MAX_NUMBER_OF_COLOR_SETS; a++)
+      {
+        if (other->mColors[a])
+        {
+          mesh->mColors[a] = new aiColor4D[mesh->mNumVertices];
+          memcpy(mesh->mColors[a], other->mColors[a], mesh->mNumVertices * sizeof(aiColor4D));
+        }
+      }
+
+      // Copy texture coordinates
+      for (unsigned int a = 0; a < AI_MAX_NUMBER_OF_TEXTURECOORDS; a++)
+      {
+        if (other->mTextureCoords[a])
+        {
+          mesh->mTextureCoords[a] = new aiVector3D[mesh->mNumVertices];
+          memcpy(mesh->mTextureCoords[a], other->mTextureCoords[a], mesh->mNumVertices * sizeof(aiVector3D));
+        }
+      }
+    }
+  }
+
+  // Copy nodes
+  std::function<void(aiNode*, aiNode*, aiNode*)> aiNodeCopyRecursive = [&aiNodeCopyRecursive](aiNode* dest, aiNode* src, aiNode* parent)
+  {
+    dest->mNumMeshes = src->mNumMeshes;
+    dest->mNumChildren = src->mNumChildren;
+    dest->mName = src->mName;
+    dest->mTransformation = src->mTransformation;
+    dest->mParent = parent;
+
+    dest->mMeshes = new unsigned int[dest->mNumMeshes];
+    memcpy(dest->mMeshes, src->mMeshes, dest->mNumMeshes * sizeof(unsigned int));
+
+    dest->mChildren = new aiNode*[dest->mNumChildren];
+    for (unsigned int i = 0; i < dest->mNumChildren; i++)
+    {
+      dest->mChildren[i] = new aiNode();
+      aiNodeCopyRecursive(dest->mChildren[i], src->mChildren[i], dest);
+    }
+  };
+
+  if (mMesh->mRootNode)
+  {
+    new_scene->mRootNode = new aiNode();
+    aiNodeCopyRecursive(new_scene->mRootNode, mMesh->mRootNode, nullptr);
+  }
+
+  return new_scene;
 }
 
 //==============================================================================

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -420,6 +420,18 @@ aiScene* MeshShape::copyMesh() const
     }
   }
 
+  // Copy textures
+  new_scene->mTextures = new aiTexture*[new_scene->mNumTextures];
+  for (unsigned int i = 0; i < new_scene->mNumTextures; i++)
+  {
+    new_scene->mTextures[i] = new aiTexture();
+    memcpy(new_scene->mTextures[i]->achFormatHint, mMesh->mTextures[i]->achFormatHint, 4 * sizeof(char));
+    new_scene->mTextures[i]->mHeight = mMesh->mTextures[i]->mHeight;
+    new_scene->mTextures[i]->mWidth = mMesh->mTextures[i]->mWidth;
+    new_scene->mTextures[i]->pcData = new aiTexel[new_scene->mTextures[i]->mHeight * new_scene->mTextures[i]->mWidth];
+    memcpy(new_scene->mTextures[i]->pcData, mMesh->mTextures[i]->pcData, new_scene->mTextures[i]->mHeight * new_scene->mTextures[i]->mWidth * sizeof(aiTexel));
+  }
+
   // Copy meshes
   new_scene->mMeshes = new aiMesh*[new_scene->mNumMeshes];
   for (unsigned int i = 0; i < new_scene->mNumMeshes; i++)

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -32,8 +32,6 @@
 
 #include "dart/dynamics/MeshShape.hpp"
 
-#include <iostream>
-
 #include <limits>
 #include <string>
 
@@ -425,11 +423,15 @@ aiScene* MeshShape::copyMesh() const
   for (unsigned int i = 0; i < new_scene->mNumTextures; i++)
   {
     new_scene->mTextures[i] = new aiTexture();
-    memcpy(new_scene->mTextures[i]->achFormatHint, mMesh->mTextures[i]->achFormatHint, 4 * sizeof(char));
+    strcpy(new_scene->mTextures[i]->achFormatHint, mMesh->mTextures[i]->achFormatHint);
     new_scene->mTextures[i]->mHeight = mMesh->mTextures[i]->mHeight;
     new_scene->mTextures[i]->mWidth = mMesh->mTextures[i]->mWidth;
-    new_scene->mTextures[i]->pcData = new aiTexel[new_scene->mTextures[i]->mHeight * new_scene->mTextures[i]->mWidth];
-    memcpy(new_scene->mTextures[i]->pcData, mMesh->mTextures[i]->pcData, new_scene->mTextures[i]->mHeight * new_scene->mTextures[i]->mWidth * sizeof(aiTexel));
+    new_scene->mTextures[i]->mFilename = mMesh->mTextures[i]->mFilename;
+    unsigned int size = new_scene->mTextures[i]->mWidth;
+    if (new_scene->mTextures[i]->mHeight > 0)
+      size *= new_scene->mTextures[i]->mHeight;
+    new_scene->mTextures[i]->pcData = new aiTexel[size];
+    memcpy(new_scene->mTextures[i]->pcData, mMesh->mTextures[i]->pcData, size * sizeof(aiTexel));
   }
 
   // Copy meshes

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -427,8 +427,7 @@ aiScene* MeshShape::copyMesh() const
     strcpy(new_scene->mTextures[i]->achFormatHint, mMesh->mTextures[i]->achFormatHint);
     new_scene->mTextures[i]->mHeight = mMesh->mTextures[i]->mHeight;
     new_scene->mTextures[i]->mWidth = mMesh->mTextures[i]->mWidth;
-    if (aiGetVersionMajor() > 4)
-      new_scene->mTextures[i]->mFilename = mMesh->mTextures[i]->mFilename;
+    // new_scene->mTextures[i]->mFilename = mMesh->mTextures[i]->mFilename;
     unsigned int size = new_scene->mTextures[i]->mWidth;
     if (new_scene->mTextures[i]->mHeight > 0)
       size *= new_scene->mTextures[i]->mHeight;

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -38,7 +38,6 @@
 #include <assimp/Importer.hpp>
 #include <assimp/cimport.h>
 #include <assimp/postprocess.h>
-#include <assimp/version.h>
 
 #include "dart/common/Console.hpp"
 #include "dart/common/LocalResourceRetriever.hpp"
@@ -309,9 +308,9 @@ Eigen::Matrix3d MeshShape::computeInertia(double _mass) const
 }
 
 //==============================================================================
-ShapePtr MeshShape::copy() const
+ShapePtr MeshShape::clone() const
 {
-  aiScene* new_scene = copyMesh();
+  aiScene* new_scene = cloneMesh();
 
   auto new_shape = std::make_shared<MeshShape>(mScale, new_scene, mMeshUri, mResourceRetriever);
   new_shape->mMeshPath = mMeshPath;
@@ -376,7 +375,7 @@ void MeshShape::updateVolume() const
 }
 
 //==============================================================================
-aiScene* MeshShape::copyMesh() const
+aiScene* MeshShape::cloneMesh() const
 {
   // Create new assimp mesh
   aiScene* new_scene = new aiScene();

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -164,7 +164,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  virtual ShapePtr copy() const override;
+  virtual ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.
@@ -173,7 +173,7 @@ protected:
   // Documentation inherited.
   void updateVolume() const override;
 
-  aiScene* copyMesh() const;
+  aiScene* cloneMesh() const;
 
   const aiScene* mMesh;
 

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -163,12 +163,17 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  virtual ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;
 
   // Documentation inherited.
   void updateVolume() const override;
+
+  aiScene* copyMesh() const;
 
   const aiScene* mMesh;
 

--- a/dart/dynamics/MultiSphereConvexHullShape.cpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.cpp
@@ -128,7 +128,7 @@ Eigen::Matrix3d MultiSphereConvexHullShape::computeInertia(double mass) const
 }
 
 //==============================================================================
-ShapePtr MultiSphereConvexHullShape::copy() const
+ShapePtr MultiSphereConvexHullShape::clone() const
 {
   return std::make_shared<MultiSphereConvexHullShape>(mSpheres);
 }

--- a/dart/dynamics/MultiSphereConvexHullShape.cpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.cpp
@@ -128,6 +128,12 @@ Eigen::Matrix3d MultiSphereConvexHullShape::computeInertia(double mass) const
 }
 
 //==============================================================================
+ShapePtr MultiSphereConvexHullShape::copy() const
+{
+  return std::make_shared<MultiSphereConvexHullShape>(mSpheres);
+}
+
+//==============================================================================
 void MultiSphereConvexHullShape::updateBoundingBox() const
 {
   Eigen::Vector3d min

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -85,7 +85,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -84,6 +84,9 @@ public:
   /// the axis-alinged bounding box of this MultiSphereConvexHullShape.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/PlaneShape.cpp
+++ b/dart/dynamics/PlaneShape.cpp
@@ -124,7 +124,7 @@ double PlaneShape::computeSignedDistance(const Eigen::Vector3d& _point) const
 }
 
 //==============================================================================
-ShapePtr PlaneShape::copy() const
+ShapePtr PlaneShape::clone() const
 {
   return std::make_shared<PlaneShape>(mNormal, mOffset);
 }

--- a/dart/dynamics/PlaneShape.cpp
+++ b/dart/dynamics/PlaneShape.cpp
@@ -124,6 +124,12 @@ double PlaneShape::computeSignedDistance(const Eigen::Vector3d& _point) const
 }
 
 //==============================================================================
+ShapePtr PlaneShape::copy() const
+{
+  return std::make_shared<PlaneShape>(mNormal, mOffset);
+}
+
+//==============================================================================
 void PlaneShape::updateBoundingBox() const
 {
   mBoundingBox.setMin(

--- a/dart/dynamics/PlaneShape.hpp
+++ b/dart/dynamics/PlaneShape.hpp
@@ -82,6 +82,9 @@ public:
   /// Compute signed distance between the plane and the given point
   double computeSignedDistance(const Eigen::Vector3d& _point) const;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 private:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/PlaneShape.hpp
+++ b/dart/dynamics/PlaneShape.hpp
@@ -83,7 +83,7 @@ public:
   double computeSignedDistance(const Eigen::Vector3d& _point) const;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 private:
   // Documentation inherited.

--- a/dart/dynamics/PointCloudShape.cpp
+++ b/dart/dynamics/PointCloudShape.cpp
@@ -239,6 +239,18 @@ void PointCloudShape::notifyColorUpdated(const Eigen::Vector4d& /*color*/)
 }
 
 //==============================================================================
+ShapePtr PointCloudShape::copy() const
+{
+  auto new_shape = std::make_shared<PointCloudShape>(mVisualSize);
+  new_shape->mPoints = mPoints;
+  new_shape->mPointShapeType = mPointShapeType;
+  new_shape->mColorMode = mColorMode;
+  new_shape->mColors = mColors;
+
+  return new_shape;
+}
+
+//==============================================================================
 void PointCloudShape::updateVolume() const
 {
   mVolume = 0.0;

--- a/dart/dynamics/PointCloudShape.cpp
+++ b/dart/dynamics/PointCloudShape.cpp
@@ -239,7 +239,7 @@ void PointCloudShape::notifyColorUpdated(const Eigen::Vector4d& /*color*/)
 }
 
 //==============================================================================
-ShapePtr PointCloudShape::copy() const
+ShapePtr PointCloudShape::clone() const
 {
   auto new_shape = std::make_shared<PointCloudShape>(mVisualSize);
   new_shape->mPoints = mPoints;

--- a/dart/dynamics/PointCloudShape.hpp
+++ b/dart/dynamics/PointCloudShape.hpp
@@ -153,6 +153,9 @@ public:
   // Documentation inherited.
   void notifyColorUpdated(const Eigen::Vector4d& color) override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateVolume() const override;

--- a/dart/dynamics/PointCloudShape.hpp
+++ b/dart/dynamics/PointCloudShape.hpp
@@ -154,7 +154,7 @@ public:
   void notifyColorUpdated(const Eigen::Vector4d& color) override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -155,7 +155,7 @@ Eigen::Matrix3d PyramidShape::computeInertia(double /*mass*/) const
 }
 
 //==============================================================================
-ShapePtr PyramidShape::copy() const
+ShapePtr PyramidShape::clone() const
 {
   return std::make_shared<PyramidShape>(mBaseWidth, mBaseDepth, mHeight);
 }

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -154,5 +154,11 @@ Eigen::Matrix3d PyramidShape::computeInertia(double /*mass*/) const
   return Eigen::Matrix3d::Identity();
 }
 
+//==============================================================================
+ShapePtr PyramidShape::copy() const
+{
+  return std::make_shared<PyramidShape>(mBaseWidth, mBaseDepth, mHeight);
+}
+
 } // namespace dynamics
 } // namespace dart

--- a/dart/dynamics/PyramidShape.hpp
+++ b/dart/dynamics/PyramidShape.hpp
@@ -96,7 +96,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/PyramidShape.hpp
+++ b/dart/dynamics/PyramidShape.hpp
@@ -95,6 +95,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -191,6 +191,9 @@ public:
   /// Increment the version of this Shape and notify its subscribers
   std::size_t incrementVersion() override final;
 
+  /// Deep copy shape
+  virtual ShapePtr copy() const = 0;
+
 protected:
   /// Updates volume
   virtual void updateVolume() const = 0;

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -192,7 +192,7 @@ public:
   std::size_t incrementVersion() override final;
 
   /// Deep copy shape
-  virtual ShapePtr copy() const = 0;
+  virtual ShapePtr clone() const = 0;
 
 protected:
   /// Updates volume

--- a/dart/dynamics/SoftMeshShape.cpp
+++ b/dart/dynamics/SoftMeshShape.cpp
@@ -67,22 +67,32 @@ const std::string& SoftMeshShape::getStaticType()
   return type;
 }
 
+//==============================================================================
 const aiMesh* SoftMeshShape::getAssimpMesh() const
 {
   return mAssimpMesh.get();
 }
 
+//==============================================================================
 const SoftBodyNode* SoftMeshShape::getSoftBodyNode() const
 {
   return mSoftBodyNode;
 }
 
+//==============================================================================
 Eigen::Matrix3d SoftMeshShape::computeInertia(double /*mass*/) const
 {
   dtwarn << "[SoftMeshShape::computeInertia] Not implemented yet.\n";
   // TODO(JS): Not implemented.
 
   return Eigen::Matrix3d::Zero();
+}
+
+//==============================================================================
+ShapePtr SoftMeshShape::clone() const
+{
+  dtwarn << "[SoftMeshShape::clone] This should never be called.\n";
+  return nullptr;
 }
 
 //==============================================================================

--- a/dart/dynamics/SoftMeshShape.hpp
+++ b/dart/dynamics/SoftMeshShape.hpp
@@ -74,7 +74,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override { return nullptr; }
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/SoftMeshShape.hpp
+++ b/dart/dynamics/SoftMeshShape.hpp
@@ -73,6 +73,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override { return nullptr; }
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -100,6 +100,12 @@ Eigen::Matrix3d SphereShape::computeInertia(double radius, double mass)
 }
 
 //==============================================================================
+ShapePtr SphereShape::copy() const
+{
+  return std::make_shared<SphereShape>(mRadius);
+}
+
+//==============================================================================
 Eigen::Matrix3d SphereShape::computeInertia(double mass) const
 {
   return computeInertia(mRadius, mass);

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -100,7 +100,7 @@ Eigen::Matrix3d SphereShape::computeInertia(double radius, double mass)
 }
 
 //==============================================================================
-ShapePtr SphereShape::copy() const
+ShapePtr SphereShape::clone() const
 {
   return std::make_shared<SphereShape>(mRadius);
 }

--- a/dart/dynamics/SphereShape.hpp
+++ b/dart/dynamics/SphereShape.hpp
@@ -68,6 +68,9 @@ public:
   // Documentation inherited.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/SphereShape.hpp
+++ b/dart/dynamics/SphereShape.hpp
@@ -69,7 +69,7 @@ public:
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/VoxelGridShape.cpp
+++ b/dart/dynamics/VoxelGridShape.cpp
@@ -217,7 +217,7 @@ void VoxelGridShape::notifyColorUpdated(const Eigen::Vector4d& /*color*/)
 }
 
 //==============================================================================
-ShapePtr VoxelGridShape::copy() const
+ShapePtr VoxelGridShape::clone() const
 {
   return std::make_shared<VoxelGridShape>(fcl_make_shared<octomap::OcTree>(*mOctree));
 }

--- a/dart/dynamics/VoxelGridShape.cpp
+++ b/dart/dynamics/VoxelGridShape.cpp
@@ -217,6 +217,12 @@ void VoxelGridShape::notifyColorUpdated(const Eigen::Vector4d& /*color*/)
 }
 
 //==============================================================================
+ShapePtr VoxelGridShape::copy() const
+{
+  return std::make_shared<VoxelGridShape>(fcl_make_shared<octomap::OcTree>(*mOctree));
+}
+
+//==============================================================================
 void VoxelGridShape::updateBoundingBox() const
 {
   // TODO(JS): Not implemented.

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -147,6 +147,9 @@ public:
   // Documentation inherited.
   void notifyColorUpdated(const Eigen::Vector4d& color) override;
 
+  // Documentation inherited.
+  ShapePtr copy() const override;
+
 protected:
   // Documentation inherited.
   void updateBoundingBox() const override;

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -148,7 +148,7 @@ public:
   void notifyColorUpdated(const Eigen::Vector4d& color) override;
 
   // Documentation inherited.
-  ShapePtr copy() const override;
+  ShapePtr clone() const override;
 
 protected:
   // Documentation inherited.

--- a/dart/dynamics/detail/HeightmapShape-impl.hpp
+++ b/dart/dynamics/detail/HeightmapShape-impl.hpp
@@ -186,6 +186,17 @@ void HeightmapShape<S>::notifyColorUpdated(const Eigen::Vector4d& /*color*/)
 
 //==============================================================================
 template <typename S>
+ShapePtr HeightmapShape<S>::copy() const
+{
+  auto new_mesh = std::make_shared<HeightmapShape<S>>();
+  new_mesh->mScale = mScale;
+  new_mesh->setHeightField(mHeights);
+
+  return new_mesh;
+}
+
+//==============================================================================
+template <typename S>
 Eigen::Matrix3d HeightmapShape<S>::computeInertia(double mass) const
 {
   if (mIsBoundingBoxDirty)

--- a/dart/dynamics/detail/HeightmapShape-impl.hpp
+++ b/dart/dynamics/detail/HeightmapShape-impl.hpp
@@ -186,7 +186,7 @@ void HeightmapShape<S>::notifyColorUpdated(const Eigen::Vector4d& /*color*/)
 
 //==============================================================================
 template <typename S>
-ShapePtr HeightmapShape<S>::copy() const
+ShapePtr HeightmapShape<S>::clone() const
 {
   auto new_mesh = std::make_shared<HeightmapShape<S>>();
   new_mesh->mScale = mScale;


### PR DESCRIPTION
This PR adds the possibility to deep copy shapes. In [robot_dart](https://github.com/resibots/robot_dart), we clone very frequently robots and we would like to be able to make deep copies of the robot. At the current state, DART does not copy shapes. This is generally OK unless we would like to alter the shapes later (e.g. create a damage or change the ColorMode of a MeshShape). So, this PR solves the above issue by making it able to deep copy shapes. I hope that I did not forget any shape. The only shape that I do not deep copy is the `SoftMeshShape` (for now I just return a `nullptr` in the new `copy` function; you might want to handle this differently [e.g. output a warning or exception]). Here there is a tight relationship between the `SoftBodyNode` it is attached to, so I do not touch this. By the way, when cloning a skeleton, is this type of meshes re-created to point to the correct `BodyNode`?

Let me know if this is OK for you or you would like to handle it differently. If this is OK, we can do unit tests.

***

**Before creating a pull request**

- [x] Document new methods and classes
- [x] Format new code files using `clang-format`

**Before merging a pull request**

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
