### PR TITLE
Fix finding OSG on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 #===============================================================================
 # CMake settings
 #===============================================================================
-cmake_minimum_required(VERSION 3.10.2)
+if(WIN32)
+  cmake_minimum_required(VERSION 3.11)
+else()
+  cmake_minimum_required(VERSION 3.10.2)
+endif()
 
 project(dart)
 

--- a/cmake/DARTFindBullet.cmake
+++ b/cmake/DARTFindBullet.cmake
@@ -6,27 +6,20 @@
 #
 # This file is provided under the "BSD-style" License
 
-include(CMakeParseArguments)
-
 # Bullet. Force MODULE mode to use the FindBullet.cmake file distributed with
 # CMake. Otherwise, we may end up using the BulletConfig.cmake file distributed
 # with Bullet, which uses relative paths and may break transitive dependencies.
 find_package(Bullet COMPONENTS BulletMath BulletCollision MODULE QUIET)
 
 if((BULLET_FOUND OR Bullet_FOUND) AND NOT TARGET Bullet)
-  if(WIN32 AND "optimized" IN_LIST BULLET_LIBRARIES
-           AND     "debug" IN_LIST BULLET_LIBRARIES)
-    cmake_parse_arguments(BULLET_INTERFACE_LIBRARIES "" "" "debug;optimized"
-        ${BULLET_LIBRARIES})
-    set(BULLET_INTERFACE_LIBRARIES
-        $<$<CONFIG:Debug>:${BULLET_INTERFACE_LIBRARIES_debug}>
-        $<$<NOT:$<CONFIG:Debug>>:${BULLET_INTERFACE_LIBRARIES_optimized}>)
-  else()
-    set(BULLET_INTERFACE_LIBRARIES ${BULLET_LIBRARIES})
-  endif()
   add_library(Bullet INTERFACE IMPORTED)
