### PR TITLE
Remove deprecated APIs from DART 6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   * Removed `DART_COMMON_MAKE_SHARED_WEAK` macro (deprecated in DART 6.4).
   * Removed all APIs deprecated in DART 6.9 (`dart::common::make_unique`, `FreeJoint::setTransform` static helpers, and `NloptSolver` overloads taking raw `nlopt::algorithm` values).
   * Removed all APIs deprecated in DART 6.10 (`common::Signal::cleanupConnections`, `SharedLibrary`/`SharedLibraryManager` filesystem-path overloads, BodyNode friction/restitution helpers and aspect properties, and `Joint::{set,is}PositionLimitEnforced()` aliases).
+  * Removed all APIs deprecated in DART 6.11 (`DartLoader::Flags` and the `parseSkeleton`/`parseWorld` overloads that accepted explicit resource retrievers and flag arguments).
 
 ## DART 6
 

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -105,25 +105,6 @@ void DartLoader::addPackageDirectory(
 }
 
 //==============================================================================
-dynamics::SkeletonPtr DartLoader::parseSkeleton(
-    const common::Uri& _uri,
-    const common::ResourceRetrieverPtr& _resourceRetriever,
-    unsigned int flags)
-{
-  const auto oldOptions = mOptions;
-  auto options = mOptions;
-  options.mResourceRetriever = _resourceRetriever;
-  if (flags & DartLoader::Flags::FIXED_BASE_LINK)
-    options.mDefaultRootJointType = RootJointType::FIXED;
-  else
-    options.mDefaultRootJointType = RootJointType::FLOATING;
-  mOptions = options;
-  auto out = parseSkeleton(_uri);
-  mOptions = oldOptions;
-  return out;
-}
-
-//==============================================================================
 dynamics::SkeletonPtr DartLoader::parseSkeleton(const common::Uri& uri)
 {
   const common::ResourceRetrieverPtr resourceRetriever
@@ -142,26 +123,6 @@ dynamics::SkeletonPtr DartLoader::parseSkeleton(const common::Uri& uri)
 
   return modelInterfaceToSkeleton(
       urdfInterface.get(), uri, resourceRetriever, mOptions);
-}
-
-//==============================================================================
-dynamics::SkeletonPtr DartLoader::parseSkeletonString(
-    const std::string& _urdfString,
-    const common::Uri& _baseUri,
-    const common::ResourceRetrieverPtr& _resourceRetriever,
-    unsigned int flags)
-{
-  const auto oldOptions = mOptions;
-  auto options = mOptions;
-  options.mResourceRetriever = _resourceRetriever;
-  if (flags & DartLoader::Flags::FIXED_BASE_LINK)
-    options.mDefaultRootJointType = RootJointType::FIXED;
-  else
-    options.mDefaultRootJointType = RootJointType::FLOATING;
-  mOptions = options;
-  auto out = parseSkeletonString(_urdfString, _baseUri);
-  mOptions = oldOptions;
-  return out;
 }
 
 //==============================================================================
@@ -188,25 +149,6 @@ dynamics::SkeletonPtr DartLoader::parseSkeletonString(
 }
 
 //==============================================================================
-simulation::WorldPtr DartLoader::parseWorld(
-    const common::Uri& _uri,
-    const common::ResourceRetrieverPtr& _resourceRetriever,
-    unsigned int flags)
-{
-  const auto oldOptions = mOptions;
-  auto options = mOptions;
-  options.mResourceRetriever = _resourceRetriever;
-  if (flags & DartLoader::Flags::FIXED_BASE_LINK)
-    options.mDefaultRootJointType = RootJointType::FIXED;
-  else
-    options.mDefaultRootJointType = RootJointType::FLOATING;
-  mOptions = options;
-  auto out = parseWorld(_uri);
-  mOptions = oldOptions;
-  return out;
-}
-
-//==============================================================================
 simulation::WorldPtr DartLoader::parseWorld(const common::Uri& uri)
 {
   const common::ResourceRetrieverPtr resourceRetriever
@@ -217,26 +159,6 @@ simulation::WorldPtr DartLoader::parseWorld(const common::Uri& uri)
     return nullptr;
 
   return parseWorldString(content, uri);
-}
-
-//==============================================================================
-simulation::WorldPtr DartLoader::parseWorldString(
-    const std::string& _urdfString,
-    const common::Uri& _baseUri,
-    const common::ResourceRetrieverPtr& _resourceRetriever,
-    unsigned int flags)
-{
-  const auto oldOptions = mOptions;
-  auto options = mOptions;
-  options.mResourceRetriever = _resourceRetriever;
-  if (flags & DartLoader::Flags::FIXED_BASE_LINK)
-    options.mDefaultRootJointType = RootJointType::FIXED;
-  else
-    options.mDefaultRootJointType = RootJointType::FLOATING;
-  mOptions = options;
-  auto out = parseWorldString(_urdfString, _baseUri);
-  mOptions = oldOptions;
-  return out;
 }
 
 //==============================================================================

