### PR TITLE
Fix dartpy joint bindings and enable python constraints tests

### DIFF
--- a/python/dartpy/dynamics/skeleton.cpp
+++ b/python/dartpy/dynamics/skeleton.cpp
@@ -127,6 +127,23 @@ void defSkeleton(nb::module_& m)
           },
           nb::rv_policy::reference_internal)
       .def(
+          "get_joint",
+          [](Skeleton& self, std::size_t idx) -> dart::dynamics::Joint* {
+            return self.getJoint(idx);
+          },
+          nb::rv_policy::reference_internal)
+      .def(
+          "get_joint",
+          [](Skeleton& self, const std::string& name)
+              -> dart::dynamics::Joint* { return self.getJoint(name); },
+          nb::rv_policy::reference_internal)
+      .def(
+          "get_root_joint",
+          [](Skeleton& self) -> dart::dynamics::Joint* {
+            return self.getRootJoint();
+          },
+          nb::rv_policy::reference_internal)
+      .def(
           "getDof",
           [](Skeleton& self, std::size_t idx) { return self.getDof(idx); },
           nb::rv_policy::reference_internal,

--- a/python/tests/integration/test_joint_force_torque.py
+++ b/python/tests/integration/test_joint_force_torque.py
@@ -4,9 +4,6 @@ import dartpy as dart
 import numpy as np
 import pytest
 
-# TODO: investigate segfault in force/torque IK after namespace flattening
-pytestmark = pytest.mark.skip(reason="Force/torque integration tests currently segfault")
-
 
 def read_world(uri: dart.common.Uri):
     options = dart.io.SdfParser.Options()

--- a/python/tests/unit/constraint/test_constraint.py
+++ b/python/tests/unit/constraint/test_constraint.py
@@ -1,10 +1,6 @@
-import platform
-
 import dartpy as dart
 import numpy as np
 import pytest
-
-pytestmark = pytest.mark.skip(reason="Constraint bindings need investigation post-dartpy flattening (segfault)")
 
 
 def test_ball_joint_constraint():
@@ -25,8 +21,8 @@ def test_ball_joint_constraint():
     offset1 = [0, 0.025, 0]
     joint_pos = bd1.get_transform().multiply(offset1)
     offset2 = bd2.get_transform().inverse().multiply(joint_pos)
-    constraint = dart.constraint.BallJointConstraint(bd1, bd2, joint_pos)
-    assert constraint.get_type() == dart.constraint.BallJointConstraint.get_static_type()
+    constraint = dart.BallJointConstraint(bd1, bd2, joint_pos)
+    assert constraint.get_type() == dart.BallJointConstraint.get_static_type()
 
     # Add ball joint constraint to the constraint solver
     constraint_solver = world.get_constraint_solver()
@@ -61,12 +57,10 @@ def test_revolute_joint_constraint():
     joint_pos = bd1.get_transform().multiply(offset)
     axis = [0, 1, 0]
 
-    constraint = dart.constraint.RevoluteJointConstraint(
-        bd1, bd2, joint_pos, axis, axis
-    )
+    constraint = dart.RevoluteJointConstraint(bd1, bd2, joint_pos, axis, axis)
     assert (
         constraint.get_type()
-        == dart.constraint.RevoluteJointConstraint.get_static_type()
+        == dart.RevoluteJointConstraint.get_static_type()
     )
 
     constraint_solver = world.get_constraint_solver()


### PR DESCRIPTION
## Summary
- restore functional snake_case joint accessors in dartpy bindings so joint lookups return valid objects
- switch python constraint tests to flattened dartpy classes and remove skips from joint force/torque tests
- ran `pixi run test-py` and `pixi run test-all`

#### Before creating a pull request
- [x] Run `pixi run test-all` to lint, build, and test your changes
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
