### PR TITLE
Update copyright year to 2026 (DART 7)

### DIFF
--- a/dart/All.hpp
+++ b/dart/All.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/Export.hpp
+++ b/dart/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionDetector.cpp
+++ b/dart/collision/CollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionDetector.hpp
+++ b/dart/collision/CollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionGroup.cpp
+++ b/dart/collision/CollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionGroup.hpp
+++ b/dart/collision/CollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionObject.cpp
+++ b/dart/collision/CollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionObject.hpp
+++ b/dart/collision/CollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionOption.cpp
+++ b/dart/collision/CollisionOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionOption.hpp
+++ b/dart/collision/CollisionOption.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionResult.cpp
+++ b/dart/collision/CollisionResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionResult.hpp
+++ b/dart/collision/CollisionResult.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/Contact.cpp
+++ b/dart/collision/Contact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/Contact.hpp
+++ b/dart/collision/Contact.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceFilter.cpp
+++ b/dart/collision/DistanceFilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceFilter.hpp
+++ b/dart/collision/DistanceFilter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceOption.cpp
+++ b/dart/collision/DistanceOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceOption.hpp
+++ b/dart/collision/DistanceOption.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceResult.cpp
+++ b/dart/collision/DistanceResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceResult.hpp
+++ b/dart/collision/DistanceResult.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/Fwd.hpp
+++ b/dart/collision/Fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastOption.cpp
+++ b/dart/collision/RaycastOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastOption.hpp
+++ b/dart/collision/RaycastOption.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastResult.cpp
+++ b/dart/collision/RaycastResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastResult.hpp
+++ b/dart/collision/RaycastResult.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/SmartPointer.hpp
+++ b/dart/collision/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionDetector.hpp
+++ b/dart/collision/bullet/BulletCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionGroup.cpp
+++ b/dart/collision/bullet/BulletCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionGroup.hpp
+++ b/dart/collision/bullet/BulletCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionObject.cpp
+++ b/dart/collision/bullet/BulletCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionObject.hpp
+++ b/dart/collision/bullet/BulletCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionShape.cpp
+++ b/dart/collision/bullet/BulletCollisionShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionShape.hpp
+++ b/dart/collision/bullet/BulletCollisionShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletInclude.hpp
+++ b/dart/collision/bullet/BulletInclude.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletTypes.cpp
+++ b/dart/collision/bullet/BulletTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletTypes.hpp
+++ b/dart/collision/bullet/BulletTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
+++ b/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletCollisionDispatcher.hpp
+++ b/dart/collision/bullet/detail/BulletCollisionDispatcher.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletContact.hpp
+++ b/dart/collision/bullet/detail/BulletContact.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
+++ b/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletOverlapFilterCallback.hpp
+++ b/dart/collision/bullet/detail/BulletOverlapFilterCallback.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollide.hpp
+++ b/dart/collision/dart/DARTCollide.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionDetector.hpp
+++ b/dart/collision/dart/DARTCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionGroup.cpp
+++ b/dart/collision/dart/DARTCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionGroup.hpp
+++ b/dart/collision/dart/DARTCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionObject.cpp
+++ b/dart/collision/dart/DARTCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionObject.hpp
+++ b/dart/collision/dart/DARTCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/CollisionDetector.hpp
+++ b/dart/collision/detail/CollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/CollisionGroup.hpp
+++ b/dart/collision/detail/CollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/Contact-impl.hpp
+++ b/dart/collision/detail/Contact-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/UnorderedPairs.hpp
+++ b/dart/collision/detail/UnorderedPairs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/BackwardCompatibility.cpp
+++ b/dart/collision/fcl/BackwardCompatibility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/CollisionShapes.hpp
+++ b/dart/collision/fcl/CollisionShapes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionDetector.hpp
+++ b/dart/collision/fcl/FCLCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionGroup.cpp
+++ b/dart/collision/fcl/FCLCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionGroup.hpp
+++ b/dart/collision/fcl/FCLCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionObject.cpp
+++ b/dart/collision/fcl/FCLCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionObject.hpp
+++ b/dart/collision/fcl/FCLCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLTypes.cpp
+++ b/dart/collision/fcl/FCLTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLTypes.hpp
+++ b/dart/collision/fcl/FCLTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/tri_tri_intersection_test.hpp
+++ b/dart/collision/fcl/tri_tri_intersection_test.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionGroup.cpp
+++ b/dart/collision/ode/OdeCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionGroup.hpp
+++ b/dart/collision/ode/OdeCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeTypes.cpp
+++ b/dart/collision/ode/OdeTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeTypes.hpp
+++ b/dart/collision/ode/OdeTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeBox.cpp
+++ b/dart/collision/ode/detail/OdeBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeBox.hpp
+++ b/dart/collision/ode/detail/OdeBox.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCapsule.cpp
+++ b/dart/collision/ode/detail/OdeCapsule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCapsule.hpp
+++ b/dart/collision/ode/detail/OdeCapsule.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinder.cpp
+++ b/dart/collision/ode/detail/OdeCylinder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinder.hpp
+++ b/dart/collision/ode/detail/OdeCylinder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinderMesh.cpp
+++ b/dart/collision/ode/detail/OdeCylinderMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinderMesh.hpp
+++ b/dart/collision/ode/detail/OdeCylinderMesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeGeom.cpp
+++ b/dart/collision/ode/detail/OdeGeom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeGeom.hpp
+++ b/dart/collision/ode/detail/OdeGeom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeHeightmap-impl.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeHeightmap.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeMesh.cpp
+++ b/dart/collision/ode/detail/OdeMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeMesh.hpp
+++ b/dart/collision/ode/detail/OdeMesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdePlane.cpp
+++ b/dart/collision/ode/detail/OdePlane.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdePlane.hpp
+++ b/dart/collision/ode/detail/OdePlane.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeSphere.cpp
+++ b/dart/collision/ode/detail/OdeSphere.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeSphere.hpp
+++ b/dart/collision/ode/detail/OdeSphere.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Aspect.cpp
+++ b/dart/common/Aspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Aspect.hpp
+++ b/dart/common/Aspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/AspectWithVersion.hpp
+++ b/dart/common/AspectWithVersion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/CAllocator.cpp
+++ b/dart/common/CAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/CAllocator.hpp
+++ b/dart/common/CAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Castable.hpp
+++ b/dart/common/Castable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ClassWithVirtualBase.hpp
+++ b/dart/common/ClassWithVirtualBase.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Cloneable.hpp
+++ b/dart/common/Cloneable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Composite.cpp
+++ b/dart/common/Composite.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Composite.hpp
+++ b/dart/common/Composite.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/CompositeJoiner.hpp
+++ b/dart/common/CompositeJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Deprecated.hpp
+++ b/dart/common/Deprecated.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Diagnostics.hpp
+++ b/dart/common/Diagnostics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/EmbeddedAspect.hpp
+++ b/dart/common/EmbeddedAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Empty.hpp
+++ b/dart/common/Empty.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Export.hpp
+++ b/dart/common/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Factory.hpp
+++ b/dart/common/Factory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Filesystem.hpp
+++ b/dart/common/Filesystem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors:
+ * Copyright (c) 2011-2026, The DART development contributors:
  * https://github.com/dartsim/dart/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dart/common/FreeListAllocator.cpp
