### PR TITLE
Docs: align PR template (DART 6.16)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,44 @@
-> Describe this pull request. Link to relevant GitHub issues, if any.
+## Summary
 
-***
+-
 
-#### Before creating a pull request
+<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->
 
-- [ ] Format code using `pixi run lint` and verify with `pixi run check-lint`
+## Motivation / Problem
+
+-
+
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Changes / Key Changes
+
+-
+
+<!-- High-level list of key changes. -->
+
+## Testing
+
+- What you tested (commands, manual steps, or explain why not). Example: `pixi run lint`, `pixi run test-all`
+
+## Breaking Changes
+
+- [ ] None
+- 
+
+<!-- If breaking changes exist, describe impact and migration steps. -->
+
+## Related Issues / PRs (backports)
+
+-
+
+<!-- List issue links and any related/backport PRs. -->
+
+---
+
+#### Checklist
+
+- [ ] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
+- [ ] CHANGELOG.md updated if required
+- [ ] Add unit tests for new functionality
 - [ ] Document new methods and classes
-- [ ] Build with `-DDART_TREAT_WARNINGS_AS_ERRORS=ON` and resolve warnings
-
-#### Before merging
-
-- [ ] Set milestone
-- [ ] Update `CHANGELOG.md`
-- [ ] Add unit tests
 - [ ] Add Python bindings (dartpy) if applicable


### PR DESCRIPTION
## Summary

- Backport the updated PR template to `release-6.16`.

## Motivation / Problem

- Keep PR metadata and review expectations consistent across branches.

## Changes / Key Changes

- Update `.github/PULL_REQUEST_TEMPLATE.md` to match the main-branch template.

## Testing

- Not run (docs/metadata-only changes).

## Breaking Changes

- [ ] None

## Related Issues / PRs (backports)

- Backport of #2451
