### PR TITLE
Remove deprecated APIs from DART 6.8

### DIFF
--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -54,17 +54,6 @@ namespace dart {
 namespace constraint {
 
 //==============================================================================
-BoxedLcpConstraintSolver::BoxedLcpConstraintSolver(
-    double timeStep,
-    BoxedLcpSolverPtr boxedLcpSolver,
-    BoxedLcpSolverPtr secondaryBoxedLcpSolver)
-  : BoxedLcpConstraintSolver(
-      std::move(boxedLcpSolver), std::move(secondaryBoxedLcpSolver))
-{
-  setTimeStep(timeStep);
-}
-
-//==============================================================================
 BoxedLcpConstraintSolver::BoxedLcpConstraintSolver()
   : BoxedLcpConstraintSolver(std::make_shared<DantzigBoxedLcpSolver>())
 {

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -44,23 +44,6 @@ class BoxedLcpConstraintSolver : public ConstraintSolver
 public:
   /// Constructor
   ///
-  /// \param[in] timeStep Simulation time step
-  /// \param[in] boxedLcpSolver The primary boxed LCP solver. When nullptr is
-  /// passed, Dantzig solver will be used.
-  /// \param[in] secondaryBoxedLcpSolver The secondary boxed-LCP solver. When
-  /// nullptr is passed, PGS solver will be used. This is to make the default
-  /// solver setting to be Dantzig + PGS. In order to disable use of secondary
-  /// solver, call setSecondaryBoxedLcpSolver(nullptr) explicitly.
-  ///
-  /// \deprecated Deprecated in DART 6.8. Please use other constructors that
-  /// doesn't take timespte. Timestep should be set by the owner of this solver
-  /// such as dart::simulation::World when the solver added.
-  DART_DEPRECATED(6.8)
-  BoxedLcpConstraintSolver(
-      double timeStep,
-      BoxedLcpSolverPtr boxedLcpSolver = nullptr,
-      BoxedLcpSolverPtr secondaryBoxedLcpSolver = nullptr);
-
   /// Constructs with default primary and secondary LCP solvers, which are
   /// Dantzig and PGS, respectively.
   BoxedLcpConstraintSolver();

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -62,26 +62,6 @@ namespace constraint {
 using namespace dynamics;
 
 //==============================================================================
-ConstraintSolver::ConstraintSolver(double timeStep)
-  : mCollisionDetector(collision::FCLCollisionDetector::create()),
-    mCollisionGroup(mCollisionDetector->createCollisionGroupAsSharedPtr()),
-    mCollisionOption(collision::CollisionOption(
-        true, 1000u, std::make_shared<collision::BodyNodeCollisionFilter>())),
-    mTimeStep(timeStep),
-    mContactSurfaceHandler(std::make_shared<DefaultContactSurfaceHandler>())
-{
-  DART_ASSERT(timeStep > 0.0);
-
-  auto cd = std::static_pointer_cast<collision::FCLCollisionDetector>(
-      mCollisionDetector);
-
-  cd->setPrimitiveShapeType(collision::FCLCollisionDetector::MESH);
-  // TODO(JS): Consider using FCL's primitive shapes once FCL addresses
-  // incorrect contact point computation.
-  // (see: https://github.com/flexible-collision-library/fcl/issues/106)
-}
-
-//==============================================================================
 ConstraintSolver::ConstraintSolver()
   : mCollisionDetector(collision::FCLCollisionDetector::create()),
     mCollisionGroup(mCollisionDetector->createCollisionGroupAsSharedPtr()),

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -59,14 +59,6 @@ namespace constraint {
 class ConstraintSolver
 {
 public:
-  /// Constructor
-  ///
-  /// \deprecated Deprecated in DART 6.8. Please use other constructors that
-  /// doesn't take timespte. Timestep should be set by the owner of this solver
-  /// such as dart::simulation::World when the solver added.
-  DART_DEPRECATED(6.8)
-  explicit ConstraintSolver(double timeStep);
-
   // TODO(JS): Remove timeStep. The timestep can be set by world when a
   // constraint solver is assigned to a world.
   // Deprecate

--- a/dart/dynamics/HierarchicalIK.cpp
+++ b/dart/dynamics/HierarchicalIK.cpp
@@ -43,26 +43,6 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-bool HierarchicalIK::solve(bool applySolution)
-{
-  if (applySolution) {
-    return solveAndApply(true);
-  } else {
-    Eigen::VectorXd positions;
-    return findSolution(positions);
-  }
-}
-
-//==============================================================================
-bool HierarchicalIK::solve(Eigen::VectorXd& positions, bool applySolution)
-{
-  if (applySolution)
-    return solveAndApply(positions, true);
-  else
-    return findSolution(positions);
-}
-
-//==============================================================================
 bool HierarchicalIK::findSolution(Eigen::VectorXd& positions)
 {
   if (nullptr == mSolver) [[unlikely]] {

--- a/dart/dynamics/HierarchicalIK.hpp
+++ b/dart/dynamics/HierarchicalIK.hpp
@@ -66,23 +66,6 @@ public:
   /// Virtual destructor
   virtual ~HierarchicalIK() = default;
 
-  /// Solve the IK Problem. By default, the Skeleton itself will retain the
-  /// solved joint positions. If you pass in false for \c applySolution, then
-  /// the joint positions will be return to their original positions after the
-  /// problem is solved.
-  ///
-  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() instead.
-  DART_DEPRECATED(6.8)
-  bool solve(bool applySolution = true);
-
-  /// Same as solve(bool), but the positions vector will be filled with the
-  /// solved positions.
-  ///
-  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() or
-  /// findSolution() instead.
-  DART_DEPRECATED(6.8)
-  bool solve(Eigen::VectorXd& positions, bool applySolution = true);
-
   /// Finds a solution of the IK problem without applying the solution.
   ///
   /// \param[out] positions The solution of the IK problem. If the solver failed

--- a/dart/dynamics/InverseKinematics.cpp
+++ b/dart/dynamics/InverseKinematics.cpp
@@ -56,26 +56,6 @@ InverseKinematics::~InverseKinematics()
 }
 
 //==============================================================================
-bool InverseKinematics::solve(bool applySolution)
-{
-  if (applySolution) {
-    return solveAndApply(true);
-  } else {
-    Eigen::VectorXd positions;
-    return findSolution(positions);
-  }
-}
-
-//==============================================================================
-bool InverseKinematics::solve(Eigen::VectorXd& positions, bool applySolution)
-{
-  if (applySolution)
-    return solveAndApply(positions, true);
-  else
-    return findSolution(positions);
-}
-
-//==============================================================================
 bool InverseKinematics::findSolution(Eigen::VectorXd& positions)
 {
   if (nullptr == mSolver) {

--- a/dart/dynamics/InverseKinematics.hpp
+++ b/dart/dynamics/InverseKinematics.hpp
@@ -134,18 +134,6 @@ public:
   /// taken care of automatically, and Problem::setInitialGuess(~) will be
   /// called with the current positions of the Degrees Of Freedom.
   ///
-  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() instead.
-  DART_DEPRECATED(6.8)
-  bool solve(bool applySolution = true);
-
-  /// Same as solve(bool), but the positions vector will be filled with the
-  /// solved positions.
-  ///
-  /// \deprecated Deprecated in DART 6.8. Please use solveAndApply() or
-  /// findSolution() instead.
-  DART_DEPRECATED(6.8)
-  bool solve(Eigen::VectorXd& positions, bool applySolution = true);
-
   /// Finds a solution of the IK problem without applying the solution.
   ///
   /// The initial guess for the IK optimization problem is the current joint


### PR DESCRIPTION
Remove the remaining 6.8-deprecated APIs.

* Drop the time-step-taking constructors for `ConstraintSolver` and `BoxedLcpConstraintSolver`; owners should set the timestep explicitly via `setTimeStep()`.
* Remove the legacy `solve()` overloads on `InverseKinematics` and `HierarchicalIK` in favor of `solveAndApply()`/`findSolution()`.
* Update the changelog with the 6.8 cleanup.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
