### PR TITLE
Fix build with urdfdom 4.0.0

### DIFF
--- a/dart/utils/urdf/urdf_world_parser.cpp
+++ b/dart/utils/urdf/urdf_world_parser.cpp
@@ -216,7 +216,7 @@ std::shared_ptr<World> parseWorldURDF(
           auto* origin = entity_xml->FirstChildElement("origin");
           if (origin)
           {
-            if (!parsePose(entity.origin, origin))
+            if (!urdf_parsing::parsePose(entity.origin, origin))
             {
               dtwarn << "[ERROR] Missing origin tag for '"
                      << entity.model->getName() << "'\n";


### PR DESCRIPTION
There is a parsePose method in urdfdom 4.0.0 with the same signature as the function defined locally in urdf_world_parser, which causes build errors due to an ambiguous call. This adds `urdf_parsing::` to the reference to `parsePose` to eliminate the ambiguity. Needed for https://github.com/Homebrew/homebrew-core/pull/158963.

I was confused about why this error occurs since I don't see `using namespace urdf;` anywhere, but I believe it's due to [argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl) (thanks @azeey for the pointer).

#### Before creating a pull request

- [X] Document new methods and classes
- [X] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