--- a/dart/utils/urdf/DartLoader.hpp
+++ b/dart/utils/urdf/DartLoader.hpp
@@ -80,21 +80,6 @@ namespace utils {
 class DartLoader
 {
 public:
-  /// \deprecated Deprecated in 6.11. Use RootJointType and Options instead.
-  ///
-  /// Flags for specifying URDF file parsing policies.
-  enum Flags
-  {
-    NONE = 0,
-
-    /// Parser the root link's joint type to be "fixed" joint when not
-    /// specified.
-    FIXED_BASE_LINK = 1 << 1,
-
-    /// The default flgas
-    DEFAULT = NONE,
-  };
-
   /// Root joint type to be used when the parent joint of the root link is not
   /// specified in the URDF file.
   enum class RootJointType
@@ -159,44 +144,14 @@ public:
       const std::string& packageName, const std::string& packageDirectory);
 
   /// Parse a file to produce a Skeleton
-  DART_DEPRECATED(6.11)
-  dynamics::SkeletonPtr parseSkeleton(
-      const common::Uri& uri,
-      const common::ResourceRetrieverPtr& resourceRetriever,
-      unsigned int flags = DEFAULT);
-
-  /// Parse a file to produce a Skeleton
   dynamics::SkeletonPtr parseSkeleton(const common::Uri& uri);
-
-  /// Parse a text string to produce a Skeleton
-  DART_DEPRECATED(6.11)
-  dynamics::SkeletonPtr parseSkeletonString(
-      const std::string& urdfString,
-      const common::Uri& baseUri,
-      const common::ResourceRetrieverPtr& resourceRetriever,
-      unsigned int flags = DEFAULT);
 
   /// Parse a text string to produce a Skeleton
   dynamics::SkeletonPtr parseSkeletonString(
       const std::string& urdfString, const common::Uri& baseUri);
 
   /// Parse a file to produce a World
-  DART_DEPRECATED(6.11)
-  dart::simulation::WorldPtr parseWorld(
-      const common::Uri& uri,
-      const common::ResourceRetrieverPtr& resourceRetriever,
-      unsigned int flags = DEFAULT);
-
-  /// Parse a file to produce a World
   dart::simulation::WorldPtr parseWorld(const common::Uri& uri);
-
-  /// Parse a text string to produce a World
-  DART_DEPRECATED(6.11)
-  dart::simulation::WorldPtr parseWorldString(
-      const std::string& urdfString,
-      const common::Uri& baseUri,
-      const common::ResourceRetrieverPtr& resourceRetriever,
-      unsigned int flags = DEFAULT);
 
   /// Parse a text string to produce a World
   dart::simulation::WorldPtr parseWorldString(

--- a/python/dartpy/utils/DartLoader.cpp
+++ b/python/dartpy/utils/DartLoader.cpp
@@ -43,12 +43,6 @@ namespace python {
 
 void DartLoader(py::module& m)
 {
-  auto dartLoaderFlags
-      = ::py::enum_<utils::DartLoader::Flags>(m, "DartLoaderFlags")
-            .value("NONE", utils::DartLoader::Flags::NONE)
-            .value("FIXED_BASE_LINK", utils::DartLoader::Flags::FIXED_BASE_LINK)
-            .value("DEFAULT", utils::DartLoader::Flags::DEFAULT);
-
   auto dartLoaderRootJointType
       = ::py::enum_<utils::DartLoader::RootJointType>(
             m, "DartLoaderRootJointType")
@@ -91,38 +85,9 @@ void DartLoader(py::module& m)
                 ::py::arg("packageDirectory"))
             .def(
                 "parseSkeleton",
-                +[](dart::utils::DartLoader* self,
-                    const dart::common::Uri& uri,
-                    const common::ResourceRetrieverPtr& resourceRetriever,
-                    unsigned int flags) -> dart::dynamics::SkeletonPtr {
-                  DART_SUPPRESS_DEPRECATED_BEGIN
-                  return self->parseSkeleton(uri, resourceRetriever, flags);
-                  DART_SUPPRESS_DEPRECATED_END
-                },
-                ::py::arg("uri"),
-                ::py::arg("resourceRetriever"),
-                ::py::arg("flags") = utils::DartLoader::DEFAULT)
-            .def(
-                "parseSkeleton",
                 ::py::overload_cast<const common::Uri&>(
                     &utils::DartLoader::parseSkeleton),
                 ::py::arg("uri"))
-            .def(
-                "parseSkeletonString",
-                +[](utils::DartLoader* self,
-                    const std::string& urdfString,
-                    const common::Uri& baseUri,
-                    const common::ResourceRetrieverPtr& resourceRetriever,
-                    unsigned int flags) -> dynamics::SkeletonPtr {
-                  DART_SUPPRESS_DEPRECATED_BEGIN
-                  return self->parseSkeletonString(
-                      urdfString, baseUri, resourceRetriever, flags);
-                  DART_SUPPRESS_DEPRECATED_END
-                },
-                ::py::arg("urdfString"),
-                ::py::arg("baseUri"),
-                ::py::arg("resourceRetriever"),
-                ::py::arg("flags") = utils::DartLoader::DEFAULT)
             .def(
                 "parseSkeletonString",
                 ::py::overload_cast<const std::string&, const common::Uri&>(
@@ -131,38 +96,9 @@ void DartLoader(py::module& m)
                 ::py::arg("baseUri"))
             .def(
                 "parseWorld",
-                +[](utils::DartLoader* self,
-                    const common::Uri& _uri,
-                    const common::ResourceRetrieverPtr& resourceRetriever,
-                    unsigned int flags) -> simulation::WorldPtr {
-                  DART_SUPPRESS_DEPRECATED_BEGIN
-                  return self->parseWorld(_uri, resourceRetriever, flags);
-                  DART_SUPPRESS_DEPRECATED_END
-                },
-                ::py::arg("uri"),
-                ::py::arg("resourceRetriever"),
-                ::py::arg("flags") = utils::DartLoader::DEFAULT)
-            .def(
-                "parseWorld",
                 ::py::overload_cast<const common::Uri&>(
                     &utils::DartLoader::parseWorld),
                 ::py::arg("uri"))
-            .def(
-                "parseWorldString",
-                +[](utils::DartLoader* self,
-                    const std::string& urdfString,
-                    const common::Uri& baseUri,
-                    const common::ResourceRetrieverPtr& resourceRetriever,
-                    unsigned int flags) -> simulation::WorldPtr {
-                  DART_SUPPRESS_DEPRECATED_BEGIN
-                  return self->parseWorldString(
-                      urdfString, baseUri, resourceRetriever, flags);
-                  DART_SUPPRESS_DEPRECATED_END
-                },
-                ::py::arg("urdfString"),
-                ::py::arg("baseUri"),
-                ::py::arg("resourceRetriever"),
-                ::py::arg("flags") = utils::DartLoader::DEFAULT)
             .def(
                 "parseWorldString",
                 ::py::overload_cast<const std::string&, const common::Uri&>(
@@ -170,7 +106,6 @@ void DartLoader(py::module& m)
                 ::py::arg("urdfString"),
                 ::py::arg("baseUri"));
 
-  dartLoader.attr("Flags") = dartLoaderFlags;
   dartLoader.attr("RootJointType") = dartLoaderRootJointType;
   dartLoader.attr("Options") = dartLoaderOptions;
 }

--- a/python/dartpy_docs/utils/__init__.py
+++ b/python/dartpy_docs/utils/__init__.py
@@ -6,7 +6,7 @@ import typing
 from . import MjcfParser
 from . import SdfParser
 from . import SkelParser
-__all__: list[str] = ['CompositeResourceRetriever', 'DartLoader', 'DartLoaderFlags', 'DartLoaderOptions', 'DartLoaderRootJointType', 'DartResourceRetriever', 'MjcfParser', 'PackageResourceRetriever', 'SdfParser', 'SkelParser']
+__all__: list[str] = ['CompositeResourceRetriever', 'DartLoader', 'DartLoaderOptions', 'DartLoaderRootJointType', 'DartResourceRetriever', 'MjcfParser', 'PackageResourceRetriever', 'SdfParser', 'SkelParser']
 class CompositeResourceRetriever(dartpy.common.ResourceRetriever):
     def __init__(self) -> None:
         ...
@@ -15,7 +15,6 @@ class CompositeResourceRetriever(dartpy.common.ResourceRetriever):
     def addSchemaRetriever(self, schema: str, resourceRetriever: dartpy.common.ResourceRetriever) -> bool:
         ...
 class DartLoader:
-    Flags = DartLoaderFlags
     Options = DartLoaderOptions
     RootJointType = DartLoaderRootJointType
     def __init__(self) -> None:
@@ -25,70 +24,18 @@ class DartLoader:
     def getOptions(self) -> DartLoaderOptions:
         ...
     @typing.overload
-    def parseSkeleton(self, uri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.dynamics.Skeleton:
-        ...
-    @typing.overload
     def parseSkeleton(self, uri: dartpy.common.Uri) -> dartpy.dynamics.Skeleton:
-        ...
-    @typing.overload
-    def parseSkeletonString(self, urdfString: str, baseUri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.dynamics.Skeleton:
         ...
     @typing.overload
     def parseSkeletonString(self, urdfString: str, baseUri: dartpy.common.Uri) -> dartpy.dynamics.Skeleton:
         ...
     @typing.overload
-    def parseWorld(self, uri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.simulation.World:
-        ...
-    @typing.overload
     def parseWorld(self, uri: dartpy.common.Uri) -> dartpy.simulation.World:
-        ...
-    @typing.overload
-    def parseWorldString(self, urdfString: str, baseUri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.simulation.World:
         ...
     @typing.overload
     def parseWorldString(self, urdfString: str, baseUri: dartpy.common.Uri) -> dartpy.simulation.World:
         ...
     def setOptions(self, options: DartLoaderOptions = ...) -> None:
-        ...
-class DartLoaderFlags:
-    """
-    Members:
-    
-      NONE
-    
-      FIXED_BASE_LINK
-    
-      DEFAULT
-    """
-    DEFAULT: typing.ClassVar[DartLoaderFlags]  # value = <DartLoaderFlags.NONE: 0>
-    FIXED_BASE_LINK: typing.ClassVar[DartLoaderFlags]  # value = <DartLoaderFlags.FIXED_BASE_LINK: 2>
-    NONE: typing.ClassVar[DartLoaderFlags]  # value = <DartLoaderFlags.NONE: 0>
-    __members__: typing.ClassVar[dict[str, DartLoaderFlags]]  # value = {'NONE': <DartLoaderFlags.NONE: 0>, 'FIXED_BASE_LINK': <DartLoaderFlags.FIXED_BASE_LINK: 2>, 'DEFAULT': <DartLoaderFlags.NONE: 0>}
-    def __eq__(self, other: typing.Any) -> bool:
-        ...
-    def __getstate__(self) -> int:
-        ...
-    def __hash__(self) -> int:
-        ...
-    def __index__(self) -> int:
-        ...
-    def __init__(self, value: int) -> None:
-        ...
-    def __int__(self) -> int:
-        ...
-    def __ne__(self, other: typing.Any) -> bool:
-        ...
-    def __repr__(self) -> str:
-        ...
-    def __setstate__(self, state: int) -> None:
-        ...
-    def __str__(self) -> str:
-        ...
-    @property
-    def name(self) -> str:
-        ...
-    @property
-    def value(self) -> int:
         ...
 class DartLoaderOptions:
     mDefaultInertia: dartpy.dynamics.Inertia

--- a/python/stubs/dartpy/utils/__init__.pyi
+++ b/python/stubs/dartpy/utils/__init__.pyi
@@ -6,7 +6,7 @@ import typing
 from . import MjcfParser
 from . import SdfParser
 from . import SkelParser
-__all__: list[str] = ['CompositeResourceRetriever', 'DartLoader', 'DartLoaderFlags', 'DartLoaderOptions', 'DartLoaderRootJointType', 'DartResourceRetriever', 'MjcfParser', 'PackageResourceRetriever', 'SdfParser', 'SkelParser']
+__all__: list[str] = ['CompositeResourceRetriever', 'DartLoader', 'DartLoaderOptions', 'DartLoaderRootJointType', 'DartResourceRetriever', 'MjcfParser', 'PackageResourceRetriever', 'SdfParser', 'SkelParser']
 class CompositeResourceRetriever(dartpy.common.ResourceRetriever):
     def __init__(self) -> None:
         ...
@@ -15,7 +15,6 @@ class CompositeResourceRetriever(dartpy.common.ResourceRetriever):
     def addSchemaRetriever(self, schema: str, resourceRetriever: dartpy.common.ResourceRetriever) -> bool:
         ...
 class DartLoader:
-    Flags = DartLoaderFlags
     Options = DartLoaderOptions
     RootJointType = DartLoaderRootJointType
     def __init__(self) -> None:
@@ -25,70 +24,18 @@ class DartLoader:
     def getOptions(self) -> DartLoaderOptions:
         ...
     @typing.overload
-    def parseSkeleton(self, uri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.dynamics.Skeleton:
-        ...
-    @typing.overload
     def parseSkeleton(self, uri: dartpy.common.Uri) -> dartpy.dynamics.Skeleton:
-        ...
-    @typing.overload
-    def parseSkeletonString(self, urdfString: str, baseUri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.dynamics.Skeleton:
         ...
     @typing.overload
     def parseSkeletonString(self, urdfString: str, baseUri: dartpy.common.Uri) -> dartpy.dynamics.Skeleton:
         ...
     @typing.overload
-    def parseWorld(self, uri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.simulation.World:
-        ...
-    @typing.overload
     def parseWorld(self, uri: dartpy.common.Uri) -> dartpy.simulation.World:
-        ...
-    @typing.overload
-    def parseWorldString(self, urdfString: str, baseUri: dartpy.common.Uri, resourceRetriever: dartpy.common.ResourceRetriever, flags: int = ...) -> dartpy.simulation.World:
         ...
     @typing.overload
     def parseWorldString(self, urdfString: str, baseUri: dartpy.common.Uri) -> dartpy.simulation.World:
         ...
     def setOptions(self, options: DartLoaderOptions = ...) -> None:
-        ...
-class DartLoaderFlags:
-    """
-    Members:
-    
-      NONE
-    
-      FIXED_BASE_LINK
-    
-      DEFAULT
-    """
-    DEFAULT: typing.ClassVar[DartLoaderFlags]  # value = <DartLoaderFlags.NONE: 0>
-    FIXED_BASE_LINK: typing.ClassVar[DartLoaderFlags]  # value = <DartLoaderFlags.FIXED_BASE_LINK: 2>
-    NONE: typing.ClassVar[DartLoaderFlags]  # value = <DartLoaderFlags.NONE: 0>
-    __members__: typing.ClassVar[dict[str, DartLoaderFlags]]  # value = {'NONE': <DartLoaderFlags.NONE: 0>, 'FIXED_BASE_LINK': <DartLoaderFlags.FIXED_BASE_LINK: 2>, 'DEFAULT': <DartLoaderFlags.NONE: 0>}
-    def __eq__(self, other: typing.Any) -> bool:
-        ...
-    def __getstate__(self) -> int:
-        ...
-    def __hash__(self) -> int:
-        ...
-    def __index__(self) -> int:
-        ...
-    def __init__(self, value: int) -> None:
-        ...
-    def __int__(self) -> int:
-        ...
-    def __ne__(self, other: typing.Any) -> bool:
-        ...
-    def __repr__(self) -> str:
-        ...
-    def __setstate__(self, state: int) -> None:
-        ...
-    def __str__(self) -> str:
-        ...
-    @property
-    def name(self) -> str:
-        ...
-    @property
-    def value(self) -> int:
         ...
 class DartLoaderOptions:
     mDefaultInertia: dartpy.dynamics.Inertia


### PR DESCRIPTION
## Summary
- drop DartLoader flag enum and the URDF parse overloads that took explicit retrievers/flags
- update python bindings/docs/stubs accordingly and expand changelog

## Testing
- pixi run lint
