### PR TITLE
Set DART_ENABLE_SIMD=OFF by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 # compile options, which may cause runtime errors especially memory alignment
 # errors.
 dart_option(DART_ENABLE_SIMD
-  "Build DART with all SIMD instructions on the current local machine" ON)
+  "Build DART with all SIMD instructions on the current local machine" OFF)
 dart_option(DART_BUILD_GUI_OSG "Build osgDart library" ON)
 dart_option(DART_BUILD_DARTPY "Build dartpy" ON)
 dart_option(DART_BUILD_PROFILE "Build DART with profiling options" OFF)


### PR DESCRIPTION
https://github.com/gazebosim/gz-physics/issues/662

***

#### Before creating a pull request

- [x] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [x] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [x] Add unit test(s) for this change
- [x] Add Python bindings for new methods and classes
