### PR TITLE
docs: auto-resolve review threads after pushing fixes

### DIFF
--- a/.claude/commands/dart-review-pr.md
+++ b/.claude/commands/dart-review-pr.md
@@ -27,6 +27,10 @@ gh pr view $1 --comments
 
 Apply minimal fixes, verify, push.
 
-## AI-Generated Reviews
+## AI-Generated Reviews (Codex, Copilot, etc.)
 
-See `docs/onboarding/ai-tools.md` § "Handling Automated Reviews" — do NOT reply directly.
+1. Push fix silently (no reply)
+2. Resolve thread via GraphQL (see ai-tools.md)
+3. Re-trigger: `gh pr comment $1 --body "@codex review"`
+
+Full details: `docs/onboarding/ai-tools.md` § "Handling Automated Reviews"

--- a/.opencode/command/dart-review-pr.md
+++ b/.opencode/command/dart-review-pr.md
@@ -27,6 +27,10 @@ gh pr view $1 --comments
 
 Apply minimal fixes, verify, push.
 
-## AI-Generated Reviews
+## AI-Generated Reviews (Codex, Copilot, etc.)
 
-See `docs/onboarding/ai-tools.md` § "Handling Automated Reviews" — do NOT reply directly.
+1. Push fix silently (no reply)
+2. Resolve thread via GraphQL (see ai-tools.md)
+3. Re-trigger: `gh pr comment $1 --body "@codex review"`
+
+Full details: `docs/onboarding/ai-tools.md` § "Handling Automated Reviews"


### PR DESCRIPTION
## Summary

Updates the AI review handling workflow to automatically resolve review threads after pushing fixes, rather than leaving them for manual resolution.

### Changes

**`docs/onboarding/ai-tools.md`**:
- Clarified workflow: push fix → resolve thread → re-trigger review
- Added "Agents MUST resolve threads automatically" directive
- Added one-liner command to resolve all unresolved threads:
  ```bash
  PR=2458; gh api graphql -f query="..." | while read -r tid; do ... done
  ```

**`dart-review-pr.md` commands** (both `.claude/` and `.opencode/`):
- Added step-by-step for AI reviews: push → resolve → re-trigger

### Why

- Keeps PR history clean (no manual UI clicking needed)
- Agents now have explicit instructions to resolve threads
- One-liner makes batch resolution easy