### PR TITLE
Suppress MSVC C4250 warning in virtual base class macros

### DIFF
--- a/dart/common/ClassWithVirtualBase.hpp
+++ b/dart/common/ClassWithVirtualBase.hpp
@@ -36,9 +36,16 @@
 // This macro is used to mark all the class that inherit
 // virtually from another to avoid problems on MSVC
 // See https://github.com/dartsim/dart/issues/1522
+//
+// C4250: 'class1' : inherits 'class2::member' via dominance
+// This warning is expected with virtual inheritance and is safe to suppress.
+// See https://github.com/gazebosim/gz-physics/pull/837
 #if defined(_MSC_VER)
-  #define DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN __pragma(vtordisp(push, 2))
-  #define DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_END __pragma(vtordisp(pop))
+  #define DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN                           \
+    __pragma(warning(push)) __pragma(warning(disable : 4250))                  \
+        __pragma(vtordisp(push, 2))
+  #define DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_END                             \
+    __pragma(vtordisp(pop)) __pragma(warning(pop))
 #else
   #define DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
   #define DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_END


### PR DESCRIPTION
## Summary

Suppress MSVC C4250 ('inherits via dominance') warnings for downstream users by adding `warning(push/pop)` pragmas to the `DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN/END` macros.

## Problem

Downstream projects (e.g., [gz-physics](https://github.com/gazebosim/gz-physics/pull/837)) building on Windows with MSVC receive numerous C4250 warnings when including DART headers. These warnings originate from DART's use of virtual inheritance in classes like `BodyNode`, `Skeleton`, `JacobianNode`, etc.

Currently, downstream projects must add `/wd4250` compiler flags to suppress these warnings, which is not ideal as it affects all code, not just DART headers.

## Solution

Add `__pragma(warning(push))` and `__pragma(warning(disable: 4250))` to `DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN`, and `__pragma(warning(pop))` to `DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_END`. This ensures the warning is only suppressed for classes that intentionally use virtual inheritance, while preserving any legitimate C4250 warnings in downstream code.

## Testing

- The macro expansion is MSVC-only (`#if defined(_MSC_VER)`)
- Non-MSVC platforms are unaffected
- The warning suppression is scoped to class declarations using these macros

## References

- https://github.com/gazebosim/gz-physics/pull/837
- https://github.com/dartsim/dart/issues/1522 (original vtordisp fix)