### PR TITLE
Clarify zero contact handling

### DIFF
--- a/dart/collision/CollisionOption.hpp
+++ b/dart/collision/CollisionOption.hpp
@@ -54,7 +54,8 @@ struct DART_API CollisionOption
 
   /// Maximum number of contacts to detect. Once the contacts are found up to
   /// this number, the collision checking will terminate at that moment. Set
-  /// this to 1 for binary check.
+  /// this to 1 for binary check. A value of 0 short-circuits collision
+  /// detection and returns false immediately.
   std::size_t maxNumContacts;
 
   /// CollisionFilter

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -229,8 +229,12 @@ bool BulletCollisionDetector::collide(
   if (result)
     result->clear();
 
-  if (0u == option.maxNumContacts)
+  if (0u == option.maxNumContacts) {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
     return false;
+  }
 
   // Check if 'this' is the collision engine of 'group'.
   if (!checkGroupValidity(this, group))
@@ -268,8 +272,12 @@ bool BulletCollisionDetector::collide(
   if (result)
     result->clear();
 
-  if (0u == option.maxNumContacts)
+  if (0u == option.maxNumContacts) {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
     return false;
+  }
 
   if (!checkGroupValidity(this, group1))
     return false;

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -37,6 +37,7 @@
 #include "dart/collision/dart/DARTCollide.hpp"
 #include "dart/collision/dart/DARTCollisionGroup.hpp"
 #include "dart/collision/dart/DARTCollisionObject.hpp"
+#include "dart/common/Logging.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/ShapeFrame.hpp"
@@ -128,8 +129,12 @@ bool DARTCollisionDetector::collide(
   if (result)
     result->clear();
 
-  if (0u == option.maxNumContacts) [[unlikely]]
+  if (0u == option.maxNumContacts) [[unlikely]] {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
     return false;
+  }
 
   if (!checkGroupValidity(this, group))
     return false;
@@ -179,8 +184,12 @@ bool DARTCollisionDetector::collide(
   if (result)
     result->clear();
 
-  if (0u == option.maxNumContacts)
+  if (0u == option.maxNumContacts) {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
     return false;
+  }
 
   if (!checkGroupValidity(this, group1))
     return false;

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -654,8 +654,12 @@ bool FCLCollisionDetector::collide(
   if (result)
     result->clear();
 
-  if (0u == option.maxNumContacts)
+  if (0u == option.maxNumContacts) {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
     return false;
+  }
 
   if (!checkGroupValidity(this, group))
     return false;
@@ -683,8 +687,12 @@ bool FCLCollisionDetector::collide(
   if (result)
     result->clear();
 
-  if (0u == option.maxNumContacts)
+  if (0u == option.maxNumContacts) {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
     return false;
+  }
 
   if (!checkGroupValidity(this, group1))
     return false;

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -37,6 +37,7 @@
 #include "dart/collision/ode/OdeCollisionGroup.hpp"
 #include "dart/collision/ode/OdeCollisionObject.hpp"
 #include "dart/collision/ode/OdeTypes.hpp"
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
@@ -214,6 +215,13 @@ bool OdeCollisionDetector::collide(
     const CollisionOption& option,
     CollisionResult* result)
 {
+  if (0u == option.maxNumContacts) {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
+    return false;
+  }
+
   auto odeGroup = static_cast<OdeCollisionGroup*>(group);
   odeGroup->updateEngineData();
 
@@ -237,6 +245,13 @@ bool OdeCollisionDetector::collide(
     const CollisionOption& option,
     CollisionResult* result)
 {
+  if (0u == option.maxNumContacts) {
+    DART_WARN(
+        "CollisionOption::maxNumContacts is 0; skipping collision detection. "
+        "Use maxNumContacts >= 1 for binary checks.");
+    return false;
+  }
+
   auto odeGroup1 = static_cast<OdeCollisionGroup*>(group1);
   odeGroup1->updateEngineData();
 


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

Fixes #701.

- Clarify in docs that `CollisionOption::maxNumContacts=0` short-circuits and advise using >=1 for binary checks
- Emit runtime warnings on the zero-contact fast path in FCL, Bullet, ODE, and DART collision detectors

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
