### PR TITLE
Add symbol control to dart::gui

### DIFF
--- a/dart/gui/CMakeLists.txt
+++ b/dart/gui/CMakeLists.txt
@@ -34,6 +34,7 @@ dart_add_component(
     cxx_std_17
   SUB_DIRECTORIES
     glut osg
+  GENERATE_EXPORT_HEADER
   GENERATE_META_HEADER
   FORMAT_CODE
 )

--- a/dart/gui/GLFuncs.hpp
+++ b/dart/gui/GLFuncs.hpp
@@ -33,13 +33,15 @@
 #ifndef DART_GUI_GLFUNCS_HPP_
 #define DART_GUI_GLFUNCS_HPP_
 
+#include "dart/gui/Export.hpp"
+
 #include <Eigen/Eigen>
 
 namespace dart {
 namespace gui {
 
 /// \brief
-void drawArrow3D(
+DART_GUI_API void drawArrow3D(
     const Eigen::Vector3d& _pt,
     const Eigen::Vector3d& _dir,
     const double _length,
@@ -47,11 +49,11 @@ void drawArrow3D(
     const double _arrowThickness = -1);
 
 /// \brief
-void drawArrow2D(
+DART_GUI_API void drawArrow2D(
     const Eigen::Vector2d& _pt, const Eigen::Vector2d& _vec, double _thickness);
 
 /// \brief
-void drawProgressBar(int _currFrame, int _totalFrame);
+DART_GUI_API void drawProgressBar(int _currFrame, int _totalFrame);
 
 } // namespace gui
 } // namespace dart

--- a/dart/gui/glut/SimWindow.hpp
+++ b/dart/gui/glut/SimWindow.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_GLUT_SIMWINDOW_HPP_
 #define DART_GUI_GLUT_SIMWINDOW_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/glut/Win3D.hpp"
 #include "dart/simulation/World.hpp"
 
@@ -47,7 +48,7 @@ namespace glut {
 class GraphWindow;
 
 /// \brief
-class SimWindow : public Win3D
+class DART_GUI_API SimWindow : public Win3D
 {
 public:
   /// \brief

--- a/dart/gui/glut/SoftSimWindow.hpp
+++ b/dart/gui/glut/SoftSimWindow.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_GLUT_SOFTSIMWINDOW_HPP_
 #define DART_GUI_GLUT_SOFTSIMWINDOW_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/glut/SimWindow.hpp"
 
 namespace dart {
@@ -40,7 +41,7 @@ namespace gui {
 namespace glut {
 
 /// \brief
-class SoftSimWindow : public SimWindow
+class DART_GUI_API SoftSimWindow : public SimWindow
 {
 public:
   /// \brief

--- a/dart/gui/glut/Win3D.hpp
+++ b/dart/gui/glut/Win3D.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_GLUT_WIN3D_HPP_
 #define DART_GUI_GLUT_WIN3D_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/Trackball.hpp"
 #include "dart/gui/glut/Window.hpp"
 
@@ -42,7 +43,7 @@ namespace dart {
 namespace gui {
 namespace glut {
 
-class Win3D : public glut::Window
+class DART_GUI_API Win3D : public glut::Window
 {
 public:
   Win3D();

--- a/dart/gui/glut/Window.hpp
+++ b/dart/gui/glut/Window.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_GLUT_WINDOW_HPP_
 #define DART_GUI_GLUT_WINDOW_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/LoadOpengl.hpp"
 #include "dart/gui/RenderInterface.hpp"
 
@@ -43,7 +44,7 @@ namespace gui {
 namespace glut {
 
 /// \brief
-class Window
+class DART_GUI_API Window
 {
 public:
   Window();

--- a/dart/gui/osg/DefaultEventHandler.hpp
+++ b/dart/gui/osg/DefaultEventHandler.hpp
@@ -36,6 +36,7 @@
 #include "dart/common/ClassWithVirtualBase.hpp"
 #include "dart/common/Observer.hpp"
 #include "dart/common/Subject.hpp"
+#include "dart/gui/Export.hpp"
 
 #include <Eigen/Core>
 #include <osgGA/GUIEventHandler>
@@ -99,9 +100,9 @@ enum ConstraintType
 class MouseEventHandler;
 
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class DefaultEventHandler : public ::osgGA::GUIEventHandler,
-                            public virtual dart::common::Subject,
-                            public virtual dart::common::Observer
+class DART_GUI_API DefaultEventHandler : public ::osgGA::GUIEventHandler,
+                                         public virtual dart::common::Subject,
+                                         public virtual dart::common::Observer
 {
 public:
   /// Constructor takes in a pointer to a viewer

--- a/dart/gui/osg/DragAndDrop.hpp
+++ b/dart/gui/osg/DragAndDrop.hpp
@@ -37,6 +37,7 @@
 #include "dart/common/sub_ptr.hpp"
 #include "dart/dynamics/Entity.hpp"
 #include "dart/dynamics/Shape.hpp"
+#include "dart/gui/Export.hpp"
 
 #include <Eigen/Geometry>
 
@@ -56,7 +57,8 @@ class InteractiveFrame;
 
 /// DragAndDrop is a class that facilitates enabling various kinds of dart
 /// Entities to be dragged and dropped in an dart::gui::osg environment
-class DragAndDrop : public dart::common::Subject, public dart::common::Observer
+class DART_GUI_API DragAndDrop : public dart::common::Subject,
+                                 public dart::common::Observer
 {
 public:
   enum class RotationOption : int
@@ -173,7 +175,7 @@ protected:
 
 //==============================================================================
 /// SimpleFrameDnD is a DragAndDrop implementation for SimpleFrame objects
-class SimpleFrameDnD : public DragAndDrop
+class DART_GUI_API SimpleFrameDnD : public DragAndDrop
 {
 public:
   /// Constructor
@@ -203,7 +205,7 @@ protected:
 /// SimpleFrameShapeDnD is a version of SimpleFrameDnD that allows a specific
 /// Shape within the SimpleFrame to be dragged and dropped (although it will
 /// carry the entire SimpleFrame with it)
-class SimpleFrameShapeDnD : public SimpleFrameDnD
+class DART_GUI_API SimpleFrameShapeDnD : public SimpleFrameDnD
 {
 public:
   /// Constructor
@@ -231,7 +233,7 @@ protected:
 };
 
 //==============================================================================
-class InteractiveFrameDnD : public DragAndDrop
+class DART_GUI_API InteractiveFrameDnD : public DragAndDrop
 {
 public:
   /// Constructor
@@ -261,7 +263,7 @@ protected:
 };
 
 //==============================================================================
-class BodyNodeDnD : public DragAndDrop
+class DART_GUI_API BodyNodeDnD : public DragAndDrop
 {
 public:
   /// Constructor

--- a/dart/gui/osg/GridVisual.hpp
+++ b/dart/gui/osg/GridVisual.hpp
@@ -34,6 +34,7 @@
 #define DART_GUI_OSG_GRIDVISUAL_HPP_
 
 #include "dart/dynamics/SmartPointer.hpp"
+#include "dart/gui/Export.hpp"
 #include "dart/gui/osg/ShapeFrameNode.hpp"
 #include "dart/gui/osg/Viewer.hpp"
 
@@ -45,7 +46,7 @@ namespace gui {
 namespace osg {
 
 /// Attach this to a Viewer in order to visualize grid.
-class GridVisual : public ViewerAttachment
+class DART_GUI_API GridVisual : public ViewerAttachment
 {
 public:
   enum class PlaneType : unsigned char

--- a/dart/gui/osg/ImGuiHandler.hpp
+++ b/dart/gui/osg/ImGuiHandler.hpp
@@ -39,6 +39,8 @@
 #ifndef DART_GUI_OSG_IMGUIHANDLER_HPP_
 #define DART_GUI_OSG_IMGUIHANDLER_HPP_
 
+#include "dart/gui/Export.hpp"
+
 #include <osg/GraphicsContext>
 #include <osgGA/GUIActionAdapter>
 #include <osgGA/GUIEventAdapter>
@@ -54,7 +56,7 @@ namespace osg {
 
 class ImGuiWidget;
 
-class ImGuiHandler : public osgGA::GUIEventHandler
+class DART_GUI_API ImGuiHandler : public osgGA::GUIEventHandler
 {
 public:
   /// Constructor

--- a/dart/gui/osg/ImGuiViewer.hpp
+++ b/dart/gui/osg/ImGuiViewer.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_OSG_IMGUIVIEWER_HPP_
 #define DART_GUI_OSG_IMGUIVIEWER_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/osg/Viewer.hpp"
 
 #include <memory>
@@ -45,7 +46,7 @@ class ImGuiHandler;
 class MainMenuWidget;
 class AboutWidget;
 
-class ImGuiViewer : public Viewer
+class DART_GUI_API ImGuiViewer : public Viewer
 {
 public:
   /// Constructor for dart::gui::osg::Viewer. This will automatically create the

--- a/dart/gui/osg/ImGuiWidget.hpp
+++ b/dart/gui/osg/ImGuiWidget.hpp
@@ -39,13 +39,14 @@
 #ifndef DART_GUI_OSG_IMGUIWIDGET_HPP_
 #define DART_GUI_OSG_IMGUIWIDGET_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/osg/ImGuiViewer.hpp"
 
 namespace dart {
 namespace gui {
 namespace osg {
 
-class ImGuiWidget
+class DART_GUI_API ImGuiWidget
 {
 public:
   /// Constructor

--- a/dart/gui/osg/InteractiveFrame.hpp
+++ b/dart/gui/osg/InteractiveFrame.hpp
@@ -34,6 +34,7 @@
 #define DART_GUI_OSG_INTERACTIVEFRAME_HPP_
 
 #include "dart/dynamics/SimpleFrame.hpp"
+#include "dart/gui/Export.hpp"
 
 namespace dart {
 
@@ -46,7 +47,7 @@ namespace osg {
 
 class InteractiveFrame;
 
-class InteractiveTool : public dart::dynamics::SimpleFrame
+class DART_GUI_API InteractiveTool : public dart::dynamics::SimpleFrame
 {
 public:
   enum Type
@@ -106,7 +107,7 @@ protected:
   InteractiveFrame* mInteractiveFrame;
 };
 
-class InteractiveFrame : public dart::dynamics::SimpleFrame
+class DART_GUI_API InteractiveFrame : public dart::dynamics::SimpleFrame
 {
 public:
   DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(InteractiveFrame)

--- a/dart/gui/osg/RealTimeWorldNode.hpp
+++ b/dart/gui/osg/RealTimeWorldNode.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_OSG_REALTIMEWORLDNODE_HPP_
 #define DART_GUI_OSG_REALTIMEWORLDNODE_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/osg/WorldNode.hpp"
 
 #include <osg/Timer>
@@ -41,7 +42,7 @@ namespace dart {
 namespace gui {
 namespace osg {
 
-class RealTimeWorldNode : public WorldNode
+class DART_GUI_API RealTimeWorldNode : public WorldNode
 {
 public:
   /// Construct a world node that will attempt to run a simulation with close

--- a/dart/gui/osg/SupportPolygonVisual.hpp
+++ b/dart/gui/osg/SupportPolygonVisual.hpp
@@ -34,6 +34,7 @@
 #define DART_GUI_OSG_SUPPORTPOLYGONVISUAL_HPP_
 
 #include "dart/dynamics/SmartPointer.hpp"
+#include "dart/gui/Export.hpp"
 #include "dart/gui/osg/ShapeFrameNode.hpp"
 #include "dart/gui/osg/Viewer.hpp"
 
@@ -45,7 +46,7 @@ namespace osg {
 
 /// Attach this to a Viewer in order to visualize the support polygon of a
 /// Skeleton
-class SupportPolygonVisual : public ViewerAttachment
+class DART_GUI_API SupportPolygonVisual : public ViewerAttachment
 {
 public:
   /// Visualize the support polygon of an entire Skeleton

--- a/dart/gui/osg/Viewer.hpp
+++ b/dart/gui/osg/Viewer.hpp
@@ -35,6 +35,7 @@
 
 #include "dart/common/ClassWithVirtualBase.hpp"
 #include "dart/common/Subject.hpp"
+#include "dart/gui/Export.hpp"
 
 #include <Eigen/Core>
 #include <osgShadow/ShadowTechnique>
@@ -88,7 +89,7 @@ enum class CameraMode
 };
 
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
-class ViewerAttachment : public virtual ::osg::Group
+class DART_GUI_API ViewerAttachment : public virtual ::osg::Group
 {
 public:
   friend class Viewer;
@@ -123,7 +124,8 @@ private:
   Viewer* mViewer;
 };
 
-class Viewer : public osgViewer::Viewer, public dart::common::Subject
+class DART_GUI_API Viewer : public osgViewer::Viewer,
+                            public dart::common::Subject
 {
 public:
   /// Constructor for dart::gui::osg::Viewer. This will automatically create the

--- a/dart/gui/osg/WorldNode.hpp
+++ b/dart/gui/osg/WorldNode.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_GUI_OSG_WORLDNODE_HPP_
 #define DART_GUI_OSG_WORLDNODE_HPP_
 
+#include "dart/gui/Export.hpp"
 #include "dart/gui/osg/Viewer.hpp"
 
 #include <osg/Group>
@@ -62,7 +63,7 @@ class EntityNode;
 class Viewer;
 
 /// WorldNode class encapsulates a World to be displayed in OpenSceneGraph
-class WorldNode : public ::osg::Group
+class DART_GUI_API WorldNode : public ::osg::Group
 {
 public:
   friend class Viewer;


### PR DESCRIPTION
**Change of `libdart7-gui` in `Release` mode on Ubuntu**:
- Number of symbols: 4,024 -> 1,665
- Size of binary: 2.6M -> 2.3M
> Disclaimer: Some APIs could be hidden when they are supposed to be exported but just not caught by the CI. They will be exported eventually as discovered...

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
