### PR TITLE
Fix: Validate external forces to prevent NaN/Inf crash (DART 6.16)

### DIFF
--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1186,6 +1186,22 @@ void BodyNode::addExtForce(
     bool _isForceLocal,
     bool _isOffsetLocal)
 {
+  if (math::isNan(_force) || math::isInf(_force)) {
+    dtwarn << "[BodyNode::addExtForce] Invalid value (NaN or Inf) detected in "
+              "force vector for body ["
+           << getName()
+           << "]. The force is ignored to prevent simulation instability.\n";
+    return;
+  }
+
+  if (math::isNan(_offset) || math::isInf(_offset)) {
+    dtwarn << "[BodyNode::addExtForce] Invalid value (NaN or Inf) detected in "
+              "offset vector for body ["
+           << getName()
+           << "]. The force is ignored to prevent simulation instability.\n";
+    return;
+  }
+
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
   Eigen::Vector6d F = Eigen::Vector6d::Zero();
   const Eigen::Isometry3d& W = getWorldTransform();
@@ -1212,6 +1228,22 @@ void BodyNode::setExtForce(
     bool _isForceLocal,
     bool _isOffsetLocal)
 {
+  if (math::isNan(_force) || math::isInf(_force)) {
+    dtwarn << "[BodyNode::setExtForce] Invalid value (NaN or Inf) detected in "
+              "force vector for body ["
+           << getName()
+           << "]. The force is ignored to prevent simulation instability.\n";
+    return;
+  }
+
+  if (math::isNan(_offset) || math::isInf(_offset)) {
+    dtwarn << "[BodyNode::setExtForce] Invalid value (NaN or Inf) detected in "
+              "offset vector for body ["
+           << getName()
+           << "]. The force is ignored to prevent simulation instability.\n";
+    return;
+  }
+
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
   Eigen::Vector6d F = Eigen::Vector6d::Zero();
   const Eigen::Isometry3d& W = getWorldTransform();
@@ -1234,6 +1266,14 @@ void BodyNode::setExtForce(
 //==============================================================================
 void BodyNode::addExtTorque(const Eigen::Vector3d& _torque, bool _isLocal)
 {
+  if (math::isNan(_torque) || math::isInf(_torque)) {
+    dtwarn << "[BodyNode::addExtTorque] Invalid value (NaN or Inf) detected in "
+              "torque vector for body ["
+           << getName()
+           << "]. The torque is ignored to prevent simulation instability.\n";
+    return;
+  }
+
   if (_isLocal)
     mAspectState.mFext.head<3>() += _torque;
   else
@@ -1246,6 +1286,14 @@ void BodyNode::addExtTorque(const Eigen::Vector3d& _torque, bool _isLocal)
 //==============================================================================
 void BodyNode::setExtTorque(const Eigen::Vector3d& _torque, bool _isLocal)
 {
+  if (math::isNan(_torque) || math::isInf(_torque)) {
+    dtwarn << "[BodyNode::setExtTorque] Invalid value (NaN or Inf) detected in "
+              "torque vector for body ["
+           << getName()
+           << "]. The torque is ignored to prevent simulation instability.\n";
+    return;
+  }
+
   if (_isLocal)
     mAspectState.mFext.head<3>() = _torque;
   else

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1181,12 +1181,12 @@ bool BodyNode::isColliding()
 
 //==============================================================================
 void BodyNode::addExtForce(
-    const Eigen::Vector3d& _force,
-    const Eigen::Vector3d& _offset,
-    bool _isForceLocal,
-    bool _isOffsetLocal)
+    const Eigen::Vector3d& force,
+    const Eigen::Vector3d& offset,
+    bool isForceLocal,
+    bool isOffsetLocal)
 {
-  if (math::isNan(_force) || math::isInf(_force)) {
+  if (math::isNan(force) || math::isInf(force)) {
     dtwarn << "[BodyNode::addExtForce] Invalid value (NaN or Inf) detected in "
               "force vector for body ["
            << getName()
@@ -1194,7 +1194,7 @@ void BodyNode::addExtForce(
     return;
   }
 
-  if (math::isNan(_offset) || math::isInf(_offset)) {
+  if (math::isNan(offset) || math::isInf(offset)) {
     dtwarn << "[BodyNode::addExtForce] Invalid value (NaN or Inf) detected in "
               "offset vector for body ["
            << getName()
@@ -1206,15 +1206,15 @@ void BodyNode::addExtForce(
   Eigen::Vector6d F = Eigen::Vector6d::Zero();
   const Eigen::Isometry3d& W = getWorldTransform();
 
-  if (_isOffsetLocal)
-    T.translation() = _offset;
+  if (isOffsetLocal)
+    T.translation() = offset;
   else
-    T.translation() = W.inverse() * _offset;
+    T.translation() = W.inverse() * offset;
 
-  if (_isForceLocal)
-    F.tail<3>() = _force;
+  if (isForceLocal)
+    F.tail<3>() = force;
   else
-    F.tail<3>() = W.linear().transpose() * _force;
+    F.tail<3>() = W.linear().transpose() * force;
 
   mAspectState.mFext += math::dAdInvT(T, F);
 
@@ -1223,12 +1223,12 @@ void BodyNode::addExtForce(
 
 //==============================================================================
 void BodyNode::setExtForce(
-    const Eigen::Vector3d& _force,
-    const Eigen::Vector3d& _offset,
-    bool _isForceLocal,
-    bool _isOffsetLocal)
+    const Eigen::Vector3d& force,
+    const Eigen::Vector3d& offset,
+    bool isForceLocal,
+    bool isOffsetLocal)
 {
-  if (math::isNan(_force) || math::isInf(_force)) {
+  if (math::isNan(force) || math::isInf(force)) {
     dtwarn << "[BodyNode::setExtForce] Invalid value (NaN or Inf) detected in "
               "force vector for body ["
            << getName()
@@ -1236,7 +1236,7 @@ void BodyNode::setExtForce(
     return;
   }
 
-  if (math::isNan(_offset) || math::isInf(_offset)) {
+  if (math::isNan(offset) || math::isInf(offset)) {
     dtwarn << "[BodyNode::setExtForce] Invalid value (NaN or Inf) detected in "
               "offset vector for body ["
            << getName()
@@ -1248,15 +1248,15 @@ void BodyNode::setExtForce(
   Eigen::Vector6d F = Eigen::Vector6d::Zero();
   const Eigen::Isometry3d& W = getWorldTransform();
 
-  if (_isOffsetLocal)
-    T.translation() = _offset;
+  if (isOffsetLocal)
+    T.translation() = offset;
   else
-    T.translation() = W.inverse() * _offset;
+    T.translation() = W.inverse() * offset;
 
-  if (_isForceLocal)
-    F.tail<3>() = _force;
+  if (isForceLocal)
+    F.tail<3>() = force;
   else
-    F.tail<3>() = W.linear().transpose() * _force;
+    F.tail<3>() = W.linear().transpose() * force;
 
   mAspectState.mFext = math::dAdInvT(T, F);
 
@@ -1264,9 +1264,9 @@ void BodyNode::setExtForce(
 }
 
 //==============================================================================
-void BodyNode::addExtTorque(const Eigen::Vector3d& _torque, bool _isLocal)
+void BodyNode::addExtTorque(const Eigen::Vector3d& torque, bool isLocal)
 {
-  if (math::isNan(_torque) || math::isInf(_torque)) {
+  if (math::isNan(torque) || math::isInf(torque)) {
     dtwarn << "[BodyNode::addExtTorque] Invalid value (NaN or Inf) detected in "
               "torque vector for body ["
            << getName()
@@ -1274,19 +1274,19 @@ void BodyNode::addExtTorque(const Eigen::Vector3d& _torque, bool _isLocal)
     return;
   }
 
-  if (_isLocal)
-    mAspectState.mFext.head<3>() += _torque;
+  if (isLocal)
+    mAspectState.mFext.head<3>() += torque;
   else
     mAspectState.mFext.head<3>()
-        += getWorldTransform().linear().transpose() * _torque;
+        += getWorldTransform().linear().transpose() * torque;
 
   SKEL_SET_FLAGS(mExternalForces);
 }
 
 //==============================================================================
-void BodyNode::setExtTorque(const Eigen::Vector3d& _torque, bool _isLocal)
+void BodyNode::setExtTorque(const Eigen::Vector3d& torque, bool isLocal)
 {
-  if (math::isNan(_torque) || math::isInf(_torque)) {
+  if (math::isNan(torque) || math::isInf(torque)) {
     dtwarn << "[BodyNode::setExtTorque] Invalid value (NaN or Inf) detected in "
               "torque vector for body ["
            << getName()
@@ -1294,11 +1294,11 @@ void BodyNode::setExtTorque(const Eigen::Vector3d& _torque, bool _isLocal)
     return;
   }
 
-  if (_isLocal)
-    mAspectState.mFext.head<3>() = _torque;
+  if (isLocal)
+    mAspectState.mFext.head<3>() = torque;
   else
     mAspectState.mFext.head<3>()
-        = getWorldTransform().linear().transpose() * _torque;
+        = getWorldTransform().linear().transpose() * torque;
 
   SKEL_SET_FLAGS(mExternalForces);
 }

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -745,27 +745,27 @@ public:
   /// application and the force in local coordinates are stored in mContacts.
   /// When conversion is needed, make sure the transformations are avaialble.
   void addExtForce(
-      const Eigen::Vector3d& _force,
-      const Eigen::Vector3d& _offset = Eigen::Vector3d::Zero(),
-      bool _isForceLocal = false,
-      bool _isOffsetLocal = true);
+      const Eigen::Vector3d& force,
+      const Eigen::Vector3d& offset = Eigen::Vector3d::Zero(),
+      bool isForceLocal = false,
+      bool isOffsetLocal = true);
 
   /// Set Applying linear Cartesian forces to this node.
   void setExtForce(
-      const Eigen::Vector3d& _force,
-      const Eigen::Vector3d& _offset = Eigen::Vector3d::Zero(),
-      bool _isForceLocal = false,
-      bool _isOffsetLocal = true);
+      const Eigen::Vector3d& force,
+      const Eigen::Vector3d& offset = Eigen::Vector3d::Zero(),
+      bool isForceLocal = false,
+      bool isOffsetLocal = true);
 
   /// Add applying Cartesian torque to the node.
   ///
   /// The torque in local coordinates is accumulated in mExtTorqueBody.
-  void addExtTorque(const Eigen::Vector3d& _torque, bool _isLocal = false);
+  void addExtTorque(const Eigen::Vector3d& torque, bool isLocal = false);
 
   /// Set applying Cartesian torque to the node.
   ///
   /// The torque in local coordinates is accumulated in mExtTorqueBody.
-  void setExtTorque(const Eigen::Vector3d& _torque, bool _isLocal = false);
+  void setExtTorque(const Eigen::Vector3d& torque, bool isLocal = false);
 
   /// Clean up structures that store external forces: mContacts, mFext,
   /// mExtForceBody and mExtTorqueBody.

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -524,20 +524,20 @@ void PointMass::integrateVelocities(double _dt)
 }
 
 //==============================================================================
-void PointMass::addExtForce(const Eigen::Vector3d& _force, bool _isForceLocal)
+void PointMass::addExtForce(const Eigen::Vector3d& force, bool isForceLocal)
 {
-  if (math::isNan(_force) || math::isInf(_force)) {
+  if (math::isNan(force) || math::isInf(force)) {
     dtwarn << "[PointMass::addExtForce] Invalid value (NaN or Inf) detected in "
               "force vector. The force is ignored to prevent simulation "
               "instability.\n";
     return;
   }
 
-  if (_isForceLocal) {
-    mFext += _force;
+  if (isForceLocal) {
+    mFext += force;
   } else {
     mFext += mParentSoftBodyNode->getWorldTransform().linear().transpose()
-             * _force;
+             * force;
   }
 }
 

--- a/dart/dynamics/PointMass.cpp
+++ b/dart/dynamics/PointMass.cpp
@@ -526,6 +526,13 @@ void PointMass::integrateVelocities(double _dt)
 //==============================================================================
 void PointMass::addExtForce(const Eigen::Vector3d& _force, bool _isForceLocal)
 {
+  if (math::isNan(_force) || math::isInf(_force)) {
+    dtwarn << "[PointMass::addExtForce] Invalid value (NaN or Inf) detected in "
+              "force vector. The force is ignored to prevent simulation "
+              "instability.\n";
+    return;
+  }
+
   if (_isForceLocal) {
     mFext += _force;
   } else {

--- a/dart/dynamics/PointMass.hpp
+++ b/dart/dynamics/PointMass.hpp
@@ -340,7 +340,7 @@ public:
   /// \param[in] _isForceLocal True if _force's reference frame is of the parent
   ///                          soft body node. False if _force's reference frame
   ///                          is of the world.
-  void addExtForce(const Eigen::Vector3d& _force, bool _isForceLocal = false);
+  void addExtForce(const Eigen::Vector3d& force, bool isForceLocal = false);
 
   ///
   void clearExtForce();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,5 +2,6 @@
 
 add_subdirectory(common)
 add_subdirectory(collision)
+add_subdirectory(dynamics)
 add_subdirectory(math)
 add_subdirectory(utils)

--- a/tests/unit/dynamics/CMakeLists.txt
+++ b/tests/unit/dynamics/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2011-2025, The DART development contributors
+
+dart_build_tests(
+  TYPE unit
+  COMPONENT_NAME dynamics
+  TARGET_PREFIX UNIT_dynamics
+  LINK_LIBRARIES dart
+  GLOB_SOURCES
+)

--- a/tests/unit/dynamics/test_BodyNodeExternalForce.cpp
+++ b/tests/unit/dynamics/test_BodyNodeExternalForce.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025, The DART development contributors
+ * Copyright (c) 2011, The DART development contributors
  * All rights reserved.
  *
  * The list of contributors can be found at:

--- a/tests/unit/dynamics/test_BodyNodeExternalForce.cpp
+++ b/tests/unit/dynamics/test_BodyNodeExternalForce.cpp
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dart.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+using namespace dart;
+using namespace dart::dynamics;
+
+//==============================================================================
+// Helper function to create a simple skeleton for testing
+SkeletonPtr createTestSkeleton()
+{
+  SkeletonPtr skel = Skeleton::create("TestSkeleton");
+
+  // Create a free joint with a body
+  FreeJoint::Properties jointProps;
+  jointProps.mName = "FreeJoint";
+
+  BodyNode::Properties bodyProps;
+  bodyProps.mName = "TestBody";
+  bodyProps.mInertia.setMass(1.0);
+
+  skel->createJointAndBodyNodePair<FreeJoint>(nullptr, jointProps, bodyProps);
+
+  return skel;
+}
+
+//==============================================================================
+// Tests for addExtForce with NaN values
+TEST(BodyNodeExternalForce, AddExtForceWithNaN)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Store original external force
+  Eigen::Vector6d originalFext = body->getExternalForceLocal();
+
+  // Create a force vector with NaN
+  Eigen::Vector3d nanForce(1.0, std::numeric_limits<double>::quiet_NaN(), 3.0);
+  Eigen::Vector3d offset = Eigen::Vector3d::Zero();
+
+  // Apply NaN force - should be ignored
+  body->addExtForce(nanForce, offset, true, true);
+
+  // Verify the external force did not change
+  EXPECT_TRUE(body->getExternalForceLocal().isApprox(originalFext));
+}
+
+//==============================================================================
+// Tests for addExtForce with Inf values
+TEST(BodyNodeExternalForce, AddExtForceWithInf)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Store original external force
+  Eigen::Vector6d originalFext = body->getExternalForceLocal();
+
+  // Create a force vector with Inf
+  Eigen::Vector3d infForce(
+      std::numeric_limits<double>::infinity(), 2.0, 3.0);
+  Eigen::Vector3d offset = Eigen::Vector3d::Zero();
+
+  // Apply Inf force - should be ignored
+  body->addExtForce(infForce, offset, true, true);
+
+  // Verify the external force did not change
+  EXPECT_TRUE(body->getExternalForceLocal().isApprox(originalFext));
+}
+
+//==============================================================================
+// Tests for addExtForce with NaN offset
+TEST(BodyNodeExternalForce, AddExtForceWithNaNOffset)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Store original external force
+  Eigen::Vector6d originalFext = body->getExternalForceLocal();
+
+  // Create valid force but NaN offset
+  Eigen::Vector3d force(1.0, 2.0, 3.0);
+  Eigen::Vector3d nanOffset(0.0, std::numeric_limits<double>::quiet_NaN(), 0.0);
+
+  // Apply force with NaN offset - should be ignored
+  body->addExtForce(force, nanOffset, true, true);
+
+  // Verify the external force did not change
+  EXPECT_TRUE(body->getExternalForceLocal().isApprox(originalFext));
+}
+
+//==============================================================================
+// Tests for setExtForce with NaN values
+TEST(BodyNodeExternalForce, SetExtForceWithNaN)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Apply a valid force first
+  Eigen::Vector3d validForce(1.0, 2.0, 3.0);
+  Eigen::Vector3d offset = Eigen::Vector3d::Zero();
+  body->setExtForce(validForce, offset, true, true);
+
+  // Store current external force
+  Eigen::Vector6d currentFext = body->getExternalForceLocal();
+
+  // Try to set NaN force - should be ignored
+  Eigen::Vector3d nanForce(std::numeric_limits<double>::quiet_NaN(), 2.0, 3.0);
+  body->setExtForce(nanForce, offset, true, true);
+
+  // Verify the external force did not change
+  EXPECT_TRUE(body->getExternalForceLocal().isApprox(currentFext));
+}
+
+//==============================================================================
+// Tests for addExtTorque with NaN values
+TEST(BodyNodeExternalForce, AddExtTorqueWithNaN)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Store original external force (torque is part of Fext)
+  Eigen::Vector6d originalFext = body->getExternalForceLocal();
+
+  // Create a torque vector with NaN
+  Eigen::Vector3d nanTorque(1.0, 2.0, std::numeric_limits<double>::quiet_NaN());
+
+  // Apply NaN torque - should be ignored
+  body->addExtTorque(nanTorque, true);
+
+  // Verify the external force did not change
+  EXPECT_TRUE(body->getExternalForceLocal().isApprox(originalFext));
+}
+
+//==============================================================================
+// Tests for addExtTorque with Inf values
+TEST(BodyNodeExternalForce, AddExtTorqueWithInf)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Store original external force
+  Eigen::Vector6d originalFext = body->getExternalForceLocal();
+
+  // Create a torque vector with negative infinity
+  Eigen::Vector3d infTorque(
+      -std::numeric_limits<double>::infinity(), 2.0, 3.0);
+
+  // Apply Inf torque - should be ignored
+  body->addExtTorque(infTorque, true);
+
+  // Verify the external force did not change
+  EXPECT_TRUE(body->getExternalForceLocal().isApprox(originalFext));
+}
+
+//==============================================================================
+// Tests for setExtTorque with NaN values
+TEST(BodyNodeExternalForce, SetExtTorqueWithNaN)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Apply a valid torque first
+  Eigen::Vector3d validTorque(1.0, 2.0, 3.0);
+  body->setExtTorque(validTorque, true);
+
+  // Store current external force
+  Eigen::Vector6d currentFext = body->getExternalForceLocal();
+
+  // Try to set NaN torque - should be ignored
+  Eigen::Vector3d nanTorque(1.0, std::numeric_limits<double>::quiet_NaN(), 3.0);
+  body->setExtTorque(nanTorque, true);
+
+  // Verify the external force did not change
+  EXPECT_TRUE(body->getExternalForceLocal().isApprox(currentFext));
+}
+
+//==============================================================================
+// Tests for valid force application (sanity check)
+TEST(BodyNodeExternalForce, ValidForceApplication)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Clear any existing external forces
+  body->clearExternalForces();
+
+  // Apply a valid force
+  Eigen::Vector3d force(10.0, 20.0, 30.0);
+  Eigen::Vector3d offset = Eigen::Vector3d::Zero();
+
+  body->addExtForce(force, offset, true, true);
+
+  // Verify the force was applied (linear part should be non-zero)
+  Eigen::Vector6d fext = body->getExternalForceLocal();
+  EXPECT_FALSE(fext.tail<3>().isZero());
+}
+
+//==============================================================================
+// Integration test: Simulate scenario from gz-physics#844
+// NaN parameters from hydrodynamics plugin should not crash simulation
+TEST(BodyNodeExternalForce, GzPhysics844Scenario)
+{
+  auto skel = createTestSkeleton();
+  auto body = skel->getBodyNode(0);
+
+  // Simulate the scenario where hydrodynamics plugin provides NaN parameters
+  // like <xDotU>NaN</xDotU>
+
+  // Clear forces
+  body->clearExternalForces();
+
+  // Try to apply NaN forces multiple times (simulating continuous plugin
+  // updates)
+  for (int i = 0; i < 10; ++i) {
+    Eigen::Vector3d nanForce(
+        std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::quiet_NaN());
+
+    // This should not crash or corrupt state
+    body->addExtForce(nanForce);
+    body->addExtTorque(nanForce, true);
+  }
+
+  // External forces should remain zero (all NaN forces were rejected)
+  Eigen::Vector6d fext = body->getExternalForceLocal();
+  EXPECT_TRUE(fext.isZero());
+
+  // Skeleton should still be valid
+  EXPECT_TRUE(skel != nullptr);
+  EXPECT_EQ(skel->getNumBodyNodes(), 1u);
+}

--- a/tests/unit/dynamics/test_BodyNodeExternalForce.cpp
+++ b/tests/unit/dynamics/test_BodyNodeExternalForce.cpp
@@ -34,8 +34,9 @@
 
 #include <gtest/gtest.h>
 
-#include <cmath>
 #include <limits>
+
+#include <cmath>
 
 using namespace dart;
 using namespace dart::dynamics;
@@ -91,8 +92,7 @@ TEST(BodyNodeExternalForce, AddExtForceWithInf)
   Eigen::Vector6d originalFext = body->getExternalForceLocal();
 
   // Create a force vector with Inf
-  Eigen::Vector3d infForce(
-      std::numeric_limits<double>::infinity(), 2.0, 3.0);
+  Eigen::Vector3d infForce(std::numeric_limits<double>::infinity(), 2.0, 3.0);
   Eigen::Vector3d offset = Eigen::Vector3d::Zero();
 
   // Apply Inf force - should be ignored
@@ -177,8 +177,7 @@ TEST(BodyNodeExternalForce, AddExtTorqueWithInf)
   Eigen::Vector6d originalFext = body->getExternalForceLocal();
 
   // Create a torque vector with negative infinity
-  Eigen::Vector3d infTorque(
-      -std::numeric_limits<double>::infinity(), 2.0, 3.0);
+  Eigen::Vector3d infTorque(-std::numeric_limits<double>::infinity(), 2.0, 3.0);
 
   // Apply Inf torque - should be ignored
   body->addExtTorque(infTorque, true);


### PR DESCRIPTION
## Summary

- Add NaN/Inf validation to `BodyNode::addExtForce`, `setExtForce`, `addExtTorque`, `setExtTorque`
- Add NaN/Inf validation to `PointMass::addExtForce`
- Invalid values are logged as warnings and ignored to prevent simulation crashes

## Related Issue

Addresses [gz-physics#844](https://github.com/gazebosim/gz-physics/issues/844) - Crash in `BodyNode::updateBiasForce` when Gazebo Hydrodynamics plugin passes NaN parameters (e.g., `<xDotU>NaN</xDotU>`).

## Changes

| File | Change |
|------|--------|
| `dart/dynamics/BodyNode.cpp` | Validate force/torque vectors before applying |
| `dart/dynamics/PointMass.cpp` | Validate force vector before applying |
| `tests/unit/dynamics/test_BodyNodeExternalForce.cpp` | 9 unit tests for NaN/Inf handling |
| `tests/unit/dynamics/CMakeLists.txt` | New test target |
| `tests/unit/CMakeLists.txt` | Add dynamics subdirectory |

## Testing

All 9 new unit tests pass locally:
- `AddExtForceWithNaN`
- `AddExtForceWithInf`
- `AddExtForceWithNaNOffset`
- `SetExtForceWithNaN`
- `AddExtTorqueWithNaN`
- `AddExtTorqueWithInf`
- `SetExtTorqueWithNaN`
- `ValidForceApplication`
- `GzPhysics844Scenario`