### PR TITLE
Fix Python code formatting to pass black check

### DIFF
--- a/docker/freebsd/entrypoint.py
+++ b/docker/freebsd/entrypoint.py
@@ -111,7 +111,6 @@ def write_seed(vm_dir, ssh_key, user_data, meta_data, seed_img, user):
             ]
         )
 
-
     lines.append("")
     user_data.write_text("\n".join(lines))
     meta_data.write_text(

--- a/scripts/altlinux.py
+++ b/scripts/altlinux.py
@@ -56,7 +56,15 @@ def repo_root():
 
 def container_exists(container):
     result = run(
-        ["docker", "ps", "-a", "--filter", f"name={container}", "--format", "{{.Names}}"],
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            f"name={container}",
+            "--format",
+            "{{.Names}}",
+        ],
         check=False,
         capture=True,
     )
@@ -150,8 +158,7 @@ def sync_repo(args):
     work_dir = shlex.quote(args.work_dir)
     src_dir = shlex.quote(args.source_dir)
     command = (
-        f"mkdir -p {work_dir} && "
-        f"rsync -az --delete {excludes} {src_dir}/ {work_dir}/"
+        f"mkdir -p {work_dir} && rsync -az --delete {excludes} {src_dir}/ {work_dir}/"
     )
     exec_in_container(args, command)
 
@@ -192,9 +199,7 @@ def test_container(args):
             f"-R {shlex.quote(test_regex)} --output-on-failure"
         )
     else:
-        test_command = (
-            f"ctest --test-dir {shlex.quote(build_dir)} --output-on-failure"
-        )
+        test_command = f"ctest --test-dir {shlex.quote(build_dir)} --output-on-failure"
 
     command = (
         f"cd {shlex.quote(args.work_dir)} && "

--- a/scripts/freebsd.py
+++ b/scripts/freebsd.py
@@ -104,7 +104,15 @@ def image_exists(image):
 
 def container_exists(container):
     result = run(
-        ["docker", "ps", "-a", "--filter", f"name={container}", "--format", "{{.Names}}"],
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            f"name={container}",
+            "--format",
+            "{{.Names}}",
+        ],
         check=False,
         capture=True,
     )
@@ -213,6 +221,7 @@ def ensure_ssh_key(args):
         return
     vm_dir.mkdir(parents=True, exist_ok=True)
     run(["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", ""])
+
 
 def wait_for_ssh_key(args, timeout=120):
     vm_dir = vm_dir_path(args.vm_dir)
@@ -358,10 +367,7 @@ def apply_ports_patches(args):
     remote_dir = args.remote_dir or f"/home/{args.user}/dart"
     for patch_file in patch_files:
         rel_path = os.path.relpath(patch_file, repo_root())
-        command = (
-            f"cd {remote_dir} && "
-            f"patch -p0 -N -i {shlex.quote(rel_path)}"
-        )
+        command = f"cd {remote_dir} && patch -p0 -N -i {shlex.quote(rel_path)}"
         ssh_command(args, command, user=args.user)
 
 
@@ -375,11 +381,7 @@ def bootstrap_vm(args):
     if should_skip_bootstrap():
         return
     packages_env = os.getenv("FREEBSD_VM_PACKAGES")
-    packages = (
-        shlex.split(packages_env)
-        if packages_env
-        else DEFAULT_PACKAGES
-    )
+    packages = shlex.split(packages_env) if packages_env else DEFAULT_PACKAGES
     package_list = " ".join(packages)
     root_password = os.getenv("FREEBSD_VM_ROOT_PASSWORD", "freebsd")
     command = (
@@ -443,8 +445,7 @@ def test_vm(args):
     ctest_arg_str = " ".join(shlex.quote(arg) for arg in ctest_args)
     if test_regex:
         test_command = (
-            f"ctest --test-dir {build_dir} -R {shlex.quote(test_regex)} "
-            f"{ctest_arg_str}"
+            f"ctest --test-dir {build_dir} -R {shlex.quote(test_regex)} {ctest_arg_str}"
         )
     else:
         test_command = f"ctest --test-dir {build_dir} {ctest_arg_str}"
@@ -469,6 +470,7 @@ def test_vm(args):
         )
         raise exc
 
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
@@ -477,7 +479,9 @@ def parse_args():
         )
     )
     parser.add_argument("--image", default=DEFAULT_IMAGE, help="Docker image tag.")
-    parser.add_argument("--container", default=DEFAULT_CONTAINER, help="Container name.")
+    parser.add_argument(
+        "--container", default=DEFAULT_CONTAINER, help="Container name."
+    )
     parser.add_argument("--vm-dir", default=str(repo_root() / "build" / "freebsd-vm"))
     parser.add_argument("--ssh-port", type=int, default=DEFAULT_SSH_PORT)
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Fix Python formatting issues in `scripts/altlinux.py`, `docker/freebsd/entrypoint.py`, and `scripts/freebsd.py` to pass the CI black check
- Addresses CI failure in https://github.com/dartsim/dart/actions/runs/20881272950/job/59997965953

## Changes
- Break long list arguments in `container_exists()` functions across multiple lines
- Remove extra blank line in `entrypoint.py`
- Add missing blank line between function definitions in `freebsd.py`
- Consolidate multi-line string expressions where appropriate