### PR TITLE
chore: remove manylinux artifacts

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -40,8 +40,8 @@ jobs:
   build_wheels:
     name: Wheels | ${{ matrix.os }} Py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    # Note: No manylinux container used. All platforms use pixi environments.
-    # Linux wheels: auditwheel auto-detects manylinux tag based on glibc symbols.
+    # Note: No dedicated container image is used; all platforms rely on pixi environments.
+    # Linux wheels: auditwheel derives the glibc compatibility tag from bundled symbols.
     # macOS wheels: delocate bundles dylibs. Windows wheels: delvewheel bundles DLLs.
     strategy:
       fail-fast: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,7 +428,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
   execute_process(
     COMMAND ${CMAKE_CXX_COMPILER} -dumpfullversion -dumpversion OUTPUT_VARIABLE GCC_VERSION)
   if(DART_BUILD_WHEELS)
-    set(gcc_required_version 10.2.1) # Lowered from 11.2.0 to support building in manylinux2014
+    set(gcc_required_version 10.2.1) # Lowered from 11.2.0 to support older glibc-based wheel builds
   else()
     set(gcc_required_version 11.2.0)
   endif()

--- a/docs/onboarding/python-bindings.md
+++ b/docs/onboarding/python-bindings.md
@@ -31,7 +31,7 @@
 **Choice**: pixi-based wheel building (not cibuildwheel + Docker)
 
 **Rationale**:
-- **No Docker maintenance**: No custom manylinux images to maintain
+- **No Docker maintenance**: No custom container images to maintain
 - **Local reproducibility**: Same commands work locally and in CI
 - **Unified tooling**: pixi handles both development and distribution
 - **Cross-platform**: Consistent environment via conda-forge
@@ -140,7 +140,7 @@ Wheels are built using **pixi** environments defined in `pixi.toml`:
 pixi run -e py312-wheel wheel-build
 pixi run -e py313-wheel wheel-build
 
-# Repair (Linux only - convert to manylinux)
+# Repair (Linux only - run auditwheel)
 pixi run -e py312-wheel wheel-repair
 pixi run -e py313-wheel wheel-repair
 

--- a/docs/readthedocs/README.md
+++ b/docs/readthedocs/README.md
@@ -89,8 +89,8 @@ The `docs-build` task:
 
 Read the Docs now installs `dartpy` prior to running Sphinx so the Python API pages
 render there as well. RTD's Ubuntu 22.04 images are still on glibc 2.35, so the
-requirements file pins `dartpy==6.16.0`, the last release that ships manylinux_2_27
-wheels. That wheel set only targets CPython 3.12+ (cp312–cp314), so `.readthedocs.yml`
+requirements file pins `dartpy==6.16.0`, the last release whose wheels remain compatible
+with glibc 2.27. That wheel set only targets CPython 3.12+ (cp312–cp314), so `.readthedocs.yml`
 now pins the RTD runtime to Python 3.12. Local builds can continue using the
 `pip install --pre dartpy` flow for the bleeding-edge bindings. Once RTD upgrades
 (or we ship compatible wheels), update `docs/readthedocs/requirements.txt` and

