### PR TITLE
ci: restrict manual dartpy publishing to tags

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -16,11 +16,11 @@ name: Publish dartpy
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref (tag/sha) to build (optional)"
+        description: "Git ref (tag/sha) to build; publishing requires a version tag (v*)"
         required: false
         default: ""
       publish:
-        description: "Set to 'true' to publish to PyPI"
+        description: "Set to 'true' to publish to PyPI (version tags only)"
         required: false
         default: "false"
 
@@ -125,6 +125,17 @@ jobs:
         with:
           ref: ${{ env.DARTPY_REF }}
 
+      - name: Validate publish inputs
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' }}
+        run: |
+          case "${DARTPY_REF}" in
+            v*|refs/tags/v*) ;;
+            *)
+              echo "::error::When publish=true, ref must be a version tag (e.g. v6.16.1). Got '${DARTPY_REF}'."
+              exit 1
+              ;;
+          esac
+
       - name: Set up Vcpkg
         if: ${{ matrix.os == 'windows-latest' && (matrix.release_only == false || env.DARTPY_REF == 'refs/heads/main' || env.DARTPY_REF == 'main' || startsWith(env.DARTPY_REF, 'refs/heads/release-') || startsWith(env.DARTPY_REF, 'release-') || startsWith(env.DARTPY_REF, 'refs/tags/v') || startsWith(env.DARTPY_REF, 'v')) }}
         uses: johnwason/vcpkg-action@v7
@@ -199,7 +210,7 @@ jobs:
     # upload to PyPI on every tag starting with 'release-'
     # if: github.event_name == 'push' && startsWith(github.ref, 'release-')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && (github.event.inputs.ref != '' || startsWith(github.ref, 'refs/tags/v')))
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.event.inputs.ref, 'v') || startsWith(github.event.inputs.ref, 'refs/tags/v')))
     steps:
       - uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
`upload_pypi` should only ever publish for version tags.

This tightens the `workflow_dispatch` path so `publish: true` only works when:
- the workflow is run on a tag (`refs/tags/v*`), or
- `inputs.ref` is a version tag (e.g. `v6.16.1`).

It also adds an early validation step in `build_wheels` to fail fast if someone tries to publish from a non-tag ref.
