### PR TITLE
Update copyright year to 2026 (DART 6.16)

### DIFF
--- a/dart/collision/CollisionDetector.cpp
+++ b/dart/collision/CollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionDetector.hpp
+++ b/dart/collision/CollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionFilter.cpp
+++ b/dart/collision/CollisionFilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionGroup.cpp
+++ b/dart/collision/CollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionGroup.hpp
+++ b/dart/collision/CollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionObject.cpp
+++ b/dart/collision/CollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionObject.hpp
+++ b/dart/collision/CollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionOption.cpp
+++ b/dart/collision/CollisionOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionOption.hpp
+++ b/dart/collision/CollisionOption.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionResult.cpp
+++ b/dart/collision/CollisionResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/CollisionResult.hpp
+++ b/dart/collision/CollisionResult.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/Contact.cpp
+++ b/dart/collision/Contact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/Contact.hpp
+++ b/dart/collision/Contact.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceFilter.cpp
+++ b/dart/collision/DistanceFilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceFilter.hpp
+++ b/dart/collision/DistanceFilter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceOption.cpp
+++ b/dart/collision/DistanceOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceOption.hpp
+++ b/dart/collision/DistanceOption.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceResult.cpp
+++ b/dart/collision/DistanceResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/DistanceResult.hpp
+++ b/dart/collision/DistanceResult.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/Option.hpp
+++ b/dart/collision/Option.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastOption.cpp
+++ b/dart/collision/RaycastOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastOption.hpp
+++ b/dart/collision/RaycastOption.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastResult.cpp
+++ b/dart/collision/RaycastResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/RaycastResult.hpp
+++ b/dart/collision/RaycastResult.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/Result.hpp
+++ b/dart/collision/Result.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/SmartPointer.hpp
+++ b/dart/collision/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionDetector.hpp
+++ b/dart/collision/bullet/BulletCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionGroup.cpp
+++ b/dart/collision/bullet/BulletCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionGroup.hpp
+++ b/dart/collision/bullet/BulletCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionObject.cpp
+++ b/dart/collision/bullet/BulletCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionObject.hpp
+++ b/dart/collision/bullet/BulletCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionShape.cpp
+++ b/dart/collision/bullet/BulletCollisionShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletCollisionShape.hpp
+++ b/dart/collision/bullet/BulletCollisionShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletInclude.hpp
+++ b/dart/collision/bullet/BulletInclude.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletTypes.cpp
+++ b/dart/collision/bullet/BulletTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/BulletTypes.hpp
+++ b/dart/collision/bullet/BulletTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
+++ b/dart/collision/bullet/detail/BulletCollisionDispatcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletCollisionDispatcher.hpp
+++ b/dart/collision/bullet/detail/BulletCollisionDispatcher.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
+++ b/dart/collision/bullet/detail/BulletOverlapFilterCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/bullet/detail/BulletOverlapFilterCallback.hpp
+++ b/dart/collision/bullet/detail/BulletOverlapFilterCallback.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollide.hpp
+++ b/dart/collision/dart/DARTCollide.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionDetector.hpp
+++ b/dart/collision/dart/DARTCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionGroup.cpp
+++ b/dart/collision/dart/DARTCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionGroup.hpp
+++ b/dart/collision/dart/DARTCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionObject.cpp
+++ b/dart/collision/dart/DARTCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/dart/DARTCollisionObject.hpp
+++ b/dart/collision/dart/DARTCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/CollisionDetector.hpp
+++ b/dart/collision/detail/CollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/CollisionGroup.hpp
+++ b/dart/collision/detail/CollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/Contact-impl.hpp
+++ b/dart/collision/detail/Contact-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/detail/UnorderedPairs.hpp
+++ b/dart/collision/detail/UnorderedPairs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/BackwardCompatibility.cpp
+++ b/dart/collision/fcl/BackwardCompatibility.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/CollisionShapes.hpp
+++ b/dart/collision/fcl/CollisionShapes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionDetector.hpp
+++ b/dart/collision/fcl/FCLCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionGroup.cpp
+++ b/dart/collision/fcl/FCLCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionGroup.hpp
+++ b/dart/collision/fcl/FCLCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionObject.cpp
+++ b/dart/collision/fcl/FCLCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLCollisionObject.hpp
+++ b/dart/collision/fcl/FCLCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLTypes.cpp
+++ b/dart/collision/fcl/FCLTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/FCLTypes.hpp
+++ b/dart/collision/fcl/FCLTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/fcl/tri_tri_intersection_test.hpp
+++ b/dart/collision/fcl/tri_tri_intersection_test.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionGroup.cpp
+++ b/dart/collision/ode/OdeCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionGroup.hpp
+++ b/dart/collision/ode/OdeCollisionGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeCollisionObject.hpp
+++ b/dart/collision/ode/OdeCollisionObject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeTypes.cpp
+++ b/dart/collision/ode/OdeTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/OdeTypes.hpp
+++ b/dart/collision/ode/OdeTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeBox.cpp
+++ b/dart/collision/ode/detail/OdeBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeBox.hpp
+++ b/dart/collision/ode/detail/OdeBox.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCapsule.cpp
+++ b/dart/collision/ode/detail/OdeCapsule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCapsule.hpp
+++ b/dart/collision/ode/detail/OdeCapsule.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinder.cpp
+++ b/dart/collision/ode/detail/OdeCylinder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinder.hpp
+++ b/dart/collision/ode/detail/OdeCylinder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinderMesh.cpp
+++ b/dart/collision/ode/detail/OdeCylinderMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeCylinderMesh.hpp
+++ b/dart/collision/ode/detail/OdeCylinderMesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeGeom.cpp
+++ b/dart/collision/ode/detail/OdeGeom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeGeom.hpp
+++ b/dart/collision/ode/detail/OdeGeom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeHeightmap-impl.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeHeightmap.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeMesh.cpp
+++ b/dart/collision/ode/detail/OdeMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeMesh.hpp
+++ b/dart/collision/ode/detail/OdeMesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdePlane.cpp
+++ b/dart/collision/ode/detail/OdePlane.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdePlane.hpp
+++ b/dart/collision/ode/detail/OdePlane.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeSphere.cpp
+++ b/dart/collision/ode/detail/OdeSphere.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/collision/ode/detail/OdeSphere.hpp
+++ b/dart/collision/ode/detail/OdeSphere.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Aspect.cpp
+++ b/dart/common/Aspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Aspect.hpp
+++ b/dart/common/Aspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/AspectWithVersion.hpp
+++ b/dart/common/AspectWithVersion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/CAllocator.cpp
+++ b/dart/common/CAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/CAllocator.hpp
+++ b/dart/common/CAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Castable.hpp
+++ b/dart/common/Castable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ClassWithVirtualBase.hpp
+++ b/dart/common/ClassWithVirtualBase.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Cloneable.hpp
+++ b/dart/common/Cloneable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Composite.cpp
+++ b/dart/common/Composite.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Composite.hpp
+++ b/dart/common/Composite.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/CompositeJoiner.hpp
+++ b/dart/common/CompositeJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Console.cpp
+++ b/dart/common/Console.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Console.hpp
+++ b/dart/common/Console.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Deprecated.hpp
+++ b/dart/common/Deprecated.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/EmbeddedAspect.hpp
+++ b/dart/common/EmbeddedAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Empty.hpp
+++ b/dart/common/Empty.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Factory.hpp
+++ b/dart/common/Factory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Filesystem.hpp
+++ b/dart/common/Filesystem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors:
+ * Copyright (c) 2011-2026, The DART development contributors:
  * https://github.com/dartsim/dart/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dart/common/FreeListAllocator.cpp
