### PR TITLE
Add depth rendering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * GUI
 
   * Fixed depth testing for transparent objects: [#1643](https://github.com/dartsim/dart/pull/1643)
+  * Added depth rendering mode: [#1652](https://github.com/dartsim/dart/pull/1652)
 
 ### [DART 6.12.1 (2021-11-04)](https://github.com/dartsim/dart/milestone/71?closed=1)
 

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -29,9 +29,11 @@ endif()
 # Search all header and source files
 file(GLOB hdrs "*.hpp")
 file(GLOB srcs "*.cpp")
+file(GLOB detail_hdrs "detail/*.hpp")
+file(GLOB detail_srcs "detail/*.cpp")
 
-set(dart_gui_osg_hdrs ${hdrs})
-set(dart_gui_osg_srcs ${srcs})
+set(dart_gui_osg_hdrs ${hdrs} ${detail_hdrs})
+set(dart_gui_osg_srcs ${srcs} ${detail_srcs})
 
 add_subdirectory(render)
 
@@ -58,6 +60,11 @@ dart_generate_include_header_file(
 install(
   FILES ${hdrs} ${CMAKE_CURRENT_BINARY_DIR}/osg.hpp
   DESTINATION include/dart/gui/osg
+  COMPONENT headers
+)
+install(
+  FILES ${detail_hdrs}
+  DESTINATION include/dart/gui/osg/detail
   COMPONENT headers
 )
 

--- a/dart/gui/osg/Utils.cpp
+++ b/dart/gui/osg/Utils.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2011-2022, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/gui/osg/Utils.hpp"
+
+#include <osg/Geode>
+#include <osg/Geometry>
+#include <osg/PolygonMode>
+#include <osg/Texture2D>
+
+namespace dart::gui::osg {
+
+//==============================================================================
+Eigen::Vector3f osgToEigVec3(const ::osg::Vec3f& vec)
+{
+  return Eigen::Vector3f(vec[0], vec[1], vec[2]);
+}
+
+//==============================================================================
+Eigen::Vector3d osgToEigVec3(const ::osg::Vec3d& vec)
+{
+  return Eigen::Vector3d(vec[0], vec[1], vec[2]);
+}
+
+//==============================================================================
+Eigen::Vector4f osgToEigVec4(const ::osg::Vec4f& vec)
+{
+  return Eigen::Vector4f(vec[0], vec[1], vec[2], vec[3]);
+}
+
+//==============================================================================
+Eigen::Vector4d osgToEigVec4(const ::osg::Vec4d& vec)
+{
+  return Eigen::Vector4d(vec[0], vec[1], vec[2], vec[3]);
+}
+
+//==============================================================================
+::osg::Camera* createRttCamera(
+    ::osg::Camera::BufferComponent buffer, ::osg::Texture* tex, bool isAbsolute)
+{
+  ::osg::ref_ptr<::osg::Camera> camera = new ::osg::Camera;
+  camera->setClearColor(::osg::Vec4());
+  camera->setClearMask(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  camera->setRenderTargetImplementation(::osg::Camera::FRAME_BUFFER_OBJECT);
+  camera->setRenderOrder(::osg::Camera::PRE_RENDER);
+
+  if (tex)
+  {
+    tex->setFilter(::osg::Texture2D::MIN_FILTER, ::osg::Texture2D::LINEAR);
+    tex->setFilter(::osg::Texture2D::MAG_FILTER, ::osg::Texture2D::LINEAR);
+    camera->setViewport(0, 0, tex->getTextureWidth(), tex->getTextureHeight());
+    camera->attach(buffer, tex);
+  }
+
+  if (isAbsolute)
+  {
+    camera->setReferenceFrame(::osg::Transform::ABSOLUTE_RF);
+    camera->setProjectionMatrix(::osg::Matrix::ortho2D(0.0, 1.0, 0.0, 1.0));
+    camera->setViewMatrix(::osg::Matrix::identity());
+    camera->addChild(createScreenQuad(1.0f, 1.0f));
+  }
+
+  return camera.release();
+}
+
+//==============================================================================
+::osg::Camera* createHudCamera(
+    double left, double right, double bottom, double top)
+{
+  ::osg::ref_ptr<::osg::Camera> camera = new ::osg::Camera;
+
+  camera->setReferenceFrame(::osg::Transform::ABSOLUTE_RF);
+  camera->setClearMask(GL_DEPTH_BUFFER_BIT);
+  camera->setRenderOrder(::osg::Camera::POST_RENDER);
+  camera->setAllowEventFocus(false);
+  camera->setProjectionMatrix(::osg::Matrix::ortho2D(left, right, bottom, top));
+  camera->getOrCreateStateSet()->setMode(
+      GL_LIGHTING, ::osg::StateAttribute::OFF);
+
+  return camera.release();
+}
+
+//==============================================================================
+::osg::Geode* createScreenQuad(float width, float height, float scale)
+{
+  ::osg::Geometry* geom = ::osg::createTexturedQuadGeometry(
+      ::osg::Vec3(),
+      ::osg::Vec3(width, 0.0f, 0.0f),
+      ::osg::Vec3(0.0f, height, 0.0f),
+      0.0f,
+      0.0f,
+      width * scale,
+      height * scale);
+
+  ::osg::ref_ptr<::osg::Geode> quad = new ::osg::Geode;
+  quad->addDrawable(geom);
+
+  int values = ::osg::StateAttribute::OFF | ::osg::StateAttribute::PROTECTED;
+  quad->getOrCreateStateSet()->setAttribute(
+      new ::osg::PolygonMode(
+          ::osg::PolygonMode::FRONT_AND_BACK, ::osg::PolygonMode::FILL),
+      values);
+  quad->getOrCreateStateSet()->setMode(GL_LIGHTING, values);
+
+  return quad.release();
+}
+
+} // namespace dart::gui::osg

--- a/dart/gui/osg/Utils.hpp
+++ b/dart/gui/osg/Utils.hpp
@@ -34,153 +34,87 @@
 #define DART_GUI_OSG_UTILS_HPP_
 
 #include <Eigen/Geometry>
+#include <osg/Camera>
 #include <osg/Matrix>
 
-//==============================================================================
-template <typename T = double>
-constexpr T getAlphaThreshold()
-{
-  if constexpr (std::is_same_v<T, float>)
-  {
-    return 1e-6;
-  }
-  else if constexpr (std::is_same_v<T, double>)
-  {
-    return 1e-9;
-  }
-  else
-  {
-    return 1e-9;
-  }
-}
+namespace dart::gui::osg {
 
-//==============================================================================
+/// Returns the alpha threshold for demining if the object is a transparent
+/// object or not
+template <typename T = double>
+constexpr T getAlphaThreshold();
+
+/// Converts Eigen::Isometry to osg::Matrix
 template <typename Scalar>
 ::osg::Matrix eigToOsgMatrix(
-    const Eigen::Transform<Scalar, 3, Eigen::Isometry>& tf)
-{
-  return ::osg::Matrix(
-      tf(0, 0),
-      tf(1, 0),
-      tf(2, 0),
-      tf(3, 0),
-      tf(0, 1),
-      tf(1, 1),
-      tf(2, 1),
-      tf(3, 1),
-      tf(0, 2),
-      tf(1, 2),
-      tf(2, 2),
-      tf(3, 2),
-      tf(0, 3),
-      tf(1, 3),
-      tf(2, 3),
-      tf(3, 3));
-}
+    const Eigen::Transform<Scalar, 3, Eigen::Isometry>& tf);
 
-//==============================================================================
+/// Converts Eigen::DenseBase to osg::Matrix
 template <typename Derived>
-::osg::Matrix eigToOsgMatrix(const Eigen::DenseBase<Derived>& M)
-{
-  return ::osg::Matrix(
-      M(0, 0),
-      M(1, 0),
-      M(2, 0),
-      M(3, 0),
-      M(0, 1),
-      M(1, 1),
-      M(2, 1),
-      M(3, 1),
-      M(0, 2),
-      M(1, 2),
-      M(2, 2),
-      M(3, 2),
-      M(0, 3),
-      M(1, 3),
-      M(2, 3),
-      M(3, 3));
-}
+::osg::Matrix eigToOsgMatrix(const Eigen::DenseBase<Derived>& M);
 
-//==============================================================================
+/// Converts Eigen::MatrixBase to osg::Vec3f
 template <typename Derived>
-::osg::Vec3f eigToOsgVec3f(const Eigen::MatrixBase<Derived>& vec)
-{
-  return ::osg::Vec3f(vec[0], vec[1], vec[2]);
-}
+::osg::Vec3f eigToOsgVec3f(const Eigen::MatrixBase<Derived>& vec);
 
-//==============================================================================
+/// Converts Eigen::MatrixBase to osg::Vec3d
 template <typename Derived>
-::osg::Vec3d eigToOsgVec3d(const Eigen::MatrixBase<Derived>& vec)
-{
-  return ::osg::Vec3d(vec[0], vec[1], vec[2]);
-}
+::osg::Vec3d eigToOsgVec3d(const Eigen::MatrixBase<Derived>& vec);
 
-//==============================================================================
+/// Converts Eigen::MatrixBase to osg::Vec3f or osg::Vec3d based on the scalar
+/// type
 template <typename Derived>
 typename std::conditional<
     std::is_same<typename Derived::Scalar, float>::value,
     ::osg::Vec3f,
     ::osg::Vec3d>::type
-eigToOsgVec3(const Eigen::MatrixBase<Derived>& vec)
-{
-  using Vec3 = typename std::conditional<
-      std::is_same<typename Derived::Scalar, float>::value,
-      ::osg::Vec3f,
-      ::osg::Vec3d>::type;
+eigToOsgVec3(const Eigen::MatrixBase<Derived>& vec);
 
-  return Vec3(vec[0], vec[1], vec[2]);
-}
+/// Converts osg::Vec3f to Eigen::Vector3f
+Eigen::Vector3f osgToEigVec3(const ::osg::Vec3f& vec);
 
-//==============================================================================
-inline Eigen::Vector3f osgToEigVec3(const ::osg::Vec3f& vec)
-{
-  return Eigen::Vector3f(vec[0], vec[1], vec[2]);
-}
+/// Converts osg::Vec3d to Eigen::Vector3d
+Eigen::Vector3d osgToEigVec3(const ::osg::Vec3d& vec);
 
-//==============================================================================
-inline Eigen::Vector3d osgToEigVec3(const ::osg::Vec3d& vec)
-{
-  return Eigen::Vector3d(vec[0], vec[1], vec[2]);
-}
-
-//==============================================================================
+/// Converts Eigen::MatrixBase to osg::Vec4f
 template <typename Derived>
-::osg::Vec4f eigToOsgVec4f(const Eigen::MatrixBase<Derived>& vec)
-{
-  return ::osg::Vec4f(vec[0], vec[1], vec[2], vec[3]);
-}
+::osg::Vec4f eigToOsgVec4f(const Eigen::MatrixBase<Derived>& vec);
 
-//==============================================================================
+/// Converts Eigen::MatrixBase to osg::Vec4d
 template <typename Derived>
-::osg::Vec4d eigToOsgVec4d(const Eigen::MatrixBase<Derived>& vec)
-{
-  return ::osg::Vec4d(vec[0], vec[1], vec[2], vec[3]);
-}
+::osg::Vec4d eigToOsgVec4d(const Eigen::MatrixBase<Derived>& vec);
 
-//==============================================================================
+/// Converts Eigen::MatrixBase to osg::Vec4f or osg::Vec4d based on the scalar
+/// type
 template <typename Derived>
 std::conditional<
     std::is_same<typename Derived::Scalar, float>::value,
     ::osg::Vec4f,
     ::osg::Vec4d>
-eigToOsgVec4(const Eigen::MatrixBase<Derived>& vec)
-{
-  return std::conditional<
-      std::is_same<typename Derived::Scalar, float>::value,
-      ::osg::Vec4f,
-      ::osg::Vec4d>(vec[0], vec[1], vec[2], vec[3]);
-}
+eigToOsgVec4(const Eigen::MatrixBase<Derived>& vec);
 
-//==============================================================================
-inline Eigen::Vector4f osgToEigVec4(const ::osg::Vec4f& vec)
-{
-  return Eigen::Vector4f(vec[0], vec[1], vec[2], vec[3]);
-}
+/// Converts osg::Vec4f to Eigen::Vector4f
+Eigen::Vector4f osgToEigVec4(const ::osg::Vec4f& vec);
 
-//==============================================================================
-inline Eigen::Vector4d osgToEigVec4(const ::osg::Vec4d& vec)
-{
-  return Eigen::Vector4d(vec[0], vec[1], vec[2], vec[3]);
-}
+/// Converts osg::Vec4d to Eigen::Vector4d
+Eigen::Vector4d osgToEigVec4(const ::osg::Vec4d& vec);
+
+/// Create a Render-To-Texture (RTT) camera.
+::osg::Camera* createRttCamera(
+    ::osg::Camera::BufferComponent buffer,
+    ::osg::Texture* tex,
+    bool isAbsolute = false);
+
+/// Creates a head-up display (HUD) camera that renders on the top after the
+/// main scene is drawn, which is generally used for heads-up display
+::osg::Camera* createHudCamera(
+    double left = 0, double right = 1, double bottom = 0, double top = 1);
+
+/// Creates a osg::Geode of quad shape
+::osg::Geode* createScreenQuad(float width, float height, float scale = 1.0f);
+
+} // namespace dart::gui::osg
+
+#include "dart/gui/osg/detail/Utils-impl.hpp"
 
 #endif // DART_GUI_OSG_UTILS_HPP_

--- a/dart/gui/osg/Viewer.cpp
+++ b/dart/gui/osg/Viewer.cpp
@@ -45,6 +45,7 @@
 #include "dart/gui/osg/TrackballManipulator.hpp"
 #include "dart/gui/osg/Utils.hpp"
 #include "dart/gui/osg/WorldNode.hpp"
+#include "dart/gui/osg/detail/CameraModeCallback.hpp"
 #include "dart/simulation/World.hpp"
 
 namespace dart {
@@ -210,6 +211,11 @@ Viewer::Viewer(const ::osg::Vec4& clearColor)
   getCamera()->setClearColor(clearColor);
 
   getCamera()->setFinalDrawCallback(new SaveScreen(this));
+
+  // Settings for camera mode (RGBA/Depth)
+  mCameraModeCallback = new detail::CameraModeCallback;
+  mCameraModeCallback->setCameraMode(CameraMode::RGBA);
+  mRootGroup->addUpdateCallback(mCameraModeCallback);
 }
 
 //==============================================================================
@@ -367,6 +373,8 @@ void Viewer::addWorldNode(WorldNode* _newWorldNode, bool _active)
 
   mWorldNodes[_newWorldNode] = _active;
   mRootGroup->addChild(_newWorldNode);
+  mCameraModeCallback->setSceneData(
+      _newWorldNode); // TODO(JS): Change to addSceneData
   if (_active)
     _newWorldNode->simulate(mSimulating);
   _newWorldNode->mViewer = this;
@@ -900,6 +908,18 @@ double Viewer::getVerticalFieldOfView() const
   }
 
   return fovy;
+}
+
+//==============================================================================
+void Viewer::setCameraMode(CameraMode mode)
+{
+  mCameraModeCallback->setCameraMode(mode);
+}
+
+//========================================================================================
+CameraMode Viewer::getCameraMode() const
+{
+  return mCameraModeCallback->getCameraMode();
 }
 
 } // namespace osg

