### PR TITLE
Make inertial warnings optional when setting tensor

### DIFF
--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -196,7 +196,14 @@ Eigen::Matrix3d Inertia::getMoment() const
 //==============================================================================
 void Inertia::setSpatialTensor(const Eigen::Matrix6d& _spatial)
 {
-  if (!verifySpatialTensor(_spatial, true))
+  setSpatialTensor(_spatial, true);
+}
+
+//==============================================================================
+void Inertia::setSpatialTensor(const Eigen::Matrix6d& _spatial,
+      bool _printWarnings)
+{
+  if (!verifySpatialTensor(_spatial, _printWarnings))
     dtwarn << "[Inertia::setSpatialTensor] Passing in an invalid spatial "
            << "inertia tensor. Results might not be physically accurate or "
            << "meaningful.\n";

--- a/dart/dynamics/Inertia.hpp
+++ b/dart/dynamics/Inertia.hpp
@@ -122,6 +122,9 @@ public:
   /// Set the spatial tensor
   void setSpatialTensor(const Eigen::Matrix6d& _spatial);
 
+  /// Set the spatial tensor, with option to silence warnings.
+  void setSpatialTensor(const Eigen::Matrix6d& _spatial, bool _printWarnings);
+
   /// Get the spatial inertia tensor
   const Eigen::Matrix6d& getSpatialTensor() const;
 


### PR DESCRIPTION
* Part of https://github.com/gazebosim/gz-sim/issues/1462
* Used by https://github.com/gazebosim/gz-physics/pull/384

***

We're adding support for fluid added mass to Gazebo, see the [Fluid Added Mass Proposal](http://sdformat.org/tutorials?tut=added_mass_proposal&branch=chapulina/added_mass). This feature makes use of values in a body's spatial tensor which break the current assumptions in the inertia class. Since this is a valid use case for us, we'd like to suppress those warnings.

So far I haven't noticed any other places where DART misbehaves when passing those values to the spatial tensor. As an example, without this PR I see warnings like this:

```
Warning [Inertia.cpp:287] [Inertia::verifySpatialTensor] Invalid entry for (3,3): 0.261666. Value should be exactly zero.
Warning [Inertia.cpp:296] [Inertia::verifySpatialTensor] Invalid entry for (4,3): 0.261666. Value should be exactly zero.
Warning [Inertia.cpp:287] [Inertia::verifySpatialTensor] Invalid entry for (3,3): 0.261666. Value should be exactly zero.
Warning [Inertia.cpp:296] [Inertia::verifySpatialTensor] Invalid entry for (5,3): 0.261666. Value should be exactly zero.
Warning [Inertia.cpp:185] [Inertia::setSpatialTensor] Passing in an invalid spatial inertia tensor. Results might not be physically accurate or meaningful.
Warning [Inertia.cpp:287] [Inertia::verifySpatialTensor] Invalid entry for (3,3): 0.261666. Value should be exactly zero.
Warning [Inertia.cpp:296] [Inertia::verifySpatialTensor] Invalid entry for (4,3): 0.261666. Value should be exactly zero.
Warning [Inertia.cpp:185] [Inertia::setSpatialTensor] Passing in an invalid spatial inertia tensor. Results might not be physically accurate or meaningful.
```

I added the option to suppress the warnings in a way that doesn't break ABI, so that this change can be included in future releases in a backwards-compatible manner. I considered skipping the verification completely when `!_printWarnings`, please let me know if you'd like me to do that instead.

I'm not sure about DART's backporting policy, but it would be great to have this change be released in a 6.X release. Please let me know if this is the correct branch to target this change.

#### Before creating a pull request

- [x] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
