### PR TITLE
package.xml: fix version number

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>7.0.0.dev0</version>
+  <version>7.0.0</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics


### PR DESCRIPTION
According to [ROS REP 149](https://ros.org/reps/rep-0149.html#version), version numbers must have the format MAJOR.MINOR.PATCH.

Without this change, `colcon` fails to build a workspace containing dart.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
