### PR TITLE
Add symbol control to dart::optimization

### DIFF
--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -10,21 +10,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${DART_BINARY_DIR}/lib")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${DART_BINARY_DIR}/lib")
 
 #===============================================================================
-# Targets - {dependency targets}, source directories, [external dependency libs]
-#===============================================================================
-# dart - common, math, optimization, dynamics, collision,
-#        collision/dart, collision/fcl, simulation, [assimp, eigen3,
-#        fcl, fmt, libccd]
-# dart-optimization-ipopt - {dart}, optimization/ipopt, [ipopt]
-# dart-optimization-nlopt - {dart}, optimization/nlopt, [nlopt]
-# dart-collision-bullet - {dart}, collision/bullet, [bullet]
-# dart-io - {dart}, io, io/sdf, [tinyxml2]
-# dart-io-urdf - {dart-io}, io/urdf, [urdfdom]
-# dart-gui - {dart}, gui, [opengl]
-# dart-gui-glut - {dart-gui}, gui/glut, [glut]
-# dart-gui-osg - {dart-gui}, gui/osg, gui/osg/render, [openscenegraph]
-
-#===============================================================================
 # Components: (dependency component), {external dependency}, [optional external dependency]
 #===============================================================================
 #

--- a/dart/optimization/CMakeLists.txt
+++ b/dart/optimization/CMakeLists.txt
@@ -32,6 +32,7 @@ dart_add_component(
     cxx_std_17
   SUB_DIRECTORIES
     nlopt ipopt pagmo
+  GENERATE_EXPORT_HEADER
   GENERATE_META_HEADER
   FORMAT_CODE
 )

--- a/dart/optimization/Function.hpp
+++ b/dart/optimization/Function.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_OPTIMIZER_FUNCTION_HPP_
 #define DART_OPTIMIZER_FUNCTION_HPP_
 
+#include "dart/optimization/Export.hpp"
+
 #include <Eigen/Dense>
 
 #include <functional>
@@ -42,7 +44,7 @@
 namespace dart {
 namespace optimization {
 
-class Function
+class DART_OPTIMIZATION_API Function
 {
 public:
   /// Constructor
@@ -96,7 +98,7 @@ typedef std::function<void(
 /// ModularFunction uses C++11 std::function to allow you to easily swap
 /// out the cost function, gradient function, and Hessian function during
 /// runtime for an optimization::Function instance.
-class ModularFunction : public Function
+class DART_OPTIMIZATION_API ModularFunction : public Function
 {
 public:
   /// Constructor
@@ -156,7 +158,7 @@ protected:
 };
 
 /// NullFunction is a constant-zero Function
-class NullFunction : public Function
+class DART_OPTIMIZATION_API NullFunction : public Function
 {
 public:
   /// Constructor
@@ -182,7 +184,7 @@ public:
 };
 
 /// class MultiFunction
-class MultiFunction
+class DART_OPTIMIZATION_API MultiFunction
 {
 public:
   /// Constructor

--- a/dart/optimization/GradientDescentSolver.hpp
+++ b/dart/optimization/GradientDescentSolver.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_OPTIMIZER_GRADIENTDESCENTSOLVER_HPP_
 #define DART_OPTIMIZER_GRADIENTDESCENTSOLVER_HPP_
 
+#include "dart/optimization/Export.hpp"
 #include "dart/optimization/Solver.hpp"
 
 #include <random>
@@ -46,7 +47,7 @@ namespace optimization {
 /// objective function and assigned weights) to solve nonlinear problems. Note
 /// that this is not a good option for Problems with difficult constraint
 /// functions that need to be solved exactly.
-class GradientDescentSolver : public Solver
+class DART_OPTIMIZATION_API GradientDescentSolver : public Solver
 {
 public:
   static const std::string Type;

--- a/dart/optimization/Problem.hpp
+++ b/dart/optimization/Problem.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_OPTIMIZER_PROBLEM_HPP_
 #define DART_OPTIMIZER_PROBLEM_HPP_
 
+#include "dart/optimization/Export.hpp"
 #include "dart/optimization/Function.hpp"
 
 #include <Eigen/Dense>
@@ -45,7 +46,7 @@ namespace dart {
 namespace optimization {
 
 /// \brief class Problem
-class Problem
+class DART_OPTIMIZATION_API Problem
 {
 public:
   /// \brief Constructor

--- a/dart/optimization/Solver.hpp
+++ b/dart/optimization/Solver.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_OPTIMIZER_SOLVER_HPP_
 #define DART_OPTIMIZER_SOLVER_HPP_
 
+#include "dart/optimization/Export.hpp"
+
 #include <Eigen/Dense>
 
 #include <iostream>
@@ -49,7 +51,7 @@ class Problem;
 /// problem types. This base class allows the different Solver implementations
 /// to be swapped out with each other quickly and easily to help with testing,
 /// benchmarking, and experimentation.
-class Solver
+class DART_OPTIMIZATION_API Solver
 {
 public:
   /// The Solver::Properties class contains Solver parameters that are common

--- a/dart/optimization/ipopt/IpoptSolver.hpp
+++ b/dart/optimization/ipopt/IpoptSolver.hpp
@@ -53,7 +53,7 @@ class Problem;
 class DartTNLP;
 
 /// \brief class IpoptSolver
-class IpoptSolver : public Solver
+class DART_OPTIMIZATION_API IpoptSolver : public Solver
 {
 public:
   /// Default constructor

--- a/dart/optimization/nlopt/NloptSolver.hpp
+++ b/dart/optimization/nlopt/NloptSolver.hpp
@@ -56,7 +56,7 @@ class Problem;
 /// optimization and N/D denotes derivative-free/gradient-based algorithms,
 /// respectively. For the details, please see:
 /// https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/
-class NloptSolver : public Solver
+class DART_OPTIMIZATION_API NloptSolver : public Solver
 {
 public:
   enum Algorithm

--- a/dart/optimization/pagmo/PagmoMultiObjectiveSolver.hpp
+++ b/dart/optimization/pagmo/PagmoMultiObjectiveSolver.hpp
@@ -46,7 +46,8 @@ namespace optimization {
 
 class MultiObjectiveProblem;
 
-class PagmoMultiObjectiveSolver : public MultiObjectiveSolver
+class DART_OPTIMIZATION_API PagmoMultiObjectiveSolver
+  : public MultiObjectiveSolver
 {
 public:
   /// Reference: https://esa.github.io/pagmo2/docs/algorithm_list.html


### PR DESCRIPTION
**Change of `libdart7-math` in `Release` mode on Ubuntu**:
- Number of symbols: 1,496 -> 561
- Size of binary: 701K -> 582K
> Disclaimer: Some APIs could be hidden when they are supposed to be exported but just not caught by the CI. They will be exported eventually as discovered...

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
