### PR TITLE
[build] Fix GLUT dependency handling on Windows

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -69,3 +69,7 @@ jobs:
       - name: Test DART and dartpy
         run: |
           pixi run test-all
+
+      - name: Install
+        run: |
+          pixi run install

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -102,3 +102,7 @@ jobs:
       - name: Test DART and dartpy
         run: |
           pixi run test-all
+  
+      - name: Install
+        run: |
+          pixi run install

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -110,3 +110,7 @@ jobs:
       - name: Test DART and dartpy
         run: |
           pixi run test # TODO: Change to test-all
+  
+      - name: Install
+        run: |
+          pixi run install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## DART 6
 
+### [DART 6.14.4 (TBD)](https://github.com/dartsim/dart/milestone/81?closed=1)
+
+* Tested Platforms
+
+  * Linux
+    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  * macOS 14 / Clang 15 / arm64
+  * Windows / MSVC 19.40 / x86_64
+
+* Fixed GLUT dependency handling on Windows: [#1827](https://github.com/dartsim/dart/pull/1827)
+
 ### [DART 6.14.3 (2024-07-05)](https://github.com/dartsim/dart/milestone/80?closed=1)
 
 * Tested Platforms

--- a/dart/gui/CMakeLists.txt
+++ b/dart/gui/CMakeLists.txt
@@ -14,11 +14,6 @@ if(WIN32 AND NOT CYGWIN)
 else()
   dart_check_optional_package(GLUT "dart-gui" "freeglut3")
 endif()
-if(GLUT_FOUND)
-  set(HAVE_GLUT TRUE)
-else()
-  set(HAVE_GLUT FALSE)
-endif()
 
 # Search all header and source files
 file(GLOB hdrs "*.hpp" "*.h" "detail/*.hpp")
@@ -68,9 +63,7 @@ add_component_dependencies(
   external-lodepng
 )
 add_component_dependency_packages(${PROJECT_NAME} ${component_name} OpenGL)
-if(NOT WIN32 OR CYGWIN)
-  add_component_dependency_packages(${PROJECT_NAME} ${component_name} GLUT)
-endif()
+add_component_dependency_packages(${PROJECT_NAME} ${component_name} GLUT)
 
 # Add subdirectories
 add_subdirectory(osg)

--- a/pixi.toml
+++ b/pixi.toml
@@ -47,7 +47,7 @@ install-local = { cmd = "cmake --install build --prefix $CONDA_PREFIX", depends_
     "build",
 ] }
 
-configure = { cmd = "cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release -DDART_VERBOSE=ON -DDART_USE_SYSTEM_IMGUI=ON" }
+configure = { cmd = "cmake -G Ninja -S . -B build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DDART_VERBOSE=ON -DDART_USE_SYSTEM_IMGUI=ON" }
 
 lint = { cmd = "cmake --build build --target format && black . && isort .", depends_on = [
     "configure",
@@ -149,7 +149,7 @@ imgui = ">=1.90.4,<1.91"
 freeglut = ">=3.2.2,<3.3"
 
 [target.win-64.tasks]
-configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DDART_VERBOSE=ON -DDART_MSVC_DEFAULT_OPTIONS=ON -DBUILD_SHARED_LIBS=OFF -DDART_USE_SYSTEM_IMGUI=OFF" }
+configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DDART_VERBOSE=ON -DDART_MSVC_DEFAULT_OPTIONS=ON -DBUILD_SHARED_LIBS=OFF -DDART_USE_SYSTEM_IMGUI=OFF" }
 lint = { cmd = "black . && isort .", depends_on = ["configure"] }
 check-lint = { cmd = "black . --check && isort . --check", depends_on = [
     "configure",

--- a/pixi.toml
+++ b/pixi.toml
@@ -96,6 +96,10 @@ bm-kinematics = { cmd = "cmake --build build --target BM_INTEGRATION_kinematics 
     "configure",
 ] }
 
+install = { cmd = "cmake --build build --target install --parallel", depends_on = [
+    "build",
+] }
+
 create-deps-dir = { cmd = "mkdir -p .deps" }
 remove-deps-dir = { cmd = "rm -rf .deps" }
 
@@ -167,4 +171,7 @@ test-dartpy = { cmd = "cmake --build build --config Release -j --target pytest",
 ] }
 test-all = { cmd = "cmake --build build --config Release -j --target ALL", depends_on = [
     "configure",
+] }
+install = { cmd = "cmake --build build --config Release -j --target install", depends_on = [
+    "build",
 ] }


### PR DESCRIPTION
The detection of GLUT is already handled by `dart_check_optional_package()` (will skip building the `osg` component), so there is no need to check it again. Additionally, the logic `if(NOT WIN32 OR CYGWIN)` is inconsistent.

As a result, `FindDARTGLUT.cmake` is not installed on Windows:

Linux:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=969952&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=986b1512-c876-5f92-0d81-ba851554a0a3&l=1964

Windows:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=969952&view=logs&j=a70f640f-cc53-5cd3-6cdc-236a1aa90802&t=6119ccbe-9301-594f-7c27-f792b80a7fcc&l=2373

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [x] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
