### PR TITLE
Add Castable class

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 - [ ] Document new methods and classes
 - [ ] Format new code files using ClangFormat by running `make format`
-- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve build warnings
+- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings
 
 #### Before merging a pull request
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [DART 6.13.0 (TBD)](https://github.com/dartsim/dart/milestone/69?closed=1)
 
+* Common
+
+  * Added Castable class: [#1634](https://github.com/dartsim/dart/pull/1634)
+
 * Dynamics
 
   * Added deep copy for shapes: [#1612](https://github.com/dartsim/dart/pull/1612)

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -495,11 +495,8 @@ BulletCollisionDetector::createBulletCollisionShape(
   using dynamics::SoftMeshShape;
   using dynamics::SphereShape;
 
-  if (shape->is<SphereShape>())
+  if (const auto sphere = shape->as<SphereShape>())
   {
-    assert(dynamic_cast<const SphereShape*>(shape.get()));
-
-    const auto sphere = static_cast<const SphereShape*>(shape.get());
     const auto radius = sphere->getRadius();
 
     auto bulletCollisionShape = std::make_unique<btSphereShape>(radius);
@@ -507,11 +504,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<BoxShape>())
+  else if (const auto box = shape->as<BoxShape>())
   {
-    assert(dynamic_cast<const BoxShape*>(shape.get()));
-
-    const auto box = static_cast<const BoxShape*>(shape.get());
     const Eigen::Vector3d& size = box->getSize();
 
     auto bulletCollisionShape
@@ -520,11 +514,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<EllipsoidShape>())
+  else if (const auto ellipsoid = shape->as<EllipsoidShape>())
   {
-    assert(dynamic_cast<const EllipsoidShape*>(shape.get()));
-
-    const auto ellipsoid = static_cast<const EllipsoidShape*>(shape.get());
     const Eigen::Vector3d& radii = ellipsoid->getRadii();
 
     auto bulletCollisionShape = createBulletEllipsoidMesh(
@@ -533,11 +524,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<CylinderShape>())
+  else if (const auto cylinder = shape->as<CylinderShape>())
   {
-    assert(dynamic_cast<const CylinderShape*>(shape.get()));
-
-    const auto cylinder = static_cast<const CylinderShape*>(shape.get());
     const auto radius = cylinder->getRadius();
     const auto height = cylinder->getHeight();
     const auto size = btVector3(radius, radius, height * 0.5);
@@ -547,11 +535,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<CapsuleShape>())
+  else if (const auto capsule = shape->as<CapsuleShape>())
   {
-    assert(dynamic_cast<const CapsuleShape*>(shape.get()));
-
-    const auto capsule = static_cast<const CapsuleShape*>(shape.get());
     const auto radius = capsule->getRadius();
     const auto height = capsule->getHeight();
 
@@ -561,11 +546,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<ConeShape>())
+  else if (const auto cone = shape->as<ConeShape>())
   {
-    assert(dynamic_cast<const ConeShape*>(shape.get()));
-
-    const auto cone = static_cast<const ConeShape*>(shape.get());
     const auto radius = cone->getRadius();
     const auto height = cone->getHeight();
 
@@ -579,11 +561,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<PlaneShape>())
+  else if (const auto plane = shape->as<PlaneShape>())
   {
-    assert(dynamic_cast<const PlaneShape*>(shape.get()));
-
-    const auto plane = static_cast<const PlaneShape*>(shape.get());
     const Eigen::Vector3d normal = plane->getNormal();
     const double offset = plane->getOffset();
 
@@ -593,12 +572,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<MultiSphereConvexHullShape>())
+  else if (const auto multiSphere = shape->as<MultiSphereConvexHullShape>())
   {
-    assert(dynamic_cast<const MultiSphereConvexHullShape*>(shape.get()));
-
-    const auto multiSphere
-        = static_cast<const MultiSphereConvexHullShape*>(shape.get());
     const auto numSpheres = multiSphere->getNumSpheres();
     const auto& spheres = multiSphere->getSpheres();
 
@@ -617,11 +592,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<MeshShape>())
+  else if (const auto shapeMesh = shape->as<MeshShape>())
   {
-    assert(dynamic_cast<const MeshShape*>(shape.get()));
-
-    const auto shapeMesh = static_cast<const MeshShape*>(shape.get());
     const auto scale = shapeMesh->getScale();
     const auto mesh = shapeMesh->getMesh();
 
@@ -631,11 +603,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<SoftMeshShape>())
+  else if (const auto softMeshShape = shape->as<SoftMeshShape>())
   {
-    assert(dynamic_cast<const SoftMeshShape*>(shape.get()));
-
-    const auto softMeshShape = static_cast<const SoftMeshShape*>(shape.get());
     const auto mesh = softMeshShape->getAssimpMesh();
 
     auto bulletCollisionShape = createBulletCollisionShapeFromAssimpMesh(mesh);
@@ -643,12 +612,8 @@ BulletCollisionDetector::createBulletCollisionShape(
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
   }
-  else if (shape->is<HeightmapShapef>())
+  else if (const auto heightMap = shape->as<HeightmapShapef>())
   {
-    assert(dynamic_cast<const HeightmapShapef*>(shape.get()));
-
-    const auto heightMap = static_cast<const HeightmapShapef*>(shape.get());
-
     return createBulletCollisionShapeFromHeightmap(heightMap);
   }
   else if (shape->is<HeightmapShaped>())

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -185,60 +185,52 @@ detail::OdeGeom* createOdeGeom(
   detail::OdeGeom* geom = nullptr;
   const auto shape = shapeFrame->getShape().get();
 
-  if (shape->is<SphereShape>())
+  if (const auto sphere = shape->as<SphereShape>())
   {
-    const auto sphere = static_cast<const SphereShape*>(shape);
     const auto radius = sphere->getRadius();
 
     geom = new detail::OdeSphere(collObj, radius);
   }
-  else if (shape->is<BoxShape>())
+  else if (const auto box = shape->as<BoxShape>())
   {
-    const auto box = static_cast<const BoxShape*>(shape);
     const Eigen::Vector3d& size = box->getSize();
 
     geom = new detail::OdeBox(collObj, size);
   }
-  else if (shape->is<CapsuleShape>())
+  else if (const auto capsule = shape->as<CapsuleShape>())
   {
-    const auto capsule = static_cast<const CapsuleShape*>(shape);
     const auto radius = capsule->getRadius();
     const auto height = capsule->getHeight();
 
     geom = new detail::OdeCapsule(collObj, radius, height);
   }
-  else if (shape->is<CylinderShape>())
+  else if (const auto cylinder = shape->as<CylinderShape>())
   {
-    const auto cylinder = static_cast<const CylinderShape*>(shape);
     const auto radius = cylinder->getRadius();
     const auto height = cylinder->getHeight();
 
     geom = new detail::OdeCylinder(collObj, radius, height);
   }
-  else if (shape->is<PlaneShape>())
+  else if (const auto plane = shape->as<PlaneShape>())
   {
-    const auto plane = static_cast<const PlaneShape*>(shape);
     const Eigen::Vector3d normal = plane->getNormal();
     const double offset = plane->getOffset();
 
     geom = new detail::OdePlane(collObj, normal, offset);
   }
-  else if (shape->is<MeshShape>())
+  else if (const auto shapeMesh = shape->as<MeshShape>())
   {
-    auto shapeMesh = static_cast<const MeshShape*>(shape);
     const Eigen::Vector3d& scale = shapeMesh->getScale();
     auto aiScene = shapeMesh->getMesh();
 
     geom = new detail::OdeMesh(collObj, aiScene, scale);
   }
-  else if (shape->is<HeightmapShapef>())
+  else if (const auto heightMap = shape->as<HeightmapShapef>())
   {
-    auto heightMap = static_cast<const HeightmapShapef*>(shape);
     geom = new detail::OdeHeightmapf(collObj, heightMap);
   }
-  else if (shape->is<HeightmapShaped>())
+  else if (const auto heightMap = shape->as<HeightmapShaped>())
   {
-    auto heightMap = static_cast<const HeightmapShaped*>(shape);
     geom = new detail::OdeHeightmapd(collObj, heightMap);
   }
   else

--- a/dart/common/Castable.hpp
+++ b/dart/common/Castable.hpp
@@ -30,21 +30,57 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_DYNAMICS_DETAIL_SHAPE_HPP_
-#define DART_DYNAMICS_DETAIL_SHAPE_HPP_
+#ifndef DART_COMMON_CASTABLE_HPP_
+#define DART_COMMON_CASTABLE_HPP_
 
-#include "dart/dynamics/Shape.hpp"
+namespace dart::common {
 
-namespace dart {
-namespace dynamics {
-
-template <typename ShapeT>
-bool Shape::is() const
+/// A CRTP base class that provides an interface for easily casting to the
+/// derived types.
+template <typename Base>
+class Castable
 {
-  return getType() == ShapeT::getStaticType();
-}
+public:
+  /// Returns true if the types of this \c Base and the template parameter (a
+  /// base class) are identical. This function is a syntactic sugar, which
+  /// is identical to: (getType() == ShapeType::getStaticType()).
+  ///
+  /// Example code:
+  /// \code
+  /// if (shape->is<Sphere>())
+  ///   std::cout << "The shape type is sphere!\n";
+  /// \endcode
+  template <typename Derived>
+  [[nodiscard]] bool is() const;
 
-} // namespace dynamics
-} // namespace dart
+  /// Casts to pointer of Derived if Base is its base class. Returns nullptr
+  /// otherwise.
+  template <typename Derived>
+  [[nodiscard]] const Derived* as() const;
 
-#endif // DART_DYNAMICS_DETAIL_SHAPE_HPP_
+  /// Casts to pointer of Derived if Base is its base class. Returns nullptr
+  /// otherwise.
+  template <typename Derived>
+  [[nodiscard]] Derived* as();
+
+  /// Casts to reference of Derived if Base is its base class. UB otherwise.
+  template <typename Derived>
+  [[nodiscard]] const Derived& as_ref() const;
+
+  /// Casts to reference of Derived if Base is its base class. UB otherwise.
+  template <typename Derived>
+  [[nodiscard]] Derived& as_ref();
+
+private:
+  /// Casts to Base const-reference
+  [[nodiscard]] const Base& base() const;
+
+  /// Casts to Base reference
+  [[nodiscard]] Base& base();
+};
+
+} // namespace dart::common
+
+#include "dart/common/detail/Castable-impl.hpp"
+
+#endif // DART_COMMON_CASTABLE_HPP_

--- a/dart/common/Metaprogramming.hpp
+++ b/dart/common/Metaprogramming.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2021, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COMMON_METAPROGRAMMING_HPP_
+#define DART_COMMON_METAPROGRAMMING_HPP_
+
+// Check for any member with given name, whether var, func, class, union, enum.
+#define DART_CREATE_MEMBER_CHECK(member)                                       \
+                                                                               \
+  template <typename T, typename = std::true_type>                             \
+  struct Alias_##member;                                                       \
+                                                                               \
+  template <typename T>                                                        \
+  struct Alias_##member<                                                       \
+      T,                                                                       \
+      ::std::integral_constant<                                                \
+          bool,                                                                \
+          ::dart::common::detail::got_type<decltype(&T::member)>::value>>      \
+  {                                                                            \
+    static const decltype(&T::member) value;                                   \
+  };                                                                           \
+                                                                               \
+  struct AmbiguitySeed_##member                                                \
+  {                                                                            \
+    char member;                                                               \
+  };                                                                           \
+                                                                               \
+  template <typename T>                                                        \
+  struct has_member_##member                                                   \
+  {                                                                            \
+    static const bool value = ::dart::common::detail::has_member<              \
+        Alias_##member<                                                        \
+            ::dart::common::detail::ambiguate<T, AmbiguitySeed_##member>>,     \
+        Alias_##member<AmbiguitySeed_##member>>::value;                        \
+  }
+
+#include "dart/common/detail/Metaprogramming-impl.hpp"
+
+#endif // DART_COMMON_METAPROGRAMMING_HPP_

--- a/dart/common/detail/Castable-impl.hpp
+++ b/dart/common/detail/Castable-impl.hpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2011-2021, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COMMON_DETAIL_CASTABLE_HPP_
+#define DART_COMMON_DETAIL_CASTABLE_HPP_
+
+#include "dart/common/Castable.hpp"
+#include "dart/common/Metaprogramming.hpp"
+
+namespace dart::common {
+
+//==============================================================================
+DART_CREATE_MEMBER_CHECK(getType);
+DART_CREATE_MEMBER_CHECK(getStaticType);
+
+//==============================================================================
+template <typename Base>
+template <typename Derived>
+bool Castable<Base>::is() const
+{
+  if constexpr (
+      has_member_getType<Base>::value
+      && has_member_getStaticType<Derived>::value)
+  {
+    return (base().getType() == Derived::getStaticType());
+  }
+  else
+  {
+    return (dynamic_cast<const Derived*>(&base()) != nullptr);
+  }
+}
+
+//==============================================================================
+template <typename Base>
+template <typename Derived>
+const Derived* Castable<Base>::as() const
+{
+  return is<Derived>() ? static_cast<const Derived*>(&base()) : nullptr;
+}
+
+//==============================================================================
+template <typename Base>
+template <typename Derived>
+Derived* Castable<Base>::as()
+{
+  return is<Derived>() ? static_cast<Derived*>(&base()) : nullptr;
+}
+
+//==============================================================================
+template <typename Base>
+template <typename Derived>
+const Derived& Castable<Base>::as_ref() const
+{
+  assert(is<Derived>());
+  return *as<Derived>();
+}
+
+//==============================================================================
+template <typename Base>
+template <typename Derived>
+Derived& Castable<Base>::as_ref()
+{
+  assert(is<Derived>());
+  return *as<Derived>();
+}
+
+//==============================================================================
+template <typename Base>
+const Base& Castable<Base>::base() const
+{
+  return *static_cast<const Base*>(this);
+}
+
+//==============================================================================
+template <typename Base>
+Base& Castable<Base>::base()
+{
+  return *static_cast<Base*>(this);
+}
+
+} // namespace dart::common
+
+#endif // DART_COMMON_DETAIL_CASTABLE_HPP_

--- a/dart/constraint/BoxedLcpSolver.hpp
+++ b/dart/constraint/BoxedLcpSolver.hpp
@@ -37,10 +37,12 @@
 
 #include <Eigen/Core>
 
+#include "dart/common/Castable.hpp"
+
 namespace dart {
 namespace constraint {
 
-class BoxedLcpSolver
+class BoxedLcpSolver : public common::Castable<BoxedLcpSolver>
 {
 public:
   /// Destructor
@@ -48,22 +50,6 @@ public:
 
   /// Returns the type
   virtual const std::string& getType() const = 0;
-
-  /// Returns true if this solver and the template parameter (a solver class)
-  /// are the same type. This function is a syntactic sugar, which is identical
-  /// to:
-  /// \code getType() == BoxedLcpSolver::getStaticType() \endcode.
-  ///
-  /// Example code:
-  /// \code
-  /// auto lcpSolver = constraintSolver->getBoxedLcpSolver();
-  /// if (shape->is<DantzigBoxedLcpSolver>())
-  ///   std::cout << "The LCP solver type is Dantzig!\n";
-  /// \endcode
-  ///
-  /// \sa getType()
-  template <typename BoxedLcpSolverT>
-  bool is() const;
 
   /// Solves constriant impulses for a constrained group. The LCP formulation
   /// setting that this function solve is A*x = b + w where each x[i], w[i]
@@ -109,7 +95,5 @@ public:
 
 } // namespace constraint
 } // namespace dart
-
-#include "dart/constraint/detail/BoxedLcpSolver-impl.hpp"
 
 #endif // DART_CONSTRAINT_BOXEDLCPSOLVER_HPP_

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -37,6 +37,7 @@
 
 #include <Eigen/Dense>
 
+#include "dart/common/Castable.hpp"
 #include "dart/common/ClassWithVirtualBase.hpp"
 #include "dart/common/Deprecated.hpp"
 #include "dart/common/Signal.hpp"
@@ -50,7 +51,8 @@ namespace dynamics {
 
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
 class Shape : public virtual common::Subject,
-              public virtual common::VersionCounter
+              public virtual common::VersionCounter,
+              public common::Castable<Shape>
 {
 public:
   using VersionChangedSignal
@@ -111,21 +113,6 @@ public:
   /// Returns a string representing the shape type
   /// \sa is()
   virtual const std::string& getType() const = 0;
-
-  /// Get true if the types of this Shape and the template parameter (a shape
-  /// class) are identical. This function is a syntactic sugar, which is
-  /// identical to: (getType() == ShapeType::getStaticType()).
-  ///
-  /// Example code:
-  /// \code
-  /// auto shape = bodyNode->getShapeNode(0)->getShape();
-  /// if (shape->is<BoxShape>())
-  ///   std::cout << "The shape type is box!\n";
-  /// \endcode
-  ///
-  /// \sa getType()
-  template <typename ShapeT>
-  bool is() const;
 
   /// \brief Get the bounding box of the shape in its local coordinate frame.
   ///        The dimension will be automatically determined by the sub-classes
@@ -238,7 +225,5 @@ DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_END
 
 } // namespace dynamics
 } // namespace dart
-
-#include "dart/dynamics/detail/Shape.hpp"
 
 #endif // DART_DYNAMICS_SHAPE_HPP_

--- a/dart/gui/glut/SimWindow.cpp
+++ b/dart/gui/glut/SimWindow.cpp
@@ -444,52 +444,41 @@ void SimWindow::drawShape(
   using dynamics::SoftMeshShape;
   using dynamics::SphereShape;
 
-  if (shape->is<SphereShape>())
+  if (const auto* sphere = shape->as<SphereShape>())
   {
-    const auto* sphere = static_cast<const SphereShape*>(shape);
     mRI->drawSphere(sphere->getRadius());
   }
-  else if (shape->is<BoxShape>())
+  else if (const auto* box = shape->as<BoxShape>())
   {
-    const auto* box = static_cast<const BoxShape*>(shape);
     mRI->drawCube(box->getSize());
   }
-  else if (shape->is<EllipsoidShape>())
+  else if (const auto* ellipsoid = shape->as<EllipsoidShape>())
   {
-    const auto* ellipsoid = static_cast<const EllipsoidShape*>(shape);
     mRI->drawEllipsoid(ellipsoid->getDiameters());
   }
-  else if (shape->is<CylinderShape>())
+  else if (const auto* cylinder = shape->as<CylinderShape>())
   {
-    const auto* cylinder = static_cast<const CylinderShape*>(shape);
     mRI->drawCylinder(cylinder->getRadius(), cylinder->getHeight());
   }
-  else if (shape->is<CapsuleShape>())
+  else if (const auto* capsule = shape->as<CapsuleShape>())
   {
-    const auto* capsule = static_cast<const CapsuleShape*>(shape);
     mRI->drawCapsule(capsule->getRadius(), capsule->getHeight());
   }
-  else if (shape->is<ConeShape>())
+  else if (const auto* cone = shape->as<ConeShape>())
   {
-    const auto* cone = static_cast<const ConeShape*>(shape);
     mRI->drawCone(cone->getRadius(), cone->getHeight());
   }
-  else if (shape->is<PyramidShape>())
+  else if (const auto* pyramid = shape->as<PyramidShape>())
   {
-    const auto* pyramid = static_cast<const PyramidShape*>(shape);
     mRI->drawPyramid(
         pyramid->getBaseWidth(), pyramid->getBaseDepth(), pyramid->getHeight());
   }
-  else if (shape->is<MultiSphereConvexHullShape>())
+  else if (const auto* multiSphere = shape->as<MultiSphereConvexHullShape>())
   {
-    const auto* multiSphere
-        = static_cast<const MultiSphereConvexHullShape*>(shape);
     mRI->drawMultiSphereConvexHull(multiSphere->getSpheres(), 3u);
   }
-  else if (shape->is<MeshShape>())
+  else if (const auto* mesh = shape->as<MeshShape>())
   {
-    const auto& mesh = static_cast<const MeshShape*>(shape);
-
     glDisable(GL_COLOR_MATERIAL); // Use mesh colors to draw
 
     if (mesh->getDisplayList())
@@ -497,14 +486,12 @@ void SimWindow::drawShape(
     else
       mRI->drawMesh(mesh->getScale(), mesh->getMesh());
   }
-  else if (shape->is<SoftMeshShape>())
+  else if (const auto* softMesh = shape->as<SoftMeshShape>())
   {
-    const auto& softMesh = static_cast<const SoftMeshShape*>(shape);
     mRI->drawSoftMesh(softMesh->getAssimpMesh());
   }
-  else if (shape->is<LineSegmentShape>())
+  else if (const auto* lineSegmentShape = shape->as<LineSegmentShape>())
   {
-    const auto& lineSegmentShape = static_cast<const LineSegmentShape*>(shape);
     mRI->drawLineSegments(
         lineSegmentShape->getVertices(), lineSegmentShape->getConnections());
   }


### PR DESCRIPTION
Add `Castable` class, a CRTP base class that provides an interface for easily casting to the derived types

***

#### Before creating a pull request

- [x] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
