### PR TITLE
Remove deprecated APIs from DART 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   * Added `DART_EXAMPLES_INSTALL_PATH` CMake cache variable to customize where example sources are installed or disable their installation.
 
 * Core
-  * TBD
+  * Removed all APIs deprecated in DART 6.2 (legacy Entity/BodyNode/JacobianNode/Joints/Skeleton notifiers, `Shape::notify*Update`, `EllipsoidShape::getSize`/`setSize`, `MultiSphereShape` alias, and `Eigen::make_aligned_shared` alias).
 
 ## DART 6
 

--- a/dart/common/detail/AspectWithVersion.hpp
+++ b/dart/common/detail/AspectWithVersion.hpp
@@ -157,10 +157,6 @@ public:
   std::size_t incrementVersion();
 
   /// Call UpdateProperties(this) and incrementVersion()
-  DART_DEPRECATED(6.2)
-  void notifyPropertiesUpdate();
-
-  /// Call UpdateProperties(this) and incrementVersion()
   void notifyPropertiesUpdated();
 
 protected:
@@ -411,23 +407,6 @@ std::size_t AspectWithVersionedProperties<
     return comp->incrementVersion();
 
   return 0;
-}
-
-//==============================================================================
-template <
-    class BaseT,
-    class DerivedT,
-    typename PropertiesData,
-    class CompositeT,
-    void (*updateProperties)(DerivedT*)>
-void AspectWithVersionedProperties<
-    BaseT,
-    DerivedT,
-    PropertiesData,
-    CompositeT,
-    updateProperties>::notifyPropertiesUpdate()
-{
-  notifyPropertiesUpdated();
 }
 
 //==============================================================================

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1560,12 +1560,6 @@ void BodyNode::dirtyAcceleration()
 }
 
 //==============================================================================
-void BodyNode::notifyArticulatedInertiaUpdate()
-{
-  dirtyArticulatedInertia();
-}
-
-//==============================================================================
 void BodyNode::dirtyArticulatedInertia()
 {
   const SkeletonPtr& skel = getSkeleton();
@@ -1574,21 +1568,9 @@ void BodyNode::dirtyArticulatedInertia()
 }
 
 //==============================================================================
-void BodyNode::notifyExternalForcesUpdate()
-{
-  dirtyExternalForces();
-}
-
-//==============================================================================
 void BodyNode::dirtyExternalForces()
 {
   SKEL_SET_FLAGS(mExternalForces);
-}
-
-//==============================================================================
-void BodyNode::notifyCoriolisUpdate()
-{
-  dirtyCoriolisForces();
 }
 
 //==============================================================================

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -859,23 +859,10 @@ public:
 
   /// Notify the Skeleton that the tree of this BodyNode needs an articulated
   /// inertia update
-  DART_DEPRECATED(6.2)
-  void notifyArticulatedInertiaUpdate();
-
-  /// Notify the Skeleton that the tree of this BodyNode needs an articulated
-  /// inertia update
   void dirtyArticulatedInertia();
 
   /// Tell the Skeleton that the external forces need to be updated
-  DART_DEPRECATED(6.2)
-  void notifyExternalForcesUpdate();
-
-  /// Tell the Skeleton that the external forces need to be updated
   void dirtyExternalForces();
-
-  /// Tell the Skeleton that the coriolis forces need to be update
-  DART_DEPRECATED(6.2)
-  void notifyCoriolisUpdate();
 
   /// Tell the Skeleton that the coriolis forces need to be update
   void dirtyCoriolisForces();

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -65,18 +65,6 @@ const std::string& EllipsoidShape::getStaticType()
 }
 
 //==============================================================================
