### PR TITLE
CMake: add DART_USE_SYSTEM_PYBIND11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ dart_option(DART_FORCE_COLORED_OUTPUT
 dart_option(DART_USE_SYSTEM_IMGUI "Use system ImGui" OFF)
 dart_option(DART_USE_SYSTEM_GOOGLEBENCHMARK "Use system GoogleBenchmark" OFF)
 dart_option(DART_USE_SYSTEM_GOOGLETEST "Use system GoogleTest" OFF)
+dart_option(DART_USE_SYSTEM_PYBIND11 "Use system pybind11" OFF)
 
 #===============================================================================
 # Print intro

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -6,13 +6,17 @@ if(NOT DART_BUILD_DARTPY)
 endif()
 
 # Set up pybind11
-include(FetchContent)
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.12.0
-)
-FetchContent_MakeAvailable(pybind11)
+if(DART_USE_SYSTEM_PYBIND11)
+  find_package(pybind11 CONFIG REQUIRED)
+else()
+  include(FetchContent)
+  FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11
+    GIT_TAG v2.12.0
+  )
+  FetchContent_MakeAvailable(pybind11)
+endif()
 
 if(NOT pybind11_FOUND)
   message(WARNING "Disabling [dartpy] due to missing pybind11 >= 2.2.0.")


### PR DESCRIPTION
Hi,

This follows #1904, but for python bindings.
ref. https://pybind11.readthedocs.io/en/stable/compiling.html

***

#### Before creating a pull request

- [ ] Document new methods and classes
- [ ] Format new code files using ClangFormat by running `make format`
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve all the compile warnings

#### Before merging a pull request

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
- [ ] Add Python bindings for new methods and classes