+++ b/dart/common/FreeListAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/FreeListAllocator.hpp
+++ b/dart/common/FreeListAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/IncludeWindows.hpp
+++ b/dart/common/IncludeWindows.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResource.cpp
+++ b/dart/common/LocalResource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResource.hpp
+++ b/dart/common/LocalResource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResourceRetriever.cpp
+++ b/dart/common/LocalResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResourceRetriever.hpp
+++ b/dart/common/LocalResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LockableReference.hpp
+++ b/dart/common/LockableReference.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Logging.hpp
+++ b/dart/common/Logging.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Macros.hpp
+++ b/dart/common/Macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Memory.hpp
+++ b/dart/common/Memory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryAllocator.cpp
+++ b/dart/common/MemoryAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryAllocator.hpp
+++ b/dart/common/MemoryAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryAllocatorDebugger.hpp
+++ b/dart/common/MemoryAllocatorDebugger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryManager.cpp
+++ b/dart/common/MemoryManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryManager.hpp
+++ b/dart/common/MemoryManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Metaprogramming.hpp
+++ b/dart/common/Metaprogramming.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/NameManager.hpp
+++ b/dart/common/NameManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Observer.cpp
+++ b/dart/common/Observer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Observer.hpp
+++ b/dart/common/Observer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Platform.hpp
+++ b/dart/common/Platform.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/PoolAllocator.cpp
+++ b/dart/common/PoolAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/PoolAllocator.hpp
+++ b/dart/common/PoolAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Profile.hpp
+++ b/dart/common/Profile.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ProxyAspect.hpp
+++ b/dart/common/ProxyAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/RequiresAspect.hpp
+++ b/dart/common/RequiresAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Resource.cpp
+++ b/dart/common/Resource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Resource.hpp
+++ b/dart/common/Resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ResourceRetriever.cpp
+++ b/dart/common/ResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ResourceRetriever.hpp
+++ b/dart/common/ResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SharedLibrary.cpp
+++ b/dart/common/SharedLibrary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SharedLibrary.hpp
+++ b/dart/common/SharedLibrary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Signal.cpp
+++ b/dart/common/Signal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Signal.hpp
+++ b/dart/common/Signal.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Singleton.hpp
+++ b/dart/common/Singleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SmartPointer.hpp
+++ b/dart/common/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SpecializedForAspect.hpp
+++ b/dart/common/SpecializedForAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/StlAllocator.hpp
+++ b/dart/common/StlAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/StlHelpers.hpp
+++ b/dart/common/StlHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Stopwatch.cpp
+++ b/dart/common/Stopwatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Stopwatch.hpp
+++ b/dart/common/Stopwatch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/String.cpp
+++ b/dart/common/String.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/String.hpp
+++ b/dart/common/String.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Subject.hpp
+++ b/dart/common/Subject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Uri.cpp
+++ b/dart/common/Uri.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Uri.hpp
+++ b/dart/common/Uri.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/VersionCounter.cpp
+++ b/dart/common/VersionCounter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/VersionCounter.hpp
+++ b/dart/common/VersionCounter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Virtual.hpp
+++ b/dart/common/Virtual.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Aspect.hpp
+++ b/dart/common/detail/Aspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/AspectWithVersion.hpp
+++ b/dart/common/detail/AspectWithVersion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Castable-impl.hpp
+++ b/dart/common/detail/Castable-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Cloneable.hpp
+++ b/dart/common/detail/Cloneable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Composite.hpp
+++ b/dart/common/detail/Composite.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/CompositeData.hpp
+++ b/dart/common/detail/CompositeData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/CompositeJoiner.hpp
+++ b/dart/common/detail/CompositeJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/ConnectionBody.cpp
+++ b/dart/common/detail/ConnectionBody.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/ConnectionBody.hpp
+++ b/dart/common/detail/ConnectionBody.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/EmbeddedAspect.hpp
+++ b/dart/common/detail/EmbeddedAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Factory-impl.hpp
+++ b/dart/common/detail/Factory-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/LockableReference-impl.hpp
+++ b/dart/common/detail/LockableReference-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Logging-impl.hpp
+++ b/dart/common/detail/Logging-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Memory-impl.hpp
+++ b/dart/common/detail/Memory-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/MemoryAllocator-impl.hpp
+++ b/dart/common/detail/MemoryAllocator-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/MemoryAllocatorDebugger-impl.hpp
+++ b/dart/common/detail/MemoryAllocatorDebugger-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/MemoryManager-impl.hpp
+++ b/dart/common/detail/MemoryManager-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Metaprogramming-impl.hpp
+++ b/dart/common/detail/Metaprogramming-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/NameManager.hpp
+++ b/dart/common/detail/NameManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/NoOp.hpp
+++ b/dart/common/detail/NoOp.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Profiler.cpp
+++ b/dart/common/detail/Profiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Profiler.hpp
+++ b/dart/common/detail/Profiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/ProxyAspect.hpp
+++ b/dart/common/detail/ProxyAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/RequiresAspect.hpp
+++ b/dart/common/detail/RequiresAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/SharedLibraryManager.cpp
+++ b/dart/common/detail/SharedLibraryManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/SharedLibraryManager.hpp
+++ b/dart/common/detail/SharedLibraryManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Signal.hpp
+++ b/dart/common/detail/Signal.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Singleton-impl.hpp
+++ b/dart/common/detail/Singleton-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/SpecializedForAspect.hpp
+++ b/dart/common/detail/SpecializedForAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/StlAllocator-impl.hpp
+++ b/dart/common/detail/StlAllocator-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Stopwatch-impl.hpp
+++ b/dart/common/detail/Stopwatch-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/TemplateJoinerDispatchMacro.hpp
+++ b/dart/common/detail/TemplateJoinerDispatchMacro.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/sub_ptr.hpp
+++ b/dart/common/detail/sub_ptr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/sub_ptr.hpp
+++ b/dart/common/sub_ptr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BalanceConstraint.cpp
+++ b/dart/constraint/BalanceConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BalanceConstraint.hpp
+++ b/dart/constraint/BalanceConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BallJointConstraint.cpp
+++ b/dart/constraint/BallJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BallJointConstraint.hpp
+++ b/dart/constraint/BallJointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BoxedLcpSolver.hpp
+++ b/dart/constraint/BoxedLcpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstrainedGroup.cpp
+++ b/dart/constraint/ConstrainedGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstrainedGroup.hpp
+++ b/dart/constraint/ConstrainedGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintBase.cpp
+++ b/dart/constraint/ConstraintBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintBase.hpp
+++ b/dart/constraint/ConstraintBase.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactSurface.cpp
+++ b/dart/constraint/ContactSurface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactSurface.hpp
+++ b/dart/constraint/ContactSurface.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/CouplerConstraint.cpp
+++ b/dart/constraint/CouplerConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/CouplerConstraint.hpp
+++ b/dart/constraint/CouplerConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DantzigBoxedLcpSolver.cpp
+++ b/dart/constraint/DantzigBoxedLcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DantzigBoxedLcpSolver.hpp
+++ b/dart/constraint/DantzigBoxedLcpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DynamicJointConstraint.cpp
+++ b/dart/constraint/DynamicJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DynamicJointConstraint.hpp
+++ b/dart/constraint/DynamicJointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/Fwd.hpp
+++ b/dart/constraint/Fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointConstraint.hpp
+++ b/dart/constraint/JointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointCoulombFrictionConstraint.cpp
+++ b/dart/constraint/JointCoulombFrictionConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointCoulombFrictionConstraint.hpp
+++ b/dart/constraint/JointCoulombFrictionConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointLimitConstraint.cpp
+++ b/dart/constraint/JointLimitConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointLimitConstraint.hpp
+++ b/dart/constraint/JointLimitConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/MimicMotorConstraint.cpp
+++ b/dart/constraint/MimicMotorConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/MimicMotorConstraint.hpp
+++ b/dart/constraint/MimicMotorConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/PgsBoxedLcpSolver.cpp
+++ b/dart/constraint/PgsBoxedLcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/PgsBoxedLcpSolver.hpp
+++ b/dart/constraint/PgsBoxedLcpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/RevoluteJointConstraint.cpp
+++ b/dart/constraint/RevoluteJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/RevoluteJointConstraint.hpp
+++ b/dart/constraint/RevoluteJointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ServoMotorConstraint.cpp
+++ b/dart/constraint/ServoMotorConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ServoMotorConstraint.hpp
+++ b/dart/constraint/ServoMotorConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/SmartPointer.hpp
+++ b/dart/constraint/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/SoftContactConstraint.cpp
+++ b/dart/constraint/SoftContactConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/SoftContactConstraint.hpp
+++ b/dart/constraint/SoftContactConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/WeldJointConstraint.cpp
+++ b/dart/constraint/WeldJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/WeldJointConstraint.hpp
+++ b/dart/constraint/WeldJointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/detail/ConstraintSolver-impl.hpp
+++ b/dart/constraint/detail/ConstraintSolver-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dart.cpp
+++ b/dart/dart.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dart.hpp
+++ b/dart/dart.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ArrowShape.hpp
+++ b/dart/dynamics/ArrowShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/AssimpInputResourceAdaptor.hpp
+++ b/dart/dynamics/AssimpInputResourceAdaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BallJoint.cpp
+++ b/dart/dynamics/BallJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BallJoint.hpp
+++ b/dart/dynamics/BallJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BoxShape.hpp
+++ b/dart/dynamics/BoxShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Branch.cpp
+++ b/dart/dynamics/Branch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Branch.hpp
+++ b/dart/dynamics/Branch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CapsuleShape.cpp
+++ b/dart/dynamics/CapsuleShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CapsuleShape.hpp
+++ b/dart/dynamics/CapsuleShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Chain.cpp
+++ b/dart/dynamics/Chain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Chain.hpp
+++ b/dart/dynamics/Chain.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CompositeNode.hpp
+++ b/dart/dynamics/CompositeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ConvexMeshShape.cpp
+++ b/dart/dynamics/ConvexMeshShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ConvexMeshShape.hpp
+++ b/dart/dynamics/ConvexMeshShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CylinderShape.cpp
+++ b/dart/dynamics/CylinderShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CylinderShape.hpp
+++ b/dart/dynamics/CylinderShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/DegreeOfFreedom.cpp
+++ b/dart/dynamics/DegreeOfFreedom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/DegreeOfFreedom.hpp
+++ b/dart/dynamics/DegreeOfFreedom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EndEffector.cpp
+++ b/dart/dynamics/EndEffector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EndEffector.hpp
+++ b/dart/dynamics/EndEffector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Entity.cpp
+++ b/dart/dynamics/Entity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Entity.hpp
+++ b/dart/dynamics/Entity.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EntityNode.hpp
+++ b/dart/dynamics/EntityNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EulerJoint.hpp
+++ b/dart/dynamics/EulerJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedFrame.cpp
+++ b/dart/dynamics/FixedFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedFrame.hpp
+++ b/dart/dynamics/FixedFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedJacobianNode.cpp
+++ b/dart/dynamics/FixedJacobianNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedJacobianNode.hpp
+++ b/dart/dynamics/FixedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Frame.cpp
+++ b/dart/dynamics/Frame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Frame.hpp
+++ b/dart/dynamics/Frame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FreeJoint.hpp
+++ b/dart/dynamics/FreeJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Fwd.hpp
+++ b/dart/dynamics/Fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/GenericJoint.hpp
+++ b/dart/dynamics/GenericJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Group.cpp
+++ b/dart/dynamics/Group.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Group.hpp
+++ b/dart/dynamics/Group.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/HeightmapShape.hpp
+++ b/dart/dynamics/HeightmapShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/HierarchicalIK.cpp
+++ b/dart/dynamics/HierarchicalIK.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/HierarchicalIK.hpp
+++ b/dart/dynamics/HierarchicalIK.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/IkFast.cpp
+++ b/dart/dynamics/IkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/IkFast.hpp
+++ b/dart/dynamics/IkFast.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Inertia.hpp
+++ b/dart/dynamics/Inertia.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/InvalidIndex.hpp
+++ b/dart/dynamics/InvalidIndex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/InverseKinematics.cpp
+++ b/dart/dynamics/InverseKinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/InverseKinematics.hpp
+++ b/dart/dynamics/InverseKinematics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/JacobianNode.cpp
+++ b/dart/dynamics/JacobianNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/JacobianNode.hpp
+++ b/dart/dynamics/JacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/LineSegmentShape.hpp
+++ b/dart/dynamics/LineSegmentShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Linkage.cpp
+++ b/dart/dynamics/Linkage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Linkage.hpp
+++ b/dart/dynamics/Linkage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Marker.cpp
+++ b/dart/dynamics/Marker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Marker.hpp
+++ b/dart/dynamics/Marker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MeshMaterial.hpp
+++ b/dart/dynamics/MeshMaterial.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MetaSkeleton.cpp
+++ b/dart/dynamics/MetaSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MimicDofProperties.hpp
+++ b/dart/dynamics/MimicDofProperties.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MultiSphereConvexHullShape.cpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Node.cpp
+++ b/dart/dynamics/Node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Node.hpp
+++ b/dart/dynamics/Node.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/NodeManagerJoiner.hpp
+++ b/dart/dynamics/NodeManagerJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlanarJoint.cpp
+++ b/dart/dynamics/PlanarJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlanarJoint.hpp
+++ b/dart/dynamics/PlanarJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlaneShape.cpp
+++ b/dart/dynamics/PlaneShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlaneShape.hpp
+++ b/dart/dynamics/PlaneShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointCloudShape.cpp
+++ b/dart/dynamics/PointCloudShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointCloudShape.hpp
+++ b/dart/dynamics/PointCloudShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointMass.hpp
+++ b/dart/dynamics/PointMass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PrismaticJoint.cpp
+++ b/dart/dynamics/PrismaticJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PrismaticJoint.hpp
+++ b/dart/dynamics/PrismaticJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PyramidShape.hpp
+++ b/dart/dynamics/PyramidShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ReferentialSkeleton.cpp
+++ b/dart/dynamics/ReferentialSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ReferentialSkeleton.hpp
+++ b/dart/dynamics/ReferentialSkeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/RevoluteJoint.cpp
+++ b/dart/dynamics/RevoluteJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/RevoluteJoint.hpp
+++ b/dart/dynamics/RevoluteJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ScrewJoint.cpp
+++ b/dart/dynamics/ScrewJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ScrewJoint.hpp
+++ b/dart/dynamics/ScrewJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Shape.cpp
+++ b/dart/dynamics/Shape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeNode.cpp
+++ b/dart/dynamics/ShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeNode.hpp
+++ b/dart/dynamics/ShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SharedLibraryIkFast.cpp
+++ b/dart/dynamics/SharedLibraryIkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SharedLibraryIkFast.hpp
+++ b/dart/dynamics/SharedLibraryIkFast.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SimpleFrame.cpp
+++ b/dart/dynamics/SimpleFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SimpleFrame.hpp
+++ b/dart/dynamics/SimpleFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SmartPointer.hpp
+++ b/dart/dynamics/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftBodyNode.hpp
+++ b/dart/dynamics/SoftBodyNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftMeshShape.cpp
+++ b/dart/dynamics/SoftMeshShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftMeshShape.hpp
+++ b/dart/dynamics/SoftMeshShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SpecializedNodeManager.hpp
+++ b/dart/dynamics/SpecializedNodeManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SphereShape.hpp
+++ b/dart/dynamics/SphereShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TemplatedJacobianNode.hpp
+++ b/dart/dynamics/TemplatedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint.cpp
+++ b/dart/dynamics/TranslationalJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint.hpp
+++ b/dart/dynamics/TranslationalJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint2D.cpp
+++ b/dart/dynamics/TranslationalJoint2D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint2D.hpp
+++ b/dart/dynamics/TranslationalJoint2D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/UniversalJoint.cpp
+++ b/dart/dynamics/UniversalJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/UniversalJoint.hpp
+++ b/dart/dynamics/UniversalJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/VoxelGridShape.cpp
+++ b/dart/dynamics/VoxelGridShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/WeldJoint.cpp
+++ b/dart/dynamics/WeldJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/WeldJoint.hpp
+++ b/dart/dynamics/WeldJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ZeroDofJoint.cpp
+++ b/dart/dynamics/ZeroDofJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ZeroDofJoint.hpp
+++ b/dart/dynamics/ZeroDofJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/AssimpInputResourceAdaptor.cpp
+++ b/dart/dynamics/detail/AssimpInputResourceAdaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/AssimpInputResourceAdaptor.hpp
+++ b/dart/dynamics/detail/AssimpInputResourceAdaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BallJointAspect.cpp
+++ b/dart/dynamics/detail/BallJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BallJointAspect.hpp
+++ b/dart/dynamics/detail/BallJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BasicNodeManager.hpp
+++ b/dart/dynamics/detail/BasicNodeManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BodyNode.hpp
+++ b/dart/dynamics/detail/BodyNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BodyNodeAspect.hpp
+++ b/dart/dynamics/detail/BodyNodeAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BodyNodePtr.hpp
+++ b/dart/dynamics/detail/BodyNodePtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/CompositeNode.hpp
+++ b/dart/dynamics/detail/CompositeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/DegreeOfFreedomPtr.hpp
+++ b/dart/dynamics/detail/DegreeOfFreedomPtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EndEffectorAspect.hpp
+++ b/dart/dynamics/detail/EndEffectorAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EntityNode.hpp
+++ b/dart/dynamics/detail/EntityNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EntityNodeAspect.cpp
+++ b/dart/dynamics/detail/EntityNodeAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EntityNodeAspect.hpp
+++ b/dart/dynamics/detail/EntityNodeAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EulerJointAspect.cpp
+++ b/dart/dynamics/detail/EulerJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EulerJointAspect.hpp
+++ b/dart/dynamics/detail/EulerJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/FixedFrameAspect.hpp
+++ b/dart/dynamics/detail/FixedFrameAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/FixedJacobianNode.hpp
+++ b/dart/dynamics/detail/FixedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/FreeJointAspect.cpp
+++ b/dart/dynamics/detail/FreeJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/FreeJointAspect.hpp
+++ b/dart/dynamics/detail/FreeJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/GenericJointAspect.hpp
+++ b/dart/dynamics/detail/GenericJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/HeightmapShape-impl.hpp
+++ b/dart/dynamics/detail/HeightmapShape-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/InverseKinematics.hpp
+++ b/dart/dynamics/detail/InverseKinematics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/InverseKinematicsPtr.hpp
+++ b/dart/dynamics/detail/InverseKinematicsPtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/JointAspect.hpp
+++ b/dart/dynamics/detail/JointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/JointCoordinateChart.hpp
+++ b/dart/dynamics/detail/JointCoordinateChart.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/JointPtr.hpp
+++ b/dart/dynamics/detail/JointPtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/MarkerAspect.hpp
+++ b/dart/dynamics/detail/MarkerAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/MetaSkeleton-impl.hpp
+++ b/dart/dynamics/detail/MetaSkeleton-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/Node.hpp
+++ b/dart/dynamics/detail/Node.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/NodeManagerJoiner.hpp
+++ b/dart/dynamics/detail/NodeManagerJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/NodePtr.hpp
+++ b/dart/dynamics/detail/NodePtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PlanarJointAspect.cpp
+++ b/dart/dynamics/detail/PlanarJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PlanarJointAspect.hpp
+++ b/dart/dynamics/detail/PlanarJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PrismaticJointAspect.cpp
+++ b/dart/dynamics/detail/PrismaticJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PrismaticJointAspect.hpp
+++ b/dart/dynamics/detail/PrismaticJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/RevoluteJointAspect.cpp
+++ b/dart/dynamics/detail/RevoluteJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/RevoluteJointAspect.hpp
+++ b/dart/dynamics/detail/RevoluteJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ScrewJointAspect.cpp
+++ b/dart/dynamics/detail/ScrewJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ScrewJointAspect.hpp
+++ b/dart/dynamics/detail/ScrewJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ShapeNode.hpp
+++ b/dart/dynamics/detail/ShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/Skeleton.hpp
+++ b/dart/dynamics/detail/Skeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/SkeletonAspect.hpp
+++ b/dart/dynamics/detail/SkeletonAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/SoftBodyNodeAspect.hpp
+++ b/dart/dynamics/detail/SoftBodyNodeAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/SpecializedNodeManager.hpp
+++ b/dart/dynamics/detail/SpecializedNodeManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/TemplatedJacobianNode.hpp
+++ b/dart/dynamics/detail/TemplatedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/UniversalJointAspect.cpp
+++ b/dart/dynamics/detail/UniversalJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/UniversalJointAspect.hpp
+++ b/dart/dynamics/detail/UniversalJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/CameraMode.hpp
+++ b/dart/gui/CameraMode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/DefaultEventHandler.cpp
+++ b/dart/gui/DefaultEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/DefaultEventHandler.hpp
+++ b/dart/gui/DefaultEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/DragAndDrop.cpp
+++ b/dart/gui/DragAndDrop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/DragAndDrop.hpp
+++ b/dart/gui/DragAndDrop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Export.hpp
+++ b/dart/gui/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Fwd.hpp
+++ b/dart/gui/Fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/GridVisual.cpp
+++ b/dart/gui/GridVisual.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/GridVisual.hpp
+++ b/dart/gui/GridVisual.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/ImGuiHandler.cpp
+++ b/dart/gui/ImGuiHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/ImGuiHandler.hpp
+++ b/dart/gui/ImGuiHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/ImGuiViewer.cpp
+++ b/dart/gui/ImGuiViewer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/ImGuiViewer.hpp
+++ b/dart/gui/ImGuiViewer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/ImGuiWidget.cpp
+++ b/dart/gui/ImGuiWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:
@@ -91,7 +91,7 @@ void AboutWidget::render()
   ImGui::Begin("About DART", &mIsVisible, ImGuiWindowFlags_AlwaysAutoResize);
   // ImGui::Text("HIT %s", Version::asString().c_str());
   ImGui::Separator();