--- a/dart/gui/osg/Viewer.hpp
+++ b/dart/gui/osg/Viewer.hpp
@@ -60,6 +60,10 @@ class BodyNode;
 namespace gui {
 namespace osg {
 
+namespace detail {
+class CameraModeCallback;
+} // namespace detail
+
 class WorldNode;
 class DefaultEventHandler;
 class DragAndDrop;
@@ -70,6 +74,18 @@ class InteractiveFrameDnD;
 class BodyNodeDnD;
 class Viewer;
 class SaveScreen;
+
+/// Camera mode
+enum class CameraMode
+{
+  /// To render the RGBA color
+  RGBA,
+
+  /// To render the depth buffer
+  ///
+  /// \warning The DEPTH mode currently not compatible with the ImGui wigets.
+  DEPTH,
+};
 
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
 class ViewerAttachment : public virtual ::osg::Group
@@ -302,6 +318,12 @@ public:
   /// view, 0.0 otherwise.
   double getVerticalFieldOfView() const;
 
+  /// Sets the camera mode of the primary camera.
+  void setCameraMode(CameraMode mode);
+
+  /// Returns the camera mode of the primary camera.
+  CameraMode getCameraMode() const;
+
 protected:
   friend class SaveScreen;
 
@@ -388,7 +410,12 @@ protected:
 
   /// Map from BodyNode ptrs to BodyNodeDnD ptrs
   std::map<dart::dynamics::BodyNode*, BodyNodeDnD*> mBodyNodeDnDMap;
+
+private:
+  /// Callback to control the camera mode
+  ::osg::ref_ptr<detail::CameraModeCallback> mCameraModeCallback;
 };
+
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_END
 
 } // namespace osg

