### PR TITLE
Fix: Validate SphereShape radius to prevent assertion failures (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Dynamics
 
-  * Validate SphereShape radius to prevent assertion failures with NaN/Inf/non-positive values: [#????](https://github.com/dartsim/dart/pull/????)
+  * Validate SphereShape radius to prevent assertion failures with NaN/Inf/non-positive values: [#2441](https://github.com/dartsim/dart/pull/2441)
 
 * Parsers
   * Fix null pointer dereference in XmlHelpers getValue* functions: [#2429](https://github.com/dartsim/dart/pull/2429)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### [DART 6.16.5 (TBD)](https://github.com/dartsim/dart/milestone/90?closed=1)
 
+* Dynamics
+
+  * Validate SphereShape radius to prevent assertion failures with NaN/Inf/non-positive values: [#????](https://github.com/dartsim/dart/pull/????)
+
 * Parsers
   * Fix null pointer dereference in XmlHelpers getValue* functions: [#2429](https://github.com/dartsim/dart/pull/2429)
 

--- a/dart/dynamics/SphereShape.cpp
+++ b/dart/dynamics/SphereShape.cpp
@@ -32,8 +32,11 @@
 
 #include "dart/dynamics/SphereShape.hpp"
 
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
+
+#include <cmath>
 
 namespace dart {
 namespace dynamics {
@@ -66,7 +69,13 @@ const std::string& SphereShape::getStaticType()
 //==============================================================================
 void SphereShape::setRadius(double radius)
 {
-  DART_ASSERT(radius > 0.0);
+  if (!std::isfinite(radius) || radius <= 0.0) {
+    DART_WARN(
+        "SphereShape::setRadius: Invalid radius '{}'. "
+        "Radius must be a positive finite value. Ignoring request.",
+        radius);
+    return;
+  }
 
   mRadius = radius;
 

--- a/dart/dynamics/SphereShape.hpp
+++ b/dart/dynamics/SphereShape.hpp
@@ -80,7 +80,7 @@ protected:
 
 private:
   /// Radius of this Sphere
-  double mRadius;
+  double mRadius{1.0};
 };
 
 } // namespace dynamics

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,5 +2,6 @@
 
 add_subdirectory(common)
 add_subdirectory(collision)
+add_subdirectory(dynamics)
 add_subdirectory(math)
 add_subdirectory(utils)

--- a/tests/unit/dynamics/CMakeLists.txt
+++ b/tests/unit/dynamics/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2011-2025, The DART development contributors
+
+dart_build_tests(
+  TYPE unit
+  COMPONENT_NAME dynamics
+  TARGET_PREFIX UNIT_dynamics
+  LINK_LIBRARIES dart
+  GLOB_SOURCES
+)

--- a/tests/unit/dynamics/test_SphereShape.cpp
+++ b/tests/unit/dynamics/test_SphereShape.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/SphereShape.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+using namespace dart::dynamics;
+
+//==============================================================================
+TEST(SphereShapeValidation, AcceptsValidPositiveFiniteRadius)
+{
+  auto sphere = std::make_shared<SphereShape>(1.0);
+
+  sphere->setRadius(0.5);
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), 0.5);
+
+  sphere->setRadius(1.0);
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), 1.0);
+
+  sphere->setRadius(100.0);
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), 100.0);
+
+  sphere->setRadius(1e-6);
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), 1e-6);
+}
+
+//==============================================================================
+TEST(SphereShapeValidation, RejectsNaNAndPreservesOriginalRadius)
+{
+  auto sphere = std::make_shared<SphereShape>(1.0);
+  const double originalRadius = sphere->getRadius();
+
+  sphere->setRadius(std::numeric_limits<double>::quiet_NaN());
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), originalRadius);
+
+  sphere->setRadius(std::numeric_limits<double>::signaling_NaN());
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), originalRadius);
+}
+
+//==============================================================================
+TEST(SphereShapeValidation, RejectsInfinityAndPreservesOriginalRadius)
+{
+  auto sphere = std::make_shared<SphereShape>(1.0);
+  const double originalRadius = sphere->getRadius();
+
+  sphere->setRadius(std::numeric_limits<double>::infinity());
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), originalRadius);
+
+  sphere->setRadius(-std::numeric_limits<double>::infinity());
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), originalRadius);
+}
+
+//==============================================================================
+TEST(SphereShapeValidation, RejectsNonPositiveAndPreservesOriginalRadius)
+{
+  auto sphere = std::make_shared<SphereShape>(1.0);
+  const double originalRadius = sphere->getRadius();
+
+  sphere->setRadius(0.0);
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), originalRadius);
+
+  sphere->setRadius(-1.0);
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), originalRadius);
+
+  sphere->setRadius(-0.001);
+  EXPECT_DOUBLE_EQ(sphere->getRadius(), originalRadius);
+}
+
+//==============================================================================
+TEST(SphereShapeValidation, ConstructorWithInvalidRadiusDoesNotCrash)
+{
+  EXPECT_NO_THROW(
+      std::make_shared<SphereShape>(std::numeric_limits<double>::quiet_NaN()));
+
+  EXPECT_NO_THROW(
+      std::make_shared<SphereShape>(std::numeric_limits<double>::infinity()));
+
+  EXPECT_NO_THROW(std::make_shared<SphereShape>(-1.0));
+
+  EXPECT_NO_THROW(std::make_shared<SphereShape>(0.0));
+}

