### PR TITLE
ci: exclude INTEGRATION_io_IkFast from FreeBSD tests

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -43,7 +43,7 @@ jobs:
           FREEBSD_VM_MEM: "4096"
           FREEBSD_VM_BUILD_PARALLEL_LEVEL: "1"
           FREEBSD_VM_CTEST_TIMEOUT: "2400"
-          FREEBSD_VM_TEST_EXCLUDE_REGEX: "ForwardKinematics|AtlasIK|INTEGRATION_io_Read|INTEGRATION_io_UrdfParser|INTEGRATION_io_UrdfMaterialParsing"
+          FREEBSD_VM_TEST_EXCLUDE_REGEX: "ForwardKinematics|AtlasIK|INTEGRATION_io_Read|INTEGRATION_io_UrdfParser|INTEGRATION_io_UrdfMaterialParsing|INTEGRATION_io_IkFast"
         run: pixi run freebsd-test
 
       - name: Stop FreeBSD VM


### PR DESCRIPTION
## Summary
Exclude `INTEGRATION_io_IkFast` from FreeBSD CI tests due to pre-existing URDF shape parsing bug.

The test fails with "Unknown URDF Shape type" error when loading the WAM arm URDF, which is caused by the same FreeBSD-specific URDF parsing issue that affects other URDF-related tests.

## Context
This commit was prepared as part of PR #2411 but was pushed after the merge completed, so it wasn't included.

## Changes
- Add `INTEGRATION_io_IkFast` to `FREEBSD_VM_TEST_EXCLUDE_REGEX` in `.github/workflows/ci_freebsd.yml`

## Note
The FreeBSD CI job has `continue-on-error: true`, so this is a quality-of-life fix to reduce noise in CI results rather than a blocking issue.