### PR TITLE
Fix utils CMake: register sources correctly

### DIFF
--- a/dart/utils/mjcf/CMakeLists.txt
+++ b/dart/utils/mjcf/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB detail_hdrs "detail/*.hpp")
 file(GLOB detail_srcs "detail/*.cpp")
 
 dart_add_utils_headers(${hdrs} ${detail_hdrs})
-dart_add_utils_headers(${srcs} ${detail_srcs})
+dart_add_utils_sources(${srcs} ${detail_srcs})
 
 # Generate header for this namespace
 dart_get_filename_components(header_names "utils_mjcf headers" ${hdrs})

--- a/dart/utils/sdf/CMakeLists.txt
+++ b/dart/utils/sdf/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB detail_hdrs "detail/*.hpp")
 file(GLOB detail_srcs "detail/*.cpp")
 
 dart_add_utils_headers(${hdrs})
-dart_add_utils_headers(${srcs})
+dart_add_utils_sources(${srcs})
 dart_add_utils_headers(${detail_hdrs})
 dart_add_utils_sources(${detail_srcs})
 


### PR DESCRIPTION
Fix incorrect use of `dart_add_utils_headers()` when registering `*.cpp` files in the utils subcomponents.

This switches those calls to `dart_add_utils_sources()` so the correct CMake properties are populated.

---

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
