### PR TITLE
Change how version requirement for Eigen3 package is enforced

### DIFF
--- a/cmake/DARTFindEigen3.cmake
+++ b/cmake/DARTFindEigen3.cmake
@@ -7,3 +7,7 @@
 # This file is provided under the "BSD-style" License
 
 find_package(Eigen3 REQUIRED CONFIG)
+
+if (Eigen3_VERSION VERSION_LESS 3.4)
+  message(FATAL_ERROR "Eigen version>=3.4 is required, but found ${Eigen3_VERSION}")
+endif()


### PR DESCRIPTION
Eigen3 5.0.0 was released some time ago, and now it is start being used in package managers, see https://github.com/Homebrew/homebrew-core/pull/246477 and https://github.com/conda-forge/eigen-feedstock/pull/47 . 

As `Eigen3` is not released with version 5.0.0, and the CMake version config considers version to be compatible if they have the same major version, requiring Eigen3 3.4.0 does not work with Eigen3 5.0.0, so we can't pass the version directly to the `find_package` anymore. See https://gitlab.com/libeigen/eigen/-/issues/2972 and https://github.com/PointCloudLibrary/pcl/pull/6354 .

#### Before creating a pull request

- [x] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
