### PR TITLE
Add dedicated lint CI job and skip doc-only changes for FreeBSD/AltLinux

### DIFF
--- a/.github/workflows/ci_altlinux.yml
+++ b/.github/workflows/ci_altlinux.yml
@@ -7,12 +7,26 @@ on:
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
+      - "docs/**"
+      - ".readthedocs.yml"
+      - "tutorials/**"
+      - "**/*.md"
+      - "**/*.rst"
+      - "**/*.po"
+      - "**/*.pot"
   pull_request:
     branches:
       - "**"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
+      - "docs/**"
+      - ".readthedocs.yml"
+      - "tutorials/**"
+      - "**/*.md"
+      - "**/*.rst"
+      - "**/*.po"
+      - "**/*.pot"
   schedule:
     # Run every Monday at 05:00 UTC
     - cron: "0 5 * * 1"

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -7,12 +7,26 @@ on:
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
+      - "docs/**"
+      - ".readthedocs.yml"
+      - "tutorials/**"
+      - "**/*.md"
+      - "**/*.rst"
+      - "**/*.po"
+      - "**/*.pot"
   pull_request:
     branches:
       - "**"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
+      - "docs/**"
+      - ".readthedocs.yml"
+      - "tutorials/**"
+      - "**/*.md"
+      - "**/*.rst"
+      - "**/*.po"
+      - "**/*.pot"
   schedule:
     # Run every Monday at 04:00 UTC
     - cron: "0 4 * * 1"

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,0 +1,35 @@
+name: CI Lint
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - ".github/workflows/cache_*.yml"
+  pull_request:
+    branches:
+      - "**"
+    paths-ignore:
+      - ".github/workflows/cache_*.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
+
+      - name: Check Lint
+        run: pixi run check-lint

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -115,12 +115,6 @@ jobs:
       - name: Configure environment for compiler cache
         uses: ./.github/actions/configure-compiler-cache
 
-      - name: Check Lint
-        run: |
-          DART_VERBOSE=ON \
-          BUILD_TYPE=Release \
-          pixi run check-lint
-
       - name: Test DART and dartpy
         run: |
           DART_VERBOSE=ON \


### PR DESCRIPTION
## Summary

- Create `ci_lint.yml`: dedicated lint job that runs on ALL changes (including docs)
- Remove lint step from `ci_ubuntu.yml` (now covered by `ci_lint.yml`)
- Add doc-only skip patterns to `ci_freebsd.yml` and `ci_altlinux.yml`

## Motivation

After commit 8de81f3 added doc files (CLAUDE.md, GEMINI.md, AGENTS.md updates), the FreeBSD and AltLinux CI jobs were triggered unnecessarily. These platform-specific jobs take significant time/resources to run VMs/containers.

## Changes

| File | Change |
|------|--------|
| `ci_lint.yml` | New dedicated lint job (runs on all changes) |
| `ci_ubuntu.yml` | Removed `Check Lint` step (covered by `ci_lint.yml`) |
| `ci_freebsd.yml` | Added doc-only skip patterns |
| `ci_altlinux.yml` | Added doc-only skip patterns |

## Result

1. Fast lint feedback on every commit (including doc changes)
2. No wasted CI minutes running FreeBSD/AltLinux VMs for doc-only changes
3. Platform-specific jobs still run when actual code changes