### PR TITLE
ci: fix manual publish validation on Windows

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -127,6 +127,7 @@ jobs:
 
       - name: Validate publish inputs
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' }}
+        shell: bash
         run: |
           case "${DARTPY_REF}" in
             v*|refs/tags/v*) ;;


### PR DESCRIPTION
The `Validate publish inputs` step uses a bash `case` statement, but on Windows the default `run` shell is PowerShell, which caused the manual `workflow_dispatch` run for `v6.16.1` to fail.

Set `shell: bash` for that step so it runs correctly on all runners.

Ref: https://github.com/dartsim/dart/actions/runs/20277232838
