### PR TITLE
CI: prevent scheduled runs from canceling push/PR

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -36,7 +36,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Scheduled runs should not preempt push/PR validation runs.
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -36,7 +36,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Scheduled runs should not preempt push/PR validation runs.
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -36,7 +36,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Scheduled runs should not preempt push/PR validation runs.
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

Prevent scheduled CI runs from canceling push/PR validation runs by making workflow-level `concurrency.cancel-in-progress` conditional on `github.event_name != 'schedule'` in the OS CI workflows.

This addresses cancellations like:
- https://github.com/dartsim/dart/actions/runs/20202077816/job/57995022426

---

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
