### PR TITLE
Fix API doc workflow for Ubuntu 24.04

### DIFF
--- a/.github/workflows/api_doc.yml
+++ b/.github/workflows/api_doc.yml
@@ -56,7 +56,7 @@ jobs:
             build-essential
             libboost-all-dev
             clang
-            clang-format-12
+            clang-format-14
             cmake
             curl
             doxygen
@@ -89,7 +89,6 @@ jobs:
             pybind11-dev
             python3
             python3-dev
-            python3-distutils
             python3-numpy
             python3-pip
             python3-setuptools

--- a/.github/workflows/api_doc.yml
+++ b/.github/workflows/api_doc.yml
@@ -92,7 +92,7 @@ jobs:
             python3-numpy
             python3-pip
             python3-setuptools
-          version: 1.1
+          version: 1.2
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Summary
- fix apt package list for API docs workflow
- install `clang-format-14` instead of unavailable `clang-format-12`

## Testing
- `pytest -q` *(fails: command not found)*
