### PR TITLE
Add DART_BUILD_DARTPY option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,10 @@ option(DART_ENABLE_SIMD
   "Build DART with all SIMD instructions on the current local machine" OFF)
 option(DART_BUILD_GUI_OSG "Build osgDart library" ON)
 option(DART_BUILD_EXTRAS "Build extra projects" OFF)
+option(DART_BUILD_DARTPY "Build dartpy" ON)
 option(DART_CODECOV "Turn on codecov support" OFF)
 option(DART_FAST_DEBUG "Add -O1 option for DEBUG mode build" OFF)
-# GCC and Clang add ANSI-formatted colors when they detect the output medium is a 
+# GCC and Clang add ANSI-formatted colors when they detect the output medium is a
 # terminal. However, this doesn't work in some cases such as when the makefile is
 # invoked by Ninja. DART_FORCE_COLORED_OUTPUT can be used in this case to enforce
 # to always generate ANSI-formatted colors regardless of the output medium types.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright (c) 2011-2022, The DART development contributors
+# All rights reserved.
+
+if(NOT DART_BUILD_DARTPY)
+  return()
+endif()
+
 set(DART_DARTPY_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/dartpy")
 
 add_subdirectory(dartpy)


### PR DESCRIPTION
so that building dartpy can be programmatically disabled if needed even when the deps are detected

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
