### PR TITLE
Remove deprecated CollisionFilter::needCollision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * Core
   * Removed all APIs deprecated in DART 6.2 (legacy Entity/BodyNode/JacobianNode/Joints/Skeleton notifiers, `Shape::notify*Update`, `EllipsoidShape::getSize`/`setSize`, `MultiSphereShape` alias, and `Eigen::make_aligned_shared` alias).
+  * Removed `CollisionFilter::needCollision()` (deprecated in DART 6.3).
 
 ## DART 6
 

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -46,13 +46,6 @@ CollisionFilter::~CollisionFilter()
 }
 
 //==============================================================================
-bool CollisionFilter::needCollision(
-    const CollisionObject* object1, const CollisionObject* object2) const
-{
-  return !ignoresCollision(object1, object2);
-}
-
-//==============================================================================
 void CompositeCollisionFilter::addCollisionFilter(const CollisionFilter* filter)
 {
   // nullptr is not an allowed filter

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -55,15 +55,6 @@ public:
 
   /// Returns true if the given two CollisionObjects should be checked by the
   /// collision detector, false otherwise.
-  /// \deprecated Deprecated in 6.3.0. Please use ignoreCollision instead. Note
-  /// that ignoreCollision returns logically opposite to what needCollision
-  /// returns.
-  DART_DEPRECATED(6.3)
-  bool needCollision(
-      const CollisionObject* object1, const CollisionObject* object2) const;
-
-  /// Returns true if the given two CollisionObjects should be checked by the
-  /// collision detector, false otherwise.
   virtual bool ignoresCollision(
       const CollisionObject* object1, const CollisionObject* object2) const = 0;
 };


### PR DESCRIPTION
Remove the last API deprecated in DART 6.3.

* Drop `CollisionFilter::needCollision()` so filter implementations expose only the inverted `ignoresCollision()` hook.
* Document the removal in the 7.0 changelog.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
