### PR TITLE
Rename loader variables to parser

### DIFF
--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -1298,8 +1298,8 @@ robot->eachBodyNode([&](BodyNode* bodyNode) {
 
 ```cpp
 // URDF
-dart::utils::UrdfParser loader;
-auto robot = loader.parseSkeleton("path/to/robot.urdf");
+dart::utils::UrdfParser parser;
+auto robot = parser.parseSkeleton("path/to/robot.urdf");
 world->addSkeleton(robot);
 
 // SDF

--- a/docs/onboarding/python-bindings.md
+++ b/docs/onboarding/python-bindings.md
@@ -204,8 +204,8 @@ pixi run -e py313-wheel wheel-upload
 import dartpy as dart
 
 world = dart.simulation.World()
-loader = dart.utils.UrdfParser()
-robot = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
+parser = dart.utils.UrdfParser()
+robot = parser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
 world.addSkeleton(robot)
 
 for _ in range(100):

--- a/docs/readthedocs/locales/ko/LC_MESSAGES/dart/user_guide/tutorials/dominoes.po
+++ b/docs/readthedocs/locales/ko/LC_MESSAGES/dart/user_guide/tutorials/dominoes.po
@@ -286,10 +286,10 @@ msgstr "2a단원: URDF 파일 로드"
 msgid ""
 "Our manipulator is going to be loaded from a URDF file. URDF files are "
 "loaded by the ``dart::utils::UrdfParser`` class (pending upcoming changes to "
-"DART's loading system). First, create a loader:"
+"DART's loading system). First, create a parser:"
 msgstr ""
 "조작자는 URDF 파일에서 로드됩니다. URDF 파일은 ``dart::utils::UrdfParser`` 클래스에 의해 로드됩니다(DART "
-"로딩 시스템에 대한 향후 변경 사항이 있을 때까지 대기 중). 먼저 로더를 만듭니다."
+"로딩 시스템에 대한 향후 변경 사항이 있을 때까지 대기 중). 먼저 파서를 만듭니다."
 
 #: ../../user_guide/tutorials/dominoes.md:227 abb6ff6c8bc34795b700b19dd969b455
 msgid ""
@@ -305,8 +305,8 @@ msgstr ""
 "``UrdfParser::addPackageDirectory`` 함수를 사용하여 이러한 패키지의 위치를 ​​지정해야 합니다."
 
 #: ../../user_guide/tutorials/dominoes.md:233 0dbe6ce2f55c4027806f84f5ec6d65c5
-msgid "Now we'll have ``loader`` parse the file into a Skeleton:"
-msgstr "이제 ``loader``가 파일을 Skeleton으로 구문 분석하게 됩니다:"
+msgid "Now we'll have ``parser`` parse the file into a Skeleton:"
+msgstr "이제 ``parser``가 파일을 Skeleton으로 구문 분석하게 됩니다:"
 
 #: ../../user_guide/tutorials/dominoes.md:240 a8815b0090ee4ba08a31a8bfa936a716
 msgid "And we should give the Skeleton a convenient name:"

--- a/docs/readthedocs/locales/ko/LC_MESSAGES/tutorials/dominoes.po
+++ b/docs/readthedocs/locales/ko/LC_MESSAGES/tutorials/dominoes.po
@@ -353,10 +353,10 @@ msgstr "2a단원: URDF 파일 로드"
 msgid ""
 "Our manipulator is going to be loaded from a URDF file. URDF files are "
 "loaded by the ``dart::utils::UrdfParser`` class (pending upcoming changes to"
-" DART's loading system). First, create a loader:"
+" DART's loading system). First, create a parser:"
 msgstr ""
 "조작자는 URDF 파일에서 로드됩니다. URDF 파일은 ``dart::utils::UrdfParser`` 클래스에 의해 "
-"로드됩니다(DART 로딩 시스템에 대한 향후 변경 사항이 있을 때까지 대기 중). 먼저 로더를 만듭니다."
+"로드됩니다(DART 로딩 시스템에 대한 향후 변경 사항이 있을 때까지 대기 중). 먼저 파서를 만듭니다."
 
 #: ../../tutorials/dominoes.md:339 83b8b0e84ea74874bfee7c6b7a8c9510
 msgid ""
@@ -372,8 +372,8 @@ msgstr ""
 "``UrdfParser::addPackageDirectory`` 함수를 사용하여 이러한 패키지의 위치를 ​​지정해야 합니다."
 
 #: ../../tutorials/dominoes.md:345 b89abfe01903418baf37695a06776258
-msgid "Now we'll have ``loader`` parse the file into a Skeleton:"
-msgstr "이제 ``loader``가 파일을 Skeleton으로 구문 분석하게 됩니다:"
+msgid "Now we'll have ``parser`` parse the file into a Skeleton:"
+msgstr "이제 ``parser``가 파일을 Skeleton으로 구문 분석하게 됩니다:"
 
 #: ../../tutorials/dominoes.md:365 cb581b1a5a1e4f529671725d4382e09a
 msgid "And we should give the Skeleton a convenient name:"

--- a/docs/readthedocs/locales/ko/LC_MESSAGES/user_guide/tutorials/dominoes.po
+++ b/docs/readthedocs/locales/ko/LC_MESSAGES/user_guide/tutorials/dominoes.po
@@ -286,10 +286,10 @@ msgstr "2a단원: URDF 파일 로드"
 msgid ""
 "Our manipulator is going to be loaded from a URDF file. URDF files are "
 "loaded by the ``dart::utils::UrdfParser`` class (pending upcoming changes to "
-"DART's loading system). First, create a loader:"
+"DART's loading system). First, create a parser:"
 msgstr ""
 "조작자는 URDF 파일에서 로드됩니다. URDF 파일은 ``dart::utils::UrdfParser`` 클래스에 의해 로드됩니다(DART "
-"로딩 시스템에 대한 향후 변경 사항이 있을 때까지 대기 중). 먼저 로더를 만듭니다."
+"로딩 시스템에 대한 향후 변경 사항이 있을 때까지 대기 중). 먼저 파서를 만듭니다."
 
 #: ../../user_guide/tutorials/dominoes.md:227 abb6ff6c8bc34795b700b19dd969b455
 msgid ""
@@ -305,8 +305,8 @@ msgstr ""
 "``UrdfParser::addPackageDirectory`` 함수를 사용하여 이러한 패키지의 위치를 ​​지정해야 합니다."
 
 #: ../../user_guide/tutorials/dominoes.md:233 0dbe6ce2f55c4027806f84f5ec6d65c5
-msgid "Now we'll have ``loader`` parse the file into a Skeleton:"
-msgstr "이제 ``loader``가 파일을 Skeleton으로 구문 분석하게 됩니다:"
+msgid "Now we'll have ``parser`` parse the file into a Skeleton:"
+msgstr "이제 ``parser``가 파일을 Skeleton으로 구문 분석하게 됩니다:"
 
 #: ../../user_guide/tutorials/dominoes.md:240 a8815b0090ee4ba08a31a8bfa936a716
 msgid "And we should give the Skeleton a convenient name:"

--- a/docs/readthedocs/tutorials/dominoes.md
+++ b/docs/readthedocs/tutorials/dominoes.md
@@ -315,7 +315,7 @@ Instead, let's load a robotic manipulator and have it push over the first domino
 ### Lesson 2a: Load a URDF file
 
 Our manipulator is going to be loaded from a URDF file. URDF files are loaded
-by the `dart::utils::UrdfParser` class. First, create a loader:
+by the `dart::utils::UrdfParser` class. First, create a parser:
 
 ```{eval-rst}
 .. tabs::
@@ -341,7 +341,7 @@ but in general you should use the function `UrdfParser::addPackageDirectory` to
 specify the locations of these packages, because DART does not have the same
 package resolving abilities of ROS.
 
-Now we'll have `loader` parse the file into a Skeleton:
+Now we'll have `parser` parse the file into a Skeleton:
 
 ```{eval-rst}
 .. tabs::

--- a/examples/g1_puppet/main.cpp
+++ b/examples/g1_puppet/main.cpp
@@ -364,11 +364,11 @@ std::vector<std::shared_ptr<IkHandle>> setupIkHandles(
 SkeletonPtr loadG1(
     const Options& options, const ResourceRetrieverPtr& retriever)
 {
-  UrdfParser::Options loaderOptions;
-  loaderOptions.mResourceRetriever = retriever;
-  UrdfParser loader(loaderOptions);
+  UrdfParser::Options parserOptions;
+  parserOptions.mResourceRetriever = retriever;
+  UrdfParser parser(parserOptions);
 
-  SkeletonPtr robot = loader.parseSkeleton(options.robotUri);
+  SkeletonPtr robot = parser.parseSkeleton(options.robotUri);
   if (!robot) {
     std::cerr << "Failed to load robot from '" << options.robotUri << "'.\n";
     return nullptr;

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -1114,9 +1114,9 @@ SkeletonPtr createGround()
 
 SkeletonPtr createHubo()
 {
-  dart::utils::UrdfParser loader;
-  loader.addPackageDirectory("drchubo", dart::config::dataPath("urdf/drchubo"));
-  SkeletonPtr hubo = loader.parseSkeleton(
+  dart::utils::UrdfParser parser;
+  parser.addPackageDirectory("drchubo", dart::config::dataPath("urdf/drchubo"));
+  SkeletonPtr hubo = parser.parseSkeleton(
       dart::config::dataPath("urdf/drchubo/drchubo.urdf"));
 
   for (std::size_t i = 0; i < hubo->getNumBodyNodes(); ++i) {

--- a/examples/operational_space_control/main.cpp
+++ b/examples/operational_space_control/main.cpp
@@ -281,11 +281,11 @@ protected:
 int main()
 {
   dart::simulation::WorldPtr world(new dart::simulation::World);
-  dart::utils::UrdfParser loader;
+  dart::utils::UrdfParser parser;
 
   // Load the robot
   dart::dynamics::SkeletonPtr robot
-      = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+      = parser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
   world->addSkeleton(robot);
 
   // Rotate the robot so that z is upwards (default transform is not Identity)
@@ -294,7 +294,7 @@ int main()
 
   // Load the ground
   dart::dynamics::SkeletonPtr ground
-      = loader.parseSkeleton("dart://sample/urdf/KR5/ground.urdf");
+      = parser.parseSkeleton("dart://sample/urdf/KR5/ground.urdf");
   world->addSkeleton(ground);
 
   // Rotate and move the ground so that z is upwards

--- a/python/tests/unit/utils/test_urdf_parser.py
+++ b/python/tests/unit/utils/test_urdf_parser.py
@@ -9,34 +9,34 @@ from tests.util import get_asset_path
 
 def test_parse_skeleton_non_existing_path_returns_null():
     assert os.path.isfile(get_asset_path("skel/cubes.skel")) is True
-    loader = DartLoader()
-    assert loader.parse_skeleton(get_asset_path("skel/test/does_not_exist.urdf")) is None
+    parser = DartLoader()
+    assert parser.parse_skeleton(get_asset_path("skel/test/does_not_exist.urdf")) is None
 
 
 def test_parse_skeleton_invalid_urdf_returns_null():
-    loader = DartLoader()
-    assert loader.parse_skeleton(get_asset_path("urdf/invalid.urdf")) is None
+    parser = DartLoader()
+    assert parser.parse_skeleton(get_asset_path("urdf/invalid.urdf")) is None
 
 
 def test_parse_skeleton_missing_mesh_returns_null():
-    loader = DartLoader()
-    assert loader.parse_skeleton(get_asset_path("urdf/missing_mesh.urdf")) is None
+    parser = DartLoader()
+    assert parser.parse_skeleton(get_asset_path("urdf/missing_mesh.urdf")) is None
 
 
 def test_parse_skeleton_invalid_mesh_returns_null():
-    loader = DartLoader()
-    assert loader.parse_skeleton(get_asset_path("urdf/invalid_mesh.urdf")) is None
+    parser = DartLoader()
+    assert parser.parse_skeleton(get_asset_path("urdf/invalid_mesh.urdf")) is None
 
 
 def test_parse_skeleton_missing_package_returns_null():
-    loader = DartLoader()
-    assert loader.parse_skeleton(get_asset_path("urdf/missing_package.urdf")) is None
+    parser = DartLoader()
+    assert parser.parse_skeleton(get_asset_path("urdf/missing_package.urdf")) is None
 
 
 def test_parse_skeleton_loads_primitive_geometry():
-    loader = DartLoader()
+    parser = DartLoader()
     assert (
-        loader.parse_skeleton(get_asset_path("urdf/test/primitive_geometry.urdf"))
+        parser.parse_skeleton(get_asset_path("urdf/test/primitive_geometry.urdf"))
         is not None
     )
 
@@ -45,11 +45,11 @@ def test_parse_skeleton_loads_primitive_geometry():
 # TypeError: No to_python (by-value) converter found for C++ type: std::shared_ptr<dart::simulation::World>
 #
 # def test_parse_world():
-#     loader = DartLoader()
-#     assert loader.parse_world(get_asset_path('urdf/testWorld.urdf')) is not None
+#     parser = DartLoader()
+#     assert parser.parse_world(get_asset_path('urdf/testWorld.urdf')) is not None
 def test_parse_joint_properties():
-    loader = DartLoader()
-    robot = loader.parse_skeleton(get_asset_path("urdf/test/joint_properties.urdf"))
+    parser = DartLoader()
+    robot = parser.parse_skeleton(get_asset_path("urdf/test/joint_properties.urdf"))
     assert robot is not None
 
 

--- a/python/tutorials/03_dominoes/main_finished.py
+++ b/python/tutorials/03_dominoes/main_finished.py
@@ -398,10 +398,10 @@ def create_floor() -> dart.dynamics.Skeleton:
 
 def create_manipulator() -> dart.dynamics.Skeleton:
     # snippet:py-dominoes-lesson2a-loader-start
-    loader = dart.utils.UrdfParser()
+    parser = dart.utils.UrdfParser()
     # snippet:py-dominoes-lesson2a-loader-end
     # snippet:py-dominoes-lesson2a-parse-start
-    manipulator = loader.parseSkeleton(
+    manipulator = parser.parseSkeleton(
         "dart://sample/urdf/KR5/KR5 sixx R650.urdf"
     )
     # snippet:py-dominoes-lesson2a-parse-end

--- a/python/tutorials/wholebody_ik/main.py
+++ b/python/tutorials/wholebody_ik/main.py
@@ -37,8 +37,8 @@ def parse_args():
 
 
 def load_atlas_robot():
-    loader = dart.utils.UrdfParser()
-    atlas = loader.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf")
+    parser = dart.utils.UrdfParser()
+    atlas = parser.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf")
 
     if not atlas:
         raise RuntimeError("Failed to load Atlas robot!")

--- a/python/tutorials/wholebody_ik/main_finished.py
+++ b/python/tutorials/wholebody_ik/main_finished.py
@@ -74,8 +74,8 @@ def parse_args() -> argparse.Namespace:
 # snippet:py-load-atlas-start
 def load_atlas_robot():
     """Load the Atlas humanoid robot and configure initial pose."""
-    loader = dart.utils.UrdfParser()
-    atlas = loader.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf")
+    parser = dart.utils.UrdfParser()
+    atlas = parser.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf")
 
     if not atlas:
         raise RuntimeError("Failed to load Atlas robot!")

--- a/tests/integration/dynamics/test_AtlasIK.cpp
+++ b/tests/integration/dynamics/test_AtlasIK.cpp
@@ -51,9 +51,9 @@ using namespace dart::test;
 TEST(AtlasIK, HandReachesTarget)
 {
   // Load Atlas
-  utils::UrdfParser loader;
+  utils::UrdfParser parser;
   SkeletonPtr atlas
-      = loader.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
+      = parser.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
   ASSERT_NE(atlas, nullptr);
 
   // Set standing pose

--- a/tests/integration/dynamics/test_ForwardKinematics.cpp
+++ b/tests/integration/dynamics/test_ForwardKinematics.cpp
@@ -177,9 +177,9 @@ TEST(ForwardKinematics, JacobianPartialChange)
   // This is a regression test for issue #499
   const double tolerance = 1e-8;
 
-  dart::utils::UrdfParser loader;
+  dart::utils::UrdfParser parser;
   SkeletonPtr skeleton1
-      = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+      = parser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
 
   SkeletonPtr skeleton2 = skeleton1->cloneSkeleton();
 
@@ -226,9 +226,9 @@ TEST(ForwardKinematics, JacobianEndEffectorChange)
   // This is a regression test for pull request #683
   const double tolerance = 1e-8;
 
-  dart::utils::UrdfParser loader;
+  dart::utils::UrdfParser parser;
   SkeletonPtr skeleton1
-      = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+      = parser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
 
   BodyNode* last_bn1 = skeleton1->getBodyNode(skeleton1->getNumBodyNodes() - 1);
   EndEffector* ee1 = last_bn1->createEndEffector();

--- a/tests/integration/io/test_UrdfMaterialParsing.cpp
+++ b/tests/integration/io/test_UrdfMaterialParsing.cpp
@@ -43,9 +43,9 @@ using namespace dart::test;
 //==============================================================================
 TEST(Issue838, MaterialParsing)
 {
-  dart::utils::UrdfParser loader;
+  dart::utils::UrdfParser parser;
   dart::dynamics::SkeletonPtr skeleton
-      = loader.parseSkeleton("dart://sample/urdf/test/issue838.urdf");
+      = parser.parseSkeleton("dart://sample/urdf/test/issue838.urdf");
   EXPECT_TRUE(nullptr != skeleton);
 
   std::vector<Eigen::Vector4d> colors;

--- a/tests/integration/io/test_UrdfParser.cpp
+++ b/tests/integration/io/test_UrdfParser.cpp
@@ -51,63 +51,63 @@ using dart::utils::UrdfParser;
 //==============================================================================
 TEST(UrdfParser, parseSkeleton_NonExistantPathReturnsNull)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   EXPECT_EQ(
       nullptr,
-      loader.parseSkeleton("dart://sample/skel/test/does_not_exist.urdf"));
+      parser.parseSkeleton("dart://sample/skel/test/does_not_exist.urdf"));
 }
 
 //==============================================================================
 TEST(UrdfParser, parseSkeleton_InvalidUrdfReturnsNull)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   EXPECT_EQ(
-      nullptr, loader.parseSkeleton("dart://sample/urdf/test/invalid.urdf)"));
+      nullptr, parser.parseSkeleton("dart://sample/urdf/test/invalid.urdf)"));
 }
 
 //==============================================================================
 TEST(UrdfParser, parseSkeleton_MissingMeshReturnsNull)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   EXPECT_EQ(
       nullptr,
-      loader.parseSkeleton("dart://sample/urdf/test/missing_mesh.urdf"));
+      parser.parseSkeleton("dart://sample/urdf/test/missing_mesh.urdf"));
 }
 
 //==============================================================================
 TEST(UrdfParser, parseSkeleton_InvalidMeshReturnsNull)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   EXPECT_EQ(
       nullptr,
-      loader.parseSkeleton("dart://sample/urdf/test/invalid_mesh.urdf"));
+      parser.parseSkeleton("dart://sample/urdf/test/invalid_mesh.urdf"));
 }
 
 //==============================================================================
 TEST(UrdfParser, parseSkeleton_MissingPackageReturnsNull)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   EXPECT_EQ(
       nullptr,
-      loader.parseSkeleton("dart://sample/urdf/test/missing_package.urdf"));
+      parser.parseSkeleton("dart://sample/urdf/test/missing_package.urdf"));
 }
 
 //==============================================================================
 TEST(UrdfParser, parseSkeleton_LoadsPrimitiveGeometry)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   EXPECT_TRUE(
       nullptr
-      != loader.parseSkeleton(
+      != parser.parseSkeleton(
           "dart://sample/urdf/test/primitive_geometry.urdf"));
 }
 
 //==============================================================================
 TEST(UrdfParser, parseWorld)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   EXPECT_TRUE(
-      nullptr != loader.parseWorld("dart://sample/urdf/test/testWorld.urdf"));
+      nullptr != parser.parseWorld("dart://sample/urdf/test/testWorld.urdf"));
 }
 
 //==============================================================================
@@ -177,8 +177,8 @@ TEST(UrdfParser, parseJointProperties)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
 
   auto joint1 = robot->getJoint(1);
@@ -211,8 +211,8 @@ TEST(UrdfParser, parsePlanarJointLimitsAndAxis)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(robot);
 
   auto* joint
@@ -264,8 +264,8 @@ TEST(UrdfParser, parsePlanarJointArbitraryAxis)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(robot);
 
   auto* joint
@@ -302,8 +302,8 @@ TEST(UrdfParser, parseFloatingJointLimits)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(robot);
 
   auto* joint
@@ -349,11 +349,11 @@ TEST(UrdfParser, parseUrdfWithoutWorldLink)
   )";
   // clang-format on
 
-  UrdfParser loader;
+  UrdfParser parser;
   UrdfParser::Options options;
 
   // Default
-  auto robot1 = loader.parseSkeletonString(urdfStr, "");
+  auto robot1 = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot1);
   EXPECT_EQ(
       robot1->getRootJoint()->getType(), dynamics::FreeJoint::getStaticType());
@@ -361,8 +361,8 @@ TEST(UrdfParser, parseUrdfWithoutWorldLink)
 
   // Floating
   options.mDefaultRootJointType = UrdfParser::RootJointType::Floating;
-  loader.setOptions(options);
-  auto robot2 = loader.parseSkeletonString(urdfStr, "");
+  parser.setOptions(options);
+  auto robot2 = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot2);
   EXPECT_EQ(
       robot2->getRootJoint()->getType(), dynamics::FreeJoint::getStaticType());
@@ -370,8 +370,8 @@ TEST(UrdfParser, parseUrdfWithoutWorldLink)
 
   // Fixed
   options.mDefaultRootJointType = UrdfParser::RootJointType::Fixed;
-  loader.setOptions(options);
-  auto robot3 = loader.parseSkeletonString(urdfStr, "");
+  parser.setOptions(options);
+  auto robot3 = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot3);
   EXPECT_EQ(
       robot3->getRootJoint()->getType(), dynamics::WeldJoint::getStaticType());
@@ -446,8 +446,8 @@ TEST(UrdfParser, mimicJoint)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
 
   auto joint1 = robot->getJoint(1);
@@ -534,8 +534,8 @@ TEST(UrdfParser, badMimicJoint)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
 
   auto joint1 = robot->getJoint(1);
@@ -573,8 +573,8 @@ TEST(UrdfParser, WorldShouldBeTreatedAsKeyword)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
 
   EXPECT_TRUE(robot->getNumBodyNodes() == 1u);
@@ -592,8 +592,8 @@ TEST(UrdfParser, SingleLinkWithoutJoint)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
 
   EXPECT_TRUE(robot->getNumBodyNodes() == 1u);
@@ -634,8 +634,8 @@ TEST(UrdfParser, MultiTreeRobot)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
 
   EXPECT_EQ(robot->getNumBodyNodes(), 2u);
@@ -645,9 +645,9 @@ TEST(UrdfParser, MultiTreeRobot)
 //==============================================================================
 TEST(UrdfParser, KR5MeshColor)
 {
-  UrdfParser loader;
+  UrdfParser parser;
   auto robot
-      = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+      = parser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
   ASSERT_TRUE(nullptr != robot);
 
   EXPECT_EQ(robot->getNumBodyNodes(), 7u);
@@ -710,8 +710,8 @@ TEST(UrdfParser, parseVisualCollisionName)
   )";
   // clang-format on
 
-  UrdfParser loader;
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  UrdfParser parser;
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
 
   auto body0 = robot->getBodyNode(0);
@@ -744,11 +744,11 @@ TEST(UrdfParser, Options)
   )";
   // clang-format on
 
-  UrdfParser loader;
+  UrdfParser parser;
   UrdfParser::Options options;
 
   // Default inertia
-  auto robot = loader.parseSkeletonString(urdfStr, "");
+  auto robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
   auto link_0 = robot->getBodyNode("link_0");
   ASSERT_TRUE(link_0 != nullptr);
@@ -759,8 +759,8 @@ TEST(UrdfParser, Options)
   // Custom inertia
   options.mDefaultInertia.setMass(5);
   options.mDefaultInertia.setMoment(1, 2, 3, 4, 5, 6);
-  loader.setOptions(options);
-  robot = loader.parseSkeletonString(urdfStr, "");
+  parser.setOptions(options);
+  robot = parser.parseSkeletonString(urdfStr, "");
   ASSERT_TRUE(nullptr != robot);
   link_0 = robot->getBodyNode("link_0");
   ASSERT_TRUE(link_0 != nullptr);

--- a/tutorials/tutorial_dominoes_finished/main.cpp
+++ b/tutorials/tutorial_dominoes_finished/main.cpp
@@ -555,11 +555,11 @@ SkeletonPtr createManipulator()
 {
   // Load the Skeleton from a file
   // snippet:cpp-dominoes-lesson2a-loader-start
-  dart::utils::UrdfParser loader;
+  dart::utils::UrdfParser parser;
   // snippet:cpp-dominoes-lesson2a-loader-end
   // snippet:cpp-dominoes-lesson2a-parse-start
   SkeletonPtr manipulator
-      = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+      = parser.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
   // snippet:cpp-dominoes-lesson2a-parse-end
   // snippet:cpp-dominoes-lesson2a-name-start
   manipulator->setName("manipulator");

--- a/tutorials/tutorial_wholebody_ik/main.cpp
+++ b/tutorials/tutorial_wholebody_ik/main.cpp
@@ -116,9 +116,9 @@ protected:
 SkeletonPtr loadAtlasRobot()
 {
   // Lesson 1: Load the Atlas robot and configure it for a standing pose
-  UrdfParser loader;
+  UrdfParser parser;
   SkeletonPtr atlas
-      = loader.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
+      = parser.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
 
   if (!atlas) {
     std::cerr << "Failed to load Atlas robot!" << std::endl;

--- a/tutorials/tutorial_wholebody_ik_finished/main.cpp
+++ b/tutorials/tutorial_wholebody_ik_finished/main.cpp
@@ -127,9 +127,9 @@ protected:
 // snippet:cpp-load-atlas-start
 SkeletonPtr loadAtlasRobot()
 {
-  UrdfParser loader;
+  UrdfParser parser;
   SkeletonPtr atlas
-      = loader.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
+      = parser.parseSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
 
   if (!atlas) {
     std::cerr << "Failed to load Atlas robot!" << std::endl;


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

Rename remaining UrdfParser variables from `loader` to `parser` across tutorials, examples, tests, and docs so naming matches the class rename.

---

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
