### PR TITLE
Backport fix for finding eigen to release-6.15

### DIFF
--- a/cmake/DARTFindEigen3.cmake
+++ b/cmake/DARTFindEigen3.cmake
@@ -6,4 +6,8 @@
 #
 # This file is provided under the "BSD-style" License
 
-find_package(Eigen3 3.4.0 REQUIRED CONFIG)
+find_package(Eigen3 REQUIRED CONFIG)
+
+if (Eigen3_VERSION VERSION_LESS 3.4)
+  message(FATAL_ERROR "Eigen version>=3.4 is required, but found ${Eigen3_VERSION}")
+endif()


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

This backports #2107 to the `release-6.15` branch, as a follow-up to adding that patch to the dartsim homebrew-core formula in https://github.com/Homebrew/homebrew-core/pull/253003. That PR isn't working yet due to issues with asserts. It's possible that #2109 would need to be backported as well, though that patch does not apply cleanly to this release branch.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
