### PR TITLE
Cancel workflows when branch is deleted

### DIFF
--- a/.github/workflows/cancel_branch_jobs.yml
+++ b/.github/workflows/cancel_branch_jobs.yml
@@ -1,10 +1,11 @@
-# Cancel queued or running workflow runs for a branch once its PR is merged.
+# Cancel queued or running workflow runs for a branch once its PR is merged or the branch is deleted.
 name: Cancel PR Branch Jobs
 
 on:
   pull_request:
     types:
       - closed
+  delete:
 
 permissions:
   actions: write
@@ -12,60 +13,112 @@ permissions:
 
 jobs:
   cancel-jobs:
-    name: Cancel workflows for merged branch
-    if: github.event.pull_request.merged == true
+    name: Cancel workflows for merged or deleted branch
+    if: github.event_name == 'pull_request' || github.event_name == 'delete'
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel runs for PR branch
+      - name: Cancel runs for branch
         uses: actions/github-script@v7
         with:
           script: |
-            const branch = context.payload.pull_request.head.ref;
-            const headRepo = context.payload.pull_request.head.repo;
-            const baseRepo = context.payload.pull_request.base.repo;
+            const eventName = context.eventName;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const currentRunId = context.runId;
+            const payload = context.payload;
 
-            if (!headRepo || !baseRepo) {
+            let branch;
+            let headRepo;
+
+            if (eventName === 'pull_request') {
+              const pr = payload.pull_request;
+
+              if (!pr) {
+                core.warning(
+                  'Missing pull request details; skip cancellation to avoid affecting other forks.',
+                );
+                return;
+              }
+
+              if (pr.merged !== true) {
+                core.info(
+                  `Pull request #${pr.number ?? 'unknown'} was closed without merge; skipping cancellation.`,
+                );
+                return;
+              }
+
+              branch = pr.head?.ref;
+              headRepo = pr.head?.repo;
+              const baseRepo = pr.base?.repo;
+
+              if (!headRepo || !baseRepo) {
+                core.warning(
+                  'Head/base repository information is unavailable; skip cancellation to avoid affecting other forks.',
+                );
+                return;
+              }
+
+              const headOwnerLogin = headRepo?.owner?.login?.toLowerCase();
+              const baseOwnerLogin = baseRepo?.owner?.login?.toLowerCase();
+              const headOwnerId =
+                typeof headRepo?.owner?.id === 'number'
+                  ? headRepo.owner.id
+                  : undefined;
+              const baseOwnerId =
+                typeof baseRepo?.owner?.id === 'number'
+                  ? baseRepo.owner.id
+                  : undefined;
+
+              const ownersDiffer =
+                (typeof headOwnerId === 'number' &&
+                  typeof baseOwnerId === 'number' &&
+                  headOwnerId !== baseOwnerId) ||
+                (headOwnerLogin &&
+                  baseOwnerLogin &&
+                  headOwnerLogin !== baseOwnerLogin);
+
+              if (ownersDiffer) {
+                core.info(
+                  `Skipping cancellation: PR head repo owner (${headOwnerLogin ??
+                    headOwnerId}) differs from base repo owner (${baseOwnerLogin ??
+                    baseOwnerId}).`,
+                );
+                return;
+              }
+            } else if (eventName === 'delete') {
+              if (payload.ref_type !== 'branch') {
+                core.info(
+                  `Delete event for ref type "${payload.ref_type}"; skipping.`,
+                );
+                return;
+              }
+
+              branch = payload.ref;
+              headRepo = payload.repository;
+
+              if (!branch || !headRepo) {
+                core.warning(
+                  'Repository or branch information missing from delete event; skipping cancellation.',
+                );
+                return;
+              }
+            } else {
+              core.info(`Unsupported event "${eventName}"; skipping.`);
+              return;
+            }
+
+            if (!branch) {
               core.warning(
-                'Head/base repository information is unavailable; skip cancellation to avoid affecting other forks.',
+                'Branch information is unavailable; nothing to cancel.',
               );
               return;
             }
 
             const headRepoId =
-              typeof headRepo.id === 'number' ? headRepo.id : undefined;
+              typeof headRepo?.id === 'number' ? headRepo.id : undefined;
             const headRepoFullName = headRepo?.full_name?.toLowerCase();
             const headRepoLabel =
               headRepoFullName ?? (headRepoId ? String(headRepoId) : 'unknown');
-            const headOwnerLogin = headRepo?.owner?.login?.toLowerCase();
-            const baseOwnerLogin = baseRepo?.owner?.login?.toLowerCase();
-            const headOwnerId =
-              typeof headRepo?.owner?.id === 'number'
-                ? headRepo.owner.id
-                : undefined;
-            const baseOwnerId =
-              typeof baseRepo?.owner?.id === 'number'
-                ? baseRepo.owner.id
-                : undefined;
-
-            const ownersDiffer =
-              (typeof headOwnerId === 'number' &&
-                typeof baseOwnerId === 'number' &&
-                headOwnerId !== baseOwnerId) ||
-              (headOwnerLogin &&
-                baseOwnerLogin &&
-                headOwnerLogin !== baseOwnerLogin);
-
-            if (ownersDiffer) {
-              core.info(
-                `Skipping cancellation: PR head repo owner (${headOwnerLogin ??
-                  headOwnerId}) differs from base repo owner (${baseOwnerLogin ??
-                  baseOwnerId}).`,
-              );
-              return;
-            }
 
             core.info(
               `Searching for unfinished runs on branch "${branch}" from repo "${headRepoLabel}"...`,


### PR DESCRIPTION
Extend the cancel-branch workflow so queued or running jobs are canceled when a branch disappears after its PR merges or is deleted directly. This helps free CI capacity and avoid stale runs.

- add the `delete` trigger and branch-specific guardrails so only branch deletions in this repo fire the workflow
- share the cancellation logic between merge and delete events while keeping the fork/owner safeguards intact
- keep the logs descriptive so we can trace what was canceled and why the workflow might early-exit

Verification: `pixi run lint`, local Node harness that simulated merged-PR and branch-delete events calling the JS snippet.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
