### PR TITLE
Fix dart7 ctest build-type handling

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -239,12 +239,7 @@ test-no-plane = { cmd = ["bash", "-lc", "set -euo pipefail\nBUILD_TYPE={{ build_
     { arg = "build_type", default = "Release" }
 ] }
 
-test-dart7 = { cmd = """
-    ctest \
-        --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \
-        --output-on-failure \
-        -L dart7
-""", depends-on = [
+test-dart7 = { cmd = ["bash", "-lc", "set -euo pipefail\nBUILD_TYPE={{ build_type }}\nctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE --output-on-failure -L dart7"], depends-on = [
     { task = "build-tests", args = ["{{ dartpy }}", "{{ build_type }}"] },
     { task = "build-dart7-tests", args = ["{{ dartpy }}", "{{ build_type }}"] }
 ], args = [
@@ -823,13 +818,7 @@ test-no-plane = { cmd = ["bash", "-lc", "set -euo pipefail\nBUILD_TYPE={{ build_
     { arg = "build_type", default = "Release" }
 ] }
 
-test-dart7 = { cmd = """
-    ctest \
-        --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp \
-        --build-config $BUILD_TYPE \
-        --output-on-failure \
-        -L dart7
-""", depends-on = [
+test-dart7 = { cmd = ["bash", "-lc", "set -euo pipefail\nBUILD_TYPE={{ build_type }}\nctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp --build-config $BUILD_TYPE --output-on-failure -L dart7"], depends-on = [
     { task = "build-tests", args = ["{{ dartpy }}", "{{ build_type }}"] },
     { task = "build-dart7-tests", args = ["{{ dartpy }}", "{{ build_type }}"] }
 ], args = [


### PR DESCRIPTION
## Summary
- change the `test-dart7` pixi task for single-config generators to run via `bash -lc` and hard-set `BUILD_TYPE` before invoking `ctest`, so it always executes the matching build tree
- mirror the same fix for the Visual Studio task (using `--build-config $BUILD_TYPE`), eliminating the `ctest --test-dir build/.../Debug` lookups when CI forces `BUILD_TYPE=Debug`

## Testing
- CI (macOS, Linux, Windows, gz-physics, publish-dartpy) all green for fix-ci-dart7-build-type