--- a/dart/gui/osg/detail/CameraModeCallback.cpp
+++ b/dart/gui/osg/detail/CameraModeCallback.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2011-2022, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/gui/osg/detail/CameraModeCallback.hpp"
+
+#include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
+#include "dart/gui/osg/Utils.hpp"
+
+namespace dart::gui::osg::detail {
+
+//==============================================================================
+CameraModeCallback::CameraModeCallback()
+  : mCameraMode(CameraMode::RGBA), mCameraModeChanged(false)
+{
+  // Do nothing
+}
+
+//==============================================================================
+void CameraModeCallback::operator()(::osg::Node* node, ::osg::NodeVisitor* nv)
+{
+  ::osg::ref_ptr<::osg::Group> group = dynamic_cast<::osg::Group*>(node);
+
+  if (group)
+  {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    if (mSceneToChange)
+    {
+      mScene = mSceneToChange;
+      if (mDepthRrtCam)
+      {
+        mDepthRrtCam->removeChildren(0, mDepthHudCam->getNumChildren());
+        mDepthRrtCam->addChild(mScene);
+      }
+      mSceneToChange = nullptr;
+    }
+
+    if (mCameraModeChanged)
+    {
+      if (mCameraMode == CameraMode::RGBA)
+      {
+        if (mDepthRrtCam)
+        {
+          group->removeChild(mDepthRrtCam);
+          mDepthRrtCam.release();
+        }
+
+        if (mDepthHudCam)
+        {
+          group->removeChild(mDepthHudCam);
+          mDepthHudCam.release();
+        }
+      }
+      else if (mCameraMode == CameraMode::DEPTH)
+      {
+        // Allocate an empty texture by specifying its size for RTT operation
+        ::osg::ref_ptr<::osg::Texture2D> tex2d = new ::osg::Texture2D;
+        tex2d->setTextureSize(1024, 1024);
+        tex2d->setInternalFormat(GL_DEPTH_COMPONENT24);
+        tex2d->setSourceFormat(GL_DEPTH_COMPONENT);
+        tex2d->setSourceType(GL_FLOAT);
+        // TODO(JS): Make these configurable
+
+        // Create a RTT camera and apply the required buffer value
+        // (DEPTH_BUFFER) and the texture object to it
+        mDepthRrtCam = createRttCamera(::osg::Camera::DEPTH_BUFFER, tex2d);
+
+        // Create a HUD camera over the scene, and add a quad shown over the
+        // screen
+        mDepthHudCam = createHudCamera(0, 1, 0, 1);
+        mDepthHudCam->addChild(createScreenQuad(1.0, 1.0));
+        mDepthHudCam->getOrCreateStateSet()->setTextureAttributeAndModes(
+            0, tex2d);
+        mDepthRrtCam->setComputeNearFarMode(
+            ::osg::CullSettings::COMPUTE_NEAR_FAR_USING_PRIMITIVES);
+        // TODO(JS): Make these configurable
+
+        if (mScene)
+        {
+          mDepthRrtCam->addChild(mScene);
+        }
+
+        group->addChild(mDepthRrtCam);
+        group->addChild(mDepthHudCam);
+      }
+      else
+      {
+        DART_ASSERT(false);
+      }
+
+      mCameraModeChanged = false;
+    }
+  }
+
+  traverse(node, nv);
+}
+
+//==============================================================================
+void CameraModeCallback::setCameraMode(CameraMode mode)
+{
+  if (mode != CameraMode::RGBA && mode != CameraMode::DEPTH)
+  {
+    DART_WARN(
+        "Unsupported camera mode '{}'. Use RGBA or DEPTH.",
+        static_cast<int>(mode));
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mMutex);
+  if (mode == mCameraMode)
+  {
+    return;
+  }
+
+  mCameraMode = mode;
+  mCameraModeChanged = true;
+}
+
+//==============================================================================
+CameraMode CameraModeCallback::getCameraMode() const
+{
+  std::lock_guard<std::mutex> lock(mMutex);
+  return mCameraMode;
+}
+
+//==============================================================================
+void CameraModeCallback::setSceneData(::osg::Node* scene)
+{
+  std::lock_guard<std::mutex> lock(mMutex);
+  if (scene == mScene)
+  {
+    return;
+  }
+  mSceneToChange = scene;
+}
+
+} // namespace dart::gui::osg::detail

