### PR TITLE
Fix passive joint commands

### DIFF
--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -401,7 +401,7 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
           Base::mAspectProperties.mForceUpperLimits);
       break;
     case Joint::PASSIVE:
-      if (Vector::Zero() != commands) {
+      if (!commands.isZero()) {
         dtwarn << "[GenericJoint::setCommands] Attempting to set a non-zero ("
                << commands.transpose() << ") command for a PASSIVE joint ["
                << this->getName() << "].\n";
@@ -415,7 +415,7 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
           Base::mAspectProperties.mVelocityUpperLimits);
       break;
     case Joint::MIMIC:
-      if (Vector::Zero() != commands) {
+      if (!commands.isZero()) {
         dtwarn << "[GenericJoint::setCommands] Attempting to set a non-zero ("
                << commands.transpose() << ") command for a MIMIC joint ["
                << this->getName() << "].\n";
@@ -436,7 +436,7 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
       // TODO: This possibly makes the acceleration to exceed the limits.
       break;
     case Joint::LOCKED:
-      if (Vector::Zero() != commands) {
+      if (!commands.isZero()) {
         dtwarn << "[GenericJoint::setCommands] Attempting to set a non-zero ("
                << commands.transpose() << ") command for a LOCKED joint ["
                << this->getName() << "].\n";

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -329,7 +329,7 @@ void GenericJoint<ConfigSpaceT>::setCommand(size_t index, double command)
                << command << ") command for a PASSIVE joint ["
                << this->getName() << "].\n";
       }
-      this->mAspectState.mCommands[index] = command;
+      this->mAspectState.mCommands[index] = 0.0;
       break;
     case Joint::SERVO:
       this->mAspectState.mCommands[index] = math::clip(
@@ -343,10 +343,7 @@ void GenericJoint<ConfigSpaceT>::setCommand(size_t index, double command)
                << command << ") command for a MIMIC joint [" << this->getName()
                << "].\n";
       }
-      this->mAspectState.mCommands[index] = math::clip(
-          command,
-          Base::mAspectProperties.mVelocityLowerLimits[index],
-          Base::mAspectProperties.mVelocityUpperLimits[index]);
+      this->mAspectState.mCommands[index] = 0.0;
       break;
     case Joint::ACCELERATION:
       this->mAspectState.mCommands[index] = math::clip(
@@ -367,7 +364,7 @@ void GenericJoint<ConfigSpaceT>::setCommand(size_t index, double command)
                << command << ") command for a LOCKED joint [" << this->getName()
                << "].\n";
       }
-      this->mAspectState.mCommands[index] = command;
+      this->mAspectState.mCommands[index] = 0.0;
       break;
     default:
       assert(false);
@@ -409,7 +406,7 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
                << commands.transpose() << ") command for a PASSIVE joint ["
                << this->getName() << "].\n";
       }
-      this->mAspectState.mCommands = commands;
+      this->mAspectState.mCommands.setZero();
       break;
     case Joint::SERVO:
       this->mAspectState.mCommands = math::clip(
@@ -423,10 +420,7 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
                << commands.transpose() << ") command for a MIMIC joint ["
                << this->getName() << "].\n";
       }
-      this->mAspectState.mCommands = math::clip(
-          commands,
-          Base::mAspectProperties.mVelocityLowerLimits,
-          Base::mAspectProperties.mVelocityUpperLimits);
+      this->mAspectState.mCommands.setZero();
       break;
     case Joint::ACCELERATION:
       this->mAspectState.mCommands = math::clip(
@@ -447,7 +441,7 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
                << commands.transpose() << ") command for a LOCKED joint ["
                << this->getName() << "].\n";
       }
-      this->mAspectState.mCommands = commands;
+      this->mAspectState.mCommands.setZero();
       break;
     default:
       assert(false);
@@ -1332,8 +1326,9 @@ void GenericJoint<ConfigSpaceT>::integratePositions(double dt)
 template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::integrateVelocities(double dt)
 {
-  setVelocitiesStatic(math::integrateVelocity<ConfigSpaceT>(
-      getVelocitiesStatic(), getAccelerationsStatic(), dt));
+  setVelocitiesStatic(
+      math::integrateVelocity<ConfigSpaceT>(
+          getVelocitiesStatic(), getAccelerationsStatic(), dt));
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -1326,9 +1326,8 @@ void GenericJoint<ConfigSpaceT>::integratePositions(double dt)
 template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::integrateVelocities(double dt)
 {
-  setVelocitiesStatic(
-      math::integrateVelocity<ConfigSpaceT>(
-          getVelocitiesStatic(), getAccelerationsStatic(), dt));
+  setVelocitiesStatic(math::integrateVelocity<ConfigSpaceT>(
+      getVelocitiesStatic(), getAccelerationsStatic(), dt));
 }
 
 //==============================================================================

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -135,6 +135,15 @@ if(TARGET dart-utils)
     target_link_libraries(test_Collision dart-collision-ode)
   endif()
 
+  dart_add_test("integration" test_Issue1899)
+  target_link_libraries(test_Issue1899 dart-utils)
+  if(TARGET dart-collision-bullet)
+    target_link_libraries(test_Issue1899 dart-collision-bullet)
+  endif()
+  if(TARGET dart-collision-ode)
+    target_link_libraries(test_Issue1899 dart-collision-ode)
+  endif()
+
   dart_add_test("integration" test_Dynamics)
   target_link_libraries(test_Dynamics dart-utils)
 

--- a/tests/integration/test_Issue1899.cpp
+++ b/tests/integration/test_Issue1899.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/dynamics.hpp"
+#include "dart/math/math.hpp"
+#include "dart/simulation/simulation.hpp"
+#include "dart/utils/utils.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace dart;
+using namespace dynamics;
+using namespace math;
+using namespace simulation;
+using namespace utils;
+
+// Regression test for https://github.com/dartsim/dart/issues/1899.
+//
+// This reproduces the scenario provided in the attachment
+// "Test_code_and_Reproduction_File.tar.gz" where a non-zero command is
+// applied to a PASSIVE joint while stepping the world without resetting joint
+// commands. Prior to the fix, ODE would assert when solving the constraints.
+TEST(Issue1899, CollisionOfPrescribedJointsReproduction)
+{
+  const double tol = 1e-9;
+  const double timeStep = 1e-3;
+  const std::size_t numFrames = 5;
+
+  auto world = SkelParser::readWorld(
+      "dart://sample/skel/test/collision_of_prescribed_joints_test.skel");
+  ASSERT_NE(world, nullptr);
+  world->setTimeStep(timeStep);
+  ASSERT_NEAR(world->getTimeStep(), timeStep, tol);
+
+  auto skel1 = world->getSkeleton("skeleton 1");
+  auto skel2 = world->getSkeleton("skeleton 2");
+  auto skel3 = world->getSkeleton("skeleton 3");
+  auto skel4 = world->getSkeleton("skeleton 4");
+  auto skel5 = world->getSkeleton("skeleton 5");
+  auto skel6 = world->getSkeleton("skeleton 6");
+  ASSERT_NE(skel1, nullptr);
+  ASSERT_NE(skel2, nullptr);
+  ASSERT_NE(skel3, nullptr);
+  ASSERT_NE(skel4, nullptr);
+  ASSERT_NE(skel5, nullptr);
+  ASSERT_NE(skel6, nullptr);
+
+  Joint* joint1 = skel1->getJoint(0);
+  Joint* joint2 = skel2->getJoint(0);
+  Joint* joint3 = skel3->getJoint(0);
+  Joint* joint4 = skel4->getJoint(0);
+  Joint* joint5 = skel5->getJoint(0);
+  Joint* joint6 = skel6->getJoint(0);
+  ASSERT_NE(joint1, nullptr);
+  ASSERT_NE(joint2, nullptr);
+  ASSERT_NE(joint3, nullptr);
+  ASSERT_NE(joint4, nullptr);
+  ASSERT_NE(joint5, nullptr);
+  ASSERT_NE(joint6, nullptr);
+  ASSERT_EQ(joint1->getActuatorType(), Joint::FORCE);
+  ASSERT_EQ(joint2->getActuatorType(), Joint::PASSIVE);
+  ASSERT_EQ(joint3->getActuatorType(), Joint::SERVO);
+  ASSERT_EQ(joint4->getActuatorType(), Joint::ACCELERATION);
+  ASSERT_EQ(joint5->getActuatorType(), Joint::VELOCITY);
+  ASSERT_EQ(joint6->getActuatorType(), Joint::LOCKED);
+
+  for (std::size_t i = 0; i < numFrames; ++i) {
+    const double time = world->getTime();
+
+    joint1->setCommand(0, -0.5 * constantsd::pi() * std::cos(time));
+    joint2->setCommand(0, -0.5 * constantsd::pi() * std::cos(time));
+    joint3->setCommand(0, -0.5 * constantsd::pi() * std::cos(time));
+    joint4->setCommand(0, -0.5 * constantsd::pi() * std::cos(time));
+    joint5->setCommand(0, -0.5 * constantsd::pi() * std::sin(time));
+    joint6->setCommand(0, -0.5 * constantsd::pi() * std::sin(time));
+
+    // Do not reset joint commands after stepping.
+    world->step(false);
+
+    EXPECT_TRUE(joint1->isDynamic());
+    EXPECT_TRUE(joint2->isDynamic());
+    EXPECT_TRUE(joint3->isDynamic());
+
+    EXPECT_TRUE(joint4->isKinematic());
+    EXPECT_NEAR(joint4->getAcceleration(0), joint4->getCommand(0), tol);
+    EXPECT_TRUE(joint5->isKinematic());
+    EXPECT_NEAR(joint5->getVelocity(0), joint5->getCommand(0), tol);
+
+    // The PASSIVE joint's command should have been cleared.
+    EXPECT_EQ(joint2->getCommand(0), 0.0);
+
+    EXPECT_TRUE(joint6->isKinematic());
+    EXPECT_NEAR(joint6->getVelocity(0), 0.0, tol);
+    EXPECT_NEAR(joint6->getAcceleration(0), 0.0, tol);
+  }
+}


### PR DESCRIPTION
## Summary
- Prevent non-zero commands from being stored on passive, mimic, and locked joints
- Add regression test for issue #1899 ensuring passive joint commands are ignored
- Register new regression test in integration CMake configuration

## Testing
- `cmake --build build --target test_Issue1899`
- `cd build && ctest -R test_Issue1899`


------
https://chatgpt.com/codex/tasks/task_e_688f9bc8414483228684aab2604ed0fe