-  set_target_properties(Bullet PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${BULLET_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES "${BULLET_INTERFACE_LIBRARIES}"
-  )
+  if(CMAKE_VERSION VERSION_LESS 3.11)
+    set_target_properties(Bullet PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${BULLET_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${BULLET_LIBRARIES}"
+    )
+  else()
+    target_include_directories(Bullet INTERFACE ${BULLET_INCLUDE_DIRS})
+    target_link_libraries(Bullet INTERFACE ${BULLET_LIBRARIES})
+  endif()
 endif()

--- a/cmake/DARTFindBullet.cmake
+++ b/cmake/DARTFindBullet.cmake
@@ -6,6 +6,8 @@
 #
 # This file is provided under the "BSD-style" License
 
+include(CMakeParseArguments)
+
 # Bullet. Force MODULE mode to use the FindBullet.cmake file distributed with
 # CMake. Otherwise, we may end up using the BulletConfig.cmake file distributed
 # with Bullet, which uses relative paths and may break transitive dependencies.

--- a/cmake/DARTFindOpenSceneGraph.cmake
+++ b/cmake/DARTFindOpenSceneGraph.cmake
@@ -14,7 +14,7 @@ if (CMAKE_VERSION VERSION_LESS 3.12)
 endif()
 
 find_package(OpenSceneGraph 3.0 QUIET
-  COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow
+  COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow osgUtil
 )
 
 if (CMAKE_VERSION VERSION_LESS 3.12)

--- a/cmake/DARTFindOpenSceneGraph.cmake
+++ b/cmake/DARTFindOpenSceneGraph.cmake
@@ -6,8 +6,6 @@
 #
 # This file is provided under the "BSD-style" License
 
-include(CMakeParseArguments)
-
 if (CMAKE_VERSION VERSION_LESS 3.12)
   get_property(old_find_library_use_lib64_paths GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
@@ -57,19 +55,14 @@ endif()
 # variables contain absolute paths of OpenSceneGraph that could be different in
 # where the system that DART is built and where the system that consumes DART.
 if((OPENSCENEGRAPH_FOUND OR OpenSceneGraph_FOUND) AND NOT TARGET osg::osg)
-  if(WIN32 AND "optimized" IN_LIST OPENSCENEGRAPH_LIBRARIES
-          AND     "debug" IN_LIST OPENSCENEGRAPH_LIBRARIES)
-    cmake_parse_arguments(OPENSCENEGRAPH_INTERFACE_LIBRARIES "" "" "debug;optimized"
-        ${OPENSCENEGRAPH_LIBRARIES})
-    set(OPENSCENEGRAPH_INTERFACE_LIBRARIES
-        $<$<CONFIG:Debug>:${OPENSCENEGRAPH_INTERFACE_LIBRARIES_debug}>
-        $<$<NOT:$<CONFIG:Debug>>:${OPENSCENEGRAPH_INTERFACE_LIBRARIES_optimized}>)
-  else()
-    set(OPENSCENEGRAPH_INTERFACE_LIBRARIES ${OPENSCENEGRAPH_LIBRARIES})
-  endif()
   add_library(osg::osg INTERFACE IMPORTED)
-  set_target_properties(osg::osg PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${OPENSCENEGRAPH_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES "${OPENSCENEGRAPH_INTERFACE_LIBRARIES}"
-  )
+  if(CMAKE_VERSION VERSION_LESS 3.11)
+    set_target_properties(osg::osg PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OPENSCENEGRAPH_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${OPENSCENEGRAPH_LIBRARIES}"
+    )
+  else()
+    target_include_directories(osg::osg INTERFACE ${OPENSCENEGRAPH_INCLUDE_DIRS})
+    target_link_libraries(osg::osg INTERFACE ${OPENSCENEGRAPH_LIBRARIES})
+  endif()
 endif()

--- a/cmake/DARTFindOpenSceneGraph.cmake
+++ b/cmake/DARTFindOpenSceneGraph.cmake
@@ -6,6 +6,8 @@
 #
 # This file is provided under the "BSD-style" License
 
+include(CMakeParseArguments)
+
 if (CMAKE_VERSION VERSION_LESS 3.12)
   get_property(old_find_library_use_lib64_paths GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
   set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
@@ -55,9 +57,19 @@ endif()
 # variables contain absolute paths of OpenSceneGraph that could be different in
 # where the system that DART is built and where the system that consumes DART.
 if((OPENSCENEGRAPH_FOUND OR OpenSceneGraph_FOUND) AND NOT TARGET osg::osg)
+  if(WIN32 AND "optimized" IN_LIST OPENSCENEGRAPH_LIBRARIES
+          AND     "debug" IN_LIST OPENSCENEGRAPH_LIBRARIES)
+    cmake_parse_arguments(OPENSCENEGRAPH_INTERFACE_LIBRARIES "" "" "debug;optimized"
+        ${OPENSCENEGRAPH_LIBRARIES})
+    set(OPENSCENEGRAPH_INTERFACE_LIBRARIES
+        $<$<CONFIG:Debug>:${OPENSCENEGRAPH_INTERFACE_LIBRARIES_debug}>
+        $<$<NOT:$<CONFIG:Debug>>:${OPENSCENEGRAPH_INTERFACE_LIBRARIES_optimized}>)
+  else()
+    set(OPENSCENEGRAPH_INTERFACE_LIBRARIES ${OPENSCENEGRAPH_LIBRARIES})
+  endif()
   add_library(osg::osg INTERFACE IMPORTED)
   set_target_properties(osg::osg PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${OPENSCENEGRAPH_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES "${OPENSCENEGRAPH_LIBRARIES}"
+    INTERFACE_LINK_LIBRARIES "${OPENSCENEGRAPH_INTERFACE_LIBRARIES}"
   )
 endif()

--- a/dart/common/IncludeWindows.hpp
+++ b/dart/common/IncludeWindows.hpp
@@ -30,21 +30,21 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_GUI_LOADOPENGL_HPP_
-#define DART_GUI_LOADOPENGL_HPP_
+#ifndef DART_COMMON_INCLUDEWINDOWS_HPP_
+#define DART_COMMON_INCLUDEWINDOWS_HPP_
 
-#if defined(_WIN32)
-  #include "dart/common/IncludeWindows.hpp"
-  #include <GL/gl.h>
-  #include <GL/glu.h>
-#elif defined(__linux__)
-  #include <GL/gl.h>
-  #include <GL/glu.h>
-#elif defined(__APPLE__)
-  #include <OpenGL/gl.h>
-  #include <OpenGL/glu.h>
-#else
-  #error "Load OpenGL Error: What's your operating system?"
+#ifdef _WIN32
+  #ifdef NOMINMAX
+    #include <windows.h>
+    #undef near
+    #undef far
+  #else
+    #define NOMINMAX
+    #include <windows.h>
+    #undef NOMINMAX
+    #undef near
+    #undef far
+  #endif
 #endif
 
-#endif // DART_GUI_LOADOPENGL_HPP_
+#endif // DART_COMMON_INCLUDEWINDOWS_HPP_

--- a/dart/common/SharedLibrary.hpp
+++ b/dart/common/SharedLibrary.hpp
@@ -50,13 +50,7 @@
 
 #elif DART_OS_WINDOWS
 
-  #ifdef NOMINMAX
-    #include <windows.h>
-  #else
-    #define NOMINMAX
-    #include <windows.h>
-    #undef NOMINMAX
-  #endif
+  #include "dart/common/IncludeWindows.hpp"
 using hInstance = HINSTANCE__*;
   #define DYNLIB_HANDLE hInstance
 

--- a/dart/common/Timer.hpp
+++ b/dart/common/Timer.hpp
@@ -36,18 +36,7 @@
 #include <string>
 
 #ifdef _WIN32
-  #ifdef NOMINMAX
-    #include <windows.h>
-  #else
-    #define NOMINMAX
-    #include <windows.h>
-    #undef NOMINMAX
-  #endif
-typedef struct
-{
-  LARGE_INTEGER start;
-  LARGE_INTEGER stop;
-} stopWatch;
+  #include "dart/common/IncludeWindows.hpp"
 #else
   #include <sys/time.h>
 #endif
@@ -101,7 +90,12 @@ private:
   int mCount;
 
 #ifdef _WIN32
-  stopWatch mTimer;
+  struct StopWatch
+  {
+    LARGE_INTEGER start;
+    LARGE_INTEGER stop;
+  };
+  StopWatch mTimer;
 #else
   timeval mTimeVal;
   double mStartedTime;

--- a/dart/common/detail/SharedLibraryManager.hpp
+++ b/dart/common/detail/SharedLibraryManager.hpp
@@ -41,19 +41,6 @@
 #include "dart/common/Filesystem.hpp"
 #include "dart/common/Singleton.hpp"
 
-namespace std {
-
-template <>
-struct hash<::dart::common::filesystem::path>
-{
-  size_t operator()(const ::dart::common::filesystem::path& p) const
-  {
-    return ::dart::common::filesystem::hash_value(p);
-  }
-};
-
-} // namespace std
-
 namespace dart {
 namespace common {
 
@@ -91,8 +78,19 @@ protected:
   friend class Singleton<SharedLibraryManager>;
 
 protected:
+  struct FileSystemHash
+  {
+    size_t operator()(const ::dart::common::filesystem::path& p) const
+    {
+      return ::dart::common::filesystem::hash_value(p);
+    }
+  };
+
   /// Map from library path to the library instances.
-  std::unordered_map<common::filesystem::path, std::weak_ptr<SharedLibrary>>
+  std::unordered_map<
+      common::filesystem::path,
+      std::weak_ptr<SharedLibrary>,
+      FileSystemHash>
       mLibraries;
   // TODO(JS): Remove this in DART 7.
 

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -406,8 +406,13 @@ bool ConstraintSolver::containSkeleton(const ConstSkeletonPtr& skeleton) const
 //==============================================================================
 bool ConstraintSolver::hasSkeleton(const ConstSkeletonPtr& skeleton) const
 {
+#if _WIN32
+  DART_ASSERT(
+      skeleton != nullptr && "Not allowed to insert null pointer skeleton.");
+#else
   DART_ASSERT(
       skeleton != nullptr, "Not allowed to insert null pointer skeleton.");
+#endif
 
   for (const auto& itrSkel : mSkeletons)
   {

--- a/dart/gui/osg/DefaultEventHandler.cpp
+++ b/dart/gui/osg/DefaultEventHandler.cpp
@@ -103,13 +103,13 @@ Eigen::Vector3d DefaultEventHandler::getDeltaCursor(
   ::osg::Vec3d eye, center, up;
   mViewer->getCamera()->getViewMatrixAsLookAt(eye, center, up);
 
-  Eigen::Vector3d near, far;
-  getNearAndFarPointUnderCursor(near, far);
-  Eigen::Vector3d v1 = far - near;
+  Eigen::Vector3d nearPt, farPt;
+  getNearAndFarPointUnderCursor(nearPt, farPt);
+  Eigen::Vector3d v1 = farPt - nearPt;
 
   if (LINE_CONSTRAINT == _constraint)
   {
-    const Eigen::Vector3d& b1 = near;
+    const Eigen::Vector3d& b1 = nearPt;
     const Eigen::Vector3d& v2 = _constraintVector;
     const Eigen::Vector3d& b2 = _fromPosition;
 
@@ -131,14 +131,14 @@ Eigen::Vector3d DefaultEventHandler::getDeltaCursor(
   else if (PLANE_CONSTRAINT == _constraint)
   {
     const Eigen::Vector3d& n = _constraintVector;
-    double s = n.dot(_fromPosition - near) / n.dot(v1);
-    return near - _fromPosition + s * v1;
+    double s = n.dot(_fromPosition - nearPt) / n.dot(v1);
+    return nearPt - _fromPosition + s * v1;
   }
   else
   {
     Eigen::Vector3d n = osgToEigVec3(center - eye);
-    double s = n.dot(_fromPosition - near) / n.dot(v1);
-    return near - _fromPosition + s * v1;
+    double s = n.dot(_fromPosition - nearPt) / n.dot(v1);
+    return nearPt - _fromPosition + s * v1;
   }
 
   return Eigen::Vector3d::Zero();
@@ -146,7 +146,7 @@ Eigen::Vector3d DefaultEventHandler::getDeltaCursor(
 
 //==============================================================================
 void DefaultEventHandler::getNearAndFarPointUnderCursor(
-    Eigen::Vector3d& near, Eigen::Vector3d& far, double distance) const
+    Eigen::Vector3d& nearPt, Eigen::Vector3d& farPt, double distance) const
 {
   ::osg::Camera* C = mViewer->getCamera();
   ::osg::Matrix VPW = C->getViewMatrix() * C->getProjectionMatrix()
@@ -158,8 +158,8 @@ void DefaultEventHandler::getNearAndFarPointUnderCursor(
   auto osgNear = ::osg::Vec3d(x, y, 0.0) * invVPW;
   auto osgFar = ::osg::Vec3d(x, y, distance) * invVPW;
 
-  near = osgToEigVec3(osgNear);
-  far = osgToEigVec3(osgFar);
+  nearPt = osgToEigVec3(osgNear);
+  farPt = osgToEigVec3(osgFar);
 }
 
 //==============================================================================

--- a/dart/gui/osg/TrackballManipulator.hpp
+++ b/dart/gui/osg/TrackballManipulator.hpp
@@ -64,7 +64,7 @@ namespace osg {
 // and dart::gui::osg, we need to explicitly specify the root namespace osg as
 // ::osg
 
-class OSGGA_EXPORT TrackballManipulator : public ::osgGA::OrbitManipulator
+class TrackballManipulator : public ::osgGA::OrbitManipulator
 {
 public:
   /// Constructor

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -935,7 +935,7 @@ void MeshShapeGeometry::extractData(bool firstTime)
   // Load textures on the first pass through
   if (firstTime)
   {
-    uint unit = 0;
+    unsigned int unit = 0;
     const aiVector3D* aiTexCoords = mAiMesh->mTextureCoords[unit];
 
     while (nullptr != aiTexCoords)

--- a/python/dartpy/CMakeLists.txt
+++ b/python/dartpy/CMakeLists.txt
@@ -13,19 +13,12 @@ endif()
 # Find pybind11, including PythonInterp and PythonLibs
 # Needs to set PYBIND11_PYTHON_VERSION before finding pybind11
 set(PYBIND11_PYTHON_VERSION ${DARTPY_PYTHON_VERSION})
+if(WIN32)
+  set(PYBIND11_FINDPYTHON TRUE)
+endif()
 find_package(pybind11 2.2.0 QUIET)
 if(NOT pybind11_FOUND)
   message(WARNING "Disabling [dartpy] due to missing pybind11 >= 2.2.0.")
-  return()
-endif()
-
-if(NOT PythonInterp_FOUND AND NOT PYTHONINTERP_FOUND)
-  message(WARNING "Disabling [dartpy] due to missing [PythonInterp].")
-  return()
-endif()
-
-if(NOT PythonLibs_FOUND AND NOT PYTHONLIBS_FOUND)
-  message(WARNING "Disabling [dartpy] due to missing [PythonLibs].")
   return()
 endif()
 

--- a/python/dartpy/gui/osg/GUIEventHandler.cpp
+++ b/python/dartpy/gui/osg/GUIEventHandler.cpp
@@ -65,7 +65,7 @@ class PyGUIEventHandler final : public GUIEventHandlerNoRef
 {
 public:
   // Inherit the constructors
-  using GUIEventHandlerNoRef::GUIEventHandler;
+  using GUIEventHandlerNoRef::GUIEventHandlerNoRef;
 
   // Trampoline for virtual function
   bool handle(


### PR DESCRIPTION
- Use `target_link_libraries()` instead of `set_target_properties()` to handle the link-type keywords in `*_LIBRARIES` (inspired by https://github.com/PointCloudLibrary/pcl/pull/3341)
- Fix build errors on Windows + VS2022

***

#### Before creating a pull request

- [x] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
