### PR TITLE
Silence Clang-14 bitwise instead of logical

### DIFF
--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -365,7 +365,7 @@ createJointAndBodyNodePairForMultipleJoints(
 
       // Limits
       props.mIsPositionLimitEnforced
-          = static_cast<int>(mjcfJoint0.isLimited()) & mjcfJoint1.isLimited();
+          = mjcfJoint0.isLimited() && mjcfJoint1.isLimited();
       props.mPositionLowerLimits[0] = mjcfJoint0.getRange()[0];
       props.mPositionLowerLimits[1] = mjcfJoint1.getRange()[0];
       props.mPositionLowerLimits[2] = mjcfJoint2.getRange()[0];

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -306,7 +306,7 @@ createJointAndBodyNodePairForMultipleJoints(
 
       // Limits
       props.mIsPositionLimitEnforced
-          = static_cast<int>(mjcfJoint0.isLimited()) & mjcfJoint1.isLimited();
+          = mjcfJoint0.isLimited() && mjcfJoint1.isLimited();
       props.mPositionLowerLimits[0] = mjcfJoint0.getRange()[0];
       props.mPositionLowerLimits[1] = mjcfJoint1.getRange()[0];
       props.mPositionUpperLimits[0] = mjcfJoint0.getRange()[1];

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -306,7 +306,7 @@ createJointAndBodyNodePairForMultipleJoints(
 
       // Limits
       props.mIsPositionLimitEnforced
-          = mjcfJoint0.isLimited() & mjcfJoint1.isLimited();
+          = static_cast<int>(mjcfJoint0.isLimited()) & mjcfJoint1.isLimited();
       props.mPositionLowerLimits[0] = mjcfJoint0.getRange()[0];
       props.mPositionLowerLimits[1] = mjcfJoint1.getRange()[0];
       props.mPositionUpperLimits[0] = mjcfJoint0.getRange()[1];
@@ -365,7 +365,7 @@ createJointAndBodyNodePairForMultipleJoints(
 
       // Limits
       props.mIsPositionLimitEnforced
-          = mjcfJoint0.isLimited() & mjcfJoint1.isLimited();
+          = static_cast<int>(mjcfJoint0.isLimited()) & mjcfJoint1.isLimited();
       props.mPositionLowerLimits[0] = mjcfJoint0.getRange()[0];
       props.mPositionLowerLimits[1] = mjcfJoint1.getRange()[0];
       props.mPositionLowerLimits[2] = mjcfJoint2.getRange()[0];


### PR DESCRIPTION
- Addresses Issue #1673
- Switches to logical and rather than bitwise
***

#### Before creating a pull request
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
