### PR TITLE
Fix Dependabot docker path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,8 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "docker"
-    directory: "/"
+    # Devcontainer Dockerfile lives under the hidden .devcontainer directory.
+    directory: "/.devcontainer"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

Point the Docker Dependabot update at `/.devcontainer` so it can find the devcontainer `Dockerfile` and stop failing the scheduled update job.

---

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
