### PR TITLE
Silence repeated Dantzig LCP warnings

### DIFF
--- a/dart/lcpsolver/dantzig/lcp.cpp
+++ b/dart/lcpsolver/dantzig/lcp.cpp
@@ -473,8 +473,8 @@ bool dSolveLCP(
 
           // We shouldn't be overly aggressive about printing this warning,
           // because sometimes it gets spammed if s is just a tiny bit beneath
-          // 0.0.
-          DART_WARN_IF(
+          // 0.0. Rely on the *_ONCE helper so we only emit the first instance.
+          DART_WARN_ONCE_IF(
               s < REAL(-1e-6), "LCP internal error, s <= 0 (s={:.4e})", s);
 
           if (i < n) {

--- a/tests/unit/common/test_Logging.cpp
+++ b/tests/unit/common/test_Logging.cpp
@@ -36,9 +36,97 @@
 // For version macros
 #include <dart/config.hpp>
 
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#if DART_HAVE_spdlog
+  #include <spdlog/sinks/ostream_sink.h>
+  #include <spdlog/spdlog.h>
+#endif
+
 #include <gtest/gtest.h>
 
 using namespace dart;
+
+namespace {
+
+std::size_t countOccurrences(
+    const std::string& haystack, const std::string& needle)
+{
+  if (needle.empty())
+    return 0u;
+
+  std::size_t count = 0u;
+  std::string::size_type pos = haystack.find(needle);
+  while (pos != std::string::npos) {
+    ++count;
+    pos = haystack.find(needle, pos + needle.size());
+  }
+  return count;
+}
+
+class WarningCapture
+{
+public:
+  WarningCapture()
+  {
+#if DART_HAVE_spdlog
+    stream = std::make_shared<std::ostringstream>();
+    sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(*stream);
+    previousLogger = spdlog::default_logger();
+    logger = std::make_shared<spdlog::logger>("warn-once-test", sink);
+    logger->set_level(spdlog::level::trace);
+    logger->flush_on(spdlog::level::trace);
+    spdlog::set_default_logger(logger);
+#else
+    oldCout = std::cout.rdbuf(stream.rdbuf());
+    oldCerr = std::cerr.rdbuf(stream.rdbuf());
+#endif
+  }
+
+  ~WarningCapture()
+  {
+#if DART_HAVE_spdlog
+    if (logger)
+      logger->flush();
+    spdlog::set_default_logger(previousLogger);
+    if (logger)
+      spdlog::drop(logger->name());
+#else
+    std::cout.rdbuf(oldCout);
+    std::cerr.rdbuf(oldCerr);
+#endif
+  }
+
+  std::string contents()
+  {
+#if DART_HAVE_spdlog
+    if (logger)
+      logger->flush();
+    if (stream)
+      return stream->str();
+    return {};
+#else
+    return stream.str();
+#endif
+  }
+
+private:
+#if DART_HAVE_spdlog
+  std::shared_ptr<std::ostringstream> stream;
+  std::shared_ptr<spdlog::sinks::ostream_sink_mt> sink;
+  std::shared_ptr<spdlog::logger> previousLogger;
+  std::shared_ptr<spdlog::logger> logger;
+#else
+  std::ostringstream stream;
+  std::streambuf* oldCout{nullptr};
+  std::streambuf* oldCerr{nullptr};
+#endif
+};
+
+} // namespace
 
 //==============================================================================
 TEST(LoggingTest, Basics)
@@ -66,4 +154,33 @@ TEST(LoggingTest, VersionMacros)
   EXPECT_TRUE(DART_VERSION_AT_LEAST(5, 999, 999));
   EXPECT_TRUE(DART_VERSION_AT_LEAST(6, 13, 999));
   EXPECT_TRUE(DART_VERSION_AT_LEAST(6, 14, 1));
+}
+
+//==============================================================================
+TEST(LoggingTest, WarnOnce)
+{
+  const std::string sentinel = "warn-once sentinel";
+  auto triggerWarningOnce = [&]() {
+    DART_WARN_ONCE_IF(true, "{}", sentinel);
+  };
+
+  {
+    WarningCapture capture;
+    for (int i = 0; i < 3; ++i)
+      triggerWarningOnce();
+
+    const std::size_t occurrences
+        = countOccurrences(capture.contents(), sentinel);
+    if (occurrences == 0u)
+      GTEST_SKIP()
+          << "warn-once sentinel already emitted earlier in this process";
+
+    EXPECT_EQ(occurrences, 1u);
+  }
+
+  {
+    WarningCapture capture;
+    triggerWarningOnce();
+    EXPECT_EQ(countOccurrences(capture.contents(), sentinel), 0u);
+  }
 }


### PR DESCRIPTION
Resolves #1242.

## Summary
- replace the Dantzig solver's hot-loop warning with DART_WARN_ONCE_IF so it only emits once
- add a logging unit test that captures spdlog and std::cout paths to ensure warn-once suppression

## Testing
- pixi run test

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
