### PR TITLE
Packaging 6.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## DART 6
 
-### [DART 6.16.5 (TBD)](https://github.com/dartsim/dart/milestone/90?closed=1)
+### [DART 6.16.5 (2026-01-21)](https://github.com/dartsim/dart/milestone/90?closed=1)
 
 * Constraint
 

--- a/examples/atlas_puppet/CMakeLists.txt
+++ b/examples/atlas_puppet/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/atlas_puppet/CMakeLists.txt
+++ b/examples/atlas_puppet/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/atlas_simbicon/CMakeLists.txt
+++ b/examples/atlas_simbicon/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/atlas_simbicon/CMakeLists.txt
+++ b/examples/atlas_simbicon/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/biped_stand/CMakeLists.txt
+++ b/examples/biped_stand/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/biped_stand/CMakeLists.txt
+++ b/examples/biped_stand/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/box_stacking/CMakeLists.txt
+++ b/examples/box_stacking/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/box_stacking/CMakeLists.txt
+++ b/examples/box_stacking/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/boxes/CMakeLists.txt
+++ b/examples/boxes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/boxes/CMakeLists.txt
+++ b/examples/boxes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_add_delete_skels/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_add_delete_skels/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_add_delete_skels/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_add_delete_skels/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_atlas_simbicon/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_atlas_simbicon/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_atlas_simbicon/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_atlas_simbicon/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_biped_stand/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_biped_stand/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_biped_stand/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_biped_stand/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_hardcoded_design/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_hardcoded_design/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_hardcoded_design/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_hardcoded_design/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
@@ -41,7 +41,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
@@ -41,7 +41,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_hybrid_dynamics/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_hybrid_dynamics/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_hybrid_dynamics/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_hybrid_dynamics/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_joint_constraints/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_joint_constraints/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_joint_constraints/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_joint_constraints/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_mixed_chain/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_mixed_chain/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_mixed_chain/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_mixed_chain/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_operational_space_control/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_operational_space_control/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_operational_space_control/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_operational_space_control/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_chain/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_chain/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_chain/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_chain/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_cubes/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_cubes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_cubes/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_cubes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_loop/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_loop/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_loop/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_loop/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_shapes/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_shapes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_shapes/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_shapes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_simple_frames/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_simple_frames/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_simple_frames/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_simple_frames/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_soft_bodies/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_soft_bodies/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_soft_bodies/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_soft_bodies/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_vehicle/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_vehicle/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_vehicle/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_vehicle/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/drag_and_drop/CMakeLists.txt
+++ b/examples/drag_and_drop/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/drag_and_drop/CMakeLists.txt
+++ b/examples/drag_and_drop/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/empty/CMakeLists.txt
+++ b/examples/empty/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/empty/CMakeLists.txt
+++ b/examples/empty/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/fetch/CMakeLists.txt
+++ b/examples/fetch/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/fetch/CMakeLists.txt
+++ b/examples/fetch/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/heightmap/CMakeLists.txt
+++ b/examples/heightmap/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/heightmap/CMakeLists.txt
+++ b/examples/heightmap/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/hubo_puppet/CMakeLists.txt
+++ b/examples/hubo_puppet/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/hubo_puppet/CMakeLists.txt
+++ b/examples/hubo_puppet/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/imgui/CMakeLists.txt
+++ b/examples/imgui/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/imgui/CMakeLists.txt
+++ b/examples/imgui/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/operational_space_control/CMakeLists.txt
+++ b/examples/operational_space_control/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/operational_space_control/CMakeLists.txt
+++ b/examples/operational_space_control/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/point_cloud/CMakeLists.txt
+++ b/examples/point_cloud/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/point_cloud/CMakeLists.txt
+++ b/examples/point_cloud/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/rerun/CMakeLists.txt
+++ b/examples/rerun/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/rerun/CMakeLists.txt
+++ b/examples/rerun/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/rigid_shapes/CMakeLists.txt
+++ b/examples/rigid_shapes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/rigid_shapes/CMakeLists.txt
+++ b/examples/rigid_shapes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/soft_bodies/CMakeLists.txt
+++ b/examples/soft_bodies/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/soft_bodies/CMakeLists.txt
+++ b/examples/soft_bodies/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/speed_test/CMakeLists.txt
+++ b/examples/speed_test/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/speed_test/CMakeLists.txt
+++ b/examples/speed_test/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/tinkertoy/CMakeLists.txt
+++ b/examples/tinkertoy/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/tinkertoy/CMakeLists.txt
+++ b/examples/tinkertoy/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/wam_ikfast/CMakeLists.txt
+++ b/examples/wam_ikfast/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/wam_ikfast/CMakeLists.txt
+++ b/examples/wam_ikfast/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.16.4</version>
+  <version>6.16.5</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.16.4"
+version = "6.16.5"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]

--- a/tutorials/tutorial_biped/CMakeLists.txt
+++ b/tutorials/tutorial_biped/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_biped/CMakeLists.txt
+++ b/tutorials/tutorial_biped/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_biped_finished/CMakeLists.txt
+++ b/tutorials/tutorial_biped_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_biped_finished/CMakeLists.txt
+++ b/tutorials/tutorial_biped_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_collisions/CMakeLists.txt
+++ b/tutorials/tutorial_collisions/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_collisions/CMakeLists.txt
+++ b/tutorials/tutorial_collisions/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_collisions_finished/CMakeLists.txt
+++ b/tutorials/tutorial_collisions_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_collisions_finished/CMakeLists.txt
+++ b/tutorials/tutorial_collisions_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_dominoes/CMakeLists.txt
+++ b/tutorials/tutorial_dominoes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_dominoes/CMakeLists.txt
+++ b/tutorials/tutorial_dominoes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_dominoes_finished/CMakeLists.txt
+++ b/tutorials/tutorial_dominoes_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_dominoes_finished/CMakeLists.txt
+++ b/tutorials/tutorial_dominoes_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_multi_pendulum/CMakeLists.txt
+++ b/tutorials/tutorial_multi_pendulum/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_multi_pendulum/CMakeLists.txt
+++ b/tutorials/tutorial_multi_pendulum/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_multi_pendulum_finished/CMakeLists.txt
+++ b/tutorials/tutorial_multi_pendulum_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_multi_pendulum_finished/CMakeLists.txt
+++ b/tutorials/tutorial_multi_pendulum_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16.4 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.16.5 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})


### PR DESCRIPTION
## Summary
- Bump packaging version to 6.16.5 (package.xml, pixi.toml) and refresh the CHANGELOG date.
- Update examples/tutorials to require DART 6.16 (minor-only) to avoid patch pinning.

## Testing
- Not run (packaging/metadata-only changes)