-void EllipsoidShape::setSize(const Eigen::Vector3d& diameters)
-{
-  setDiameters(diameters);
-}
-
-//==============================================================================
-const Eigen::Vector3d& EllipsoidShape::getSize() const
-{
-  return getDiameters();
-}
-
-//==============================================================================
 void EllipsoidShape::setDiameters(const Eigen::Vector3d& diameters)
 {
   DART_ASSERT(diameters[0] > 0.0);

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -56,16 +56,6 @@ public:
   static const std::string& getStaticType();
 
   /// \brief Set diameters of this ellipsoid.
-  /// \deprecated Deprecated in 6.2. Please use setDiameters() instead.
-  DART_DEPRECATED(6.2)
-  void setSize(const Eigen::Vector3d& diameters);
-
-  /// \brief Get diameters of this ellipsoid.
-  /// \deprecated Deprecated in 6.2. Please use getDiameters() instead.
-  DART_DEPRECATED(6.2)
-  const Eigen::Vector3d& getSize() const;
-
-  /// \brief Set diameters of this ellipsoid.
   void setDiameters(const Eigen::Vector3d& diameters);
 
   /// \brief Get diameters of this ellipsoid.

--- a/dart/dynamics/Entity.cpp
+++ b/dart/dynamics/Entity.cpp
@@ -128,12 +128,6 @@ bool Entity::isFrame() const
 }
 
 //==============================================================================
-void Entity::notifyTransformUpdate()
-{
-  dirtyTransform();
-}
-
-//==============================================================================
 void Entity::dirtyTransform()
 {
   mNeedTransformUpdate = true;
@@ -150,12 +144,6 @@ bool Entity::needsTransformUpdate() const
 }
 
 //==============================================================================
-void Entity::notifyVelocityUpdate()
-{
-  dirtyVelocity();
-}
-
-//==============================================================================
 void Entity::dirtyVelocity()
 {
   mNeedVelocityUpdate = true;
@@ -169,12 +157,6 @@ void Entity::dirtyVelocity()
 bool Entity::needsVelocityUpdate() const
 {
   return mNeedVelocityUpdate;
-}
-
-//==============================================================================
-void Entity::notifyAccelerationUpdate()
-{
-  dirtyAcceleration();
 }
 
 //==============================================================================

--- a/dart/dynamics/Entity.hpp
+++ b/dart/dynamics/Entity.hpp
@@ -117,11 +117,6 @@ public:
 
   /// Notify the transformation update of this Entity that its parent Frame's
   /// pose is needed
-  DART_DEPRECATED(6.2)
-  virtual void notifyTransformUpdate();
-
-  /// Notify the transformation update of this Entity that its parent Frame's
-  /// pose is needed
   virtual void dirtyTransform();
 
   /// Returns true iff a transform update is needed for this Entity
@@ -129,20 +124,10 @@ public:
 
   /// Notify the velocity update of this Entity that its parent Frame's velocity
   /// is needed
-  DART_DEPRECATED(6.2)
-  virtual void notifyVelocityUpdate();
-
-  /// Notify the velocity update of this Entity that its parent Frame's velocity
-  /// is needed
   virtual void dirtyVelocity();
 
   /// Returns true iff a velocity update is needed for this Entity
   bool needsVelocityUpdate() const;
-
-  /// Notify the acceleration of this Entity that its parent Frame's
-  /// acceleration is needed
-  DART_DEPRECATED(6.2)
-  virtual void notifyAccelerationUpdate();
 
   /// Notify the acceleration of this Entity that its parent Frame's
   /// acceleration is needed

--- a/dart/dynamics/JacobianNode.cpp
+++ b/dart/dynamics/JacobianNode.cpp
@@ -97,12 +97,6 @@ JacobianNode::JacobianNode(BodyNode* bn)
 }
 
 //==============================================================================
-void JacobianNode::notifyJacobianUpdate()
-{
-  dirtyJacobian();
-}
-
-//==============================================================================
 void JacobianNode::dirtyJacobian()
 {
   // mIsWorldJacobianDirty depends on mIsBodyJacobianDirty, so we only need to
@@ -115,12 +109,6 @@ void JacobianNode::dirtyJacobian()
 
   for (JacobianNode* child : mChildJacobianNodes)
     child->dirtyJacobian();
-}
-
-//==============================================================================
-void JacobianNode::notifyJacobianDerivUpdate()
-{
-  dirtyJacobianDeriv();
 }
 
 //==============================================================================