--- a/dart/gui/osg/detail/Utils-impl.hpp
+++ b/dart/gui/osg/detail/Utils-impl.hpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2011-2022, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_GUI_OSG_DETAIL_UTILS_IMPL_HPP_
+#define DART_GUI_OSG_DETAIL_UTILS_IMPL_HPP_
+
+#include "dart/gui/osg/Utils.hpp"
+
+namespace dart::gui::osg {
+
+//==============================================================================
+template <typename T>
+constexpr T getAlphaThreshold()
+{
+  if constexpr (std::is_same_v<T, float>)
+  {
+    return 1e-6;
+  }
+  else if constexpr (std::is_same_v<T, double>)
+  {
+    return 1e-9;
+  }
+  else
+  {
+    return 1e-9;
+  }
+}
+
+//==============================================================================
+template <typename Scalar>
+::osg::Matrix eigToOsgMatrix(
+    const Eigen::Transform<Scalar, 3, Eigen::Isometry>& tf)
+{
+  return ::osg::Matrix(
+      tf(0, 0),
+      tf(1, 0),
+      tf(2, 0),
+      tf(3, 0),
+      tf(0, 1),
+      tf(1, 1),
+      tf(2, 1),
+      tf(3, 1),
+      tf(0, 2),
+      tf(1, 2),
+      tf(2, 2),
+      tf(3, 2),
+      tf(0, 3),
+      tf(1, 3),
+      tf(2, 3),
+      tf(3, 3));
+}
+
+//==============================================================================
+template <typename Derived>
+::osg::Matrix eigToOsgMatrix(const Eigen::DenseBase<Derived>& M)
+{
+  return ::osg::Matrix(
+      M(0, 0),
+      M(1, 0),
+      M(2, 0),
+      M(3, 0),
+      M(0, 1),
+      M(1, 1),
+      M(2, 1),
+      M(3, 1),
+      M(0, 2),
+      M(1, 2),
+      M(2, 2),
+      M(3, 2),
+      M(0, 3),
+      M(1, 3),
+      M(2, 3),
+      M(3, 3));
+}
+
+//==============================================================================
+template <typename Derived>
+::osg::Vec3f eigToOsgVec3f(const Eigen::MatrixBase<Derived>& vec)
+{
+  return ::osg::Vec3f(vec[0], vec[1], vec[2]);
+}
+
+//==============================================================================
+template <typename Derived>
+::osg::Vec3d eigToOsgVec3d(const Eigen::MatrixBase<Derived>& vec)
+{
+  return ::osg::Vec3d(vec[0], vec[1], vec[2]);
+}
+
+//==============================================================================
+template <typename Derived>
+typename std::conditional<
+    std::is_same<typename Derived::Scalar, float>::value,
+    ::osg::Vec3f,
+    ::osg::Vec3d>::type
+eigToOsgVec3(const Eigen::MatrixBase<Derived>& vec)
+{
+  using Vec3 = typename std::conditional<
+      std::is_same<typename Derived::Scalar, float>::value,
+      ::osg::Vec3f,
+      ::osg::Vec3d>::type;
+
+  return Vec3(vec[0], vec[1], vec[2]);
+}
+
+//==============================================================================
+template <typename Derived>
+::osg::Vec4f eigToOsgVec4f(const Eigen::MatrixBase<Derived>& vec)
+{
+  return ::osg::Vec4f(vec[0], vec[1], vec[2], vec[3]);
+}
+
+//==============================================================================
+template <typename Derived>
+::osg::Vec4d eigToOsgVec4d(const Eigen::MatrixBase<Derived>& vec)
+{
+  return ::osg::Vec4d(vec[0], vec[1], vec[2], vec[3]);
+}
+
+//==============================================================================
+template <typename Derived>
+std::conditional<
+    std::is_same<typename Derived::Scalar, float>::value,
+    ::osg::Vec4f,
+    ::osg::Vec4d>
+eigToOsgVec4(const Eigen::MatrixBase<Derived>& vec)
+{
+  return std::conditional<
+      std::is_same<typename Derived::Scalar, float>::value,
+      ::osg::Vec4f,
+      ::osg::Vec4d>(vec[0], vec[1], vec[2], vec[3]);
+}
+
+} // namespace dart::gui::osg
+
+#endif // DART_GUI_OSG_DETAIL_UTILS_IMPL_HPP_

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
@@ -144,6 +144,15 @@ void AtlasSimbiconWidget::render()
       else
         mNode->hideShadow();
     }
