### PR TITLE
Fix API doc workflow for Ubuntu 24.04

### DIFF
--- a/.github/workflows/api_doc.yml
+++ b/.github/workflows/api_doc.yml
@@ -89,7 +89,6 @@ jobs:
             pybind11-dev
             python3
             python3-dev
-            python3-distutils
             python3-numpy
             python3-pip
             python3-setuptools


### PR DESCRIPTION
## Summary
- fix apt package list for API docs workflow

## Testing
- `pytest -q` *(fails: command not found)*