### PR TITLE
ci: cover asserts-enabled build and fix API docs PR ref

### DIFF
--- a/.github/workflows/api_doc.yml
+++ b/.github/workflows/api_doc.yml
@@ -41,9 +41,11 @@ jobs:
         id: extract_branch
 
       # Extract branch name on pull request
-      - name: Print branch name
+      # Note: build_docs.sh clones from dartsim/dart, so fork PR head refs may
+      # not exist there. Use the base ref to ensure the checkout succeeds.
+      - name: Set docs branch for pull requests
         if: github.event_name == 'pull_request'
-        run: echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        run: echo "BRANCH_NAME=${GITHUB_BASE_REF}" >> $GITHUB_ENV
 
       - name: Detect passwordless sudo
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -101,3 +101,48 @@ jobs:
           DART_VERBOSE=ON \
           BUILD_TYPE=${{ matrix.build_type }} \
           pixi run install
+
+  # Catch compile failures when assertions are enabled but we're not in a Debug
+  # build type (e.g., downstream builds that drop -DNDEBUG in Release).
+  build-asserts:
+    name: Asserts enabled (no -DNDEBUG)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          cache: true
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: libgl1-mesa-dev libglu1-mesa-dev
+          version: 1.0
+
+      - name: Build with assertions (no -DNDEBUG)
+        run: |
+          # NOTE: pixi tasks on release-6.16 set BUILD_TYPE internally, so we
+          # configure this variant explicitly to ensure NDEBUG is not defined.
+          pixi run -- bash -lc '
+            set -euo pipefail
+            BUILD_TYPE=None
+            DART_VERBOSE=ON
+            cmake \
+              -G Ninja \
+              -S . \
+              -B build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \
+              -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+              -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+              -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
+              -DDART_BUILD_DARTPY=ON \
+              -DDART_BUILD_PROFILE=ON \
+              -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
+              -DDART_USE_SYSTEM_GOOGLETEST=ON \
+              -DDART_USE_SYSTEM_IMGUI=ON \
+              -DDART_USE_SYSTEM_TRACY=ON \
+              -DDART_VERBOSE=$DART_VERBOSE
+            cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE -j --target ALL
+          '


### PR DESCRIPTION
Fix CI gaps on `release-6.16` that let PR #2326 slip through.

- Add an Ubuntu CI job that configures/builds with assertions enabled but without `-DNDEBUG` (i.e., `CMAKE_BUILD_TYPE=None`) to catch compilation issues that only show up in that configuration.
- Make the API docs workflow use the PR base ref for fork PRs, since `scripts/build_docs.sh` clones `dartsim/dart` and cannot `git checkout` fork head branches.

***

#### Before creating a pull request

- [ ] Format code using `pixi run lint` and verify with `pixi run check-lint`
- [ ] Document new methods and classes
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve warnings

#### Before merging

- [x] Set milestone
- [ ] Update `CHANGELOG.md`
- [ ] Add unit tests
- [ ] Add Python bindings (dartpy) if applicable
