### PR TITLE
Fix crash when joint limits are invalid (lower > upper) (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Constraint
 
+  * Fix crash when joint limits are invalid (lower > upper) by emitting a warning and skipping limit enforcement: [gz-physics#846](https://github.com/gazebosim/gz-physics/issues/846)
+
   * Validate contact surface parameters to prevent LCP solver crashes: [#2435](https://github.com/dartsim/dart/pull/2435)
 
 * Dynamics

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -322,10 +322,10 @@ void JointConstraint::update()
       const double servoCommand
           = isServo ? mJoint->getCommand(static_cast<std::size_t>(i)) : 0.0;
       const bool atLowerLimit
-          = mJoint->areLimitsEnforced()
+          = hasValidPositionLimits && mJoint->areLimitsEnforced()
             && positions[i] <= positionLowerLimits[i] + mErrorAllowance;
       const bool atUpperLimit
-          = mJoint->areLimitsEnforced()
+          = hasValidPositionLimits && mJoint->areLimitsEnforced()
             && positions[i] >= positionUpperLimits[i] - mErrorAllowance;
       const bool servoHasFiniteLowerLimit
           = isServo

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -231,10 +231,10 @@ void JointConstraint::update()
     // treat as unbounded (no position-derived velocity constraints).
     const double vel_to_pos_lb = hasValidPositionLimits
         ? (positionLowerLimits[i] - positions[i]) / timeStep
-        : negInf;
+        : -static_cast<double>(dInfinity);
     const double vel_to_pos_ub = hasValidPositionLimits
         ? (positionUpperLimits[i] - positions[i]) / timeStep
-        : inf;
+        : static_cast<double>(dInfinity);
 
     // Joint position and velocity constraint check
     if (mJoint->areLimitsEnforced()) {

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/JointConstraint.hpp"
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
@@ -199,8 +200,29 @@ void JointConstraint::update()
   mActive.setConstant(false);
 
   for (int i = 0; i < dof; ++i) {
-    DART_ASSERT(positionLowerLimits[i] <= positionUpperLimits[i]);
-    DART_ASSERT(velocityLowerLimits[i] <= velocityUpperLimits[i]);
+    // Check for invalid limits (lower > upper) and skip this DOF if so.
+    // This can happen from malformed model files (e.g., SDF with swapped
+    // limits). See: https://github.com/gazebosim/gz-physics/issues/846
+    if (positionLowerLimits[i] > positionUpperLimits[i]) {
+      DART_WARN(
+          "Joint '{}' DOF {} has invalid position limits: lower ({}) > upper "
+          "({}). Skipping limit enforcement for this DOF.",
+          mJoint->getName(),
+          i,
+          positionLowerLimits[i],
+          positionUpperLimits[i]);
+      continue;
+    }
+    if (velocityLowerLimits[i] > velocityUpperLimits[i]) {
+      DART_WARN(
+          "Joint '{}' DOF {} has invalid velocity limits: lower ({}) > upper "
+          "({}). Skipping limit enforcement for this DOF.",
+          mJoint->getName(),
+          i,
+          velocityLowerLimits[i],
+          velocityUpperLimits[i]);
+      continue;
+    }
 
     // Velocity limits due to position limits
     const double vel_to_pos_lb

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -229,12 +229,14 @@ void JointConstraint::update()
 
     // Velocity limits due to position limits. When position limits are invalid,
     // treat as unbounded (no position-derived velocity constraints).
-    const double vel_to_pos_lb = hasValidPositionLimits
-        ? (positionLowerLimits[i] - positions[i]) / timeStep
-        : -static_cast<double>(dInfinity);
-    const double vel_to_pos_ub = hasValidPositionLimits
-        ? (positionUpperLimits[i] - positions[i]) / timeStep
-        : static_cast<double>(dInfinity);
+    const double vel_to_pos_lb
+        = hasValidPositionLimits
+              ? (positionLowerLimits[i] - positions[i]) / timeStep
+              : -static_cast<double>(dInfinity);
+    const double vel_to_pos_ub
+        = hasValidPositionLimits
+              ? (positionUpperLimits[i] - positions[i]) / timeStep
+              : static_cast<double>(dInfinity);
 
     // Joint position and velocity constraint check
     if (mJoint->areLimitsEnforced()) {
@@ -349,9 +351,9 @@ void JointConstraint::update()
       if (!skipVelocityLimitsForServoRecovery) {
         // Check lower velocity bound. When velocity limits are invalid, use
         // only position-derived velocity constraints.
-        const double vel_lb = hasValidVelocityLimits
-            ? std::max(velocityLowerLimits[i], vel_to_pos_lb)
-            : vel_to_pos_lb;
+        const double vel_lb = hasValidVelocityLimits ? std::max(
+                                  velocityLowerLimits[i], vel_to_pos_lb)
+                                                     : vel_to_pos_lb;
         const double vel_lb_error = velocities[i] - vel_lb;
         if (vel_lb_error < 0.0) {
           if (!relaxLowerVelocityBound) {
@@ -373,9 +375,9 @@ void JointConstraint::update()
 
         // Check upper velocity bound. When velocity limits are invalid, use
         // only position-derived velocity constraints.
-        const double vel_ub = hasValidVelocityLimits
-            ? std::min(velocityUpperLimits[i], vel_to_pos_ub)
-            : vel_to_pos_ub;
+        const double vel_ub = hasValidVelocityLimits ? std::min(
+                                  velocityUpperLimits[i], vel_to_pos_ub)
+                                                     : vel_to_pos_ub;
         const double vel_ub_error = velocities[i] - vel_ub;
         if (vel_ub_error > 0.0) {
           if (!relaxUpperVelocityBound) {

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -335,7 +335,8 @@ void JointConstraint::update()
       const bool servoHasFiniteUpperLimit
           = isServo && velocityUpperLimits[i] != static_cast<double>(dInfinity);
       const bool processServoVelocityLimits
-          = servoHasFiniteLowerLimit || servoHasFiniteUpperLimit;
+          = hasValidVelocityLimits
+            && (servoHasFiniteLowerLimit || servoHasFiniteUpperLimit);
       const bool skipVelocityLimitsForServoRecovery
           = isServo
             && ((atUpperLimit && servoCommand < 0.0)

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -200,35 +200,41 @@ void JointConstraint::update()
   mActive.setConstant(false);
 
   for (int i = 0; i < dof; ++i) {
-    // Check for invalid limits (lower > upper) and skip this DOF if so.
-    // This can happen from malformed model files (e.g., SDF with swapped
-    // limits). See: https://github.com/gazebosim/gz-physics/issues/846
-    if (positionLowerLimits[i] > positionUpperLimits[i]) {
+    // Check for invalid limits (lower > upper). When invalid, skip only that
+    // specific limit enforcement but keep other constraints (e.g., servo motor)
+    // active. See: https://github.com/gazebosim/gz-physics/issues/846
+    const bool hasValidPositionLimits
+        = positionLowerLimits[i] <= positionUpperLimits[i];
+    const bool hasValidVelocityLimits
+        = velocityLowerLimits[i] <= velocityUpperLimits[i];
+
+    if (!hasValidPositionLimits) {
       DART_WARN(
           "Joint '{}' DOF {} has invalid position limits: lower ({}) > upper "
-          "({}). Skipping limit enforcement for this DOF.",
+          "({}). Skipping position limit enforcement for this DOF.",
           mJoint->getName(),
           i,
           positionLowerLimits[i],
           positionUpperLimits[i]);
-      continue;
     }
-    if (velocityLowerLimits[i] > velocityUpperLimits[i]) {
+    if (!hasValidVelocityLimits) {
       DART_WARN(
           "Joint '{}' DOF {} has invalid velocity limits: lower ({}) > upper "
-          "({}). Skipping limit enforcement for this DOF.",
+          "({}). Skipping velocity limit enforcement for this DOF.",
           mJoint->getName(),
           i,
           velocityLowerLimits[i],
           velocityUpperLimits[i]);
-      continue;
     }
 
-    // Velocity limits due to position limits
-    const double vel_to_pos_lb
-        = (positionLowerLimits[i] - positions[i]) / timeStep;
-    const double vel_to_pos_ub
-        = (positionUpperLimits[i] - positions[i]) / timeStep;
+    // Velocity limits due to position limits. When position limits are invalid,
+    // treat as unbounded (no position-derived velocity constraints).
+    const double vel_to_pos_lb = hasValidPositionLimits
+        ? (positionLowerLimits[i] - positions[i]) / timeStep
+        : negInf;
+    const double vel_to_pos_ub = hasValidPositionLimits
+        ? (positionUpperLimits[i] - positions[i]) / timeStep
+        : inf;
 
     // Joint position and velocity constraint check
     if (mJoint->areLimitsEnforced()) {
@@ -236,7 +242,7 @@ void JointConstraint::update()
       const double B1 = A1 + mErrorAllowance;
       const double A2 = positions[i] - positionUpperLimits[i];
       const double B2 = A2 - mErrorAllowance;
-      if (B1 < 0) {
+      if (hasValidPositionLimits && B1 < 0) {
         // The current position is lower than the lower bound.
         //
         //    pos            LB                               UB
@@ -273,7 +279,7 @@ void JointConstraint::update()
 
         ++mDim;
         continue;
-      } else if (0 < B2) {
+      } else if (hasValidPositionLimits && 0 < B2) {
         // The current position is greater than the upper bound.
         //
         //    LB                               UB            pos
@@ -341,8 +347,11 @@ void JointConstraint::update()
       const bool relaxUpperVelocityBound = relaxVelocityBoundsForServoRecovery;
 
       if (!skipVelocityLimitsForServoRecovery) {
-        // Check lower velocity bound
-        const double vel_lb = std::max(velocityLowerLimits[i], vel_to_pos_lb);
+        // Check lower velocity bound. When velocity limits are invalid, use
+        // only position-derived velocity constraints.
+        const double vel_lb = hasValidVelocityLimits
+            ? std::max(velocityLowerLimits[i], vel_to_pos_lb)
+            : vel_to_pos_lb;
         const double vel_lb_error = velocities[i] - vel_lb;
         if (vel_lb_error < 0.0) {
           if (!relaxLowerVelocityBound) {
@@ -362,8 +371,11 @@ void JointConstraint::update()
           }
         }
 
-        // Check upper velocity bound
-        const double vel_ub = std::min(velocityUpperLimits[i], vel_to_pos_ub);
+        // Check upper velocity bound. When velocity limits are invalid, use
+        // only position-derived velocity constraints.
+        const double vel_ub = hasValidVelocityLimits
+            ? std::min(velocityUpperLimits[i], vel_to_pos_ub)
+            : vel_to_pos_ub;
         const double vel_ub_error = velocities[i] - vel_ub;
         if (vel_ub_error > 0.0) {
           if (!relaxUpperVelocityBound) {
@@ -387,13 +399,13 @@ void JointConstraint::update()
 
     // Servo motor constraint check
     if (mJoint->getActuatorType() == dynamics::Joint::SERVO) {
-      // The desired velocity shouldn't be out of the velocity limits
-      double desired_velocity = math::clip(
-          mJoint->getCommand(static_cast<std::size_t>(i)),
-          velocityLowerLimits[i],
-          velocityUpperLimits[i]);
+      double desired_velocity = mJoint->getCommand(static_cast<std::size_t>(i));
 
-      // The next position shouldn't be out of the position limits
+      // Clip to velocity limits (when valid) and position-derived limits
+      if (hasValidVelocityLimits) {
+        desired_velocity = math::clip(
+            desired_velocity, velocityLowerLimits[i], velocityUpperLimits[i]);
+      }
       desired_velocity
           = math::clip(desired_velocity, vel_to_pos_lb, vel_to_pos_ub);
 


### PR DESCRIPTION
## Summary

Backport of #2472 to release-6.16.

- Replace `DART_ASSERT` with graceful handling in `JointConstraint::update()` when position or velocity limits are invalid (lower > upper)
- Emit a warning and skip limit enforcement for that DOF instead of crashing

## Motivation

Fixes [gazebosim/gz-physics#846](https://github.com/gazebosim/gz-physics/issues/846) - Gazebo crashes when loading SDF models with swapped joint limits (`<lower>1.0</lower><upper>0.0</upper>`).

## Changes

| File | Change |
|------|--------|
| `dart/constraint/JointConstraint.cpp` | Replace assertions with warning + skip |
| `CHANGELOG.md` | Document the fix |

## Testing

Tested in main branch PR #2472.

## Breaking Changes

None. This is a behavioral fix that improves robustness.

## Related Issues

- Fixes: https://github.com/gazebosim/gz-physics/issues/846
- Main branch PR: #2472