### PR TITLE
Fix: Uncomment dartpy install target

### DIFF
--- a/python/dartpy/CMakeLists.txt
+++ b/python/dartpy/CMakeLists.txt
@@ -91,9 +91,9 @@ endif()
 
 # TODO: Fix installing dartpy to site-packages directory
 # Install the pybind module to site-packages directory
-# install(TARGETS ${pybind_module}
-#   LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}"
-# )
+ install(TARGETS ${pybind_module}
+   LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}"
+ )
 
 list(REMOVE_ITEM dartpy_headers
   ${CMAKE_CURRENT_LIST_DIR}/eigen_geometry_pybind.h


### PR DESCRIPTION
## Summary

- Uncomments dartpy install target in `python/dartpy/CMakeLists.txt`

## Motivation / Problem

- Currently dartpy is built, but not installed.

## Changes / Key Changes

- The only change in this PR is simply uncommenting the relevant target.

## Testing

- Same build process with this patch successfully installs dartpy.

## Breaking Changes

- [X] None

## Related Issues / PRs (backports)

- Resolves #2479

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
