### PR TITLE
Remove use of boost::filesystem and boost::optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Added spdlog support as underlying logging framework: [#1633](https://github.com/dartsim/dart/pull/1633)
   * Added custom memory allocators: [#1636](https://github.com/dartsim/dart/pull/1636), [#1637](https://github.com/dartsim/dart/pull/1637), [#1639](https://github.com/dartsim/dart/pull/1639), [#1645](https://github.com/dartsim/dart/pull/1645), [#1646](https://github.com/dartsim/dart/pull/1646)
   * Added Stopwatch class to replace Timer: [#1638](https://github.com/dartsim/dart/pull/1638)
+  * Removed use of boos::filesystem and boost::optional: [#1648](https://github.com/dartsim/dart/pull/1648)
 
 * Dynamics
 

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -158,7 +158,12 @@ endif()
 if(TARGET octomap)
   target_link_libraries(dart PUBLIC octomap)
 endif()
+
+# C++ standard settings
 target_compile_features(dart PUBLIC cxx_std_17)
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+  target_link_libraries(dart PUBLIC "stdc++fs")
+endif()
 
 # Build DART with all available SIMD instructions
 if(DART_ENABLE_SIMD)

--- a/dart/common/Filesystem.hpp
+++ b/dart/common/Filesystem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021, The DART development contributors:
+ * Copyright (c) 2011-2022, The DART development contributors:
  * https://github.com/dartsim/dart/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dart/common/Filesystem.hpp
+++ b/dart/common/Filesystem.hpp
@@ -25,7 +25,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef DART_COMMON_FILESYSTEM_HPP_
+#define DART_COMMON_FILESYSTEM_HPP_
 
 #include "dart/common/Platform.hpp"
 
@@ -107,3 +108,5 @@ using error_code = ::std::error_code;
   #endif
 
 #endif // #ifndef DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+
+#endif // #ifndef DART_COMMON_FILESYSTEM_HPP_

--- a/dart/common/Filesystem.hpp
+++ b/dart/common/Filesystem.hpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2011-2021, The DART development contributors:
+ * https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "dart/common/Platform.hpp"
+
+#if !defined(DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL)
+
+  // Check for feature test macro for <filesystem>
+  #if defined(__cpp_lib_filesystem)
+    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+
+  // Check for feature test macro for <experimental/filesystem>
+  #elif defined(__cpp_lib_experimental_filesystem)
+    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+  // We can't check if headers exist...
+  // Let's assume experimental to be safe
+  #elif !defined(__has_include)
+    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+  // Check if the header "<filesystem>" exists
+  #elif __has_include(<filesystem>)
+
+    // If we're compiling on Visual Studio and are not compiling with C++17, we
+    // need to use experimental
+    #ifdef _MSC_VER
+
+      // Check and include header that defines "_HAS_CXX17"
+      #if __has_include(<yvals_core.h>)
+        #include <yvals_core.h>
+
+        // Check for enabled C++17 support
+        #if defined(_HAS_CXX17) && _HAS_CXX17
+          // We're using C++17, so let's use the normal version
+          #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+        #endif
+      #endif
+
+      // If the marco isn't defined yet, that means any of the other VS specific
+      // checks failed, so we need to use experimental
+      #ifndef DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+        #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+      #endif
+
+    // Not on Visual Studio. Let's use the normal version
+    #else // #ifdef _MSC_VER
+      #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+    #endif
+
+  // Check if the header "<filesystem>" exists
+  #elif __has_include(<experimental/filesystem>)
+    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+  // Fail if neither header is available with a nice error message
+  #else
+    #error Could not find system header "<filesystem>" or "<experimental/filesystem>"
+  #endif
+
+  // We priously determined that we need the exprimental version
+  #if DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+    // Include it
+    #include <experimental/filesystem>
+
+namespace dart::common {
+
+namespace filesystem = ::std::experimental::filesystem;
+using error_code = ::std::error_code;
+
+} // namespace dart::common
+
+  // We have a decent compiler and can use the normal version
+  #else
+    // Include it
+    #include <filesystem>
+
+namespace dart::common {
+namespace filesystem = ::std::filesystem;
+using error_code = ::std::error_code;
+} // namespace dart::common
+
+  #endif
+
+#endif // #ifndef DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL

--- a/dart/common/Optional.hpp
+++ b/dart/common/Optional.hpp
@@ -35,14 +35,11 @@
 
 #include <optional>
 
-#include "dart/common/Deprecated.hpp"
-
 namespace dart {
 namespace common {
 
 /// \deprecated Use std::optional instead
 template <class T>
-DART_DEPRECATED(6.13)
 using optional = std::optional<T>;
 
 } // namespace common

--- a/dart/common/Optional.hpp
+++ b/dart/common/Optional.hpp
@@ -33,22 +33,17 @@
 #ifndef DART_COMMON_OPTIONAL_HPP_
 #define DART_COMMON_OPTIONAL_HPP_
 
-#if __cplusplus >= 201703L
-  #include <optional>
-#else
-  #include <boost/optional.hpp>
-#endif
+#include <optional>
+
+#include "dart/common/Deprecated.hpp"
 
 namespace dart {
 namespace common {
 
-#if __cplusplus >= 201703L
+/// \deprecated Use std::optional instead
 template <class T>
+DART_DEPRECATED(6.13)
 using optional = std::optional<T>;
-#else
-template <class T>
-using optional = boost::optional<T>;
-#endif
 
 } // namespace common
 } // namespace dart

--- a/dart/common/SharedLibrary.cpp
+++ b/dart/common/SharedLibrary.cpp
@@ -57,7 +57,7 @@ namespace common {
 
 //==============================================================================
 std::shared_ptr<SharedLibrary> SharedLibrary::create(
-    const boost::filesystem::path& path)
+    const common::filesystem::path& path)
 {
   return create(path.string());
 }
@@ -70,7 +70,7 @@ std::shared_ptr<SharedLibrary> SharedLibrary::create(const std::string& path)
 
 //==============================================================================
 SharedLibrary::SharedLibrary(
-    ProtectedConstructionTag, const boost::filesystem::path& canonicalPath)
+    ProtectedConstructionTag, const common::filesystem::path& canonicalPath)
   : SharedLibrary(ProtectedConstruction, canonicalPath.string())
 {
   // Do nothing
@@ -104,7 +104,7 @@ SharedLibrary::~SharedLibrary()
 }
 
 //==============================================================================
-const boost::filesystem::path& SharedLibrary::getCanonicalPath() const
+const common::filesystem::path& SharedLibrary::getCanonicalPath() const
 {
   return mCanonicalPath;
 }

--- a/dart/common/SharedLibrary.hpp
+++ b/dart/common/SharedLibrary.hpp
@@ -36,9 +36,8 @@
 #include <memory>
 #include <string>
 
-#include <boost/filesystem.hpp>
-
 #include "dart/common/Deprecated.hpp"
+#include "dart/common/Filesystem.hpp"
 #include "dart/common/Platform.hpp"
 
 #if DART_OS_LINUX
@@ -115,7 +114,7 @@ public:
   /// instead.
   DART_DEPRECATED(6.10)
   static std::shared_ptr<SharedLibrary> create(
-      const boost::filesystem::path& path);
+      const common::filesystem::path& path);
 
   /// Creates a SharedLibrary from a path to the shared library.
   ///
@@ -145,7 +144,7 @@ public:
   /// SharedLibrary(ProtectedConstructionTag, const std::string&) instead.
   DART_DEPRECATED(6.10)
   explicit SharedLibrary(
-      ProtectedConstructionTag, const boost::filesystem::path& path);
+      ProtectedConstructionTag, const common::filesystem::path& path);
 
   /// Constructs from a path to the shared library.
   ///
@@ -164,7 +163,7 @@ public:
   virtual ~SharedLibrary();
 
   /// Returns the path to the shared library file.
-  const boost::filesystem::path& getCanonicalPath() const;
+  const common::filesystem::path& getCanonicalPath() const;
 
   /// Returns the path to the shared library file.
   const std::string& path() const;
@@ -185,7 +184,8 @@ protected:
   /// Canonical path to the shared library where a canonical path is an absolute
   /// path that has no elements which are symbolic links, and no dot or dot dot
   /// elements such as "/path/../to/yourfile".
-  boost::filesystem::path mCanonicalPath;
+  /// \deprecated Use mCanonicalPath2 instead.
+  common::filesystem::path mCanonicalPath;
   // TODO(JS): Remove in DART 7.
 
   /// Canonical path to the shared library where a canonical path is an absolute

--- a/dart/common/detail/SharedLibraryManager.cpp
+++ b/dart/common/detail/SharedLibraryManager.cpp
@@ -43,7 +43,7 @@ namespace detail {
 
 //==============================================================================
 std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
-    const boost::filesystem::path& path)
+    const common::filesystem::path& path)
 {
   return load(path.string());
 }
@@ -62,7 +62,7 @@ std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
   }
 
   // Convert the given path to the canonical path
