### PR TITLE
Fix nondeterministic finite difference test

### DIFF
--- a/tests/integration/test_Dynamics.cpp
+++ b/tests/integration/test_Dynamics.cpp
@@ -2270,6 +2270,7 @@ TEST_F(DynamicsTest, testJacobians)
 //==============================================================================
 TEST_F(DynamicsTest, testFiniteDifference)
 {
+  dart::math::Random::setSeed(42);
   for (std::size_t i = 0; i < getList().size(); ++i) {
 #if DART_BUILD_MODE_DEBUG
     dtdbg << getList()[i].toString() << std::endl;


### PR DESCRIPTION
## Summary
- seed Random generator in `DynamicsTest.testFiniteDifference` for reproducible state generation

## Testing
- `pixi run test` *(fails: build step did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68939b44a7c88322bb1422056ff0a3d2