### PR TITLE
Gazebo: fix gz-physics gtest header mismatch

### DIFF
--- a/cmake/gz_physics_force_vendor_gtest.cmake
+++ b/cmake/gz_physics_force_vendor_gtest.cmake
@@ -1,0 +1,22 @@
+# Ensure gz-physics test targets compile against the vendored GoogleTest headers
+# that match the vendored gtest static library built in `test/gtest_vendor`.
+#
+# Some environments also provide GoogleTest headers in their global include
+# paths (e.g., `${prefix}/include/gtest`). If those headers take precedence over
+# gz-physics' vendored headers, the build can fail at link time due to mismatched
+# internal symbols (e.g., `MakeAndRegisterTestInfo(std::string, ...)`).
+
+if(PROJECT_NAME STREQUAL "gz-physics")
+  set(_gz_physics_vendor_gtest_include "${CMAKE_SOURCE_DIR}/test/gtest_vendor/include")
+  if(EXISTS "${_gz_physics_vendor_gtest_include}/gtest/gtest.h")
+    # Use a build-tree copy of the headers so we can force a distinct `-I`
+    # entry that reliably wins include resolution.
+    set(_gtest_include_overlay "${CMAKE_BINARY_DIR}/gtest_vendor_include")
+    if(NOT EXISTS "${_gtest_include_overlay}/gtest/gtest.h")
+      file(MAKE_DIRECTORY "${_gtest_include_overlay}")
+      file(COPY "${_gz_physics_vendor_gtest_include}/gtest" DESTINATION "${_gtest_include_overlay}")
+    endif()
+
+    include_directories(BEFORE "${_gtest_include_overlay}")
+  endif()
+endif()

--- a/pixi.toml
+++ b/pixi.toml
@@ -1629,7 +1629,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
-    -DCMAKE_CXX_FLAGS=-I$PWD/.deps/gz-physics/test/gtest_vendor/include \
+    -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES:FILEPATH=$PWD/cmake/gz_physics_force_vendor_gtest.cmake \
     -DCMAKE_EXE_LINKER_FLAGS=-L$CONDA_PREFIX/lib \
     -DCMAKE_SHARED_LINKER_FLAGS=-L$CONDA_PREFIX/lib \
     -DBUILD_TESTING=ON \


### PR DESCRIPTION
<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

Fix `pixi -e gazebo test-gz` builds by preventing a GoogleTest header/library mismatch in gz-physics tests.

The failure was caused by gz-physics test targets linking against its vendored `libgtest.a` while compiling against the pixi environment's `gtest` headers, leading to undefined references such as:

- `testing::internal::MakeAndRegisterTestInfo(std::string, ...)`

This PR fixes the include precedence without patching upstream gz-physics sources:

- `pixi.toml` passes `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=.../cmake/gz_physics_force_vendor_gtest.cmake` when configuring gz-physics.
- `cmake/gz_physics_force_vendor_gtest.cmake` copies the vendored gtest headers into the gz-physics build tree and prepends that directory as a non-system include, ensuring the headers match the vendored gtest library.

Fixes: https://github.com/dartsim/dart/actions/runs/20216215992/job/58029581216

---

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable

Used in this task:
- `pixi run lint`
- `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz`
