### PR TITLE
Fix null pointer dereference in getValue* functions (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## DART 6
 
+### [DART 6.16.5 (TBD)](https://github.com/dartsim/dart/milestone/90?closed=1)
+
+* Parsers
+  * Fix null pointer dereference in XmlHelpers getValue* functions: [#2429](https://github.com/dartsim/dart/pull/2429)
+
 ### [DART 6.16.4 (2026-01-06)](https://github.com/dartsim/dart/milestone/89?closed=1)
 
 * Physics

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -40,6 +40,7 @@
 #include <fmt/format.h>
 
 #include <iostream>
+#include <stdexcept>
 #include <vector>
 
 namespace dart {
@@ -376,15 +377,46 @@ Eigen::Isometry3d toIsometry3dWithExtrinsicRotation(const std::string& str)
 }
 
 //==============================================================================
+// Helper function to safely get text from a child element
+// Throws std::runtime_error if the child element is missing or has no text
+static std::string getChildElementText(
+    const tinyxml2::XMLElement* parentElement,
+    const std::string& childName)
+{
+  const tinyxml2::XMLElement* childElement
+      = parentElement->FirstChildElement(childName.c_str());
+  if (childElement == nullptr) {
+    const std::string parentName
+        = parentElement->Name() ? parentElement->Name() : "unknown";
+    dterr << "Child element [" << childName << "] not found in parent element ["
+          << parentName << "]" << std::endl;
+    throw std::runtime_error(
+        "Child element [" + childName + "] not found in parent element ["
+        + parentName + "]");
+  }
+
+  const char* text = childElement->GetText();
+  if (text == nullptr) {
+    const std::string parentName
+        = parentElement->Name() ? parentElement->Name() : "unknown";
+    dterr << "Child element [" << childName << "] in parent [" << parentName
+          << "] has no text content" << std::endl;
+    throw std::runtime_error(
+        "Child element [" + childName + "] in parent [" + parentName
+        + "] has no text content");
+  }
+
+  return std::string(text);
+}
+
+//==============================================================================
 std::string getValueString(
     const tinyxml2::XMLElement* parentElement, const std::string& name)
 {
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return str;
+  return getChildElementText(parentElement, name);
 }
 
 //==============================================================================
@@ -394,15 +426,15 @@ bool getValueBool(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
+  const std::string str = getChildElementText(parentElement, name);
 
   if (common::toUpper(str) == "TRUE" || str == "1")
     return true;
   else if (common::toUpper(str) == "FALSE" || str == "0")
     return false;
   else {
-    std::cerr << "value [" << str << "] is not a valid boolean type. "
-              << "Returning false." << std::endl;
+    dterr << "value [" << str << "] is not a valid boolean type. "
+          << "Returning false." << std::endl;
     DART_ASSERT(0);
     return false;
   }
@@ -415,9 +447,7 @@ int getValueInt(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toInt(str);
+  return toInt(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -427,9 +457,7 @@ unsigned int getValueUInt(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toUInt(str);
+  return toUInt(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -439,9 +467,7 @@ float getValueFloat(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toFloat(str);
+  return toFloat(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -451,9 +477,7 @@ double getValueDouble(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toDouble(str);
+  return toDouble(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -463,9 +487,7 @@ char getValueChar(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toChar(str);
+  return toChar(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -475,9 +497,7 @@ Eigen::Vector2d getValueVector2d(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toVector2d(str);
+  return toVector2d(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -487,9 +507,7 @@ Eigen::Vector3d getValueVector3d(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toVector3d(str);
+  return toVector3d(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -499,9 +517,7 @@ Eigen::Vector3i getValueVector3i(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toVector3i(str);
+  return toVector3i(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -511,9 +527,7 @@ Eigen::Vector6d getValueVector6d(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toVector6d(str);
+  return toVector6d(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -523,9 +537,7 @@ Eigen::VectorXd getValueVectorXd(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toVectorXd(str);
+  return toVectorXd(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -535,9 +547,7 @@ Eigen::Vector3d getValueVec3(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toVector3d(str);
+  return toVector3d(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -547,9 +557,7 @@ Eigen::Isometry3d getValueIsometry3d(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toIsometry3d(str);
+  return toIsometry3d(getChildElementText(parentElement, name));
 }
 
 //==============================================================================
@@ -559,9 +567,7 @@ Eigen::Isometry3d getValueIsometry3dWithExtrinsicRotation(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  std::string str = parentElement->FirstChildElement(name.c_str())->GetText();
-
-  return toIsometry3dWithExtrinsicRotation(str);
+  return toIsometry3dWithExtrinsicRotation(getChildElementText(parentElement, name));
 }
 
 //==============================================================================

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -380,8 +380,7 @@ Eigen::Isometry3d toIsometry3dWithExtrinsicRotation(const std::string& str)
 // Helper function to safely get text from a child element
 // Throws std::runtime_error if the child element is missing or has no text
 static std::string getChildElementText(
-    const tinyxml2::XMLElement* parentElement,
-    const std::string& childName)
+    const tinyxml2::XMLElement* parentElement, const std::string& childName)
 {
   const tinyxml2::XMLElement* childElement
       = parentElement->FirstChildElement(childName.c_str());
@@ -567,7 +566,8 @@ Eigen::Isometry3d getValueIsometry3dWithExtrinsicRotation(
   DART_ASSERT(parentElement != nullptr);
   DART_ASSERT(!name.empty());
 
-  return toIsometry3dWithExtrinsicRotation(getChildElementText(parentElement, name));
+  return toIsometry3dWithExtrinsicRotation(
+      getChildElementText(parentElement, name));
 }
 
 //==============================================================================

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -387,22 +387,24 @@ static std::string getChildElementText(
   if (childElement == nullptr) {
     const std::string parentName
         = parentElement->Name() ? parentElement->Name() : "unknown";
-    dterr << "Child element [" << childName << "] not found in parent element ["
-          << parentName << "]" << std::endl;
-    throw std::runtime_error(
-        "Child element [" + childName + "] not found in parent element ["
-        + parentName + "]");
+    const auto msg = fmt::format(
+        "Child element [{}] not found in parent element [{}]",
+        childName,
+        parentName);
+    dterr << msg << std::endl;
+    throw std::runtime_error(msg);
   }
 
   const char* text = childElement->GetText();
   if (text == nullptr) {
     const std::string parentName
         = parentElement->Name() ? parentElement->Name() : "unknown";
-    dterr << "Child element [" << childName << "] in parent [" << parentName
-          << "] has no text content" << std::endl;
-    throw std::runtime_error(
-        "Child element [" + childName + "] in parent [" + parentName
-        + "] has no text content");
+    const auto msg = fmt::format(
+        "Child element [{}] in parent [{}] has no text content",
+        childName,
+        parentName);
+    dterr << msg << std::endl;
+    throw std::runtime_error(msg);
   }
 
   return std::string(text);

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -5,7 +5,7 @@ if(TARGET dart-utils)
     TYPE unit
     COMPONENT_NAME utils
     TARGET_PREFIX UNIT_utils
-    LINK_LIBRARIES dart-utils tinyxml2::tinyxml2
+    LINK_LIBRARIES dart-utils
     GLOB_SOURCES
   )
 endif()

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -5,7 +5,7 @@ if(TARGET dart-utils)
     TYPE unit
     COMPONENT_NAME utils
     TARGET_PREFIX UNIT_utils
-    LINK_LIBRARIES dart-utils
+    LINK_LIBRARIES dart-utils tinyxml2::tinyxml2
     GLOB_SOURCES
   )
 endif()

--- a/tests/unit/utils/test_XmlHelpers.cpp
+++ b/tests/unit/utils/test_XmlHelpers.cpp
@@ -399,3 +399,236 @@ TEST(XmlHelpers, GetValueIsometry3dWithMissingChildThrows)
 
   EXPECT_THROW(getValueIsometry3d(root, "missing"), std::runtime_error);
 }
+
+//==============================================================================
+// Additional valid-case tests for comprehensive coverage
+//==============================================================================
+
+TEST(XmlHelpers, GetValueStringWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("name");
+  child->SetText("hello world");
+  root->InsertEndChild(child);
+
+  EXPECT_EQ(getValueString(root, "name"), "hello world");
+}
+
+TEST(XmlHelpers, GetValueUIntWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("count");
+  child->SetText("42");
+  root->InsertEndChild(child);
+
+  EXPECT_EQ(getValueUInt(root, "count"), 42u);
+}
+
+TEST(XmlHelpers, GetValueFloatWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("value");
+  child->SetText("3.14");
+  root->InsertEndChild(child);
+
+  EXPECT_FLOAT_EQ(getValueFloat(root, "value"), 3.14f);
+}
+
+TEST(XmlHelpers, GetValueCharWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("letter");
+  child->SetText("A");
+  root->InsertEndChild(child);
+
+  EXPECT_EQ(getValueChar(root, "letter"), 'A');
+}
+
+TEST(XmlHelpers, GetValueVector2dWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("pos");
+  child->SetText("1.5 2.5");
+  root->InsertEndChild(child);
+
+  const Eigen::Vector2d result = getValueVector2d(root, "pos");
+  EXPECT_DOUBLE_EQ(result[0], 1.5);
+  EXPECT_DOUBLE_EQ(result[1], 2.5);
+}
+
+TEST(XmlHelpers, GetValueVector3iWithMissingChildThrows)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  EXPECT_THROW(getValueVector3i(root, "missing"), std::runtime_error);
+}
+
+TEST(XmlHelpers, GetValueVector3iWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("pos");
+  child->SetText("1 2 3");
+  root->InsertEndChild(child);
+
+  const Eigen::Vector3i result = getValueVector3i(root, "pos");
+  EXPECT_EQ(result[0], 1);
+  EXPECT_EQ(result[1], 2);
+  EXPECT_EQ(result[2], 3);
+}
+
+TEST(XmlHelpers, GetValueVector6dWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("vec");
+  child->SetText("1.0 2.0 3.0 4.0 5.0 6.0");
+  root->InsertEndChild(child);
+
+  const Eigen::Vector6d result = getValueVector6d(root, "vec");
+  EXPECT_DOUBLE_EQ(result[0], 1.0);
+  EXPECT_DOUBLE_EQ(result[1], 2.0);
+  EXPECT_DOUBLE_EQ(result[2], 3.0);
+  EXPECT_DOUBLE_EQ(result[3], 4.0);
+  EXPECT_DOUBLE_EQ(result[4], 5.0);
+  EXPECT_DOUBLE_EQ(result[5], 6.0);
+}
+
+TEST(XmlHelpers, GetValueVectorXdWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("vec");
+  child->SetText("1.0 2.0 3.0 4.0");
+  root->InsertEndChild(child);
+
+  const Eigen::VectorXd result = getValueVectorXd(root, "vec");
+  ASSERT_EQ(result.size(), 4);
+  EXPECT_DOUBLE_EQ(result[0], 1.0);
+  EXPECT_DOUBLE_EQ(result[1], 2.0);
+  EXPECT_DOUBLE_EQ(result[2], 3.0);
+  EXPECT_DOUBLE_EQ(result[3], 4.0);
+}
+
+TEST(XmlHelpers, GetValueVec3WithMissingChildThrows)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  EXPECT_THROW(getValueVec3(root, "missing"), std::runtime_error);
+}
+
+TEST(XmlHelpers, GetValueVec3WithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("pos");
+  child->SetText("1.0 2.0 3.0");
+  root->InsertEndChild(child);
+
+  const Eigen::Vector3d result = getValueVec3(root, "pos");
+  EXPECT_DOUBLE_EQ(result[0], 1.0);
+  EXPECT_DOUBLE_EQ(result[1], 2.0);
+  EXPECT_DOUBLE_EQ(result[2], 3.0);
+}
+
+TEST(XmlHelpers, GetValueIsometry3dWithValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("transform");
+  child->SetText("1.0 2.0 3.0 0.0 0.0 0.0");
+  root->InsertEndChild(child);
+
+  const Eigen::Isometry3d result = getValueIsometry3d(root, "transform");
+  EXPECT_DOUBLE_EQ(result.translation()[0], 1.0);
+  EXPECT_DOUBLE_EQ(result.translation()[1], 2.0);
+  EXPECT_DOUBLE_EQ(result.translation()[2], 3.0);
+}
+
+TEST(XmlHelpers, GetValueIsometry3dWithExtrinsicRotationMissingChildThrows)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  EXPECT_THROW(
+      getValueIsometry3dWithExtrinsicRotation(root, "missing"),
+      std::runtime_error);
+}
+
+TEST(XmlHelpers, GetValueIsometry3dWithExtrinsicRotationValidChild)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("transform");
+  child->SetText("1.0 2.0 3.0 0.0 0.0 0.0");
+  root->InsertEndChild(child);
+
+  const Eigen::Isometry3d result
+      = getValueIsometry3dWithExtrinsicRotation(root, "transform");
+  EXPECT_DOUBLE_EQ(result.translation()[0], 1.0);
+  EXPECT_DOUBLE_EQ(result.translation()[1], 2.0);
+  EXPECT_DOUBLE_EQ(result.translation()[2], 3.0);
+}
+
+TEST(XmlHelpers, GetValueBoolFalseValue)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* child = doc.NewElement("flag");
+  child->SetText("false");
+  root->InsertEndChild(child);
+
+  EXPECT_FALSE(getValueBool(root, "flag"));
+}
+
+TEST(XmlHelpers, GetValueBoolNumericValues)
+{
+  tinyxml2::XMLDocument doc;
+  tinyxml2::XMLElement* root = doc.NewElement("root");
+  doc.InsertEndChild(root);
+
+  tinyxml2::XMLElement* trueChild = doc.NewElement("trueFlag");
+  trueChild->SetText("1");
+  root->InsertEndChild(trueChild);
+
+  tinyxml2::XMLElement* falseChild = doc.NewElement("falseFlag");
+  falseChild->SetText("0");
+  root->InsertEndChild(falseChild);
+
+  EXPECT_TRUE(getValueBool(root, "trueFlag"));
+  EXPECT_FALSE(getValueBool(root, "falseFlag"));
+}

--- a/tests/unit/utils/test_XmlHelpers.cpp
+++ b/tests/unit/utils/test_XmlHelpers.cpp
@@ -36,9 +36,10 @@
 #include <gtest/gtest.h>
 #include <tinyxml2.h>
 
-#include <cmath>
 #include <stdexcept>
 #include <string>
+
+#include <cmath>
 
 using namespace dart::utils;
 

--- a/tests/unit/utils/test_XmlHelpers.cpp
+++ b/tests/unit/utils/test_XmlHelpers.cpp
@@ -533,31 +533,6 @@ TEST(XmlHelpers, GetValueVectorXdWithValidChild)
   EXPECT_DOUBLE_EQ(result[3], 4.0);
 }
 
-TEST(XmlHelpers, GetValueVec3WithMissingChildThrows)
-{
-  tinyxml2::XMLDocument doc;
-  tinyxml2::XMLElement* root = doc.NewElement("root");
-  doc.InsertEndChild(root);
-
-  EXPECT_THROW(getValueVec3(root, "missing"), std::runtime_error);
-}
-
-TEST(XmlHelpers, GetValueVec3WithValidChild)
-{
-  tinyxml2::XMLDocument doc;
-  tinyxml2::XMLElement* root = doc.NewElement("root");
-  doc.InsertEndChild(root);
-
-  tinyxml2::XMLElement* child = doc.NewElement("pos");
-  child->SetText("1.0 2.0 3.0");
-  root->InsertEndChild(child);
-
-  const Eigen::Vector3d result = getValueVec3(root, "pos");
-  EXPECT_DOUBLE_EQ(result[0], 1.0);
-  EXPECT_DOUBLE_EQ(result[1], 2.0);
-  EXPECT_DOUBLE_EQ(result[2], 3.0);
-}
-
 TEST(XmlHelpers, GetValueIsometry3dWithValidChild)
 {
   tinyxml2::XMLDocument doc;


### PR DESCRIPTION
## Summary

Fix issue #2425: `XmlHelpers` `getValue*` functions crash with SIGSEGV when child element is missing due to null pointer dereference.

## Changes

- Add `getChildElementText()` helper function that validates child element exists and has text content
- Update all 15 `getValue*` functions to use the safe helper
- Throw `std::runtime_error` with descriptive message on missing/empty child element
- Add comprehensive unit tests for null child element handling

## Functions Fixed

- `getValueString`, `getValueBool`, `getValueInt`, `getValueUInt`
- `getValueFloat`, `getValueDouble`, `getValueChar`
- `getValueVector2d`, `getValueVector3d`, `getValueVector3i`
- `getValueVector6d`, `getValueVectorXd`, `getValueVec3`
- `getValueIsometry3d`, `getValueIsometry3dWithExtrinsicRotation`

## Related

- Fixes #2425
- Companion PR for `main`: #2428

## Testing

- Added 19 unit tests covering:
  - Valid input parsing
  - Missing child element - verifies exception is thrown
  - Empty child element - verifies exception is thrown