### PR TITLE
Fix imgui is not properly set when DART_USE_SYSTEM_IMGUI=ON

### DIFF
--- a/cmake/DARTFindOpenSceneGraph.cmake
+++ b/cmake/DARTFindOpenSceneGraph.cmake
@@ -6,20 +6,19 @@
 #
 # This file is provided under the "BSD-style" License
 
-set(min_osg_version 3.0.0)
+find_package(OpenSceneGraph 3.0.0 QUIET
+  COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow osgUtil
+)
+
 # OpenSceneGraph 3.6.5 or less are not compatible with macOS 10.15 (Catalina) or greater
 # See:
 #   - https://github.com/openscenegraph/OpenSceneGraph/issues/926
 #   - https://github.com/dartsim/dart/issues/1439
 if(APPLE)
-  if(NOT ${CMAKE_SYSTEM_VERSION} VERSION_LESS 19)
-    set(min_osg_version 3.7.0)
+  if(OPENSCENEGRAPH_VERSION VERSION_LESS 3.7.0)
+    message(WARNING "OSG (${OPENSCENEGRAPH_VERSION} < 3.7.0) doesn't work on macOS 10.15 or greater. See: https://github.com/openscenegraph/OpenSceneGraph/issues/926")
   endif()
 endif()
-
-find_package(OpenSceneGraph ${min_osg_version} QUIET
-  COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow osgUtil
-)
 
 # It seems that OPENSCENEGRAPH_FOUND will inadvertently get set to true when
 # OpenThreads is found, even if OpenSceneGraph is not installed. This is quite