-  ImGui::Text("Copyright (c) 2011-2025, The DART development contributors");
+  ImGui::Text("Copyright (c) 2011-2026, The DART development contributors");
   ImGui::Text("DART is licensed under the BSD 2 Clause License.");
   ImGui::Separator();
   ImGui::Text(

--- a/dart/gui/ImGuiWidget.hpp
+++ b/dart/gui/ImGuiWidget.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/IncludeImGui.hpp
+++ b/dart/gui/IncludeImGui.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/InteractiveFrame.cpp
+++ b/dart/gui/InteractiveFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/InteractiveFrame.hpp
+++ b/dart/gui/InteractiveFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/MouseEventHandler.hpp
+++ b/dart/gui/MouseEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/PolyhedronVisual.cpp
+++ b/dart/gui/PolyhedronVisual.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/PolyhedronVisual.hpp
+++ b/dart/gui/PolyhedronVisual.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/RealTimeWorldNode.cpp
+++ b/dart/gui/RealTimeWorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/RealTimeWorldNode.hpp
+++ b/dart/gui/RealTimeWorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/ShapeFrameNode.cpp
+++ b/dart/gui/ShapeFrameNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/ShapeFrameNode.hpp
+++ b/dart/gui/ShapeFrameNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/SupportPolygonVisual.cpp
+++ b/dart/gui/SupportPolygonVisual.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/SupportPolygonVisual.hpp
+++ b/dart/gui/SupportPolygonVisual.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/TrackballManipulator.cpp
+++ b/dart/gui/TrackballManipulator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/TrackballManipulator.hpp
+++ b/dart/gui/TrackballManipulator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Utils.cpp
+++ b/dart/gui/Utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Utils.hpp
+++ b/dart/gui/Utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Viewer.cpp
+++ b/dart/gui/Viewer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Viewer.hpp
+++ b/dart/gui/Viewer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/WorldNode.cpp
+++ b/dart/gui/WorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/WorldNode.hpp
+++ b/dart/gui/WorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/detail/CameraModeCallback.cpp
+++ b/dart/gui/detail/CameraModeCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/detail/CameraModeCallback.hpp
+++ b/dart/gui/detail/CameraModeCallback.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/detail/Utils-impl.hpp
+++ b/dart/gui/detail/Utils-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/BoxShapeNode.cpp
+++ b/dart/gui/render/BoxShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/BoxShapeNode.hpp
+++ b/dart/gui/render/BoxShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/CapsuleShapeNode.cpp
+++ b/dart/gui/render/CapsuleShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/CapsuleShapeNode.hpp
+++ b/dart/gui/render/CapsuleShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/ConeShapeNode.cpp
+++ b/dart/gui/render/ConeShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/ConeShapeNode.hpp
+++ b/dart/gui/render/ConeShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/ConvexMeshShapeNode.cpp
+++ b/dart/gui/render/ConvexMeshShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/ConvexMeshShapeNode.hpp
+++ b/dart/gui/render/ConvexMeshShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/CylinderShapeNode.cpp
+++ b/dart/gui/render/CylinderShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/CylinderShapeNode.hpp
+++ b/dart/gui/render/CylinderShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/EllipsoidShapeNode.cpp
+++ b/dart/gui/render/EllipsoidShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/EllipsoidShapeNode.hpp
+++ b/dart/gui/render/EllipsoidShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/HeightmapShapeNode.hpp
+++ b/dart/gui/render/HeightmapShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/LineSegmentShapeNode.cpp
+++ b/dart/gui/render/LineSegmentShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/LineSegmentShapeNode.hpp
+++ b/dart/gui/render/LineSegmentShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/MeshShapeNode.cpp
+++ b/dart/gui/render/MeshShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/MeshShapeNode.hpp
+++ b/dart/gui/render/MeshShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/MultiSphereShapeNode.cpp
+++ b/dart/gui/render/MultiSphereShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/MultiSphereShapeNode.hpp
+++ b/dart/gui/render/MultiSphereShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/PlaneShapeNode.cpp
+++ b/dart/gui/render/PlaneShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/PlaneShapeNode.hpp
+++ b/dart/gui/render/PlaneShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/PointCloudShapeNode.cpp
+++ b/dart/gui/render/PointCloudShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/PointCloudShapeNode.hpp
+++ b/dart/gui/render/PointCloudShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/PyramidShapeNode.cpp
+++ b/dart/gui/render/PyramidShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/PyramidShapeNode.hpp
+++ b/dart/gui/render/PyramidShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/ShapeNode.cpp
+++ b/dart/gui/render/ShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/ShapeNode.hpp
+++ b/dart/gui/render/ShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/SoftMeshShapeNode.cpp
+++ b/dart/gui/render/SoftMeshShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/SoftMeshShapeNode.hpp
+++ b/dart/gui/render/SoftMeshShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/SphereShapeNode.cpp
+++ b/dart/gui/render/SphereShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/SphereShapeNode.hpp
+++ b/dart/gui/render/SphereShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/VoxelGridShapeNode.cpp
+++ b/dart/gui/render/VoxelGridShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/VoxelGridShapeNode.hpp
+++ b/dart/gui/render/VoxelGridShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/WarningShapeNode.cpp
+++ b/dart/gui/render/WarningShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/WarningShapeNode.hpp
+++ b/dart/gui/render/WarningShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/render/detail/HeightmapShapeGeometry.hpp
+++ b/dart/gui/render/detail/HeightmapShapeGeometry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/io/Export.hpp
+++ b/dart/io/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/io/Read.cpp
+++ b/dart/io/Read.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/io/Read.hpp
+++ b/dart/io/Read.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/ConfigurationSpace.cpp
+++ b/dart/math/ConfigurationSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/ConfigurationSpace.hpp
+++ b/dart/math/ConfigurationSpace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Constants.hpp
+++ b/dart/math/Constants.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Geometry.hpp
+++ b/dart/math/Geometry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Helpers.hpp
+++ b/dart/math/Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Icosphere.hpp
+++ b/dart/math/Icosphere.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/MathTypes.hpp
+++ b/dart/math/MathTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Mesh.hpp
+++ b/dart/math/Mesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/PolygonMesh.cpp
+++ b/dart/math/PolygonMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/PolygonMesh.hpp
+++ b/dart/math/PolygonMesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Random.cpp
+++ b/dart/math/Random.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Random.hpp
+++ b/dart/math/Random.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/TriMesh.cpp
+++ b/dart/math/TriMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/TriMesh.hpp
+++ b/dart/math/TriMesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/ConfigurationSpace.hpp
+++ b/dart/math/detail/ConfigurationSpace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Convhull-impl.hpp
+++ b/dart/math/detail/Convhull-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Convhull.hpp
+++ b/dart/math/detail/Convhull.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Geometry-impl.hpp
+++ b/dart/math/detail/Geometry-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Icosphere-impl.hpp
+++ b/dart/math/detail/Icosphere-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Mesh-impl.hpp
+++ b/dart/math/detail/Mesh-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/PolygonMesh-impl.hpp
+++ b/dart/math/detail/PolygonMesh-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Random-impl.hpp
+++ b/dart/math/detail/Random-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/TriMesh-impl.hpp
+++ b/dart/math/detail/TriMesh-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/LcpSolver.cpp
+++ b/dart/math/lcp/LcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/LcpSolver.hpp
+++ b/dart/math/lcp/LcpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/LcpTypes.cpp
+++ b/dart/math/lcp/LcpTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/LcpTypes.hpp
+++ b/dart/math/lcp/LcpTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/LcpUtils.hpp
+++ b/dart/math/lcp/LcpUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/LcpValidation.hpp
+++ b/dart/math/lcp/LcpValidation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/newton/FischerBurmeisterNewtonSolver.cpp
+++ b/dart/math/lcp/newton/FischerBurmeisterNewtonSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/newton/FischerBurmeisterNewtonSolver.hpp
+++ b/dart/math/lcp/newton/FischerBurmeisterNewtonSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/newton/MinimumMapNewtonSolver.cpp
+++ b/dart/math/lcp/newton/MinimumMapNewtonSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/newton/MinimumMapNewtonSolver.hpp
+++ b/dart/math/lcp/newton/MinimumMapNewtonSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/newton/PenalizedFischerBurmeisterNewtonSolver.cpp
+++ b/dart/math/lcp/newton/PenalizedFischerBurmeisterNewtonSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/newton/PenalizedFischerBurmeisterNewtonSolver.hpp
+++ b/dart/math/lcp/newton/PenalizedFischerBurmeisterNewtonSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/InteriorPointSolver.cpp
+++ b/dart/math/lcp/other/InteriorPointSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/InteriorPointSolver.hpp
+++ b/dart/math/lcp/other/InteriorPointSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/MprgpSolver.cpp
+++ b/dart/math/lcp/other/MprgpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/MprgpSolver.hpp
+++ b/dart/math/lcp/other/MprgpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/ShockPropagationSolver.cpp
+++ b/dart/math/lcp/other/ShockPropagationSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/ShockPropagationSolver.hpp
+++ b/dart/math/lcp/other/ShockPropagationSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/StaggeringSolver.cpp
+++ b/dart/math/lcp/other/StaggeringSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/other/StaggeringSolver.hpp
+++ b/dart/math/lcp/other/StaggeringSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/BaraffSolver.cpp
+++ b/dart/math/lcp/pivoting/BaraffSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/BaraffSolver.hpp
+++ b/dart/math/lcp/pivoting/BaraffSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/DantzigSolver.cpp
+++ b/dart/math/lcp/pivoting/DantzigSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/DantzigSolver.hpp
+++ b/dart/math/lcp/pivoting/DantzigSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/DirectSolver.cpp
+++ b/dart/math/lcp/pivoting/DirectSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/DirectSolver.hpp
+++ b/dart/math/lcp/pivoting/DirectSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/LemkeSolver.cpp
+++ b/dart/math/lcp/pivoting/LemkeSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/LemkeSolver.hpp
+++ b/dart/math/lcp/pivoting/LemkeSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Common.hpp
+++ b/dart/math/lcp/pivoting/dantzig/Common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Lcp-impl.hpp
+++ b/dart/math/lcp/pivoting/dantzig/Lcp-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Lcp.cpp
+++ b/dart/math/lcp/pivoting/dantzig/Lcp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Lcp.hpp
+++ b/dart/math/lcp/pivoting/dantzig/Lcp.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Matrix-impl.hpp
+++ b/dart/math/lcp/pivoting/dantzig/Matrix-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Matrix.hpp
+++ b/dart/math/lcp/pivoting/dantzig/Matrix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Misc.cpp
+++ b/dart/math/lcp/pivoting/dantzig/Misc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/Misc.hpp
+++ b/dart/math/lcp/pivoting/dantzig/Misc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/pivoting/dantzig/PivotMatrix.hpp
+++ b/dart/math/lcp/pivoting/dantzig/PivotMatrix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/BgsSolver.cpp
+++ b/dart/math/lcp/projection/BgsSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/BgsSolver.hpp
+++ b/dart/math/lcp/projection/BgsSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/BlockedJacobiSolver.cpp
+++ b/dart/math/lcp/projection/BlockedJacobiSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/BlockedJacobiSolver.hpp
+++ b/dart/math/lcp/projection/BlockedJacobiSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/JacobiSolver.cpp
+++ b/dart/math/lcp/projection/JacobiSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/JacobiSolver.hpp
+++ b/dart/math/lcp/projection/JacobiSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/NncgSolver.cpp
+++ b/dart/math/lcp/projection/NncgSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/NncgSolver.hpp
+++ b/dart/math/lcp/projection/NncgSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/PgsSolver.cpp
+++ b/dart/math/lcp/projection/PgsSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/PgsSolver.hpp
+++ b/dart/math/lcp/projection/PgsSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/RedBlackGaussSeidelSolver.cpp
+++ b/dart/math/lcp/projection/RedBlackGaussSeidelSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/RedBlackGaussSeidelSolver.hpp
+++ b/dart/math/lcp/projection/RedBlackGaussSeidelSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/SubspaceMinimizationSolver.cpp
+++ b/dart/math/lcp/projection/SubspaceMinimizationSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/SubspaceMinimizationSolver.hpp
+++ b/dart/math/lcp/projection/SubspaceMinimizationSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/SymmetricPsorSolver.cpp
+++ b/dart/math/lcp/projection/SymmetricPsorSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/lcp/projection/SymmetricPsorSolver.hpp
+++ b/dart/math/lcp/projection/SymmetricPsorSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/Function.cpp
+++ b/dart/math/optimization/Function.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/Function.hpp
+++ b/dart/math/optimization/Function.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/GradientDescentSolver.cpp
+++ b/dart/math/optimization/GradientDescentSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/GradientDescentSolver.hpp
+++ b/dart/math/optimization/GradientDescentSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/Problem.cpp
+++ b/dart/math/optimization/Problem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/Problem.hpp
+++ b/dart/math/optimization/Problem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/Solver.cpp
+++ b/dart/math/optimization/Solver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/optimization/Solver.hpp
+++ b/dart/math/optimization/Solver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Function.hpp
+++ b/dart/optimizer/Function.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the same BSD-style license as DART.

--- a/dart/optimizer/GradientDescentSolver.hpp
+++ b/dart/optimizer/GradientDescentSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  */
 

--- a/dart/optimizer/Problem.hpp
+++ b/dart/optimizer/Problem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the same BSD-style license as DART.

--- a/dart/optimizer/Solver.hpp
+++ b/dart/optimizer/Solver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the same BSD-style license as DART.

--- a/dart/optimizer/ipopt/Export.hpp
+++ b/dart/optimizer/ipopt/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/nlopt/Export.hpp
+++ b/dart/optimizer/nlopt/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/pagmo/Export.hpp
+++ b/dart/optimizer/pagmo/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/sensor/Fwd.hpp
+++ b/dart/sensor/Fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/sensor/Sensor.cpp
+++ b/dart/sensor/Sensor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/sensor/Sensor.hpp
+++ b/dart/sensor/Sensor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/sensor/SensorManager.cpp
+++ b/dart/sensor/SensorManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/sensor/SensorManager.hpp
+++ b/dart/sensor/SensorManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/Fwd.hpp
+++ b/dart/simulation/Fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/Recording.cpp
+++ b/dart/simulation/Recording.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/Recording.hpp
+++ b/dart/simulation/Recording.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/SmartPointer.hpp
+++ b/dart/simulation/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/detail/World-impl.hpp
+++ b/dart/simulation/detail/World-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/CMakeLists.txt
+++ b/dart/simulation/experimental/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/dart/simulation/experimental/body/rigid_body.cpp
+++ b/dart/simulation/experimental/body/rigid_body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/body/rigid_body.hpp
+++ b/dart/simulation/experimental/body/rigid_body.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/body/rigid_body_options.hpp
+++ b/dart/simulation/experimental/body/rigid_body_options.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/assert.hpp
+++ b/dart/simulation/experimental/common/assert.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/constants.hpp
+++ b/dart/simulation/experimental/common/constants.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/diagnostics.cpp
+++ b/dart/simulation/experimental/common/diagnostics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/diagnostics.hpp
+++ b/dart/simulation/experimental/common/diagnostics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/ecs_utils.hpp
+++ b/dart/simulation/experimental/common/ecs_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/exceptions.cpp
+++ b/dart/simulation/experimental/common/exceptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/exceptions.hpp
+++ b/dart/simulation/experimental/common/exceptions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/logging.hpp
+++ b/dart/simulation/experimental/common/logging.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/macros.hpp
+++ b/dart/simulation/experimental/common/macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/profiling.cpp
+++ b/dart/simulation/experimental/common/profiling.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/profiling.hpp
+++ b/dart/simulation/experimental/common/profiling.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/common/type_list.hpp
+++ b/dart/simulation/experimental/common/type_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/all.hpp
+++ b/dart/simulation/experimental/comps/all.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/component_category.hpp
+++ b/dart/simulation/experimental/comps/component_category.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/dynamics.cpp
+++ b/dart/simulation/experimental/comps/dynamics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/dynamics.hpp
+++ b/dart/simulation/experimental/comps/dynamics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/frame.hpp
+++ b/dart/simulation/experimental/comps/frame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/frame_types.cpp
+++ b/dart/simulation/experimental/comps/frame_types.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/frame_types.hpp
+++ b/dart/simulation/experimental/comps/frame_types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/joint.cpp
+++ b/dart/simulation/experimental/comps/joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/joint.hpp
+++ b/dart/simulation/experimental/comps/joint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/link.cpp
+++ b/dart/simulation/experimental/comps/link.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/link.hpp
+++ b/dart/simulation/experimental/comps/link.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/multi_body.cpp
+++ b/dart/simulation/experimental/comps/multi_body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/multi_body.hpp
+++ b/dart/simulation/experimental/comps/multi_body.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/name.cpp
+++ b/dart/simulation/experimental/comps/name.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/name.hpp
+++ b/dart/simulation/experimental/comps/name.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/rigid_body.cpp
+++ b/dart/simulation/experimental/comps/rigid_body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/comps/rigid_body.hpp
+++ b/dart/simulation/experimental/comps/rigid_body.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/ecs/entity_object.hpp
+++ b/dart/simulation/experimental/ecs/entity_object.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/ecs/entity_object_base.hpp
+++ b/dart/simulation/experimental/ecs/entity_object_base.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/ecs/entity_object_with.hpp
+++ b/dart/simulation/experimental/ecs/entity_object_with.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/ecs/entity_object_with_impl.hpp
+++ b/dart/simulation/experimental/ecs/entity_object_with_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/export.hpp
+++ b/dart/simulation/experimental/export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/frame/fixed_frame.cpp
+++ b/dart/simulation/experimental/frame/fixed_frame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/frame/fixed_frame.hpp
+++ b/dart/simulation/experimental/frame/fixed_frame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/frame/frame.cpp
+++ b/dart/simulation/experimental/frame/frame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/frame/frame.hpp
+++ b/dart/simulation/experimental/frame/frame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/frame/free_frame.cpp
+++ b/dart/simulation/experimental/frame/free_frame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/frame/free_frame.hpp
+++ b/dart/simulation/experimental/frame/free_frame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/fwd.hpp
+++ b/dart/simulation/experimental/fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/io/auto_serialization.hpp
+++ b/dart/simulation/experimental/io/auto_serialization.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/io/binary_io.cpp
+++ b/dart/simulation/experimental/io/binary_io.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/io/binary_io.hpp
+++ b/dart/simulation/experimental/io/binary_io.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/io/category_serializer.hpp
+++ b/dart/simulation/experimental/io/category_serializer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/io/serializer.cpp
+++ b/dart/simulation/experimental/io/serializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/io/serializer.hpp
+++ b/dart/simulation/experimental/io/serializer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/multi_body/joint.cpp
+++ b/dart/simulation/experimental/multi_body/joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/multi_body/joint.hpp
+++ b/dart/simulation/experimental/multi_body/joint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/multi_body/link.cpp
+++ b/dart/simulation/experimental/multi_body/link.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/multi_body/link.hpp
+++ b/dart/simulation/experimental/multi_body/link.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/multi_body/multi_body.cpp
+++ b/dart/simulation/experimental/multi_body/multi_body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/multi_body/multi_body.hpp
+++ b/dart/simulation/experimental/multi_body/multi_body.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/space/auto_mapper.hpp
+++ b/dart/simulation/experimental/space/auto_mapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/space/component_mapper.hpp
+++ b/dart/simulation/experimental/space/component_mapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/space/state_space.cpp
+++ b/dart/simulation/experimental/space/state_space.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/space/state_space.hpp
+++ b/dart/simulation/experimental/space/state_space.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/space/vector_mapper.cpp
+++ b/dart/simulation/experimental/space/vector_mapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/space/vector_mapper.hpp
+++ b/dart/simulation/experimental/space/vector_mapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/version.hpp
+++ b/dart/simulation/experimental/version.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/world.cpp
+++ b/dart/simulation/experimental/world.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/experimental/world.hpp
+++ b/dart/simulation/experimental/world.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/AssimpMeshLoader.hpp
+++ b/dart/utils/AssimpMeshLoader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/CompositeResourceRetriever.cpp
+++ b/dart/utils/CompositeResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/CompositeResourceRetriever.hpp
+++ b/dart/utils/CompositeResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/DartResourceRetriever.cpp
+++ b/dart/utils/DartResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/DartResourceRetriever.hpp
+++ b/dart/utils/DartResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/Export.hpp
+++ b/dart/utils/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoDof.cpp
+++ b/dart/utils/FileInfoDof.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoDof.hpp
+++ b/dart/utils/FileInfoDof.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoWorld.cpp
+++ b/dart/utils/FileInfoWorld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoWorld.hpp
+++ b/dart/utils/FileInfoWorld.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/Fwd.hpp
+++ b/dart/utils/Fwd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/HttpResourceRetriever.cpp
+++ b/dart/utils/HttpResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/HttpResourceRetriever.hpp
+++ b/dart/utils/HttpResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/MeshLoader.hpp
+++ b/dart/utils/MeshLoader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/PackageResourceRetriever.cpp
+++ b/dart/utils/PackageResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/PackageResourceRetriever.hpp
+++ b/dart/utils/PackageResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/SkelParser.hpp
+++ b/dart/utils/SkelParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/XmlHelpers.hpp
+++ b/dart/utils/XmlHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/detail/XmlHelpers-impl.hpp
+++ b/dart/utils/detail/XmlHelpers-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/MjcfParser.hpp
+++ b/dart/utils/mjcf/MjcfParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Asset.cpp
+++ b/dart/utils/mjcf/detail/Asset.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Asset.hpp
+++ b/dart/utils/mjcf/detail/Asset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Body.hpp
+++ b/dart/utils/mjcf/detail/Body.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/BodyAttributes.cpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/BodyAttributes.hpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Compiler.cpp
+++ b/dart/utils/mjcf/detail/Compiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Compiler.hpp
+++ b/dart/utils/mjcf/detail/Compiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Default.cpp
+++ b/dart/utils/mjcf/detail/Default.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Default.hpp
+++ b/dart/utils/mjcf/detail/Default.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Equality.cpp
+++ b/dart/utils/mjcf/detail/Equality.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Equality.hpp
+++ b/dart/utils/mjcf/detail/Equality.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Error.cpp
+++ b/dart/utils/mjcf/detail/Error.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Error.hpp
+++ b/dart/utils/mjcf/detail/Error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Geom.cpp
+++ b/dart/utils/mjcf/detail/Geom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Geom.hpp
+++ b/dart/utils/mjcf/detail/Geom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/GeomAttributes.cpp
+++ b/dart/utils/mjcf/detail/GeomAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/GeomAttributes.hpp
+++ b/dart/utils/mjcf/detail/GeomAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Inertial.cpp
+++ b/dart/utils/mjcf/detail/Inertial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Inertial.hpp
+++ b/dart/utils/mjcf/detail/Inertial.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Joint.cpp
+++ b/dart/utils/mjcf/detail/Joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Joint.hpp
+++ b/dart/utils/mjcf/detail/Joint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/JointAttributes.cpp
+++ b/dart/utils/mjcf/detail/JointAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/JointAttributes.hpp
+++ b/dart/utils/mjcf/detail/JointAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Mesh.cpp
+++ b/dart/utils/mjcf/detail/Mesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Mesh.hpp
+++ b/dart/utils/mjcf/detail/Mesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MeshAttributes.cpp
+++ b/dart/utils/mjcf/detail/MeshAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MeshAttributes.hpp
+++ b/dart/utils/mjcf/detail/MeshAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MujocoModel.cpp
+++ b/dart/utils/mjcf/detail/MujocoModel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MujocoModel.hpp
+++ b/dart/utils/mjcf/detail/MujocoModel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Option.cpp
+++ b/dart/utils/mjcf/detail/Option.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Option.hpp
+++ b/dart/utils/mjcf/detail/Option.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Site.cpp
+++ b/dart/utils/mjcf/detail/Site.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Site.hpp
+++ b/dart/utils/mjcf/detail/Site.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Size.cpp
+++ b/dart/utils/mjcf/detail/Size.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Size.hpp
+++ b/dart/utils/mjcf/detail/Size.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Types.hpp
+++ b/dart/utils/mjcf/detail/Types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Utils.cpp
+++ b/dart/utils/mjcf/detail/Utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Utils.hpp
+++ b/dart/utils/mjcf/detail/Utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Weld.cpp
+++ b/dart/utils/mjcf/detail/Weld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Weld.hpp
+++ b/dart/utils/mjcf/detail/Weld.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/WeldAttributes.cpp
+++ b/dart/utils/mjcf/detail/WeldAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/WeldAttributes.hpp
+++ b/dart/utils/mjcf/detail/WeldAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Worldbody.cpp
+++ b/dart/utils/mjcf/detail/Worldbody.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Worldbody.hpp
+++ b/dart/utils/mjcf/detail/Worldbody.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/SdfParser.hpp
+++ b/dart/utils/sdf/SdfParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/detail/GeometryParsers.cpp
+++ b/dart/utils/sdf/detail/GeometryParsers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/detail/GeometryParsers.hpp
+++ b/dart/utils/sdf/detail/GeometryParsers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/detail/SdfHelpers.cpp
+++ b/dart/utils/sdf/detail/SdfHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/detail/SdfHelpers.hpp
+++ b/dart/utils/sdf/detail/SdfHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/DartLoader.hpp
+++ b/dart/utils/urdf/DartLoader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/Export.hpp
+++ b/dart/utils/urdf/Export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/IncludeUrdf.hpp
+++ b/dart/utils/urdf/IncludeUrdf.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/UrdfParser.cpp
+++ b/dart/utils/urdf/UrdfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/UrdfParser.hpp
+++ b/dart/utils/urdf/UrdfParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/add_delete_skels/main.cpp
+++ b/examples/add_delete_skels/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_puppet/main.cpp
+++ b/examples/atlas_puppet/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconEventHandler.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconEventHandler.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/Controller.cpp
+++ b/examples/atlas_simbicon/Controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/Controller.hpp
+++ b/examples/atlas_simbicon/Controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/State.cpp
+++ b/examples/atlas_simbicon/State.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/State.hpp
+++ b/examples/atlas_simbicon/State.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/StateMachine.cpp
+++ b/examples/atlas_simbicon/StateMachine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/StateMachine.hpp
+++ b/examples/atlas_simbicon/StateMachine.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/TerminalCondition.cpp
+++ b/examples/atlas_simbicon/TerminalCondition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/TerminalCondition.hpp
+++ b/examples/atlas_simbicon/TerminalCondition.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/main.cpp
+++ b/examples/atlas_simbicon/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/biped_stand/main.cpp
+++ b/examples/biped_stand/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/box_stacking/main.cpp
+++ b/examples/box_stacking/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/boxes/main.cpp
+++ b/examples/boxes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/capsule_ground_contact/main.cpp
+++ b/examples/capsule_ground_contact/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/coupler_constraint/main.cpp
+++ b/examples/coupler_constraint/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/csv_logger/main.cpp
+++ b/examples/csv_logger/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/drag_and_drop/main.cpp
+++ b/examples/drag_and_drop/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/empty/main.cpp
+++ b/examples/empty/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/fetch/main.cpp
+++ b/examples/fetch/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/free_joint_cases/main.cpp
+++ b/examples/free_joint_cases/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hardcoded_design/HardcodedEventHandler.cpp
+++ b/examples/hardcoded_design/HardcodedEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hardcoded_design/HardcodedEventHandler.hpp
+++ b/examples/hardcoded_design/HardcodedEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hardcoded_design/main.cpp
+++ b/examples/hardcoded_design/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/headless_simulation/main.cpp
+++ b/examples/headless_simulation/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/heightmap/main.cpp
+++ b/examples/heightmap/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hello_world/main.cpp
+++ b/examples/hello_world/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/human_joint_limits/HumanArmJointLimitConstraint.cpp
+++ b/examples/human_joint_limits/HumanArmJointLimitConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/human_joint_limits/HumanArmJointLimitConstraint.hpp
+++ b/examples/human_joint_limits/HumanArmJointLimitConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/human_joint_limits/HumanLegJointLimitConstraint.cpp
+++ b/examples/human_joint_limits/HumanLegJointLimitConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/human_joint_limits/HumanLegJointLimitConstraint.hpp
+++ b/examples/human_joint_limits/HumanLegJointLimitConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/human_joint_limits/main.cpp
+++ b/examples/human_joint_limits/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hybrid_dynamics/main.cpp
+++ b/examples/hybrid_dynamics/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/imgui/main.cpp
+++ b/examples/imgui/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/joint_constraints/Controller.cpp
+++ b/examples/joint_constraints/Controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/joint_constraints/Controller.hpp
+++ b/examples/joint_constraints/Controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/joint_constraints/main.cpp
+++ b/examples/joint_constraints/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/lcp_solvers/main.cpp
+++ b/examples/lcp_solvers/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/mimic_pendulums/main.cpp
+++ b/examples/mimic_pendulums/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/mixed_chain/main.cpp
+++ b/examples/mixed_chain/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/operational_space_control/main.cpp
+++ b/examples/operational_space_control/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/polyhedron_visual/main.cpp
+++ b/examples/polyhedron_visual/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/raylib/main.cpp
+++ b/examples/raylib/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/rigid_chain/main.cpp
+++ b/examples/rigid_chain/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/rigid_cubes/main.cpp
+++ b/examples/rigid_cubes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/rigid_loop/main.cpp
+++ b/examples/rigid_loop/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/rigid_shapes/main.cpp
+++ b/examples/rigid_shapes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/simple_frames/main.cpp
+++ b/examples/simple_frames/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/simulation_event_handler/SimulationEventHandler.cpp
+++ b/examples/simulation_event_handler/SimulationEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/simulation_event_handler/SimulationEventHandler.hpp
+++ b/examples/simulation_event_handler/SimulationEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/simulation_event_handler/main.cpp
+++ b/examples/simulation_event_handler/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/soft_bodies/main.cpp
+++ b/examples/soft_bodies/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/speed_test/main.cpp
+++ b/examples/speed_test/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWidget.cpp
+++ b/examples/tinkertoy/TinkertoyWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWidget.hpp
+++ b/examples/tinkertoy/TinkertoyWidget.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWorldNode.cpp
+++ b/examples/tinkertoy/TinkertoyWorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWorldNode.hpp
+++ b/examples/tinkertoy/TinkertoyWorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/main.cpp
+++ b/examples/tinkertoy/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/unified_loading/main.cpp
+++ b/examples/unified_loading/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/vehicle/main.cpp
+++ b/examples/vehicle/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/Helpers.cpp
+++ b/examples/wam_ikfast/Helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/Helpers.hpp
+++ b/examples/wam_ikfast/Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/InputHandler.cpp
+++ b/examples/wam_ikfast/InputHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/InputHandler.hpp
+++ b/examples/wam_ikfast/InputHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/WamWorld.cpp
+++ b/examples/wam_ikfast/WamWorld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/WamWorld.hpp
+++ b/examples/wam_ikfast/WamWorld.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/osgWamIkFast.cpp
+++ b/examples/wam_ikfast/osgWamIkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dartpy.cpp
+++ b/python/dartpy/dartpy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/math/TriMesh.cpp
+++ b/python/dartpy/math/TriMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/math/constants.cpp
+++ b/python/dartpy/math/constants.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/math/geometry.cpp
+++ b/python/dartpy/math/geometry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:

--- a/python/dartpy/math/module.cpp
+++ b/python/dartpy/math/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/math/random.cpp
+++ b/python/dartpy/math/random.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/examples/atlas_puppet/main.py
+++ b/python/examples/atlas_puppet/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tests/unit/common/test_string.py
+++ b/python/tests/unit/common/test_string.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tests/unit/utils/test_sdf_parser.py
+++ b/python/tests/unit/utils/test_sdf_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tests/unit/utils/test_skel_parser.py
+++ b/python/tests/unit/utils/test_skel_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/01_multi_pendulum/main.py
+++ b/python/tutorials/01_multi_pendulum/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/01_multi_pendulum/main_finished.py
+++ b/python/tutorials/01_multi_pendulum/main_finished.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/02_collisions/main.py
+++ b/python/tutorials/02_collisions/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/02_collisions/main_finished.py
+++ b/python/tutorials/02_collisions/main_finished.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/03_dominoes/main.py
+++ b/python/tutorials/03_dominoes/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/03_dominoes/main_finished.py
+++ b/python/tutorials/03_dominoes/main_finished.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/04_biped/main.py
+++ b/python/tutorials/04_biped/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tutorials/04_biped/main_finished.py
+++ b/python/tutorials/04_biped/main_finished.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/tests/baseline/CMakeLists.txt
+++ b/tests/baseline/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 #
 # Baseline ODE LCP Solver Library
 # This is the original ODE implementation used as ground truth for testing

--- a/tests/benchmark/collision/bm_boxes.cpp
+++ b/tests/benchmark/collision/bm_boxes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/dynamics/bm_kinematics.cpp
+++ b/tests/benchmark/dynamics/bm_kinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/integration/bm_empty.cpp
+++ b/tests/benchmark/integration/bm_empty.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/lcpsolver/CMakeLists.txt
+++ b/tests/benchmark/lcpsolver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 #
 # Benchmark tests for LCP solvers
 

--- a/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/lcpsolver/bm_lcpsolver.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcpsolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/lcpsolver/bm_lcpsolver_solvers.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcpsolver_solvers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/lcpsolver/bm_matrix_multiply.cpp
+++ b/tests/benchmark/lcpsolver/bm_matrix_multiply.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/lcpsolver/bm_row_swapping.cpp
+++ b/tests/benchmark/lcpsolver/bm_row_swapping.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  */
 

--- a/tests/benchmark/simulation/experimental/bm_ecs_safety.cpp
+++ b/tests/benchmark/simulation/experimental/bm_ecs_safety.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/unit/bm_convhull.cpp
+++ b/tests/benchmark/unit/bm_convhull.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 #
 # Common test utilities shared across test types
 

--- a/tests/common/lcpsolver/CMakeLists.txt
+++ b/tests/common/lcpsolver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 #
 # Common test utilities for LCP solver tests
 

--- a/tests/common/lcpsolver/LCPTestProblems.hpp
+++ b/tests/common/lcpsolver/LCPTestProblems.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/common/lcpsolver/LcpTestFixtures.hpp
+++ b/tests/common/lcpsolver/LcpTestFixtures.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/common/lcpsolver/LcpTestHarness.hpp
+++ b/tests/common/lcpsolver/LcpTestHarness.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/helpers/GTestUtils.hpp
+++ b/tests/helpers/GTestUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/helpers/common_helpers.hpp
+++ b/tests/helpers/common_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/helpers/dynamics_helpers.hpp
+++ b/tests/helpers/dynamics_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 # ==============================================================================
 # Collision Tests

--- a/tests/integration/collision/test_BulletBoxStack.cpp
+++ b/tests/integration/collision/test_BulletBoxStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_BulletCylinderRolling.cpp
+++ b/tests/integration/collision/test_BulletCylinderRolling.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_BulletEllipsoidRolling.cpp
+++ b/tests/integration/collision/test_BulletEllipsoidRolling.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_CapsuleGroundContact.cpp
+++ b/tests/integration/collision/test_CapsuleGroundContact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_Collision.cpp
+++ b/tests/integration/collision/test_Collision.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_CollisionAccuracy.cpp
+++ b/tests/integration/collision/test_CollisionAccuracy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_CollisionGroups.cpp
+++ b/tests/integration/collision/test_CollisionGroups.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_ContactGrouping.cpp
+++ b/tests/integration/collision/test_ContactGrouping.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_FclPrimitiveContactMatrix.cpp
+++ b/tests/integration/collision/test_FclPrimitiveContactMatrix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_FclPrimitiveContactMatrixFcl.cpp
+++ b/tests/integration/collision/test_FclPrimitiveContactMatrixFcl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_MeshContactRegression.cpp
+++ b/tests/integration/collision/test_MeshContactRegression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_NoFalseContacts.cpp
+++ b/tests/integration/collision/test_NoFalseContacts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_PlaneShapeCollision.cpp
+++ b/tests/integration/collision/test_PlaneShapeCollision.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/collision/test_SelfCollisionFiltering.cpp
+++ b/tests/integration/collision/test_SelfCollisionFiltering.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/constraint/test_Constraint.cpp
+++ b/tests/integration/constraint/test_Constraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/constraint/test_ContactConstraint.cpp
+++ b/tests/integration/constraint/test_ContactConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/constraint/test_ForceDependentSlip.cpp
+++ b/tests/integration/constraint/test_ForceDependentSlip.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/constraint/test_Friction.cpp
+++ b/tests/integration/constraint/test_Friction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/constraint/test_LcpSolverStability.cpp
+++ b/tests/integration/constraint/test_LcpSolverStability.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/constraint/test_SplitImpulse.cpp
+++ b/tests/integration/constraint/test_SplitImpulse.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/DynamicsTestFixture.cpp
+++ b/tests/integration/dynamics/DynamicsTestFixture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_AtlasIK.cpp
+++ b/tests/integration/dynamics/test_AtlasIK.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_ForwardKinematics.cpp
+++ b/tests/integration/dynamics/test_ForwardKinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_JointForceTorque.cpp
+++ b/tests/integration/dynamics/test_JointForceTorque.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_Joints.cpp
+++ b/tests/integration/dynamics/test_Joints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_MetaSkeleton.cpp
+++ b/tests/integration/dynamics/test_MetaSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_NameManagement.cpp
+++ b/tests/integration/dynamics/test_NameManagement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_ServoJointLimits.cpp
+++ b/tests/integration/dynamics/test_ServoJointLimits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_Skeleton.cpp
+++ b/tests/integration/dynamics/test_Skeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_SkeletonState.cpp
+++ b/tests/integration/dynamics/test_SkeletonState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_SkeletonTopology.cpp
+++ b/tests/integration/dynamics/test_SkeletonTopology.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_SoftDynamics.cpp
+++ b/tests/integration/dynamics/test_SoftDynamics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/dynamics/test_UniversalJointLimits.cpp
+++ b/tests/integration/dynamics/test_UniversalJointLimits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/SharedLibraryWamIkFast.cpp
+++ b/tests/integration/io/SharedLibraryWamIkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/SharedLibraryWamIkFast.hpp
+++ b/tests/integration/io/SharedLibraryWamIkFast.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/test_IkFast.cpp
+++ b/tests/integration/io/test_IkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/test_MjcfParser.cpp
+++ b/tests/integration/io/test_MjcfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/test_Read.cpp
+++ b/tests/integration/io/test_Read.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/test_SdfParser.cpp
+++ b/tests/integration/io/test_SdfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/test_SkelParser.cpp
+++ b/tests/integration/io/test_SkelParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/test_UrdfMaterialParsing.cpp
+++ b/tests/integration/io/test_UrdfMaterialParsing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/io/test_UrdfParser.cpp
+++ b/tests/integration/io/test_UrdfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/optimization/test_InverseKinematics.cpp
+++ b/tests/integration/optimization/test_InverseKinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/optimization/test_Optimizer.cpp
+++ b/tests/integration/optimization/test_Optimizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_Building.cpp
+++ b/tests/integration/simulation/test_Building.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_FileInfoWorld.cpp
+++ b/tests/integration/simulation/test_FileInfoWorld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_Issue410.cpp
+++ b/tests/integration/simulation/test_Issue410.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_Issue743.cpp
+++ b/tests/integration/simulation/test_Issue743.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_Issue870.cpp
+++ b/tests/integration/simulation/test_Issue870.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_MimicConstraint.cpp
+++ b/tests/integration/simulation/test_MimicConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_MomentumConservation.cpp
+++ b/tests/integration/simulation/test_MomentumConservation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_Sensors.cpp
+++ b/tests/integration/simulation/test_Sensors.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/simulation/test_World.cpp
+++ b/tests/integration/simulation/test_World.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_Aspect.cpp
+++ b/tests/integration/utils/test_Aspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_CompositeResourceRetriever.cpp
+++ b/tests/integration/utils/test_CompositeResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_Concurrency.cpp
+++ b/tests/integration/utils/test_Concurrency.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_DartResourceRetriever.cpp
+++ b/tests/integration/utils/test_DartResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_Frames.cpp
+++ b/tests/integration/utils/test_Frames.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_LocalResourceRetriever.cpp
+++ b/tests/integration/utils/test_LocalResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_PackageResourceRetriever.cpp
+++ b/tests/integration/utils/test_PackageResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_Signal.cpp
+++ b/tests/integration/utils/test_Signal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/utils/test_Subscriptions.cpp
+++ b/tests/integration/utils/test_Subscriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 # ==============================================================================
 # Collision Tests

--- a/tests/unit/collision/test_BulletContact.cpp
+++ b/tests/unit/collision/test_BulletContact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_CollisionGroup.cpp
+++ b/tests/unit/collision/test_CollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_CollisionResult.cpp
+++ b/tests/unit/collision/test_CollisionResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_Contact.cpp
+++ b/tests/unit/collision/test_Contact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_ConvexMeshShapeCollision.cpp
+++ b/tests/unit/collision/test_ConvexMeshShapeCollision.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_Distance.cpp
+++ b/tests/unit/collision/test_Distance.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_DistanceFilter.cpp
+++ b/tests/unit/collision/test_DistanceFilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_FCLCollisionObject.cpp
+++ b/tests/unit/collision/test_FCLCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_OdeHeightmap.cpp
+++ b/tests/unit/collision/test_OdeHeightmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/collision/test_Raycast.cpp
+++ b/tests/unit/collision/test_Raycast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_CAllocator.cpp
+++ b/tests/unit/common/test_CAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Composite.cpp
+++ b/tests/unit/common/test_Composite.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Factory.cpp
+++ b/tests/unit/common/test_Factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_FreeListAllocator.cpp
+++ b/tests/unit/common/test_FreeListAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Logging.cpp
+++ b/tests/unit/common/test_Logging.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_MemoryManager.cpp
+++ b/tests/unit/common/test_MemoryManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_PoolAllocator.cpp
+++ b/tests/unit/common/test_PoolAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Profile.cpp
+++ b/tests/unit/common/test_Profile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Resource.cpp
+++ b/tests/unit/common/test_Resource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_StlAllocator.cpp
+++ b/tests/unit/common/test_StlAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Stopwatch.cpp
+++ b/tests/unit/common/test_Stopwatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_String.cpp
+++ b/tests/unit/common/test_String.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_SubjectObserver.cpp
+++ b/tests/unit/common/test_SubjectObserver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Uri.cpp
+++ b/tests/unit/common/test_Uri.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/constraint/test_BalanceConstraint.cpp
+++ b/tests/unit/constraint/test_BalanceConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/constraint/test_BoxedLcpConstraintSolver.cpp
+++ b/tests/unit/constraint/test_BoxedLcpConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the BSD-style License.

--- a/tests/unit/constraint/test_ConstraintSolver.cpp
+++ b/tests/unit/constraint/test_ConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the BSD-style License.

--- a/tests/unit/constraint/test_JointLimitConstraint.cpp
+++ b/tests/unit/constraint/test_JointLimitConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_BodyNodeCollisionSignals.cpp
+++ b/tests/unit/dynamics/test_BodyNodeCollisionSignals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_BodyNodeDerivatives.cpp
+++ b/tests/unit/dynamics/test_BodyNodeDerivatives.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_BodyNodePotentialEnergy.cpp
+++ b/tests/unit/dynamics/test_BodyNodePotentialEnergy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_ConvexMeshShape.cpp
+++ b/tests/unit/dynamics/test_ConvexMeshShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_CreateShapeNodeApi.cpp
+++ b/tests/unit/dynamics/test_CreateShapeNodeApi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_GenericJoints.cpp
+++ b/tests/unit/dynamics/test_GenericJoints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_HeightmapShape.cpp
+++ b/tests/unit/dynamics/test_HeightmapShape.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2025, The DART development contributors
+// Copyright (c) 2011-2026, The DART development contributors
 
 #include <dart/dynamics/HeightmapShape.hpp>
 

--- a/tests/unit/dynamics/test_Inertia.cpp
+++ b/tests/unit/dynamics/test_Inertia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_ScrewJoint.cpp
+++ b/tests/unit/dynamics/test_ScrewJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_ShapeNodeInertia.cpp
+++ b/tests/unit/dynamics/test_ShapeNodeInertia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_ShapeNodePtr.cpp
+++ b/tests/unit/dynamics/test_ShapeNodePtr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_SkeletonAccessors.cpp
+++ b/tests/unit/dynamics/test_SkeletonAccessors.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_SkeletonClone.cpp
+++ b/tests/unit/dynamics/test_SkeletonClone.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_WeldJointMerge.cpp
+++ b/tests/unit/dynamics/test_WeldJointMerge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/gui/test_ConvexMeshShapeNode.cpp
+++ b/tests/unit/gui/test_ConvexMeshShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:

--- a/tests/unit/gui/test_HeightmapShapeNode.cpp
+++ b/tests/unit/gui/test_HeightmapShapeNode.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2025, The DART development contributors
+// Copyright (c) 2011-2026, The DART development contributors
 
 #include <dart/gui/render/detail/HeightmapShapeGeometry.hpp>
 

--- a/tests/unit/gui/test_ImGuiWindowScaling.cpp
+++ b/tests/unit/gui/test_ImGuiWindowScaling.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:

--- a/tests/unit/gui/test_MeshShapeNodeMaterialUpdates.cpp
+++ b/tests/unit/gui/test_MeshShapeNodeMaterialUpdates.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:

--- a/tests/unit/gui/test_PlaneShapeNode.cpp
+++ b/tests/unit/gui/test_PlaneShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:

--- a/tests/unit/io/test_Read.cpp
+++ b/tests/unit/io/test_Read.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_DantzigSolver.cpp
+++ b/tests/unit/math/lcp/test_DantzigSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_DantzigVsODE.cpp
+++ b/tests/unit/math/lcp/test_DantzigVsODE.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_LCPTestProblems.cpp
+++ b/tests/unit/math/lcp/test_LCPTestProblems.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_LcpComparisonHarness.cpp
+++ b/tests/unit/math/lcp/test_LcpComparisonHarness.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_LcpEdgeCases.cpp
+++ b/tests/unit/math/lcp/test_LcpEdgeCases.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_LcpSolversStress.cpp
+++ b/tests/unit/math/lcp/test_LcpSolversStress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_Lemke.cpp
+++ b/tests/unit/math/lcp/test_Lemke.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_PGS.cpp
+++ b/tests/unit/math/lcp/test_PGS.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/lcp/test_PivotMatrix.cpp
+++ b/tests/unit/math/lcp/test_PivotMatrix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  */
 

--- a/tests/unit/math/test_ConfigurationSpace.cpp
+++ b/tests/unit/math/test_ConfigurationSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Convhull.cpp
+++ b/tests/unit/math/test_Convhull.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Geometry.cpp
+++ b/tests/unit/math/test_Geometry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Icosphere.cpp
+++ b/tests/unit/math/test_Icosphere.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Math.cpp
+++ b/tests/unit/math/test_Math.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_PolygonMesh.cpp
+++ b/tests/unit/math/test_PolygonMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Random.cpp
+++ b/tests/unit/math/test_Random.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_TriMesh.cpp
+++ b/tests/unit/math/test_TriMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_ValueEqual.cpp
+++ b/tests/unit/math/test_ValueEqual.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/CMakeLists.txt
+++ b/tests/unit/simulation/experimental/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/common/test_assert.cpp
+++ b/tests/unit/simulation/experimental/common/test_assert.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/common/test_logging.cpp
+++ b/tests/unit/simulation/experimental/common/test_logging.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/frame/test_frame.cpp
+++ b/tests/unit/simulation/experimental/frame/test_frame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/multi_body/test_multi_body.cpp
+++ b/tests/unit/simulation/experimental/multi_body/test_multi_body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/space/test_auto_mapper.cpp
+++ b/tests/unit/simulation/experimental/space/test_auto_mapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/space/test_state_space.cpp
+++ b/tests/unit/simulation/experimental/space/test_state_space.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/space/test_vector_mapper.cpp
+++ b/tests/unit/simulation/experimental/space/test_vector_mapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/world/test_frames.cpp
+++ b/tests/unit/simulation/experimental/world/test_frames.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/world/test_serialization.cpp
+++ b/tests/unit/simulation/experimental/world/test_serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/utils/test_MeshLoader.cpp
+++ b/tests/unit/utils/test_MeshLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file provides unit tests for the new MeshLoader abstraction

--- a/tests/unit/utils/test_XmlHelpers.cpp
+++ b/tests/unit/utils/test_XmlHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:

--- a/tutorials/tutorial_biped/main.cpp
+++ b/tutorials/tutorial_biped/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_biped_finished/main.cpp
+++ b/tutorials/tutorial_biped_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_collisions/main.cpp
+++ b/tutorials/tutorial_collisions/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_collisions_finished/main.cpp
+++ b/tutorials/tutorial_collisions_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_dominoes/main.cpp
+++ b/tutorials/tutorial_dominoes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_dominoes_finished/main.cpp
+++ b/tutorials/tutorial_dominoes_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_multi_pendulum/main.cpp
+++ b/tutorials/tutorial_multi_pendulum/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_multi_pendulum_finished/main.cpp
+++ b/tutorials/tutorial_multi_pendulum_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_wholebody_ik/CMakeLists.txt
+++ b/tutorials/tutorial_wholebody_ik/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 get_filename_component(tutorial_name ${CMAKE_CURRENT_LIST_DIR} NAME)
 

--- a/tutorials/tutorial_wholebody_ik/main.cpp
+++ b/tutorials/tutorial_wholebody_ik/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_wholebody_ik_finished/CMakeLists.txt
+++ b/tutorials/tutorial_wholebody_ik_finished/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 get_filename_component(tutorial_name ${CMAKE_CURRENT_LIST_DIR} NAME)
 

--- a/tutorials/tutorial_wholebody_ik_finished/main.cpp
+++ b/tutorials/tutorial_wholebody_ik_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:


### PR DESCRIPTION
## Summary

Update all source file copyright headers from `2011-2025` to `2011-2026` as new DART releases are being made in 2026.

## Changes

- Updated 1016 source files (`.hpp`, `.cpp`, `.h`, `.c`, `.py`, `CMakeLists.txt`)
- Pattern: `Copyright (c) 2011-2025` → `Copyright (c) 2011-2026`

## Testing

- Lint passed
- No functional changes, copyright header update only