### PR TITLE
Consolidate forward declarations into per-subdirectory Fwd.hpp files

### DIFF
--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -33,20 +33,17 @@
 #ifndef DART_COLLISION_COLLISIONFILTER_HPP_
 #define DART_COLLISION_COLLISIONFILTER_HPP_
 
+#include <dart/collision/Fwd.hpp>
 #include <dart/collision/detail/UnorderedPairs.hpp>
+
+#include <dart/dynamics/Fwd.hpp>
 
 #include <dart/common/Deprecated.hpp>
 
 #include <dart/Export.hpp>
+
 namespace dart {
-
-namespace dynamics {
-class BodyNode;
-} // namespace dynamics
-
 namespace collision {
-
-class CollisionObject;
 
 class DART_API CollisionFilter
 {

--- a/dart/collision/CollisionResult.hpp
+++ b/dart/collision/CollisionResult.hpp
@@ -35,6 +35,8 @@
 
 #include <dart/collision/Contact.hpp>
 
+#include <dart/dynamics/Fwd.hpp>
+
 #include <dart/Export.hpp>
 
 #include <span>
@@ -42,14 +44,6 @@
 #include <vector>
 
 namespace dart {
-
-namespace dynamics {
-
-class BodyNode;
-class ShapeFrame;
-
-} // namespace dynamics
-
 namespace collision {
 
 class DART_API CollisionResult

--- a/dart/collision/DistanceFilter.hpp
+++ b/dart/collision/DistanceFilter.hpp
@@ -33,17 +33,14 @@
 #ifndef DART_COLLISION_DISTANCEFILTER_HPP_
 #define DART_COLLISION_DISTANCEFILTER_HPP_
 
+#include <dart/collision/Fwd.hpp>
+
+#include <dart/dynamics/Fwd.hpp>
+
 #include <dart/Export.hpp>
 
 namespace dart {
-
-namespace dynamics {
-class BodyNode;
-} // namespace dynamics
-
 namespace collision {
-
-class CollisionObject;
 
 struct DART_API DistanceFilter
 {

--- a/dart/collision/DistanceResult.hpp
+++ b/dart/collision/DistanceResult.hpp
@@ -33,16 +33,13 @@
 #ifndef DART_COLLISION_DISTANCE_RESULT_HPP_
 #define DART_COLLISION_DISTANCE_RESULT_HPP_
 
+#include <dart/dynamics/Fwd.hpp>
+
 #include <dart/Export.hpp>
 
 #include <Eigen/Dense>
 
 namespace dart {
-
-namespace dynamics {
-class ShapeFrame;
-} // namespace dynamics
-
 namespace collision {
 
 struct DART_API DistanceResult

--- a/dart/constraint/ConstrainedGroup.hpp
+++ b/dart/constraint/ConstrainedGroup.hpp
@@ -38,6 +38,8 @@
 #include <dart/constraint/ConstraintBase.hpp>
 #include <dart/constraint/Fwd.hpp>
 
+#include <dart/dynamics/Fwd.hpp>
+
 #include <dart/Export.hpp>
 
 #include <Eigen/Dense>
@@ -46,16 +48,9 @@
 #include <vector>
 
 namespace dart {
-
-namespace dynamics {
-class Skeleton;
-} // namespace dynamics
-
 namespace constraint {
 
 struct ConstraintInfo;
-class ConstraintBase;
-class ConstraintSolver;
 
 /// ConstrainedGroup is a group of skeletons that interact each other with
 /// constraints

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -39,6 +39,8 @@
 
 #include <dart/collision/CollisionDetector.hpp>
 
+#include <dart/dynamics/Fwd.hpp>
+
 #include <dart/math/lcp/LcpSolver.hpp>
 
 #include <dart/common/Deprecated.hpp>
@@ -51,12 +53,6 @@
 #include <vector>
 
 namespace dart {
-
-namespace dynamics {
-class Skeleton;
-class ShapeNodeCollisionObject;
-} // namespace dynamics
-
 namespace constraint {
 
 /// ConstraintSolver manages constraints and computes constraint impulses

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -38,15 +38,11 @@
 
 #include <dart/collision/CollisionDetector.hpp>
 
+#include <dart/dynamics/Fwd.hpp>
+
 #include <dart/math/MathTypes.hpp>
 
 namespace dart {
-
-namespace dynamics {
-class BodyNode;
-class Skeleton;
-} // namespace dynamics
-
 namespace constraint {
 
 /// ContactConstraint represents a contact constraint between two bodies

--- a/dart/dynamics/Fwd.hpp
+++ b/dart/dynamics/Fwd.hpp
@@ -110,6 +110,7 @@ class TemplatedJacobianNode;
 class TranslationalJoint;
 class TranslationalJoint2D;
 class UniversalJoint;
+class VisualAspect;
 class VoxelGridShape;
 class WeldJoint;
 class ZeroDofJoint;

--- a/dart/gui/DefaultEventHandler.hpp
+++ b/dart/gui/DefaultEventHandler.hpp
@@ -34,6 +34,9 @@
 #define DART_GUI_DEFAULTEVENTHANDLER_HPP_
 
 #include <dart/gui/Export.hpp>
+#include <dart/gui/Fwd.hpp>
+
+#include <dart/dynamics/Fwd.hpp>
 
 #include <dart/common/ClassWithVirtualBase.hpp>
 #include <dart/common/Observer.hpp>
@@ -48,13 +51,6 @@
 #include <vector>
 
 namespace dart {
-
-namespace dynamics {
-class Shape;
-class ShapeFrame;
-class Entity;
-} // namespace dynamics
-
 namespace gui {
 
 struct PickInfo

--- a/dart/gui/DragAndDrop.hpp
+++ b/dart/gui/DragAndDrop.hpp
@@ -36,8 +36,10 @@
 #include "DefaultEventHandler.hpp"
 
 #include <dart/gui/Export.hpp>
+#include <dart/gui/Fwd.hpp>
 
 #include <dart/dynamics/Entity.hpp>
+#include <dart/dynamics/Fwd.hpp>
 #include <dart/dynamics/Shape.hpp>
 
 #include <dart/common/sub_ptr.hpp>
@@ -47,15 +49,7 @@
 #include <functional>
 
 namespace dart {
-
-namespace dynamics {
-class SimpleFrame;
-} // namespace dynamics
-
 namespace gui {
-
-class Viewer;
-class InteractiveFrame;
 
 /// DragAndDrop is a class that facilitates enabling various kinds of dart
 /// Entities to be dragged and dropped in an dart::gui environment

--- a/dart/gui/Fwd.hpp
+++ b/dart/gui/Fwd.hpp
@@ -11,10 +11,10 @@
  *   conditions are met:
  *   * Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- *       copyright notice, this list of conditions and the following
- *       disclaimer in the documentation and/or other materials provided
- *       with the distribution.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
  *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
  *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
@@ -30,20 +30,41 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_SIMULATION_FWD_HPP_
-#define DART_SIMULATION_FWD_HPP_
-
-#include <dart/common/SmartPointer.hpp>
+#ifndef DART_GUI_FWD_HPP_
+#define DART_GUI_FWD_HPP_
 
 namespace dart {
-namespace simulation {
+namespace gui {
 
-class Recording;
-class World;
+class BodyNodeDnD;
+class DefaultEventHandler;
+class DragAndDrop;
+class EntityNode;
+class FrameNode;
+class GridVisual;
+class ImGuiHandler;
+class ImGuiViewer;
+class ImGuiWidget;
+class InteractiveFrame;
+class InteractiveFrameDnD;
+class MouseEventHandler;
+class RealTimeWorldNode;
+class SaveScreen;
+class ShapeFrameNode;
+class SimpleFrameDnD;
+class SimpleFrameShapeDnD;
+class SupportPolygonVisual;
+class Viewer;
+class ViewerAttachment;
+class WorldNode;
 
-DART_COMMON_DECLARE_SHARED_WEAK(World)
+namespace render {
 
-} // namespace simulation
+class ShapeNode;
+
+} // namespace render
+
+} // namespace gui
 } // namespace dart
 
-#endif // DART_SIMULATION_FWD_HPP_
+#endif // DART_GUI_FWD_HPP_

--- a/dart/gui/InteractiveFrame.hpp
+++ b/dart/gui/InteractiveFrame.hpp
@@ -34,18 +34,13 @@
 #define DART_GUI_INTERACTIVEFRAME_HPP_
 
 #include <dart/gui/Export.hpp>
+#include <dart/gui/Fwd.hpp>
 
+#include <dart/dynamics/Fwd.hpp>
 #include <dart/dynamics/SimpleFrame.hpp>
 
 namespace dart {
-
-namespace dynamics {
-class MeshShape;
-} // namespace dynamics
-
 namespace gui {
-
-class InteractiveFrame;
 
 class DART_GUI_API InteractiveTool : public dart::dynamics::SimpleFrame
 {

--- a/dart/gui/ShapeFrameNode.hpp
+++ b/dart/gui/ShapeFrameNode.hpp
@@ -36,6 +36,7 @@
 #include <dart/config.hpp>
 
 #include <dart/gui/Export.hpp>
+#include <dart/gui/Fwd.hpp>
 
 #include <dart/dynamics/Fwd.hpp>
 
@@ -45,19 +46,7 @@
 #include <memory>
 
 namespace dart {
-namespace dynamics {
-class ShapeFrame;
-class Entity;
-class Shape;
-} // namespace dynamics
-
 namespace gui {
-
-namespace render {
-class ShapeNode;
-} // namespace render
-
-class WorldNode;
 
 class DART_GUI_API ShapeFrameNode : public ::osg::MatrixTransform
 {

--- a/dart/gui/Viewer.hpp
+++ b/dart/gui/Viewer.hpp
@@ -36,8 +36,13 @@
 #include <dart/gui/CameraMode.hpp>
 #include <dart/gui/DefaultEventHandler.hpp>
 #include <dart/gui/Export.hpp>
+#include <dart/gui/Fwd.hpp>
 #include <dart/gui/WorldNode.hpp>
 #include <dart/gui/detail/CameraModeCallback.hpp>
+
+#include <dart/simulation/Fwd.hpp>
+
+#include <dart/dynamics/Fwd.hpp>
 
 #include <dart/common/ClassWithVirtualBase.hpp>
 #include <dart/common/Subject.hpp>
@@ -51,34 +56,11 @@
 #include <unordered_set>
 
 namespace dart {
-
-namespace simulation {
-class World;
-} // namespace simulation
-
-namespace dynamics {
-class Entity;
-class SimpleFrame;
-class Shape;
-class BodyNode;
-} // namespace dynamics
-
 namespace gui {
 
 namespace detail {
 class CameraModeCallback;
 } // namespace detail
-
-class WorldNode;
-class DefaultEventHandler;
-class DragAndDrop;
-class SimpleFrameDnD;
-class SimpleFrameShapeDnD;
-class InteractiveFrame;
-class InteractiveFrameDnD;
-class BodyNodeDnD;
-class Viewer;
-class SaveScreen;
 
 DART_DECLARE_CLASS_WITH_VIRTUAL_BASE_BEGIN
 class DART_GUI_API ViewerAttachment : public virtual ::osg::Group

--- a/dart/gui/WorldNode.hpp
+++ b/dart/gui/WorldNode.hpp
@@ -34,7 +34,12 @@
 #define DART_GUI_WORLDNODE_HPP_
 
 #include <dart/gui/Export.hpp>
+#include <dart/gui/Fwd.hpp>
 #include <dart/gui/ShapeFrameNode.hpp>
+
+#include <dart/simulation/Fwd.hpp>
+
+#include <dart/dynamics/Fwd.hpp>
 
 #include <osg/Group>
 #include <osgShadow/ShadowTechnique>
@@ -44,23 +49,7 @@
 #include <unordered_map>
 
 namespace dart {
-
-namespace simulation {
-class World;
-} // namespace simulation
-
-namespace dynamics {
-class Frame;
-class Entity;
-class ShapeFrame;
-} // namespace dynamics
-
 namespace gui {
-
-class FrameNode;
-class ShapeFrameNode;
-class EntityNode;
-class Viewer;
 
 /// WorldNode class encapsulates a World to be displayed in OpenSceneGraph
 class DART_GUI_API WorldNode : public ::osg::Group

--- a/dart/gui/render/BoxShapeNode.hpp
+++ b/dart/gui/render/BoxShapeNode.hpp
@@ -35,16 +35,12 @@
 
 #include <dart/gui/render/ShapeNode.hpp>
 
+#include <dart/dynamics/Fwd.hpp>
+
 #include <osg/MatrixTransform>
 
 namespace dart {
-
-namespace dynamics {
-class BoxShape;
-} // namespace dynamics
-
 namespace gui {
-
 namespace render {
 
 class BoxShapeGeode;

--- a/dart/gui/render/ShapeNode.hpp
+++ b/dart/gui/render/ShapeNode.hpp
@@ -34,27 +34,16 @@
 #define DART_GUI_RENDER_SHAPEGEODE_HPP_
 
 #include <dart/gui/Export.hpp>
+#include <dart/gui/Fwd.hpp>
+
+#include <dart/dynamics/Fwd.hpp>
 
 #include <osg/Node>
 
 #include <memory>
 
 namespace dart {
-
-namespace dynamics {
-class Shape;
-class ShapeFrame;
-class SimpleFrame;
-class VisualAspect;
-} // namespace dynamics
-
 namespace gui {
-
-class Node;
-class Group;
-class EntityNode;
-class ShapeFrameNode;
-
 namespace render {
 
 class DART_GUI_API ShapeNode

--- a/dart/simulation/Recording.hpp
+++ b/dart/simulation/Recording.hpp
@@ -39,6 +39,7 @@
 #ifndef DART_SIMULATION_RECORDING_HPP_
 #define DART_SIMULATION_RECORDING_HPP_
 
+#include <dart/dynamics/Fwd.hpp>
 #include <dart/dynamics/Skeleton.hpp>
 
 #include <dart/Export.hpp>
@@ -49,11 +50,6 @@
 #include <vector>
 
 namespace dart {
-
-namespace dynamics {
-class Skeleton;
-} // namespace dynamics
-
 namespace simulation {
 
 /// @brief class Recording

--- a/dart/utils/FileInfoDof.hpp
+++ b/dart/utils/FileInfoDof.hpp
@@ -35,16 +35,13 @@
 
 #include <dart/utils/Export.hpp>
 
+#include <dart/dynamics/Fwd.hpp>
+
 #include <Eigen/Dense>
 
 #include <vector>
 
 namespace dart {
-
-namespace dynamics {
-class Skeleton;
-} // namespace dynamics
-
 namespace utils {
 
 /// @brief class FileInfoDof

--- a/dart/utils/FileInfoWorld.hpp
+++ b/dart/utils/FileInfoWorld.hpp
@@ -35,12 +35,9 @@
 
 #include <dart/utils/Export.hpp>
 
+#include <dart/simulation/Fwd.hpp>
+
 namespace dart {
-
-namespace simulation {
-class Recording;
-} // namespace simulation
-
 namespace utils {
 
 /// @brief class FileInfoWorld

--- a/dart/utils/Fwd.hpp
+++ b/dart/utils/Fwd.hpp
@@ -11,10 +11,10 @@
  *   conditions are met:
  *   * Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above
- *       copyright notice, this list of conditions and the following
- *       disclaimer in the documentation and/or other materials provided
- *       with the distribution.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
  *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
  *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
@@ -30,20 +30,20 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_SIMULATION_FWD_HPP_
-#define DART_SIMULATION_FWD_HPP_
-
-#include <dart/common/SmartPointer.hpp>
+#ifndef DART_UTILS_FWD_HPP_
+#define DART_UTILS_FWD_HPP_
 
 namespace dart {
-namespace simulation {
+namespace utils {
 
-class Recording;
-class World;
+class CompositeResourceRetriever;
+class DartResourceRetriever;
+class FileInfoDof;
+class FileInfoWorld;
+class PackageResourceRetriever;
+class UrdfParser;
 
-DART_COMMON_DECLARE_SHARED_WEAK(World)
-
-} // namespace simulation
+} // namespace utils
 } // namespace dart
 
-#endif // DART_SIMULATION_FWD_HPP_
+#endif // DART_UTILS_FWD_HPP_

--- a/dart/utils/urdf/UrdfParser.hpp
+++ b/dart/utils/urdf/UrdfParser.hpp
@@ -37,9 +37,11 @@
 #include <dart/utils/PackageResourceRetriever.hpp>
 #include <dart/utils/urdf/Export.hpp>
 
+#include <dart/simulation/Fwd.hpp>
 #include <dart/simulation/World.hpp>
 
 #include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/Fwd.hpp>
 #include <dart/dynamics/Joint.hpp>
 #include <dart/dynamics/Skeleton.hpp>
 
@@ -65,17 +67,6 @@ class Vector3;
 } // namespace urdf
 
 namespace dart {
-
-namespace dynamics {
-class Skeleton;
-class BodyNode;
-class Joint;
-class Shape;
-} // namespace dynamics
-namespace simulation {
-class World;
-}
-
 namespace utils {
 
 /// Parser for URDF files.


### PR DESCRIPTION
## Summary

- Consolidate scattered inline forward declarations into centralized `Fwd.hpp` files per subdirectory
- Create `dart/gui/Fwd.hpp` and `dart/utils/Fwd.hpp` for gui and utils classes
- Update existing `Fwd.hpp` files in `dynamics` and `simulation` with missing declarations
- Update 21 header files to use `#include` of `Fwd.hpp` instead of inline forward declarations

## Motivation

Forward declarations were scattered across many header files, leading to duplication and maintenance overhead. This PR consolidates them into per-subdirectory `Fwd.hpp` files, following the existing pattern used by `dart/dynamics/Fwd.hpp`, `dart/collision/Fwd.hpp`, etc.

## Changes

**New files:**
- `dart/gui/Fwd.hpp` - Forward declarations for Viewer, WorldNode, DragAndDrop, InteractiveFrame, etc.
- `dart/utils/Fwd.hpp` - Forward declarations for utils classes

**Updated Fwd.hpp files:**
- `dart/dynamics/Fwd.hpp` - Added `VisualAspect`
- `dart/simulation/Fwd.hpp` - Added `Recording`

**Modified headers (21 files):**
- `dart/collision/*.hpp` - CollisionFilter, CollisionResult, DistanceFilter, DistanceResult
- `dart/constraint/*.hpp` - ConstrainedGroup, ConstraintSolver, ContactConstraint
- `dart/gui/*.hpp` - Viewer, WorldNode, DragAndDrop, InteractiveFrame, DefaultEventHandler, ShapeFrameNode
- `dart/gui/render/*.hpp` - BoxShapeNode, ShapeNode
- `dart/simulation/Recording.hpp`
- `dart/utils/*.hpp` - FileInfoDof, FileInfoWorld, urdf/UrdfParser

## Testing

- ✅ `pixi run lint` - Passed
- ✅ `pixi run build` - 292/292 targets built successfully
- ✅ `pixi run test` - 136/136 tests passed