--- a/dart/dynamics/JacobianNode.hpp
+++ b/dart/dynamics/JacobianNode.hpp
@@ -266,17 +266,7 @@ public:
 
   /// Notify this BodyNode and all its descendents that their Jacobians need to
   /// be updated.
-  DART_DEPRECATED(6.2)
-  void notifyJacobianUpdate();
-
-  /// Notify this BodyNode and all its descendents that their Jacobians need to
-  /// be updated.
   void dirtyJacobian();
-
-  /// Notify this BodyNode and all its descendents that their Jacobian
-  /// derivatives need to be updated.
-  DART_DEPRECATED(6.2)
-  void notifyJacobianDerivUpdate();
 
   /// Notify this BodyNode and all its descendents that their Jacobian
   /// derivatives need to be updated.

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -675,12 +675,6 @@ void Joint::updateArticulatedInertia() const
 //}
 
 //==============================================================================
-void Joint::notifyPositionUpdate()
-{
-  notifyPositionUpdated();
-}
-
-//==============================================================================
 void Joint::notifyPositionUpdated()
 {
   if (mChildBodyNode) {
@@ -707,12 +701,6 @@ void Joint::notifyPositionUpdated()
 }
 
 //==============================================================================
-void Joint::notifyVelocityUpdate()
-{
-  notifyVelocityUpdated();
-}
-
-//==============================================================================
 void Joint::notifyVelocityUpdated()
 {
   if (mChildBodyNode) {
@@ -724,12 +712,6 @@ void Joint::notifyVelocityUpdated()
 
   mNeedSpatialVelocityUpdate = true;
   mNeedSpatialAccelerationUpdate = true;
-}
-
-//==============================================================================
-void Joint::notifyAccelerationUpdate()
-{
-  notifyAccelerationUpdated();
 }
 
 //==============================================================================

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -775,22 +775,10 @@ public:
   //----------------------------------------------------------------------------
 
   /// Notify that a position has updated
-  DART_DEPRECATED(6.2)
-  void notifyPositionUpdate();
-
-  /// Notify that a position has updated
   void notifyPositionUpdated();
 
   /// Notify that a velocity has updated
-  DART_DEPRECATED(6.2)
-  void notifyVelocityUpdate();
-
-  /// Notify that a velocity has updated
   void notifyVelocityUpdated();
-
-  /// Notify that an acceleration has updated
-  DART_DEPRECATED(6.2)
-  void notifyAccelerationUpdate();
 
   /// Notify that an acceleration has updated
   void notifyAccelerationUpdated();

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -102,9 +102,6 @@ private:
   Spheres mSpheres;
 };
 
-DART_DEPRECATED(6.2)
-typedef MultiSphereConvexHullShape MultiSphereShape;
-
 } // namespace dynamics
 } // namespace dart
 

--- a/dart/dynamics/Shape.cpp
+++ b/dart/dynamics/Shape.cpp
@@ -147,21 +147,9 @@ void Shape::refreshData()
 }
 
 //==============================================================================
-void Shape::notifyAlphaUpdate(double alpha)
-{
-  notifyAlphaUpdated(alpha);
-}
-
-//==============================================================================
 void Shape::notifyAlphaUpdated(double /*alpha*/)
 {
   // Do nothing
-}
-
-//==============================================================================
-void Shape::notifyColorUpdate(const Eigen::Vector4d& color)
-{
-  notifyColorUpdated(color);
 }
 
 //==============================================================================

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -160,15 +160,7 @@ public:
   virtual void refreshData();
 
   /// Notify that the alpha of this shape has updated
-  DART_DEPRECATED(6.2)
-  virtual void notifyAlphaUpdate(double alpha);
-
-  /// Notify that the alpha of this shape has updated
   virtual void notifyAlphaUpdated(double alpha);
-
-  /// Notify that the color (rgba) of this shape has updated
-  DART_DEPRECATED(6.2)
-  virtual void notifyColorUpdate(const Eigen::Vector4d& color);
 
   /// Notify that the color (rgba) of this shape has updated
   virtual void notifyColorUpdated(const Eigen::Vector4d& color);

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -3714,12 +3714,6 @@ void Skeleton::clearInternalForces()
 }
 
 //==============================================================================
