### PR TITLE
fix: validate joint commands to prevent NaN/Inf crash (gz-physics#845)

### DIFF
--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -400,6 +400,18 @@ void GenericJoint<ConfigSpaceT>::setCommand(size_t index, double command)
   if (index >= getNumDofs())
     GenericJoint_REPORT_OUT_OF_RANGE(setCommand, index);
 
+  // Validate command is finite to prevent NaN/Inf from propagating through
+  // the simulation and causing assertion failures (gz-physics#845)
+  if (!std::isfinite(command)) {
+    DART_WARN(
+        "Non-finite command ({}) passed to setCommand() for Joint [{}] "
+        "DOF [{}]. Command ignored.",
+        command,
+        this->getName(),
+        index);
+    return;
+  }
+
   const auto actuatorType = this->getActuatorType(index);
   switch (actuatorType) {
     case Joint::FORCE:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -88,6 +88,7 @@ dart_add_test("unit" UNIT_dynamics_ShapeNodePtr dynamics/test_ShapeNodePtr.cpp)
 dart_add_test("unit" UNIT_dynamics_MeshShape dynamics/test_MeshShape.cpp)
 dart_add_test("unit" UNIT_dynamics_HeightmapShape dynamics/test_HeightmapShape.cpp)
 dart_add_test("unit" UNIT_dynamics_SphereShape dynamics/test_SphereShape.cpp)
+dart_add_test("unit" UNIT_dynamics_JointCommand dynamics/test_JointCommand.cpp)
 dart_add_test("unit" UNIT_dynamics_ConvexMeshShape dynamics/test_ConvexMeshShape.cpp)
 dart_add_test("unit" UNIT_dynamics_BodyNodeDerivatives dynamics/test_BodyNodeDerivatives.cpp)
 dart_add_test(

--- a/tests/unit/dynamics/test_JointCommand.cpp
+++ b/tests/unit/dynamics/test_JointCommand.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/All.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace dart;
+using namespace dart::dynamics;
+
+//==============================================================================
+static SkeletonPtr createSkeletonWithRevoluteJoint()
+{
+  auto skel = Skeleton::create("test_skeleton");
+
+  auto pair = skel->createJointAndBodyNodePair<RevoluteJoint>();
+  auto* joint = pair.first;
+  auto* body = pair.second;
+  joint->setName("test_joint");
+  body->setName("test_body");
+  body->setMass(1.0);
+
+  return skel;
+}
+
+//==============================================================================
+TEST(JointCommand, NaNCommandIgnored)
+{
+  auto skel = createSkeletonWithRevoluteJoint();
+  auto* joint = skel->getJoint(0);
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+
+  joint->setActuatorType(Joint::ACCELERATION);
+  joint->setCommand(0, 0.0);
+  const double originalCommand = joint->getCommand(0);
+  EXPECT_DOUBLE_EQ(originalCommand, 0.0);
+
+  joint->setCommand(0, nan);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), originalCommand)
+      << "NaN command should be ignored";
+
+  joint->setCommand(0, std::numeric_limits<double>::signaling_NaN());
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), originalCommand)
+      << "Signaling NaN command should be ignored";
+}
+
+//==============================================================================
+TEST(JointCommand, InfinityCommandIgnored)
+{
+  auto skel = createSkeletonWithRevoluteJoint();
+  auto* joint = skel->getJoint(0);
+
+  const double inf = std::numeric_limits<double>::infinity();
+
+  joint->setActuatorType(Joint::ACCELERATION);
+  joint->setCommand(0, 1.5);
+  const double originalCommand = joint->getCommand(0);
+  EXPECT_DOUBLE_EQ(originalCommand, 1.5);
+
+  joint->setCommand(0, inf);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), originalCommand)
+      << "+Inf command should be ignored";
+
+  joint->setCommand(0, -inf);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), originalCommand)
+      << "-Inf command should be ignored";
+}
+
+//==============================================================================
+TEST(JointCommand, ValidCommandAccepted)
+{
+  auto skel = createSkeletonWithRevoluteJoint();
+  auto* joint = skel->getJoint(0);
+
+  joint->setActuatorType(Joint::ACCELERATION);
+
+  joint->setCommand(0, 5.0);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), 5.0);
+
+  joint->setCommand(0, -3.0);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), -3.0);
+
+  joint->setCommand(0, 0.0);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), 0.0);
+
+  joint->setCommand(0, 1e-10);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), 1e-10);
+
+  joint->setCommand(0, 1e10);
+  EXPECT_DOUBLE_EQ(joint->getCommand(0), 1e10);
+}
+
+//==============================================================================
+TEST(JointCommand, NaNCommandIgnoredForAllActuatorTypes)
+{
+  auto skel = createSkeletonWithRevoluteJoint();
+  auto* joint = skel->getJoint(0);
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const std::vector<Joint::ActuatorType> actuatorTypes
+      = {Joint::FORCE, Joint::SERVO, Joint::VELOCITY, Joint::ACCELERATION};
+
+  for (auto actuatorType : actuatorTypes) {
+    joint->setActuatorType(actuatorType);
+    joint->setCommand(0, 1.0);
+    const double originalCommand = joint->getCommand(0);
+
+    joint->setCommand(0, nan);
+    EXPECT_DOUBLE_EQ(joint->getCommand(0), originalCommand)
+        << "NaN command should be ignored for actuator type " << actuatorType;
+  }
+}
+
+//==============================================================================
+TEST(JointCommand, SimulationDoesNotCrashWithInfAccelerationCommand)
+{
+  auto skel = createSkeletonWithRevoluteJoint();
+  auto world = simulation::World::create();
+  world->addSkeleton(skel);
+
+  auto* joint = skel->getJoint(0);
+  const double inf = std::numeric_limits<double>::infinity();
+
+  joint->setActuatorType(Joint::ACCELERATION);
+  joint->setCommand(0, inf);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 100; ++i) {
+      world->step();
+    }
+  });
+
+  Eigen::VectorXd positions = skel->getPositions();
+  for (Eigen::Index i = 0; i < positions.size(); ++i) {
+    EXPECT_TRUE(std::isfinite(positions[i]))
+        << "Position " << i << " should be finite after simulation";
+  }
+
+  Eigen::VectorXd velocities = skel->getVelocities();
+  for (Eigen::Index i = 0; i < velocities.size(); ++i) {
+    EXPECT_TRUE(std::isfinite(velocities[i]))
+        << "Velocity " << i << " should be finite after simulation";
+  }
+}
+
+//==============================================================================
+TEST(JointCommand, GzPhysics845Scenario)
+{
+  auto skel = createSkeletonWithRevoluteJoint();
+  auto world = simulation::World::create();
+  world->addSkeleton(skel);
+
+  auto* joint = skel->getJoint(0);
+  const double inf = std::numeric_limits<double>::infinity();
+
+  joint->setActuatorType(Joint::ACCELERATION);
+
+  joint->setAccelerationLowerLimit(0, -inf);
+  joint->setAccelerationUpperLimit(0, inf);
+
+  joint->setCommand(0, inf);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 10; ++i) {
+      world->step();
+    }
+  }) << "Simulation should not crash with Inf acceleration command "
+        "(gz-physics#845)";
+}