+++ b/dart/common/FreeListAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/FreeListAllocator.hpp
+++ b/dart/common/FreeListAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/IncludeWindows.hpp
+++ b/dart/common/IncludeWindows.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResource.cpp
+++ b/dart/common/LocalResource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResource.hpp
+++ b/dart/common/LocalResource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResourceRetriever.cpp
+++ b/dart/common/LocalResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LocalResourceRetriever.hpp
+++ b/dart/common/LocalResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/LockableReference.hpp
+++ b/dart/common/LockableReference.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Logging.hpp
+++ b/dart/common/Logging.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Macros.hpp
+++ b/dart/common/Macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Memory.hpp
+++ b/dart/common/Memory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryAllocator.cpp
+++ b/dart/common/MemoryAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryAllocator.hpp
+++ b/dart/common/MemoryAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryAllocatorDebugger.hpp
+++ b/dart/common/MemoryAllocatorDebugger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryManager.cpp
+++ b/dart/common/MemoryManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/MemoryManager.hpp
+++ b/dart/common/MemoryManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Metaprogramming.hpp
+++ b/dart/common/Metaprogramming.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/NameManager.hpp
+++ b/dart/common/NameManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Observer.cpp
+++ b/dart/common/Observer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Observer.hpp
+++ b/dart/common/Observer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Optional.hpp
+++ b/dart/common/Optional.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Platform.hpp
+++ b/dart/common/Platform.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/PoolAllocator.cpp
+++ b/dart/common/PoolAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/PoolAllocator.hpp
+++ b/dart/common/PoolAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Profile.hpp
+++ b/dart/common/Profile.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ProxyAspect.hpp
+++ b/dart/common/ProxyAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/RequiresAspect.hpp
+++ b/dart/common/RequiresAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Resource.cpp
+++ b/dart/common/Resource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Resource.hpp
+++ b/dart/common/Resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ResourceRetriever.cpp
+++ b/dart/common/ResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/ResourceRetriever.hpp
+++ b/dart/common/ResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SharedLibrary.cpp
+++ b/dart/common/SharedLibrary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SharedLibrary.hpp
+++ b/dart/common/SharedLibrary.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Signal.cpp
+++ b/dart/common/Signal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Signal.hpp
+++ b/dart/common/Signal.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Singleton.hpp
+++ b/dart/common/Singleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SmartPointer.hpp
+++ b/dart/common/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/SpecializedForAspect.hpp
+++ b/dart/common/SpecializedForAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/StlAllocator.hpp
+++ b/dart/common/StlAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/StlHelpers.hpp
+++ b/dart/common/StlHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Stopwatch.cpp
+++ b/dart/common/Stopwatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Stopwatch.hpp
+++ b/dart/common/Stopwatch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/String.cpp
+++ b/dart/common/String.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/String.hpp
+++ b/dart/common/String.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Subject.hpp
+++ b/dart/common/Subject.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Timer.cpp
+++ b/dart/common/Timer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Timer.hpp
+++ b/dart/common/Timer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Uri.cpp
+++ b/dart/common/Uri.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Uri.hpp
+++ b/dart/common/Uri.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/VersionCounter.cpp
+++ b/dart/common/VersionCounter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/VersionCounter.hpp
+++ b/dart/common/VersionCounter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/Virtual.hpp
+++ b/dart/common/Virtual.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Aspect.hpp
+++ b/dart/common/detail/Aspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/AspectWithVersion.hpp
+++ b/dart/common/detail/AspectWithVersion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Castable-impl.hpp
+++ b/dart/common/detail/Castable-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Cloneable.hpp
+++ b/dart/common/detail/Cloneable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Composite.hpp
+++ b/dart/common/detail/Composite.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/CompositeData.hpp
+++ b/dart/common/detail/CompositeData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/CompositeJoiner.hpp
+++ b/dart/common/detail/CompositeJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/ConnectionBody.cpp
+++ b/dart/common/detail/ConnectionBody.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/ConnectionBody.hpp
+++ b/dart/common/detail/ConnectionBody.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/EmbeddedAspect.hpp
+++ b/dart/common/detail/EmbeddedAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Factory-impl.hpp
+++ b/dart/common/detail/Factory-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/LockableReference-impl.hpp
+++ b/dart/common/detail/LockableReference-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Logging-impl.hpp
+++ b/dart/common/detail/Logging-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Memory-impl.hpp
+++ b/dart/common/detail/Memory-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/MemoryAllocator-impl.hpp
+++ b/dart/common/detail/MemoryAllocator-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/MemoryAllocatorDebugger-impl.hpp
+++ b/dart/common/detail/MemoryAllocatorDebugger-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/MemoryManager-impl.hpp
+++ b/dart/common/detail/MemoryManager-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Metaprogramming-impl.hpp
+++ b/dart/common/detail/Metaprogramming-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/NameManager.hpp
+++ b/dart/common/detail/NameManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/NoOp.hpp
+++ b/dart/common/detail/NoOp.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/ProxyAspect.hpp
+++ b/dart/common/detail/ProxyAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/RequiresAspect.hpp
+++ b/dart/common/detail/RequiresAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/SharedLibraryManager.cpp
+++ b/dart/common/detail/SharedLibraryManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/SharedLibraryManager.hpp
+++ b/dart/common/detail/SharedLibraryManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Signal.hpp
+++ b/dart/common/detail/Signal.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Singleton-impl.hpp
+++ b/dart/common/detail/Singleton-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/SpecializedForAspect.hpp
+++ b/dart/common/detail/SpecializedForAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/StlAllocator-impl.hpp
+++ b/dart/common/detail/StlAllocator-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/Stopwatch-impl.hpp
+++ b/dart/common/detail/Stopwatch-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/TemplateJoinerDispatchMacro.hpp
+++ b/dart/common/detail/TemplateJoinerDispatchMacro.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/detail/sub_ptr.hpp
+++ b/dart/common/detail/sub_ptr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/common/sub_ptr.hpp
+++ b/dart/common/sub_ptr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BalanceConstraint.cpp
+++ b/dart/constraint/BalanceConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BalanceConstraint.hpp
+++ b/dart/constraint/BalanceConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BallJointConstraint.cpp
+++ b/dart/constraint/BallJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BallJointConstraint.hpp
+++ b/dart/constraint/BallJointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/BoxedLcpSolver.hpp
+++ b/dart/constraint/BoxedLcpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstrainedGroup.cpp
+++ b/dart/constraint/ConstrainedGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstrainedGroup.hpp
+++ b/dart/constraint/ConstrainedGroup.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintBase.cpp
+++ b/dart/constraint/ConstraintBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintBase.hpp
+++ b/dart/constraint/ConstraintBase.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactSurface.cpp
+++ b/dart/constraint/ContactSurface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ContactSurface.hpp
+++ b/dart/constraint/ContactSurface.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DantzigBoxedLcpSolver.cpp
+++ b/dart/constraint/DantzigBoxedLcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DantzigBoxedLcpSolver.hpp
+++ b/dart/constraint/DantzigBoxedLcpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DantzigLCPSolver.cpp
+++ b/dart/constraint/DantzigLCPSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DantzigLCPSolver.hpp
+++ b/dart/constraint/DantzigLCPSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DynamicJointConstraint.cpp
+++ b/dart/constraint/DynamicJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/DynamicJointConstraint.hpp
+++ b/dart/constraint/DynamicJointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointConstraint.hpp
+++ b/dart/constraint/JointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointCoulombFrictionConstraint.cpp
+++ b/dart/constraint/JointCoulombFrictionConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointCoulombFrictionConstraint.hpp
+++ b/dart/constraint/JointCoulombFrictionConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointLimitConstraint.cpp
+++ b/dart/constraint/JointLimitConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/JointLimitConstraint.hpp
+++ b/dart/constraint/JointLimitConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/LCPSolver.cpp
+++ b/dart/constraint/LCPSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/LCPSolver.hpp
+++ b/dart/constraint/LCPSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/MimicMotorConstraint.cpp
+++ b/dart/constraint/MimicMotorConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/MimicMotorConstraint.hpp
+++ b/dart/constraint/MimicMotorConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/PGSLCPSolver.cpp
+++ b/dart/constraint/PGSLCPSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/PGSLCPSolver.hpp
+++ b/dart/constraint/PGSLCPSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/PgsBoxedLcpSolver.cpp
+++ b/dart/constraint/PgsBoxedLcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/PgsBoxedLcpSolver.hpp
+++ b/dart/constraint/PgsBoxedLcpSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ServoMotorConstraint.cpp
+++ b/dart/constraint/ServoMotorConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/ServoMotorConstraint.hpp
+++ b/dart/constraint/ServoMotorConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/SmartPointer.hpp
+++ b/dart/constraint/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/SoftContactConstraint.cpp
+++ b/dart/constraint/SoftContactConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/SoftContactConstraint.hpp
+++ b/dart/constraint/SoftContactConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/WeldJointConstraint.cpp
+++ b/dart/constraint/WeldJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/WeldJointConstraint.hpp
+++ b/dart/constraint/WeldJointConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/constraint/detail/ConstraintSolver-impl.hpp
+++ b/dart/constraint/detail/ConstraintSolver-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dart.cpp
+++ b/dart/dart.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dart.hpp
+++ b/dart/dart.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ArrowShape.hpp
+++ b/dart/dynamics/ArrowShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/AssimpInputResourceAdaptor.cpp
+++ b/dart/dynamics/AssimpInputResourceAdaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/AssimpInputResourceAdaptor.hpp
+++ b/dart/dynamics/AssimpInputResourceAdaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BallJoint.cpp
+++ b/dart/dynamics/BallJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BallJoint.hpp
+++ b/dart/dynamics/BallJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/BoxShape.hpp
+++ b/dart/dynamics/BoxShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Branch.cpp
+++ b/dart/dynamics/Branch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Branch.hpp
+++ b/dart/dynamics/Branch.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CapsuleShape.cpp
+++ b/dart/dynamics/CapsuleShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CapsuleShape.hpp
+++ b/dart/dynamics/CapsuleShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Chain.cpp
+++ b/dart/dynamics/Chain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Chain.hpp
+++ b/dart/dynamics/Chain.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CompositeNode.hpp
+++ b/dart/dynamics/CompositeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CylinderShape.cpp
+++ b/dart/dynamics/CylinderShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/CylinderShape.hpp
+++ b/dart/dynamics/CylinderShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/DegreeOfFreedom.cpp
+++ b/dart/dynamics/DegreeOfFreedom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/DegreeOfFreedom.hpp
+++ b/dart/dynamics/DegreeOfFreedom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EndEffector.cpp
+++ b/dart/dynamics/EndEffector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EndEffector.hpp
+++ b/dart/dynamics/EndEffector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Entity.cpp
+++ b/dart/dynamics/Entity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Entity.hpp
+++ b/dart/dynamics/Entity.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EntityNode.hpp
+++ b/dart/dynamics/EntityNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/EulerJoint.hpp
+++ b/dart/dynamics/EulerJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedFrame.cpp
+++ b/dart/dynamics/FixedFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedFrame.hpp
+++ b/dart/dynamics/FixedFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedJacobianNode.cpp
+++ b/dart/dynamics/FixedJacobianNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FixedJacobianNode.hpp
+++ b/dart/dynamics/FixedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Frame.cpp
+++ b/dart/dynamics/Frame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Frame.hpp
+++ b/dart/dynamics/Frame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/FreeJoint.hpp
+++ b/dart/dynamics/FreeJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/GenericJoint.hpp
+++ b/dart/dynamics/GenericJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Group.cpp
+++ b/dart/dynamics/Group.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Group.hpp
+++ b/dart/dynamics/Group.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/HeightmapShape.hpp
+++ b/dart/dynamics/HeightmapShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/HierarchicalIK.cpp
+++ b/dart/dynamics/HierarchicalIK.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/HierarchicalIK.hpp
+++ b/dart/dynamics/HierarchicalIK.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/IkFast.cpp
+++ b/dart/dynamics/IkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/IkFast.hpp
+++ b/dart/dynamics/IkFast.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Inertia.hpp
+++ b/dart/dynamics/Inertia.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/InvalidIndex.hpp
+++ b/dart/dynamics/InvalidIndex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/InverseKinematics.cpp
+++ b/dart/dynamics/InverseKinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/InverseKinematics.hpp
+++ b/dart/dynamics/InverseKinematics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/JacobianNode.cpp
+++ b/dart/dynamics/JacobianNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/JacobianNode.hpp
+++ b/dart/dynamics/JacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/LineSegmentShape.cpp
+++ b/dart/dynamics/LineSegmentShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/LineSegmentShape.hpp
+++ b/dart/dynamics/LineSegmentShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Linkage.cpp
+++ b/dart/dynamics/Linkage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Linkage.hpp
+++ b/dart/dynamics/Linkage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Marker.cpp
+++ b/dart/dynamics/Marker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Marker.hpp
+++ b/dart/dynamics/Marker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MetaSkeleton.cpp
+++ b/dart/dynamics/MetaSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MetaSkeleton.hpp
+++ b/dart/dynamics/MetaSkeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MimicDofProperties.hpp
+++ b/dart/dynamics/MimicDofProperties.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MultiSphereConvexHullShape.cpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MultiSphereConvexHullShape.hpp
+++ b/dart/dynamics/MultiSphereConvexHullShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/MultiSphereShape.hpp
+++ b/dart/dynamics/MultiSphereShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Node.cpp
+++ b/dart/dynamics/Node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Node.hpp
+++ b/dart/dynamics/Node.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/NodeManagerJoiner.hpp
+++ b/dart/dynamics/NodeManagerJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlanarJoint.cpp
+++ b/dart/dynamics/PlanarJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlanarJoint.hpp
+++ b/dart/dynamics/PlanarJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlaneShape.cpp
+++ b/dart/dynamics/PlaneShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PlaneShape.hpp
+++ b/dart/dynamics/PlaneShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointCloudShape.cpp
+++ b/dart/dynamics/PointCloudShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointCloudShape.hpp
+++ b/dart/dynamics/PointCloudShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PointMass.hpp
+++ b/dart/dynamics/PointMass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PrismaticJoint.cpp
+++ b/dart/dynamics/PrismaticJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PrismaticJoint.hpp
+++ b/dart/dynamics/PrismaticJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/PyramidShape.hpp
+++ b/dart/dynamics/PyramidShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ReferentialSkeleton.cpp
+++ b/dart/dynamics/ReferentialSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ReferentialSkeleton.hpp
+++ b/dart/dynamics/ReferentialSkeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/RevoluteJoint.cpp
+++ b/dart/dynamics/RevoluteJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/RevoluteJoint.hpp
+++ b/dart/dynamics/RevoluteJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ScrewJoint.cpp
+++ b/dart/dynamics/ScrewJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ScrewJoint.hpp
+++ b/dart/dynamics/ScrewJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Shape.cpp
+++ b/dart/dynamics/Shape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Shape.hpp
+++ b/dart/dynamics/Shape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeNode.cpp
+++ b/dart/dynamics/ShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ShapeNode.hpp
+++ b/dart/dynamics/ShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SharedLibraryIkFast.cpp
+++ b/dart/dynamics/SharedLibraryIkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SharedLibraryIkFast.hpp
+++ b/dart/dynamics/SharedLibraryIkFast.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SimpleFrame.cpp
+++ b/dart/dynamics/SimpleFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SimpleFrame.hpp
+++ b/dart/dynamics/SimpleFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SmartPointer.hpp
+++ b/dart/dynamics/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftBodyNode.cpp
+++ b/dart/dynamics/SoftBodyNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftBodyNode.hpp
+++ b/dart/dynamics/SoftBodyNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftMeshShape.cpp
+++ b/dart/dynamics/SoftMeshShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SoftMeshShape.hpp
+++ b/dart/dynamics/SoftMeshShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SpecializedNodeManager.hpp
+++ b/dart/dynamics/SpecializedNodeManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/SphereShape.hpp
+++ b/dart/dynamics/SphereShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TemplatedJacobianNode.hpp
+++ b/dart/dynamics/TemplatedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint.cpp
+++ b/dart/dynamics/TranslationalJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint.hpp
+++ b/dart/dynamics/TranslationalJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint2D.cpp
+++ b/dart/dynamics/TranslationalJoint2D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/TranslationalJoint2D.hpp
+++ b/dart/dynamics/TranslationalJoint2D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/UniversalJoint.cpp
+++ b/dart/dynamics/UniversalJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/UniversalJoint.hpp
+++ b/dart/dynamics/UniversalJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/VoxelGridShape.cpp
+++ b/dart/dynamics/VoxelGridShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/VoxelGridShape.hpp
+++ b/dart/dynamics/VoxelGridShape.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/WeldJoint.cpp
+++ b/dart/dynamics/WeldJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/WeldJoint.hpp
+++ b/dart/dynamics/WeldJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ZeroDofJoint.cpp
+++ b/dart/dynamics/ZeroDofJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/ZeroDofJoint.hpp
+++ b/dart/dynamics/ZeroDofJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BasicNodeManager.hpp
+++ b/dart/dynamics/detail/BasicNodeManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BodyNode.hpp
+++ b/dart/dynamics/detail/BodyNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BodyNodeAspect.hpp
+++ b/dart/dynamics/detail/BodyNodeAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/BodyNodePtr.hpp
+++ b/dart/dynamics/detail/BodyNodePtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/CompositeNode.hpp
+++ b/dart/dynamics/detail/CompositeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/DegreeOfFreedomPtr.hpp
+++ b/dart/dynamics/detail/DegreeOfFreedomPtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EndEffectorAspect.hpp
+++ b/dart/dynamics/detail/EndEffectorAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EntityNode.hpp
+++ b/dart/dynamics/detail/EntityNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EntityNodeAspect.cpp
+++ b/dart/dynamics/detail/EntityNodeAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EntityNodeAspect.hpp
+++ b/dart/dynamics/detail/EntityNodeAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EulerJointAspect.cpp
+++ b/dart/dynamics/detail/EulerJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/EulerJointAspect.hpp
+++ b/dart/dynamics/detail/EulerJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/FixedFrameAspect.hpp
+++ b/dart/dynamics/detail/FixedFrameAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/FixedJacobianNode.hpp
+++ b/dart/dynamics/detail/FixedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/GenericJointAspect.hpp
+++ b/dart/dynamics/detail/GenericJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/HeightmapShape-impl.hpp
+++ b/dart/dynamics/detail/HeightmapShape-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/InverseKinematics.hpp
+++ b/dart/dynamics/detail/InverseKinematics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/InverseKinematicsPtr.hpp
+++ b/dart/dynamics/detail/InverseKinematicsPtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/JointAspect.hpp
+++ b/dart/dynamics/detail/JointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/JointPtr.hpp
+++ b/dart/dynamics/detail/JointPtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/MarkerAspect.hpp
+++ b/dart/dynamics/detail/MarkerAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/MetaSkeleton-impl.hpp
+++ b/dart/dynamics/detail/MetaSkeleton-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/Node.hpp
+++ b/dart/dynamics/detail/Node.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/NodeManagerJoiner.hpp
+++ b/dart/dynamics/detail/NodeManagerJoiner.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/NodePtr.hpp
+++ b/dart/dynamics/detail/NodePtr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PlanarJointAspect.cpp
+++ b/dart/dynamics/detail/PlanarJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PlanarJointAspect.hpp
+++ b/dart/dynamics/detail/PlanarJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PrismaticJointAspect.cpp
+++ b/dart/dynamics/detail/PrismaticJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/PrismaticJointAspect.hpp
+++ b/dart/dynamics/detail/PrismaticJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/RevoluteJointAspect.cpp
+++ b/dart/dynamics/detail/RevoluteJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/RevoluteJointAspect.hpp
+++ b/dart/dynamics/detail/RevoluteJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ScrewJointAspect.cpp
+++ b/dart/dynamics/detail/ScrewJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ScrewJointAspect.hpp
+++ b/dart/dynamics/detail/ScrewJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ShapeFrameAspect.hpp
+++ b/dart/dynamics/detail/ShapeFrameAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/ShapeNode.hpp
+++ b/dart/dynamics/detail/ShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/Skeleton.hpp
+++ b/dart/dynamics/detail/Skeleton.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/SkeletonAspect.hpp
+++ b/dart/dynamics/detail/SkeletonAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/SoftBodyNodeAspect.hpp
+++ b/dart/dynamics/detail/SoftBodyNodeAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/SpecializedNodeManager.hpp
+++ b/dart/dynamics/detail/SpecializedNodeManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/TemplatedJacobianNode.hpp
+++ b/dart/dynamics/detail/TemplatedJacobianNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/UniversalJointAspect.cpp
+++ b/dart/dynamics/detail/UniversalJointAspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/dynamics/detail/UniversalJointAspect.hpp
+++ b/dart/dynamics/detail/UniversalJointAspect.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/external/convhull_3d/safe_convhull_3d.h
+++ b/dart/external/convhull_3d/safe_convhull_3d.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/GLFuncs.cpp
+++ b/dart/gui/GLFuncs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/GLFuncs.hpp
+++ b/dart/gui/GLFuncs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/GlutWindow.hpp
+++ b/dart/gui/GlutWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/GraphWindow.hpp
+++ b/dart/gui/GraphWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/LoadGlut.hpp
+++ b/dart/gui/LoadGlut.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/LoadOpengl.hpp
+++ b/dart/gui/LoadOpengl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/OpenGLRenderInterface.cpp
+++ b/dart/gui/OpenGLRenderInterface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/OpenGLRenderInterface.hpp
+++ b/dart/gui/OpenGLRenderInterface.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/RenderInterface.cpp
+++ b/dart/gui/RenderInterface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/RenderInterface.hpp
+++ b/dart/gui/RenderInterface.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/SimWindow.hpp
+++ b/dart/gui/SimWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/SoftSimWindow.hpp
+++ b/dart/gui/SoftSimWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Trackball.cpp
+++ b/dart/gui/Trackball.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Trackball.hpp
+++ b/dart/gui/Trackball.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Win2D.hpp
+++ b/dart/gui/Win2D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/Win3D.hpp
+++ b/dart/gui/Win3D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/GLUTFuncs.cpp
+++ b/dart/gui/glut/GLUTFuncs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/GLUTFuncs.hpp
+++ b/dart/gui/glut/GLUTFuncs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/GlutWindow.cpp
+++ b/dart/gui/glut/GlutWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/GraphWindow.cpp
+++ b/dart/gui/glut/GraphWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/GraphWindow.hpp
+++ b/dart/gui/glut/GraphWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/LoadGlut.hpp
+++ b/dart/gui/glut/LoadGlut.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/MotionBlurSimWindow.hpp
+++ b/dart/gui/glut/MotionBlurSimWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/SimWindow.cpp
+++ b/dart/gui/glut/SimWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/SimWindow.hpp
+++ b/dart/gui/glut/SimWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/SoftSimWindow.cpp
+++ b/dart/gui/glut/SoftSimWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/SoftSimWindow.hpp
+++ b/dart/gui/glut/SoftSimWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/Win2D.cpp
+++ b/dart/gui/glut/Win2D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/Win2D.hpp
+++ b/dart/gui/glut/Win2D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/Win3D.cpp
+++ b/dart/gui/glut/Win3D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/Win3D.hpp
+++ b/dart/gui/glut/Win3D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/glut/Window.hpp
+++ b/dart/gui/glut/Window.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/DefaultEventHandler.cpp
+++ b/dart/gui/osg/DefaultEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/DefaultEventHandler.hpp
+++ b/dart/gui/osg/DefaultEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/DragAndDrop.cpp
+++ b/dart/gui/osg/DragAndDrop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/DragAndDrop.hpp
+++ b/dart/gui/osg/DragAndDrop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/GridVisual.cpp
+++ b/dart/gui/osg/GridVisual.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/GridVisual.hpp
+++ b/dart/gui/osg/GridVisual.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/ImGuiHandler.cpp
+++ b/dart/gui/osg/ImGuiHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/ImGuiHandler.hpp
+++ b/dart/gui/osg/ImGuiHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/ImGuiViewer.cpp
+++ b/dart/gui/osg/ImGuiViewer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/ImGuiViewer.hpp
+++ b/dart/gui/osg/ImGuiViewer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/ImGuiWidget.cpp
+++ b/dart/gui/osg/ImGuiWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:
@@ -92,7 +92,7 @@ void AboutWidget::render()
   ImGui::Begin("About DART", &mIsVisible, ImGuiWindowFlags_AlwaysAutoResize);
   // ImGui::Text("HIT %s", Version::asString().c_str());
   ImGui::Separator();
