### PR TITLE
Allow servo joints to recover from lower bound position limits

### DIFF
--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -307,7 +307,9 @@ void JointConstraint::update()
       const bool processServoVelocityLimits
           = servoHasFiniteLowerLimit || servoHasFiniteUpperLimit;
       const bool skipVelocityLimitsForServoRecovery
-          = isServo && atUpperLimit && servoCommand < 0.0
+          = isServo
+            && ((atUpperLimit && servoCommand < 0.0)
+                || (atLowerLimit && servoCommand > 0.0))
             && !processServoVelocityLimits;
       const bool relaxLowerVelocityBound
           = processServoVelocityLimits && atUpperLimit && servoCommand < 0.0;

--- a/tests/regression/test_Issue1583.cpp
+++ b/tests/regression/test_Issue1583.cpp
@@ -129,7 +129,7 @@ TEST(Issue1683, ServoJointRecoversFromPositionLimits)
       bodyNode->addExtTorque(Eigen::Vector3d(0.0, 0.0, holdTorque));
       world->step();
       if (firstMovementStep == 0
-        && joint->getPosition(0) < posUpperBound - 1e-6) {
+          && joint->getPosition(0) < posUpperBound - 1e-6) {
         firstMovementStep = i + 1;
       }
     }
@@ -156,7 +156,7 @@ TEST(Issue1683, ServoJointRecoversFromPositionLimits)
       bodyNode->addExtTorque(Eigen::Vector3d(0.0, 0.0, holdTorque));
       world->step();
       if (firstMovementStep == 0
-        && joint->getPosition(0) > posLowerBound + 1e-6) {
+          && joint->getPosition(0) > posLowerBound + 1e-6) {
         firstMovementStep = i + 1;
       }
     }


### PR DESCRIPTION
## Summary

- https://github.com/dartsim/dart/pull/2086 fixes the bug where servo joints couldn't recover from position limits, however, this only works for upper bound position limits. This PR fixes that and updates the test to cover both upper and lower bounds.

## Testing

- `tests/regression/test_Issue1583`

---

#### Checklist

- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
