### PR TITLE
Fix coverage workflow failure

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -620,6 +620,11 @@ build-coverage = { cmd = """
 
 # Note: --rc flag is needed for lcov compatibility with gcc 13+
 coverage-report = { cmd = """
+    # Drop coverage artifacts for directories we filter out later so that
+    # stale gcda files without matching gcno files do not break lcov.
+    find build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \
+        '(' -path '*/tests/*' -o -path '*/examples/*' -o -path '*/tutorials/*' ')' \
+        '(' -name '*.gcda' -o -name '*.gcno' ')' -delete
     lcov \
         --capture \
         --directory build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \


### PR DESCRIPTION
Fix the failing coverage job from https://github.com/dartsim/dart/actions/runs/19411936575/job/55534547176.

- delete coverage artifacts produced under tests/examples/tutorials before running lcov so stale gcda files do not cause stamp mismatches
- reran `pixi run coverage-report` to ensure the workflow stage succeeds locally

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
