### PR TITLE
Added python binding for WholeBodyIK

### DIFF
--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -573,6 +573,13 @@ void Skeleton(py::module& m)
             return self->getIK();
           })
       .def(
+          "getIK",
+          +[](dart::dynamics::Skeleton* self, bool createIfNull)
+              -> std::shared_ptr<const dart::dynamics::WholeBodyIK> {
+            return  std::const_pointer_cast<dart::dynamics::WholeBodyIK>(self->getIK(createIfNull));
+          },
+          ::py::arg("createIfNull"))
+      .def(
           "clearIK",
           +[](dart::dynamics::Skeleton* self)
               -> void { return self->clearIK(); })

--- a/python/dartpy/dynamics/WholeBodyIK.cpp
+++ b/python/dartpy/dynamics/WholeBodyIK.cpp
@@ -33,9 +33,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <dart/dynamics/InverseKinematics.hpp>
-#include <unordered_set>
-
 #include "eigen_geometry_pybind.h"
 #include "eigen_pybind.h"
 

--- a/python/dartpy/dynamics/WholeBodyIK.cpp
+++ b/python/dartpy/dynamics/WholeBodyIK.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011-2023, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/master/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <dart/dart.hpp>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <dart/dynamics/InverseKinematics.hpp>
+#include <unordered_set>
+
+#include "eigen_geometry_pybind.h"
+#include "eigen_pybind.h"
+
+namespace py = pybind11;
+
+namespace dart {
+namespace python {
+
+
+void WholeBodyIK(py::module& m)
+{
+
+    ::py::class_<
+        dart::dynamics::HierarchicalIK,
+        dart::common::Subject,
+        std::shared_ptr<dart::dynamics::HierarchicalIK>>(
+        m, "HierarchicalIK");
+
+    ::py::class_<
+      dart::dynamics::WholeBodyIK,
+      dart::dynamics::HierarchicalIK,
+      std::shared_ptr<dart::dynamics::WholeBodyIK>>(
+      m, "WholeBodyIK")
+        .def(
+            ::py::init(
+                +[](const std::shared_ptr<dart::dynamics::Skeleton>& skel)
+                    -> std::shared_ptr<dart::dynamics::WholeBodyIK> {
+                    return dart::dynamics::WholeBodyIK::create(skel);
+                }),
+            ::py::arg("skel"))
+        .def(
+            "solveAndApply",
+            +[](dart::dynamics::WholeBodyIK* self) -> bool {
+                return self->solveAndApply();
+            });
+}
+} // namespace python
+} // namespace dart

--- a/python/dartpy/dynamics/dartpy_dynamics.cpp
+++ b/python/dartpy/dynamics/dartpy_dynamics.cpp
@@ -77,6 +77,7 @@ void Chain(py::module& sm);
 void Skeleton(py::module& sm);
 
 void InverseKinematics(py::module& sm);
+void WholeBodyIK(py::module& sm);
 void Inertia(py::module& sm);
 
 void ConstraintBase(py::module& sm);
@@ -140,7 +141,8 @@ PYBIND11_MODULE(dartpy_dynamics, sm)
   Skeleton(sm);
 
   InverseKinematics(sm);
-
+  WholeBodyIK(sm);
+  
   Inertia(sm);
 
   ConstraintBase(sm);


### PR DESCRIPTION
Hi, I noted an error when trying to use get the InverseKinematics of a skeletion from python. 
The dart.dynamics.skel.getIK() method resulted in an error: could not be converted into a python type. 
So I added a binding for the WholeBodyIK class. This seems to fix it.
Unfortunately, I do not have the time to bind the whole class atm, so I only bound the solveAnApply method, which allows most basic usage.

Let me know if this needs some futher work before merging.

Cheers