### PR TITLE
Port Eigen version guard to release-6.16

### DIFF
--- a/cmake/DARTFindEigen3.cmake
+++ b/cmake/DARTFindEigen3.cmake
@@ -7,3 +7,7 @@
 # This file is provided under the "BSD-style" License
 
 find_package(Eigen3 REQUIRED CONFIG)
+
+if (Eigen3_VERSION VERSION_LESS 3.4)
+  message(FATAL_ERROR "Eigen version>=3.4 is required, but found ${Eigen3_VERSION}")
+endif()


### PR DESCRIPTION
Cherry-picks #2107 onto release-6.16 to relax the Eigen3 package requirement while still enforcing the 3.4 minimum.