### PR TITLE
Add symbol control to dart::math

### DIFF
--- a/dart/math/CMakeLists.txt
+++ b/dart/math/CMakeLists.txt
@@ -38,6 +38,7 @@ dart_add_component(
     ${compile_options_public}
   SUB_DIRECTORIES
     detail
+  GENERATE_EXPORT_HEADER
   GENERATE_META_HEADER
   FORMAT_CODE
 )

--- a/dart/math/Geometry.hpp
+++ b/dart/math/Geometry.hpp
@@ -34,6 +34,7 @@
 #define DART_MATH_GEOMETRY_HPP_
 
 #include "dart/math/Constants.hpp"
+#include "dart/math/Export.hpp"
 #include "dart/math/MathTypes.hpp"
 
 #include <Eigen/Dense>
@@ -42,114 +43,114 @@ namespace dart {
 namespace math {
 
 /// \brief
-Eigen::Matrix3d makeSkewSymmetric(const Eigen::Vector3d& _v);
+DART_MATH_API Eigen::Matrix3d makeSkewSymmetric(const Eigen::Vector3d& _v);
 
 /// \brief
-Eigen::Vector3d fromSkewSymmetric(const Eigen::Matrix3d& _m);
+DART_MATH_API Eigen::Vector3d fromSkewSymmetric(const Eigen::Matrix3d& _m);
 
 //------------------------------------------------------------------------------
 /// \brief
-Eigen::Quaterniond expToQuat(const Eigen::Vector3d& _v);
+DART_MATH_API Eigen::Quaterniond expToQuat(const Eigen::Vector3d& _v);
 
 /// \brief
-Eigen::Vector3d quatToExp(const Eigen::Quaterniond& _q);
+DART_MATH_API Eigen::Vector3d quatToExp(const Eigen::Quaterniond& _q);
 
 /// \brief
-Eigen::Vector3d rotatePoint(
+DART_MATH_API Eigen::Vector3d rotatePoint(
     const Eigen::Quaterniond& _q, const Eigen::Vector3d& _pt);
 
 /// \brief
-Eigen::Vector3d rotatePoint(
+DART_MATH_API Eigen::Vector3d rotatePoint(
     const Eigen::Quaterniond& _q, double _x, double _y, double _z);
 
 /// \brief
-Eigen::Matrix3d quatDeriv(const Eigen::Quaterniond& _q, int _el);
+DART_MATH_API Eigen::Matrix3d quatDeriv(const Eigen::Quaterniond& _q, int _el);
 
 /// \brief
-Eigen::Matrix3d quatSecondDeriv(
+DART_MATH_API Eigen::Matrix3d quatSecondDeriv(
     const Eigen::Quaterniond& _q, int _el1, int _el2);
 
 //------------------------------------------------------------------------------
 /// \brief Given Euler XYX angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotX(angle(0)) * RotY(angle(1)) * RotX(angle(2)).
-Eigen::Matrix3d eulerXYXToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerXYXToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerXYZ angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotX(angle(0)) * RotY(angle(1)) * RotZ(angle(2)).
-Eigen::Matrix3d eulerXYZToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerXYZToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerXZX angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotX(angle(0)) * RotZ(angle(1)) * RotX(angle(2)).
-Eigen::Matrix3d eulerXZXToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerXZXToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerXZY angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotX(angle(0)) * RotZ(angle(1)) * RotY(angle(2)).
-Eigen::Matrix3d eulerXZYToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerXZYToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerYXY angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotY(angle(0)) * RotX(angle(1)) * RotY(angle(2)).
-Eigen::Matrix3d eulerYXYToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerYXYToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerYXZ angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotY(angle(0)) * RotX(angle(1)) * RotZ(angle(2)).
-Eigen::Matrix3d eulerYXZToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerYXZToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerYZX angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotY(angle(0)) * RotZ(angle(1)) * RotX(angle(2)).
-Eigen::Matrix3d eulerYZXToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerYZXToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerYZY angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotY(angle(0)) * RotZ(angle(1)) * RotY(angle(2)).
-Eigen::Matrix3d eulerYZYToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerYZYToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerZXY angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotZ(angle(0)) * RotX(angle(1)) * RotY(angle(2)).
-Eigen::Matrix3d eulerZXYToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerZXYToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerZYX angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotZ(angle(0)) * RotY(angle(1)) * RotX(angle(2)).
 /// singularity : angle[1] = -+ 0.5*PI
-Eigen::Matrix3d eulerZYXToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerZYXToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerZXZ angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotZ(angle(0)) * RotX(angle(1)) * RotZ(angle(2)).
-Eigen::Matrix3d eulerZXZToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerZXZToMatrix(const Eigen::Vector3d& _angle);
 
 /// \brief Given EulerZYZ angles, return a 3x3 rotation matrix, which is
 /// equivalent to RotZ(angle(0)) * RotY(angle(1)) * RotZ(angle(2)).
 /// singularity : angle[1] = 0, PI
-Eigen::Matrix3d eulerZYZToMatrix(const Eigen::Vector3d& _angle);
+DART_MATH_API Eigen::Matrix3d eulerZYZToMatrix(const Eigen::Vector3d& _angle);
 
 //------------------------------------------------------------------------------
 /// \brief get the Euler XYX angle from R
-Eigen::Vector3d matrixToEulerXYX(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d matrixToEulerXYX(const Eigen::Matrix3d& _R);
 
 /// \brief get the Euler XYZ angle from R
-Eigen::Vector3d matrixToEulerXYZ(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d matrixToEulerXYZ(const Eigen::Matrix3d& _R);
 
 ///// \brief get the Euler XZX angle from R
 // Eigen::Vector3d matrixToEulerXZX(const Eigen::Matrix3d& R);
 
 /// \brief get the Euler XZY angle from R
-Eigen::Vector3d matrixToEulerXZY(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d matrixToEulerXZY(const Eigen::Matrix3d& _R);
 
 ///// \brief get the Euler YXY angle from R
 // Eigen::Vector3d matrixToEulerYXY(const Eigen::Matrix3d& R);
 
 /// \brief get the Euler YXZ angle from R
-Eigen::Vector3d matrixToEulerYXZ(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d matrixToEulerYXZ(const Eigen::Matrix3d& _R);
 
 /// \brief get the Euler YZX angle from R
-Eigen::Vector3d matrixToEulerYZX(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d matrixToEulerYZX(const Eigen::Matrix3d& _R);
 
 ///// \brief get the Euler YZY angle from R
 // Eigen::Vector3d matrixToEulerYZY(const Eigen::Matrix3d& R);
 
 /// \brief get the Euler ZXY angle from R
-Eigen::Vector3d matrixToEulerZXY(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d matrixToEulerZXY(const Eigen::Matrix3d& _R);
 
 /// \brief get the Euler ZYX angle from R
-Eigen::Vector3d matrixToEulerZYX(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d matrixToEulerZYX(const Eigen::Matrix3d& _R);
 
 ///// \brief get the Euler ZXZ angle from R
 // Eigen::Vector3d matrixToEulerZXZ(const Eigen::Matrix3d& R);
@@ -159,35 +160,36 @@ Eigen::Vector3d matrixToEulerZYX(const Eigen::Matrix3d& _R);
 
 //------------------------------------------------------------------------------
 /// \brief Exponential mapping
-Eigen::Isometry3d expMap(const Eigen::Vector6d& _S);
+DART_MATH_API Eigen::Isometry3d expMap(const Eigen::Vector6d& _S);
 
 /// \brief fast version of Exp(se3(s, 0))
 /// \todo This expAngular() can be replaced by Eigen::AngleAxis() but we need
 /// to verify that they have exactly same functionality.
 /// See: https://github.com/dartsim/dart/issues/88
-Eigen::Isometry3d expAngular(const Eigen::Vector3d& _s);
+DART_MATH_API Eigen::Isometry3d expAngular(const Eigen::Vector3d& _s);
 
 /// \brief Computes the Rotation matrix from a given expmap vector.
-Eigen::Matrix3d expMapRot(const Eigen::Vector3d& _expmap);
+DART_MATH_API Eigen::Matrix3d expMapRot(const Eigen::Vector3d& _expmap);
 
 /// \brief Computes the Jacobian of the expmap
-Eigen::Matrix3d expMapJac(const Eigen::Vector3d& _expmap);
+DART_MATH_API Eigen::Matrix3d expMapJac(const Eigen::Vector3d& _expmap);
 
 /// \brief Computes the time derivative of the expmap Jacobian.
-Eigen::Matrix3d expMapJacDot(
+DART_MATH_API Eigen::Matrix3d expMapJacDot(
     const Eigen::Vector3d& _expmap, const Eigen::Vector3d& _qdot);
 
 /// \brief computes the derivative of the Jacobian of the expmap wrt to _qi
 /// indexed dof; _qi \f$ \in \f$ {0,1,2}
-Eigen::Matrix3d expMapJacDeriv(const Eigen::Vector3d& _expmap, int _qi);
+DART_MATH_API Eigen::Matrix3d expMapJacDeriv(
+    const Eigen::Vector3d& _expmap, int _qi);
 
 /// \brief Log mapping
 /// \note When @f$|Log(R)| = @pi@f$, Exp(LogR(R) = Exp(-Log(R)).
 /// The implementation returns only the positive one.
-Eigen::Vector3d logMap(const Eigen::Matrix3d& _R);
+DART_MATH_API Eigen::Vector3d logMap(const Eigen::Matrix3d& _R);
 
 /// \brief Log mapping
-Eigen::Vector6d logMap(const Eigen::Isometry3d& _T);
+DART_MATH_API Eigen::Vector6d logMap(const Eigen::Isometry3d& _T);
 
 //------------------------------------------------------------------------------
 /// \brief Rectify the rotation part so as that it satifies the orthogonality
@@ -205,10 +207,11 @@ Eigen::Vector6d logMap(const Eigen::Isometry3d& _T);
 /// \brief adjoint mapping
 /// \note @f$Ad_TV = ( Rw@,, ~p @times Rw + Rv)@f$,
 /// where @f$T=(R,p)@in SE(3), @quad V=(w,v)@in se(3) @f$.
-Eigen::Vector6d AdT(const Eigen::Isometry3d& _T, const Eigen::Vector6d& _V);
+DART_MATH_API Eigen::Vector6d AdT(
+    const Eigen::Isometry3d& _T, const Eigen::Vector6d& _V);
 
 /// \brief Get linear transformation matrix of Adjoint mapping
-Eigen::Matrix6d getAdTMatrix(const Eigen::Isometry3d& T);
+DART_MATH_API Eigen::Matrix6d getAdTMatrix(const Eigen::Isometry3d& T);
 
 /// Adjoint mapping for dynamic size Jacobian
 template <typename Derived>
@@ -254,14 +257,15 @@ typename Derived::PlainObject AdTJacFixed(
 }
 
 /// \brief Fast version of Ad([R 0; 0 1], V)
-Eigen::Vector6d AdR(const Eigen::Isometry3d& _T, const Eigen::Vector6d& _V);
+DART_MATH_API Eigen::Vector6d AdR(
+    const Eigen::Isometry3d& _T, const Eigen::Vector6d& _V);
 
 /// \brief fast version of Ad(T, se3(w, 0))
-Eigen::Vector6d AdTAngular(
+DART_MATH_API Eigen::Vector6d AdTAngular(
     const Eigen::Isometry3d& _T, const Eigen::Vector3d& _w);
 
 /// \brief fast version of Ad(T, se3(0, v))
-Eigen::Vector6d AdTLinear(
+DART_MATH_API Eigen::Vector6d AdTLinear(
     const Eigen::Isometry3d& _T, const Eigen::Vector3d& _v);
 
 ///// \brief fast version of Ad([I p; 0 1], V)
@@ -326,7 +330,8 @@ typename Derived::PlainObject adJac(
 }
 
 /// \brief fast version of Ad(Inv(T), V)
-Eigen::Vector6d AdInvT(const Eigen::Isometry3d& _T, const Eigen::Vector6d& _V);
+DART_MATH_API Eigen::Vector6d AdInvT(
+    const Eigen::Isometry3d& _T, const Eigen::Vector6d& _V);
 
 /// Adjoint mapping for dynamic size Jacobian
 template <typename Derived>
@@ -384,22 +389,25 @@ typename Derived::PlainObject AdInvTJacFixed(
 // se3 AdInvR(const SE3& T, const se3& V);
 
 /// \brief Fast version of Ad(Inv([R 0; 0 1]), se3(0, v))
-Eigen::Vector6d AdInvRLinear(
+DART_MATH_API Eigen::Vector6d AdInvRLinear(
     const Eigen::Isometry3d& _T, const Eigen::Vector3d& _v);
 
 /// \brief dual adjoint mapping
 /// \note @f$Ad^{@,*}_TF = ( R^T (m - p@times f)@,,~ R^T f)@f$,
 /// where @f$T=(R,p)@in SE(3), F=(m,f)@in se(3)^*@f$.
-Eigen::Vector6d dAdT(const Eigen::Isometry3d& _T, const Eigen::Vector6d& _F);
+DART_MATH_API Eigen::Vector6d dAdT(
+    const Eigen::Isometry3d& _T, const Eigen::Vector6d& _F);
 
 ///// \brief fast version of Ad(Inv(T), dse3(Eigen_Vec3(0), F))
 // dse3 dAdTLinear(const SE3& T, const Vec3& F);
 
 /// \brief fast version of dAd(Inv(T), F)
-Eigen::Vector6d dAdInvT(const Eigen::Isometry3d& _T, const Eigen::Vector6d& _F);
+DART_MATH_API Eigen::Vector6d dAdInvT(
+    const Eigen::Isometry3d& _T, const Eigen::Vector6d& _F);
 
 /// \brief fast version of dAd(Inv([R 0; 0 1]), F)
-Eigen::Vector6d dAdInvR(const Eigen::Isometry3d& _T, const Eigen::Vector6d& _F);
+DART_MATH_API Eigen::Vector6d dAdInvR(
+    const Eigen::Isometry3d& _T, const Eigen::Vector6d& _F);
 
 ///// \brief fast version of dAd(Inv(SE3(p)), dse3(Eigen_Vec3(0), F))
 // dse3 dAdInvPLinear(const Vec3& p, const Vec3& F);
@@ -407,7 +415,8 @@ Eigen::Vector6d dAdInvR(const Eigen::Isometry3d& _T, const Eigen::Vector6d& _F);
 /// \brief adjoint mapping
 /// \note @f$ad_X Y = ( w_X @times w_Y@,,~w_X @times v_Y - w_Y @times v_X),@f$,
 /// where @f$X=(w_X,v_X)@in se(3), @quad Y=(w_Y,v_Y)@in se(3) @f$.
-Eigen::Vector6d ad(const Eigen::Vector6d& _X, const Eigen::Vector6d& _Y);
+DART_MATH_API Eigen::Vector6d ad(
+    const Eigen::Vector6d& _X, const Eigen::Vector6d& _Y);
 
 /// \brief fast version of ad(se3(Eigen_Vec3(0), v), S)
 // Vec3 ad_Vec3_se3(const Vec3& v, const se3& S);
@@ -418,14 +427,16 @@ Eigen::Vector6d ad(const Eigen::Vector6d& _X, const Eigen::Vector6d& _Y);
 /// \brief dual adjoint mapping
 /// \note @f$ad^{@,*}_V F = (m @times w + f @times v@,,~ f @times w),@f$
 /// , where @f$F=(m,f)@in se^{@,*}(3), @quad V=(w,v)@in se(3) @f$.
-Eigen::Vector6d dad(const Eigen::Vector6d& _s, const Eigen::Vector6d& _t);
+DART_MATH_API Eigen::Vector6d dad(
+    const Eigen::Vector6d& _s, const Eigen::Vector6d& _t);
 
 /// \brief
-Inertia transformInertia(const Eigen::Isometry3d& _T, const Inertia& _AI);
+DART_MATH_API Inertia
+transformInertia(const Eigen::Isometry3d& _T, const Inertia& _AI);
 
 /// Use the Parallel Axis Theorem to compute the moment of inertia of a body
 /// whose center of mass has been shifted from the origin
-Eigen::Matrix3d parallelAxisTheorem(
+DART_MATH_API Eigen::Matrix3d parallelAxisTheorem(
     const Eigen::Matrix3d& _original,
     const Eigen::Vector3d& _comShift,
     double _mass);
@@ -440,24 +451,24 @@ enum AxisType
 /// Compute a rotation matrix from a vector. One axis of the rotated coordinates
 /// by the rotation matrix matches the input axis where the axis is specified
 /// by axisType.
-Eigen::Matrix3d computeRotation(
+DART_MATH_API Eigen::Matrix3d computeRotation(
     const Eigen::Vector3d& axis, AxisType axisType = AxisType::AXIS_X);
 
 /// Compute a transform from a vector and a position. The rotation of the result
 /// transform is computed by computeRotationMatrix(), and the translation is
 /// just the input translation.
-Eigen::Isometry3d computeTransform(
+DART_MATH_API Eigen::Isometry3d computeTransform(
     const Eigen::Vector3d& axis,
     const Eigen::Vector3d& translation,
     AxisType axisType = AxisType::AXIS_X);
 
 /// \brief Check if determinant of _R is equat to 1 and all the elements are not
 /// NaN values.
-bool verifyRotation(const Eigen::Matrix3d& _R);
+DART_MATH_API bool verifyRotation(const Eigen::Matrix3d& _R);
 
 /// \brief Check if determinant of the rotational part of _T is equat to 1 and
 /// all the elements are not NaN values.
-bool verifyTransform(const Eigen::Isometry3d& _T);
+DART_MATH_API bool verifyTransform(const Eigen::Isometry3d& _T);
 
 /// Compute the angle (in the range of -pi to +pi) which ignores any full
 /// rotations
@@ -503,7 +514,7 @@ typedef std::vector<Eigen::Vector2d> SupportPolygon;
 /// and then compute their convex hull, which will take the form of a polgyon.
 /// _axis1 and _axis2 must both have unit length for this function to work
 /// correctly.
-SupportPolygon computeSupportPolgyon(
+DART_MATH_API SupportPolygon computeSupportPolgyon(
     const SupportGeometry& _geometry,
     const Eigen::Vector3d& _axis1 = Eigen::Vector3d::UnitX(),
     const Eigen::Vector3d& _axis2 = Eigen::Vector3d::UnitY());
@@ -512,18 +523,18 @@ SupportPolygon computeSupportPolgyon(
 /// std::vector<std::size_t> which will have the same size as the returned
 /// SupportPolygon, and each entry will contain the original index of each point
 /// in the SupportPolygon
-SupportPolygon computeSupportPolgyon(
+DART_MATH_API SupportPolygon computeSupportPolgyon(
     std::vector<std::size_t>& _originalIndices,
     const SupportGeometry& _geometry,
     const Eigen::Vector3d& _axis1 = Eigen::Vector3d::UnitX(),
     const Eigen::Vector3d& _axis2 = Eigen::Vector3d::UnitY());
 
 /// Computes the convex hull of a set of 2D points
-SupportPolygon computeConvexHull(const SupportPolygon& _points);
+DART_MATH_API SupportPolygon computeConvexHull(const SupportPolygon& _points);
 
 /// Computes the convex hull of a set of 2D points and fills in _originalIndices
 /// with the original index of each entry in the returned SupportPolygon
-SupportPolygon computeConvexHull(
+DART_MATH_API SupportPolygon computeConvexHull(
     std::vector<std::size_t>& _originalIndices, const SupportPolygon& _points);
 
 /// Generates a 3D convex hull given vertices and indices.
@@ -543,7 +554,8 @@ computeConvexHull3D(
     const std::vector<Eigen::Matrix<S, 3, 1>>& vertices, bool optimize = true);
 
 /// Compute the centroid of a polygon, assuming the polygon is a convex hull
-Eigen::Vector2d computeCentroidOfHull(const SupportPolygon& _convexHull);
+DART_MATH_API Eigen::Vector2d computeCentroidOfHull(
+    const SupportPolygon& _convexHull);
 
 /// Intersection_t is returned by the computeIntersection() function to indicate
 /// whether there was a valid intersection between the two line segments
@@ -559,7 +571,7 @@ enum IntersectionResult
 
 /// Compute the intersection between a line segment that goes from a1 -> a2 and
 /// a line segment that goes from b1 -> b2.
-IntersectionResult computeIntersection(
+DART_MATH_API IntersectionResult computeIntersection(
     Eigen::Vector2d& _intersectionPoint,
     const Eigen::Vector2d& a1,
     const Eigen::Vector2d& a2,
@@ -567,36 +579,37 @@ IntersectionResult computeIntersection(
     const Eigen::Vector2d& b2);
 
 /// Compute a 2D cross product
-double cross(const Eigen::Vector2d& _v1, const Eigen::Vector2d& _v2);
+DART_MATH_API double cross(
+    const Eigen::Vector2d& _v1, const Eigen::Vector2d& _v2);
 
 /// Returns true if the point _p is inside the support polygon
-bool isInsideSupportPolygon(
+DART_MATH_API bool isInsideSupportPolygon(
     const Eigen::Vector2d& _p,
     const SupportPolygon& _support,
     bool _includeEdge = true);
 
 /// Returns the point which is closest to _p that also lays on the line segment
 /// that goes from _s1 -> _s2
-Eigen::Vector2d computeClosestPointOnLineSegment(
+DART_MATH_API Eigen::Vector2d computeClosestPointOnLineSegment(
     const Eigen::Vector2d& _p,
     const Eigen::Vector2d& _s1,
     const Eigen::Vector2d& _s2);
 
 /// Returns the point which is closest to _p that also lays on the edge of the
 /// support polygon
-Eigen::Vector2d computeClosestPointOnSupportPolygon(
+DART_MATH_API Eigen::Vector2d computeClosestPointOnSupportPolygon(
     const Eigen::Vector2d& _p, const SupportPolygon& _support);
 
 /// Same as closestPointOnSupportPolygon, but also fills in _index1 and _index2
 /// with the indices of the line segment
-Eigen::Vector2d computeClosestPointOnSupportPolygon(
+DART_MATH_API Eigen::Vector2d computeClosestPointOnSupportPolygon(
     std::size_t& _index1,
     std::size_t& _index2,
     const Eigen::Vector2d& _p,
     const SupportPolygon& _support);
 
 // Represents a bounding box with minimum and maximum coordinates.
-class BoundingBox
+class DART_MATH_API BoundingBox
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/dart/math/Random.hpp
+++ b/dart/math/Random.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_MATH_RANDOM_HPP_
 #define DART_MATH_RANDOM_HPP_
 
+#include "dart/math/Export.hpp"
+
 #include <Eigen/Core>
 
 #include <random>
@@ -40,7 +42,7 @@
 namespace dart {
 namespace math {
 
-class Random final
+class DART_MATH_API Random final
 {
 public:
   using GeneratorType = std::mt19937;

--- a/dart/math/TriMesh.hpp
+++ b/dart/math/TriMesh.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_MATH_TRIMESH_HPP_
 #define DART_MATH_TRIMESH_HPP_
 
+#include "dart/math/Export.hpp"
 #include "dart/math/Mesh.hpp"
 
 #include <memory>
@@ -108,7 +109,7 @@ protected:
   Normals mTriangleNormals;
 };
 
-extern template class TriMesh<double>;
+extern template class DART_MATH_API TriMesh<double>;
 
 using TriMeshf = TriMesh<float>;
 using TriMeshd = TriMesh<double>;


### PR DESCRIPTION
**Change of `libdart7-math` in `Release` mode on Ubuntu**:
- Number of symbols: 1,166 -> 314
- Size of binary: 745K -> 640K
> Disclaimer: Some APIs could be hidden when they are supposed to be exported but just not caught by the CI. They will be exported eventually as discovered...

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
