### PR TITLE
Replace assert with DART_ASSERT

### DIFF
--- a/dart/collision/CollisionDetector.cpp
+++ b/dart/collision/CollisionDetector.cpp
@@ -35,6 +35,7 @@
 #include "dart/collision/CollisionGroup.hpp"
 #include "dart/collision/CollisionObject.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 
@@ -91,7 +92,7 @@ CollisionDetector::CollisionObjectManager::CollisionObjectManager(
     CollisionDetector* cd)
   : mCollisionDetector(cd)
 {
-  assert(cd);
+  DART_ASSERT(cd);
 }
 
 //==============================================================================
@@ -127,7 +128,7 @@ CollisionDetector::ManagerForUnsharableCollisionObjects::
         ManagerForUnsharableCollisionObjects* mgr)
   : mCollisionObjectManager(mgr)
 {
-  assert(mgr);
+  DART_ASSERT(mgr);
 }
 
 //==============================================================================
@@ -152,7 +153,7 @@ CollisionDetector::ManagerForSharableCollisionObjects::
 CollisionDetector::ManagerForSharableCollisionObjects::
     ~ManagerForSharableCollisionObjects()
 {
-  assert(mCollisionObjectMap.empty());
+  DART_ASSERT(mCollisionObjectMap.empty());
 }
 
 //==============================================================================
@@ -165,7 +166,7 @@ CollisionDetector::ManagerForSharableCollisionObjects::claimCollisionObject(
   const auto found = mCollisionObjectMap.end() != search;
   if (found) {
     const auto& collObj = search->second;
-    assert(collObj.lock());
+    DART_ASSERT(collObj.lock());
     // Ensure all the collision objects in the map are valid pointers
 
     return collObj.lock();
@@ -185,7 +186,7 @@ CollisionDetector::ManagerForSharableCollisionObjects::CollisionObjectDeleter::
     CollisionObjectDeleter(ManagerForSharableCollisionObjects* mgr)
   : mCollisionObjectManager(mgr)
 {
-  assert(mgr);
+  DART_ASSERT(mgr);
 }
 
 //==============================================================================

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/CollisionFilter.hpp"
 
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 
 namespace dart {
@@ -163,7 +164,7 @@ bool BodyNodeCollisionFilter::areAdjacentBodies(
 {
   if ((bodyNode1->getParentBodyNode() == bodyNode2)
       || (bodyNode2->getParentBodyNode() == bodyNode1)) {
-    assert(bodyNode1->getSkeleton() == bodyNode2->getSkeleton());
+    DART_ASSERT(bodyNode1->getSkeleton() == bodyNode2->getSkeleton());
     return true;
   }
 

--- a/dart/collision/CollisionGroup.cpp
+++ b/dart/collision/CollisionGroup.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/collision/CollisionDetector.hpp"
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 
@@ -46,7 +47,7 @@ namespace collision {
 CollisionGroup::CollisionGroup(const CollisionDetectorPtr& collisionDetector)
   : mCollisionDetector(collisionDetector), mUpdateAutomatically(true)
 {
-  assert(mCollisionDetector);
+  DART_ASSERT(mCollisionDetector);
 }
 
 //==============================================================================
@@ -184,7 +185,7 @@ std::size_t CollisionGroup::getNumShapeFrames() const
 const dynamics::ShapeFrame* CollisionGroup::getShapeFrame(
     std::size_t index) const
 {
-  assert(index < mObjectInfoList.size());
+  DART_ASSERT(index < mObjectInfoList.size());
   if (index < mObjectInfoList.size())
     return mObjectInfoList[index]->mFrame;
 

--- a/dart/collision/CollisionObject.cpp
+++ b/dart/collision/CollisionObject.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/CollisionObject.hpp"
 
 #include "dart/collision/CollisionDetector.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/ShapeFrame.hpp"
 
 namespace dart {
@@ -74,8 +75,8 @@ CollisionObject::CollisionObject(
     const dynamics::ShapeFrame* shapeFrame)
   : mCollisionDetector(collisionDetector), mShapeFrame(shapeFrame)
 {
-  assert(mCollisionDetector);
-  assert(mShapeFrame);
+  DART_ASSERT(mCollisionDetector);
+  DART_ASSERT(mShapeFrame);
 }
 
 } // namespace collision

--- a/dart/collision/CollisionResult.cpp
+++ b/dart/collision/CollisionResult.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/CollisionResult.hpp"
 
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/ShapeFrame.hpp"
 #include "dart/dynamics/ShapeNode.hpp"
@@ -57,7 +58,7 @@ std::size_t CollisionResult::getNumContacts() const
 //==============================================================================
 Contact& CollisionResult::getContact(std::size_t index)
 {
-  assert(index < mContacts.size());
+  DART_ASSERT(index < mContacts.size());
 
   return mContacts[index];
 }
@@ -65,7 +66,7 @@ Contact& CollisionResult::getContact(std::size_t index)
 //==============================================================================
 const Contact& CollisionResult::getContact(std::size_t index) const
 {
-  assert(index < mContacts.size());
+  DART_ASSERT(index < mContacts.size());
 
   return mContacts[index];
 }
@@ -130,7 +131,7 @@ void CollisionResult::addObject(CollisionObject* object)
         "[CollisionResult::addObject] Attempting to add a collision with a "
         "nullptr object to a CollisionResult instance. This is not allowed. "
         "Please report this as a bug!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 

--- a/dart/collision/DistanceFilter.cpp
+++ b/dart/collision/DistanceFilter.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/DistanceFilter.hpp"
 
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 
 namespace dart {
@@ -81,7 +82,7 @@ bool BodyNodeDistanceFilter::areAdjacentBodies(
 {
   if ((bodyNode1->getParentBodyNode() == bodyNode2)
       || (bodyNode2->getParentBodyNode() == bodyNode1)) {
-    assert(bodyNode1->getSkeleton() == bodyNode2->getSkeleton());
+    DART_ASSERT(bodyNode1->getSkeleton() == bodyNode2->getSkeleton());
     return true;
   }
 

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -41,6 +41,7 @@
 #include "dart/collision/bullet/detail/BulletCollisionDispatcher.hpp"
 #include "dart/collision/bullet/detail/BulletOverlapFilterCallback.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
@@ -117,7 +118,7 @@ std::shared_ptr<BulletCollisionDetector> BulletCollisionDetector::create()
 //==============================================================================
 BulletCollisionDetector::~BulletCollisionDetector()
 {
-  assert(mShapeMap.empty());
+  DART_ASSERT(mShapeMap.empty());
 }
 
 //==============================================================================
@@ -165,10 +166,10 @@ static bool checkGroupValidity(
 //==============================================================================
 static bool isCollision(btCollisionWorld* world)
 {
-  assert(world);
+  DART_ASSERT(world);
 
   auto dispatcher = world->getDispatcher();
-  assert(dispatcher);
+  DART_ASSERT(dispatcher);
 
   const auto numManifolds = dispatcher->getNumManifolds();
 
@@ -185,11 +186,11 @@ static bool isCollision(btCollisionWorld* world)
 //==============================================================================
 void filterOutCollisions(btCollisionWorld* world)
 {
-  assert(world);
+  DART_ASSERT(world);
 
   auto dispatcher
       = static_cast<detail::BulletCollisionDispatcher*>(world->getDispatcher());
-  assert(dispatcher);
+  DART_ASSERT(dispatcher);
 
   const auto filter = dispatcher->getFilter();
   if (!filter)
@@ -431,7 +432,7 @@ BulletCollisionDetector::claimBulletCollisionShape(
 
   if (!inserted && currentVersion == info.mLastKnownVersion) {
     const auto& bulletCollShape = info.mShape.lock();
-    assert(bulletCollShape);
+    DART_ASSERT(bulletCollShape);
 
     return bulletCollShape;
   }
@@ -577,7 +578,7 @@ BulletCollisionDetector::createBulletCollisionShape(
   } else if (const auto heightMap = shape->as<HeightmapShapef>()) {
     return createBulletCollisionShapeFromHeightmap(heightMap);
   } else if (shape->is<HeightmapShaped>()) {
-    assert(dynamic_cast<const HeightmapShaped*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const HeightmapShaped*>(shape.get()));
 
     DART_ERROR(
         "[BulletCollisionDetector::createBulletCollisionShape] Bullet does not "
@@ -629,8 +630,8 @@ Contact convertContact(
     BulletCollisionObject* collObj1,
     BulletCollisionObject* collObj2)
 {
-  assert(collObj1);
-  assert(collObj2);
+  DART_ASSERT(collObj1);
+  DART_ASSERT(collObj2);
 
   Contact contact;
 
@@ -649,11 +650,11 @@ void reportContacts(
     const CollisionOption& option,
     CollisionResult& result)
 {
-  assert(world);
+  DART_ASSERT(world);
 
   auto dispatcher
       = static_cast<detail::BulletCollisionDispatcher*>(world->getDispatcher());
-  assert(dispatcher);
+  DART_ASSERT(dispatcher);
 
   const auto numManifolds = dispatcher->getNumManifolds();
 
@@ -699,11 +700,11 @@ RayHit convertRayHit(
     btScalar closestHitFraction)
 {
   RayHit rayHit;
-  assert(btCollObj);
+  DART_ASSERT(btCollObj);
   const auto* userPointer = btCollObj->getUserPointer();
-  assert(userPointer);
+  DART_ASSERT(userPointer);
   const auto* collObj = static_cast<const BulletCollisionObject*>(userPointer);
-  assert(collObj);
+  DART_ASSERT(collObj);
   rayHit.mCollisionObject = collObj;
   rayHit.mPoint = convertVector3(hitPointWorld);
   rayHit.mNormal = convertVector3(hitNormalWorld);
@@ -719,7 +720,7 @@ void reportRayHits(
     RaycastResult& result)
 {
   // This function shouldn't be called if callback has not ray hit.
-  assert(callback.hasHit());
+  DART_ASSERT(callback.hasHit());
 
   const auto rayHit = convertRayHit(
       callback.m_collisionObject,

--- a/dart/collision/bullet/BulletCollisionObject.cpp
+++ b/dart/collision/bullet/BulletCollisionObject.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/bullet/BulletCollisionObject.hpp"
 
 #include "dart/collision/bullet/BulletTypes.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/ShapeFrame.hpp"
 
 namespace dart {
@@ -59,7 +60,7 @@ BulletCollisionObject::BulletCollisionObject(
     mBulletCollisionShape(bulletCollisionShape),
     mBulletCollisionObject(new btCollisionObject())
 {
-  assert(bulletCollisionShape);
+  DART_ASSERT(bulletCollisionShape);
 
   mBulletCollisionObject->setCollisionShape(
       mBulletCollisionShape->mCollisionShape.get());

--- a/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
+++ b/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
@@ -35,6 +35,7 @@
 #include "dart/collision/CollisionFilter.hpp"
 #include "dart/collision/bullet/BulletCollisionGroup.hpp"
 #include "dart/collision/bullet/BulletCollisionObject.hpp"
+#include "dart/common/Macros.hpp"
 
 namespace dart {
 namespace collision {
@@ -61,7 +62,7 @@ bool BulletOverlapFilterCallback::needBroadphaseCollision(
   if (done)
     return false;
 
-  assert(
+  DART_ASSERT(
       (proxy0 != nullptr && proxy1 != nullptr)
       && "Bullet broadphase overlapping pair proxies are nullptr");
 

--- a/dart/collision/detail/CollisionGroup.hpp
+++ b/dart/collision/detail/CollisionGroup.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_DETAIL_COLLISIONGROUP_HPP_
 #define DART_COLLISION_DETAIL_COLLISIONGROUP_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/collision/CollisionGroup.hpp>
 
 #include <dart/dynamics/BodyNode.hpp>
@@ -67,7 +69,7 @@ template <typename... Others>
 void CollisionGroup::addShapeFramesOf(
     const CollisionGroup* otherGroup, const Others*... others)
 {
-  assert(otherGroup);
+  DART_ASSERT(otherGroup);
 
   if (otherGroup && this != otherGroup) {
     for (const auto& info : otherGroup->mObjectInfoList)
@@ -82,7 +84,7 @@ template <typename... Others>
 void CollisionGroup::addShapeFramesOf(
     const dynamics::BodyNode* bodyNode, const Others*... others)
 {
-  assert(bodyNode);
+  DART_ASSERT(bodyNode);
 
   bodyNode->eachShapeNodeWith<dynamics::CollisionAspect>(
       [this](const dynamics::ShapeNode* shapeNode) {
@@ -97,7 +99,7 @@ template <typename... Others>
 void CollisionGroup::addShapeFramesOf(
     const dynamics::MetaSkeleton* skel, const Others*... others)
 {
-  assert(skel);
+  DART_ASSERT(skel);
 
   auto numBodyNodes = skel->getNumBodyNodes();
   for (auto i = 0u; i < numBodyNodes; ++i)
@@ -185,7 +187,7 @@ template <typename... Others>
 void CollisionGroup::removeShapeFramesOf(
     const CollisionGroup* otherGroup, const Others*... others)
 {
-  assert(otherGroup);
+  DART_ASSERT(otherGroup);
 
   if (otherGroup) {
     if (this == otherGroup) {
@@ -205,7 +207,7 @@ template <typename... Others>
 void CollisionGroup::removeShapeFramesOf(
     const dynamics::BodyNode* bodyNode, const Others*... others)
 {
-  assert(bodyNode);
+  DART_ASSERT(bodyNode);
 
   bodyNode->eachShapeNodeWith<dynamics::CollisionAspect>(
       [&](const dynamics::ShapeNode* shapeNode) {
@@ -220,7 +222,7 @@ template <typename... Others>
 void CollisionGroup::removeShapeFramesOf(
     const dynamics::MetaSkeleton* skel, const Others*... others)
 {
-  assert(skel);
+  DART_ASSERT(skel);
 
   auto numBodyNodes = skel->getNumBodyNodes();
   for (auto i = 0u; i < numBodyNodes; ++i)

--- a/dart/collision/fcl/CollisionShapes.hpp
+++ b/dart/collision/fcl/CollisionShapes.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COLLISION_FCL_MESH_COLLISIONSHAPES_HPP_
 #define DART_COLLISION_FCL_MESH_COLLISIONSHAPES_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/collision/fcl/BackwardCompatibility.hpp>
 
 #include <dart/math/Constants.hpp>
@@ -52,7 +54,7 @@ template <class BV>
     const aiScene* _mesh,
     const dart::collision::fcl::Transform3& _transform)
 {
-  assert(_mesh);
+  DART_ASSERT(_mesh);
   ::fcl::BVHModel<BV>* model = new ::fcl::BVHModel<BV>;
   model->beginModel();
 

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -40,6 +40,7 @@
 #include "dart/collision/fcl/FCLTypes.hpp"
 #include "dart/collision/fcl/tri_tri_intersection_test.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
@@ -535,7 +536,7 @@ template <class BV>
 {
   // Create FCL mesh from Assimp mesh
 
-  assert(_mesh);
+  DART_ASSERT(_mesh);
   ::fcl::BVHModel<BV>* model = new ::fcl::BVHModel<BV>;
   model->beginModel();
   for (std::size_t i = 0; i < _mesh->mNumMeshes; i++) {
@@ -561,7 +562,7 @@ template <class BV>
 {
   // Create FCL mesh from Assimp mesh
 
-  assert(_mesh);
+  DART_ASSERT(_mesh);
   ::fcl::BVHModel<BV>* model = new ::fcl::BVHModel<BV>;
   model->beginModel();
 
@@ -597,7 +598,7 @@ std::shared_ptr<FCLCollisionDetector> FCLCollisionDetector::create()
 //==============================================================================
 FCLCollisionDetector::~FCLCollisionDetector()
 {
-  assert(mShapeMap.empty());
+  DART_ASSERT(mShapeMap.empty());
 }
 
 //==============================================================================
@@ -663,7 +664,7 @@ bool FCLCollisionDetector::collide(
       option, result, mPrimitiveShapeType, mContactPointComputationMethod);
 
   const auto* collMgr = casted->getFCLCollisionManager();
-  assert(collMgr);
+  DART_ASSERT(collMgr);
   collMgr->collide(&collData, collisionCallback);
 
   return collData.isCollision();
@@ -841,7 +842,7 @@ FCLCollisionDetector::claimFCLCollisionGeometry(
 
   if (!inserted && currentVersion == info.mLastKnownVersion) {
     const auto& fclCollGeom = info.mShape;
-    assert(fclCollGeom.lock());
+    DART_ASSERT(fclCollGeom.lock());
     // Ensure all the collision geometry in the map should be alive pointers.
 
     return fclCollGeom.lock();
@@ -880,7 +881,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
   const auto& shapeType = shape->getType();
 
   if (SphereShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const SphereShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const SphereShape*>(shape.get()));
 
     auto* sphere = static_cast<const SphereShape*>(shape.get());
     const auto radius = sphere->getRadius();
@@ -891,7 +892,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
       geom = createEllipsoid<fcl::OBBRSS>(
           radius * 2.0, radius * 2.0, radius * 2.0);
   } else if (BoxShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const BoxShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const BoxShape*>(shape.get()));
 
     auto box = static_cast<const BoxShape*>(shape.get());
     const Eigen::Vector3d& size = box->getSize();
@@ -901,7 +902,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
     else
       geom = createCube<fcl::OBBRSS>(size[0], size[1], size[2]);
   } else if (EllipsoidShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const EllipsoidShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const EllipsoidShape*>(shape.get()));
 
     auto ellipsoid = static_cast<const EllipsoidShape*>(shape.get());
     const Eigen::Vector3d& radii = ellipsoid->getRadii();
@@ -913,7 +914,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
           radii[0] * 2.0, radii[1] * 2.0, radii[2] * 2.0);
     }
   } else if (CylinderShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const CylinderShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const CylinderShape*>(shape.get()));
 
     const auto cylinder = static_cast<const CylinderShape*>(shape.get());
     const auto radius = cylinder->getRadius();
@@ -929,7 +930,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
       geom = createCylinder<fcl::OBBRSS>(radius, radius, height, 16, 16);
     }
   } else if (ConeShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const ConeShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const ConeShape*>(shape.get()));
 
     const auto cone = std::static_pointer_cast<const ConeShape>(shape);
     const auto radius = cone->getRadius();
@@ -953,14 +954,14 @@ FCLCollisionDetector::createFCLCollisionGeometry(
       geom = fclMesh;
     }
   } else if (PyramidShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const PyramidShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const PyramidShape*>(shape.get()));
 
     const auto pyramid = std::static_pointer_cast<const PyramidShape>(shape);
     // Use mesh since FCL doesn't support pyramid shape.
     geom = createPyramid<fcl::OBBRSS>(*pyramid, fcl::getTransform3Identity());
   } else if (PlaneShape::getStaticType() == shapeType) {
     if (FCLCollisionDetector::PRIMITIVE == type) {
-      assert(dynamic_cast<const PlaneShape*>(shape.get()));
+      DART_ASSERT(dynamic_cast<const PlaneShape*>(shape.get()));
       auto plane = static_cast<const PlaneShape*>(shape.get());
       const Eigen::Vector3d normal = plane->getNormal();
       const double offset = plane->getOffset();
@@ -975,7 +976,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
           "size is [1000 0 1000].");
     }
   } else if (MeshShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const MeshShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const MeshShape*>(shape.get()));
 
     auto shapeMesh = static_cast<const MeshShape*>(shape.get());
     const Eigen::Vector3d& scale = shapeMesh->getScale();
@@ -983,7 +984,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
 
     geom = createMesh<fcl::OBBRSS>(scale[0], scale[1], scale[2], aiScene);
   } else if (SoftMeshShape::getStaticType() == shapeType) {
-    assert(dynamic_cast<const SoftMeshShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const SoftMeshShape*>(shape.get()));
 
     auto softMeshShape = static_cast<const SoftMeshShape*>(shape.get());
     auto aiMesh = softMeshShape->getAssimpMesh();
@@ -993,7 +994,7 @@ FCLCollisionDetector::createFCLCollisionGeometry(
 #if HAVE_OCTOMAP
   else if (VoxelGridShape::getStaticType() == shapeType) {
   #if FCL_HAVE_OCTOMAP
-    assert(dynamic_cast<const VoxelGridShape*>(shape.get()));
+    DART_ASSERT(dynamic_cast<const VoxelGridShape*>(shape.get()));
 
     auto octreeShape = static_cast<const VoxelGridShape*>(shape.get());
     auto octree = octreeShape->getOctree();
@@ -1028,8 +1029,8 @@ FCLCollisionDetector::FCLCollisionGeometryDeleter::FCLCollisionGeometryDeleter(
     FCLCollisionDetector* cd, const dynamics::ConstShapePtr& shape)
   : mFCLCollisionDetector(cd), mShape(shape)
 {
-  assert(cd);
-  assert(shape);
+  DART_ASSERT(cd);
+  DART_ASSERT(shape);
 }
 
 //==============================================================================
@@ -1065,8 +1066,8 @@ bool collisionCallback(
   if (filter) {
     auto collisionObject1 = static_cast<FCLCollisionObject*>(o1->getUserData());
     auto collisionObject2 = static_cast<FCLCollisionObject*>(o2->getUserData());
-    assert(collisionObject1);
-    assert(collisionObject2);
+    DART_ASSERT(collisionObject1);
+    DART_ASSERT(collisionObject2);
 
     if (filter->ignoresCollision(collisionObject2, collisionObject1))
       return collData->done;
@@ -1125,8 +1126,8 @@ bool distanceCallback(
   if (filter) {
     auto collisionObject1 = static_cast<FCLCollisionObject*>(o1->getUserData());
     auto collisionObject2 = static_cast<FCLCollisionObject*>(o2->getUserData());
-    assert(collisionObject1);
-    assert(collisionObject2);
+    DART_ASSERT(collisionObject1);
+    DART_ASSERT(collisionObject2);
 
     if (!filter->needDistance(collisionObject2, collisionObject1))
       return distData->done;

--- a/dart/collision/fcl/FCLCollisionObject.cpp
+++ b/dart/collision/fcl/FCLCollisionObject.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/fcl/FCLCollisionObject.hpp"
 
 #include "dart/collision/fcl/FCLTypes.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/ShapeFrame.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 
@@ -75,7 +76,7 @@ void FCLCollisionObject::updateEngineData()
 
   // Update soft-body's vertices
   if (shape->getType() == dynamics::SoftMeshShape::getStaticType()) {
-    assert(dynamic_cast<const SoftMeshShape*>(shape));
+    DART_ASSERT(dynamic_cast<const SoftMeshShape*>(shape));
     auto softMeshShape = static_cast<const SoftMeshShape*>(shape);
 
     const aiMesh* mesh = softMeshShape->getAssimpMesh();
@@ -84,7 +85,7 @@ void FCLCollisionObject::updateEngineData()
 
     auto collGeom = const_cast<dart::collision::fcl::CollisionGeometry*>(
         mFCLCollisionObject->collisionGeometry().get());
-    assert(
+    DART_ASSERT(
         dynamic_cast<::fcl::BVHModel<dart::collision::fcl::OBBRSS>*>(collGeom));
     auto bvhModel
         = static_cast<::fcl::BVHModel<dart::collision::fcl::OBBRSS>*>(collGeom);

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -36,6 +36,7 @@
 #include "dart/collision/ode/OdeCollisionGroup.hpp"
 #include "dart/collision/ode/OdeCollisionObject.hpp"
 #include "dart/collision/ode/OdeTypes.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
@@ -219,13 +220,13 @@ OdeCollisionDetector::OdeCollisionDetector()
 {
   // Initialize ODE. dInitODE is deprecated.
   const auto initialized = dInitODE2(0);
-  assert(initialized);
+  DART_ASSERT(initialized);
   DART_UNUSED(initialized);
 
   dAllocateODEDataForThread(dAllocateMaskAll);
 
   mWorldId = dWorldCreate();
-  assert(mWorldId);
+  DART_ASSERT(mWorldId);
 }
 
 //==============================================================================
@@ -257,8 +258,8 @@ namespace {
 //==============================================================================
 void CollisionCallback(void* data, dGeomID o1, dGeomID o2)
 {
-  assert(!dGeomIsSpace(o1));
-  assert(!dGeomIsSpace(o2));
+  DART_ASSERT(!dGeomIsSpace(o1));
+  DART_ASSERT(!dGeomIsSpace(o2));
 
   auto cdData = static_cast<OdeCollisionCallbackData*>(data);
 
@@ -275,8 +276,8 @@ void CollisionCallback(void* data, dGeomID o1, dGeomID o2)
 
   auto collObj1 = static_cast<OdeCollisionObject*>(geomData1);
   auto collObj2 = static_cast<OdeCollisionObject*>(geomData2);
-  assert(collObj1);
-  assert(collObj2);
+  DART_ASSERT(collObj1);
+  DART_ASSERT(collObj2);
 
   if (filter && filter->ignoresCollision(collObj1, collObj2))
     return;

--- a/dart/collision/ode/OdeCollisionGroup.cpp
+++ b/dart/collision/ode/OdeCollisionGroup.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/ode/OdeCollisionGroup.hpp"
 
 #include "dart/collision/ode/OdeCollisionObject.hpp"
+#include "dart/common/Macros.hpp"
 
 namespace dart {
 namespace collision {
@@ -52,7 +53,7 @@ OdeCollisionGroup::OdeCollisionGroup(
   // Source:
   // https://www.ode-wiki.org/wiki/index.php?title=Manual:_Collision_Detection#Space_functions
   mSpaceId = dHashSpaceCreate(0);
-  assert(mSpaceId);
+  DART_ASSERT(mSpaceId);
   dHashSpaceSetLevels(mSpaceId, -2, 8);
 }
 

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -40,6 +40,7 @@
 #include "dart/collision/ode/detail/OdeMesh.hpp"
 #include "dart/collision/ode/detail/OdePlane.hpp"
 #include "dart/collision/ode/detail/OdeSphere.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
@@ -82,7 +83,7 @@ OdeCollisionObject::OdeCollisionObject(
   mOdeGeom.reset(createOdeGeom(this, shapeFrame));
 
   const auto geomId = mOdeGeom->getOdeGeomId();
-  assert(geomId);
+  DART_ASSERT(geomId);
 
   if (mOdeGeom->isPlaceable()) {
     // if the geometry already has a pose, it is to be considered
@@ -93,7 +94,7 @@ OdeCollisionObject::OdeCollisionObject(
     dQuaternion geomRelRot;
     dGeomGetQuaternion(geomId, geomRelRot);
     const dReal* geomRelPos = dGeomGetPosition(geomId);
-    assert(geomRelPos);
+    DART_ASSERT(geomRelPos);
 
     // create the body
     mBodyId = dBodyCreate(collisionDetector->getOdeWorldId());
@@ -111,15 +112,15 @@ OdeCollisionObject& OdeCollisionObject::operator=(OdeCollisionObject&& other)
 {
   // This should only be used for refreshing the collision objects, so the
   // detector and the shape frame should never need to change
-  assert(mCollisionDetector == other.mCollisionDetector);
-  assert(mShapeFrame == other.mShapeFrame);
+  DART_ASSERT(mCollisionDetector == other.mCollisionDetector);
+  DART_ASSERT(mShapeFrame == other.mShapeFrame);
 
   // We should never be assigning a collision object to itself
-  assert(this != &other);
+  DART_ASSERT(this != &other);
 
   // There should never be duplicate body IDs or geometries
-  assert(!mBodyId || mBodyId != other.mBodyId);
-  assert(mOdeGeom.get() != other.mOdeGeom.get());
+  DART_ASSERT(!mBodyId || mBodyId != other.mBodyId);
+  DART_ASSERT(mOdeGeom.get() != other.mOdeGeom.get());
 
   mOdeGeom = std::move(other.mOdeGeom);
   std::swap(mBodyId, other.mBodyId);
@@ -227,7 +228,7 @@ detail::OdeGeom* createOdeGeom(
   // TODO(JS): not implemented for EllipsoidShape, ConeShape, MultiSphereShape,
   // and SoftMeshShape.
 
-  assert(geom);
+  DART_ASSERT(geom);
   const auto geomId = geom->getOdeGeomId();
   dGeomSetData(geomId, collObj);
 

--- a/dart/collision/ode/detail/OdeHeightmap-impl.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap-impl.hpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/collision/ode/detail/OdeHeightmap.hpp>
 
 #include <dart/dynamics/HeightmapShape.hpp>
@@ -53,8 +55,8 @@ void setOdeHeightfieldDetails(
     const Eigen::Matrix<S, 3, 1>& scale,
     typename std::enable_if<std::is_same<float, S>::value>::type* = 0)
 {
-  assert(width >= 2);
-  assert(height >= 2);
+  DART_ASSERT(width >= 2);
+  DART_ASSERT(height >= 2);
   if ((width < 2) || (height < 2)) {
     DART_WARN(
         "Cannot create height field of dimensions {}x{}, needs to be at least "
@@ -88,8 +90,8 @@ void setOdeHeightfieldDetails(
     const Eigen::Matrix<S, 3, 1>& scale,
     typename std::enable_if<std::is_same<double, S>::value>::type* = 0)
 {
-  assert(width >= 2);
-  assert(height >= 2);
+  DART_ASSERT(width >= 2);
+  DART_ASSERT(height >= 2);
   if ((width < 2) || (height < 2)) {
     DART_WARN(
         "Cannot create height field of dimensions {}x{}, needs to be at least "
@@ -120,7 +122,7 @@ OdeHeightmap<S>::OdeHeightmap(
     const dynamics::HeightmapShape<S>* heightMap)
   : OdeGeom(parent)
 {
-  assert(heightMap);
+  DART_ASSERT(heightMap);
 
   // get the heightmap parameters
   const auto& scale = heightMap->getScale();

--- a/dart/common/Composite.cpp
+++ b/dart/common/Composite.cpp
@@ -33,6 +33,7 @@
 #include "dart/common/Composite.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <iostream>
 
@@ -195,7 +196,7 @@ void Composite::duplicateAspects(const Composite* fromComposite)
     DART_ERROR(
         "[Composite::duplicateAspects] You have asked to duplicate the Aspects "
         "of a nullptr, which is not allowed!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -237,7 +238,7 @@ void Composite::matchAspects(const Composite* otherComposite)
     DART_ERROR(
         "[Composite::matchAspects] You have asked to match the Aspects of a "
         "nullptr, which is not allowed!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 

--- a/dart/common/StlHelpers.hpp
+++ b/dart/common/StlHelpers.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COMMON_STLHELPERS_HPP_
 #define DART_COMMON_STLHELPERS_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/common/Memory.hpp>
 
 #include <vector>
@@ -48,7 +50,7 @@ template <typename T>
 static T getVectorObjectIfAvailable(
     std::size_t index, const std::vector<T>& vec)
 {
-  assert(index < vec.size());
+  DART_ASSERT(index < vec.size());
   if (index < vec.size())
     return vec[index];
 

--- a/dart/common/Uri.cpp
+++ b/dart/common/Uri.cpp
@@ -33,6 +33,7 @@
 #include "dart/common/Uri.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <regex>
 #include <sstream>
@@ -122,14 +123,14 @@ void UriComponent::reset()
 //==============================================================================
 auto UriComponent::get() -> reference_type
 {
-  assert(mExists);
+  DART_ASSERT(mExists);
   return mValue;
 }
 
 //==============================================================================
 auto UriComponent::get() const -> reference_const_type
 {
-  assert(mExists);
+  DART_ASSERT(mExists);
   return mValue;
 }
 
@@ -207,27 +208,27 @@ bool Uri::fromString(const std::string& _input)
   if (!regex_match(_input, matches, uriRegex))
     return false;
 
-  assert(matches.size() > schemeIndex);
+  DART_ASSERT(matches.size() > schemeIndex);
   const std::ssub_match& schemeMatch = matches[schemeIndex];
   if (schemeMatch.matched)
     mScheme = schemeMatch;
 
-  assert(matches.size() > authorityIndex);
+  DART_ASSERT(matches.size() > authorityIndex);
   const std::ssub_match& authorityMatch = matches[authorityIndex];
   if (authorityMatch.matched)
     mAuthority = authorityMatch;
 
-  assert(matches.size() > pathIndex);
+  DART_ASSERT(matches.size() > pathIndex);
   const std::ssub_match& pathMatch = matches[pathIndex];
   if (pathMatch.matched)
     mPath = pathMatch;
 
-  assert(matches.size() > queryIndex);
+  DART_ASSERT(matches.size() > queryIndex);
   const std::ssub_match& queryMatch = matches[queryIndex];
   if (queryMatch.matched)
     mQuery = queryMatch;
 
-  assert(matches.size() > fragmentIndex);
+  DART_ASSERT(matches.size() > fragmentIndex);
   const std::ssub_match& fragmentMatch = matches[fragmentIndex];
   if (fragmentMatch.matched)
     mFragment = fragmentMatch;
@@ -330,8 +331,8 @@ bool Uri::fromRelativeUri(const Uri& _base, const char* _relative, bool _strict)
 bool Uri::fromRelativeUri(
     const Uri& _base, const Uri& _relative, bool /*_strict*/)
 {
-  assert(_base.mPath && "The path component is always defined.");
-  assert(_relative.mPath && "The path component is always defined.");
+  DART_ASSERT(_base.mPath && "The path component is always defined.");
+  DART_ASSERT(_relative.mPath && "The path component is always defined.");
 
   // TODO If (!_strict && _relative.mScheme == _base.mScheme), then we need to
   // enable backwards compatability.
@@ -563,8 +564,8 @@ std::string Uri::getFilesystemPath() const
 //==============================================================================
 std::string Uri::mergePaths(const Uri& _base, const Uri& _relative)
 {
-  assert(_base.mPath && "The path component is always defined.");
-  assert(_relative.mPath && "The path component is always defined.");
+  DART_ASSERT(_base.mPath && "The path component is always defined.");
+  DART_ASSERT(_relative.mPath && "The path component is always defined.");
 
   // This directly implements the logic from Section 5.2.3. of RFC 3986.
   if (_base.mAuthority && _base.mPath->empty())

--- a/dart/common/VersionCounter.cpp
+++ b/dart/common/VersionCounter.cpp
@@ -33,6 +33,7 @@
 #include "dart/common/VersionCounter.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <iostream>
 
@@ -78,7 +79,7 @@ void VersionCounter::setVersionDependentObject(VersionCounter* dependent)
         next = next->mDependent;
       }
       std::cerr << " -- " << this << "\n";
-      assert(false);
+      DART_ASSERT(false);
       return;
     }
 

--- a/dart/common/detail/Aspect.hpp
+++ b/dart/common/detail/Aspect.hpp
@@ -78,7 +78,7 @@ template <class CompositeType>
 void CompositeTrackingAspect<CompositeType>::setComposite(
     Composite* newComposite)
 {
-  assert(nullptr == mComposite);
+  DART_ASSERT(nullptr == mComposite);
 
   mComposite = dynamic_cast<CompositeType*>(newComposite);
   // Note: Derived classes should be responsible for handling the case in which
@@ -92,7 +92,7 @@ void CompositeTrackingAspect<CompositeType>::loseComposite(
     Composite* oldComposite)
 {
   DART_UNUSED(oldComposite);
-  assert(oldComposite == mComposite);
+  DART_ASSERT(oldComposite == mComposite);
   mComposite = nullptr;
 }
 

--- a/dart/common/detail/Castable-impl.hpp
+++ b/dart/common/detail/Castable-impl.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COMMON_DETAIL_CASTABLE_HPP_
 #define DART_COMMON_DETAIL_CASTABLE_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/common/Castable.hpp>
 #include <dart/common/Metaprogramming.hpp>
 
@@ -77,7 +79,7 @@ template <typename Base>
 template <typename Derived>
 const Derived& Castable<Base>::asRef() const
 {
-  assert(is<Derived>());
+  DART_ASSERT(is<Derived>());
   return *as<Derived>();
 }
 
@@ -86,7 +88,7 @@ template <typename Base>
 template <typename Derived>
 Derived& Castable<Base>::asRef()
 {
-  assert(is<Derived>());
+  DART_ASSERT(is<Derived>());
   return *as<Derived>();
 }
 

--- a/dart/common/detail/Composite.hpp
+++ b/dart/common/detail/Composite.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COMMON_DETAIL_COMPOSITE_HPP_
 #define DART_COMMON_DETAIL_COMPOSITE_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/common/Composite.hpp>
 
 #define DART_COMMON_CHECK_ILLEGAL_ASPECT_ERASE(Func, T, ReturnType)            \
@@ -41,7 +43,7 @@
         "[Composite::{}] Illegal request to remove required Aspect [{}]!",     \
         #Func,                                                                 \
         typeid(T).name());                                                     \
-    assert(false);                                                             \
+    DART_ASSERT(false);                                                        \
     return ReturnType;                                                         \
   }
 

--- a/dart/common/detail/EmbeddedAspect.hpp
+++ b/dart/common/detail/EmbeddedAspect.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COMMON_DETAIL_EMBEDDEDASPECT_HPP_
 #define DART_COMMON_DETAIL_EMBEDDEDASPECT_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/common/Aspect.hpp>
 #include <dart/common/StlHelpers.hpp>
 
@@ -176,7 +178,7 @@ public:
           "[detail::EmbeddedStateAspect::getState] This Aspect is not in a "
           "Composite, but it also does not have a temporary State available. "
           "This should not happen! Please report this as a bug!");
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return *mTemporaryState;
@@ -212,7 +214,7 @@ protected:
   /// Pass the temporary State of this Aspect into the new Composite
   void setComposite(Composite* newComposite) override
   {
-    assert(nullptr == this->getComposite());
+    DART_ASSERT(nullptr == this->getComposite());
 
     Base::setComposite(newComposite);
     if (mTemporaryState)
@@ -346,7 +348,7 @@ public:
           "[detail::EmbeddedPropertiesAspect::getProperties] This Aspect is "
           "not in a Composite, but it also does not have temporary Properties "
           "available. This should not happen! Please report this as a bug!");
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return *mTemporaryProperties;
@@ -383,7 +385,7 @@ protected:
   /// Pass the temporary Properties of this Aspect into the new Composite
   void setComposite(Composite* newComposite) override
   {
-    assert(nullptr == this->getComposite());
+    DART_ASSERT(nullptr == this->getComposite());
 
     Base::setComposite(newComposite);
     if (mTemporaryProperties)

--- a/dart/common/detail/NameManager.hpp
+++ b/dart/common/detail/NameManager.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COMMON_DETAIL_NAMEMANAGER_HPP_
 #define DART_COMMON_DETAIL_NAMEMANAGER_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/common/Logging.hpp>
 #include <dart/common/NameManager.hpp>
 
@@ -143,7 +145,7 @@ bool NameManager<T>::addName(const std::string& _name, const T& _obj)
   mMap.insert(std::pair<std::string, T>(_name, _obj));
   mReverseMap.insert(std::pair<T, std::string>(_obj, _name));
 
-  assert(mReverseMap.size() == mMap.size());
+  DART_ASSERT(mReverseMap.size() == mMap.size());
 
   return true;
 }
@@ -152,7 +154,7 @@ bool NameManager<T>::addName(const std::string& _name, const T& _obj)
 template <class T>
 bool NameManager<T>::removeName(const std::string& _name)
 {
-  assert(mReverseMap.size() == mMap.size());
+  DART_ASSERT(mReverseMap.size() == mMap.size());
 
   typename std::map<std::string, T>::iterator it = mMap.find(_name);
 
@@ -174,7 +176,7 @@ bool NameManager<T>::removeName(const std::string& _name)
 template <class T>
 bool NameManager<T>::removeObject(const T& _obj)
 {
-  assert(mReverseMap.size() == mMap.size());
+  DART_ASSERT(mReverseMap.size() == mMap.size());
 
   typename std::map<T, std::string>::iterator rit = mReverseMap.find(_obj);
 
@@ -243,7 +245,7 @@ T NameManager<T>::getObject(const std::string& _name) const
 template <class T>
 std::string NameManager<T>::getName(const T& _obj) const
 {
-  assert(mReverseMap.size() == mMap.size());
+  DART_ASSERT(mReverseMap.size() == mMap.size());
 
   typename std::map<T, std::string>::const_iterator result
       = mReverseMap.find(_obj);
@@ -259,7 +261,7 @@ template <class T>
 std::string NameManager<T>::changeObjectName(
     const T& _obj, const std::string& _newName)
 {
-  assert(mReverseMap.size() == mMap.size());
+  DART_ASSERT(mReverseMap.size() == mMap.size());
 
   typename std::map<T, std::string>::iterator rit = mReverseMap.find(_obj);
   if (rit == mReverseMap.end())

--- a/dart/common/detail/SharedLibraryManager.cpp
+++ b/dart/common/detail/SharedLibraryManager.cpp
@@ -33,6 +33,7 @@
 #include "dart/common/detail/SharedLibraryManager.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/SharedLibrary.hpp"
 
 #include <fstream>
@@ -89,7 +90,7 @@ std::shared_ptr<SharedLibrary> SharedLibraryManager::load(
     return nullptr;
 
   mSharedLibraries[canonicalPath] = newLib;
-  assert(canonicalPath == newLib->getCanonicalPath());
+  DART_ASSERT(canonicalPath == newLib->getCanonicalPath());
 
   return newLib;
 }

--- a/dart/constraint/BalanceConstraint.cpp
+++ b/dart/constraint/BalanceConstraint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/constraint/BalanceConstraint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/EndEffector.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 
@@ -71,7 +72,7 @@ double BalanceConstraint::eval(const Eigen::VectorXd& _x)
     DART_ERROR(
         "[BalanceConstraint::eval] Attempting to call a BalanceConstraint "
         "function associated to a HierarchicalIK that no longer exists!");
-    assert(false);
+    DART_ASSERT(false);
     return 0.0;
   }
 
@@ -81,7 +82,7 @@ double BalanceConstraint::eval(const Eigen::VectorXd& _x)
     DART_ERROR(
         "[BalanceConstraint::eval] Attempting to call a BalanceConstraint "
         "function on a Skeleton which no longer exists!");
-    assert(false);
+    DART_ASSERT(false);
     return 0.0;
   }
 

--- a/dart/constraint/BallJointConstraint.cpp
+++ b/dart/constraint/BallJointConstraint.cpp
@@ -31,6 +31,7 @@
  */
 #include "dart/constraint/BallJointConstraint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/lcpsolver/dantzig/lcp.h"
@@ -107,7 +108,7 @@ const std::string& BallJointConstraint::getStaticType()
 void BallJointConstraint::update()
 {
   // mBodyNode1 should not be null pointer ever
-  assert(mBodyNode1);
+  DART_ASSERT(mBodyNode1);
 
   // Update Jacobian for body2
   if (mBodyNode2) {
@@ -137,13 +138,13 @@ void BallJointConstraint::update()
 //==============================================================================
 void BallJointConstraint::getInformation(ConstraintInfo* _lcp)
 {
-  assert(_lcp->w[0] == 0.0);
-  assert(_lcp->w[1] == 0.0);
-  assert(_lcp->w[2] == 0.0);
+  DART_ASSERT(_lcp->w[0] == 0.0);
+  DART_ASSERT(_lcp->w[1] == 0.0);
+  DART_ASSERT(_lcp->w[2] == 0.0);
 
-  assert(_lcp->findex[0] == -1);
-  assert(_lcp->findex[1] == -1);
-  assert(_lcp->findex[2] == -1);
+  DART_ASSERT(_lcp->findex[0] == -1);
+  DART_ASSERT(_lcp->findex[1] == -1);
+  DART_ASSERT(_lcp->findex[2] == -1);
 
   _lcp->lo[0] = -dInfinity;
   _lcp->lo[1] = -dInfinity;
@@ -174,11 +175,11 @@ void BallJointConstraint::getInformation(ConstraintInfo* _lcp)
 //==============================================================================
 void BallJointConstraint::applyUnitImpulse(std::size_t _index)
 {
-  assert(_index < mDim && "Invalid Index.");
-  assert(isActive());
+  DART_ASSERT(_index < mDim && "Invalid Index.");
+  DART_ASSERT(isActive());
 
   if (mBodyNode2) {
-    assert(mBodyNode1->isReactive() || mBodyNode2->isReactive());
+    DART_ASSERT(mBodyNode1->isReactive() || mBodyNode2->isReactive());
 
     // Self collision case
     if (mBodyNode1->getSkeleton() == mBodyNode2->getSkeleton()) {
@@ -200,7 +201,7 @@ void BallJointConstraint::applyUnitImpulse(std::size_t _index)
           mBodyNode2->getSkeleton()->updateBiasImpulse(
               mBodyNode2, -mJacobian2.row(_index));
         } else {
-          assert(0);
+          DART_ASSERT(0);
         }
       }
       mBodyNode1->getSkeleton()->updateVelocityChange();
@@ -222,7 +223,7 @@ void BallJointConstraint::applyUnitImpulse(std::size_t _index)
       }
     }
   } else {
-    assert(mBodyNode1->isReactive());
+    DART_ASSERT(mBodyNode1->isReactive());
 
     mBodyNode1->getSkeleton()->clearConstraintImpulses();
     mBodyNode1->getSkeleton()->updateBiasImpulse(
@@ -236,7 +237,7 @@ void BallJointConstraint::applyUnitImpulse(std::size_t _index)
 //==============================================================================
 void BallJointConstraint::getVelocityChange(double* _vel, bool _withCfm)
 {
-  assert(_vel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(_vel != nullptr && "Null pointer is not allowed.");
 
   for (std::size_t i = 0; i < mDim; ++i)
     _vel[i] = 0.0;
@@ -320,11 +321,11 @@ dynamics::SkeletonPtr BallJointConstraint::getRootSkeleton() const
     if (mBodyNode2->isReactive()) {
       return ConstraintBase::getRootSkeleton(mBodyNode2->getSkeleton());
     } else {
-      assert(0);
+      DART_ASSERT(0);
       return nullptr;
     }
   } else {
-    assert(0);
+    DART_ASSERT(0);
     return nullptr;
   }
 }

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/constraint/BoxedLcpConstraintSolver.hpp"
 
+#include "dart/common/Macros.hpp"
+
 #include <fmt/ostream.h>
 
 #include <cassert>
@@ -172,7 +174,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
   mOffset[0] = 0;
   for (std::size_t i = 1; i < numConstraints; ++i) {
     const ConstraintBasePtr& constraint = group.getConstraint(i - 1);
-    assert(constraint->getDimension() > 0);
+    DART_ASSERT(constraint->getDimension() > 0);
     mOffset[i] = mOffset[i - 1] + constraint->getDimension();
   }
 
@@ -241,7 +243,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
   }
 
 #if DART_BUILD_MODE_DEBUG
-  assert(isSymmetric(n, mA.data()));
+  DART_ASSERT(isSymmetric(n, mA.data()));
 #endif
 
   // Print LCP formulation
@@ -262,7 +264,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
     mFIndexBackup = mFIndex;
   }
   const bool earlyTermination = (mSecondaryBoxedLcpSolver != nullptr);
-  assert(mBoxedLcpSolver);
+  DART_ASSERT(mBoxedLcpSolver);
   bool success = mBoxedLcpSolver->solve(
       n,
       mA.data(),

--- a/dart/constraint/ConstrainedGroup.cpp
+++ b/dart/constraint/ConstrainedGroup.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/ConstrainedGroup.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/constraint/ConstraintBase.hpp"
 #include "dart/constraint/ConstraintSolver.hpp"
 
@@ -52,13 +53,13 @@ ConstrainedGroup::~ConstrainedGroup() {}
 //==============================================================================
 void ConstrainedGroup::addConstraint(const ConstraintBasePtr& _constraint)
 {
-  assert(_constraint != nullptr && "Attempted to add nullptr.");
+  DART_ASSERT(_constraint != nullptr && "Attempted to add nullptr.");
 #if DART_BUILD_MODE_DEBUG
-  assert(
+  DART_ASSERT(
       !containConstraint(_constraint)
       && "Attempted to add a duplicate constraint.");
 #endif
-  assert(_constraint->isActive());
+  DART_ASSERT(_constraint->isActive());
 
   mConstraints.push_back(_constraint);
 }
@@ -72,23 +73,23 @@ std::size_t ConstrainedGroup::getNumConstraints() const
 //==============================================================================
 ConstraintBasePtr ConstrainedGroup::getConstraint(std::size_t _index)
 {
-  assert(_index < mConstraints.size());
+  DART_ASSERT(_index < mConstraints.size());
   return mConstraints[_index];
 }
 
 //==============================================================================
 ConstConstraintBasePtr ConstrainedGroup::getConstraint(std::size_t _index) const
 {
-  assert(_index < mConstraints.size());
+  DART_ASSERT(_index < mConstraints.size());
   return mConstraints[_index];
 }
 
 //==============================================================================
 void ConstrainedGroup::removeConstraint(const ConstraintBasePtr& _constraint)
 {
-  assert(_constraint != nullptr && "Attempted to add nullptr.");
+  DART_ASSERT(_constraint != nullptr && "Attempted to add nullptr.");
 #if DART_BUILD_MODE_DEBUG
-  assert(
+  DART_ASSERT(
       containConstraint(_constraint)
       && "Attempted to remove not existing constraint.");
 #endif

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -70,7 +70,7 @@ ConstraintSolver::ConstraintSolver(double timeStep)
     mTimeStep(timeStep),
     mContactSurfaceHandler(std::make_shared<DefaultContactSurfaceHandler>())
 {
-  assert(timeStep > 0.0);
+  DART_ASSERT(timeStep > 0.0);
 
   auto cd = std::static_pointer_cast<collision::FCLCollisionDetector>(
       mCollisionDetector);
@@ -102,7 +102,7 @@ ConstraintSolver::ConstraintSolver()
 //==============================================================================
 void ConstraintSolver::addSkeleton(const SkeletonPtr& skeleton)
 {
-  assert(
+  DART_ASSERT(
       skeleton
       && "Null pointer skeleton is now allowed to add to ConstraintSover.");
 
@@ -136,7 +136,7 @@ const std::vector<SkeletonPtr>& ConstraintSolver::getSkeletons() const
 //==============================================================================
 void ConstraintSolver::removeSkeleton(const SkeletonPtr& skeleton)
 {
-  assert(
+  DART_ASSERT(
       skeleton
       && "Null pointer skeleton is now allowed to add to ConstraintSover.");
 
@@ -169,7 +169,7 @@ void ConstraintSolver::removeAllSkeletons()
 //==============================================================================
 void ConstraintSolver::addConstraint(const ConstraintBasePtr& constraint)
 {
-  assert(constraint);
+  DART_ASSERT(constraint);
 
   if (containConstraint(constraint)) {
     DART_WARN(
@@ -184,7 +184,7 @@ void ConstraintSolver::addConstraint(const ConstraintBasePtr& constraint)
 //==============================================================================
 void ConstraintSolver::removeConstraint(const ConstraintBasePtr& constraint)
 {
-  assert(constraint);
+  DART_ASSERT(constraint);
 
   if (!containConstraint(constraint)) {
     DART_WARN(
@@ -251,7 +251,7 @@ void ConstraintSolver::clearLastCollisionResult()
 //==============================================================================
 void ConstraintSolver::setTimeStep(double _timeStep)
 {
-  assert(_timeStep > 0.0 && "Time step should be positive value.");
+  DART_ASSERT(_timeStep > 0.0 && "Time step should be positive value.");
   mTimeStep = _timeStep;
 }
 
@@ -709,8 +709,8 @@ bool ConstraintSolver::isSoftContact(const collision::Contact& contact) const
 {
   auto* shapeNode1 = contact.collisionObject1->getShapeFrame()->asShapeNode();
   auto* shapeNode2 = contact.collisionObject2->getShapeFrame()->asShapeNode();
-  assert(shapeNode1);
-  assert(shapeNode2);
+  DART_ASSERT(shapeNode1);
+  DART_ASSERT(shapeNode2);
 
   auto* bodyNode1 = shapeNode1->getBodyNodePtr().get();
   auto* bodyNode2 = shapeNode2->getBodyNodePtr().get();

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/collision/CollisionObject.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/lcpsolver/dantzig/lcp.h"
@@ -99,7 +100,7 @@ ContactConstraint::ContactConstraint(
     mIsBounceOn(false),
     mActive(false)
 {
-  assert(
+  DART_ASSERT(
       contact.normal.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED);
 
   //----------------------------------------------
@@ -135,8 +136,8 @@ ContactConstraint::ContactConstraint(
   mContactSurfaceMotionVelocity
       = contactSurfaceParams.mContactSurfaceMotionVelocity;
 
-  assert(mBodyNodeA->getSkeleton());
-  assert(mBodyNodeB->getSkeleton());
+  DART_ASSERT(mBodyNodeA->getSkeleton());
+  DART_ASSERT(mBodyNodeB->getSkeleton());
   mIsSelfCollision = (mBodyNodeA->getSkeleton() == mBodyNodeB->getSkeleton());
 
   // Compute local contact Jacobians expressed in body frame
@@ -163,9 +164,9 @@ ContactConstraint::ContactConstraint(
     // TODO(JS): Assumed that the number of tangent basis is 2.
     const TangentBasisMatrix D = getTangentBasisMatrixODE(ct.normal);
 
-    assert(std::abs(ct.normal.dot(D.col(0))) < DART_EPSILON);
-    assert(std::abs(ct.normal.dot(D.col(1))) < DART_EPSILON);
-    assert(std::abs(D.col(0).dot(D.col(1))) < DART_EPSILON);
+    DART_ASSERT(std::abs(ct.normal.dot(D.col(0))) < DART_EPSILON);
+    DART_ASSERT(std::abs(ct.normal.dot(D.col(1))) < DART_EPSILON);
+    DART_ASSERT(std::abs(D.col(0).dot(D.col(1))) < DART_EPSILON);
 
     // Jacobian for normal contact
     bodyDirectionA.noalias()
@@ -205,8 +206,8 @@ ContactConstraint::ContactConstraint(
     mSpatialNormalA.col(2).tail<3>() = bodyDirectionA;
     mSpatialNormalB.col(2).tail<3>() = bodyDirectionB;
 
-    assert(!dart::math::isNan(mSpatialNormalA));
-    assert(!dart::math::isNan(mSpatialNormalB));
+    DART_ASSERT(!dart::math::isNan(mSpatialNormalA));
+    DART_ASSERT(!dart::math::isNan(mSpatialNormalB));
   } else {
     // Set the dimension of this constraint.
     mDim = 1;
@@ -370,14 +371,14 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
   //----------------------------------------------------------------------------
   if (mIsFrictionOn) {
     // Bias term, w, should be zero
-    assert(info->w[0] == 0.0);
-    assert(info->w[1] == 0.0);
-    assert(info->w[2] == 0.0);
+    DART_ASSERT(info->w[0] == 0.0);
+    DART_ASSERT(info->w[1] == 0.0);
+    DART_ASSERT(info->w[2] == 0.0);
 
     // Upper and lower bounds of normal impulsive force
     info->lo[0] = 0.0;
     info->hi[0] = static_cast<double>(dInfinity);
-    assert(info->findex[0] == -1);
+    DART_ASSERT(info->findex[0] == -1);
 
     // Upper and lower bounds of tangential direction-1 impulsive force
     info->lo[1] = -mPrimaryFrictionCoeff;
@@ -439,7 +440,7 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
     // Upper and lower bounds of normal impulsive force
     info->lo[0] = 0.0;
     info->hi[0] = static_cast<double>(dInfinity);
-    assert(info->findex[0] == -1);
+    DART_ASSERT(info->findex[0] == -1);
 
     //------------------------------------------------------------------------
     // Bouncing
@@ -481,9 +482,9 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
 //==============================================================================
 void ContactConstraint::applyUnitImpulse(std::size_t index)
 {
-  assert(index < mDim && "Invalid Index.");
+  DART_ASSERT(index < mDim && "Invalid Index.");
   // assert(isActive());
-  assert(mBodyNodeA->isReactive() || mBodyNodeB->isReactive());
+  DART_ASSERT(mBodyNodeA->isReactive() || mBodyNodeB->isReactive());
 
   dynamics::Skeleton* skelA = mBodyNodeA->getSkeleton().get();
   dynamics::Skeleton* skelB = mBodyNodeB->getSkeleton().get();
@@ -513,7 +514,7 @@ void ContactConstraint::applyUnitImpulse(std::size_t index)
       // Both bodies are not reactive
       else {
         // This case should not be happened
-        assert(0);
+        DART_ASSERT(0);
       }
     }
 
@@ -540,7 +541,7 @@ void ContactConstraint::applyUnitImpulse(std::size_t index)
 //==============================================================================
 void ContactConstraint::getVelocityChange(double* vel, bool withCfm)
 {
-  assert(vel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(vel != nullptr && "Null pointer is not allowed.");
 
   Eigen::Map<Eigen::VectorXd> velMap(vel, static_cast<int>(mDim));
   velMap.setZero();
@@ -596,9 +597,9 @@ void ContactConstraint::applyImpulse(double* lambda)
   // Friction case
   //----------------------------------------------------------------------------
   if (mIsFrictionOn) {
-    assert(!math::isNan(lambda[0]));
-    assert(!math::isNan(lambda[1]));
-    assert(!math::isNan(lambda[2]));
+    DART_ASSERT(!math::isNan(lambda[0]));
+    DART_ASSERT(!math::isNan(lambda[1]));
+    DART_ASSERT(!math::isNan(lambda[2]));
 
     // Store contact impulse (force) toward the normal w.r.t. world frame
     mContact.force = mContact.normal * lambda[0] / mTimeStep;
@@ -647,7 +648,7 @@ void ContactConstraint::applyImpulse(double* lambda)
 //==============================================================================
 void ContactConstraint::getRelVelocity(double* relVel)
 {
-  assert(relVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(relVel != nullptr && "Null pointer is not allowed.");
 
   Eigen::Map<Eigen::VectorXd> relVelMap(relVel, static_cast<int>(mDim));
   relVelMap.setZero();
@@ -716,7 +717,7 @@ double ContactConstraint::computeRestitutionCoefficient(
 //==============================================================================
 dynamics::SkeletonPtr ContactConstraint::getRootSkeleton() const
 {
-  assert(isActive());
+  DART_ASSERT(isActive());
 
   if (mBodyNodeA->isReactive())
     return ConstraintBase::getRootSkeleton(mBodyNodeA->getSkeleton());
@@ -769,16 +770,16 @@ ContactConstraint::getTangentBasisMatrixODE(const Eigen::Vector3d& n)
         // zero-length, which shouldn't the case because ConstraintSolver
         // shouldn't create a ContactConstraint for a contact with zero-length
         // normal.
-        assert(
+        DART_ASSERT(
             tangent.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED);
       }
     }
   }
 
-  assert(tangent.norm() > 1e-06);
+  DART_ASSERT(tangent.norm() > 1e-06);
   tangent.normalize();
 
-  assert(!dart::math::isNan(tangent));
+  DART_ASSERT(!dart::math::isNan(tangent));
 
   TangentBasisMatrix T;
 

--- a/dart/constraint/ContactSurface.cpp
+++ b/dart/constraint/ContactSurface.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/collision/CollisionObject.hpp"
 #include "dart/collision/Contact.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/constraint/ContactConstraint.hpp"
 #include "dart/constraint/ContactSurface.hpp"
 
@@ -196,7 +197,7 @@ ContactConstraintPtr DefaultContactSurfaceHandler::createConstraint(
 double DefaultContactSurfaceHandler::computeFrictionCoefficient(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 
@@ -216,7 +217,7 @@ double DefaultContactSurfaceHandler::computeFrictionCoefficient(
 double DefaultContactSurfaceHandler::computePrimaryFrictionCoefficient(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 
@@ -236,7 +237,7 @@ double DefaultContactSurfaceHandler::computePrimaryFrictionCoefficient(
 double DefaultContactSurfaceHandler::computeSecondaryFrictionCoefficient(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 
@@ -256,7 +257,7 @@ double DefaultContactSurfaceHandler::computeSecondaryFrictionCoefficient(
 double DefaultContactSurfaceHandler::computePrimarySlipCompliance(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 
@@ -280,7 +281,7 @@ double DefaultContactSurfaceHandler::computePrimarySlipCompliance(
 double DefaultContactSurfaceHandler::computeSecondarySlipCompliance(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 
@@ -304,7 +305,7 @@ double DefaultContactSurfaceHandler::computeSecondarySlipCompliance(
 Eigen::Vector3d DefaultContactSurfaceHandler::computeWorldFirstFrictionDir(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 
@@ -332,7 +333,7 @@ Eigen::Vector3d DefaultContactSurfaceHandler::computeWorldFirstFrictionDir(
 double DefaultContactSurfaceHandler::computeRestitutionCoefficient(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 

--- a/dart/constraint/DantzigLCPSolver.cpp
+++ b/dart/constraint/DantzigLCPSolver.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/constraint/DantzigLCPSolver.hpp"
 
+#include "dart/common/Macros.hpp"
+
 #if DART_BUILD_MODE_DEBUG
   #include <iomanip>
   #include <iostream>
@@ -91,7 +93,7 @@ void DantzigLCPSolver::solve(ConstrainedGroup* _group)
   //  std::cout << "offset[" << 0 << "]: " << offset[0] << std::endl;
   for (std::size_t i = 1; i < numConstraints; ++i) {
     const ConstraintBasePtr& constraint = _group->getConstraint(i - 1);
-    assert(constraint->getDimension() > 0);
+    DART_ASSERT(constraint->getDimension() > 0);
     offset[i] = offset[i - 1] + constraint->getDimension();
     //    std::cout << "offset[" << i << "]: " << offset[i] << std::endl;
   }
@@ -143,7 +145,7 @@ void DantzigLCPSolver::solve(ConstrainedGroup* _group)
     }
 
 #if DART_BUILD_MODE_DEBUG
-    assert(isSymmetric(
+    DART_ASSERT(isSymmetric(
         n, A, offset[i], offset[i] + constraint->getDimension() - 1));
 #endif
 
@@ -151,7 +153,7 @@ void DantzigLCPSolver::solve(ConstrainedGroup* _group)
   }
 
 #if DART_BUILD_MODE_DEBUG
-  assert(isSymmetric(n, A));
+  DART_ASSERT(isSymmetric(n, A));
 #endif
 
   // Print LCP formulation

--- a/dart/constraint/DynamicJointConstraint.cpp
+++ b/dart/constraint/DynamicJointConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/DynamicJointConstraint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <cassert>
 
@@ -53,7 +54,7 @@ double DynamicJointConstraint::mConstraintForceMixing = DART_CFM;
 DynamicJointConstraint::DynamicJointConstraint(dynamics::BodyNode* body)
   : ConstraintBase(), mBodyNode1(body), mBodyNode2(nullptr)
 {
-  assert(body);
+  DART_ASSERT(body);
 }
 
 //==============================================================================
@@ -61,8 +62,8 @@ DynamicJointConstraint::DynamicJointConstraint(
     dynamics::BodyNode* body1, dynamics::BodyNode* body2)
   : ConstraintBase(), mBodyNode1(body1), mBodyNode2(body2)
 {
-  assert(body1);
-  assert(body2);
+  DART_ASSERT(body1);
+  DART_ASSERT(body2);
 }
 
 //==============================================================================

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/JointConstraint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -62,8 +63,8 @@ JointConstraint::JointConstraint(dynamics::Joint* joint)
     mBodyNode(joint->getChildBodyNode()),
     mAppliedImpulseIndex(0)
 {
-  assert(joint);
-  assert(mBodyNode);
+  DART_ASSERT(joint);
+  DART_ASSERT(mBodyNode);
   mLifeTime.setZero();
   mActive.setConstant(false);
 }
@@ -207,8 +208,8 @@ void JointConstraint::update()
   mActive.setConstant(false);
 
   for (int i = 0; i < dof; ++i) {
-    assert(positionLowerLimits[i] <= positionUpperLimits[i]);
-    assert(velocityLowerLimits[i] <= velocityUpperLimits[i]);
+    DART_ASSERT(positionLowerLimits[i] <= positionUpperLimits[i]);
+    DART_ASSERT(velocityLowerLimits[i] <= velocityUpperLimits[i]);
 
     // Velocity limits due to position limits
     const double vel_to_pos_lb
@@ -240,7 +241,7 @@ void JointConstraint::update()
 
         const double C1 = mErrorAllowance * A1;
         double bouncing_vel = -std::min(B1, C1) / timeStep;
-        assert(bouncing_vel >= 0);
+        DART_ASSERT(bouncing_vel >= 0);
         bouncing_vel = std::min(bouncing_vel, mMaxErrorReductionVelocity);
 
         mDesiredVelocityChange[i] = bouncing_vel - velocities[i];
@@ -277,7 +278,7 @@ void JointConstraint::update()
 
         const double C2 = mErrorAllowance * A2;
         double bouncing_vel = -std::max(B2, C2) / timeStep;
-        assert(bouncing_vel <= 0);
+        DART_ASSERT(bouncing_vel <= 0);
         bouncing_vel = std::max(bouncing_vel, -mMaxErrorReductionVelocity);
 
         mDesiredVelocityChange[i] = bouncing_vel - velocities[i];
@@ -418,7 +419,7 @@ void JointConstraint::getInformation(ConstraintInfo* lcp)
           "Invalid {}-th slack variable. Expected: 0.0. Actual: {}.",
           index,
           lcp->w[index]);
-      assert(false);
+      DART_ASSERT(false);
     }
 #endif
 
@@ -433,7 +434,7 @@ void JointConstraint::getInformation(ConstraintInfo* lcp)
           "Invalid {}-th friction index. Expected: -1. Actual: {}.",
           index,
           lcp->findex[index]);
-      assert(false);
+      DART_ASSERT(false);
     }
 #endif
 
@@ -449,7 +450,7 @@ void JointConstraint::getInformation(ConstraintInfo* lcp)
 //==============================================================================
 void JointConstraint::applyUnitImpulse(std::size_t index)
 {
-  assert(index < mDim && "Invalid Index.");
+  DART_ASSERT(index < mDim && "Invalid Index.");
 
   std::size_t localIndex = 0;
   const dynamics::SkeletonPtr& skeleton = mJoint->getSkeleton();
@@ -477,7 +478,7 @@ void JointConstraint::applyUnitImpulse(std::size_t index)
 //==============================================================================
 void JointConstraint::getVelocityChange(double* delVel, bool withCfm)
 {
-  assert(delVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(delVel != nullptr && "Null pointer is not allowed.");
 
   std::size_t localIndex = 0;
   std::size_t dof = mJoint->getNumDofs();
@@ -501,7 +502,7 @@ void JointConstraint::getVelocityChange(double* delVel, bool withCfm)
         += delVel[mAppliedImpulseIndex] * mConstraintForceMixing;
   }
 
-  assert(localIndex == mDim);
+  DART_ASSERT(localIndex == mDim);
 }
 
 //==============================================================================

--- a/dart/constraint/JointCoulombFrictionConstraint.cpp
+++ b/dart/constraint/JointCoulombFrictionConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/JointCoulombFrictionConstraint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -54,8 +55,8 @@ JointCoulombFrictionConstraint::JointCoulombFrictionConstraint(
     mBodyNode(_joint->getChildBodyNode()),
     mAppliedImpulseIndex(0)
 {
-  assert(_joint);
-  assert(mBodyNode);
+  DART_ASSERT(_joint);
+  DART_ASSERT(mBodyNode);
 
   mLifeTime[0] = 0;
   mLifeTime[1] = 0;
@@ -156,13 +157,13 @@ void JointCoulombFrictionConstraint::getInformation(ConstraintInfo* _lcp)
     if (mActive[i] == false)
       continue;
 
-    assert(_lcp->w[index] == 0.0);
+    DART_ASSERT(_lcp->w[index] == 0.0);
 
     _lcp->b[index] = mNegativeVel[i];
     _lcp->lo[index] = mLowerBound[i];
     _lcp->hi[index] = mUpperBound[i];
 
-    assert(_lcp->findex[index] == -1);
+    DART_ASSERT(_lcp->findex[index] == -1);
 
     if (mLifeTime[i])
       _lcp->x[index] = mOldX[i];
@@ -176,7 +177,7 @@ void JointCoulombFrictionConstraint::getInformation(ConstraintInfo* _lcp)
 //==============================================================================
 void JointCoulombFrictionConstraint::applyUnitImpulse(std::size_t _index)
 {
-  assert(_index < mDim && "Invalid Index.");
+  DART_ASSERT(_index < mDim && "Invalid Index.");
 
   std::size_t localIndex = 0;
   const dynamics::SkeletonPtr& skeleton = mJoint->getSkeleton();
@@ -204,7 +205,7 @@ void JointCoulombFrictionConstraint::applyUnitImpulse(std::size_t _index)
 void JointCoulombFrictionConstraint::getVelocityChange(
     double* _delVel, bool _withCfm)
 {
-  assert(_delVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(_delVel != nullptr && "Null pointer is not allowed.");
 
   std::size_t localIndex = 0;
   std::size_t dof = mJoint->getNumDofs();
@@ -227,7 +228,7 @@ void JointCoulombFrictionConstraint::getVelocityChange(
         += _delVel[mAppliedImpulseIndex] * mConstraintForceMixing;
   }
 
-  assert(localIndex == mDim);
+  DART_ASSERT(localIndex == mDim);
 }
 
 //==============================================================================

--- a/dart/constraint/JointLimitConstraint.cpp
+++ b/dart/constraint/JointLimitConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/JointLimitConstraint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -62,8 +63,8 @@ JointLimitConstraint::JointLimitConstraint(dynamics::Joint* joint)
     mBodyNode(joint->getChildBodyNode()),
     mAppliedImpulseIndex(0)
 {
-  assert(joint);
-  assert(mBodyNode);
+  DART_ASSERT(joint);
+  DART_ASSERT(mBodyNode);
 
   mLifeTime.setZero();
 
@@ -276,7 +277,7 @@ void JointLimitConstraint::getInformation(ConstraintInfo* lcp)
   const int dof = static_cast<int>(mJoint->getNumDofs());
   for (int i = 0; i < dof; ++i) {
     if (mIsPositionLimitViolated[i]) {
-      assert(lcp->w[index] == 0.0);
+      DART_ASSERT(lcp->w[index] == 0.0);
 
       double bouncingVel = -mViolation[i];
 
@@ -305,7 +306,7 @@ void JointLimitConstraint::getInformation(ConstraintInfo* lcp)
       }
 #endif
 
-      assert(lcp->findex[index] == -1);
+      DART_ASSERT(lcp->findex[index] == -1);
 
       if (mLifeTime[i])
         lcp->x[index] = mOldX[i];
@@ -316,13 +317,13 @@ void JointLimitConstraint::getInformation(ConstraintInfo* lcp)
     }
 
     if (mIsVelocityLimitViolated[i]) {
-      assert(lcp->w[index] == 0.0);
+      DART_ASSERT(lcp->w[index] == 0.0);
 
       lcp->b[index] = mNegativeVel[i];
       lcp->lo[index] = mLowerBound[i];
       lcp->hi[index] = mUpperBound[i];
 
-      assert(lcp->findex[index] == -1);
+      DART_ASSERT(lcp->findex[index] == -1);
 
       if (mLifeTime[i])
         lcp->x[index] = mOldX[i];
@@ -337,7 +338,7 @@ void JointLimitConstraint::getInformation(ConstraintInfo* lcp)
 //==============================================================================
 void JointLimitConstraint::applyUnitImpulse(std::size_t index)
 {
-  assert(index < mDim && "Invalid Index.");
+  DART_ASSERT(index < mDim && "Invalid Index.");
 
   std::size_t localIndex = 0;
   const dynamics::SkeletonPtr& skeleton = mJoint->getSkeleton();
@@ -366,7 +367,7 @@ void JointLimitConstraint::applyUnitImpulse(std::size_t index)
 //==============================================================================
 void JointLimitConstraint::getVelocityChange(double* delVel, bool withCfm)
 {
-  assert(delVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(delVel != nullptr && "Null pointer is not allowed.");
 
   std::size_t localIndex = 0;
   std::size_t dof = mJoint->getNumDofs();
@@ -391,7 +392,7 @@ void JointLimitConstraint::getVelocityChange(double* delVel, bool withCfm)
         += delVel[mAppliedImpulseIndex] * mConstraintForceMixing;
   }
 
-  assert(localIndex == mDim);
+  DART_ASSERT(localIndex == mDim);
 }
 
 //==============================================================================

--- a/dart/constraint/LCPSolver.cpp
+++ b/dart/constraint/LCPSolver.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/constraint/LCPSolver.hpp"
 
+#include "dart/common/Macros.hpp"
+
 #include <cassert>
 
 namespace dart {
@@ -40,7 +42,7 @@ namespace constraint {
 //==============================================================================
 void LCPSolver::setTimeStep(double _timeStep)
 {
-  assert(_timeStep > 0.0);
+  DART_ASSERT(_timeStep > 0.0);
   mTimeStep = _timeStep;
 }
 

--- a/dart/constraint/MimicMotorConstraint.cpp
+++ b/dart/constraint/MimicMotorConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/MimicMotorConstraint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -57,9 +58,9 @@ MimicMotorConstraint::MimicMotorConstraint(
     mBodyNode(joint->getChildBodyNode()),
     mAppliedImpulseIndex(0)
 {
-  assert(joint);
-  assert(joint->getNumDofs() <= mMimicProps.size());
-  assert(mBodyNode);
+  DART_ASSERT(joint);
+  DART_ASSERT(joint->getNumDofs() <= mMimicProps.size());
+  DART_ASSERT(mBodyNode);
 
   mLifeTime[0] = 0;
   mLifeTime[1] = 0;
@@ -166,13 +167,13 @@ void MimicMotorConstraint::getInformation(ConstraintInfo* lcp)
     if (mActive[i] == false)
       continue;
 
-    assert(lcp->w[index] == 0.0);
+    DART_ASSERT(lcp->w[index] == 0.0);
 
     lcp->b[index] = mNegativeVelocityError[i];
     lcp->lo[index] = mLowerBound[i];
     lcp->hi[index] = mUpperBound[i];
 
-    assert(lcp->findex[index] == -1);
+    DART_ASSERT(lcp->findex[index] == -1);
 
     if (mLifeTime[i])
       lcp->x[index] = mOldX[i];
@@ -186,7 +187,7 @@ void MimicMotorConstraint::getInformation(ConstraintInfo* lcp)
 //==============================================================================
 void MimicMotorConstraint::applyUnitImpulse(std::size_t index)
 {
-  assert(index < mDim && "Invalid Index.");
+  DART_ASSERT(index < mDim && "Invalid Index.");
 
   std::size_t localIndex = 0;
   const dynamics::SkeletonPtr& skeleton = mJoint->getSkeleton();
@@ -213,7 +214,7 @@ void MimicMotorConstraint::applyUnitImpulse(std::size_t index)
 //==============================================================================
 void MimicMotorConstraint::getVelocityChange(double* delVel, bool withCfm)
 {
-  assert(delVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(delVel != nullptr && "Null pointer is not allowed.");
 
   std::size_t localIndex = 0;
   std::size_t dof = mJoint->getNumDofs();
@@ -236,7 +237,7 @@ void MimicMotorConstraint::getVelocityChange(double* delVel, bool withCfm)
         += delVel[mAppliedImpulseIndex] * mConstraintForceMixing;
   }
 
-  assert(localIndex == mDim);
+  DART_ASSERT(localIndex == mDim);
 }
 
 //==============================================================================

--- a/dart/constraint/PGSLCPSolver.cpp
+++ b/dart/constraint/PGSLCPSolver.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/constraint/PGSLCPSolver.hpp"
 
+#include "dart/common/Macros.hpp"
+
 #if DART_BUILD_MODE_DEBUG
   #include <iomanip>
   #include <iostream>
@@ -86,7 +88,7 @@ void PGSLCPSolver::solve(ConstrainedGroup* _group)
   //  std::cout << "offset[" << 0 << "]: " << offset[0] << std::endl;
   for (std::size_t i = 1; i < numConstraints; ++i) {
     const ConstraintBasePtr& constraint = _group->getConstraint(i - 1);
-    assert(constraint->getDimension() > 0);
+    DART_ASSERT(constraint->getDimension() > 0);
     offset[i] = offset[i - 1] + constraint->getDimension();
     //    std::cout << "offset[" << i << "]: " << offset[i] << std::endl;
   }
@@ -138,7 +140,7 @@ void PGSLCPSolver::solve(ConstrainedGroup* _group)
     }
 
 #if DART_BUILD_MODE_DEBUG
-    assert(isSymmetric(
+    DART_ASSERT(isSymmetric(
         n, A, offset[i], offset[i] + constraint->getDimension() - 1));
 #endif
 
@@ -146,7 +148,7 @@ void PGSLCPSolver::solve(ConstrainedGroup* _group)
   }
 
 #if DART_BUILD_MODE_DEBUG
-  assert(isSymmetric(n, A));
+  DART_ASSERT(isSymmetric(n, A));
 #endif
 
   // Print LCP formulation

--- a/dart/constraint/ServoMotorConstraint.cpp
+++ b/dart/constraint/ServoMotorConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/ServoMotorConstraint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -54,8 +55,8 @@ ServoMotorConstraint::ServoMotorConstraint(dynamics::Joint* joint)
     mBodyNode(joint->getChildBodyNode()),
     mAppliedImpulseIndex(0)
 {
-  assert(joint);
-  assert(mBodyNode);
+  DART_ASSERT(joint);
+  DART_ASSERT(mBodyNode);
 
   mLifeTime[0] = 0;
   mLifeTime[1] = 0;
@@ -156,13 +157,13 @@ void ServoMotorConstraint::getInformation(ConstraintInfo* lcp)
     if (mActive[i] == false)
       continue;
 
-    assert(lcp->w[index] == 0.0);
+    DART_ASSERT(lcp->w[index] == 0.0);
 
     lcp->b[index] = mNegativeVelocityError[i];
     lcp->lo[index] = mLowerBound[i];
     lcp->hi[index] = mUpperBound[i];
 
-    assert(lcp->findex[index] == -1);
+    DART_ASSERT(lcp->findex[index] == -1);
 
     if (mLifeTime[i])
       lcp->x[index] = mOldX[i];
@@ -176,7 +177,7 @@ void ServoMotorConstraint::getInformation(ConstraintInfo* lcp)
 //==============================================================================
 void ServoMotorConstraint::applyUnitImpulse(std::size_t index)
 {
-  assert(index < mDim && "Invalid Index.");
+  DART_ASSERT(index < mDim && "Invalid Index.");
 
   std::size_t localIndex = 0;
   const dynamics::SkeletonPtr& skeleton = mJoint->getSkeleton();
@@ -203,7 +204,7 @@ void ServoMotorConstraint::applyUnitImpulse(std::size_t index)
 //==============================================================================
 void ServoMotorConstraint::getVelocityChange(double* delVel, bool withCfm)
 {
-  assert(delVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(delVel != nullptr && "Null pointer is not allowed.");
 
   std::size_t localIndex = 0;
   std::size_t dof = mJoint->getNumDofs();
@@ -226,7 +227,7 @@ void ServoMotorConstraint::getVelocityChange(double* delVel, bool withCfm)
         += delVel[mAppliedImpulseIndex] * mConstraintForceMixing;
   }
 
-  assert(localIndex == mDim);
+  DART_ASSERT(localIndex == mDim);
 }
 
 //==============================================================================

--- a/dart/constraint/SoftContactConstraint.cpp
+++ b/dart/constraint/SoftContactConstraint.cpp
@@ -35,6 +35,7 @@
 #include "dart/collision/CollisionObject.hpp"
 #include "dart/collision/Contact.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/PointMass.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -195,12 +196,12 @@ SoftContactConstraint::SoftContactConstraint(
       // TODO(JS): Assumed that the number of tangent basis is 2.
       Eigen::MatrixXd D = getTangentBasisMatrixODE(ct->normal);
 
-      assert(std::abs(ct->normal.dot(D.col(0))) < DART_EPSILON);
-      assert(std::abs(ct->normal.dot(D.col(1))) < DART_EPSILON);
+      DART_ASSERT(std::abs(ct->normal.dot(D.col(0))) < DART_EPSILON);
+      DART_ASSERT(std::abs(ct->normal.dot(D.col(1))) < DART_EPSILON);
       //      if (D.col(0).dot(D.col(1)) > 0.0)
       //        std::cout << "D.col(0).dot(D.col(1): " << D.col(0).dot(D.col(1))
       //        << std::endl;
-      assert(std::abs(D.col(0).dot(D.col(1))) < DART_EPSILON);
+      DART_ASSERT(std::abs(D.col(0).dot(D.col(1))) < DART_EPSILON);
 
       //      std::cout << "D: " << std::endl << D << std::endl;
 
@@ -423,7 +424,7 @@ const Eigen::Vector3d& SoftContactConstraint::getFrictionDirection1() const
 //==============================================================================
 void SoftContactConstraint::update()
 {
-  assert(mSoftBodyNode1 || mSoftBodyNode2);
+  DART_ASSERT(mSoftBodyNode1 || mSoftBodyNode2);
 
   // One of body node is soft body node and soft body node is always active
   mActive = true;
@@ -442,14 +443,14 @@ void SoftContactConstraint::getInformation(ConstraintInfo* _info)
     std::size_t index = 0;
     for (std::size_t i = 0; i < mContacts.size(); ++i) {
       // Bias term, w, should be zero
-      assert(_info->w[index] == 0.0);
-      assert(_info->w[index + 1] == 0.0);
-      assert(_info->w[index + 2] == 0.0);
+      DART_ASSERT(_info->w[index] == 0.0);
+      DART_ASSERT(_info->w[index + 1] == 0.0);
+      DART_ASSERT(_info->w[index + 2] == 0.0);
 
       // Upper and lower bounds of normal impulsive force
       _info->lo[index] = 0.0;
       _info->hi[index] = dInfinity;
-      assert(_info->findex[index] == -1);
+      DART_ASSERT(_info->findex[index] == -1);
 
       // Upper and lower bounds of tangential direction-1 impulsive force
       _info->lo[index + 1] = -mFrictionCoeff;
@@ -524,7 +525,7 @@ void SoftContactConstraint::getInformation(ConstraintInfo* _info)
       // Upper and lower bounds of normal impulsive force
       _info->lo[i] = 0.0;
       _info->hi[i] = dInfinity;
-      assert(_info->findex[i] == -1);
+      DART_ASSERT(_info->findex[i] == -1);
 
       //------------------------------------------------------------------------
       // Bouncing
@@ -574,9 +575,9 @@ void SoftContactConstraint::getInformation(ConstraintInfo* _info)
 //==============================================================================
 void SoftContactConstraint::applyUnitImpulse(std::size_t _idx)
 {
-  assert(_idx < mDim && "Invalid Index.");
-  assert(isActive());
-  assert(mBodyNode1->isReactive() || mBodyNode2->isReactive());
+  DART_ASSERT(_idx < mDim && "Invalid Index.");
+  DART_ASSERT(isActive());
+  DART_ASSERT(mBodyNode1->isReactive() || mBodyNode2->isReactive());
 
   // Self collision case
   if (mBodyNode1->getSkeleton() == mBodyNode2->getSkeleton()) {
@@ -641,7 +642,7 @@ void SoftContactConstraint::applyUnitImpulse(std::size_t _idx)
 //==============================================================================
 void SoftContactConstraint::getVelocityChange(double* _vel, bool _withCfm)
 {
-  assert(_vel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(_vel != nullptr && "Null pointer is not allowed.");
 
   for (std::size_t i = 0; i < mDim; ++i) {
     _vel[i] = 0.0;
@@ -716,7 +717,7 @@ void SoftContactConstraint::applyImpulse(double* _lambda)
       //      _lambda[_idx + 1] << std::endl; std::cout << "imp3: " <<
       //      mJacobians2[i * 3 + 2] * _lambda[_idx + 2] << std::endl;
 
-      assert(!math::isNan(_lambda[index]));
+      DART_ASSERT(!math::isNan(_lambda[index]));
 
       // Store contact impulse (force) toward the normal w.r.t. world frame
       mContacts[i]->force = mContacts[i]->normal * _lambda[index] / mTimeStep;
@@ -741,7 +742,7 @@ void SoftContactConstraint::applyImpulse(double* _lambda)
       //      std::cout << "_lambda: " << _lambda[_idx] << std::endl;
       index++;
 
-      assert(!math::isNan(_lambda[index]));
+      DART_ASSERT(!math::isNan(_lambda[index]));
 
       // Add contact impulse (force) toward the tangential w.r.t. world frame
       Eigen::MatrixXd D = getTangentBasisMatrixODE(mContacts[i]->normal);
@@ -767,7 +768,7 @@ void SoftContactConstraint::applyImpulse(double* _lambda)
       //      std::cout << "_lambda: " << _lambda[_idx] << std::endl;
       index++;
 
-      assert(!math::isNan(_lambda[index]));
+      DART_ASSERT(!math::isNan(_lambda[index]));
 
       // Add contact impulse (force) toward the tangential w.r.t. world frame
       mContacts[i]->force += D.col(1) * _lambda[index] / mTimeStep;
@@ -826,7 +827,7 @@ void SoftContactConstraint::applyImpulse(double* _lambda)
 //==============================================================================
 void SoftContactConstraint::getRelVelocity(double* _vel)
 {
-  assert(_vel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(_vel != nullptr && "Null pointer is not allowed.");
 
   for (std::size_t i = 0; i < mDim; ++i) {
     _vel[i] = 0.0;
@@ -855,7 +856,7 @@ bool SoftContactConstraint::isActive() const
 double SoftContactConstraint::computeFrictionCoefficient(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 
@@ -875,7 +876,7 @@ double SoftContactConstraint::computeFrictionCoefficient(
 double SoftContactConstraint::computeRestitutionCoefficient(
     const dynamics::ShapeNode* shapeNode)
 {
-  assert(shapeNode);
+  DART_ASSERT(shapeNode);
 
   auto dynamicAspect = shapeNode->getDynamicsAspect();
 

--- a/dart/constraint/WeldJointConstraint.cpp
+++ b/dart/constraint/WeldJointConstraint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/constraint/WeldJointConstraint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/lcpsolver/dantzig/lcp.h"
@@ -70,7 +71,7 @@ WeldJointConstraint::WeldJointConstraint(
     mAppliedImpulseIndex(0)
 {
   // The bodies should be different bodies.
-  assert(_body1 != _body2);
+  DART_ASSERT(_body1 != _body2);
 
   mDim = 6;
 
@@ -117,7 +118,7 @@ const std::string& WeldJointConstraint::getStaticType()
 void WeldJointConstraint::update()
 {
   // mBodyNode1 should not be null pointer ever
-  assert(mBodyNode1);
+  DART_ASSERT(mBodyNode1);
 
   // Update Jacobian for body2
   if (mBodyNode2) {
@@ -144,21 +145,21 @@ void WeldJointConstraint::update()
 //==============================================================================
 void WeldJointConstraint::getInformation(ConstraintInfo* _lcp)
 {
-  assert(isActive());
+  DART_ASSERT(isActive());
 
-  assert(_lcp->w[0] == 0.0);
-  assert(_lcp->w[1] == 0.0);
-  assert(_lcp->w[2] == 0.0);
-  assert(_lcp->w[3] == 0.0);
-  assert(_lcp->w[4] == 0.0);
-  assert(_lcp->w[5] == 0.0);
+  DART_ASSERT(_lcp->w[0] == 0.0);
+  DART_ASSERT(_lcp->w[1] == 0.0);
+  DART_ASSERT(_lcp->w[2] == 0.0);
+  DART_ASSERT(_lcp->w[3] == 0.0);
+  DART_ASSERT(_lcp->w[4] == 0.0);
+  DART_ASSERT(_lcp->w[5] == 0.0);
 
-  assert(_lcp->findex[0] == -1);
-  assert(_lcp->findex[1] == -1);
-  assert(_lcp->findex[2] == -1);
-  assert(_lcp->findex[3] == -1);
-  assert(_lcp->findex[4] == -1);
-  assert(_lcp->findex[5] == -1);
+  DART_ASSERT(_lcp->findex[0] == -1);
+  DART_ASSERT(_lcp->findex[1] == -1);
+  DART_ASSERT(_lcp->findex[2] == -1);
+  DART_ASSERT(_lcp->findex[3] == -1);
+  DART_ASSERT(_lcp->findex[4] == -1);
+  DART_ASSERT(_lcp->findex[5] == -1);
 
   _lcp->lo[0] = -dInfinity;
   _lcp->lo[1] = -dInfinity;
@@ -198,11 +199,11 @@ void WeldJointConstraint::getInformation(ConstraintInfo* _lcp)
 //==============================================================================
 void WeldJointConstraint::applyUnitImpulse(std::size_t _index)
 {
-  assert(_index < mDim && "Invalid Index.");
-  assert(isActive());
+  DART_ASSERT(_index < mDim && "Invalid Index.");
+  DART_ASSERT(isActive());
 
   if (mBodyNode2) {
-    assert(mBodyNode1->isReactive() || mBodyNode2->isReactive());
+    DART_ASSERT(mBodyNode1->isReactive() || mBodyNode2->isReactive());
 
     // Weld joint between two bodies in one skeleton
     if (mBodyNode1->getSkeleton() == mBodyNode2->getSkeleton()) {
@@ -224,7 +225,7 @@ void WeldJointConstraint::applyUnitImpulse(std::size_t _index)
           mBodyNode2->getSkeleton()->updateBiasImpulse(
               mBodyNode2, -mJacobian2.row(_index));
         } else {
-          assert(0);
+          DART_ASSERT(0);
         }
       }
 
@@ -247,7 +248,7 @@ void WeldJointConstraint::applyUnitImpulse(std::size_t _index)
       }
     }
   } else {
-    assert(mBodyNode1->isReactive());
+    DART_ASSERT(mBodyNode1->isReactive());
 
     mBodyNode1->getSkeleton()->clearConstraintImpulses();
     mBodyNode1->getSkeleton()->updateBiasImpulse(
@@ -261,8 +262,8 @@ void WeldJointConstraint::applyUnitImpulse(std::size_t _index)
 //==============================================================================
 void WeldJointConstraint::getVelocityChange(double* _vel, bool _withCfm)
 {
-  assert(_vel != nullptr && "Null pointer is not allowed.");
-  assert(isActive());
+  DART_ASSERT(_vel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(isActive());
 
   Eigen::Vector6d velChange = Eigen::Vector6d::Zero();
   if (mBodyNode1->getSkeleton()->isImpulseApplied()
@@ -343,11 +344,11 @@ dynamics::SkeletonPtr WeldJointConstraint::getRootSkeleton() const
       return ConstraintBase::getRootSkeleton(
           mBodyNode2->getSkeleton()->getSkeleton());
     } else {
-      assert(0);
+      DART_ASSERT(0);
       return nullptr;
     }
   } else {
-    assert(0);
+    DART_ASSERT(0);
     return nullptr;
   }
 }

--- a/dart/dynamics/AssimpInputResourceAdaptor.cpp
+++ b/dart/dynamics/AssimpInputResourceAdaptor.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/AssimpInputResourceAdaptor.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <assimp/IOStream.hpp>
 
@@ -110,7 +111,7 @@ AssimpInputResourceAdaptor::AssimpInputResourceAdaptor(
     const common::ResourcePtr& _resource)
   : mResource(_resource)
 {
-  assert(_resource);
+  DART_ASSERT(_resource);
 }
 
 //==============================================================================

--- a/dart/dynamics/BallJoint.cpp
+++ b/dart/dynamics/BallJoint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/BallJoint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
@@ -156,7 +157,7 @@ void BallJoint::updateRelativeTransform() const
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mR
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -171,7 +172,7 @@ void BallJoint::updateRelativeJacobian(bool _mandatory) const
 //==============================================================================
 void BallJoint::updateRelativeJacobianTimeDeriv() const
 {
-  assert(Eigen::Matrix6d::Zero().leftCols<3>() == mJacobianDeriv);
+  DART_ASSERT(Eigen::Matrix6d::Zero().leftCols<3>() == mJacobianDeriv);
 }
 
 //==============================================================================

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/BodyNode.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/StlHelpers.hpp"
 #include "dart/dynamics/Chain.hpp"
 #include "dart/dynamics/EndEffector.hpp"
@@ -377,7 +378,7 @@ void BodyNode::duplicateNodes(const BodyNode* otherBodyNode)
     DART_ERROR(
         "[BodyNode::duplicateNodes] You have asked to duplicate the Nodes of a "
         "nullptr, which is not allowed!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -395,7 +396,7 @@ void BodyNode::matchNodes(const BodyNode* otherBodyNode)
     DART_ERROR(
         "[BodyNode::matchNodes] You have asked to match the Nodes of a "
         "nullptr, which is not allowed!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -664,7 +665,7 @@ void BodyNode::setFrictionCoeff(double coeff)
   if (mAspectProperties.mFrictionCoeff == coeff)
     return;
 
-  assert(
+  DART_ASSERT(
       0.0 <= coeff && "Coefficient of friction should be non-negative value.");
   mAspectProperties.mFrictionCoeff = coeff;
 
@@ -691,7 +692,7 @@ void BodyNode::setRestitutionCoeff(double coeff)
   if (coeff == mAspectProperties.mRestitutionCoeff)
     return;
 
-  assert(
+  DART_ASSERT(
       0.0 <= coeff && coeff <= 1.0
       && "Coefficient of restitution should be in range of [0, 1].");
   mAspectProperties.mRestitutionCoeff = coeff;
@@ -880,7 +881,7 @@ const BodyNode* BodyNode::getParentBodyNode() const
 //==============================================================================
 void BodyNode::addChildBodyNode(BodyNode* _body)
 {
-  assert(_body != nullptr);
+  DART_ASSERT(_body != nullptr);
 
   if (std::find(mChildBodyNodes.begin(), mChildBodyNodes.end(), _body)
       != mChildBodyNodes.end()) {
@@ -1039,7 +1040,7 @@ std::size_t BodyNode::getNumDependentGenCoords() const
 //==============================================================================
 std::size_t BodyNode::getDependentGenCoordIndex(std::size_t _arrayIndex) const
 {
-  assert(_arrayIndex < mDependentGenCoordIndices.size());
+  DART_ASSERT(_arrayIndex < mDependentGenCoordIndices.size());
 
   return mDependentGenCoordIndices[_arrayIndex];
 }
@@ -1348,7 +1349,7 @@ Node* BodyNode::cloneNode(BodyNode* /*bn*/) const
   DART_ERROR(
       "[BodyNode::cloneNode] This function should never be called! Please "
       "report this as an error!");
-  assert(false);
+  DART_ASSERT(false);
   return nullptr;
 }
 
@@ -1356,7 +1357,7 @@ Node* BodyNode::cloneNode(BodyNode* /*bn*/) const
 void BodyNode::init(const SkeletonPtr& _skeleton)
 {
   mSkeleton = _skeleton;
-  assert(_skeleton);
+  DART_ASSERT(_skeleton);
   if (mReferenceCount > 0) {
     mReferenceSkeleton = mSkeleton.lock();
   }
@@ -1402,7 +1403,7 @@ void BodyNode::init(const SkeletonPtr& _skeleton)
   std::size_t nDepGenCoordIndices = mDependentGenCoordIndices.size();
   for (std::size_t i = 0; i < nDepGenCoordIndices; ++i) {
     for (std::size_t j = i + 1; j < nDepGenCoordIndices; ++j) {
-      assert(
+      DART_ASSERT(
           mDependentGenCoordIndices[i] != mDependentGenCoordIndices[j]
           && "Duplicated index is found in mDependentGenCoordIndices.");
     }
@@ -1627,7 +1628,7 @@ void BodyNode::updateTransform()
 {
   // Calling getWorldTransform will update the transform if an update is needed
   getWorldTransform();
-  assert(math::verifyTransform(mWorldTransform));
+  DART_ASSERT(math::verifyTransform(mWorldTransform));
 }
 
 //==============================================================================
@@ -1635,7 +1636,7 @@ void BodyNode::updateVelocity()
 {
   // Calling getSpatialVelocity will update the velocity if an update is needed
   getSpatialVelocity();
-  assert(!math::isNan(mVelocity));
+  DART_ASSERT(!math::isNan(mVelocity));
 }
 
 //==============================================================================
@@ -1653,7 +1654,7 @@ void BodyNode::updateAccelerationID()
   // Note: auto-updating has replaced this function
   getSpatialAcceleration();
   // Verification
-  assert(!math::isNan(mAcceleration));
+  DART_ASSERT(!math::isNan(mAcceleration));
 }
 
 //==============================================================================
@@ -1676,7 +1677,7 @@ void BodyNode::updateTransmittedForceID(
     mF -= mAspectState.mFext;
 
   // Verification
-  assert(!math::isNan(mF));
+  DART_ASSERT(!math::isNan(mF));
 
   // Gravity force
   mF -= mFgravity;
@@ -1688,14 +1689,14 @@ void BodyNode::updateTransmittedForceID(
   //
   for (const auto& childBodyNode : mChildBodyNodes) {
     Joint* childJoint = childBodyNode->getParentJoint();
-    assert(childJoint != nullptr);
+    DART_ASSERT(childJoint != nullptr);
 
     mF += math::dAdInvT(
         childJoint->getRelativeTransform(), childBodyNode->getBodyForce());
   }
 
   // Verification
-  assert(!math::isNan(mF));
+  DART_ASSERT(!math::isNan(mF));
 }
 
 //==============================================================================
@@ -1716,7 +1717,7 @@ void BodyNode::updateArtInertia(double _timeStep) const
 
   // Verification
   //  assert(!math::isNan(mArtInertia));
-  assert(!math::isNan(mArtInertiaImplicit));
+  DART_ASSERT(!math::isNan(mArtInertiaImplicit));
 
   // Update parent joint's inverse of projected articulated body inertia
   mParentJoint->updateInvProjArtInertia(mArtInertia);
@@ -1724,7 +1725,7 @@ void BodyNode::updateArtInertia(double _timeStep) const
 
   // Verification
   //  assert(!math::isNan(mArtInertia));
-  assert(!math::isNan(mArtInertiaImplicit));
+  DART_ASSERT(!math::isNan(mArtInertiaImplicit));
 }
 
 //==============================================================================
@@ -1744,7 +1745,7 @@ void BodyNode::updateBiasForce(
   mBiasForce = -math::dad(V, mI * V) - mAspectState.mFext - mFgravity;
 
   // Verification
-  assert(!math::isNan(mBiasForce));
+  DART_ASSERT(!math::isNan(mBiasForce));
 
   // And add child bias force
   for (const auto& childBodyNode : mChildBodyNodes) {
@@ -1758,7 +1759,7 @@ void BodyNode::updateBiasForce(
   }
 
   // Verification
-  assert(!math::isNan(mBiasForce));
+  DART_ASSERT(!math::isNan(mBiasForce));
 
   // Update parent joint's total force with implicit joint damping and spring
   // forces
@@ -1784,7 +1785,7 @@ void BodyNode::updateBiasImpulse()
   }
 
   // Verification
-  assert(!math::isNan(mBiasImpulse));
+  DART_ASSERT(!math::isNan(mBiasImpulse));
 
   // Update parent joint's total force
   mParentJoint->updateTotalImpulse(mBiasImpulse);
@@ -1796,7 +1797,7 @@ void BodyNode::updateTransmittedForceFD()
   mF = mBiasForce;
   mF.noalias() += getArticulatedInertiaImplicit() * getSpatialAcceleration();
 
-  assert(!math::isNan(mF));
+  DART_ASSERT(!math::isNan(mF));
 }
 
 //==============================================================================
@@ -1805,7 +1806,7 @@ void BodyNode::updateTransmittedImpulse()
   mImpF = mBiasImpulse;
   mImpF.noalias() += getArticulatedInertia() * mDelV;
 
-  assert(!math::isNan(mImpF));
+  DART_ASSERT(!math::isNan(mImpF));
 }
 
 //==============================================================================
@@ -1823,7 +1824,7 @@ void BodyNode::updateAccelerationFD()
   }
 
   // Verify the spatial acceleration of this body
-  assert(!math::isNan(mAcceleration));
+  DART_ASSERT(!math::isNan(mAcceleration));
 }
 
 //==============================================================================
@@ -1850,14 +1851,14 @@ void BodyNode::updateVelocityChangeFD()
   mParentJoint->addVelocityChangeTo(mDelV);
 
   // Verify the spatial velocity change of this body
-  assert(!math::isNan(mDelV));
+  DART_ASSERT(!math::isNan(mDelV));
 }
 
 //==============================================================================
 void BodyNode::updateJointForceID(
     double _timeStep, bool _withDampingForces, bool _withSpringForces)
 {
-  assert(mParentJoint != nullptr);
+  DART_ASSERT(mParentJoint != nullptr);
   mParentJoint->updateForceID(
       mF, _timeStep, _withDampingForces, _withSpringForces);
 }
@@ -1866,7 +1867,7 @@ void BodyNode::updateJointForceID(
 void BodyNode::updateJointForceFD(
     double _timeStep, bool _withDampingForces, bool _withSpringForces)
 {
-  assert(mParentJoint != nullptr);
+  DART_ASSERT(mParentJoint != nullptr);
   mParentJoint->updateForceFD(
       mF, _timeStep, _withDampingForces, _withSpringForces);
 }
@@ -1874,7 +1875,7 @@ void BodyNode::updateJointForceFD(
 //==============================================================================
 void BodyNode::updateJointImpulseFD()
 {
-  assert(mParentJoint != nullptr);
+  DART_ASSERT(mParentJoint != nullptr);
   mParentJoint->updateImpulseFD(mF);
 }
 
@@ -1963,14 +1964,14 @@ const Eigen::Vector6d& BodyNode::getBodyForce() const
 //==============================================================================
 void BodyNode::setConstraintImpulse(const Eigen::Vector6d& _constImp)
 {
-  assert(!math::isNan(_constImp));
+  DART_ASSERT(!math::isNan(_constImp));
   mConstraintImpulse = _constImp;
 }
 
 //==============================================================================
 void BodyNode::addConstraintImpulse(const Eigen::Vector6d& _constImp)
 {
-  assert(!math::isNan(_constImp));
+  DART_ASSERT(!math::isNan(_constImp));
   mConstraintImpulse += _constImp;
 }
 
@@ -2181,12 +2182,12 @@ void BodyNode::updateMassMatrix()
   if (dof > 0) {
     mM_dV.noalias() += mParentJoint->getRelativeJacobian()
                        * mParentJoint->getAccelerations();
-    assert(!math::isNan(mM_dV));
+    DART_ASSERT(!math::isNan(mM_dV));
   }
   if (mParentBodyNode)
     mM_dV += math::AdInvT(
         mParentJoint->getRelativeTransform(), mParentBodyNode->mM_dV);
-  assert(!math::isNan(mM_dV));
+  DART_ASSERT(!math::isNan(mM_dV));
 }
 
 //==============================================================================
@@ -2197,7 +2198,7 @@ void BodyNode::aggregateMassMatrix(Eigen::MatrixXd& _MCol, std::size_t _col)
   mM_F.noalias() = mI * mM_dV;
 
   // Verification
-  assert(!math::isNan(mM_F));
+  DART_ASSERT(!math::isNan(mM_F));
 
   //
   for (std::vector<BodyNode*>::const_iterator it = mChildBodyNodes.begin();
@@ -2208,7 +2209,7 @@ void BodyNode::aggregateMassMatrix(Eigen::MatrixXd& _MCol, std::size_t _col)
   }
 
   // Verification
-  assert(!math::isNan(mM_F));
+  DART_ASSERT(!math::isNan(mM_F));
 
   //
   std::size_t dof = mParentJoint->getNumDofs();
@@ -2230,7 +2231,7 @@ void BodyNode::aggregateAugMassMatrix(
   mM_F.noalias() = mI * mM_dV;
 
   // Verification
-  assert(!math::isNan(mM_F));
+  DART_ASSERT(!math::isNan(mM_F));
 
   //
   for (std::vector<BodyNode*>::const_iterator it = mChildBodyNodes.begin();
@@ -2241,7 +2242,7 @@ void BodyNode::aggregateAugMassMatrix(
   }
 
   // Verification
-  assert(!math::isNan(mM_F));
+  DART_ASSERT(!math::isNan(mM_F));
 
   //
   std::size_t dof = mParentJoint->getNumDofs();
@@ -2277,7 +2278,7 @@ void BodyNode::updateInvMassMatrix()
   }
 
   // Verification
-  assert(!math::isNan(mInvM_c));
+  DART_ASSERT(!math::isNan(mInvM_c));
 
   // Update parent joint's total force for inverse mass matrix
   mParentJoint->updateTotalForceForInvMassMatrix(mInvM_c);
@@ -2298,7 +2299,7 @@ void BodyNode::updateInvAugMassMatrix()
   }
 
   // Verification
-  assert(!math::isNan(mInvM_c));
+  DART_ASSERT(!math::isNan(mInvM_c));
 
   // Update parent joint's total force for inverse mass matrix
   mParentJoint->updateTotalForceForInvMassMatrix(mInvM_c);
@@ -2379,17 +2380,17 @@ void BodyNode::updateBodyJacobian() const
     return;
 
   const std::size_t localDof = mParentJoint->getNumDofs();
-  assert(getNumDependentGenCoords() >= localDof);
+  DART_ASSERT(getNumDependentGenCoords() >= localDof);
   const std::size_t ascendantDof = getNumDependentGenCoords() - localDof;
 
   // Parent Jacobian
   if (mParentBodyNode) {
-    assert(
+    DART_ASSERT(
         static_cast<std::size_t>(mParentBodyNode->getJacobian().cols())
             + mParentJoint->getNumDofs()
         == static_cast<std::size_t>(mBodyJacobian.cols()));
 
-    assert(mParentJoint);
+    DART_ASSERT(mParentJoint);
     mBodyJacobian.leftCols(ascendantDof) = math::AdInvTJac(
         mParentJoint->getRelativeTransform(), mParentBodyNode->getJacobian());
   }
@@ -2430,14 +2431,14 @@ void BodyNode::updateBodyJacobianSpatialDeriv() const
     return;
 
   const auto numLocalDOFs = mParentJoint->getNumDofs();
-  assert(getNumDependentGenCoords() >= numLocalDOFs);
+  DART_ASSERT(getNumDependentGenCoords() >= numLocalDOFs);
   const auto numParentDOFs = getNumDependentGenCoords() - numLocalDOFs;
 
   // Parent Jacobian: Ad(T(i, parent(i)), dJ_parent(i))
   if (mParentBodyNode) {
     const auto& dJ_parent = mParentBodyNode->getJacobianSpatialDeriv();
 
-    assert(
+    DART_ASSERT(
         static_cast<std::size_t>(dJ_parent.cols()) + mParentJoint->getNumDofs()
         == static_cast<std::size_t>(mBodyJacobianSpatialDeriv.cols()));
 
@@ -2479,7 +2480,7 @@ void BodyNode::updateWorldJacobianClassicDeriv() const
     return;
 
   const std::size_t numLocalDOFs = mParentJoint->getNumDofs();
-  assert(getNumDependentGenCoords() >= numLocalDOFs);
+  DART_ASSERT(getNumDependentGenCoords() >= numLocalDOFs);
   const std::size_t numParentDOFs = getNumDependentGenCoords() - numLocalDOFs;
 
   if (mParentBodyNode) {
@@ -2495,7 +2496,7 @@ void BodyNode::updateWorldJacobianClassicDeriv() const
            - mParentBodyNode->getWorldTransform().translation())
               .eval();
 
-    assert(
+    DART_ASSERT(
         static_cast<std::size_t>(dJ_parent.cols()) + mParentJoint->getNumDofs()
         == static_cast<std::size_t>(mWorldJacobianClassicDeriv.cols()));
 

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/dynamics/BoxShape.hpp"
 
+#include "dart/common/Macros.hpp"
+
 #include <cmath>
 
 namespace dart {
@@ -40,9 +42,9 @@ namespace dynamics {
 //==============================================================================
 BoxShape::BoxShape(const Eigen::Vector3d& _size) : Shape(BOX), mSize(_size)
 {
-  assert(_size[0] > 0.0);
-  assert(_size[1] > 0.0);
-  assert(_size[2] > 0.0);
+  DART_ASSERT(_size[0] > 0.0);
+  DART_ASSERT(_size[1] > 0.0);
+  DART_ASSERT(_size[2] > 0.0);
 }
 
 //==============================================================================
@@ -86,9 +88,9 @@ Eigen::Matrix3d BoxShape::computeInertia(
 //==============================================================================
 void BoxShape::setSize(const Eigen::Vector3d& _size)
 {
-  assert(_size[0] > 0.0);
-  assert(_size[1] > 0.0);
-  assert(_size[2] > 0.0);
+  DART_ASSERT(_size[0] > 0.0);
+  DART_ASSERT(_size[1] > 0.0);
+  DART_ASSERT(_size[2] > 0.0);
   mSize = _size;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/Branch.cpp
+++ b/dart/dynamics/Branch.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/Branch.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 
 namespace dart {
@@ -111,7 +112,7 @@ BranchPtr Branch::cloneBranch(const std::string& cloneName) const
 
   // Create a Criteria
   Criteria newCriteria = Criteria::convert(mCriteria);
-  assert(newCriteria.mStart.lock());
+  DART_ASSERT(newCriteria.mStart.lock());
   newCriteria.mStart
       = skelClone->getBodyNode(newCriteria.mStart.lock()->getName());
 

--- a/dart/dynamics/CapsuleShape.cpp
+++ b/dart/dynamics/CapsuleShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/CapsuleShape.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
 #include "dart/math/Helpers.hpp"
@@ -45,8 +46,8 @@ namespace dynamics {
 CapsuleShape::CapsuleShape(double radius, double height)
   : Shape(CAPSULE), mRadius(radius), mHeight(height)
 {
-  assert(0.0 < radius);
-  assert(0.0 < height);
+  DART_ASSERT(0.0 < radius);
+  DART_ASSERT(0.0 < height);
 }
 
 //==============================================================================
@@ -71,7 +72,7 @@ double CapsuleShape::getRadius() const
 //==============================================================================
 void CapsuleShape::setRadius(double radius)
 {
-  assert(0.0 < radius);
+  DART_ASSERT(0.0 < radius);
   mRadius = radius;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -88,7 +89,7 @@ double CapsuleShape::getHeight() const
 //==============================================================================
 void CapsuleShape::setHeight(double height)
 {
-  assert(0.0 < height);
+  DART_ASSERT(0.0 < height);
   mHeight = height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/Chain.cpp
+++ b/dart/dynamics/Chain.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/Chain.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/FreeJoint.hpp"
 
 namespace dart {
@@ -181,8 +182,8 @@ ChainPtr Chain::cloneChain(const std::string& cloneName) const
 
   // Create a Criteria
   Criteria newCriteria = Criteria::convert(mCriteria);
-  assert(newCriteria.mStart.lock());
-  assert(newCriteria.mTarget.lock());
+  DART_ASSERT(newCriteria.mStart.lock());
+  DART_ASSERT(newCriteria.mTarget.lock());
   newCriteria.mStart
       = skelClone->getBodyNode(newCriteria.mStart.lock()->getName());
   newCriteria.mTarget

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/ConeShape.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
 #include "dart/math/Helpers.hpp"
@@ -45,8 +46,8 @@ namespace dynamics {
 ConeShape::ConeShape(double radius, double height)
   : Shape(CONE), mRadius(radius), mHeight(height)
 {
-  assert(0.0 < radius);
-  assert(0.0 < height);
+  DART_ASSERT(0.0 < radius);
+  DART_ASSERT(0.0 < height);
 }
 
 //==============================================================================
@@ -71,7 +72,7 @@ double ConeShape::getRadius() const
 //==============================================================================
 void ConeShape::setRadius(double radius)
 {
-  assert(0.0 < radius);
+  DART_ASSERT(0.0 < radius);
   mRadius = radius;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -88,7 +89,7 @@ double ConeShape::getHeight() const
 //==============================================================================
 void ConeShape::setHeight(double height)
 {
-  assert(0.0 < height);
+  DART_ASSERT(0.0 < height);
   mHeight = height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/CylinderShape.cpp
+++ b/dart/dynamics/CylinderShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/CylinderShape.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 
 #include <cmath>
@@ -43,8 +44,8 @@ namespace dynamics {
 CylinderShape::CylinderShape(double _radius, double _height)
   : Shape(CYLINDER), mRadius(_radius), mHeight(_height)
 {
-  assert(0.0 < _radius);
-  assert(0.0 < _height);
+  DART_ASSERT(0.0 < _radius);
+  DART_ASSERT(0.0 < _height);
 }
 
 //==============================================================================
@@ -69,7 +70,7 @@ double CylinderShape::getRadius() const
 //==============================================================================
 void CylinderShape::setRadius(double _radius)
 {
-  assert(0.0 < _radius);
+  DART_ASSERT(0.0 < _radius);
   mRadius = _radius;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -86,7 +87,7 @@ double CylinderShape::getHeight() const
 //==============================================================================
 void CylinderShape::setHeight(double _height)
 {
-  assert(0.0 < _height);
+  DART_ASSERT(0.0 < _height);
   mHeight = _height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/EllipsoidShape.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 
 namespace dart {
@@ -78,9 +79,9 @@ const Eigen::Vector3d& EllipsoidShape::getSize() const
 //==============================================================================
 void EllipsoidShape::setDiameters(const Eigen::Vector3d& diameters)
 {
-  assert(diameters[0] > 0.0);
-  assert(diameters[1] > 0.0);
-  assert(diameters[2] > 0.0);
+  DART_ASSERT(diameters[0] > 0.0);
+  DART_ASSERT(diameters[1] > 0.0);
+  DART_ASSERT(diameters[2] > 0.0);
 
   mDiameters = diameters;
 

--- a/dart/dynamics/Entity.cpp
+++ b/dart/dynamics/Entity.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/Entity.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/StlHelpers.hpp"
 #include "dart/dynamics/Frame.hpp"
 #include "dart/dynamics/Shape.hpp"
@@ -226,7 +227,7 @@ Entity::Entity(ConstructAbstractTag)
   DART_ERROR(
       "[Entity::Entity] Your class implementation is calling the Entity "
       "constructor that is meant to be reserved for abstract classes!");
-  assert(false);
+  DART_ASSERT(false);
 }
 
 //==============================================================================

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/EulerJoint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/math/Geometry.hpp"
 
@@ -253,7 +254,7 @@ Eigen::Matrix<double, 6, 3> EulerJoint::getRelativeJacobianStatic(
   J.col(1) = math::AdT(Joint::mAspectProperties.mT_ChildBodyToJoint, J1);
   J.col(2) = math::AdT(Joint::mAspectProperties.mT_ChildBodyToJoint, J2);
 
-  assert(!math::isNan(J));
+  DART_ASSERT(!math::isNan(J));
 
 #if DART_BUILD_MODE_DEBUG
   Eigen::MatrixXd JTJ = J.transpose() * J;
@@ -328,7 +329,7 @@ void EulerJoint::updateRelativeTransform() const
        * convertToTransform(getPositionsStatic())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -407,7 +408,7 @@ void EulerJoint::updateRelativeJacobianTimeDeriv() const
   mJacobianDeriv.col(2)
       = math::AdT(Joint::mAspectProperties.mT_ChildBodyToJoint, dJ2);
 
-  assert(!math::isNan(mJacobianDeriv));
+  DART_ASSERT(!math::isNan(mJacobianDeriv));
 }
 
 } // namespace dynamics

--- a/dart/dynamics/FixedFrame.cpp
+++ b/dart/dynamics/FixedFrame.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/dynamics/FixedFrame.hpp"
 
+#include "dart/common/Macros.hpp"
+
 namespace dart {
 namespace dynamics {
 
@@ -122,7 +124,7 @@ FixedFrame::FixedFrame(ConstructAbstractTag)
   DART_ERROR(
       "[FixedFrame::FixedFrame] Attempting to construct a pure abstract "
       "FixedFrame object. This is not allowed!");
-  assert(false);
+  DART_ASSERT(false);
 }
 
 } // namespace dynamics

--- a/dart/dynamics/Frame.cpp
+++ b/dart/dynamics/Frame.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/Frame.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/Shape.hpp"
 
 namespace dart {
@@ -119,8 +120,8 @@ Eigen::Isometry3d Frame::getTransform(const Frame* _withRespectTo) const
 Eigen::Isometry3d Frame::getTransform(
     const Frame* withRespectTo, const Frame* inCoordinatesOf) const
 {
-  assert(nullptr != withRespectTo);
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != withRespectTo);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   if (withRespectTo == inCoordinatesOf)
     return getTransform(withRespectTo);
@@ -549,7 +550,7 @@ Frame::Frame(ConstructAbstractTag)
       "[Frame::constructor] You are calling a constructor for the Frame class "
       "which is only meant to be used by pure abstract classes. If you are "
       "seeing this, then there is a bug!");
-  assert(false);
+  DART_ASSERT(false);
 }
 
 //==============================================================================

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/FreeJoint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
@@ -194,7 +195,7 @@ void FreeJoint::setRelativeTransform(const Eigen::Isometry3d& newTransform)
 void FreeJoint::setTransform(
     const Eigen::Isometry3d& newTransform, const Frame* withRespectTo)
 {
-  assert(nullptr != withRespectTo);
+  DART_ASSERT(nullptr != withRespectTo);
 
   setRelativeTransform(
       withRespectTo->getTransform(getChildBodyNode()->getParentFrame())
@@ -213,7 +214,7 @@ void FreeJoint::setRelativeSpatialVelocity(
 void FreeJoint::setRelativeSpatialVelocity(
     const Eigen::Vector6d& newSpatialVelocity, const Frame* inCoordinatesOf)
 {
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   if (getChildBodyNode() == inCoordinatesOf) {
     setRelativeSpatialVelocity(newSpatialVelocity);
@@ -229,8 +230,8 @@ void FreeJoint::setSpatialVelocity(
     const Frame* relativeTo,
     const Frame* inCoordinatesOf)
 {
-  assert(nullptr != relativeTo);
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != relativeTo);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   if (getChildBodyNode() == relativeTo) {
     DART_WARN(
@@ -278,8 +279,8 @@ void FreeJoint::setLinearVelocity(
     const Frame* relativeTo,
     const Frame* inCoordinatesOf)
 {
-  assert(nullptr != relativeTo);
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != relativeTo);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   Eigen::Vector6d targetSpatialVelocity;
 
@@ -312,8 +313,8 @@ void FreeJoint::setAngularVelocity(
     const Frame* relativeTo,
     const Frame* inCoordinatesOf)
 {
-  assert(nullptr != relativeTo);
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != relativeTo);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   Eigen::Vector6d targetSpatialVelocity;
 
@@ -355,7 +356,7 @@ void FreeJoint::setRelativeSpatialAcceleration(
 void FreeJoint::setRelativeSpatialAcceleration(
     const Eigen::Vector6d& newSpatialAcceleration, const Frame* inCoordinatesOf)
 {
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   if (getChildBodyNode() == inCoordinatesOf) {
     setRelativeSpatialAcceleration(newSpatialAcceleration);
@@ -372,8 +373,8 @@ void FreeJoint::setSpatialAcceleration(
     const Frame* relativeTo,
     const Frame* inCoordinatesOf)
 {
-  assert(nullptr != relativeTo);
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != relativeTo);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   if (getChildBodyNode() == relativeTo) {
     DART_WARN(
@@ -435,8 +436,8 @@ void FreeJoint::setLinearAcceleration(
     const Frame* relativeTo,
     const Frame* inCoordinatesOf)
 {
-  assert(nullptr != relativeTo);
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != relativeTo);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   Eigen::Vector6d targetSpatialAcceleration;
 
@@ -473,8 +474,8 @@ void FreeJoint::setAngularAcceleration(
     const Frame* relativeTo,
     const Frame* inCoordinatesOf)
 {
-  assert(nullptr != relativeTo);
-  assert(nullptr != inCoordinatesOf);
+  DART_ASSERT(nullptr != relativeTo);
+  DART_ASSERT(nullptr != inCoordinatesOf);
 
   Eigen::Vector6d targetSpatialAcceleration;
 
@@ -639,7 +640,7 @@ void FreeJoint::updateRelativeTransform() const
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mQ
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -653,7 +654,7 @@ void FreeJoint::updateRelativeJacobian(bool _mandatory) const
 //==============================================================================
 void FreeJoint::updateRelativeJacobianTimeDeriv() const
 {
-  assert(Eigen::Matrix6d::Zero() == mJacobianDeriv);
+  DART_ASSERT(Eigen::Matrix6d::Zero() == mJacobianDeriv);
 }
 
 //==============================================================================

--- a/dart/dynamics/Group.cpp
+++ b/dart/dynamics/Group.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/Group.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/Joint.hpp"
@@ -109,27 +110,27 @@ GroupPtr Group::cloneGroup(const std::string& cloneName) const
   // Add BodyNodes
   for (const BodyNodePtr& bodyNode : mBodyNodes) {
     SkeletonPtr skelClone = mapToSkeletonClones[bodyNode->getSkeleton().get()];
-    assert(skelClone);
+    DART_ASSERT(skelClone);
     BodyNode* bodyNodeClone = skelClone->getBodyNode(bodyNode->getName());
-    assert(bodyNodeClone);
+    DART_ASSERT(bodyNodeClone);
     newGroup->addBodyNode(bodyNodeClone);
   }
 
   // Add Joints
   for (const JointPtr& joint : mJoints) {
     SkeletonPtr skelClone = mapToSkeletonClones[joint->getSkeleton().get()];
-    assert(skelClone);
+    DART_ASSERT(skelClone);
     Joint* jointClone = skelClone->getJoint(joint->getName());
-    assert(jointClone);
+    DART_ASSERT(jointClone);
     newGroup->addJoint(jointClone, false);
   }
 
   // Add DegreeOfFreedoms
   for (const DegreeOfFreedomPtr& dof : mDofs) {
     SkeletonPtr skelClone = mapToSkeletonClones[dof->getSkeleton().get()];
-    assert(skelClone);
+    DART_ASSERT(skelClone);
     DegreeOfFreedom* dofClone = skelClone->getDof(dof->getName());
-    assert(dofClone);
+    DART_ASSERT(dofClone);
     newGroup->addDof(dofClone, false);
   }
 
@@ -155,7 +156,7 @@ void Group::swapBodyNodeIndices(std::size_t _index1, std::size_t _index2)
         _index1,
         _index2,
         mBodyNodes.size());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -173,7 +174,7 @@ void Group::swapBodyNodeIndices(std::size_t _index1, std::size_t _index2)
         static_cast<const void*>(bn1),
         getName(),
         static_cast<const void*>(this));
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -188,7 +189,7 @@ void Group::swapBodyNodeIndices(std::size_t _index1, std::size_t _index2)
         static_cast<const void*>(bn2),
         getName(),
         static_cast<const void*>(this));
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -213,7 +214,7 @@ void Group::swapDofIndices(std::size_t _index1, std::size_t _index2)
         _index1,
         _index2,
         mDofs.size());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -231,7 +232,7 @@ void Group::swapDofIndices(std::size_t _index1, std::size_t _index2)
         static_cast<const void*>(dof1),
         getName(),
         static_cast<const void*>(this));
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -246,7 +247,7 @@ void Group::swapDofIndices(std::size_t _index1, std::size_t _index2)
         static_cast<const void*>(dof2),
         getName(),
         static_cast<const void*>(this));
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -272,7 +273,7 @@ bool Group::addComponent(BodyNode* _bn, bool _warning)
           "Group [{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -293,7 +294,7 @@ bool Group::addComponent(BodyNode* _bn, bool _warning)
         static_cast<const void*>(_bn),
         getName(),
         static_cast<const void*>(this));
-    assert(false);
+    DART_ASSERT(false);
   }
 
   return added;
@@ -320,7 +321,7 @@ bool Group::removeComponent(BodyNode* _bn, bool _warning)
           "from the Group [{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -341,7 +342,7 @@ bool Group::removeComponent(BodyNode* _bn, bool _warning)
         static_cast<const void*>(_bn),
         getName(),
         static_cast<const void*>(this));
-    assert(false);
+    DART_ASSERT(false);
   }
 
   return removed;
@@ -368,7 +369,7 @@ bool Group::addBodyNode(BodyNode* _bn, bool _warning)
           "Group [{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -383,7 +384,7 @@ bool Group::addBodyNode(BodyNode* _bn, bool _warning)
           static_cast<const void*>(_bn),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -414,7 +415,7 @@ bool Group::removeBodyNode(BodyNode* _bn, bool _warning)
           "from the Group [{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -429,7 +430,7 @@ bool Group::removeBodyNode(BodyNode* _bn, bool _warning)
           static_cast<const void*>(_bn),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -460,7 +461,7 @@ bool Group::addJoint(Joint* _joint, bool _addDofs, bool _warning)
           "[{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -486,7 +487,7 @@ bool Group::addJoint(Joint* _joint, bool _addDofs, bool _warning)
           static_cast<const void*>(_joint),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     } else {
       DART_WARN(
           "[Group::addJoint] The Joint named [{}] ({}) is already in the Group "
@@ -495,7 +496,7 @@ bool Group::addJoint(Joint* _joint, bool _addDofs, bool _warning)
           static_cast<const void*>(_joint),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -523,7 +524,7 @@ bool Group::removeJoint(Joint* _joint, bool _removeDofs, bool _warning)
           "Group [{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -552,7 +553,7 @@ bool Group::removeJoint(Joint* _joint, bool _removeDofs, bool _warning)
           static_cast<const void*>(_joint),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     } else {
       DART_WARN(
           "[Group::removeJoint] The Joint named [{}] ({}) was NOT in the Group "
@@ -561,7 +562,7 @@ bool Group::removeJoint(Joint* _joint, bool _removeDofs, bool _warning)
           static_cast<const void*>(_joint),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -589,7 +590,7 @@ bool Group::addDof(DegreeOfFreedom* _dof, bool _addJoint, bool _warning)
           "Group [{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -613,7 +614,7 @@ bool Group::addDof(DegreeOfFreedom* _dof, bool _addJoint, bool _warning)
           static_cast<const void*>(_dof),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     } else {
       DART_WARN(
           "[Group::addDof] The DegreeOfFreedom named [{}] ({}) is already in "
@@ -622,7 +623,7 @@ bool Group::addDof(DegreeOfFreedom* _dof, bool _addJoint, bool _warning)
           static_cast<const void*>(_dof),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -650,7 +651,7 @@ bool Group::removeDof(DegreeOfFreedom* _dof, bool _cleanupJoint, bool _warning)
           "from the Group [{}] ({})",
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
 
     return false;
@@ -692,7 +693,7 @@ bool Group::removeDof(DegreeOfFreedom* _dof, bool _cleanupJoint, bool _warning)
           static_cast<const void*>(_dof),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     } else {
       DART_WARN(
           "[Group::removeDof] The DegreeOfFreedom named [{}] ({}) was NOT in "
@@ -701,7 +702,7 @@ bool Group::removeDof(DegreeOfFreedom* _dof, bool _cleanupJoint, bool _warning)
           static_cast<const void*>(_dof),
           getName(),
           static_cast<const void*>(this));
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 

--- a/dart/dynamics/HierarchicalIK.cpp
+++ b/dart/dynamics/HierarchicalIK.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/HierarchicalIK.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/EndEffector.hpp"
@@ -396,7 +397,7 @@ double HierarchicalIK::Objective::eval(const Eigen::VectorXd& _x)
     DART_ERROR(
         "[HierarchicalIK::Objective::eval] Attempting to use an Objective "
         "function of an expired HierarchicalIK module!");
-    assert(false);
+    DART_ASSERT(false);
     return 0;
   }
 
@@ -421,7 +422,7 @@ void HierarchicalIK::Objective::evalGradient(
     DART_ERROR(
         "[HierarchicalIK::Objective::evalGradient] Attempting to use an "
         "Objective function of an expired HierarchicalIK module!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -470,7 +471,7 @@ double HierarchicalIK::Constraint::eval(const Eigen::VectorXd& _x)
     DART_ERROR(
         "[HierarchicalIK::Constraint::eval] Attempting to use a Constraint "
         "function of an expired HierarchicalIK module!");
-    assert(false);
+    DART_ASSERT(false);
     return 0.0;
   }
 
@@ -701,7 +702,7 @@ void CompositeIK::refreshIKHierarchy()
         = std::max(static_cast<int>(module->getHierarchyLevel()), highestLevel);
   }
 
-  assert(highestLevel >= 0);
+  DART_ASSERT(highestLevel >= 0);
 
   mHierarchy.resize(highestLevel + 1);
   for (auto& level : mHierarchy)

--- a/dart/dynamics/IkFast.cpp
+++ b/dart/dynamics/IkFast.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/IkFast.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/RevoluteJoint.hpp"
@@ -93,7 +94,7 @@ std::vector<bool> getFreeJointFlags(
   std::vector<bool> flags(numParams, false);
 
   for (int i = 0; i < numFreeParams; ++i) {
-    assert(freeParams[i] < numParams);
+    DART_ASSERT(freeParams[i] < numParams);
     flags[freeParams[i]] = true;
   }
 
@@ -124,7 +125,7 @@ void convertIkSolution(
   bool limitViolated = false;
 
   auto index = 0u;
-  assert(solutionValues.size());
+  DART_ASSERT(solutionValues.size());
   solution.mConfig.resize(dofIndices.size());
   for (auto i = 0u; i < solutionValues.size(); ++i) {
     const auto isFreeJoint = freeJointFlags[i];
@@ -259,7 +260,7 @@ auto IkFast::getDofs() const -> const std::vector<std::size_t>&
           "[IkFast::getDofs] This analytical IK was not able to configure "
           "properly, so it will not be able to compute solutions. Returning an "
           "empty list of dofs.");
-      assert(mDofs.empty());
+      DART_ASSERT(mDofs.empty());
     }
   }
 
@@ -464,7 +465,7 @@ bool wrapCyclicSolution(
   if (currentValue < lb) {
     const auto diff_lb = lb - solutionValue;
     const auto lb_ceil = solutionValue + std::ceil(diff_lb / pi2) * pi2;
-    assert(lb <= lb_ceil);
+    DART_ASSERT(lb <= lb_ceil);
     if (lb_ceil <= ub) {
       solutionValue = lb_ceil;
     } else {
@@ -473,7 +474,7 @@ bool wrapCyclicSolution(
   } else if (ub < currentValue) {
     const auto diff_ub = ub - solutionValue;
     const auto ub_floor = solutionValue + std::floor(diff_ub / pi2) * pi2;
-    assert(ub_floor <= ub);
+    DART_ASSERT(ub_floor <= ub);
     if (lb <= ub_floor) {
       solutionValue = ub_floor;
     } else {

--- a/dart/dynamics/InverseKinematics.cpp
+++ b/dart/dynamics/InverseKinematics.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/InverseKinematics.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
@@ -507,7 +508,7 @@ Eigen::Vector6d InverseKinematics::TaskSpaceRegion::computeError()
   const Frame* referenceFrame = mTaskSpaceP.mReferenceFrame.get();
   if (referenceFrame == nullptr)
     referenceFrame = mIK->getTarget()->getParentFrame();
-  assert(referenceFrame != nullptr);
+  DART_ASSERT(referenceFrame != nullptr);
 
   // Use the target's transform with respect to its reference frame
   const Eigen::Isometry3d targetTf
@@ -637,7 +638,7 @@ void InverseKinematics::GradientMethod::evalGradient(
         mIK->getNode()->getSkeleton()->getName(),
         mIK->getNode()->getName(),
         mMethodName);
-    assert(false);
+    DART_ASSERT(false);
     mLastGradient.resize(_q.size());
     mLastGradient.setZero();
     _grad = mLastGradient;
@@ -1654,7 +1655,7 @@ double InverseKinematics::Objective::eval(const Eigen::VectorXd& _x)
     DART_ERROR(
         "[InverseKinematics::Objective::eval] Attempting to use an Objective "
         "function of an expired InverseKinematics module!");
-    assert(false);
+    DART_ASSERT(false);
     return 0;
   }
 
@@ -1677,7 +1678,7 @@ void InverseKinematics::Objective::evalGradient(
     DART_ERROR(
         "[InverseKinematics::Objective::evalGradient] Attempting to use an "
         "Objective function of an expired InverseKinematics module!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -1720,7 +1721,7 @@ double InverseKinematics::Constraint::eval(const Eigen::VectorXd& _x)
     DART_ERROR(
         "[InverseKinematics::Constraint::eval] Attempting to use a Constraint "
         "function of an expired InverseKinematics module!");
-    assert(false);
+    DART_ASSERT(false);
     return 0;
   }
 
@@ -1735,7 +1736,7 @@ void InverseKinematics::Constraint::evalGradient(
     DART_ERROR(
         "[InverseKinematics::Constraint::evalGradient] Attempting to use a "
         "Constraint function of an expired InverseKinematics module!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/Joint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -562,7 +563,7 @@ double Joint::getPotentialEnergy() const
 //==============================================================================
 void Joint::setTransformFromParentBodyNode(const Eigen::Isometry3d& _T)
 {
-  assert(math::verifyTransform(_T));
+  DART_ASSERT(math::verifyTransform(_T));
   mAspectProperties.mT_ParentBodyToJoint = _T;
   notifyPositionUpdated();
 }
@@ -570,7 +571,7 @@ void Joint::setTransformFromParentBodyNode(const Eigen::Isometry3d& _T)
 //==============================================================================
 void Joint::setTransformFromChildBodyNode(const Eigen::Isometry3d& _T)
 {
-  assert(math::verifyTransform(_T));
+  DART_ASSERT(math::verifyTransform(_T));
   mAspectProperties.mT_ChildBodyToJoint = _T;
   updateRelativeJacobian();
   notifyPositionUpdated();

--- a/dart/dynamics/Linkage.cpp
+++ b/dart/dynamics/Linkage.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/Linkage.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/FreeJoint.hpp"
 
 #include <algorithm>
@@ -469,10 +470,10 @@ Linkage::Criteria::Target createTargetFromClone(
     Skeleton& skelClone, const Linkage::Criteria::Target& target)
 {
   BodyNodePtr bodyNodePtr = target.mNode.lock();
-  assert(bodyNodePtr);
+  DART_ASSERT(bodyNodePtr);
   BodyNode* bodyNodeClone = skelClone.getBodyNode(bodyNodePtr->getName());
-  assert(bodyNodeClone);
-  assert(bodyNodeClone != bodyNodePtr.get());
+  DART_ASSERT(bodyNodeClone);
+  DART_ASSERT(bodyNodeClone != bodyNodePtr.get());
 
   return Linkage::Criteria::Target(
       bodyNodeClone, target.mPolicy, target.mPolicy);
@@ -483,10 +484,10 @@ Linkage::Criteria::Terminal createTerminalFromClone(
     Skeleton& skelClone, const Linkage::Criteria::Terminal& terminal)
 {
   BodyNodePtr bodyNodePtr = terminal.mTerminal.lock();
-  assert(bodyNodePtr);
+  DART_ASSERT(bodyNodePtr);
   BodyNode* bodyNodeClone = skelClone.getBodyNode(bodyNodePtr->getName());
-  assert(bodyNodeClone);
-  assert(bodyNodeClone != bodyNodePtr.get());
+  DART_ASSERT(bodyNodeClone);
+  DART_ASSERT(bodyNodeClone != bodyNodePtr.get());
 
   return Linkage::Criteria::Terminal(bodyNodeClone, terminal.mInclusive);
 }
@@ -510,7 +511,7 @@ LinkagePtr Linkage::cloneLinkage(const std::string& cloneName) const
     return nullptr;
   }
   SkeletonPtr skelClone = bodyNode->getSkeleton()->cloneSkeleton();
-  assert(skelClone != bodyNode->getSkeleton());
+  DART_ASSERT(skelClone != bodyNode->getSkeleton());
 
   // Create a Criteria
   Criteria newCriteria;

--- a/dart/dynamics/MetaSkeleton.cpp
+++ b/dart/dynamics/MetaSkeleton.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/MetaSkeleton.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/JacobianNode.hpp"
@@ -94,7 +95,7 @@ static bool checkIndexArrayAgreement(
         _values.size(),
         skel->getName(),
         static_cast<const void*>(skel));
-    assert(false);
+    DART_ASSERT(false);
     return false;
   }
 
@@ -127,7 +128,7 @@ static void setValuesFromVector(
           _indices[i],
           i,
           _vname);
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 }
@@ -152,7 +153,7 @@ static void setAllValuesFromVector(
         skel->getName(),
         static_cast<const void*>(skel),
         skel->getNumDofs());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -170,7 +171,7 @@ static void setAllValuesFromVector(
           i,
           skel->getName(),
           static_cast<const void*>(skel));
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 }
@@ -212,7 +213,7 @@ static Eigen::VectorXd getValuesFromVector(
             static_cast<const void*>(skel),
             skel->getNumDofs());
       }
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -240,7 +241,7 @@ static Eigen::VectorXd getValuesFromAllDofs(
           _fname,
           i);
       values[i] = 0.0;
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -285,7 +286,7 @@ static void setValueFromIndex(
           _index,
           skel->getName(),
           static_cast<const void*>(skel));
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -302,7 +303,7 @@ static void setValueFromIndex(
         _index,
         skel->getName(),
         static_cast<const void*>(skel));
-    assert(false);
+    DART_ASSERT(false);
   }
 }
 
@@ -329,7 +330,7 @@ static double getValueFromIndex(
           _index,
           skel->getName(),
           static_cast<const void*>(skel));
-    assert(false);
+    DART_ASSERT(false);
     return 0.0;
   }
 
@@ -347,7 +348,7 @@ static double getValueFromIndex(
       _index,
       skel->getName(),
       static_cast<const void*>(skel));
-  assert(false);
+  DART_ASSERT(false);
   return 0.0;
 }
 

--- a/dart/dynamics/Node.cpp
+++ b/dart/dynamics/Node.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/Node.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 
 #define REPORT_INVALID_NODE(func)                                              \
@@ -39,7 +40,7 @@
       "[Node::{}] A valid BodyNode pointer is required during construction. "  \
       "Please report this as a bug if this is not a custom node type!",        \
       #func);                                                                  \
-  assert(false);
+  DART_ASSERT(false);
 
 namespace dart {
 namespace dynamics {
@@ -210,11 +211,11 @@ void Node::attach()
   if (INVALID_INDEX == mIndexInBodyNode) {
     // If the Node was not in the map, then its destructor should not be in the
     // set
-    assert(destructors.find(destructor) == destructors.end());
+    DART_ASSERT(destructors.find(destructor) == destructors.end());
 
     // If this Node believes its index is invalid, then it should not exist
     // anywhere in the vector
-    assert(std::find(nodes.begin(), nodes.end(), this) == nodes.end());
+    DART_ASSERT(std::find(nodes.begin(), nodes.end(), this) == nodes.end());
 
     nodes.push_back(this);
     mIndexInBodyNode = nodes.size() - 1;
@@ -222,8 +223,8 @@ void Node::attach()
     destructors.insert(destructor);
   }
 
-  assert(std::find(nodes.begin(), nodes.end(), this) != nodes.end());
-  assert(destructors.find(destructor) != destructors.end());
+  DART_ASSERT(std::find(nodes.begin(), nodes.end(), this) != nodes.end());
+  DART_ASSERT(destructors.find(destructor) != destructors.end());
 
   const SkeletonPtr& skel = mBodyNode->getSkeleton();
   if (skel)
@@ -255,23 +256,23 @@ void Node::stageForRemoval()
 
   if (mBodyNode->mNodeMap.end() == it) {
     // If the Node was not in the map, then its index should be invalid
-    assert(INVALID_INDEX == mIndexInBodyNode);
+    DART_ASSERT(INVALID_INDEX == mIndexInBodyNode);
 
     // If the Node was not in the map, then its destructor should not be in the
     // set
-    assert(destructors.find(destructor) == destructors.end());
+    DART_ASSERT(destructors.find(destructor) == destructors.end());
     return;
   }
 
   BodyNode::NodeDestructorSet::iterator destructor_iter
       = destructors.find(destructor);
   // This Node's destructor should be in the set of destructors
-  assert(destructors.end() != destructor_iter);
+  DART_ASSERT(destructors.end() != destructor_iter);
 
   std::vector<Node*>& nodes = it->second;
 
   // This Node's index in the vector should be referring to this Node
-  assert(nodes[mIndexInBodyNode] == this);
+  DART_ASSERT(nodes[mIndexInBodyNode] == this);
   nodes.erase(nodes.begin() + mIndexInBodyNode);
   destructors.erase(destructor_iter);
 
@@ -279,7 +280,7 @@ void Node::stageForRemoval()
   for (std::size_t i = mIndexInBodyNode; i < nodes.size(); ++i)
     nodes[i]->mIndexInBodyNode = i;
 
-  assert(std::find(nodes.begin(), nodes.end(), this) == nodes.end());
+  DART_ASSERT(std::find(nodes.begin(), nodes.end(), this) == nodes.end());
 
   const SkeletonPtr& skel = mBodyNode->getSkeleton();
   if (skel)

--- a/dart/dynamics/PlanarJoint.cpp
+++ b/dart/dynamics/PlanarJoint.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/PlanarJoint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
@@ -204,7 +205,7 @@ Eigen::Matrix<double, 6, 3> PlanarJoint::getRelativeJacobianStatic(
       = math::AdTJac(Joint::mAspectProperties.mT_ChildBodyToJoint, J.col(2));
 
   // Verification
-  assert(!math::isNan(J));
+  DART_ASSERT(!math::isNan(J));
 
   return J;
 }
@@ -273,7 +274,7 @@ void PlanarJoint::updateRelativeTransform() const
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
   // Verification
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -308,9 +309,9 @@ void PlanarJoint::updateRelativeJacobianTimeDeriv() const
                   mAspectProperties.mRotAxis * -getPositionsStatic()[2]),
           J.col(1)));
 
-  assert(mJacobianDeriv.col(2) == Eigen::Vector6d::Zero());
-  assert(!math::isNan(mJacobianDeriv.col(0)));
-  assert(!math::isNan(mJacobianDeriv.col(1)));
+  DART_ASSERT(mJacobianDeriv.col(2) == Eigen::Vector6d::Zero());
+  DART_ASSERT(!math::isNan(mJacobianDeriv.col(0)));
+  DART_ASSERT(!math::isNan(mJacobianDeriv.col(1)));
 }
 
 } // namespace dynamics

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/PointMass.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/SoftBodyNode.hpp"
 #include "dart/math/Geometry.hpp"
@@ -170,7 +171,7 @@ PointMass::PointMass(SoftBodyNode* _softBodyNode)
     mImpF(Eigen::Vector3d::Zero()),
     mNotifier(_softBodyNode->mNotifier)
 {
-  assert(mParentSoftBodyNode != nullptr);
+  DART_ASSERT(mParentSoftBodyNode != nullptr);
   mNotifier->dirtyTransform();
 }
 
@@ -201,7 +202,7 @@ std::size_t PointMass::getIndexInSoftBodyNode() const
 //==============================================================================
 void PointMass::setMass(double _mass)
 {
-  assert(0.0 < _mass);
+  DART_ASSERT(0.0 < _mass);
   double& mMass
       = mParentSoftBodyNode->mAspectProperties.mPointProps[mIndex].mMass;
   if (_mass == mMass)
@@ -248,7 +249,7 @@ double PointMass::getImplicitPi() const
 //==============================================================================
 void PointMass::addConnectedPointMass(PointMass* _pointMass)
 {
-  assert(_pointMass != nullptr);
+  DART_ASSERT(_pointMass != nullptr);
 
   mParentSoftBodyNode->mAspectProperties.mPointProps[mIndex]
       .mConnectedPointMassIndices.push_back(_pointMass->mIndex);
@@ -265,7 +266,7 @@ std::size_t PointMass::getNumConnectedPointMasses() const
 //==============================================================================
 PointMass* PointMass::getConnectedPointMass(std::size_t _idx)
 {
-  assert(_idx < getNumConnectedPointMasses());
+  DART_ASSERT(_idx < getNumConnectedPointMasses());
 
   return mParentSoftBodyNode
       ->mPointMasses[mParentSoftBodyNode->mAspectProperties.mPointProps[mIndex]
@@ -316,7 +317,7 @@ std::size_t PointMass::getNumDofs() const
 //==============================================================================
 void PointMass::setPosition(std::size_t _index, double _position)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   getState().mPositions[_index] = _position;
   mNotifier->dirtyTransform();
@@ -325,7 +326,7 @@ void PointMass::setPosition(std::size_t _index, double _position)
 //==============================================================================
 double PointMass::getPosition(std::size_t _index) const
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   return getState().mPositions[_index];
 }
@@ -353,7 +354,7 @@ void PointMass::resetPositions()
 //==============================================================================
 void PointMass::setVelocity(std::size_t _index, double _velocity)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   getState().mVelocities[_index] = _velocity;
   mNotifier->dirtyVelocity();
@@ -362,7 +363,7 @@ void PointMass::setVelocity(std::size_t _index, double _velocity)
 //==============================================================================
 double PointMass::getVelocity(std::size_t _index) const
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   return getState().mVelocities[_index];
 }
@@ -390,7 +391,7 @@ void PointMass::resetVelocities()
 //==============================================================================
 void PointMass::setAcceleration(std::size_t _index, double _acceleration)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   getState().mAccelerations[_index] = _acceleration;
   mNotifier->dirtyAcceleration();
@@ -399,7 +400,7 @@ void PointMass::setAcceleration(std::size_t _index, double _acceleration)
 //==============================================================================
 double PointMass::getAcceleration(std::size_t _index) const
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   return getState().mAccelerations[_index];
 }
@@ -435,7 +436,7 @@ void PointMass::resetAccelerations()
 //==============================================================================
 void PointMass::setForce(std::size_t _index, double _force)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   getState().mForces[_index] = _force;
 }
@@ -443,7 +444,7 @@ void PointMass::setForce(std::size_t _index, double _force)
 //==============================================================================
 double PointMass::getForce(std::size_t _index)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   return getState().mForces[_index];
 }
@@ -469,7 +470,7 @@ void PointMass::resetForces()
 //==============================================================================
 void PointMass::setVelocityChange(std::size_t _index, double _velocityChange)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   mVelocityChanges[_index] = _velocityChange;
 }
@@ -477,7 +478,7 @@ void PointMass::setVelocityChange(std::size_t _index, double _velocityChange)
 //==============================================================================
 double PointMass::getVelocityChange(std::size_t _index)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   return mVelocityChanges[_index];
 }
@@ -491,7 +492,7 @@ void PointMass::resetVelocityChanges()
 //==============================================================================
 void PointMass::setConstraintImpulse(std::size_t _index, double _impulse)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   mConstraintImpulses[_index] = _impulse;
 }
@@ -499,7 +500,7 @@ void PointMass::setConstraintImpulse(std::size_t _index, double _impulse)
 //==============================================================================
 double PointMass::getConstraintImpulse(std::size_t _index)
 {
-  assert(_index < 3);
+  DART_ASSERT(_index < 3);
 
   return mConstraintImpulses[_index];
 }
@@ -574,7 +575,7 @@ Eigen::Vector3d PointMass::getConstraintImpulses() const
 //==============================================================================
 void PointMass::clearConstraintImpulse()
 {
-  assert(getNumDofs() == 3);
+  DART_ASSERT(getNumDofs() == 3);
   mConstraintImpulses.setZero();
   mDelV.setZero();
   mImpB.setZero();
@@ -621,7 +622,7 @@ const Eigen::Vector3d& PointMass::getWorldPosition() const
 //==============================================================================
 Eigen::Matrix<double, 3, Eigen::Dynamic> PointMass::getBodyJacobian()
 {
-  assert(mParentSoftBodyNode != nullptr);
+  DART_ASSERT(mParentSoftBodyNode != nullptr);
 
   int dof = mParentSoftBodyNode->getNumDependentGenCoords();
   int totalDof = mParentSoftBodyNode->getNumDependentGenCoords() + 3;
@@ -717,12 +718,12 @@ void PointMass::updateTransform() const
 {
   // Local translation
   mX = getPositions() + getRestingPosition();
-  assert(!math::isNan(mX));
+  DART_ASSERT(!math::isNan(mX));
 
   // World translation
   const Eigen::Isometry3d& parentW = mParentSoftBodyNode->getWorldTransform();
   mW = parentW.translation() + parentW.linear() * mX;
-  assert(!math::isNan(mW));
+  DART_ASSERT(!math::isNan(mW));
 }
 
 //==============================================================================
@@ -732,7 +733,7 @@ void PointMass::updateVelocity() const
   const Eigen::Vector6d& v_parent = mParentSoftBodyNode->getSpatialVelocity();
   mV = v_parent.head<3>().cross(getLocalPosition()) + v_parent.tail<3>()
        + getVelocities();
-  assert(!math::isNan(mV));
+  DART_ASSERT(!math::isNan(mV));
 }
 
 //==============================================================================
@@ -741,7 +742,7 @@ void PointMass::updatePartialAcceleration() const
   // eta = w(parent) x dq
   const Eigen::Vector3d& dq = getVelocities();
   mEta = mParentSoftBodyNode->getSpatialVelocity().head<3>().cross(dq);
-  assert(!math::isNan(mEta));
+  DART_ASSERT(!math::isNan(mEta));
 }
 
 //==============================================================================
@@ -752,7 +753,7 @@ void PointMass::updateAccelerationID() const
       = mParentSoftBodyNode->getSpatialAcceleration();
   mA = a_parent.head<3>().cross(getLocalPosition()) + a_parent.tail<3>()
        + getPartialAccelerations() + getAccelerations();
-  assert(!math::isNan(mA));
+  DART_ASSERT(!math::isNan(mA));
 }
 
 //==============================================================================
@@ -769,7 +770,7 @@ void PointMass::updateTransmittedForceID(
           * (mParentSoftBodyNode->getWorldTransform().linear().transpose()
              * _gravity);
   }
-  assert(!math::isNan(mF));
+  DART_ASSERT(!math::isNan(mF));
 }
 
 //==============================================================================
@@ -785,7 +786,7 @@ void PointMass::updateArtInertiaFD(double _timeStep) const
         / (getMass() + _timeStep * mParentSoftBodyNode->getDampingCoefficient()
            + _timeStep * _timeStep
                  * mParentSoftBodyNode->getVertexSpringStiffness());
-  assert(!math::isNan(mImplicitPsi));
+  DART_ASSERT(!math::isNan(mImplicitPsi));
 
   // Cache data: AI_S_Psi
   // - Do nothing
@@ -793,8 +794,8 @@ void PointMass::updateArtInertiaFD(double _timeStep) const
   // Cache data: Pi
   mPi = getMass() - getMass() * getMass() * mPsi;
   mImplicitPi = getMass() - getMass() * getMass() * mImplicitPsi;
-  assert(!math::isNan(mPi));
-  assert(!math::isNan(mImplicitPi));
+  DART_ASSERT(!math::isNan(mPi));
+  DART_ASSERT(!math::isNan(mImplicitPi));
 }
 
 //==============================================================================
@@ -822,7 +823,7 @@ void PointMass::updateBiasForceFD(double _dt, const Eigen::Vector3d& _gravity)
           * (mParentSoftBodyNode->getWorldTransform().linear().transpose()
              * _gravity);
   }
-  assert(!math::isNan(mB));
+  DART_ASSERT(!math::isNan(mB));
 
   const State& state = getState();
 
@@ -838,13 +839,13 @@ void PointMass::updateBiasForceFD(double _dt, const Eigen::Vector3d& _gravity)
     const State& i_state = getConnectedPointMass(i)->getState();
     mAlpha += ke * (i_state.mPositions + _dt * i_state.mVelocities);
   }
-  assert(!math::isNan(mAlpha));
+  DART_ASSERT(!math::isNan(mAlpha));
 
   // Cache data: beta
   mBeta = mB;
   mBeta.noalias()
       += getMass() * (getPartialAccelerations() + getImplicitPsi() * mAlpha);
-  assert(!math::isNan(mBeta));
+  DART_ASSERT(!math::isNan(mBeta));
 }
 
 //==============================================================================
@@ -859,12 +860,12 @@ void PointMass::updateAccelerationFD()
         * (mAlpha
            - getMass() * (a_parent.head<3>().cross(X) + a_parent.tail<3>()));
   setAccelerations(ddq);
-  assert(!math::isNan(ddq));
+  DART_ASSERT(!math::isNan(ddq));
 
   // dv = dw(parent) x mX + dv(parent) + eata + ddq
   mA = a_parent.head<3>().cross(X) + a_parent.tail<3>()
        + getPartialAccelerations() + getAccelerations();
-  assert(!math::isNan(mA));
+  DART_ASSERT(!math::isNan(mA));
 }
 
 //==============================================================================
@@ -873,7 +874,7 @@ void PointMass::updateTransmittedForce()
   // f = m*dv + B
   mF = mB;
   mF.noalias() += getMass() * getBodyAcceleration();
-  assert(!math::isNan(mF));
+  DART_ASSERT(!math::isNan(mF));
 }
 
 //==============================================================================
@@ -882,22 +883,22 @@ void PointMass::updateMassMatrix()
   mM_dV = getAccelerations()
           + mParentSoftBodyNode->mM_dV.head<3>().cross(getLocalPosition())
           + mParentSoftBodyNode->mM_dV.tail<3>();
-  assert(!math::isNan(mM_dV));
+  DART_ASSERT(!math::isNan(mM_dV));
 }
 
 //==============================================================================
 void PointMass::updateBiasImpulseFD()
 {
   mImpB = -mConstraintImpulses;
-  assert(!math::isNan(mImpB));
+  DART_ASSERT(!math::isNan(mImpB));
 
   // Cache data: alpha
   mImpAlpha = -mImpB;
-  assert(!math::isNan(mImpAlpha));
+  DART_ASSERT(!math::isNan(mImpAlpha));
 
   // Cache data: beta
   mImpBeta.setZero();
-  assert(!math::isNan(mImpBeta));
+  DART_ASSERT(!math::isNan(mImpBeta));
 }
 
 //==============================================================================
@@ -919,12 +920,12 @@ void PointMass::updateVelocityChangeFD()
   //  del_dq = Eigen::Vector3d::Zero();
 
   mVelocityChanges = del_dq;
-  assert(!math::isNan(del_dq));
+  DART_ASSERT(!math::isNan(del_dq));
 
   mDelV = mParentSoftBodyNode->getBodyVelocityChange().head<3>().cross(X)
           + mParentSoftBodyNode->getBodyVelocityChange().tail<3>()
           + mVelocityChanges;
-  assert(!math::isNan(mDelV));
+  DART_ASSERT(!math::isNan(mDelV));
 }
 
 //==============================================================================
@@ -932,7 +933,7 @@ void PointMass::updateTransmittedImpulse()
 {
   mImpF = mImpB;
   mImpF.noalias() += getMass() * mDelV;
-  assert(!math::isNan(mImpF));
+  DART_ASSERT(!math::isNan(mImpF));
 }
 
 //==============================================================================

--- a/dart/dynamics/PrismaticJoint.cpp
+++ b/dart/dynamics/PrismaticJoint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/PrismaticJoint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
@@ -144,7 +145,7 @@ PrismaticJoint::getRelativeJacobianStatic(
       Joint::mAspectProperties.mT_ChildBodyToJoint, getAxis());
 
   // Verification
-  assert(!math::isNan(jacobian));
+  DART_ASSERT(!math::isNan(jacobian));
 
   return jacobian;
 }
@@ -182,7 +183,7 @@ void PrismaticJoint::updateRelativeTransform() const
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
   // Verification
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -196,7 +197,7 @@ void PrismaticJoint::updateRelativeJacobian(bool _mandatory) const
 void PrismaticJoint::updateRelativeJacobianTimeDeriv() const
 {
   // Time derivative of prismatic joint is always zero
-  assert(mJacobianDeriv == Eigen::Vector6d::Zero());
+  DART_ASSERT(mJacobianDeriv == Eigen::Vector6d::Zero());
 }
 
 } // namespace dynamics

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/PyramidShape.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
 #include "dart/math/Helpers.hpp"
@@ -49,9 +50,9 @@ PyramidShape::PyramidShape(double baseWidth, double baseDepth, double height)
     mBaseDepth(baseDepth),
     mHeight(height)
 {
-  assert(0.0 < baseWidth);
-  assert(0.0 < baseDepth);
-  assert(0.0 < height);
+  DART_ASSERT(0.0 < baseWidth);
+  DART_ASSERT(0.0 < baseDepth);
+  DART_ASSERT(0.0 < height);
 }
 
 //==============================================================================
@@ -76,7 +77,7 @@ double PyramidShape::getBaseWidth() const
 //==============================================================================
 void PyramidShape::setBaseWidth(double width)
 {
-  assert(0.0 < width);
+  DART_ASSERT(0.0 < width);
   mBaseWidth = width;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -93,7 +94,7 @@ double PyramidShape::getBaseDepth() const
 //==============================================================================
 void PyramidShape::setBaseDepth(double depth)
 {
-  assert(0.0 < depth);
+  DART_ASSERT(0.0 < depth);
   mBaseDepth = depth;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -110,7 +111,7 @@ double PyramidShape::getHeight() const
 //==============================================================================
 void PyramidShape::setHeight(double height)
 {
-  assert(0.0 < height);
+  DART_ASSERT(0.0 < height);
   mHeight = height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/ReferentialSkeleton.cpp
+++ b/dart/dynamics/ReferentialSkeleton.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/ReferentialSkeleton.hpp"
 
 #include "dart/common/Deprecated.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/Joint.hpp"
@@ -197,7 +198,7 @@ std::size_t ReferentialSkeleton::getIndexOf(
       DART_ERROR(
           "[ReferentialSkeleton::getIndexOf] Requesting index of a nullptr "
           "BodyNode!");
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -213,7 +214,7 @@ std::size_t ReferentialSkeleton::getIndexOf(
           _bn,
           getName(),
           this);
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -332,7 +333,7 @@ std::size_t ReferentialSkeleton::getIndexOf(
       DART_ERROR(
           "[ReferentialSkeleton::getIndexOf] Requesting index of a nullptr "
           "Joint!");
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -348,7 +349,7 @@ std::size_t ReferentialSkeleton::getIndexOf(
           _joint,
           getName(),
           this);
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -402,7 +403,7 @@ std::size_t ReferentialSkeleton::getIndexOf(
       DART_ERROR(
           "[ReferentialSkeleton::getIndexOf] Requesting index of a nullptr "
           "DegreeOfFreedom!");
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -420,7 +421,7 @@ std::size_t ReferentialSkeleton::getIndexOf(
           _dof,
           getName(),
           this);
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -438,7 +439,7 @@ std::size_t ReferentialSkeleton::getIndexOf(
           getName(),
           this,
           localIndex);
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -457,7 +458,7 @@ static bool isValidBodyNode(
         "[ReferentialSkeleton::{}] Invalid BodyNode pointer: nullptr. "
         "Returning zero Jacobian.",
         _fname);
-    assert(false);
+    DART_ASSERT(false);
     return false;
   }
 
@@ -947,7 +948,7 @@ double ReferentialSkeleton::computeKineticEnergy() const
   for (const BodyNode* bn : mRawBodyNodes)
     KE += bn->computeKineticEnergy();
 
-  assert(KE >= 0.0 && "Kinetic Energy should always be zero or greater");
+  DART_ASSERT(KE >= 0.0 && "Kinetic Energy should always be zero or greater");
   return KE;
 }
 
@@ -994,7 +995,7 @@ Eigen::Vector3d ReferentialSkeleton::getCOM(const Frame* _withRespectTo) const
     totalMass += bn->getMass();
   }
 
-  assert(totalMass != 0.0);
+  DART_ASSERT(totalMass != 0.0);
   return com / totalMass;
 }
 
@@ -1018,7 +1019,7 @@ PropertyType getCOMPropertyTemplate(
     totalMass += bn->getMass();
   }
 
-  assert(totalMass != 0.0);
+  DART_ASSERT(totalMass != 0.0);
   return result / totalMass;
 }
 
@@ -1092,7 +1093,7 @@ JacType getCOMJacobianTemplate(
     }
   }
 
-  assert(totalMass != 0.0);
+  DART_ASSERT(totalMass != 0.0);
   return J / totalMass;
 }
 
@@ -1245,7 +1246,7 @@ void ReferentialSkeleton::registerDegreeOfFreedom(DegreeOfFreedom* _dof)
 //==============================================================================
 void ReferentialSkeleton::unregisterComponent(BodyNode* _bn)
 {
-  assert(_bn);
+  DART_ASSERT(_bn);
   unregisterBodyNode(_bn, true);
   unregisterJoint(_bn);
 }
@@ -1258,7 +1259,7 @@ void ReferentialSkeleton::unregisterBodyNode(
     DART_ERROR(
         "[ReferentialSkeleton::unregisterBodyNode] Attempting to unregister a "
         "nullptr BodyNode. This is most likely a bug. Please report this!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -1270,7 +1271,7 @@ void ReferentialSkeleton::unregisterBodyNode(
         "[ReferentialSkeleton::unregisterBodyNode] Attempting to unregister a "
         "BodyNode that is not referred to by this ReferentialSkeleton. This is "
         "most likely a bug. Please report this!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -1308,7 +1309,7 @@ void ReferentialSkeleton::unregisterJoint(BodyNode* _child)
         "[ReferentialSkeleton::unregisterJoint] Attempting to unregister a "
         "Joint from a nullptr BodyNode. This is most likely a bug. Please "
         "report this!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -1327,7 +1328,7 @@ void ReferentialSkeleton::unregisterJoint(BodyNode* _child)
         joint,
         _child->getName(),
         _child);
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -1363,7 +1364,7 @@ void ReferentialSkeleton::unregisterDegreeOfFreedom(
         "[ReferentialSkeleton::unregisterDegreeOfFreedom] Attempting to "
         "unregister a DegreeOfFreedom from a nullptr BodyNode. This is most "
         "likely a bug. Please report this!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -1380,7 +1381,7 @@ void ReferentialSkeleton::unregisterDegreeOfFreedom(
         _localIndex,
         _bn->getName(),
         _bn);
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -1446,7 +1447,7 @@ void ReferentialSkeleton::registerSkeleton(const Skeleton* skel)
 {
   // We assume skel is not nullptr. If it's not, this function should be updated
   // to take that into account.
-  assert(skel);
+  DART_ASSERT(skel);
 
   if (hasSkeleton(skel))
     return;
@@ -1462,7 +1463,7 @@ void ReferentialSkeleton::unregisterSkeleton(const Skeleton* skel)
     DART_ERROR(
         "[ReferentialSkeleton::unregisterSkeleton] Attempting to unregister a "
         "nullptr Skeleton. This is most likely a bug. Please report this!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 

--- a/dart/dynamics/RevoluteJoint.cpp
+++ b/dart/dynamics/RevoluteJoint.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/RevoluteJoint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
@@ -145,7 +146,7 @@ RevoluteJoint::getRelativeJacobianStatic(
       Joint::mAspectProperties.mT_ChildBodyToJoint, getAxis());
 
   // Verification
-  assert(!math::isNan(jacobian));
+  DART_ASSERT(!math::isNan(jacobian));
 
   return jacobian;
 }
@@ -183,7 +184,7 @@ void RevoluteJoint::updateRelativeTransform() const
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
   // Verification
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -197,7 +198,7 @@ void RevoluteJoint::updateRelativeJacobian(bool _mandatory) const
 void RevoluteJoint::updateRelativeJacobianTimeDeriv() const
 {
   // Time derivative of revolute joint is always zero
-  assert(mJacobianDeriv == Eigen::Vector6d::Zero());
+  DART_ASSERT(mJacobianDeriv == Eigen::Vector6d::Zero());
 }
 
 } // namespace dynamics

--- a/dart/dynamics/ScrewJoint.cpp
+++ b/dart/dynamics/ScrewJoint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/ScrewJoint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
@@ -168,7 +169,7 @@ ScrewJoint::getRelativeJacobianStatic(
   GenericJoint<math::R1Space>::JacobianMatrix jacobian
       = math::AdT(Joint::mAspectProperties.mT_ChildBodyToJoint, S);
 
-  assert(!math::isNan(jacobian));
+  DART_ASSERT(!math::isNan(jacobian));
 
   return jacobian;
 }
@@ -209,7 +210,7 @@ void ScrewJoint::updateRelativeTransform() const
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint
        * math::expMap(S * getPositionsStatic())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -223,7 +224,7 @@ void ScrewJoint::updateRelativeJacobian(bool _mandatory) const
 void ScrewJoint::updateRelativeJacobianTimeDeriv() const
 {
   // Time derivative of screw joint is always zero
-  assert(mJacobianDeriv == Eigen::Vector6d::Zero());
+  DART_ASSERT(mJacobianDeriv == Eigen::Vector6d::Zero());
 }
 
 } // namespace dynamics

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/dynamics/ShapeFrame.hpp"
 
+#include "dart/common/Macros.hpp"
+
 namespace dart {
 namespace dynamics {
 
@@ -276,7 +278,7 @@ void ShapeFrame::setShape(const ShapePtr& shape)
   if (shape) {
     mConnectionForShapeVersionChange
         = shape->onVersionChanged.connect([this](Shape* shape, std::size_t) {
-            assert(shape == this->mAspectProperties.mShape.get());
+            DART_ASSERT(shape == this->mAspectProperties.mShape.get());
             DART_UNUSED(shape);
             this->incrementVersion();
           });

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/common/Deprecated.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/StlHelpers.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
@@ -75,7 +76,7 @@
           #V,                                                                  \
           nonzero_size,                                                        \
           V.size());                                                           \
-      assert(false);                                                           \
+      DART_ASSERT(false);                                                      \
     } else if (nonzero_size == INVALID_INDEX)                                  \
       nonzero_size = V.size();                                                 \
   }
@@ -112,7 +113,7 @@ void setAllMemberObjectData(Owner* owner, const std::vector<Data>& data)
         typeid(Data).name(),
         typeid(Object).name(),
         typeid(Owner).name());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -166,7 +167,7 @@ std::vector<Data> getAllMemberObjectData(const Owner* owner)
         typeid(Data).name(),
         typeid(Object).name(),
         typeid(Owner).name());
-    assert(false);
+    DART_ASSERT(false);
     return std::vector<Data>();
   }
 
@@ -555,7 +556,7 @@ MetaSkeletonPtr Skeleton::cloneMetaSkeleton(const std::string& cloneName) const
           #V,                                                                  \
           configuration.mIndices.size(),                                       \
           configuration.m##V.size());                                          \
-      assert(false);                                                           \
+      DART_ASSERT(false);                                                      \
     } else                                                                     \
       set##V(configuration.mIndices, configuration.m##V);                      \
   }
@@ -815,7 +816,7 @@ bool Skeleton::isMobile() const
 //==============================================================================
 void Skeleton::setTimeStep(double _timeStep)
 {
-  assert(_timeStep > 0.0);
+  DART_ASSERT(_timeStep > 0.0);
   mAspectProperties.mTimeStep = _timeStep;
 
   for (std::size_t i = 0; i < mTreeCache.size(); ++i)
@@ -877,14 +878,14 @@ BodyNode* Skeleton::getRootBodyNode(std::size_t _treeIdx)
     DART_ERROR(
         "[Skeleton::getRootBodyNode] Requested a root BodyNode from a Skeleton "
         "with no BodyNodes!");
-    assert(false);
+    DART_ASSERT(false);
   } else {
     DART_ERROR(
         "[Skeleton::getRootBodyNode] Requested invalid root BodyNode index "
         "({})! Must be less than {}.",
         _treeIdx,
         mTreeCache.size());
-    assert(false);
+    DART_ASSERT(false);
   }
 
   return nullptr;
@@ -1038,7 +1039,7 @@ static std::size_t templatedGetIndexOf(
           _type,
           _skel->getName(),
           _skel);
-      assert(false);
+      DART_ASSERT(false);
     }
     return INVALID_INDEX;
   }
@@ -1053,7 +1054,7 @@ static std::size_t templatedGetIndexOf(
         _type,
         _obj->getName(),
         _obj);
-    assert(false);
+    DART_ASSERT(false);
   }
 
   return INVALID_INDEX;
@@ -1078,7 +1079,7 @@ const std::vector<BodyNode*>& Skeleton::getTreeBodyNodes(std::size_t _treeIdx)
              ? (std::string("when the max tree index is (")
                 + std::to_string(count - 1) + ")\n")
              : std::string("when there are no trees in this Skeleton\n")));
-    assert(false);
+    DART_ASSERT(false);
   }
 
   return mTreeCache[_treeIdx].mBodyNodes;
@@ -1282,7 +1283,7 @@ bool Skeleton::checkIndexingConsistency() const
           i,
           bn->mIndexInSkeleton);
       consistent = false;
-      assert(false);
+      DART_ASSERT(false);
     }
 
     const BodyNode* nameEntryForBodyNode = getBodyNode(bn->getName());
@@ -1298,7 +1299,7 @@ bool Skeleton::checkIndexingConsistency() const
           nameEntryForBodyNode->getName(),
           nameEntryForBodyNode);
       consistent = false;
-      assert(false);
+      DART_ASSERT(false);
     }
 
     const Joint* joint = bn->getParentJoint();
@@ -1315,7 +1316,7 @@ bool Skeleton::checkIndexingConsistency() const
           nameEntryForJoint->getName(),
           nameEntryForJoint);
       consistent = false;
-      assert(false);
+      DART_ASSERT(false);
     }
 
     const BodyNode::NodeMap& nodeMap = bn->mNodeMap;
@@ -1335,7 +1336,7 @@ bool Skeleton::checkIndexingConsistency() const
               node->getBodyNodePtr()->getName(),
               node->getBodyNodePtr());
           consistent = false;
-          assert(false);
+          DART_ASSERT(false);
         }
 
         if (node->mIndexInBodyNode != k) {
@@ -1350,7 +1351,7 @@ bool Skeleton::checkIndexingConsistency() const
               k,
               node->mIndexInBodyNode);
           consistent = false;
-          assert(false);
+          DART_ASSERT(false);
         }
 
         // TODO(MXG): Consider checking Node names here
@@ -1373,7 +1374,7 @@ bool Skeleton::checkIndexingConsistency() const
           i,
           dof->getIndexInSkeleton());
       consistent = false;
-      assert(false);
+      DART_ASSERT(false);
     }
 
     const DegreeOfFreedom* nameEntryForDof = getDof(dof->getName());
@@ -1389,7 +1390,7 @@ bool Skeleton::checkIndexingConsistency() const
           nameEntryForDof->getName(),
           nameEntryForDof);
       consistent = false;
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -1412,7 +1413,7 @@ bool Skeleton::checkIndexingConsistency() const
               node->getSkeleton()->getName(),
               node->getSkeleton());
           consistent = false;
-          assert(false);
+          DART_ASSERT(false);
         }
 
         if (node->mIndexInSkeleton != k) {
@@ -1427,7 +1428,7 @@ bool Skeleton::checkIndexingConsistency() const
               k,
               node->mIndexInSkeleton);
           consistent = false;
-          assert(false);
+          DART_ASSERT(false);
         }
       }
     }
@@ -1448,7 +1449,7 @@ bool Skeleton::checkIndexingConsistency() const
             i,
             bn->mTreeIndex);
         consistent = false;
-        assert(false);
+        DART_ASSERT(false);
       }
 
       if (bn->mIndexInTree != j) {
@@ -1463,7 +1464,7 @@ bool Skeleton::checkIndexingConsistency() const
             j,
             bn->mIndexInTree);
         consistent = false;
-        assert(false);
+        DART_ASSERT(false);
       }
     }
 
@@ -1481,7 +1482,7 @@ bool Skeleton::checkIndexingConsistency() const
             i,
             dof->getTreeIndex());
         consistent = false;
-        assert(false);
+        DART_ASSERT(false);
       }
     }
   }
@@ -1497,7 +1498,7 @@ bool Skeleton::checkIndexingConsistency() const
         this,
         mTreeCache.size(),
         mTreeNodeMaps.size());
-    assert(false);
+    DART_ASSERT(false);
   }
 
   // Check each Node in the NodeMap of each Tree
@@ -1520,7 +1521,7 @@ bool Skeleton::checkIndexingConsistency() const
               i,
               node->getBodyNodePtr()->mTreeIndex);
           consistent = false;
-          assert(false);
+          DART_ASSERT(false);
         }
 
         if (node->mIndexInTree != k) {
@@ -1535,7 +1536,7 @@ bool Skeleton::checkIndexingConsistency() const
               k,
               node->mIndexInTree);
           consistent = false;
-          assert(false);
+          DART_ASSERT(false);
         }
       }
     }
@@ -1673,7 +1674,7 @@ static bool isValidBodyNode(
         "[Skeleton::{}] Invalid BodyNode pointer: nullptr. Returning zero "
         "Jacobian.",
         _fname);
-    assert(false);
+    DART_ASSERT(false);
     return false;
   }
 
@@ -1689,7 +1690,7 @@ static bool isValidBodyNode(
         _node,
         _skeleton->getName(),
         _skeleton);
-    assert(false);
+    DART_ASSERT(false);
     return false;
   }
 
@@ -1706,7 +1707,7 @@ void assignJacobian(
   const auto& indices = _node->getDependentGenCoordIndices();
   for (const auto& index : indices) {
     // Each index should be less than the number of dofs of this Skeleton.
-    assert(index < _node->getSkeleton()->getNumDofs());
+    DART_ASSERT(index < _node->getSkeleton()->getNumDofs());
 
     _J.col(index) = _JBodyNode.col(localIndex++);
   }
@@ -2197,7 +2198,7 @@ void Skeleton::constructNewTree()
     std::vector<NodeMap::iterator>* nodeVec = nodeType.second;
     nodeVec->push_back(nodeMap.find(index));
 
-    assert(nodeVec->size() == mTreeCache.size());
+    DART_ASSERT(nodeVec->size() == mTreeCache.size());
   }
 }
 
@@ -2214,7 +2215,7 @@ void Skeleton::registerBodyNode(BodyNode* _newBodyNode)
         "a bug!",
         _newBodyNode->getName(),
         getName());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 #endif // -------- Debug mode
@@ -2266,7 +2267,7 @@ void Skeleton::registerBodyNode(BodyNode* _newBodyNode)
           getName(),
           i,
           mSkelCache.mBodyNodes[i]->mIndexInSkeleton);
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -2283,7 +2284,7 @@ void Skeleton::registerBodyNode(BodyNode* _newBodyNode)
             getName(),
             i,
             bn->mTreeIndex);
-        assert(false);
+        DART_ASSERT(false);
       }
 
       if (bn->mIndexInTree != j) {
@@ -2295,7 +2296,7 @@ void Skeleton::registerBodyNode(BodyNode* _newBodyNode)
             getName(),
             j,
             bn->mIndexInTree);
-        assert(false);
+        DART_ASSERT(false);
       }
     }
   }
@@ -2319,7 +2320,7 @@ void Skeleton::registerJoint(Joint* _newJoint)
         mAspectProperties.mName,
         "]. Report "
         "this as a bug!\n");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -2353,13 +2354,13 @@ void Skeleton::registerNode(
   if (INVALID_INDEX == _index) {
     // If this Node believes its index is invalid, then it should not exist
     // anywhere in the vector
-    assert(std::find(nodes.begin(), nodes.end(), _newNode) == nodes.end());
+    DART_ASSERT(std::find(nodes.begin(), nodes.end(), _newNode) == nodes.end());
 
     nodes.push_back(_newNode);
     _index = nodes.size() - 1;
   }
 
-  assert(std::find(nodes.begin(), nodes.end(), _newNode) != nodes.end());
+  DART_ASSERT(std::find(nodes.begin(), nodes.end(), _newNode) != nodes.end());
 }
 
 //==============================================================================
@@ -2427,7 +2428,7 @@ void Skeleton::unregisterBodyNode(BodyNode* _oldBodyNode)
   mNameMgrForBodyNodes.removeName(_oldBodyNode->getName());
 
   std::size_t index = _oldBodyNode->getIndexInSkeleton();
-  assert(mSkelCache.mBodyNodes[index] == _oldBodyNode);
+  DART_ASSERT(mSkelCache.mBodyNodes[index] == _oldBodyNode);
   mSkelCache.mBodyNodes.erase(mSkelCache.mBodyNodes.begin() + index);
   for (std::size_t i = index; i < mSkelCache.mBodyNodes.size(); ++i) {
     BodyNode* bn = mSkelCache.mBodyNodes[i];
@@ -2444,15 +2445,15 @@ void Skeleton::unregisterBodyNode(BodyNode* _oldBodyNode)
     // root.
 
     std::size_t tree = _oldBodyNode->getTreeIndex();
-    assert(mTreeCache[tree].mBodyNodes.size() == 1);
-    assert(mTreeCache[tree].mBodyNodes[0] == _oldBodyNode);
+    DART_ASSERT(mTreeCache[tree].mBodyNodes.size() == 1);
+    DART_ASSERT(mTreeCache[tree].mBodyNodes[0] == _oldBodyNode);
 
     destructOldTree(tree);
     updateCacheDimensions(mSkelCache);
   } else {
     std::size_t tree = _oldBodyNode->getTreeIndex();
     std::size_t indexInTree = _oldBodyNode->getIndexInTree();
-    assert(mTreeCache[tree].mBodyNodes[indexInTree] == _oldBodyNode);
+    DART_ASSERT(mTreeCache[tree].mBodyNodes[indexInTree] == _oldBodyNode);
     mTreeCache[tree].mBodyNodes.erase(
         mTreeCache[tree].mBodyNodes.begin() + indexInTree);
 
@@ -2489,7 +2490,7 @@ void Skeleton::unregisterJoint(Joint* _oldJoint)
         "[Skeleton::unregisterJoint] Attempting to unregister nullptr Joint "
         "from Skeleton named [{}]. Report this as a bug!",
         getName());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -2533,14 +2534,14 @@ void Skeleton::unregisterNode(
 
   if (nodeMap.end() == it) {
     // If the Node was not in the map, then its index should be invalid
-    assert(INVALID_INDEX == _index);
+    DART_ASSERT(INVALID_INDEX == _index);
     return;
   }
 
   std::vector<Node*>& nodes = it->second;
 
   // This Node's index in the vector should be referring to this Node
-  assert(nodes[_index] == _oldNode);
+  DART_ASSERT(nodes[_index] == _oldNode);
   nodes.erase(nodes.begin() + _index);
 
   _index = INVALID_INDEX;
@@ -2553,7 +2554,7 @@ void Skeleton::unregisterNode(Node* _oldNode)
   unregisterNode(mNodeMap, _oldNode, _oldNode->mIndexInSkeleton);
 
   NodeMap::iterator node_it = mNodeMap.find(typeid(*_oldNode));
-  assert(mNodeMap.end() != node_it);
+  DART_ASSERT(mNodeMap.end() != node_it);
 
   const std::vector<Node*>& skelNodes = node_it->second;
   for (std::size_t i = indexInSkel; i < skelNodes.size(); ++i)
@@ -2565,7 +2566,7 @@ void Skeleton::unregisterNode(Node* _oldNode)
   unregisterNode(treeNodeMap, _oldNode, _oldNode->mIndexInTree);
 
   node_it = treeNodeMap.find(typeid(*_oldNode));
-  assert(treeNodeMap.end() != node_it);
+  DART_ASSERT(treeNodeMap.end() != node_it);
 
   const std::vector<Node*>& treeNodes = node_it->second;
   for (std::size_t i = indexInTree; i < treeNodes.size(); ++i)
@@ -2593,7 +2594,7 @@ bool Skeleton::moveBodyNodeTree(
         "to move a nullptr BodyNode. Please report this as a bug!",
         getName(),
         this);
-    assert(false);
+    DART_ASSERT(false);
     return false;
   }
 
@@ -2607,7 +2608,7 @@ bool Skeleton::moveBodyNodeTree(
         _bodyNode->getName(),
         _bodyNode->getSkeleton()->getName(),
         _bodyNode->getSkeleton());
-    assert(false);
+    DART_ASSERT(false);
     return false;
   }
 
@@ -2859,7 +2860,7 @@ void Skeleton::updateMassMatrix(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(cache.mM.cols()) == dof
       && static_cast<std::size_t>(cache.mM.rows()) == dof);
   if (dof == 0) {
@@ -2918,7 +2919,7 @@ void Skeleton::updateMassMatrix(std::size_t _treeIdx) const
 void Skeleton::updateMassMatrix() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(mSkelCache.mM.cols()) == dof
       && static_cast<std::size_t>(mSkelCache.mM.rows()) == dof);
   if (dof == 0) {
@@ -2950,7 +2951,7 @@ void Skeleton::updateAugMassMatrix(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(cache.mAugM.cols()) == dof
       && static_cast<std::size_t>(cache.mAugM.rows()) == dof);
   if (dof == 0) {
@@ -3010,7 +3011,7 @@ void Skeleton::updateAugMassMatrix(std::size_t _treeIdx) const
 void Skeleton::updateAugMassMatrix() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(mSkelCache.mAugM.cols()) == dof
       && static_cast<std::size_t>(mSkelCache.mAugM.rows()) == dof);
   if (dof == 0) {
@@ -3042,7 +3043,7 @@ void Skeleton::updateInvMassMatrix(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(cache.mInvM.cols()) == dof
       && static_cast<std::size_t>(cache.mInvM.rows()) == dof);
   if (dof == 0) {
@@ -3102,7 +3103,7 @@ void Skeleton::updateInvMassMatrix(std::size_t _treeIdx) const
 void Skeleton::updateInvMassMatrix() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(mSkelCache.mInvM.cols()) == dof
       && static_cast<std::size_t>(mSkelCache.mInvM.rows()) == dof);
   if (dof == 0) {
@@ -3134,7 +3135,7 @@ void Skeleton::updateInvAugMassMatrix(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(cache.mInvAugM.cols()) == dof
       && static_cast<std::size_t>(cache.mInvAugM.rows()) == dof);
   if (dof == 0) {
@@ -3196,7 +3197,7 @@ void Skeleton::updateInvAugMassMatrix(std::size_t _treeIdx) const
 void Skeleton::updateInvAugMassMatrix() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(mSkelCache.mInvAugM.cols()) == dof
       && static_cast<std::size_t>(mSkelCache.mInvAugM.rows()) == dof);
   if (dof == 0) {
@@ -3228,7 +3229,7 @@ void Skeleton::updateCoriolisForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(static_cast<std::size_t>(cache.mCvec.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(cache.mCvec.size()) == dof);
   if (dof == 0) {
     cache.mDirty.mCoriolisForces = false;
     return;
@@ -3256,7 +3257,7 @@ void Skeleton::updateCoriolisForces(std::size_t _treeIdx) const
 void Skeleton::updateCoriolisForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(static_cast<std::size_t>(mSkelCache.mCvec.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mCvec.size()) == dof);
   if (dof == 0) {
     mSkelCache.mDirty.mCoriolisForces = false;
     return;
@@ -3282,7 +3283,7 @@ void Skeleton::updateGravityForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(static_cast<std::size_t>(cache.mG.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(cache.mG.size()) == dof);
   if (dof == 0) {
     cache.mDirty.mGravityForces = false;
     return;
@@ -3304,7 +3305,7 @@ void Skeleton::updateGravityForces(std::size_t _treeIdx) const
 void Skeleton::updateGravityForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(static_cast<std::size_t>(mSkelCache.mG.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mG.size()) == dof);
   if (dof == 0) {
     mSkelCache.mDirty.mGravityForces = false;
     return;
@@ -3330,7 +3331,7 @@ void Skeleton::updateCoriolisAndGravityForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(static_cast<std::size_t>(cache.mCg.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(cache.mCg.size()) == dof);
   if (dof == 0) {
     cache.mDirty.mCoriolisAndGravityForces = false;
     return;
@@ -3358,7 +3359,7 @@ void Skeleton::updateCoriolisAndGravityForces(std::size_t _treeIdx) const
 void Skeleton::updateCoriolisAndGravityForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(static_cast<std::size_t>(mSkelCache.mCg.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mCg.size()) == dof);
   if (dof == 0) {
     mSkelCache.mDirty.mCoriolisAndGravityForces = false;
     return;
@@ -3384,7 +3385,7 @@ void Skeleton::updateExternalForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  assert(static_cast<std::size_t>(cache.mFext.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(cache.mFext.size()) == dof);
   if (dof == 0) {
     cache.mDirty.mExternalForces = false;
     return;
@@ -3438,7 +3439,7 @@ void Skeleton::updateExternalForces(std::size_t _treeIdx) const
 void Skeleton::updateExternalForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  assert(static_cast<std::size_t>(mSkelCache.mFext.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mFext.size()) == dof);
   if (dof == 0) {
     mSkelCache.mDirty.mExternalForces = false;
     return;
@@ -3463,7 +3464,7 @@ void Skeleton::updateExternalForces() const
 const Eigen::VectorXd& Skeleton::computeConstraintForces(DataCache& cache) const
 {
   const std::size_t dof = cache.mDofs.size();
-  assert(static_cast<std::size_t>(cache.mFc.size()) == dof);
+  DART_ASSERT(static_cast<std::size_t>(cache.mFc.size()) == dof);
 
   // Body constraint impulses
   for (std::vector<BodyNode*>::reverse_iterator it = cache.mBodyNodes.rbegin();
@@ -3781,19 +3782,19 @@ void Skeleton::updateBiasImpulse(BodyNode* _bodyNode)
 {
   if (nullptr == _bodyNode) {
     DART_ERROR("[Skeleton::updateBiasImpulse] Passed in a nullptr!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
-  assert(getNumDofs() > 0);
+  DART_ASSERT(getNumDofs() > 0);
 
   // This skeleton should contain _bodyNode
-  assert(_bodyNode->getSkeleton().get() == this);
+  DART_ASSERT(_bodyNode->getSkeleton().get() == this);
 
 #if DART_BUILD_MODE_DEBUG
   // All the constraint impulse should be zero
   for (std::size_t i = 0; i < mSkelCache.mBodyNodes.size(); ++i)
-    assert(
+    DART_ASSERT(
         mSkelCache.mBodyNodes[i]->mConstraintImpulse
         == Eigen::Vector6d::Zero());
 #endif
@@ -3812,19 +3813,19 @@ void Skeleton::updateBiasImpulse(
 {
   if (nullptr == _bodyNode) {
     DART_ERROR("[Skeleton::updateBiasImpulse] Passed in a nullptr!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
-  assert(getNumDofs() > 0);
+  DART_ASSERT(getNumDofs() > 0);
 
   // This skeleton should contain _bodyNode
-  assert(_bodyNode->getSkeleton().get() == this);
+  DART_ASSERT(_bodyNode->getSkeleton().get() == this);
 
 #if DART_BUILD_MODE_DEBUG
   // All the constraint impulse should be zero
   for (std::size_t i = 0; i < mSkelCache.mBodyNodes.size(); ++i)
-    assert(
+    DART_ASSERT(
         mSkelCache.mBodyNodes[i]->mConstraintImpulse
         == Eigen::Vector6d::Zero());
 #endif
@@ -3853,27 +3854,27 @@ void Skeleton::updateBiasImpulse(
   if (nullptr == _bodyNode1) {
     DART_ERROR(
         "[Skeleton::updateBiasImpulse] Passed in nullptr for BodyNode1!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
   if (nullptr == _bodyNode2) {
     DART_ERROR(
         "[Skeleton::updateBiasImpulse] Passed in nullptr for BodyNode2!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
-  assert(getNumDofs() > 0);
+  DART_ASSERT(getNumDofs() > 0);
 
   // This skeleton should contain _bodyNode
-  assert(_bodyNode1->getSkeleton().get() == this);
-  assert(_bodyNode2->getSkeleton().get() == this);
+  DART_ASSERT(_bodyNode1->getSkeleton().get() == this);
+  DART_ASSERT(_bodyNode2->getSkeleton().get() == this);
 
 #if DART_BUILD_MODE_DEBUG
   // All the constraint impulse should be zero
   for (std::size_t i = 0; i < mSkelCache.mBodyNodes.size(); ++i)
-    assert(
+    DART_ASSERT(
         mSkelCache.mBodyNodes[i]->mConstraintImpulse
         == Eigen::Vector6d::Zero());
 #endif
@@ -3903,18 +3904,18 @@ void Skeleton::updateBiasImpulse(
     const Eigen::Vector3d& _imp)
 {
   // Assertions
-  assert(_softBodyNode != nullptr);
-  assert(getNumDofs() > 0);
+  DART_ASSERT(_softBodyNode != nullptr);
+  DART_ASSERT(getNumDofs() > 0);
 
   // This skeleton should contain _bodyNode
-  assert(
+  DART_ASSERT(
       std::find(mSoftBodyNodes.begin(), mSoftBodyNodes.end(), _softBodyNode)
       != mSoftBodyNodes.end());
 
 #if DART_BUILD_MODE_DEBUG
   // All the constraint impulse should be zero
   for (std::size_t i = 0; i < mSkelCache.mBodyNodes.size(); ++i)
-    assert(
+    DART_ASSERT(
         mSkelCache.mBodyNodes[i]->mConstraintImpulse
         == Eigen::Vector6d::Zero());
 #endif
@@ -3987,7 +3988,7 @@ double Skeleton::computeKineticEnergy() const
   for (auto* bodyNode : mSkelCache.mBodyNodes)
     KE += bodyNode->computeKineticEnergy();
 
-  assert(KE >= 0.0 && "Kinetic energy should be positive value.");
+  DART_ASSERT(KE >= 0.0 && "Kinetic energy should be positive value.");
   return KE;
 }
 
@@ -4034,7 +4035,7 @@ Eigen::Vector3d Skeleton::getCOM(const Frame* _withRespectTo) const
     com += bodyNode->getMass() * bodyNode->getCOM(_withRespectTo);
   }
 
-  assert(mTotalMass != 0.0);
+  DART_ASSERT(mTotalMass != 0.0);
   return com / mTotalMass;
 }
 
@@ -4058,7 +4059,7 @@ PropertyType getCOMPropertyTemplate(
               * (bodyNode->*getPropertyFn)(_relativeTo, _inCoordinatesOf);
   }
 
-  assert(_skel->getMass() != 0.0);
+  DART_ASSERT(_skel->getMass() != 0.0);
   return result / _skel->getMass();
 }
 
@@ -4132,7 +4133,7 @@ JacType getCOMJacobianTemplate(
     }
   }
 
-  assert(_skel->getMass() != 0.0);
+  DART_ASSERT(_skel->getMass() != 0.0);
   return J / _skel->getMass();
 }
 

--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/SoftBodyNode.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/PointMass.hpp"
 #include "dart/dynamics/Shape.hpp"
@@ -104,16 +105,16 @@ bool SoftBodyNodeUniqueProperties::connectPointMasses(
 //==============================================================================
 void SoftBodyNodeUniqueProperties::addFace(const Eigen::Vector3i& _newFace)
 {
-  assert(_newFace[0] != _newFace[1]);
-  assert(_newFace[1] != _newFace[2]);
-  assert(_newFace[2] != _newFace[0]);
-  assert(
+  DART_ASSERT(_newFace[0] != _newFace[1]);
+  DART_ASSERT(_newFace[1] != _newFace[2]);
+  DART_ASSERT(_newFace[2] != _newFace[0]);
+  DART_ASSERT(
       0 <= _newFace[0]
       && static_cast<std::size_t>(_newFace[0]) < mPointProps.size());
-  assert(
+  DART_ASSERT(
       0 <= _newFace[1]
       && static_cast<std::size_t>(_newFace[1]) < mPointProps.size());
-  assert(
+  DART_ASSERT(
       0 <= _newFace[2]
       && static_cast<std::size_t>(_newFace[2]) < mPointProps.size());
   mFaces.push_back(_newFace);
@@ -232,7 +233,7 @@ std::size_t SoftBodyNode::getNumPointMasses() const
 //==============================================================================
 PointMass* SoftBodyNode::getPointMass(std::size_t _idx)
 {
-  assert(_idx < mPointMasses.size());
+  DART_ASSERT(_idx < mPointMasses.size());
   if (_idx < mPointMasses.size())
     return mPointMasses[_idx];
 
@@ -418,7 +419,7 @@ double SoftBodyNode::getMass() const
 //==============================================================================
 void SoftBodyNode::setVertexSpringStiffness(double _kv)
 {
-  assert(0.0 <= _kv);
+  DART_ASSERT(0.0 <= _kv);
 
   if (_kv == mAspectProperties.mKv)
     return;
@@ -436,7 +437,7 @@ double SoftBodyNode::getVertexSpringStiffness() const
 //==============================================================================
 void SoftBodyNode::setEdgeSpringStiffness(double _ke)
 {
-  assert(0.0 <= _ke);
+  DART_ASSERT(0.0 <= _ke);
 
   if (_ke == mAspectProperties.mKe)
     return;
@@ -454,7 +455,7 @@ double SoftBodyNode::getEdgeSpringStiffness() const
 //==============================================================================
 void SoftBodyNode::setDampingCoefficient(double _damp)
 {
-  assert(_damp >= 0.0);
+  DART_ASSERT(_damp >= 0.0);
 
   if (_damp == mAspectProperties.mDampCoeff)
     return;
@@ -492,9 +493,9 @@ PointMass* SoftBodyNode::addPointMass(const PointMass::Properties& _properties)
 //==============================================================================
 void SoftBodyNode::connectPointMasses(std::size_t _idx1, std::size_t _idx2)
 {
-  assert(_idx1 != _idx2);
-  assert(_idx1 < mPointMasses.size());
-  assert(_idx2 < mPointMasses.size());
+  DART_ASSERT(_idx1 != _idx2);
+  DART_ASSERT(_idx1 < mPointMasses.size());
+  DART_ASSERT(_idx2 < mPointMasses.size());
   mPointMasses[_idx1]->addConnectedPointMass(mPointMasses[_idx2]);
   mPointMasses[_idx2]->addConnectedPointMass(mPointMasses[_idx1]);
   // Version incremented in addConnectedPointMass
@@ -510,7 +511,7 @@ void SoftBodyNode::addFace(const Eigen::Vector3i& _face)
 //==============================================================================
 const Eigen::Vector3i& SoftBodyNode::getFace(std::size_t _idx) const
 {
-  assert(_idx < mAspectProperties.mFaces.size());
+  DART_ASSERT(_idx < mAspectProperties.mFaces.size());
   return mAspectProperties.mFaces[_idx];
 }
 
@@ -605,7 +606,7 @@ void SoftBodyNode::updateTransmittedForceID(
     mF -= BodyNode::mAspectState.mFext;
 
   // Verification
-  assert(!math::isNan(mF));
+  DART_ASSERT(!math::isNan(mF));
 
   // Gravity force
   mF -= mFgravity;
@@ -617,7 +618,7 @@ void SoftBodyNode::updateTransmittedForceID(
   //
   for (const auto& childBodyNode : mChildBodyNodes) {
     Joint* childJoint = childBodyNode->getParentJoint();
-    assert(childJoint != nullptr);
+    DART_ASSERT(childJoint != nullptr);
 
     mF += math::dAdInvT(
         childJoint->getRelativeTransform(), childBodyNode->getBodyForce());
@@ -628,7 +629,7 @@ void SoftBodyNode::updateTransmittedForceID(
   }
 
   // Verification
-  assert(!math::isNan(mF));
+  DART_ASSERT(!math::isNan(mF));
 }
 
 //==============================================================================
@@ -665,7 +666,7 @@ void SoftBodyNode::updateArtInertia(double _timeStep) const
   for (auto& pointMass : mPointMasses)
     pointMass->updateArtInertiaFD(_timeStep);
 
-  assert(mParentJoint != nullptr);
+  DART_ASSERT(mParentJoint != nullptr);
 
   // Set spatial inertia to the articulated body inertia
   mArtInertia = mI;
@@ -688,16 +689,16 @@ void SoftBodyNode::updateArtInertia(double _timeStep) const
   }
 
   // Verification
-  assert(!math::isNan(mArtInertia));
-  assert(!math::isNan(mArtInertiaImplicit));
+  DART_ASSERT(!math::isNan(mArtInertia));
+  DART_ASSERT(!math::isNan(mArtInertiaImplicit));
 
   // Update parent joint's inverse of projected articulated body inertia
   mParentJoint->updateInvProjArtInertia(mArtInertia);
   mParentJoint->updateInvProjArtInertiaImplicit(mArtInertiaImplicit, _timeStep);
 
   // Verification
-  assert(!math::isNan(mArtInertia));
-  assert(!math::isNan(mArtInertiaImplicit));
+  DART_ASSERT(!math::isNan(mArtInertia));
+  DART_ASSERT(!math::isNan(mArtInertiaImplicit));
 }
 
 //==============================================================================
@@ -728,7 +729,7 @@ void SoftBodyNode::updateBiasForce(
   mBiasForce = -math::dad(V, mI * V) - BodyNode::mAspectState.mFext - mFgravity;
 
   // Verifycation
-  assert(!math::isNan(mBiasForce));
+  DART_ASSERT(!math::isNan(mBiasForce));
 
   // And add child bias force
   for (const auto& childBodyNode : mChildBodyNodes) {
@@ -749,7 +750,7 @@ void SoftBodyNode::updateBiasForce(
   }
 
   // Verifycation
-  assert(!math::isNan(mBiasForce));
+  DART_ASSERT(!math::isNan(mBiasForce));
 
   // Update parent joint's total force with implicit joint damping and spring
   // forces
@@ -804,7 +805,7 @@ void SoftBodyNode::updateBiasImpulse()
   }
 
   // Verification
-  assert(!math::isNan(mBiasImpulse));
+  DART_ASSERT(!math::isNan(mBiasImpulse));
 
   // Update parent joint's total force
   mParentJoint->updateTotalImpulse(mBiasImpulse);
@@ -906,7 +907,7 @@ void SoftBodyNode::aggregateAugMassMatrix(
 
   //----------------------- SoftBodyNode Part ----------------------------------
   mM_F.noalias() = mI * mM_dV;
-  assert(!math::isNan(mM_F));
+  DART_ASSERT(!math::isNan(mM_F));
 
   for (std::vector<BodyNode*>::const_iterator it = mChildBodyNodes.begin();
        it != mChildBodyNodes.end();
@@ -920,7 +921,7 @@ void SoftBodyNode::aggregateAugMassMatrix(
     mM_F.head<3>() += (*it)->getLocalPosition().cross((*it)->mM_F);
     mM_F.tail<3>() += (*it)->mM_F;
   }
-  assert(!math::isNan(mM_F));
+  DART_ASSERT(!math::isNan(mM_F));
 
   std::size_t dof = mParentJoint->getNumDofs();
   if (dof > 0) {
@@ -969,7 +970,7 @@ void SoftBodyNode::updateInvMassMatrix()
   }
 
   // Verification
-  assert(!math::isNan(mInvM_c));
+  DART_ASSERT(!math::isNan(mInvM_c));
 
   // Update parent joint's total force for inverse mass matrix
   mParentJoint->updateTotalForceForInvMassMatrix(mInvM_c);
@@ -1373,7 +1374,7 @@ void SoftBodyNodeHelper::setBox(
     double _edgeStiffness,
     double _dampingCoeff)
 {
-  assert(_softBodyNode != nullptr);
+  DART_ASSERT(_softBodyNode != nullptr);
   _softBodyNode->setProperties(makeBoxProperties(
       _size,
       _localTransform,
@@ -1416,7 +1417,7 @@ SoftBodyNode::UniqueProperties SoftBodyNodeHelper::makeBoxProperties(
   // Point masses
   //----------------------------------------------------------------------------
   // Number of point masses
-  assert(frags[0] > 1 && frags[1] > 1 && frags[2] > 1);
+  DART_ASSERT(frags[0] > 1 && frags[1] > 1 && frags[2] > 1);
 
   std::size_t nCorners = 8;
   std::size_t nVerticesAtEdgeX = frags[0] - 2;
@@ -2427,7 +2428,7 @@ void SoftBodyNodeHelper::setBox(
     double _edgeStiffness,
     double _dampingCoeff)
 {
-  assert(_softBodyNode != nullptr);
+  DART_ASSERT(_softBodyNode != nullptr);
   _softBodyNode->setProperties(makeBoxProperties(
       _size,
       _localTransform,
@@ -2480,7 +2481,7 @@ void SoftBodyNodeHelper::setSinglePointMass(
     double _edgeStiffness,
     double _dampingCoeff)
 {
-  assert(_softBodyNode != nullptr);
+  DART_ASSERT(_softBodyNode != nullptr);
   _softBodyNode->setProperties(makeSinglePointMassProperties(
       _totalMass, _vertexStiffness, _edgeStiffness, _dampingCoeff));
 }
@@ -2664,7 +2665,7 @@ void SoftBodyNodeHelper::setEllipsoid(
     double _edgeStiffness,
     double _dampingCoeff)
 {
-  assert(_softBodyNode != nullptr);
+  DART_ASSERT(_softBodyNode != nullptr);
   _softBodyNode->setProperties(makeEllipsoidProperties(
       _size,
       _nSlices,
@@ -3000,7 +3001,7 @@ void SoftBodyNodeHelper::setCylinder(
     double _edgeStiffness,
     double _dampingCoeff)
 {
-  assert(_softBodyNode != nullptr);
+  DART_ASSERT(_softBodyNode != nullptr);
   _softBodyNode->setProperties(makeCylinderProperties(
       _radius,
       _height,

--- a/dart/dynamics/SoftMeshShape.cpp
+++ b/dart/dynamics/SoftMeshShape.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/SoftMeshShape.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/PointMass.hpp"
 #include "dart/dynamics/SoftBodyNode.hpp"
 
@@ -42,7 +43,7 @@ namespace dynamics {
 SoftMeshShape::SoftMeshShape(SoftBodyNode* _softBodyNode)
   : Shape(SOFT_MESH), mSoftBodyNode(_softBodyNode), mAssimpMesh(nullptr)
 {
-  assert(_softBodyNode != nullptr);
+  DART_ASSERT(_softBodyNode != nullptr);
   // Build mesh here using soft body node
   // TODO(JS): Not implemented.
   _buildMesh();

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/SphereShape.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 
 namespace dart {
@@ -65,7 +66,7 @@ const std::string& SphereShape::getStaticType()
 //==============================================================================
 void SphereShape::setRadius(double radius)
 {
-  assert(radius > 0.0);
+  DART_ASSERT(radius > 0.0);
 
   mRadius = radius;
 

--- a/dart/dynamics/TranslationalJoint.cpp
+++ b/dart/dynamics/TranslationalJoint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/TranslationalJoint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
 
@@ -122,7 +123,7 @@ void TranslationalJoint::updateRelativeTransform() const
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
   // Verification
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -133,8 +134,8 @@ void TranslationalJoint::updateRelativeJacobian(bool _mandatory) const
         = Joint::mAspectProperties.mT_ChildBodyToJoint.linear();
 
     // Verification
-    assert(mJacobian.topRows<3>() == Eigen::Matrix3d::Zero());
-    assert(!math::isNan(mJacobian.bottomRows<3>()));
+    DART_ASSERT(mJacobian.topRows<3>() == Eigen::Matrix3d::Zero());
+    DART_ASSERT(!math::isNan(mJacobian.bottomRows<3>()));
   }
 }
 
@@ -142,7 +143,7 @@ void TranslationalJoint::updateRelativeJacobian(bool _mandatory) const
 void TranslationalJoint::updateRelativeJacobianTimeDeriv() const
 {
   // Time derivative of translational joint is always zero
-  assert(mJacobianDeriv == (Eigen::Matrix<double, 6, 3>::Zero()));
+  DART_ASSERT(mJacobianDeriv == (Eigen::Matrix<double, 6, 3>::Zero()));
 }
 
 } // namespace dynamics

--- a/dart/dynamics/TranslationalJoint2D.cpp
+++ b/dart/dynamics/TranslationalJoint2D.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/TranslationalJoint2D.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
@@ -228,7 +229,7 @@ void TranslationalJoint2D::updateRelativeTransform() const
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
   // Verification
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -240,8 +241,9 @@ void TranslationalJoint2D::updateRelativeJacobian(bool mandatory) const
           * mAspectProperties.getTranslationalAxes();
 
     // Verification
-    assert(mJacobian.topRows<3>() == (Eigen::Matrix<double, 3, 2>::Zero()));
-    assert(!math::isNan(mJacobian.bottomRows<3>()));
+    DART_ASSERT(
+        mJacobian.topRows<3>() == (Eigen::Matrix<double, 3, 2>::Zero()));
+    DART_ASSERT(!math::isNan(mJacobian.bottomRows<3>()));
   }
 }
 
@@ -249,7 +251,7 @@ void TranslationalJoint2D::updateRelativeJacobian(bool mandatory) const
 void TranslationalJoint2D::updateRelativeJacobianTimeDeriv() const
 {
   // Time derivative of translational joint is always zero
-  assert(mJacobianDeriv == (Eigen::Matrix<double, 6, 2>::Zero()));
+  DART_ASSERT(mJacobianDeriv == (Eigen::Matrix<double, 6, 2>::Zero()));
 }
 
 } // namespace dynamics

--- a/dart/dynamics/UniversalJoint.cpp
+++ b/dart/dynamics/UniversalJoint.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/UniversalJoint.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
 
@@ -156,7 +157,7 @@ Eigen::Matrix<double, 6, 2> UniversalJoint::getRelativeJacobianStatic(
       getAxis1());
   J.col(1) = math::AdTAngular(
       Joint::mAspectProperties.mT_ChildBodyToJoint, getAxis2());
-  assert(!math::isNan(J));
+  DART_ASSERT(!math::isNan(J));
   return J;
 }
 
@@ -194,7 +195,7 @@ void UniversalJoint::updateRelativeTransform() const
        * Eigen::AngleAxisd(positions[0], getAxis1())
        * Eigen::AngleAxisd(positions[1], getAxis2())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
-  assert(math::verifyTransform(mT));
+  DART_ASSERT(math::verifyTransform(mT));
 }
 
 //==============================================================================
@@ -217,8 +218,8 @@ void UniversalJoint::updateRelativeJacobianTimeDeriv() const
 
   mJacobianDeriv.col(0) = -math::ad(tmpV1, tmpV2);
 
-  assert(!math::isNan(mJacobianDeriv.col(0)));
-  assert(mJacobianDeriv.col(1) == Eigen::Vector6d::Zero());
+  DART_ASSERT(!math::isNan(mJacobianDeriv.col(0)));
+  DART_ASSERT(mJacobianDeriv.col(1) == Eigen::Vector6d::Zero());
 }
 
 } // namespace dynamics

--- a/dart/dynamics/ZeroDofJoint.cpp
+++ b/dart/dynamics/ZeroDofJoint.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/ZeroDofJoint.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/math/Helpers.hpp"
@@ -65,7 +66,7 @@ DegreeOfFreedom* ZeroDofJoint::getDof(std::size_t)
   DART_ERROR(
       "[ZeroDofJoint::getDof] Attempting to get a DegreeOfFreedom from a "
       "ZeroDofJoint. This is not allowed!");
-  assert(false);
+  DART_ASSERT(false);
   return nullptr;
 }
 
@@ -75,7 +76,7 @@ const DegreeOfFreedom* ZeroDofJoint::getDof(std::size_t) const
   DART_ERROR(
       "[ZeroDofJoint::getDof] Attempting to get a DegreeOfFreedom from a "
       "ZeroDofJoint. This is not allowed!");
-  assert(false);
+  DART_ASSERT(false);
   return nullptr;
 }
 
@@ -117,7 +118,7 @@ std::size_t ZeroDofJoint::getIndexInSkeleton(std::size_t _index) const
       "[ZeroDofJoint::getIndexInSkeleton] This function should never be called "
       "({})!",
       _index);
-  assert(false);
+  DART_ASSERT(false);
 
   return 0;
 }
@@ -129,7 +130,7 @@ std::size_t ZeroDofJoint::getIndexInTree(std::size_t _index) const
       "ZeroDofJoint::getIndexInTree] This function should never be called "
       "({})!",
       _index);
-  assert(false);
+  DART_ASSERT(false);
 
   return 0;
 }
@@ -694,7 +695,7 @@ void ZeroDofJoint::updateDegreeOfFreedomNames()
 //==============================================================================
 Eigen::Vector6d ZeroDofJoint::getBodyConstraintWrench() const
 {
-  assert(mChildBodyNode);
+  DART_ASSERT(mChildBodyNode);
   return mChildBodyNode->getBodyForce();
 }
 

--- a/dart/dynamics/detail/BasicNodeManager.hpp
+++ b/dart/dynamics/detail/BasicNodeManager.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_DYNAMICS_DETAIL_BASICNODEMANAGER_HPP_
 #define DART_DYNAMICS_DETAIL_BASICNODEMANAGER_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/dynamics/Node.hpp>
 
 #include <dart/common/ClassWithVirtualBase.hpp>
@@ -190,7 +192,7 @@ std::size_t BasicNodeManagerForSkeleton::getNumNodes(
         typeid(NodeType).name(),
         treeIndex,
         mTreeNodeMaps.size());
-    assert(false);
+    DART_ASSERT(false);
     return 0;
   }
 
@@ -214,7 +216,7 @@ NodeType* BasicNodeManagerForSkeleton::getNode(
         typeid(NodeType).name(),
         treeIndex,
         mTreeNodeMaps.size());
-    assert(false);
+    DART_ASSERT(false);
     return nullptr;
   }
 
@@ -227,7 +229,7 @@ NodeType* BasicNodeManagerForSkeleton::getNode(
         typeid(NodeType).name(),
         nodeIndex,
         treeIndex);
-    assert(false);
+    DART_ASSERT(false);
     return nullptr;
   }
 
@@ -239,7 +241,7 @@ NodeType* BasicNodeManagerForSkeleton::getNode(
         nodeIndex,
         treeIndex,
         it->second.size());
-    assert(false);
+    DART_ASSERT(false);
     return nullptr;
   }
 

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_DYNAMICS_DETAIL_GenericJoint_HPP_
 #define DART_DYNAMICS_DETAIL_GenericJoint_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/config.hpp>
 
 #include <dart/dynamics/BodyNode.hpp>
@@ -54,7 +56,7 @@
         (arg).size(),                                                          \
         this->getNumDofs(),                                                    \
         this->getName());                                                      \
-    assert(false);                                                             \
+    DART_ASSERT(false);                                                        \
   }
 
 #define GenericJoint_REPORT_OUT_OF_RANGE(func, index)                          \
@@ -66,7 +68,7 @@
         (index),                                                               \
         this->getName(),                                                       \
         this->getNumDofs());                                                   \
-    assert(false);                                                             \
+    DART_ASSERT(false);                                                        \
   }
 
 #define GenericJoint_REPORT_UNSUPPORTED_ACTUATOR(func)                         \
@@ -76,7 +78,7 @@
         #func,                                                                 \
         static_cast<int>(Joint::mAspectProperties.mActuatorType),              \
         this->getName());                                                      \
-    assert(false);                                                             \
+    DART_ASSERT(false);                                                        \
   }
 
 #define GenericJoint_SET_IF_DIFFERENT(mField, value)                           \
@@ -251,7 +253,7 @@ const std::string& GenericJoint<ConfigSpaceT>::setDofName(
         "of DOF index 0 instead.",
         index,
         this->getName());
-    assert(false);
+    DART_ASSERT(false);
     index = 0u;
   }
 
@@ -307,7 +309,7 @@ const std::string& GenericJoint<ConfigSpaceT>::getDofName(size_t index) const
         index,
         this->getName(),
         NumDofs - 1);
-    assert(false);
+    DART_ASSERT(false);
     return Base::mAspectProperties.mDofNames[0];
   }
 
@@ -399,7 +401,7 @@ void GenericJoint<ConfigSpaceT>::setCommand(size_t index, double command)
       this->mAspectState.mCommands[index] = 0.0;
       break;
     default:
-      assert(false);
+      DART_ASSERT(false);
       break;
   }
 }
@@ -479,7 +481,7 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
       this->mAspectState.mCommands.setZero();
       break;
     default:
-      assert(false);
+      DART_ASSERT(false);
       break;
   }
 }
@@ -1379,7 +1381,7 @@ Eigen::VectorXd GenericJoint<ConfigSpaceT>::getPositionDifferences(
         q2.size(),
         this->getNumDofs(),
         this->getName());
-    assert(false);
+    DART_ASSERT(false);
     return Eigen::VectorXd::Zero(getNumDofs());
   }
 
@@ -1405,7 +1407,7 @@ void GenericJoint<ConfigSpaceT>::setSpringStiffness(size_t index, double k)
     return;
   }
 
-  assert(k >= 0.0);
+  DART_ASSERT(k >= 0.0);
 
   GenericJoint_SET_IF_DIFFERENT(mSpringStiffnesses[index], k);
 }
@@ -1455,7 +1457,7 @@ void GenericJoint<ConfigSpaceT>::setDampingCoefficient(size_t index, double d)
     return;
   }
 
-  assert(d >= 0.0);
+  DART_ASSERT(d >= 0.0);
 
   GenericJoint_SET_IF_DIFFERENT(mDampingCoefficients[index], d);
 }
@@ -1482,7 +1484,7 @@ void GenericJoint<ConfigSpaceT>::setCoulombFriction(
     return;
   }
 
-  assert(friction >= 0.0);
+  DART_ASSERT(friction >= 0.0);
 
   GenericJoint_SET_IF_DIFFERENT(mFrictions[index], friction);
 }
@@ -1601,7 +1603,7 @@ void GenericJoint<ConfigSpaceT>::registerDofs()
 template <class ConfigSpaceT>
 Eigen::Vector6d GenericJoint<ConfigSpaceT>::getBodyConstraintWrench() const
 {
-  assert(this->mChildBodyNode);
+  DART_ASSERT(this->mChildBodyNode);
   return this->mChildBodyNode->getBodyForce()
          - this->getRelativeJacobianStatic() * this->mAspectState.mForces;
 }
@@ -1639,7 +1641,7 @@ void GenericJoint<ConfigSpaceT>::addVelocityTo(Eigen::Vector6d& vel)
   vel.noalias() += getRelativeJacobianStatic() * getVelocitiesStatic();
 
   // Verification
-  assert(!math::isNan(vel));
+  DART_ASSERT(!math::isNan(vel));
 }
 
 //==============================================================================
@@ -1653,7 +1655,7 @@ void GenericJoint<ConfigSpaceT>::setPartialAccelerationTo(
             childVelocity, getRelativeJacobianStatic() * getVelocitiesStatic())
         + getRelativeJacobianTimeDerivStatic() * getVelocitiesStatic();
   // Verification
-  assert(!math::isNan(partialAcceleration));
+  DART_ASSERT(!math::isNan(partialAcceleration));
 }
 
 //==============================================================================
@@ -1664,7 +1666,7 @@ void GenericJoint<ConfigSpaceT>::addAccelerationTo(Eigen::Vector6d& acc)
   acc.noalias() += getRelativeJacobianStatic() * getAccelerationsStatic();
 
   // Verification
-  assert(!math::isNan(acc));
+  DART_ASSERT(!math::isNan(acc));
 }
 
 //==============================================================================
@@ -1676,7 +1678,7 @@ void GenericJoint<ConfigSpaceT>::addVelocityChangeTo(
   velocityChange.noalias() += getRelativeJacobianStatic() * mVelocityChanges;
 
   // Verification
-  assert(!math::isNan(velocityChange));
+  DART_ASSERT(!math::isNan(velocityChange));
 }
 
 //==============================================================================
@@ -1731,7 +1733,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaToDynamic(
   JacobianMatrix AIS = childArtInertia * getRelativeJacobianStatic();
   Eigen::Matrix6d PI = childArtInertia;
   PI.noalias() -= AIS * mInvProjArtInertia * AIS.transpose();
-  assert(!math::isNan(PI));
+  DART_ASSERT(!math::isNan(PI));
 
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.
@@ -1782,7 +1784,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaImplicitToDynamic(
   JacobianMatrix AIS = childArtInertia * getRelativeJacobianStatic();
   Eigen::Matrix6d PI = childArtInertia;
   PI.noalias() -= AIS * mInvProjArtInertiaImplicit * AIS.transpose();
-  assert(!math::isNan(PI));
+  DART_ASSERT(!math::isNan(PI));
 
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.
@@ -1837,7 +1839,7 @@ void GenericJoint<ConfigSpaceT>::updateInvProjArtInertiaDynamic(
   mInvProjArtInertia = math::inverse<ConfigSpaceT>(projAI);
 
   // Verification
-  assert(!math::isNan(mInvProjArtInertia));
+  DART_ASSERT(!math::isNan(mInvProjArtInertia));
 }
 
 //==============================================================================
@@ -1889,7 +1891,7 @@ void GenericJoint<ConfigSpaceT>::updateInvProjArtInertiaImplicitDynamic(
   mInvProjArtInertiaImplicit = math::inverse<ConfigSpaceT>(projAI);
 
   // Verification
-  assert(!math::isNan(mInvProjArtInertiaImplicit));
+  DART_ASSERT(!math::isNan(mInvProjArtInertiaImplicit));
 }
 
 //==============================================================================
@@ -1951,7 +1953,7 @@ void GenericJoint<ConfigSpaceT>::addChildBiasForceToDynamic(
   //    getInvProjArtInertiaImplicit() * mTotalForce;
 
   // Verification
-  assert(!math::isNan(beta));
+  DART_ASSERT(!math::isNan(beta));
 
   // Add child body's bias force to parent body's bias force. Note that mT
   // should be updated.
@@ -1980,7 +1982,7 @@ void GenericJoint<ConfigSpaceT>::addChildBiasForceToKinematic(
   //    getInvProjArtInertiaImplicit() * mTotalForce;
 
   // Verification
-  assert(!math::isNan(beta));
+  DART_ASSERT(!math::isNan(beta));
 
   // Add child body's bias force to parent body's bias force. Note that mT
   // should be updated.
@@ -2027,7 +2029,7 @@ void GenericJoint<ConfigSpaceT>::addChildBiasImpulseToDynamic(
                                      * getInvProjArtInertia() * mTotalImpulse;
 
   // Verification
-  assert(!math::isNan(beta));
+  DART_ASSERT(!math::isNan(beta));
 
   // Add child body's bias force to parent body's bias force. Note that mT
   // should be updated.
@@ -2052,7 +2054,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::updateTotalForce(
     const Eigen::Vector6d& bodyForce, double timeStep)
 {
-  assert(timeStep > 0.0);
+  DART_ASSERT(timeStep > 0.0);
 
   switch (Joint::mAspectProperties.mActuatorType) {
     case Joint::FORCE:
@@ -2198,7 +2200,7 @@ void GenericJoint<ConfigSpaceT>::updateAccelerationDynamic(
                * math::AdInvT(this->getRelativeTransform(), spatialAcc)));
 
   // Verification
-  assert(!math::isNan(getAccelerationsStatic()));
+  DART_ASSERT(!math::isNan(getAccelerationsStatic()));
 }
 
 //==============================================================================
@@ -2246,7 +2248,7 @@ void GenericJoint<ConfigSpaceT>::updateVelocityChangeDynamic(
                  * math::AdInvT(this->getRelativeTransform(), velocityChange));
 
   // Verification
-  assert(!math::isNan(mVelocityChanges));
+  DART_ASSERT(!math::isNan(mVelocityChanges));
 }
 
 //==============================================================================
@@ -2401,7 +2403,7 @@ void GenericJoint<ConfigSpaceT>::addChildBiasForceForInvMassMatrix(
                     * getInvProjArtInertia() * mInvM_a;
 
   // Verification
-  assert(!math::isNan(beta));
+  DART_ASSERT(!math::isNan(beta));
 
   // Add child body's bias force to parent body's bias force. Note that mT
   // should be updated.
@@ -2421,7 +2423,7 @@ void GenericJoint<ConfigSpaceT>::addChildBiasForceForInvAugMassMatrix(
                     * getInvProjArtInertiaImplicit() * mInvM_a;
 
   // Verification
-  assert(!math::isNan(beta));
+  DART_ASSERT(!math::isNan(beta));
 
   // Add child body's bias force to parent body's bias force. Note that mT
   // should be updated.
@@ -2454,7 +2456,7 @@ void GenericJoint<ConfigSpaceT>::getInvMassMatrixSegment(
                  * math::AdInvT(this->getRelativeTransform(), spatialAcc));
 
   // Verification
-  assert(!math::isNan(mInvMassMatrixSegment));
+  DART_ASSERT(!math::isNan(mInvMassMatrixSegment));
 
   // Index
   size_t iStart = mDofs[0]->mIndexInTree;
@@ -2479,7 +2481,7 @@ void GenericJoint<ConfigSpaceT>::getInvAugMassMatrixSegment(
                  * math::AdInvT(this->getRelativeTransform(), spatialAcc));
 
   // Verification
-  assert(!math::isNan(mInvMassMatrixSegment));
+  DART_ASSERT(!math::isNan(mInvMassMatrixSegment));
 
   // Index
   size_t iStart = mDofs[0]->mIndexInTree;

--- a/dart/dynamics/detail/HeightmapShape-impl.hpp
+++ b/dart/dynamics/detail/HeightmapShape-impl.hpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/dynamics/BoxShape.hpp>
 #include <dart/dynamics/HeightmapShape.hpp>
 
@@ -72,9 +74,9 @@ const std::string& HeightmapShape<S>::getStaticType()
 template <typename S>
 void HeightmapShape<S>::setScale(const Vector3& scale)
 {
-  assert(scale[0] > 0.0);
-  assert(scale[1] > 0.0);
-  assert(scale[2] > 0.0);
+  DART_ASSERT(scale[0] > 0.0);
+  DART_ASSERT(scale[1] > 0.0);
+  DART_ASSERT(scale[2] > 0.0);
   mScale = scale;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -96,7 +98,7 @@ void HeightmapShape<S>::setHeightField(
     const std::size_t& depth,
     const std::vector<S>& heights)
 {
-  assert(heights.size() == width * depth);
+  DART_ASSERT(heights.size() == width * depth);
   if ((width * depth) != heights.size()) {
     DART_ERROR(
         "[HeightmapShape] Size of height field needs to be width*depth={}",

--- a/dart/dynamics/detail/Node.hpp
+++ b/dart/dynamics/detail/Node.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_DYNAMICS_DETAIL_NODE_HPP_
 #define DART_DYNAMICS_DETAIL_NODE_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/dynamics/Node.hpp>
 
 #include <dart/common/StlHelpers.hpp>
@@ -301,7 +303,7 @@ public:                                                                        \
         #func,                                                                 \
         treeIndex,                                                             \
         treeIts.size());                                                       \
-    assert(false);                                                             \
+    DART_ASSERT(false);                                                        \
     return 0;                                                                  \
   }
 

--- a/dart/dynamics/detail/PlanarJointAspect.cpp
+++ b/dart/dynamics/detail/PlanarJointAspect.cpp
@@ -30,6 +30,7 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/PlanarJoint.hpp"
 
 namespace dart {
@@ -148,7 +149,7 @@ void PlanarJointUniqueProperties::setArbitraryPlane(
 
   // Orthogonalize translational axes
   double dotProduct = mTransAxis1.dot(mTransAxis2);
-  assert(std::abs(dotProduct) < 1.0 - 1e-6);
+  DART_ASSERT(std::abs(dotProduct) < 1.0 - 1e-6);
   if (std::abs(dotProduct) > 1e-6)
     mTransAxis2 = (mTransAxis2 - dotProduct * mTransAxis1).normalized();
 

--- a/dart/dynamics/detail/SpecializedNodeManager.hpp
+++ b/dart/dynamics/detail/SpecializedNodeManager.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_DYNAMICS_DETAIL_SPECIALIZEDNODEMANAGER_HPP_
 #define DART_DYNAMICS_DETAIL_SPECIALIZEDNODEMANAGER_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/dynamics/SpecializedNodeManager.hpp>
 
 namespace dart {
@@ -234,7 +236,7 @@ std::size_t SkeletonSpecializedFor<SpecNode>::_getNumNodes(
         typeid(SpecNode).name(),
         treeIndex,
         mTreeNodeMaps.size());
-    assert(false);
+    DART_ASSERT(false);
     return 0;
   }
 
@@ -267,7 +269,7 @@ SpecNode* SkeletonSpecializedFor<SpecNode>::_getNode(
         typeid(SpecNode).name(),
         treeIndex,
         mTreeNodeMaps.size());
-    assert(false);
+    DART_ASSERT(false);
     return nullptr;
   }
 
@@ -281,7 +283,7 @@ SpecNode* SkeletonSpecializedFor<SpecNode>::_getNode(
         nodeIndex,
         treeIndex,
         it->second.size());
-    assert(false);
+    DART_ASSERT(false);
     return nullptr;
   }
 

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
@@ -30,6 +30,7 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/TranslationalJoint2D.hpp"
 
 namespace dart {
@@ -151,7 +152,7 @@ void TranslationalJoint2DUniqueProperties::setArbitraryPlane(
 
   // Orthogonalize translational axes
   const double dotProduct = mTransAxes.col(0).dot(mTransAxes.col(1));
-  assert(std::abs(dotProduct) < 1.0 - 1e-6);
+  DART_ASSERT(std::abs(dotProduct) < 1.0 - 1e-6);
   if (std::abs(dotProduct) > 1e-6)
     mTransAxes.col(1)
         = (mTransAxes.col(1) - dotProduct * mTransAxes.col(0)).normalized();
@@ -172,7 +173,7 @@ void TranslationalJoint2DUniqueProperties::setArbitraryPlane(
 
   // Orthogonalize translational axes
   const double dotProduct = mTransAxes.col(0).dot(mTransAxes.col(1));
-  assert(std::abs(dotProduct) < 1.0 - 1e-6);
+  DART_ASSERT(std::abs(dotProduct) < 1.0 - 1e-6);
   if (std::abs(dotProduct) > 1e-6)
     mTransAxes.col(1)
         = (mTransAxes.col(1) - dotProduct * mTransAxes.col(0)).normalized();

--- a/dart/gui/osg/GridVisual.cpp
+++ b/dart/gui/osg/GridVisual.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/gui/osg/GridVisual.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -157,7 +158,7 @@ bool GridVisual::isDisplayed() const
 //==============================================================================
 void GridVisual::setMajorLineColor(const Eigen::Vector4d& color)
 {
-  assert(mMajorLineColor->size() == 1);
+  DART_ASSERT(mMajorLineColor->size() == 1);
   mMajorLineColor->at(0) = ::osg::Vec4(
       static_cast<float>(color[0]),
       static_cast<float>(color[1]),
@@ -176,7 +177,7 @@ Eigen::Vector4d GridVisual::getMajorLineColor() const
 //==============================================================================
 void GridVisual::setMinorLineColor(const Eigen::Vector4d& color)
 {
-  assert(mMinorLineColor->size() == 1);
+  DART_ASSERT(mMinorLineColor->size() == 1);
   mMinorLineColor->at(0) = ::osg::Vec4(
       static_cast<float>(color[0]),
       static_cast<float>(color[1]),
@@ -260,9 +261,9 @@ void setVertices(
     GridVisual::PlaneType planeType,
     const Eigen::Vector3d& offset)
 {
-  assert(axisLineVertices);
-  assert(majorLineVertices);
-  assert(minorLineVertices);
+  DART_ASSERT(axisLineVertices);
+  DART_ASSERT(majorLineVertices);
+  DART_ASSERT(minorLineVertices);
 
   int axis1 = 0;
   int axis2 = 1;

--- a/dart/gui/osg/ImGuiHandler.cpp
+++ b/dart/gui/osg/ImGuiHandler.cpp
@@ -39,6 +39,7 @@
 #include "dart/gui/osg/ImGuiHandler.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/gui/osg/ImGuiWidget.hpp"
 #include "dart/gui/osg/IncludeImGui.hpp"
 
@@ -359,8 +360,8 @@ bool ImGuiHandler::handle(
 #else
       const ConvertedKey specialKey = convertFromOSGKey(key);
       if (specialKey != ConvertedKey_None) {
-        assert(specialKey < 512 && "ImGui KeysDown is an array of 512");
-        assert(
+        DART_ASSERT(specialKey < 512 && "ImGui KeysDown is an array of 512");
+        DART_ASSERT(
             specialKey > 256
             && "ASCII stop at 127, but we use the range [257, 511]");
 
@@ -393,8 +394,8 @@ bool ImGuiHandler::handle(
 #else
       const ConvertedKey specialKey = convertFromOSGKey(key);
       if (specialKey != ConvertedKey_None) {
-        assert(specialKey < 512 && "ImGui KeysDown is an array of 512");
-        assert(
+        DART_ASSERT(specialKey < 512 && "ImGui KeysDown is an array of 512");
+        DART_ASSERT(
             specialKey > 256
             && "ASCII stop at 127, but we use the range [257, 511]");
 
@@ -500,7 +501,7 @@ void ImGuiHandler::newFrame(::osg::RenderInfo& renderInfo)
       = mTime > 0.0 ? static_cast<float>(currentTime - mTime) : 1.0f / 60.0f;
   io.DeltaTime = std::max(io.DeltaTime, std::numeric_limits<float>::min());
   mTime = currentTime;
-  assert(mTime >= 0.0);
+  DART_ASSERT(mTime >= 0.0);
 
   for (auto i = 0u; i < mMousePressed.size(); ++i)
     io.MouseDown[i] = mMousePressed[i];

--- a/dart/gui/osg/SupportPolygonVisual.cpp
+++ b/dart/gui/osg/SupportPolygonVisual.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/gui/osg/SupportPolygonVisual.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -305,7 +306,7 @@ void SupportPolygonVisual::refresh()
         mass += bn->getMass();
       }
 
-      assert(mass != 0.0);
+      DART_ASSERT(mass != 0.0);
       com = com / mass;
     }
 

--- a/dart/gui/osg/Viewer.cpp
+++ b/dart/gui/osg/Viewer.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/gui/osg/Viewer.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Shape.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
@@ -472,7 +473,7 @@ const ::osg::Group* Viewer::getLightGroup() const
 const ::osg::ref_ptr<::osg::LightSource>& Viewer::getLightSource(
     std::size_t index) const
 {
-  assert(index < 2);
+  DART_ASSERT(index < 2);
   if (index == 0)
     return mLightSource1;
   return mLightSource2;

--- a/dart/gui/osg/WorldNode.cpp
+++ b/dart/gui/osg/WorldNode.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/gui/osg/WorldNode.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/gui/osg/ShapeFrameNode.hpp"
@@ -348,7 +349,7 @@ void WorldNode::setShadowTechnique(
 ::osg::ref_ptr<osgShadow::ShadowTechnique>
 WorldNode::createDefaultShadowTechnique(const Viewer* viewer)
 {
-  assert(viewer);
+  DART_ASSERT(viewer);
 
   ::osg::ref_ptr<osgShadow::ShadowMap> sm = new osgShadow::ShadowMap;
   // increase the resolution of default shadow texture for higher quality

--- a/dart/gui/osg/render/HeightmapShapeNode.hpp
+++ b/dart/gui/osg/render/HeightmapShapeNode.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_GUI_OSG_RENDER_HEIGHTMAPSHAPENODE_HPP_
 #define DART_GUI_OSG_RENDER_HEIGHTMAPSHAPENODE_HPP_
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/config.hpp>
 
 #include <dart/gui/osg/Utils.hpp>
@@ -450,8 +452,8 @@ void HeightmapShapeDrawable<S>::refresh(bool /*firstTime*/)
   // the heightmap could be updated in the version up. So we always update the
   // heightmap.
   {
-    assert(mElements);
-    assert(mNormals);
+    DART_ASSERT(mElements);
+    DART_ASSERT(mNormals);
     setVertices<S>(
         heightmap,
         *mVertices,

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/common/Filesystem.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/gui/osg/Utils.hpp"
@@ -238,7 +239,7 @@ void MeshShapeNode::extractData(bool firstTime)
 
     for (std::size_t i = 0; i < scene->mNumMaterials; ++i) {
       aiMaterial* aiMat = scene->mMaterials[i];
-      assert(aiMat);
+      DART_ASSERT(aiMat);
 
       ::osg::ref_ptr<::osg::Material> material = new ::osg::Material;
 

--- a/dart/gui/osg/render/MultiSphereShapeNode.cpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/gui/osg/render/MultiSphereShapeNode.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/gui/osg/Utils.hpp"
@@ -225,7 +226,7 @@ void MultiSphereShapeDrawable::refresh(bool firstTime)
     const auto& meshVertices = convexHull->getVertices();
     const auto& meshNormals = convexHull->getVertexNormals();
     const auto& meshTriangles = convexHull->getTriangles();
-    assert(meshVertices.size() == meshNormals.size());
+    DART_ASSERT(meshVertices.size() == meshNormals.size());
 
     // Convert the convex hull to OSG data types
     mVertices->resize(meshVertices.size());

--- a/dart/gui/osg/render/ShapeNode.cpp
+++ b/dart/gui/osg/render/ShapeNode.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/gui/osg/render/ShapeNode.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/gui/osg/ShapeFrameNode.hpp"
 
@@ -51,7 +52,7 @@ ShapeNode::ShapeNode(
 {
   mShapeFrame = mParentShapeFrameNode->getShapeFrame();
   mVisualAspect = mShapeFrame->getVisualAspect();
-  assert(mVisualAspect);
+  DART_ASSERT(mVisualAspect);
 }
 
 //==============================================================================

--- a/dart/lcpsolver/ODELCPSolver.cpp
+++ b/dart/lcpsolver/ODELCPSolver.cpp
@@ -67,7 +67,7 @@ bool ODELCPSolver::Solve(
     int err = Lemke(_A, _b, _x);
     return (err == 0);
   } else {
-    assert(_numDir >= 4);
+    DART_ASSERT(_numDir >= 4);
     DART_UNUSED(_numDir);
 
     double *A, *b, *x, *w, *lo, *hi;

--- a/dart/lcpsolver/dantzig/PivotMatrix.hpp
+++ b/dart/lcpsolver/dantzig/PivotMatrix.hpp
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include "dart/common/Macros.hpp"
 #include "dart/lcpsolver/dantzig/common.h"
 
 #include <Eigen/Core>

--- a/dart/lcpsolver/dantzig/lcp-impl.hpp
+++ b/dart/lcpsolver/dantzig/lcp-impl.hpp
@@ -56,6 +56,7 @@
 #ifndef DART_LCPSOLVER_DANTZIG_LCP_IMPL_HPP_
 #define DART_LCPSOLVER_DANTZIG_LCP_IMPL_HPP_
 
+#include "dart/common/Macros.hpp"
 #include "dart/lcpsolver/dantzig/PivotMatrix.hpp"
 #include "dart/lcpsolver/dantzig/matrix.h"
 #include "dart/lcpsolver/dantzig/misc.h"

--- a/dart/lcpsolver/dantzig/lcp.cpp
+++ b/dart/lcpsolver/dantzig/lcp.cpp
@@ -154,6 +154,7 @@ rows/columns and manipulate C.
 
 #include "dart/lcpsolver/dantzig/lcp.h"
 
+#include "dart/common/Macros.hpp"
 #include "dart/lcpsolver/dantzig/matrix.h"
 #include "dart/lcpsolver/dantzig/misc.h"
 

--- a/dart/lcpsolver/dantzig/matrix-impl.hpp
+++ b/dart/lcpsolver/dantzig/matrix-impl.hpp
@@ -55,6 +55,7 @@
 
 #pragma once
 
+#include "dart/common/Macros.hpp"
 #include "dart/lcpsolver/dantzig/common.h"
 
 namespace dart::lcpsolver {

--- a/dart/lcpsolver/dantzig/matrix.h
+++ b/dart/lcpsolver/dantzig/matrix.h
@@ -55,6 +55,7 @@
 
 #pragma once
 
+#include "dart/common/Macros.hpp"
 #include "dart/lcpsolver/dantzig/common.h"
 
 #include <Eigen/Core>

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -33,6 +33,7 @@
 #include "dart/math/Geometry.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 
 #include <algorithm>
@@ -505,7 +506,7 @@ Eigen::Matrix3d expMapJacDot(
 
 Eigen::Matrix3d expMapJacDeriv(const Eigen::Vector3d& _q, int _qi)
 {
-  assert(_qi >= 0 && _qi <= 2);
+  DART_ASSERT(_qi >= 0 && _qi <= 2);
 
   Eigen::Vector3d qdot = Eigen::Vector3d::Zero();
   qdot[_qi] = 1.0;
@@ -1510,7 +1511,7 @@ Eigen::Matrix3d makeSkewSymmetric(const Eigen::Vector3d& _v)
 Eigen::Matrix3d computeRotation(
     const Eigen::Vector3d& axis, const AxisType axisType)
 {
-  assert(axis != Eigen::Vector3d::Zero());
+  DART_ASSERT(axis != Eigen::Vector3d::Zero());
 
   // First axis
   const Eigen::Vector3d axis0 = axis.normalized();
@@ -1531,7 +1532,7 @@ Eigen::Matrix3d computeRotation(
   result.col(++index % 3) = axis1;
   result.col(++index % 3) = axis2;
 
-  assert(verifyRotation(result));
+  DART_ASSERT(verifyRotation(result));
 
   return result;
 }
@@ -1548,7 +1549,7 @@ Eigen::Isometry3d computeTransform(
   result.translation() = translation;
 
   // Verification
-  assert(verifyTransform(result));
+  DART_ASSERT(verifyTransform(result));
 
   return result;
 }
@@ -1693,7 +1694,7 @@ Eigen::Vector2d computeCentroidOfHull(const SupportPolygon& _convexHull)
   }
 
   // A negative area means we have a bug in the code
-  assert(area >= 0.0);
+  DART_ASSERT(area >= 0.0);
 
   if (area == 0.0)
     return c;

--- a/dart/math/detail/Convhull-impl.hpp
+++ b/dart/math/detail/Convhull-impl.hpp
@@ -66,6 +66,8 @@
 
 #pragma once
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/math/Constants.hpp>
 
 #include <Eigen/Core>
@@ -279,7 +281,7 @@ inline void convexHull3dBuild(
       minP = std::min(minP, perturbedVertices[i * (kSpatialDimension + 1) + j]);
     }
     axisAlignedExtents[j] = maxP - minP;
-    assert(axisAlignedExtents[j] > static_cast<S>(0.000000001));
+    DART_ASSERT(axisAlignedExtents[j] > static_cast<S>(0.000000001));
   }
 
   // Initialize simplex
@@ -689,7 +691,7 @@ inline void convexHull3dBuild(
               A[l * (kSpatialDimension + 1) + j] = perturbedVertices
                   [nonMatchingTriangles[index] * (kSpatialDimension + 1) + j];
           orientationDeterminant = convhull_internal::det4x4(A);
-          assert(
+          DART_ASSERT(
               orientationDeterminant
               > -std::numeric_limits<S>::epsilon() * static_cast<S>(100.0));
 #endif

--- a/dart/math/detail/Icosphere-impl.hpp
+++ b/dart/math/detail/Icosphere-impl.hpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/math/Constants.hpp>
 #include <dart/math/Icosphere.hpp>
 
@@ -105,7 +107,7 @@ Icosphere<S>::Icosphere(S radius, std::size_t subdivisions)
   static_assert(
       std::is_floating_point<S>::value,
       "Scalar must be a floating point type.");
-  assert(radius > 0);
+  DART_ASSERT(radius > 0);
 
   build();
 }

--- a/dart/optimizer/GenericMultiObjectiveProblem.cpp
+++ b/dart/optimizer/GenericMultiObjectiveProblem.cpp
@@ -33,6 +33,7 @@
 #include "dart/optimizer/GenericMultiObjectiveProblem.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 #include "dart/optimizer/Function.hpp"
 
@@ -101,7 +102,7 @@ void GenericMultiObjectiveProblem::setObjectiveFunctions(
 //==============================================================================
 void GenericMultiObjectiveProblem::addObjectiveFunction(FunctionPtr objective)
 {
-  assert(objective && "nullptr pointer is not allowed.");
+  DART_ASSERT(objective && "nullptr pointer is not allowed.");
   mObjectiveFunctions.emplace_back(std::move(objective));
   mObjectiveDimension = mObjectiveFunctions.size();
 }
@@ -116,7 +117,7 @@ GenericMultiObjectiveProblem::getObjectiveFunctions() const
 //==============================================================================
 void GenericMultiObjectiveProblem::addEqConstraintFunction(FunctionPtr eqConst)
 {
-  assert(eqConst);
+  DART_ASSERT(eqConst);
   mEqConstraintFunctions.push_back(eqConst);
   mEqConstraintDimension = mEqConstraintFunctions.size();
 }
@@ -125,7 +126,7 @@ void GenericMultiObjectiveProblem::addEqConstraintFunction(FunctionPtr eqConst)
 void GenericMultiObjectiveProblem::addIneqConstraintFunction(
     FunctionPtr ineqConst)
 {
-  assert(ineqConst);
+  DART_ASSERT(ineqConst);
   mIneqConstraintFunctions.push_back(ineqConst);
   mIneqConstraintDimension = mIneqConstraintFunctions.size();
 }
@@ -134,7 +135,7 @@ void GenericMultiObjectiveProblem::addIneqConstraintFunction(
 FunctionPtr GenericMultiObjectiveProblem::getEqConstraintFunction(
     std::size_t index) const
 {
-  assert(index < mEqConstraintFunctions.size());
+  DART_ASSERT(index < mEqConstraintFunctions.size());
   return getVectorObjectIfAvailable<FunctionPtr>(index, mEqConstraintFunctions);
 }
 
@@ -142,7 +143,7 @@ FunctionPtr GenericMultiObjectiveProblem::getEqConstraintFunction(
 FunctionPtr GenericMultiObjectiveProblem::getIneqConstraintFunction(
     std::size_t index) const
 {
-  assert(index < mIneqConstraintFunctions.size());
+  DART_ASSERT(index < mIneqConstraintFunctions.size());
   return getVectorObjectIfAvailable<FunctionPtr>(
       index, mIneqConstraintFunctions);
 }

--- a/dart/optimizer/GradientDescentSolver.cpp
+++ b/dart/optimizer/GradientDescentSolver.cpp
@@ -33,6 +33,7 @@
 #include "dart/optimizer/GradientDescentSolver.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 #include "dart/optimizer/Problem.hpp"
 
@@ -129,7 +130,7 @@ bool GradientDescentSolver::solve()
   }
 
   Eigen::VectorXd x = problem->getInitialGuess();
-  assert(x.size() == static_cast<int>(dim));
+  DART_ASSERT(x.size() == static_cast<int>(dim));
 
   Eigen::VectorXd lastx = x;
   Eigen::VectorXd dx(x.size());
@@ -453,12 +454,12 @@ void GradientDescentSolver::clampToBoundary(Eigen::VectorXd& _x)
         "configuration size [{}] and the dimension of the Problem [{}]",
         _x.size(),
         mProperties.mProblem->getDimension());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
-  assert(mProperties.mProblem->getLowerBounds().size() == _x.size());
-  assert(mProperties.mProblem->getUpperBounds().size() == _x.size());
+  DART_ASSERT(mProperties.mProblem->getLowerBounds().size() == _x.size());
+  DART_ASSERT(mProperties.mProblem->getUpperBounds().size() == _x.size());
 
   for (int i = 0; i < _x.size(); ++i) {
     _x[i] = math::clip(

--- a/dart/optimizer/MultiObjectiveProblem.cpp
+++ b/dart/optimizer/MultiObjectiveProblem.cpp
@@ -33,6 +33,7 @@
 #include "dart/optimizer/MultiObjectiveProblem.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 #include "dart/optimizer/Function.hpp"
 
@@ -105,7 +106,8 @@ std::size_t MultiObjectiveProblem::getIntegerDimension() const
 //==============================================================================
 void MultiObjectiveProblem::setLowerBounds(const Eigen::VectorXd& lb)
 {
-  assert(static_cast<std::size_t>(lb.size()) == mDimension && "Invalid size.");
+  DART_ASSERT(
+      static_cast<std::size_t>(lb.size()) == mDimension && "Invalid size.");
   mLowerBounds = lb;
 }
 
@@ -118,7 +120,8 @@ const Eigen::VectorXd& MultiObjectiveProblem::getLowerBounds() const
 //==============================================================================
 void MultiObjectiveProblem::setUpperBounds(const Eigen::VectorXd& ub)
 {
-  assert(static_cast<std::size_t>(ub.size()) == mDimension && "Invalid size.");
+  DART_ASSERT(
+      static_cast<std::size_t>(ub.size()) == mDimension && "Invalid size.");
   mUpperBounds = ub;
 }
 

--- a/dart/optimizer/Population.cpp
+++ b/dart/optimizer/Population.cpp
@@ -33,6 +33,7 @@
 #include "dart/optimizer/Population.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/math/Random.hpp"
 
 namespace dart {
@@ -81,7 +82,7 @@ Population::Population(
   // MultiObjectiveProblem and clone it once MultiObjectiveProblem::clone()
   // is added.
 
-  assert(mProblem);
+  DART_ASSERT(mProblem);
 
   const int xSize = static_cast<int>(mProblem->getSolutionDimension());
   const int fSize = static_cast<int>(mProblem->getFitnessDimension());
@@ -159,7 +160,7 @@ void Population::set(
 //==============================================================================
 std::size_t Population::getSize() const
 {
-  assert(mPopulation.cols() == mFitness.cols());
+  DART_ASSERT(mPopulation.cols() == mFitness.cols());
   return static_cast<std::size_t>(mPopulation.cols());
 }
 

--- a/dart/optimizer/Problem.cpp
+++ b/dart/optimizer/Problem.cpp
@@ -33,6 +33,7 @@
 #include "dart/optimizer/Problem.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 #include "dart/optimizer/Function.hpp"
 
@@ -88,7 +89,7 @@ std::size_t Problem::getDimension() const
 //==============================================================================
 void Problem::setInitialGuess(const Eigen::VectorXd& _initGuess)
 {
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(_initGuess.size()) == mDimension
       && "Invalid size.");
 
@@ -173,7 +174,8 @@ void Problem::clearAllSeeds()
 //==============================================================================
 void Problem::setLowerBounds(const Eigen::VectorXd& _lb)
 {
-  assert(static_cast<std::size_t>(_lb.size()) == mDimension && "Invalid size.");
+  DART_ASSERT(
+      static_cast<std::size_t>(_lb.size()) == mDimension && "Invalid size.");
   mLowerBounds = _lb;
 }
 
@@ -186,7 +188,8 @@ const Eigen::VectorXd& Problem::getLowerBounds() const
 //==============================================================================
 void Problem::setUpperBounds(const Eigen::VectorXd& _ub)
 {
-  assert(static_cast<std::size_t>(_ub.size()) == mDimension && "Invalid size.");
+  DART_ASSERT(
+      static_cast<std::size_t>(_ub.size()) == mDimension && "Invalid size.");
   mUpperBounds = _ub;
 }
 
@@ -199,7 +202,7 @@ const Eigen::VectorXd& Problem::getUpperBounds() const
 //==============================================================================
 void Problem::setObjective(FunctionPtr _obj)
 {
-  assert(_obj && "nullptr pointer is not allowed.");
+  DART_ASSERT(_obj && "nullptr pointer is not allowed.");
   mObjective = _obj;
 }
 
@@ -212,14 +215,14 @@ FunctionPtr Problem::getObjective() const
 //==============================================================================
 void Problem::addEqConstraint(FunctionPtr _eqConst)
 {
-  assert(_eqConst);
+  DART_ASSERT(_eqConst);
   mEqConstraints.push_back(_eqConst);
 }
 
 //==============================================================================
 void Problem::addIneqConstraint(FunctionPtr _ineqConst)
 {
-  assert(_ineqConst);
+  DART_ASSERT(_ineqConst);
   mIneqConstraints.push_back(_ineqConst);
 }
 
@@ -238,14 +241,14 @@ std::size_t Problem::getNumIneqConstraints() const
 //==============================================================================
 FunctionPtr Problem::getEqConstraint(std::size_t _idx) const
 {
-  assert(_idx < mEqConstraints.size());
+  DART_ASSERT(_idx < mEqConstraints.size());
   return getVectorObjectIfAvailable<FunctionPtr>(_idx, mEqConstraints);
 }
 
 //==============================================================================
 FunctionPtr Problem::getIneqConstraint(std::size_t _idx) const
 {
-  assert(_idx < mIneqConstraints.size());
+  DART_ASSERT(_idx < mIneqConstraints.size());
   return getVectorObjectIfAvailable<FunctionPtr>(_idx, mIneqConstraints);
 }
 
@@ -296,7 +299,7 @@ double Problem::getOptimumValue() const
 //==============================================================================
 void Problem::setOptimalSolution(const Eigen::VectorXd& _optParam)
 {
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(_optParam.size()) == mDimension
       && "Invalid size.");
   mOptimalSolution = _optParam;

--- a/dart/optimizer/ipopt/IpoptSolver.cpp
+++ b/dart/optimizer/ipopt/IpoptSolver.cpp
@@ -52,7 +52,7 @@ IpoptSolver::IpoptSolver(const Solver::Properties& _properties)
 //==============================================================================
 IpoptSolver::IpoptSolver(std::shared_ptr<Problem> _problem) : Solver(_problem)
 {
-  assert(_problem);
+  DART_ASSERT(_problem);
 
   // Create a new instance of nlp (use a SmartPtr, not raw)
   mNlp = new DartTNLP(this);
@@ -93,7 +93,7 @@ bool IpoptSolver::solve()
   Ipopt::ApplicationReturnStatus init_status = mIpoptApp->Initialize();
   if (init_status != Ipopt::Solve_Succeeded) {
     DART_ERROR("[IpoptSolver::solve] Error during ipopt initialization.");
-    assert(false);
+    DART_ASSERT(false);
     return false;
   }
 
@@ -146,7 +146,7 @@ IpoptSolver::IpoptSolver(
 //==============================================================================
 DartTNLP::DartTNLP(IpoptSolver* _solver) : Ipopt::TNLP(), mSolver(_solver)
 {
-  assert(_solver && "Null pointer is not allowed.");
+  DART_ASSERT(_solver && "Null pointer is not allowed.");
 }
 
 //==============================================================================
@@ -196,8 +196,8 @@ bool DartTNLP::get_bounds_info(
 
   // here, the n and m we gave IPOPT in get_nlp_info are passed back to us.
   // If desired, we could assert to make sure they are what we think they are.
-  assert(static_cast<std::size_t>(n) == problem->getDimension());
-  assert(
+  DART_ASSERT(static_cast<std::size_t>(n) == problem->getDimension());
+  DART_ASSERT(
       static_cast<std::size_t>(m)
       == problem->getNumEqConstraints() + problem->getNumIneqConstraints());
   DART_UNUSED(m);
@@ -309,7 +309,7 @@ bool DartTNLP::eval_g(
 {
   const std::shared_ptr<Problem>& problem = mSolver->getProblem();
 
-  assert(
+  DART_ASSERT(
       static_cast<std::size_t>(_m)
       == problem->getNumEqConstraints() + problem->getNumIneqConstraints());
   DART_UNUSED(_m);

--- a/dart/optimizer/nlopt/NloptSolver.cpp
+++ b/dart/optimizer/nlopt/NloptSolver.cpp
@@ -33,6 +33,7 @@
 #include "dart/optimizer/nlopt/NloptSolver.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/StlHelpers.hpp"
 #include "dart/optimizer/Function.hpp"
 #include "dart/optimizer/Problem.hpp"
@@ -137,14 +138,14 @@ bool NloptSolver::solve()
           e.what(),
           nlopt::algorithm_name(mAlg),
           mAlg);
-      assert(false);
+      DART_ASSERT(false);
     } catch (const std::exception& e) {
       DART_ERROR(
           "[NloptSolver::solve] Encountered exception [{}] while adding an "
           "equality constraint to the Nlopt solver. This might be a bug in "
           "DART; please report this!",
           e.what());
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 
@@ -161,14 +162,14 @@ bool NloptSolver::solve()
           e.what(),
           nlopt::algorithm_name(mAlg),
           mAlg);
-      assert(false);
+      DART_ASSERT(false);
     } catch (const std::exception& e) {
       DART_ERROR(
           "[NloptSolver::solve] Encountered exception [{}] while adding an "
           "inequality constraint to the Nlopt solver. This might be a bug in "
           "DART; please report this!",
           e.what());
-      assert(false);
+      DART_ASSERT(false);
     }
   }
 

--- a/dart/optimizer/pagmo/PagmoMultiObjectiveProblemAdaptor.cpp
+++ b/dart/optimizer/pagmo/PagmoMultiObjectiveProblemAdaptor.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/optimizer/pagmo/PagmoMultiObjectiveProblemAdaptor.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/optimizer/pagmo/PagmoUtils.hpp"
 
 namespace dart {
@@ -42,7 +43,7 @@ PagmoMultiObjectiveProblemAdaptor::PagmoMultiObjectiveProblemAdaptor(
     std::shared_ptr<MultiObjectiveProblem> problem)
   : mProb(std::move(problem))
 {
-  assert(mProb);
+  DART_ASSERT(mProb);
 }
 
 //==============================================================================
@@ -51,7 +52,7 @@ pagmo::vector_double PagmoMultiObjectiveProblemAdaptor::fitness(
 {
   const Eigen::VectorXd val = PagmoTypes::convertVector(x);
 
-  assert(mProb.get());
+  DART_ASSERT(mProb.get());
   return PagmoTypes::convertVector(mProb->evaluateFitness(val));
 }
 

--- a/dart/optimizer/snopt/SnoptInterface.cpp
+++ b/dart/optimizer/snopt/SnoptInterface.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <iostream>
+#include "dart/common/Macros.hpp"
 #include "SnoptInterface.h"
 
 namespace dart {
@@ -488,7 +489,7 @@ void  SnoptInterface::snoptObj(int *mode, int *nn_obj, double *x,
                                double *ru, int *lenru) {
 
     SnoptInterface *s = SnoptInterface::mRef;
-    assert(s != NULL);
+    DART_ASSERT(s != NULL);
 
     s->update(SnoptInterface::Obj, *mode, x);
 
@@ -507,7 +508,7 @@ void SnoptInterface::snoptJac(int *mode, int *nn_con, int *nn_jac, int *ne_jac,
                               int *iu, int *leniu,
                               double *ru, int *lenru) {
     SnoptInterface *s = SnoptInterface::mRef;
-    assert(s != NULL);
+    DART_ASSERT(s != NULL);
     if(s->mNumConstr == 0){
         f_con[0] = 0.0;
         return;

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -40,6 +40,7 @@
 
 #include "dart/collision/CollisionGroup.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/Profile.hpp"
 #include "dart/constraint/BoxedLcpConstraintSolver.hpp"
 #include "dart/constraint/ConstrainedGroup.hpp"
@@ -143,7 +144,7 @@ void World::setTimeStep(double _timeStep)
   }
 
   mTimeStep = _timeStep;
-  assert(mConstraintSolver);
+  DART_ASSERT(mConstraintSolver);
   mConstraintSolver->setTimeStep(_timeStep);
   for (auto& skel : mSkeletons)
     skel->setTimeStep(_timeStep);
@@ -341,7 +342,7 @@ std::string World::addSkeleton(const dynamics::SkeletonPtr& _skeleton)
 //==============================================================================
 void World::removeSkeleton(const dynamics::SkeletonPtr& _skeleton)
 {
-  assert(
+  DART_ASSERT(
       _skeleton != nullptr
       && "Attempted to remove nullptr Skeleton from world");
 
@@ -455,7 +456,8 @@ std::size_t World::getNumSimpleFrames() const
 //==============================================================================
 std::string World::addSimpleFrame(const dynamics::SimpleFramePtr& _frame)
 {
-  assert(_frame != nullptr && "Attempted to add nullptr SimpleFrame to world");
+  DART_ASSERT(
+      _frame != nullptr && "Attempted to add nullptr SimpleFrame to world");
 
   if (nullptr == _frame) {
     DART_WARN(
@@ -490,7 +492,7 @@ std::string World::addSimpleFrame(const dynamics::SimpleFramePtr& _frame)
 //==============================================================================
 void World::removeSimpleFrame(const dynamics::SimpleFramePtr& _frame)
 {
-  assert(
+  DART_ASSERT(
       _frame != nullptr
       && "Attempted to remove nullptr SimpleFrame from world");
 
@@ -631,7 +633,7 @@ void World::handleSkeletonNameChange(
         "[World::handleSkeletonNameChange] Received a name change callback for "
         "a nullptr Skeleton. This is most likely a bug. Please report "
         "this!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -648,7 +650,7 @@ void World::handleSkeletonNameChange(
         "Please report this!",
         _skeleton->getName(),
         getName());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
   dynamics::SkeletonPtr sharedSkel = it->second;
@@ -669,7 +671,7 @@ void World::handleSkeletonNameChange(
         sharedSkel->getName(),
         sharedSkel,
         getName());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 }
@@ -685,7 +687,7 @@ void World::handleSimpleFrameNameChange(const dynamics::Entity* _entity)
     DART_ERROR(
         "[World::handleFrameNameChange] Received a callback for a nullptr "
         "enity. This is most likely a bug. Please report this!");
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 
@@ -702,7 +704,7 @@ void World::handleSimpleFrameNameChange(const dynamics::Entity* _entity)
         "Please report this!",
         frame->getName(),
         getName());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
   dynamics::SimpleFramePtr sharedFrame = it->second;
@@ -720,7 +722,7 @@ void World::handleSimpleFrameNameChange(const dynamics::Entity* _entity)
         frame->getName(),
         frame,
         getName());
-    assert(false);
+    DART_ASSERT(false);
     return;
   }
 }

--- a/dart/utils/FileInfoDof.cpp
+++ b/dart/utils/FileInfoDof.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/FileInfoDof.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -167,7 +168,7 @@ void FileInfoDof::addDof(const Eigen::VectorXd& _dofs)
 //==============================================================================
 double FileInfoDof::getDofAt(std::size_t _frame, std::size_t _id) const
 {
-  assert(_frame < mNumFrames);
+  DART_ASSERT(_frame < mNumFrames);
   return mDofs.at(_frame)[_id];
 }
 

--- a/dart/utils/MayaExportMotion.cpp_
+++ b/dart/utils/MayaExportMotion.cpp_
@@ -29,6 +29,7 @@
  */
 
 #include "MayaExportMotion.h"
+#include "dart/common/Macros.hpp"
 #include "MayaExportSkeleton.h"
 #include "math/UtilsRotation.h"
 
@@ -454,7 +455,7 @@ namespace utils {
             }
 
 
-            assert(MayaExportSkeleton::mRotOrder==dart_math::XYZ);	// else change the euler angle order
+            DART_ASSERT(MayaExportSkeleton::mRotOrder==dart_math::XYZ);	// else change the euler angle order
             // X rotation
             outFile0<<"anim rotate.rotateX rotateX "<<bodyname.c_str()<<" "<<level<<" "<<numChildJoints<<" "<<dofNum++<<endl;
             outFile0<<"animData {\n";

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -36,6 +36,7 @@
 #include "dart/collision/dart/DARTCollisionDetector.hpp"
 #include "dart/collision/fcl/FCLCollisionDetector.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/config.hpp"
 #include "dart/constraint/ConstraintSolver.hpp"
 #include "dart/dynamics/BallJoint.hpp"
@@ -511,7 +512,7 @@ dynamics::ShapeNode* readShapeNode(
     const common::Uri& baseUri,
     const common::ResourceRetrieverPtr& retriever)
 {
-  assert(bodyNode);
+  DART_ASSERT(bodyNode);
 
   auto shape = readShape(shapeNodeEle, bodyNode->getName(), baseUri, retriever);
   auto shapeNode = bodyNode->createShapeNode(shape, shapeNodeName);
@@ -680,7 +681,7 @@ simulation::WorldPtr readWorld(
     const common::Uri& _baseUri,
     const common::ResourceRetrieverPtr& _retriever)
 {
-  assert(_worldElement != nullptr);
+  DART_ASSERT(_worldElement != nullptr);
 
   // Create a world
   simulation::WorldPtr newWorld = simulation::World::create();
@@ -941,7 +942,7 @@ dynamics::SkeletonPtr readSkeleton(
     const common::Uri& _baseUri,
     const common::ResourceRetrieverPtr& _retriever)
 {
-  assert(_skeletonElement != nullptr);
+  DART_ASSERT(_skeletonElement != nullptr);
 
   dynamics::SkeletonPtr newSkeleton = dynamics::Skeleton::create();
   Eigen::Isometry3d skeletonFrame = Eigen::Isometry3d::Identity();
@@ -1059,7 +1060,7 @@ SkelBodyNode readBodyNode(
     const common::Uri& /*_baseUri*/,
     const common::ResourceRetrieverPtr& /*_retriever*/)
 {
-  assert(_bodyNodeElement != nullptr);
+  DART_ASSERT(_bodyNodeElement != nullptr);
 
   BodyPropPtr newBodyNode(new dynamics::BodyNode::Properties);
   Eigen::Isometry3d initTransform = Eigen::Isometry3d::Identity();
@@ -1149,7 +1150,7 @@ SkelBodyNode readSoftBodyNode(
   // Otherwise, BodyNode is created.
 
   //----------------------------------------------------------------------------
-  assert(_softBodyNodeElement != nullptr);
+  DART_ASSERT(_softBodyNodeElement != nullptr);
 
   SkelBodyNode standardBodyNode = readBodyNode(
       _softBodyNodeElement, _skeletonFrame, _baseUri, _retriever);
@@ -1247,7 +1248,7 @@ dynamics::ShapePtr readShape(
   dynamics::ShapePtr newShape;
 
   // Geometry
-  assert(hasElement(vizEle, "geometry"));
+  DART_ASSERT(hasElement(vizEle, "geometry"));
   tinyxml2::XMLElement* geometryEle = getElement(vizEle, "geometry");
 
   if (hasElement(geometryEle, "sphere")) {
@@ -1336,7 +1337,7 @@ dynamics::ShapePtr readShape(
     DART_ERROR(
         "[readShape] Unknown visualization shape in BodyNode named [{}]",
         bodyName);
-    assert(0);
+    DART_ASSERT(0);
     return nullptr;
   }
 
@@ -1370,7 +1371,7 @@ void readJoint(
     IndexToJoint& _order,
     JointToIndex& _lookup)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   //--------------------------------------------------------------------------
   // Name attribute
@@ -1381,7 +1382,7 @@ void readJoint(
   //--------------------------------------------------------------------------
   // Type attribute
   joint.type = getAttributeString(_jointElement, "type");
-  assert(!joint.type.empty());
+  DART_ASSERT(!joint.type.empty());
   if (joint.type == std::string("weld"))
     joint.properties = readWeldJoint(_jointElement, joint, name);
   else if (joint.type == std::string("prismatic"))
@@ -1412,7 +1413,7 @@ void readJoint(
         name);
     return;
   }
-  assert(joint.properties != nullptr);
+  DART_ASSERT(joint.properties != nullptr);
 
   joint.properties->mName = name;
 
@@ -1451,7 +1452,7 @@ void readJoint(
   } else {
     DART_ERROR(
         "[readJoint] Joint named [{}] is missing a parent BodyNode!", name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   // Use an empty string (rather than "world") to indicate that the joint has no
@@ -1478,7 +1479,7 @@ void readJoint(
   } else {
     DART_ERROR(
         "[readJoint] Joint named [{}] is missing a child BodyNode!", name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   if (child == _bodyNodes.end()) {
@@ -1825,8 +1826,8 @@ void readJointDynamicsAndLimit(
   // the dof tag instead, because all functionality of these tags have been
   // moved to the dof tag
 
-  assert(_jointElement != nullptr);
-  assert(_numAxis <= 6);
+  DART_ASSERT(_jointElement != nullptr);
+  DART_ASSERT(_numAxis <= 6);
 
   std::string axisName = "axis";
 
@@ -1915,7 +1916,7 @@ JointPropPtr readRevoluteJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::RevoluteJoint::Properties properties;
 
@@ -1932,7 +1933,7 @@ JointPropPtr readRevoluteJoint(
         "[readRevoluteJoint] Revolute Joint named [{}] is missing axis "
         "information!",
         _name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   readJointDynamicsAndLimit<dynamics::GenericJoint<math::R1Space>::Properties>(
@@ -1970,7 +1971,7 @@ JointPropPtr readPrismaticJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::PrismaticJoint::Properties properties;
 
@@ -1987,7 +1988,7 @@ JointPropPtr readPrismaticJoint(
         "[readPrismaticJoint] Prismatic Joint named [{}] is missing axis "
         "information!",
         _name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   readJointDynamicsAndLimit<dynamics::GenericJoint<math::R1Space>::Properties>(
@@ -2025,7 +2026,7 @@ JointPropPtr readScrewJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::ScrewJoint::Properties properties;
 
@@ -2048,7 +2049,7 @@ JointPropPtr readScrewJoint(
         "[readScrewJoint] Screw Joint named [{}] is missing axis "
         "information!",
         _name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   readJointDynamicsAndLimit<dynamics::GenericJoint<math::R1Space>::Properties>(
@@ -2086,7 +2087,7 @@ JointPropPtr readUniversalJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::UniversalJoint::Properties properties;
 
@@ -2103,7 +2104,7 @@ JointPropPtr readUniversalJoint(
         "[readUniversalJoint] Universal Joint named [{}] is missing axis "
         "information!",
         _name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   //--------------------------------------------------------------------------
@@ -2119,7 +2120,7 @@ JointPropPtr readUniversalJoint(
         "[readUniversalJoint] Universal Joint named [{}] is missing axis2 "
         "information!",
         _name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   readJointDynamicsAndLimit(_jointElement, properties, _joint, _name, 2);
@@ -2151,7 +2152,7 @@ JointPropPtr readBallJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::BallJoint::Properties properties;
 
@@ -2182,7 +2183,7 @@ JointPropPtr readEulerJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::EulerJoint::Properties properties;
 
@@ -2198,7 +2199,7 @@ JointPropPtr readEulerJoint(
         "[readEulerJoint] Undefined Euler axis order for Euler Joint named "
         "[{}]",
         _name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   //--------------------------------------------------------------------------
@@ -2232,7 +2233,7 @@ JointPropPtr readTranslationalJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::TranslationalJoint::Properties properties;
 
@@ -2267,7 +2268,7 @@ JointPropPtr readTranslationalJoint2D(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::TranslationalJoint2D::Properties properties;
 
@@ -2341,7 +2342,7 @@ JointPropPtr readPlanarJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::PlanarJoint::Properties properties;
 
@@ -2417,7 +2418,7 @@ JointPropPtr readFreeJoint(
     SkelJoint& _joint,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::FreeJoint::Properties properties;
 

--- a/dart/utils/VskParser.cpp
+++ b/dart/utils/VskParser.cpp
@@ -32,6 +32,8 @@
 
 #include "dart/utils/VskParser.hpp"
 
+#include "dart/common/Macros.hpp"
+
 // Standard Library
 #include <Eigen/Dense>
 
@@ -319,7 +321,7 @@ bool readSkeletonElement(
 double getParameter(
     const ParameterMap& ParameterMap, const std::string& paramNameOrValue)
 {
-  assert(!paramNameOrValue.empty());
+  DART_ASSERT(!paramNameOrValue.empty());
 
   int sign = 1;
   std::string paramNameOrValueWithoutSign = paramNameOrValue;
@@ -347,7 +349,7 @@ Eigen::Matrix<double, NumParams, 1> getParameters(
   std::vector<std::string> tokens;
   tokenize(paramNamesOrValues, tokens);
 
-  assert(tokens.size() == NumParams);
+  DART_ASSERT(tokens.size() == NumParams);
 
   Eigen::Matrix<double, NumParams, 1> result;
 
@@ -445,7 +447,7 @@ bool readSegment(
       jointProperties.get(),
       bodyNodeProperties);
   bodyNode = pair.second;
-  assert(bodyNode != nullptr);
+  DART_ASSERT(bodyNode != nullptr);
 
   if (hasAttribute(segment, "MASS")) {
     // Assign the given mass

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/common/LocalResourceRetriever.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/math/Geometry.hpp"
 
 #include <fmt/format.h>
@@ -136,7 +137,7 @@ Eigen::Vector2d toVector2d(const std::string& str)
   Eigen::Vector2d ret;
 
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 2);
+  DART_ASSERT(pieces.size() == 2);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -159,7 +160,7 @@ Eigen::Vector2i toVector2i(const std::string& str)
   Eigen::Vector2i ret;
 
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 2);
+  DART_ASSERT(pieces.size() == 2);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -182,7 +183,7 @@ Eigen::Vector3d toVector3d(const std::string& str)
   Eigen::Vector3d ret;
 
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 3);
+  DART_ASSERT(pieces.size() == 3);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -205,7 +206,7 @@ Eigen::Vector3i toVector3i(const std::string& str)
   Eigen::Vector3i ret;
 
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 3);
+  DART_ASSERT(pieces.size() == 3);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -228,7 +229,7 @@ Eigen::Vector4d toVector4d(const std::string& str)
   Eigen::Vector4d ret;
 
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 4);
+  DART_ASSERT(pieces.size() == 4);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -251,7 +252,7 @@ Eigen::Vector6d toVector6d(const std::string& str)
   Eigen::Vector6d ret;
 
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 6);
+  DART_ASSERT(pieces.size() == 6);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -272,7 +273,7 @@ Eigen::Vector6d toVector6d(const std::string& str)
 Eigen::VectorXd toVectorXd(const std::string& str)
 {
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() > 0);
+  DART_ASSERT(pieces.size() > 0);
 
   Eigen::VectorXd ret(pieces.size());
 
@@ -297,7 +298,7 @@ Eigen::Isometry3d toIsometry3d(const std::string& str)
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
   Eigen::Vector6d elements = Eigen::Vector6d::Zero();
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 6);
+  DART_ASSERT(pieces.size() == 6);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -322,7 +323,7 @@ Eigen::Isometry3d toIsometry3dWithExtrinsicRotation(const std::string& str)
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
   Eigen::Vector6d elements = Eigen::Vector6d::Zero();
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  assert(pieces.size() == 6);
+  DART_ASSERT(pieces.size() == 6);
 
   for (std::size_t i = 0; i < pieces.size(); ++i) {
     if (pieces[i] != "") {
@@ -348,8 +349,8 @@ Eigen::Isometry3d toIsometry3dWithExtrinsicRotation(const std::string& str)
 std::string getValueString(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -360,8 +361,8 @@ std::string getValueString(
 bool getValueBool(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -372,7 +373,7 @@ bool getValueBool(
   else {
     std::cerr << "value [" << str << "] is not a valid boolean type. "
               << "Returning false." << std::endl;
-    assert(0);
+    DART_ASSERT(0);
     return false;
   }
 }
@@ -381,8 +382,8 @@ bool getValueBool(
 int getValueInt(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -393,8 +394,8 @@ int getValueInt(
 unsigned int getValueUInt(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -405,8 +406,8 @@ unsigned int getValueUInt(
 float getValueFloat(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -417,8 +418,8 @@ float getValueFloat(
 double getValueDouble(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -429,8 +430,8 @@ double getValueDouble(
 char getValueChar(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -441,8 +442,8 @@ char getValueChar(
 Eigen::Vector2d getValueVector2d(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -453,8 +454,8 @@ Eigen::Vector2d getValueVector2d(
 Eigen::Vector3d getValueVector3d(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -465,8 +466,8 @@ Eigen::Vector3d getValueVector3d(
 Eigen::Vector3i getValueVector3i(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -477,8 +478,8 @@ Eigen::Vector3i getValueVector3i(
 Eigen::Vector6d getValueVector6d(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -489,8 +490,8 @@ Eigen::Vector6d getValueVector6d(
 Eigen::VectorXd getValueVectorXd(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -501,8 +502,8 @@ Eigen::VectorXd getValueVectorXd(
 Eigen::Vector3d getValueVec3(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -513,8 +514,8 @@ Eigen::Vector3d getValueVec3(
 Eigen::Isometry3d getValueIsometry3d(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -525,8 +526,8 @@ Eigen::Isometry3d getValueIsometry3d(
 Eigen::Isometry3d getValueIsometry3dWithExtrinsicRotation(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
 
@@ -537,8 +538,8 @@ Eigen::Isometry3d getValueIsometry3dWithExtrinsicRotation(
 bool hasElement(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(parentElement != nullptr);
-  assert(!name.empty());
+  DART_ASSERT(parentElement != nullptr);
+  DART_ASSERT(!name.empty());
 
   return parentElement->FirstChildElement(name.c_str()) == nullptr ? false
                                                                    : true;
@@ -548,7 +549,7 @@ bool hasElement(
 const tinyxml2::XMLElement* getElement(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(!name.empty());
+  DART_ASSERT(!name.empty());
 
   return parentElement->FirstChildElement(name.c_str());
 }
@@ -557,7 +558,7 @@ const tinyxml2::XMLElement* getElement(
 tinyxml2::XMLElement* getElement(
     tinyxml2::XMLElement* parentElement, const std::string& name)
 {
-  assert(!name.empty());
+  DART_ASSERT(!name.empty());
 
   return parentElement->FirstChildElement(name.c_str());
 }

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -33,6 +33,7 @@
 #include "dart/utils/mjcf/MjcfParser.hpp"
 
 #include "dart/collision/all.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/all.hpp"
 #include "dart/config.hpp"
 #include "dart/constraint/all.hpp"
@@ -449,9 +450,9 @@ dynamics::ShapePtr createShape(
     }
     case detail::GeomType::MESH: {
       const detail::Mesh* mjcfMesh = mjcfAsset.getMesh(geom.getMesh());
-      assert(mjcfMesh);
+      DART_ASSERT(mjcfMesh);
       shape = mjcfMesh->getMeshShape();
-      assert(shape);
+      DART_ASSERT(shape);
       break;
     }
     default: {
@@ -591,8 +592,8 @@ bool populateSkeletonRecurse(
     return false;
   }
 
-  assert(bodyNode != nullptr);
-  assert(joint != nullptr);
+  DART_ASSERT(bodyNode != nullptr);
+  DART_ASSERT(joint != nullptr);
 
   // Create ShapeNodes for the current BodyNode
   if (!createShapeNodes(bodyNode, mjcfBody, mjcfAsset))

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Body.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 #include "dart/utils/mjcf/detail/Compiler.hpp"
 #include "dart/utils/mjcf/detail/Size.hpp"
@@ -79,7 +80,7 @@ Errors Body::read(
   // Read <inertial>
   if (hasElement(element, "inertial")) {
     auto inertialElement = getElement(element, "inertial");
-    assert(inertialElement);
+    DART_ASSERT(inertialElement);
     mAttributes.mInertial = Inertial();
     const Errors inertialErrors = mAttributes.mInertial->read(inertialElement);
     errors.insert(errors.end(), inertialErrors.begin(), inertialErrors.end());
@@ -231,7 +232,7 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
           mAttributes.mXYAxes,
           mAttributes.mZAxis,
           compiler);
-      assert(math::verifyTransform(mRelativeTransform));
+      DART_ASSERT(math::verifyTransform(mRelativeTransform));
     } else {
       mWorldTransform.translation() = *mAttributes.mPos;
       mWorldTransform.linear() = compileRotation(
@@ -245,21 +246,21 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
         mInertial.setRelativeTransform(
             mWorldTransform.inverse() * mInertial.getWorldTransform());
       }
-      assert(math::verifyTransform(mWorldTransform));
+      DART_ASSERT(math::verifyTransform(mWorldTransform));
     }
   } else {
     if (compiler.getCoordinate() == Coordinate::LOCAL) {
       mRelativeTransform = mInertial.getRelativeTransform();
-      assert(math::verifyTransform(mRelativeTransform));
+      DART_ASSERT(math::verifyTransform(mRelativeTransform));
     } else {
       mWorldTransform = mInertial.getWorldTransform();
       if (parent != nullptr) {
         mRelativeTransform
             = parent->getWorldTransform().inverse() * mWorldTransform;
-        assert(math::verifyTransform(mRelativeTransform));
+        DART_ASSERT(math::verifyTransform(mRelativeTransform));
       } else {
         mRelativeTransform = mWorldTransform;
-        assert(math::verifyTransform(mRelativeTransform));
+        DART_ASSERT(math::verifyTransform(mRelativeTransform));
       }
       mInertial.setRelativeTransform(Eigen::Isometry3d::Identity());
     }
@@ -357,7 +358,7 @@ const Site& Body::getSite(std::size_t index) const
 //==============================================================================
 void Body::setRelativeTransform(const Eigen::Isometry3d& tf)
 {
-  assert(math::verifyTransform(tf));
+  DART_ASSERT(math::verifyTransform(tf));
   mRelativeTransform = tf;
 }
 
@@ -370,7 +371,7 @@ const Eigen::Isometry3d& Body::getRelativeTransform() const
 //==============================================================================
 void Body::setWorldTransform(const Eigen::Isometry3d& tf)
 {
-  assert(math::verifyTransform(tf));
+  DART_ASSERT(math::verifyTransform(tf));
   mWorldTransform = tf;
 }
 
@@ -391,7 +392,7 @@ Inertial Body::computeInertialFromGeoms(
     DART_ERROR(
         "[MjcfParser] Faled to infer <inertial> because of no <geom> "
         "found.");
-    assert(false);
+    DART_ASSERT(false);
     return inertial;
   }
 

--- a/dart/utils/mjcf/detail/BodyAttributes.cpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/BodyAttributes.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 #include "dart/utils/mjcf/detail/Size.hpp"
 #include "dart/utils/mjcf/detail/Utils.hpp"
@@ -135,7 +136,7 @@ Errors appendBodyAttributes(
   // Read <inertial>
   if (hasElement(element, "inertial")) {
     auto inertialElement = getElement(element, "inertial");
-    assert(inertialElement);
+    DART_ASSERT(inertialElement);
     attributes.mInertial = Inertial();
     const Errors inertialErrors = attributes.mInertial->read(inertialElement);
     errors.insert(errors.end(), inertialErrors.begin(), inertialErrors.end());

--- a/dart/utils/mjcf/detail/Default.cpp
+++ b/dart/utils/mjcf/detail/Default.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Default.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 #include "dart/utils/mjcf/detail/Utils.hpp"
 
@@ -143,7 +144,7 @@ const Default* Defaults::getDefault(const std::string& className) const
 //==============================================================================
 const Default* Defaults::getRootDefault() const
 {
-  assert(hasDefault(mRootClassName));
+  DART_ASSERT(hasDefault(mRootClassName));
   return getDefault(mRootClassName);
 }
 

--- a/dart/utils/mjcf/detail/Geom.cpp
+++ b/dart/utils/mjcf/detail/Geom.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Geom.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
@@ -189,7 +190,7 @@ Errors Geom::preprocess(const Compiler& compiler, bool autoName)
 
   Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
   if (canUseFromTo(mType, mAttributes.mFromTo)) {
-    assert(mAttributes.mFromTo);
+    DART_ASSERT(mAttributes.mFromTo);
     const Eigen::Vector6d& fromto = *mAttributes.mFromTo;
     const Eigen::Vector3d from = fromto.head<3>();
     const Eigen::Vector3d to = fromto.tail<3>();

--- a/dart/utils/mjcf/detail/Inertial.cpp
+++ b/dart/utils/mjcf/detail/Inertial.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Inertial.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 #include "dart/utils/mjcf/detail/Utils.hpp"
 
@@ -164,7 +165,7 @@ Errors Inertial::compile(const Compiler& compiler)
     mDiagonalInertia = *mData.mDiagInertia;
     mOffDiagonalInertia.setZero();
   } else {
-    assert(mData.mFullInertia);
+    DART_ASSERT(mData.mFullInertia);
     mDiagonalInertia = mData.mFullInertia->head<3>();
     mOffDiagonalInertia = mData.mFullInertia->tail<3>();
   }

--- a/dart/utils/mjcf/detail/MujocoModel.cpp
+++ b/dart/utils/mjcf/detail/MujocoModel.cpp
@@ -33,6 +33,7 @@
 #include "dart/utils/mjcf/detail/MujocoModel.hpp"
 
 #include "dart/common/LocalResourceRetriever.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/utils/CompositeResourceRetriever.hpp"
 #include "dart/utils/DartResourceRetriever.hpp"
 #include "dart/utils/XmlHelpers.hpp"
@@ -71,7 +72,7 @@ Errors MujocoModel::read(
   // Read <compiler>
   if (hasElement(element, "compiler")) {
     auto compilerElement = getElement(element, "compiler");
-    assert(compilerElement);
+    DART_ASSERT(compilerElement);
     const auto compilerErrors = mCompiler.read(compilerElement);
     errors.insert(errors.end(), compilerErrors.begin(), compilerErrors.end());
   }
@@ -81,7 +82,7 @@ Errors MujocoModel::read(
   // Read <option>
   if (hasElement(element, "option")) {
     auto optionElement = getElement(element, "option");
-    assert(optionElement);
+    DART_ASSERT(optionElement);
     const auto optionErrors = mOption.read(optionElement);
     errors.insert(errors.end(), optionErrors.begin(), optionErrors.end());
   }
@@ -89,7 +90,7 @@ Errors MujocoModel::read(
   // Read <size>
   if (hasElement(element, "size")) {
     auto sizeElement = getElement(element, "size");
-    assert(sizeElement);
+    DART_ASSERT(sizeElement);
     const auto sizeErrors = mSize.read(sizeElement);
     errors.insert(errors.end(), sizeErrors.begin(), sizeErrors.end());
   }
@@ -97,7 +98,7 @@ Errors MujocoModel::read(
   // Read <asset>
   if (hasElement(element, "asset")) {
     auto assetElement = getElement(element, "asset");
-    assert(assetElement);
+    DART_ASSERT(assetElement);
     const auto assetErrors = mAsset.read(assetElement);
     errors.insert(errors.end(), assetErrors.begin(), assetErrors.end());
   }
@@ -105,7 +106,7 @@ Errors MujocoModel::read(
   // Read <default>
   if (hasElement(element, "default")) {
     auto defaultElement = getElement(element, "default");
-    assert(defaultElement);
+    DART_ASSERT(defaultElement);
     const auto defaultErrors = mDefaults.read(defaultElement, nullptr);
     errors.insert(errors.end(), defaultErrors.begin(), defaultErrors.end());
   }
@@ -113,7 +114,7 @@ Errors MujocoModel::read(
   // Read <worldbody>
   if (hasElement(element, "worldbody")) {
     auto worldnodeElement = getElement(element, "worldbody");
-    assert(worldnodeElement);
+    DART_ASSERT(worldnodeElement);
     mWorldbody = Worldbody();
     const auto worldbodyErrors = mWorldbody.read(
         worldnodeElement,
@@ -160,7 +161,7 @@ Errors MujocoModel::read(
   // Read <equality>
   if (hasElement(element, "equality")) {
     auto equalityElement = getElement(element, "equality");
-    assert(equalityElement);
+    DART_ASSERT(equalityElement);
     const auto equalityErrors = mEquality.read(equalityElement, mDefaults);
     errors.insert(errors.end(), equalityErrors.begin(), equalityErrors.end());
   }

--- a/dart/utils/mjcf/detail/Site.cpp
+++ b/dart/utils/mjcf/detail/Site.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Site.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 #include "dart/utils/mjcf/detail/Body.hpp"
 #include "dart/utils/mjcf/detail/Utils.hpp"
@@ -232,7 +233,7 @@ Errors Site::preprocess(const Compiler& compiler)
 
   Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
   if (canUseFromTo(mData.mType, mData.mFromTo)) {
-    assert(mData.mFromTo);
+    DART_ASSERT(mData.mFromTo);
     const Eigen::Vector6d& fromto = *mData.mFromTo;
     const Eigen::Vector3d from = fromto.head<3>();
     const Eigen::Vector3d to = fromto.tail<3>();

--- a/dart/utils/mjcf/detail/Utils.cpp
+++ b/dart/utils/mjcf/detail/Utils.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Utils.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/CompositeResourceRetriever.hpp"
 #include "dart/utils/DartResourceRetriever.hpp"
 #include "dart/utils/XmlHelpers.hpp"
@@ -110,7 +111,7 @@ Eigen::Matrix3d compileRotation(
       angle = math::toRadian(angle);
     }
     rot = Eigen::AngleAxisd(angle, axis).toRotationMatrix();
-    assert(math::verifyRotation(rot));
+    DART_ASSERT(math::verifyRotation(rot));
   } else if (euler) {
     Eigen::Vector3d angles = *euler;
     if (compiler.getAngle() == Angle::DEGREE) {
@@ -121,10 +122,10 @@ Eigen::Matrix3d compileRotation(
 
     if (compiler.getEulerSeq() == "xyz") {
       rot = math::eulerXYZToMatrix(angles);
-      assert(math::verifyRotation(rot));
+      DART_ASSERT(math::verifyRotation(rot));
     } else if (compiler.getEulerSeq() == "zyx") {
       rot = math::eulerZYXToMatrix(angles);
-      assert(math::verifyRotation(rot));
+      DART_ASSERT(math::verifyRotation(rot));
     } else {
       DART_ERROR(
           "[MjcfParser] Unsupported Euler angle sequence: '{}'. Please report "
@@ -136,15 +137,15 @@ Eigen::Matrix3d compileRotation(
     rot.col(0) = (*xyAxes).head<3>().normalized();                    // X axis
     rot.col(1) = (*xyAxes).tail<3>().normalized();                    // Y axis
     rot.col(2).noalias() = rot.col(0).cross(rot.col(1)).normalized(); // Z axis
-    assert(math::verifyRotation(rot));
+    DART_ASSERT(math::verifyRotation(rot));
   } else if (zAxis) {
     rot = Eigen::Quaterniond::FromTwoVectors(
               Eigen::Vector3d::UnitZ(), zAxis->normalized())
               .toRotationMatrix();
-    assert(math::verifyRotation(rot));
+    DART_ASSERT(math::verifyRotation(rot));
   } else {
     rot = quat.normalized().toRotationMatrix();
-    assert(math::verifyRotation(rot));
+    DART_ASSERT(math::verifyRotation(rot));
   }
 
   return rot;

--- a/dart/utils/mjcf/detail/Weld.cpp
+++ b/dart/utils/mjcf/detail/Weld.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Weld.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 
 namespace dart {
@@ -109,7 +110,7 @@ Errors Weld::read(tinyxml2::XMLElement* element, const Defaults& defaults)
   } else {
     currentDefault = defaults.getRootDefault();
   }
-  assert(currentDefault != nullptr);
+  DART_ASSERT(currentDefault != nullptr);
 
   mAttributes = currentDefault->getWeldAttributes();
 

--- a/dart/utils/mjcf/detail/Worldbody.cpp
+++ b/dart/utils/mjcf/detail/Worldbody.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Worldbody.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 #include "dart/utils/mjcf/detail/Compiler.hpp"
 #include "dart/utils/mjcf/detail/Size.hpp"
@@ -51,7 +52,7 @@ Errors Worldbody::read(
     const common::Uri& baseUri,
     const common::ResourceRetrieverPtr& retriever)
 {
-  assert(currentDefault != nullptr);
+  DART_ASSERT(currentDefault != nullptr);
 
   Errors errors;
 

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/common/LocalResourceRetriever.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/common/ResourceRetriever.hpp"
 #include "dart/common/Uri.hpp"
 #include "dart/dynamics/BallJoint.hpp"
@@ -384,7 +385,7 @@ simulation::WorldPtr readWorld(
     const common::Uri& baseUri,
     const Options& options)
 {
-  assert(worldElement != nullptr);
+  DART_ASSERT(worldElement != nullptr);
 
   // Create a world
   simulation::WorldPtr newWorld = simulation::World::create();
@@ -448,7 +449,7 @@ dynamics::SkeletonPtr readSkeleton(
     const common::Uri& baseUri,
     const Options& options)
 {
-  assert(skeletonElement != nullptr);
+  DART_ASSERT(skeletonElement != nullptr);
 
   Eigen::Isometry3d skeletonFrame = Eigen::Isometry3d::Identity();
   dynamics::SkeletonPtr newSkeleton
@@ -596,7 +597,7 @@ NextResult getNextJointAndNodePair(
 dynamics::SkeletonPtr makeSkeleton(
     tinyxml2::XMLElement* _skeletonElement, Eigen::Isometry3d& skeletonFrame)
 {
-  assert(_skeletonElement != nullptr);
+  DART_ASSERT(_skeletonElement != nullptr);
 
   dynamics::SkeletonPtr newSkeleton = dynamics::Skeleton::create();
 
@@ -715,7 +716,7 @@ SDFBodyNode readBodyNode(
     const common::Uri& /*baseUri*/,
     const common::ResourceRetrieverPtr& /*retriever*/)
 {
-  assert(bodyNodeElement != nullptr);
+  DART_ASSERT(bodyNodeElement != nullptr);
 
   dynamics::BodyNode::Properties properties;
   Eigen::Isometry3d initTransform = Eigen::Isometry3d::Identity();
@@ -809,7 +810,7 @@ dynamics::SoftBodyNode::UniqueProperties readSoftBodyProperties(
   // Otherwise, BodyNode is created.
 
   //----------------------------------------------------------------------------
-  assert(softBodyNodeElement != nullptr);
+  DART_ASSERT(softBodyNodeElement != nullptr);
 
   dynamics::SoftBodyNode::UniqueProperties softProperties;
 
@@ -890,7 +891,7 @@ dynamics::ShapePtr readShape(
   dynamics::ShapePtr newShape;
 
   // type
-  assert(hasElement(_shapelement, "geometry"));
+  DART_ASSERT(hasElement(_shapelement, "geometry"));
   tinyxml2::XMLElement* geometryElement = getElement(_shapelement, "geometry");
 
   if (hasElement(geometryElement, "sphere")) {
@@ -967,7 +968,7 @@ dynamics::ShapeNode* readShapeNode(
     const common::Uri& baseUri,
     const common::ResourceRetrieverPtr& retriever)
 {
-  assert(bodyNode);
+  DART_ASSERT(bodyNode);
 
   auto shape = readShape(shapeNodeEle, baseUri, retriever);
   auto shapeNode = bodyNode->createShapeNode(shape, shapeNodeName);
@@ -1133,12 +1134,12 @@ SDFJoint readJoint(
     const BodyMap& _sdfBodyNodes,
     const Eigen::Isometry3d& _skeletonFrame)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   //--------------------------------------------------------------------------
   // Type attribute
   std::string type = getAttributeString(_jointElement, "type");
-  assert(!type.empty());
+  DART_ASSERT(!type.empty());
 
   //--------------------------------------------------------------------------
   // Name attribute
@@ -1160,7 +1161,7 @@ SDFJoint readJoint(
             "the parent of the Joint named [{}]",
             strParent,
             name);
-        assert(0);
+        DART_ASSERT(0);
       }
     }
   } else {
@@ -1168,7 +1169,7 @@ SDFJoint readJoint(
         "[SdfParser::readJoint] You must set parent link for the Joint "
         "[{}]!",
         name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   //--------------------------------------------------------------------------
@@ -1186,14 +1187,14 @@ SDFJoint readJoint(
           "the child of the Joint named [{}]",
           strChild,
           name);
-      assert(0);
+      DART_ASSERT(0);
     }
   } else {
     DART_ERROR(
         "[SdfParser::readJoint] You must set the child link for the Joint "
         "[{}]!",
         name);
-    assert(0);
+    DART_ASSERT(0);
   }
 
   SDFJoint newJoint;
@@ -1270,7 +1271,7 @@ static void reportMissingElement(
       elementName,
       objectType,
       objectName);
-  assert(0);
+  DART_ASSERT(0);
 }
 
 static void readAxisElement(
@@ -1367,7 +1368,7 @@ dynamics::RevoluteJoint::Properties readRevoluteJoint(
     const Eigen::Isometry3d& _parentModelFrame,
     const std::string& _name)
 {
-  assert(_revoluteJointElement != nullptr);
+  DART_ASSERT(_revoluteJointElement != nullptr);
 
   dynamics::RevoluteJoint::Properties newRevoluteJoint;
 
@@ -1400,7 +1401,7 @@ dynamics::PrismaticJoint::Properties readPrismaticJoint(
     const Eigen::Isometry3d& _parentModelFrame,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::PrismaticJoint::Properties newPrismaticJoint;
 
@@ -1432,7 +1433,7 @@ dynamics::ScrewJoint::Properties readScrewJoint(
     const Eigen::Isometry3d& _parentModelFrame,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::ScrewJoint::Properties newScrewJoint;
 
@@ -1470,7 +1471,7 @@ dynamics::UniversalJoint::Properties readUniversalJoint(
     const Eigen::Isometry3d& _parentModelFrame,
     const std::string& _name)
 {
-  assert(_jointElement != nullptr);
+  DART_ASSERT(_jointElement != nullptr);
 
   dynamics::UniversalJoint::Properties newUniversalJoint;
 

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/urdf/DartLoader.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
@@ -360,7 +361,7 @@ bool DartLoader::createSkeletonRecursive(
     const common::ResourceRetrieverPtr& resourceRetriever,
     const Options& options)
 {
-  assert(lk);
+  DART_ASSERT(lk);
 
   DART_WARN_IF(
       parentNode != nullptr && lk->name == "world",

--- a/examples/add_delete_skels/main.cpp
+++ b/examples/add_delete_skels/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -118,7 +120,7 @@ int main()
 {
   // Create and initialize the world
   WorldPtr myWorld = SkelParser::readWorld("dart://sample/skel/ground.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
   Eigen::Vector3d gravity(0.0, -9.81, 0.0);
   myWorld->setGravity(gravity);
 

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
@@ -32,6 +32,8 @@
 
 #include "AtlasSimbiconWorldNode.hpp"
 
+#include "dart/common/Macros.hpp"
+
 #include <osgShadow/ShadowMap>
 
 //==============================================================================
@@ -42,8 +44,8 @@ AtlasSimbiconWorldNode::AtlasSimbiconWorldNode(
     mExternalForce(Eigen::Vector3d::Zero()),
     mForceDuration(0.0)
 {
-  assert(world);
-  assert(atlas);
+  DART_ASSERT(world);
+  DART_ASSERT(atlas);
 
   mController.reset(new Controller(atlas, world->getConstraintSolver()));
 }

--- a/examples/atlas_simbicon/Controller.cpp
+++ b/examples/atlas_simbicon/Controller.cpp
@@ -35,6 +35,7 @@
 #include "State.hpp"
 #include "StateMachine.hpp"
 #include "TerminalCondition.hpp"
+#include "dart/common/Macros.hpp"
 
 using namespace std;
 
@@ -112,7 +113,7 @@ StateMachine* Controller::getCurrentState()
 void Controller::changeStateMachine(
     StateMachine* _stateMachine, double _currentTime)
 {
-  assert(
+  DART_ASSERT(
       _containStateMachine(_stateMachine)
       && "_stateMachine should be in mStateMachines");
 
@@ -143,7 +144,7 @@ void Controller::changeStateMachine(const string& _name, double _currentTime)
   // _state should be in mStates
   StateMachine* stateMachine = _findStateMachine(_name);
 
-  assert(stateMachine != nullptr && "Invaild state machine.");
+  DART_ASSERT(stateMachine != nullptr && "Invaild state machine.");
 
   changeStateMachine(stateMachine, _currentTime);
 }
@@ -151,7 +152,8 @@ void Controller::changeStateMachine(const string& _name, double _currentTime)
 //==============================================================================
 void Controller::changeStateMachine(std::size_t _idx, double _currentTime)
 {
-  assert(_idx <= mStateMachines.size() && "Invalid index of StateMachine.");
+  DART_ASSERT(
+      _idx <= mStateMachines.size() && "Invalid index of StateMachine.");
 
   changeStateMachine(mStateMachines[_idx], _currentTime);
 }

--- a/examples/atlas_simbicon/State.cpp
+++ b/examples/atlas_simbicon/State.cpp
@@ -33,6 +33,7 @@
 #include "State.hpp"
 
 #include "TerminalCondition.hpp"
+#include "dart/common/Macros.hpp"
 
 // Macro for functions not implemented yet
 #define NOT_YET(FUNCTION)                                                      \
@@ -83,11 +84,11 @@ State::State(SkeletonPtr _skeleton, const std::string& _name)
   mRightThigh = mSkeleton->getBodyNode("r_uleg");
   mStanceFoot = nullptr;
 
-  assert(mPelvis != nullptr);
-  assert(mLeftFoot != nullptr);
-  assert(mRightFoot != nullptr);
-  assert(mLeftThigh != nullptr);
-  assert(mRightThigh != nullptr);
+  DART_ASSERT(mPelvis != nullptr);
+  DART_ASSERT(mLeftFoot != nullptr);
+  DART_ASSERT(mRightFoot != nullptr);
+  DART_ASSERT(mLeftThigh != nullptr);
+  DART_ASSERT(mRightThigh != nullptr);
   //  assert(mStanceFoot != nullptr);
 
   mCoronalLeftHip = mSkeleton->getDof("l_leg_hpx")->getIndexInSkeleton();  // 10
@@ -120,7 +121,7 @@ void State::setNextState(State* _nextState)
 //==============================================================================
 void State::setTerminalCondition(TerminalCondition* _condition)
 {
-  assert(_condition != nullptr);
+  DART_ASSERT(_condition != nullptr);
 
   mTerminalCondition = _condition;
 }
@@ -136,7 +137,7 @@ void State::begin(double _currentTime)
 //==============================================================================
 void State::computeControlForce(double _timestep)
 {
-  assert(mNextState != nullptr && "Next state should be set.");
+  DART_ASSERT(mNextState != nullptr && "Next state should be set.");
 
   int dof = mSkeleton->getNumDofs();
   VectorXd q = mSkeleton->getPositions();
@@ -198,7 +199,7 @@ void State::computeControlForce(double _timestep)
 //==============================================================================
 bool State::isTerminalConditionSatisfied() const
 {
-  assert(mTerminalCondition != nullptr && "Invalid terminal condition.");
+  DART_ASSERT(mTerminalCondition != nullptr && "Invalid terminal condition.");
 
   return mTerminalCondition->isSatisfied();
 }
@@ -523,7 +524,7 @@ void State::setDesiredJointPosition(const string& _jointName, double _val)
 //==============================================================================
 double State::getDesiredJointPosition(int _idx) const
 {
-  assert(
+  DART_ASSERT(
       0 <= _idx && _idx <= mDesiredJointPositions.size()
       && "Invalid joint index.");
 
@@ -536,7 +537,7 @@ double State::getDesiredJointPosition(const string& _jointName) const
   // TODO(JS)
   NOT_YET(State::getDesiredJointPosition());
 
-  assert(mSkeleton->getJoint(_jointName) != nullptr);
+  DART_ASSERT(mSkeleton->getJoint(_jointName) != nullptr);
 
   return mDesiredJointPositions[mJointMap.at(_jointName)];
 }
@@ -568,7 +569,7 @@ void State::setDesiredPelvisGlobalAngleOnCoronal(double _val)
 //==============================================================================
 void State::setProportionalGain(int _idx, double _val)
 {
-  assert(0 <= _idx && _idx <= mKp.size() && "Invalid joint index.");
+  DART_ASSERT(0 <= _idx && _idx <= mKp.size() && "Invalid joint index.");
 
   mKd[_idx] = _val;
 }
@@ -583,7 +584,7 @@ void State::setProportionalGain(const string& /*_jointName*/, double /*_val*/)
 //==============================================================================
 double State::getProportionalGain(int _idx) const
 {
-  assert(0 <= _idx && _idx <= mKp.size() && "Invalid joint index.");
+  DART_ASSERT(0 <= _idx && _idx <= mKp.size() && "Invalid joint index.");
 
   return mKp[_idx];
 }
@@ -594,7 +595,7 @@ double State::getProportionalGain(const string& _jointName) const
   // TODO(JS)
   NOT_YET(State::getProportionalGain());
 
-  assert(mSkeleton->getJoint(_jointName) != nullptr);
+  DART_ASSERT(mSkeleton->getJoint(_jointName) != nullptr);
 
   return mKp[mJointMap.at(_jointName)];
 }
@@ -602,7 +603,7 @@ double State::getProportionalGain(const string& _jointName) const
 //==============================================================================
 void State::setDerivativeGain(int _idx, double _val)
 {
-  assert(0 <= _idx && _idx <= mKd.size() && "Invalid joint index.");
+  DART_ASSERT(0 <= _idx && _idx <= mKd.size() && "Invalid joint index.");
 
   mKd[_idx] = _val;
 }
@@ -617,7 +618,7 @@ void State::setDerivativeGain(const string& /*_jointName*/, double /*_val*/)
 //==============================================================================
 double State::getDerivativeGain(int _idx) const
 {
-  assert(0 <= _idx && _idx <= mKd.size() && "Invalid joint index.");
+  DART_ASSERT(0 <= _idx && _idx <= mKd.size() && "Invalid joint index.");
 
   return mKd[_idx];
 }
@@ -632,7 +633,8 @@ double State::getDerivativeGain(int _idx) const
 //==============================================================================
 void State::setFeedbackSagitalCOMDistance(std::size_t _index, double _val)
 {
-  assert(static_cast<int>(_index) <= mSagitalCd.size() && "Invalid index.");
+  DART_ASSERT(
+      static_cast<int>(_index) <= mSagitalCd.size() && "Invalid index.");
 
   mSagitalCd[_index] = _val;
 }
@@ -640,7 +642,8 @@ void State::setFeedbackSagitalCOMDistance(std::size_t _index, double _val)
 //==============================================================================
 void State::setFeedbackSagitalCOMVelocity(std::size_t _index, double _val)
 {
-  assert(static_cast<int>(_index) <= mSagitalCv.size() && "Invalid index.");
+  DART_ASSERT(
+      static_cast<int>(_index) <= mSagitalCv.size() && "Invalid index.");
 
   mSagitalCv[_index] = _val;
 }
@@ -648,7 +651,8 @@ void State::setFeedbackSagitalCOMVelocity(std::size_t _index, double _val)
 //==============================================================================
 void State::setFeedbackCoronalCOMDistance(std::size_t _index, double _val)
 {
-  assert(static_cast<int>(_index) <= mCoronalCd.size() && "Invalid index.");
+  DART_ASSERT(
+      static_cast<int>(_index) <= mCoronalCd.size() && "Invalid index.");
 
   mCoronalCd[_index] = _val;
 }
@@ -656,7 +660,8 @@ void State::setFeedbackCoronalCOMDistance(std::size_t _index, double _val)
 //==============================================================================
 void State::setFeedbackCoronalCOMVelocity(std::size_t _index, double _val)
 {
-  assert(static_cast<int>(_index) <= mCoronalCv.size() && "Invalid index.");
+  DART_ASSERT(
+      static_cast<int>(_index) <= mCoronalCv.size() && "Invalid index.");
 
   mCoronalCv[_index] = _val;
 }

--- a/examples/atlas_simbicon/StateMachine.cpp
+++ b/examples/atlas_simbicon/StateMachine.cpp
@@ -33,6 +33,7 @@
 #include "StateMachine.hpp"
 
 #include "State.hpp"
+#include "dart/common/Macros.hpp"
 
 // Macro for functions not implemented yet
 #define NOT_YET(FUNCTION)                                                      \
@@ -80,8 +81,8 @@ const std::string& StateMachine::getName() const
 //==============================================================================
 void StateMachine::addState(State* _state)
 {
-  assert(_state != nullptr && "Invalid state");
-  assert(!_containState(_state) && "_state shouldn't be in mStates");
+  DART_ASSERT(_state != nullptr && "Invalid state");
+  DART_ASSERT(!_containState(_state) && "_state shouldn't be in mStates");
 
   mStates.push_back(_state);
 }
@@ -89,8 +90,8 @@ void StateMachine::addState(State* _state)
 //==============================================================================
 void StateMachine::setInitialState(State* _state)
 {
-  assert(_state != nullptr);
-  assert(_containState(_state));
+  DART_ASSERT(_state != nullptr);
+  DART_ASSERT(_containState(_state));
 
   mCurrentState = _state;
 }
@@ -108,7 +109,7 @@ void StateMachine::begin(double _currentTime)
 //==============================================================================
 void StateMachine::computeControlForce(double _dt)
 {
-  assert(mCurrentState != nullptr && "Invaild current state.");
+  DART_ASSERT(mCurrentState != nullptr && "Invaild current state.");
 
   // Check transition is needed from current state
   if (mCurrentState->isTerminalConditionSatisfied())
@@ -144,7 +145,7 @@ void StateMachine::transiteToNextState(double _currentTime)
 //==============================================================================
 void StateMachine::transiteTo(State* _state, double _currentTime)
 {
-  assert(_containState(_state) && "_state should be in mStates");
+  DART_ASSERT(_containState(_state) && "_state should be in mStates");
 
   string prevStateName = mCurrentState->getName();
   string nextStateName = _state->getName();
@@ -166,7 +167,7 @@ void StateMachine::transiteTo(string& _stateName, double _currentTime)
   // _state should be in mStates
   State* state = _findState(_stateName);
 
-  assert(state != nullptr && "Invaild state.");
+  DART_ASSERT(state != nullptr && "Invaild state.");
 
   transiteTo(state, _currentTime);
 }
@@ -174,7 +175,7 @@ void StateMachine::transiteTo(string& _stateName, double _currentTime)
 //==============================================================================
 void StateMachine::transiteTo(std::size_t _idx, double _currentTime)
 {
-  assert(_idx <= mStates.size() && "Invalid index of State.");
+  DART_ASSERT(_idx <= mStates.size() && "Invalid index of State.");
 
   transiteTo(mStates[_idx], _currentTime);
 }

--- a/examples/atlas_simbicon/TerminalCondition.cpp
+++ b/examples/atlas_simbicon/TerminalCondition.cpp
@@ -33,6 +33,7 @@
 #include "TerminalCondition.hpp"
 
 #include "State.hpp"
+#include "dart/common/Macros.hpp"
 
 // Macro for functions not implemented yet
 #define NOT_YET(FUNCTION)                                                      \
@@ -46,7 +47,7 @@ using namespace dart::constraint;
 //==============================================================================
 TerminalCondition::TerminalCondition(State* _state) : mState(_state)
 {
-  assert(_state != nullptr);
+  DART_ASSERT(_state != nullptr);
 }
 
 //==============================================================================
@@ -74,8 +75,8 @@ bool TimerCondition::isSatisfied()
 BodyContactCondition::BodyContactCondition(State* _state, BodyNode* _body)
   : TerminalCondition(_state), mBodyNode(_body)
 {
-  assert(_state != nullptr);
-  assert(_body != nullptr);
+  DART_ASSERT(_state != nullptr);
+  DART_ASSERT(_body != nullptr);
 }
 
 //==============================================================================

--- a/examples/fetch/main.cpp
+++ b/examples/fetch/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -154,13 +156,13 @@ int main()
   // Create a world from ant.xml
   auto world = utils::MjcfParser::readWorld(
       "dart://sample/mjcf/openai/robotics/fetch/pick_and_place.xml");
-  assert(world);
+  DART_ASSERT(world);
   world->getConstraintSolver()->setCollisionDetector(
       collision::BulletCollisionDetector::create());
 
   // Get Fetch robot and set properties
   auto robot = world->getSkeleton("robot0:base_link");
-  assert(robot);
+  DART_ASSERT(robot);
   robot->getJoint(0)->setActuatorType(dynamics::Joint::ActuatorType::LOCKED);
   robot->eachDof(
       [](dynamics::DegreeOfFreedom* dof) { dof->setSpringStiffness(1e+3); });
@@ -182,20 +184,20 @@ int main()
 
   // Get object and set initial object transform
   auto object = world->getSkeleton("object0");
-  assert(object);
+  DART_ASSERT(object);
   object->setPosition(3, 1.25);
   object->setPosition(4, 0.53);
   object->setPosition(5, 0.40);
 
   // Get mocap object
   auto mocap = world->getSkeleton("robot0:mocap");
-  assert(mocap);
+  DART_ASSERT(mocap);
 
   // Reset the relative transform constraint of mocap object and fetch's EE
   auto weldJointConstraint
       = std::dynamic_pointer_cast<constraint::WeldJointConstraint>(
           world->getConstraintSolver()->getConstraint(0));
-  assert(weldJointConstraint);
+  DART_ASSERT(weldJointConstraint);
   weldJointConstraint->setRelativeTransform(Eigen::Isometry3d::Identity());
 
   // Create interactive frame to control the EE of Fetch

--- a/examples/heightmap/main.cpp
+++ b/examples/heightmap/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -218,7 +220,7 @@ public:
 
         auto shape = std::dynamic_pointer_cast<dynamics::HeightmapShapef>(
             mTerrain->getShape());
-        assert(shape);
+        DART_ASSERT(shape);
 
         int xResolution = static_cast<int>(mXResolution);
         if (ImGui::InputInt("X Resolution", &xResolution, 5, 10)) {
@@ -421,7 +423,7 @@ int main()
   auto terrain = createHeightmapFrame<float>(100u, 100u, 2.f, 2.f, 0.f, 0.1f);
   world->addSimpleFrame(terrain);
 
-  assert(world->getNumSimpleFrames() == 1u);
+  DART_ASSERT(world->getNumSimpleFrames() == 1u);
 
   // Create an instance of our customized WorldNode
   ::osg::ref_ptr<HeightmapWorld> node = new HeightmapWorld(world);

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -207,7 +209,7 @@ public:
           "[HuboArmIK::computeSolutions] Attempting to perform an IK on a limb "
           "that no longer exists [{}]!",
           getMethodName());
-      assert(false);
+      DART_ASSERT(false);
       return mSolutions;
     }
 
@@ -215,7 +217,7 @@ public:
       DART_ERROR(
           "[HuboArmIK::computeSolutions] Attempting to perform IK without a "
           "wrist!");
-      assert(false);
+      DART_ASSERT(false);
       return mSolutions;
     }
 
@@ -358,7 +360,7 @@ protected:
     BodyNode* base = mBaseLink.lock();
     if (nullptr == base) {
       DART_ERROR("[HuboArmIK::configure] base link is a nullptr");
-      assert(false);
+      DART_ASSERT(false);
       return;
     }
 
@@ -367,7 +369,7 @@ protected:
     if (nullptr == pelvis) {
       DART_ERROR(
           "[HuboArmIK::configure] Could not find Hubo's pelvis (Body_TSY)");
-      assert(false);
+      DART_ASSERT(false);
       return;
     }
 
@@ -383,7 +385,7 @@ protected:
             "[{}]",
             joint->getNumDofs(),
             joint->getName());
-        assert(false);
+        DART_ASSERT(false);
         return;
       }
 
@@ -489,7 +491,7 @@ public:
       DART_ERROR(
           "[HuboLegIK::computeSolutions] Attempting to perform IK on a limb "
           "that no longer exists!");
-      assert(false);
+      DART_ASSERT(false);
       return mSolutions;
     }
 
@@ -604,7 +606,7 @@ protected:
     BodyNode* base = mBaseLink.lock();
     if (nullptr == base) {
       DART_ERROR("[HuboLegIK::configure] base link is a nullptr");
-      assert(false);
+      DART_ASSERT(false);
       return;
     }
 
@@ -613,7 +615,7 @@ protected:
     if (nullptr == pelvis) {
       DART_ERROR(
           "[HuboLegIK::configure] Could not find Hubo's pelvis (Body_TSY)");
-      assert(false);
+      DART_ASSERT(false);
       return;
     }
 
@@ -629,7 +631,7 @@ protected:
             "[{}]",
             joint->getNumDofs(),
             joint->getName());
-        assert(false);
+        DART_ASSERT(false);
         return;
       }
 

--- a/examples/human_joint_limits/HumanArmJointLimitConstraint.cpp
+++ b/examples/human_joint_limits/HumanArmJointLimitConstraint.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "HumanArmJointLimitConstraint.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/Joint.hpp>
@@ -68,15 +69,15 @@ HumanArmJointLimitConstraint::HumanArmJointLimitConstraint(
     mIsMirror(isMirror),
     mAppliedImpulseIndex(0)
 {
-  assert(mShldJoint);
-  assert(mElbowJoint);
-  assert(mUArmNode);
-  assert(mLArmNode);
+  DART_ASSERT(mShldJoint);
+  DART_ASSERT(mElbowJoint);
+  DART_ASSERT(mUArmNode);
+  DART_ASSERT(mLArmNode);
 
-  assert(mShldJoint->getNumDofs() == 3);
-  assert(mElbowJoint->getNumDofs() == 1);
-  assert(mUArmNode->getSkeleton() == mLArmNode->getSkeleton());
-  assert(mElbowJoint->getParentBodyNode() == mUArmNode);
+  DART_ASSERT(mShldJoint->getNumDofs() == 3);
+  DART_ASSERT(mElbowJoint->getNumDofs() == 1);
+  DART_ASSERT(mUArmNode->getSkeleton() == mLArmNode->getSkeleton());
+  DART_ASSERT(mElbowJoint->getParentBodyNode() == mUArmNode);
 
   mLifeTime = 0;
   mActive = false;
@@ -284,11 +285,11 @@ void HumanArmJointLimitConstraint::getInformation(
     constraint::ConstraintInfo* lcp)
 {
   // if non-active, should not call getInfo()
-  assert(isActive());
+  DART_ASSERT(isActive());
 
   // assume caller will allocate enough space for _lcp variables
-  assert(lcp->w[0] == 0.0);
-  assert(lcp->findex[0] == -1);
+  DART_ASSERT(lcp->w[0] == 0.0);
+  DART_ASSERT(lcp->findex[0] == -1);
 
   double bouncingVel = -mViolation - mErrorAllowance;
   if (bouncingVel < 0.0) {
@@ -312,8 +313,8 @@ void HumanArmJointLimitConstraint::getInformation(
 void HumanArmJointLimitConstraint::applyUnitImpulse(std::size_t index)
 {
   // the dim of constraint = 1, valid _index can only be 0
-  assert(index < mDim && "Invalid Index.");
-  assert(isActive());
+  DART_ASSERT(index < mDim && "Invalid Index.");
+  DART_ASSERT(isActive());
 
   const dynamics::SkeletonPtr& skeleton = mShldJoint->getSkeleton();
   skeleton->clearConstraintImpulses();
@@ -340,7 +341,7 @@ void HumanArmJointLimitConstraint::applyUnitImpulse(std::size_t index)
 void HumanArmJointLimitConstraint::getVelocityChange(
     double* delVel, bool withCfm)
 {
-  assert(delVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(delVel != nullptr && "Null pointer is not allowed.");
   delVel[0] = 0.0;
 
   if (mShldJoint->getSkeleton()->isImpulseApplied()) {
@@ -374,7 +375,7 @@ void HumanArmJointLimitConstraint::unexcite()
 //==============================================================================
 void HumanArmJointLimitConstraint::applyImpulse(double* lambda)
 {
-  assert(isActive());
+  DART_ASSERT(isActive());
 
   // the dim of constraint = 1
   auto con_force = lambda[0];

--- a/examples/human_joint_limits/HumanLegJointLimitConstraint.cpp
+++ b/examples/human_joint_limits/HumanLegJointLimitConstraint.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "HumanLegJointLimitConstraint.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <dart/dynamics/BodyNode.hpp>
 #include <dart/dynamics/Joint.hpp>
@@ -73,21 +74,21 @@ HumanLegJointLimitConstraint::HumanLegJointLimitConstraint(
     mIsMirror(isMirror),
     mAppliedImpulseIndex(0)
 {
-  assert(mHipJoint);
-  assert(mKneeJoint);
-  assert(mAnkleJoint);
-  assert(mThighNode);
-  assert(mLowerLegNode);
-  assert(mFootNode);
+  DART_ASSERT(mHipJoint);
+  DART_ASSERT(mKneeJoint);
+  DART_ASSERT(mAnkleJoint);
+  DART_ASSERT(mThighNode);
+  DART_ASSERT(mLowerLegNode);
+  DART_ASSERT(mFootNode);
 
-  assert(mHipJoint->getNumDofs() == 3);
-  assert(mKneeJoint->getNumDofs() == 1);
-  assert(mAnkleJoint->getNumDofs() == 2);
+  DART_ASSERT(mHipJoint->getNumDofs() == 3);
+  DART_ASSERT(mKneeJoint->getNumDofs() == 1);
+  DART_ASSERT(mAnkleJoint->getNumDofs() == 2);
 
-  assert(mThighNode->getSkeleton() == mLowerLegNode->getSkeleton());
-  assert(mLowerLegNode->getSkeleton() == mFootNode->getSkeleton());
-  assert(mKneeJoint->getParentBodyNode() == mThighNode);
-  assert(mAnkleJoint->getParentBodyNode() == mLowerLegNode);
+  DART_ASSERT(mThighNode->getSkeleton() == mLowerLegNode->getSkeleton());
+  DART_ASSERT(mLowerLegNode->getSkeleton() == mFootNode->getSkeleton());
+  DART_ASSERT(mKneeJoint->getParentBodyNode() == mThighNode);
+  DART_ASSERT(mAnkleJoint->getParentBodyNode() == mLowerLegNode);
 
   mLifeTime = 0;
   mActive = false;
@@ -293,11 +294,11 @@ void HumanLegJointLimitConstraint::getInformation(
     constraint::ConstraintInfo* lcp)
 {
   // if non-active, should not call getInfo()
-  assert(isActive());
+  DART_ASSERT(isActive());
 
   // assume caller will allocate enough space for _lcp variables
-  assert(lcp->w[0] == 0.0);
-  assert(lcp->findex[0] == -1);
+  DART_ASSERT(lcp->w[0] == 0.0);
+  DART_ASSERT(lcp->findex[0] == -1);
 
   double bouncingVel = -mViolation - mErrorAllowance;
   if (bouncingVel < 0.0) {
@@ -321,8 +322,8 @@ void HumanLegJointLimitConstraint::getInformation(
 void HumanLegJointLimitConstraint::applyUnitImpulse(std::size_t index)
 {
   // the dim of constraint = 1, valid _index can only be 0
-  assert(index < mDim && "Invalid Index.");
-  assert(isActive());
+  DART_ASSERT(index < mDim && "Invalid Index.");
+  DART_ASSERT(isActive());
 
   const dynamics::SkeletonPtr& skeleton = mHipJoint->getSkeleton();
   skeleton->clearConstraintImpulses();
@@ -355,7 +356,7 @@ void HumanLegJointLimitConstraint::applyUnitImpulse(std::size_t index)
 void HumanLegJointLimitConstraint::getVelocityChange(
     double* delVel, bool withCfm)
 {
-  assert(delVel != nullptr && "Null pointer is not allowed.");
+  DART_ASSERT(delVel != nullptr && "Null pointer is not allowed.");
   delVel[0] = 0.0;
 
   if (mHipJoint->getSkeleton()->isImpulseApplied()) {
@@ -391,7 +392,7 @@ void HumanLegJointLimitConstraint::unexcite()
 //==============================================================================
 void HumanLegJointLimitConstraint::applyImpulse(double* lambda)
 {
-  assert(isActive());
+  DART_ASSERT(isActive());
 
   // the dim of constraint = 1
   auto con_force = lambda[0];

--- a/examples/human_joint_limits/main.cpp
+++ b/examples/human_joint_limits/main.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "HumanArmJointLimitConstraint.hpp"
+#include "dart/common/Macros.hpp"
 #include "HumanLegJointLimitConstraint.hpp"
 
 #include <dart/gui/osg/all.hpp>
@@ -125,7 +126,7 @@ int main()
 {
   WorldPtr world = SkelParser::readWorld(
       DART_DATA_PATH "/skel/kima/kima_human_edited.skel");
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
 
   auto skel = world->getSkeleton("human");
   for (auto joint : skel->getJoints()) {

--- a/examples/hybrid_dynamics/main.cpp
+++ b/examples/hybrid_dynamics/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -125,7 +127,7 @@ int main(int /*argc*/, char* /*argv*/[])
 {
   // Create and initialize the world
   WorldPtr myWorld = SkelParser::readWorld("dart://sample/skel/fullbody1.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
   Eigen::Vector3d gravity(0.0, -9.81, 0.0);
   myWorld->setGravity(gravity);
 

--- a/examples/joint_constraints/main.cpp
+++ b/examples/joint_constraints/main.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "Controller.hpp"
+#include "dart/common/Macros.hpp"
 
 #include <dart/gui/osg/all.hpp>
 
@@ -177,7 +178,7 @@ int main(int /*argc*/, char* /*argv*/[])
 {
   // Create and initialize the world
   WorldPtr myWorld = SkelParser::readWorld("dart://sample/skel/fullbody1.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
 
   Eigen::Vector3d gravity(0.0, -9.81, 0.0);
   myWorld->setGravity(gravity);

--- a/examples/mixed_chain/main.cpp
+++ b/examples/mixed_chain/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -136,7 +138,7 @@ int main()
   // Load the skeleton file
   dart::simulation::WorldPtr myWorld = dart::utils::SkelParser::readWorld(
       "dart://sample/skel/test/test_articulated_bodies_10bodies.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
 
   // Set initial pose for the skeleton
   int dof = myWorld->getSkeleton(1)->getNumDofs();

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -74,7 +76,7 @@ public:
     mVoxelGridVisualAspect = voxelGridFrame->getVisualAspect();
     mVoxelGridVisualAspect->show();
 
-    assert(mVoxelGridShape);
+    DART_ASSERT(mVoxelGridShape);
   }
 
   void setPointSamplingMode(PointSamplingMode mode)
@@ -127,7 +129,7 @@ public:
     sensorPos[2] = 0.5 + 0.25 * std::sin(time * 2.0);
     time += dt;
     auto sensorFrame = mWorld->getSimpleFrame("sensor");
-    assert(sensorFrame);
+    DART_ASSERT(sensorFrame);
     sensorFrame->setTranslation(sensorPos);
 
     // Update point cloud
@@ -135,7 +137,7 @@ public:
 
     // Update point cloud colors
     auto colors = generatePointCloudColors(pointCloud);
-    assert(pointCloud.size() == colors.size());
+    DART_ASSERT(pointCloud.size() == colors.size());
     mPointCloudShape->setColors(colors);
 
     // Update voxel
@@ -179,7 +181,7 @@ protected:
     pointCloud.reserve(numPoints);
 
     const auto numBodies = mRobot->getNumBodyNodes();
-    assert(numBodies > 0);
+    DART_ASSERT(numBodies > 0);
     while (true) {
       const auto bodyIndex
           = math::Random::uniform<std::size_t>(0, numBodies - 1);
@@ -194,14 +196,14 @@ protected:
       auto shapeNode
           = body->getShapeNodeWith<dynamics::VisualAspect>(shapeIndex);
       auto shape = shapeNode->getShape();
-      assert(shape);
+      DART_ASSERT(shape);
 
       if (!shape->is<dynamics::MeshShape>())
         continue;
       auto mesh = std::static_pointer_cast<dynamics::MeshShape>(shape);
 
       auto assimpScene = mesh->getMesh();
-      assert(assimpScene);
+      DART_ASSERT(assimpScene);
 
       if (assimpScene->mNumMeshes < 1)
         continue;
@@ -488,7 +490,7 @@ public:
       }
 
       if (ImGui::CollapsingHeader("Grid", ImGuiTreeNodeFlags_None)) {
-        assert(mGrid);
+        DART_ASSERT(mGrid);
         ImGui::Text("Grid");
 
         bool display = mGrid->isDisplayed();

--- a/examples/rigid_chain/main.cpp
+++ b/examples/rigid_chain/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -70,7 +72,7 @@ int main()
   // create and initialize the world
   dart::simulation::WorldPtr myWorld
       = dart::utils::SkelParser::readWorld("dart://sample/skel/chain.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
 
   // create and initialize the world
   Eigen::Vector3d gravity(0.0, -9.81, 0.0);

--- a/examples/rigid_loop/main.cpp
+++ b/examples/rigid_loop/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -77,7 +79,7 @@ int main()
   // create and initialize the world
   dart::simulation::WorldPtr myWorld
       = utils::SkelParser::readWorld("dart://sample/skel/chain.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
 
   // create and initialize the world
   Eigen::Vector3d gravity(0.0, -9.81, 0.0);

--- a/examples/rigid_shapes/main.cpp
+++ b/examples/rigid_shapes/main.cpp
@@ -36,6 +36,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -218,7 +220,7 @@ public:
 int main()
 {
   WorldPtr myWorld = SkelParser::readWorld("dart://sample/skel/shapes.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
 
   auto handler = new RigidShapesEventHandler(myWorld);
 

--- a/examples/vehicle/main.cpp
+++ b/examples/vehicle/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -120,7 +122,7 @@ public:
   void customPreStep() override
   {
     SkeletonPtr vehicle = mWorld->getSkeleton("car_skeleton");
-    assert(vehicle != nullptr);
+    DART_ASSERT(vehicle != nullptr);
 
     std::size_t dof = vehicle->getNumDofs();
 
@@ -151,7 +153,7 @@ int main(int /*argc*/, char* /*argv*/[])
 {
   // Create and initialize the world
   WorldPtr myWorld = SkelParser::readWorld("dart://sample/skel/vehicle.skel");
-  assert(myWorld != nullptr);
+  DART_ASSERT(myWorld != nullptr);
   Eigen::Vector3d gravity(0.0, -9.81, 0.0);
   myWorld->setGravity(gravity);
 

--- a/python/dartpy/eigen_geometry_pybind.cpp
+++ b/python/dartpy/eigen_geometry_pybind.cpp
@@ -33,6 +33,7 @@
 //
 
 #include "eigen_geometry_pybind.h"
+#include "dart/common/Macros.hpp"
 
 #include <cassert>
 #include <cmath>
@@ -72,11 +73,11 @@ void CheckRotMat(const Eigen::Matrix<T, 3, 3>& R)
             .abs()
             .maxCoeff();
   DART_UNUSED(identity_error);
-  assert(
+  DART_ASSERT(
       identity_error < kCheckTolerance && "Rotation matrix is not orthonormal");
   const T det_error = fabs(R.determinant() - 1);
   DART_UNUSED(det_error);
-  assert(
+  DART_ASSERT(
       det_error < kCheckTolerance
       && "Rotation matrix violates right-hand rule");
 }
@@ -91,7 +92,7 @@ void CheckIsometry(const Eigen::Transform<T, 3, Eigen::Isometry>& X)
       = (X.matrix().bottomRows(1) - bottom_expected).array().abs().maxCoeff();
 
   DART_UNUSED(bottom_error);
-  assert(
+  DART_ASSERT(
       bottom_error < kCheckTolerance
       && "Homogeneous matrix is improperly scaled.");
 }
@@ -101,7 +102,7 @@ void CheckQuaternion(const Eigen::Quaternion<T>& q)
 {
   const T norm_error = fabs(q.coeffs().norm() - 1);
   DART_UNUSED(norm_error);
-  assert(norm_error < kCheckTolerance && "Quaternion is not normalized");
+  DART_ASSERT(norm_error < kCheckTolerance && "Quaternion is not normalized");
 }
 
 template <typename T>
@@ -109,7 +110,7 @@ void CheckAngleAxis(const Eigen::AngleAxis<T>& value)
 {
   const T norm_error = fabs(value.axis().norm() - 1);
   DART_UNUSED(norm_error);
-  assert(norm_error < kCheckTolerance && "Axis is not normalized");
+  DART_ASSERT(norm_error < kCheckTolerance && "Axis is not normalized");
 }
 
 } // namespace

--- a/python/dartpy/eigen_geometry_pybind.h
+++ b/python/dartpy/eigen_geometry_pybind.h
@@ -42,6 +42,7 @@
 /// more details on custom type casters.
 
 #include <string>
+#include "dart/common/Macros.hpp"
 #include <utility>
 
 #include <Eigen/Dense>
@@ -79,7 +80,7 @@ struct type_caster_wrapped {
   // N.B. Do not use `PYBIND11_TYPE_CASTER(...)` so we can avoid casting
   // garbage values.
   operator Type&() {
-    assert(loaded_);
+    DART_ASSERT(loaded_);
     return value_;
   }
   template <typename T> using cast_op_type =

--- a/tests/helpers/dynamics_helpers.hpp
+++ b/tests/helpers/dynamics_helpers.hpp
@@ -39,6 +39,7 @@
 #ifndef DART_UNITTESTS_DYNAMICS_HELPERS_HPP_
 #define DART_UNITTESTS_DYNAMICS_HELPERS_HPP_
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/all.hpp"
 #include "dart/math/Geometry.hpp"
 
@@ -264,7 +265,7 @@ SkeletonPtr createTwoLinkRobot(
 SkeletonPtr createNLinkRobot(
     int _n, Vector3d dim, TypeOfDOF type, bool finished = false)
 {
-  assert(_n > 0);
+  DART_ASSERT(_n > 0);
 
   SkeletonPtr robot = Skeleton::create();
   robot->disableSelfCollisionCheck();
@@ -347,7 +348,7 @@ SkeletonPtr createNLinkPendulum(
     const Vector3d& offset,
     bool finished = false)
 {
-  assert(numBodyNodes > 0);
+  DART_ASSERT(numBodyNodes > 0);
 
   SkeletonPtr robot = Skeleton::create();
   robot->disableSelfCollisionCheck();

--- a/tests/integration/constraint/test_Constraint.cpp
+++ b/tests/integration/constraint/test_Constraint.cpp
@@ -36,6 +36,7 @@
 
 #include "dart/collision/dart/DARTCollisionDetector.hpp"
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/constraint/ConstraintSolver.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -137,7 +138,7 @@ void ConstraintTest::SingleContactTest(const std::string& /*_fileName*/)
   sphereJoint->setVelocity(5, Random::uniform(-2.0, 2.0)); // z-axis
   world->addSkeleton(sphereSkel);
   EXPECT_EQ(sphereSkel->getGravity(), world->getGravity());
-  assert(sphere);
+  DART_ASSERT(sphere);
 
   SkeletonPtr boxSkel
       = createBox(Vector3d(1.0, 1.0, 1.0), Vector3d(0.0, 1.0, 0.0));

--- a/tests/integration/dynamics/test_Dynamics.cpp
+++ b/tests/integration/dynamics/test_Dynamics.cpp
@@ -35,6 +35,7 @@
 #include "helpers/dynamics_helpers.hpp"
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -696,7 +697,7 @@ void compareBodyNodeFkToJacobianRelative(
   using math::Jacobian;
   using math::LinearJacobian;
 
-  assert(bn->getSkeleton() == relativeTo->getSkeleton());
+  DART_ASSERT(bn->getSkeleton() == relativeTo->getSkeleton());
   auto skel = bn->getSkeleton();
 
   VectorXd dq = skel->getVelocities();
@@ -792,7 +793,7 @@ void compareBodyNodeFkToJacobianRelative(
   using math::Jacobian;
   using math::LinearJacobian;
 
-  assert(bn->getSkeleton() == relativeTo->getSkeleton());
+  DART_ASSERT(bn->getSkeleton() == relativeTo->getSkeleton());
   auto skel = bn->getSkeleton();
 
   VectorXd dq = skel->getVelocities();
@@ -885,13 +886,13 @@ void DynamicsTest::testJacobians(const common::Uri& uri)
 
   // load skeleton
   WorldPtr world = SkelParser::readWorld(uri);
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
   world->setGravity(gravity);
 
   //------------------------------ Tests ---------------------------------------
   for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
     SkeletonPtr skeleton = world->getSkeleton(i);
-    assert(skeleton != nullptr);
+    DART_ASSERT(skeleton != nullptr);
     int dof = skeleton->getNumDofs();
 
     for (int j = 0; j < nTestItr; ++j) {
@@ -1059,14 +1060,14 @@ void DynamicsTest::testFiniteDifferenceGeneralizedCoordinates(
 
   // load skeleton
   WorldPtr world = SkelParser::readWorld(uri);
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
   world->setGravity(gravity);
   world->setTimeStep(timeStep);
 
   //------------------------------ Tests ---------------------------------------
   for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
     SkeletonPtr skeleton = world->getSkeleton(i);
-    assert(skeleton != nullptr);
+    DART_ASSERT(skeleton != nullptr);
     int dof = skeleton->getNumDofs();
 
     for (int j = 0; j < nRandomItr; ++j) {
@@ -1148,7 +1149,7 @@ void DynamicsTest::testFiniteDifferenceBodyNodeVelocity(const common::Uri& uri)
 
   // load skeleton
   WorldPtr world = SkelParser::readWorld(uri);
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
   world->setGravity(gravity);
   world->setTimeStep(timeStep);
 
@@ -1235,14 +1236,14 @@ void DynamicsTest::testFiniteDifferenceBodyNodeAcceleration(
 
   // load skeleton
   WorldPtr world = SkelParser::readWorld(uri);
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
   world->setGravity(gravity);
   world->setTimeStep(timeStep);
 
   //------------------------------ Tests ---------------------------------------
   for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
     SkeletonPtr skeleton = world->getSkeleton(i);
-    assert(skeleton != nullptr);
+    DART_ASSERT(skeleton != nullptr);
     int dof = skeleton->getNumDofs();
 
     for (int j = 0; j < nRandomItr; ++j) {
@@ -2168,7 +2169,7 @@ void DynamicsTest::testConstraintImpulse(const common::Uri& uri)
           EXPECT_NEAR(constraintVector1(l), constraintVector2(index), 1e-6);
           index++;
         }
-        assert(static_cast<std::size_t>(bodyJacobian.cols()) == index);
+        DART_ASSERT(static_cast<std::size_t>(bodyJacobian.cols()) == index);
       }
     }
   }

--- a/tests/integration/dynamics/test_SoftDynamics.cpp
+++ b/tests/integration/dynamics/test_SoftDynamics.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "dart/common/Logging.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/PointMass.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -371,7 +372,7 @@ void SoftDynamicsTest::compareEquationsOfMotion(const std::string& _fileName)
       vector<double> oldKe(nSoftBodyNodes, 0.0);
       vector<double> oldD(nSoftBodyNodes, 0.0);
       for (int k = 0; k < nSoftBodyNodes; ++k) {
-        assert(softSkel != nullptr);
+        DART_ASSERT(softSkel != nullptr);
         dynamics::SoftBodyNode* sbn = softSkel->getSoftBodyNode(k);
         oldKv[k] = sbn->getVertexSpringStiffness();
         oldKe[k] = sbn->getEdgeSpringStiffness();
@@ -382,7 +383,7 @@ void SoftDynamicsTest::compareEquationsOfMotion(const std::string& _fileName)
       softSkel->clearExternalForces();
       softSkel->setAccelerations(VectorXd::Zero(dof));
       for (int k = 0; k < nSoftBodyNodes; ++k) {
-        assert(softSkel != nullptr);
+        DART_ASSERT(softSkel != nullptr);
         dynamics::SoftBodyNode* sbn = softSkel->getSoftBodyNode(k);
         sbn->setVertexSpringStiffness(0.0);
         sbn->setEdgeSpringStiffness(0.0);

--- a/tests/integration/simulation/test_World.cpp
+++ b/tests/integration/simulation/test_World.cpp
@@ -35,6 +35,7 @@
 #include "helpers/dynamics_helpers.hpp"
 
 #include "dart/collision/all.hpp"
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/RevoluteJoint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -339,7 +340,7 @@ simulation::WorldPtr createWorld()
   // Create and initialize the world
   simulation::WorldPtr world
       = utils::SkelParser::readWorld("dart://sample/skel/chain.skel");
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
 
   // Create and initialize the world
   world->setGravity(Eigen::Vector3d(0.0, -9.81, 0.0));

--- a/tests/integration/utils/test_Frames.cpp
+++ b/tests/integration/utils/test_Frames.cpp
@@ -32,6 +32,7 @@
 
 #include "helpers/GTestUtils.hpp"
 
+#include "dart/common/Macros.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/math/Helpers.hpp"
 #include "dart/math/Random.hpp"
@@ -743,7 +744,7 @@ void test_relative_values(bool spatial_targets, bool spatial_followers)
   followers.push_back(&DR);
   followers.push_back(&RR);
 
-  assert(targets.size() == followers.size());
+  DART_ASSERT(targets.size() == followers.size());
 
   randomize_target_values(targets, spatial_targets);
   set_relative_values(targets, followers, spatial_followers);

--- a/tests/integration/utils/test_Signal.cpp
+++ b/tests/integration/utils/test_Signal.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/all.hpp>
 
 #include <gtest/gtest.h>
@@ -306,7 +308,7 @@ void frameChangeCallback(
     const Frame* _oldParentFrame,
     const Frame* _newParentFrame)
 {
-  assert(_entity);
+  DART_ASSERT(_entity);
 
   std::string oldFrameName
       = _oldParentFrame == nullptr ? "(empty)" : _oldParentFrame->getName();
@@ -326,7 +328,7 @@ void nameChangedCallback(
     const std::string& oldName,
     const std::string& newName)
 {
-  assert(entity);
+  DART_ASSERT(entity);
 
   std::cout << "[" << entity->getName() << "]: Name changed: '" << oldName
             << "' --> '" << newName << "'.\n";

--- a/tutorials/tutorial_biped/main.cpp
+++ b/tutorials/tutorial_biped/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -252,7 +254,7 @@ SkeletonPtr loadBiped()
 
   // Create the world with a skeleton
   WorldPtr world = SkelParser::readWorld("dart://sample/skel/biped.skel");
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
 
   SkeletonPtr biped = world->getSkeleton("biped");
 

--- a/tutorials/tutorial_biped_finished/main.cpp
+++ b/tutorials/tutorial_biped_finished/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/utils/all.hpp>
@@ -316,7 +318,7 @@ SkeletonPtr loadBiped()
 {
   // Create the world with a skeleton
   WorldPtr world = SkelParser::readWorld("dart://sample/skel/biped.skel");
-  assert(world != nullptr);
+  DART_ASSERT(world != nullptr);
 
   SkeletonPtr biped = world->getSkeleton("biped");
 

--- a/tutorials/tutorial_multi_pendulum/main.cpp
+++ b/tutorials/tutorial_multi_pendulum/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/all.hpp>
@@ -66,7 +68,7 @@ public:
       mBodyForce(false)
   {
     // Find the Skeleton named "pendulum"
-    assert(mPendulum != nullptr);
+    DART_ASSERT(mPendulum != nullptr);
 
     mForceCountDown.resize(mPendulum->getNumDofs(), 0);
 

--- a/tutorials/tutorial_multi_pendulum_finished/main.cpp
+++ b/tutorials/tutorial_multi_pendulum_finished/main.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "dart/common/Macros.hpp"
+
 #include <dart/gui/osg/all.hpp>
 
 #include <dart/all.hpp>
@@ -67,7 +69,7 @@ public:
       mBodyForce(false)
   {
     // Make sure that the pendulum was found in the World
-    assert(mPendulum != nullptr);
+    DART_ASSERT(mPendulum != nullptr);
 
     mForceCountDown.resize(mPendulum->getNumDofs(), 0);
 
@@ -183,7 +185,8 @@ public:
       // attached. We should remove it in case this body is no longer
       // experiencing a force
       if (bn->getNumShapeNodesWith<VisualAspect>() == 3u) {
-        assert(bn->getShapeNodeWith<VisualAspect>(2)->getShape() == mArrow);
+        DART_ASSERT(
+            bn->getShapeNodeWith<VisualAspect>(2)->getShape() == mArrow);
         bn->getShapeNodeWith<VisualAspect>(2)->remove();
       }
 


### PR DESCRIPTION
Replace all direct uses of the C library assert macro with DART_ASSERT so every build path goes through DART's logging/assertion infrastructure. Along the way I also added the missing includes for dart/common/Macros.hpp in every file that now references the macro.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
