### PR TITLE
chore: Use @file imports for context loading (2/4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,20 +25,21 @@ If this fails, see `docs/onboarding/ci-cd.md` for troubleshooting.
 
 ## Context Loading (IMPORTANT)
 
-**Agents MUST load relevant docs before starting work.** Don't assume context is available.
+**Agents MUST load relevant docs before starting work.** Use `@file` syntax to auto-load context:
 
-| Task Type       | Required Reading                                               |
-| --------------- | -------------------------------------------------------------- |
-| **Any task**    | This file (`AGENTS.md`)                                        |
-| Building        | `docs/onboarding/building.md`                                  |
-| Testing         | `docs/onboarding/testing.md`                                   |
-| Contributing    | `docs/onboarding/contributing.md`, `CONTRIBUTING.md`           |
-| Code style      | `docs/onboarding/code-style.md`                                |
-| Architecture    | `docs/onboarding/architecture.md`, `docs/onboarding/README.md` |
-| CI/CD issues    | `docs/onboarding/ci-cd.md`                                     |
-| Python bindings | `docs/onboarding/python-bindings.md`                           |
-| Model loading   | `docs/onboarding/io-parsing.md`                                |
-| Build system    | `docs/onboarding/build-system.md`                              |
+| Task Type       | Load These Files                                            |
+| --------------- | ----------------------------------------------------------- |
+| **Any task**    | This file (auto-loaded)                                     |
+| Building        | @docs/onboarding/building.md                                |
+| Testing         | @docs/onboarding/testing.md                                 |
+| Contributing    | @docs/onboarding/contributing.md @CONTRIBUTING.md           |
+| Code style      | @docs/onboarding/code-style.md                              |
+| Architecture    | @docs/onboarding/architecture.md @docs/onboarding/README.md |
+| CI/CD issues    | @docs/onboarding/ci-cd.md                                   |
+| Python bindings | @docs/onboarding/python-bindings.md                         |
+| Model loading   | @docs/onboarding/io-parsing.md                              |
+| Build system    | @docs/onboarding/build-system.md                            |
+| AI tools        | @docs/onboarding/ai-tools.md                                |
 
 ## Slash Commands
 

--- a/docs/onboarding/ai-tools.md
+++ b/docs/onboarding/ai-tools.md
@@ -47,7 +47,37 @@ This document tracks AI coding assistant compatibility with DART's documentation
 | **Skill naming**              | `dart-` prefix (e.g., `dart-build`)                            |
 | **No tool-specific language** | Use generic terms; avoid "Claude will..." or "Codex should..." |
 | **Placeholders**              | Use `$ARGUMENTS`, `$1`, `$2` for command args                  |
-| **File references**           | Use `@file` syntax in commands                                 |
+| **File references**           | Use `@file` syntax for auto-loading context                    |
+
+### @file Import Syntax
+
+The `@path/to/file` syntax tells agents to automatically load referenced files into context.
+
+**Usage in AGENTS.md**:
+
+```markdown
+| Task Type | Load These Files             |
+| --------- | ---------------------------- |
+| Building  | @docs/onboarding/building.md |
+```
+
+**Usage in commands/skills**:
+
+```markdown
+@AGENTS.md
+@docs/onboarding/contributing.md
+
+## Workflow
+
+...
+```
+
+**Notes**:
+
+- Paths are relative to repository root
+- Imports are NOT evaluated inside code blocks (use backticks to escape)
+- Recursive imports are supported (imported files can import other files)
+- Use `@~/.claude/file.md` for home directory references
 
 ### File Ownership
 


### PR DESCRIPTION
## Summary

Adopts Anthropic's `@file` import syntax for automatic context loading.

**Phase 2 of 4** - Improves how agents load context.

## Changes

- Convert context loading table to use `@file` syntax (e.g., `@docs/onboarding/building.md`)
- Add AI tools entry to context loading table
- Document @file import syntax convention in ai-tools.md

## Before

```markdown
| Building | `docs/onboarding/building.md` |
```

## After

```markdown
| Building | @docs/onboarding/building.md |
```

## Why

- Agents automatically load @-referenced files when relevant
- Reduces manual file reading decisions
- Follows Anthropic best practices

## PR Stack

1. #2446: Foundation + quick wins ← **base**
2. **→ This PR**: @file import syntax
3. #2448: Subdirectory AGENTS.md files
4. #2449: Command sync automation

**Merge order**: 1 → 2 → 3 → 4