### PR TITLE
Fix identity comparisons in unit tests

### DIFF
--- a/python/tests/unit/collision/test_collision.py
+++ b/python/tests/unit/collision/test_collision.py
@@ -22,7 +22,7 @@ def collision_groups_tester(cd):
     group = cd.createCollisionGroup()
     group.addShapeFrame(simple_frame1)
     group.addShapeFrame(simple_frame2)
-    assert group.getNumShapeFrames() is 2
+    assert group.getNumShapeFrames() == 2
 
     #
     #    ( s1,s2 )              collision!
@@ -44,19 +44,19 @@ def collision_groups_tester(cd):
 
     group.collide(option, result)
     assert not result.isCollision()
-    assert result.getNumContacts() is 0
+    assert result.getNumContacts() == 0
 
     option.enableContact = True
     simple_frame2.setTranslation([1.99, 0, 0])
 
     group.collide(option, result)
     assert result.isCollision()
-    assert result.getNumContacts() is not 0
+    assert result.getNumContacts() != 0
 
     # Repeat the same test with BodyNodes instead of SimpleFrames
 
     group.removeAllShapeFrames()
-    assert group.getNumShapeFrames() is 0
+    assert group.getNumShapeFrames() == 0
 
     skel1 = dart.dynamics.Skeleton()
     skel2 = dart.dynamics.Skeleton()
@@ -75,7 +75,7 @@ def collision_groups_tester(cd):
     group.addShapeFramesOf(body1)
     group.addShapeFramesOf(body2)
 
-    assert group.getNumShapeFrames() is 2
+    assert group.getNumShapeFrames() == 2
 
     assert group.collide()
 
@@ -87,14 +87,14 @@ def collision_groups_tester(cd):
     joint2.setPosition(3, 0)
 
     group.removeAllShapeFrames()
-    assert group.getNumShapeFrames() is 0
+    assert group.getNumShapeFrames() == 0
     group2 = cd.createCollisionGroup()
 
     group.addShapeFramesOf(body1)
     group2.addShapeFramesOf(body2)
 
-    assert group.getNumShapeFrames() is 1
-    assert group2.getNumShapeFrames() is 1
+    assert group.getNumShapeFrames() == 1
+    assert group2.getNumShapeFrames() == 1
 
     assert group.collide(group2)
 

--- a/python/tests/unit/dynamics/test_inverse_kinematics.py
+++ b/python/tests/unit/dynamics/test_inverse_kinematics.py
@@ -26,8 +26,8 @@ def test_solve_for_free_joint():
     error_method = ik.getErrorMethod()
     assert error_method.getMethodName() == "TaskSpaceRegion"
     [lb, ub] = error_method.getBounds()
-    assert len(lb) is 6
-    assert len(ub) is 6
+    assert len(lb) == 6
+    assert len(ub) == 6
     error_method.setBounds(np.ones(6) * -1e-8, np.ones(6) * 1e-8)
     [lb, ub] = error_method.getBounds()
     assert lb == pytest.approx(-1e-8)

--- a/python/tests/unit/dynamics/test_meta_skeleton.py
+++ b/python/tests/unit/dynamics/test_meta_skeleton.py
@@ -19,16 +19,16 @@ def test_basic():
 
     chain1 = dart.dynamics.Chain(shoulder, elbow, False, "midchain")
     assert chain1 is not None
-    assert chain1.getNumBodyNodes() is 2
+    assert chain1.getNumBodyNodes() == 2
 
     chain2 = dart.dynamics.Chain(shoulder, elbow, True, "midchain")
     assert chain2 is not None
-    assert chain2.getNumBodyNodes() is 3
+    assert chain2.getNumBodyNodes() == 3
 
-    assert len(kr5.getPositions()) is not 0
-    assert kr5.getNumJoints() is not 0
+    assert len(kr5.getPositions()) != 0
+    assert kr5.getNumJoints() != 0
     assert kr5.getRootJoint() is not None
-    assert len(kr5.getRootJoint().getPositions()) is 0
+    assert len(kr5.getRootJoint().getPositions()) == 0
 
     rootBody = kr5.getBodyNode(0)
     assert rootBody is not None

--- a/python/tests/unit/math/test_random.py
+++ b/python/tests/unit/math/test_random.py
@@ -30,7 +30,7 @@ def test_seed():
 
     for i in range(N):
         Random.setSeed(i)
-        assert Random.getSeed() is i
+        assert Random.getSeed() == i
         assert Random.uniform(min, max) == pytest.approx(first[i], tol)
         assert Random.uniform(min, max) == pytest.approx(second[i], tol)
         assert Random.uniform(min, max) == pytest.approx(third[i], tol)

--- a/python/tests/unit/optimizer/test_optimizer.py
+++ b/python/tests/unit/optimizer/test_optimizer.py
@@ -32,7 +32,7 @@ class SampleConstFunc(dart.optimizer.Function):
 
 def test_gradient_descent_solver():
     prob = dart.optimizer.Problem(2)
-    assert prob.getDimension() is 2
+    assert prob.getDimension() == 2
 
     prob.setLowerBounds([-1e100, 0])
     prob.setInitialGuess([1.234, 5.678])
@@ -60,7 +60,7 @@ def test_nlopt_solver():
         return
 
     prob = dart.optimizer.Problem(2)
-    assert prob.getDimension() is 2
+    assert prob.getDimension() == 2
 
     prob.setLowerBounds([-1e100, 0])
     prob.setInitialGuess([1.234, 5.678])

--- a/python/tests/unit/simulation/test_world.py
+++ b/python/tests/unit/simulation/test_world.py
@@ -6,8 +6,8 @@ import pytest
 
 def test_empty_world():
     world = dart.simulation.World("my world")
-    assert world.getNumSkeletons() is 0
-    assert world.getNumSimpleFrames() is 0
+    assert world.getNumSkeletons() == 0
+    assert world.getNumSimpleFrames() == 0
 
 
 def test_collision_detector_change():


### PR DESCRIPTION
## Summary
- fix misuse of `is` for numeric equality checks in Python test suite

## Testing
- `python -m py_compile python/tests/unit/dynamics/test_inverse_kinematics.py`
- `python -m py_compile python/tests/unit/dynamics/test_meta_skeleton.py`
- `python -m py_compile python/tests/unit/optimizer/test_optimizer.py`
- `python -m py_compile python/tests/unit/collision/test_collision.py`
- `python -m py_compile python/tests/unit/simulation/test_world.py`
- `python -m py_compile python/tests/unit/math/test_random.py`
