### PR TITLE
Add symbol control to dart::dynamics

### DIFF
--- a/cmake/DARTFindEigen3.cmake
+++ b/cmake/DARTFindEigen3.cmake
@@ -7,4 +7,3 @@
 # This file is provided under the "BSD-style" License
 
 find_package(Eigen3 3.4.0 REQUIRED CONFIG)
-

--- a/dart/collision/CMakeLists.txt
+++ b/dart/collision/CMakeLists.txt
@@ -26,6 +26,7 @@ dart_add_component(
     common math
   TARGET_COMPILE_FEATURES_PUBLIC
     cxx_std_17
+  GENERATE_EXPORT_HEADER
   GENERATE_META_HEADER
   FORMAT_CODE
 )

--- a/dart/dynamics/ArrowShape.hpp
+++ b/dart/dynamics/ArrowShape.hpp
@@ -33,12 +33,13 @@
 #ifndef DART_DYNAMICS_ARROWSHAPE_HPP_
 #define DART_DYNAMICS_ARROWSHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 
 namespace dart {
 namespace dynamics {
 
-class ArrowShape : public MeshShape
+class DART_DYNAMICS_API ArrowShape : public MeshShape
 {
 public:
   struct Properties

--- a/dart/dynamics/BalanceConstraint.hpp
+++ b/dart/dynamics/BalanceConstraint.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_CONSTRAINT_BALANCECONSTRAINT_HPP_
 #define DART_CONSTRAINT_BALANCECONSTRAINT_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/HierarchicalIK.hpp"
 
 namespace dart {
@@ -42,8 +43,9 @@ namespace dynamics {
 /// into a HierarchicalIK module. Adding this constraint to the Problem of a
 /// HierarchicalIK will allow the IK solver to constrain the Skeleton so that it
 /// satisfies a support polygon style balancing constraint.
-class BalanceConstraint : public optimization::Function,
-                          public dynamics::HierarchicalIK::Function
+class DART_DYNAMICS_API BalanceConstraint
+  : public optimization::Function,
+    public dynamics::HierarchicalIK::Function
 {
 public:
   /// The ErrorMethod_t determines whether the error should be computed based on

--- a/dart/dynamics/BallJoint.hpp
+++ b/dart/dynamics/BallJoint.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_BALLJOINT_HPP_
 #define DART_DYNAMICS_BALLJOINT_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/GenericJoint.hpp"
 
 #include <Eigen/Dense>
@@ -41,7 +42,7 @@ namespace dart {
 namespace dynamics {
 
 /// class BallJoint
-class BallJoint : public GenericJoint<math::SO3Space>
+class DART_DYNAMICS_API BallJoint : public GenericJoint<math::SO3Space>
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/BallJointConstraint.hpp
+++ b/dart/dynamics/BallJointConstraint.hpp
@@ -34,6 +34,7 @@
 #define DART_CONSTRAINT_BALLJOINTCONSTRAINT_HPP_
 
 #include "dart/dynamics/DynamicJointConstraint.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/math/MathTypes.hpp"
 
 #include <Eigen/Dense>
@@ -43,7 +44,7 @@ namespace dynamics {
 
 /// BallJointConstraint represents ball joint constraint between a body and the
 /// world or between two bodies
-class BallJointConstraint : public DynamicJointConstraint
+class DART_DYNAMICS_API BallJointConstraint : public DynamicJointConstraint
 {
 public:
   /// Constructor that takes one body and the joint position in the world frame

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -37,6 +37,7 @@
 #include "dart/common/Signal.hpp"
 #include "dart/config.hpp"
 #include "dart/dynamics/EndEffector.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Frame.hpp"
 #include "dart/dynamics/Marker.hpp"
 #include "dart/dynamics/Node.hpp"
@@ -71,7 +72,7 @@ class Marker;
 /// BodyNode inherits Frame, and a parent Frame of a BodyNode is the parent
 /// BodyNode of the BodyNode.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class BodyNode
+class DART_DYNAMICS_API BodyNode
   : public detail::BodyNodeCompositeBase,
     public virtual BodyNodeSpecializedFor<ShapeNode, EndEffector, Marker>,
     public SkeletonRefCountingBase,

--- a/dart/dynamics/BoxShape.hpp
+++ b/dart/dynamics/BoxShape.hpp
@@ -33,12 +33,13 @@
 #ifndef DART_DYNAMICS_BOXSHAPE_HPP_
 #define DART_DYNAMICS_BOXSHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
 namespace dynamics {
 
-class BoxShape : public Shape
+class DART_DYNAMICS_API BoxShape : public Shape
 {
 public:
   /// \brief Constructor.

--- a/dart/dynamics/BoxedLcpConstraintSolver.hpp
+++ b/dart/dynamics/BoxedLcpConstraintSolver.hpp
@@ -34,12 +34,13 @@
 #define DART_CONSTRAINT_BOXEDLCPCONSTRAINTSOLVER_HPP_
 
 #include "dart/dynamics/ConstraintSolver.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 namespace dart {
 namespace dynamics {
 
-class BoxedLcpConstraintSolver : public ConstraintSolver
+class DART_DYNAMICS_API BoxedLcpConstraintSolver : public ConstraintSolver
 {
 public:
   /// Constructos with default primary and secondary LCP solvers, which are

--- a/dart/dynamics/BoxedLcpSolver.hpp
+++ b/dart/dynamics/BoxedLcpSolver.hpp
@@ -34,6 +34,7 @@
 #define DART_CONSTRAINT_BOXEDLCPSOLVER_HPP_
 
 #include "dart/common/Castable.hpp"
+#include "dart/dynamics/Export.hpp"
 
 #include <Eigen/Core>
 
@@ -42,7 +43,7 @@
 namespace dart {
 namespace dynamics {
 
-class BoxedLcpSolver : public common::Castable<BoxedLcpSolver>
+class DART_DYNAMICS_API BoxedLcpSolver : public common::Castable<BoxedLcpSolver>
 {
 public:
   /// Destructor

--- a/dart/dynamics/Branch.hpp
+++ b/dart/dynamics/Branch.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_BRANCH_HPP_
 #define DART_DYNAMICS_BRANCH_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Linkage.hpp"
 
 namespace dart {
@@ -41,7 +42,7 @@ namespace dynamics {
 /// Branch is a specialized type of Linkage that represents a complete subtree
 /// of a Skeleton. The Branch will start at a specific BodyNode and will include
 /// every BodyNode that descends from it, all the way to the leaves.
-class Branch : public Linkage
+class DART_DYNAMICS_API Branch : public Linkage
 {
 public:
   struct Criteria

--- a/dart/dynamics/CMakeLists.txt
+++ b/dart/dynamics/CMakeLists.txt
@@ -32,6 +32,7 @@ dart_add_component(
     cxx_std_17
   SUB_DIRECTORIES
     detail dart fcl bullet ode
+  GENERATE_EXPORT_HEADER
   GENERATE_META_HEADER
   FORMAT_CODE
 )

--- a/dart/dynamics/CapsuleShape.hpp
+++ b/dart/dynamics/CapsuleShape.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_CAPSULESHAPE_HPP_
 #define DART_DYNAMICS_CAPSULESHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
@@ -40,7 +41,7 @@ namespace dynamics {
 
 /// CapsuleShape represents a three-dimensional geometric shape consisting of a
 /// cylinder with hemispherical ends.
-class CapsuleShape : public Shape
+class DART_DYNAMICS_API CapsuleShape : public Shape
 {
 public:
   /// Constructor.

--- a/dart/dynamics/Chain.hpp
+++ b/dart/dynamics/Chain.hpp
@@ -43,7 +43,7 @@ namespace dynamics {
 /// specified BodyNode and include every BodyNode on the way to a target
 /// BodyNode, except it will stop if it encounters a branching (BodyNode with
 /// multiple child BodyNodes) or a FreeJoint.
-class Chain : public Linkage
+class DART_DYNAMICS_API Chain : public Linkage
 {
 public:
   struct Criteria

--- a/dart/dynamics/CollisionDetector.hpp
+++ b/dart/dynamics/CollisionDetector.hpp
@@ -39,6 +39,7 @@
 #include "dart/dynamics/Contact.hpp"
 #include "dart/dynamics/DistanceOption.hpp"
 #include "dart/dynamics/DistanceResult.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/RaycastOption.hpp"
 #include "dart/dynamics/RaycastResult.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
@@ -53,7 +54,8 @@ namespace collision {
 
 class CollisionObject;
 
-class CollisionDetector : public std::enable_shared_from_this<CollisionDetector>
+class DART_DYNAMICS_API CollisionDetector
+  : public std::enable_shared_from_this<CollisionDetector>
 {
 public:
   friend class CollisionObject;

--- a/dart/dynamics/CollisionFilter.hpp
+++ b/dart/dynamics/CollisionFilter.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_COLLISION_COLLISIONFILTER_HPP_
 #define DART_COLLISION_COLLISIONFILTER_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/detail/UnorderedPairs.hpp"
 
 namespace dart {
@@ -45,7 +46,7 @@ namespace collision {
 
 class CollisionObject;
 
-class CollisionFilter
+class DART_DYNAMICS_API CollisionFilter
 {
 public:
   /// Destructor.
@@ -57,7 +58,7 @@ public:
       const CollisionObject* object1, const CollisionObject* object2) const = 0;
 };
 
-class CompositeCollisionFilter : public CollisionFilter
+class DART_DYNAMICS_API CompositeCollisionFilter : public CollisionFilter
 {
 public:
   /// Adds a collision filter to this CompositeCollisionFilter.
@@ -79,7 +80,7 @@ protected:
   std::unordered_set<const CollisionFilter*> mFilters;
 };
 
-class BodyNodeCollisionFilter : public CollisionFilter
+class DART_DYNAMICS_API BodyNodeCollisionFilter : public CollisionFilter
 {
 public:
   /// Add a BodyNode pair to the blacklist.

--- a/dart/dynamics/CollisionGroup.hpp
+++ b/dart/dynamics/CollisionGroup.hpp
@@ -38,6 +38,7 @@
 #include "dart/dynamics/CollisionResult.hpp"
 #include "dart/dynamics/DistanceOption.hpp"
 #include "dart/dynamics/DistanceResult.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/RaycastOption.hpp"
 #include "dart/dynamics/RaycastResult.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
@@ -49,7 +50,7 @@
 namespace dart {
 namespace collision {
 
-class CollisionGroup
+class DART_DYNAMICS_API CollisionGroup
 {
 public:
   /// Constructor

--- a/dart/dynamics/CollisionObject.hpp
+++ b/dart/dynamics/CollisionObject.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_COLLISION_COLLISIONOBJECT_HPP_
 #define DART_COLLISION_COLLISIONOBJECT_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 #include <Eigen/Dense>
@@ -40,7 +41,7 @@
 namespace dart {
 namespace collision {
 
-class CollisionObject
+class DART_DYNAMICS_API CollisionObject
 {
 public:
   friend class CollisionGroup;

--- a/dart/dynamics/CollisionOption.hpp
+++ b/dart/dynamics/CollisionOption.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_COLLISIONOPTION_HPP_
 #define DART_COLLISION_COLLISIONOPTION_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <memory>
 
 #include <cstddef>
@@ -42,7 +44,7 @@ namespace collision {
 
 class CollisionFilter;
 
-struct CollisionOption
+struct DART_DYNAMICS_API CollisionOption
 {
   /// Flag whether the collision detector computes contact information (contact
   /// point, normal, and penetration depth). If it is set to false, only the

--- a/dart/dynamics/CollisionResult.hpp
+++ b/dart/dynamics/CollisionResult.hpp
@@ -34,6 +34,7 @@
 #define DART_COLLISION_COLLISIONRESULT_HPP_
 
 #include "dart/dynamics/Contact.hpp"
+#include "dart/dynamics/Export.hpp"
 
 #include <unordered_set>
 #include <vector>
@@ -49,7 +50,7 @@ class ShapeFrame;
 
 namespace collision {
 
-class CollisionResult
+class DART_DYNAMICS_API CollisionResult
 {
 public:
   /// Add one contact

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_CONESHAPE_HPP_
 #define DART_DYNAMICS_CONESHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
@@ -40,7 +41,7 @@ namespace dynamics {
 
 /// ConeShape represents a three-dimensional geometric shape that tapers
 /// smoothly from a flat circular base to a point called the apex or vertex.
-class ConeShape : public Shape
+class DART_DYNAMICS_API ConeShape : public Shape
 {
 public:
   /// Constructor.

--- a/dart/dynamics/ConstraintBase.hpp
+++ b/dart/dynamics/ConstraintBase.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_CONSTRAINT_CONSTRAINTBASE_HPP_
 #define DART_CONSTRAINT_CONSTRAINTBASE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 #include <cstddef>
@@ -71,7 +72,7 @@ struct ConstraintInfo
 };
 
 /// Constraint is a base class of concrete constraints classes
-class ConstraintBase
+class DART_DYNAMICS_API ConstraintBase
 {
 public:
   /// Returns a string representing the constraint type

--- a/dart/dynamics/ConstraintSolver.hpp
+++ b/dart/dynamics/ConstraintSolver.hpp
@@ -36,6 +36,7 @@
 #include "dart/dynamics/CollisionDetector.hpp"
 #include "dart/dynamics/ConstrainedGroup.hpp"
 #include "dart/dynamics/ConstraintBase.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 #include <Eigen/Dense>
@@ -52,7 +53,7 @@ class ShapeNodeCollisionObject;
 namespace dynamics {
 
 /// ConstraintSolver manages constraints and computes constraint impulses
-class ConstraintSolver
+class DART_DYNAMICS_API ConstraintSolver
 {
 public:
   /// Default constructor

--- a/dart/dynamics/Contact.hpp
+++ b/dart/dynamics/Contact.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_COLLISION_CONTACT_HPP_
 #define DART_COLLISION_CONTACT_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 #include <Eigen/Dense>
@@ -41,7 +42,7 @@ namespace dart {
 namespace collision {
 
 /// Contact information
-struct Contact
+struct DART_DYNAMICS_API Contact
 {
   /// Default constructor
   Contact();

--- a/dart/dynamics/CylinderShape.hpp
+++ b/dart/dynamics/CylinderShape.hpp
@@ -33,12 +33,13 @@
 #ifndef DART_DYNAMICS_CYLINDERSHAPE_HPP_
 #define DART_DYNAMICS_CYLINDERSHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
 namespace dynamics {
 
-class CylinderShape : public Shape
+class DART_DYNAMICS_API CylinderShape : public Shape
 {
 public:
   /// \brief Constructor.

--- a/dart/dynamics/DantzigBoxedLcpSolver.hpp
+++ b/dart/dynamics/DantzigBoxedLcpSolver.hpp
@@ -38,7 +38,7 @@
 namespace dart {
 namespace dynamics {
 
-class DantzigBoxedLcpSolver : public BoxedLcpSolver
+class DART_DYNAMICS_API DantzigBoxedLcpSolver : public BoxedLcpSolver
 {
 public:
   // Documentation inherited.

--- a/dart/dynamics/DegreeOfFreedom.hpp
+++ b/dart/dynamics/DegreeOfFreedom.hpp
@@ -35,6 +35,7 @@
 
 #include "dart/common/ClassWithVirtualBase.hpp"
 #include "dart/common/Subject.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 #include <Eigen/Core>
@@ -52,7 +53,7 @@ class BodyNode;
 /// DegreeOfFreedom class is a proxy class for accessing single degrees of
 /// freedom (aka generalized coordinates) of the Skeleton.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class DegreeOfFreedom : public virtual common::Subject
+class DART_DYNAMICS_API DegreeOfFreedom : public virtual common::Subject
 {
 public:
   friend class Joint;

--- a/dart/dynamics/DistanceFilter.hpp
+++ b/dart/dynamics/DistanceFilter.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_DISTANCEFILTER_HPP_
 #define DART_COLLISION_DISTANCEFILTER_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 namespace dart {
 
 namespace dynamics {
@@ -43,13 +45,13 @@ namespace collision {
 
 class CollisionObject;
 
-struct DistanceFilter
+struct DART_DYNAMICS_API DistanceFilter
 {
   virtual bool needDistance(
       const CollisionObject* object1, const CollisionObject* object2) const = 0;
 };
 
-struct BodyNodeDistanceFilter : DistanceFilter
+struct DART_DYNAMICS_API BodyNodeDistanceFilter : DistanceFilter
 {
   bool needDistance(
       const CollisionObject* object1,

--- a/dart/dynamics/DistanceOption.hpp
+++ b/dart/dynamics/DistanceOption.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_DISTANCE_OPTION_HPP_
 #define DART_COLLISION_DISTANCE_OPTION_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <memory>
 
 #include <cstddef>
@@ -42,7 +44,7 @@ namespace collision {
 
 struct DistanceFilter;
 
-struct DistanceOption
+struct DART_DYNAMICS_API DistanceOption
 {
   /// Whether to calculate the nearest points.
   ///

--- a/dart/dynamics/DistanceResult.hpp
+++ b/dart/dynamics/DistanceResult.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_DISTANCE_RESULT_HPP_
 #define DART_COLLISION_DISTANCE_RESULT_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <Eigen/Dense>
 
 namespace dart {
@@ -43,7 +45,7 @@ class ShapeFrame;
 
 namespace collision {
 
-struct DistanceResult
+struct DART_DYNAMICS_API DistanceResult
 {
   /// Minimum \b singed distance between the checked Shape pairs.
   ///

--- a/dart/dynamics/DynamicJointConstraint.hpp
+++ b/dart/dynamics/DynamicJointConstraint.hpp
@@ -34,6 +34,7 @@
 #define DART_CONSTRAINT_DYNAMICJOINTCONSTRAINT_HPP_
 
 #include "dart/dynamics/ConstraintBase.hpp"
+#include "dart/dynamics/Export.hpp"
 
 namespace dart {
 
@@ -43,9 +44,9 @@ class BodyNode;
 
 namespace dynamics {
 
-/// Base class for joint constraints that are being created or destructed during
-/// simulation.
-class DynamicJointConstraint : public ConstraintBase
+/// Base class for joint constraints that are created or destructed dynamically
+/// during simulation.
+class DART_DYNAMICS_API DynamicJointConstraint : public ConstraintBase
 {
 public:
   /// Contructor

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -33,12 +33,13 @@
 #ifndef DART_DYNAMICS_ELLIPSOIDSHAPE_HPP_
 #define DART_DYNAMICS_ELLIPSOIDSHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
 namespace dynamics {
 
-class EllipsoidShape : public Shape
+class DART_DYNAMICS_API EllipsoidShape : public Shape
 {
 public:
   /// \brief Constructor.

--- a/dart/dynamics/EndEffector.hpp
+++ b/dart/dynamics/EndEffector.hpp
@@ -37,6 +37,7 @@
 #include "dart/common/AspectWithVersion.hpp"
 #include "dart/common/SpecializedForAspect.hpp"
 #include "dart/dynamics/CompositeNode.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/FixedJacobianNode.hpp"
 #include "dart/dynamics/detail/EndEffectorAspect.hpp"
 
@@ -48,12 +49,13 @@ class Skeleton;
 class EndEffector;
 
 //==============================================================================
-class Support final : public common::AspectWithStateAndVersionedProperties<
-                          Support,
-                          detail::SupportStateData,
-                          detail::SupportPropertiesData,
-                          EndEffector,
-                          &detail::SupportUpdate>
+class DART_DYNAMICS_API Support final
+  : public common::AspectWithStateAndVersionedProperties<
+        Support,
+        detail::SupportStateData,
+        detail::SupportPropertiesData,
+        EndEffector,
+        &detail::SupportUpdate>
 {
 public:
   DART_COMMON_ASPECT_STATE_PROPERTY_CONSTRUCTORS(Support)
@@ -74,10 +76,11 @@ public:
 };
 
 //==============================================================================
-class EndEffector final : public common::EmbedPropertiesOnTopOf<
-                              EndEffector,
-                              detail::EndEffectorProperties,
-                              detail::EndEffectorCompositeBase>
+class DART_DYNAMICS_API EndEffector final
+  : public common::EmbedPropertiesOnTopOf<
+        EndEffector,
+        detail::EndEffectorProperties,
+        detail::EndEffectorCompositeBase>
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/Entity.hpp
+++ b/dart/dynamics/Entity.hpp
@@ -36,6 +36,7 @@
 #include "dart/common/Composite.hpp"
 #include "dart/common/Signal.hpp"
 #include "dart/common/Subject.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
@@ -58,7 +59,7 @@ class Frame;
 /// can be changed. Use the Detachable class to create an Entity whose reference
 /// Frame can be changed arbitrarily.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class Entity : public virtual common::Subject
+class DART_DYNAMICS_API Entity : public virtual common::Subject
 {
 public:
   friend class Frame;
@@ -220,7 +221,7 @@ DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_END
 /// The Detachable class is a special case of the Entity base class. Detachable
 /// allows the Entity's reference Frame to be changed arbitrarily by the user.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class Detachable : public virtual Entity
+class DART_DYNAMICS_API Detachable : public virtual Entity
 {
 public:
   /// Constructor

--- a/dart/dynamics/EulerJoint.hpp
+++ b/dart/dynamics/EulerJoint.hpp
@@ -33,13 +33,14 @@
 #ifndef DART_DYNAMICS_EULERJOINT_HPP_
 #define DART_DYNAMICS_EULERJOINT_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/detail/EulerJointAspect.hpp"
 
 namespace dart {
 namespace dynamics {
 
 /// class EulerJoint
-class EulerJoint : public detail::EulerJointBase
+class DART_DYNAMICS_API EulerJoint : public detail::EulerJointBase
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/FixedFrame.hpp
+++ b/dart/dynamics/FixedFrame.hpp
@@ -35,6 +35,7 @@
 
 #include "dart/common/EmbeddedAspect.hpp"
 #include "dart/common/VersionCounter.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Frame.hpp"
 #include "dart/dynamics/detail/FixedFrameAspect.hpp"
 
@@ -46,7 +47,7 @@ namespace dynamics {
 /// its relative transform is set. However, classes that inherit the FixedFrame
 /// class may alter its relative transform or change what its parent Frame is.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class FixedFrame
+class DART_DYNAMICS_API FixedFrame
   : public virtual Frame,
     public virtual common::VersionCounter,
     public common::EmbedProperties<FixedFrame, detail::FixedFrameProperties>

--- a/dart/dynamics/FixedJacobianNode.hpp
+++ b/dart/dynamics/FixedJacobianNode.hpp
@@ -38,8 +38,9 @@
 namespace dart {
 namespace dynamics {
 
-class FixedJacobianNode : public detail::FixedJacobianNodeCompositeBase,
-                          public AccessoryNode<FixedJacobianNode>
+class DART_DYNAMICS_API FixedJacobianNode
+  : public detail::FixedJacobianNodeCompositeBase,
+    public AccessoryNode<FixedJacobianNode>
 {
 public:
   /// Set the current relative transform of this Fixed Frame

--- a/dart/dynamics/Frame.hpp
+++ b/dart/dynamics/Frame.hpp
@@ -34,6 +34,7 @@
 #define DART_DYNAMICS_FRAME_HPP_
 
 #include "dart/dynamics/Entity.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/math/MathTypes.hpp"
 
 #include <Eigen/Geometry>
@@ -54,7 +55,7 @@ namespace dynamics {
 /// so-called "diamond problem". Because of that, the Entity's constructor will
 /// be called directly by the most derived class's constructor.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class Frame : public virtual Entity
+class DART_DYNAMICS_API Frame : public virtual Entity
 {
 public:
   friend class Entity;
@@ -340,7 +341,7 @@ public:
 /// singleton World Frame. This class cannot be instantiated directly: you must
 /// use the Frame::World() function to access it. Only one World Frame exists
 /// in any application.
-class WorldFrame : public Frame
+class DART_DYNAMICS_API WorldFrame : public Frame
 {
 public:
   friend class Frame;

--- a/dart/dynamics/FreeJoint.hpp
+++ b/dart/dynamics/FreeJoint.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_FREEJOINT_HPP_
 #define DART_DYNAMICS_FREEJOINT_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/GenericJoint.hpp"
 
 #include <Eigen/Dense>
@@ -43,7 +44,7 @@ namespace dart {
 namespace dynamics {
 
 /// class FreeJoint
-class FreeJoint : public GenericJoint<math::SE3Space>
+class DART_DYNAMICS_API FreeJoint : public GenericJoint<math::SE3Space>
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/HierarchicalIK.hpp
+++ b/dart/dynamics/HierarchicalIK.hpp
@@ -60,7 +60,7 @@ typedef std::vector<std::vector<std::shared_ptr<InverseKinematics> > >
 /// put into the IK modules' Problems. Any additional constraints or objectives
 /// that you want the HierarchicalIK to solve should be put directly into the
 /// HierarchicalIK's Problem.
-class HierarchicalIK : public common::Subject
+class DART_DYNAMICS_API HierarchicalIK : public common::Subject
 {
 public:
   /// Virtual destructor
@@ -332,7 +332,7 @@ public:
 /// The CompositeIK class allows you to specify an arbitrary hierarchy of
 /// InverseKinematics modules for a single Skeleton. Simply add in each IK
 /// module that should be used.
-class CompositeIK : public HierarchicalIK
+class DART_DYNAMICS_API CompositeIK : public HierarchicalIK
 {
 public:
   typedef std::unordered_set<std::shared_ptr<InverseKinematics> > ModuleSet;
@@ -375,7 +375,7 @@ protected:
 /// The WholeBodyIK class provides an interface for simultaneously solving all
 /// the IK constraints of all BodyNodes and EndEffectors belonging to a single
 /// Skeleton.
-class WholeBodyIK : public HierarchicalIK
+class DART_DYNAMICS_API WholeBodyIK : public HierarchicalIK
 {
 public:
   /// Create a WholeBodyIK

--- a/dart/dynamics/Inertia.hpp
+++ b/dart/dynamics/Inertia.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_INERTIA_HPP_
 #define DART_DYNAMICS_INERTIA_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/math/MathTypes.hpp"
 
 #include <array>
@@ -40,7 +41,7 @@
 namespace dart {
 namespace dynamics {
 
-class Inertia
+class DART_DYNAMICS_API Inertia
 {
 public:
   /// Enumeration for minimal inertia parameters

--- a/dart/dynamics/InverseKinematics.hpp
+++ b/dart/dynamics/InverseKinematics.hpp
@@ -36,6 +36,7 @@
 #include "dart/common/Signal.hpp"
 #include "dart/common/Subject.hpp"
 #include "dart/common/sub_ptr.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/JacobianNode.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 #include "dart/math/Geometry.hpp"
@@ -72,7 +73,7 @@ const double DefaultIKLinearWeight = 1.0;
 /// safely cloned  over to another JacobianNode, as long as every
 /// optimization::Function that depends on the JacobianNode inherits the
 /// InverseKinematics::Function class and correctly overloads the clone function
-class InverseKinematics : public common::Subject
+class DART_DYNAMICS_API InverseKinematics : public common::Subject
 {
 public:
   /// Create an InverseKinematics module for a specified node

--- a/dart/dynamics/JacobianNode.hpp
+++ b/dart/dynamics/JacobianNode.hpp
@@ -51,7 +51,7 @@ class InverseKinematics;
 /// EndEffectors to both be used as references for IK modules. This is a pure
 /// abstract class.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class JacobianNode : public virtual Frame, public Node
+class DART_DYNAMICS_API JacobianNode : public virtual Frame, public Node
 {
 public:
   /// Virtual destructor

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -54,9 +54,10 @@ class DegreeOfFreedom;
 
 /// class Joint
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class Joint : public virtual common::Subject,
-              public virtual common::VersionCounter,
-              public common::EmbedProperties<Joint, detail::JointProperties>
+class DART_DYNAMICS_API Joint
+  : public virtual common::Subject,
+    public virtual common::VersionCounter,
+    public common::EmbedProperties<Joint, detail::JointProperties>
 {
 public:
   using CompositeProperties = common::Composite::Properties;

--- a/dart/dynamics/JointConstraint.hpp
+++ b/dart/dynamics/JointConstraint.hpp
@@ -50,7 +50,7 @@ namespace dynamics {
 
 /// JointConstraint handles multiple constraints that are defined in the joint
 /// space, such as joint position/velocity limits and servo motor.
-class JointConstraint : public ConstraintBase
+class DART_DYNAMICS_API JointConstraint : public ConstraintBase
 {
 public:
   /// Constructor

--- a/dart/dynamics/JointCoulombFrictionConstraint.hpp
+++ b/dart/dynamics/JointCoulombFrictionConstraint.hpp
@@ -45,7 +45,7 @@ class Joint;
 namespace dynamics {
 
 /// Joint Coulomb friction constraint
-class JointCoulombFrictionConstraint : public ConstraintBase
+class DART_DYNAMICS_API JointCoulombFrictionConstraint : public ConstraintBase
 {
 public:
   /// Constructor

--- a/dart/dynamics/JointLimitConstraint.hpp
+++ b/dart/dynamics/JointLimitConstraint.hpp
@@ -47,7 +47,7 @@ class Joint;
 namespace dynamics {
 
 /// JointLimitConstraint handles joint position and velocity limits
-class JointLimitConstraint : public ConstraintBase
+class DART_DYNAMICS_API JointLimitConstraint : public ConstraintBase
 {
 public:
   /// Constructor

--- a/dart/dynamics/LineSegmentShape.hpp
+++ b/dart/dynamics/LineSegmentShape.hpp
@@ -42,7 +42,7 @@ namespace dynamics {
 /// can consist of a single line segment or many interconnected line segments.
 /// Note: LineSegmentShape may NOT be used as a collision shape for BodyNodes,
 /// but it may be used for visualization purposes.
-class LineSegmentShape : public Shape
+class DART_DYNAMICS_API LineSegmentShape : public Shape
 {
 public:
   /// Default constructor

--- a/dart/dynamics/Linkage.hpp
+++ b/dart/dynamics/Linkage.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_LINKAGE_HPP_
 #define DART_DYNAMICS_LINKAGE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/ReferentialSkeleton.hpp"
 
 #include <unordered_set>
@@ -51,7 +52,7 @@ namespace dynamics {
 /// so that they match whatever assembly they had the last time
 /// Linkage::reassemble() was called (or the assembly that they had when the
 /// Linkage was constructed, if Linkage::reassemble has never been called).
-class Linkage : public ReferentialSkeleton
+class DART_DYNAMICS_API Linkage : public ReferentialSkeleton
 {
 public:
   /// The Criteria class is used to specify how a Linkage should be constructed

--- a/dart/dynamics/Marker.hpp
+++ b/dart/dynamics/Marker.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_MARKER_HPP_
 #define DART_DYNAMICS_MARKER_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/FixedJacobianNode.hpp"
 #include "dart/dynamics/detail/MarkerAspect.hpp"
 
@@ -43,10 +44,10 @@ namespace dynamics {
 
 class BodyNode;
 
-class Marker final : public common::EmbedPropertiesOnTopOf<
-                         Marker,
-                         detail::MarkerProperties,
-                         FixedJacobianNode>
+class DART_DYNAMICS_API Marker final : public common::EmbedPropertiesOnTopOf<
+                                           Marker,
+                                           detail::MarkerProperties,
+                                           FixedJacobianNode>
 {
 public:
   using ConstraintType = detail::MarkerProperties::ConstraintType;

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -34,6 +34,7 @@
 #define DART_DYNAMICS_MESHSHAPE_HPP_
 
 #include "dart/common/ResourceRetriever.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 #include <assimp/scene.h>
@@ -43,7 +44,7 @@
 namespace dart {
 namespace dynamics {
 
-class MeshShape : public Shape
+class DART_DYNAMICS_API MeshShape : public Shape
 {
 public:
   enum ColorMode

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -36,6 +36,7 @@
 #include "dart/common/LockableReference.hpp"
 #include "dart/common/Signal.hpp"
 #include "dart/common/Subject.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Frame.hpp"
 #include "dart/dynamics/InvalidIndex.hpp"
 #include "dart/math/Geometry.hpp"
@@ -57,7 +58,7 @@ class DegreeOfFreedom;
 /// MetaSkeleton is a pure abstract base class that provides a common interface
 /// for obtaining data (such as Jacobians and Mass Matrices) from groups of
 /// BodyNodes.
-class MetaSkeleton : public common::Subject
+class DART_DYNAMICS_API MetaSkeleton : public common::Subject
 {
 public:
   using NameChangedSignal = common::Signal<void(

--- a/dart/dynamics/MimicMotorConstraint.hpp
+++ b/dart/dynamics/MimicMotorConstraint.hpp
@@ -45,7 +45,7 @@ class Joint;
 namespace dynamics {
 
 /// Servo motor constraint
-class MimicMotorConstraint : public ConstraintBase
+class DART_DYNAMICS_API MimicMotorConstraint : public ConstraintBase
 {
 public:
   /// Constructor

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -42,7 +42,7 @@ namespace dynamics {
 
 /// MultiSphereConvexHullShape represents the convex hull of a collection of
 /// spheres.
-class MultiSphereConvexHullShape : public Shape
+class DART_DYNAMICS_API MultiSphereConvexHullShape : public Shape
 {
 public:
   using Sphere = std::pair<double, Eigen::Vector3d>;
@@ -81,7 +81,7 @@ public:
   /// Compute the inertia of this MultiSphereConvexHullShape.
   ///
   /// \note The return value is an approximated inertia that is the inertia of
-  /// the axis-alinged bounding box of this MultiSphereConvexHullShape.
+  /// the axis-aligned bounding box of this MultiSphereConvexHullShape.
   Eigen::Matrix3d computeInertia(double mass) const override;
 
   // Documentation inherited.
@@ -93,8 +93,8 @@ protected:
 
   /// Update the volume of this MultiSphereConvexHullShape.
   ///
-  /// \note The result volume is an approximated volumen that is the volume of
-  /// the axis-alinged bounding box of this MultiSphereConvexHullShape.
+  /// \note The result volume is an approximated volume that is the volume of
+  /// the axis-aligned bounding box of this MultiSphereConvexHullShape.
   void updateVolume() const override;
 
 private:

--- a/dart/dynamics/Node.hpp
+++ b/dart/dynamics/Node.hpp
@@ -37,6 +37,7 @@
 #include "dart/common/EmbeddedAspect.hpp"
 #include "dart/common/Subject.hpp"
 #include "dart/common/VersionCounter.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 #include <memory>
@@ -75,8 +76,8 @@ private:
 /// In most cases, when creating your own custom Node class, you will also want
 /// to inherit from AccessoryNode using CRTP.
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class Node : public virtual common::Subject,
-             public virtual common::VersionCounter
+class DART_DYNAMICS_API Node : public virtual common::Subject,
+                               public virtual common::VersionCounter
 {
 public:
   friend class BodyNode;

--- a/dart/dynamics/PgsBoxedLcpSolver.hpp
+++ b/dart/dynamics/PgsBoxedLcpSolver.hpp
@@ -41,7 +41,7 @@ namespace dart {
 namespace dynamics {
 
 /// Implementation of projected Gauss-Seidel (PGS) LCP solver.
-class PgsBoxedLcpSolver : public BoxedLcpSolver
+class DART_DYNAMICS_API PgsBoxedLcpSolver : public BoxedLcpSolver
 {
 public:
   struct Option

--- a/dart/dynamics/PlanarJoint.hpp
+++ b/dart/dynamics/PlanarJoint.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_PLANARRJOINT_HPP_
 #define DART_DYNAMICS_PLANARRJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/detail/PlanarJointAspect.hpp"
 
 namespace dart {
@@ -44,7 +45,7 @@ namespace dynamics {
 /// First and second coordiantes represent translation along first and second
 /// translational axes, respectively. Third coordinate represents rotation
 /// along rotational axis.
-class PlanarJoint : public detail::PlanarJointBase
+class DART_DYNAMICS_API PlanarJoint : public detail::PlanarJointBase
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/PlaneShape.hpp
+++ b/dart/dynamics/PlaneShape.hpp
@@ -33,13 +33,14 @@
 #ifndef DART_DYNAMICS_PLANESHAPE_HPP_
 #define DART_DYNAMICS_PLANESHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
 namespace dynamics {
 
 /// PlaneShape represents infinite plane has normal and offset as properties.
-class PlaneShape : public Shape
+class DART_DYNAMICS_API PlaneShape : public Shape
 {
 public:
   /// Constructor

--- a/dart/dynamics/PointCloudShape.hpp
+++ b/dart/dynamics/PointCloudShape.hpp
@@ -43,7 +43,7 @@ namespace dart {
 namespace dynamics {
 
 /// The PointCloudShape represents point cloud data.
-class PointCloudShape : public Shape
+class DART_DYNAMICS_API PointCloudShape : public Shape
 {
 public:
   enum ColorMode

--- a/dart/dynamics/PointMass.hpp
+++ b/dart/dynamics/PointMass.hpp
@@ -49,7 +49,7 @@ class SoftBodyNode;
 class PointMassNotifier;
 
 ///
-class PointMass : public common::Subject
+class DART_DYNAMICS_API PointMass : public common::Subject
 {
 public:
   friend class SoftBodyNode;

--- a/dart/dynamics/PrismaticJoint.hpp
+++ b/dart/dynamics/PrismaticJoint.hpp
@@ -33,13 +33,14 @@
 #ifndef DART_DYNAMICS_PRISMATICJOINT_HPP_
 #define DART_DYNAMICS_PRISMATICJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/detail/PrismaticJointAspect.hpp"
 
 namespace dart {
 namespace dynamics {
 
 /// class RevoluteJoint
-class PrismaticJoint : public detail::PrismaticJointBase
+class DART_DYNAMICS_API PrismaticJoint : public detail::PrismaticJointBase
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/PyramidShape.hpp
+++ b/dart/dynamics/PyramidShape.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_PYRAMIDSHAPE_HPP_
 #define DART_DYNAMICS_PYRAMIDSHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
@@ -46,7 +47,7 @@ namespace dynamics {
 /// to the apex is aligned with the Z-axis while the lateral and the
 /// longitudinal lengths of the base are aligned with the X-axis and Y-axis,
 /// respectively.
-class PyramidShape : public Shape
+class DART_DYNAMICS_API PyramidShape : public Shape
 {
 public:
   /// Constructor.

--- a/dart/dynamics/RaycastOption.hpp
+++ b/dart/dynamics/RaycastOption.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_RAYCASTOPTION_HPP_
 #define DART_COLLISION_RAYCASTOPTION_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <memory>
 
 #include <cstddef>
@@ -40,7 +42,7 @@
 namespace dart {
 namespace collision {
 
-struct RaycastOption
+struct DART_DYNAMICS_API RaycastOption
 {
   /// Constructor
   RaycastOption(bool enableAllHits = false, bool sortByClosest = false);

--- a/dart/dynamics/RaycastResult.hpp
+++ b/dart/dynamics/RaycastResult.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_RAYCASTRESULT_HPP_
 #define DART_COLLISION_RAYCASTRESULT_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <Eigen/Dense>
 
 #include <vector>
@@ -42,7 +44,7 @@ namespace collision {
 
 class CollisionObject;
 
-struct RayHit
+struct DART_DYNAMICS_API RayHit
 {
   /// The collision object the ray hit
   const CollisionObject* mCollisionObject;
@@ -60,7 +62,7 @@ struct RayHit
   RayHit();
 };
 
-struct RaycastResult
+struct DART_DYNAMICS_API RaycastResult
 {
   /// Clear the result
   void clear();

--- a/dart/dynamics/ReferentialSkeleton.hpp
+++ b/dart/dynamics/ReferentialSkeleton.hpp
@@ -44,7 +44,7 @@ namespace dynamics {
 
 /// ReferentialSkeleton is a base class used to implement Linkage, Group, and
 /// other classes that are used to reference subsections of Skeletons.
-class ReferentialSkeleton : public MetaSkeleton
+class DART_DYNAMICS_API ReferentialSkeleton : public MetaSkeleton
 {
 public:
   /// Remove copy operator

--- a/dart/dynamics/RevoluteJoint.hpp
+++ b/dart/dynamics/RevoluteJoint.hpp
@@ -33,13 +33,14 @@
 #ifndef DART_DYNAMICS_REVOLUTEJOINT_HPP_
 #define DART_DYNAMICS_REVOLUTEJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/detail/RevoluteJointAspect.hpp"
 
 namespace dart {
 namespace dynamics {
 
 /// class RevoluteJoint
-class RevoluteJoint : public detail::RevoluteJointBase
+class DART_DYNAMICS_API RevoluteJoint : public detail::RevoluteJointBase
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/ScrewJoint.hpp
+++ b/dart/dynamics/ScrewJoint.hpp
@@ -33,13 +33,14 @@
 #ifndef DART_DYNAMICS_SCREWJOINT_HPP_
 #define DART_DYNAMICS_SCREWJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/detail/ScrewJointAspect.hpp"
 
 namespace dart {
 namespace dynamics {
 
 /// class ScrewJoint
-class ScrewJoint : public detail::ScrewJointBase
+class DART_DYNAMICS_API ScrewJoint : public detail::ScrewJointBase
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/ServoMotorConstraint.hpp
+++ b/dart/dynamics/ServoMotorConstraint.hpp
@@ -45,7 +45,7 @@ class Joint;
 namespace dynamics {
 
 /// Servo motor constraint
-class ServoMotorConstraint : public ConstraintBase
+class DART_DYNAMICS_API ServoMotorConstraint : public ConstraintBase
 {
 public:
   /// Constructor

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -38,6 +38,7 @@
 #include "dart/common/Signal.hpp"
 #include "dart/common/Subject.hpp"
 #include "dart/common/VersionCounter.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 #include "dart/math/Geometry.hpp"
 
@@ -49,9 +50,9 @@ namespace dart {
 namespace dynamics {
 
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class Shape : public virtual common::Subject,
-              public virtual common::VersionCounter,
-              public common::Castable<Shape>
+class DART_DYNAMICS_API Shape : public virtual common::Subject,
+                                public virtual common::VersionCounter,
+                                public common::Castable<Shape>
 {
 public:
   using VersionChangedSignal

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -37,6 +37,7 @@
 #include "dart/common/Signal.hpp"
 #include "dart/common/SpecializedForAspect.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/FixedFrame.hpp"
 #include "dart/dynamics/TemplatedJacobianNode.hpp"
 #include "dart/dynamics/detail/ShapeFrameAspect.hpp"
@@ -47,10 +48,11 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-class VisualAspect final : public common::AspectWithVersionedProperties<
-                               VisualAspect,
-                               detail::VisualAspectProperties,
-                               ShapeFrame>
+class DART_DYNAMICS_API VisualAspect final
+  : public common::AspectWithVersionedProperties<
+        VisualAspect,
+        detail::VisualAspectProperties,
+        ShapeFrame>
 {
 public:
   using Base = common::AspectWithVersionedProperties<
@@ -110,10 +112,11 @@ public:
 };
 
 //==============================================================================
-class CollisionAspect final : public common::AspectWithVersionedProperties<
-                                  CollisionAspect,
-                                  detail::CollisionAspectProperties,
-                                  ShapeFrame>
+class DART_DYNAMICS_API CollisionAspect final
+  : public common::AspectWithVersionedProperties<
+        CollisionAspect,
+        detail::CollisionAspectProperties,
+        ShapeFrame>
 {
 public:
   CollisionAspect(const CollisionAspect&) = delete;
@@ -128,10 +131,11 @@ public:
 };
 
 //==============================================================================
-class DynamicsAspect final : public common::AspectWithVersionedProperties<
-                                 DynamicsAspect,
-                                 detail::DynamicsAspectProperties,
-                                 ShapeFrame>
+class DART_DYNAMICS_API DynamicsAspect final
+  : public common::AspectWithVersionedProperties<
+        DynamicsAspect,
+        detail::DynamicsAspectProperties,
+        ShapeFrame>
 {
 public:
   using Base = common::AspectWithVersionedProperties<
@@ -186,9 +190,9 @@ public:
 
 //==============================================================================
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class ShapeFrame : public virtual common::VersionCounter,
-                   public detail::ShapeFrameCompositeBase,
-                   public virtual Frame
+class DART_DYNAMICS_API ShapeFrame : public virtual common::VersionCounter,
+                                     public detail::ShapeFrameCompositeBase,
+                                     public virtual Frame
 {
 public:
   friend class BodyNode;

--- a/dart/dynamics/ShapeNode.hpp
+++ b/dart/dynamics/ShapeNode.hpp
@@ -34,6 +34,7 @@
 #define DART_DYNAMICS_SHAPENODE_HPP_
 
 #include "dart/common/Signal.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/detail/ShapeNode.hpp"
 
 #include <Eigen/Dense>
@@ -45,7 +46,7 @@ class VisualAspect;
 class CollisionAspect;
 class DynamicsAspect;
 
-class ShapeNode : public detail::ShapeNodeCompositeBase
+class DART_DYNAMICS_API ShapeNode : public detail::ShapeNodeCompositeBase
 {
 public:
   friend class BodyNode;

--- a/dart/dynamics/SharedLibraryIkFast.hpp
+++ b/dart/dynamics/SharedLibraryIkFast.hpp
@@ -34,6 +34,7 @@
 #define DART_DYNAMICS_SHAREDLIBRARYIKFAST_HPP_
 
 #include "dart/common/SharedLibrary.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/IkFast.hpp"
 
 namespace dart {
@@ -43,7 +44,7 @@ namespace dynamics {
 ///
 /// The detail of IkFast can be found here:
 /// http://openrave.org/docs/0.8.2/openravepy/ikfast/
-class SharedLibraryIkFast : public IkFast
+class DART_DYNAMICS_API SharedLibraryIkFast : public IkFast
 {
 public:
   /// Constructor

--- a/dart/dynamics/SimpleFrame.hpp
+++ b/dart/dynamics/SimpleFrame.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_SIMPLEFRAME_HPP_
 #define DART_DYNAMICS_SIMPLEFRAME_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/ShapeNode.hpp"
 
 namespace dart {
@@ -48,7 +49,7 @@ namespace dynamics {
 /// (such as position, velocity, and acceleration) can be modified. Conversely,
 /// the SimpleFrame class is nothing but a simple abstract Frame whose
 /// properties can be arbitrarily set and modified by the user.
-class SimpleFrame : public Detachable, public ShapeFrame
+class DART_DYNAMICS_API SimpleFrame : public Detachable, public ShapeFrame
 {
 public:
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(SimpleFrame)

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -36,6 +36,7 @@
 #include "dart/common/NameManager.hpp"
 #include "dart/common/VersionCounter.hpp"
 #include "dart/dynamics/EndEffector.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/HierarchicalIK.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Marker.hpp"
@@ -53,10 +54,11 @@ namespace dynamics {
 
 /// class Skeleton
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class Skeleton : public virtual common::VersionCounter,
-                 public MetaSkeleton,
-                 public SkeletonSpecializedFor<ShapeNode, EndEffector, Marker>,
-                 public detail::SkeletonAspectBase
+class DART_DYNAMICS_API Skeleton
+  : public virtual common::VersionCounter,
+    public MetaSkeleton,
+    public SkeletonSpecializedFor<ShapeNode, EndEffector, Marker>,
+    public detail::SkeletonAspectBase
 {
 public:
   // Some of non-virtual functions of MetaSkeleton are hidden because of the

--- a/dart/dynamics/SoftBodyNode.hpp
+++ b/dart/dynamics/SoftBodyNode.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_SOFTBODYNODE_HPP_
 #define DART_DYNAMICS_SOFTBODYNODE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/detail/SoftBodyNodeAspect.hpp"
 
 namespace dart {
@@ -42,7 +43,7 @@ namespace dynamics {
 ///
 /// This class is implementation of Sumit Jain and C. Karen Liu's paper:
 /// http://www.cc.gatech.edu/graphics/projects/Sumit/homepage/projects/softcontacts/index.html
-class SoftBodyNode : public detail::SoftBodyNodeBase
+class DART_DYNAMICS_API SoftBodyNode : public detail::SoftBodyNodeBase
 {
 public:
   using UniqueProperties = detail::SoftBodyNodeUniqueProperties;
@@ -331,7 +332,7 @@ private:
   void updateInertiaWithPointMass();
 };
 
-class SoftBodyNodeHelper
+class DART_DYNAMICS_API SoftBodyNodeHelper
 {
 public:
   /// Create a Properties struct for a box-shaped SoftBodyNode with 8

--- a/dart/dynamics/SoftContactConstraint.hpp
+++ b/dart/dynamics/SoftContactConstraint.hpp
@@ -53,7 +53,7 @@ class Skeleton;
 namespace dynamics {
 
 /// SoftContactConstraint represents a contact constraint between two bodies
-class SoftContactConstraint : public ConstraintBase
+class DART_DYNAMICS_API SoftContactConstraint : public ConstraintBase
 {
 public:
   /// Constructor

--- a/dart/dynamics/SoftMeshShape.hpp
+++ b/dart/dynamics/SoftMeshShape.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_SOFTMESHSHAPE_HPP_
 #define DART_DYNAMICS_SOFTMESHSHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 #include <Eigen/Dense>
@@ -44,7 +45,7 @@ namespace dynamics {
 class SoftBodyNode;
 
 // TODO(JS): Implement
-class SoftMeshShape : public Shape
+class DART_DYNAMICS_API SoftMeshShape : public Shape
 {
 public:
   friend class SoftBodyNode;

--- a/dart/dynamics/SphereShape.hpp
+++ b/dart/dynamics/SphereShape.hpp
@@ -33,12 +33,13 @@
 #ifndef DART_DYNAMICS_SPHERESHAPE_HPP_
 #define DART_DYNAMICS_SPHERESHAPE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
 namespace dynamics {
 
-class SphereShape : public Shape
+class DART_DYNAMICS_API SphereShape : public Shape
 {
 public:
   /// Constructor.

--- a/dart/dynamics/TranslationalJoint.hpp
+++ b/dart/dynamics/TranslationalJoint.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_TRANSLATIONALJOINT_HPP_
 #define DART_DYNAMICS_TRANSLATIONALJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/GenericJoint.hpp"
 
 #include <string>
@@ -41,7 +42,7 @@ namespace dart {
 namespace dynamics {
 
 /// class TranslationalJoint
-class TranslationalJoint : public GenericJoint<math::R3Space>
+class DART_DYNAMICS_API TranslationalJoint : public GenericJoint<math::R3Space>
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/TranslationalJoint2D.hpp
+++ b/dart/dynamics/TranslationalJoint2D.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_TRANSLATIONALJOINT2D_HPP_
 #define DART_DYNAMICS_TRANSLATIONALJOINT2D_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/detail/PlanarJointAspect.hpp"
 #include "dart/dynamics/detail/TranslationalJoint2DAspect.hpp"
 
@@ -44,7 +45,8 @@ namespace dynamics {
 ///
 /// First and second coordiantes represent the translations along first and
 /// second translational axes, respectively.
-class TranslationalJoint2D : public detail::TranslationalJoint2DBase
+class DART_DYNAMICS_API TranslationalJoint2D
+  : public detail::TranslationalJoint2DBase
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/UniversalJoint.hpp
+++ b/dart/dynamics/UniversalJoint.hpp
@@ -33,13 +33,14 @@
 #ifndef DART_DYNAMICS_UNIVERSALJOINT_HPP_
 #define DART_DYNAMICS_UNIVERSALJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/detail/UniversalJointAspect.hpp"
 
 namespace dart {
 namespace dynamics {
 
 /// class UniversalJoint
-class UniversalJoint : public detail::UniversalJointBase
+class DART_DYNAMICS_API UniversalJoint : public detail::UniversalJointBase
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -37,6 +37,7 @@
 
 #if DART_HAVE_OCTOMAP
 
+  #include "dart/dynamics/Export.hpp"
   #include "dart/dynamics/Frame.hpp"
   #include "dart/dynamics/Shape.hpp"
   #include "dart/dynamics/fcl/BackwardCompatibility.hpp"
@@ -47,7 +48,7 @@ namespace dart {
 namespace dynamics {
 
 /// VoxelGridShape represents a probabilistic 3D occupancy voxel grid.
-class VoxelGridShape : public Shape
+class DART_DYNAMICS_API VoxelGridShape : public Shape
 {
 public:
   /// Constructor.

--- a/dart/dynamics/WeldJoint.hpp
+++ b/dart/dynamics/WeldJoint.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_WELDJOINT_HPP_
 #define DART_DYNAMICS_WELDJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/ZeroDofJoint.hpp"
 
 #include <Eigen/Dense>
@@ -43,7 +44,7 @@ namespace dart {
 namespace dynamics {
 
 /// class WeldJoint
-class WeldJoint : public ZeroDofJoint
+class DART_DYNAMICS_API WeldJoint : public ZeroDofJoint
 {
 public:
   friend class Skeleton;

--- a/dart/dynamics/WeldJointConstraint.hpp
+++ b/dart/dynamics/WeldJointConstraint.hpp
@@ -34,6 +34,7 @@
 #define DART_CONSTRAINT_WELDJOINTCONSTRAINT_HPP_
 
 #include "dart/dynamics/DynamicJointConstraint.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/math/MathTypes.hpp"
 
 #include <Eigen/Dense>
@@ -43,7 +44,7 @@ namespace dynamics {
 
 /// WeldJointConstraint represents weld joint constraint between a body and the
 /// world or between two bodies
-class WeldJointConstraint : public DynamicJointConstraint
+class DART_DYNAMICS_API WeldJointConstraint : public DynamicJointConstraint
 {
 public:
   /// Constructor that takes one body

--- a/dart/dynamics/ZeroDofJoint.hpp
+++ b/dart/dynamics/ZeroDofJoint.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_ZERODOFJOINT_HPP_
 #define DART_DYNAMICS_ZERODOFJOINT_HPP_
 
+#include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/Joint.hpp"
 
 #include <string>
@@ -44,7 +45,7 @@ class BodyNode;
 class Skeleton;
 
 /// class ZeroDofJoint
-class ZeroDofJoint : public Joint
+class DART_DYNAMICS_API ZeroDofJoint : public Joint
 {
 public:
   struct Properties : Joint::Properties

--- a/dart/dynamics/bullet/BulletCollisionDetector.hpp
+++ b/dart/dynamics/bullet/BulletCollisionDetector.hpp
@@ -34,6 +34,7 @@
 #define DART_COLLISION_BULLET_BULLETCOLLISIONDETECTOR_HPP_
 
 #include "dart/dynamics/CollisionDetector.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/bullet/BulletCollisionGroup.hpp"
 #include "dart/dynamics/bullet/BulletCollisionShape.hpp"
 #include "dart/dynamics/bullet/BulletInclude.hpp"
@@ -45,7 +46,7 @@
 namespace dart {
 namespace collision {
 
-class BulletCollisionDetector : public CollisionDetector
+class DART_DYNAMICS_API BulletCollisionDetector : public CollisionDetector
 {
 public:
   using CollisionDetector::createCollisionGroup;

--- a/dart/dynamics/bullet/BulletCollisionGroup.hpp
+++ b/dart/dynamics/bullet/BulletCollisionGroup.hpp
@@ -39,7 +39,7 @@
 namespace dart {
 namespace collision {
 
-class BulletCollisionGroup : public CollisionGroup
+class DART_DYNAMICS_API BulletCollisionGroup : public CollisionGroup
 {
 public:
   friend class BulletCollisionDetector;

--- a/dart/dynamics/dart/DARTCollisionDetector.hpp
+++ b/dart/dynamics/dart/DARTCollisionDetector.hpp
@@ -42,7 +42,7 @@ namespace collision {
 
 class DARTCollisionObject;
 
-class DARTCollisionDetector : public CollisionDetector
+class DART_DYNAMICS_API DARTCollisionDetector : public CollisionDetector
 {
 public:
   using CollisionDetector::createCollisionGroup;

--- a/dart/dynamics/dart/DARTCollisionGroup.hpp
+++ b/dart/dynamics/dart/DARTCollisionGroup.hpp
@@ -40,7 +40,7 @@ namespace collision {
 
 class DARTCollisionObject;
 
-class DARTCollisionGroup : public CollisionGroup
+class DART_DYNAMICS_API DARTCollisionGroup : public CollisionGroup
 {
 public:
   friend class DARTCollisionDetector;

--- a/dart/dynamics/detail/BodyNodeAspect.hpp
+++ b/dart/dynamics/detail/BodyNodeAspect.hpp
@@ -46,7 +46,7 @@ class Skeleton;
 namespace detail {
 
 //==============================================================================
-struct BodyNodeState
+struct DART_DYNAMICS_API BodyNodeState
 {
   /// External spatial force
   Eigen::Vector6d mFext;
@@ -60,7 +60,7 @@ struct BodyNodeState
 };
 
 //==============================================================================
-struct BodyNodeAspectProperties
+struct DART_DYNAMICS_API BodyNodeAspectProperties
 {
   /// Name of the Entity
   std::string mName;

--- a/dart/dynamics/detail/BodyNodePtr.hpp
+++ b/dart/dynamics/detail/BodyNodePtr.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_DYNAMICS_DETAIL_BODYNODEPTR_HPP_
 #define DART_DYNAMICS_DETAIL_BODYNODEPTR_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -50,7 +52,7 @@ struct MutexedWeakSkeletonPtr
 };
 
 //==============================================================================
-class SkeletonRefCountingBase
+class DART_DYNAMICS_API SkeletonRefCountingBase
 {
 public:
   template <class>

--- a/dart/dynamics/detail/EndEffectorAspect.hpp
+++ b/dart/dynamics/detail/EndEffectorAspect.hpp
@@ -35,6 +35,7 @@
 
 #include "dart/common/SpecializedForAspect.hpp"
 #include "dart/dynamics/CompositeNode.hpp"
+#include "dart/dynamics/Export.hpp"
 
 #include <Eigen/Geometry>
 
@@ -92,7 +93,7 @@ struct SupportPropertiesData
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
-void SupportUpdate(Support* support);
+DART_DYNAMICS_API void SupportUpdate(Support* support);
 
 using EndEffectorCompositeBase = CompositeNode<common::CompositeJoiner<
     FixedJacobianNode,

--- a/dart/dynamics/detail/EntityNodeAspect.hpp
+++ b/dart/dynamics/detail/EntityNodeAspect.hpp
@@ -44,7 +44,7 @@ class EntityNode;
 namespace detail {
 
 //==============================================================================
-struct EntityNodeProperties
+struct DART_DYNAMICS_API EntityNodeProperties
 {
   /// Name of the Entity/Node
   std::string mName;

--- a/dart/dynamics/detail/EulerJointAspect.hpp
+++ b/dart/dynamics/detail/EulerJointAspect.hpp
@@ -53,7 +53,7 @@ enum class AxisOrder : int
 };
 
 //==============================================================================
-struct EulerJointUniqueProperties
+struct DART_DYNAMICS_API EulerJointUniqueProperties
 {
   /// Euler angle order
   AxisOrder mAxisOrder;
@@ -65,8 +65,9 @@ struct EulerJointUniqueProperties
 };
 
 //==============================================================================
-struct EulerJointProperties : GenericJoint<math::R3Space>::Properties,
-                              EulerJointUniqueProperties
+struct DART_DYNAMICS_API EulerJointProperties
+  : GenericJoint<math::R3Space>::Properties,
+    EulerJointUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(EulerJointProperties)
 

--- a/dart/dynamics/detail/FixedFrameAspect.hpp
+++ b/dart/dynamics/detail/FixedFrameAspect.hpp
@@ -33,13 +33,15 @@
 #ifndef DART_DYNAMICS_DETAIL_FIXEDFRAMEASPECT_HPP_
 #define DART_DYNAMICS_DETAIL_FIXEDFRAMEASPECT_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <Eigen/Geometry>
 
 namespace dart {
 namespace dynamics {
 namespace detail {
 
-struct FixedFrameProperties
+struct DART_DYNAMICS_API FixedFrameProperties
 {
   /// The relative transform of the FixedFrame
   Eigen::Isometry3d mRelativeTf;

--- a/dart/dynamics/detail/JointAspect.hpp
+++ b/dart/dynamics/detail/JointAspect.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_DYNAMICS_DETAIL_JOINTASPECT_HPP_
 #define DART_DYNAMICS_DETAIL_JOINTASPECT_HPP_
 
+#include "dart/dynamics/Export.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
@@ -108,7 +110,7 @@ enum ActuatorType
 
 const ActuatorType DefaultActuatorType = FORCE;
 
-struct JointProperties
+struct DART_DYNAMICS_API JointProperties
 {
   /// Joint name
   std::string mName;

--- a/dart/dynamics/detail/MarkerAspect.hpp
+++ b/dart/dynamics/detail/MarkerAspect.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_DETAIL_MARKERASPECT_HPP_
 #define DART_DYNAMICS_DETAIL_MARKERASPECT_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/math/Helpers.hpp"
 
 #include <Eigen/Core>
@@ -41,7 +42,7 @@ namespace dart {
 namespace dynamics {
 namespace detail {
 
-struct MarkerProperties
+struct DART_DYNAMICS_API MarkerProperties
 {
   enum ConstraintType
   {

--- a/dart/dynamics/detail/PlanarJointAspect.hpp
+++ b/dart/dynamics/detail/PlanarJointAspect.hpp
@@ -62,7 +62,7 @@ enum class PlaneType : int
 /// it use mTransAxis1 and mTransAxis2. mRotAxis has no authority; it will
 /// always be recomputed from mTransAxis1 and mTransAxis2 when copying it into a
 /// PlanarJoint
-struct PlanarJointUniqueProperties
+struct DART_DYNAMICS_API PlanarJointUniqueProperties
 {
   /// Plane type
   PlaneType mPlaneType;
@@ -109,8 +109,9 @@ struct PlanarJointUniqueProperties
 };
 
 //==============================================================================
-struct PlanarJointProperties : GenericJoint<math::R3Space>::Properties,
-                               PlanarJointUniqueProperties
+struct DART_DYNAMICS_API PlanarJointProperties
+  : GenericJoint<math::R3Space>::Properties,
+    PlanarJointUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(PlanarJointProperties)
 

--- a/dart/dynamics/detail/PrismaticJointAspect.hpp
+++ b/dart/dynamics/detail/PrismaticJointAspect.hpp
@@ -47,7 +47,7 @@ class PrismaticJoint;
 namespace detail {
 
 //==============================================================================
-struct PrismaticJointUniqueProperties
+struct DART_DYNAMICS_API PrismaticJointUniqueProperties
 {
   Eigen::Vector3d mAxis;
 
@@ -58,8 +58,9 @@ struct PrismaticJointUniqueProperties
 };
 
 //==============================================================================
-struct PrismaticJointProperties : GenericJoint<math::R1Space>::Properties,
-                                  PrismaticJointUniqueProperties
+struct DART_DYNAMICS_API PrismaticJointProperties
+  : GenericJoint<math::R1Space>::Properties,
+    PrismaticJointUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(PrismaticJointProperties)
 

--- a/dart/dynamics/detail/RevoluteJointAspect.hpp
+++ b/dart/dynamics/detail/RevoluteJointAspect.hpp
@@ -47,7 +47,7 @@ class RevoluteJoint;
 namespace detail {
 
 //==============================================================================
-struct RevoluteJointUniqueProperties
+struct DART_DYNAMICS_API RevoluteJointUniqueProperties
 {
   Eigen::Vector3d mAxis;
 
@@ -58,8 +58,9 @@ struct RevoluteJointUniqueProperties
 };
 
 //==============================================================================
-struct RevoluteJointProperties : GenericJoint<math::R1Space>::Properties,
-                                 RevoluteJointUniqueProperties
+struct DART_DYNAMICS_API RevoluteJointProperties
+  : GenericJoint<math::R1Space>::Properties,
+    RevoluteJointUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(RevoluteJointProperties)
 

--- a/dart/dynamics/detail/ScrewJointAspect.hpp
+++ b/dart/dynamics/detail/ScrewJointAspect.hpp
@@ -47,7 +47,7 @@ class ScrewJoint;
 namespace detail {
 
 //==============================================================================
-struct ScrewJointUniqueProperties
+struct DART_DYNAMICS_API ScrewJointUniqueProperties
 {
   /// Rotational axis
   Eigen::Vector3d mAxis;
@@ -63,8 +63,9 @@ struct ScrewJointUniqueProperties
 };
 
 //==============================================================================
-struct ScrewJointProperties : GenericJoint<math::R1Space>::Properties,
-                              ScrewJointUniqueProperties
+struct DART_DYNAMICS_API ScrewJointProperties
+  : GenericJoint<math::R1Space>::Properties,
+    ScrewJointUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(ScrewJointProperties)
 

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -34,6 +34,7 @@
 #define DART_DYNAMICS_DETAIL_SHAPEFRAMEASPECT_HPP_
 
 #include "dart/common/EmbeddedAspect.hpp"
+#include "dart/dynamics/Export.hpp"
 #include "dart/dynamics/SmartPointer.hpp"
 
 #include <Eigen/Core>
@@ -48,7 +49,7 @@ class ShapeFrame;
 
 namespace detail {
 
-struct VisualAspectProperties
+struct DART_DYNAMICS_API VisualAspectProperties
 {
   /// Color for the primitive shape
   Eigen::Vector4d mRGBA;
@@ -74,7 +75,7 @@ struct VisualAspectProperties
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
-struct CollisionAspectProperties
+struct DART_DYNAMICS_API CollisionAspectProperties
 {
   /// This object is collidable if true
   bool mCollidable;
@@ -86,7 +87,7 @@ struct CollisionAspectProperties
   virtual ~CollisionAspectProperties() = default;
 };
 
-struct DynamicsAspectProperties
+struct DART_DYNAMICS_API DynamicsAspectProperties
 {
   /// Primary coefficient of friction
   double mFrictionCoeff;
@@ -143,7 +144,7 @@ struct DynamicsAspectProperties
   virtual ~DynamicsAspectProperties() = default;
 };
 
-struct ShapeFrameProperties
+struct DART_DYNAMICS_API ShapeFrameProperties
 {
   /// Pointer to a shape
   ShapePtr mShape;

--- a/dart/dynamics/detail/SkeletonAspect.hpp
+++ b/dart/dynamics/detail/SkeletonAspect.hpp
@@ -51,7 +51,7 @@ namespace detail {
 /// The Properties of this Skeleton which are independent of the components
 /// within the Skeleton, such as its BodyNodes and Joints. This does not
 /// include any Properties of the Skeleton's Aspects.
-struct SkeletonAspectProperties
+struct DART_DYNAMICS_API SkeletonAspectProperties
 {
   /// Name of the Skeleton
   std::string mName;

--- a/dart/dynamics/detail/SoftBodyNodeAspect.hpp
+++ b/dart/dynamics/detail/SoftBodyNodeAspect.hpp
@@ -53,7 +53,7 @@ namespace detail {
 class SoftBodyAspect;
 
 //==============================================================================
-struct SoftBodyNodeUniqueState
+struct DART_DYNAMICS_API SoftBodyNodeUniqueState
 {
   /// Array of States for PointMasses
   std::vector<PointMass::State> mPointStates;
@@ -62,7 +62,7 @@ struct SoftBodyNodeUniqueState
 };
 
 //==============================================================================
-struct SoftBodyNodeUniqueProperties
+struct DART_DYNAMICS_API SoftBodyNodeUniqueProperties
 {
   /// Spring stiffness for vertex deformation restoring spring force of the
   /// point masses
@@ -104,8 +104,8 @@ struct SoftBodyNodeUniqueProperties
 };
 
 //==============================================================================
-struct SoftBodyNodeProperties : BodyNode::Properties,
-                                SoftBodyNodeUniqueProperties
+struct DART_DYNAMICS_API SoftBodyNodeProperties : BodyNode::Properties,
+                                                  SoftBodyNodeUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(SoftBodyNodeProperties)
 

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
@@ -48,7 +48,7 @@ class TranslationalJoint2D;
 namespace detail {
 
 //==============================================================================
-class TranslationalJoint2DUniqueProperties
+class DART_DYNAMICS_API TranslationalJoint2DUniqueProperties
 {
 public:
   /// Constructor for pre-defined plane types. Defaults to the XY plane if
@@ -113,8 +113,9 @@ private:
 };
 
 //==============================================================================
-struct TranslationalJoint2DProperties : GenericJoint<math::R2Space>::Properties,
-                                        TranslationalJoint2DUniqueProperties
+struct DART_DYNAMICS_API TranslationalJoint2DProperties
+  : GenericJoint<math::R2Space>::Properties,
+    TranslationalJoint2DUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(TranslationalJoint2DProperties)
 

--- a/dart/dynamics/detail/UniversalJointAspect.hpp
+++ b/dart/dynamics/detail/UniversalJointAspect.hpp
@@ -47,7 +47,7 @@ class UniversalJoint;
 namespace detail {
 
 //==============================================================================
-struct UniversalJointUniqueProperties
+struct DART_DYNAMICS_API UniversalJointUniqueProperties
 {
   std::array<Eigen::Vector3d, 2> mAxis;
 
@@ -59,8 +59,9 @@ struct UniversalJointUniqueProperties
 };
 
 //==============================================================================
-struct UniversalJointProperties : GenericJoint<math::R2Space>::Properties,
-                                  UniversalJointUniqueProperties
+struct DART_DYNAMICS_API UniversalJointProperties
+  : GenericJoint<math::R2Space>::Properties,
+    UniversalJointUniqueProperties
 {
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(UniversalJointProperties)
 

--- a/dart/dynamics/fcl/FCLCollisionDetector.hpp
+++ b/dart/dynamics/fcl/FCLCollisionDetector.hpp
@@ -43,7 +43,7 @@ namespace collision {
 
 class FCLCollisionObject;
 
-class FCLCollisionDetector : public CollisionDetector
+class DART_DYNAMICS_API FCLCollisionDetector : public CollisionDetector
 {
 public:
   using CollisionDetector::createCollisionGroup;

--- a/dart/dynamics/fcl/FCLCollisionGroup.hpp
+++ b/dart/dynamics/fcl/FCLCollisionGroup.hpp
@@ -42,7 +42,7 @@ namespace collision {
 class CollisionObject;
 class FCLCollisionObjectUserData;
 
-class FCLCollisionGroup : public CollisionGroup
+class DART_DYNAMICS_API FCLCollisionGroup : public CollisionGroup
 {
 public:
   friend class FCLCollisionDetector;

--- a/dart/dynamics/ode/OdeCollisionDetector.hpp
+++ b/dart/dynamics/ode/OdeCollisionDetector.hpp
@@ -49,7 +49,7 @@ namespace collision {
 ///
 /// ODE additionally supports ray and heightfiled, but DART doesn't support them
 /// yet.
-class OdeCollisionDetector : public CollisionDetector
+class DART_DYNAMICS_API OdeCollisionDetector : public CollisionDetector
 {
 public:
   using CollisionDetector::createCollisionGroup;

--- a/dart/dynamics/ode/OdeCollisionGroup.hpp
+++ b/dart/dynamics/ode/OdeCollisionGroup.hpp
@@ -40,7 +40,7 @@
 namespace dart {
 namespace collision {
 
-class OdeCollisionGroup : public CollisionGroup
+class DART_DYNAMICS_API OdeCollisionGroup : public CollisionGroup
 {
 public:
   friend class OdeCollisionDetector;

--- a/dart/gui/osg/render/MultiSphereShapeNode.hpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_OSG_RENDER_MULTISPHERESHAPENODE_HPP_
 #define DART_GUI_OSG_RENDER_MULTISPHERESHAPENODE_HPP_
 
+#include "dart/dynamics/Export.hpp"
 #include "dart/gui/osg/render/ShapeNode.hpp"
 
 #include <osg/MatrixTransform>
@@ -51,7 +52,8 @@ namespace render {
 class MultiSphereShapeGeode;
 class MultiSphereShapeDrawable;
 
-class MultiSphereShapeNode : public ShapeNode, public ::osg::MatrixTransform
+class DART_DYNAMICS_API MultiSphereShapeNode : public ShapeNode,
+                                               public ::osg::MatrixTransform
 {
 public:
   MultiSphereShapeNode(


### PR DESCRIPTION
**Change of `libdart7-dynamics` in `Release` mode on Ubuntu**:
- Number of symbols: 10,063 -> 5,200
- Size of binary: 9.5M -> 8.6M
> Disclaimer: Some APIs could be hidden when they are supposed to be exported but just not caught by the CI. They will be exported eventually as discovered...

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