+
+    // Depth
+    if (ImGui::Checkbox("Depth mode", &mDepthMode))
+    {
+      if (mDepthMode)
+        mViewer->setCameraMode(dart::gui::osg::CameraMode::DEPTH);
+      else
+        mViewer->setCameraMode(dart::gui::osg::CameraMode::RGBA);
+    }
   }
 
   if (ImGui::CollapsingHeader(

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
@@ -69,6 +69,9 @@ protected:
 
   bool mShadow;
 
+  /// Whether render in depth mode
+  bool mDepthMode = false;
+
   /// Control mode value for GUI
   int mGuiControlMode;
 

--- a/python/dartpy/gui/osg/Viewer.cpp
+++ b/python/dartpy/gui/osg/Viewer.cpp
@@ -63,7 +63,7 @@ void Viewer(py::module& m)
             .def(
                 ::py::init([](const Eigen::Vector4f& clearColor) {
                   return new ::dart::gui::osg::Viewer(
-                      eigToOsgVec4d(clearColor));
+                      gui::osg::eigToOsgVec4d(clearColor));
                 }),
                 ::py::arg("clearColor"))
             .def(::py::init<const osg::Vec4&>(), ::py::arg("clearColor"))
@@ -119,14 +119,14 @@ void Viewer(py::module& m)
                 })
             .def(
                 "switchDefaultEventHandler",
-                +[](dart::gui::osg::Viewer* self, bool _on) {
-                  self->switchDefaultEventHandler(_on);
+                +[](dart::gui::osg::Viewer* self, bool on) {
+                  self->switchDefaultEventHandler(on);
                 },
                 ::py::arg("on"))
             .def(
                 "switchHeadlights",
-                +[](dart::gui::osg::Viewer* self, bool _on) {
-                  self->switchHeadlights(_on);
+                +[](dart::gui::osg::Viewer* self, bool on) {
+                  self->switchHeadlights(on);
                 },
                 ::py::arg("on"))
             .def(
@@ -142,45 +142,43 @@ void Viewer(py::module& m)
             .def(
                 "addWorldNode",
                 +[](dart::gui::osg::Viewer* self,
-                    dart::gui::osg::WorldNode* _newWorldNode) {
-                  self->addWorldNode(_newWorldNode);
+                    dart::gui::osg::WorldNode* newWorldNode) {
+                  self->addWorldNode(newWorldNode);
                 },
                 ::py::arg("newWorldNode"))
             .def(
                 "addWorldNode",
                 +[](dart::gui::osg::Viewer* self,
-                    dart::gui::osg::WorldNode* _newWorldNode,
-                    bool _active) {
-                  self->addWorldNode(_newWorldNode, _active);
-                },
+                    dart::gui::osg::WorldNode* newWorldNode,
+                    bool active) { self->addWorldNode(newWorldNode, active); },
                 ::py::arg("newWorldNode"),
                 ::py::arg("active"))
             .def(
                 "removeWorldNode",
                 +[](dart::gui::osg::Viewer* self,
-                    dart::gui::osg::WorldNode* _oldWorldNode) {
-                  self->removeWorldNode(_oldWorldNode);
+                    dart::gui::osg::WorldNode* oldWorldNode) {
+                  self->removeWorldNode(oldWorldNode);
                 },
                 ::py::arg("oldWorldNode"))
             .def(
                 "removeWorldNode",
                 +[](dart::gui::osg::Viewer* self,
-                    std::shared_ptr<dart::simulation::World> _oldWorld) {
-                  self->removeWorldNode(_oldWorld);
+                    std::shared_ptr<dart::simulation::World> oldWorld) {
+                  self->removeWorldNode(oldWorld);
                 },
                 ::py::arg("oldWorld"))
             .def(
                 "addAttachment",
                 +[](dart::gui::osg::Viewer* self,
-                    dart::gui::osg::ViewerAttachment* _attachment) {
-                  self->addAttachment(_attachment);
+                    dart::gui::osg::ViewerAttachment* attachment) {
+                  self->addAttachment(attachment);
                 },
                 ::py::arg("attachment"))
             .def(
                 "removeAttachment",
                 +[](dart::gui::osg::Viewer* self,
-                    dart::gui::osg::ViewerAttachment* _attachment) {
-                  self->removeAttachment(_attachment);
+                    dart::gui::osg::ViewerAttachment* attachment) {
+                  self->removeAttachment(attachment);
                 },
                 ::py::arg("attachment"))
             .def(
@@ -190,50 +188,48 @@ void Viewer(py::module& m)
                 })
             .def(
                 "setUpwardsDirection",
-                +[](dart::gui::osg::Viewer* self, const osg::Vec3& _up) {
-                  self->setUpwardsDirection(_up);
+                +[](dart::gui::osg::Viewer* self, const osg::Vec3& up) {
+                  self->setUpwardsDirection(up);
                 },
                 ::py::arg("up"))
             .def(
                 "setUpwardsDirection",
-                +[](dart::gui::osg::Viewer* self, const Eigen::Vector3d& _up) {
-                  self->setUpwardsDirection(_up);
+                +[](dart::gui::osg::Viewer* self, const Eigen::Vector3d& up) {
+                  self->setUpwardsDirection(up);
                 },
                 ::py::arg("up"))
             .def(
                 "setWorldNodeActive",
                 +[](dart::gui::osg::Viewer* self,
-                    dart::gui::osg::WorldNode* _node) {
-                  self->setWorldNodeActive(_node);
+                    dart::gui::osg::WorldNode* node) {
+                  self->setWorldNodeActive(node);
                 },
                 ::py::arg("node"))
             .def(
                 "setWorldNodeActive",
                 +[](dart::gui::osg::Viewer* self,
-                    dart::gui::osg::WorldNode* _node,
-                    bool _active) { self->setWorldNodeActive(_node, _active); },
+                    dart::gui::osg::WorldNode* node,
+                    bool active) { self->setWorldNodeActive(node, active); },
                 ::py::arg("node"),
                 ::py::arg("active"))
             .def(
                 "setWorldNodeActive",
                 +[](dart::gui::osg::Viewer* self,
-                    std::shared_ptr<dart::simulation::World> _world) {
-                  self->setWorldNodeActive(_world);
+                    std::shared_ptr<dart::simulation::World> world) {
+                  self->setWorldNodeActive(world);
                 },
                 ::py::arg("world"))
             .def(
                 "setWorldNodeActive",
                 +[](dart::gui::osg::Viewer* self,
-                    std::shared_ptr<dart::simulation::World> _world,
-                    bool _active) {
-                  self->setWorldNodeActive(_world, _active);
-                },
+                    std::shared_ptr<dart::simulation::World> world,
+                    bool active) { self->setWorldNodeActive(world, active); },
                 ::py::arg("world"),
                 ::py::arg("active"))
             .def(
                 "simulate",
-                +[](dart::gui::osg::Viewer* self, bool _on) {
-                  self->simulate(_on);
+                +[](dart::gui::osg::Viewer* self, bool on) {
+                  self->simulate(on);
                 },
                 ::py::arg("on"))
             .def(
@@ -243,8 +239,8 @@ void Viewer(py::module& m)
                 })
             .def(
                 "allowSimulation",
-                +[](dart::gui::osg::Viewer* self, bool _allow) {
-                  self->allowSimulation(_allow);
+                +[](dart::gui::osg::Viewer* self, bool allow) {
+                  self->allowSimulation(allow);
                 },
                 ::py::arg("allow"))
             .def(
@@ -370,17 +366,27 @@ void Viewer(py::module& m)
                     const Eigen::Vector3d& center,
                     const Eigen::Vector3d& up) {
                   self->getCameraManipulator()->setHomePosition(
-                      eigToOsgVec3(eye),
-                      eigToOsgVec3(center),
-                      eigToOsgVec3(up));
+                      gui::osg::eigToOsgVec3(eye),
+                      gui::osg::eigToOsgVec3(center),
+                      gui::osg::eigToOsgVec3(up));
 
                   self->setCameraManipulator(self->getCameraManipulator());
-                });
+                })
+            .def(
+                "setCameraMode",
+                &gui::osg::Viewer::setCameraMode,
+                py::arg("mode"))
+            .def("getCameraMode", &gui::osg::Viewer::getCameraMode);
 
   ::py::enum_<dart::gui::osg::Viewer::LightingMode>(viewer, "LightingMode")
       .value("NO_LIGHT", dart::gui::osg::Viewer::NO_LIGHT)
       .value("HEADLIGHT", dart::gui::osg::Viewer::HEADLIGHT)
       .value("SKY_LIGHT", dart::gui::osg::Viewer::SKY_LIGHT);
+
+  ::py::enum_<dart::gui::osg::CameraMode>(viewer, "CameraMode")
+      .value("NO_LIGHT", dart::gui::osg::CameraMode::RGBA)
+      .value("HEADLIGHT", dart::gui::osg::CameraMode::DEPTH);
+
 } // namespace python
 
 } // namespace python


### PR DESCRIPTION
**Usage**:
```cpp
auto viewer = dart::gui::osg::Viewer();
viewer.setCameraMode(dart::gui::osg::CameraMode::DEPTH);  // or dart::gui::osg::CameraMode::RGBA (default)
```

**RGBA mode**:
![image](https://user-images.githubusercontent.com/4038467/150247942-1bfebd3d-bd6c-456b-af46-7b945ddd23cc.png)

**Depth mode**
![image](https://user-images.githubusercontent.com/4038467/150247970-7846c308-54e9-4745-b7d6-783c4218a855.png)


***

#### Before creating a pull request

- [x] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [x] Add Python bindings for new methods and classes