### PR DESCRIPTION
## Summary

- Add NaN/Inf validation to `Joint::setCommand()` to prevent simulation crashes from invalid command values

## Motivation / Problem

[gz-physics#845](https://github.com/gazebosim/gz-physics/issues/845): When gz-sim's DiffDrive plugin sets `max_linear_acceleration` to `Inf`, DART crashes with an assertion failure:
```
Assertion 'math::isNan(mVelocityChanges)' failed
```

The root cause is that `Inf` values passed to `setCommand()` propagate through the simulation and eventually produce NaN in velocity calculations, triggering the assertion at `GenericJoint.hpp:2362`.

## Changes / Key Changes

| File | Change |
|------|--------|
| `dart/dynamics/detail/GenericJoint.hpp` | Add `std::isfinite()` validation at the start of `setCommand()` - rejects NaN/Inf with warning |
| `tests/unit/dynamics/test_JointCommand.cpp` | 6 unit tests covering validation behavior |
| `tests/unit/CMakeLists.txt` | Register new test target |

## Testing

- `pixi run lint` - Code formatted
- `pixi run build` - Compilation successful
- `pixi run test-unit` - All dynamics tests pass (20/20)
- New tests specifically verify the gz-physics#845 scenario

## Breaking Changes

- [x] None

Invalid commands are now gracefully rejected with a warning instead of causing a crash. Valid commands work exactly as before.

## Related Issues / PRs (backports)

- Addresses [gz-physics#845](https://github.com/gazebosim/gz-physics/issues/845)
- Similar pattern to #2444 (NaN/Inf validation for external forces)
- Similar pattern to #2442 (SphereShape radius validation)

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable