### PR TITLE
[pixi] Exclude hidden folders from formatting

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -49,12 +49,20 @@ install-local = { cmd = "cmake --install build --prefix $CONDA_PREFIX", depends_
 
 configure = { cmd = "cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release -DDART_VERBOSE=ON -DDART_USE_SYSTEM_IMGUI=ON" }
 
-lint = { cmd = "cmake --build build --target format && black . && isort .", depends_on = [
+lint-cpp = { cmd = "cmake --build build --target format", depends_on = [
     "configure",
 ] }
-check-lint = { cmd = "cmake --build build --target check-format && black . --check && isort . --check", depends_on = [
+lint-py = { cmd = "black . --exclude '\\..*' && isort . --skip-glob '.*'", depends_on = [
     "configure",
 ] }
+lint = { depends_on = ["lint-cpp", "lint-py"] }
+check-lint-cpp = { cmd = "cmake --build build --target check-format", depends_on = [
+    "configure",
+] }
+check-lint-py = { cmd = "black . --check --exclude '\\..*' && isort . --check --skip-glob '.*'", depends_on = [
+    "configure",
+] }
+check-lint = { depends_on = ["check-lint-cpp", "check-lint-py"] }
 
 build = { cmd = "cmake --build build -j --target all", depends_on = [
     "configure",
@@ -146,10 +154,14 @@ freeglut = ">=3.2.2,<3.3"
 
 [target.win-64.tasks]
 configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DDART_VERBOSE=ON -DDART_MSVC_DEFAULT_OPTIONS=ON -DBUILD_SHARED_LIBS=OFF -DDART_USE_SYSTEM_IMGUI=OFF" }
-lint = { cmd = "black . && isort .", depends_on = ["configure"] }
-check-lint = { cmd = "black . --check && isort . --check", depends_on = [
+lint-py = { cmd = "black . --exclude '\\..*' && isort . --skip-glob '.*'", depends_on = [
     "configure",
 ] }
+lint = { depends_on = ["lint-py"] }
+check-lint-py = { cmd = "black . --check --exclude '\\..*' && isort . --check --skip-glob '.*'", depends_on = [
+    "configure",
+] }
+check-lint = { depends_on = ["check-lint-py"] }
 build = { cmd = "cmake --build build --config Release -j", depends_on = [
     "configure",
 ] }


### PR DESCRIPTION
Otherwise:

```
✨ Pixi task (lint in default): cmake --build build --target format && black . && isort .
[1/1] /bin/sh CMakeFiles/format-5a20493.sh db459a6990039168
Formatting 988 files... 
Done.
error: cannot format /home/js/dev/dartsim/dart/main/.git/logs/refs/remotes/peci1/dartpy/setup.py: Cannot parse: 1:41: 0000000000000000000000000000000000000000 d98d7e3ba7997d71a4c1ca8f0371d42f415dc6af Jeongseok Lee <jslee02@gmail.com> 1639865355 -0800  fetch --progress --prune --recurse-submodules=no peci1: storing head
```

Tested on Ubuntu

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