--- a/tests/unit/dynamics/test_SphereShape.cpp
+++ b/tests/unit/dynamics/test_SphereShape.cpp
@@ -34,8 +34,9 @@
 
 #include <gtest/gtest.h>
 
-#include <cmath>
 #include <limits>
+
+#include <cmath>
 
 using namespace dart::dynamics;
 

--- a/tests/unit/dynamics/test_SphereShape.cpp
+++ b/tests/unit/dynamics/test_SphereShape.cpp
@@ -103,13 +103,17 @@ TEST(SphereShapeValidation, RejectsNonPositiveAndPreservesOriginalRadius)
 //==============================================================================
 TEST(SphereShapeValidation, ConstructorWithInvalidRadiusDoesNotCrash)
 {
-  EXPECT_NO_THROW(
-      std::make_shared<SphereShape>(std::numeric_limits<double>::quiet_NaN()));
+  std::shared_ptr<SphereShape> sphere;
 
   EXPECT_NO_THROW(
-      std::make_shared<SphereShape>(std::numeric_limits<double>::infinity()));
+      sphere
+      = std::make_shared<SphereShape>(std::numeric_limits<double>::quiet_NaN()));
 
-  EXPECT_NO_THROW(std::make_shared<SphereShape>(-1.0));
+  EXPECT_NO_THROW(
+      sphere = std::make_shared<SphereShape>(
+          std::numeric_limits<double>::infinity()));
 
-  EXPECT_NO_THROW(std::make_shared<SphereShape>(0.0));
+  EXPECT_NO_THROW(sphere = std::make_shared<SphereShape>(-1.0));
+
+  EXPECT_NO_THROW(sphere = std::make_shared<SphereShape>(0.0));
 }

--- a/tests/unit/dynamics/test_SphereShape.cpp
+++ b/tests/unit/dynamics/test_SphereShape.cpp
@@ -106,12 +106,12 @@ TEST(SphereShapeValidation, ConstructorWithInvalidRadiusDoesNotCrash)
   std::shared_ptr<SphereShape> sphere;
 
   EXPECT_NO_THROW(
-      sphere
-      = std::make_shared<SphereShape>(std::numeric_limits<double>::quiet_NaN()));
+      sphere = std::make_shared<SphereShape>(
+          std::numeric_limits<double>::quiet_NaN()));
 
   EXPECT_NO_THROW(
-      sphere = std::make_shared<SphereShape>(
-          std::numeric_limits<double>::infinity()));
+      sphere
+      = std::make_shared<SphereShape>(std::numeric_limits<double>::infinity()));
 
   EXPECT_NO_THROW(sphere = std::make_shared<SphereShape>(-1.0));
 


### PR DESCRIPTION
## Summary

- Replace `DART_ASSERT(radius > 0.0)` with proper validation using `std::isfinite()` and `DART_WARN()`
- Invalid values (NaN, infinity, non-positive) are now rejected with a warning instead of crashing
- Add unit tests covering all validation cases

## Motivation

Addresses [gz-physics#843](https://github.com/gazebosim/gz-physics/issues/843) where DART crashes with an assertion failure when `SphereShape::setRadius()` receives invalid radius values from upstream physics interfaces.

## Changes

- `dart/dynamics/SphereShape.cpp`: Added validation with graceful rejection
- `tests/unit/dynamics/test_SphereShape.cpp`: New test file with 5 test cases
- `tests/unit/dynamics/CMakeLists.txt`: New CMake config for dynamics tests
- `tests/unit/CMakeLists.txt`: Added dynamics subdirectory
- `CHANGELOG.md`: Added entry under DART 6.16.5

## Testing

- Unit tests verify valid radius acceptance and invalid value rejection (NaN, Inf, zero, negative)
- Follows existing validation pattern from `World::setTimeStep()`