### PR TITLE
Allow negative scale for MeshShape

### DIFF
--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -124,8 +124,24 @@ public:
 
   common::ResourceRetrieverPtr getResourceRetriever();
 
+  /// Sets the scale of the object using a 3D vector.
+  ///
+  /// The scale is applied independently along each axis (x, y, z). Negative
+  /// values will mirror the object along the corresponding axis, potentially
+  /// flipping normals and causing inside-out geometry.
+  ///
+  /// Use caution when applying negative scales as it may affect rendering and
+  /// physics calculations.
   void setScale(const Eigen::Vector3d& scale);
 
+  /// Sets a uniform scale for the object across all axes.
+  void setScale(double scale);
+
+  /// Returns the current scale of the object as a 3D vector.
+  ///
+  /// Each component of the vector represents the scale factor along the
+  /// corresponding axis (x, y, z). Negative values indicate that the object has
+  /// been mirrored along that axis.
   const Eigen::Vector3d& getScale() const;
 
   /// Set how the color of this mesh should be determined

--- a/python/dartpy/dynamics/Shape.cpp
+++ b/python/dartpy/dynamics/Shape.cpp
@@ -399,11 +399,12 @@ void Shape(py::module& m)
           })
       .def(
           "setScale",
-          py::overload_cast<const Eigen::Vector3d&>(&dart::dynamics::MeshShape),
+          py::overload_cast<const Eigen::Vector3d&>(
+              &dart::dynamics::MeshShape::setScale),
           py::arg("scale"))
       .def(
           "setScale",
-          py::overload_cast<double>(&dart::dynamics::MeshShape),
+          py::overload_cast<double>(&dart::dynamics::MeshShape::setScale),
           py::arg("scale"))
       .def(
           "getScale",

--- a/python/dartpy/dynamics/Shape.cpp
+++ b/python/dartpy/dynamics/Shape.cpp
@@ -397,8 +397,14 @@ void Shape(py::module& m)
               -> dart::common::ResourceRetrieverPtr {
             return self->getResourceRetriever();
           })
-      .def("setScale", py::overload_cast<const Eigen::Vector3d&>(&dart::dynamics::MeshShape), py::arg("scale"))
-      .def("setScale", py::overload_cast<double>(&dart::dynamics::MeshShape), py::arg("scale"))
+      .def(
+          "setScale",
+          py::overload_cast<const Eigen::Vector3d&>(&dart::dynamics::MeshShape),
+          py::arg("scale"))
+      .def(
+          "setScale",
+          py::overload_cast<double>(&dart::dynamics::MeshShape),
+          py::arg("scale"))
       .def(
           "getScale",
           +[](const dart::dynamics::MeshShape* self) -> const Eigen::Vector3d& {

--- a/python/dartpy/dynamics/Shape.cpp
+++ b/python/dartpy/dynamics/Shape.cpp
@@ -397,12 +397,8 @@ void Shape(py::module& m)
               -> dart::common::ResourceRetrieverPtr {
             return self->getResourceRetriever();
           })
-      .def(
-          "setScale",
-          +[](dart::dynamics::MeshShape* self, const Eigen::Vector3d& scale) {
-            self->setScale(scale);
-          },
-          ::py::arg("scale"))
+      .def("setScale", py::overload_cast<const Eigen::Vector3d&>(&dart::dynamics::MeshShape), py::arg("scale"))
+      .def("setScale", py::overload_cast<double>(&dart::dynamics::MeshShape), py::arg("scale"))
       .def(
           "getScale",
           +[](const dart::dynamics::MeshShape* self) -> const Eigen::Vector3d& {


### PR DESCRIPTION
This PR supports negative scaling in MeshShape as requested #1839. While it's not extensively tested yet, initial results are promising. Scaling the pelvis mesh by positive (5) and negative (-5) values worked as expected in preliminary tests.

Pelvis with scale(5, 5, 5):

https://github.com/user-attachments/assets/9bb243a1-ba4b-479c-944d-cb2de7541b31

Pelvis with scale(-5, -5, -5):

https://github.com/user-attachments/assets/81ada3b6-6f55-40bd-bd35-0dbeb49fd3a8

Resolves #1839.

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
