### PR TITLE
Remove deprecated DART_COMMON_MAKE_SHARED_WEAK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Core
   * Removed all APIs deprecated in DART 6.2 (legacy Entity/BodyNode/JacobianNode/Joints/Skeleton notifiers, `Shape::notify*Update`, `EllipsoidShape::getSize`/`setSize`, `MultiSphereShape` alias, and `Eigen::make_aligned_shared` alias).
   * Removed `CollisionFilter::needCollision()` (deprecated in DART 6.3).
+  * Removed `DART_COMMON_MAKE_SHARED_WEAK` macro (deprecated in DART 6.4).
 
 ## DART 6
 

--- a/dart/common/SmartPointer.hpp
+++ b/dart/common/SmartPointer.hpp
@@ -45,13 +45,6 @@
   using Weak##X##Ptr = std::weak_ptr<X>;                                       \
   using WeakConst##X##Ptr = std::weak_ptr<const X>;
 
-// Deprecated in DART 6.4. Please use DART_COMMON_DECLARE_SHARED_WEAK
-//
-// -- Standard shared/weak pointers --
-// Define a typedef for const and non-const version of shared_ptr and weak_ptr
-// for the class X
-#define DART_COMMON_MAKE_SHARED_WEAK(X) DART_COMMON_DECLARE_SHARED_WEAK(X)
-
 // -- Standard shared/weak/unique pointers --
 // Type aliases for const and non-const version of shared_ptr, weak_ptr, and
 // unique_ptr for the class X

--- a/docs/onboarding/code-style.md
+++ b/docs/onboarding/code-style.md
@@ -117,7 +117,7 @@ namespace example {
 // Use the following macro (defined in dart/common/SmartPointer.hpp) to declare
 // STL "smart" pointers. Pointers should be declared ahead of the class so
 // that the class itself can use the pointers.
-DART_COMMON_MAKE_SHARED_WEAK(ExampleClass)
+DART_COMMON_DECLARE_SHARED_WEAK(ExampleClass)
 
 /// A required Doxygen comment description for this class. This can be extended
 /// to include various useful details about the class, and can use the standard

--- a/examples/human_joint_limits/HumanArmJointLimitConstraint.hpp
+++ b/examples/human_joint_limits/HumanArmJointLimitConstraint.hpp
@@ -37,7 +37,7 @@
 
   #include <tiny_dnn/tiny_dnn.h>
 
-DART_COMMON_MAKE_SHARED_WEAK(HumanArmJointLimitConstraint)
+DART_COMMON_DECLARE_SHARED_WEAK(HumanArmJointLimitConstraint)
 
 /// HumanArmJointLimitConstraint handles joint position limits on human arm,
 /// representing range of motion of shoulder and elbow joints.

--- a/examples/human_joint_limits/HumanLegJointLimitConstraint.hpp
+++ b/examples/human_joint_limits/HumanLegJointLimitConstraint.hpp
@@ -37,7 +37,7 @@
 
 #include <tiny_dnn/tiny_dnn.h>
 
-DART_COMMON_MAKE_SHARED_WEAK(HumanLegJointLimitConstraint)
+DART_COMMON_DECLARE_SHARED_WEAK(HumanLegJointLimitConstraint)
 
 /// HumanLegJointLimitConstraint handles joint position limits on human leg,
 /// representing range of motion of hip, knee and ankle joints.


### PR DESCRIPTION
Prune the legacy smart-pointer macro deprecated in DART 6.4.

* Delete `DART_COMMON_MAKE_SHARED_WEAK` so code uses `DART_COMMON_DECLARE_SHARED_WEAK` directly.
* Update documentation and examples to reference the supported macro.
* Note the removal in the DART 7 changelog.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