--- a/pixi.toml
+++ b/pixi.toml
@@ -968,14 +968,12 @@ test-dartpy-install = { cmd = """
 #   pixi run docker-build-ubuntu jammy                 # Build Ubuntu 22.04 (by codename)
 #   pixi run docker-build-ubuntu 22.04                 # Build Ubuntu 22.04 (by version)
 #   pixi run docker-build-ubuntu 24.04                 # Build Ubuntu 24.04 (by version)
-#   pixi run docker-build-manylinux                    # Build manylinux image
 docker-build = { cmd = "python scripts/build_docker.py all" }
 
 docker-build-ubuntu = { cmd = "python scripts/build_docker.py ubuntu {{ distro }}", args = [
   { arg = "distro", default = "jammy" },
 ] }
 
-docker-build-manylinux = { cmd = "python scripts/build_docker.py manylinux" }
 config-asan = { cmd = [
   "bash",
   "-lc",
@@ -1662,7 +1660,7 @@ delvewheel = ">=1.8.1"
 [feature.py312-wheel.target.linux-64.tasks]
 wheel-build = { depends-on = ["wheel-build-core"] }
 
-# auditwheel auto-detects an appropriate manylinux tag from the bundled libraries.
+# auditwheel auto-detects the glibc compatibility tag from the bundled libraries.
 wheel-repair = { depends-on = [
   { task = "wheel-repair-linux-core", args = [
     "cp312",
@@ -1778,7 +1776,7 @@ libglvnd = ">=1.7"
 [feature.py313-wheel.target.linux-64.tasks]
 wheel-build = { depends-on = ["wheel-build-core"] }
 
-# auditwheel auto-detects an appropriate manylinux tag from the bundled libraries.
+# auditwheel auto-detects the glibc compatibility tag from the bundled libraries.
 wheel-repair = { depends-on = [
   { task = "wheel-repair-linux-core", args = [
     "cp313",
@@ -1906,7 +1904,7 @@ libglvnd = ">=1.7"
 [feature.py314-wheel.target.linux-64.tasks]
 wheel-build = { depends-on = ["wheel-build-core"] }
 
-# auditwheel auto-detects an appropriate manylinux tag from the bundled libraries.
+# auditwheel auto-detects the glibc compatibility tag from the bundled libraries.
 wheel-repair = { depends-on = [
   { task = "wheel-repair-linux-core", args = [
     "cp314",

--- a/scripts/build_docker.py
+++ b/scripts/build_docker.py
@@ -7,7 +7,6 @@ Usage:
     python scripts/build_docker.py ubuntu jammy     # Build specific Ubuntu distro
     python scripts/build_docker.py ubuntu noble     # Build specific Ubuntu distro
     python scripts/build_docker.py ubuntu questing  # Build specific Ubuntu distro
-    python scripts/build_docker.py manylinux        # Build manylinux image
 """
 
 import argparse
@@ -143,37 +142,6 @@ def build_all_ubuntu(container_tool: str, dart_version: str = "v6.16"):
     return success
 
 
-def build_manylinux(container_tool: str, dart_version: str = "v6.16"):
-    """Build manylinux Docker image."""
-    dockerfile = Path(f"docker/dev/{dart_version}/Dockerfile.manylinux_2_28_x86_64")
-    if not dockerfile.exists():
-        print(f"❌ Error: Dockerfile not found: {dockerfile}")
-        return False
-
-    tag = f"dart-dev:manylinux_2_28_x86_64-{dart_version}"
-    print(f"🔨 Building {tag}...")
-
-    cmd = [
-        container_tool,
-        "build",  # Use 'build' instead of 'buildx build' for podman compatibility
-        "--file",
-        str(dockerfile),
-        "--build-arg",
-        "BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64",
-        "--tag",
-        tag,
-        ".",
-    ]
-
-    try:
-        result = subprocess.run(cmd, check=True)
-        print(f"✅ Successfully built {tag}")
-        return result.returncode == 0
-    except subprocess.CalledProcessError:
-        print(f"❌ Failed to build {tag}")
-        return False
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Build DART Docker images locally for testing",
@@ -185,14 +153,13 @@ Examples:
   %(prog)s ubuntu jammy         # Build Ubuntu 22.04 (Jammy) - same as above
   %(prog)s ubuntu 24.04         # Build Ubuntu 24.04 (Noble)
   %(prog)s ubuntu 25.10         # Build Ubuntu 25.10 (Questing)
-  %(prog)s manylinux            # Build manylinux image
         """,
     )
 
     parser.add_argument(
         "target",
-        choices=["all", "ubuntu", "manylinux"],
-        help="What to build: all (all Ubuntu versions), ubuntu (specific distro), or manylinux",
+        choices=["all", "ubuntu"],
+        help="What to build: all (all Ubuntu versions) or a specific Ubuntu distro",
     )
 
     parser.add_argument(
@@ -229,8 +196,6 @@ Examples:
         success = build_all_ubuntu(container_tool, args.dart_version)
     elif args.target == "ubuntu":
         success = build_ubuntu(args.distro, container_tool, args.dart_version)
-    elif args.target == "manylinux":
-        success = build_manylinux(container_tool, args.dart_version)
 
     return 0 if success else 1
 


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

Remove the unused manylinux build path. The dev Docker tooling now only targets Ubuntu images, pixi no longer exposes the manylinux task, and the docs/workflows refer to generic glibc compatibility instead of the retired custom Docker image.

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
