### PR TITLE
Add lint-md pixi task to format markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,36 +1,40 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: 'type: bug'
-assignees: ''
-
+title: ""
+labels: "type: bug"
+assignees: ""
 ---
 
 > For questions, use [Discussions](https://github.com/dartsim/dart/discussions) instead.
 
 **Before submitting:**
+
 - [ ] Checked [documentation](http://dartsim.github.io/) and existing issues
 
 **Environment:**
-* DART version: [e.g., main, 6.15.0]
-* OS: [e.g., Ubuntu 24.04, macOS Sequoia, Windows 11]
-* Installation: [e.g., pixi, conda, apt, homebrew, vcpkg, source]
-* Compiler (if source): [e.g., GCC 13.2.0, Clang 18.0.0, MSVC 2022]
+
+- DART version: [e.g., main, 6.15.0]
+- OS: [e.g., Ubuntu 24.04, macOS Sequoia, Windows 11]
+- Installation: [e.g., pixi, conda, apt, homebrew, vcpkg, source]
+- Compiler (if source): [e.g., GCC 13.2.0, Clang 18.0.0, MSVC 2022]
 
 **Expected vs Current Behavior:**
 Describe what you expected and what actually happens.
 
 **Steps to Reproduce:**
+
 1.
 2.
 3.
 
 **Code to Reproduce:**
+
 ```cpp
 // Minimal reproducible example
 ```
 
 **Additional Info:**
-* For build issues, share verbose build output: `pixi run config` with `DART_VERBOSE=ON`
-* Share gist links for long outputs
+
+- For build issues, share verbose build output: `pixi run config` with `DART_VERBOSE=ON`
+- Share gist links for long outputs

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: 'type: enhancement'
-assignees: ''
-
+title: ""
+labels: "type: enhancement"
+assignees: ""
 ---
 
 > For general questions, use [Discussions](https://github.com/dartsim/dart/discussions) instead.
@@ -19,6 +18,7 @@ Describe your proposed solution.
 Alternative solutions considered.
 
 **Target API:**
+
 - [ ] C++
 - [ ] Python (dartpy)
 - [ ] Both

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Describe your changes here.
 
-***
+---
 
 #### Before creating a pull request
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Guidelines for DART
 
-This file is a pointer board for agents working in this repository.  Keep it concise and expand other documents instead.
+This file is a pointer board for agents working in this repository. Keep it concise and expand other documents instead.
 
 ## Read First
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,1594 +4,1420 @@
 
 ### [DART 7.0.0 (TBD)](https://github.com/dartsim/dart/milestone/TBD?closed=1)
 
-* Breaking Changes
-  * Increased required C++ standard from C++17 to C++20
-    * See [Compatibility Policy](docs/onboarding/compatibility-policy.md) for details
-  * Renamed `RootJointType` enum values to PascalCase (`Floating`, `Fixed`) across `dart::utils::SdfParser`, `dart::utils::DartLoader`, and their dartpy bindings to align with the code-style guidelines.
-  * Removed all optional optimizer plugins (`dart-optimizer-ipopt`, `dart-optimizer-nlopt`, `dart-optimizer-pagmo`, and `dart-optimizer-snopt`) along with the pagmo-based multi-objective optimization APIs since they were only exercised by tests.
-  * Moved the generic optimization primitives (`Function`, `Problem`, `Solver`, `GradientDescentSolver`) under `dart/math/optimization`; the legacy `<dart/optimizer/...>` headers and `dart::optimizer::*` namespace now forward (with deprecation notices) to the new `dart::math::*` definitions.
-  * Dropped the deprecated `docker/dev/v6.15` images; use the maintained v6.16 images instead.
-  * Renamed the OpenSceneGraph GUI component/target to `gui`/`dart-gui` (previously `gui-osg`/`dart-gui-osg`) and replaced the `DART_BUILD_GUI_OSG` toggle with `DART_BUILD_GUI`.
+- Breaking Changes
+  - Increased required C++ standard from C++17 to C++20
+    - See [Compatibility Policy](docs/onboarding/compatibility-policy.md) for details
+  - Renamed `RootJointType` enum values to PascalCase (`Floating`, `Fixed`) across `dart::utils::SdfParser`, `dart::utils::DartLoader`, and their dartpy bindings to align with the code-style guidelines.
+  - Removed all optional optimizer plugins (`dart-optimizer-ipopt`, `dart-optimizer-nlopt`, `dart-optimizer-pagmo`, and `dart-optimizer-snopt`) along with the pagmo-based multi-objective optimization APIs since they were only exercised by tests.
+  - Moved the generic optimization primitives (`Function`, `Problem`, `Solver`, `GradientDescentSolver`) under `dart/math/optimization`; the legacy `<dart/optimizer/...>` headers and `dart::optimizer::*` namespace now forward (with deprecation notices) to the new `dart::math::*` definitions.
+  - Dropped the deprecated `docker/dev/v6.15` images; use the maintained v6.16 images instead.
+  - Renamed the OpenSceneGraph GUI component/target to `gui`/`dart-gui` (previously `gui-osg`/`dart-gui-osg`) and replaced the `DART_BUILD_GUI_OSG` toggle with `DART_BUILD_GUI`.
 
-* Minimum Compiler Requirements
-  * Linux: GCC 11.0+
-  * macOS: Clang 12.0+
-  * Windows: MSVC 19.40+ (Visual Studio 2022)
+- Minimum Compiler Requirements
+  - Linux: GCC 11.0+
+  - macOS: Clang 12.0+
+  - Windows: MSVC 19.40+ (Visual Studio 2022)
 
-* Tested Platforms
-  * TBD (will be updated upon release)
+- Tested Platforms
+  - TBD (will be updated upon release)
 
-* Build
-  * Minimum C++ standard: C++20 (previously C++17)
-  * Added `DART_BUILD_TESTS`, `DART_BUILD_EXAMPLES`, and `DART_BUILD_TUTORIALS` to allow optionally skipping the tests/examples/tutorial targets (examples/tutorials now auto-disable if `dart-gui` is not built).
-  * `dart.pc` now reports the installed include directory via `Cflags`, improving downstream `pkg-config` usage without breaking relocatable installs.
-  * Added `DART_EXAMPLES_INSTALL_PATH` CMake cache variable to customize where example sources are installed or disable their installation.
-  * Added `libsdformat` as a required dependency so that SDF files are normalized through the official parser before being handed to DART: [#264](https://github.com/dartsim/dart/issues/264)
-  * Introduced per-target export headers (`dart/<component>/Export.hpp`) that define `DART_<COMPONENT>_API` macros. Each library now controls symbol visibility independently on Windows instead of sharing the monolithic `DART_API`, which fixes long‑standing DLL import inconsistencies.
-  * Pixi tasks and helper scripts now guard optional targets (dartpy, GUI examples) automatically, detect missing generator targets before invoking `cmake --build`, and expose `DART_BUILD_*_OVERRIDE` environment hooks so CI and local workflows can toggle bindings/apps without editing `pixi.toml`.
-* Simulation
-  * Added `dart::simulation::WorldConfig`, `World::setCollisionDetector(...)`, and corresponding dartpy bindings so users can switch collision detectors (FCL, Bullet, ODE, etc.) without reaching into the constraint solver internals.
-  * Removed the string-based `World::setCollisionDetector()` overload in favor of the strongly typed enum helper to make switching detectors simpler in user code.
+- Build
+  - Minimum C++ standard: C++20 (previously C++17)
+  - Added `DART_BUILD_TESTS`, `DART_BUILD_EXAMPLES`, and `DART_BUILD_TUTORIALS` to allow optionally skipping the tests/examples/tutorial targets (examples/tutorials now auto-disable if `dart-gui` is not built).
+  - `dart.pc` now reports the installed include directory via `Cflags`, improving downstream `pkg-config` usage without breaking relocatable installs.
+  - Added `DART_EXAMPLES_INSTALL_PATH` CMake cache variable to customize where example sources are installed or disable their installation.
+  - Added `libsdformat` as a required dependency so that SDF files are normalized through the official parser before being handed to DART: [#264](https://github.com/dartsim/dart/issues/264)
+  - Introduced per-target export headers (`dart/<component>/Export.hpp`) that define `DART_<COMPONENT>_API` macros. Each library now controls symbol visibility independently on Windows instead of sharing the monolithic `DART_API`, which fixes long‑standing DLL import inconsistencies.
+  - Pixi tasks and helper scripts now guard optional targets (dartpy, GUI examples) automatically, detect missing generator targets before invoking `cmake --build`, and expose `DART_BUILD_*_OVERRIDE` environment hooks so CI and local workflows can toggle bindings/apps without editing `pixi.toml`.
+- Simulation
+  - Added `dart::simulation::WorldConfig`, `World::setCollisionDetector(...)`, and corresponding dartpy bindings so users can switch collision detectors (FCL, Bullet, ODE, etc.) without reaching into the constraint solver internals.
+  - Removed the string-based `World::setCollisionDetector()` overload in favor of the strongly typed enum helper to make switching detectors simpler in user code.
 
-* Core
-  * Added `<numbers>`-style variable templates (`dart::math::pi`, `phi`, `two_pi`, etc.) plus numeric-limits helpers (`inf_v`, `max_v`, `min_v`, `eps_v`) in `dart/math/Constants.hpp` and deprecated `dart::math::constants<T>` (the legacy struct/header will be removed in DART 7.1).
-  * Removed all APIs deprecated in DART 6.0 (legacy BodyNode collision flags, Skeleton self-collision aliases, Joint `getLocal*`/`updateLocal*` accessors, `World::checkCollision(bool)`, `ConstraintSolver::setCollisionDetector(raw*)`, Marker `getBodyNode()`, `SdfParser::readSdfFile`, and deprecated XML helpers).
-  * Removed all APIs deprecated in DART 6.7 (legacy math random helpers, `Skeleton::clone()` overloads, and `ConstraintSolver::set/getLCPSolver()`).
-  * Removed all APIs deprecated in DART 6.2 (legacy Entity/BodyNode/JacobianNode/Joints/Skeleton notifiers, `Shape::notify*Update`, `EllipsoidShape::getSize`/`setSize`, `MultiSphereShape` alias, and `Eigen::make_aligned_shared` alias).
-  * Deprecated `ResourceRetriever::getFilePath()` and the overriding implementations across retrievers. The method now emits compiler deprecation warnings and will be removed in DART 8.0; use the new resource-materialization helpers (e.g., the SDF/OSG utilities) instead.
-  * Removed the final compatibility headers that only re-included their replacements (`dart/collision/Option.hpp`, `dart/collision/Result.hpp`, and `dart/dynamics/MultiSphereShape.hpp`) and scrubbed the remaining deprecated documentation strings.
-  * Removed `CollisionFilter::needCollision()` (deprecated in DART 6.3).
-  * Removed `DART_COMMON_MAKE_SHARED_WEAK` macro (deprecated in DART 6.4).
-  * Removed all APIs deprecated in DART 6.9 (`dart::common::make_unique`, `FreeJoint::setTransform` static helpers, and `NloptSolver` overloads taking raw `nlopt::algorithm` values).
-  * Removed all APIs deprecated in DART 6.10 (`common::Signal::cleanupConnections`, `SharedLibrary`/`SharedLibraryManager` filesystem-path overloads, BodyNode friction/restitution helpers and aspect properties, and `Joint::{set,is}PositionLimitEnforced()` aliases).
-  * Removed all APIs deprecated in DART 6.11 (`DartLoader::Flags` and the `parseSkeleton`/`parseWorld` overloads that accepted explicit resource retrievers and flag arguments).
-  * Removed all APIs deprecated in DART 6.12 (the `SdfParser::readWorld`/`readSkeleton` overloads that accepted direct `ResourceRetriever` parameters).
-  * Removed all APIs deprecated in DART 6.13 (the legacy `dart::common::Timer` utility, `ConstraintSolver::getConstraints()`/`containSkeleton()`, `ContactConstraint`'s raw constructor and material helper statics, and the `MetaSkeleton` vector-returning `getBodyNodes()`/`getJoints()` accessors).
-  * Removed the remaining 6.13 compatibility shims: deleted `dart/utils/urdf/URDFTypes.hpp`, the Eigen alias typedefs in `math/MathTypes.hpp`, the `dart7::comps::NameComponent` alias, and the legacy `dInfinity`/`dPAD` helpers, and tightened `SkelParser` plane parsing to treat `<point>` as an error.
-  * Updated `dart::utils::SdfParser` to canonicalize input through libsdformat so it can parse SDF 1.7+ models without the legacy version gate: [#264](https://github.com/dartsim/dart/issues/264)
-  * Fixed Collada mesh imports ignoring `<unit>` metadata by preserving the Assimp-provided scale transform ([#287](https://github.com/dartsim/dart/issues/287)).
+- Core
+  - Added `<numbers>`-style variable templates (`dart::math::pi`, `phi`, `two_pi`, etc.) plus numeric-limits helpers (`inf_v`, `max_v`, `min_v`, `eps_v`) in `dart/math/Constants.hpp` and deprecated `dart::math::constants<T>` (the legacy struct/header will be removed in DART 7.1).
+  - Removed all APIs deprecated in DART 6.0 (legacy BodyNode collision flags, Skeleton self-collision aliases, Joint `getLocal*`/`updateLocal*` accessors, `World::checkCollision(bool)`, `ConstraintSolver::setCollisionDetector(raw*)`, Marker `getBodyNode()`, `SdfParser::readSdfFile`, and deprecated XML helpers).
+  - Removed all APIs deprecated in DART 6.7 (legacy math random helpers, `Skeleton::clone()` overloads, and `ConstraintSolver::set/getLCPSolver()`).
+  - Removed all APIs deprecated in DART 6.2 (legacy Entity/BodyNode/JacobianNode/Joints/Skeleton notifiers, `Shape::notify*Update`, `EllipsoidShape::getSize`/`setSize`, `MultiSphereShape` alias, and `Eigen::make_aligned_shared` alias).
+  - Deprecated `ResourceRetriever::getFilePath()` and the overriding implementations across retrievers. The method now emits compiler deprecation warnings and will be removed in DART 8.0; use the new resource-materialization helpers (e.g., the SDF/OSG utilities) instead.
+  - Removed the final compatibility headers that only re-included their replacements (`dart/collision/Option.hpp`, `dart/collision/Result.hpp`, and `dart/dynamics/MultiSphereShape.hpp`) and scrubbed the remaining deprecated documentation strings.
+  - Removed `CollisionFilter::needCollision()` (deprecated in DART 6.3).
+  - Removed `DART_COMMON_MAKE_SHARED_WEAK` macro (deprecated in DART 6.4).
+  - Removed all APIs deprecated in DART 6.9 (`dart::common::make_unique`, `FreeJoint::setTransform` static helpers, and `NloptSolver` overloads taking raw `nlopt::algorithm` values).
+  - Removed all APIs deprecated in DART 6.10 (`common::Signal::cleanupConnections`, `SharedLibrary`/`SharedLibraryManager` filesystem-path overloads, BodyNode friction/restitution helpers and aspect properties, and `Joint::{set,is}PositionLimitEnforced()` aliases).
+  - Removed all APIs deprecated in DART 6.11 (`DartLoader::Flags` and the `parseSkeleton`/`parseWorld` overloads that accepted explicit resource retrievers and flag arguments).
+  - Removed all APIs deprecated in DART 6.12 (the `SdfParser::readWorld`/`readSkeleton` overloads that accepted direct `ResourceRetriever` parameters).
+  - Removed all APIs deprecated in DART 6.13 (the legacy `dart::common::Timer` utility, `ConstraintSolver::getConstraints()`/`containSkeleton()`, `ContactConstraint`'s raw constructor and material helper statics, and the `MetaSkeleton` vector-returning `getBodyNodes()`/`getJoints()` accessors).
+  - Removed the remaining 6.13 compatibility shims: deleted `dart/utils/urdf/URDFTypes.hpp`, the Eigen alias typedefs in `math/MathTypes.hpp`, the `dart7::comps::NameComponent` alias, and the legacy `dInfinity`/`dPAD` helpers, and tightened `SkelParser` plane parsing to treat `<point>` as an error.
+  - Updated `dart::utils::SdfParser` to canonicalize input through libsdformat so it can parse SDF 1.7+ models without the legacy version gate: [#264](https://github.com/dartsim/dart/issues/264)
+  - Fixed Collada mesh imports ignoring `<unit>` metadata by preserving the Assimp-provided scale transform ([#287](https://github.com/dartsim/dart/issues/287)).
 
-* dartpy
-  * Added bindings for `dynamics::EndEffector` (including the `Support` aspect) and exposed `BodyNode::createEndEffector`/`getEndEffector` plus the `Skeleton::getEndEffector` overloads to unblock the Atlas puppet Python example and IK tests.
-* Tutorials
-  * Added explicit placeholder bodies to unfinished domino and biped Python tutorials so users can import/run the scaffolds without `IndentationError`s.
+- dartpy
+  - Added bindings for `dynamics::EndEffector` (including the `Support` aspect) and exposed `BodyNode::createEndEffector`/`getEndEffector` plus the `Skeleton::getEndEffector` overloads to unblock the Atlas puppet Python example and IK tests.
+- Tutorials
+  - Added explicit placeholder bodies to unfinished domino and biped Python tutorials so users can import/run the scaffolds without `IndentationError`s.
 
 ## DART 6
 
 ### [DART 6.16.0 (2025-11-09)](https://github.com/dartsim/dart/milestone/83?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
+- Simulation
+  - Allow servo joints to recover from position limits: [#2086](https://github.com/dartsim/dart/pull/2086)
+  - Fix passive joint commands to respect joint actuation limits: [#1997](https://github.com/dartsim/dart/pull/1997)
 
-* Simulation
-  * Allow servo joints to recover from position limits: [#2086](https://github.com/dartsim/dart/pull/2086)
-  * Fix passive joint commands to respect joint actuation limits: [#1997](https://github.com/dartsim/dart/pull/1997)
+- Core
+  - Replace legacy `assert` macros with `DART_ASSERT` on release-6.16 (backport of #2109): [#2117](https://github.com/dartsim/dart/pull/2117)
 
-* Core
-  * Replace legacy `assert` macros with `DART_ASSERT` on release-6.16 (backport of #2109): [#2117](https://github.com/dartsim/dart/pull/2117)
+- Build
+  - Fix pybind11 detection and assert include handling with pixi builds: [#2118](https://github.com/dartsim/dart/pull/2118)
+  - Port Eigen compatibility guard to keep 3.4+ builds working on release-6.16: [#2108](https://github.com/dartsim/dart/pull/2108)
+  - Add `DART_USE_SYSTEM_TRACY`, `DART_USE_SYSTEM_PYBIND11`, and `DART_USE_SYSTEM_GOOGLEBENCHMARK` toggles: [#1911](https://github.com/dartsim/dart/pull/1911), [#1907](https://github.com/dartsim/dart/pull/1907), [#1904](https://github.com/dartsim/dart/pull/1904)
+  - Fix absolute install directory handling in CMake exports: [#2006](https://github.com/dartsim/dart/pull/2006)
 
-* Build
-  * Fix pybind11 detection and assert include handling with pixi builds: [#2118](https://github.com/dartsim/dart/pull/2118)
-  * Port Eigen compatibility guard to keep 3.4+ builds working on release-6.16: [#2108](https://github.com/dartsim/dart/pull/2108)
-  * Add `DART_USE_SYSTEM_TRACY`, `DART_USE_SYSTEM_PYBIND11`, and `DART_USE_SYSTEM_GOOGLEBENCHMARK` toggles: [#1911](https://github.com/dartsim/dart/pull/1911), [#1907](https://github.com/dartsim/dart/pull/1907), [#1904](https://github.com/dartsim/dart/pull/1904)
-  * Fix absolute install directory handling in CMake exports: [#2006](https://github.com/dartsim/dart/pull/2006)
-
-* Tooling and Docs
-  * Use system `googletest` and `googlebenchmark` in pixi environments and upgrade bundled dependencies: [#1905](https://github.com/dartsim/dart/pull/1905)
-  * Switch coverage and API docs workflows to pixi tasks and GitHub Pages deploy actions: [#2036](https://github.com/dartsim/dart/pull/2036), [#2032](https://github.com/dartsim/dart/pull/2032)
-  * Install OpenSceneGraph from source on macOS builds to avoid flaky CI: [#2037](https://github.com/dartsim/dart/pull/2037)
-  * Restructure documentation to clearly separate C++ and Python guidance: [#2040](https://github.com/dartsim/dart/pull/2040)
-  * Add pixi-powered developer tasks (including Python workflows) and refresh GitHub templates: [#2034](https://github.com/dartsim/dart/pull/2034), [#2039](https://github.com/dartsim/dart/pull/2039)
-  * Add gz-physics integration tests to CI to guard the public plugin: [#2000](https://github.com/dartsim/dart/pull/2000)
+- Tooling and Docs
+  - Use system `googletest` and `googlebenchmark` in pixi environments and upgrade bundled dependencies: [#1905](https://github.com/dartsim/dart/pull/1905)
+  - Switch coverage and API docs workflows to pixi tasks and GitHub Pages deploy actions: [#2036](https://github.com/dartsim/dart/pull/2036), [#2032](https://github.com/dartsim/dart/pull/2032)
+  - Install OpenSceneGraph from source on macOS builds to avoid flaky CI: [#2037](https://github.com/dartsim/dart/pull/2037)
+  - Restructure documentation to clearly separate C++ and Python guidance: [#2040](https://github.com/dartsim/dart/pull/2040)
+  - Add pixi-powered developer tasks (including Python workflows) and refresh GitHub templates: [#2034](https://github.com/dartsim/dart/pull/2034), [#2039](https://github.com/dartsim/dart/pull/2039)
+  - Add gz-physics integration tests to CI to guard the public plugin: [#2000](https://github.com/dartsim/dart/pull/2000)
 
 ### [DART 6.15.0 (2024-11-15)](https://github.com/dartsim/dart/milestone/77?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
-
-* Build
-  * Added ImGui 1.91.5 support: [#1872](https://github.com/dartsim/dart/pull/1872)
-  * Added nlopt 2.9.0 support: [#1875](https://github.com/dartsim/dart/pull/1875)
-  * Fixed imgui is not added as transitive dependency: [#1877](https://github.com/dartsim/dart/pull/1877)
+- Build
+  - Added ImGui 1.91.5 support: [#1872](https://github.com/dartsim/dart/pull/1872)
+  - Added nlopt 2.9.0 support: [#1875](https://github.com/dartsim/dart/pull/1875)
+  - Fixed imgui is not added as transitive dependency: [#1877](https://github.com/dartsim/dart/pull/1877)
 
 ### [DART 6.14.5 (2024-09-08)](https://github.com/dartsim/dart/milestone/82?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
-
-* Fixed missing parentheses in config.hpp: [#1838](https://github.com/dartsim/dart/pull/1838)
-* Allowed negative scale for MeshShape: [#1841](https://github.com/dartsim/dart/pull/1841)
+- Fixed missing parentheses in config.hpp: [#1838](https://github.com/dartsim/dart/pull/1838)
+- Allowed negative scale for MeshShape: [#1841](https://github.com/dartsim/dart/pull/1841)
 
 ### [DART 6.14.4 (2024-07-06)](https://github.com/dartsim/dart/milestone/81?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
-
-* Fixed GLUT dependency handling on Windows: [#1827](https://github.com/dartsim/dart/pull/1827)
+- Fixed GLUT dependency handling on Windows: [#1827](https://github.com/dartsim/dart/pull/1827)
 
 ### [DART 6.14.3 (2024-07-05)](https://github.com/dartsim/dart/milestone/80?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
-
-* Changed the default CMake option to DART_ENABLE_SIMD=OFF: [#1825](https://github.com/dartsim/dart/pull/1825)
+- Changed the default CMake option to DART_ENABLE_SIMD=OFF: [#1825](https://github.com/dartsim/dart/pull/1825)
 
 ### [DART 6.14.2 (2024-06-28)](https://github.com/dartsim/dart/milestone/79?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
-
-* Fixed version definitions: [#1820](https://github.com/dartsim/dart/pull/1820)
+- Fixed version definitions: [#1820](https://github.com/dartsim/dart/pull/1820)
 
 ### [DART 6.14.2 (2024-06-26)](https://github.com/dartsim/dart/milestone/78?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
-
-* Included CTest for BUILD_TESTING option: [#1819](https://github.com/dartsim/dart/pull/1819)
+- Included CTest for BUILD_TESTING option: [#1819](https://github.com/dartsim/dart/pull/1819)
 
 ### [DART 6.14.0 (2024-06-24)](https://github.com/dartsim/dart/milestone/73?closed=1)
 
 This release is mostly a maintenance update, including various CI updates and build fixes for recent development environment toolsets and dependencies.
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS / GCC 11.4 / x86_64
+    - Ubuntu 24.04 LTS / GCC 13.2 / x86_64
+  - macOS 14 / Clang 15 / arm64
+  - Windows / MSVC 19.40 / x86_64
 
-  * Linux
-    * Ubuntu 22.04 LTS / GCC 11.4 / x86_64
-    * Ubuntu 24.04 LTS / GCC 13.2 / x86_64
-  * macOS 14 / Clang 15 / arm64
-  * Windows / MSVC 19.40 / x86_64
+- Breaking Changes
+  - Removed planning component
 
-* Breaking Changes
+- Build
+  - Added Pixi support
 
-  * Removed planning component
+- General
+  - Added profile interface with Tracy backend support
+  - Added benchmark setup, including boxes and kinematics benchmarks
 
-* Build
-
-  * Added Pixi support
-
-* General
-
-  * Added profile interface with Tracy backend support
-  * Added benchmark setup, including boxes and kinematics benchmarks
-
-* Dynamics
-
-  * Allowed specifying mimic joint properties per DoF: [#1752](https://github.com/dartsim/dart/pull/1752)
-  * [Improved performance in constructing LCP problem](https://github.com/dartsim/dart/commit/76d8fe1a72f6925c06f64eea3d2cd135234b59de)
+- Dynamics
+  - Allowed specifying mimic joint properties per DoF: [#1752](https://github.com/dartsim/dart/pull/1752)
+  - [Improved performance in constructing LCP problem](https://github.com/dartsim/dart/commit/76d8fe1a72f6925c06f64eea3d2cd135234b59de)
 
 ### [DART 6.13.2 (2024-03-17)](https://github.com/dartsim/dart/milestone/75?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Linux
+    - Ubuntu 22.04 LTS on amd64 / GCC 11.2 / amd64
+    - Ubuntu 24.04 LTS on amd64 / GCC 13.2 / amd64
+  - macOS 12 (Monterey) / AppleClang 14 / amd64
+  - Windows / MSVC 19.38 / amd64
 
-  * Linux
-    * Ubuntu 22.04 LTS on amd64 / GCC 11.2 / amd64
-    * Ubuntu 24.04 LTS on amd64 / GCC 13.2 / amd64
-  * macOS 12 (Monterey) / AppleClang 14 / amd64
-  * Windows / MSVC 19.38 / amd64
-
-* Build
-
-  * Fixed build with GCC >= 13: [#1793](https://github.com/dartsim/dart/pull/1793)
+- Build
+  - Fixed build with GCC >= 13: [#1793](https://github.com/dartsim/dart/pull/1793)
 
 ### [DART 6.13.1 (2024-01-04)](https://github.com/dartsim/dart/milestone/74?closed=1)
 
-* Tested Platforms
+- Tested Platforms
+  - Ubuntu Focal on amd64 / GCC 9.4 / amd64
+  - Ubuntu Jammy on amd64 / GCC 11.3 / amd64
+  - macOS 12 (Monterey) / Clang 14 / amd64
+  - Windows / MSVC 19.37 / amd64
 
-  * Ubuntu Focal on amd64 / GCC 9.4 / amd64
-  * Ubuntu Jammy on amd64 / GCC 11.3 / amd64
-  * macOS 12 (Monterey) / Clang 14 / amd64
-  * Windows / MSVC 19.37 / amd64
+- Build
+  - Fixed build with urdfdom 4.0.0: [#1779](https://github.com/dartsim/dart/pull/1779)
+  - Fixed invalid array access in moving skeleton subtree: [#1778](https://github.com/dartsim/dart/pull/1778)
 
-* Build
-
-  * Fixed build with urdfdom 4.0.0: [#1779](https://github.com/dartsim/dart/pull/1779)
-  * Fixed invalid array access in moving skeleton subtree: [#1778](https://github.com/dartsim/dart/pull/1778)
-
-* Dynamics
-
-  * Fixed joint not recovering after reaching position limits in servo mode: [#1774](https://github.com/dartsim/dart/pull/1774)
+- Dynamics
+  - Fixed joint not recovering after reaching position limits in servo mode: [#1774](https://github.com/dartsim/dart/pull/1774)
 
 ### [DART 6.13.0 (2022-12-31)](https://github.com/dartsim/dart/milestone/69?closed=1)
 
-* Supported Platforms
+- Supported Platforms
+  - Ubuntu Focal on amd64 / GCC 9.3 / amd64
+  - Ubuntu Jammy on amd64 / GCC 11.2 / amd64
+  - macOS 12 (Monterey) / Clang 13 / amd64
+  - Windows / Microsoft Visual Studio 2019 / amd64
 
-  * Ubuntu Focal on amd64 / GCC 9.3 / amd64
-  * Ubuntu Jammy on amd64 / GCC 11.2 / amd64
-  * macOS 12 (Monterey) / Clang 13 / amd64
-  * Windows / Microsoft Visual Studio 2019 / amd64
+- Dependency
+  - Added required dependencies: fmt
+  - Added optional dependencies: spdlog
+  - Removed required dependencies: Boost
 
-* Dependency
+- Build
+  - Dropped supporting FCL < 0.5: [#1647](https://github.com/dartsim/dart/pull/1647)
 
-  * Added required dependencies: fmt
-  * Added optional dependencies: spdlog
-  * Removed required dependencies: Boost
+- Common
+  - Added Castable class: [#1634](https://github.com/dartsim/dart/pull/1634)
+  - Added spdlog support as underlying logging framework: [#1633](https://github.com/dartsim/dart/pull/1633)
+  - Added custom memory allocators: [#1636](https://github.com/dartsim/dart/pull/1636), [#1637](https://github.com/dartsim/dart/pull/1637), [#1639](https://github.com/dartsim/dart/pull/1639), [#1645](https://github.com/dartsim/dart/pull/1645), [#1646](https://github.com/dartsim/dart/pull/1646)
+  - Added Stopwatch class to replace Timer: [#1638](https://github.com/dartsim/dart/pull/1638)
+  - Removed Boost dependency: [#1648](https://github.com/dartsim/dart/pull/1648), [#1651](https://github.com/dartsim/dart/pull/1651)
 
-* Build
+- Collision Detection
+  - Updated to use convex mesh of Bullet when possible: [#1664](https://github.com/dartsim/dart/pull/1664), [#1667](https://github.com/dartsim/dart/pull/1667)
 
-  * Dropped supporting FCL < 0.5: [#1647](https://github.com/dartsim/dart/pull/1647)
+- Dynamics
+  - Fixed setResitutionCoeff() calling setFrictionCoeff(): [#1677](https://github.com/dartsim/dart/pull/1677)
+  - Made inertial warnings optional when setting tensor: [#1672](https://github.com/dartsim/dart/pull/1672)
+  - Added deep copy for shapes: [#1612](https://github.com/dartsim/dart/pull/1612)
+  - Added iterator methods to container-like classes: [#1644](https://github.com/dartsim/dart/pull/1644)
+  - Fixed grouping of constraints: [#1624](https://github.com/dartsim/dart/pull/1624), [#1628](https://github.com/dartsim/dart/pull/1628)
+  - Fixed issue with removing skeletons without shapes: [#1625](https://github.com/dartsim/dart/pull/1625)
+  - Added support for custom contact surface handlers: [#1626](https://github.com/dartsim/dart/pull/1626)
 
-* Common
-
-  * Added Castable class: [#1634](https://github.com/dartsim/dart/pull/1634)
-  * Added spdlog support as underlying logging framework: [#1633](https://github.com/dartsim/dart/pull/1633)
-  * Added custom memory allocators: [#1636](https://github.com/dartsim/dart/pull/1636), [#1637](https://github.com/dartsim/dart/pull/1637), [#1639](https://github.com/dartsim/dart/pull/1639), [#1645](https://github.com/dartsim/dart/pull/1645), [#1646](https://github.com/dartsim/dart/pull/1646)
-  * Added Stopwatch class to replace Timer: [#1638](https://github.com/dartsim/dart/pull/1638)
-  * Removed Boost dependency: [#1648](https://github.com/dartsim/dart/pull/1648), [#1651](https://github.com/dartsim/dart/pull/1651)
-
-* Collision Detection
-
-  * Updated to use convex mesh of Bullet when possible: [#1664](https://github.com/dartsim/dart/pull/1664), [#1667](https://github.com/dartsim/dart/pull/1667)
-
-* Dynamics
-
-  * Fixed setResitutionCoeff() calling setFrictionCoeff(): [#1677](https://github.com/dartsim/dart/pull/1677)
-  * Made inertial warnings optional when setting tensor: [#1672](https://github.com/dartsim/dart/pull/1672)
-  * Added deep copy for shapes: [#1612](https://github.com/dartsim/dart/pull/1612)
-  * Added iterator methods to container-like classes: [#1644](https://github.com/dartsim/dart/pull/1644)
-  * Fixed grouping of constraints: [#1624](https://github.com/dartsim/dart/pull/1624), [#1628](https://github.com/dartsim/dart/pull/1628)
-  * Fixed issue with removing skeletons without shapes: [#1625](https://github.com/dartsim/dart/pull/1625)
-  * Added support for custom contact surface handlers: [#1626](https://github.com/dartsim/dart/pull/1626)
-
-* GUI
-
-  * Fixed depth testing for transparent objects: [#1643](https://github.com/dartsim/dart/pull/1643)
-  * Added depth rendering mode: [#1652](https://github.com/dartsim/dart/pull/1652)
+- GUI
+  - Fixed depth testing for transparent objects: [#1643](https://github.com/dartsim/dart/pull/1643)
+  - Added depth rendering mode: [#1652](https://github.com/dartsim/dart/pull/1652)
 
 ### [DART 6.12.2 (2022-07-31)](https://github.com/dartsim/dart/milestone/72?closed=1)
 
-* Build
-
-  * Fixed build with urdfdom 3.1.0 on Windows: [#1675](https://github.com/dartsim/dart/pull/1675)
+- Build
+  - Fixed build with urdfdom 3.1.0 on Windows: [#1675](https://github.com/dartsim/dart/pull/1675)
 
 ### [DART 6.12.1 (2021-11-04)](https://github.com/dartsim/dart/milestone/71?closed=1)
 
-* Build
+- Build
+  - Fixed bullet header include: [#1620](https://github.com/dartsim/dart/pull/1620)
 
-  * Fixed bullet header include: [#1620](https://github.com/dartsim/dart/pull/1620)
-
-* dartpy
-
-  * Added Python bindings for Joint::getWrenchTo{Child|Parent}BodyNode: [#1621](https://github.com/dartsim/dart/pull/1621)
+- dartpy
+  - Added Python bindings for Joint::getWrenchTo{Child|Parent}BodyNode: [#1621](https://github.com/dartsim/dart/pull/1621)
 
 ### [DART 6.12.0 (2021-11-01)](https://github.com/dartsim/dart/milestone/66?closed=1)
 
-* API Breaking Changes
+- API Breaking Changes
+  - DART 6.12.0 and later require compilers that support C++17: [#1600](https://github.com/dartsim/dart/pull/1600)
+    - Increased minimum CMake version to 3.10.2
+    - Increased minimum compiler versions to GCC 7.3.0, Clang 6.0, MSVC 16.0
+    - Dropped Ubuntu Xenial (16.04 LTS) support
 
-  * DART 6.12.0 and later require compilers that support C++17: [#1600](https://github.com/dartsim/dart/pull/1600)
-    * Increased minimum CMake version to 3.10.2
-    * Increased minimum compiler versions to GCC 7.3.0, Clang 6.0, MSVC 16.0
-    * Dropped Ubuntu Xenial (16.04 LTS) support
+- Build
+  - Remove DART_BUILD_DARTPY option: [#1600](https://github.com/dartsim/dart/pull/1600)
 
-* Build
+- Dynamics
+  - Added joint force/torque getter: [#1616](https://github.com/dartsim/dart/pull/1616)
 
-  * Remove DART_BUILD_DARTPY option: [#1600](https://github.com/dartsim/dart/pull/1600)
+- Parsers
+  - Added default options to DartLoader for missing properties in URDF files: [#1605](https://github.com/dartsim/dart/pull/1605)
+  - Allowed SdfParser to set default root joint type: [#1617](https://github.com/dartsim/dart/pull/1617)
 
-* Dynamics
+- GUI
+  - Updated ImGui to 1.84.2: [#1608](https://github.com/dartsim/dart/pull/1608)
 
-  * Added joint force/torque getter: [#1616](https://github.com/dartsim/dart/pull/1616)
-
-* Parsers
-
-  * Added default options to DartLoader for missing properties in URDF files: [#1605](https://github.com/dartsim/dart/pull/1605)
-  * Allowed SdfParser to set default root joint type: [#1617](https://github.com/dartsim/dart/pull/1617)
-
-* GUI
-
-  * Updated ImGui to 1.84.2: [#1608](https://github.com/dartsim/dart/pull/1608)
-
-* dartpy
-
-  * Added Python bindings for ResourceRetriever and SdfParser: [#1610](https://github.com/dartsim/dart/pull/1610)
+- dartpy
+  - Added Python bindings for ResourceRetriever and SdfParser: [#1610](https://github.com/dartsim/dart/pull/1610)
 
 ### [DART 6.11.2 (2021-10-29)](https://github.com/dartsim/dart/milestone/68?closed=1)
 
-* dartpy
-
-  * Added Python binding for global lighting mode setting: [#1615](https://github.com/dartsim/dart/pull/1615)
+- dartpy
+  - Added Python binding for global lighting mode setting: [#1615](https://github.com/dartsim/dart/pull/1615)
 
 ### [DART 6.11.1 (2021-08-23)](https://github.com/dartsim/dart/milestone/67?closed=1)
 
-* Dynamics
-
-  * Fixed incorrect LCP construction in JointConstraint for multi-DOFs joints: [#1597](https://github.com/dartsim/dart/pull/1597)
+- Dynamics
+  - Fixed incorrect LCP construction in JointConstraint for multi-DOFs joints: [#1597](https://github.com/dartsim/dart/pull/1597)
 
 ### [DART 6.11.0 (2021-07-15)](https://github.com/dartsim/dart/milestone/64?closed=1)
 
-* Math
+- Math
+  - Added `Mesh`, `TriMesh`, and `Icosphere` classes: [#1579](https://github.com/dartsim/dart/pull/1579)
 
-  * Added `Mesh`, `TriMesh`, and `Icosphere` classes: [#1579](https://github.com/dartsim/dart/pull/1579)
+- Collision
+  - Fixed incorrect group-group collision checking for BulletCollisionDetector: [#1585](https://github.com/dartsim/dart/pull/1585), [#717](https://github.com/dartsim/dart/issues/717)
 
-* Collision
+- Dynamics
+  - Fixed servo motor doesn't respect joint position limits: [#1587](https://github.com/dartsim/dart/pull/1587)
 
-  * Fixed incorrect group-group collision checking for BulletCollisionDetector: [#1585](https://github.com/dartsim/dart/pull/1585), [#717](https://github.com/dartsim/dart/issues/717)
+- GUI
+  - Fixed incorrect MultiSphereConvexHull rendering: [#1579](https://github.com/dartsim/dart/pull/1579)
+  - Use GLVND over the legacy OpenGL libraries: [#1584](https://github.com/dartsim/dart/pull/1584)
 
-* Dynamics
-
-  * Fixed servo motor doesn't respect joint position limits: [#1587](https://github.com/dartsim/dart/pull/1587)
-
-* GUI
-
-  * Fixed incorrect MultiSphereConvexHull rendering: [#1579](https://github.com/dartsim/dart/pull/1579)
-  * Use GLVND over the legacy OpenGL libraries: [#1584](https://github.com/dartsim/dart/pull/1584)
-
-* Build and testing
-
-  * Add DART_ prefix to macros to avoid potential conflicts: [#1586](https://github.com/dartsim/dart/pull/1586)
+- Build and testing
+  - Add DART\_ prefix to macros to avoid potential conflicts: [#1586](https://github.com/dartsim/dart/pull/1586)
 
 ### [DART 6.10.1 (2021-04-19)](https://github.com/dartsim/dart/milestone/65?closed=1)
 
-* Dynamics
+- Dynamics
+  - Fixed inertia calculation of CapsuleShape: [#1561](https://github.com/dartsim/dart/pull/1561)
 
-  * Fixed inertia calculation of CapsuleShape: [#1561](https://github.com/dartsim/dart/pull/1561)
+- GUI
+  - Changed to protect OpenGL attributes shared by ImGui and OSG: [#1558](https://github.com/dartsim/dart/pull/1558)
+  - Changed to set backface culling by default: [#1559](https://github.com/dartsim/dart/pull/1559)
 
-* GUI
-
-  * Changed to protect OpenGL attributes shared by ImGui and OSG: [#1558](https://github.com/dartsim/dart/pull/1558)
-  * Changed to set backface culling by default: [#1559](https://github.com/dartsim/dart/pull/1559)
-
-* dartpy
-
-  * Added Python binding for BodyNode::getBodyForce(): [#1563](https://github.com/dartsim/dart/pull/1563)
+- dartpy
+  - Added Python binding for BodyNode::getBodyForce(): [#1563](https://github.com/dartsim/dart/pull/1563)
 
 ### [DART 6.10.0 (2021-04-09)](https://github.com/dartsim/dart/milestone/58?closed=1)
 
-* Common
+- Common
+  - Removed use of boost::filesystem in public APIs: [#1417](https://github.com/dartsim/dart/pull/1417)
+  - Changed Signal to remove connection when they're being disconnected: [#1462](https://github.com/dartsim/dart/pull/1462)
 
-  * Removed use of boost::filesystem in public APIs: [#1417](https://github.com/dartsim/dart/pull/1417)
-  * Changed Signal to remove connection when they're being disconnected: [#1462](https://github.com/dartsim/dart/pull/1462)
+- Collision
+  - Added ConeShape support for FCLCollisionDetector: [#1447](https://github.com/dartsim/dart/pull/1447)
+  - Fixed segfault from raycast when no ray hit: [#1461](https://github.com/dartsim/dart/pull/1461)
+  - Added PyramidShape class: [#1466](https://github.com/dartsim/dart/pull/1466)
 
-* Collision
+- Kinematics
+  - Added IkFast parameter accessors to IkFast class: [#1396](https://github.com/dartsim/dart/pull/1396)
+  - Changed IkFast to wrap IK solutions into the joint limits for RevoluteJoint: [#1452](https://github.com/dartsim/dart/pull/1452)
+  - Added option to specify reference frame of TaskSpaceRegion: [#1548](https://github.com/dartsim/dart/pull/1548)
 
-  * Added ConeShape support for FCLCollisionDetector: [#1447](https://github.com/dartsim/dart/pull/1447)
-  * Fixed segfault from raycast when no ray hit: [#1461](https://github.com/dartsim/dart/pull/1461)
-  * Added PyramidShape class: [#1466](https://github.com/dartsim/dart/pull/1466)
+- Dynamics
+  - Fixed friction and restitution of individual shapes in a body: [#1369](https://github.com/dartsim/dart/pull/1369)
+  - Fixed soft body simulation when command input is not resetted: [#1372](https://github.com/dartsim/dart/pull/1372)
+  - Added joint velocity limit constraint support: [#1407](https://github.com/dartsim/dart/pull/1407)
+  - Added type property to constrain classes: [#1415](https://github.com/dartsim/dart/pull/1415)
+  - Allowed to set joint rest position out of joint limits: [#1418](https://github.com/dartsim/dart/pull/1418)
+  - Added secondary friction coefficient parameter: [#1424](https://github.com/dartsim/dart/pull/1424)
+  - Allowed to set friction direction per ShapeFrame: [#1427](https://github.com/dartsim/dart/pull/1427)
+  - Fixed incorrect vector resizing in BoxedLcpConstraintSolver: [#1459](https://github.com/dartsim/dart/pull/1459)
+  - Changed to increment BodyNode version when it's being removed from Skeleton: [#1489](https://github.com/dartsim/dart/pull/1489)
+  - Changed to print warning only once from BulletCollisionDetector::collide/distance: [#1546](https://github.com/dartsim/dart/pull/1546)
+  - Added force dependent slip: [#1505](https://github.com/dartsim/dart/pull/1505)
 
-* Kinematics
+- GUI
+  - Fixed memory leaks from dart::gui::osg::Viewer: [#1349](https://github.com/dartsim/dart/pull/1349)
+  - Added point rendering mode to PointCloudShape: [#1351](https://github.com/dartsim/dart/pull/1351), [#1355](https://github.com/dartsim/dart/pull/1355)
+  - Updated ImGui to 1.71: [#1362](https://github.com/dartsim/dart/pull/1362)
+  - Updated ImGui to 1.79: [#1498](https://github.com/dartsim/dart/pull/1498)
+  - Fixed refresh of LineSegmentShapeNode: [#1381](https://github.com/dartsim/dart/pull/1381)
+  - Fixed OSG transparent object sorting: [#1414](https://github.com/dartsim/dart/pull/1414)
+  - Added modifier key support to ImGuiHandler: [#1436](https://github.com/dartsim/dart/pull/1436)
+  - Fixed mixed intrinsic and extrinsic camera parameters in OpenGL projection matrix: [#1485](https://github.com/dartsim/dart/pull/1485)
+  - Enabled mouse middle and right buttons in ImGuiHandler: [#1500](https://github.com/dartsim/dart/pull/1500)
 
-  * Added IkFast parameter accessors to IkFast class: [#1396](https://github.com/dartsim/dart/pull/1396)
-  * Changed IkFast to wrap IK solutions into the joint limits for RevoluteJoint: [#1452](https://github.com/dartsim/dart/pull/1452)
-  * Added option to specify reference frame of TaskSpaceRegion: [#1548](https://github.com/dartsim/dart/pull/1548)
+- Parser
+  - Allowed parsing SDF up to version 1.6: [#1385](https://github.com/dartsim/dart/pull/1385)
+  - Fixed SDF parser not creating dynamics aspect for collision shape: [#1386](https://github.com/dartsim/dart/pull/1386)
+  - Added root joint parsing option in URDF parser: [#1399](https://github.com/dartsim/dart/pull/1399), [#1406](https://github.com/dartsim/dart/pull/1406)
+  - Enabled URDF parser to read visual and collision names: [#1410](https://github.com/dartsim/dart/pull/1410)
+  - Added (experimental) MJCF parser: [#1416](https://github.com/dartsim/dart/pull/1416)
 
-* Dynamics
+- dartpy
+  - Added raycast option and result: [#1343](https://github.com/dartsim/dart/pull/1343)
+  - Added GUI event handler: [#1346](https://github.com/dartsim/dart/pull/1346)
+  - Added shadow technique: [#1348](https://github.com/dartsim/dart/pull/1348)
+  - Added findSolution and solveAndApply to InverseKinematics: [#1358](https://github.com/dartsim/dart/pull/1358)
+  - Added InteractiveFrame and ImGui APIs: [#1359](https://github.com/dartsim/dart/pull/1359)
+  - Added bindings for Joint::getTransformFrom{Parent|Child}BodyNode(): [#1377](https://github.com/dartsim/dart/pull/1377)
+  - Added bindings for BodyNode::getChild{BodyNode|Joint}(): [#1387](https://github.com/dartsim/dart/pull/1387)
+  - Added bindings for Inertia: [#1388](https://github.com/dartsim/dart/pull/1388)
+  - Added bindings for getting all BodyNodes from a Skeleton: [#1397](https://github.com/dartsim/dart/pull/1397)
+  - Added bindings for background color support in osg viewer: [#1398](https://github.com/dartsim/dart/pull/1398)
+  - Added bindings for BallJoint::convertToPositions(): [#1408](https://github.com/dartsim/dart/pull/1408)
+  - Fixed typos in Skeleton: [#1392](https://github.com/dartsim/dart/pull/1392)
+  - Fixed enabling drag and drop for InteractiveFrame: [#1432](https://github.com/dartsim/dart/pull/1432)
+  - Added bindings for pointcloud and contact retrieval: [#1455](https://github.com/dartsim/dart/pull/1455)
+  - Fixed TypeError from dartpy.dynamics.Node.getBodyNodePtr(): [#1463](https://github.com/dartsim/dart/pull/1463)
+  - Added pybind/eigen.h to DistanceResult.cpp for read/write of eigen types: [#1480](https://github.com/dartsim/dart/pull/1480)
+  - Added bindings for adding ShapeFrames to CollisionGroup: [#1490](https://github.com/dartsim/dart/pull/1490)
+  - Changed dartpy install command to make install-dartpy: [#1503](https://github.com/dartsim/dart/pull/1503)
+  - Added bindings for CollisionFilter, CollisionGroup, and Node: [#1545](https://github.com/dartsim/dart/pull/1545)
+  - Added bindings for TaskSpaceRegion: [#1550](https://github.com/dartsim/dart/pull/1550)
 
-  * Fixed friction and restitution of individual shapes in a body: [#1369](https://github.com/dartsim/dart/pull/1369)
-  * Fixed soft body simulation when command input is not resetted: [#1372](https://github.com/dartsim/dart/pull/1372)
-  * Added joint velocity limit constraint support: [#1407](https://github.com/dartsim/dart/pull/1407)
-  * Added type property to constrain classes: [#1415](https://github.com/dartsim/dart/pull/1415)
-  * Allowed to set joint rest position out of joint limits: [#1418](https://github.com/dartsim/dart/pull/1418)
-  * Added secondary friction coefficient parameter: [#1424](https://github.com/dartsim/dart/pull/1424)
-  * Allowed to set friction direction per ShapeFrame: [#1427](https://github.com/dartsim/dart/pull/1427)
-  * Fixed incorrect vector resizing in BoxedLcpConstraintSolver: [#1459](https://github.com/dartsim/dart/pull/1459)
-  * Changed to increment BodyNode version when it's being removed from Skeleton: [#1489](https://github.com/dartsim/dart/pull/1489)
-  * Changed to print warning only once from BulletCollisionDetector::collide/distance: [#1546](https://github.com/dartsim/dart/pull/1546)
-  * Added force dependent slip: [#1505](https://github.com/dartsim/dart/pull/1505)
+- Build and testing
+  - Fixed compiler warnings from GCC 9.1: [#1366](https://github.com/dartsim/dart/pull/1366)
+  - Replaced M_PI with dart::math::pi: [#1367](https://github.com/dartsim/dart/pull/1367)
+  - Enabled octomap support on macOS: [#1078](https://github.com/dartsim/dart/pull/1078)
+  - Removed dependency on Boost::regex: [#1412](https://github.com/dartsim/dart/pull/1412)
+  - Added support new if() IN_LIST operator in DARTConfig.cmake: [#1434](https://github.com/dartsim/dart/pull/1434)
+  - Updated Findfcl.cmake to support FCL 0.6: [#1441](https://github.com/dartsim/dart/pull/1441)
+  - Added gtest macros for Eigen object comparisons: [#1443](https://github.com/dartsim/dart/pull/1443)
+  - Removed gccfilter: [#1464](https://github.com/dartsim/dart/pull/1464)
+  - Allowed to set CMAKE_INSTALL_PREFIX on Windows: [#1478](https://github.com/dartsim/dart/pull/1478)
+  - Enforced to use OpenSceneGraph 3.7.0 or greater on macOS Catalina: [#1479](https://github.com/dartsim/dart/pull/1479)
+  - Fixed compatibility with clang-cl: [#1509](https://github.com/dartsim/dart/pull/1509)
+  - Fixed MSVC linking for assimp and fcl: [#1510](https://github.com/dartsim/dart/pull/1510)
+  - Fixed AspectWithState-relate compile error on Windows: [#1528](https://github.com/dartsim/dart/pull/1528)
+  - Made `dart.pc` relocatable: [#1529](https://github.com/dartsim/dart/pull/1529)
+  - Added CI for multiple Linux platforms: arm64 and ppc64le: [#1531](https://github.com/dartsim/dart/pull/1531)
+  - Fixed Aspect/Composite-relate tests on Windows/MSVC: [#1541](https://github.com/dartsim/dart/pull/1541), [#1542](https://github.com/dartsim/dart/pull/1542)
+  - Added `DART_SKIP_<dep>`\_advanced option: [#1529](https://github.com/dartsim/dart/pull/1529)
+  - Replaced OpenGL dependency variables with targets: [#1552](https://github.com/dartsim/dart/pull/1552)
 
-* GUI
-
-  * Fixed memory leaks from dart::gui::osg::Viewer: [#1349](https://github.com/dartsim/dart/pull/1349)
-  * Added point rendering mode to PointCloudShape: [#1351](https://github.com/dartsim/dart/pull/1351), [#1355](https://github.com/dartsim/dart/pull/1355)
-  * Updated ImGui to 1.71: [#1362](https://github.com/dartsim/dart/pull/1362)
-  * Updated ImGui to 1.79: [#1498](https://github.com/dartsim/dart/pull/1498)
-  * Fixed refresh of LineSegmentShapeNode: [#1381](https://github.com/dartsim/dart/pull/1381)
-  * Fixed OSG transparent object sorting: [#1414](https://github.com/dartsim/dart/pull/1414)
-  * Added modifier key support to ImGuiHandler: [#1436](https://github.com/dartsim/dart/pull/1436)
-  * Fixed mixed intrinsic and extrinsic camera parameters in OpenGL projection matrix: [#1485](https://github.com/dartsim/dart/pull/1485)
-  * Enabled mouse middle and right buttons in ImGuiHandler: [#1500](https://github.com/dartsim/dart/pull/1500)
-
-* Parser
-
-  * Allowed parsing SDF up to version 1.6: [#1385](https://github.com/dartsim/dart/pull/1385)
-  * Fixed SDF parser not creating dynamics aspect for collision shape: [#1386](https://github.com/dartsim/dart/pull/1386)
-  * Added root joint parsing option in URDF parser: [#1399](https://github.com/dartsim/dart/pull/1399), [#1406](https://github.com/dartsim/dart/pull/1406)
-  * Enabled URDF parser to read visual and collision names: [#1410](https://github.com/dartsim/dart/pull/1410)
-  * Added (experimental) MJCF parser: [#1416](https://github.com/dartsim/dart/pull/1416)
-
-* dartpy
-
-  * Added raycast option and result: [#1343](https://github.com/dartsim/dart/pull/1343)
-  * Added GUI event handler: [#1346](https://github.com/dartsim/dart/pull/1346)
-  * Added shadow technique: [#1348](https://github.com/dartsim/dart/pull/1348)
-  * Added findSolution and solveAndApply to InverseKinematics: [#1358](https://github.com/dartsim/dart/pull/1358)
-  * Added InteractiveFrame and ImGui APIs: [#1359](https://github.com/dartsim/dart/pull/1359)
-  * Added bindings for Joint::getTransformFrom{Parent|Child}BodyNode(): [#1377](https://github.com/dartsim/dart/pull/1377)
-  * Added bindings for BodyNode::getChild{BodyNode|Joint}(): [#1387](https://github.com/dartsim/dart/pull/1387)
-  * Added bindings for Inertia: [#1388](https://github.com/dartsim/dart/pull/1388)
-  * Added bindings for getting all BodyNodes from a Skeleton: [#1397](https://github.com/dartsim/dart/pull/1397)
-  * Added bindings for background color support in osg viewer: [#1398](https://github.com/dartsim/dart/pull/1398)
-  * Added bindings for BallJoint::convertToPositions(): [#1408](https://github.com/dartsim/dart/pull/1408)
-  * Fixed typos in Skeleton: [#1392](https://github.com/dartsim/dart/pull/1392)
-  * Fixed enabling drag and drop for InteractiveFrame: [#1432](https://github.com/dartsim/dart/pull/1432)
-  * Added bindings for pointcloud and contact retrieval: [#1455](https://github.com/dartsim/dart/pull/1455)
-  * Fixed TypeError from dartpy.dynamics.Node.getBodyNodePtr(): [#1463](https://github.com/dartsim/dart/pull/1463)
-  * Added pybind/eigen.h to DistanceResult.cpp for read/write of eigen types: [#1480](https://github.com/dartsim/dart/pull/1480)
-  * Added bindings for adding ShapeFrames to CollisionGroup: [#1490](https://github.com/dartsim/dart/pull/1490)
-  * Changed dartpy install command to make install-dartpy: [#1503](https://github.com/dartsim/dart/pull/1503)
-  * Added bindings for CollisionFilter, CollisionGroup, and Node: [#1545](https://github.com/dartsim/dart/pull/1545)
-  * Added bindings for TaskSpaceRegion: [#1550](https://github.com/dartsim/dart/pull/1550)
-
-* Build and testing
-
-  * Fixed compiler warnings from GCC 9.1: [#1366](https://github.com/dartsim/dart/pull/1366)
-  * Replaced M_PI with dart::math::pi: [#1367](https://github.com/dartsim/dart/pull/1367)
-  * Enabled octomap support on macOS: [#1078](https://github.com/dartsim/dart/pull/1078)
-  * Removed dependency on Boost::regex: [#1412](https://github.com/dartsim/dart/pull/1412)
-  * Added support new if() IN_LIST operator in DARTConfig.cmake: [#1434](https://github.com/dartsim/dart/pull/1434)
-  * Updated Findfcl.cmake to support FCL 0.6: [#1441](https://github.com/dartsim/dart/pull/1441)
-  * Added gtest macros for Eigen object comparisons: [#1443](https://github.com/dartsim/dart/pull/1443)
-  * Removed gccfilter: [#1464](https://github.com/dartsim/dart/pull/1464)
-  * Allowed to set CMAKE_INSTALL_PREFIX on Windows: [#1478](https://github.com/dartsim/dart/pull/1478)
-  * Enforced to use OpenSceneGraph 3.7.0 or greater on macOS Catalina: [#1479](https://github.com/dartsim/dart/pull/1479)
-  * Fixed compatibility with clang-cl: [#1509](https://github.com/dartsim/dart/pull/1509)
-  * Fixed MSVC linking for assimp and fcl: [#1510](https://github.com/dartsim/dart/pull/1510)
-  * Fixed AspectWithState-relate compile error on Windows: [#1528](https://github.com/dartsim/dart/pull/1528)
-  * Made `dart.pc` relocatable: [#1529](https://github.com/dartsim/dart/pull/1529)
-  * Added CI for multiple Linux platforms: arm64 and ppc64le: [#1531](https://github.com/dartsim/dart/pull/1531)
-  * Fixed Aspect/Composite-relate tests on Windows/MSVC: [#1541](https://github.com/dartsim/dart/pull/1541), [#1542](https://github.com/dartsim/dart/pull/1542)
-  * Added `DART_SKIP_<dep>`_advanced option: [#1529](https://github.com/dartsim/dart/pull/1529)
-  * Replaced OpenGL dependency variables with targets: [#1552](https://github.com/dartsim/dart/pull/1552)
-
-* Documentation
-
-  * Updated tutorial documentation and code to reflect new APIs: [#1481](https://github.com/dartsim/dart/pull/1481)
+- Documentation
+  - Updated tutorial documentation and code to reflect new APIs: [#1481](https://github.com/dartsim/dart/pull/1481)
 
 ### [DART 6.9.5 (2020-10-17)](https://github.com/dartsim/dart/milestone/63?closed=1)
 
-* Optimization
-
-  * Added Ipopt >= 3.13 support: [#1506](https://github.com/dartsim/dart/pull/1506)
+- Optimization
+  - Added Ipopt >= 3.13 support: [#1506](https://github.com/dartsim/dart/pull/1506)
 
 ### [DART 6.9.4 (2020-08-30)](https://github.com/dartsim/dart/milestone/62?closed=1)
 
-* Build
-
-  * Added support new if() IN_LIST operator in DARTConfig.cmake (6.9 backport): [#1494](https://github.com/dartsim/dart/pull/1494)
+- Build
+  - Added support new if() IN_LIST operator in DARTConfig.cmake (6.9 backport): [#1494](https://github.com/dartsim/dart/pull/1494)
 
 ### [DART 6.9.3 (2020-08-26)](https://github.com/dartsim/dart/milestone/61?closed=1)
 
-* Dynamics
-
-  * Changed to update the Properties version of a BodyNode when moved to a new Skeleton: [#1445](https://github.com/dartsim/dart/pull/1445)
-  * Fixed incorrect implicit joint damping/spring force computation in inverse dynamics: [#1451](https://github.com/dartsim/dart/pull/1451)
+- Dynamics
+  - Changed to update the Properties version of a BodyNode when moved to a new Skeleton: [#1445](https://github.com/dartsim/dart/pull/1445)
+  - Fixed incorrect implicit joint damping/spring force computation in inverse dynamics: [#1451](https://github.com/dartsim/dart/pull/1451)
 
 ### [DART 6.9.2 (2019-08-16)](https://github.com/dartsim/dart/milestone/60?closed=1)
 
-* Dynamics
-
-  * Allowed constraint force mixing > 1: [#1371](https://github.com/dartsim/dart/pull/1371)
+- Dynamics
+  - Allowed constraint force mixing > 1: [#1371](https://github.com/dartsim/dart/pull/1371)
 
 ### [DART 6.9.1 (2019-06-06)](https://github.com/dartsim/dart/milestone/59?closed=1)
 
-* Collision
+- Collision
+  - Added default constructor to RayHit: [#1345](https://github.com/dartsim/dart/pull/1345)
 
-  * Added default constructor to RayHit: [#1345](https://github.com/dartsim/dart/pull/1345)
-
-* dartpy
-
-  * Updated build scripts for uploading dartpy to PyPI: [#1341](https://github.com/dartsim/dart/pull/1341)
+- dartpy
+  - Updated build scripts for uploading dartpy to PyPI: [#1341](https://github.com/dartsim/dart/pull/1341)
 
 ### [DART 6.9.0 (2019-05-26)](https://github.com/dartsim/dart/milestone/52?closed=1)
 
-* API Breaking Changes
+- API Breaking Changes
+  - DART 6.9.0 and later require compilers that support C++14.
 
-  * DART 6.9.0 and later require compilers that support C++14.
+- Common
+  - Deprecated custom make_unique in favor of std::make_unique: [#1317](https://github.com/dartsim/dart/pull/1317)
 
-* Common
+- Collision Detection
+  - Added raycast query to BulletCollisionDetector: [#1309](https://github.com/dartsim/dart/pull/1309)
 
-  * Deprecated custom make_unique in favor of std::make_unique: [#1317](https://github.com/dartsim/dart/pull/1317)
+- Dynamics
+  - Added safeguard for accessing Assimp color: [#1313](https://github.com/dartsim/dart/pull/1313)
 
-* Collision Detection
+- Parser
+  - Changed URDF parser to use URDF material color when specified: [#1295](https://github.com/dartsim/dart/pull/1295)
 
-  * Added raycast query to BulletCollisionDetector: [#1309](https://github.com/dartsim/dart/pull/1309)
+- GUI
+  - Added heightmap support to OSG renderer: [#1293](https://github.com/dartsim/dart/pull/1293)
+  - Improved voxel grid and point cloud rendering performance: [#1294](https://github.com/dartsim/dart/pull/1294)
+  - Fixed incorrect alpha value update of InteractiveFrame: [#1297](https://github.com/dartsim/dart/pull/1297)
+  - Fixed dereferencing a dangling pointer in WorldNode: [#1311](https://github.com/dartsim/dart/pull/1311)
+  - Removed warning of ImGuiViewer + OSG shadow: [#1312](https://github.com/dartsim/dart/pull/1312)
+  - Added shape type and color options to PointCloudShape: [#1314](https://github.com/dartsim/dart/pull/1314), [#1316](https://github.com/dartsim/dart/pull/1316)
+  - Fixed incorrect transparency of MeshShape for MATERIAL_COLOR mode: [#1315](https://github.com/dartsim/dart/pull/1315)
+  - Fixed incorrect PointCloudShape transparency: [#1330](https://github.com/dartsim/dart/pull/1330)
+  - Improved voxel rendering by using multiple nodes instead of CompositeShape: [#1334](https://github.com/dartsim/dart/pull/1334)
 
-* Dynamics
+- Examples and Tutorials
+  - Updated examples directory to make dart::gui::osg more accessible: [#1305](https://github.com/dartsim/dart/pull/1305)
 
-  * Added safeguard for accessing Assimp color: [#1313](https://github.com/dartsim/dart/pull/1313)
-
-* Parser
-
-  * Changed URDF parser to use URDF material color when specified: [#1295](https://github.com/dartsim/dart/pull/1295)
-
-* GUI
-
-  * Added heightmap support to OSG renderer: [#1293](https://github.com/dartsim/dart/pull/1293)
-  * Improved voxel grid and point cloud rendering performance: [#1294](https://github.com/dartsim/dart/pull/1294)
-  * Fixed incorrect alpha value update of InteractiveFrame: [#1297](https://github.com/dartsim/dart/pull/1297)
-  * Fixed dereferencing a dangling pointer in WorldNode: [#1311](https://github.com/dartsim/dart/pull/1311)
-  * Removed warning of ImGuiViewer + OSG shadow: [#1312](https://github.com/dartsim/dart/pull/1312)
-  * Added shape type and color options to PointCloudShape: [#1314](https://github.com/dartsim/dart/pull/1314), [#1316](https://github.com/dartsim/dart/pull/1316)
-  * Fixed incorrect transparency of MeshShape for MATERIAL_COLOR mode: [#1315](https://github.com/dartsim/dart/pull/1315)
-  * Fixed incorrect PointCloudShape transparency: [#1330](https://github.com/dartsim/dart/pull/1330)
-  * Improved voxel rendering by using multiple nodes instead of CompositeShape: [#1334](https://github.com/dartsim/dart/pull/1334)
-
-* Examples and Tutorials
-
-  * Updated examples directory to make dart::gui::osg more accessible: [#1305](https://github.com/dartsim/dart/pull/1305)
-
-* dartpy
-
-  * Switched to pybind11: [#1307](https://github.com/dartsim/dart/pull/1307)
-  * Added grid visual: [#1318](https://github.com/dartsim/dart/pull/1318)
-  * Added ReferentialSkeleton, Linkage, and Chain: [#1321](https://github.com/dartsim/dart/pull/1321)
-  * Enabled WorldNode classes to overload virtual functions in Python: [#1322](https://github.com/dartsim/dart/pull/1322)
-  * Added JacobianNode and operational space controller example: [#1323](https://github.com/dartsim/dart/pull/1323)
-  * Removed static create() functions in favor of custom constructors: [#1324](https://github.com/dartsim/dart/pull/1324)
-  * Added optimizer APIs with GradientDescentSolver and NloptSolver: [#1325](https://github.com/dartsim/dart/pull/1325)
-  * Added SimpleFrame: [#1326](https://github.com/dartsim/dart/pull/1326)
-  * Added basic inverse kinematics APIs: [#1327](https://github.com/dartsim/dart/pull/1327)
-  * Added shapes and ShapeFrame aspects: [#1328](https://github.com/dartsim/dart/pull/1328)
-  * Added collision APIs: [#1329](https://github.com/dartsim/dart/pull/1329)
-  * Added DegreeOfFreedom and ShapeNode: [#1332](https://github.com/dartsim/dart/pull/1332)
-  * Added constraint APIs: [#1333](https://github.com/dartsim/dart/pull/1333)
-  * Added BallJoint, RevoluteJoint, joint properties, and chain tutorial (incomplete): [#1335](https://github.com/dartsim/dart/pull/1335)
-  * Added all the joints: [#1337](https://github.com/dartsim/dart/pull/1337)
-  * Added DART, Bullet, Ode collision detectors: [#1339](https://github.com/dartsim/dart/pull/1339)
+- dartpy
+  - Switched to pybind11: [#1307](https://github.com/dartsim/dart/pull/1307)
+  - Added grid visual: [#1318](https://github.com/dartsim/dart/pull/1318)
+  - Added ReferentialSkeleton, Linkage, and Chain: [#1321](https://github.com/dartsim/dart/pull/1321)
+  - Enabled WorldNode classes to overload virtual functions in Python: [#1322](https://github.com/dartsim/dart/pull/1322)
+  - Added JacobianNode and operational space controller example: [#1323](https://github.com/dartsim/dart/pull/1323)
+  - Removed static create() functions in favor of custom constructors: [#1324](https://github.com/dartsim/dart/pull/1324)
+  - Added optimizer APIs with GradientDescentSolver and NloptSolver: [#1325](https://github.com/dartsim/dart/pull/1325)
+  - Added SimpleFrame: [#1326](https://github.com/dartsim/dart/pull/1326)
+  - Added basic inverse kinematics APIs: [#1327](https://github.com/dartsim/dart/pull/1327)
+  - Added shapes and ShapeFrame aspects: [#1328](https://github.com/dartsim/dart/pull/1328)
+  - Added collision APIs: [#1329](https://github.com/dartsim/dart/pull/1329)
+  - Added DegreeOfFreedom and ShapeNode: [#1332](https://github.com/dartsim/dart/pull/1332)
+  - Added constraint APIs: [#1333](https://github.com/dartsim/dart/pull/1333)
+  - Added BallJoint, RevoluteJoint, joint properties, and chain tutorial (incomplete): [#1335](https://github.com/dartsim/dart/pull/1335)
+  - Added all the joints: [#1337](https://github.com/dartsim/dart/pull/1337)
+  - Added DART, Bullet, Ode collision detectors: [#1339](https://github.com/dartsim/dart/pull/1339)
 
 ### [DART 6.8.5 (2019-05-26)](https://github.com/dartsim/dart/milestone/57?closed=1)
 
-* Collision
-
-  * Fixed handling of submeshes in ODE collision detector: [#1336](https://github.com/dartsim/dart/pull/1336)
+- Collision
+  - Fixed handling of submeshes in ODE collision detector: [#1336](https://github.com/dartsim/dart/pull/1336)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
+  - GCC 32-bit: 5.4.0
 
-  * GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
-  * GCC 32-bit: 5.4.0
-
-* macOS
-
-  * AppleClang: 9.1.0, 10.0.0
+- macOS
+  - AppleClang: 9.1.0, 10.0.0
 
 ### [DART 6.8.4 (2019-05-03)](https://github.com/dartsim/dart/milestone/56?closed=1)
 
 #### Changes
 
-* GUI
-
-  * Fixed crashing on exiting OSG + ImGui applications: [#1303](https://github.com/dartsim/dart/pull/1303)
+- GUI
+  - Fixed crashing on exiting OSG + ImGui applications: [#1303](https://github.com/dartsim/dart/pull/1303)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
+  - GCC 32-bit: 5.4.0
 
-  * GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
-  * GCC 32-bit: 5.4.0
-
-* macOS
-
-  * AppleClang: 9.1.0, 10.0.0
+- macOS
+  - AppleClang: 9.1.0, 10.0.0
 
 ### [DART 6.8.3 (2019-05-01)](https://github.com/dartsim/dart/milestone/55?closed=1)
 
 #### Changes
 
-* Parser
+- Parser
+  - Fixed VskParker returning incorrect resource retriever: [#1300](https://github.com/dartsim/dart/pull/1300)
 
-  * Fixed VskParker returning incorrect resource retriever: [#1300](https://github.com/dartsim/dart/pull/1300)
-
-* Build
-
-  * Fixed building with pagmo's optional dependencies: [#1301](https://github.com/dartsim/dart/pull/1301)
+- Build
+  - Fixed building with pagmo's optional dependencies: [#1301](https://github.com/dartsim/dart/pull/1301)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
+  - GCC 32-bit: 5.4.0
 
-  * GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
-  * GCC 32-bit: 5.4.0
-
-* macOS
-
-  * AppleClang: 9.1.0, 10.0.0
+- macOS
+  - AppleClang: 9.1.0, 10.0.0
 
 ### [DART 6.8.2 (2019-04-23)](https://github.com/dartsim/dart/milestone/54?closed=1)
 
 #### Changes
 
-* Dynamics
+- Dynamics
+  - Fixed BoxedLcpConstraintSolver is not API compatible with 6.7: [#1291](https://github.com/dartsim/dart/pull/1291)
 
-  * Fixed BoxedLcpConstraintSolver is not API compatible with 6.7: [#1291](https://github.com/dartsim/dart/pull/1291)
-
-* Build
-
-  * Fixed building with FCL built without Octomap: [#1292](https://github.com/dartsim/dart/pull/1292)
+- Build
+  - Fixed building with FCL built without Octomap: [#1292](https://github.com/dartsim/dart/pull/1292)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
+  - GCC 32-bit: 5.4.0
 
-  * GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
-  * GCC 32-bit: 5.4.0
-
-* macOS
-
-  * AppleClang: 9.1.0, 10.0.0
+- macOS
+  - AppleClang: 9.1.0, 10.0.0
 
 ### [DART 6.8.1 (2019-04-23)](https://github.com/dartsim/dart/milestone/53?closed=1)
 
 #### Changes
 
-* Build System
-
-  * Fixed invalid double quotation marks in DARTFindBoost.cmake: [#1283](https://github.com/dartsim/dart/pull/1283)
-  * Disabled octomap support on macOS: [#1284](https://github.com/dartsim/dart/pull/1284)
+- Build System
+  - Fixed invalid double quotation marks in DARTFindBoost.cmake: [#1283](https://github.com/dartsim/dart/pull/1283)
+  - Disabled octomap support on macOS: [#1284](https://github.com/dartsim/dart/pull/1284)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
+  - GCC 32-bit: 5.4.0
 
-  * GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
-  * GCC 32-bit: 5.4.0
-
-* macOS
-
-  * AppleClang: 9.1.0, 10.0.0
+- macOS
+  - AppleClang: 9.1.0, 10.0.0
 
 ### [DART 6.8.0 (2019-04-22)](https://github.com/dartsim/dart/milestone/48?closed=1)
 
 #### Changes
 
-* Kinematics
+- Kinematics
+  - Added findSolution() and solveAndApply() to InverseKinematics and HierarchicalIk classes and deprecated solve(~) member functions: [#1266](https://github.com/dartsim/dart/pull/1266)
+  - Added an utility constructor to Linkage::Criteria to create sequence Linkage: [#1273](https://github.com/dartsim/dart/pull/1273)
 
-  * Added findSolution() and solveAndApply() to InverseKinematics and HierarchicalIk classes and deprecated solve(~) member functions: [#1266](https://github.com/dartsim/dart/pull/1266)
-  * Added an utility constructor to Linkage::Criteria to create sequence Linkage: [#1273](https://github.com/dartsim/dart/pull/1273)
+- Dynamics
+  - Fixed incorrect transpose check in Inertia::verifySpatialTensor(): [#1258](https://github.com/dartsim/dart/pull/1258)
+  - Allowed BoxedLcpConstraintSolver to have a secondary LCP solver: [#1265](https://github.com/dartsim/dart/pull/1265)
 
-* Dynamics
+- Simulation
+  - The LCP solver will be less aggressive about printing out unnecessary warnings: [#1238](https://github.com/dartsim/dart/pull/1238)
+  - Fixed not copying constraints in World::setConstraintSolver(): [#1260](https://github.com/dartsim/dart/pull/1260)
 
-  * Fixed incorrect transpose check in Inertia::verifySpatialTensor(): [#1258](https://github.com/dartsim/dart/pull/1258)
-  * Allowed BoxedLcpConstraintSolver to have a secondary LCP solver: [#1265](https://github.com/dartsim/dart/pull/1265)
+- Collision Detection
+  - The BodyNodeCollisionFilter will ignore contacts between immobile bodies: [#1232](https://github.com/dartsim/dart/pull/1232)
 
-* Simulation
+- Planning
+  - Fixed linking error of FLANN by explicitly linking to lz4: [#1221](https://github.com/dartsim/dart/pull/1221)
 
-  * The LCP solver will be less aggressive about printing out unnecessary warnings: [#1238](https://github.com/dartsim/dart/pull/1238)
-  * Fixed not copying constraints in World::setConstraintSolver(): [#1260](https://github.com/dartsim/dart/pull/1260)
+- Python
+  - Added (experimental) Python binding: [#1237](https://github.com/dartsim/dart/pull/1237)
 
-* Collision Detection
+- Parsers
+  - Changed urdf parser to warn if robot model has multi-tree: [#1270](https://github.com/dartsim/dart/pull/1270)
 
-  * The BodyNodeCollisionFilter will ignore contacts between immobile bodies: [#1232](https://github.com/dartsim/dart/pull/1232)
+- GUI
+  - Updated ImGui to 1.69: [#1274](https://github.com/dartsim/dart/pull/1274)
+  - Added VoxelGridShape support to OSG renderer: [#1276](https://github.com/dartsim/dart/pull/1276)
+  - Added PointCloudShape and its OSG rendering: [#1277](https://github.com/dartsim/dart/pull/1277)
+  - Added grid visual to OSG renderer: [#1278](https://github.com/dartsim/dart/pull/1278), [#1280](https://github.com/dartsim/dart/pull/1280)
 
-* Planning
-
-  * Fixed linking error of FLANN by explicitly linking to lz4: [#1221](https://github.com/dartsim/dart/pull/1221)
-
-* Python
-
-  * Added (experimental) Python binding: [#1237](https://github.com/dartsim/dart/pull/1237)
-
-* Parsers
-
-  * Changed urdf parser to warn if robot model has multi-tree: [#1270](https://github.com/dartsim/dart/pull/1270)
-
-* GUI
-
-  * Updated ImGui to 1.69: [#1274](https://github.com/dartsim/dart/pull/1274)
-  * Added VoxelGridShape support to OSG renderer: [#1276](https://github.com/dartsim/dart/pull/1276)
-  * Added PointCloudShape and its OSG rendering: [#1277](https://github.com/dartsim/dart/pull/1277)
-  * Added grid visual to OSG renderer: [#1278](https://github.com/dartsim/dart/pull/1278), [#1280](https://github.com/dartsim/dart/pull/1280)
-
-* Build System
-
-  * Changed to use GNUInstallDirs for install paths: [#1241](https://github.com/dartsim/dart/pull/1241)
-  * Fixed not failing for missing required dependencies: [#1250](https://github.com/dartsim/dart/pull/1250)
-  * Fixed attempting to link octomap when not imported: [#1253](https://github.com/dartsim/dart/pull/1253)
-  * Fixed not defining boost targets: [#1254](https://github.com/dartsim/dart/pull/1254)
+- Build System
+  - Changed to use GNUInstallDirs for install paths: [#1241](https://github.com/dartsim/dart/pull/1241)
+  - Fixed not failing for missing required dependencies: [#1250](https://github.com/dartsim/dart/pull/1250)
+  - Fixed attempting to link octomap when not imported: [#1253](https://github.com/dartsim/dart/pull/1253)
+  - Fixed not defining boost targets: [#1254](https://github.com/dartsim/dart/pull/1254)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
+  - GCC 32-bit: 5.4.0
 
-  * GCC 64-bit: 5.4.0, 7.3.0, 8.2.0
-  * GCC 32-bit: 5.4.0
-
-* macOS
-
-  * AppleClang: 9.1.0, 10.0.0
+- macOS
+  - AppleClang: 9.1.0, 10.0.0
 
 ### [DART 6.7.3 (2019-02-19)](https://github.com/dartsim/dart/milestone/51?closed=1)
 
 #### Changes
 
-* Dynamics
-
-  * Fixed Skeleton::setState(): [#1245](https://github.com/dartsim/dart/pull/1245)
+- Dynamics
+  - Fixed Skeleton::setState(): [#1245](https://github.com/dartsim/dart/pull/1245)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC (C++11): 5.4.0, 7.3.0, 8.2.0
 
-  * GCC (C++11): 5.4.0, 7.3.0, 8.2.0
+- Linux (32-bit)
+  - GCC (C++11): 5.4.0
 
-* Linux (32-bit)
-
-  * GCC (C++11): 5.4.0
-
-* macOS
-
-  * AppleClang (C++11): 9.1.0
+- macOS
+  - AppleClang (C++11): 9.1.0
 
 ### [DART 6.7.2 (2019-01-17)](https://github.com/dartsim/dart/milestone/50?closed=1)
 
 #### Changes
 
-* Build system
-
-  * Fixed #1223 for the recursive case: [#1227](https://github.com/dartsim/dart/pull/1227)
-  * Specified mode for find_package(): [#1228](https://github.com/dartsim/dart/pull/1228)
+- Build system
+  - Fixed #1223 for the recursive case: [#1227](https://github.com/dartsim/dart/pull/1227)
+  - Specified mode for find_package(): [#1228](https://github.com/dartsim/dart/pull/1228)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC (C++11): 5.4.0, 7.3.0, 8.2.0
 
-  * GCC (C++11): 5.4.0, 7.3.0, 8.2.0
+- Linux (32-bit)
+  - GCC (C++11): 5.4.0
 
-* Linux (32-bit)
-
-  * GCC (C++11): 5.4.0
-
-* macOS
-
-  * AppleClang (C++11): 9.1.0
+- macOS
+  - AppleClang (C++11): 9.1.0
 
 ### [DART 6.7.1 (2019-01-15)](https://github.com/dartsim/dart/milestone/49?closed=1)
 
 #### Changes
 
-* Build system
-
-  * Ensure that imported targets of dependencies are always created when finding the dart package: [#1222](https://github.com/dartsim/dart/pull/1222)
-  * Set components to not-found when their external dependencies are missing: [#1223](https://github.com/dartsim/dart/pull/1223)
+- Build system
+  - Ensure that imported targets of dependencies are always created when finding the dart package: [#1222](https://github.com/dartsim/dart/pull/1222)
+  - Set components to not-found when their external dependencies are missing: [#1223](https://github.com/dartsim/dart/pull/1223)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC (C++11): 5.4.0, 7.3.0, 8.2.0
 
-  * GCC (C++11): 5.4.0, 7.3.0, 8.2.0
+- Linux (32-bit)
+  - GCC (C++11): 5.4.0
 
-* Linux (32-bit)
-
-  * GCC (C++11): 5.4.0
-
-* macOS
-
-  * AppleClang (C++11): 9.1.0
+- macOS
+  - AppleClang (C++11): 9.1.0
 
 ### [DART 6.7.0 (2019-01-10)](https://github.com/dartsim/dart/milestone/45?closed=1)
 
 #### Changes
 
-* Build system
+- Build system
+  - Fixed compilation warnings for newer versions of compilers: [#1177](https://github.com/dartsim/dart/pull/1177)
+  - Changed to generate namespace headers without requiring \*.hpp.in files: [#1192](https://github.com/dartsim/dart/pull/1192)
+  - Dropped supporting Ubuntu Trusty and started using imported targets of dependencies: [#1212](https://github.com/dartsim/dart/pull/1212)
 
-  * Fixed compilation warnings for newer versions of compilers: [#1177](https://github.com/dartsim/dart/pull/1177)
-  * Changed to generate namespace headers without requiring *.hpp.in files: [#1192](https://github.com/dartsim/dart/pull/1192)
-  * Dropped supporting Ubuntu Trusty and started using imported targets of dependencies: [#1212](https://github.com/dartsim/dart/pull/1212)
+- Collision Detection
+  - CollisionGroups will automatically update their objects when any changes occur to Skeletons or BodyNodes that they are subscribed to: [#1112](https://github.com/dartsim/dart/pull/1112)
+  - Contact points with negative penetration depth will be ignored: [#1185](https://github.com/dartsim/dart/pull/1185)
 
-* Collision Detection
+- Math
+  - Consolidated random functions into Random class: [#1109](https://github.com/dartsim/dart/pull/1109)
 
-  * CollisionGroups will automatically update their objects when any changes occur to Skeletons or BodyNodes that they are subscribed to: [#1112](https://github.com/dartsim/dart/pull/1112)
-  * Contact points with negative penetration depth will be ignored: [#1185](https://github.com/dartsim/dart/pull/1185)
+- Dynamics
+  - Refactor constraint solver: [#1099](https://github.com/dartsim/dart/pull/1099), [#1101](https://github.com/dartsim/dart/pull/1101)
+  - Added mimic joint functionality as a new actuator type: [#1178](https://github.com/dartsim/dart/pull/1178)
+  - Added clone function to MetaSkeleton: [#1201](https://github.com/dartsim/dart/pull/1201)
 
-* Math
+- Optimization
+  - Added multi-objective optimization with pagmo2 support: [#1106](https://github.com/dartsim/dart/pull/1106)
 
-  * Consolidated random functions into Random class: [#1109](https://github.com/dartsim/dart/pull/1109)
+- GUI
+  - Reorganized OpenGL and GLUT files: [#1088](https://github.com/dartsim/dart/pull/1088)
+  - Added the RealTimeWorldNode to display simulations at real-time rates: [#1216](https://github.com/dartsim/dart/pull/1216)
 
-* Dynamics
-
-  * Refactor constraint solver: [#1099](https://github.com/dartsim/dart/pull/1099), [#1101](https://github.com/dartsim/dart/pull/1101)
-  * Added mimic joint functionality as a new actuator type: [#1178](https://github.com/dartsim/dart/pull/1178)
-  * Added clone function to MetaSkeleton: [#1201](https://github.com/dartsim/dart/pull/1201)
-
-* Optimization
-
-  * Added multi-objective optimization with pagmo2 support: [#1106](https://github.com/dartsim/dart/pull/1106)
-
-* GUI
-
-  * Reorganized OpenGL and GLUT files: [#1088](https://github.com/dartsim/dart/pull/1088)
-  * Added the RealTimeWorldNode to display simulations at real-time rates: [#1216](https://github.com/dartsim/dart/pull/1216)
-
-* Misc
-
-  * Updated Googletest to version 1.8.1: [#1214](https://github.com/dartsim/dart/pull/1214)
+- Misc
+  - Updated Googletest to version 1.8.1: [#1214](https://github.com/dartsim/dart/pull/1214)
 
 #### Compilers Tested
 
-* Linux
+- Linux
+  - GCC (C++11): 5.4.0, 7.3.0, 8.2.0
 
-  * GCC (C++11): 5.4.0, 7.3.0, 8.2.0
+- Linux (32-bit)
+  - GCC (C++11): 5.4.0
 
-* Linux (32-bit)
-
-  * GCC (C++11): 5.4.0
-
-* macOS
-
-  * AppleClang (C++11): 9.1.0
+- macOS
+  - AppleClang (C++11): 9.1.0
 
 ### [DART 6.6.2 (2018-09-03)](https://github.com/dartsim/dart/milestone/47?closed=1)
 
-* Utils
-
-  * Fixed checking file existence in DartResourceRetriever: [#1107](https://github.com/dartsim/dart/pull/1107)
+- Utils
+  - Fixed checking file existence in DartResourceRetriever: [#1107](https://github.com/dartsim/dart/pull/1107)
 
 ### [DART 6.6.1 (2018-08-04)](https://github.com/dartsim/dart/milestone/46?closed=1)
 
-* Utils
+- Utils
+  - Added option to DartResourceRetriever to search from environment variable DART_DATA_PATH: [#1095](https://github.com/dartsim/dart/pull/1095)
 
-  * Added option to DartResourceRetriever to search from environment variable DART_DATA_PATH: [#1095](https://github.com/dartsim/dart/pull/1095)
-
-* Examples
-
-  * Fixed CMakeLists.txt of humanJointLimits: [#1094](https://github.com/dartsim/dart/pull/1094)
+- Examples
+  - Fixed CMakeLists.txt of humanJointLimits: [#1094](https://github.com/dartsim/dart/pull/1094)
 
 ### [DART 6.6.0 (2018-08-02)](https://github.com/dartsim/dart/milestone/44?closed=1)
 
-* Collision detection
-
-  * Added voxel grid map: [#1076](https://github.com/dartsim/dart/pull/1076), [#1083](https://github.com/dartsim/dart/pull/1083)
-  * Added heightmap support: [#1069](https://github.com/dartsim/dart/pull/1069)
+- Collision detection
+  - Added voxel grid map: [#1076](https://github.com/dartsim/dart/pull/1076), [#1083](https://github.com/dartsim/dart/pull/1083)
+  - Added heightmap support: [#1069](https://github.com/dartsim/dart/pull/1069)
 
 ### [DART 6.5.0 (2018-05-12)](https://github.com/dartsim/dart/milestone/41?closed=1)
 
-* Common
+- Common
+  - Added LockableReference classes: [#1011](https://github.com/dartsim/dart/pull/1011)
+  - Added missing \<vector\> to Memory.hpp: [#1057](https://github.com/dartsim/dart/pull/1057)
 
-  * Added LockableReference classes: [#1011](https://github.com/dartsim/dart/pull/1011)
-  * Added missing \<vector\> to Memory.hpp: [#1057](https://github.com/dartsim/dart/pull/1057)
+- GUI
+  - Added FOV API to OSG viewer: [#1048](https://github.com/dartsim/dart/pull/1048)
 
-* GUI
+- Parsers
+  - Fixed incorrect parsing of continuous joints specified in URDF [#1064](https://github.com/dartsim/dart/pull/1064)
 
-  * Added FOV API to OSG viewer: [#1048](https://github.com/dartsim/dart/pull/1048)
+- Simulation
+  - Added World::hasSkeleton(): [#1050](https://github.com/dartsim/dart/pull/1050)
 
-* Parsers
-
-  * Fixed incorrect parsing of continuous joints specified in URDF [#1064](https://github.com/dartsim/dart/pull/1064)
-
-* Simulation
-
-  * Added World::hasSkeleton(): [#1050](https://github.com/dartsim/dart/pull/1050)
-
-* Misc
-
-  * Fixed memory leaks in mesh loading: [#1066](https://github.com/dartsim/dart/pull/1066)
+- Misc
+  - Fixed memory leaks in mesh loading: [#1066](https://github.com/dartsim/dart/pull/1066)
 
 ### [DART 6.4.0 (2018-03-26)](https://github.com/dartsim/dart/milestone/39?closed=1)
 
-* Common
+- Common
+  - Added DART_COMMON_DECLARE_SMART_POINTERS macro: [#1022](https://github.com/dartsim/dart/pull/1022)
+  - Added ResourceRetriever::getFilePath(): [#972](https://github.com/dartsim/dart/pull/972)
 
-  * Added DART_COMMON_DECLARE_SMART_POINTERS macro: [#1022](https://github.com/dartsim/dart/pull/1022)
-  * Added ResourceRetriever::getFilePath(): [#972](https://github.com/dartsim/dart/pull/972)
+- Kinematics/Dynamics
+  - Added relative Jacobian functions to MetaSkeleton: [#997](https://github.com/dartsim/dart/pull/997)
+  - Added vectorized joint limit functions: [#996](https://github.com/dartsim/dart/pull/996)
+  - Added lazy evaluation for shape's volume and bounding-box computation: [#959](https://github.com/dartsim/dart/pull/959)
+  - Added IkFast support as analytic IK solver: [#887](https://github.com/dartsim/dart/pull/887)
+  - Added TranslationalJoint2D: [#1003](https://github.com/dartsim/dart/pull/1003)
+  - Fixed NaN values caused by zero-length normals in ContactConstraint: [#881](https://github.com/dartsim/dart/pull/881)
+  - Extended BodyNode::createShapeNode() to accept more types of arguments: [#986](https://github.com/dartsim/dart/pull/986)
 
-* Kinematics/Dynamics
+- Collision detection
+  - Added FCL 0.6 support (backport of #873): [#936](https://github.com/dartsim/dart/pull/936)
 
-  * Added relative Jacobian functions to MetaSkeleton: [#997](https://github.com/dartsim/dart/pull/997)
-  * Added vectorized joint limit functions: [#996](https://github.com/dartsim/dart/pull/996)
-  * Added lazy evaluation for shape's volume and bounding-box computation: [#959](https://github.com/dartsim/dart/pull/959)
-  * Added IkFast support as analytic IK solver: [#887](https://github.com/dartsim/dart/pull/887)
-  * Added TranslationalJoint2D: [#1003](https://github.com/dartsim/dart/pull/1003)
-  * Fixed NaN values caused by zero-length normals in ContactConstraint: [#881](https://github.com/dartsim/dart/pull/881)
-  * Extended BodyNode::createShapeNode() to accept more types of arguments: [#986](https://github.com/dartsim/dart/pull/986)
+- GUI
+  - Added support of rendering texture images: [#973](https://github.com/dartsim/dart/pull/973)
+  - Added OSG shadows: [#978](https://github.com/dartsim/dart/pull/978)
 
-* Collision detection
+- Examples
+  - Added humanJointLimits: [#1016](https://github.com/dartsim/dart/pull/1016)
 
-  * Added FCL 0.6 support (backport of #873): [#936](https://github.com/dartsim/dart/pull/936)
+- License
+  - Added Personal Robotics Lab and Open Source Robotics Foundation as contributors: [#929](https://github.com/dartsim/dart/pull/929)
 
-* GUI
-
-  * Added support of rendering texture images: [#973](https://github.com/dartsim/dart/pull/973)
-  * Added OSG shadows: [#978](https://github.com/dartsim/dart/pull/978)
-
-* Examples
-
-  * Added humanJointLimits: [#1016](https://github.com/dartsim/dart/pull/1016)
-
-* License
-
-  * Added Personal Robotics Lab and Open Source Robotics Foundation as contributors: [#929](https://github.com/dartsim/dart/pull/929)
-
-* Misc
-
-  * Added World::create(): [#962](https://github.com/dartsim/dart/pull/962)
-  * Added MetaSkeleton::hasBodyNode() and MetaSkeleton::hasJoint(): [#1000](https://github.com/dartsim/dart/pull/1000)
-  * Suppressed -Winjected-class-name warnings from Clang 5.0.0: [#964](https://github.com/dartsim/dart/pull/964)
-  * Suppressed -Wdangling-else warnings from GCC 7.2.0: [#937](https://github.com/dartsim/dart/pull/937)
-  * Changed console macros to use global namespace resolutions: [#1010](https://github.com/dartsim/dart/pull/1010)
-  * Fixed build with Eigen 3.2.1-3.2.8: [#1042](https://github.com/dartsim/dart/pull/1042)
-  * Fixed various build issues with Visual Studio: [#956](https://github.com/dartsim/dart/pull/956)
-  * Removed TinyXML dependency: [#993](https://github.com/dartsim/dart/pull/993)
+- Misc
+  - Added World::create(): [#962](https://github.com/dartsim/dart/pull/962)
+  - Added MetaSkeleton::hasBodyNode() and MetaSkeleton::hasJoint(): [#1000](https://github.com/dartsim/dart/pull/1000)
+  - Suppressed -Winjected-class-name warnings from Clang 5.0.0: [#964](https://github.com/dartsim/dart/pull/964)
+  - Suppressed -Wdangling-else warnings from GCC 7.2.0: [#937](https://github.com/dartsim/dart/pull/937)
+  - Changed console macros to use global namespace resolutions: [#1010](https://github.com/dartsim/dart/pull/1010)
+  - Fixed build with Eigen 3.2.1-3.2.8: [#1042](https://github.com/dartsim/dart/pull/1042)
+  - Fixed various build issues with Visual Studio: [#956](https://github.com/dartsim/dart/pull/956)
+  - Removed TinyXML dependency: [#993](https://github.com/dartsim/dart/pull/993)
 
 ### [DART 6.3.1 (2018-03-21)](https://github.com/dartsim/dart/milestone/42?closed=1)
 
-* Build system
+- Build system
+  - Removed an undefined cmake macro/function: [#1036](https://github.com/dartsim/dart/pull/1036)
 
-  * Removed an undefined cmake macro/function: [#1036](https://github.com/dartsim/dart/pull/1036)
-
-* ROS support
-
-  * Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031), [#1032](https://github.com/dartsim/dart/pull/1031), [#1033](https://github.com/dartsim/dart/pull/1033)
+- ROS support
+  - Tweaked package.xml for catkin support: [#1027](https://github.com/dartsim/dart/pull/1027), [#1029](https://github.com/dartsim/dart/pull/1029), [#1031](https://github.com/dartsim/dart/pull/1031), [#1032](https://github.com/dartsim/dart/pull/1031), [#1033](https://github.com/dartsim/dart/pull/1033)
 
 ### [DART 6.3.0 (2017-10-04)](https://github.com/dartsim/dart/milestone/36?closed=1)
 
-* Collision detection
+- Collision detection
+  - Added a feature of disabling body node pairs to BodyNodeCollisionFilter: [#911](https://github.com/dartsim/dart/pull/911)
 
-  * Added a feature of disabling body node pairs to BodyNodeCollisionFilter: [#911](https://github.com/dartsim/dart/pull/911)
+- Kinematics/Dynamics
+  - Added setter and getter for WeldJointConstraint::mRelativeTransform: [#910](https://github.com/dartsim/dart/pull/910)
 
-* Kinematics/Dynamics
+- Parsers
+  - Improved SkelParser to read alpha value: [#914](https://github.com/dartsim/dart/pull/914)
 
-  * Added setter and getter for WeldJointConstraint::mRelativeTransform: [#910](https://github.com/dartsim/dart/pull/910)
-
-* Parsers
-
-  * Improved SkelParser to read alpha value: [#914](https://github.com/dartsim/dart/pull/914)
-
-* Misc
-
-  * Changed not to use lambda function as an workaround for DART python binding: [#916](https://github.com/dartsim/dart/pull/916)
+- Misc
+  - Changed not to use lambda function as an workaround for DART python binding: [#916](https://github.com/dartsim/dart/pull/916)
 
 ### [DART 6.2.1 (2017-08-08)](https://github.com/dartsim/dart/milestone/37?closed=1)
 
-* Collision detection
+- Collision detection
+  - Fixed collision checking between objects from the same body node: [#894](https://github.com/dartsim/dart/pull/894)
 
-  * Fixed collision checking between objects from the same body node: [#894](https://github.com/dartsim/dart/pull/894)
+- Kinematics/Dynamics
+  - Fixed transform of ScrewJoint with thread pitch: [#855](https://github.com/dartsim/dart/pull/855)
 
-* Kinematics/Dynamics
+- Parsers
+  - Fixed incorrect reading of <use_parent_model_frame> from SDF: [#893](https://github.com/dartsim/dart/pull/893)
+  - Fixed missing reading of joint friction from URDF: [#891](https://github.com/dartsim/dart/pull/891)
 
-  * Fixed transform of ScrewJoint with thread pitch: [#855](https://github.com/dartsim/dart/pull/855)
+- Testing
+  - Fixed testing ODE collision detector on macOS: [#884](https://github.com/dartsim/dart/pull/884)
+  - Removed redundant main body for each test source file: [#856](https://github.com/dartsim/dart/pull/856)
 
-* Parsers
-
-  * Fixed incorrect reading of <use_parent_model_frame> from SDF: [#893](https://github.com/dartsim/dart/pull/893)
-  * Fixed missing reading of joint friction from URDF: [#891](https://github.com/dartsim/dart/pull/891)
-
-* Testing
-
-  * Fixed testing ODE collision detector on macOS: [#884](https://github.com/dartsim/dart/pull/884)
-  * Removed redundant main body for each test source file: [#856](https://github.com/dartsim/dart/pull/856)
-
-* Misc
-
-  * Fixed build of the OpenSceneGraph GUI library (`dart-gui`, historically `dart-gui-osg`) that depends on the presence of OSG: [#898](https://github.com/dartsim/dart/pull/898)
-  * Fixed build of examples and tutorials on macOS: [#889](https://github.com/dartsim/dart/pull/889)
-  * Fixed missing overriding method OdePlane::isPlaceable(): [#886](https://github.com/dartsim/dart/pull/886)
-  * Replaced use of enum by static constexpr: [#852](https://github.com/dartsim/dart/pull/852), [#904](https://github.com/dartsim/dart/pull/904)
+- Misc
+  - Fixed build of the OpenSceneGraph GUI library (`dart-gui`, historically `dart-gui-osg`) that depends on the presence of OSG: [#898](https://github.com/dartsim/dart/pull/898)
+  - Fixed build of examples and tutorials on macOS: [#889](https://github.com/dartsim/dart/pull/889)
+  - Fixed missing overriding method OdePlane::isPlaceable(): [#886](https://github.com/dartsim/dart/pull/886)
+  - Replaced use of enum by static constexpr: [#852](https://github.com/dartsim/dart/pull/852), [#904](https://github.com/dartsim/dart/pull/904)
 
 ### [DART 6.2.0 (2017-05-15)](https://github.com/dartsim/dart/milestone/30?closed=1)
 
-* Common
+- Common
+  - Added Factory class and applied it to collision detection creation: [#864](https://github.com/dartsim/dart/pull/864)
+  - Added readAll() to Resource and ResourceRetriever: [#875](https://github.com/dartsim/dart/pull/875)
 
-  * Added Factory class and applied it to collision detection creation: [#864](https://github.com/dartsim/dart/pull/864)
-  * Added readAll() to Resource and ResourceRetriever: [#875](https://github.com/dartsim/dart/pull/875)
+- Math
+  - Added accessors for diameters and radii of EllipsoidShape, and deprecated EllipsoidShape::get/setSize(): [#829](https://github.com/dartsim/dart/pull/829)
+  - Fixed Lemke LCP solver (#808 for DART 6): [#812](https://github.com/dartsim/dart/pull/812)
 
-* Math
+- Collision Detection
+  - Added support of ODE collision detector: [#861](https://github.com/dartsim/dart/pull/861)
+  - Fixed incorrect collision filtering of BulletCollisionDetector: [#859](https://github.com/dartsim/dart/pull/859)
 
-  * Added accessors for diameters and radii of EllipsoidShape, and deprecated EllipsoidShape::get/setSize(): [#829](https://github.com/dartsim/dart/pull/829)
-  * Fixed Lemke LCP solver (#808 for DART 6): [#812](https://github.com/dartsim/dart/pull/812)
+- Simulation
+  - Fixed World didn't clear collision results on reset: [#863](https://github.com/dartsim/dart/pull/863)
 
-* Collision Detection
+- Parsers
+  - Fixed incorrect creation of resource retriever in SkelParser and SdfParser: [#847](https://github.com/dartsim/dart/pull/847), [#849](https://github.com/dartsim/dart/pull/849)
 
-  * Added support of ODE collision detector: [#861](https://github.com/dartsim/dart/pull/861)
-  * Fixed incorrect collision filtering of BulletCollisionDetector: [#859](https://github.com/dartsim/dart/pull/859)
+- GUI
+  - Added MotionBlurSimWindow: [#840](https://github.com/dartsim/dart/pull/840)
+  - Improved MultiSphereShape rendering in GLUT renderer: [#862](https://github.com/dartsim/dart/pull/862)
+  - Fixed incorrect parsing of materials and normal scaling from URDF: [#851](https://github.com/dartsim/dart/pull/851)
+  - Fixed the OSG renderer not rendering collision geometries: [#851](https://github.com/dartsim/dart/pull/851)
+  - Fixed that GUI was rendering white lines with nvidia drivers: [#805](https://github.com/dartsim/dart/pull/805)
 
-* Simulation
+- Misc
+  - Added createShared() and createUnique() pattern: [#844](https://github.com/dartsim/dart/pull/844)
+  - Added Skeleton::getRootJoint(): [#832](https://github.com/dartsim/dart/pull/832)
+  - Added CMake targets for code formatting using clang-format: [#811](https://github.com/dartsim/dart/pull/811), [#817](https://github.com/dartsim/dart/pull/817)
+  - Renamed MultiSphereShape to MultiSphereConvexHullShape: [#865](https://github.com/dartsim/dart/pull/865)
+  - Modified the member function names pertain to lazy evaluation to be more relevant to their functionalities: [#833](https://github.com/dartsim/dart/pull/833)
 
-  * Fixed World didn't clear collision results on reset: [#863](https://github.com/dartsim/dart/pull/863)
-
-* Parsers
-
-  * Fixed incorrect creation of resource retriever in SkelParser and SdfParser: [#847](https://github.com/dartsim/dart/pull/847), [#849](https://github.com/dartsim/dart/pull/849)
-
-* GUI
-
-  * Added MotionBlurSimWindow: [#840](https://github.com/dartsim/dart/pull/840)
-  * Improved MultiSphereShape rendering in GLUT renderer: [#862](https://github.com/dartsim/dart/pull/862)
-  * Fixed incorrect parsing of materials and normal scaling from URDF: [#851](https://github.com/dartsim/dart/pull/851)
-  * Fixed the OSG renderer not rendering collision geometries: [#851](https://github.com/dartsim/dart/pull/851)
-  * Fixed that GUI was rendering white lines with nvidia drivers: [#805](https://github.com/dartsim/dart/pull/805)
-
-* Misc
-
-  * Added createShared() and createUnique() pattern: [#844](https://github.com/dartsim/dart/pull/844)
-  * Added Skeleton::getRootJoint(): [#832](https://github.com/dartsim/dart/pull/832)
-  * Added CMake targets for code formatting using clang-format: [#811](https://github.com/dartsim/dart/pull/811), [#817](https://github.com/dartsim/dart/pull/817)
-  * Renamed MultiSphereShape to MultiSphereConvexHullShape: [#865](https://github.com/dartsim/dart/pull/865)
-  * Modified the member function names pertain to lazy evaluation to be more relevant to their functionalities: [#833](https://github.com/dartsim/dart/pull/833)
-
-* Tutorials & Examples
-
-  * Allowed tutorials and examples to be built out of DART source tree: [#842](https://github.com/dartsim/dart/pull/842)
-  * Fixed tutorialDominoes-Finished that didn't work with the latest DART: [#807](https://github.com/dartsim/dart/pull/807)
+- Tutorials & Examples
+  - Allowed tutorials and examples to be built out of DART source tree: [#842](https://github.com/dartsim/dart/pull/842)
+  - Fixed tutorialDominoes-Finished that didn't work with the latest DART: [#807](https://github.com/dartsim/dart/pull/807)
 
 ### DART 6.1.2 (2017-01-13)
 
-* Dynamics
+- Dynamics
+  - Fixed bug of ContactConstraint with kinematic joints: [#809](https://github.com/dartsim/dart/pull/809)
 
-  * Fixed bug of ContactConstraint with kinematic joints: [#809](https://github.com/dartsim/dart/pull/809)
-
-* Misc
-
-  * Fixed that ZeroDofJoint::getIndexInTree was called: [#818](https://github.com/dartsim/dart/pull/818)
+- Misc
+  - Fixed that ZeroDofJoint::getIndexInTree was called: [#818](https://github.com/dartsim/dart/pull/818)
 
 ### DART 6.1.1 (2016-10-14)
 
-* Build
+- Build
+  - Modified to build DART without SIMD options by default: [#790](https://github.com/dartsim/dart/pull/790)
+  - Modified to build external libraries as separately build targets: [#787](https://github.com/dartsim/dart/pull/787)
+  - Modified to export CMake target files separately per target: [#786](https://github.com/dartsim/dart/pull/786)
 
-  * Modified to build DART without SIMD options by default: [#790](https://github.com/dartsim/dart/pull/790)
-  * Modified to build external libraries as separately build targets: [#787](https://github.com/dartsim/dart/pull/787)
-  * Modified to export CMake target files separately per target: [#786](https://github.com/dartsim/dart/pull/786)
-
-* Misc
-
-  * Updated lodepng up to version 20160501: [#791](https://github.com/dartsim/dart/pull/791)
+- Misc
+  - Updated lodepng up to version 20160501: [#791](https://github.com/dartsim/dart/pull/791)
 
 ### DART 6.1.0 (2016-10-07)
 
-* Collision detection
+- Collision detection
+  - Added distance API: [#744](https://github.com/dartsim/dart/pull/744)
+  - Fixed direction of contact normal of BulletCollisionDetector: [#763](https://github.com/dartsim/dart/pull/763)
 
-  * Added distance API: [#744](https://github.com/dartsim/dart/pull/744)
-  * Fixed direction of contact normal of BulletCollisionDetector: [#763](https://github.com/dartsim/dart/pull/763)
+- Dynamics
+  - Added `computeLagrangian()` to `MetaSkeleton` and `BodyNode`: [#746](https://github.com/dartsim/dart/pull/746)
+  - Added new shapes: sphere, capsule, cone, and multi-sphere: [#770](https://github.com/dartsim/dart/pull/770), [#769](https://github.com/dartsim/dart/pull/769), [#745](https://github.com/dartsim/dart/pull/745)
+  - Changed base class of joint from SingleDofJoint/MultiDofJoint to GenericJoint: [#747](https://github.com/dartsim/dart/pull/747)
 
-* Dynamics
+- Planning
+  - Fixed incorrect linking to flann library: [#761](https://github.com/dartsim/dart/pull/761)
 
-  * Added `computeLagrangian()` to `MetaSkeleton` and `BodyNode`: [#746](https://github.com/dartsim/dart/pull/746)
-  * Added new shapes: sphere, capsule, cone, and multi-sphere: [#770](https://github.com/dartsim/dart/pull/770), [#769](https://github.com/dartsim/dart/pull/769), [#745](https://github.com/dartsim/dart/pull/745)
-  * Changed base class of joint from SingleDofJoint/MultiDofJoint to GenericJoint: [#747](https://github.com/dartsim/dart/pull/747)
+- Parsers
+  - Added `sdf` parsing for `fixed` joint and `material` tag of visual shape: [#775](https://github.com/dartsim/dart/pull/775)
+  - Added support of urdfdom_headers 1.0: [#766](https://github.com/dartsim/dart/pull/766)
 
-* Planning
+- GUI
+  - Added ImGui for 2D graphical interface: [#781](https://github.com/dartsim/dart/pull/781)
 
-  * Fixed incorrect linking to flann library: [#761](https://github.com/dartsim/dart/pull/761)
+- Examples
+  - Added osgAtlasSimbicon and osgTinkertoy: [#781](https://github.com/dartsim/dart/pull/781)
 
-* Parsers
-
-  * Added `sdf` parsing for `fixed` joint and `material` tag of visual shape: [#775](https://github.com/dartsim/dart/pull/775)
-  * Added support of urdfdom_headers 1.0: [#766](https://github.com/dartsim/dart/pull/766)
-
-* GUI
-
-  * Added ImGui for 2D graphical interface: [#781](https://github.com/dartsim/dart/pull/781)
-
-* Examples
-
-  * Added osgAtlasSimbicon and osgTinkertoy: [#781](https://github.com/dartsim/dart/pull/781)
-
-* Misc improvements and bug fixes
-
-  * Added `virtual Shape::getType()` and deprecated `ShapeType Shape::getShapeType()`: [#725](https://github.com/dartsim/dart/pull/725)
-  * Changed building with SIMD optional: [#765](https://github.com/dartsim/dart/pull/765), [#760](https://github.com/dartsim/dart/pull/760)
-  * Fixed minor build and install issues: [#773](https://github.com/dartsim/dart/pull/773), [#772](https://github.com/dartsim/dart/pull/772)
-  * Fixed Doxyfile to show missing member functions in API documentation: [#768](https://github.com/dartsim/dart/pull/768)
-  * Fixed typo: [#756](https://github.com/dartsim/dart/pull/756), [#755](https://github.com/dartsim/dart/pull/755)
+- Misc improvements and bug fixes
+  - Added `virtual Shape::getType()` and deprecated `ShapeType Shape::getShapeType()`: [#725](https://github.com/dartsim/dart/pull/725)
+  - Changed building with SIMD optional: [#765](https://github.com/dartsim/dart/pull/765), [#760](https://github.com/dartsim/dart/pull/760)
+  - Fixed minor build and install issues: [#773](https://github.com/dartsim/dart/pull/773), [#772](https://github.com/dartsim/dart/pull/772)
+  - Fixed Doxyfile to show missing member functions in API documentation: [#768](https://github.com/dartsim/dart/pull/768)
+  - Fixed typo: [#756](https://github.com/dartsim/dart/pull/756), [#755](https://github.com/dartsim/dart/pull/755)
 
 ### DART 6.0.1 (2016-06-29)
 
-* Collision detection
+- Collision detection
+  - Added support of FCL 0.5 and tinyxml2 4.0: [#749](https://github.com/dartsim/dart/pull/749)
+  - Added warnings for unsupported shape pairs of DARTCollisionDetector: [#722](https://github.com/dartsim/dart/pull/722)
 
-  * Added support of FCL 0.5 and tinyxml2 4.0: [#749](https://github.com/dartsim/dart/pull/749)
-  * Added warnings for unsupported shape pairs of DARTCollisionDetector: [#722](https://github.com/dartsim/dart/pull/722)
+- Dynamics
+  - Fixed total mass is not being updated when bodies removed from Skeleton: [#731](https://github.com/dartsim/dart/pull/731)
 
-* Dynamics
-
-  * Fixed total mass is not being updated when bodies removed from Skeleton: [#731](https://github.com/dartsim/dart/pull/731)
-
-* Misc improvements and bug fixes
-
-  * Renamed `DEPRECATED` and `FORCEINLINE` to `DART_DEPRECATED` and `DART_FORCEINLINE` to avoid name conflicts: [#742](https://github.com/dartsim/dart/pull/742)
-  * Updated copyright: added CMU to copyright holder, moved individual contributors to CONTRIBUTING.md: [#723](https://github.com/dartsim/dart/pull/723)
+- Misc improvements and bug fixes
+  - Renamed `DEPRECATED` and `FORCEINLINE` to `DART_DEPRECATED` and `DART_FORCEINLINE` to avoid name conflicts: [#742](https://github.com/dartsim/dart/pull/742)
+  - Updated copyright: added CMU to copyright holder, moved individual contributors to CONTRIBUTING.md: [#723](https://github.com/dartsim/dart/pull/723)
 
 ### DART 6.0.0 (2016-05-10)
 
-* Common data structures
+- Common data structures
+  - Added `Node`, `Aspect`, `State`, and `Properties`: [#713](https://github.com/dartsim/dart/pull/713), [#712](https://github.com/dartsim/dart/issues/712), [#708](https://github.com/dartsim/dart/pull/708), [#707](https://github.com/dartsim/dart/pull/707), [#659](https://github.com/dartsim/dart/pull/659), [#649](https://github.com/dartsim/dart/pull/649), [#645](https://github.com/dartsim/dart/issues/645), [#607](https://github.com/dartsim/dart/pull/607), [#598](https://github.com/dartsim/dart/pull/598), [#591](https://github.com/dartsim/dart/pull/591), [#531](https://github.com/dartsim/dart/pull/531)
+  - Added mathematical constants and user-defined literals for radian, degree, and pi: [#669](https://github.com/dartsim/dart/pull/669), [#314](https://github.com/dartsim/dart/issues/314)
+  - Added `ShapeFrame` and `ShapeNode`: [#608](https://github.com/dartsim/dart/pull/608)
+  - Added `BoundingBox`: [#547](https://github.com/dartsim/dart/pull/547), [#546](https://github.com/dartsim/dart/issues/546)
 
-  * Added `Node`, `Aspect`, `State`, and `Properties`: [#713](https://github.com/dartsim/dart/pull/713), [#712](https://github.com/dartsim/dart/issues/712), [#708](https://github.com/dartsim/dart/pull/708), [#707](https://github.com/dartsim/dart/pull/707), [#659](https://github.com/dartsim/dart/pull/659), [#649](https://github.com/dartsim/dart/pull/649), [#645](https://github.com/dartsim/dart/issues/645), [#607](https://github.com/dartsim/dart/pull/607), [#598](https://github.com/dartsim/dart/pull/598), [#591](https://github.com/dartsim/dart/pull/591), [#531](https://github.com/dartsim/dart/pull/531)
-  * Added mathematical constants and user-defined literals for radian, degree, and pi: [#669](https://github.com/dartsim/dart/pull/669), [#314](https://github.com/dartsim/dart/issues/314)
-  * Added `ShapeFrame` and `ShapeNode`: [#608](https://github.com/dartsim/dart/pull/608)
-  * Added `BoundingBox`: [#547](https://github.com/dartsim/dart/pull/547), [#546](https://github.com/dartsim/dart/issues/546)
+- Kinematics
+  - Added convenient functions for setting joint limits: [#703](https://github.com/dartsim/dart/pull/703)
+  - Added more description on `InverseKinematics::solve()`: [#624](https://github.com/dartsim/dart/pull/624)
+  - Added API for utilizing analytical inverse kinematics: [#530](https://github.com/dartsim/dart/pull/530), [#463](https://github.com/dartsim/dart/issues/463)
+  - Added color property to `Marker`: [#187](https://github.com/dartsim/dart/issues/187)
+  - Improved `Skeleton` to clone `State` as well: [#691](https://github.com/dartsim/dart/pull/691)
+  - Improved `ReferentialSkeleton` to be able to add and remove `BodyNode`s and `DegreeOfFreedom`s to/from `Group`s freely: [#557](https://github.com/dartsim/dart/pull/557), [#556](https://github.com/dartsim/dart/issues/556), [#548](https://github.com/dartsim/dart/issues/548)
+  - Changed `Marker` into `Node`: [#692](https://github.com/dartsim/dart/pull/692), [#609](https://github.com/dartsim/dart/issues/609)
+  - Renamed `Joint::get/setLocal[~]` to `Joint::get/setRelative[~]`: [#715](https://github.com/dartsim/dart/pull/715), [#714](https://github.com/dartsim/dart/issues/714)
+  - Renamed `PositionLimited` to `PositionLimitEnforced`: [#447](https://github.com/dartsim/dart/issues/447)
+  - Fixed initialization of joint position and velocity: [#691](https://github.com/dartsim/dart/pull/691), [#621](https://github.com/dartsim/dart/pull/621)
+  - Fixed `InverseKinematics` when it's used with `FreeJoint` and `BallJoint`: [#683](https://github.com/dartsim/dart/pull/683)
+  - Fixed ambiguous overload on `MetaSkeleton::getLinearJacobianDeriv`: [#628](https://github.com/dartsim/dart/pull/628), [#626](https://github.com/dartsim/dart/issues/626)
 
-* Kinematics
+- Dynamics
+  - Added `get/setLCPSolver` functions to `ConstraintSolver`: [#633](https://github.com/dartsim/dart/pull/633)
+  - Added `ServoMotorConstraint` as a preliminary implementation for `SERVO` actuator type: [#566](https://github.com/dartsim/dart/pull/566)
+  - Improved `ConstraintSolver` to obey C++11 ownership conventions: [#616](https://github.com/dartsim/dart/pull/616)
+  - Fixed segfualting of `DantzigLCPSolver` when the constraint dimension is zero: [#634](https://github.com/dartsim/dart/pull/634)
+  - Fixed missing implementations in ConstrainedGroup: [#586](https://github.com/dartsim/dart/pull/586)
+  - Fixed incorrect applying of joint constraint impulses: [#317](https://github.com/dartsim/dart/issues/317)
+  - Deprecated `draw()` functions of dynamics classes: [#654](https://github.com/dartsim/dart/pull/654)
 
-  * Added convenient functions for setting joint limits: [#703](https://github.com/dartsim/dart/pull/703)
-  * Added more description on `InverseKinematics::solve()`: [#624](https://github.com/dartsim/dart/pull/624)
-  * Added API for utilizing analytical inverse kinematics: [#530](https://github.com/dartsim/dart/pull/530), [#463](https://github.com/dartsim/dart/issues/463)
-  * Added color property to `Marker`: [#187](https://github.com/dartsim/dart/issues/187)
-  * Improved `Skeleton` to clone `State` as well: [#691](https://github.com/dartsim/dart/pull/691)
-  * Improved `ReferentialSkeleton` to be able to add and remove `BodyNode`s and `DegreeOfFreedom`s to/from `Group`s freely: [#557](https://github.com/dartsim/dart/pull/557), [#556](https://github.com/dartsim/dart/issues/556), [#548](https://github.com/dartsim/dart/issues/548)
-  * Changed `Marker` into `Node`: [#692](https://github.com/dartsim/dart/pull/692), [#609](https://github.com/dartsim/dart/issues/609)
-  * Renamed `Joint::get/setLocal[~]` to `Joint::get/setRelative[~]`: [#715](https://github.com/dartsim/dart/pull/715), [#714](https://github.com/dartsim/dart/issues/714)
-  * Renamed `PositionLimited` to `PositionLimitEnforced`: [#447](https://github.com/dartsim/dart/issues/447)
-  * Fixed initialization of joint position and velocity: [#691](https://github.com/dartsim/dart/pull/691), [#621](https://github.com/dartsim/dart/pull/621)
-  * Fixed `InverseKinematics` when it's used with `FreeJoint` and `BallJoint`: [#683](https://github.com/dartsim/dart/pull/683)
-  * Fixed ambiguous overload on `MetaSkeleton::getLinearJacobianDeriv`: [#628](https://github.com/dartsim/dart/pull/628), [#626](https://github.com/dartsim/dart/issues/626)
+- Collision detection
+  - Added `CollisionGroup` and refactored `CollisionDetector` to be more versatile: [#711](https://github.com/dartsim/dart/pull/711), [#704](https://github.com/dartsim/dart/pull/704), [#689](https://github.com/dartsim/dart/pull/689), [#631](https://github.com/dartsim/dart/pull/631), [#642](https://github.com/dartsim/dart/issues/642), [#20](https://github.com/dartsim/dart/issues/20)
+  - Improved API for self collision checking options: [#718](https://github.com/dartsim/dart/pull/718), [#702](https://github.com/dartsim/dart/issues/702)
+  - Deprecated `BodyNode::isColliding`; collision sets are moved to `CollisionResult`: [#694](https://github.com/dartsim/dart/pull/694), [#670](https://github.com/dartsim/dart/pull/670), [#668](https://github.com/dartsim/dart/pull/668), [#666](https://github.com/dartsim/dart/issues/666)
 
-* Dynamics
+- Parsers
+  - Added back VSK parser: [#602](https://github.com/dartsim/dart/pull/602), [#561](https://github.com/dartsim/dart/pull/561), [#254](https://github.com/dartsim/dart/issues/254)
+  - Fixed segfault of `SdfParser` when `nullptr` `ResourceRetriever` is passed: [#663](https://github.com/dartsim/dart/pull/663)
 
-  * Added `get/setLCPSolver` functions to `ConstraintSolver`: [#633](https://github.com/dartsim/dart/pull/633)
-  * Added `ServoMotorConstraint` as a preliminary implementation for `SERVO` actuator type: [#566](https://github.com/dartsim/dart/pull/566)
-  * Improved `ConstraintSolver` to obey C++11 ownership conventions: [#616](https://github.com/dartsim/dart/pull/616)
-  * Fixed segfualting of `DantzigLCPSolver` when the constraint dimension is zero: [#634](https://github.com/dartsim/dart/pull/634)
-  * Fixed missing implementations in ConstrainedGroup: [#586](https://github.com/dartsim/dart/pull/586)
-  * Fixed incorrect applying of joint constraint impulses: [#317](https://github.com/dartsim/dart/issues/317)
-  * Deprecated `draw()` functions of dynamics classes: [#654](https://github.com/dartsim/dart/pull/654)
+- GUI features
+  - Merged `renderer` namespace into `gui` namespace: [#652](https://github.com/dartsim/dart/pull/652), [#589](https://github.com/dartsim/dart/issues/589)
+  - Moved `osgDart` under `dart::gui` namespace as `dart::gui::osg`: [#651](https://github.com/dartsim/dart/pull/651)
+  - Fixed GlutWindow::screenshot(): [#623](https://github.com/dartsim/dart/pull/623), [#395](https://github.com/dartsim/dart/issues/395)
 
-* Collision detection
+- Simulation
+  - Fixed `World::clone()` didn't clone the collision detector: [#658](https://github.com/dartsim/dart/pull/658)
+  - Fixed bug of `World` concurrency: [#577](https://github.com/dartsim/dart/pull/577), [#576](https://github.com/dartsim/dart/issues/576)
 
-  * Added `CollisionGroup` and refactored `CollisionDetector` to be more versatile: [#711](https://github.com/dartsim/dart/pull/711), [#704](https://github.com/dartsim/dart/pull/704), [#689](https://github.com/dartsim/dart/pull/689), [#631](https://github.com/dartsim/dart/pull/631), [#642](https://github.com/dartsim/dart/issues/642), [#20](https://github.com/dartsim/dart/issues/20)
-  * Improved API for self collision checking options: [#718](https://github.com/dartsim/dart/pull/718), [#702](https://github.com/dartsim/dart/issues/702)
-  * Deprecated `BodyNode::isColliding`; collision sets are moved to `CollisionResult`: [#694](https://github.com/dartsim/dart/pull/694), [#670](https://github.com/dartsim/dart/pull/670), [#668](https://github.com/dartsim/dart/pull/668), [#666](https://github.com/dartsim/dart/issues/666)
+- Misc improvements and bug fixes
+  - Added `make_unique<T>` that was omitted from C++11: [#639](https://github.com/dartsim/dart/pull/639)
+  - Added missing `override` keywords: [#617](https://github.com/dartsim/dart/pull/617), [#535](https://github.com/dartsim/dart/pull/535)
+  - Added gcc warning flag `-Wextra`: [#600](https://github.com/dartsim/dart/pull/600)
+  - Improved memory management of `constraint` namespace: [#584](https://github.com/dartsim/dart/pull/584), [#583](https://github.com/dartsim/dart/issues/583)
+  - Changed the extension of headers from `.h` to `.hpp`: [#709](https://github.com/dartsim/dart/pull/709), [#693](https://github.com/dartsim/dart/pull/693), [#568](https://github.com/dartsim/dart/issues/568)
+  - Changed Doxyfile to gnerate tag file: [#690](https://github.com/dartsim/dart/pull/690)
+  - Changed the convention to use `std::size_t` over `size_t`: [#681](https://github.com/dartsim/dart/pull/681), [#656](https://github.com/dartsim/dart/issues/656)
+  - Changed CMake to configure preprocessors using `#cmakedefine`: [#648](https://github.com/dartsim/dart/pull/648), [#641](https://github.com/dartsim/dart/pull/641)
+  - Updated copyright years: [#679](https://github.com/dartsim/dart/pull/679), [#160](https://github.com/dartsim/dart/issues/160)
+  - Renamed directory name `apps` to `examples`: [#685](https://github.com/dartsim/dart/pull/685)
+  - Fixed warnings of unused variables in release mode: [#646](https://github.com/dartsim/dart/pull/646)
+  - Fixed typo of `getNumPluralAddoName` in utility macro: [#615](https://github.com/dartsim/dart/issues/615)
+  - Fixed linker error by adding namespace-scope definitions for `constexpr static` members: [#603](https://github.com/dartsim/dart/pull/603)
+  - Fixed segfault from nullptr meshes: [#585](https://github.com/dartsim/dart/pull/585)
+  - Fixed typo of tutorial with minor improvements: [#573](https://github.com/dartsim/dart/pull/573)
+  - Fixed `NameManager<T>::removeEntries(~)` called a function that does not exist: [#564](https://github.com/dartsim/dart/pull/564), [#554](https://github.com/dartsim/dart/issues/554)
+  - Fixed missing definitions for various functions: [#558](https://github.com/dartsim/dart/pull/558), [#555](https://github.com/dartsim/dart/issues/555)
+  - Fixed const correctness of `BodyNode::getMomentsOfInertia()`: [#541](https://github.com/dartsim/dart/pull/541), [#540](https://github.com/dartsim/dart/issues/540)
+  - Fixed `ftel` bug in Linux with an workaround: [#533](https://github.com/dartsim/dart/pull/533)
+  - Removed unnecessary `virtual` keyword for overriding functions: [#680](https://github.com/dartsim/dart/pull/680)
+  - Removed deprecated APIs in DART 5: [#678](https://github.com/dartsim/dart/pull/678)
 
-* Parsers
-
-  * Added back VSK parser: [#602](https://github.com/dartsim/dart/pull/602), [#561](https://github.com/dartsim/dart/pull/561), [#254](https://github.com/dartsim/dart/issues/254)
-  * Fixed segfault of `SdfParser` when `nullptr` `ResourceRetriever` is passed: [#663](https://github.com/dartsim/dart/pull/663)
-
-* GUI features
-
-  * Merged `renderer` namespace into `gui` namespace: [#652](https://github.com/dartsim/dart/pull/652), [#589](https://github.com/dartsim/dart/issues/589)
-  * Moved `osgDart` under `dart::gui` namespace as `dart::gui::osg`: [#651](https://github.com/dartsim/dart/pull/651)
-  * Fixed GlutWindow::screenshot(): [#623](https://github.com/dartsim/dart/pull/623), [#395](https://github.com/dartsim/dart/issues/395)
-
-* Simulation
-
-  * Fixed `World::clone()` didn't clone the collision detector: [#658](https://github.com/dartsim/dart/pull/658)
-  * Fixed bug of `World` concurrency: [#577](https://github.com/dartsim/dart/pull/577), [#576](https://github.com/dartsim/dart/issues/576)
-
-* Misc improvements and bug fixes
-
-  * Added `make_unique<T>` that was omitted from C++11: [#639](https://github.com/dartsim/dart/pull/639)
-  * Added missing `override` keywords: [#617](https://github.com/dartsim/dart/pull/617), [#535](https://github.com/dartsim/dart/pull/535)
-  * Added gcc warning flag `-Wextra`: [#600](https://github.com/dartsim/dart/pull/600)
-  * Improved memory management of `constraint` namespace: [#584](https://github.com/dartsim/dart/pull/584), [#583](https://github.com/dartsim/dart/issues/583)
-  * Changed the extension of headers from `.h` to `.hpp`: [#709](https://github.com/dartsim/dart/pull/709), [#693](https://github.com/dartsim/dart/pull/693), [#568](https://github.com/dartsim/dart/issues/568)
-  * Changed Doxyfile to gnerate tag file: [#690](https://github.com/dartsim/dart/pull/690)
-  * Changed the convention to use `std::size_t` over `size_t`: [#681](https://github.com/dartsim/dart/pull/681), [#656](https://github.com/dartsim/dart/issues/656)
-  * Changed CMake to configure preprocessors using `#cmakedefine`: [#648](https://github.com/dartsim/dart/pull/648), [#641](https://github.com/dartsim/dart/pull/641)
-  * Updated copyright years: [#679](https://github.com/dartsim/dart/pull/679), [#160](https://github.com/dartsim/dart/issues/160)
-  * Renamed directory name `apps` to `examples`: [#685](https://github.com/dartsim/dart/pull/685)
-  * Fixed warnings of unused variables in release mode: [#646](https://github.com/dartsim/dart/pull/646)
-  * Fixed typo of `getNumPluralAddoName` in utility macro: [#615](https://github.com/dartsim/dart/issues/615)
-  * Fixed linker error by adding namespace-scope definitions for `constexpr static` members: [#603](https://github.com/dartsim/dart/pull/603)
-  * Fixed segfault from nullptr meshes: [#585](https://github.com/dartsim/dart/pull/585)
-  * Fixed typo of tutorial with minor improvements: [#573](https://github.com/dartsim/dart/pull/573)
-  * Fixed `NameManager<T>::removeEntries(~)` called a function that does not exist: [#564](https://github.com/dartsim/dart/pull/564), [#554](https://github.com/dartsim/dart/issues/554)
-  * Fixed missing definitions for various functions: [#558](https://github.com/dartsim/dart/pull/558), [#555](https://github.com/dartsim/dart/issues/555)
-  * Fixed const correctness of `BodyNode::getMomentsOfInertia()`: [#541](https://github.com/dartsim/dart/pull/541), [#540](https://github.com/dartsim/dart/issues/540)
-  * Fixed `ftel` bug in Linux with an workaround: [#533](https://github.com/dartsim/dart/pull/533)
-  * Removed unnecessary `virtual` keyword for overriding functions: [#680](https://github.com/dartsim/dart/pull/680)
-  * Removed deprecated APIs in DART 5: [#678](https://github.com/dartsim/dart/pull/678)
-
-* Build and test issues
-
-  * Added CMake target for code coverage testing, and automatic reporting: [#688](https://github.com/dartsim/dart/pull/688), [#687](https://github.com/dartsim/dart/issues/687), [#638](https://github.com/dartsim/dart/pull/638), [#632](https://github.com/dartsim/dart/pull/632)
-  * Added missing `liburdfdom-dev` dependency in Ubuntu package: [#574](https://github.com/dartsim/dart/pull/574)
-  * Modulized DART libraries: [#706](https://github.com/dartsim/dart/pull/706), [#675](https://github.com/dartsim/dart/pull/675), [#652](https://github.com/dartsim/dart/pull/652), [#477](https://github.com/dartsim/dart/issues/477)
-  * Improved Travis-CI script: [#655](https://github.com/dartsim/dart/pull/655)
-  * Improved CMake script by splitting tutorials, examples, and tests into separate targets: [#644](https://github.com/dartsim/dart/pull/644)
-  * Improved wording of the cmake warning messages for ASSIMP: [#553](https://github.com/dartsim/dart/pull/553)
-  * Changed Travis-CI to treat warning as errors using `-Werror` flags: [#682](https://github.com/dartsim/dart/pull/682), [#677](https://github.com/dartsim/dart/issues/677)
-  * Changed Travis-CI to test DART with bullet collision detector: [#650](https://github.com/dartsim/dart/pull/650), [#376](https://github.com/dartsim/dart/issues/376)
-  * Changed the minimum requirement of Visual Studio version to 2015: [#592](https://github.com/dartsim/dart/issues/592)
-  * Changed CMake to build gui::osg examples when `DART_BUILD_EXAMPLES` is on: [#536](https://github.com/dartsim/dart/pull/536)
-  * Simplfied Travis-CI tests for general pushes: [#700](https://github.com/dartsim/dart/pull/700)
-  * Fixed Eigen memory alignment issue in testCollision.cpp: [#719](https://github.com/dartsim/dart/pull/719)
-  * Fixed `BULLET_INCLUDE_DIRS` in `DARTConfig.cmake`: [#697](https://github.com/dartsim/dart/pull/697)
-  * Fixed linking with Bullet on OS X El Capitan by supporting for Bullet built with double precision: [#660](https://github.com/dartsim/dart/pull/660), [#657](https://github.com/dartsim/dart/issues/657)
-  * Fixed FCL version check logic in the main `CMakeLists.txt`: [#640](https://github.com/dartsim/dart/pull/640)
-  * Fixed `find_package(DART)` on optimizer components: [#637](https://github.com/dartsim/dart/pull/637)
-  * Fixed linking against `${DART_LIBRARIES}` not working in Ubuntu 14.04: [#630](https://github.com/dartsim/dart/pull/630), [#629](https://github.com/dartsim/dart/issues/629)
-  * Fixed Visual Studio 2015 build errors: [#580](https://github.com/dartsim/dart/pull/580)
-  * Removed OpenGL dependency from `dart` library: [#667](https://github.com/dartsim/dart/pull/667)
-  * Removed version check for Bullet: [#636](https://github.com/dartsim/dart/pull/636), [#625](https://github.com/dartsim/dart/issues/625)
+- Build and test issues
+  - Added CMake target for code coverage testing, and automatic reporting: [#688](https://github.com/dartsim/dart/pull/688), [#687](https://github.com/dartsim/dart/issues/687), [#638](https://github.com/dartsim/dart/pull/638), [#632](https://github.com/dartsim/dart/pull/632)
+  - Added missing `liburdfdom-dev` dependency in Ubuntu package: [#574](https://github.com/dartsim/dart/pull/574)
+  - Modulized DART libraries: [#706](https://github.com/dartsim/dart/pull/706), [#675](https://github.com/dartsim/dart/pull/675), [#652](https://github.com/dartsim/dart/pull/652), [#477](https://github.com/dartsim/dart/issues/477)
+  - Improved Travis-CI script: [#655](https://github.com/dartsim/dart/pull/655)
+  - Improved CMake script by splitting tutorials, examples, and tests into separate targets: [#644](https://github.com/dartsim/dart/pull/644)
+  - Improved wording of the cmake warning messages for ASSIMP: [#553](https://github.com/dartsim/dart/pull/553)
+  - Changed Travis-CI to treat warning as errors using `-Werror` flags: [#682](https://github.com/dartsim/dart/pull/682), [#677](https://github.com/dartsim/dart/issues/677)
+  - Changed Travis-CI to test DART with bullet collision detector: [#650](https://github.com/dartsim/dart/pull/650), [#376](https://github.com/dartsim/dart/issues/376)
+  - Changed the minimum requirement of Visual Studio version to 2015: [#592](https://github.com/dartsim/dart/issues/592)
+  - Changed CMake to build gui::osg examples when `DART_BUILD_EXAMPLES` is on: [#536](https://github.com/dartsim/dart/pull/536)
+  - Simplfied Travis-CI tests for general pushes: [#700](https://github.com/dartsim/dart/pull/700)
+  - Fixed Eigen memory alignment issue in testCollision.cpp: [#719](https://github.com/dartsim/dart/pull/719)
+  - Fixed `BULLET_INCLUDE_DIRS` in `DARTConfig.cmake`: [#697](https://github.com/dartsim/dart/pull/697)
+  - Fixed linking with Bullet on OS X El Capitan by supporting for Bullet built with double precision: [#660](https://github.com/dartsim/dart/pull/660), [#657](https://github.com/dartsim/dart/issues/657)
+  - Fixed FCL version check logic in the main `CMakeLists.txt`: [#640](https://github.com/dartsim/dart/pull/640)
+  - Fixed `find_package(DART)` on optimizer components: [#637](https://github.com/dartsim/dart/pull/637)
+  - Fixed linking against `${DART_LIBRARIES}` not working in Ubuntu 14.04: [#630](https://github.com/dartsim/dart/pull/630), [#629](https://github.com/dartsim/dart/issues/629)
+  - Fixed Visual Studio 2015 build errors: [#580](https://github.com/dartsim/dart/pull/580)
+  - Removed OpenGL dependency from `dart` library: [#667](https://github.com/dartsim/dart/pull/667)
+  - Removed version check for Bullet: [#636](https://github.com/dartsim/dart/pull/636), [#625](https://github.com/dartsim/dart/issues/625)
 
 ## DART 5
 
 ### Version 5.1.6 (2017-08-08)
 
 1. Improved camera movement of OpenGL GUI: smooth zooming and translation
-    * [Pull request #843](https://github.com/dartsim/dart/pull/843)
+   - [Pull request #843](https://github.com/dartsim/dart/pull/843)
 
 2. Removed debian meta files from the main DART repository
-    * [Pull request #853](https://github.com/dartsim/dart/pull/853)
+   - [Pull request #853](https://github.com/dartsim/dart/pull/853)
 
 ### Version 5.1.5 (2017-01-20)
 
 1. Fixed Lemke LCP solver for several failing cases
-    * [Pull request #808](https://github.com/dartsim/dart/pull/808)
+   - [Pull request #808](https://github.com/dartsim/dart/pull/808)
 
 1. Increase minimum required Ipopt version to 3.11.9
-    * [Pull request #800](https://github.com/dartsim/dart/pull/800)
+   - [Pull request #800](https://github.com/dartsim/dart/pull/800)
 
 1. Added support of urdfdom_headers 1.0 for DART 5.1 (backport of [#766](https://github.com/dartsim/dart/pull/766))
-    * [Pull request #799](https://github.com/dartsim/dart/pull/799)
+   - [Pull request #799](https://github.com/dartsim/dart/pull/799)
 
 ### Version 5.1.4 (2016-10-14)
 
 1. Fixed inconsistent frame rate of GlutWindow
-    * [Pull request #794](https://github.com/dartsim/dart/pull/794)
+   - [Pull request #794](https://github.com/dartsim/dart/pull/794)
 
 ### Version 5.1.3 (2016-10-07)
 
 1. Updated to support Bullet built with double precision (backport of [#660](https://github.com/dartsim/dart/pull/660))
-    * [Pull request #777](https://github.com/dartsim/dart/pull/777)
+   - [Pull request #777](https://github.com/dartsim/dart/pull/777)
 
 1. Modified to use btGImpactMeshShape instead of btConvexTriangleMeshShape for mesh
-    * [Pull request #764](https://github.com/dartsim/dart/pull/764)
+   - [Pull request #764](https://github.com/dartsim/dart/pull/764)
 
 1. Updated to support FCL 0.5 and tinyxml 4.0 (backport of [#749](https://github.com/dartsim/dart/pull/749))
-    * [Pull request #759](https://github.com/dartsim/dart/pull/759)
+   - [Pull request #759](https://github.com/dartsim/dart/pull/759)
 
 ### Version 5.1.2 (2016-04-25)
 
 1. Fixed inverse kinematics (backporting)
-    * [Pull request #684](https://github.com/dartsim/dart/pull/684)
+   - [Pull request #684](https://github.com/dartsim/dart/pull/684)
 
 1. Fixed aligned memory allocation with Eigen objects in loading meshes
-    * [Pull request #606](https://github.com/dartsim/dart/pull/606)
+   - [Pull request #606](https://github.com/dartsim/dart/pull/606)
 
 1. Fixed incorrect applying joint constraint impulses (backporting)
-    * [Pull request #579](https://github.com/dartsim/dart/pull/579)
+   - [Pull request #579](https://github.com/dartsim/dart/pull/579)
 
 1. Fixed some build and packaging issues
-    * [Pull request #559](https://github.com/dartsim/dart/pull/559)
-    * [Pull request #595](https://github.com/dartsim/dart/pull/595)
-    * [Pull request #696](https://github.com/dartsim/dart/pull/696)
+   - [Pull request #559](https://github.com/dartsim/dart/pull/559)
+   - [Pull request #595](https://github.com/dartsim/dart/pull/595)
+   - [Pull request #696](https://github.com/dartsim/dart/pull/696)
 
 ### Version 5.1.1 (2015-11-06)
 
 1. Add bullet dependency to package.xml
-    * [Pull request #523](https://github.com/dartsim/dart/pull/523)
+   - [Pull request #523](https://github.com/dartsim/dart/pull/523)
 
 1. Improved handling of missing symbols of Assimp package
-    * [Pull request #542](https://github.com/dartsim/dart/pull/542)
+   - [Pull request #542](https://github.com/dartsim/dart/pull/542)
 
 1. Improved travis-ci build log for Mac
-    * [Pull request #529](https://github.com/dartsim/dart/pull/529)
+   - [Pull request #529](https://github.com/dartsim/dart/pull/529)
 
 1. Fixed warnings in Function.cpp
-    * [Pull request #550](https://github.com/dartsim/dart/pull/550)
+   - [Pull request #550](https://github.com/dartsim/dart/pull/550)
 
 1. Fixed build failures on AppVeyor
-    * [Pull request #543](https://github.com/dartsim/dart/pull/543)
+   - [Pull request #543](https://github.com/dartsim/dart/pull/543)
 
 1. Fixed const qualification of ResourceRetriever
-    * [Pull request #534](https://github.com/dartsim/dart/pull/534)
-    * [Issue #532](https://github.com/dartsim/dart/issues/532)
+   - [Pull request #534](https://github.com/dartsim/dart/pull/534)
+   - [Issue #532](https://github.com/dartsim/dart/issues/532)
 
 1. Fixed aligned memory allocation with Eigen objects
-    * [Pull request #527](https://github.com/dartsim/dart/pull/527)
+   - [Pull request #527](https://github.com/dartsim/dart/pull/527)
 
 1. Fixed copy safety for various classes
-    * [Pull request #526](https://github.com/dartsim/dart/pull/526)
-    * [Pull request #539](https://github.com/dartsim/dart/pull/539)
-    * [Issue #524](https://github.com/dartsim/dart/issues/524)
+   - [Pull request #526](https://github.com/dartsim/dart/pull/526)
+   - [Pull request #539](https://github.com/dartsim/dart/pull/539)
+   - [Issue #524](https://github.com/dartsim/dart/issues/524)
 
 ### Version 5.1.0 (2015-10-15)
 
 1. Fixed incorrect rotational motion of BallJoint and FreeJoint
-    * [Pull request #518](https://github.com/dartsim/dart/pull/518)
+   - [Pull request #518](https://github.com/dartsim/dart/pull/518)
 
 1. Removed old documents: dart-tutorial, programmingGuide
-    * [Pull request #515](https://github.com/dartsim/dart/pull/515)
+   - [Pull request #515](https://github.com/dartsim/dart/pull/515)
 
 1. Fixed aligned memory allocation with Eigen objects
-    * [Pull request #513](https://github.com/dartsim/dart/pull/513)
+   - [Pull request #513](https://github.com/dartsim/dart/pull/513)
 
 1. Fixed segfault in Linkage::Criteria
-    * [Pull request #491](https://github.com/dartsim/dart/pull/491)
-    * [Issue #489](https://github.com/dartsim/dart/issues/489)
+   - [Pull request #491](https://github.com/dartsim/dart/pull/491)
+   - [Issue #489](https://github.com/dartsim/dart/issues/489)
 
 1. Improved sdf/urdf parser
-    * [Pull request #497](https://github.com/dartsim/dart/pull/497)
-    * [Pull request #485](https://github.com/dartsim/dart/pull/485)
+   - [Pull request #497](https://github.com/dartsim/dart/pull/497)
+   - [Pull request #485](https://github.com/dartsim/dart/pull/485)
 
 1. Fixed CMake warnings
-    * [Pull request #483](https://github.com/dartsim/dart/pull/483)
+   - [Pull request #483](https://github.com/dartsim/dart/pull/483)
 
 1. Fixed build issues on Windows
-    * [Pull request #516](https://github.com/dartsim/dart/pull/516)
-    * [Pull request #509](https://github.com/dartsim/dart/pull/509)
-    * [Pull request #486](https://github.com/dartsim/dart/pull/486)
-    * [Pull request #482](https://github.com/dartsim/dart/pull/482)
-    * [Issue #487](https://github.com/dartsim/dart/issues/487)
+   - [Pull request #516](https://github.com/dartsim/dart/pull/516)
+   - [Pull request #509](https://github.com/dartsim/dart/pull/509)
+   - [Pull request #486](https://github.com/dartsim/dart/pull/486)
+   - [Pull request #482](https://github.com/dartsim/dart/pull/482)
+   - [Issue #487](https://github.com/dartsim/dart/issues/487)
 
 1. Fixed IpoptSolver bugs
-    * [Pull request #481](https://github.com/dartsim/dart/pull/481)
+   - [Pull request #481](https://github.com/dartsim/dart/pull/481)
 
 1. Added Frame::getTransform(withRespecTo, inCoordinatesOf)
-    * [Pull request #475](https://github.com/dartsim/dart/pull/475)
-    * [Issue #471](https://github.com/dartsim/dart/issues/471)
+   - [Pull request #475](https://github.com/dartsim/dart/pull/475)
+   - [Issue #471](https://github.com/dartsim/dart/issues/471)
 
 1. Improved API documentation -- set the SHOW_USED_FILES tag to NO
-    * [Pull request #474](https://github.com/dartsim/dart/pull/474)
+   - [Pull request #474](https://github.com/dartsim/dart/pull/474)
 
 1. Added convenience setters for generalized coordinates of FreeJoint
-    * [Pull request #470](https://github.com/dartsim/dart/pull/470)
-    * [Pull request #507](https://github.com/dartsim/dart/pull/507)
+   - [Pull request #470](https://github.com/dartsim/dart/pull/470)
+   - [Pull request #507](https://github.com/dartsim/dart/pull/507)
 
 1. Fixed compilation warnings
-    * [Pull request #480](https://github.com/dartsim/dart/pull/480)
-    * [Pull request #469](https://github.com/dartsim/dart/pull/469)
-    * [Issue #418](https://github.com/dartsim/dart/issues/418)
+   - [Pull request #480](https://github.com/dartsim/dart/pull/480)
+   - [Pull request #469](https://github.com/dartsim/dart/pull/469)
+   - [Issue #418](https://github.com/dartsim/dart/issues/418)
 
 1. Added a mutex to Skeleton
-    * [Pull request #466](https://github.com/dartsim/dart/pull/466)
+   - [Pull request #466](https://github.com/dartsim/dart/pull/466)
 
 1. Added generic URIs support
-    * [Pull request #464](https://github.com/dartsim/dart/pull/464)
-    * [Pull request #517](https://github.com/dartsim/dart/pull/517)
+   - [Pull request #464](https://github.com/dartsim/dart/pull/464)
+   - [Pull request #517](https://github.com/dartsim/dart/pull/517)
 
 1. Added End Effector, Inverse Kinematics, and osgDart
-    * [Pull request #461](https://github.com/dartsim/dart/pull/461)
-    * [Pull request #495](https://github.com/dartsim/dart/pull/495)
-    * [Pull request #502](https://github.com/dartsim/dart/pull/502)
-    * [Pull request #506](https://github.com/dartsim/dart/pull/506)
-    * [Pull request #514](https://github.com/dartsim/dart/pull/514)
-    * [Issue #381](https://github.com/dartsim/dart/issues/381)
-    * [Issue #454](https://github.com/dartsim/dart/issues/454)
-    * [Issue #478](https://github.com/dartsim/dart/issues/478)
+   - [Pull request #461](https://github.com/dartsim/dart/pull/461)
+   - [Pull request #495](https://github.com/dartsim/dart/pull/495)
+   - [Pull request #502](https://github.com/dartsim/dart/pull/502)
+   - [Pull request #506](https://github.com/dartsim/dart/pull/506)
+   - [Pull request #514](https://github.com/dartsim/dart/pull/514)
+   - [Issue #381](https://github.com/dartsim/dart/issues/381)
+   - [Issue #454](https://github.com/dartsim/dart/issues/454)
+   - [Issue #478](https://github.com/dartsim/dart/issues/478)
 
 1. Removed outdated packaging scripts
-    * [Pull request #456](https://github.com/dartsim/dart/pull/456)
+   - [Pull request #456](https://github.com/dartsim/dart/pull/456)
 
 1. Added initial position and initial velocity properties
-    * [Pull request #449](https://github.com/dartsim/dart/pull/449)
+   - [Pull request #449](https://github.com/dartsim/dart/pull/449)
 
 1. Added a package.xml file for REP-136 support
-    * [Pull request #446](https://github.com/dartsim/dart/pull/446)
+   - [Pull request #446](https://github.com/dartsim/dart/pull/446)
 
 1. Improved Linkage and Chain Criteria
-    * [Pull request #443](https://github.com/dartsim/dart/pull/443)
-    * [Issue #437](https://github.com/dartsim/dart/issues/437)
+   - [Pull request #443](https://github.com/dartsim/dart/pull/443)
+   - [Issue #437](https://github.com/dartsim/dart/issues/437)
 
 1. Added Joint::isCyclic to mark SO(2) topology
-    * [Pull request #441](https://github.com/dartsim/dart/pull/441)
+   - [Pull request #441](https://github.com/dartsim/dart/pull/441)
 
 1. Fixed SEGFAULTs in DartLoader
-    * [Pull request #439](https://github.com/dartsim/dart/pull/439)
+   - [Pull request #439](https://github.com/dartsim/dart/pull/439)
 
 1. Added the SYSTEM flag to include_directories
-    * [Pull request #435](https://github.com/dartsim/dart/pull/435)
+   - [Pull request #435](https://github.com/dartsim/dart/pull/435)
 
 1. Improved Joint warning
-    * [Pull request #430](https://github.com/dartsim/dart/pull/430)
+   - [Pull request #430](https://github.com/dartsim/dart/pull/430)
 
 1. Added tutorials (http://dart.readthedocs.org/)
-    * [Pull request #504](https://github.com/dartsim/dart/pull/504)
-    * [Pull request #484](https://github.com/dartsim/dart/pull/484)
-    * [Pull request #423](https://github.com/dartsim/dart/pull/423)
-    * [Pull request #511](https://github.com/dartsim/dart/pull/511)
+   - [Pull request #504](https://github.com/dartsim/dart/pull/504)
+   - [Pull request #484](https://github.com/dartsim/dart/pull/484)
+   - [Pull request #423](https://github.com/dartsim/dart/pull/423)
+   - [Pull request #511](https://github.com/dartsim/dart/pull/511)
 
 ### Version 5.0.2 (2015-09-28)
 
 1. Fixed bug in Jacobian update notifications
-    * [Pull request #500](https://github.com/dartsim/dart/pull/500)
-    * [Issue #499](https://github.com/dartsim/dart/issues/499)
+   - [Pull request #500](https://github.com/dartsim/dart/pull/500)
+   - [Issue #499](https://github.com/dartsim/dart/issues/499)
 
 ### Version 5.0.1 (2015-07-28)
 
 1. Improved app indexing for bipedStand and atlasSimbicon
-    * [Pull request #417](https://github.com/dartsim/dart/pull/417)
+   - [Pull request #417](https://github.com/dartsim/dart/pull/417)
 
 1. Added clipping command when it exceeds the limits
-    * [Pull request #419](https://github.com/dartsim/dart/pull/419)
+   - [Pull request #419](https://github.com/dartsim/dart/pull/419)
 
 1. Improved CollisionNode's index validity check
-    * [Pull request #421](https://github.com/dartsim/dart/pull/421)
+   - [Pull request #421](https://github.com/dartsim/dart/pull/421)
 
 1. Standardized warning messages for Joints
-    * [Pull request #425](https://github.com/dartsim/dart/pull/425)
-    * [Pull request #429](https://github.com/dartsim/dart/pull/429)
+   - [Pull request #425](https://github.com/dartsim/dart/pull/425)
+   - [Pull request #429](https://github.com/dartsim/dart/pull/429)
 
 1. Fixed bug in SDF parser -- correct child for a joint
-    * [Pull request #431](https://github.com/dartsim/dart/pull/431)
+   - [Pull request #431](https://github.com/dartsim/dart/pull/431)
 
 1. Fixed SDF parsing for single link model without joint
-    * [Pull request #444](https://github.com/dartsim/dart/pull/444)
+   - [Pull request #444](https://github.com/dartsim/dart/pull/444)
 
 1. Added missing virtual destructors to Properties in Entity and [Soft]BodyNode
-    * [Pull request #458](https://github.com/dartsim/dart/pull/458)
+   - [Pull request #458](https://github.com/dartsim/dart/pull/458)
 
 1. Limited maximum required version of Assimp less than 3.0~dfsg-4
-    * [Pull request #459](https://github.com/dartsim/dart/pull/459)
+   - [Pull request #459](https://github.com/dartsim/dart/pull/459)
 
 1. Fixed SEGFAULTs in DartLoader
-    * [Pull request #472](https://github.com/dartsim/dart/pull/472)
+   - [Pull request #472](https://github.com/dartsim/dart/pull/472)
 
 ### Version 5.0.0 (2015-06-15)
 
 1. Fixed aligned memory allocation with Eigen objects
-    * [Pull request #414](https://github.com/dartsim/dart/pull/414)
+   - [Pull request #414](https://github.com/dartsim/dart/pull/414)
 
 1. Added some missing API for DegreeOfFreedom
-    * [Pull request #408](https://github.com/dartsim/dart/pull/408)
+   - [Pull request #408](https://github.com/dartsim/dart/pull/408)
 
 1. Replaced logMaps with Eigen::AngleAxisd
-    * [Pull request #407](https://github.com/dartsim/dart/pull/407)
+   - [Pull request #407](https://github.com/dartsim/dart/pull/407)
 
 1. Improved FCL collision detector
-    * [Pull request #405](https://github.com/dartsim/dart/pull/405)
+   - [Pull request #405](https://github.com/dartsim/dart/pull/405)
 
 1. Removed deprecated API and suppressed warnings
-    * [Pull request #404](https://github.com/dartsim/dart/pull/404)
+   - [Pull request #404](https://github.com/dartsim/dart/pull/404)
 
 1. Added use of OpenGL's multisample anti-aliasing
-    * [Pull request #402](https://github.com/dartsim/dart/pull/402)
+   - [Pull request #402](https://github.com/dartsim/dart/pull/402)
 
 1. Added computation of differences of generalized coordinates
-    * [Pull request #389](https://github.com/dartsim/dart/pull/389)
-    * [Issue #290](https://github.com/dartsim/dart/issues/290)
+   - [Pull request #389](https://github.com/dartsim/dart/pull/389)
+   - [Issue #290](https://github.com/dartsim/dart/issues/290)
 
 1. Added deprecated and force-linline definitions for clang
-    * [Pull request #384](https://github.com/dartsim/dart/pull/384)
-    * [Issue #379](https://github.com/dartsim/dart/issues/379)
+   - [Pull request #384](https://github.com/dartsim/dart/pull/384)
+   - [Issue #379](https://github.com/dartsim/dart/issues/379)
 
 1. Eradicated memory leaks and maked classes copy-safe and clonable
-    * [Pull request #369](https://github.com/dartsim/dart/pull/369)
-    * [Pull request #390](https://github.com/dartsim/dart/pull/390)
-    * [Pull request #391](https://github.com/dartsim/dart/pull/391)
-    * [Pull request #392](https://github.com/dartsim/dart/pull/392)
-    * [Pull request #397](https://github.com/dartsim/dart/pull/397)
-    * [Pull request #415](https://github.com/dartsim/dart/pull/415)
-    * [Issue #280](https://github.com/dartsim/dart/issues/280)
-    * [Issue #339](https://github.com/dartsim/dart/issues/339)
-    * [Issue #370](https://github.com/dartsim/dart/issues/370)
-    * [Issue #383](https://github.com/dartsim/dart/issues/383)
+   - [Pull request #369](https://github.com/dartsim/dart/pull/369)
+   - [Pull request #390](https://github.com/dartsim/dart/pull/390)
+   - [Pull request #391](https://github.com/dartsim/dart/pull/391)
+   - [Pull request #392](https://github.com/dartsim/dart/pull/392)
+   - [Pull request #397](https://github.com/dartsim/dart/pull/397)
+   - [Pull request #415](https://github.com/dartsim/dart/pull/415)
+   - [Issue #280](https://github.com/dartsim/dart/issues/280)
+   - [Issue #339](https://github.com/dartsim/dart/issues/339)
+   - [Issue #370](https://github.com/dartsim/dart/issues/370)
+   - [Issue #383](https://github.com/dartsim/dart/issues/383)
 
 1. Improved PlaneShape constructors
-    * [Pull request #366](https://github.com/dartsim/dart/pull/366)
-    * [Pull request #377](https://github.com/dartsim/dart/pull/377)
-    * [Issue #373](https://github.com/dartsim/dart/issues/373)
+   - [Pull request #366](https://github.com/dartsim/dart/pull/366)
+   - [Pull request #377](https://github.com/dartsim/dart/pull/377)
+   - [Issue #373](https://github.com/dartsim/dart/issues/373)
 
 1. Added appveyor options for parallel build and detailed log
-    * [Pull request #365](https://github.com/dartsim/dart/pull/365)
+   - [Pull request #365](https://github.com/dartsim/dart/pull/365)
 
 1. Improved robustness and package handling for URDF parsing
-    * [Pull request #364](https://github.com/dartsim/dart/pull/364)
+   - [Pull request #364](https://github.com/dartsim/dart/pull/364)
 
-1. Fixed bug in BodyNode::_updateBodyJacobianSpatialDeriv()
-    * [Pull request #363](https://github.com/dartsim/dart/pull/363)
+1. Fixed bug in BodyNode::\_updateBodyJacobianSpatialDeriv()
+   - [Pull request #363](https://github.com/dartsim/dart/pull/363)
 
 1. Added alpha channel and Color functions
-    * [Pull request #359](https://github.com/dartsim/dart/pull/359)
-    * [Issue #358](https://github.com/dartsim/dart/issues/358)
+   - [Pull request #359](https://github.com/dartsim/dart/pull/359)
+   - [Issue #358](https://github.com/dartsim/dart/issues/358)
 
 1. Added Jacobian getters to Skeleton
-    * [Pull request #357](https://github.com/dartsim/dart/pull/357)
+   - [Pull request #357](https://github.com/dartsim/dart/pull/357)
 
 1. Added ArrowShape for visualizing arrows
-    * [Pull request #356](https://github.com/dartsim/dart/pull/356)
+   - [Pull request #356](https://github.com/dartsim/dart/pull/356)
 
 1. Fixed matrix dimension bug in operationalSpaceControl app
-    * [Pull request #354](https://github.com/dartsim/dart/pull/354)
+   - [Pull request #354](https://github.com/dartsim/dart/pull/354)
 
 1. Added build type definitions
-    * [Pull request #353](https://github.com/dartsim/dart/pull/353)
+   - [Pull request #353](https://github.com/dartsim/dart/pull/353)
 
 1. Added Signal class
-    * [Pull request #350](https://github.com/dartsim/dart/pull/350)
+   - [Pull request #350](https://github.com/dartsim/dart/pull/350)
 
 1. Added LineSegmentShape for visualizing line segments
-    * [Pull request #349](https://github.com/dartsim/dart/pull/349)
-    * [Issue #346](https://github.com/dartsim/dart/issues/346)
+   - [Pull request #349](https://github.com/dartsim/dart/pull/349)
+   - [Issue #346](https://github.com/dartsim/dart/issues/346)
 
 1. Fixed segfault in SoftSdfParser
-    * [Pull request #345](https://github.com/dartsim/dart/pull/345)
+   - [Pull request #345](https://github.com/dartsim/dart/pull/345)
 
 1. Added subscriptions for destructions and notifications
-    * [Pull request #343](https://github.com/dartsim/dart/pull/343)
+   - [Pull request #343](https://github.com/dartsim/dart/pull/343)
 
 1. Added NloptSolver::[get/set]NumMaxEvaluations()
-    * [Pull request #342](https://github.com/dartsim/dart/pull/342)
+   - [Pull request #342](https://github.com/dartsim/dart/pull/342)
 
 1. Added support of Eigen::VectorXd in parser
-    * [Pull request #341](https://github.com/dartsim/dart/pull/341)
+   - [Pull request #341](https://github.com/dartsim/dart/pull/341)
 
 1. Added Skeleton::getNumJoints()
-    * [Pull request #335](https://github.com/dartsim/dart/pull/335)
+   - [Pull request #335](https://github.com/dartsim/dart/pull/335)
 
 1. Fixed bug in DARTCollide for sphere-sphere collision
-    * [Pull request #332](https://github.com/dartsim/dart/pull/332)
+   - [Pull request #332](https://github.com/dartsim/dart/pull/332)
 
 1. Fixed naming issues for Skeletons in World
-    * [Pull request #331](https://github.com/dartsim/dart/pull/331)
-    * [Issue #330](https://github.com/dartsim/dart/issues/330)
+   - [Pull request #331](https://github.com/dartsim/dart/pull/331)
+   - [Issue #330](https://github.com/dartsim/dart/issues/330)
 
 1. Added PlanarJoint support for URDF loader
-    * [Pull request #326](https://github.com/dartsim/dart/pull/326)
+   - [Pull request #326](https://github.com/dartsim/dart/pull/326)
 
 1. Fixed rotation of the inertia reference frame for URDF loader
-    * [Pull request #326](https://github.com/dartsim/dart/pull/326)
-    * [Issue #47](https://github.com/dartsim/dart/issues/47)
+   - [Pull request #326](https://github.com/dartsim/dart/pull/326)
+   - [Issue #47](https://github.com/dartsim/dart/issues/47)
 
 1. Fixed bug in loading WorldFile
-    * [Pull request #325](https://github.com/dartsim/dart/pull/325)
+   - [Pull request #325](https://github.com/dartsim/dart/pull/325)
 
 1. Added plotting of 2D trajectories
-    * [Pull request #324](https://github.com/dartsim/dart/pull/324)
+   - [Pull request #324](https://github.com/dartsim/dart/pull/324)
 
 1. Removed unsupported axis orders of EulerJoint
-    * [Pull request #323](https://github.com/dartsim/dart/pull/323)
-    * [Issue #321](https://github.com/dartsim/dart/issues/321)
+   - [Pull request #323](https://github.com/dartsim/dart/pull/323)
+   - [Issue #321](https://github.com/dartsim/dart/issues/321)
 
 1. Added convenience functions to help with setting joint positions
-    * [Pull request #322](https://github.com/dartsim/dart/pull/322)
-    * [Pull request #338](https://github.com/dartsim/dart/pull/338)
+   - [Pull request #322](https://github.com/dartsim/dart/pull/322)
+   - [Pull request #338](https://github.com/dartsim/dart/pull/338)
 
 1. Added Frame class and auto-updating for forward kinematics
-    * [Pull request #319](https://github.com/dartsim/dart/pull/319)
-    * [Pull request #344](https://github.com/dartsim/dart/pull/344)
-    * [Pull request #367](https://github.com/dartsim/dart/pull/367)
-    * [Pull request #380](https://github.com/dartsim/dart/pull/380)
-    * [Issue #289](https://github.com/dartsim/dart/issues/289)
-    * [Issue #294](https://github.com/dartsim/dart/issues/294)
-    * [Issue #305](https://github.com/dartsim/dart/issues/305)
+   - [Pull request #319](https://github.com/dartsim/dart/pull/319)
+   - [Pull request #344](https://github.com/dartsim/dart/pull/344)
+   - [Pull request #367](https://github.com/dartsim/dart/pull/367)
+   - [Pull request #380](https://github.com/dartsim/dart/pull/380)
+   - [Issue #289](https://github.com/dartsim/dart/issues/289)
+   - [Issue #294](https://github.com/dartsim/dart/issues/294)
+   - [Issue #305](https://github.com/dartsim/dart/issues/305)
 
 1. Added Travis-CI build test for OSX
-    * [Pull request #313](https://github.com/dartsim/dart/pull/313)
-    * [Issue #258](https://github.com/dartsim/dart/issues/258)
+   - [Pull request #313](https://github.com/dartsim/dart/pull/313)
+   - [Issue #258](https://github.com/dartsim/dart/issues/258)
 
 1. Added specification of minimum dependency version
-    * [Pull request #306](https://github.com/dartsim/dart/pull/306)
+   - [Pull request #306](https://github.com/dartsim/dart/pull/306)
 
 ## DART 4
 
 ### Version 4.3.7 (2018-01-05)
 
 1. Updated DART 4.3 to be compatible with urdf 1.0/tinyxml2 6/flann 1.9.1
-    * [Pull request #955](https://github.com/dartsim/dart/pull/955)
+   - [Pull request #955](https://github.com/dartsim/dart/pull/955)
 
 ### Version 4.3.6 (2016-04-16)
 
 1. Fixed duplicate entries in Skeleton::mBodyNodes causing segfault in destructor
-    * [Issue #671](https://github.com/dartsim/dart/issues/671)
-    * [Pull request #672](https://github.com/dartsim/dart/pull/672)
+   - [Issue #671](https://github.com/dartsim/dart/issues/671)
+   - [Pull request #672](https://github.com/dartsim/dart/pull/672)
 
 ### Version 4.3.5 (2016-01-09)
 
 1. Fixed incorrect applying of joint constraint impulses (backported from 6.0.0)
-    * [Pull request #578](https://github.com/dartsim/dart/pull/578)
+   - [Pull request #578](https://github.com/dartsim/dart/pull/578)
 
 ### Version 4.3.4 (2015-01-24)
 
 1. Fixed build issue with gtest on Mac
-    * [Pull request #315](https://github.com/dartsim/dart/pull/315)
+   - [Pull request #315](https://github.com/dartsim/dart/pull/315)
 
 ### Version 4.3.3 (2015-01-23)
 
 1. Fixed joint Coulomb friction
-    * [Pull request #311](https://github.com/dartsim/dart/pull/311)
+   - [Pull request #311](https://github.com/dartsim/dart/pull/311)
 
 ### Version 4.3.2 (2015-01-22)
 
@@ -1600,86 +1426,86 @@ This release is mostly a maintenance update, including various CI updates and bu
 ### Version 4.3.1 (2015-01-21)
 
 1. Fixed API incompatibility introduced by dart-4.3.0
-    * [Issue #303](https://github.com/dartsim/dart/issues/303)
-    * [Pull request #309](https://github.com/dartsim/dart/pull/309)
+   - [Issue #303](https://github.com/dartsim/dart/issues/303)
+   - [Pull request #309](https://github.com/dartsim/dart/pull/309)
 
 ### Version 4.3.0 (2015-01-19)
 
 1. Added name manager for efficient name look-up and unique naming
-    * [Pull request #277](https://github.com/dartsim/dart/pull/277)
+   - [Pull request #277](https://github.com/dartsim/dart/pull/277)
 1. Added all-inclusive header and namespace headers
-    * [Pull request #278](https://github.com/dartsim/dart/pull/278)
+   - [Pull request #278](https://github.com/dartsim/dart/pull/278)
 1. Added DegreeOfFreedom class for getting/setting data of individual generalized coordinates
-    * [Pull request #288](https://github.com/dartsim/dart/pull/288)
+   - [Pull request #288](https://github.com/dartsim/dart/pull/288)
 1. Added hybrid dynamics
-    * [Pull request #298](https://github.com/dartsim/dart/pull/298)
+   - [Pull request #298](https://github.com/dartsim/dart/pull/298)
 1. Added joint actuator types
-    * [Pull request #298](https://github.com/dartsim/dart/pull/298)
+   - [Pull request #298](https://github.com/dartsim/dart/pull/298)
 1. Added Coulomb joint friction
-    * [Pull request #301](https://github.com/dartsim/dart/pull/301)
+   - [Pull request #301](https://github.com/dartsim/dart/pull/301)
 1. Migrated to C++11
-    * [Pull request #268](https://github.com/dartsim/dart/pull/268)
-    * [Pull request #299](https://github.com/dartsim/dart/pull/299)
+   - [Pull request #268](https://github.com/dartsim/dart/pull/268)
+   - [Pull request #299](https://github.com/dartsim/dart/pull/299)
 1. Improved readability of CMake output messages
-    * [Pull request #272](https://github.com/dartsim/dart/pull/272)
+   - [Pull request #272](https://github.com/dartsim/dart/pull/272)
 1. Fixed const-correctneess of member functions
-    * [Pull request #277](https://github.com/dartsim/dart/pull/277)
+   - [Pull request #277](https://github.com/dartsim/dart/pull/277)
 1. Added handling use of 'package:/' in URDF
-    * [Pull request #273](https://github.com/dartsim/dart/pull/273)
-    * [Issue #271](https://github.com/dartsim/dart/issues/271)
+   - [Pull request #273](https://github.com/dartsim/dart/pull/273)
+   - [Issue #271](https://github.com/dartsim/dart/issues/271)
 
 ### Version 4.2.1 (2015-01-07)
 
 1. Fixed version numbering of shared libraries in debian packages
-    * [Pull request #286](https://github.com/dartsim/dart/pull/286)
+   - [Pull request #286](https://github.com/dartsim/dart/pull/286)
 1. Fixed Jacobian and its derivatives of FreeJoint/BallJoint
-    * [Pull request #284](https://github.com/dartsim/dart/pull/284)
+   - [Pull request #284](https://github.com/dartsim/dart/pull/284)
 
 ### Version 4.2.0 (2014-11-22)
 
 1. Added reset functions for Simulation and Recording class
-    * [Pull request #231](https://github.com/dartsim/dart/pull/231)
+   - [Pull request #231](https://github.com/dartsim/dart/pull/231)
 1. Added operational space control example
-    * [Pull request #257](https://github.com/dartsim/dart/pull/257)
+   - [Pull request #257](https://github.com/dartsim/dart/pull/257)
 1. Fixed misuse of Bullet collision shapes
-    * [Pull request #228](https://github.com/dartsim/dart/pull/228)
+   - [Pull request #228](https://github.com/dartsim/dart/pull/228)
 1. Fixed adjacent body pair check for Bullet collision detector
-    * [Pull request #246](https://github.com/dartsim/dart/pull/246)
+   - [Pull request #246](https://github.com/dartsim/dart/pull/246)
 1. Fixed incorrect computation of constraint impulse for BallJointConstraint and WeldJointContraint
-    * [Pull request #247](https://github.com/dartsim/dart/pull/247)
+   - [Pull request #247](https://github.com/dartsim/dart/pull/247)
 1. Improved generation of soft box shape for soft body
-    * [Commit ec31f44](https://github.com/dartsim/dart/commit/ec31f44)
+   - [Commit ec31f44](https://github.com/dartsim/dart/commit/ec31f44)
 
 ### Version 4.1.1 (2014-07-17)
 
 1. Added ABI check script
-    * [Pull request #226](https://github.com/dartsim/dart/pull/226)
-    * [Pull request #227](https://github.com/dartsim/dart/pull/227)
+   - [Pull request #226](https://github.com/dartsim/dart/pull/226)
+   - [Pull request #227](https://github.com/dartsim/dart/pull/227)
 1. Fixed build issues on Linux
-    * [Pull request #214](https://github.com/dartsim/dart/pull/214)
-    * [Pull request #219](https://github.com/dartsim/dart/pull/219)
+   - [Pull request #214](https://github.com/dartsim/dart/pull/214)
+   - [Pull request #219](https://github.com/dartsim/dart/pull/219)
 1. Fixed build issues on Windows
-    * [Pull request #215](https://github.com/dartsim/dart/pull/215)
-    * [Pull request #217](https://github.com/dartsim/dart/pull/217)
+   - [Pull request #215](https://github.com/dartsim/dart/pull/215)
+   - [Pull request #217](https://github.com/dartsim/dart/pull/217)
 1. Fixed unintended warning messages
-    * [Pull request #220](https://github.com/dartsim/dart/pull/220)
+   - [Pull request #220](https://github.com/dartsim/dart/pull/220)
 
 ### Version 4.1.0 (2014-07-02)
 
 1. Fixed bug in switching collision detectors
-    * [Issue #127](https://github.com/dartsim/dart/issues/127)
-    * [Pull request #195](https://github.com/dartsim/dart/pull/195)
+   - [Issue #127](https://github.com/dartsim/dart/issues/127)
+   - [Pull request #195](https://github.com/dartsim/dart/pull/195)
 1. Fixed kinematics and dynamics when a skeleton has multiple parent-less bodies
-    * [Pull request #196](https://github.com/dartsim/dart/pull/196)
+   - [Pull request #196](https://github.com/dartsim/dart/pull/196)
 1. Fixed issue on installing DART 4 alongside DART 3 on Linux
-    * [Issue #122](https://github.com/dartsim/dart/issues/122)
-    * [Pull request #203](https://github.com/dartsim/dart/pull/203)
+   - [Issue #122](https://github.com/dartsim/dart/issues/122)
+   - [Pull request #203](https://github.com/dartsim/dart/pull/203)
 1. Fixed warnings on gcc
-    * [Pull request #206](https://github.com/dartsim/dart/pull/206)
+   - [Pull request #206](https://github.com/dartsim/dart/pull/206)
 1. Renamed getDof() to getNumDofs()
-    * [Pull request #209](https://github.com/dartsim/dart/pull/209)
+   - [Pull request #209](https://github.com/dartsim/dart/pull/209)
 1. Added cylinder shape for soft body
-    * [Pull request #210](https://github.com/dartsim/dart/pull/210)
+   - [Pull request #210](https://github.com/dartsim/dart/pull/210)
 
 ### Version 4.0.0 (2014-06-02)
 
@@ -1688,24 +1514,39 @@ This release is mostly a maintenance update, including various CI updates and bu
 1. Added soft body dynamics
 1. Added computation of velocity and acceleration of COM
 1. Added bullet collision detector
-  * [Pull request #156](https://github.com/dartsim/dart/pull/156)
+
+- [Pull request #156](https://github.com/dartsim/dart/pull/156)
+
 1. Improved performance of forward dynamics algorithm
-  * [Pull request #188](https://github.com/dartsim/dart/pull/188)
+
+- [Pull request #188](https://github.com/dartsim/dart/pull/188)
+
 1. Improved dynamics API for Skeleton and Joint
-  * [Pull request #161](https://github.com/dartsim/dart/pull/161)
-  * [Pull request #192](https://github.com/dartsim/dart/pull/192)
-  * [Pull request #193](https://github.com/dartsim/dart/pull/193)
+
+- [Pull request #161](https://github.com/dartsim/dart/pull/161)
+- [Pull request #192](https://github.com/dartsim/dart/pull/192)
+- [Pull request #193](https://github.com/dartsim/dart/pull/193)
+
 1. Improved constraint dynamics solver
-  * [Pull request #184](https://github.com/dartsim/dart/pull/184)
+
+- [Pull request #184](https://github.com/dartsim/dart/pull/184)
+
 1. Improved calculation of equations of motion using Featherstone algorithm
-  * [Issue #85](https://github.com/dartsim/dart/issues/87)
+
+- [Issue #85](https://github.com/dartsim/dart/issues/87)
+
 1. Improved optimizer interface and added nlopt solver
-  * [Pull request #152](https://github.com/dartsim/dart/pull/152)
+
+- [Pull request #152](https://github.com/dartsim/dart/pull/152)
+
 1. Fixed self collision bug
-  * [Issue #125](https://github.com/dartsim/dart/issues/125)
+
+- [Issue #125](https://github.com/dartsim/dart/issues/125)
+
 1. Fixed incorrect integration of BallJoint and FreeJoint
-  * [Issue #122](https://github.com/dartsim/dart/issues/122)
-  * [Pull request #168](https://github.com/dartsim/dart/pull/168)
+
+- [Issue #122](https://github.com/dartsim/dart/issues/122)
+- [Pull request #168](https://github.com/dartsim/dart/pull/168)
 
 ## DART 3
 
@@ -1724,14 +1565,17 @@ This release is mostly a maintenance update, including various CI updates and bu
 ### Version 2.6 (2013-09-07)
 
 1. Clean-up of build system:
-  * Renamed DART_INCLUDEDIR to the standard-compliant DART_INCLUDE_DIRS in CMake files. Users need to adapt their CMake files for this change.
-  * Users no longer need to call find_package(DARTExt) in the CMake files. A call to find_package(DART) also finds its dependencies now.
-  * Allow user to overwrite installation prefix
-  * Add possibility to include DART header files as '#include \<dart/dynamics/Skeleton.h\>' in addition to '#include \<dynamics/Skeleton.h\>'
-  * Allow out-of-source builds
+
+- Renamed DART_INCLUDEDIR to the standard-compliant DART_INCLUDE_DIRS in CMake files. Users need to adapt their CMake files for this change.
+- Users no longer need to call find_package(DARTExt) in the CMake files. A call to find_package(DART) also finds its dependencies now.
+- Allow user to overwrite installation prefix
+- Add possibility to include DART header files as '#include \<dart/dynamics/Skeleton.h\>' in addition to '#include \<dynamics/Skeleton.h\>'
+- Allow out-of-source builds
+
 1. URDF loader:
-  * Major clean-up
-  * Consider mesh scaling factor
+
+- Major clean-up
+- Consider mesh scaling factor
 
 ### Version 2.5 (2013-07-16)
 
@@ -1757,12 +1601,14 @@ This release is mostly a maintenance update, including various CI updates and bu
 1. Different shapes for collision and visualization (not just different meshes)
 1. Shapes are no longer centered at the COM but can be transformed independently relative to the link frame.
 1. Improved URDF support
-  * Support for non-mesh shapes
-  * Does not create dummy root nodes anymore
-  * Support for continuous joints
-  * Support for arbitrary joint axes for revolute joints (but not for prismatic joints) instead of only axis-aligned joint axes
-  * Support for relative mesh paths even if the robot and world URDF files are in different directories
-  * All supported joint types can be root joints
+
+- Support for non-mesh shapes
+- Does not create dummy root nodes anymore
+- Support for continuous joints
+- Support for arbitrary joint axes for revolute joints (but not for prismatic joints) instead of only axis-aligned joint axes
+- Support for relative mesh paths even if the robot and world URDF files are in different directories
+- All supported joint types can be root joints
+
 1. Clean-up of the Robot class
 1. Removed Object class
 1. More robust build and installation process on Linux

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ dynamics.
 Install DART using your preferred package manager:
 
 **Python**
+
 ```shell
 uv add dartpy                             # uv (preferred)
 pip install dartpy                        # PyPI
@@ -29,6 +30,7 @@ conda install -c conda-forge dartpy       # or Conda
 ```
 
 **C++**
+
 ```shell
 # Cross-platform (recommended)
 pixi add dartsim-cpp  # or: conda install -c conda-forge dartsim-cpp
@@ -56,12 +58,12 @@ An overview of DART is also available on [DeepWiki](https://deepwiki.com/dartsim
 
 ## Project Status
 
-| Item                  | Status |
-| --------------------- | ------ |
-| Build                 | [![CI Ubuntu](https://github.com/dartsim/dart/actions/workflows/ci_ubuntu.yml/badge.svg)](https://github.com/dartsim/dart/actions/workflows/ci_ubuntu.yml) [![CI macOS](https://github.com/dartsim/dart/actions/workflows/ci_macos.yml/badge.svg)](https://github.com/dartsim/dart/actions/workflows/ci_macos.yml) [![CI Windows](https://github.com/dartsim/dart/actions/workflows/ci_windows.yml/badge.svg)](https://github.com/dartsim/dart/actions/workflows/ci_windows.yml) |
-| Doc, Coverage, Linter | [![Documentation Status](https://readthedocs.org/projects/dart/badge/?version=latest)](https://dart.readthedocs.io/en/latest/?badge=latest) [![codecov](https://codecov.io/gh/dartsim/dart/branch/main/graph/badge.svg)](https://codecov.io/gh/dartsim/dart) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2d95a9b951be4b73a71097670ec351e8)](https://www.codacy.com/gh/dartsim/dart/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=dartsim/dart&amp;utm_campaign=Badge_Grade) |
-| Packages              | [![Anaconda-Server Badge](https://anaconda.org/conda-forge/dartsim/badges/version.svg)](https://anaconda.org/conda-forge/dartsim) [![PyPI Version](https://img.shields.io/pypi/v/dartpy)](https://pypi.org/project/dartpy/) [All Distributions →](https://repology.org/project/dart-sim/versions) |
-| Maintenance           | [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/dartsim/dart.svg)](http://isitmaintained.com/project/dartsim/dart "Average time to resolve an issue") [![Percentage of issues still open](http://isitmaintained.com/badge/open/dartsim/dart.svg)](http://isitmaintained.com/project/dartsim/dart "Percentage of issues still open") |
+| Item                  | Status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Build                 | [![CI Ubuntu](https://github.com/dartsim/dart/actions/workflows/ci_ubuntu.yml/badge.svg)](https://github.com/dartsim/dart/actions/workflows/ci_ubuntu.yml) [![CI macOS](https://github.com/dartsim/dart/actions/workflows/ci_macos.yml/badge.svg)](https://github.com/dartsim/dart/actions/workflows/ci_macos.yml) [![CI Windows](https://github.com/dartsim/dart/actions/workflows/ci_windows.yml/badge.svg)](https://github.com/dartsim/dart/actions/workflows/ci_windows.yml)                          |
+| Doc, Coverage, Linter | [![Documentation Status](https://readthedocs.org/projects/dart/badge/?version=latest)](https://dart.readthedocs.io/en/latest/?badge=latest) [![codecov](https://codecov.io/gh/dartsim/dart/branch/main/graph/badge.svg)](https://codecov.io/gh/dartsim/dart) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2d95a9b951be4b73a71097670ec351e8)](https://www.codacy.com/gh/dartsim/dart/dashboard?utm_source=github.com&utm_medium=referral&utm_content=dartsim/dart&utm_campaign=Badge_Grade) |
+| Packages              | [![Anaconda-Server Badge](https://anaconda.org/conda-forge/dartsim/badges/version.svg)](https://anaconda.org/conda-forge/dartsim) [![PyPI Version](https://img.shields.io/pypi/v/dartpy)](https://pypi.org/project/dartpy/) [All Distributions →](https://repology.org/project/dart-sim/versions)                                                                                                                                                                                                         |
+| Maintenance           | [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/dartsim/dart.svg)](http://isitmaintained.com/project/dartsim/dart "Average time to resolve an issue") [![Percentage of issues still open](http://isitmaintained.com/badge/open/dartsim/dart.svg)](http://isitmaintained.com/project/dartsim/dart "Percentage of issues still open")                                                                                                                                       |
 
 ## Citation
 

--- a/data/mjcf/openai/LICENSE.md
+++ b/data/mjcf/openai/LICENSE.md
@@ -23,7 +23,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 # Mujoco models
+
 This work is derived from [MuJuCo models](http://www.mujoco.org/forum/index.php?resources/) used under the following license:
+
 ```
 This file is part of MuJoCo.
 Copyright 2009-2015 Roboti LLC.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Located in `onboarding/` - **Architecture guides for developers:**
 - [Building from Source](onboarding/building.md) - Step-by-step build instructions
 - [Code Style Guide](onboarding/code-style.md) - Code conventions for C++, Python, and CMake
 
-*Format: Markdown (GitHub/LLM-friendly) for internal codebase understanding*
+_Format: Markdown (GitHub/LLM-friendly) for internal codebase understanding_
 
 ### User Documentation (ReadTheDocs)
 
@@ -31,7 +31,7 @@ Located in `readthedocs/` - **Published documentation for end users:**
 - **[User Guides](readthedocs/dart/user_guide/)** - Installation, tutorials, migration guides
 - **[API Reference](https://dart.readthedocs.io/)** - Published API documentation
 
-*Format: ReStructuredText (RST) for Sphinx/ReadTheDocs publishing*
+_Format: ReStructuredText (RST) for Sphinx/ReadTheDocs publishing_
 
 ## Quick Links by Task
 

--- a/docs/dev_tasks/README.md
+++ b/docs/dev_tasks/README.md
@@ -9,6 +9,7 @@ Documentation for development tasks in DART.
 ## Documentation Principles
 
 **Task docs should**:
+
 - ✅ Track **current status** and **next steps**
 - ✅ Document **key decisions** and **why** (not just what)
 - ✅ Point to **code as source of truth**
@@ -16,11 +17,13 @@ Documentation for development tasks in DART.
 - ❌ Avoid full history - focus on current state
 
 **When task is completed**:
+
 1. **Add brief section** to existing `docs/onboarding/` file (e.g., add to constraints.md, not new file)
 2. **Remove the entire task folder** from `docs/dev_tasks/`
 3. **Keep onboarding docs concise** - too many docs make them hard to use effectively
 
 **Onboarding docs must stay lean**:
+
 - ❌ Don't create new detailed files for every completed task
 - ✅ Add brief sections to existing relevant docs
 - ✅ Focus on key design decisions only (2-5 sentences)
@@ -28,6 +31,7 @@ Documentation for development tasks in DART.
 - ⚠️ LLMs struggle with bloated documentation - keep it minimal
 
 **What NOT to include in onboarding docs**:
+
 - ❌ **Hardcoded file lists** - Files change, become outdated
 - ❌ **Code snippets** - Code evolves, docs won't
 - ❌ **Detailed API documentation** - Code comments are source of truth
@@ -37,14 +41,16 @@ Documentation for development tasks in DART.
 - ✅ **DO**: Architectural patterns used (e.g., "hybrid approach", "threshold-based")
 - ✅ **DO**: Directory pointers (e.g., "see `dart/math/lcp/Dantzig/`")
 
-**Remember**: Code is the source of truth. Documentation explains *why*, code shows *how*.
+**Remember**: Code is the source of truth. Documentation explains _why_, code shows _how_.
 
 **Before submitting PRs:**
+
 1. Run `pixi run test-all` - comprehensive test suite
 2. Fix any failures before pushing
 3. **Important**: If GitHub CI fails but `test-all` passed locally, update `test-all` to catch that failure
 
 **Before committing:**
+
 - Run `validate_changes` to check for errors
 - Update task status in tracker
 - No author names or ownership attribution

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -3,6 +3,7 @@
 ## Documentation Principles
 
 **Onboarding docs should**:
+
 - ✅ Explain **design decisions** and **why** (not just what)
 - ✅ Point to **code as source of truth** (CMakeLists.txt, pixi.toml, source files)
 - ✅ Focus on **current state**, not history
@@ -19,6 +20,7 @@
 ### Documentation Principles
 
 **This documentation prioritizes the codebase as the source of truth:**
+
 - Minimal code snippets (prefer links to actual source)
 - Avoid details that can become outdated or out-of-sync
 - Focus on concepts, patterns, and architecture
@@ -27,6 +29,7 @@
 ### Design Principles
 
 **Prefer simplicity over premature generalization:**
+
 - Start with the simplest solution that solves the current problem
 - Only add abstraction, hierarchy, or scalability when actually needed
 - Resist the urge to design for hypothetical future requirements
@@ -54,6 +57,7 @@ This onboarding guide is organized into several focused documents:
 ### Purpose and Problem Solved
 
 DART addresses the need for:
+
 - **High-fidelity physics simulation** for articulated rigid and soft body systems
 - **Efficient algorithms** - O(n) complexity for forward/inverse dynamics using Featherstone algorithms
 - **Interactive 3D visualization** for robotics research and development
@@ -76,18 +80,18 @@ DART addresses the need for:
 
 ### Technologies Used
 
-| Category | Technology | Purpose |
-|----------|-----------|---------|
-| **Core Language** | C++17 | Main implementation |
-| **Build System** | CMake 3.22.1+ | Cross-platform builds |
-| **Python Bindings** | pybind11 2.13.6 | Python API |
-| **Linear Algebra** | Eigen 3.4.0+ | Math operations |
-| **Collision Detection** | FCL 0.7.0+ | Primary collision backend |
-| **3D Rendering** | OpenSceneGraph 3.0.0+ | Visualization |
-| **GUI Framework** | Dear ImGui 1.91.9 | Immediate-mode UI |
-| **Model Loading** | assimp 5.4.3+ | 3D asset import |
-| **Environment** | pixi/conda-forge | Dependency management |
-| **Graphics API** | OpenGL 2+ | Rendering backend |
+| Category                | Technology            | Purpose                   |
+| ----------------------- | --------------------- | ------------------------- |
+| **Core Language**       | C++17                 | Main implementation       |
+| **Build System**        | CMake 3.22.1+         | Cross-platform builds     |
+| **Python Bindings**     | pybind11 2.13.6       | Python API                |
+| **Linear Algebra**      | Eigen 3.4.0+          | Math operations           |
+| **Collision Detection** | FCL 0.7.0+            | Primary collision backend |
+| **3D Rendering**        | OpenSceneGraph 3.0.0+ | Visualization             |
+| **GUI Framework**       | Dear ImGui 1.91.9     | Immediate-mode UI         |
+| **Model Loading**       | assimp 5.4.3+         | 3D asset import           |
+| **Environment**         | pixi/conda-forge      | Dependency management     |
+| **Graphics API**        | OpenGL 2+             | Rendering backend         |
 
 ---
 
@@ -190,10 +194,12 @@ graph TB
 ### Component Explanations
 
 **Application Layer:**
+
 - Entry point for user code (examples, tutorials, custom applications)
 - Can be written in C++ or Python (via dartpy bindings)
 
 **GUI Layer:**
+
 - **Viewer**: Main window manager for 3D visualization with camera control and event handling
 - **ImGuiViewer**: Extended viewer with Dear ImGui widget support for interactive UI
 - **WorldNode/RealTimeWorldNode**: Bridge between DART World and OSG scene graph, handles real-time simulation
@@ -201,12 +207,14 @@ graph TB
 - **InteractiveFrame**: Visual 3D manipulator with translation/rotation handles
 
 **Rendering Layer:**
+
 - **OpenSceneGraph (OSG)**: Scene graph management and OpenGL rendering
 - **ShapeFrameNode**: Converts DART frames to OSG nodes
 - **Shape Render Nodes**: Specialized renderers for 16+ shape types (box, sphere, mesh, etc.)
 - **Shadow Rendering**: Configurable shadow techniques
 
 **Simulation Core:**
+
 - **World**: Top-level simulation container with time-stepping
 - **Skeleton**: Articulated body system (robot/character)
 - **Collision Detection**: Multi-backend support (FCL, Bullet, ODE)
@@ -214,12 +222,14 @@ graph TB
 - **Integration**: Time-stepping schemes (Euler, Semi-Implicit Euler, RK4)
 
 **Dynamics Layer:**
+
 - **BodyNode**: Individual rigid body with mass, inertia, shapes
 - **Joint System**: 10+ joint types (revolute, prismatic, free, ball, etc.)
 - **Shape System**: Collision/visual geometry (box, sphere, mesh, etc.)
 - **Inverse Kinematics**: IK solvers for end-effector control
 
 **Foundation:**
+
 - **Math Utilities**: Eigen-based linear algebra, transformations, geometry
 - **Common/Aspect**: Design patterns (Factory, Observer, Aspect-oriented)
 - **LCP Solver**: Lemke's algorithm for constraint solving
@@ -235,6 +245,7 @@ graph TB
 **Purpose**: Main 3D visualization window that integrates OpenSceneGraph rendering with DART simulation. Manages camera, lighting, shadows, event handling, and world node registration.
 
 **Key Elements**:
+
 - [`Viewer::Viewer()`](dart/gui/osg/Viewer.cpp#L86) - Constructor that sets up OSG viewer with default camera and lighting
 - [`Viewer::addWorldNode()`](dart/gui/osg/Viewer.cpp#L122) - Registers a WorldNode for rendering
 - [`Viewer::enableDragAndDrop()`](dart/gui/osg/Viewer.cpp#L189) - Activates interactive manipulation for frames/bodies
@@ -243,6 +254,7 @@ graph TB
 - [`Viewer::captureScreen()`](dart/gui/osg/Viewer.cpp#L373) - Screenshot functionality
 
 **Depends On**:
+
 - **Internal**: OpenSceneGraph scene graph, camera manipulators, event handlers
 - **External**: OSG (OpenSceneGraph library), OpenGL
 
@@ -255,12 +267,14 @@ graph TB
 **Purpose**: Extended viewer with Dear ImGui integration for modern UI widgets and controls. Provides immediate-mode GUI capabilities for debugging, controls, and custom interfaces.
 
 **Key Elements**:
+
 - [`ImGuiViewer::ImGuiViewer()`](dart/gui/osg/ImGuiViewer.cpp#L46) - Initializes ImGui handler and default widgets
 - [`ImGuiHandler`](dart/gui/osg/ImGuiHandler.hpp) - Bridges OSG events to ImGui input system
 - [`ImGuiWidget`](dart/gui/osg/ImGuiWidget.hpp) - Base class for custom widgets
 - [`AboutWidget`](dart/gui/osg/ImGuiViewer.cpp#L49) - Default about dialog
 
 **Depends On**:
+
 - **Internal**: Viewer base class, ImGuiHandler, ImGuiWidget system
 - **External**: Dear ImGui library, OpenGL2 backend
 
@@ -273,6 +287,7 @@ graph TB
 **Purpose**: Encapsulates a DART World for OSG rendering. Manages skeleton visualization, shape nodes, shadow groups, and synchronization between simulation and rendering state.
 
 **Key Elements**:
+
 - [`WorldNode::WorldNode()`](dart/gui/osg/WorldNode.cpp#L59) - Creates OSG node wrapping DART World
 - [`WorldNode::refresh()`](dart/gui/osg/WorldNode.cpp#L138) - Updates visual state from simulation
 - [`WorldNode::customPreRefresh()`](dart/gui/osg/WorldNode.hpp#L81) - Hook for custom update logic
@@ -280,6 +295,7 @@ graph TB
 - Dual scene graph: Normal group and shadow group for optimized shadow rendering
 
 **Depends On**:
+
 - **Internal**: DART World, Skeleton, ShapeFrameNode, shadow utilities
 - **External**: OSG scene graph nodes
 
@@ -292,12 +308,14 @@ graph TB
 **Purpose**: Real-time simulation with adaptive time stepping. Maintains target real-time factor (RTF) and provides hooks for custom logic before/after each simulation step.
 
 **Key Elements**:
+
 - [`RealTimeWorldNode::refresh()`](dart/gui/osg/RealTimeWorldNode.cpp#L103) - Advances simulation and updates visuals
 - [`RealTimeWorldNode::customPreStep()`](dart/gui/osg/RealTimeWorldNode.hpp#L69) - Pre-step hook for control
 - [`RealTimeWorldNode::customPostStep()`](dart/gui/osg/RealTimeWorldNode.hpp#L74) - Post-step hook for logging
 - Adaptive stepping: Multiple sub-steps per frame to maintain RTF
 
 **Depends On**:
+
 - **Internal**: WorldNode base class, DART World time-stepping
 - **External**: System clock for timing
 
@@ -310,12 +328,14 @@ graph TB
 **Purpose**: Bridges DART frames to OSG scene graph. Manages transformation updates, shape rendering, visual properties (color, transparency), and lifecycle.
 
 **Key Elements**:
+
 - [`ShapeFrameNode::ShapeFrameNode()`](dart/gui/osg/ShapeFrameNode.cpp#L56) - Creates OSG node for a DART frame
 - [`ShapeFrameNode::refresh()`](dart/gui/osg/ShapeFrameNode.cpp#L109) - Updates transformations and visual properties
 - [`ShapeFrameNode::createShapeNode()`](dart/gui/osg/ShapeFrameNode.cpp#L190) - Factory for shape-specific renderers
 - Utilization tracking for automatic garbage collection
 
 **Depends On**:
+
 - **Internal**: DART Frame, Shape, VisualAspect, shape render nodes
 - **External**: OSG transformation nodes
 
@@ -328,6 +348,7 @@ graph TB
 **Purpose**: Specialized renderers for 16+ DART shape types. Each renderer converts DART shape geometry to OSG drawable geometry with proper materials and textures.
 
 **Key Shape Nodes**:
+
 - [`BoxShapeNode`](dart/gui/osg/render/BoxShapeNode.hpp) - Box primitives
 - [`SphereShapeNode`](dart/gui/osg/render/SphereShapeNode.hpp) - Sphere primitives
 - [`CylinderShapeNode`](dart/gui/osg/render/CylinderShapeNode.hpp) - Cylinder primitives
@@ -337,6 +358,7 @@ graph TB
 - [`PointCloudShapeNode`](dart/gui/osg/render/PointCloudShapeNode.hpp) - Point cloud visualization
 
 **Depends On**:
+
 - **Internal**: DART Shape classes, VisualAspect properties
 - **External**: OSG geometry, materials, textures
 
@@ -349,6 +371,7 @@ graph TB
 **Purpose**: Comprehensive drag-and-drop framework for interactive manipulation with constraint support, rotation modes, and specialized handlers for different entity types.
 
 **Key Elements**:
+
 - [`DragAndDrop`](dart/gui/osg/DragAndDrop.hpp#L61) - Abstract base class
 - [`SimpleFrameDnD`](dart/gui/osg/DragAndDrop.hpp#L178) - Drag SimpleFrame objects
 - [`InteractiveFrameDnD`](dart/gui/osg/DragAndDrop.hpp#L236) - Drag interactive frame tools
@@ -357,6 +380,7 @@ graph TB
 - Rotation modes: `HOLD_MODKEY`, `ALWAYS_ON`, `ALWAYS_OFF`
 
 **Depends On**:
+
 - **Internal**: DART frames, BodyNode, IK module, picking system
 - **External**: OSG event adapters for mouse input
 
@@ -369,6 +393,7 @@ graph TB
 **Purpose**: 3D manipulator widget with visual handles for translation and rotation. Creates arrows, rings, and planes for intuitive 3D object manipulation.
 
 **Key Elements**:
+
 - [`InteractiveFrame`](dart/gui/osg/InteractiveFrame.hpp#L109) - Composite frame with 9 manipulation tools
 - [`InteractiveTool`](dart/gui/osg/InteractiveFrame.hpp#L49) - Individual tool (arrow, ring, plane)
 - Tool types: `LINEAR` (translation arrows), `ANGULAR` (rotation rings), `PLANAR` (2D planes)
@@ -376,6 +401,7 @@ graph TB
 - [`resizeStandardVisuals()`](dart/gui/osg/InteractiveFrame.cpp#L570) - Customize tool size/thickness
 
 **Depends On**:
+
 - **Internal**: DART SimpleFrame, Shape system
 - **External**: None (pure DART component)
 
@@ -388,6 +414,7 @@ graph TB
 **Purpose**: Top-level simulation container that manages skeletons, simple frames, time-stepping, and coordinates collision detection and constraint solving.
 
 **Key Elements**:
+
 - [`World::step()`](dart/simulation/World.cpp#L356) - Main simulation loop
 - [`World::addSkeleton()`](dart/simulation/World.cpp#L196) - Register articulated bodies
 - [`World::addSimpleFrame()`](dart/simulation/World.cpp#L241) - Register non-simulated frames
@@ -396,6 +423,7 @@ graph TB
 - Recording support for playback and analysis
 
 **Depends On**:
+
 - **Internal**: Skeleton, SimpleFrame, CollisionDetector, ConstraintSolver (handles time integration internally)
 - **External**: Eigen for math operations
 
@@ -408,6 +436,7 @@ graph TB
 **Purpose**: Represents articulated rigid body systems (robots, characters) as a tree of BodyNodes connected by Joints. Manages kinematics, dynamics, and state.
 
 **Key Elements**:
+
 - [`Skeleton::create()`](dart/dynamics/Skeleton.cpp#L148) - Factory for creating skeletons
 - [`Skeleton::createJointAndBodyNodePair<>()`](dart/dynamics/Skeleton.cpp#L521) - Add body to tree
 - [`Skeleton::getMassMatrix()`](dart/dynamics/Skeleton.cpp#L1567) - Compute mass matrix (O(n²))
@@ -416,6 +445,7 @@ graph TB
 - Support for kinematic trees and closed-loop structures
 
 **Depends On**:
+
 - **Internal**: BodyNode, Joint, IK module, algorithms (ABA, RNEA, CRBA)
 - **External**: Eigen for linear algebra
 
@@ -428,6 +458,7 @@ graph TB
 **Purpose**: Individual rigid body in an articulated system. Manages mass properties, inertia, shapes (collision/visual), and local transformations.
 
 **Key Elements**:
+
 - [`BodyNode::createShapeNodeWith<>()`](dart/dynamics/BodyNode.cpp#L357) - Add shape with aspects
 - [`BodyNode::setMass()`](dart/dynamics/BodyNode.cpp#L545) - Configure mass
 - [`BodyNode::setInertia()`](dart/dynamics/BodyNode.cpp#L580) - Configure inertia tensor
@@ -435,6 +466,7 @@ graph TB
 - [`BodyNode::getJacobian()`](dart/dynamics/BodyNode.cpp#L1143) - Compute Jacobian
 
 **Depends On**:
+
 - **Internal**: Joint (parent), Shape, Inertia, Aspect system
 - **External**: Eigen for transformations
 
@@ -447,6 +479,7 @@ graph TB
 **Purpose**: Connects BodyNodes and defines their relative motion constraints. Provides 10+ joint types for various kinematic configurations.
 
 **Key Joint Types**:
+
 - [`RevoluteJoint`](dart/dynamics/RevoluteJoint.hpp) - 1-DOF rotation (1D)
 - [`PrismaticJoint`](dart/dynamics/PrismaticJoint.hpp) - 1-DOF translation (1D)
 - [`FreeJoint`](dart/dynamics/FreeJoint.hpp) - 6-DOF unconstrained (6D)
@@ -456,12 +489,14 @@ graph TB
 - [`EulerJoint`](dart/dynamics/EulerJoint.hpp) - 3-DOF Euler angles (3D)
 
 **Key Features**:
+
 - Position/velocity limits
 - Damping and spring forces
 - Coulomb friction
 - Servo control
 
 **Depends On**:
+
 - **Internal**: BodyNode, math utilities
 - **External**: Eigen for transformations
 
@@ -474,17 +509,20 @@ graph TB
 **Purpose**: Pluggable collision detection system supporting multiple backends. Detects collisions between shapes and generates contact points.
 
 **Key Backends**:
+
 - [`FCLCollisionDetector`](dart/collision/fcl/FCLCollisionDetector.hpp) - Default, uses FCL library
 - [`BulletCollisionDetector`](dart/collision/bullet/BulletCollisionDetector.hpp) - Uses Bullet physics
 - [`DARTCollisionDetector`](dart/collision/dart/DARTCollisionDetector.hpp) - Native implementation
 - [`OdeCollisionDetector`](dart/collision/ode/OdeCollisionDetector.hpp) - Uses ODE library
 
 **Key Elements**:
+
 - [`CollisionDetector::detectCollision()`](dart/collision/CollisionDetector.cpp#L84) - Run collision detection
 - [`CollisionGroup`](dart/collision/CollisionGroup.hpp) - Groups shapes for broad-phase optimization
 - [`Contact`](dart/collision/Contact.hpp) - Contact point data structure
 
 **Depends On**:
+
 - **Internal**: Shape, CollisionObject
 - **External**: FCL, Bullet, or ODE depending on backend
 
@@ -497,6 +535,7 @@ graph TB
 **Purpose**: Resolves constraints (contacts, joint limits, motors) using LCP-based formulation. Computes constraint impulses to satisfy constraint equations.
 
 **Key Elements**:
+
 - [`ConstraintSolver::solve()`](dart/constraint/ConstraintSolver.cpp#L159) - Main constraint solving loop
 - [`ConstraintSolver::addConstraint()`](dart/constraint/ConstraintSolver.cpp#L86) - Register constraint
 - Constraint types: Contact, JointLimit, Motor, Servo, Mimic (MimicMotor or
@@ -505,6 +544,7 @@ graph TB
 - Skeleton grouping for independent constraint solving
 
 **Depends On**:
+
 - **Internal**: Constraint classes, BoxedLcpSolver, Skeleton
 - **External**: Eigen for matrix operations
 
@@ -517,6 +557,7 @@ graph TB
 **Purpose**: Complete Python API for DART using pybind11. Enables rapid prototyping, machine learning integration, and scripting.
 
 **Key Modules**:
+
 - `dartpy.math` - Mathematical utilities and Eigen↔NumPy conversion
 - `dartpy.dynamics` - Skeletons, BodyNodes, Joints, IK
 - `dartpy.collision` - Collision detection backends
@@ -526,12 +567,14 @@ graph TB
 - `dartpy.utils` - File parsers (URDF, SDF, SKEL, MJCF)
 
 **Key Files**:
+
 - [`pyproject.toml`](pyproject.toml) - Python package configuration
 - [`setup.py`](setup.py) - Build script using pybind11
 - [`python/dartpy/`](python/dartpy/) - Python bindings source
 - Type stubs (`.pyi` files) for IDE support
 
 **Depends On**:
+
 - **Internal**: All DART C++ modules
 - **External**: pybind11, NumPy
 
@@ -545,7 +588,7 @@ graph TB
 
 **Sequence Diagram**:
 
-```mermaid
+````mermaid
 sequenceDiagram
     participant User as User Code
     participant Skeleton as Skeleton
@@ -1058,7 +1101,7 @@ pixi run atlas-puppet
 # Build Python bindings
 pixi run build-py-dev
 pixi run test-py
-```
+````
 
 ### Manual CMake Build
 
@@ -1086,6 +1129,7 @@ For the complete list of CMake configuration options and their defaults, refer t
 ### Running Examples
 
 **C++ Examples** ([`examples/`](examples/)):
+
 ```bash
 # Using pixi
 pixi run hello-world
@@ -1099,6 +1143,7 @@ pixi run atlas-puppet
 ```
 
 **Python Examples**:
+
 ```bash
 # Using pixi
 pixi run hello-world-py
@@ -1147,6 +1192,7 @@ dart_gui/
 ### Key Entry Points
 
 **C++ API**:
+
 ```cpp
 #include <dart/All.hpp>              // Core DART
 #include <dart/gui/osg/osg.hpp>       // OSG GUI
@@ -1154,6 +1200,7 @@ dart_gui/
 ```
 
 **Python API**:
+
 ```python
 import dartpy as dart
 from dartpy.gui.osg import Viewer, RealTimeWorldNode
@@ -1294,17 +1341,21 @@ viewer.getImGuiHandler()->addWidget(widget, true);
 ## 8. Additional Resources
 
 ### Documentation
+
 - **Main Website**: https://docs.dartsim.org/
 - **API Documentation**: Built with Doxygen (run `pixi run api-docs-cpp`)
 - **Tutorials**: [`tutorials/`](tutorials/)
 - **Examples**: [`examples/`](examples/)
 
 ### Community
+
 - **GitHub**: https://github.com/dartsim/dart
 - **Maintained by**: Jeongseok Lee (Meta employee) and robotics community
 
 ### Related Analysis Documents
+
 This repository contains additional detailed analysis documents:
+
 - [`architecture.md`](docs/onboarding/architecture.md) - Core DART architecture deep dive
 - [`gui-rendering.md`](docs/onboarding/gui-rendering.md) - OpenSceneGraph integration details
 - [`python-bindings.md`](docs/onboarding/python-bindings.md) - Python bindings (dartpy) reference
@@ -1313,6 +1364,7 @@ This repository contains additional detailed analysis documents:
 - [`constraints.md`](docs/onboarding/constraints.md) - Constraint solver analysis
 
 ### Key Design Patterns Used in DART
+
 - **Factory Pattern**: Skeleton::create(), Joint factories
 - **Strategy Pattern**: Pluggable collision backends, integrators, solvers
 - **Observer Pattern**: Event handlers, callbacks

--- a/docs/onboarding/api-documentation.md
+++ b/docs/onboarding/api-documentation.md
@@ -7,7 +7,7 @@ notes, and the C++ API reference—through a single Sphinx project under
 `docs/readthedocs`. The Read the Docs (RTD) build runs `sphinx-build` against
 that tree, renders the prose content, and executes Doxygen during the
 `builder-inited` hook to generate the HTML C++ API bundle. The generated
-artifacts are staged inside ``docs/readthedocs/_generated/cpp-api`` and copied
+artifacts are staged inside `docs/readthedocs/_generated/cpp-api` and copied
 into the built site so each RTD version automatically receives the matching API
 reference with no dependency on GitHub Pages.
 
@@ -94,12 +94,12 @@ pixi run api-docs-build    # Convenience task that runs both builders
 
 ## Configuration Files
 
-| File | Purpose |
-| ---- | ------- |
-| `.readthedocs.yml` | RTD build definition |
+| File                       | Purpose                                                             |
+| -------------------------- | ------------------------------------------------------------------- |
+| `.readthedocs.yml`         | RTD build definition                                                |
 | `docs/readthedocs/conf.py` | Sphinx configuration for the main documentation site (runs Doxygen) |
-| `docs/python_api/conf.py` | Standalone Python API Sphinx configuration |
-| `pixi.toml` | Local task definitions (`docs-build`, `api-docs-*`, etc.) |
+| `docs/python_api/conf.py`  | Standalone Python API Sphinx configuration                          |
+| `pixi.toml`                | Local task definitions (`docs-build`, `api-docs-*`, etc.)           |
 
 ## Deployment Pipeline
 

--- a/docs/onboarding/build-system.md
+++ b/docs/onboarding/build-system.md
@@ -8,6 +8,7 @@
 ---
 
 ## Table of Contents
+
 1. [Build System Overview](#build-system-overview)
 2. [CMake Structure](#cmake-structure)
 3. [External Dependencies](#external-dependencies)
@@ -22,6 +23,7 @@
 ## Build System Overview
 
 ### Build Tool Chain
+
 - **CMake Version:** ≥ 3.22.1
 - **Build Generator:** Ninja (via pixi) / CMake default
 - **C++ Standard:** C++17
@@ -29,12 +31,14 @@
 - **Python:** Python 3 (for dartpy bindings)
 
 ### Build Configurations
+
 - **Release** (default): `-O3 -DNDEBUG`
 - **Debug**: `-g -fno-omit-frame-pointer -fno-inline-functions`
 - **RelWithDebInfo**: Combines Release + Debug flags
 - **Profile**: Debug + profiling (`-pg`)
 
 ### Key Build Options
+
 ```cmake
 DART_BUILD_GUI          = ON   # Build OpenSceneGraph GUI
 DART_BUILD_DARTPY           = OFF  # Build Python bindings
@@ -54,9 +58,11 @@ BUILD_SHARED_LIBS           = ON   # Build shared libraries (Linux/macOS)
 ### Primary CMakeLists Files
 
 #### 1. Root CMakeLists.txt
+
 **File:** `CMakeLists.txt`
 
 **Responsibilities:**
+
 - Project configuration and version extraction from `package.xml`
 - Compiler flags setup (GCC, Clang, MSVC)
 - Build type configuration
@@ -67,15 +73,18 @@ BUILD_SHARED_LIBS           = ON   # Build shared libraries (Linux/macOS)
 - Component exports and CMake config generation
 
 **Key Features:**
+
 - Extracts version (7.0.0) from `package.xml` using regex
 - Sets up custom targets: `tests`, `examples`, `tutorials`, `ALL`
 - Generates pkg-config file (`dart.pc`)
 - Supports both absolute and relative install paths
 
 #### 2. dart/CMakeLists.txt
+
 **File:** `dart/CMakeLists.txt`
 
 **Responsibilities:**
+
 - Defines core DART library
 - Manages subdirectory structure
 - Links core dependencies (Eigen3, FCL, assimp, fmt, spdlog)
@@ -84,6 +93,7 @@ BUILD_SHARED_LIBS           = ON   # Build shared libraries (Linux/macOS)
 - Generates `dart/config.hpp`
 
 **Component Hierarchy:**
+
 ```
 dart/
 ├── common/         # Common utilities
@@ -100,9 +110,11 @@ dart/
 ```
 
 #### 3. dart/gui/osg/CMakeLists.txt
+
 **File:** `dart/gui/osg/CMakeLists.txt`
 
 **Responsibilities:**
+
 - Builds `dart-gui` library
 - Integrates OpenSceneGraph
 - Integrates ImGui (system or fetched)
@@ -110,6 +122,7 @@ dart/
 - Generates component headers (`All.hpp`, `osg.hpp`)
 
 **Dependencies:**
+
 - `dart-utils` (dependent target)
 - OpenSceneGraph 3.0.0+ (external)
 - ImGui 1.80+ (external or fetched)
@@ -122,30 +135,35 @@ dart/
 ### Required Core Dependencies
 
 #### 1. Eigen3 (Linear Algebra)
+
 - **Version:** ≥ 3.4.0
 - **Purpose:** Matrix operations, linear algebra
 - **CMake Module:** `cmake/DARTFindEigen3.cmake`
 - **Find Package:** `Eigen3` (CONFIG mode)
 
 #### 2. FCL (Flexible Collision Library)
+
 - **Version:** ≥ 0.7.0, < 0.8
 - **Purpose:** Collision detection
 - **CMake Module:** `cmake/DARTFindfcl.cmake`
 - **ROS Dependency:** `libfcl-dev`
 
 #### 3. assimp (Asset Importer)
+
 - **Version:** ≥ 5.4.3, < 6
 - **Purpose:** 3D model loading (meshes, skeletons)
 - **CMake Module:** `cmake/DARTFindassimp.cmake`
 - **Special Checks:** Constructor/destructor availability for `aiScene` and `aiMaterial`
 
 #### 4. fmt (Formatting Library)
+
 - **Version:** ≥ 11.1.4, < 12
 - **Purpose:** String formatting
 - **CMake Module:** `cmake/DARTFindfmt.cmake`
 - **Targets:** `fmt::fmt` or `fmt::fmt-header-only`
 
 #### 5. octomap (Octree-based 3D mapping)
+
 - **Version:** ≥ 1.10.0, < 2
 - **Purpose:** VoxelGridShape support
 - **CMake Module:** `cmake/DARTFindoctomap.cmake`
@@ -154,6 +172,7 @@ dart/
 ### Optional Dependencies
 
 #### 6. spdlog (Logging)
+
 - **Version:** ≥ 1.15.3, < 2
 - **Purpose:** Fast C++ logging library
 - **CMake Module:** `cmake/DARTFindspdlog.cmake`
@@ -163,6 +182,7 @@ dart/
 ### GUI-Specific Dependencies
 
 #### 7. OpenSceneGraph (OSG)
+
 - **Version:** ≥ 3.0.0, < 4
 - **Recommended:** ≥ 3.7.0 (for macOS 10.15+ compatibility)
 - **Purpose:** 3D visualization and rendering
@@ -182,6 +202,7 @@ dart/
   - Windows: Available via conda-forge
 
 #### 8. ImGui (Immediate Mode GUI)
+
 - **Version:** ≥ 1.91.9, < 2 (system), v1.84.2 (fetched)
 - **Purpose:** In-scene GUI widgets and overlays
 - **CMake Module:** `cmake/DARTFindimgui.cmake`
@@ -196,6 +217,7 @@ dart/
     - Not installed with DART (local build only)
 
 #### 9. OpenGL
+
 - **Purpose:** Graphics rendering (required by ImGui backend)
 - **Target:** `OpenGL::GL`
 - **Platform:** All (system-provided)
@@ -203,6 +225,7 @@ dart/
 ### Collision Engine Dependencies (Optional Components)
 
 #### 10. Bullet Physics
+
 - **Version:** ≥ 3.25, < 4
 - **Purpose:** Alternative collision detection
 - **Option:** `DART_BUILD_COLLISION_BULLET`
@@ -212,6 +235,7 @@ dart/
 - **Disable:** There is no `DART_SKIP_Bullet`; set `DART_BUILD_COLLISION_BULLET=OFF` to omit the backend entirely.
 
 #### 11. Open Dynamics Engine (ODE)
+
 - **Version:** ≥ 0.13, < 1
 - **Purpose:** Alternative collision detection
 - **Option:** `DART_BUILD_COLLISION_ODE`
@@ -223,12 +247,14 @@ dart/
 ### Utility Dependencies
 
 #### 12. tinyxml2
+
 - **Version:** ≥ 11.0.0, < 12
 - **Purpose:** XML parsing (for SDF)
 - **Component:** `dart-utils`
 - **CMake Module:** `cmake/DARTFindtinyxml2.cmake`
 
 #### 13. libsdformat
+
 - **Version:** ≥ 16.0.0, < 17
 - **Purpose:** Official SDFormat parser used to canonicalize files (version conversion, `<include>` resolution, URI normalization) before DART walks the DOM.
 - **Component:** `dart-utils`
@@ -236,6 +262,7 @@ dart/
 - **Notes:** Required for all SDF parsing. DART no longer ships a fallback XML code path, so builds without libsdformat cannot load `.sdf`/`.world` assets.
 
 #### 14. urdfdom
+
 - **Version:** ≥ 4.0.1, < 5
 - **Purpose:** URDF parsing
 - **Component:** `dart-utils-urdf`
@@ -245,16 +272,19 @@ dart/
 ### Build/Test Dependencies (Build-time only)
 
 #### 15. Google Test (gtest)
+
 - **Version:** ≥ 1.17.0, < 2
 - **Purpose:** Unit testing framework
 - **Option:** `DART_USE_SYSTEM_GOOGLETEST`
 
 #### 16. Google Benchmark
+
 - **Version:** ≥ 1.9.3, < 2
 - **Purpose:** Performance benchmarking
 - **Option:** `DART_USE_SYSTEM_GOOGLEBENCHMARK`
 
 #### 17. Tracy Profiler
+
 - **Version:** ≥ 0.11.1, < 0.12
 - **Purpose:** Frame profiling
 - **Option:** `DART_USE_SYSTEM_TRACY`
@@ -265,9 +295,11 @@ dart/
 ### Additional Platform Dependencies
 
 #### Linux (linux-64)
+
 - **lcov:** ≥ 1.16, < 2 (coverage reports)
 
 #### macOS
+
 - **Cocoa Framework** (linked with ImGui)
 - **Git:** ≥ 2.40.0 (for OSG build)
 
@@ -276,9 +308,11 @@ dart/
 ## Bundled Dependencies
 
 ### Overview
+
 DART includes several dependencies as part of the source tree under `dart/external/`.
 
 ### 1. ODE LCP Solver
+
 **Location:** `dart/external/odelcpsolver/`
 
 **Purpose:** Linear Complementarity Problem (LCP) solver from Open Dynamics Engine
@@ -286,6 +320,7 @@ DART includes several dependencies as part of the source tree under `dart/extern
 **Target:** `dart-external-odelcpsolver`
 
 **Source Files:**
+
 - `lcp.cpp/h` - LCP solver implementation
 - `matrix.cpp/h` - Matrix operations
 - `fastldlt.cpp` - Fast LDLT decomposition
@@ -298,6 +333,7 @@ DART includes several dependencies as part of the source tree under `dart/extern
 **Linked By:** Core `dart` library
 
 ### 2. ImGui (Conditionally Bundled)
+
 **Location:** `dart/external/imgui/`
 
 **Condition:** `DART_USE_SYSTEM_IMGUI=OFF` (default)
@@ -307,17 +343,20 @@ DART includes several dependencies as part of the source tree under `dart/extern
 **Target:** `dart-external-imgui`
 
 **Fetch Method:** CMake FetchContent
+
 - **Repository:** `https://github.com/ocornut/imgui.git`
 - **Tag:** `v1.84.2`
 - **Minimum Version:** 1.80
 - **Shallow Clone:** Yes
 
 **Source Files (Fetched):**
+
 - Core: `imgui.cpp`, `imgui_draw.cpp`, `imgui_tables.cpp`, `imgui_widgets.cpp`
 - Headers: `imgui.h`, `imgui_internal.h`, `imconfig.h`, `imstb_*.h`
 - Backend: `imgui_impl_opengl2.cpp/h` (OpenGL2 backend for OSG)
 
 **Dependencies:**
+
 - OpenGL (via `OpenGL::GL`)
 - Cocoa framework (macOS only)
 
@@ -326,23 +365,28 @@ DART includes several dependencies as part of the source tree under `dart/extern
 **Linked By:** `dart-gui` library
 
 ### 3. ConvHull 3D
+
 **Location:** `dart/external/convhull_3d/`
 
 **Purpose:** 3D convex hull computation
 
 **Source Files:**
+
 - `convhull_3d.h` - Convex hull algorithm
 - `safe_convhull_3d.h` - Safe wrapper
 
 ### 4. IKFast
+
 **Location:** `dart/external/ikfast/`
 
 **Purpose:** IKFast solver interface
 
 **Source Files:**
+
 - `ikfast.h` - IKFast header
 
 **Notes:**
+
 - The actual solver binaries are supplied by users (generated with OpenRAVE's
   IkFast tooling). See
   `docs/readthedocs/shared/inverse_kinematics/ikfast.rst` for the current
@@ -379,13 +423,13 @@ Component Dependency Tree:
 
 ### Component Targets
 
-| Component | Library Target | Dependencies |
-|-----------|---------------|--------------|
-| `dart` | `dart` | `dart-external-odelcpsolver`, `Eigen3::Eigen`, `fcl`, `assimp`, `fmt::fmt` (plus Bullet/ODE when the collision options are enabled) |
-| `utils` | `dart-utils` | `dart`, `tinyxml2`, `libsdformat` |
-| `utils-urdf` | `dart-utils-urdf` | `dart-utils`, `urdfdom` |
-| `gui` | `dart-gui` | `dart-utils`, `osg::osg`, `imgui::imgui` |
-| `external-imgui` | `dart-external-imgui` | `OpenGL::GL` |
+| Component        | Library Target        | Dependencies                                                                                                                        |
+| ---------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `dart`           | `dart`                | `dart-external-odelcpsolver`, `Eigen3::Eigen`, `fcl`, `assimp`, `fmt::fmt` (plus Bullet/ODE when the collision options are enabled) |
+| `utils`          | `dart-utils`          | `dart`, `tinyxml2`, `libsdformat`                                                                                                   |
+| `utils-urdf`     | `dart-utils-urdf`     | `dart-utils`, `urdfdom`                                                                                                             |
+| `gui`            | `dart-gui`            | `dart-utils`, `osg::osg`, `imgui::imgui`                                                                                            |
+| `external-imgui` | `dart-external-imgui` | `OpenGL::GL`                                                                                                                        |
 
 > Bullet and ODE no longer create standalone `dart-collision-*` components. When `DART_BUILD_COLLISION_BULLET` or `DART_BUILD_COLLISION_ODE` is `ON`, their sources and link dependencies are baked directly into the `dart` target.
 
@@ -424,6 +468,7 @@ dart/
 ### Library Targets
 
 #### Core Libraries
+
 - **`dart`** - Main DART library
   - Type: Shared/Static (platform-dependent)
   - Output: `libdart.so` / `libdart.a` / `dart.lib`
@@ -438,11 +483,13 @@ dart/
   - Install: No (local build only)
 
 #### Component Libraries
+
 - **`dart-utils`** - Utility functions
 - **`dart-utils-urdf`** - URDF parser
 - **`dart-gui`** - OpenSceneGraph GUI
 
 ### Python Bindings Target
+
 - **`dartpy`** - Python bindings
   - Condition: `DART_BUILD_DARTPY=ON`
   - Build Type: Python extension module
@@ -451,6 +498,7 @@ dart/
 ### Custom Targets
 
 #### Development Targets
+
 - **`format`** - Auto-format C++ code with clang-format-14
 - **`check-format`** - Check C++ code formatting
 - **`examples`** - Build all examples
@@ -459,34 +507,42 @@ dart/
 - **`ALL`** - Build everything (dartpy, tests, examples, tutorials)
 
 #### Test Targets
+
 - **`tests_and_run`** - Build and run tests
 - **`pytest`** - Run Python tests
 
 #### Documentation Targets
+
 - **`docs`** - Generate Doxygen API documentation
 - **`docs_forced`** - Force regenerate documentation
 - **`view_docs`** - Open documentation in browser
 
 #### Coverage Targets (when `DART_CODECOV=ON`)
+
 - **`coverage`** - Generate coverage report
 - **`coverage_html`** - Generate HTML coverage report
 - **`coverage_view`** - View coverage report in browser
 
 ### Example Executables
+
 Examples are built in `build/.../bin/`:
+
 - `hello_world` - Basic DART usage
 - `atlas_puppet` - Atlas robot control
 - `atlas_simbicon` - Atlas robot with Simbicon controller
 - Various other examples...
 
 ### Tutorial Executables
+
 Tutorials are built in `build/.../bin/`:
+
 - `tutorial_biped` / `tutorial_biped_finished`
 - `tutorial_collisions` / `tutorial_collisions_finished`
 - `tutorial_dominoes` / `tutorial_dominoes_finished`
 - `tutorial_multi_pendulum` / `tutorial_multi_pendulum_finished`
 
 ### Benchmark Executables (Performance Testing)
+
 - `BM_INTEGRATION_empty`
 - `BM_INTEGRATION_boxes`
 - `BM_INTEGRATION_kinematics`
@@ -496,11 +552,13 @@ Tutorials are built in `build/.../bin/`:
 ## Environment Management
 
 ### Pixi Configuration
+
 **File:** `pixi.toml`
 
 **Purpose:** Cross-platform environment and dependency management using conda-forge packages.
 
 ### Platforms Supported
+
 - `linux-64` - Linux x86_64
 - `osx-64` - macOS x86_64 (Intel)
 - `osx-arm64` - macOS ARM64 (Apple Silicon)
@@ -509,6 +567,7 @@ Tutorials are built in `build/.../bin/`:
 ### Pixi Tasks
 
 #### Configuration Tasks
+
 ```bash
 pixi run config          # Configure CMake (Release)
 pixi run config-debug    # Configure CMake (Debug)
@@ -518,6 +577,7 @@ pixi run config-install  # Configure for installation
 ```
 
 #### Build Tasks
+
 ```bash
 pixi run build           # Build DART (Release)
 pixi run build-debug     # Build DART (Debug)
@@ -527,6 +587,7 @@ pixi run build-coverage  # Build with coverage
 ```
 
 #### Test Tasks
+
 ```bash
 pixi run test            # Run C++ tests
 pixi run test-py         # Run Python tests
@@ -534,6 +595,7 @@ pixi run test-all        # Run all tests
 ```
 
 #### Linting Tasks
+
 ```bash
 pixi run lint            # Format C++ and Python code
 pixi run lint-cpp        # Format C++ code only
@@ -544,6 +606,7 @@ pixi run check-lint-py   # Check Python formatting
 ```
 
 #### Example/Tutorial Tasks
+
 ```bash
 pixi run ex-hello-world  # Run hello_world example
 pixi run ex-atlas-puppet # Run atlas_puppet example
@@ -555,6 +618,7 @@ pixi run tu-dominoes     # Run dominoes tutorial
 ```
 
 #### Python Example Tasks
+
 ```bash
 pixi run py-ex-hello-world      # Python hello world
 pixi run py-ex-rigid-cubes      # Python rigid cubes
@@ -563,6 +627,7 @@ pixi run py-ex-operational-space-control
 ```
 
 #### Documentation Tasks
+
 ```bash
 pixi run docs-build      # Build user documentation
 pixi run docs-serve      # Serve documentation (port 8000)
@@ -571,11 +636,13 @@ pixi run api-docs-py     # Build Python API docs
 ```
 
 #### Profiling Tasks
+
 ```bash
 pixi run tracy           # Launch Tracy profiler GUI
 ```
 
 #### Utility Tasks
+
 ```bash
 pixi run clean           # Clean build artifacts
 pixi run install         # Install DART to conda prefix
@@ -585,11 +652,13 @@ pixi run generate-stubs  # Generate Python stub files
 ### Environment Variables
 
 #### CMake Configuration
+
 - `CMAKE_INSTALL_PREFIX` - `$CONDA_PREFIX`
 - `CMAKE_BUILD_TYPE` - `Release` / `Debug`
 - `CMAKE_PREFIX_PATH` - `$CONDA_PREFIX`
 
 #### Build Options
+
 - `DART_BUILD_DARTPY` - `ON` (for Python tasks)
 - `DART_BUILD_PROFILE` - `ON`
 - `DART_USE_SYSTEM_GOOGLEBENCHMARK` - `ON`
@@ -599,9 +668,11 @@ pixi run generate-stubs  # Generate Python stub files
 - `DART_VERBOSE` - `OFF` (configurable)
 
 #### Python Environment
+
 - `PYTHONPATH` - `build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE/python/dartpy`
 
 ### Build Output Structure
+
 ```
 build/
 └── $PIXI_ENVIRONMENT_NAME/
@@ -621,11 +692,13 @@ build/
 ### Special Features
 
 #### Gazebo Integration Feature
+
 **Environment:** `pixi run -e gazebo <task>`
 
 **Purpose:** Test DART integration with Gazebo Physics
 
 **Tasks:**
+
 - `download-gz` - Download gz-physics source
 - `patch-gz` - Patch DART version requirement
 - `config-gz` - Configure gz-physics build
@@ -633,6 +706,7 @@ build/
 - `test-gz` - Verify DART integration
 
 **Dependencies:**
+
 - `libgz-cmake4`, `libgz-plugin3`, `libgz-math8`
 - `libgz-common6`, `libgz-utils2`, `libsdformat15`
 
@@ -641,11 +715,13 @@ build/
 ## ROS Integration
 
 ### Package Manifest
+
 **File:** `package.xml`
 
 **Format:** Catkin package.xml (format 2)
 
 ### Package Information
+
 - **Name:** `dartsim`
 - **Version:** 7.0.0
 - **Build Type:** `cmake`
@@ -655,11 +731,13 @@ build/
 ### ROS Dependencies
 
 #### Build Dependencies
+
 ```xml
 <build_depend>pkg-config</build_depend>
 ```
 
 #### Runtime Dependencies
+
 ```xml
 <depend>assimp</depend>
 <depend>bullet</depend>

--- a/docs/onboarding/building.md
+++ b/docs/onboarding/building.md
@@ -6,11 +6,11 @@ This guide describes how to build DART from source, including both the C++ libra
 
 DART is supported on the following operating systems and compilers:
 
-| Operating System      | Compiler              |
-|-----------------------|-----------------------|
-| Ubuntu 22.04 or later | GCC 11.2 or later     |
-| Windows 2022 or later | Visual Studio 2022    |
-| macOS 13 or later     | Clang 13 or later     |
+| Operating System      | Compiler           |
+| --------------------- | ------------------ |
+| Ubuntu 22.04 or later | GCC 11.2 or later  |
+| Windows 2022 or later | Visual Studio 2022 |
+| macOS 13 or later     | Clang 13 or later  |
 
 > **Note:** DART requires C++20. See [Compatibility Policy](compatibility-policy.md) for details on how platform requirements are determined.
 
@@ -103,6 +103,7 @@ TODO
 ## Dependency Reference
 
 For the complete and up-to-date list of dependencies with version requirements, refer to:
+
 - [`CMakeLists.txt`](../../CMakeLists.txt) - Authoritative source for CMake dependencies and version requirements
 - [`pixi.toml`](../../pixi.toml) - Managed dependencies for reproducible builds
 
@@ -174,6 +175,7 @@ DART uses CMake as its build system. CMake generates build files for various bui
 ### CMake Options
 
 For all available CMake configuration options and their defaults, refer to [`CMakeLists.txt`](../../CMakeLists.txt). Common options include:
+
 - `CMAKE_BUILD_TYPE` - Build configuration (Release, Debug, etc.). Only applies to single-config generators (e.g., Ninja, Unix Makefiles). Multi-config generators (Visual Studio, Xcode) expose the configuration inside the IDE or via `cmake --build` `--config`.
 - `DART_BUILD_DARTPY` - Enable Python bindings
 - `DART_BUILD_GUI` - Enable OpenSceneGraph GUI

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -8,13 +8,13 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
 
 ### Core CI Workflows
 
-| Workflow             | Purpose               | Platforms      | Trigger                    |
-| -------------------- | --------------------- | -------------- | -------------------------- |
-| `ci_ubuntu.yml`      | Build, test, coverage | Ubuntu         | PR, push, schedule         |
-| `ci_macos.yml`       | Build, test           | macOS          | PR, push, schedule         |
-| `ci_windows.yml`     | Build, test           | Windows        | PR, push, schedule         |
-| `ci_gz_physics.yml`  | Gazebo integration    | Ubuntu         | PR, push, schedule         |
-| `publish_dartpy.yml` | Python wheels         | Multi-platform | Push, schedule, tags       |
+| Workflow             | Purpose               | Platforms      | Trigger              |
+| -------------------- | --------------------- | -------------- | -------------------- |
+| `ci_ubuntu.yml`      | Build, test, coverage | Ubuntu         | PR, push, schedule   |
+| `ci_macos.yml`       | Build, test           | macOS          | PR, push, schedule   |
+| `ci_windows.yml`     | Build, test           | Windows        | PR, push, schedule   |
+| `ci_gz_physics.yml`  | Gazebo integration    | Ubuntu         | PR, push, schedule   |
+| `publish_dartpy.yml` | Python wheels         | Multi-platform | Push, schedule, tags |
 
 ### Design Principles
 

--- a/docs/onboarding/code-style.md
+++ b/docs/onboarding/code-style.md
@@ -22,6 +22,7 @@ C++ headers and sources should be contained in the same subdirectory of `dart/` 
 DART uses C++20 features to improve code clarity, maintainability, and performance. Use these patterns when appropriate:
 
 **Concepts for Template Constraints:**
+
 ```cpp
 // Prefer concepts over SFINAE
 template <std::floating_point T>
@@ -33,6 +34,7 @@ concept UniformIntCompatible = std::integral<T> && !std::same_as<T, bool>;
 ```
 
 **std::span for Function Parameters:**
+
 ```cpp
 // Prefer std::span over const std::vector<T>&
 void addSkeletons(std::span<const SkeletonPtr> skeletons);
@@ -41,6 +43,7 @@ void addSkeletons(std::span<const SkeletonPtr> skeletons);
 ```
 
 **Spaceship Operator for Comparisons:**
+
 ```cpp
 // Replace 6 operators with 2
 auto operator<=>(const Ptr& other) const {
@@ -50,6 +53,7 @@ bool operator==(const Ptr& other) const = default;
 ```
 
 **Branch Prediction Attributes:**
+
 ```cpp
 // Use [[likely]] / [[unlikely]] for hot paths
 if (objects.empty()) [[unlikely]]
@@ -60,6 +64,7 @@ if (!result.isCollision()) [[likely]]
 ```
 
 **When NOT to use C++20 features:**
+
 - Avoid `std::format` until Ubuntu 24.04 LTS (GCC 13+)
 - Don't replace clear index-based loops with complex range expressions
 - Keep SFINAE for Eigen compile-time traits (not proper constexpr)
@@ -83,7 +88,7 @@ DART now maintains two naming schemes in parallel:
 - **Enum members**: PascalCase (e.g., `enum class Mode { Disabled, Enabled };`)
 - **Member variables**: Prefixed with `m` (e.g., `mExampleMember`)
 - **File extensions**: `.hpp` for headers, `.cpp` for sources
-- **File naming**: PascalCase in `dart/` and `python/dartpy/`; snake_case everywhere in `dart8/` and its dependents; legacy `tests/` use `test_` + PascalCase while dart8-era tests stay fully snake_case
+- **File naming**: PascalCase in `dart/` and `python/dartpy/`; snake*case everywhere in `dart8/` and its dependents; legacy `tests/` use `test*` + PascalCase while dart8-era tests stay fully snake_case
 - **Header guards**: `DART_NAMESPACE_CLASSNAME_HPP_`
 - **Braces**: No "cuddled" braces (except namespaces)
 - **Documentation**: Doxygen-style comments (`///`)
@@ -96,6 +101,7 @@ DART now maintains two naming schemes in parallel:
 ### Header Style
 
 **Rules:**
+
 - Use **two-space** indentation
 - Use **camelCase** function names
 - Use **PascalCase** class names
@@ -190,6 +196,7 @@ private:
 ### Source Style
 
 **Rules:**
+
 - Use **two-space** indentation
 - Use **camelCase** function names
 - Use **PascalCase** class names
@@ -240,6 +247,7 @@ int ExampleClass::exampleMethod(int a, int b, int* out) const
 These guidelines are based on [Herb Sutter's article](https://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/). Consider looking at the full article for details.
 
 **General Rules:**
+
 - Use a by-value `std::shared_ptr` as a parameter if the function surely takes the shared ownership.
 - Use a `const std::shared_ptr&` as a parameter only if you're not sure whether or not you'll take a copy and share ownership.
 - Use a non-const `std::shared_ptr&` parameter only to modify the `std::shared_ptr`.
@@ -262,13 +270,13 @@ Use all-caps for all macro names to ensure consistency and to visually distingui
 
 The Python bindings use different naming conventions than the C++ code to follow Python community standards:
 
-| Element           | C++ Style     | Python Style  | Example (C++)           | Example (Python)        |
-|-------------------|---------------|---------------|-------------------------|-------------------------|
-| Functions         | camelCase     | snake_case    | `isIdentity()`          | `is_identity()`         |
-| Classes           | PascalCase    | PascalCase    | `MyClass`               | `MyClass`               |
-| Variables         | snake_case    | snake_case    | `my_variable`           | `my_variable`           |
-| Constants         | ALL_CAPS      | ALL_CAPS      | `MY_CONSTANT`           | `MY_CONSTANT`           |
-| Namespaces/Modules| N/A           | snake_case    | `dart::dynamics`        | `dart.dynamics`         |
+| Element            | C++ Style  | Python Style | Example (C++)    | Example (Python) |
+| ------------------ | ---------- | ------------ | ---------------- | ---------------- |
+| Functions          | camelCase  | snake_case   | `isIdentity()`   | `is_identity()`  |
+| Classes            | PascalCase | PascalCase   | `MyClass`        | `MyClass`        |
+| Variables          | snake_case | snake_case   | `my_variable`    | `my_variable`    |
+| Constants          | ALL_CAPS   | ALL_CAPS     | `MY_CONSTANT`    | `MY_CONSTANT`    |
+| Namespaces/Modules | N/A        | snake_case   | `dart::dynamics` | `dart.dynamics`  |
 
 ### Example
 

--- a/docs/onboarding/compatibility-policy.md
+++ b/docs/onboarding/compatibility-policy.md
@@ -9,6 +9,7 @@ DART determines minimum compiler versions, C++ standards, and dependency version
 **DART supports at least two active Ubuntu LTS versions at any given time.**
 
 All minimum requirements are determined by the **oldest supported Ubuntu LTS version**:
+
 - Compiler versions match the default compiler in that LTS
 - C++ standard is based on what those compilers fully support
 - Library dependency versions match what's available in the Ubuntu repositories
@@ -18,11 +19,13 @@ All minimum requirements are determined by the **oldest supported Ubuntu LTS ver
 Rather than documenting specific version numbers here (which become outdated), refer to these authoritative sources:
 
 ### Current C++ Standard and Compiler Requirements
+
 - **C++ Standard**: See [`cmake/dart_defs.cmake`](../../cmake/dart_defs.cmake) - search for `target_compile_features` with `cxx_std_XX`
 - **Tested Platforms**: See [`CHANGELOG.md`](../../CHANGELOG.md) - check the latest release for tested compilers
 - **CI Configuration**: See [`.github/workflows/`](../../.github/workflows/) for actual tested platforms
 
 ### Dependency Versions
+
 - **CMake Requirements**: See root [`CMakeLists.txt`](../../CMakeLists.txt) - look for `find_package()` calls with version requirements
 - **Managed Dependencies**: See [`pixi.toml`](../../pixi.toml) - lists all dependencies with pinned versions for reproducible builds
 - **Ubuntu Packages**: See [`docs/onboarding/building.md`](building.md) for platform-specific installation commands
@@ -30,6 +33,7 @@ Rather than documenting specific version numbers here (which become outdated), r
 ## Rationale
 
 This approach provides:
+
 1. **Predictability** - Clear policy tied to Ubuntu LTS cycles
 2. **Stability** - Two-LTS support window for adoption
 3. **Modernity** - Regular updates enable new C++ features
@@ -39,6 +43,7 @@ This approach provides:
 ## When Requirements Change
 
 Changes occur with major DART releases and are:
+
 1. Announced in [`CHANGELOG.md`](../../CHANGELOG.md)
 2. Documented in migration guides
 3. Given at least one release cycle of deprecation notice
@@ -46,5 +51,6 @@ Changes occur with major DART releases and are:
 ## Questions
 
 For questions about this policy:
+
 - [GitHub Issues](https://github.com/dartsim/dart/issues)
 - [GitHub Discussions](https://github.com/dartsim/dart/discussions)

--- a/docs/onboarding/constraints.md
+++ b/docs/onboarding/constraints.md
@@ -11,12 +11,14 @@ This document provides a comprehensive analysis of the constraint subsystem in t
 ### Constraint Module (`dart/constraint`)
 
 **Core Components:**
+
 - ConstraintBase.hpp/cpp - Base class for all constraints
 - ConstraintSolver.hpp/cpp - Main solver managing constraints
 - ConstrainedGroup.hpp/cpp - Groups of interacting skeletons
 - BoxedLcpConstraintSolver.hpp/cpp - LCP-based constraint solver
 
 **Constraint Types:**
+
 - ContactConstraint.hpp/cpp - Contact between rigid bodies
 - SoftContactConstraint.hpp/cpp - Soft body contacts
 - JointConstraint.hpp/cpp - Joint-space constraints
@@ -31,6 +33,7 @@ This document provides a comprehensive analysis of the constraint subsystem in t
 - DynamicJointConstraint.hpp/cpp - Dynamic joint constraints
 
 **LCP Solvers:**
+
 - LCPSolver.hpp/cpp - Base LCP solver
 - BoxedLcpSolver.hpp - Boxed LCP solver interface
 - DantzigLCPSolver.hpp/cpp - Dantzig LCP solver
@@ -40,11 +43,13 @@ This document provides a comprehensive analysis of the constraint subsystem in t
 
 **Dantzig Solver Implementation:**
 Modern C++20 template-based implementation in `dart/math/lcp/Dantzig/` with two key design decisions:
+
 - **PivotMatrix:** Hybrid architecture combining Eigen storage with pointer-based O(1) row swapping
 - **Hybrid SIMD:** Threshold-based strategy switching between raw pointers and Eigen SIMD based on problem size
-See code for implementation details.
+  See code for implementation details.
 
 **Utilities:**
+
 - ContactSurface.hpp/cpp - Contact surface parameters
 - SmartPointer.hpp - Smart pointer definitions
 
@@ -63,6 +68,7 @@ Time integration is no longer a standalone module. `dart::simulation::World::ste
 **Role:** Abstract base class defining the interface for all constraint types.
 
 **Key Responsibilities:**
+
 - Define constraint dimension
 - Update constraint state based on skeleton states
 - Provide constraint information for LCP formulation
@@ -70,6 +76,7 @@ Time integration is no longer a standalone module. `dart::simulation::World::ste
 - Track constraint activation state
 
 **Key Data Structures:**
+
 ```cpp
 struct ConstraintInfo {
     double* x;        // Impulse
@@ -83,6 +90,7 @@ struct ConstraintInfo {
 ```
 
 **Core Interface:**
+
 - `update()` - Update constraint using skeleton states
 - `getInformation(ConstraintInfo*)` - Fill LCP variables
 - `applyUnitImpulse(index)` - Apply unit impulse to constraint space
@@ -98,6 +106,7 @@ struct ConstraintInfo {
 **Role:** Central manager for all constraints in a simulation, orchestrating constraint solving.
 
 **Key Responsibilities:**
+
 - Manage multiple skeletons
 - Handle constraint registration (manual and automatic)
 - Perform collision detection
@@ -105,6 +114,7 @@ struct ConstraintInfo {
 - Coordinate with LCP solvers
 
 **Constraint Categories:**
+
 1. **Automatic Constraints** (created by solver):
    - Contact constraints (from collision detection)
    - Soft contact constraints
@@ -116,6 +126,7 @@ struct ConstraintInfo {
    - Custom constraints added via `addConstraint()`
 
 **Workflow:**
+
 ```
 solve()
   → updateConstraints()
@@ -125,12 +136,14 @@ solve()
 ```
 
 **Collision Detection Integration:**
+
 - Uses `CollisionDetector` to find contacts
 - Creates `ContactConstraint` objects for each contact
 - Manages `ContactSurfaceHandler` for surface parameters
 - Supports multiple collision detection backends
 
 **Key Features:**
+
 - Separates constraints into independent groups for efficiency
 - Supports skeleton unification for articulated systems
 - Configurable time stepping
@@ -143,6 +156,7 @@ solve()
 **Role:** Represents a group of skeletons that interact through constraints.
 
 **Key Responsibilities:**
+
 - Group constraints affecting the same set of bodies
 - Provide unified interface for group-based solving
 - Track total constraint dimension
@@ -156,11 +170,13 @@ solve()
 **Role:** Concrete implementation of ConstraintSolver using Boxed LCP formulation.
 
 **Key Responsibilities:**
+
 - Formulate constraints as boxed LCP: `A*x = b + w`
 - Solve using primary and optional secondary LCP solvers
 - Handle solver fallback on failure
 
 **LCP Formulation:**
+
 ```
 A*x = b + w
 where each x[i], w[i] satisfies:
@@ -170,6 +186,7 @@ where each x[i], w[i] satisfies:
 ```
 
 **Solver Strategy:**
+
 - Primary solver: DantzigBoxedLcpSolver (default)
 - Secondary solver: PgsBoxedLcpSolver (fallback, default)
 - Caches matrix data (A, x, b, lo, hi, w, findex) for efficiency
@@ -183,6 +200,7 @@ where each x[i], w[i] satisfies:
 **Role:** Handles rigid body contact constraints with friction.
 
 **Key Features:**
+
 - Normal contact impulse (non-penetration)
 - Tangential friction (Coulomb friction model)
 - Restitution (bounce) modeling
@@ -191,12 +209,14 @@ where each x[i], w[i] satisfies:
 - Constraint force mixing (CFM) for soft constraints
 
 **Physics Parameters:**
+
 - Primary and secondary friction coefficients
 - Slip compliance (for soft friction)
 - Restitution coefficient
 - Error allowance and reduction velocity
 
 **Formulation:**
+
 - 3D constraint (1 normal + 2 tangential directions)
 - Uses spatial jacobians for constraint application
 - Supports self-collision detection
@@ -208,6 +228,7 @@ where each x[i], w[i] satisfies:
 **Role:** Handles multiple joint-space constraints (limits, servo motors).
 
 **Key Features:**
+
 - Joint position limits
 - Joint velocity limits
 - Servo motor control
@@ -215,6 +236,7 @@ where each x[i], w[i] satisfies:
 - Per-DOF activation tracking
 
 **Constraint Parameters:**
+
 - Impulse bounds (upper/lower)
 - Desired velocity change
 - Lifetime tracking (for iterative solvers)
@@ -227,12 +249,14 @@ where each x[i], w[i] satisfies:
 **Role:** Specifically handles joint position and velocity limits.
 
 **Key Features:**
+
 - Position limit violation detection and correction
 - Velocity limit enforcement
 - Per-DOF activation (up to 6 DOF)
 - Violation magnitude tracking
 
 **Implementation:**
+
 - Computes required negative velocity to satisfy limits
 - Uses impulse bounds to enforce constraints
 - Tracks lifetime for stability
@@ -244,6 +268,7 @@ where each x[i], w[i] satisfies:
 **Role:** Implements servo motor control as a constraint.
 
 **Key Features:**
+
 - Position/velocity tracking
 - Force limits (impulse bounds)
 - Per-DOF activation
@@ -261,6 +286,7 @@ reference joint and the dependent joint participate in the constraint solve, so
 reaction torques propagate through the articulated system.
 
 **Key Features:**
+
 - Shares the same `MimicDofProperties` multipliers/offsets as mimic motors
 - Activated by `Joint::setUseCouplerConstraint(true)` (per mimic joint)
 - Couples multiple skeletons when reference and dependent joints belong to
@@ -281,6 +307,7 @@ the legacy servo-style behavior when bilateral coupling is not required.
 **Role:** Abstract interface for boxed LCP solvers.
 
 **Key Method:**
+
 ```cpp
 bool solve(int n, double* A, double* x, double* b,
            int nub, double* lo, double* hi,
@@ -288,10 +315,12 @@ bool solve(int n, double* A, double* x, double* b,
 ```
 
 **Available Implementations:**
+
 1. **DantzigBoxedLcpSolver** - Dantzig pivoting method (accurate but slower)
 2. **PgsBoxedLcpSolver** - Projected Gauss-Seidel (fast iterative method)
 
 **Solver Selection Strategy:**
+
 - Dantzig: Better for small, dense systems; guaranteed convergence
 - PGS: Better for large systems; faster but may not converge
 - Default: Dantzig with PGS fallback
@@ -382,26 +411,31 @@ ConstraintSolver::solve()
 ## Key Design Patterns
 
 ### 1. Strategy Pattern
+
 - **Where:** BoxedLcpSolver hierarchy
 - **Purpose:** Allow runtime selection of constraint solving method
 - **Benefit:** Easy to add new solvers without modifying existing code
 
 ### 2. Template Method Pattern
+
 - **Where:** ConstraintSolver with abstract `solveConstrainedGroup()`
 - **Purpose:** Define skeleton of constraint solving algorithm
 - **Benefit:** Concrete solvers only implement specific solving logic
 
 ### 3. Factory Pattern
+
 - **Where:** Automatic constraint creation in ConstraintSolver
 - **Purpose:** Centralized constraint creation based on simulation state
 - **Benefit:** Encapsulates constraint creation logic
 
 ### 4. Visitor Pattern (Implicit)
+
 - **Where:** Constraint iteration with callbacks
 - **Purpose:** `eachConstraint()` allows operations on all constraints
 - **Benefit:** Extensible without modifying ConstraintSolver
 
 ### 5. Object Pool Pattern (Implicit)
+
 - **Where:** Constraint caching in ConstraintSolver
 - **Purpose:** Reuse constraint objects across timesteps
 - **Benefit:** Reduces allocation overhead
@@ -411,6 +445,7 @@ ConstraintSolver::solve()
 ## Performance Considerations
 
 ### Constraint Solving
+
 1. **Group Independence:** Independent groups can be solved in parallel
 2. **LCP Caching:** Matrix data cached and reused when possible
 3. **Solver Selection:** Dantzig for accuracy, PGS for speed
@@ -418,6 +453,7 @@ ConstraintSolver::solve()
 5. **Constraint Activation:** Inactive constraints skipped
 
 ### Integration
+
 1. **Method Selection:**
    - Semi-implicit Euler: Best balance for real-time
    - RK4: Better accuracy, 4x cost
@@ -432,30 +468,33 @@ ConstraintSolver::solve()
 ### Constraint Parameters
 
 **Contact Constraints:**
+
 - `ErrorAllowance` - How much penetration is allowed (default: small value)
 - `ErrorReductionParameter` (ERP) - Constraint stabilization strength (0-1, default: 0.01)
 - `MaxErrorReductionVelocity` - Maximum correction velocity
 - `ConstraintForceMixing` (CFM) - Soft constraint parameter (1e-9 to 1, default: 1e-5)
 
 **Joint Constraints:**
+
 - Similar parameters as contact constraints
 - Configured per constraint type
 
 ### Solver Configuration
 
 **Primary Solver Selection:**
+
 ```cpp
 auto dantzig = std::make_shared<DantzigBoxedLcpSolver>();
 auto solver = std::make_shared<BoxedLcpConstraintSolver>(dantzig);
 ```
 
 **With Fallback:**
+
 ```cpp
 auto primary = std::make_shared<DantzigBoxedLcpSolver>();
 auto secondary = std::make_shared<PgsBoxedLcpSolver>();
 auto solver = std::make_shared<BoxedLcpConstraintSolver>(primary, secondary);
 ```
-
 
 ## Extension Points
 
@@ -474,35 +513,42 @@ auto solver = std::make_shared<BoxedLcpConstraintSolver>(primary, secondary);
 3. Handle the boxed LCP formulation
 4. Register with `BoxedLcpConstraintSolver`
 
-
 ## Common Issues and Solutions
 
 ### Issue 1: Constraint Jitter
+
 **Symptom:** Bodies vibrate at contacts
 **Solution:**
+
 - Reduce ERP (slower correction)
 - Increase CFM (softer constraints)
 - Use smaller timestep
 
 ### Issue 2: Penetration
+
 **Symptom:** Bodies pass through each other
 **Solution:**
+
 - Reduce timestep
 - Increase ERP (faster correction)
 - Check collision detection accuracy
 - Verify constraint activation
 
 ### Issue 3: Instability
+
 **Symptom:** Simulation explodes
 **Solution:**
+
 - Keep timestep modest (semi-implicit Euler remains stable with small dt)
 - Reduce timestep
 - Check mass/inertia values
 - Verify constraint bounds
 
 ### Issue 4: Performance
+
 **Symptom:** Simulation too slow
 **Solution:**
+
 - Use PGS solver for large systems
 - Optimize collision detection
 - Reduce timestep resolution
@@ -543,6 +589,7 @@ auto solver = std::make_shared<BoxedLcpConstraintSolver>(primary, secondary);
 ### Key Files Analyzed
 
 **Constraint Module:**
+
 - `dart/constraint/ConstraintBase.hpp`
 - `dart/constraint/ConstraintSolver.hpp`
 - `dart/constraint/ConstrainedGroup.hpp`
@@ -554,6 +601,7 @@ auto solver = std::make_shared<BoxedLcpConstraintSolver>(primary, secondary);
 - `dart/constraint/BoxedLcpSolver.hpp`
 
 ### Related Concepts
+
 - Linear Complementarity Problem (LCP)
 - Dantzig Algorithm
 - Projected Gauss-Seidel (PGS)
@@ -569,12 +617,14 @@ auto solver = std::make_shared<BoxedLcpConstraintSolver>(primary, secondary);
 The DART constraint and integration modules provide a sophisticated framework for physics-based simulation:
 
 **Constraint Module** handles:
+
 - Multiple constraint types (contact, joint limits, motors)
 - Flexible LCP-based solving with multiple solver options
 - Automatic constraint generation from collisions and joint states
 - Efficient grouping of independent constraints
 
 **Integration Module** provides:
+
 - Multiple numerical integration schemes
 - Configurable accuracy vs. performance tradeoffs
 - Support for special configuration spaces

--- a/docs/onboarding/contributing.md
+++ b/docs/onboarding/contributing.md
@@ -186,29 +186,29 @@ DART is developed by a diverse community of researchers and engineers from aroun
 
 ### Core Team
 
-| Name | Contributions |
-|------|---------------|
-| [C. Karen Liu](https://github.com/karenliu) | Project creator, multibody dynamics, constraint resolution, tutorials |
-| [Mike Stilman](https://github.com/mstilman) | Project creator |
-| [Siddhartha S. Srinivasa](https://github.com/siddhss5) | Project advisor |
-| [Jeongseok Lee](https://github.com/jslee02) | Project director, multibody dynamics, constraint resolution, collision detection, tutorials |
-| [Michael X. Grey](https://github.com/mxgrey) | Project director, extensive API improvements, inverse kinematics, gui::osg, tutorials |
-| [Tobias Kunz](https://github.com/tobiaskunz) | Former project director, motion planner |
+| Name                                                   | Contributions                                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| [C. Karen Liu](https://github.com/karenliu)            | Project creator, multibody dynamics, constraint resolution, tutorials                       |
+| [Mike Stilman](https://github.com/mstilman)            | Project creator                                                                             |
+| [Siddhartha S. Srinivasa](https://github.com/siddhss5) | Project advisor                                                                             |
+| [Jeongseok Lee](https://github.com/jslee02)            | Project director, multibody dynamics, constraint resolution, collision detection, tutorials |
+| [Michael X. Grey](https://github.com/mxgrey)           | Project director, extensive API improvements, inverse kinematics, gui::osg, tutorials       |
+| [Tobias Kunz](https://github.com/tobiaskunz)           | Former project director, motion planner                                                     |
 
 ### Major Contributors
 
-| Name | Contributions |
-|------|---------------|
-| [Sumit Jain](http://www.cc.gatech.edu/graphics/projects/Sumit/homepage/) | Multibody dynamics |
-| [Yuting Ye](https://github.com/yutingye) | Multibody dynamics, GUI |
-| [Michael Koval](https://github.com/mkoval) | URI, resource retriever, bug fixes |
-| [Ana C. Huamán Quispe](https://github.com/ana-GT) | URDF parser |
-| [Chen Tang](https://github.com/chentang) | Collision detection |
-| [Konstantinos Chatzilygeroudis](https://github.com/costashatz) | Mimic joint, OSG shadows, shape deep copy, build and bug fixes |
-| [Sehoon Ha](https://github.com/sehoonha) | Early DART data structure design, [pydart](https://github.com/sehoonha/pydart) |
-| [Addisu Taddese](https://github.com/azeey) | ODE collision detector, slip effect, velocity/position integration, constraint grouping |
-| [Christoph Hinze](https://github.com/chhinze) | Python bindings |
-| [Silvio Traversaro](https://github.com/traversaro) | Build fixes on Windows/MSVC, vcpkg packaging |
+| Name                                                                     | Contributions                                                                           |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [Sumit Jain](http://www.cc.gatech.edu/graphics/projects/Sumit/homepage/) | Multibody dynamics                                                                      |
+| [Yuting Ye](https://github.com/yutingye)                                 | Multibody dynamics, GUI                                                                 |
+| [Michael Koval](https://github.com/mkoval)                               | URI, resource retriever, bug fixes                                                      |
+| [Ana C. Huamán Quispe](https://github.com/ana-GT)                        | URDF parser                                                                             |
+| [Chen Tang](https://github.com/chentang)                                 | Collision detection                                                                     |
+| [Konstantinos Chatzilygeroudis](https://github.com/costashatz)           | Mimic joint, OSG shadows, shape deep copy, build and bug fixes                          |
+| [Sehoon Ha](https://github.com/sehoonha)                                 | Early DART data structure design, [pydart](https://github.com/sehoonha/pydart)          |
+| [Addisu Taddese](https://github.com/azeey)                               | ODE collision detector, slip effect, velocity/position integration, constraint grouping |
+| [Christoph Hinze](https://github.com/chhinze)                            | Python bindings                                                                         |
+| [Silvio Traversaro](https://github.com/traversaro)                       | Build fixes on Windows/MSVC, vcpkg packaging                                            |
 
 ### Community Contributors
 

--- a/docs/onboarding/dynamics.md
+++ b/docs/onboarding/dynamics.md
@@ -1,20 +1,24 @@
 # DART Dynamics Module Exploration
 
 ## Overview
+
 This document provides an exploration of the core dynamics classes in DART (Dynamic Animation and Robotics Toolkit), located in the `dart/dynamics` directory.
 
 ## Coding Conventions
+
 - Follow `CONTRIBUTING.md` for formatting (two-space indentation, camelCase functions, PascalCase classes, no cuddled braces).
 - Always wrap conditional bodies in braces, even when the branch contains a single statement. This keeps future edits safe and matches the repository style enforced in current work.
 
 ## Core Dynamics Classes
 
 ### 1. Skeleton (`Skeleton.hpp`)
+
 **File Path:** `dart/dynamics/Skeleton.hpp`
 
 **Purpose:** The Skeleton class represents a complete articulated rigid body system. It is the top-level container that manages the entire kinematic tree.
 
 **Key Features:**
+
 - **Hierarchical Structure:** Contains multiple trees of interconnected BodyNodes and Joints
 - **State Management:** Manages positions, velocities, accelerations, forces, and commands for all degrees of freedom
 - **Configuration:** Provides `Configuration` struct for joint configurations (positions, velocities, accelerations, forces, commands)
@@ -25,6 +29,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   - Time step and gravity settings
 
 **Key Methods:**
+
 - **Structure:** `createJointAndBodyNodePair()` - Creates Joint and BodyNode pairs
 - **Kinematics:** `computeForwardKinematics()` - Computes transforms, velocities, and accelerations
 - **Dynamics:**
@@ -40,6 +45,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
 - **Impulse-based Dynamics:** Support for constraint impulses and impulse-based forward dynamics
 
 **Internal Structure:**
+
 - Manages multiple trees (allows for disconnected kinematic structures)
 - Uses `DataCache` for computational efficiency
 - Implements dirty flags for lazy evaluation
@@ -48,11 +54,13 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
 ---
 
 ### 2. BodyNode (`BodyNode.hpp`)
+
 **File Path:** `dart/dynamics/BodyNode.hpp`
 
 **Purpose:** Represents a single rigid body (link) in the articulated system. BodyNodes are hierarchically connected through Joints.
 
 **Key Features:**
+
 - **Physical Properties:**
   - Mass
   - Moment of inertia (spatial inertia)
@@ -79,6 +87,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   - Collidable flag
 
 **Key Methods:**
+
 - **Property Management:**
   - `setMass()`, `getMass()`
   - `setMomentOfInertia()`, `getMomentOfInertia()`
@@ -115,6 +124,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   - Marker support
 
 **Internal Dynamics Routines:**
+
 - `updateTransform()`, `updateVelocity()` - Kinematic updates
 - `updateArtInertia()` - Articulated body inertia computation
 - `updateBiasForce()`, `updateBiasImpulse()` - Bias force updates
@@ -124,11 +134,13 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
 ---
 
 ### 3. Joint (`Joint.hpp`)
+
 **File Path:** `dart/dynamics/Joint.hpp`
 
 **Purpose:** Abstract base class representing a kinematic constraint between two BodyNodes. Defines the degrees of freedom and their constraints.
 
 **Key Features:**
+
 - **Actuator Types:**
   - `FORCE` - Force-controlled (dynamic)
   - `PASSIVE` - No actuation (dynamic)
@@ -150,6 +162,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   - Relative transform between parent and child
 
 **Key Methods (All Pure Virtual):**
+
 - **DOF Access:**
   - `getNumDofs()` - Number of degrees of freedom
   - `getDof(index)` - Access specific DOF
@@ -203,6 +216,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   - `setVelocityChange()`, `getVelocityChange()`
 
 **Mimic Joint Feature:**
+
 - Allows a joint to mimic the motion of another joint
 - Supports different multipliers and offsets per DOF
 - Useful for coupled mechanisms
@@ -212,6 +226,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   the original MimicMotorConstraint behavior.
 
 **Internal Update Methods:**
+
 - `updateRelativeTransform()`, `updateRelativeSpatialVelocity()`
 - `updateRelativeSpatialAcceleration()`, `updateRelativePrimaryAcceleration()`
 - `updateRelativeJacobian()`, `updateRelativeJacobianTimeDeriv()`
@@ -220,11 +235,13 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
 ---
 
 ### 4. DegreeOfFreedom (`DegreeOfFreedom.hpp`)
+
 **File Path:** `dart/dynamics/DegreeOfFreedom.hpp`
 
 **Purpose:** Proxy class for accessing individual degrees of freedom (generalized coordinates). Provides a unified interface to control single DOFs.
 
 **Key Features:**
+
 - **Naming:** Automatic naming based on Joint, with option to preserve custom names
 - **Indexing:**
   - Index within Skeleton
@@ -242,6 +259,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   - Passive force parameters (spring, damping, friction)
 
 **Key Methods:**
+
 - **Naming:**
   - `setName()`, `getName()`
   - `preserveName()` - Prevent automatic renaming
@@ -262,6 +280,7 @@ This document provides an exploration of the core dynamics classes in DART (Dyna
   - `getChildBodyNode()`, `getParentBodyNode()` - Connected bodies
 
 **Usage Pattern:**
+
 ```cpp
 // Access DOF through Skeleton or Joint
 DegreeOfFreedom* dof = skeleton->getDof(index);
@@ -272,11 +291,13 @@ double pos = dof->getPosition();
 ---
 
 ### 5. Inertia (`Inertia.hpp`)
+
 **File Path:** `dart/dynamics/Inertia.hpp`
 
 **Purpose:** Represents the inertial properties of a rigid body (mass, center of mass, moment of inertia).
 
 **Key Features:**
+
 - **Minimal Parameters:**
   - Mass
   - Center of mass (3D vector)
@@ -286,6 +307,7 @@ double pos = dof->getPosition();
 - **Validation:** Methods to verify physical validity of inertia parameters
 
 **Key Capabilities:**
+
 - Manage minimal mass properties (mass, COM, moment of inertia) or work directly
   with the 6x6 spatial inertia tensor for Featherstone-style algorithms.
 - Convert between parameter sets on demand; the class keeps the spatial tensor
@@ -297,6 +319,7 @@ double pos = dof->getPosition();
   downstream dynamics code can safely assume well-formed inertias.
 
 **Physical Constraints:**
+
 - Mass must be positive
 - Moment of inertia must be positive semi-definite
 - Triangle inequality for principal moments
@@ -304,11 +327,13 @@ double pos = dof->getPosition();
 ---
 
 ### 6. Shape (`Shape.hpp`)
+
 **File Path:** `dart/dynamics/Shape.hpp`
 
 **Purpose:** Abstract base class for geometric shapes used for collision detection and visualization.
 
 **Key Features:**
+
 - **Shape Types:** (legacy enumeration; prefer `Shape::getType()` for new code)
   - Primitive shapes: Sphere, Box, Ellipsoid, Cylinder, Capsule, Cone, Pyramid
   - Complex shapes: Mesh, SoftMesh, MultiSphere, HeightMap, LineSegment, Plane
@@ -327,6 +352,7 @@ double pos = dof->getPosition();
 - **Inertia:** Can compute inertia tensor from mass or density
 
 **Key Methods:**
+
 - **Type:**
   - `getType()` - String representing shape type
   - `is<Type>()` - Template method for type checking (from Castable)
@@ -385,6 +411,7 @@ DegreeOfFreedom
 ## Dynamics Computation Flow
 
 ### Forward Kinematics
+
 1. Start from root BodyNode
 2. For each BodyNode in tree order:
    - Update Joint transform (`updateRelativeTransform()`)
@@ -393,12 +420,14 @@ DegreeOfFreedom
    - Update spatial accelerations
 
 ### Inverse Dynamics
+
 1. Forward kinematics (compute transforms, velocities, accelerations)
 2. Backward recursion from leaves to root:
    - Compute spatial forces at each BodyNode
    - Project forces to joint space to get required torques
 
 ### Forward Dynamics
+
 1. Forward kinematics (transforms and velocities)
 2. Forward pass (root to leaves):
    - Compute articulated body inertias
@@ -409,35 +438,42 @@ DegreeOfFreedom
    - Update body accelerations
 
 ### Impulse-based Dynamics
+
 Similar to forward dynamics but works with impulses and velocity changes instead of forces and accelerations. Used for contact resolution.
 
 ## Important Design Patterns
 
 ### 1. Lazy Evaluation
+
 - Uses dirty flags to avoid redundant computations
 - Jacobians, mass matrices, force vectors are computed only when needed
 - Example: `mNeedTransformUpdate`, `mIsBodyJacobianDirty`
 
 ### 2. Aspect-Oriented Programming
+
 - Uses Aspects to add properties/behaviors to classes
 - Example: ShapeNode can have VisualAspect, CollisionAspect, DynamicsAspect
 
 ### 3. Smart Pointers
+
 - Uses std::shared_ptr and std::weak_ptr for memory management
 - Defines type aliases like SkeletonPtr, BodyNodePtr, etc.
 
 ### 4. Composite Pattern
+
 - Skeleton contains trees of BodyNodes
 - Each BodyNode can have multiple children
 - Properties can be aggregated from components
 
 ### 5. Template Specialization
+
 - GenericJoint<SpaceT> provides concrete joint types
 - TemplatedJacobianNode<NodeT> provides Jacobian functionality
 
 ## Common Joint Types (Derived from Joint)
 
 While not in the files we examined, DART provides several concrete Joint types:
+
 - `RevoluteJoint` - 1-DOF rotational joint
 - `PrismaticJoint` - 1-DOF translational joint
 - `UniversalJoint` - 2-DOF joint (2 perpendicular revolute axes)
@@ -484,6 +520,7 @@ const Eigen::VectorXd& g = skeleton->getGravityForces();
 ## Summary
 
 The DART dynamics module provides a comprehensive framework for:
+
 1. **Modeling** articulated rigid body systems with arbitrary topology
 2. **Kinematics** - Computing positions, velocities, accelerations, and Jacobians
 3. **Dynamics** - Computing forces, torques, mass matrices, and solving equations of motion

--- a/docs/onboarding/gui-rendering.md
+++ b/docs/onboarding/gui-rendering.md
@@ -13,6 +13,7 @@ The DART GUI uses OpenSceneGraph (OSG) as its rendering backend to visualize phy
 **Purpose**: Main visualization window that manages the rendering loop and coordinates all visual components.
 
 **Key Responsibilities**:
+
 - Inherits from `osgViewer::Viewer` (OSG's core viewer class)
 - Manages multiple `WorldNode` instances (one per DART World)
 - Coordinates camera control, lighting, and event handling
@@ -53,6 +54,7 @@ The DART GUI uses OpenSceneGraph (OSG) as its rendering backend to visualize phy
    - Integration with Inverse Kinematics for body node manipulation
 
 **Key Member Variables**:
+
 ```cpp
 ::osg::ref_ptr<::osg::Group> mRootGroup;           // Scene root
 ::osg::ref_ptr<DefaultEventHandler> mDefaultEventHandler; // Event handler
@@ -69,6 +71,7 @@ bool mAllowSimulation;                             // Simulation permission
 **Purpose**: Encapsulates a DART `simulation::World` for OSG rendering.
 
 **Key Responsibilities**:
+
 - Manages the visual representation of a DART physics world
 - Maintains scene graph of all entities and frames in the world
 - Handles simulation stepping and refresh cycles
@@ -77,14 +80,17 @@ bool mAllowSimulation;                             // Simulation permission
 **Architecture**:
 
 1. **Dual Group System**:
+
    ```cpp
    ::osg::ref_ptr<::osg::Group> mNormalGroup;          // Non-shadowed objects
    ::osg::ref_ptr<::osgShadow::ShadowedScene> mShadowedGroup; // Shadowed objects
    ```
+
    - Objects are placed in either group based on their shadow settings
    - Allows selective shadow rendering for performance
 
 2. **Refresh Cycle**:
+
    ```
    refresh() →
      ├─ customPreRefresh()
@@ -110,6 +116,7 @@ bool mAllowSimulation;                             // Simulation permission
    - `setupViewer()`: Called when added to a viewer
 
 **Node Lifecycle**:
+
 ```
 Frame Discovery → ShapeFrameNode Creation → Refresh → Utilization Check → Cleanup
 ```
@@ -128,6 +135,7 @@ Frame Discovery → ShapeFrameNode Creation → Refresh → Utilization Check �
    - Performance statistics: Min/max RTF achieved
 
 2. **Adaptive Stepping**:
+
    ```cpp
    while (mRefreshTimer.time_s() < mTargetRealTimeLapse) {
        const double nextSimTimeLapse = mWorld->getTime() - startSimTime + simTimeStep;
@@ -136,6 +144,7 @@ Frame Discovery → ShapeFrameNode Creation → Refresh → Utilization Check �
        }
    }
    ```
+
    - Takes as many steps as possible within the refresh period
    - Respects the target sim time lapse
    - Automatically adjusts to computational load
@@ -155,6 +164,7 @@ Frame Discovery → ShapeFrameNode Creation → Refresh → Utilization Check �
 **Purpose**: Represents a DART `ShapeFrame` (a frame with an attached visual shape) in the OSG scene graph.
 
 **Key Responsibilities**:
+
 - Inherits from `osg::MatrixTransform` (allows transformation)
 - Manages the render node for the actual shape geometry
 - Handles shape changes and updates
@@ -162,9 +172,11 @@ Frame Discovery → ShapeFrameNode Creation → Refresh → Utilization Check �
 **Architecture**:
 
 1. **Transformation Management**:
+
    ```cpp
    setMatrix(eigToOsgMatrix(mShapeFrame->getWorldTransform()));
    ```
+
    - Updates world transform from DART to OSG coordinates
 
 2. **Shape Node Management**:
@@ -183,6 +195,7 @@ Frame Discovery → ShapeFrameNode Creation → Refresh → Utilization Check �
 
 **Shape Type Dispatch**:
 The `createShapeNode()` method creates specialized nodes for each shape type:
+
 - `SphereShapeNode`, `BoxShapeNode`, `EllipsoidShapeNode`
 - `CylinderShapeNode`, `CapsuleShapeNode`, `ConeShapeNode`, `PyramidShapeNode`
 - `PlaneShapeNode`, `MultiSphereShapeNode`
@@ -224,6 +237,7 @@ render/
 **Purpose**: Abstract base class for all shape-specific rendering nodes.
 
 **Core Data**:
+
 ```cpp
 const std::shared_ptr<dart::dynamics::Shape> mShape;     // Shape data
 dart::dynamics::ShapeFrame* mShapeFrame;                 // Parent frame
@@ -234,11 +248,13 @@ bool mUtilized;                                         // GC tracking
 ```
 
 **Interface**:
+
 - `refresh()`: Pure virtual - update geometry/appearance
 - `getShape()`: Access to DART shape
 - `getVisualAspect()`: Access to visual properties (color, material, etc.)
 
 **Typical Subclass Pattern**:
+
 1. Inherit from both `ShapeNode` and appropriate OSG node type
 2. Extract shape-specific data in constructor
 3. Create OSG geometry in `refresh()` or helper method
@@ -277,6 +293,7 @@ class MeshShapeNode : public ShapeNode, public ::osg::MatrixTransform {
 **Purpose**: Central event processor for mouse and keyboard input.
 
 **Key Responsibilities**:
+
 - Inherits from `osgGA::GUIEventHandler`
 - Processes mouse and keyboard events
 - Performs object picking (raycasting)
@@ -286,6 +303,7 @@ class MeshShapeNode : public ShapeNode, public ::osg::MatrixTransform {
 **Event Types**:
 
 1. **Mouse Button Events**:
+
    ```cpp
    enum MouseButtonEvent {
        BUTTON_PUSH,        // Initial click
@@ -305,6 +323,7 @@ class MeshShapeNode : public ShapeNode, public ::osg::MatrixTransform {
    - `Ctrl+H`: Toggle headlights
 
 **Picking System** (`PickInfo`):
+
 ```cpp
 struct PickInfo {
     dart::dynamics::ShapeFrame* frame;    // Picked frame
@@ -315,12 +334,14 @@ struct PickInfo {
 ```
 
 **Picking Process**:
+
 1. Compute line segment intersection using OSG utilities
 2. Extract `render::ShapeNode` from hit drawable
 3. Retrieve associated DART shape and frame
 4. Convert intersection data to Eigen types
 
 **Cursor Delta Calculation**:
+
 - `getDeltaCursor()`: Projects cursor movement into 3D space
 - **Constraint Types**:
   - `UNCONSTRAINED`: Project onto plane parallel to camera
@@ -328,11 +349,13 @@ struct PickInfo {
   - `PLANE_CONSTRAINT`: Constrain to a plane
 
 **Pick Suppression**:
+
 - Can suppress picks for specific button/event combinations
 - Useful for implementing custom behaviors
 - Per-button, per-event control
 
 **MouseEventHandler Registry**:
+
 - Add handlers via `addMouseEventHandler()`
 - Automatic cleanup via Observer pattern
 - Handlers receive `update()` calls on each event
@@ -344,6 +367,7 @@ struct PickInfo {
 **Purpose**: Abstract base class for custom mouse event behaviors.
 
 **Interface**:
+
 ```cpp
 class MouseEventHandler {
 public:
@@ -354,6 +378,7 @@ protected:
 ```
 
 **Typical Usage Pattern**:
+
 ```cpp
 class MyHandler : public MouseEventHandler {
     void update() override {
@@ -367,6 +392,7 @@ class MyHandler : public MouseEventHandler {
 ```
 
 **Built-in Handlers**:
+
 - `DragAndDrop`: Base class for drag-and-drop interactions
 - `SimpleFrameDnD`: Drag simple frames
 - `SimpleFrameShapeDnD`: Drag shapes within frames
@@ -380,6 +406,7 @@ class MyHandler : public MouseEventHandler {
 **Purpose**: Camera controller for interactive viewpoint manipulation.
 
 **Key Features**:
+
 - Inherits from `osgGA::OrbitManipulator`
 - Customizes mouse button behaviors:
   - **Left Mouse**: Disabled for interaction (not camera control)
@@ -388,12 +415,14 @@ class MyHandler : public MouseEventHandler {
   - **Scroll Wheel**: Zoom (inherited from OrbitManipulator)
 
 **Configuration**:
+
 ```cpp
 setVerticalAxisFixed(false);  // Allow free rotation
 setAllowThrow(false);         // Disable momentum-based camera motion
 ```
 
 **Rationale**:
+
 - Left mouse reserved for object selection/manipulation
 - Right mouse provides intuitive camera rotation
 - Standard trackball interaction model
@@ -455,21 +484,25 @@ setAllowThrow(false);         // Disable momentum-based camera motion
 ### Shadow Technique Support
 
 **Configuration**:
+
 ```cpp
 WorldNode::setShadowTechnique(osg::ref_ptr<osgShadow::ShadowTechnique>)
 ```
 
 **Default Technique** (`createDefaultShadowTechnique`):
+
 - Uses `osgShadow::ShadowMap`
 - 4096×4096 shadow texture resolution
 - Uses Light #1 (highest positioned light)
 
 **Shadow Groups**:
+
 - `mNormalGroup`: Objects without shadows
 - `mShadowedGroup`: Objects with shadows (osgShadow::ShadowedScene)
 - Objects automatically placed based on `VisualAspect::getShadowed()`
 
 **Traversal Masks**:
+
 - `ReceivesShadowTraversalMask = 0x2`: Objects that receive shadows
 - `CastsShadowTraversalMask = 0x1`: Objects that cast shadows
 
@@ -480,11 +513,13 @@ WorldNode::setShadowTechnique(osg::ref_ptr<osgShadow::ShadowTechnique>)
 ### Screen Capture
 
 **Single Frame Capture**:
+
 ```cpp
 viewer->captureScreen("screenshot.png");
 ```
 
 **Implementation**:
+
 - Uses `SaveScreen` callback attached to camera
 - Reads pixels via `glReadPixels` (GL_RGB format)
 - Saves via `osgDB::writeImageFile`
@@ -492,12 +527,14 @@ viewer->captureScreen("screenshot.png");
 ### Screen Recording
 
 **Continuous Recording**:
+
 ```cpp
 viewer->record("output_dir", "frame_prefix", restart=false, digits=6);
 viewer->pauseRecording();
 ```
 
 **Features**:
+
 - Automatic frame numbering with zero-padding
 - Configurable prefix and number of digits
 - Resume capability (restart=false)
@@ -519,6 +556,7 @@ viewer->pauseRecording();
    - Useful for debugging
 
 **Mode Switching**:
+
 ```cpp
 viewer->setCameraMode(CameraMode::DEPTH);
 CameraMode mode = viewer->getCameraMode();
@@ -532,6 +570,7 @@ double fov = viewer->getVerticalFieldOfView();
 ```
 
 **Constraints**:
+
 - Only works with perspective projection
 - Returns 0.0 for orthographic cameras
 
@@ -542,21 +581,25 @@ double fov = viewer->getVerticalFieldOfView();
 ### Light Configuration
 
 **Two-Light Setup**:
+
 - **Light #1** (`mLight1`, `mLightSource1`): Primary scene light
 - **Light #2** (`mLight2`, `mLightSource2`): Fill light
 
 **Positioning**:
+
 ```cpp
 mLight1->setPosition(mUpwards + mOver);  // Upper-side light
 mLight2->setPosition(mUpwards - mOver);  // Upper-opposite light
 ```
 
 **Headlights Mode**:
+
 - Headlights: Camera-attached lights
 - Scene lights: Fixed-position lights
 - Toggle via `switchHeadlights(bool)`
 
 **Light Properties**:
+
 ```cpp
 // Headlights ON
 mLight->setAmbient(0.1, 0.1, 0.1);
@@ -573,6 +616,7 @@ mLight2->setDiffuse(0.3, 0.3, 0.3);
 ```cpp
 viewer->setUpwardsDirection(Eigen::Vector3d(0, 0, 1));  // Z-up (default)
 ```
+
 - Affects light positioning
 - Influences camera manipulator
 
@@ -581,32 +625,40 @@ viewer->setUpwardsDirection(Eigen::Vector3d(0, 0, 1));  // Z-up (default)
 ## Utilization Tracking and Garbage Collection
 
 ### Purpose
+
 Prevent memory leaks from deleted DART entities while avoiding dangling pointers.
 
 ### Mechanism
 
 1. **Flag Clearing**:
+
    ```cpp
    WorldNode::clearChildUtilizationFlags()
    ```
+
    - Called at start of refresh cycle
    - Sets `mUtilized = false` on all ShapeFrameNodes
 
 2. **Utilization Marking**:
+
    ```cpp
    ShapeFrameNode::refresh()
    ```
+
    - Sets `mUtilized = true` when refreshed
    - Indicates frame still exists in DART world
 
 3. **Garbage Collection**:
+
    ```cpp
    WorldNode::clearUnusedNodes()
    ```
+
    - Removes nodes where `mUtilized == false`
    - Indicates DART entity was deleted
 
 ### Benefits
+
 - Automatic cleanup of stale visual nodes
 - No manual tracking required
 - Handles dynamic entity creation/destruction
@@ -672,6 +724,7 @@ Prevent memory leaks from deleted DART entities while avoiding dangling pointers
 ### Real-Time Simulation
 
 **RealTimeWorldNode** provides:
+
 - Adaptive stepping based on computational load
 - RTF monitoring for performance feedback
 - Smooth playback even if simulation is expensive
@@ -723,84 +776,92 @@ Common attachments you can reuse without writing custom logic:
 ## File Structure Summary
 
 ### Core Components
+
 - `dart/gui/osg/Viewer.hpp/cpp`
-   - Main viewer class
+  - Main viewer class
 - `dart/gui/osg/WorldNode.hpp/cpp`
-   - World visualization
+  - World visualization
 - `dart/gui/osg/RealTimeWorldNode.hpp/cpp`
-   - Real-time simulation support
+  - Real-time simulation support
 - `dart/gui/osg/ShapeFrameNode.hpp/cpp`
-   - Frame-to-node mapping
+  - Frame-to-node mapping
 
 ### Event Handling
+
 - `dart/gui/osg/DefaultEventHandler.hpp/cpp`
-   - Central event processor
+  - Central event processor
 - `dart/gui/osg/MouseEventHandler.hpp`
-   - Custom handler base class
+  - Custom handler base class
 - `dart/gui/osg/TrackballManipulator.hpp/cpp`
-   - Camera controller
+  - Camera controller
 
 ### Rendering
+
 - `dart/gui/osg/render/ShapeNode.hpp/cpp`
-   - Base shape renderer
+  - Base shape renderer
 - `dart/gui/osg/render/BoxShapeNode.hpp/cpp`
-   - Box geometry rendering
+  - Box geometry rendering
 - `dart/gui/osg/render/SphereShapeNode.hpp/cpp`
-   - Sphere geometry rendering
+  - Sphere geometry rendering
 - `dart/gui/osg/render/CylinderShapeNode.hpp/cpp`
-   - Cylinder geometry rendering
+  - Cylinder geometry rendering
 - `dart/gui/osg/render/CapsuleShapeNode.hpp/cpp`
-   - Capsule geometry rendering
+  - Capsule geometry rendering
 - `dart/gui/osg/render/ConeShapeNode.hpp/cpp`
-   - Cone geometry rendering
+  - Cone geometry rendering
 - `dart/gui/osg/render/PyramidShapeNode.hpp/cpp`
-   - Pyramid geometry rendering
+  - Pyramid geometry rendering
 - `dart/gui/osg/render/EllipsoidShapeNode.hpp/cpp`
-   - Ellipsoid geometry rendering
+  - Ellipsoid geometry rendering
 - `dart/gui/osg/render/PlaneShapeNode.hpp/cpp`
-   - Plane geometry rendering
+  - Plane geometry rendering
 - `dart/gui/osg/render/MultiSphereShapeNode.hpp/cpp`
-   - Multi-sphere convex hull rendering
+  - Multi-sphere convex hull rendering
 - `dart/gui/osg/render/MeshShapeNode.hpp/cpp`
-   - Mesh geometry rendering (using Assimp)
+  - Mesh geometry rendering (using Assimp)
 - `dart/gui/osg/render/SoftMeshShapeNode.hpp/cpp`
-   - Deformable mesh rendering
+  - Deformable mesh rendering
 - `dart/gui/osg/render/LineSegmentShapeNode.hpp/cpp`
-   - Line segment rendering
+  - Line segment rendering
 - `dart/gui/osg/render/PointCloudShapeNode.hpp/cpp`
-   - Point cloud rendering
+  - Point cloud rendering
 - `dart/gui/osg/render/VoxelGridShapeNode.hpp/cpp`
-   - Voxel grid rendering (requires OCTOMAP)
+  - Voxel grid rendering (requires OCTOMAP)
 - `dart/gui/osg/render/HeightmapShapeNode.hpp`
-   - Heightmap terrain rendering
+  - Heightmap terrain rendering
 - `dart/gui/osg/render/WarningShapeNode.hpp/cpp`
-   - Fallback renderer for unsupported shapes
+  - Fallback renderer for unsupported shapes
 
 ---
 
 ## Key Design Patterns
 
 ### 1. Observer Pattern
+
 - `DefaultEventHandler` observes `MouseEventHandler` instances
 - Automatic cleanup when handlers are destroyed
 - Subject/Observer from DART common library
 
 ### 2. Visitor Pattern (via OSG)
+
 - Node callbacks for scene graph traversal
 - Update callbacks for per-frame logic
 - Draw callbacks for screen capture
 
 ### 3. Factory Pattern
+
 - `ShapeFrameNode::createShapeNode()` creates appropriate shape nodes
 - Type-based dispatch for different shape types
 - Extensible for new shape types
 
 ### 4. Utilization Tracking Pattern
+
 - Mark-and-sweep garbage collection
 - Prevents dangling pointers to deleted DART objects
 - Three-phase: clear flags → mark used → sweep unused
 
 ### 5. Dual Scene Graph Pattern
+
 - Separate groups for shadowed/non-shadowed objects
 - Performance optimization
 - Dynamic object migration between groups
@@ -907,6 +968,7 @@ if (MyCustomShape::getStaticType() == shapeType) {
 ### Visualizing the Scene Graph
 
 OSG provides built-in tools for scene graph inspection:
+
 ```cpp
 // Print scene graph structure
 osgDB::writeNodeFile(*viewer.getSceneData(), "scene_graph.osg");
@@ -915,6 +977,7 @@ osgDB::writeNodeFile(*viewer.getSceneData(), "scene_graph.osg");
 ### Checking Utilization
 
 Add debug output to track node lifecycle:
+
 ```cpp
 void WorldNode::clearUnusedNodes() {
     for (auto& node_pair : mFrameToNode) {
@@ -955,21 +1018,25 @@ void MyHandler::update() override {
 ## Limitations and Known Issues
 
 ### ImGui + Depth Mode Incompatibility
+
 - Depth rendering mode doesn't work with ImGui widgets
 - Use RGBA mode when ImGui UI is present
 - Documented in `CameraMode::DEPTH` enum
 
 ### Shadow Performance
+
 - Shadow rendering can be computationally expensive
 - Use shadow suppression for objects that don't need shadows
 - Consider disabling shadows on less important objects
 
 ### Real-Time Constraints
+
 - `RealTimeWorldNode` cannot guarantee real-time if simulation is too expensive
 - Monitor RTF to detect performance issues
 - Consider reducing simulation complexity if RTF < target
 
 ### OSG Namespace Conflict
+
 - DART's `dart::gui::osg` namespace conflicts with root `::osg`
 - Always use `::osg::` for OSG types (note the leading `::`)
 - Custom META macros to work around namespace issues

--- a/docs/onboarding/python-bindings.md
+++ b/docs/onboarding/python-bindings.md
@@ -7,6 +7,7 @@
 **Choice**: pybind11 for C++/Python bindings
 
 **Rationale**:
+
 - Header-only library, no external dependencies
 - Seamless Eigen ↔ NumPy integration with custom type casters
 - Automatic reference counting and lifetime management
@@ -18,6 +19,7 @@
 **Choice**: scikit-build-core (not setuptools or traditional setup.py)
 
 **Rationale**:
+
 - Modern PEP 517/518 compliant build system
 - Native CMake integration (DART is already CMake-based)
 - Supports editable installs (`pip install -e .`)
@@ -31,6 +33,7 @@
 **Choice**: pixi-based wheel building (not cibuildwheel + Docker)
 
 **Rationale**:
+
 - **No Docker maintenance**: No custom container images to maintain
 - **Local reproducibility**: Same commands work locally and in CI
 - **Unified tooling**: pixi handles both development and distribution
@@ -64,12 +67,14 @@ dartpy/
 **Implementation**: `python/dartpy/eigen_geometry_pybind.h`
 
 **Features**:
+
 - Zero-copy conversions where possible
 - Automatic bidirectional conversion
 - Support for Eigen::Isometry3 (4x4 transforms)
 - Quaternion support
 
 **Usage**:
+
 ```python
 import dartpy as dart
 import numpy as np
@@ -88,7 +93,9 @@ positions = skel.getPositions()  # Returns ndarray
 **Root Cause**: Python bindings previously checked for an undefined `HAVE_DART_GUI_OSG` preprocessor macro
 
 **Solution**:
+
 1. Use `DART_BUILD_GUI` directly in `python/dartpy/gui/module.cpp`:
+
    ```cpp
    #if DART_BUILD_GUI
      // Bind OSG module
@@ -107,6 +114,7 @@ positions = skel.getPositions()  # Returns ndarray
 ## Installation Methods
 
 ### For End Users
+
 ```bash
 # PyPI wheels (pre-built, includes OSG)
 pip install dartpy
@@ -120,6 +128,7 @@ conda install dartpy -c conda-forge
 **See**: `docs/readthedocs/dartpy/developer_guide/build.rst` for detailed instructions
 
 **Quick options**:
+
 - **Editable install**: `pip install -e . -v --no-build-isolation`
 - **Using pixi**: `pixi run build-py-dev`
 - **Traditional CMake**: Configure with `-DDART_BUILD_DARTPY=ON`, then build and install
@@ -129,6 +138,7 @@ conda install dartpy -c conda-forge
 ### Build Infrastructure
 
 Wheels are built using **pixi** environments defined in `pixi.toml`:
+
 - Features: `py312-wheel`, `py313-wheel`
 - Platform-specific build tasks
 - OSG enabled on all platforms
@@ -156,6 +166,7 @@ pixi run -e py313-wheel wheel-upload
 ### Version Management
 
 **Source of truth**: `package.xml`
+
 ```xml
 <version>7.0.0</version>          <!-- Release -->
 <version>7.0.0.dev0</version>     <!-- Development -->
@@ -164,6 +175,7 @@ pixi run -e py313-wheel wheel-upload
 **Extraction**: `pyproject.toml` regex automatically extracts version during build
 
 **Publishing policy** (to avoid PyPI 10GiB limit):
+
 - **Release versions** (`7.0.0`) → Production PyPI
 - **Dev versions** (`7.0.0.dev0`) → Test PyPI only (use `wheel-upload-test`)
 - Manual cleanup: Delete old versions via PyPI web interface when needed
@@ -171,12 +183,14 @@ pixi run -e py313-wheel wheel-upload
 ### CI/CD
 
 **Workflow**: `.github/workflows/publish_dartpy.yml`
+
 - **Every commit**: Build → Repair → Verify → Test → Upload artifacts
 - **Version tags** (`v*.*.*`): All above + Publish to PyPI
 
 ## Key Patterns
 
 ### Pattern 1: Basic Simulation
+
 ```python
 import dartpy as dart
 
@@ -190,6 +204,7 @@ for _ in range(100):
 ```
 
 ### Pattern 2: Visualization with Custom Logic
+
 ```python
 class MyWorldNode(dart.gui.osg.RealTimeWorldNode):
     def customPreStep(self):
@@ -209,6 +224,7 @@ viewer.run()
 ```
 
 ### Pattern 3: Jacobian Computation
+
 ```python
 import numpy as np
 
@@ -221,6 +237,7 @@ robot.setForces(forces)
 ## Testing
 
 **Scripts**:
+
 - `scripts/test_wheel.py` - Test wheel in isolated environment
 - `scripts/verify_version.py` - Verify version consistency
 

--- a/docs/onboarding/testing.md
+++ b/docs/onboarding/testing.md
@@ -1,6 +1,7 @@
 # DART Test Suite
 
 This directory contains the complete test suite for DART (Dynamic Animation and Robotics Toolkit). The tests are organized by type and module to facilitate easy navigation, maintenance, and scalability.
+
 ## Directory Structure
 
 ```
@@ -31,12 +32,12 @@ tests/
 └── README.md                # Points to this comprehensive guide
 ```
 
-
 ## Test Categories
 
 ### Integration Tests (`integration/`)
 
 Integration tests verify that **multiple components work correctly together** in end-to-end scenarios. These tests:
+
 - Test interactions between 2+ major subsystems (e.g., dynamics + collision + simulation)
 - Set up complex scenarios with full physics simulations
 - Validate cross-module functionality and data flow
@@ -44,6 +45,7 @@ Integration tests verify that **multiple components work correctly together** in
 - May take longer to run than unit tests
 
 **Key characteristics:**
+
 - Tests system behavior, not component behavior
 - Validates that components integrate correctly
 - Uses file parsing, complete simulations, or multi-object interactions
@@ -61,6 +63,7 @@ Integration tests verify that **multiple components work correctly together** in
 ### Unit Tests (`unit/`)
 
 Unit tests focus on testing **individual classes or functions in isolation**. These tests:
+
 - Test a single component without dependencies on other major subsystems
 - Are fast to execute (milliseconds)
 - Have minimal dependencies (e.g., only dart-math, only the collision module)
@@ -68,6 +71,7 @@ Unit tests focus on testing **individual classes or functions in isolation**. Th
 - Use simple test fixtures (SimpleFrame, basic objects)
 
 **Key characteristics:**
+
 - Tests component behavior, not system behavior
 - Validates correctness of individual algorithms or classes
 - Can run independently without complex setup
@@ -84,13 +88,15 @@ Unit tests focus on testing **individual classes or functions in isolation**. Th
 ### How to Decide: Integration vs Unit?
 
 **Use Integration Test if:**
+
 - ✅ Tests interaction between World, Skeleton, and ConstraintSolver
 - ✅ Loads files and runs full simulations
 - ✅ Tests multiple modules working together
 - ✅ Validates end-to-end workflows
-- ✅ Depends on dart-utils or multiple dart-* libraries
+- ✅ Depends on dart-utils or multiple dart-\* libraries
 
 **Use Unit Test if:**
+
 - ✅ Tests a single class or function in isolation
 - ✅ Has minimal dependencies (1-2 modules max)
 - ✅ Uses simple test fixtures (not full simulations)
@@ -102,15 +108,18 @@ Unit tests focus on testing **individual classes or functions in isolation**. Th
 **Note:** The `tests/regression/` directory has been **completely removed**. All issue-based regression tests have been renamed with descriptive names and placed in appropriate unit/ or integration/ directories.
 
 Previously, all issue-based regression tests lived in a separate `tests/regression/` directory with names like `test_Issue1234.cpp`. They have now been:
+
 1. **Renamed** with descriptive names that indicate what they test (e.g., `test_CollisionAccuracy.cpp`, `test_SkeletonState.cpp`)
 2. **Distributed** to appropriate module directories based on their test type
 
 **Migration examples:**
+
 - `test_Issue1184.cpp` → `integration/collision/test_CollisionAccuracy.cpp`
 - `test_Issue1243.cpp` → `integration/dynamics/test_SkeletonState.cpp`
 - `test_Issue986.cpp` → `unit/dynamics/test_CreateShapeNodeApi.cpp`
 
 **Rationale for migration:**
+
 - Descriptive test names improve code readability and maintainability
 - Organizing by module makes related tests easier to find
 - Eliminates redundant categorization (regression vs unit/integration)
@@ -120,6 +129,7 @@ Previously, all issue-based regression tests lived in a separate `tests/regressi
 ### Benchmarks (`benchmark/`)
 
 Performance benchmarks measure execution time and resource usage:
+
 - **collision/**: Collision detection performance with various shapes and scenarios
 - **dynamics/**: Kinematics computation performance
 - **integration/**: End-to-end system performance
@@ -151,6 +161,7 @@ Performance benchmarks measure execution time and resource usage:
    target_link_libraries(test_YourTest dart-utils)
    ```
 3. **Write your test** using GoogleTest framework:
+
    ```cpp
    #include <gtest/gtest.h>
    #include "dart/dynamics/All.hpp"
@@ -161,6 +172,7 @@ Performance benchmarks measure execution time and resource usage:
      EXPECT_TRUE(condition);
    }
    ```
+
 4. **Build and run** your test:
    ```bash
    cmake --build build
@@ -174,6 +186,7 @@ The test helpers are organized by dependency weight to minimize compilation over
 ### GTestUtils.hpp (Lightweight)
 
 Contains utility functions for GoogleTest with **minimal dependencies** (only `dart/math`):
+
 - Custom Eigen matrix/vector comparison macros (`EXPECT_VECTOR_NEAR`, `EXPECT_MATRIX_NEAR`, etc.)
 - Floating-point comparison functions
 - Transform and rotation equality checks
@@ -181,6 +194,7 @@ Contains utility functions for GoogleTest with **minimal dependencies** (only `d
 **Dependencies:** `dart/math`, `Eigen`, `gtest`
 
 **Usage:** Suitable for all tests, especially lightweight unit tests
+
 ```cpp
 #include "helpers/GTestUtils.hpp"
 ```
@@ -188,6 +202,7 @@ Contains utility functions for GoogleTest with **minimal dependencies** (only `d
 ### common_helpers.hpp (Lightweight)
 
 Provides mock utilities for common/utils testing with **lightweight dependencies**:
+
 - `TestResource` - Mock implementation of Resource interface
 - `PresentResourceRetriever` - Mock retriever that always succeeds
 - `AbsentResourceRetriever` - Mock retriever that always fails
@@ -195,6 +210,7 @@ Provides mock utilities for common/utils testing with **lightweight dependencies
 **Dependencies:** `dart/common` only
 
 **Usage:** For IO and utils tests that need resource retriever mocks
+
 ```cpp
 #include "helpers/common_helpers.hpp"
 ```
@@ -202,6 +218,7 @@ Provides mock utilities for common/utils testing with **lightweight dependencies
 ### dynamics_helpers.hpp (Heavy Dependencies)
 
 Provides skeleton and object creation utilities for **integration tests**:
+
 - Skeleton creation (`createThreeLinkRobot`, `createNLinkRobot`, `createNLinkPendulum`, etc.)
 - Object creation (`createGround`, `createBox`, `createSphere`, etc.)
 - Joint configuration utilities
@@ -209,6 +226,7 @@ Provides skeleton and object creation utilities for **integration tests**:
 **Dependencies:** Full DART library (dynamics, collision, math, etc.)
 
 **Usage:** Only for integration tests that need complex skeleton setup
+
 ```cpp
 #include "helpers/dynamics_helpers.hpp"
 ```
@@ -216,6 +234,7 @@ Provides skeleton and object creation utilities for **integration tests**:
 ### Best Practice
 
 Choose helpers based on what you actually need:
+
 - **Math/geometry unit tests**: Use only `GTestUtils.hpp`
 - **Common/utils tests**: Use `GTestUtils.hpp` + `common_helpers.hpp`
 - **Dynamics unit tests**: Avoid helpers if possible; use `dynamics_helpers.hpp` sparingly
@@ -226,12 +245,14 @@ Choose helpers based on what you actually need:
 ## Running Tests
 
 ### Run all tests:
+
 ```bash
 cd build
 ctest
 ```
 
 ### Run tests by category:
+
 ```bash
 ctest -L integration
 ctest -L unit
@@ -239,22 +260,26 @@ ctest -L regression
 ```
 
 ### Run a specific test:
+
 ```bash
 ctest -R test_Collision
 ```
 
 ### Run tests in parallel:
+
 ```bash
 ctest -j8  # Run 8 tests in parallel
 ```
 
 ### Run tests with verbose output:
+
 ```bash
 ctest --verbose
 ctest --output-on-failure  # Only show output for failing tests
 ```
 
 ### Run benchmarks:
+
 ```bash
 ./benchmark/integration/bm_empty
 ./benchmark/collision/bm_boxes
@@ -268,6 +293,7 @@ The test suite uses custom CMake functions defined in `/tests/CMakeLists.txt`:
 ### `dart_add_test(test_type target_name [source_files...])`
 
 Adds a new test executable:
+
 ```cmake
 dart_add_test("integration" test_Collision)
 dart_add_test("unit" test_Factory test_Factory.cpp)
@@ -276,6 +302,7 @@ dart_add_test("unit" test_Factory test_Factory.cpp)
 ### `dart_build_tests(...)`
 
 Builds multiple tests from a list of sources:
+
 ```cmake
 dart_build_tests(
   TYPE integration
@@ -290,6 +317,7 @@ dart_build_tests(
 ### `dart_get_tests(output_var test_type)`
 
 Retrieves all tests of a given type:
+
 ```cmake
 dart_get_tests(integration_tests "integration")
 ```
@@ -317,6 +345,7 @@ dart_get_tests(integration_tests "integration")
 **Problem:** Compilation errors like `'equals' was not declared in this scope` when using helper utilities.
 
 **Solution:** Always include the test namespace when using helpers:
+
 ```cpp
 #include "helpers/GTestUtils.hpp"
 using namespace dart::test;  // Critical for equals(), verifyTransform(), etc.
@@ -327,6 +356,7 @@ using namespace dart::test;  // Critical for equals(), verifyTransform(), etc.
 **Problem:** Clang-format reorders includes causing build issues.
 
 **Solution:** Follow the include ordering pattern (most specific to most general):
+
 1. Test helper headers (quoted paths: `"helpers/GTestUtils.hpp"`)
 2. DART library headers (angle brackets, ordered by layer: `<dart/math/...>`, `<dart/dynamics/...>`, etc.)
 3. External dependencies (`<gtest/gtest.h>`, `<Eigen/Dense>`, etc.)
@@ -337,6 +367,7 @@ using namespace dart::test;  // Critical for equals(), verifyTransform(), etc.
 **Problem:** Compilation errors in test files using Eigen types like `Matrix3d`, `Isometry3d`, etc.
 
 **Solution:** Add Eigen namespace when needed:
+
 ```cpp
 using namespace dart;
 using namespace dart::math;
@@ -348,6 +379,7 @@ using namespace Eigen;  // For Eigen types in test code
 **Problem:** Benchmark tests fail to link with "undefined reference to benchmark::State" errors.
 
 **Solution:** Ensure benchmark tests link against the benchmark library:
+
 ```cmake
 target_link_libraries(bm_yourtest dart-utils benchmark::benchmark)
 ```
@@ -357,6 +389,7 @@ target_link_libraries(bm_yourtest dart-utils benchmark::benchmark)
 **Problem:** Warnings treated as errors when using deprecated aggregate headers.
 
 **Solution:** Use modern header names:
+
 - `dart/utils/utils.hpp` → `dart/utils/All.hpp`
 - `dart/simulation/simulation.hpp` → `dart/simulation/All.hpp`
 - `dart/constraint/constraint.hpp` → `dart/constraint/All.hpp`
@@ -383,6 +416,7 @@ The test suite follows these core principles:
 ## Continuous Integration
 
 Tests are automatically run on:
+
 - Pull requests (before merging)
 - Commits to main branches
 - Scheduled nightly builds
@@ -392,22 +426,26 @@ All tests must pass before code can be merged.
 ## Debugging Tests
 
 ### Run a test in a debugger:
+
 ```bash
 gdb ./tests/integration/collision/test_Collision
 lldb ./tests/integration/collision/test_Collision
 ```
 
 ### Run a specific test case:
+
 ```bash
 ./tests/integration/collision/test_Collision --gtest_filter="CollisionTest.BoxBox"
 ```
 
 ### List all test cases without running:
+
 ```bash
 ./tests/integration/collision/test_Collision --gtest_list_tests
 ```
 
 ### Run with verbose output:
+
 ```bash
 ./tests/integration/collision/test_Collision --gtest_print_time=1
 ```
@@ -415,6 +453,7 @@ lldb ./tests/integration/collision/test_Collision
 ## Contributing
 
 When contributing tests:
+
 1. Follow the organizational structure outlined in this document
 2. Add your test to the appropriate CMakeLists.txt
 3. Ensure your test passes locally before submitting
@@ -424,6 +463,7 @@ When contributing tests:
 ## Questions?
 
 If you have questions about the test suite or where to add a new test, please:
+
 - Check this README first
 - Review existing tests in the same category
 - Ask in the DART development forum or GitHub discussions

--- a/docs/readthedocs/README.md
+++ b/docs/readthedocs/README.md
@@ -7,6 +7,7 @@ This directory contains the source for DART's documentation, including both C++ 
 ### Prerequisites
 
 1. Install pixi (if not already installed):
+
    ```bash
    curl -fsSL https://pixi.sh/install.sh | bash
    ```
@@ -45,11 +46,13 @@ pixi run docs-serve-ko
 The Python API documentation is generated using Sphinx autodoc, which requires the `dartpy` module to be importable.
 
 **Local builds:**
+
 - The `docs-build` task sets `PYTHONPATH` to the compiled dartpy module
 - Sphinx autodoc imports and introspects the module to generate full API documentation
 - All classes, methods, type hints, and docstrings are included
 
 **Read the Docs builds:**
+
 - dartpy is a C++ extension built with pybind11 and cannot be compiled on Read the Docs
 - API documentation pages will be empty until we implement pre-built wheels
 - The documentation structure and navigation will still work correctly
@@ -80,6 +83,7 @@ pixi run docs-serve-ko  # Korean at http://localhost:8001
 ```
 
 The `docs-build` task:
+
 1. Builds the compiled dartpy module (`build-py-dev`)
 2. Sets PYTHONPATH to the compiled module location
 3. Runs Sphinx autodoc to introspect and document the module
@@ -140,6 +144,7 @@ When adding new Python API documentation:
 4. Test locally with `pixi run docs-build` and `pixi run docs-serve`
 
 Example module file:
+
 ```rst
 dartpy.simulation Module
 ========================

--- a/docs/readthedocs/tutorials/biped.md
+++ b/docs/readthedocs/tutorials/biped.md
@@ -1,6 +1,7 @@
 # Biped
 
 ## Overview
+
 This tutorial demonstrates the dynamic features in DART useful for
 developing controllers for bipedal or wheel-based robots. The tutorial
 consists of seven Lessons covering the following topics:
@@ -14,12 +15,13 @@ consists of seven Lessons covering the following topics:
 Please reference the source code in [**tutorial_biped/main.cpp**](https://github.com/dartsim/dart/blob/main/tutorials/tutorial_biped/main.cpp), [**tutorial_biped_finished/main.cpp**](https://github.com/dartsim/dart/blob/main/tutorials/tutorial_biped_finished/main.cpp), and the dartpy variant [**python/tutorials/04_biped/main_finished.py**](https://github.com/dartsim/dart/blob/main/python/tutorials/04_biped/main_finished.py).
 
 ## Lesson 1: Joint limits and self-collision
-Let's start by locating the ``main`` function in tutorials/tutorial_biped/main.cpp. We first create a floor
-and call ``loadBiped`` to load a bipedal figure described in SKEL
+
+Let's start by locating the `main` function in tutorials/tutorial*biped/main.cpp. We first create a floor
+and call `loadBiped` to load a bipedal figure described in SKEL
 format, which is an XML format representing a robot model. A SKEL file
-describes a ``World`` with one or more ``Skeleton``s in it. Here we
+describes a `World` with one or more `Skeleton`s in it. Here we
 load in a World from [**biped.skel**](https://github.com/dartsim/dart/blob/main/data/skel/biped.skel) and assign the bipedal figure to a
-``Skeleton`` pointer called *biped*.
+`Skeleton` pointer called \_biped*.
 
 ```{eval-rst}
 .. tabs::
@@ -56,18 +58,19 @@ should see the description of the right knee joint in **biped.skel**:
         <limit>
             <lower>-3.14</lower>
             <upper>0.0</upper>
-        </limit>                  
+        </limit>
     </axis>
 ...
 </joint>
 ```
+
 The &lt;upper> and &lt;lower> tags make sure that the knee can only flex but
 not extend. Alternatively, you can directly specify the joint limits
 in the code using
-``setPositionUpperLimit`` and ``setPositionLowerLimit``.
+`setPositionUpperLimit` and `setPositionLowerLimit`.
 
 In either case, the joint limits on the biped will not be activated
-until you call ``setPositionLimited``:
+until you call `setPositionLimited`:
 
 ```{eval-rst}
 .. tabs::
@@ -86,9 +89,11 @@ until you call ``setPositionLimited``:
          :start-after: # snippet:py-biped-lesson1-limits-start
          :end-before: # snippet:py-biped-lesson1-limits-end
 ```
+
 Once the joint limits are set, the next task is to enforce
 self-collision. By default, DART does not check self-collision within
 a skeleton. You can enable self-collision checking on the biped by
+
 ```{eval-rst}
 .. tabs::
 
@@ -106,12 +111,15 @@ a skeleton. You can enable self-collision checking on the biped by
          :start-after: # snippet:py-biped-lesson1-self-start
          :end-before: # snippet:py-biped-lesson1-self-end
 ```
+
 This function will enable self-collision on every pair of
 body nodes. If you wish to disable self-collisions on adjacent body
 nodes, call the following function
+
 ```cpp
 biped->disableAdjacentBodyCheck();
 ```
+
 Running the program again, you should see that the character is still
 floppy like a ragdoll, but now the joints do not bend backward and the
 body nodes do not penetrate each other anymore.
@@ -131,7 +139,7 @@ damping coefficients. The detailed description of a PD controller can
 be found [here](https://en.wikipedia.org/wiki/PID_controller).
 
 The first task is to set the biped to a particular configuration. You
-can use ``setPosition`` to set each degree of freedom individually:
+can use `setPosition` to set each degree of freedom individually:
 
 ```{eval-rst}
 .. tabs::
@@ -150,13 +158,14 @@ can use ``setPosition`` to set each degree of freedom individually:
          :start-after: # snippet:py-biped-lesson2-initial-pose-start
          :end-before: # snippet:py-biped-lesson2-initial-pose-end
 ```
+
 Here the degree of freedom named "j_thigh_left_z" is set to 0.15
 radian. Note that each degree of freedom in a skeleton has a numerical
 index which can be accessed by
-``getIndexInSkeleton``. You
+`getIndexInSkeleton`. You
 can also set the entire configuration using a vector that holds the
 positions of all the degreed of freedoms using
-``setPositions``.
+`setPositions`.
 
 We continue to set more degrees of freedoms in the lower
 body to create a roughly stable standing pose.
@@ -172,7 +181,7 @@ biped->setPosition(biped->getDof("j_heel_right_1")->getIndexInSkeleton(), 0.25);
 
 Now the biped will start in this configuration, but will not maintain
 this configuration as soon as the simulation starts. We need a
-controller to make this happen. Let's take a look at the constructor of our ``Controller`` in the
+controller to make this happen. Let's take a look at the constructor of our `Controller` in the
 skeleton code:
 
 ```{eval-rst}
@@ -202,7 +211,7 @@ zero. At the end of the constructor, we set the target position of the PD
 controller to the current configuration of the biped.
 
 With these settings, we can compute the forces generated by the PD
-controller and add them to the internal forces of biped using ``setForces``:
+controller and add them to the internal forces of biped using `setForces`:
 
 ```{eval-rst}
 .. tabs::
@@ -221,7 +230,8 @@ controller and add them to the internal forces of biped using ``setForces``:
          :start-after: # snippet:py-biped-lesson2-pd-start
          :end-before: # snippet:py-biped-lesson2-pd-end
 ```
-Note that the PD control force is *added* to the current internal force
+
+Note that the PD control force is _added_ to the current internal force
 stored in mForces instead of overriding it.
 
 Now try to run the program and see what happens. The skeleton
@@ -275,11 +285,11 @@ implementation of SPD simple and concise:
 
 You can get mass matrix, Coriolis force, gravitational force, and
 constraint force projected onto generalized coordinates using function
-calls ``getMassMatrix``,
-``getCoriolisForces``,
-``getGravityForces``,
+calls `getMassMatrix`,
+`getCoriolisForces`,
+`getGravityForces`,
 and
-``getConstraintForces``,
+`getConstraintForces`,
 respectively. Constraint forces include forces due to contacts, joint
 limits, and other joint constraints set by the user (e.g. the weld
 joint constraint in the multi-pendulum tutorial).
@@ -291,7 +301,6 @@ can stand on the ground in balance indefinitely. However, if you apply
 an external push force on the biped (hit ',' or '.' key to apply a
 backward or forward push), the biped loses its balance quickly. We
 will demonstrate a more robust feedback controller in the next Lesson.
-
 
 ## Lesson 4: Ankle strategy
 
@@ -328,11 +337,11 @@ anterior-posterior axis:
 ```
 
 DART provides various APIs to access useful kinematic information. For
-example, ``getCOM`` returns the center of mass of the skeleton and
-``getTransform`` returns transformation of the body node with
+example, `getCOM` returns the center of mass of the skeleton and
+`getTransform` returns transformation of the body node with
 respect to any coordinate frame specified by the parameter (world
 coordinate frame as default). DART APIs also come in handy when
-computing the derivative term,  -k<sub>d</sub> (x&#775; - p&#775;):
+computing the derivative term, -k<sub>d</sub> (x&#775; - p&#775;):
 
 ```{eval-rst}
 .. tabs::
@@ -354,7 +363,7 @@ computing the derivative term,  -k<sub>d</sub> (x&#775; - p&#775;):
 
 The linear/angular velocity/acceleration of any point in any coordinate
 frame can be easily accessed in DART. The full list of the APIs for accessing
-various velocities/accelerations can be found in the [API Documentation](http://dartsim.github.io/dart/). The 
+various velocities/accelerations can be found in the [API Documentation](http://dartsim.github.io/dart/). The
 following table summarizes the essential APIs.
 
 | Function Name          | Description                                                                                            |
@@ -401,7 +410,7 @@ We first load a skateboard from **skateboard.skel**:
 Our goal is to make the skateboard Skeleton a subtree of the biped
 Skeleton connected to the left heel BodyNode via a newly created
 Euler joint. To do so, you need to first create an instance of
-``EulerJoint::Properties`` for this new joint.
+`EulerJoint::Properties` for this new joint.
 
 Here we increase the vertical distance between the child BodyNode and
 the joint by 0.1m to give some space between the skateboard and the
@@ -418,7 +427,6 @@ a table of some relevant functions for quick references.
 | changeParentJointType | bd1->changeParentJointType&lt;BallJoint&gt;() | Change the Joint type of the BodyNode bd1's parent joint to BallJoint                                                                     |
 | copyTo                | bd1->copyTo(bd2)                              | Create clones of the BodyNode bd1 and its subtree and attach the clones to the specified the BodyNode bd2.                                |
 | copyAs                | auto newSkel = bd1->copyAs("new skeleton")    | Create clones of the BodyNode bd1 and its subtree and create a new Skeleton with "new skeleton" name to attach them to.                   |
-
 
 ## Lesson 6: Actuator types
 
@@ -483,8 +491,8 @@ command them by directly setting the desired velocity:
          :end-before: # snippet:py-biped-lesson6-wheel-commands-end
 ```
 
-Note that ``setCommand`` only exerts commanding force in the current time step. If you wish the
-wheel to continue spinning at a particular speed, ``setCommand``
+Note that `setCommand` only exerts commanding force in the current time step. If you wish the
+wheel to continue spinning at a particular speed, `setCommand`
 needs to be called at every time step.
 
 We also set the stiffness and damping coefficients for the wheels to zero.
@@ -529,7 +537,7 @@ left foot from the ground:
 <img src="IKObjective.png" width="180">
 
 where <b>c</b> and <b>p</b> indicate the projected center of mass and center of
-pressure on the ground, and *p<sub>i</sub>* indicates the vertical height of one
+pressure on the ground, and _p<sub>i</sub>_ indicates the vertical height of one
 corner of the left foot.
 
 To compute the gradient of the above objective function, we need to evaluate
@@ -559,14 +567,14 @@ of mass of a BodyNode:
          :end-before: # snippet:py-biped-lesson7-ik-end
 ```
 
-``getCOMLinearJacobian`` returns the linear Jacobian of the
-center of mass of the Skeleton, while ``getLinearJacobian``
+`getCOMLinearJacobian` returns the linear Jacobian of the
+center of mass of the Skeleton, while `getLinearJacobian`
 returns the Jacobian of a point on a BodyNode. The BodyNode and the
 local coordinate of the point are specified as parameters to this
 function. Here the point of interest is the center of mass of the left
-foot, which local coordinates can be accessed by ``getCOM``
+foot, which local coordinates can be accessed by `getCOM`
 with a parameter indicating the left foot being the frame of
-reference. We use ``getLinearJacobian`` again to compute the
+reference. We use `getLinearJacobian` again to compute the
 gradient of the second term of the objective function:
 
 ```cpp
@@ -579,7 +587,7 @@ math::VectorXd solveIK(SkeletonPtr biped)
 }
 ```
 
-The full list of Jacobian APIs can be found in the [API Documentation](http://dartsim.github.io/dart/). The 
+The full list of Jacobian APIs can be found in the [API Documentation](http://dartsim.github.io/dart/). The
 following table summarizes the essential APIs.
 
 | Function Name           | Description                                                                                                                                                        |

--- a/docs/readthedocs/tutorials/collisions.md
+++ b/docs/readthedocs/tutorials/collisions.md
@@ -1,6 +1,7 @@
 # Collisions
 
 ## Overview
+
 This tutorial will show you how to programmatically create different kinds of
 bodies and set initial conditions for Skeletons. It will also demonstrate some
 use of DART's Frame Semantics.
@@ -17,8 +18,8 @@ Please reference the source code in [**tutorial_collisions/main.cpp**](https://g
 
 ## Lesson 1: Creating a rigid body
 
-Start by opening the Skeleton code in [``tutorials/tutorial_collisions/main.cpp``](https://github.com/dartsim/dart/blob/main/tutorials/tutorial_collisions/main.cpp).
-Find the function named ``addRigidBody``. You will notice that this is a templated
+Start by opening the Skeleton code in [`tutorials/tutorial_collisions/main.cpp`](https://github.com/dartsim/dart/blob/main/tutorials/tutorial_collisions/main.cpp).
+Find the function named `addRigidBody`. You will notice that this is a templated
 function. If you're not familiar with templates, that's okay; we won't be doing
 anything too complicated with them. Different Joint types in DART are managed by
 a bunch of different classes, so we need to use templates if we want the same
@@ -33,24 +34,24 @@ because we need its parent Joint to describe how it's attached to the world. A
 root BodyNode could be attached to the world by any kind of Joint. Most often,
 it will be attached by either a FreeJoint (if the body should be completely
 free to move with respect to the world) or a WeldJoint (if the body should be
-rigidly attached to the world, unable to move at all), but *any* Joint type
+rigidly attached to the world, unable to move at all), but _any_ Joint type
 is permissible.
 
 Joint properties are managed in a nested class, which means it's a class which
-is defined inside of another class. For example, ``RevoluteJoint`` properties are
-managed in a class called ``RevoluteJoint::Properties`` while ``PrismaticJoint``
-properties are managed in a class called ``PrismaticJoint::Properties``. However,
-both ``RevoluteJoint`` and ``PrismaticJoint`` inherit the ``SingleDofJoint`` class
-so the ``RevoluteJoint::Properties`` and ``PrismaticJoint::Properties`` classes
-both inherit the ``SingleDofJoint::Properties`` class. The difference is that
-``RevoluteJoint::Properties`` also inherits ``RevoluteJoint::UniqueProperties``
-whereas ``PrismaticJoint::Properties`` inherits ``PrismaticJoint::UniqueProperties``
-instead. Many DART classes contain nested ``Properties`` classes like this which
-are compositions of their base class's nested ``Properties`` class and their own
-``UniqueProperties`` class. As you'll see later, this is useful for providing a
+is defined inside of another class. For example, `RevoluteJoint` properties are
+managed in a class called `RevoluteJoint::Properties` while `PrismaticJoint`
+properties are managed in a class called `PrismaticJoint::Properties`. However,
+both `RevoluteJoint` and `PrismaticJoint` inherit the `SingleDofJoint` class
+so the `RevoluteJoint::Properties` and `PrismaticJoint::Properties` classes
+both inherit the `SingleDofJoint::Properties` class. The difference is that
+`RevoluteJoint::Properties` also inherits `RevoluteJoint::UniqueProperties`
+whereas `PrismaticJoint::Properties` inherits `PrismaticJoint::UniqueProperties`
+instead. Many DART classes contain nested `Properties` classes like this which
+are compositions of their base class's nested `Properties` class and their own
+`UniqueProperties` class. As you'll see later, this is useful for providing a
 consistent API that works cleanly for fundamentally different types of classes.
 
-To create a ``Properties`` class for our Joint type, we instantiate the nested
+To create a `Properties` class for our Joint type, we instantiate the nested
 struct for the joint, assign it a unique name, and, if needed, offset the joint
 from its parent BodyNode. The block below shows the complete setup, including
 the transforms that align the joint halfway between the two bodies:
@@ -73,7 +74,7 @@ the transforms that align the joint halfway between the two bodies:
          :end-before: # snippet:py-collisions-lesson1a-properties-end
 ```
 
-We need to include the ``typename`` keywords because of how the syntax works for
+We need to include the `typename` keywords because of how the syntax works for
 templated functions. Leaving it out should make your compiler complain.
 
 From here, we can set the Joint properties in any way we'd like. There are only
@@ -87,14 +88,14 @@ wants you to be aware when you are being negligent about naming things). For the
 sake of simplicity, let's just give it a name based off its child BodyNode.
 
 Next we'll want to deal with offsetting the new BodyNode from its parent BodyNode.
-An ``Isometry3`` (python) or ``Isometry3d`` (C++) is the Eigen library's version
+An `Isometry3` (python) or `Isometry3d` (C++) is the Eigen library's version
 of a homogeneous transformation matrix. Initialize it to the identity to ensure
 the contents are well-defined before applying translations. We can easily compute
 the center point between the origins of the two bodies using our default height
 value and then assign that translation to both the parent- and child-to-joint
 transforms.
 
-Remember that all of that code should go inside the ``if(parent)`` condition.
+Remember that all of that code should go inside the `if(parent)` condition.
 We do not want to create this offset for root BodyNodes, because later on we
 will rely on the assumption that the root Joint origin is lined up with the
 root BodyNode origin.
@@ -130,43 +131,43 @@ that new BodyNode:
 
 There's a lot going on in this function, so let's break it down for a moment:
 
-``chain->createJointAndBodyNodePair<JointType>``
+`chain->createJointAndBodyNodePair<JointType>`
 
 This is a Skeleton member function that takes template arguments. The first
 template argument specifies the type of Joint that you want to create. In our
 case, the type of Joint we want to create is actually a template argument of
 our current function, so we just pass that argument along. The second template
-argument of ``createJointAndBodyNodePair`` allows us to specify the BodyNode
-type that we want to create, but the default argument is a standard rigid 
+argument of `createJointAndBodyNodePair` allows us to specify the BodyNode
+type that we want to create, but the default argument is a standard rigid
 BodyNode, so we can leave the second argument blank.
 
-``(parent, joint_properties, BodyNode::AspectProperties(name))``
+`(parent, joint_properties, BodyNode::AspectProperties(name))`
 
 Now for the function arguments: The first specifies the parent BodyNode. In the
 event that you want to create a root BodyNode, you can simply pass in a nullptr
-as the parent. The second argument is a ``JointType::Properties`` struct, so we
-pass in the ``joint_properties`` object that we created earlier. The third argument is
-a ``BodyNode::Properties`` struct, but we're going to set the BodyNode properties
+as the parent. The second argument is a `JointType::Properties` struct, so we
+pass in the `joint_properties` object that we created earlier. The third argument is
+a `BodyNode::Properties` struct, but we're going to set the BodyNode properties
 later, so we'll just toss the name in by wrapping it up in a
-``BodyNode::AspectProperties`` object and leave the rest as default values.
+`BodyNode::AspectProperties` object and leave the rest as default values.
 
 Now notice the very last thing on this line of code:
 
-``.second;``
+`.second;`
 
-The function actually returns a ``std::pair`` of pointers to the new Joint and
-new BodyNode that were just created, but we only care about grabbing the 
-BodyNode once the function is finished, so we can append ``.second`` to the end
-of the line so that we just grab the BodyNode pointer and ignore the Joint 
-pointer. The joint will of course still be created; we just have no need to 
+The function actually returns a `std::pair` of pointers to the new Joint and
+new BodyNode that were just created, but we only care about grabbing the
+BodyNode once the function is finished, so we can append `.second` to the end
+of the line so that we just grab the BodyNode pointer and ignore the Joint
+pointer. The joint will of course still be created; we just have no need to
 access it at this point.
 
 ### Lesson 1c: Make a shape for the body
 
 We'll take advantage of the Shape::ShapeType enumeration to specify what kind of
 Shape we want to produce for the body. In particular, we'll allow the user to
-specify three types of Shapes: ``Shape::BOX``, ``Shape::CYLINDER``, and
-``Shape::ELLIPSOID``. 
+specify three types of Shapes: `Shape::BOX`, `Shape::CYLINDER`, and
+`Shape::ELLIPSOID`.
 
 ```{eval-rst}
 .. tabs::
@@ -186,7 +187,7 @@ specify three types of Shapes: ``Shape::BOX``, ``Shape::CYLINDER``, and
          :end-before: # snippet:py-collisions-lesson1c-shape-selection-end
 ```
 
-``ShapePtr`` is simply a typedef for ``std::shared_ptr<Shape>``. DART has this
+`ShapePtr` is simply a typedef for `std::shared_ptr<Shape>`. DART has this
 typedef in order to improve space usage and readability, because this type gets
 used very often.
 
@@ -227,8 +228,8 @@ should be after all the condition statements.
 
 For the simulations to be physically accurate, it's important for the inertia
 properties of the body to match up with the geometric properties of the shape.
-We can create an ``Inertia`` object and set its values based on the shape's
-geometry, then give that ``Inertia`` to the BodyNode.
+We can create an `Inertia` object and set its values based on the shape's
+geometry, then give that `Inertia` to the BodyNode.
 
 ```{eval-rst}
 .. tabs::
@@ -300,8 +301,8 @@ Joint to a default value.
 
 ## Lesson 2: Creating a soft body
 
-Find the templated function named ``addSoftBody``. This function will have a
-role identical to the ``addRigidBody`` function from earlier.
+Find the templated function named `addSoftBody`. This function will have a
+role identical to the `addRigidBody` function from earlier.
 
 ```{note}
 Soft body helpers are currently exposed only in the C++ API. The dartpy snippets
@@ -322,7 +323,7 @@ we'll set them beforehand.
 First, let's create a struct for the properties that are unique to SoftBodyNodes.
 Up above we defined an enumeration for a couple different SoftBodyNode types.
 There is no official DART-native enumeration for this, we created our own to use
-for this function. We'll want to fill in the ``SoftBodyNode::UniqueProperties``
+for this function. We'll want to fill in the `SoftBodyNode::UniqueProperties`
 struct based off of this enumeration.
 
 ```{eval-rst}
@@ -343,7 +344,7 @@ struct based off of this enumeration.
          :end-before: # snippet:py-collisions-lesson2b-soft-properties-end
 ```
 
-Each of the C++ conditionals leverages ``SoftBodyNodeHelper`` to construct the
+Each of the C++ conditionals leverages `SoftBodyNodeHelper` to construct the
 skin and its mass distribution (feel free to experiment with slice/stack counts,
 keeping in mind the minimum values noted in the comments). The dartpy
 implementation currently falls back to creating a rigid shell with matching
@@ -353,8 +354,8 @@ lesson still applies.
 ### Lesson 2c: Create the Joint and Soft Body pair
 
 This step is very similar to Lesson 1b, except now we'll want to specify
-that we're creating a soft BodyNode. First, let's create a full 
-``SoftBodyNode::Properties``. This will combine the ``UniqueProperties`` of the
+that we're creating a soft BodyNode. First, let's create a full
+`SoftBodyNode::Properties`. This will combine the `UniqueProperties` of the
 SoftBodyNode with the standard properties of a BodyNode. Now we can pass the
 whole thing into the creation function:
 
@@ -376,8 +377,8 @@ whole thing into the creation function:
          :end-before: # snippet:py-collisions-lesson2c-soft-node-end
 ```
 
-Notice that this time it will return a ``SoftBodyNode`` pointer rather than a
-normal ``BodyNode`` pointer. This is one of the advantages of templates!
+Notice that this time it will return a `SoftBodyNode` pointer rather than a
+normal `BodyNode` pointer. This is one of the advantages of templates!
 
 ### Lesson 2d: Zero out the BodyNode inertia
 
@@ -412,7 +413,7 @@ simulation:
 To help us visually distinguish between the soft and rigid portions of a body,
 we can make the soft part of the shape transparent. Upon creation, a SoftBodyNode
 will have exactly one visualization shape: the soft shape visualizer. We can
-reduce the value of its alpha channel (or directly call ``setAlpha`` in dartpy)
+reduce the value of its alpha channel (or directly call `setAlpha` in dartpy)
 so it stands out from the rigid pieces:
 
 ```{eval-rst}
@@ -440,7 +441,7 @@ bones. We can create a rigid shape, place it in the SoftBodyNode, and give some
 inertia to the SoftBodyNode's base BodyNode class, to act as the inertia of the
 bone.
 
-Find the function ``createSoftBody()``. Underneath the call to ``addSoftBody``,
+Find the function `createSoftBody()`. Underneath the call to `addSoftBody`,
 we can create a box shape that matches the dimensions of the soft box, but scaled
 down:
 
@@ -472,8 +473,8 @@ of the SoftBodyNode's skin.
 ### Lesson 2g: Add a rigid body attached by a WeldJoint
 
 To make a more interesting hybrid shape, we can attach a protruding rigid body
-to a SoftBodyNode using a WeldJoint. Find the ``createHybridBody()`` function
-and see where we call the ``addSoftBody`` function. Just below this, we'll
+to a SoftBodyNode using a WeldJoint. Find the `createHybridBody()` function
+and see where we call the `addSoftBody` function. Just below this, we'll
 create a new rigid body with a WeldJoint attachment:
 
 ```{eval-rst}
@@ -500,7 +501,7 @@ expected.
 
 ## Lesson 3: Setting initial conditions and taking advantage of Frames
 
-Find the ``addObject`` function in the ``MyWorld`` class. This function will
+Find the `addObject` function in the `MyWorld` class. This function will
 be called whenever the user requests for an object to be added to the world.
 In this function, we want to set up the initial conditions for the object so
 that it gets thrown at the wall. We also want to make sure that it's not in
@@ -513,6 +514,7 @@ We want to position the object in a reasonable place for us to throw it at the
 wall. We also want to have the ability to randomize its location along the y-axis.
 
 First, let's create a zero vector for the position:
+
 ```cpp
 math::Vector6d positions(math::Vector6d::Zero());
 ```
@@ -578,7 +580,7 @@ ugly printout, we'll make sure the new object has a unique name ahead of time:
 ### Lesson 3c: Add the object to the world without collisions
 
 Before we add the Skeleton to the world, we want to make sure that it
-isn't actually placed inside of something accidentally. If an object in a 
+isn't actually placed inside of something accidentally. If an object in a
 simulation starts off inside of another object, it can result in extremely
 non-physical simulations, perhaps even breaking the simulation entirely.
 We can access the world's collision detector directly to check make sure the
@@ -608,13 +610,13 @@ message explaining why.
 DART has a unique feature that we call Frame Semantics. The Frame Semantics of
 DART allow you to create reference frames and use them to get and set data
 relative to arbitrary frames. There are two crucial Frame types currently used
-in DART: ``BodyNode``s and ``SimpleFrame``s.
+in DART: `BodyNode`s and `SimpleFrame`s.
 
 The BodyNode class does not allow you to explicitly set its transform, velocity,
 or acceleration properties, because those are all strictly functions of the
 degrees of freedom that the BodyNode depends on. Because of this, the BodyNode
 is not a very convenient class if you want to create an arbitrary frame of
-reference. Instead, DART offers the ``SimpleFrame`` class which gives you the
+reference. Instead, DART offers the `SimpleFrame` class which gives you the
 freedom of arbitarily attaching it to any parent Frame and setting its transform,
 velocity, and acceleration to whatever you'd like. This makes SimpleFrame useful
 for specifying arbitrary reference frames.
@@ -641,7 +643,7 @@ SimpleFrame at the Skeleton's center of mass:
          :end-before: # snippet:py-collisions-lesson3d-reference-frame-end
 ```
 
-Calling ``object->getCOM()`` will tell us the center of mass location with
+Calling `object->getCOM()` will tell us the center of mass location with
 respect to the World Frame. We use that to set the translation of the
 SimpleFrame's relative transform so that the origin of the SimpleFrame will be
 located at the object's center of mass.
@@ -668,7 +670,7 @@ speeds into directional velocities and store them on the SimpleFrame:
          :end-before: # snippet:py-collisions-lesson3e-launch-velocity-end
 ```
 
-The ``SimpleFrame::setClassicDerivatives()`` allows you to set the classic linear
+The `SimpleFrame::setClassicDerivatives()` allows you to set the classic linear
 and angular velocities and accelerations of a SimpleFrame with respect to its
 parent Frame, which in this case is the World Frame. In DART, classic velocity and
 acceleration vectors are explicitly differentiated from spatial velocity and
@@ -704,7 +706,7 @@ Now we're ready to toss around objects!
 
 ## Lesson 4: Setting joint spring and damping properties
 
-Find the ``setupRing`` function. This is where we'll setup a chain of BodyNodes
+Find the `setupRing` function. This is where we'll setup a chain of BodyNodes
 so that it behaves more like a closed ring.
 
 ### Lesson 4a: Set the spring and damping coefficients
@@ -785,7 +787,7 @@ root BodyNode) start out in their rest positions:
 
 ## Lesson 5: Create a closed kinematic chain
 
-Find the ``CollisionsEventHandler::addRing`` function. In here, we'll want to
+Find the `CollisionsEventHandler::addRing` function. In here, we'll want to
 create a dynamic constraint that attaches the first and last BodyNodes of the chain
 together by a BallJoint-style constraint.
 

--- a/docs/readthedocs/tutorials/dominoes.md
+++ b/docs/readthedocs/tutorials/dominoes.md
@@ -22,8 +22,8 @@ very easily.
 ### Lesson 1a: Create a new domino
 
 Creating a new domino is straightforward. Find the
-``DominoEventHandler::attemptToCreateDomino`` function. The event handler keeps
-``mFirstDomino`` as the original domino created when the program starts up. To
+`DominoEventHandler::attemptToCreateDomino` function. The event handler keeps
+`mFirstDomino` as the original domino created when the program starts up. To
 make a new one, we can just clone it:
 
 ```{eval-rst}
@@ -88,7 +88,7 @@ position. First, let's grab the last domino that was placed in the environment:
 ```
 
 Now we should compute what we want its position to be. The event handler keeps a
-member called ``mTotalAngle`` which tracks how much the line of dominoes has
+member called `mTotalAngle` which tracks how much the line of dominoes has
 turned so far. We'll use that to figure out what translational offset the new
 domino should have from the last domino:
 
@@ -174,9 +174,9 @@ Finally, we should add on the change in angle for the new domino:
          :end-before: # snippet:py-dominoes-lesson1a-angle-end
 ```
 
-Be sure to uncomment the ``angle`` argument of the function.
+Be sure to uncomment the `angle` argument of the function.
 
-Now we can use ``x`` to set the positions of the domino:
+Now we can use `x` to set the positions of the domino:
 
 ```{eval-rst}
 .. tabs::
@@ -197,7 +197,7 @@ Now we can use ``x`` to set the positions of the domino:
 ```
 
 The root FreeJoint is the only joint in the domino's Skeleton, so we can just
-use the ``Skeleton::setPositions`` function to set it.
+use the `Skeleton::setPositions` function to set it.
 
 We'll hold off on adding the domino to the world until we confirm that it isn't
 going to spawn inside another object.
@@ -206,7 +206,7 @@ going to spawn inside another object.
 
 Similar to **Lesson 3** of the **Collisions** tutorial, we'll want to make sure
 that the newly inserted Skeleton is not starting out in collision with anything,
-because this could make for a very ugly (perhaps even broken) simulation. 
+because this could make for a very ugly (perhaps even broken) simulation.
 
 We grab the world's constraint solver, create a temporary collision group that
 contains just the new domino, and temporarily remove the floor from the world's
@@ -257,7 +257,7 @@ domino and try again.
 ### Lesson 1c: Delete the last domino added
 
 Ordinarily, removing a Skeleton from a scene is just a matter of calling the
-``World::removeSkeleton`` function, but we have a little bit of bookkeeping to
+`World::removeSkeleton` function, but we have a little bit of bookkeeping to
 take care of for our particular application. First, we should check whether
 there are any dominoes to actually remove:
 
@@ -285,8 +285,8 @@ there are any dominoes to actually remove:
 
 But just setting up dominoes isn't much fun without being able to knock them
 down. We can quickly and easily knock down the dominoes by magically applying
-a force to the first one. Inside ``DominoEventHandler::update()`` there is a
-label for **Lesson 1d**. ``CustomWorldNode`` calls this method each tick, so
+a force to the first one. Inside `DominoEventHandler::update()` there is a
+label for **Lesson 1d**. `CustomWorldNode` calls this method each tick, so
 whenever the user presses 'f' we apply an external force to the first domino:
 
 ```{eval-rst}
@@ -315,7 +315,7 @@ Instead, let's load a robotic manipulator and have it push over the first domino
 ### Lesson 2a: Load a URDF file
 
 Our manipulator is going to be loaded from a URDF file. URDF files are loaded
-by the ``dart::io::DartLoader`` class (pending upcoming changes to DART's
+by the `dart::io::DartLoader` class (pending upcoming changes to DART's
 loading system). First, create a loader:
 
 ```{eval-rst}
@@ -336,13 +336,13 @@ loading system). First, create a loader:
          :end-before: # snippet:py-dominoes-lesson2a-loader-end
 ```
 
-Note that many URDF files use ROS's ``package:`` scheme to specify the locations
+Note that many URDF files use ROS's `package:` scheme to specify the locations
 of the resources that need to be loaded. We won't be using this in our example,
-but in general you should use the function ``DartLoader::addPackageDirectory``
+but in general you should use the function `DartLoader::addPackageDirectory`
 to specify the locations of these packages, because DART does not have the same
 package resolving abilities of ROS.
 
-Now we'll have ``loader`` parse the file into a Skeleton:
+Now we'll have `loader` parse the file into a Skeleton:
 
 ```{eval-rst}
 .. tabs::
@@ -447,10 +447,10 @@ although all it will be able to do is collapse pitifully onto the floor.**
 
 ### Lesson 2b: Grab the desired joint angles
 
-To make the manipulator actually useful, we'll want to have the ``Controller``
-control its joint forces. For it to do that, the ``Controller`` class will need
-to be informed of what we want the manipulator's joint angles to be. This is 
-easily done in the constructor of the ``Controller`` class:
+To make the manipulator actually useful, we'll want to have the `Controller`
+control its joint forces. For it to do that, the `Controller` class will need
+to be informed of what we want the manipulator's joint angles to be. This is
+easily done in the constructor of the `Controller` class:
 
 ```{eval-rst}
 .. tabs::
@@ -470,7 +470,7 @@ easily done in the constructor of the ``Controller`` class:
          :end-before: # snippet:py-dominoes-lesson2b-desired-positions-end
 ```
 
-The function ``Skeleton::getPositions`` will get all the generalized coordinate
+The function `Skeleton::getPositions` will get all the generalized coordinate
 positions of all the joints in the Skeleton, stacked in a single vector. These
 Skeleton API functions are useful when commanding or controlling an entire
 Skeleton with a single mathematical expression.
@@ -478,8 +478,8 @@ Skeleton with a single mathematical expression.
 ### Lesson 2c: Write a stable PD controller for the manipulator
 
 Now that we know what configuration we want the manipulator to hold, we can
-write a PD controller that keeps them in place. Find the function ``setPDForces``
-in the ``Controller`` class.
+write a PD controller that keeps them in place. Find the function `setPDForces`
+in the `Controller` class.
 
 First, we'll grab the current positions and velocities:
 
@@ -783,7 +783,7 @@ to push on the domino from a very strange angle:
          :end-before: # snippet:py-dominoes-lesson3a-target-rotation-end
 ```
 
-Now we'll set the target so that it has a transform of ``target_offset`` with
+Now we'll set the target so that it has a transform of `target_offset` with
 respect to the frame of the domino:
 
 ```{eval-rst}
@@ -809,7 +809,7 @@ controller.
 
 ### Lesson 3b: Computing forces for OS Controller
 
-Find the function ``setOperationalSpaceForces()``. This is where we'll compute
+Find the function `setOperationalSpaceForces()`. This is where we'll compute
 the forces for our operational space controller.
 
 One of the key ingredients in an operational space controller is the mass matrix.
@@ -905,7 +905,7 @@ Next we'll want the time derivative of the Jacobian, as well as its pseudoinvers
 Notice that here we're compute the **classic** derivative, which means the
 derivative of the Jacobian with respect to time in classical coordinates rather
 than spatial coordinates. If you use spatial vector arithmetic, then you'll want
-to use ``BodyNode::getJacobianSpatialDeriv`` instead.
+to use `BodyNode::getJacobianSpatialDeriv` instead.
 
 Now we can compute the linear components of error:
 

--- a/docs/readthedocs/tutorials/multi-pendulum.md
+++ b/docs/readthedocs/tutorials/multi-pendulum.md
@@ -25,8 +25,8 @@ scratch. It also loads models in URDF, SDF, and SKEL formats as
 demonstrated in the later tutorials.
 
 In DART, an articulated dynamics model is represented by a
-``Skeleton``. In the ``main`` function, we first create an empty
-skeleton named *pendulum*.
+`Skeleton`. In the `main` function, we first create an empty
+skeleton named _pendulum_.
 
 ```{eval-rst}
 .. tabs::
@@ -44,11 +44,11 @@ skeleton named *pendulum*.
          pendulum = dart.dynamics.Skeleton("pendulum")
 ```
 
-A Skeleton is a structure that consists of ``BodyNode``s (bodies) which are 
-connected by ``Joint``s. Every Joint has a child BodyNode, and every BodyNode 
-has a parent Joint. Even the root BodyNode has a Joint that attaches it to the 
-World. In the function ``makeRootBody``, we create a pair of a
-``BallJoint``  and a BodyNode, and attach this pair to the currently
+A Skeleton is a structure that consists of `BodyNode`s (bodies) which are
+connected by `Joint`s. Every Joint has a child BodyNode, and every BodyNode
+has a parent Joint. Even the root BodyNode has a Joint that attaches it to the
+World. In the function `makeRootBody`, we create a pair of a
+`BallJoint` and a BodyNode, and attach this pair to the currently
 empty pendulum skeleton.
 
 ```{eval-rst}
@@ -81,7 +81,7 @@ this new BodyNode is the root of the pendulum. If we wish to append
 the new BodyNode to an existing BodyNode in the pendulum,
 we can do so by passing the pointer of the existing BodyNode as
 the first parameter. In fact, this is how we add more BodyNodes to
-the pendulum in the function ``addBody``:
+the pendulum in the function `addBody`:
 
 ```{eval-rst}
 .. tabs::
@@ -109,10 +109,11 @@ the pendulum in the function ``addBody``:
              ),
          )
 ```
-These tutorials use the OSG viewer utilities under ``dart::gui::osg``. After we
-create the ``World`` and pendulum skeleton, we instantiate a ``Controller``
-plus a GUI event handler, wrap the world in a ``RealTimeWorldNode``, and send
-that node to a ``Viewer``:
+
+These tutorials use the OSG viewer utilities under `dart::gui::osg`. After we
+create the `World` and pendulum skeleton, we instantiate a `Controller`
+plus a GUI event handler, wrap the world in a `RealTimeWorldNode`, and send
+that node to a `Viewer`:
 
 ```{eval-rst}
 .. tabs::
@@ -132,8 +133,8 @@ that node to a ``Viewer``:
          :end-before: viewer.addInstructionText("space bar
 ```
 
-The ``Viewer`` drives the world through ``CustomWorldNode::customPreStep()``,
-which we override to call ``Controller::update()`` each time step:
+The `Viewer` drives the world through `CustomWorldNode::customPreStep()`,
+which we override to call `Controller::update()` each time step:
 
 ```{eval-rst}
 .. tabs::
@@ -153,7 +154,6 @@ which we override to call ``Controller::update()`` each time step:
          :end-before: def set_geometry
 ```
 
-
 ## Lesson 1: Change shapes and applying forces
 
 We have a pendulum with five bodies, and we want to be able to apply forces to
@@ -167,10 +167,10 @@ At each step, we'll want to make sure that everything starts out with its defaul
 appearance. The default is for everything to be blue and there not to be any
 arrow attached to any body.
 
-Find the ``Controller::update`` function. The top of this function is where we
+Find the `Controller::update` function. The top of this function is where we
 reset everything to the default appearance before advancing the simulation.
 
-Each BodyNode contains visualization ``Shape``s that will be rendered during
+Each BodyNode contains visualization `Shape`s that will be rendered during
 simulation. In our case, each BodyNode has two shapes:
 
 - One shape to visualize the parent joint
@@ -224,9 +224,9 @@ Now everything will be reset to the default appearance.
 
 ### Lesson 1b: Apply joint torques based on user input
 
-The ``Controller`` class keeps a ``mForceCountDown`` vector whose entries get
-set to ``default_countdown`` whenever ``PendulumEventHandler`` sees a numeric key
-press. If an entry in ``mForceCountDown`` is greater than zero, then that implies
+The `Controller` class keeps a `mForceCountDown` vector whose entries get
+set to `default_countdown` whenever `PendulumEventHandler` sees a numeric key
+press. If an entry in `mForceCountDown` is greater than zero, then that implies
 that the user wants a force to be applied for that entry.
 
 There are two ways that forces can be applied:
@@ -235,8 +235,8 @@ There are two ways that forces can be applied:
 - As an external body force
 
 First we'll consider applying a Joint force. Inside the for-loop that goes
-through each ``DegreeOfFreedom`` using ``getNumDofs()``, there is an 
-if-statement for ``mForceCountDown``. In that if-statement, we'll grab the
+through each `DegreeOfFreedom` using `getNumDofs()`, there is an
+if-statement for `mForceCountDown`. In that if-statement, we'll grab the
 relevant DegreeOfFreedom and set its generalized (joint) force:
 
 ```{eval-rst}
@@ -257,7 +257,7 @@ relevant DegreeOfFreedom and set its generalized (joint) force:
          :end-before: # snippet:py-lesson1b-joint-force-end
 ```
 
-The ``mPositiveSign`` boolean gets toggled when the user presses the minus sign
+The `mPositiveSign` boolean gets toggled when the user presses the minus sign
 '-' key. We use this boolean to decide whether the applied force should be
 positive or negative.
 
@@ -307,8 +307,8 @@ So now we will color it red:
 
 If mBodyForce is true, we'll want to apply an external force to the body instead
 of an internal force in the joint. First, inside the for-loop that iterates
-through each ``BodyNode`` using ``getNumBodyNodes()``, there is an if-statement
-for ``mForceCountDown``. In that if-statement, we'll grab the relevant BodyNode:
+through each `BodyNode` using `getNumBodyNodes()`, there is an if-statement
+for `mForceCountDown`. In that if-statement, we'll grab the relevant BodyNode:
 
 ```{eval-rst}
 .. tabs::
@@ -326,10 +326,10 @@ for ``mForceCountDown``. In that if-statement, we'll grab the relevant BodyNode:
          body = self.pendulum.getBodyNode(i)
 ```
 
-Now we'll create an ``math::Vector3d`` that describes the force and another one
-that describes the location for that force. An ``math::Vector3d`` is the Eigen
+Now we'll create an `math::Vector3d` that describes the force and another one
+that describes the location for that force. An `math::Vector3d` is the Eigen
 C++ library's version of a three-dimensional mathematical vector. Note that the
-``d`` at the end of the name stands for ``double``, not for "dimension". An
+`d` at the end of the name stands for `double`, not for "dimension". An
 math::Vector3f would be a three-dimensional vector of floats, and an
 math::Vector3i would be a three-dimensional vector of integers.
 
@@ -351,7 +351,7 @@ math::Vector3i would be a three-dimensional vector of integers.
          location = np.array([-default_width / 2.0, 0.0, default_height / 2.0])
 ```
 
-The force will have a magnitude of ``default_force`` and it will point in the
+The force will have a magnitude of `default_force` and it will point in the
 positive x-direction. The location of the force will be in the center of the
 negative x side of the body, as if a finger on the negative side is pushing the
 body in the positive direction. However, we need to account for sign changes:
@@ -398,7 +398,7 @@ Now we can add the external force:
          body.addExtForce(force, location, True, True)
 ```
 
-The two ``true`` booleans at the end are indicating to DART that both the force
+The two `true` booleans at the end are indicating to DART that both the force
 and the location vectors are being expressed with respect to the body frame.
 
 Now we'll want to visualize the force being applied to the body. First, we'll
@@ -428,7 +428,7 @@ the 1-index visualization shape, because we trust that it is the shape for the
 body.
 
 Now we'll want to add an arrow to the visualization shapes of the body to
-represent the applied force. The ``Controller`` already owns an ``ArrowShape``
+represent the applied force. The `Controller` already owns an `ArrowShape`
 that visualizes the currently applied body force; we just need to show it:
 
 ```{eval-rst}
@@ -452,7 +452,7 @@ that visualizes the currently applied body force; we just need to show it:
 
 DART allows Joints to have implicit spring and damping properties. By default,
 these properties are zeroed out, so a joint will only exhibit the forces that
-are given to it by the ``Joint::setForces`` function. However, you can give a
+are given to it by the `Joint::setForces` function. However, you can give a
 non-zero spring coefficient to a joint so that it behaves according to Hooke's
 Law, and you can give a non-zero damping coefficient to a joint which will
 result in linear damping. These forces are computed using implicit methods in
@@ -462,11 +462,11 @@ order to improve numerical stability.
 
 First let's see how to get and set the rest positions.
 
-Find the function named ``Controller::changeRestPosition``. This function is
-triggered whenever ``PendulumEventHandler`` sees the 'q' or 'a' key. We want
+Find the function named `Controller::changeRestPosition`. This function is
+triggered whenever `PendulumEventHandler` sees the 'q' or 'a' key. We want
 those buttons to curl and uncurl the rest positions for the pendulum. To start,
 we'll go through all the generalized coordinates and change their rest positions
-by ``delta``:
+by `delta`:
 
 ```{eval-rst}
 .. tabs::
@@ -488,7 +488,7 @@ by ``delta``:
 
 However, it's important to note that the system can become somewhat unstable if
 we allow it to curl up too much, so let's put a limit on the magnitude of the
-rest angle. Right before ``dof->setRestPosition(q0);`` we can put:
+rest angle. Right before `dof->setRestPosition(q0);` we can put:
 
 ```{eval-rst}
 .. tabs::
@@ -510,7 +510,7 @@ rest angle. Right before ``dof->setRestPosition(q0);`` we can put:
 
 And there's one last thing to consider: the first joint of the pendulum is a
 BallJoint. BallJoints have three degrees of freedom, which means if we alter
-the rest positions of *all* of the pendulum's degrees of freedom, then the
+the rest positions of _all_ of the pendulum's degrees of freedom, then the
 pendulum will end up curling out of the x-z plane. You can allow this to happen
 if you want, or you can prevent it from happening by zeroing out the rest
 positions of the BallJoint's other two degrees of freedom:
@@ -559,7 +559,7 @@ spring stiffness. We can change the spring stiffness as follows:
 However, it's important to realize that if the spring stiffness were ever to
 become negative, we would get some very nasty explosive behavior. It's also a
 bad idea to just trust the user to avoid decrementing it into being negative.
-So before the line ``dof->setSpringStiffness(stiffness);`` you'll want to put:
+So before the line `dof->setSpringStiffness(stiffness);` you'll want to put:
 
 ```cpp
 if(stiffness < 0.0)
@@ -606,7 +606,7 @@ You can also create a dynamic constraint that attaches a BodyNode to the World
 instead of to another BodyNode.
 
 In our case, we want to attach the last BodyNode to the World with a BallJoint
-style constraint whenever the function ``addConstraint()`` gets called. First,
+style constraint whenever the function `addConstraint()` gets called. First,
 let's grab the last BodyNode in the pendulum:
 
 ```{eval-rst}
@@ -689,7 +689,7 @@ And then add it to the world:
 ```
 
 Now we also want to be able to remove this constraint. In the function
-``removeConstraint()``, we can put the following code:
+`removeConstraint()`, we can put the following code:
 
 ```{eval-rst}
 .. tabs::

--- a/examples/atlas_puppet/README.md
+++ b/examples/atlas_puppet/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/atlas_simbicon/README.md
+++ b/examples/atlas_simbicon/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/biped_stand/README.md
+++ b/examples/biped_stand/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/box_stacking/README.md
+++ b/examples/box_stacking/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/boxes/README.md
+++ b/examples/boxes/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/drag_and_drop/README.md
+++ b/examples/drag_and_drop/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/empty/README.md
+++ b/examples/empty/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/fetch/README.md
+++ b/examples/fetch/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/heightmap/README.md
+++ b/examples/heightmap/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/hubo_puppet/README.md
+++ b/examples/hubo_puppet/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/hybrid_dynamics/README.md
+++ b/examples/hybrid_dynamics/README.md
@@ -10,6 +10,7 @@ This example demonstrates hybrid dynamics simulation where some joints are contr
 ## Description
 
 The hybrid dynamics example showcases:
+
 - Mixed joint actuation types (passive, velocity-controlled, locked)
 - Programmed joint commands using sinusoidal patterns
 - Dynamic switching of joint actuator types during simulation

--- a/examples/imgui/README.md
+++ b/examples/imgui/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/joint_constraints/README.md
+++ b/examples/joint_constraints/README.md
@@ -14,6 +14,7 @@ This example demonstrates joint constraint handling with SPD (Stable Proportiona
 ## Description
 
 The joint constraints example showcases:
+
 - SPD (Stable Proportional-Derivative) tracking control for balance
 - External force perturbations to test robustness
 - Dynamic constraint addition/removal (harness feature)

--- a/examples/mixed_chain/README.md
+++ b/examples/mixed_chain/README.md
@@ -20,6 +20,7 @@ Launch the executable from the build directory above:
 This example demonstrates simulation of articulated bodies consisting of both rigid bodies and soft bodies in a mixed chain configuration. The example loads a world containing articulated bodies with 10 bodies and allows interactive force application to soft body nodes.
 
 Key features demonstrated:
+
 - Mixed rigid-soft body chain simulation
 - Interactive force application to soft body nodes
 - Real-time visualization using OpenSceneGraph (OSG)

--- a/examples/operational_space_control/README.md
+++ b/examples/operational_space_control/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/point_cloud/README.md
+++ b/examples/point_cloud/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/rigid_loop/README.md
+++ b/examples/rigid_loop/README.md
@@ -5,6 +5,7 @@ This example demonstrates a closed-loop chain simulation using DART with OSG for
 ## Description
 
 This example shows:
+
 - Loading a chain skeleton from a SKEL file
 - Creating ball joint constraints to form a closed loop
 - Applying damping forces during simulation

--- a/examples/simple_frames/README.md
+++ b/examples/simple_frames/README.md
@@ -21,6 +21,7 @@ renderer in DART. It shows various geometric shapes (boxes, ellipsoids, arrows)
 attached to different coordinate frames with different transformations applied.
 
 Key features demonstrated:
+
 - Creating SimpleFrame objects with different transformations
 - Attaching shapes to frames
 - Frame hierarchy and relative transformations

--- a/examples/simulation_event_handler/README.md
+++ b/examples/simulation_event_handler/README.md
@@ -5,12 +5,14 @@ This example demonstrates a comprehensive event handler class that replaces the 
 ## Features
 
 ### 1. Force Application on Rigid Bodies
+
 - Apply forces to selected rigid bodies in world coordinates
 - Real-time force magnitude adjustment
 - Support for both translational forces and rotational torques
 - Forces applied at the center of mass of selected bodies
 
 ### 2. Keyboard Interaction for Simulation Control
+
 - **Simulation Control**: Play/pause, step-by-step execution, reset
 - **Body Selection**: Navigate through all rigid bodies in the scene
 - **Force Application**: Arrow keys for linear forces, QWEAZC keys for torques
@@ -18,12 +20,14 @@ This example demonstrates a comprehensive event handler class that replaces the 
 - **Visualization Control**: Toggle force arrow visualization
 
 ### 3. Arrow Visualization
+
 - Red arrows showing applied forces in real-time
 - Arrows scale with force magnitude and direction
 - Arrows automatically clear after each application
 - Toggle on/off visualization for performance
 
 ### 4. Time Stepping Logic
+
 - Configurable simulation time step
 - Real-time time step adjustment during simulation
 - Step-by-step simulation for debugging
@@ -32,34 +36,41 @@ This example demonstrates a comprehensive event handler class that replaces the 
 ## Controls
 
 ### Simulation Control
+
 - **Space**: Toggle simulation play/pause
 - **S**: Step simulation one frame forward
 - **R**: Reset simulation to initial state
 
 ### Body Selection
+
 - **Tab**: Select next rigid body
 - **Backspace**: Select previous rigid body
 
 ### Force Application (on selected body)
+
 - **Arrow Keys**: Apply forces in X/Y directions
 - **U**: Apply upward force (+Z direction)
 - **D**: Apply downward force (-Z direction)
 
 ### Torque Application (on selected body)
+
 - **Q/A**: Apply torque around X axis (+/-)
 - **W/Z**: Apply torque around Y axis (+/-)
 - **E/C**: Apply torque around Z axis (+/-)
 
 ### Parameter Adjustment
+
 - **+/=**: Increase force/torque magnitude
-- **-/_**: Decrease force/torque magnitude
+- **-/\_**: Decrease force/torque magnitude
 - **>/.**: Increase simulation time step
 - **</, **: Decrease simulation time step
 
 ### Visualization
+
 - **V**: Toggle force arrow visualization
 
 ### Information
+
 - **I**: Print current simulation state
 - **H/?**: Show detailed help
 
@@ -106,11 +117,13 @@ void customRenderLoop() {
 ## Implementation Details
 
 ### Architecture
+
 - **Header File**: `SimulationEventHandler.hpp` - Class declaration and interface
 - **Implementation**: `SimulationEventHandler.cpp` - Full functionality implementation
 - **Demo**: `main.cpp` - Example usage with sample rigid bodies
 
 ### Key Components
+
 1. **Event Handling**: Inherits from `osgGA::GUIEventHandler` for OSG integration
 2. **Force System**: Manages force/torque application with visual feedback
 3. **Body Management**: Automatic detection and selection of rigid bodies
@@ -118,6 +131,7 @@ void customRenderLoop() {
 5. **State Management**: Tracks simulation state and user preferences
 
 ### Performance Considerations
+
 - Arrow visualization updates only every 5 frames to reduce overhead
 - Automatic cleanup of visualization objects
 - Efficient rigid body detection and caching
@@ -142,6 +156,7 @@ make simulation_event_handler
 The `SimulationEventHandler` class is designed to be easily extensible:
 
 ### Adding New Controls
+
 ```cpp
 // In handle() method, add new key cases:
 case 'n':  // Custom action
@@ -150,6 +165,7 @@ case 'n':  // Custom action
 ```
 
 ### Custom Force Application
+
 ```cpp
 // Override or extend force application methods:
 void applyCustomForce(const Eigen::Vector3d& direction) {
@@ -161,6 +177,7 @@ void applyCustomForce(const Eigen::Vector3d& direction) {
 ```
 
 ### Additional Visualizations
+
 ```cpp
 // Add new visualization types:
 void addCustomVisualization() {

--- a/examples/soft_bodies/README.md
+++ b/examples/soft_bodies/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/speed_test/README.md
+++ b/examples/speed_test/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/tinkertoy/README.md
+++ b/examples/tinkertoy/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/examples/vehicle/README.md
+++ b/examples/vehicle/README.md
@@ -14,6 +14,7 @@ This example demonstrates a simple vehicle simulation with steering control and 
 ## Description
 
 The vehicle example showcases:
+
 - Basic vehicle kinematics and dynamics
 - Steering control with angle limits
 - Differential drive control for rear wheels

--- a/examples/wam_ikfast/README.md
+++ b/examples/wam_ikfast/README.md
@@ -1,4 +1,4 @@
-This project is dependent on DART. Please make sure a proper version of DART is 
+This project is dependent on DART. Please make sure a proper version of DART is
 installed before building this project.
 
 ## Build Instructions
@@ -17,4 +17,3 @@ Launch the executable from the build directory above:
     $ ./{generated_executable}
 
 Follow the instructions detailed in the console.
-

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'DART: Dynamic Animation and Robotics Toolkit'
+title: "DART: Dynamic Animation and Robotics Toolkit"
 tags:
   - robotics
   - computer animation
@@ -7,45 +7,45 @@ tags:
   - inverse kinematics
   - multibody dynamics
 authors:
- - name: Jeongseok Lee
-   orcid: 0000-0002-2146-7502
-   affiliation: 1
- - name: Michael X. Grey
-   orcid: 0000-0002-8159-2428
-   affiliation: 2
- - name: Sehoon Ha
-   orcid: 0000-0002-1972-328X
-   affiliation: 3
- - name: Tobias Kunz
-   orcid: 0000-0002-5614-2265
-   affiliation: 4
- - name: Sumit Jain
-   orcid: 0000-0003-2244-0077
-   affiliation: 5
- - name: Yuting Ye
-   orcid: 0000-0003-2643-7457
-   affiliation: 6
- - name: Siddhartha S. Srinivasa
-   orcid: 0000-0002-5091-106X
-   affiliation: 1
- - name: Mike Stilman
-   affiliation: 4
- - name: C. Karen Liu
-   orcid: 0000-0001-5926-0905
-   affiliation: 4
+  - name: Jeongseok Lee
+    orcid: 0000-0002-2146-7502
+    affiliation: 1
+  - name: Michael X. Grey
+    orcid: 0000-0002-8159-2428
+    affiliation: 2
+  - name: Sehoon Ha
+    orcid: 0000-0002-1972-328X
+    affiliation: 3
+  - name: Tobias Kunz
+    orcid: 0000-0002-5614-2265
+    affiliation: 4
+  - name: Sumit Jain
+    orcid: 0000-0003-2244-0077
+    affiliation: 5
+  - name: Yuting Ye
+    orcid: 0000-0003-2643-7457
+    affiliation: 6
+  - name: Siddhartha S. Srinivasa
+    orcid: 0000-0002-5091-106X
+    affiliation: 1
+  - name: Mike Stilman
+    affiliation: 4
+  - name: C. Karen Liu
+    orcid: 0000-0001-5926-0905
+    affiliation: 4
 affiliations:
- - name: University of Washington
-   index: 1
- - name: Open Source Robotics Foundation
-   index: 2
- - name: Disney Research
-   index: 3
- - name: Georgia Institute of Technology
-   index: 4
- - name: Google Inc.
-   index: 5
- - name: Oculus Research
-   index: 6
+  - name: University of Washington
+    index: 1
+  - name: Open Source Robotics Foundation
+    index: 2
+  - name: Disney Research
+    index: 3
+  - name: Georgia Institute of Technology
+    index: 4
+  - name: Google Inc.
+    index: 5
+  - name: Oculus Research
+    index: 6
 date: 15 November 2017
 bibliography: paper.bib
 ---

--- a/pixi.toml
+++ b/pixi.toml
@@ -146,12 +146,17 @@ lint-yaml = { cmd = """
 
 lint-toml = { cmd = ["bash", "-lc", "python scripts/lint_toml.py"] }
 
+lint-md = { cmd = """
+    prettier --write '**/*.md' '!**/.pixi/**' '!**/build/**' '!**/external/**' '!**/node_modules/**'
+""" }
+
 lint = { depends-on = [
   "lint-cpp",
   "lint-dart8",
   "lint-py",
   "lint-yaml",
   "lint-toml",
+  "lint-md",
 ] }
 
 # Check formatting without modifying files (used in CI)

--- a/python/tutorials/wholebody_ik/README.md
+++ b/python/tutorials/wholebody_ik/README.md
@@ -38,7 +38,7 @@ ik.getErrorMethod().setAngularBounds(
 )
 ```
 
-Why? The `TaskSpaceRegion` error method only computes non-zero error when the displacement is *outside* the specified bounds. With infinite bounds (the default), any displacement is "within bounds", producing zero error and zero gradient. This prevents the optimizer from finding the solution.
+Why? The `TaskSpaceRegion` error method only computes non-zero error when the displacement is _outside_ the specified bounds. With infinite bounds (the default), any displacement is "within bounds", producing zero error and zero gradient. This prevents the optimizer from finding the solution.
 
 ## Interactive Features
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,7 @@
 # DART Test Suite
 
 For comprehensive documentation on the DART test suite, including:
+
 - Test organization and structure
 - Unit vs Integration test guidelines
 - Adding new tests
@@ -12,12 +13,14 @@ For comprehensive documentation on the DART test suite, including:
 ## Quick Reference
 
 ### Run all tests:
+
 ```bash
 cd build
 ctest
 ```
 
 ### Run tests by category:
+
 ```bash
 ctest -L integration
 ctest -L unit
@@ -25,11 +28,13 @@ ctest -L regression
 ```
 
 ### Run a specific test:
+
 ```bash
 ctest -R test_Collision
 ```
 
 ### Run tests in parallel:
+
 ```bash
 ctest -j8  # Run 8 tests in parallel
 ```

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -42,4 +42,3 @@ Launch the each executable from the build directory above (e.g.,):
     $ ./tutorial_biped/tutorial_biped
 
 Follow the instructions detailed in the console.
-


### PR DESCRIPTION
- Add lint-md task in pixi.toml to format all .md files using prettier
- Include lint-md in the lint task dependencies
- Format all markdown files in the repository using the new task
- Exclude build artifacts, dependencies, and hidden directories from formatting

***

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
