### PR TITLE
Fix typo in CollisionGroup comment

### DIFF
--- a/dart/collision/CollisionGroup.cpp
+++ b/dart/collision/CollisionGroup.cpp
@@ -554,7 +554,7 @@ bool CollisionGroup::updateBodyNodeSource(BodyNodeSources::value_type& entry)
 
   const std::size_t currentBodyNodeVersion = bn->getVersion();
 
-  // If the version hasn't changed, then tehre will be nothing to update.
+  // If the version hasn't changed, then there will be nothing to update.
   if (currentBodyNodeVersion == source.mLastKnownVersion)
     return false;
 


### PR DESCRIPTION
## Summary
- fix typo "tehre" -> "there" in `CollisionGroup.cpp`

## Testing
- `n/a`