### PR TITLE
Remove deprecated APIs from DART 6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   * Removed all APIs deprecated in DART 6.9 (`dart::common::make_unique`, `FreeJoint::setTransform` static helpers, and `NloptSolver` overloads taking raw `nlopt::algorithm` values).
   * Removed all APIs deprecated in DART 6.10 (`common::Signal::cleanupConnections`, `SharedLibrary`/`SharedLibraryManager` filesystem-path overloads, BodyNode friction/restitution helpers and aspect properties, and `Joint::{set,is}PositionLimitEnforced()` aliases).
   * Removed all APIs deprecated in DART 6.11 (`DartLoader::Flags` and the `parseSkeleton`/`parseWorld` overloads that accepted explicit resource retrievers and flag arguments).
+  * Removed all APIs deprecated in DART 6.12 (the `SdfParser::readWorld`/`readSkeleton` overloads that accepted direct `ResourceRetriever` parameters).
 
 ## DART 6
 

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -305,15 +305,6 @@ simulation::WorldPtr readWorld(const common::Uri& uri, const Options& options)
 }
 
 //==============================================================================
-simulation::WorldPtr readWorld(
-    const common::Uri& uri, const common::ResourceRetrieverPtr& nullOrRetriever)
-{
-  Options options;
-  options.mResourceRetriever = nullOrRetriever;
-  return readWorld(uri, options);
-}
-
-//==============================================================================
 dynamics::SkeletonPtr readSkeleton(
     const common::Uri& uri, const Options& options)
 {
@@ -351,15 +342,6 @@ dynamics::SkeletonPtr readSkeleton(
   dynamics::SkeletonPtr newSkeleton = readSkeleton(skelElement, uri, retriever);
 
   return newSkeleton;
-}
-
-//==============================================================================
-dynamics::SkeletonPtr readSkeleton(
-    const common::Uri& uri, const common::ResourceRetrieverPtr& nullOrRetriever)
-{
-  Options options;
-  options.mResourceRetriever = nullOrRetriever;
-  return readSkeleton(uri, options);
 }
 
 namespace {

--- a/dart/utils/sdf/SdfParser.hpp
+++ b/dart/utils/sdf/SdfParser.hpp
@@ -37,7 +37,6 @@
 
 #include <dart/dynamics/Skeleton.hpp>
 
-#include <dart/common/Deprecated.hpp>
 #include <dart/common/ResourceRetriever.hpp>
 
 namespace dart {
@@ -74,16 +73,8 @@ struct Options
 simulation::WorldPtr readWorld(
     const common::Uri& uri, const Options& options = Options());
 
-DART_DEPRECATED(6.12)
-simulation::WorldPtr readWorld(
-    const common::Uri& uri, const common::ResourceRetrieverPtr& retriever);
-
 dynamics::SkeletonPtr readSkeleton(
     const common::Uri& uri, const Options& options = Options());
-
-DART_DEPRECATED(6.12)
-dynamics::SkeletonPtr readSkeleton(
-    const common::Uri& uri, const common::ResourceRetrieverPtr& retrievers);
 
 } // namespace SdfParser
 

--- a/python/dartpy/utils/SdfParser.cpp
+++ b/python/dartpy/utils/SdfParser.cpp
@@ -65,30 +65,10 @@ void SdfParser(py::module& m)
 
   sm.def(
       "readWorld",
-      +[](const common::Uri& uri, const common::ResourceRetrieverPtr& retriever)
-          -> simulation::WorldPtr {
-        DART_SUPPRESS_DEPRECATED_BEGIN
-        return utils::SdfParser::readWorld(uri, retriever);
-        DART_SUPPRESS_DEPRECATED_END
-      },
-      ::py::arg("uri"),
-      ::py::arg("retriever"));
-  sm.def(
-      "readWorld",
       ::py::overload_cast<const common::Uri&, const utils::SdfParser::Options&>(
           &utils::SdfParser::readWorld),
       ::py::arg("uri"),
       ::py::arg("options") = utils::SdfParser::Options());
-  sm.def(
-      "readSkeleton",
-      +[](const common::Uri& uri, const common::ResourceRetrieverPtr& retriever)
-          -> dynamics::SkeletonPtr {
-        DART_SUPPRESS_DEPRECATED_BEGIN
-        return utils::SdfParser::readSkeleton(uri, retriever);
-        DART_SUPPRESS_DEPRECATED_END
-      },
-      ::py::arg("uri"),
-      ::py::arg("retriever"));
   sm.def(
       "readSkeleton",
       ::py::overload_cast<const common::Uri&, const utils::SdfParser::Options&>(

--- a/python/dartpy_docs/utils/SdfParser.py
+++ b/python/dartpy_docs/utils/SdfParser.py
@@ -47,13 +47,7 @@ class RootJointType:
     def value(self) -> int:
         ...
 @typing.overload
-def readSkeleton(uri: dartpy.common.Uri, retriever: dartpy.common.ResourceRetriever) -> dartpy.dynamics.Skeleton:
-    ...
-@typing.overload
 def readSkeleton(uri: dartpy.common.Uri, options: Options = ...) -> dartpy.dynamics.Skeleton:
-    ...
-@typing.overload
-def readWorld(uri: dartpy.common.Uri, retriever: dartpy.common.ResourceRetriever) -> dartpy.simulation.World:
     ...
 @typing.overload
 def readWorld(uri: dartpy.common.Uri, options: Options = ...) -> dartpy.simulation.World:

--- a/python/stubs/dartpy/utils/SdfParser.pyi
+++ b/python/stubs/dartpy/utils/SdfParser.pyi
@@ -47,13 +47,7 @@ class RootJointType:
     def value(self) -> int:
         ...
 @typing.overload
-def readSkeleton(uri: dartpy.common.Uri, retriever: dartpy.common.ResourceRetriever) -> dartpy.dynamics.Skeleton:
-    ...
-@typing.overload
 def readSkeleton(uri: dartpy.common.Uri, options: Options = ...) -> dartpy.dynamics.Skeleton:
-    ...
-@typing.overload
-def readWorld(uri: dartpy.common.Uri, retriever: dartpy.common.ResourceRetriever) -> dartpy.simulation.World:
     ...
 @typing.overload
 def readWorld(uri: dartpy.common.Uri, options: Options = ...) -> dartpy.simulation.World:


### PR DESCRIPTION
## Summary
- remove the SdfParser readWorld/readSkeleton overloads that accepted bare retrievers
- drop the deprecated python bindings/stubs/docs and update changelog

## Testing
- pixi run lint
