### PR TITLE
Fix dart8 tag component deserialization

### DIFF
--- a/dart8/io/serializer.hpp
+++ b/dart8/io/serializer.hpp
@@ -227,7 +227,12 @@ public:
   {
     ComponentT component;
     loadComponent(in, component);
-    registry.emplace<ComponentT>(entity, std::move(component));
+    if constexpr (std::is_empty_v<ComponentT>) {
+      // Tag components in EnTT must be emplaced without constructor args
+      registry.emplace<ComponentT>(entity);
+    } else {
+      registry.emplace<ComponentT>(entity, std::move(component));
+    }
   }
 
   bool hasComponent(


### PR DESCRIPTION
Fix dart8 tag component deserialization so empty/tag components are emplaced without constructor arguments, matching EnTT's tag storage requirements and unblocking dart8 builds in CI.

Testing:
- pixi run test (Release)
- pixi run test-dart8 (Release)

***

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