-void Skeleton::notifyArticulatedInertiaUpdate(std::size_t _treeIdx)
-{
-  dirtyArticulatedInertia(_treeIdx);
-}
-
-//==============================================================================
 void Skeleton::dirtyArticulatedInertia(std::size_t _treeIdx)
 {
   SET_FLAG(_treeIdx, mArticulatedInertia);
@@ -3730,12 +3724,6 @@ void Skeleton::dirtyArticulatedInertia(std::size_t _treeIdx)
   SET_FLAG(_treeIdx, mCoriolisForces);
   SET_FLAG(_treeIdx, mGravityForces);
   SET_FLAG(_treeIdx, mCoriolisAndGravityForces);
-}
-
-//==============================================================================
-void Skeleton::notifySupportUpdate(std::size_t _treeIdx)
-{
-  dirtySupportPolygon(_treeIdx);
 }
 
 //==============================================================================

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -901,16 +901,7 @@ public:
 
   /// Notify that the articulated inertia and everything that depends on it
   /// needs to be updated
-  DART_DEPRECATED(6.2)
-  void notifyArticulatedInertiaUpdate(std::size_t _treeIdx);
-
-  /// Notify that the articulated inertia and everything that depends on it
-  /// needs to be updated
   void dirtyArticulatedInertia(std::size_t _treeIdx);
-
-  /// Notify that the support polygon of a tree needs to be updated
-  DART_DEPRECATED(6.2)
-  void notifySupportUpdate(std::size_t _treeIdx);
 
   /// Notify that the support polygon of a tree needs to be updated
   void dirtySupportPolygon(std::size_t _treeIdx);

--- a/dart/math/MathTypes.hpp
+++ b/dart/math/MathTypes.hpp
@@ -75,15 +75,6 @@ using aligned_map = std::map<
     _Compare,
     Eigen::aligned_allocator<std::pair<const _Key, _Tp>>>;
 
-// Deprecated in favor of dart::common::make_aligned_shared
-template <typename _Tp, typename... _Args>
-DART_DEPRECATED(6.2)
-std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
-{
-  return ::dart::common::make_aligned_shared<_Tp, _Args...>(
-      std::forward<_Args>(__args)...);
-}
-
 } // namespace Eigen
 
 namespace dart {

--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -1140,20 +1140,12 @@ void Skeleton(py::module& m)
           "clearInternalForces",
           +[](dart::dynamics::Skeleton* self)
               -> void { return self->clearInternalForces(); })
-      //      .def("notifyArticulatedInertiaUpdate",
-      //      +[](dart::dynamics::Skeleton *self, std::size_t _treeIdx) -> void
-      //      { return self->notifyArticulatedInertiaUpdate(_treeIdx); },
-      //      ::py::arg("treeIdx"))
       .def(
           "dirtyArticulatedInertia",
           +[](dart::dynamics::Skeleton* self, std::size_t _treeIdx) -> void {
             return self->dirtyArticulatedInertia(_treeIdx);
           },
           ::py::arg("treeIdx"))
-      //      .def("notifySupportUpdate", +[](dart::dynamics::Skeleton *self,
-      //      std::size_t _treeIdx) -> void { return
-      //      self->notifySupportUpdate(_treeIdx); },
-      //      ::py::arg("treeIdx"))
       .def(
           "dirtySupportPolygon",
           +[](dart::dynamics::Skeleton* self, std::size_t _treeIdx) -> void {


### PR DESCRIPTION
Remove the DART 6.2 shims so only the modern APIs remain.

* Drop every `notify*Update()` shim in Entity/BodyNode/JacobianNode/Joint/Skeleton now that `dirty*` is the canonical API.
* Remove the redundant EllipsoidShape size helpers, the legacy MultiSphereShape typedef, and the Eigen namespace `make_aligned_shared` alias.
* Delete the deprecated Shape alpha/color notification names, keeping only the `notify*Updated` variants.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