-  ImGui::Text("Copyright (c) 2011-2025, The DART development contributors");
+  ImGui::Text("Copyright (c) 2011-2026, The DART development contributors");
   ImGui::Text("DART is licensed under the BSD 2 Clause License.");
   ImGui::Separator();
   ImGui::Text(

--- a/dart/gui/osg/ImGuiWidget.hpp
+++ b/dart/gui/osg/ImGuiWidget.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/IncludeImGui.hpp
+++ b/dart/gui/osg/IncludeImGui.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/InteractiveFrame.cpp
+++ b/dart/gui/osg/InteractiveFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/InteractiveFrame.hpp
+++ b/dart/gui/osg/InteractiveFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/MouseEventHandler.hpp
+++ b/dart/gui/osg/MouseEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/RealTimeWorldNode.cpp
+++ b/dart/gui/osg/RealTimeWorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/RealTimeWorldNode.hpp
+++ b/dart/gui/osg/RealTimeWorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/ShapeFrameNode.cpp
+++ b/dart/gui/osg/ShapeFrameNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/ShapeFrameNode.hpp
+++ b/dart/gui/osg/ShapeFrameNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/SupportPolygonVisual.cpp
+++ b/dart/gui/osg/SupportPolygonVisual.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/SupportPolygonVisual.hpp
+++ b/dart/gui/osg/SupportPolygonVisual.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/TrackballManipulator.cpp
+++ b/dart/gui/osg/TrackballManipulator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/TrackballManipulator.hpp
+++ b/dart/gui/osg/TrackballManipulator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/Utils.cpp
+++ b/dart/gui/osg/Utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/Utils.hpp
+++ b/dart/gui/osg/Utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/Viewer.cpp
+++ b/dart/gui/osg/Viewer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/Viewer.hpp
+++ b/dart/gui/osg/Viewer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/WorldNode.cpp
+++ b/dart/gui/osg/WorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/WorldNode.hpp
+++ b/dart/gui/osg/WorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/detail/CameraModeCallback.cpp
+++ b/dart/gui/osg/detail/CameraModeCallback.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/detail/CameraModeCallback.hpp
+++ b/dart/gui/osg/detail/CameraModeCallback.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/detail/Utils-impl.hpp
+++ b/dart/gui/osg/detail/Utils-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/BoxShapeNode.cpp
+++ b/dart/gui/osg/render/BoxShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/BoxShapeNode.hpp
+++ b/dart/gui/osg/render/BoxShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/CapsuleShapeNode.cpp
+++ b/dart/gui/osg/render/CapsuleShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/CapsuleShapeNode.hpp
+++ b/dart/gui/osg/render/CapsuleShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/ConeShapeNode.cpp
+++ b/dart/gui/osg/render/ConeShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/ConeShapeNode.hpp
+++ b/dart/gui/osg/render/ConeShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/CylinderShapeNode.cpp
+++ b/dart/gui/osg/render/CylinderShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/CylinderShapeNode.hpp
+++ b/dart/gui/osg/render/CylinderShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/EllipsoidShapeNode.cpp
+++ b/dart/gui/osg/render/EllipsoidShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/EllipsoidShapeNode.hpp
+++ b/dart/gui/osg/render/EllipsoidShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/HeightmapShapeNode.hpp
+++ b/dart/gui/osg/render/HeightmapShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/LineSegmentShapeNode.cpp
+++ b/dart/gui/osg/render/LineSegmentShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/LineSegmentShapeNode.hpp
+++ b/dart/gui/osg/render/LineSegmentShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/MeshShapeNode.hpp
+++ b/dart/gui/osg/render/MeshShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/MultiSphereShapeNode.cpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/MultiSphereShapeNode.hpp
+++ b/dart/gui/osg/render/MultiSphereShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/PlaneShapeNode.cpp
+++ b/dart/gui/osg/render/PlaneShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/PlaneShapeNode.hpp
+++ b/dart/gui/osg/render/PlaneShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/PointCloudShapeNode.cpp
+++ b/dart/gui/osg/render/PointCloudShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/PointCloudShapeNode.hpp
+++ b/dart/gui/osg/render/PointCloudShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/PyramidShapeNode.cpp
+++ b/dart/gui/osg/render/PyramidShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/PyramidShapeNode.hpp
+++ b/dart/gui/osg/render/PyramidShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/ShapeNode.cpp
+++ b/dart/gui/osg/render/ShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/ShapeNode.hpp
+++ b/dart/gui/osg/render/ShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/SoftMeshShapeNode.cpp
+++ b/dart/gui/osg/render/SoftMeshShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/SoftMeshShapeNode.hpp
+++ b/dart/gui/osg/render/SoftMeshShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/SphereShapeNode.cpp
+++ b/dart/gui/osg/render/SphereShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/SphereShapeNode.hpp
+++ b/dart/gui/osg/render/SphereShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/VoxelGridShapeNode.cpp
+++ b/dart/gui/osg/render/VoxelGridShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/VoxelGridShapeNode.hpp
+++ b/dart/gui/osg/render/VoxelGridShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/WarningShapeNode.cpp
+++ b/dart/gui/osg/render/WarningShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/gui/osg/render/WarningShapeNode.hpp
+++ b/dart/gui/osg/render/WarningShapeNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/EulerIntegrator.cpp
+++ b/dart/integration/EulerIntegrator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/EulerIntegrator.hpp
+++ b/dart/integration/EulerIntegrator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/Integrator.cpp
+++ b/dart/integration/Integrator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/Integrator.hpp
+++ b/dart/integration/Integrator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/RK4Integrator.cpp
+++ b/dart/integration/RK4Integrator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/RK4Integrator.hpp
+++ b/dart/integration/RK4Integrator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/SemiImplicitEulerIntegrator.cpp
+++ b/dart/integration/SemiImplicitEulerIntegrator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/integration/SemiImplicitEulerIntegrator.hpp
+++ b/dart/integration/SemiImplicitEulerIntegrator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/lcpsolver/Lemke.cpp
+++ b/dart/lcpsolver/Lemke.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/lcpsolver/Lemke.hpp
+++ b/dart/lcpsolver/Lemke.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/lcpsolver/ODELCPSolver.cpp
+++ b/dart/lcpsolver/ODELCPSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/lcpsolver/ODELCPSolver.hpp
+++ b/dart/lcpsolver/ODELCPSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/ConfigurationSpace.cpp
+++ b/dart/math/ConfigurationSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/ConfigurationSpace.hpp
+++ b/dart/math/ConfigurationSpace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Constants.hpp
+++ b/dart/math/Constants.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Geometry.hpp
+++ b/dart/math/Geometry.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Helpers.hpp
+++ b/dart/math/Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Icosphere.hpp
+++ b/dart/math/Icosphere.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/MathTypes.hpp
+++ b/dart/math/MathTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Mesh.hpp
+++ b/dart/math/Mesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Random.cpp
+++ b/dart/math/Random.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/Random.hpp
+++ b/dart/math/Random.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/TriMesh.cpp
+++ b/dart/math/TriMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/TriMesh.hpp
+++ b/dart/math/TriMesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/ConfigurationSpace.hpp
+++ b/dart/math/detail/ConfigurationSpace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Geometry-impl.hpp
+++ b/dart/math/detail/Geometry-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Icosphere-impl.hpp
+++ b/dart/math/detail/Icosphere-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Mesh-impl.hpp
+++ b/dart/math/detail/Mesh-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/Random-impl.hpp
+++ b/dart/math/detail/Random-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/math/detail/TriMesh-impl.hpp
+++ b/dart/math/detail/TriMesh-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Function.cpp
+++ b/dart/optimizer/Function.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Function.hpp
+++ b/dart/optimizer/Function.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/GenericMultiObjectiveProblem.cpp
+++ b/dart/optimizer/GenericMultiObjectiveProblem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/GenericMultiObjectiveProblem.hpp
+++ b/dart/optimizer/GenericMultiObjectiveProblem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/GradientDescentSolver.cpp
+++ b/dart/optimizer/GradientDescentSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/GradientDescentSolver.hpp
+++ b/dart/optimizer/GradientDescentSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/MultiObjectiveProblem.cpp
+++ b/dart/optimizer/MultiObjectiveProblem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/MultiObjectiveProblem.hpp
+++ b/dart/optimizer/MultiObjectiveProblem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/MultiObjectiveSolver.cpp
+++ b/dart/optimizer/MultiObjectiveSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/MultiObjectiveSolver.hpp
+++ b/dart/optimizer/MultiObjectiveSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Population.cpp
+++ b/dart/optimizer/Population.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Population.hpp
+++ b/dart/optimizer/Population.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Problem.cpp
+++ b/dart/optimizer/Problem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Problem.hpp
+++ b/dart/optimizer/Problem.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Solver.cpp
+++ b/dart/optimizer/Solver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/Solver.hpp
+++ b/dart/optimizer/Solver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/ipopt/BackwardCompatibility.hpp
+++ b/dart/optimizer/ipopt/BackwardCompatibility.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/ipopt/IpoptSolver.cpp
+++ b/dart/optimizer/ipopt/IpoptSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/ipopt/IpoptSolver.hpp
+++ b/dart/optimizer/ipopt/IpoptSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/nlopt/NloptSolver.cpp
+++ b/dart/optimizer/nlopt/NloptSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/nlopt/NloptSolver.hpp
+++ b/dart/optimizer/nlopt/NloptSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/pagmo/PagmoMultiObjectiveProblemAdaptor.cpp
+++ b/dart/optimizer/pagmo/PagmoMultiObjectiveProblemAdaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/pagmo/PagmoMultiObjectiveProblemAdaptor.hpp
+++ b/dart/optimizer/pagmo/PagmoMultiObjectiveProblemAdaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/pagmo/PagmoMultiObjectiveSolver.cpp
+++ b/dart/optimizer/pagmo/PagmoMultiObjectiveSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/pagmo/PagmoMultiObjectiveSolver.hpp
+++ b/dart/optimizer/pagmo/PagmoMultiObjectiveSolver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/pagmo/PagmoUtils.cpp
+++ b/dart/optimizer/pagmo/PagmoUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/optimizer/pagmo/PagmoUtils.hpp
+++ b/dart/optimizer/pagmo/PagmoUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/Recording.cpp
+++ b/dart/simulation/Recording.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/Recording.hpp
+++ b/dart/simulation/Recording.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/SmartPointer.hpp
+++ b/dart/simulation/SmartPointer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/simulation/detail/World-impl.hpp
+++ b/dart/simulation/detail/World-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/C3D.cpp
+++ b/dart/utils/C3D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/C3D.hpp
+++ b/dart/utils/C3D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/CompositeResourceRetriever.cpp
+++ b/dart/utils/CompositeResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/CompositeResourceRetriever.hpp
+++ b/dart/utils/CompositeResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/DartResourceRetriever.cpp
+++ b/dart/utils/DartResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/DartResourceRetriever.hpp
+++ b/dart/utils/DartResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoC3D.cpp
+++ b/dart/utils/FileInfoC3D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoC3D.hpp
+++ b/dart/utils/FileInfoC3D.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoDof.cpp
+++ b/dart/utils/FileInfoDof.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoDof.hpp
+++ b/dart/utils/FileInfoDof.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoWorld.cpp
+++ b/dart/utils/FileInfoWorld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/FileInfoWorld.hpp
+++ b/dart/utils/FileInfoWorld.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/PackageResourceRetriever.cpp
+++ b/dart/utils/PackageResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/PackageResourceRetriever.hpp
+++ b/dart/utils/PackageResourceRetriever.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/SkelParser.hpp
+++ b/dart/utils/SkelParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/VskParser.cpp
+++ b/dart/utils/VskParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/VskParser.hpp
+++ b/dart/utils/VskParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/XmlHelpers.hpp
+++ b/dart/utils/XmlHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/detail/XmlHelpers-impl.hpp
+++ b/dart/utils/detail/XmlHelpers-impl.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/MjcfParser.hpp
+++ b/dart/utils/mjcf/MjcfParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Asset.cpp
+++ b/dart/utils/mjcf/detail/Asset.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Asset.hpp
+++ b/dart/utils/mjcf/detail/Asset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Body.hpp
+++ b/dart/utils/mjcf/detail/Body.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/BodyAttributes.cpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/BodyAttributes.hpp
+++ b/dart/utils/mjcf/detail/BodyAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Compiler.cpp
+++ b/dart/utils/mjcf/detail/Compiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Compiler.hpp
+++ b/dart/utils/mjcf/detail/Compiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Default.cpp
+++ b/dart/utils/mjcf/detail/Default.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Default.hpp
+++ b/dart/utils/mjcf/detail/Default.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Equality.cpp
+++ b/dart/utils/mjcf/detail/Equality.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Equality.hpp
+++ b/dart/utils/mjcf/detail/Equality.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Error.cpp
+++ b/dart/utils/mjcf/detail/Error.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Error.hpp
+++ b/dart/utils/mjcf/detail/Error.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Geom.cpp
+++ b/dart/utils/mjcf/detail/Geom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Geom.hpp
+++ b/dart/utils/mjcf/detail/Geom.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/GeomAttributes.cpp
+++ b/dart/utils/mjcf/detail/GeomAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/GeomAttributes.hpp
+++ b/dart/utils/mjcf/detail/GeomAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Inertial.cpp
+++ b/dart/utils/mjcf/detail/Inertial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Inertial.hpp
+++ b/dart/utils/mjcf/detail/Inertial.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Joint.cpp
+++ b/dart/utils/mjcf/detail/Joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Joint.hpp
+++ b/dart/utils/mjcf/detail/Joint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/JointAttributes.cpp
+++ b/dart/utils/mjcf/detail/JointAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/JointAttributes.hpp
+++ b/dart/utils/mjcf/detail/JointAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Mesh.cpp
+++ b/dart/utils/mjcf/detail/Mesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Mesh.hpp
+++ b/dart/utils/mjcf/detail/Mesh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MeshAttributes.cpp
+++ b/dart/utils/mjcf/detail/MeshAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MeshAttributes.hpp
+++ b/dart/utils/mjcf/detail/MeshAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MujocoModel.cpp
+++ b/dart/utils/mjcf/detail/MujocoModel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/MujocoModel.hpp
+++ b/dart/utils/mjcf/detail/MujocoModel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Option.cpp
+++ b/dart/utils/mjcf/detail/Option.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Option.hpp
+++ b/dart/utils/mjcf/detail/Option.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Site.cpp
+++ b/dart/utils/mjcf/detail/Site.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Site.hpp
+++ b/dart/utils/mjcf/detail/Site.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Size.cpp
+++ b/dart/utils/mjcf/detail/Size.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Size.hpp
+++ b/dart/utils/mjcf/detail/Size.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Types.hpp
+++ b/dart/utils/mjcf/detail/Types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Utils.cpp
+++ b/dart/utils/mjcf/detail/Utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Utils.hpp
+++ b/dart/utils/mjcf/detail/Utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Weld.cpp
+++ b/dart/utils/mjcf/detail/Weld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Weld.hpp
+++ b/dart/utils/mjcf/detail/Weld.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/WeldAttributes.cpp
+++ b/dart/utils/mjcf/detail/WeldAttributes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/WeldAttributes.hpp
+++ b/dart/utils/mjcf/detail/WeldAttributes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Worldbody.cpp
+++ b/dart/utils/mjcf/detail/Worldbody.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/mjcf/detail/Worldbody.hpp
+++ b/dart/utils/mjcf/detail/Worldbody.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/sdf/SdfParser.hpp
+++ b/dart/utils/sdf/SdfParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/DartLoader.hpp
+++ b/dart/utils/urdf/DartLoader.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/IncludeUrdf.hpp
+++ b/dart/utils/urdf/IncludeUrdf.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/dart/utils/urdf/URDFTypes.hpp
+++ b/dart/utils/urdf/URDFTypes.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/docs/readthedocs/conf.py
+++ b/docs/readthedocs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "DART: Dynamic Animation and Robotics Toolkit"
-copyright = "Copyright (c) 2011-2025, The DART development contributors"
+copyright = "Copyright (c) 2011-2026, The DART development contributors"
 author = "The DART development contributors"
 version = "7.0.0-alpha0"
 release = "7.0.0-alpha20230101"

--- a/examples/atlas_puppet/main.cpp
+++ b/examples/atlas_puppet/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconEventHandler.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconEventHandler.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconEventHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWidget.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/AtlasSimbiconWorldNode.hpp
+++ b/examples/atlas_simbicon/AtlasSimbiconWorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/Controller.cpp
+++ b/examples/atlas_simbicon/Controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/Controller.hpp
+++ b/examples/atlas_simbicon/Controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/State.cpp
+++ b/examples/atlas_simbicon/State.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/State.hpp
+++ b/examples/atlas_simbicon/State.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/StateMachine.cpp
+++ b/examples/atlas_simbicon/StateMachine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/StateMachine.hpp
+++ b/examples/atlas_simbicon/StateMachine.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/TerminalCondition.cpp
+++ b/examples/atlas_simbicon/TerminalCondition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/TerminalCondition.hpp
+++ b/examples/atlas_simbicon/TerminalCondition.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/atlas_simbicon/main.cpp
+++ b/examples/atlas_simbicon/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/biped_stand/main.cpp
+++ b/examples/biped_stand/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/box_stacking/main.cpp
+++ b/examples/box_stacking/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/boxes/main.cpp
+++ b/examples/boxes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_add_delete_skels/Main.cpp
+++ b/examples/deprecated_examples/glut_add_delete_skels/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_add_delete_skels/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_add_delete_skels/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_add_delete_skels/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_add_delete_skels/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/Controller.cpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/Controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/Controller.hpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/Controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/Humanoid.cpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/Humanoid.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/Humanoid.hpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/Humanoid.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/Main.cpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/State.cpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/State.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/State.hpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/State.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/StateMachine.cpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/StateMachine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/StateMachine.hpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/StateMachine.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/TerminalCondition.cpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/TerminalCondition.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_atlas_simbicon/TerminalCondition.hpp
+++ b/examples/deprecated_examples/glut_atlas_simbicon/TerminalCondition.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_biped_stand/Controller.cpp
+++ b/examples/deprecated_examples/glut_biped_stand/Controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_biped_stand/Controller.hpp
+++ b/examples/deprecated_examples/glut_biped_stand/Controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_biped_stand/Main.cpp
+++ b/examples/deprecated_examples/glut_biped_stand/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_biped_stand/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_biped_stand/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_biped_stand/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_biped_stand/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_hardcoded_design/Main.cpp
+++ b/examples/deprecated_examples/glut_hardcoded_design/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_hardcoded_design/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_hardcoded_design/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_hardcoded_design/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_hardcoded_design/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_human_joint_limits/HumanArmJointLimitConstraint.cpp
+++ b/examples/deprecated_examples/glut_human_joint_limits/HumanArmJointLimitConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_human_joint_limits/HumanArmJointLimitConstraint.hpp
+++ b/examples/deprecated_examples/glut_human_joint_limits/HumanArmJointLimitConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_human_joint_limits/HumanLegJointLimitConstraint.cpp
+++ b/examples/deprecated_examples/glut_human_joint_limits/HumanLegJointLimitConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_human_joint_limits/HumanLegJointLimitConstraint.hpp
+++ b/examples/deprecated_examples/glut_human_joint_limits/HumanLegJointLimitConstraint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_human_joint_limits/humanJointLimits.cpp
+++ b/examples/deprecated_examples/glut_human_joint_limits/humanJointLimits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_hybrid_dynamics/Main.cpp
+++ b/examples/deprecated_examples/glut_hybrid_dynamics/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_hybrid_dynamics/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_hybrid_dynamics/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_hybrid_dynamics/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_hybrid_dynamics/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_joint_constraints/Controller.cpp
+++ b/examples/deprecated_examples/glut_joint_constraints/Controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_joint_constraints/Controller.hpp
+++ b/examples/deprecated_examples/glut_joint_constraints/Controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_joint_constraints/Main.cpp
+++ b/examples/deprecated_examples/glut_joint_constraints/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_joint_constraints/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_joint_constraints/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_joint_constraints/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_joint_constraints/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_mixed_chain/Main.cpp
+++ b/examples/deprecated_examples/glut_mixed_chain/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_mixed_chain/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_mixed_chain/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_mixed_chain/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_mixed_chain/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_operational_space_control/Controller.cpp
+++ b/examples/deprecated_examples/glut_operational_space_control/Controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_operational_space_control/Controller.hpp
+++ b/examples/deprecated_examples/glut_operational_space_control/Controller.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_operational_space_control/Main.cpp
+++ b/examples/deprecated_examples/glut_operational_space_control/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_operational_space_control/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_operational_space_control/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_operational_space_control/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_operational_space_control/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_chain/Main.cpp
+++ b/examples/deprecated_examples/glut_rigid_chain/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_chain/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_rigid_chain/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_chain/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_rigid_chain/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_cubes/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_rigid_cubes/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_cubes/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_rigid_cubes/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_cubes/main.cpp
+++ b/examples/deprecated_examples/glut_rigid_cubes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_loop/Main.cpp
+++ b/examples/deprecated_examples/glut_rigid_loop/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_loop/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_rigid_loop/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_loop/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_rigid_loop/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_shapes/Main.cpp
+++ b/examples/deprecated_examples/glut_rigid_shapes/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_shapes/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_rigid_shapes/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_rigid_shapes/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_rigid_shapes/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_simple_frames/Main.cpp
+++ b/examples/deprecated_examples/glut_simple_frames/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_soft_bodies/Main.cpp
+++ b/examples/deprecated_examples/glut_soft_bodies/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_soft_bodies/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_soft_bodies/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_soft_bodies/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_soft_bodies/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_vehicle/Main.cpp
+++ b/examples/deprecated_examples/glut_vehicle/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_vehicle/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_vehicle/MyWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/deprecated_examples/glut_vehicle/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_vehicle/MyWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/drag_and_drop/main.cpp
+++ b/examples/drag_and_drop/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/empty/main.cpp
+++ b/examples/empty/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/fetch/main.cpp
+++ b/examples/fetch/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/heightmap/main.cpp
+++ b/examples/heightmap/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hello_world/main.cpp
+++ b/examples/hello_world/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/imgui/main.cpp
+++ b/examples/imgui/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/operational_space_control/main.cpp
+++ b/examples/operational_space_control/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/rigid_shapes/main.cpp
+++ b/examples/rigid_shapes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/soft_bodies/main.cpp
+++ b/examples/soft_bodies/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/speed_test/main.cpp
+++ b/examples/speed_test/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWidget.cpp
+++ b/examples/tinkertoy/TinkertoyWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWidget.hpp
+++ b/examples/tinkertoy/TinkertoyWidget.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWorldNode.cpp
+++ b/examples/tinkertoy/TinkertoyWorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/TinkertoyWorldNode.hpp
+++ b/examples/tinkertoy/TinkertoyWorldNode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/tinkertoy/main.cpp
+++ b/examples/tinkertoy/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/Helpers.cpp
+++ b/examples/wam_ikfast/Helpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/Helpers.hpp
+++ b/examples/wam_ikfast/Helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/InputHandler.cpp
+++ b/examples/wam_ikfast/InputHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/InputHandler.hpp
+++ b/examples/wam_ikfast/InputHandler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/WamWorld.cpp
+++ b/examples/wam_ikfast/WamWorld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/WamWorld.hpp
+++ b/examples/wam_ikfast/WamWorld.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/examples/wam_ikfast/osgWamIkFast.cpp
+++ b/examples/wam_ikfast/osgWamIkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 
 if(NOT DART_BUILD_DARTPY)

--- a/python/dartpy/CMakeLists.txt
+++ b/python/dartpy/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/dartpy/collision/BulletCollisionDetector.cpp
+++ b/python/dartpy/collision/BulletCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/BulletCollisionGroup.cpp
+++ b/python/dartpy/collision/BulletCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/CollisionDetector.cpp
+++ b/python/dartpy/collision/CollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/CollisionFilter.cpp
+++ b/python/dartpy/collision/CollisionFilter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/CollisionGroup.cpp
+++ b/python/dartpy/collision/CollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/CollisionObject.cpp
+++ b/python/dartpy/collision/CollisionObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/CollisionOption.cpp
+++ b/python/dartpy/collision/CollisionOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/CollisionResult.cpp
+++ b/python/dartpy/collision/CollisionResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/Contact.cpp
+++ b/python/dartpy/collision/Contact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/DARTCollisionDetector.cpp
+++ b/python/dartpy/collision/DARTCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/DARTCollisionGroup.cpp
+++ b/python/dartpy/collision/DARTCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/DistanceOption.cpp
+++ b/python/dartpy/collision/DistanceOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/DistanceResult.cpp
+++ b/python/dartpy/collision/DistanceResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/FCLCollisionDetector.cpp
+++ b/python/dartpy/collision/FCLCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/FCLCollisionGroup.cpp
+++ b/python/dartpy/collision/FCLCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/OdeCollisionDetector.cpp
+++ b/python/dartpy/collision/OdeCollisionDetector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/OdeCollisionGroup.cpp
+++ b/python/dartpy/collision/OdeCollisionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/RaycastOption.cpp
+++ b/python/dartpy/collision/RaycastOption.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/RaycastResult.cpp
+++ b/python/dartpy/collision/RaycastResult.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/collision/module.cpp
+++ b/python/dartpy/collision/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/Composite.cpp
+++ b/python/dartpy/common/Composite.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/Logging.cpp
+++ b/python/dartpy/common/Logging.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/Observer.cpp
+++ b/python/dartpy/common/Observer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/Resource.cpp
+++ b/python/dartpy/common/Resource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/ResourceRetriever.cpp
+++ b/python/dartpy/common/ResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/Stopwatch.cpp
+++ b/python/dartpy/common/Stopwatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/String.cpp
+++ b/python/dartpy/common/String.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/Subject.cpp
+++ b/python/dartpy/common/Subject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/Uri.cpp
+++ b/python/dartpy/common/Uri.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/common/module.cpp
+++ b/python/dartpy/common/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/BoxedLcpConstraintSolver.cpp
+++ b/python/dartpy/constraint/BoxedLcpConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/BoxedLcpSolver.cpp
+++ b/python/dartpy/constraint/BoxedLcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/ConstraintBase.cpp
+++ b/python/dartpy/constraint/ConstraintBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/ConstraintSolver.cpp
+++ b/python/dartpy/constraint/ConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/DantzigBoxedLcpSolver.cpp
+++ b/python/dartpy/constraint/DantzigBoxedLcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/DynamicJointConstraint.cpp
+++ b/python/dartpy/constraint/DynamicJointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/JointConstraint.cpp
+++ b/python/dartpy/constraint/JointConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/JointCoulombFrictionConstraint.cpp
+++ b/python/dartpy/constraint/JointCoulombFrictionConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/PgsBoxedLcpSolver.cpp
+++ b/python/dartpy/constraint/PgsBoxedLcpSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/constraint/module.cpp
+++ b/python/dartpy/constraint/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dartpy.cpp
+++ b/python/dartpy/dartpy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/BallJoint.cpp
+++ b/python/dartpy/dynamics/BallJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/BodyNode.cpp
+++ b/python/dartpy/dynamics/BodyNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Chain.cpp
+++ b/python/dartpy/dynamics/Chain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/DegreeOfFreedom.cpp
+++ b/python/dartpy/dynamics/DegreeOfFreedom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Entity.cpp
+++ b/python/dartpy/dynamics/Entity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/EulerJoint.cpp
+++ b/python/dartpy/dynamics/EulerJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Frame.cpp
+++ b/python/dartpy/dynamics/Frame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/FreeJoint.cpp
+++ b/python/dartpy/dynamics/FreeJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/GenericJoint.cpp
+++ b/python/dartpy/dynamics/GenericJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Inertia.cpp
+++ b/python/dartpy/dynamics/Inertia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/InverseKinematics.cpp
+++ b/python/dartpy/dynamics/InverseKinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/JacobianNode.cpp
+++ b/python/dartpy/dynamics/JacobianNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Joint.cpp
+++ b/python/dartpy/dynamics/Joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Joint.hpp
+++ b/python/dartpy/dynamics/Joint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Linkage.cpp
+++ b/python/dartpy/dynamics/Linkage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/MetaSkeleton.cpp
+++ b/python/dartpy/dynamics/MetaSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Node.cpp
+++ b/python/dartpy/dynamics/Node.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/PlanarJoint.cpp
+++ b/python/dartpy/dynamics/PlanarJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/PrismaticJoint.cpp
+++ b/python/dartpy/dynamics/PrismaticJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/ReferentialSkeleton.cpp
+++ b/python/dartpy/dynamics/ReferentialSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/RevoluteJoint.cpp
+++ b/python/dartpy/dynamics/RevoluteJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/ScrewJoint.cpp
+++ b/python/dartpy/dynamics/ScrewJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Shape.cpp
+++ b/python/dartpy/dynamics/Shape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/ShapeFrame.cpp
+++ b/python/dartpy/dynamics/ShapeFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/ShapeNode.cpp
+++ b/python/dartpy/dynamics/ShapeNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/SimpleFrame.cpp
+++ b/python/dartpy/dynamics/SimpleFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/TranslationalJoint.cpp
+++ b/python/dartpy/dynamics/TranslationalJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/TranslationalJoint2D.cpp
+++ b/python/dartpy/dynamics/TranslationalJoint2D.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/UniversalJoint.cpp
+++ b/python/dartpy/dynamics/UniversalJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/WeldJoint.cpp
+++ b/python/dartpy/dynamics/WeldJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/ZeroDofJoint.cpp
+++ b/python/dartpy/dynamics/ZeroDofJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/module.cpp
+++ b/python/dartpy/dynamics/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/dynamics/pointers.hpp
+++ b/python/dartpy/dynamics/pointers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/module.cpp
+++ b/python/dartpy/gui/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/DragAndDrop.cpp
+++ b/python/dartpy/gui/osg/DragAndDrop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/GUIEventHandler.cpp
+++ b/python/dartpy/gui/osg/GUIEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/GridVisual.cpp
+++ b/python/dartpy/gui/osg/GridVisual.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/ImGuiHandler.cpp
+++ b/python/dartpy/gui/osg/ImGuiHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/ImGuiViewer.cpp
+++ b/python/dartpy/gui/osg/ImGuiViewer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/ImGuiWidget.cpp
+++ b/python/dartpy/gui/osg/ImGuiWidget.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/InteractiveFrame.cpp
+++ b/python/dartpy/gui/osg/InteractiveFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/RealTimeWorldNode.cpp
+++ b/python/dartpy/gui/osg/RealTimeWorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/ShadowTechnique.cpp
+++ b/python/dartpy/gui/osg/ShadowTechnique.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/Viewer.cpp
+++ b/python/dartpy/gui/osg/Viewer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/ViewerAttachment.cpp
+++ b/python/dartpy/gui/osg/ViewerAttachment.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/WorldNode.cpp
+++ b/python/dartpy/gui/osg/WorldNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/gui/osg/module.cpp
+++ b/python/dartpy/gui/osg/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/math/Geometry.cpp
+++ b/python/dartpy/math/Geometry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/math/Random.cpp
+++ b/python/dartpy/math/Random.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/math/module.cpp
+++ b/python/dartpy/math/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/optimizer/Function.cpp
+++ b/python/dartpy/optimizer/Function.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/optimizer/GradientDescentSolver.cpp
+++ b/python/dartpy/optimizer/GradientDescentSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/optimizer/NloptSolver.cpp
+++ b/python/dartpy/optimizer/NloptSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/optimizer/Problem.cpp
+++ b/python/dartpy/optimizer/Problem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/optimizer/Solver.cpp
+++ b/python/dartpy/optimizer/Solver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/optimizer/module.cpp
+++ b/python/dartpy/optimizer/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/simulation/World.cpp
+++ b/python/dartpy/simulation/World.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/simulation/module.cpp
+++ b/python/dartpy/simulation/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/utils.h
+++ b/python/dartpy/utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/utils/DartLoader.cpp
+++ b/python/dartpy/utils/DartLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/utils/MjcfParser.cpp
+++ b/python/dartpy/utils/MjcfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/utils/ResourceRetriever.cpp
+++ b/python/dartpy/utils/ResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/utils/SdfParser.cpp
+++ b/python/dartpy/utils/SdfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/utils/SkelParser.cpp
+++ b/python/dartpy/utils/SkelParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/dartpy/utils/module.cpp
+++ b/python/dartpy/utils/module.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/python/tests/unit/common/test_string.py
+++ b/python/tests/unit/common/test_string.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tests/unit/utils/test_sdf_parser.py
+++ b/python/tests/unit/utils/test_sdf_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/python/tests/unit/utils/test_skel_parser.py
+++ b/python/tests/unit/utils/test_skel_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-﻿# Copyright (c) 2011-2025, The DART development contributors
+﻿# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 
 # References:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 # All rights reserved.
 #
 # The list of contributors can be found at:

--- a/tests/GTestUtils.hpp
+++ b/tests/GTestUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/TestHelpers.hpp
+++ b/tests/TestHelpers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/integration/bm_boxes.cpp
+++ b/tests/benchmark/integration/bm_boxes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/integration/bm_empty.cpp
+++ b/tests/benchmark/integration/bm_empty.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/benchmark/integration/bm_kinematics.cpp
+++ b/tests/benchmark/integration/bm_kinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 dart_build_tests(
   TYPE integration

--- a/tests/integration/SharedLibraryWamIkFast.cpp
+++ b/tests/integration/SharedLibraryWamIkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/SharedLibraryWamIkFast.hpp
+++ b/tests/integration/SharedLibraryWamIkFast.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Aspect.cpp
+++ b/tests/integration/test_Aspect.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Building.cpp
+++ b/tests/integration/test_Building.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_CollisionGroups.cpp
+++ b/tests/integration/test_CollisionGroups.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Common.cpp
+++ b/tests/integration/test_Common.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_CompositeResourceRetriever.cpp
+++ b/tests/integration/test_CompositeResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Concurrency.cpp
+++ b/tests/integration/test_Concurrency.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Constraint.cpp
+++ b/tests/integration/test_Constraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_ContactConstraint.cpp
+++ b/tests/integration/test_ContactConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_DartLoader.cpp
+++ b/tests/integration/test_DartLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_DartResourceRetriever.cpp
+++ b/tests/integration/test_DartResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Distance.cpp
+++ b/tests/integration/test_Distance.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Dynamics.cpp
+++ b/tests/integration/test_Dynamics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_FileInfoWorld.cpp
+++ b/tests/integration/test_FileInfoWorld.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_ForceDependentSlip.cpp
+++ b/tests/integration/test_ForceDependentSlip.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_ForwardKinematics.cpp
+++ b/tests/integration/test_ForwardKinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Frames.cpp
+++ b/tests/integration/test_Frames.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Friction.cpp
+++ b/tests/integration/test_Friction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_GenericJoints.cpp
+++ b/tests/integration/test_GenericJoints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_IkFast.cpp
+++ b/tests/integration/test_IkFast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Inertia.cpp
+++ b/tests/integration/test_Inertia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_InverseKinematics.cpp
+++ b/tests/integration/test_InverseKinematics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_JointForceTorque.cpp
+++ b/tests/integration/test_JointForceTorque.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Joints.cpp
+++ b/tests/integration/test_Joints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Lemke.cpp
+++ b/tests/integration/test_Lemke.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_LocalResourceRetriever.cpp
+++ b/tests/integration/test_LocalResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_MetaSkeleton.cpp
+++ b/tests/integration/test_MetaSkeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_NameManagement.cpp
+++ b/tests/integration/test_NameManagement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Optimizer.cpp
+++ b/tests/integration/test_Optimizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_PackageResourceRetriever.cpp
+++ b/tests/integration/test_PackageResourceRetriever.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Raycast.cpp
+++ b/tests/integration/test_Raycast.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_ScrewJoint.cpp
+++ b/tests/integration/test_ScrewJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_SdfParser.cpp
+++ b/tests/integration/test_SdfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Signal.cpp
+++ b/tests/integration/test_Signal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_SkelParser.cpp
+++ b/tests/integration/test_SkelParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Skeleton.cpp
+++ b/tests/integration/test_Skeleton.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_SoftDynamics.cpp
+++ b/tests/integration/test_SoftDynamics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_Subscriptions.cpp
+++ b/tests/integration/test_Subscriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_VskParser.cpp
+++ b/tests/integration/test_VskParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/integration/test_World.cpp
+++ b/tests/integration/test_World.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue000Template.cpp
+++ b/tests/regression/test_Issue000Template.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1184.cpp
+++ b/tests/regression/test_Issue1184.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1193.cpp
+++ b/tests/regression/test_Issue1193.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1231.cpp
+++ b/tests/regression/test_Issue1231.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1234.cpp
+++ b/tests/regression/test_Issue1234.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1243.cpp
+++ b/tests/regression/test_Issue1243.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1445.cpp
+++ b/tests/regression/test_Issue1445.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1583.cpp
+++ b/tests/regression/test_Issue1583.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1596.cpp
+++ b/tests/regression/test_Issue1596.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue1624.cpp
+++ b/tests/regression/test_Issue1624.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue838.cpp
+++ b/tests/regression/test_Issue838.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue892.cpp
+++ b/tests/regression/test_Issue892.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue895.cpp
+++ b/tests/regression/test_Issue895.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/regression/test_Issue986.cpp
+++ b/tests/regression/test_Issue986.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 add_subdirectory(common)
 add_subdirectory(collision)

--- a/tests/unit/collision/test_Contact.cpp
+++ b/tests/unit/collision/test_Contact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 dart_build_tests(
   TYPE unit

--- a/tests/unit/common/test_CAllocator.cpp
+++ b/tests/unit/common/test_CAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Factory.cpp
+++ b/tests/unit/common/test_Factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_FreeListAllocator.cpp
+++ b/tests/unit/common/test_FreeListAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Logging.cpp
+++ b/tests/unit/common/test_Logging.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_MemoryManager.cpp
+++ b/tests/unit/common/test_MemoryManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_PoolAllocator.cpp
+++ b/tests/unit/common/test_PoolAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_StlAllocator.cpp
+++ b/tests/unit/common/test_StlAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Stopwatch.cpp
+++ b/tests/unit/common/test_Stopwatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_String.cpp
+++ b/tests/unit/common/test_String.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/common/test_Uri.cpp
+++ b/tests/unit/common/test_Uri.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/CMakeLists.txt
+++ b/tests/unit/math/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 dart_build_tests(
   TYPE unit

--- a/tests/unit/math/test_Geometry.cpp
+++ b/tests/unit/math/test_Geometry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Icosphere.cpp
+++ b/tests/unit/math/test_Icosphere.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Math.cpp
+++ b/tests/unit/math/test_Math.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_Random.cpp
+++ b/tests/unit/math/test_Random.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/math/test_TriMesh.cpp
+++ b/tests/unit/math/test_TriMesh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2025, The DART development contributors
+# Copyright (c) 2011-2026, The DART development contributors
 
 if(TARGET dart-utils)
   dart_build_tests(

--- a/tests/unit/utils/test_XmlHelpers.cpp
+++ b/tests/unit/utils/test_XmlHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * This file is provided under the following "BSD-style" License:

--- a/tutorials/tutorial_biped/main.cpp
+++ b/tutorials/tutorial_biped/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_biped_finished/main.cpp
+++ b/tutorials/tutorial_biped_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_collisions/main.cpp
+++ b/tutorials/tutorial_collisions/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_collisions_finished/main.cpp
+++ b/tutorials/tutorial_collisions_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_dominoes/main.cpp
+++ b/tutorials/tutorial_dominoes/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_dominoes_finished/main.cpp
+++ b/tutorials/tutorial_dominoes_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_multi_pendulum/main.cpp
+++ b/tutorials/tutorial_multi_pendulum/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tutorials/tutorial_multi_pendulum_finished/main.cpp
+++ b/tutorials/tutorial_multi_pendulum_finished/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011-2026, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:


### PR DESCRIPTION
## Summary

Update all source file copyright headers from `2011-2025` to `2011-2026` as new DART 6.16.x releases are being made in 2026.

## Changes

- Updated 964 source files (`.hpp`, `.cpp`, `.h`, `.c`, `.py`, `CMakeLists.txt`)
- Pattern: `Copyright (c) 2011-2025` → `Copyright (c) 2011-2026`

## Testing

- No functional changes, copyright header update only

## Related

- DART 7 PR: #2436