### PR TITLE
Enforce SDF joint limits when finite

### DIFF
--- a/tests/integration/io/test_SdfParser.cpp
+++ b/tests/integration/io/test_SdfParser.cpp
@@ -193,6 +193,7 @@ TEST(SdfParser, SDFJointProperties)
   const double epsilon = 1e-7;
 
   auto testProperties = [epsilon](const Joint* joint, const size_t idx) {
+    EXPECT_TRUE(joint->areLimitsEnforced()) << joint->getName();
     EXPECT_NEAR(joint->getPositionLowerLimit(idx), 0, epsilon);
     EXPECT_NEAR(joint->getPositionUpperLimit(idx), 3, epsilon);
     EXPECT_NEAR(joint->getDampingCoefficient(idx), 0, epsilon);
@@ -209,6 +210,8 @@ TEST(SdfParser, SDFJointProperties)
     } else if (joint->getType() == UniversalJoint::getStaticType()) {
       testProperties(joint, 0);
       testProperties(joint, 1);
+    } else if (joint->getType() == FreeJoint::getStaticType()) {
+      EXPECT_FALSE(joint->areLimitsEnforced());
     }
   });
 }


### PR DESCRIPTION
## Summary
- automatically enforce SDF joint position limits when finite bounds are provided
- propagate limit enforcement for prismatic, revolute, screw, and universal joints while leaving infinite limits unenforced
- add a regression assertion in the SDF joint properties integration test

Fixes #619.

#### Before creating a pull request
- [ ] Run `pixi run test-all` to lint, build, and test your changes (CI only per instructions)
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
