### PR TITLE
Disable sccache post-run stats in CI

### DIFF
--- a/.github/workflows/ci_gz_physics.yml
+++ b/.github/workflows/ci_gz_physics.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         run: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         run: |
@@ -103,6 +105,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         run: |
@@ -124,6 +126,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         run: |
@@ -188,6 +192,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         run: |

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         shell: powershell

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure environment for compiler cache
         run: |

--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -88,6 +88,7 @@ jobs:
         if: (matrix.skip-on-commit != true) || github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
         uses: mozilla-actions/sccache-action@v0.0.9
         with:
+          disable_annotations: true
           # Enable only when GitHub cache backend is available; otherwise skip.
           use-gha-cache: ${{ env.ACTIONS_CACHE_URL != '' }}
 

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -59,6 +59,8 @@ jobs all share the same configuration**. You can disable auto-detection with
 ```yaml
 - name: Setup sccache
   uses: mozilla-actions/sccache-action@v0.0.9
+  with:
+    disable_annotations: true
 
 - name: Configure environment for compiler cache
   run: |
@@ -78,6 +80,8 @@ jobs all share the same configuration**. You can disable auto-detection with
 ```yaml
 - name: Setup sccache
   uses: mozilla-actions/sccache-action@v0.0.9
+  with:
+    disable_annotations: true
 
 - name: Configure environment for compiler cache
   shell: powershell
@@ -93,6 +97,8 @@ jobs all share the same configuration**. You can disable auto-detection with
     echo "CCACHE_COMPRESS=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     echo "CCACHE_MAXSIZE=5G" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 ```
+
+Note: `disable_annotations` disables the post-run `sccache --show-stats` call, which avoids occasional client/server version mismatches on GitHub-hosted runners.
 
 **Local builds:** Because the detection logic is inside CMake, you do not need
 to wire anything up manually. If either `sccache` or `ccache` is on your PATH,


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

- Skip sccache post-run annotations/stats to avoid mismatched client/server errors on GitHub-hosted runners (e.g., https://github.com/dartsim/dart/actions/runs/19654670754/job/56288762964).
- Documented the change in the CI onboarding caching snippet.

---

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes (not run; workflow-only change)
- [ ] Add unit tests for new functionality (not applicable)
- [ ] Document new methods and classes (not applicable)
- [ ] Add Python bindings (dartpy) if applicable (not applicable)