-  const auto canonicalPath = boost::filesystem::canonical(path).string();
+  const auto canonicalPath = common::filesystem::canonical(path).string();
 
   const auto iter = mSharedLibraries.find(canonicalPath);
 

--- a/dart/common/detail/SharedLibraryManager.hpp
+++ b/dart/common/detail/SharedLibraryManager.hpp
@@ -37,20 +37,18 @@
 #include <string>
 #include <unordered_map>
 
-#include <boost/filesystem.hpp>
-#include <boost/functional/hash.hpp>
-
 #include "dart/common/Deprecated.hpp"
+#include "dart/common/Filesystem.hpp"
 #include "dart/common/Singleton.hpp"
 
 namespace std {
 
 template <>
-struct hash<boost::filesystem::path>
+struct hash<::dart::common::filesystem::path>
 {
-  size_t operator()(const boost::filesystem::path& p) const
+  size_t operator()(const ::dart::common::filesystem::path& p) const
   {
-    return boost::filesystem::hash_value(p);
+    return ::dart::common::filesystem::hash_value(p);
   }
 };
 
@@ -77,7 +75,7 @@ public:
   /// \deprecated Deprecated in 6.10. Please use load(const std::string&)
   /// instead.
   DART_DEPRECATED(6.10)
-  std::shared_ptr<SharedLibrary> load(const boost::filesystem::path& path);
+  std::shared_ptr<SharedLibrary> load(const common::filesystem::path& path);
 
   /// Loads the shared library with the specified path.
   ///
@@ -94,7 +92,7 @@ protected:
 
 protected:
   /// Map from library path to the library instances.
-  std::unordered_map<boost::filesystem::path, std::weak_ptr<SharedLibrary>>
+  std::unordered_map<common::filesystem::path, std::weak_ptr<SharedLibrary>>
       mLibraries;
   // TODO(JS): Remove this in DART 7.
 

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -315,7 +315,7 @@ void MeshShapeNode::extractData(bool firstTime)
           const common::filesystem::path relativeImagePath = imagePath.C_Str();
           const common::filesystem::path absoluteImagePath
               = common::filesystem::canonical(
-                  relativeImagePath, meshPath.parent_path(), ec);
+                  meshPath.parent_path() / relativeImagePath, ec);
 
           if (ec)
           {

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -34,7 +34,6 @@
 
 #include <map>
 
-#include <boost/filesystem.hpp>
 #include <osg/CullFace>
 #include <osg/Depth>
 #include <osg/Geode>
@@ -43,6 +42,7 @@
 #include <osgDB/ReadFile>
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Filesystem.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/gui/osg/Utils.hpp"
@@ -228,8 +228,6 @@ bool checkSpecularSanity(const aiColor4D& c)
 //==============================================================================
 void MeshShapeNode::extractData(bool firstTime)
 {
-  namespace bf = boost::filesystem;
-
   const aiScene* scene = mMeshShape->getMesh();
   const aiNode* root = scene->mRootNode;
 
@@ -302,7 +300,7 @@ void MeshShapeNode::extractData(bool firstTime)
       textureImageArray.reserve(count);
 
       aiString imagePath;
-      boost::system::error_code ec;
+      std::error_code ec;
       for (auto j = 0u; j < count; ++j)
       {
         if ((textureTypeAndCount.first == aiTextureType_NONE)
@@ -313,10 +311,11 @@ void MeshShapeNode::extractData(bool firstTime)
         else
         {
           aiMat->GetTexture(type, j, &imagePath);
-          const bf::path meshPath = mMeshShape->getMeshPath();
-          const bf::path relativeImagePath = imagePath.C_Str();
-          const bf::path absoluteImagePath
-              = bf::canonical(relativeImagePath, meshPath.parent_path(), ec);
+          const common::filesystem::path meshPath = mMeshShape->getMeshPath();
+          const common::filesystem::path relativeImagePath = imagePath.C_Str();
+          const common::filesystem::path absoluteImagePath
+              = common::filesystem::canonical(
+                  relativeImagePath, meshPath.parent_path(), ec);
 
           if (ec)
           {

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -46,7 +46,7 @@ namespace detail {
 //==============================================================================
 Errors Body::read(
     tinyxml2::XMLElement* element,
-    const common::optional<Size>& size,
+    const std::optional<Size>& size,
     const Defaults& defaults,
     const Default* currentDefault)
 {

--- a/dart/utils/mjcf/detail/Body.hpp
+++ b/dart/utils/mjcf/detail/Body.hpp
@@ -118,7 +118,7 @@ private:
   friend class Worldbody;
   Errors read(
       tinyxml2::XMLElement* element,
-      const common::optional<Size>& size,
+      const std::optional<Size>& size,
       const Defaults& defaults,
       const Default* currentDefault);
 

--- a/dart/utils/mjcf/detail/BodyAttributes.cpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.cpp
@@ -45,7 +45,7 @@ namespace detail {
 Errors appendBodyAttributes(
     BodyAttributes& attributes,
     tinyxml2::XMLElement* element,
-    const common::optional<Size>& size)
+    const std::optional<Size>& size)
 {
   Errors errors;
 

--- a/dart/utils/mjcf/detail/BodyAttributes.hpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.hpp
@@ -55,20 +55,20 @@ class Size;
 struct BodyAttributes final
 {
   /// Name of the body.
-  common::optional<std::string> mName;
+  std::optional<std::string> mName;
 
   /// If this attribute is present, all descendant elements that admit a
   /// defaults class will use the class specified here, unless they specify
   /// their own class or another body with a childclass attribute is
   /// encountered along the chain of nested bodies.
-  common::optional<std::string> mChildClass;
+  std::optional<std::string> mChildClass;
 
   /// If this attribute is "true", the body is labeled as a mocap body.
   bool mMocap{false};
 
   /// The 3D position of the body frame, in local or global coordinates as
   /// determined by the coordinate attribute of compiler.
-  common::optional<Eigen::Vector3d> mPos;
+  std::optional<Eigen::Vector3d> mPos;
 
   /// Quaternion
   Eigen::Quaterniond mQuat{Eigen::Quaterniond::Identity()};
@@ -76,31 +76,31 @@ struct BodyAttributes final
   /// These are the quantities (x, y, z, a) mentioned above. The last number
   /// is the angle of rotation, in degrees or radians as specified by the
   /// angle attribute of compiler.
-  common::optional<Eigen::Vector4d> mAxisAngle;
+  std::optional<Eigen::Vector4d> mAxisAngle;
 
   /// Rotation angles around three coordinate axes. The sequence of axes
   /// around which these rotations are applied is determined by the eulerseq
   /// attribute of compiler and is the same for the entire model.
-  common::optional<Eigen::Vector3d> mEuler;
+  std::optional<Eigen::Vector3d> mEuler;
 
   /// The first 3 numbers are the X axis of the frame. The next 3 numbers are
   /// the Y axis of the frame, which is automatically made orthogonal to the X
   /// axis. The Z axis is then defined as the cross-product of the X and Y
   /// axes.
-  common::optional<Eigen::Vector6d> mXYAxes;
+  std::optional<Eigen::Vector6d> mXYAxes;
 
   /// The Z axis of the frame
-  common::optional<Eigen::Vector3d> mZAxis;
+  std::optional<Eigen::Vector3d> mZAxis;
 
   Eigen::VectorXd mUser;
 
-  common::optional<Inertial> mInertial;
+  std::optional<Inertial> mInertial;
 };
 
 Errors appendBodyAttributes(
     BodyAttributes& attributes,
     tinyxml2::XMLElement* element,
-    const common::optional<Size>& size);
+    const std::optional<Size>& size);
 
 } // namespace detail
 } // namespace MjcfParser

--- a/dart/utils/mjcf/detail/Compiler.cpp
+++ b/dart/utils/mjcf/detail/Compiler.cpp
@@ -32,8 +32,6 @@
 
 #include "dart/utils/mjcf/detail/Compiler.hpp"
 
-#include <boost/filesystem.hpp>
-
 #include "dart/utils/XmlHelpers.hpp"
 
 namespace dart {

--- a/dart/utils/mjcf/detail/Geom.cpp
+++ b/dart/utils/mjcf/detail/Geom.cpp
@@ -92,7 +92,7 @@ Errors Geom::read(
 
 //==============================================================================
 static bool canUseFromTo(
-    GeomType type, const common::optional<Eigen::Vector6d>& fromto)
+    GeomType type, const std::optional<Eigen::Vector6d>& fromto)
 {
   if (!fromto)
     return false;

--- a/dart/utils/mjcf/detail/GeomAttributes.hpp
+++ b/dart/utils/mjcf/detail/GeomAttributes.hpp
@@ -51,7 +51,7 @@ namespace detail {
 struct GeomAttributes final
 {
   /// Name of the geom
-  common::optional<std::string> mName;
+  std::optional<std::string> mName;
 
   /// Type of geometric shape
   GeomType mType{GeomType::SPHERE};
@@ -74,7 +74,7 @@ struct GeomAttributes final
   Eigen::Vector3d mFriction{Eigen::Vector3d(1, 0.005, 0.0001)};
 
   /// Mass
-  common::optional<double> mMass;
+  std::optional<double> mMass;
 
   /// Material density used to compute the geom mass and inertia.
   double mDensity{1000};
@@ -95,7 +95,7 @@ struct GeomAttributes final
   /// This attribute can only be used with capsule, cylinder, ellipsoid and
   /// box geoms. It provides an alternative specification of the geom length
   /// as well as the frame position and orientation.
-  common::optional<Eigen::Vector6d> mFromTo;
+  std::optional<Eigen::Vector6d> mFromTo;
 
   /// Position of the geom frame, in local or global coordinates as determined
   /// by the coordinate attribute of compiler.
@@ -107,23 +107,23 @@ struct GeomAttributes final
   /// These are the quantities (x, y, z, a) mentioned above. The last number
   /// is the angle of rotation, in degrees or radians as specified by the
   /// angle attribute of compiler.
-  common::optional<Eigen::Vector4d> mAxisAngle;
+  std::optional<Eigen::Vector4d> mAxisAngle;
 
   /// Rotation angles around three coordinate axes.
-  common::optional<Eigen::Vector3d> mEuler;
+  std::optional<Eigen::Vector3d> mEuler;
 
   /// The first 3 numbers are the X axis of the frame. The next 3 numbers are
   /// the Y axis of the frame, which is automatically made orthogonal to the X
   /// axis. The Z axis is then defined as the cross-product of the X and Y
   /// axes.
-  common::optional<Eigen::Vector6d> mXYAxes;
+  std::optional<Eigen::Vector6d> mXYAxes;
 
   /// The Z axis of the frame
-  common::optional<Eigen::Vector3d> mZAxis;
+  std::optional<Eigen::Vector3d> mZAxis;
 
-  common::optional<std::string> mHField;
+  std::optional<std::string> mHField;
 
-  common::optional<std::string> mMesh;
+  std::optional<std::string> mMesh;
 
   double mFitScale{1};
 };

--- a/dart/utils/mjcf/detail/Inertial.hpp
+++ b/dart/utils/mjcf/detail/Inertial.hpp
@@ -86,19 +86,19 @@ private:
     /// These are the quantities (x, y, z, a) mentioned above. The last number
     /// is the angle of rotation, in degrees or radians as specified by the
     /// angle attribute of compiler.
-    common::optional<Eigen::Vector4d> mAxisAngle;
+    std::optional<Eigen::Vector4d> mAxisAngle;
 
     /// Rotation angles around three coordinate axes.
-    common::optional<Eigen::Vector3d> mEuler;
+    std::optional<Eigen::Vector3d> mEuler;
 
     /// The first 3 numbers are the X axis of the frame. The next 3 numbers are
     /// the Y axis of the frame, which is automatically made orthogonal to the X
     /// axis. The Z axis is then defined as the cross-product of the X and Y
     /// axes.
-    common::optional<Eigen::Vector6d> mXYAxes;
+    std::optional<Eigen::Vector6d> mXYAxes;
 
     /// The Z axis of the frame
-    common::optional<Eigen::Vector3d> mZAxis;
+    std::optional<Eigen::Vector3d> mZAxis;
 
     Eigen::Isometry3d mRelativeTransform{Eigen::Isometry3d::Identity()};
     Eigen::Isometry3d mWorldTransform{Eigen::Isometry3d::Identity()};
@@ -108,10 +108,10 @@ private:
 
     /// Diagonal inertia matrix, expressing the body inertia relative to the
     /// inertial frame.
-    common::optional<Eigen::Vector3d> mDiagInertia;
+    std::optional<Eigen::Vector3d> mDiagInertia;
 
     /// Full inertia matrix M.
-    common::optional<Eigen::Vector6d> mFullInertia;
+    std::optional<Eigen::Vector6d> mFullInertia;
   };
 
   Data mData;

--- a/dart/utils/mjcf/detail/JointAttributes.hpp
+++ b/dart/utils/mjcf/detail/JointAttributes.hpp
@@ -47,7 +47,7 @@ namespace detail {
 
 struct JointAttributes final
 {
-  common::optional<std::string> mName;
+  std::optional<std::string> mName;
 
   JointType mType{JointType::HINGE};
 

--- a/dart/utils/mjcf/detail/MeshAttributes.hpp
+++ b/dart/utils/mjcf/detail/MeshAttributes.hpp
@@ -49,9 +49,9 @@ namespace detail {
 struct MeshAttributes final
 {
   /// Name of the Asset
-  common::optional<std::string> mName;
+  std::optional<std::string> mName;
 
-  common::optional<std::string> mFile;
+  std::optional<std::string> mFile;
 
   Eigen::Vector3d mScale{Eigen::Vector3d::Ones()};
 };

--- a/dart/utils/mjcf/detail/Site.cpp
+++ b/dart/utils/mjcf/detail/Site.cpp
@@ -178,7 +178,7 @@ Errors Site::read(tinyxml2::XMLElement* element)
 
 //==============================================================================
 static bool canUseFromTo(
-    GeomType type, const common::optional<Eigen::Vector6d>& fromto)
+    GeomType type, const std::optional<Eigen::Vector6d>& fromto)
 {
   if (!fromto)
     return false;

--- a/dart/utils/mjcf/detail/Site.hpp
+++ b/dart/utils/mjcf/detail/Site.hpp
@@ -116,7 +116,7 @@ private:
   struct Data
   {
     /// Name of the Site
-    common::optional<std::string> mName;
+    std::optional<std::string> mName;
 
     /// Type of Siteetric shape
     GeomType mType{GeomType::SPHERE};
@@ -131,7 +131,7 @@ private:
     /// This attribute can only be used with capsule, cylinder, ellipsoid and
     /// box Sites. It provides an alternative specification of the Site length
     /// as well as the frame position and orientation.
-    common::optional<Eigen::Vector6d> mFromTo;
+    std::optional<Eigen::Vector6d> mFromTo;
 
     /// Position of the Site frame, in local or global coordinates as determined
     /// by the coordinate attribute of compiler.
@@ -143,19 +143,19 @@ private:
     /// These are the quantities (x, y, z, a) mentioned above. The last number
     /// is the angle of rotation, in degrees or radians as specified by the
     /// angle attribute of compiler.
-    common::optional<Eigen::Vector4d> mAxisAngle;
+    std::optional<Eigen::Vector4d> mAxisAngle;
 
     /// Rotation angles around three coordinate axes.
-    common::optional<Eigen::Vector3d> mEuler;
+    std::optional<Eigen::Vector3d> mEuler;
 
     /// The first 3 numbers are the X axis of the frame. The next 3 numbers are
     /// the Y axis of the frame, which is automatically made orthogonal to the X
     /// axis. The Z axis is then defined as the cross-product of the X and Y
     /// axes.
-    common::optional<Eigen::Vector6d> mXYAxes;
+    std::optional<Eigen::Vector6d> mXYAxes;
 
     /// The Z axis of the frame
-    common::optional<Eigen::Vector3d> mZAxis;
+    std::optional<Eigen::Vector3d> mZAxis;
   };
 
   Data mData;

--- a/dart/utils/mjcf/detail/Utils.cpp
+++ b/dart/utils/mjcf/detail/Utils.cpp
@@ -101,10 +101,10 @@ Errors checkOrientationValidity(const tinyxml2::XMLElement* element)
 //==============================================================================
 Eigen::Matrix3d compileRotation(
     const Eigen::Quaterniond& quat,
-    const common::optional<Eigen::Vector4d>& axisAngle,
-    const common::optional<Eigen::Vector3d>& euler,
-    const common::optional<Eigen::Vector6d>& xyAxes,
-    const common::optional<Eigen::Vector3d>& zAxis,
+    const std::optional<Eigen::Vector4d>& axisAngle,
+    const std::optional<Eigen::Vector3d>& euler,
+    const std::optional<Eigen::Vector6d>& xyAxes,
+    const std::optional<Eigen::Vector3d>& zAxis,
     const Compiler& compiler)
 {
   Eigen::Matrix3d rot = Eigen::Matrix3d::Identity();

--- a/dart/utils/mjcf/detail/Utils.hpp
+++ b/dart/utils/mjcf/detail/Utils.hpp
@@ -54,10 +54,10 @@ Errors checkOrientationValidity(const tinyxml2::XMLElement* element);
 /// compiler settings
 Eigen::Matrix3d compileRotation(
     const Eigen::Quaterniond& quat,
-    const common::optional<Eigen::Vector4d>& axisAngle,
-    const common::optional<Eigen::Vector3d>& euler,
-    const common::optional<Eigen::Vector6d>& xyAxes,
-    const common::optional<Eigen::Vector3d>& zAxis,
+    const std::optional<Eigen::Vector4d>& axisAngle,
+    const std::optional<Eigen::Vector3d>& euler,
+    const std::optional<Eigen::Vector6d>& xyAxes,
+    const std::optional<Eigen::Vector3d>& zAxis,
     const Compiler& compiler);
 
 /// Includes other MJCF model file into \c element

--- a/dart/utils/mjcf/detail/Weld.cpp
+++ b/dart/utils/mjcf/detail/Weld.cpp
@@ -76,7 +76,7 @@ const std::string& Weld::getBody2() const
 }
 
 //==============================================================================
-const common::optional<Eigen::Isometry3d>& Weld::getRelativeTransform() const
+const std::optional<Eigen::Isometry3d>& Weld::getRelativeTransform() const
 {
   return mRelativeTransfrom;
 }

--- a/dart/utils/mjcf/detail/Weld.hpp
+++ b/dart/utils/mjcf/detail/Weld.hpp
@@ -55,7 +55,7 @@ public:
   const Eigen::Matrix<double, 5, 1>& getSolImp() const;
   const std::string& getBody1() const;
   const std::string& getBody2() const;
-  const common::optional<Eigen::Isometry3d>& getRelativeTransform() const;
+  const std::optional<Eigen::Isometry3d>& getRelativeTransform() const;
 
 private:
   // Private memebers used by MujocoModel class
@@ -73,7 +73,7 @@ private:
   std::string mBody2;
   bool mUsePredefinedRelativeTransform{true};
   // Relative transform from body1 to body2
-  common::optional<Eigen::Isometry3d> mRelativeTransfrom;
+  std::optional<Eigen::Isometry3d> mRelativeTransfrom;
 };
 
 } // namespace detail

--- a/dart/utils/mjcf/detail/WeldAttributes.hpp
+++ b/dart/utils/mjcf/detail/WeldAttributes.hpp
@@ -46,12 +46,12 @@ namespace detail {
 
 struct WeldAttributes final
 {
-  common::optional<std::string> mName;
+  std::optional<std::string> mName;
   bool mActive{true};
   Eigen::Vector2d mSolRef;
   Eigen::Matrix<double, 5, 1> mSolImp;
   std::string mBody1;
-  common::optional<std::string> mBody2;
+  std::optional<std::string> mBody2;
   Eigen::Matrix<double, 7, 1> mRelPose;
 
   WeldAttributes();

--- a/dart/utils/mjcf/detail/Worldbody.cpp
+++ b/dart/utils/mjcf/detail/Worldbody.cpp
@@ -45,7 +45,7 @@ namespace detail {
 //==============================================================================
 Errors Worldbody::read(
     tinyxml2::XMLElement* element,
-    const common::optional<Size>& size,
+    const std::optional<Size>& size,
     const Defaults& defaults,
     const Default* currentDefault,
     const common::Uri& baseUri,

--- a/dart/utils/mjcf/detail/Worldbody.hpp
+++ b/dart/utils/mjcf/detail/Worldbody.hpp
@@ -79,7 +79,7 @@ private:
   friend class MujocoModel;
   Errors read(
       tinyxml2::XMLElement* element,
-      const common::optional<Size>& size,
+      const std::optional<Size>& size,
       const Defaults& defaults,
       const Default* currentDefault,
       const common::Uri& baseUri,
@@ -96,7 +96,7 @@ private:
   Errors postprocess(const Compiler& compiler);
 
 private:
-  common::optional<std::string> mChildClass;
+  std::optional<std::string> mChildClass;
   std::vector<Geom> mGeoms;
   std::vector<Site> mSites;
   std::vector<Body> mRootBodies;


### PR DESCRIPTION


***

#### Before creating a pull request

- [ ] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