--- a/cmake/DARTFindOpenSceneGraph.cmake
+++ b/cmake/DARTFindOpenSceneGraph.cmake
@@ -6,7 +6,18 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(OpenSceneGraph 3.6.5 QUIET
+set(min_osg_version 3.0.0)
+# OpenSceneGraph 3.6.5 or less are not compatible with macOS 10.15 (Catalina) or greater
+# See:
+#   - https://github.com/openscenegraph/OpenSceneGraph/issues/926
+#   - https://github.com/dartsim/dart/issues/1439
+if(APPLE)
+  if(NOT ${CMAKE_SYSTEM_VERSION} VERSION_LESS 19)
+    set(min_osg_version 3.7.0)
+  endif()
+endif()
+
+find_package(OpenSceneGraph ${min_osg_version} QUIET
   COMPONENTS osg osgViewer osgManipulator osgGA osgDB osgShadow osgUtil
 )
 

--- a/dart/gui/CMakeLists.txt
+++ b/dart/gui/CMakeLists.txt
@@ -62,8 +62,7 @@ add_component_dependencies(
   utils
   external-lodepng
 )
-add_component_dependency_packages(${PROJECT_NAME} ${component_name} OpenGL)
-add_component_dependency_packages(${PROJECT_NAME} ${component_name} GLUT)
+add_component_dependency_packages(${PROJECT_NAME} ${component_name} OpenGL GLUT)
 
 # Add subdirectories
 add_subdirectory(osg)

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -1,39 +1,32 @@
+if(NOT DART_BUILD_GUI_OSG)
+  message(STATUS "Skipping OpenSceneGraph (DART_BUILD_GUI_OSG == ${DART_BUILD_GUI_OSG})")
+  return()
+endif()
+
 # Set local target name
 set(target_name ${PROJECT_NAME}-gui-osg)
 set(component_name gui-osg)
+set(component_dependencies )
+set(component_dependency_packages )
+set(link_libraries )
 
 # Dependency checks
 dart_check_dependent_target(${target_name} dart-gui)
 
-# Minimum required OSG version
-set(min_osg_version 3.0.0)
-# OpenSceneGraph 3.6.5 or less are not compatible with macOS 10.15 (Catalina) or greater
-# See:
-#   - https://github.com/openscenegraph/OpenSceneGraph/issues/926
-#   - https://github.com/dartsim/dart/issues/1439
-if(APPLE)
-  if(NOT ${CMAKE_SYSTEM_VERSION} VERSION_LESS 19)
-    set(min_osg_version 3.7.0)
-  endif()
-endif()
-
-set(component_dependency_packages )
-
 # OpenSceneGraph
-if(DART_BUILD_GUI_OSG)
-  dart_find_package(OpenSceneGraph)
-  dart_check_required_package(OpenSceneGraph "dart-gui-osg" "OpenSceneGraph" "3.0")
-  list(APPEND component_dependency_packages OpenSceneGraph)
+dart_find_package(OpenSceneGraph)
+dart_check_required_package(OpenSceneGraph "dart-gui-osg" "OpenSceneGraph")
+list(APPEND component_dependency_packages OpenSceneGraph)
 
-  # ImGui
-  if(DART_USE_SYSTEM_IMGUI)
-    dart_find_package(imgui)
-    dart_check_required_package(imgui "imgui")
-    list(APPEND component_dependency_packages imgui)
-  endif()
+# ImGui
+if(DART_USE_SYSTEM_IMGUI)
+  dart_find_package(imgui)
+  dart_check_required_package(imgui "imgui")
+  list(APPEND component_dependency_packages imgui)
+  list(APPEND link_libraries imgui::imgui)
 else()
-  message(STATUS "Skipping OpenSceneGraph (DART_BUILD_GUI_OSG == ${DART_BUILD_GUI_OSG})")
-  return()
+  list(APPEND component_dependencies external-imgui)
+  list(APPEND link_libraries ${PROJECT_NAME}-external-imgui)
 endif()
 
 # Search all header and source files
@@ -48,18 +41,10 @@ set(dart_gui_osg_srcs ${srcs} ${detail_srcs})
 add_subdirectory(render)
 
 # Add target
-if(DART_USE_SYSTEM_IMGUI)
-  set(link_libraries imgui::imgui)
-else()
-  set(link_libraries ${PROJECT_NAME}-external-imgui)
-endif()
 dart_add_library(${target_name} ${hdrs} ${srcs} ${dart_gui_osg_hdrs} ${dart_gui_osg_srcs})
 target_link_libraries(${target_name} dart-gui osg::osg ${link_libraries})
 
 # Component
-if(NOT DART_USE_SYSTEM_IMGUI)
-  set(component_dependencies external-imgui)
-endif()
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 add_component_dependencies(${PROJECT_NAME} ${component_name} gui ${component_dependencies})

--- a/dart/gui/osg/CMakeLists.txt
+++ b/dart/gui/osg/CMakeLists.txt
@@ -17,17 +17,19 @@ if(APPLE)
   endif()
 endif()
 
+set(component_dependency_packages )
+
 # OpenSceneGraph
 if(DART_BUILD_GUI_OSG)
   dart_find_package(OpenSceneGraph)
   dart_check_required_package(OpenSceneGraph "dart-gui-osg" "OpenSceneGraph" "3.0")
+  list(APPEND component_dependency_packages OpenSceneGraph)
 
   # ImGui
   if(DART_USE_SYSTEM_IMGUI)
     dart_find_package(imgui)
     dart_check_required_package(imgui "imgui")
-  else()
-    #
+    list(APPEND component_dependency_packages imgui)
   endif()
 else()
   message(STATUS "Skipping OpenSceneGraph (DART_BUILD_GUI_OSG == ${DART_BUILD_GUI_OSG})")
@@ -61,7 +63,7 @@ endif()
 add_component(${PROJECT_NAME} ${component_name})
 add_component_targets(${PROJECT_NAME} ${component_name} ${target_name})
 add_component_dependencies(${PROJECT_NAME} ${component_name} gui ${component_dependencies})
-add_component_dependency_packages(${PROJECT_NAME} ${component_name} OpenSceneGraph)
+add_component_dependency_packages(${PROJECT_NAME} ${component_name} ${component_dependency_packages})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "gui osg headers" ${hdrs})


### PR DESCRIPTION
This PR is to prevent the downstream packages need to manually add `find_package(imgui)`, which is not ideal.

The generated `dart_gui-osgComponent.cmake` should contain both `imgui` and `OpenSceneGraph`.

Before:

```cmake
set("dart_gui-osg_DEPENDENCIES" gui)
set("dart_gui-osg_LIBRARIES" dart-gui-osg)

set_property(DIRECTORY PROPERTY "DART_gui-osg_FOUND" TRUE)
foreach(external_dep OpenSceneGraph)
...
endforeach()
```

After:

```cmake
set("dart_gui-osg_DEPENDENCIES" gui)
set("dart_gui-osg_LIBRARIES" dart-gui-osg)

foreach(external_dep OpenSceneGraph;imgui)
...
endforeach()
```

I also changed the error to a warning for building with old OSG (< 3.7.0) on macOS to allow building with the old version but with a patch for the issue.

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
