### PR TITLE
tests: stabilize World::Cloning in asserts-enabled CI

### DIFF
--- a/tests/integration/test_World.cpp
+++ b/tests/integration/test_World.cpp
@@ -37,6 +37,7 @@
 #include "dart/dynamics/RevoluteJoint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/math/Geometry.hpp"
+#include "dart/math/Random.hpp"
 #include "dart/utils/SkelParser.hpp"
 
 #include <gtest/gtest.h>
@@ -185,6 +186,9 @@ TEST(World, AddingAndRemovingSkeletons)
 //==============================================================================
 TEST(World, Cloning)
 {
+  // Seed random generator for deterministic tests
+  Random::setSeed(42);
+
   // Create a list of skel files to test with
   std::vector<common::Uri> fileList;
   fileList.push_back("dart://sample/skel/test/chainwhipa.skel");
@@ -224,10 +228,10 @@ TEST(World, Cloning)
     for (std::size_t j = 1; j < 5; ++j)
       clones.push_back(clones[j - 1]->clone());
 
-#if DART_BUILD_MODE_DEBUG
-    std::size_t numIterations = 3;
-#else
+#if DART_BUILD_MODE_RELEASE
     std::size_t numIterations = 500;
+#else
+    std::size_t numIterations = 3;
 #endif
 
     for (std::size_t j = 0; j < numIterations; ++j) {


### PR DESCRIPTION
Stabilize `World.Cloning` in asserts-enabled (no `-DNDEBUG`) CI builds.

- Seed `dart::math::Random` to make the test deterministic.
- Run the long (500-iteration) loop only in `DART_BUILD_MODE_RELEASE`; use the short loop otherwise (e.g., `BUILD_TYPE=None` in build-asserts).

***

#### Before creating a pull request

- [ ] Format code using `pixi run lint` and verify with `pixi run check-lint`
- [ ] Document new methods and classes
- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve warnings

#### Before merging

- [ ] Set milestone
- [ ] Update `CHANGELOG.md`
- [ ] Add unit tests
- [ ] Add Python bindings (dartpy) if applicable
