### PR TITLE
Fix depth testing for transparent objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   * Fixed grouping of constraints: [#1624](https://github.com/dartsim/dart/pull/1624), [#1628](https://github.com/dartsim/dart/pull/1628)
   * Fixed issue with removing skeletons without shapes: [#1625](https://github.com/dartsim/dart/pull/1625)
 
+* GUI
+
+  * Fixed depth testing for transparent objects: [#1643](https://github.com/dartsim/dart/pull/1643)
+
 ### [DART 6.12.1 (2021-11-04)](https://github.com/dartsim/dart/milestone/71?closed=1)
 
 * Build

--- a/dart/gui/osg/GridVisual.cpp
+++ b/dart/gui/osg/GridVisual.cpp
@@ -32,10 +32,13 @@
 
 #include "dart/gui/osg/GridVisual.hpp"
 
+#include <osg/Depth>
+
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/dynamics/SphereShape.hpp"
+#include "dart/gui/osg/Utils.hpp"
 #include "dart/math/Helpers.hpp"
 
 namespace dart {
@@ -443,11 +446,55 @@ void GridVisual::refresh()
     mMinorLineGeom->getOrCreateStateSet()->setAttributeAndModes(
         mMinorLineWidth);
     mMinorLineGeom->setPrimitiveSet(0, mMinorLineFaces);
+    if (mMinorLineColor->at(0).a() < 1 - getAlphaThreshold<float>())
+    {
+      mMinorLineGeom->getOrCreateStateSet()->setMode(
+          GL_BLEND, ::osg::StateAttribute::ON);
+      mMinorLineGeom->getOrCreateStateSet()->setRenderingHint(
+          ::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      mMinorLineGeom->getOrCreateStateSet()->setAttributeAndModes(
+          depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      mMinorLineGeom->getOrCreateStateSet()->setMode(
+          GL_BLEND, ::osg::StateAttribute::OFF);
+      mMinorLineGeom->getOrCreateStateSet()->setRenderingHint(
+          ::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      mMinorLineGeom->getOrCreateStateSet()->setAttributeAndModes(
+          depth, ::osg::StateAttribute::ON);
+    }
 
     mMajorLineGeom->setVertexArray(mMajorLineVertices);
     mMajorLineGeom->getOrCreateStateSet()->setAttributeAndModes(
         mMajorLineWidth);
     mMajorLineGeom->setPrimitiveSet(0, mMajorLineFaces);
+    if (mMajorLineColor->at(0).a() < 1 - getAlphaThreshold<float>())
+    {
+      mMajorLineGeom->getOrCreateStateSet()->setMode(
+          GL_BLEND, ::osg::StateAttribute::ON);
+      mMajorLineGeom->getOrCreateStateSet()->setRenderingHint(
+          ::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      mMajorLineGeom->getOrCreateStateSet()->setAttributeAndModes(
+          depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      mMajorLineGeom->getOrCreateStateSet()->setMode(
+          GL_BLEND, ::osg::StateAttribute::OFF);
+      mMajorLineGeom->getOrCreateStateSet()->setRenderingHint(
+          ::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      mMajorLineGeom->getOrCreateStateSet()->setAttributeAndModes(
+          depth, ::osg::StateAttribute::ON);
+    }
 
     static const ::osg::Vec4 xAxisLineColor(0.9f, 0.1f, 0.1f, 1.0f);
     static const ::osg::Vec4 yAxisLineColor(0.1f, 0.9f, 0.1f, 1.0f);
@@ -516,9 +563,9 @@ void GridVisual::initialize()
   mAxisLineGeom->setVertexArray(mAxisLineVertices);
   mAxisLineGeom->setDataVariance(::osg::Object::STATIC);
   mAxisLineGeom->getOrCreateStateSet()->setMode(
-      GL_BLEND, ::osg::StateAttribute::ON);
+      GL_BLEND, ::osg::StateAttribute::OFF);
   mAxisLineGeom->getOrCreateStateSet()->setRenderingHint(
-      ::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::StateSet::OPAQUE_BIN);
 
   // Set grid color
   static const ::osg::Vec4 majorLineColor(0.4f, 0.4f, 0.4f, 1.0f);
@@ -538,20 +585,12 @@ void GridVisual::initialize()
   mMajorLineColor->at(0) = majorLineColor;
   mMajorLineGeom->setColorArray(mMajorLineColor);
   mMajorLineGeom->setColorBinding(::osg::Geometry::BIND_OVERALL);
-  mMajorLineGeom->getOrCreateStateSet()->setMode(
-      GL_BLEND, ::osg::StateAttribute::ON);
-  mMajorLineGeom->getOrCreateStateSet()->setRenderingHint(
-      ::osg::StateSet::TRANSPARENT_BIN);
 
   mMinorLineColor = new ::osg::Vec4Array;
   mMinorLineColor->resize(1);
   mMinorLineColor->at(0) = minorLineColor;
   mMinorLineGeom->setColorArray(mMinorLineColor);
   mMinorLineGeom->setColorBinding(::osg::Geometry::BIND_OVERALL);
-  mMinorLineGeom->getOrCreateStateSet()->setMode(
-      GL_BLEND, ::osg::StateAttribute::ON);
-  mMinorLineGeom->getOrCreateStateSet()->setRenderingHint(
-      ::osg::StateSet::TRANSPARENT_BIN);
 
   mMinorLineFaces = new ::osg::DrawElementsUInt(::osg::PrimitiveSet::LINES, 0);
   mMinorLineGeom->addPrimitiveSet(mMinorLineFaces);

--- a/dart/gui/osg/Utils.hpp
+++ b/dart/gui/osg/Utils.hpp
@@ -37,6 +37,24 @@
 #include <osg/Matrix>
 
 //==============================================================================
+template <typename T = double>
+constexpr T getAlphaThreshold()
+{
+  if constexpr (std::is_same_v<T, float>)
+  {
+    return 1e-6;
+  }
+  else if constexpr (std::is_same_v<T, double>)
+  {
+    return 1e-9;
+  }
+  else
+  {
+    return 1e-9;
+  }
+}
+
+//==============================================================================
 template <typename Scalar>
 ::osg::Matrix eigToOsgMatrix(
     const Eigen::Transform<Scalar, 3, Eigen::Isometry>& tf)

--- a/dart/gui/osg/render/BoxShapeNode.cpp
+++ b/dart/gui/osg/render/BoxShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/BoxShapeNode.hpp"
 
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/ShapeDrawable>
 
@@ -128,8 +129,6 @@ BoxShapeGeode::BoxShapeGeode(
     mBoxShape(shape),
     mDrawable(nullptr)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   extractData();
@@ -191,7 +190,28 @@ void BoxShapeDrawable::refresh(bool firstTime)
   if (mBoxShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
       || firstTime)
   {
-    setColor(eigToOsgVec4d(mVisualAspect->getRGBA()));
+    // Set color
+    const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
+    setColor(color);
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color.a()) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 }
 

--- a/dart/gui/osg/render/CapsuleShapeNode.cpp
+++ b/dart/gui/osg/render/CapsuleShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/CapsuleShapeNode.hpp"
 
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/ShapeDrawable>
 
@@ -135,8 +136,6 @@ CapsuleShapeGeode::CapsuleShapeGeode(
     mCapsuleShape(shape),
     mDrawable(nullptr)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   extractData();
@@ -201,7 +200,28 @@ void CapsuleShapeDrawable::refresh(bool firstTime)
   if (mCapsuleShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
       || firstTime)
   {
-    setColor(eigToOsgVec4d(mVisualAspect->getRGBA()));
+    // Set color
+    const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
+    setColor(color);
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color.a()) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 }
 

--- a/dart/gui/osg/render/ConeShapeNode.cpp
+++ b/dart/gui/osg/render/ConeShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/ConeShapeNode.hpp"
 
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/ShapeDrawable>
 
@@ -134,8 +135,6 @@ ConeShapeGeode::ConeShapeGeode(
     mConeShape(shape),
     mDrawable(nullptr)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   extractData();
@@ -200,7 +199,28 @@ void ConeShapeDrawable::refresh(bool firstTime)
   if (mConeShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
       || firstTime)
   {
-    setColor(eigToOsgVec4d(mVisualAspect->getRGBA()));
+    // Set color
+    const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
+    setColor(color);
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color.a()) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 }
 

--- a/dart/gui/osg/render/CylinderShapeNode.cpp
+++ b/dart/gui/osg/render/CylinderShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/CylinderShapeNode.hpp"
 
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/ShapeDrawable>
 
@@ -135,8 +136,6 @@ CylinderShapeGeode::CylinderShapeGeode(
     mCylinderShape(shape),
     mDrawable(nullptr)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   extractData();
@@ -202,7 +201,28 @@ void CylinderShapeDrawable::refresh(bool firstTime)
   if (mCylinderShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
       || firstTime)
   {
-    setColor(eigToOsgVec4d(mVisualAspect->getRGBA()));
+    // Set color
+    const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
+    setColor(color);
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color.a()) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 }
 

--- a/dart/gui/osg/render/EllipsoidShapeNode.cpp
+++ b/dart/gui/osg/render/EllipsoidShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/EllipsoidShapeNode.hpp"
 
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/Light>
 #include <osg/Material>
@@ -159,8 +160,6 @@ EllipsoidShapeGeode::EllipsoidShapeGeode(
     mEllipsoidShape(shape),
     mDrawable(nullptr)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   extractData();
@@ -227,7 +226,28 @@ void EllipsoidShapeDrawable::refresh(bool firstTime)
   if (mEllipsoidShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
       || firstTime)
   {
-    setColor(eigToOsgVec4d(mVisualAspect->getRGBA()));
+    // Set color
+    const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
+    setColor(color);
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color.a()) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 }
 

--- a/dart/gui/osg/render/LineSegmentShapeNode.cpp
+++ b/dart/gui/osg/render/LineSegmentShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/LineSegmentShapeNode.hpp"
 
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/Geometry>
 #include <osg/LineWidth>
@@ -141,8 +142,6 @@ LineSegmentShapeGeode::LineSegmentShapeGeode(
     mDrawable(nullptr),
     mLineWidth(new ::osg::LineWidth)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   getOrCreateStateSet()->setMode(GL_LIGHTING, ::osg::StateAttribute::OFF);
@@ -248,12 +247,30 @@ void LineSegmentShapeDrawable::refresh(bool firstTime)
   if (mLineSegmentShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
       || firstTime)
   {
-    if (mColors->size() != 1)
-      mColors->resize(1);
-
-    (*mColors)[0] = eigToOsgVec4d(mVisualAspect->getRGBA());
-
+    // Set color
+    const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
+    mColors->resize(1);
+    (*mColors)[0] = color;
     setColorArray(mColors, ::osg::Array::BIND_OVERALL);
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color.a()) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 }
 

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -36,6 +36,7 @@
 
 #include <boost/filesystem.hpp>
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/Geometry>
 #include <osg/Texture2D>
@@ -53,6 +54,7 @@ namespace render {
 
 namespace {
 
+//==============================================================================
 #define GET_TEXTURE_TYPE_AND_COUNT(MATERIAL, TYPE)                             \
   {                                                                            \
     const auto count = MATERIAL.GetTextureCount(TYPE);                         \
@@ -60,6 +62,7 @@ namespace {
       return std::make_pair(TYPE, count);                                      \
   }
 
+//==============================================================================
 std::pair<aiTextureType, std::size_t> getTextureTypeAndCount(
     const aiMaterial& material)
 {
@@ -82,6 +85,28 @@ std::pair<aiTextureType, std::size_t> getTextureTypeAndCount(
 
   // This shouldn't be reached but put
   return std::make_pair(aiTextureType_UNKNOWN, 0u);
+}
+
+//==============================================================================
+bool isTransparent(const ::osg::Material* material)
+{
+  if (std::abs(material->getAmbient(::osg::Material::FRONT).a())
+      < 1 - getAlphaThreshold<float>())
+    return true;
+
+  if (std::abs(material->getDiffuse(::osg::Material::FRONT).a())
+      < 1 - getAlphaThreshold<float>())
+    return true;
+
+  if (std::abs(material->getSpecular(::osg::Material::FRONT).a())
+      < 1 - getAlphaThreshold<float>())
+    return true;
+
+  if (std::abs(material->getEmission(::osg::Material::FRONT).a())
+      < 1 - getAlphaThreshold<float>())
+    return true;
+
+  return false;
 }
 
 } // namespace
@@ -505,8 +530,6 @@ MeshShapeGeode::MeshShapeGeode(
     mAiNode(node),
     mMainNode(parentNode)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   extractData(true);
@@ -710,6 +733,7 @@ void MeshShapeGeometry::extractData(bool firstTime)
       || firstTime)
   {
     bool isColored = false;
+    ::osg::StateSet* ss = getOrCreateStateSet();
 
     if (mMeshShape->getColorMode() == dart::dynamics::MeshShape::COLOR_INDEX)
     {
@@ -755,6 +779,14 @@ void MeshShapeGeometry::extractData(bool firstTime)
 
         setColorArray(mColors);
         setColorBinding(::osg::Geometry::BIND_PER_VERTEX);
+
+        // Set as a transparent object by default
+        // TODO(JS): Revisit if this doesn't make sense
+        ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+        ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+        ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+        depth->setWriteMask(false);
+        ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
       }
     }
 
@@ -766,37 +798,104 @@ void MeshShapeGeometry::extractData(bool firstTime)
               -1)) // -1 is being used by us to indicate no material
       {
         isColored = true;
-        auto material = mMainNode->getMaterial(matIndex);
+        ::osg::Material* material = mMainNode->getMaterial(matIndex);
         if (mMeshShape->getAlphaMode() == dynamics::MeshShape::SHAPE_ALPHA)
         {
+          const float shapeAlpha
+              = static_cast<float>(mVisualAspect->getAlpha());
+
           ::osg::ref_ptr<::osg::Material> newMaterial
               = new ::osg::Material(*material);
           newMaterial->setAlpha(
-              ::osg::Material::Face::FRONT_AND_BACK,
-              static_cast<float>(mVisualAspect->getAlpha()));
-          getOrCreateStateSet()->setAttributeAndModes(newMaterial);
+              ::osg::Material::Face::FRONT_AND_BACK, shapeAlpha);
+          ss->setAttributeAndModes(newMaterial);
+
+          // Set alpha specific properties
+          if (std::abs(shapeAlpha) > 1 - getAlphaThreshold<float>())
+          {
+            ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+            ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+            ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+            depth->setWriteMask(true);
+            ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+          }
+          else
+          {
+            ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+            ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+            ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+            depth->setWriteMask(false);
+            ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+          }
         }
         else if (mMeshShape->getAlphaMode() == dynamics::MeshShape::BLEND)
         {
-          const auto shapeAlpha = static_cast<float>(mVisualAspect->getAlpha());
+          float shapeAlpha = static_cast<float>(mVisualAspect->getAlpha());
           ::osg::ref_ptr<::osg::Material> newMaterial
               = new ::osg::Material(*material);
           blendMaterialAlpha(newMaterial, shapeAlpha);
-          getOrCreateStateSet()->setAttributeAndModes(newMaterial);
+          ss->setAttributeAndModes(newMaterial);
+
+          // Set alpha specific properties
+          if (std::abs(shapeAlpha) > 1 - getAlphaThreshold<float>()
+              && !isTransparent(material))
+          {
+            ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+            ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+            ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+            depth->setWriteMask(true);
+            ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+          }
+          else
+          {
+            ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+            ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+            ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+            depth->setWriteMask(false);
+            ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+          }
         }
         else
         {
-          getOrCreateStateSet()->setAttributeAndModes(material);
+          ss->setAttributeAndModes(material);
+
+          // Set alpha specific properties
+          if (!isTransparent(material))
+          {
+            ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+            ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+            ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+            depth->setWriteMask(true);
+            ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+          }
+          else
+          {
+            ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+            ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+            ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+            depth->setWriteMask(false);
+            ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+          }
         }
       }
       else
       {
-        getOrCreateStateSet()->removeAttribute(::osg::StateAttribute::MATERIAL);
+        ss->removeAttribute(::osg::StateAttribute::MATERIAL);
+        ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+        ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+        ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+        depth->setWriteMask(true);
+        ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
       }
     }
     else
     {
-      getOrCreateStateSet()->removeAttribute(::osg::StateAttribute::MATERIAL);
+      ss->removeAttribute(::osg::StateAttribute::MATERIAL);
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
     }
 
     const aiVector3D* aiTexCoords = mAiMesh->mTextureCoords[0];
@@ -806,15 +905,31 @@ void MeshShapeGeometry::extractData(bool firstTime)
     if (!isColored
         || mMeshShape->getColorMode() == dart::dynamics::MeshShape::SHAPE_COLOR)
     {
+      // Set color
       const Eigen::Vector4f& c = mVisualAspect->getRGBA().cast<float>();
-
-      if (mColors->size() != 1)
-        mColors->resize(1);
-
+      mColors->resize(1);
       (*mColors)[0] = ::osg::Vec4(c[0], c[1], c[2], c[3]);
-
       setColorArray(mColors);
       setColorBinding(::osg::Geometry::BIND_OVERALL);
+
+      // Set alpha specific properties
+      ::osg::StateSet* ss = getOrCreateStateSet();
+      if (std::abs(c[3]) > 1 - getAlphaThreshold<float>())
+      {
+        ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+        ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+        ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+        depth->setWriteMask(true);
+        ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+      }
+      else
+      {
+        ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+        ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+        ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+        depth->setWriteMask(false);
+        ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+      }
     }
   }
 

--- a/dart/gui/osg/render/PlaneShapeNode.cpp
+++ b/dart/gui/osg/render/PlaneShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/PlaneShapeNode.hpp"
 
 #include <osg/CullFace>
+#include <osg/Depth>
 #include <osg/Geode>
 #include <osg/ShapeDrawable>
 
@@ -133,8 +134,6 @@ PlaneShapeGeode::PlaneShapeGeode(
     mPlaneShape(shape),
     mDrawable(nullptr)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
   getOrCreateStateSet()->setAttributeAndModes(
       new ::osg::CullFace(::osg::CullFace::BACK));
   extractData();
@@ -201,7 +200,28 @@ void PlaneShapeDrawable::refresh(bool firstTime)
   if (mPlaneShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
       || firstTime)
   {
-    setColor(eigToOsgVec4d(mVisualAspect->getRGBA()));
+    // Set color
+    const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
+    setColor(color);
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color.a()) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 }
 

--- a/dart/gui/osg/render/PointCloudShapeNode.cpp
+++ b/dart/gui/osg/render/PointCloudShapeNode.cpp
@@ -494,10 +494,14 @@ public:
       mGeometry = new ::osg::Geometry;
       mGeometry->setVertexArray(mVertices);
       mGeometry->setDataVariance(::osg::Object::STATIC);
+
+      // TODO(JS): This should be set by the alpha value of the color
+      // See other shapes such as BoxShapeNode and MeshShapeNode.
       mGeometry->getOrCreateStateSet()->setMode(
           GL_BLEND, ::osg::StateAttribute::ON);
       mGeometry->getOrCreateStateSet()->setRenderingHint(
           ::osg::StateSet::TRANSPARENT_BIN);
+
       mGeometry->addPrimitiveSet(mPrimitiveSet);
       mGeometry->getOrCreateStateSet()->setAttribute(
           mPoint, ::osg::StateAttribute::ON);

--- a/dart/gui/osg/render/VoxelGridShapeNode.cpp
+++ b/dart/gui/osg/render/VoxelGridShapeNode.cpp
@@ -35,6 +35,7 @@
 #if HAVE_OCTOMAP
 
   #include <osg/CullFace>
+  #include <osg/Depth>
   #include <osg/Geode>
   #include <osg/Light>
   #include <osg/Material>
@@ -77,7 +78,27 @@ public:
 
   void updateColor(const Eigen::Vector4d& color)
   {
+    // Set color
     setColor(eigToOsgVec4f(color));
+
+    // Set alpha specific properties
+    ::osg::StateSet* ss = getOrCreateStateSet();
+    if (std::abs(color[3]) > 1 - getAlphaThreshold())
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::OFF);
+      ss->setRenderingHint(::osg::StateSet::OPAQUE_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(true);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
+    else
+    {
+      ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+      ::osg::ref_ptr<::osg::Depth> depth = new ::osg::Depth;
+      depth->setWriteMask(false);
+      ss->setAttributeAndModes(depth, ::osg::StateAttribute::ON);
+    }
   }
 
 protected:


### PR DESCRIPTION
**Summary:**
This PR fixes the issue that a transparent object is sometimes not displayed when it's behind another transparent object, which is not captured by https://github.com/dartsim/dart/pull/1414. It's fixed by two changes. Firstly, set OSG to render transparent objects after opaque objects using `setRenderingHint()` (see: [this post](https://stackoverflow.com/a/26864994/3122234)). Secondly, disable z-buffer writing while enabling z-buffer testing during drawing transparent objects so transparent objects don't get rendered when they're behind opaque object but always rendered (with blending) even when they're overlapped with other transparent objects regardless of their z-depths. See [this post](https://stackoverflow.com/a/52870474/3122234).

**Not fixed by this PR:**
Fixing for `VoxelShape` is saved for the future PR. Also, there could be performance hit for MeshShape when the color mode is `COLOR_INDEX`.

Before the fix:
![before_fix](https://user-images.githubusercontent.com/4038467/148130793-de4b2ef1-9fac-4446-afca-87a489ee5c10.gif)

After the fix:
![after_fix](https://user-images.githubusercontent.com/4038467/148131161-eaae0c69-2a96-4986-b892-5a3d08c7f11c.gif)


***

#### Before creating a pull request

- [x] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
