### PR TITLE
Remove unsupported option "display_version"

### DIFF
--- a/docs/readthedocs/conf.py
+++ b/docs/readthedocs/conf.py
@@ -46,7 +46,6 @@ html_logo = "_static/img/dart_logo_long_200.png"
 html_favicon = "_static/img/dart_logo_32.png"
 html_theme_options = {
     "logo_only": True,
-    "display_version": True,
 }
 
 # Setting for multi language


### PR DESCRIPTION
RTD build fixed:
- https://readthedocs.org/projects/dart/builds/26233094/
- https://readthedocs.org/projects/dart-ko/builds/26233093/

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
