### PR TITLE
Fix uninitialized Isometry in UNIT_math_Math

### DIFF
--- a/tests/unit/math/test_Math.cpp
+++ b/tests/unit/math/test_Math.cpp
@@ -92,7 +92,7 @@ EIGEN_DONT_INLINE void inv(const T& a, T& b)
 EIGEN_DONT_INLINE
 Isometry3d Inv2(const Isometry3d& I)
 {
-  Eigen::Isometry3d ret;
+  Eigen::Isometry3d ret = Eigen::Isometry3d::Identity();
 
   ret(0, 0) = I(0, 0);
   ret(1, 0) = I(0, 1);


### PR DESCRIPTION
Fix UB in `UNIT_math_Math` by initializing the temporary `Isometry3d` in `Inv2` before writing to it, preventing the uninitialized bottom row that can trigger a macOS Release segfault.

CI:
- CI Linux
- CI macOS
- CI Windows
- CI gz-physics
- Publish dartpy

---

#### Before creating a pull request

- [ ] Run `pixi run test-all` to lint, build, and test your changes
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
