### PR TITLE
Support ImGui 1.91.5 and greater

### DIFF
--- a/dart/gui/osg/ImGuiHandler.cpp
+++ b/dart/gui/osg/ImGuiHandler.cpp
@@ -51,15 +51,17 @@ namespace dart {
 namespace gui {
 namespace osg {
 
-//==============================================================================
+#if IMGUI_VERSION_NUM < 19150
+
 // Special keys that are usually greater than 512 in osgGA
 //
-// Imporant Note: Dear ImGui expects the control Keys indices not to be greater
+// Important Note: Dear ImGui expects the control Keys indices not to be greater
 // thant 511. It actually uses an array of 512 elements. However, OSG has
 // indices greater than that. So here I do a conversion for special keys between
 // ImGui and OSG.
 enum ConvertedKey : int
 {
+  ConvertedKey_None = -1,
   ConvertedKey_Tab = 257,
   ConvertedKey_Left,
   ConvertedKey_Right,
@@ -83,14 +85,74 @@ enum ConvertedKey : int
   ConvertedKey_RightSuper,
 };
 
+#endif
+
 //==============================================================================
 // Check for a special key and return the converted code (range [257, 511]) if
 // so. Otherwise returns -1
-int convertFromOSGKey(int key)
+#if IMGUI_VERSION_NUM >= 19150
+ImGuiKey convertFromOSGKey(int key)
+#else
+ConvertedKey convertFromOSGKey(int key)
+#endif
 {
   using KeySymbol = osgGA::GUIEventAdapter::KeySymbol;
 
   switch (key) {
+#if IMGUI_VERSION_NUM >= 19150
+    case KeySymbol::KEY_Tab:
+      return ImGuiKey_Tab;
+    case KeySymbol::KEY_Left:
+      return ImGuiKey_LeftArrow;
+    case KeySymbol::KEY_Right:
+      return ImGuiKey_RightArrow;
+    case KeySymbol::KEY_Up:
+      return ImGuiKey_UpArrow;
+    case KeySymbol::KEY_Down:
+      return ImGuiKey_DownArrow;
+    case KeySymbol::KEY_Page_Up:
+      return ImGuiKey_PageUp;
+    case KeySymbol::KEY_Page_Down:
+      return ImGuiKey_PageDown;
+    case KeySymbol::KEY_Home:
+      return ImGuiKey_Home;
+    case KeySymbol::KEY_End:
+      return ImGuiKey_End;
+    case KeySymbol::KEY_Delete:
+      return ImGuiKey_Delete;
+    case KeySymbol::KEY_BackSpace:
+      return ImGuiKey_Backspace;
+    case KeySymbol::KEY_Return:
+      return ImGuiKey_Enter;
+    case KeySymbol::KEY_Escape:
+      return ImGuiKey_Escape;
+    case KeySymbol::KEY_Control_L:
+    case KeySymbol::KEY_Control_R:
+      return ImGuiKey_ModCtrl;
+    case KeySymbol::KEY_Shift_L:
+    case KeySymbol::KEY_Shift_R:
+      return ImGuiKey_ModShift;
+    case KeySymbol::KEY_Alt_L:
+    case KeySymbol::KEY_Alt_R:
+      return ImGuiKey_ModAlt;
+    case KeySymbol::KEY_Super_L:
+    case KeySymbol::KEY_Super_R:
+      return ImGuiKey_ModSuper;
+    case KeySymbol::KEY_A:
+      return ImGuiKey_A;
+    case KeySymbol::KEY_C:
+      return ImGuiKey_C;
+    case KeySymbol::KEY_V:
+      return ImGuiKey_V;
+    case KeySymbol::KEY_X:
+      return ImGuiKey_X;
+    case KeySymbol::KEY_Y:
+      return ImGuiKey_Y;
+    case KeySymbol::KEY_Z:
+      return ImGuiKey_Z;
+    default:
+      return ImGuiKey_None;
+#else
     case KeySymbol::KEY_Tab:
       return ConvertedKey_Tab;
     case KeySymbol::KEY_Left:
@@ -134,7 +196,8 @@ int convertFromOSGKey(int key)
     case KeySymbol::KEY_Super_R:
       return ConvertedKey_RightSuper;
     default:
-      return -1;
+      return ConvertedKey_None;
+#endif
   }
 }
 
@@ -182,6 +245,7 @@ ImGuiHandler::ImGuiHandler()
 
   ImGui_ImplOpenGL2_Init();
 
+#if IMGUI_VERSION_NUM < 19150
   // Keyboard mapping. ImGui will use those indices to peek into the
   // io.KeyDown[] array.
   ImGuiIO& io = ImGui::GetIO();
@@ -204,6 +268,7 @@ ImGuiHandler::ImGuiHandler()
   io.KeyMap[ImGuiKey_X] = osgGA::GUIEventAdapter::KeySymbol::KEY_X;
   io.KeyMap[ImGuiKey_Y] = osgGA::GUIEventAdapter::KeySymbol::KEY_Y;
   io.KeyMap[ImGuiKey_Z] = osgGA::GUIEventAdapter::KeySymbol::KEY_Z;
+#endif
 }
 
 //==============================================================================
@@ -272,22 +337,31 @@ bool ImGuiHandler::handle(
     ::osg::Object* /*object*/,
     ::osg::NodeVisitor* /*nodeVisitor*/)
 {
-  auto& io = ImGui::GetIO();
-  const auto wantCapureMouse = io.WantCaptureMouse;
-  const auto wantCapureKeyboard = io.WantCaptureKeyboard;
+  ImGuiIO& io = ImGui::GetIO();
+  const bool wantCaptureMouse = io.WantCaptureMouse;
+  const bool wantCaptureKeyboard = io.WantCaptureKeyboard;
 
   switch (eventAdapter.getEventType()) {
     case osgGA::GUIEventAdapter::KEYDOWN: {
-      const auto c = eventAdapter.getUnmodifiedKey();
-      const auto special_key = convertFromOSGKey(c);
+      const int key = eventAdapter.getUnmodifiedKey();
 
-      if (special_key > 0) {
-        assert(special_key < 512 && "ImGui KeysDown is an array of 512");
+#if IMGUI_VERSION_NUM >= 19150
+      const ImGuiKey specialKey = convertFromOSGKey(key);
+      if (specialKey != ImGuiKey_None) {
+        io.AddKeyEvent(specialKey, true);
+      } else if (key != 0 && key < 0x10000) {
+        const ImWchar c = static_cast<ImWchar>(eventAdapter.getKey());
+        io.AddInputCharacter(c);
+      }
+#else
+      const ConvertedKey specialKey = convertFromOSGKey(key);
+      if (specialKey != ConvertedKey_None) {
+        assert(specialKey < 512 && "ImGui KeysDown is an array of 512");
         assert(
-            special_key > 256
+            specialKey > 256
             && "ASCII stop at 127, but we use the range [257, 511]");
 
-        io.KeysDown[special_key] = true;
+        io.KeysDown[specialKey] = true;
 
         io.KeyCtrl = io.KeysDown[ConvertedKey_LeftControl]
                      || io.KeysDown[ConvertedKey_RightControl];
@@ -297,24 +371,31 @@ bool ImGuiHandler::handle(
                     || io.KeysDown[ConvertedKey_RightAlt];
         io.KeySuper = io.KeysDown[ConvertedKey_LeftSuper]
                       || io.KeysDown[ConvertedKey_RightSuper];
-      } else if (0 < c && c < 0x10000) {
-        io.KeysDown[c] = true;
-        io.AddInputCharacter(static_cast<ImWchar>(c));
+      } else if (0 < key && key < 0x10000) {
+        io.KeysDown[key] = true;
+        io.AddInputCharacter(static_cast<ImWchar>(key));
       }
+#endif
 
-      return wantCapureKeyboard;
+      return wantCaptureKeyboard;
     }
     case osgGA::GUIEventAdapter::KEYUP: {
-      const auto c = eventAdapter.getUnmodifiedKey();
-      const auto special_key = convertFromOSGKey(c);
+      const int key = eventAdapter.getUnmodifiedKey();
 
-      if (special_key > 0) {
-        assert(special_key < 512 && "ImGui KeysDown is an array of 512");
+#if IMGUI_VERSION_NUM >= 19150
+      const ImGuiKey specialKey = convertFromOSGKey(key);
+      if (specialKey != ImGuiKey_None) {
+        io.AddKeyEvent(specialKey, false);
+      }
+#else
+      const ConvertedKey specialKey = convertFromOSGKey(key);
+      if (specialKey != ConvertedKey_None) {
+        assert(specialKey < 512 && "ImGui KeysDown is an array of 512");
         assert(
-            special_key > 256
+            specialKey > 256
             && "ASCII stop at 127, but we use the range [257, 511]");
 
-        io.KeysDown[special_key] = false;
+        io.KeysDown[specialKey] = false;
 
         io.KeyCtrl = io.KeysDown[ConvertedKey_LeftControl]
                      || io.KeysDown[ConvertedKey_RightControl];
@@ -324,12 +405,13 @@ bool ImGuiHandler::handle(
                     || io.KeysDown[ConvertedKey_RightAlt];
         io.KeySuper = io.KeysDown[ConvertedKey_LeftSuper]
                       || io.KeysDown[ConvertedKey_RightSuper];
-      } else if (0 < c && c < 0x10000) {
-        io.KeysDown[c] = false;
-        io.AddInputCharacter(static_cast<ImWchar>(c));
+      } else if (0 < key && key < 0x10000) {
+        io.KeysDown[key] = false;
+        io.AddInputCharacter(static_cast<ImWchar>(key));
       }
+#endif
 
-      return wantCapureKeyboard;
+      return wantCaptureKeyboard;
     }
     case osgGA::GUIEventAdapter::PUSH: {
       io.MousePos
@@ -351,14 +433,14 @@ bool ImGuiHandler::handle(
         mMousePressed[0] = true;
       }
 
-      return wantCapureMouse;
+      return wantCaptureMouse;
     }
     case osgGA::GUIEventAdapter::DRAG:
     case osgGA::GUIEventAdapter::MOVE: {
       io.MousePos
           = ImVec2(eventAdapter.getX(), io.DisplaySize.y - eventAdapter.getY());
 
-      return wantCapureMouse;
+      return wantCaptureMouse;
     }
     case osgGA::GUIEventAdapter::RELEASE: {
       // When a mouse button is released no button mask is set. So we mark all
@@ -367,7 +449,7 @@ bool ImGuiHandler::handle(
       mMousePressed[1] = false;
       mMousePressed[2] = false;
 
-      return wantCapureMouse;
+      return wantCaptureMouse;
     }
     case osgGA::GUIEventAdapter::SCROLL: {
       constexpr float increment = 0.1f;
@@ -390,7 +472,7 @@ bool ImGuiHandler::handle(
           break;
       }
 
-      return wantCapureMouse;
+      return wantCaptureMouse;
     }
     default: {
       return false;

--- a/pixi.lock
+++ b/pixi.lock
@@ -11,10 +11,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/assimp-5.4.3-h8943939_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-h25a0e75_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py313h78bf25f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-ha87cce1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-heb4867d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-14-14.0.6-default_h7634d5b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
@@ -27,7 +27,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.4-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-ha5cdbd8_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-h543440a_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h3ef53d8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.0.2-h434a139_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -84,9 +84,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-25_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm14-14.0.6-hcd5def8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-h4bc722e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libode-0.16.2-h30efb56_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libode-0.16.5-h7469f36_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.28-openmp_hd680484_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
@@ -105,7 +105,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.4-hb346dea_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -118,8 +117,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.12.1-h297d8ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.8.0-py312h69683c5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.8.0-py313h129aefb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py313h4bf6692_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/octomap-1.10.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openscenegraph-3.6.5-h6fe4003_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
@@ -128,7 +127,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre-8.45-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pipx-1.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
@@ -136,13 +135,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.0-h9ebbce0_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.13-5_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.30.7-h3ed165c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.14.1-hed91bc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.0-h10c9db5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.0.0-hceb3a55_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-10.0.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
@@ -153,7 +152,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-1.1.2-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
@@ -179,10 +177,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ampl-mp-3.1.0-h2beb688_1006.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/assimp-5.4.3-hf9fe5ce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/black-24.10.0-py312hb401068_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/bullet-cpp-3.25-h81f2e74_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/black-24.10.0-py313habf4b1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bullet-cpp-3.25-h38cdd20_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-14-14.0.6-default_hdb78580_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
@@ -194,7 +192,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.4-h240833e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fcl-0.7.0-h74a68c9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fcl-0.7.0-h088812d_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/flann-1.9.2-h66ee4ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-11.0.2-h3c5361c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -234,8 +232,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-25_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hfdf4475_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.64.0-hc7306c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libode-0.16.2-hede676d_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libode-0.16.5-hb81edf0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.28-openmp_hbf64a52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.44-h4b8f8c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libscotch-7.0.5-h8e19eb7_2.conda
@@ -255,8 +254,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.12.1-h3c5361c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nlopt-2.8.0-py312h314ef60_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nlopt-2.8.0-py313h1f02af7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.3-py313h7ca3f3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/octomap-1.10.0-h37c8870_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openscenegraph-3.6.5-hdbe5f9d_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
@@ -264,20 +263,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pagmo-2.19.1-h0f09f18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre-8.45-he49afe7_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pipx-1.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-h00291cd_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.7-h8f8b54e_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.0-h0608dab_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.13-5_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.5-ha44c9a9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.30.7-hac325c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.14.1-h325aa07_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2022.0.0-h0ec6371_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml2-10.0.0-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
@@ -287,7 +286,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom-4.0.1-h4fa87d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom_headers-1.1.2-h37c8870_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.10-ha6c16c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h00291cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.5-h00291cd_0.conda
@@ -300,10 +298,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ampl-mp-3.1.0-hbec66e7_1006.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/assimp-5.4.3-ha9c0b8d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py312h81bd7bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bullet-cpp-3.25-py312h02baea5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py313h8f79df9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bullet-cpp-3.25-py313h47b39a6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-14-14.0.6-default_h5dc8d65_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
@@ -315,7 +313,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.4-h286801f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fcl-0.7.0-h7389230_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fcl-0.7.0-he078184_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flann-1.9.2-hedd063d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h420ef59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -357,8 +355,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-25_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libode-0.16.2-py312h20a0b95_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libode-0.16.5-py313hbab1857_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.28-openmp_hf332438_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.44-hc14010f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libscotch-7.0.5-h9f781f6_2.conda
@@ -378,8 +377,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.12.1-h420ef59_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlopt-2.8.0-py312h857dc0a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlopt-2.8.0-py313hb5c8cdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py313hca4752e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/octomap-1.10.0-h7b3277c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openscenegraph-3.6.5-hf1a0bd2_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
@@ -388,20 +387,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre-8.45-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pipx-1.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.0-h75c3a9f_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.5-h7ab814d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.30.7-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.14.1-h6d8af72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.0-h096ffd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.0.0-h0cbf7ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-10.0.0-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
@@ -411,7 +410,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom-4.0.1-h922ef61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom_headers-1.1.2-h7b3277c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.10-h2321a68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hd74edd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
@@ -423,8 +421,8 @@ environments:
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/assimp-5.4.3-hf1e84b2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/black-24.10.0-py312h2e8e312_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-hd2403df_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/black-24.10.0-py313hfa70ccb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-hf91d08e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
@@ -436,7 +434,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.4-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-h5691a02_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-h16792c9_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-h8958603_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.0.2-h7f575de_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -473,7 +471,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-25_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h53d5487_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.5-hc554db0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.47.0-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
@@ -487,8 +486,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/mumps-seq-5.7.3-h7c2359a_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ninja-1.12.1-hc790b64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/nlopt-2.8.0-py312h1fad3b1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nlopt-2.8.0-py313h32a1acb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py313hee8cc43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/octomap-1.10.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/openscenegraph-3.6.5-hf7c1acd_20.conda
@@ -498,18 +497,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre-8.45-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pipx-1.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.0-hf5aa216_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.13-5_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.30.7-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.14.1-h9f2357e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.0-h81cc0e1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-10.0.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
@@ -522,7 +521,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
@@ -713,161 +711,161 @@ packages:
 - kind: conda
   name: black
   version: 24.10.0
-  build: py312h2e8e312_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/black-24.10.0-py312h2e8e312_0.conda
-  sha256: 64df9c7e1454386b5ec763e82a40062b47e80700b1bc556878b7aa7b659c3ae1
-  md5: 6e943a224409da3599a8ec52944e3c15
-  depends:
-  - click >=8.0.0
-  - mypy_extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9
-  - platformdirs >=2
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 417913
-  timestamp: 1728504045145
-- kind: conda
-  name: black
-  version: 24.10.0
-  build: py312h7900ff3_0
+  build: py313h78bf25f_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
-  sha256: 2b4344d18328b3e8fd9b5356f4ee15556779766db8cb21ecf2ff818809773df6
-  md5: 2daba153b913b1b901cf61440ad5e019
+  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py313h78bf25f_0.conda
+  sha256: cf9a47712ee5f086d7b88bdb2c7d475886213aab945c81d0be4c851ab2c11e18
+  md5: 2cb3d25fa279bf0661bc12c5fad99b76
   depends:
   - click >=8.0.0
   - mypy_extensions >=0.4.3
   - packaging >=22.0
   - pathspec >=0.9
   - platformdirs >=2
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
-  size: 390571
-  timestamp: 1728503839694
+  size: 397990
+  timestamp: 1728503903590
 - kind: conda
   name: black
   version: 24.10.0
-  build: py312h81bd7bf_0
+  build: py313h8f79df9_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py312h81bd7bf_0.conda
-  sha256: 7e0cd77935e68717506469463546365637abf3f73aa597a890cb5f5ef3c75caf
-  md5: 702d7bf6d22135d3e30811ed9c62bb07
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.10.0-py313h8f79df9_0.conda
+  sha256: d715a26b2cedd0aaca82983a3582ea9ab662f078b49a4cceb2cc61d025f95bd5
+  md5: 953f9d3da2b0358509ea0faec2f2311e
   depends:
   - click >=8.0.0
   - mypy_extensions >=0.4.3
   - packaging >=22.0
   - pathspec >=0.9
   - platformdirs >=2
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
-  size: 392801
-  timestamp: 1728503954904
+  size: 397986
+  timestamp: 1728503908150
 - kind: conda
   name: black
   version: 24.10.0
-  build: py312hb401068_0
+  build: py313habf4b1d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/black-24.10.0-py312hb401068_0.conda
-  sha256: a1397d32f6d40ff19107bab8c1570f3934ad91a601d1d973b129eabe08b943e6
-  md5: e832f4c2afb84e85718008b600944bc0
+  url: https://conda.anaconda.org/conda-forge/osx-64/black-24.10.0-py313habf4b1d_0.conda
+  sha256: 0dd1b46c86daf91275bda0c0033af68d0120bf558df1f17dc6c9115dc98a48f2
+  md5: 898f6d094791c8bfeb02be761897165e
   depends:
   - click >=8.0.0
   - mypy_extensions >=0.4.3
   - packaging >=22.0
   - pathspec >=0.9
   - platformdirs >=2
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
-  size: 393514
-  timestamp: 1728503944080
+  size: 400395
+  timestamp: 1728503832399
+- kind: conda
+  name: black
+  version: 24.10.0
+  build: py313hfa70ccb_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/black-24.10.0-py313hfa70ccb_0.conda
+  sha256: 8f99d23fbcf0ce5fe852e2373e154dac8628497fbee15f0f9f4851a2f5ddc30b
+  md5: 9e5290e06324d03e6d2e18b410620696
+  depends:
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  size: 422911
+  timestamp: 1728504578146
 - kind: conda
   name: bullet-cpp
   version: '3.25'
-  build: h25a0e75_3
+  build: h38cdd20_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/bullet-cpp-3.25-h38cdd20_3.conda
+  sha256: 30f52e10c8e57a37eecd287b975be2f04b43411d2bcf7e16ab9ee009a60ea8d2
+  md5: ecced0936d59094c262fb64151d485eb
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.21,<3
+  - python_abi 3.13.* *_cp313
+  - xorg-libx11 >=1.8.9,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  license: Zlib
+  size: 39753899
+  timestamp: 1725367987014
+- kind: conda
+  name: bullet-cpp
+  version: '3.25'
+  build: ha87cce1_3
   build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-h25a0e75_3.conda
-  sha256: 8a36f7a24bc0f6a698d9eec8a0eff087cff0165902b49cfe6eaa8d2955cc568a
-  md5: c6a9eb05aa4e1905e594cc5c92a39761
+  url: https://conda.anaconda.org/conda-forge/linux-64/bullet-cpp-3.25-ha87cce1_3.conda
+  sha256: dec3cac70ba40c1af8dabeefca9a4a4cb0f3b43b2d2388d19cb843fae57b77f2
+  md5: e957e10375887805ac4cf96d5f69d649
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.21,<3
+  - python_abi 3.13.* *_cp313
   - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   license: Zlib
-  size: 43076734
-  timestamp: 1725367661047
+  size: 42968855
+  timestamp: 1725367707822
 - kind: conda
   name: bullet-cpp
   version: '3.25'
-  build: h81f2e74_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/bullet-cpp-3.25-h81f2e74_3.conda
-  sha256: 88038fae077999fd0ba26ab0965d3abbd38b6e25787271b015bf7b9511e084be
-  md5: 52206a784c1d25dcf5fb8d0174065177
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
-  - xorg-libx11 >=1.8.9,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  license: Zlib
-  size: 40029733
-  timestamp: 1725367829146
-- kind: conda
-  name: bullet-cpp
-  version: '3.25'
-  build: hd2403df_3
+  build: hf91d08e_3
   build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-hd2403df_3.conda
-  sha256: d7def7731487dc4d91f5734c9f621bf0c4b21ee5551392ec3c0fb53f1f8db276
-  md5: d52088f3519cb6743c752fa59ddf45a8
+  url: https://conda.anaconda.org/conda-forge/win-64/bullet-cpp-3.25-hf91d08e_3.conda
+  sha256: 60991edfb5ce2192ffc4568a44c46645b5f50a4c97025258eae08f7472c8d1d2
+  md5: 0f46df5ba327ae5cb50ffe52a74bfc88
   depends:
-  - numpy >=1.26.4,<2.0a0
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.21,<3
+  - python_abi 3.13.* *_cp313
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Zlib
-  size: 16053454
-  timestamp: 1725368384552
+  size: 15720852
+  timestamp: 1725368272988
 - kind: conda
   name: bullet-cpp
   version: '3.25'
-  build: py312h02baea5_3
+  build: py313h47b39a6_3
   build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bullet-cpp-3.25-py312h02baea5_3.conda
-  sha256: d91f054319327a9d07df5433bdbff51788c0a2fadb8ae3eb6bc5503b836718b3
-  md5: 6e5dcfab6377ac93d5a425f3b3dc1afc
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bullet-cpp-3.25-py313h47b39a6_3.conda
+  sha256: 208505ea9f8445da41399908e584339daa8144b75dc6447252f6d901150b79dd
+  md5: 1daac41b2a97a50f81f1c5ded1147de4
   depends:
   - __osx >=11.0
   - libcxx >=17
-  - numpy >=1.26.4,<2.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.21,<3
+  - python >=3.13.0rc1,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
   - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   license: Zlib
-  size: 39501680
-  timestamp: 1725368492311
+  size: 39603592
+  timestamp: 1725367974292
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -933,47 +931,47 @@ packages:
   timestamp: 1720974491916
 - kind: conda
   name: c-ares
-  version: 1.34.2
-  build: h32b1619_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
-  sha256: 972d0403c92c9cd1d1c60e34d80991258125ee880cf5a9289ae83a443d8970cd
-  md5: 724edfea6dde646c1faf2ce1423e0faa
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 182342
-  timestamp: 1729006698430
-- kind: conda
-  name: c-ares
-  version: 1.34.2
-  build: h7ab814d_0
+  version: 1.34.3
+  build: h5505292_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
-  sha256: 24d53d27397f9c2f0c168992690b5ec1bd62593fb4fc1f1e906ab91b10fd06c3
-  md5: 8a8cfc11064b521bc54bd2d8591cb137
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.3-h5505292_0.conda
+  sha256: e9e0f737286f9f4173c76fb01a11ffbe87cfc2da4e99760e1e18f47851d7ae06
+  md5: d0155a4f41f28628c7409ea000eeb19c
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 177487
-  timestamp: 1729006763496
+  size: 178951
+  timestamp: 1731182071026
 - kind: conda
   name: c-ares
-  version: 1.34.2
+  version: 1.34.3
   build: heb4867d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
-  sha256: c2a515e623ac3e17a56027c06098fbd5ab47afefefbd386b4c21289f2ec55139
-  md5: 2b780c0338fc0ffa678ac82c54af51fd
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.3-heb4867d_0.conda
+  sha256: 1015d731c05ef7de298834833d680b08dea58980b907f644345bd457f9498c99
+  md5: 09a6c610d002e54e18353c06ef61a253
   depends:
   - __glibc >=2.28,<3.0.a0
   - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 205797
-  timestamp: 1729006575652
+  size: 205575
+  timestamp: 1731181837907
+- kind: conda
+  name: c-ares
+  version: 1.34.3
+  build: hf13058a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.3-hf13058a_0.conda
+  sha256: e1bc2520ba9bfa55cd487efabd6bfaa49ccd944847895472133ba919810c9978
+  md5: c36355bc08d4623c210b00f9935ee632
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 183798
+  timestamp: 1731181957603
 - kind: conda
   name: ca-certificates
   version: 2024.8.30
@@ -1583,85 +1581,81 @@ packages:
 - kind: conda
   name: fcl
   version: 0.7.0
-  build: h5691a02_5
-  build_number: 5
+  build: h088812d_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/fcl-0.7.0-h088812d_6.conda
+  sha256: 9c1309c622d6849c5d73b161b104d46da1f66fcd3a59f3442616fa217247fb2d
+  md5: dc5a823fa88968213b3ddfbfd8eff71a
+  depends:
+  - __osx >=10.13
+  - flann >=1.9.2,<1.9.3.0a0
+  - libccd-double >=2.1,<2.2.0a0
+  - libcxx >=16
+  - octomap >=1.10.0,<1.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1176894
+  timestamp: 1731217654909
+- kind: conda
+  name: fcl
+  version: 0.7.0
+  build: h16792c9_6
+  build_number: 6
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-h5691a02_5.conda
-  sha256: 324b321b7460cb6b590632a715464ba298c699b74d1a541757d53db8f2587121
-  md5: 6c77e4f9d7bebfb0d21965c93f6cb364
+  url: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-h16792c9_6.conda
+  sha256: 7563cdadfe0204cb475d5d78d046f2833d75004a3d39ee533b68f24a3d1dcf40
+  md5: 30a14ab1f78a16c3f429800c066e1d4a
   depends:
   - flann >=1.9.2,<1.9.3.0a0
   - libccd-double >=2.1,<2.2.0a0
-  - libode >=0.16.2,<0.16.3.0a0
   - octomap >=1.10.0,<1.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 4946614
-  timestamp: 1728756980427
+  size: 4977164
+  timestamp: 1731218206645
 - kind: conda
   name: fcl
   version: 0.7.0
-  build: h7389230_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fcl-0.7.0-h7389230_5.conda
-  sha256: c200d67af5c7efbd0ca36c8fc810cc6a648babb379db72d83960f0166a2ed434
-  md5: e90f5f9ddafa70990d4e8fa74d35a354
-  depends:
-  - __osx >=11.0
-  - flann >=1.9.2,<1.9.3.0a0
-  - libccd-double >=2.1,<2.2.0a0
-  - libcxx >=16
-  - libode >=0.16.2,<0.16.3.0a0
-  - octomap >=1.10.0,<1.11.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1044527
-  timestamp: 1728756074323
-- kind: conda
-  name: fcl
-  version: 0.7.0
-  build: h74a68c9_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/fcl-0.7.0-h74a68c9_5.conda
-  sha256: af44062021a35fdc1c4c46017126d847a6b0cbea32f388ecec5cb811e863277b
-  md5: 25ecb13bdb84793410cb45b655f0a7df
-  depends:
-  - __osx >=10.13
-  - flann >=1.9.2,<1.9.3.0a0
-  - libccd-double >=2.1,<2.2.0a0
-  - libcxx >=16
-  - libode >=0.16.2,<0.16.3.0a0
-  - octomap >=1.10.0,<1.11.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1187859
-  timestamp: 1728756347622
-- kind: conda
-  name: fcl
-  version: 0.7.0
-  build: ha5cdbd8_5
-  build_number: 5
+  build: h543440a_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-ha5cdbd8_5.conda
-  sha256: e1122617123eb912cf9f3f8a77588d5f4ba30602b5043ccc00aed7ce81afb9d1
-  md5: bec42baae456a0374e56f4d254397a36
+  url: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-h543440a_6.conda
+  sha256: 3df69742828d1b52d72aba9b336895d6cd8052040f108ec61c4acf32fe274b01
+  md5: a69e2481c68b9f8bdef3287cceee30ae
   depends:
   - __glibc >=2.17,<3.0.a0
   - flann >=1.9.2,<1.9.3.0a0
   - libccd-double >=2.1,<2.2.0a0
   - libgcc >=13
-  - libode >=0.16.2,<0.16.3.0a0
   - libstdcxx >=13
   - octomap >=1.10.0,<1.11.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1556189
-  timestamp: 1728756582900
+  size: 1553565
+  timestamp: 1731217767246
+- kind: conda
+  name: fcl
+  version: 0.7.0
+  build: he078184_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fcl-0.7.0-he078184_6.conda
+  sha256: 97c971a2e04e8a8e5dd54d50307009635df00f2ec680078fb232f235e86fc8c9
+  md5: 204ba0540488041dd50f0beaecb0ed9a
+  depends:
+  - __osx >=11.0
+  - flann >=1.9.2,<1.9.3.0a0
+  - libccd-double >=2.1,<2.2.0a0
+  - libcxx >=16
+  - octomap >=1.10.0,<1.11.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1042149
+  timestamp: 1731217421887
 - kind: conda
   name: flann
   version: 1.9.2
@@ -4173,6 +4167,65 @@ packages:
   size: 20571387
   timestamp: 1690559110016
 - kind: conda
+  name: libmpdec
+  version: 4.0.0
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
+  sha256: fc529fc82c7caf51202cc5cec5bb1c2e8d90edbac6d0a4602c966366efe3c7bf
+  md5: 74860100b2029e2523cf480804c76b9b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 88657
+  timestamp: 1723861474602
+- kind: conda
+  name: libmpdec
+  version: 4.0.0
+  build: h4bc722e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-h4bc722e_0.conda
+  sha256: d02d1d3304ecaf5c728e515eb7416517a0b118200cd5eacbe829c432d1664070
+  md5: aeb98fdeb2e8f25d43ef71fbacbeec80
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 89991
+  timestamp: 1723817448345
+- kind: conda
+  name: libmpdec
+  version: 4.0.0
+  build: h99b78c6_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
+  sha256: f7917de9117d3a5fe12a39e185c7ce424f8d5010a6f97b4333e8a1dcb2889d16
+  md5: 7476305c35dd9acef48da8f754eedb40
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 69263
+  timestamp: 1723817629767
+- kind: conda
+  name: libmpdec
+  version: 4.0.0
+  build: hfdf4475_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hfdf4475_0.conda
+  sha256: 791be3d30d8e37ec49bcc23eb8f1e1415d911a7c023fa93685f2ea485179e258
+  md5: ed625b2e59dff82859c23dd24774156b
+  depends:
+  - __osx >=10.13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 76561
+  timestamp: 1723817691512
+- kind: conda
   name: libnghttp2
   version: 1.64.0
   build: h161d5f1_0
@@ -4234,91 +4287,75 @@ packages:
   size: 606663
   timestamp: 1729572019083
 - kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
-  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  license_family: GPL
-  size: 33408
-  timestamp: 1697359010159
-- kind: conda
   name: libode
-  version: 0.16.2
-  build: h30efb56_14
-  build_number: 14
+  version: 0.16.5
+  build: h7469f36_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libode-0.16.2-h30efb56_14.conda
-  sha256: ce5b4622fef82d3211f3261231c354d9e36140d0fffc65872e6c69fb32671fcc
-  md5: 4c32b00c93bb75f27314297855b2d8e2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libode-0.16.5-h7469f36_0.conda
+  sha256: e25155dc1fd6e48ea835e1c0d0114a1164bfe6d0f852784fda4f0085d44bd1a3
+  md5: a1e7fac2dbd97830d298750e2eff242c
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libccd-double >=2.1,<2.2.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - libgcc >=13
+  - libstdcxx >=13
   - pthread-stubs
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.13.* *_cp313
   license: LGPL-2.1-or-later OR BSD-4-Clause
-  size: 503518
-  timestamp: 1710841472717
+  size: 505268
+  timestamp: 1731154651694
 - kind: conda
   name: libode
-  version: 0.16.2
-  build: h53d5487_14
-  build_number: 14
+  version: 0.16.5
+  build: hb81edf0_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libode-0.16.5-hb81edf0_0.conda
+  sha256: e06a74ad6fea267d0b32200c1e87774308ea42a4fca261e18ed023346aa32d11
+  md5: 55d6fe3e4d9a25efbaabe22dc07c4aad
+  depends:
+  - __osx >=10.13
+  - libccd-double >=2.1,<2.2.0a0
+  - libcxx >=18
+  - pthread-stubs
+  - python_abi 3.13.* *_cp313
+  license: LGPL-2.1-or-later OR BSD-4-Clause
+  size: 438556
+  timestamp: 1731154780719
+- kind: conda
+  name: libode
+  version: 0.16.5
+  build: hc554db0_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.2-h53d5487_14.conda
-  sha256: 2998b838f5ca50e591905e1d8c12a13e89b53244e15731f9ed1bca5b179a698a
-  md5: 9700da78cfcaf77bd7b68d523e5fbc18
+  url: https://conda.anaconda.org/conda-forge/win-64/libode-0.16.5-hc554db0_0.conda
+  sha256: a85d26b080f22ff0df686d2ddcd22c6d8b97ce9b90e0710dbde5719e855d942b
+  md5: 1f593f6f435df6ad8715a06538674b69
   depends:
   - libccd-double >=2.1,<2.2.0a0
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.13.* *_cp313
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - vs2015_runtime
   license: LGPL-2.1-or-later OR BSD-4-Clause
-  size: 367320
-  timestamp: 1710842384440
+  size: 367595
+  timestamp: 1731154858131
 - kind: conda
   name: libode
-  version: 0.16.2
-  build: hede676d_14
-  build_number: 14
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libode-0.16.2-hede676d_14.conda
-  sha256: db46b8386f58f976b7bf669e151dd3dd2e2f89037d8740c2570c62af453af290
-  md5: 8eb0ab1c8067934df0532b37c126884f
-  depends:
-  - libccd-double >=2.1,<2.2.0a0
-  - libcxx >=16
-  - pthread-stubs
-  - python_abi 3.12.* *_cp312
-  license: LGPL-2.1-or-later OR BSD-4-Clause
-  size: 453513
-  timestamp: 1710841982923
-- kind: conda
-  name: libode
-  version: 0.16.2
-  build: py312h20a0b95_14
-  build_number: 14
+  version: 0.16.5
+  build: py313hbab1857_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libode-0.16.2-py312h20a0b95_14.conda
-  sha256: 8cb230f5916af5a2328272e9fb86dc09ef9325f5f267d123c66e442471d14c19
-  md5: 127d1d81a7ceb0365c91b5f74cb66b1e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libode-0.16.5-py313hbab1857_0.conda
+  sha256: 7e0cc2361dd7119d2b9471eeadf3a0a7f91490351ccc56a42963bcfb05929c74
+  md5: f31b93a38a33ba08c8cb0ad91e03305d
   depends:
+  - __osx >=11.0
   - libccd-double >=2.1,<2.2.0a0
-  - libcxx >=16
+  - libcxx >=18
   - pthread-stubs
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
   license: LGPL-2.1-or-later OR BSD-4-Clause
-  size: 378986
-  timestamp: 1710842064170
+  size: 374527
+  timestamp: 1731154885258
 - kind: conda
   name: libogg
   version: 1.3.5
@@ -5032,20 +5069,6 @@ packages:
   size: 323770
   timestamp: 1727278927545
 - kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
-  md5: 5aa797f8787fe7a17d1b0821485b5adc
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  size: 100393
-  timestamp: 1702724383534
-- kind: conda
   name: libxkbcommon
   version: 1.7.0
   build: h2c5496b_1
@@ -5665,114 +5688,160 @@ packages:
 - kind: conda
   name: nlopt
   version: 2.8.0
-  build: py312h1fad3b1_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/nlopt-2.8.0-py312h1fad3b1_2.conda
-  sha256: b352471c5d0289a7171e041173db48e21c5c910727169655c49db28c38a25b72
-  md5: 04f722848f54445d855cdab27463c04f
-  depends:
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LGPL-2.1-or-later
-  size: 339991
-  timestamp: 1725348958122
-- kind: conda
-  name: nlopt
-  version: 2.8.0
-  build: py312h314ef60_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nlopt-2.8.0-py312h314ef60_2.conda
-  sha256: 489006fc82a81927c085918f27cdcb21fcea155b23b0fa1e09e79d1ab8a14aeb
-  md5: c348dd603f53faa384fee46aa00e8273
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: LGPL-2.1-or-later
-  size: 385554
-  timestamp: 1725348701333
-- kind: conda
-  name: nlopt
-  version: 2.8.0
-  build: py312h69683c5_2
+  build: py313h129aefb_2
   build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.8.0-py312h69683c5_2.conda
-  sha256: 22a30934649cabd7b20a9f17062543ca610c0e3840c7679999b7299ed2be073c
-  md5: 8582b8ef6a808ace0bfb83213ac54d54
+  url: https://conda.anaconda.org/conda-forge/linux-64/nlopt-2.8.0-py313h129aefb_2.conda
+  sha256: c633f300c472deeca23c9999434b714979c0ee0cb56874c6b8606bfb6cfefc83
+  md5: 3fa87ffc2671ceb54f699d337a61e624
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.21,<3
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
   license: LGPL-2.1-or-later
-  size: 402249
-  timestamp: 1725348631250
+  size: 402314
+  timestamp: 1725348682433
 - kind: conda
   name: nlopt
   version: 2.8.0
-  build: py312h857dc0a_2
+  build: py313h1f02af7_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nlopt-2.8.0-py313h1f02af7_2.conda
+  sha256: 98340299f3fd790985d4a947730f2172dfe002aaef91eb93dcc0d3ca24138cff
+  md5: 33ab4c0ad80f0d3a2489e903870058a7
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - numpy >=1.21,<3
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: LGPL-2.1-or-later
+  size: 385576
+  timestamp: 1725348698854
+- kind: conda
+  name: nlopt
+  version: 2.8.0
+  build: py313h32a1acb_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/nlopt-2.8.0-py313h32a1acb_2.conda
+  sha256: 2b6f90fb1dd757fa0be56219af2bb013cbd48c5250ebb5f68dbd3b3d0f39b18c
+  md5: 5249157e2c6e80e3ebecfe0a7ce04320
+  depends:
+  - numpy >=1.21,<3
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  size: 340619
+  timestamp: 1725348882199
+- kind: conda
+  name: nlopt
+  version: 2.8.0
+  build: py313hb5c8cdb_2
   build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlopt-2.8.0-py312h857dc0a_2.conda
-  sha256: 93cc96f7f885b719639c4f3c0de0f4c35c8228865e1a7adb01126f1da9fa5a6c
-  md5: 43ff4f0c457575783aefdaeda1356c64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlopt-2.8.0-py313hb5c8cdb_2.conda
+  sha256: f2fe6cf597584a10ca77a25b0503b033a9aa61b9a296aafc89ad421d5164c5ef
+  md5: f22e15be2ff85ec0f4b8d83627295b33
   depends:
   - __osx >=11.0
   - libcxx >=17
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.21,<3
+  - python >=3.13.0rc1,<3.14.0a0
+  - python >=3.13.0rc1,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
   license: LGPL-2.1-or-later
-  size: 322857
-  timestamp: 1725348697612
+  size: 323329
+  timestamp: 1725348737402
 - kind: conda
   name: numpy
-  version: 1.26.4
-  build: py312h8442bc7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
-  sha256: c8841d6d6f61fd70ca80682efbab6bdb8606dc77c68d8acabfbd7c222054f518
-  md5: d83fc83d589e2625a3451c9a7e21047c
+  version: 2.1.3
+  build: py313h4bf6692_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py313h4bf6692_0.conda
+  sha256: e2e7451083c143cd61227d663e55712a7432239e9a9c758db0b66a26bc89a7f8
+  md5: 17bcf851cceab793dad11ab8089d4bc4
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
+  - libgcc >=13
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
+  - libstdcxx >=13
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6073136
-  timestamp: 1707226249608
+  size: 8404824
+  timestamp: 1730588549941
 - kind: conda
   name: numpy
-  version: 1.26.4
-  build: py312h8753938_0
+  version: 2.1.3
+  build: py313h7ca3f3b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.3-py313h7ca3f3b_0.conda
+  sha256: fe86adfc262259f1b156301d45d49d81801b1dec732e5b1dbc647cafe4659475
+  md5: b827b0af2098c63435b27b7f4e4d50dd
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7638660
+  timestamp: 1730588470617
+- kind: conda
+  name: numpy
+  version: 2.1.3
+  build: py313hca4752e_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py313hca4752e_0.conda
+  sha256: 3e8bb3474fc90e8c5c1799f4a4e8b887d31b50a0e94fd9f63e2725f7be2e3d4f
+  md5: c9d17b236cff44f7a24f19808842ec39
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=18
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6468921
+  timestamp: 1730588494311
+- kind: conda
+  name: numpy
+  version: 2.1.3
+  build: py313hee8cc43_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
-  sha256: 73570817a5109d396b4ebbe5124a89525959269fd33fa33fd413700289fbe0ef
-  md5: f9ac74c3b07c396014434aca1e58d362
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py313hee8cc43_0.conda
+  sha256: 79b8493c839cd4cc22e2a7024f289067b029ef2b09212973a98a39e5bbeecc03
+  md5: 083a90ad306f544f6eeb9ad00c4d9879
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -5780,51 +5849,8 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6495445
-  timestamp: 1707226412944
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312he3a82b2_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
-  sha256: 6152b73fba3e227afa4952df8753128fc9669bbaf142ee8f9972bf9df3bf8856
-  md5: 96c61a21c4276613748dba069554846b
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6990646
-  timestamp: 1707226178262
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312heda63a1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
-  sha256: fe3459c75cf84dcef6ef14efcc4adb0ade66038ddd27cadb894f34f4797687d8
-  md5: d8285bea2a350f63fab23bf460221f3f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7484186
-  timestamp: 1707225809722
+  size: 7072965
+  timestamp: 1730588905304
 - kind: conda
   name: octomap
   version: 1.10.0
@@ -6315,20 +6341,18 @@ packages:
 - kind: conda
   name: pip
   version: 24.3.1
-  build: pyh8b19718_0
+  build: pyh145f28c_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
-  sha256: 499313e72e20225f84c2e9690bbaf5b952c8d7e0bf34b728278538f766b81628
-  md5: 5dd546fe99b44fda83963d15f84263b7
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_0.conda
+  sha256: fc305cfe1ad0d51c61dd42a33cf27e03a075992fd0070c173d7cad86c1a48f13
+  md5: ca3afe2d7b893a8c8cdf489d30a2b1a3
   depends:
-  - python >=3.8,<3.13.0a0
-  - setuptools
-  - wheel
+  - python >=3.13.0a0
   license: MIT
   license_family: MIT
-  size: 1243168
-  timestamp: 1730203795600
+  size: 1241228
+  timestamp: 1730203795175
 - kind: conda
   name: pipx
   version: 1.7.1
@@ -6554,64 +6578,67 @@ packages:
   timestamp: 1725977334143
 - kind: conda
   name: python
-  version: 3.12.7
-  build: h739c21a_0_cpython
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
-  sha256: 45d7ca2074aa92594bd2f91a9003b338cc1df8a46b9492b7fc8167110783c3ef
-  md5: e0d82e57ebb456077565e6d82cd4a323
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.46.1,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.3.2,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 12975439
-  timestamp: 1728057819519
-- kind: conda
-  name: python
-  version: 3.12.7
-  build: h8f8b54e_0_cpython
+  version: 3.13.0
+  build: h0608dab_100_cp313
+  build_number: 100
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.7-h8f8b54e_0_cpython.conda
-  sha256: 28172d94f7193c5075c0fc3c4b1bb617c512ffc991f4e2af0dbb6a2916872b76
-  md5: 7f81191b1ca1113e694e90e15c27a12f
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.0-h0608dab_100_cp313.conda
+  sha256: f4c8ca4c34cb2a508956cfc8c2130dc30f168a75ae8254da8c43b5dce10ed2ea
+  md5: 9603103619775a3f99fe4b58d278775e
   depends:
   - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.6.3,<3.0a0
   - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
   - libsqlite >=3.46.1,<4.0a0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.3.2,<4.0a0
+  - python_abi 3.13.* *_cp313
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 13761315
-  timestamp: 1728058247482
+  size: 13933848
+  timestamp: 1729169951268
 - kind: conda
   name: python
-  version: 3.12.7
-  build: hc5c86c4_0_cpython
+  version: 3.13.0
+  build: h75c3a9f_100_cp313
+  build_number: 100
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.0-h75c3a9f_100_cp313.conda
+  sha256: be9464399b76ae1fef77853eed70267ef657a98a5f69f7df012b7c6a34792151
+  md5: 94ae22ea862d056ad1bc095443d02d73
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - python_abi 3.13.* *_cp313
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  license: Python-2.0
+  size: 12804842
+  timestamp: 1729168680448
+- kind: conda
+  name: python
+  version: 3.13.0
+  build: h9ebbce0_100_cp313
+  build_number: 100
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
-  sha256: 674be31ff152d9f0e0fe16959a45e3803a730fc4f54d87df6a9ac4e6a698c41d
-  md5: 0515111a9cdf69f83278f7c197db9807
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.0-h9ebbce0_100_cp313.conda
+  sha256: 6ab5179679f0909db828d8316f3b8b379014a82404807310fe7df5a6cf303646
+  md5: 08e9aef080f33daeb192b2ddc7e4721f
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
@@ -6619,108 +6646,107 @@ packages:
   - libexpat >=2.6.3,<3.0a0
   - libffi >=3.4,<4.0a0
   - libgcc >=13
-  - libnsl >=2.0.1,<2.1.0a0
+  - libmpdec >=4.0.0,<5.0a0
   - libsqlite >=3.46.1,<4.0a0
   - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.3.2,<4.0a0
+  - python_abi 3.13.* *_cp313
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 31574780
-  timestamp: 1728059777603
+  size: 33112481
+  timestamp: 1728419573472
 - kind: conda
   name: python
-  version: 3.12.7
-  build: hce54a09_0_cpython
+  version: 3.13.0
+  build: hf5aa216_100_cp313
+  build_number: 100
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.7-hce54a09_0_cpython.conda
-  sha256: 2308cfa9ec563360d29ced7fd13a6b60b9a7b3cf8961a95c78c69f486211d018
-  md5: 21f1f7c6ccf6b747c5086d2422c230e1
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.13.0-hf5aa216_100_cp313.conda
+  sha256: 18f3f0bd514c9101d38d57835b2d027958f3ae4b3b65c22d187a857aa26b3a08
+  md5: 3c2f7ad3f598480fe2a09e4e33cb1a2a
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.6.3,<3.0a0
   - libffi >=3.4,<4.0a0
+  - libmpdec >=4.0.0,<5.0a0
   - libsqlite >=3.46.1,<4.0a0
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
+  - python_abi 3.13.* *_cp313
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 15987537
-  timestamp: 1728057382072
+  size: 16641177
+  timestamp: 1728417810202
 - kind: conda
   name: python_abi
-  version: '3.12'
-  build: 5_cp312
+  version: '3.13'
+  build: 5_cp313
   build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
-  sha256: d10e93d759931ffb6372b45d65ff34d95c6000c61a07e298d162a3bc2accebb0
-  md5: 0424ae29b104430108f5218a66db7260
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.13-5_cp313.conda
+  sha256: 438225b241c5f9bddae6f0178a97f5870a89ecf927dfca54753e689907331442
+  md5: 381bbd2a92c863f640a55b6ff3c35161
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 6238
-  timestamp: 1723823388266
+  size: 6217
+  timestamp: 1723823393322
 - kind: conda
   name: python_abi
-  version: '3.12'
-  build: 5_cp312
+  version: '3.13'
+  build: 5_cp313
   build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
-  sha256: 4da26c7508d5bc5d8621e84dc510284402239df56aab3587a7d217de9d3c806d
-  md5: c34dd4920e0addf7cfcc725809f25d8e
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.13-5_cp313.conda
+  sha256: 075ad768648e88b78d2a94099563b43d3082e7c35979f457164f26d1079b7b5c
+  md5: 927a2186f1f997ac018d67c4eece90a6
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 6312
-  timestamp: 1723823137004
+  size: 6291
+  timestamp: 1723823083064
 - kind: conda
   name: python_abi
-  version: '3.12'
-  build: 5_cp312
+  version: '3.13'
+  build: 5_cp313
   build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
-  sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
-  md5: b76f9b1c862128e56ac7aa8cd2333de9
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
+  sha256: 4437198eae80310f40b23ae2f8a9e0a7e5c2b9ae411a8621eb03d87273666199
+  md5: b8e82d0a5c1664638f87f63cc5d241fb
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 6278
-  timestamp: 1723823099686
+  size: 6322
+  timestamp: 1723823058879
 - kind: conda
   name: python_abi
-  version: '3.12'
-  build: 5_cp312
+  version: '3.13'
+  build: 5_cp313
   build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
-  sha256: 9486662af81a219e96d343449eff242f38d7c5128ced5ce5acf85857265058d6
-  md5: e8681f534453af7afab4cd2bc1423eec
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.13-5_cp313.conda
+  sha256: 0c12cc1b84962444002c699ed21e815fb9f686f950d734332a1b74d07db97756
+  md5: 44b4fe6f22b57103afb2299935c8b68e
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 6730
-  timestamp: 1723823139725
+  size: 6716
+  timestamp: 1723823166911
 - kind: conda
   name: readline
   version: '8.2'
@@ -6888,74 +6914,70 @@ packages:
   timestamp: 1730382173961
 - kind: conda
   name: spdlog
-  version: 1.14.1
-  build: h325aa07_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.14.1-h325aa07_1.conda
-  sha256: ec594f80f82f69472cf518795303a222a03460cc4102c4758b33eab833640024
-  md5: 4aa13d84a5c71b5df6642761a6c35ce9
-  depends:
-  - __osx >=10.13
-  - fmt >=11.0.1,<12.0a0
-  - libcxx >=16
-  license: MIT
-  license_family: MIT
-  size: 171455
-  timestamp: 1722238446029
-- kind: conda
-  name: spdlog
-  version: 1.14.1
-  build: h6d8af72_1
-  build_number: 1
+  version: 1.15.0
+  build: h096ffd4_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.14.1-h6d8af72_1.conda
-  sha256: f981d4f3555125cb913be49397892f43c6b747705c0d72cba3676f7d98709f92
-  md5: 4af518b01539da8e4af17aee5fb92639
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.0-h096ffd4_0.conda
+  sha256: de653f827cca162c9eed6c78a6e33d07bf5849142e379d963a6b64f2f86cc962
+  md5: a487a4d98ad1b71c7d077e1aa3267874
   depends:
   - __osx >=11.0
-  - fmt >=11.0.1,<12.0a0
-  - libcxx >=16
+  - fmt >=11.0.2,<12.0a0
+  - libcxx >=18
   license: MIT
   license_family: MIT
-  size: 164011
-  timestamp: 1722238482313
+  size: 162704
+  timestamp: 1731185107680
 - kind: conda
   name: spdlog
-  version: 1.14.1
-  build: h9f2357e_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.14.1-h9f2357e_1.conda
-  sha256: 3ed3e9aaeb6255914472109a6d25d5119eb196c8d6cc2ec732cffe79ccc789bf
-  md5: b9bff07144f2be7ee32f0b83a79ef21d
+  version: 1.15.0
+  build: h0ec5880_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.15.0-h0ec5880_0.conda
+  sha256: 6b6ac55b025b19cb79e302284b9636ac1598d8d52bcdef01d1dde1a7ec74f6bb
+  md5: 818b052de52ee7f86ea7a6bb5bb8fb34
   depends:
-  - fmt >=11.0.1,<12.0a0
+  - __osx >=10.13
+  - fmt >=11.0.2,<12.0a0
+  - libcxx >=18
+  license: MIT
+  license_family: MIT
+  size: 168907
+  timestamp: 1731184892850
+- kind: conda
+  name: spdlog
+  version: 1.15.0
+  build: h10c9db5_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.0-h10c9db5_0.conda
+  sha256: 23a22cc59649a6e5376ff7e7f1e2ea823c5bc38f3d8508dab5435abfe6641c46
+  md5: 1187fdeda7f8e65817b3d00afe42907e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fmt >=11.0.2,<12.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  size: 193568
+  timestamp: 1731184711946
+- kind: conda
+  name: spdlog
+  version: 1.15.0
+  build: h81cc0e1_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.0-h81cc0e1_0.conda
+  sha256: c2298163c4957b17550e931ac91070852caccd5c74919df4f2d751bd9d030eb7
+  md5: f976e9b380c4035211dd1bf8743b2ecf
+  depends:
+  - fmt >=11.0.2,<12.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 169120
-  timestamp: 1722238639391
-- kind: conda
-  name: spdlog
-  version: 1.14.1
-  build: hed91bc2_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.14.1-hed91bc2_1.conda
-  sha256: 0c604fe3f78ddb2b612841722bd9b5db24d0484e30ced89fac78c0a3f524dfd6
-  md5: 909188c8979846bac8e586908cf1ca6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - fmt >=11.0.1,<12.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 195665
-  timestamp: 1722238295031
+  size: 167708
+  timestamp: 1731185043282
 - kind: conda
   name: tbb
   version: 2021.13.0
@@ -7446,20 +7468,6 @@ packages:
   license_family: MIT
   size: 321561
   timestamp: 1724530461598
-- kind: conda
-  name: wheel
-  version: 0.45.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.0-pyhd8ed1ab_0.conda
-  sha256: 8a51067f8e1a2cb0b5e89672dbcc0369e344a92e869c38b2946584aa09ab7088
-  md5: f9751d7c71df27b2d29f5cab3378982e
-  depends:
-  - python >=3.8
-  license: MIT
-  size: 62755
-  timestamp: 1731120002488
 - kind: conda
   name: xcb-util
   version: 0.4.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,92 +41,99 @@ urdfdom = ">=4.0.0"
 [tasks]
 clean = { cmd = "rm -rf build && rm -rf .deps && rm -rf .pixi && rm pixi.lock" }
 
-configure-local = { cmd = "cmake -G Ninja -S . -B build -DDART_VERBOSE=ON -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX" }
+config-local = { cmd = "cmake -G Ninja -S . -B build -DDART_VERBOSE=ON -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX" }
 install-local = { cmd = "cmake --install build --prefix $CONDA_PREFIX", depends_on = [
-    "configure_local",
+    "config_local",
     "build",
 ] }
 
-configure = { cmd = "cmake -G Ninja -S . -B build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release -DDART_VERBOSE=ON -DDART_USE_SYSTEM_IMGUI=ON" }
+config = { cmd = """
+    cmake \
+        -G Ninja \
+        -S . \
+        -B build \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DDART_VERBOSE=ON \
+        -DDART_USE_SYSTEM_IMGUI=ON
+""" }
 
 lint-cpp = { cmd = "cmake --build build --target format", depends_on = [
-    "configure",
+    "config",
 ] }
 lint-py = { cmd = "black . --exclude '\\..*' && isort . --skip-glob '.*'", depends_on = [
-    "configure",
+    "config",
 ] }
 lint = { depends_on = ["lint-cpp", "lint-py"] }
 check-lint-cpp = { cmd = "cmake --build build --target check-format", depends_on = [
-    "configure",
+    "config",
 ] }
 check-lint-py = { cmd = "black . --check --exclude '\\..*' && isort . --check --skip-glob '.*'", depends_on = [
-    "configure",
+    "config",
 ] }
 check-lint = { depends_on = ["check-lint-cpp", "check-lint-py"] }
 
-build = { cmd = "cmake --build build -j --target all", depends_on = [
-    "configure",
-] }
+build = { cmd = "cmake --build build -j --target all", depends_on = ["config"] }
 build-tests = { cmd = "cmake --build build -j --target tests", depends_on = [
-    "configure",
+    "config",
 ] }
 build-dartpy = { cmd = "cmake --build build -j --target dartpy", depends_on = [
-    "configure",
+    "config",
 ] }
 
 test = { cmd = "ctest --test-dir build --output-on-failure", depends_on = [
     "build-tests",
 ] }
 test-dartpy = { cmd = "cmake --build build -j --target pytest", depends_on = [
-    "configure",
+    "config",
 ] }
 test-all = { cmd = "cmake --build build -j --target ALL", depends_on = [
-    "configure",
+    "config",
 ] }
 
 ex-atlas-puppet = { cmd = "cmake --build build --target atlas_puppet --parallel && ./build/bin/atlas_puppet", depends_on = [
-    "configure",
+    "config",
 ] }
 ex-atlas-simbicon = { cmd = "cmake --build build --target atlas_simbicon --parallel && ./build/bin/atlas_simbicon", depends_on = [
-    "configure",
+    "config",
 ] }
 ex-hello-world = { cmd = "cmake --build build --target hello_world --parallel && ./build/bin/hello_world", depends_on = [
-    "configure",
+    "config",
 ] }
 
 bm-boxes = { cmd = "cmake --build build --target BM_INTEGRATION_boxes --parallel && ./build/bin/BM_INTEGRATION_boxes", depends_on = [
-    "configure",
+    "config",
 ] }
 bm-empty = { cmd = "cmake --build build --target BM_INTEGRATION_empty --parallel && ./build/bin/BM_INTEGRATION_empty", depends_on = [
-    "configure",
+    "config",
 ] }
 bm-kinematics = { cmd = "cmake --build build --target BM_INTEGRATION_kinematics --parallel && ./build/bin/BM_INTEGRATION_kinematics", depends_on = [
-    "configure",
+    "config",
 ] }
 
 tu-biped = { cmd = "cmake --build build --target tutorial_biped --parallel && ./build/bin/tutorial_biped", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-biped-fi = { cmd = "cmake --build build --target tutorial_biped_finished --parallel && ./build/bin/tutorial_biped_finished", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-collisions = { cmd = "cmake --build build --target tutorial_collisions --parallel && ./build/bin/tutorial_collisions", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-collisions-fi = { cmd = "cmake --build build --target tutorial_collisions_finished --parallel && ./build/bin/tutorial_collisions_finished", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-dominoes = { cmd = "cmake --build build --target tutorial_dominoes --parallel && ./build/bin/tutorial_dominoes", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-dominoes-fi = { cmd = "cmake --build build --target tutorial_dominoes_finished --parallel && ./build/bin/tutorial_dominoes_finished", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-multi-pendulum = { cmd = "cmake --build build --target tutorial_multi_pendulum --parallel && ./build/bin/tutorial_multi_pendulum", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-multi-pendulum-fi = { cmd = "cmake --build build --target tutorial_multi_pendulum_finished --parallel && ./build/bin/tutorial_multi_pendulum_finished", depends_on = [
-    "configure",
+    "config",
 ] }
 
 install = { cmd = "cmake --build build --target install --parallel", depends_on = [
@@ -179,59 +186,69 @@ clang-format-14 = ">=14.0.6,<15"
 freeglut = ">=3.2.2"
 
 [target.win-64.tasks]
-configure = { cmd = "cmake -S . -B build -G 'Visual Studio 17 2022' -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DDART_VERBOSE=ON -DDART_MSVC_DEFAULT_OPTIONS=ON -DBUILD_SHARED_LIBS=OFF -DDART_USE_SYSTEM_IMGUI=ON" }
+config = { cmd = """
+    cmake \
+        -S . \
+        -B build \
+        -G 'Visual Studio 17 2022' \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DDART_VERBOSE=ON \
+        -DDART_MSVC_DEFAULT_OPTIONS=ON \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DDART_USE_SYSTEM_IMGUI=ON
+""" }
 lint-py = { cmd = "black . --exclude '\\..*' && isort . --skip-glob '.*'", depends_on = [
-    "configure",
+    "config",
 ] }
 lint = { depends_on = ["lint-py"] }
 check-lint-py = { cmd = "black . --check --exclude '\\..*' && isort . --check --skip-glob '.*'", depends_on = [
-    "configure",
+    "config",
 ] }
 check-lint = { depends_on = ["check-lint-py"] }
 
 build = { cmd = "cmake --build build --config Release -j", depends_on = [
-    "configure",
+    "config",
 ] }
 build-tests = { cmd = "cmake --build build --config Release -j --target tests", depends_on = [
-    "configure",
+    "config",
 ] }
 build-dartpy = { cmd = "cmake --build build -j --target dartpy", depends_on = [
-    "configure",
+    "config",
 ] }
 
 test = { cmd = "ctest --test-dir build --build-config Release --output-on-failure", depends_on = [
     "build-tests",
 ] }
 test-dartpy = { cmd = "cmake --build build --config Release -j --target pytest", depends_on = [
-    "configure",
+    "config",
 ] }
 test-all = { cmd = "cmake --build build --config Release -j --target ALL", depends_on = [
-    "configure",
+    "config",
 ] }
 
 tu-biped = { cmd = "cmake --build build --config Release --target tutorial_biped --parallel && build/Release/tutorial_biped.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-biped-fi = { cmd = "cmake --build build --config Release --target tutorial_biped_finished --parallel && build/Release/tutorial_biped_finished.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-collisions = { cmd = "cmake --build build --config Release --target tutorial_collisions --parallel && build/Release/tutorial_collisions.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-collisions-fi = { cmd = "cmake --build build --config Release --target tutorial_collisions_finished --parallel && build/Release/tutorial_collisions_finished.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-dominoes = { cmd = "cmake --build build --config Release --target tutorial_dominoes --parallel && build/Release/tutorial_dominoes.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-dominoes-fi = { cmd = "cmake --build build --config Release --target tutorial_dominoes_finished --parallel && build/Release/tutorial_dominoes_finished.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-multi-pendulum = { cmd = "cmake --build build --config Release --target tutorial_multi_pendulum --parallel && build/Release/tutorial_multi_pendulum.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 tu-multi-pendulum-fi = { cmd = "cmake --build build --config Release --target tutorial_multi_pendulum_finished --parallel && build/Release/tutorial_multi_pendulum_finished.exe", depends_on = [
-    "configure",
+    "config",
 ] }
 
 install = { cmd = "cmake --build build --config Release -j --target install", depends_on = [


### PR DESCRIPTION
- Updated the special key mapping between OSG and ImGui as per https://github.com/ocornut/imgui/issues/4921 to resolve build issues caused by the removed ImGui API since version 1.91.5.
- Renamed the Pixi task from `configure` to `config` for brevity.

***

#### Before creating a pull request

- [x] Document new methods and classes
- [x] Format new code files using ClangFormat by running `make format`
- [x] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [x] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
