### PR TITLE
Use octomap also on Windows

### DIFF
--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -91,33 +91,23 @@ endif()
 
 # octomap
 dart_find_package(octomap)
-if(MSVC)
-  # Supporting Octomap on Windows is disabled for the following issue:
-  # https://github.com/OctoMap/octomap/pull/213
-  message(WARNING "Octomap ${octomap_VERSION} is found, but Octomap "
-      "is not supported on Windows until "
-      "'https://github.com/OctoMap/octomap/pull/213' "
-      "is resolved.")
-  set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
-else()
-  if(OCTOMAP_FOUND OR octomap_FOUND)
-    if(NOT DEFINED octomap_VERSION)
-      set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
-      message(WARNING "Looking for octomap - octomap_VERSION is not defined, "
-          "please install octomap with version information"
-      )
-    else()
-      set(HAVE_OCTOMAP TRUE CACHE BOOL "Check if octomap found." FORCE)
-      if(DART_VERBOSE)
-        message(STATUS "Looking for octomap - version ${octomap_VERSION} found")
-      endif()
-    endif()
-  else()
+if(OCTOMAP_FOUND OR octomap_FOUND)
+  if(NOT DEFINED octomap_VERSION)
     set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
-    message(WARNING "Looking for octomap - NOT found, to use VoxelGridShape, "
-        "please install octomap"
+    message(WARNING "Looking for octomap - octomap_VERSION is not defined, "
+        "please install octomap with version information"
     )
+  else()
+    set(HAVE_OCTOMAP TRUE CACHE BOOL "Check if octomap found." FORCE)
+    if(DART_VERBOSE)
+      message(STATUS "Looking for octomap - version ${octomap_VERSION} found")
+    endif()
   endif()
+else()
+  set(HAVE_OCTOMAP FALSE CACHE BOOL "Check if octomap found." FORCE)
+  message(WARNING "Looking for octomap - NOT found, to use VoxelGridShape, "
+      "please install octomap"
+  )
 endif()
 
 #=======================


### PR DESCRIPTION
Octomap support was disabled due to https://github.com/OctoMap/octomap/pull/213, but that fix has been released a long time ago and all the octomap versions available in package managers used on Windows (vcplconda-forge, conan) include it.

***

#### Before creating a pull request

- [x] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
