### PR TITLE
Fix dartpy API docs on Read the Docs

### DIFF
--- a/docs/readthedocs/dartpy/api/modules/collision.rst
+++ b/docs/readthedocs/dartpy/api/modules/collision.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/collision.rst

--- a/docs/readthedocs/dartpy/api/modules/common.rst
+++ b/docs/readthedocs/dartpy/api/modules/common.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/common.rst

--- a/docs/readthedocs/dartpy/api/modules/constraint.rst
+++ b/docs/readthedocs/dartpy/api/modules/constraint.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/constraint.rst

--- a/docs/readthedocs/dartpy/api/modules/dynamics.rst
+++ b/docs/readthedocs/dartpy/api/modules/dynamics.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/dynamics.rst

--- a/docs/readthedocs/dartpy/api/modules/gui.rst
+++ b/docs/readthedocs/dartpy/api/modules/gui.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/gui.rst

--- a/docs/readthedocs/dartpy/api/modules/math.rst
+++ b/docs/readthedocs/dartpy/api/modules/math.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/math.rst

--- a/docs/readthedocs/dartpy/api/modules/optimizer.rst
+++ b/docs/readthedocs/dartpy/api/modules/optimizer.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/optimizer.rst

--- a/docs/readthedocs/dartpy/api/modules/simulation.rst
+++ b/docs/readthedocs/dartpy/api/modules/simulation.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/simulation.rst

--- a/docs/readthedocs/dartpy/api/modules/utils.rst
+++ b/docs/readthedocs/dartpy/api/modules/utils.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../python_api/modules/utils.rst

--- a/docs/readthedocs/dartpy/python_api_reference.rst
+++ b/docs/readthedocs/dartpy/python_api_reference.rst
@@ -1,16 +1,56 @@
 Python API Reference
 =====================
 
-.. admonition:: dartpy Python API Documentation
+The full dartpy API reference now builds directly on Read the Docs, so you no
+longer need to leave the site or rely on a separate GitHub Pages deployment.
+This page renders the documentation straight from the published ``dartpy``
+wheel, which means the members, signatures, and type hints always match the
+latest PyPI release.
 
-   **Latest published (v6.16.0)** — `View Python API Docs → <https://dartsim.github.io/dart/v6.16.0-py/>`_
+.. admonition:: How these docs are generated
 
-   **All versions:** `Browse GitHub Pages → <https://github.com/dartsim/dart/tree/gh-pages>`_
+   * RTD installs the ``dartpy`` wheel listed in :file:`docs/readthedocs/requirements.txt`.
+   * Sphinx loads the modules under :file:`docs/python_api/` and auto-documents
+     them using the installed package.
+   * Local builds can use ``pixi run docs-build`` or ``pixi run api-docs-py``
+     for the same result.
 
-   Python API docs are hosted on GitHub Pages and include module documentation, class signatures, type hints, and usage examples.
+Getting Started
+---------------
 
-Available Versions
+To explore the bindings locally:
+
+.. code-block:: bash
+
+   pip install dartpy
+   python - <<'PY'
+   import dartpy as dart
+   world = dart.simulation.World()
+   print(world.getGravity())
+   PY
+
+The sections below mirror the module layout from :file:`docs/python_api/`.
+
+Module Reference
+----------------
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+
+   /dartpy/api/modules/common
+   /dartpy/api/modules/math
+   /dartpy/api/modules/dynamics
+   /dartpy/api/modules/simulation
+   /dartpy/api/modules/collision
+   /dartpy/api/modules/constraint
+   /dartpy/api/modules/optimizer
+   /dartpy/api/modules/utils
+   /dartpy/api/modules/gui
+
+Indices and tables
 ------------------
 
-- `v6.16.0-py <https://dartsim.github.io/dart/v6.16.0-py/>`_
-- `v6.15.0-py <https://dartsim.github.io/dart/v6.15.0-py/>`_
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/readthedocs/requirements.txt
+++ b/docs/readthedocs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-copybutton
 sphinx-intl
 sphinx_rtd_theme
 sphinx-tabs
+dartpy>=6.16.0


### PR DESCRIPTION
Fix python API reference routing so dartpy docs stay on Read the Docs instead of broken GitHub Pages links.

* install the dartpy wheel in the RTD environment so autodoc can import bindings
* embed the python_api modules inside the RTD tree for a working toctree and navigation
* update the reference page text with a local workflow overview and quick-start snippet

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
