### PR TITLE
ci: fix publish_dartpy workflow yaml

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -145,12 +145,7 @@ jobs:
           tag="${DARTPY_REF#refs/tags/}"
           tag="${tag#v}"
 
-          pkg_version="$(python - <<'PY'
-import xml.etree.ElementTree as ET
-version = ET.parse("package.xml").getroot().findtext("version", default="").strip()
-print(version)
-PY
-)"
+          pkg_version="$(python -c 'import xml.etree.ElementTree as ET; print(ET.parse("package.xml").getroot().findtext("version", default="").strip())')"
 
           if [ -z "${pkg_version}" ]; then
             echo "::error::Failed to read version from package.xml in '${DARTPY_CHECKOUT_REF}'."


### PR DESCRIPTION
Fix the post-merge GitHub Actions failure (invalid `publish_dartpy.yml`) by replacing the multi-line heredoc Python snippet with a `python -c` one-liner so the workflow remains valid YAML and `workflow_dispatch` works again.

***

#### Before creating a pull request

- [ ] Format code using `pixi run lint` and verify with `pixi run check-lint`
- [ ] Document new methods and classes
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve warnings

#### Before merging

- [ ] Set milestone
- [ ] Update `CHANGELOG.md`
- [ ] Add unit tests
- [ ] Add Python bindings (dartpy) if applicable
