### PR TITLE
Fix: guard non-finite dynamics inputs (release-6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
   * Validate contact surface parameters to prevent LCP solver crashes: [#2435](https://github.com/dartsim/dart/pull/2435)
 
+  * Warn and continue when the boxed LCP matrix is non-symmetric to avoid assertion failures with invalid contacts: [gz-physics#848](https://github.com/gazebosim/gz-physics/issues/848)
+
 * Dynamics
 
   * Validate SphereShape radius to prevent assertion failures with NaN/Inf/non-positive values: [#2441](https://github.com/dartsim/dart/pull/2441)
+
+  * Guard against non-finite articulated body computations from zero/epsilon mass or extreme spring values: [gz-physics#849](https://github.com/gazebosim/gz-physics/issues/849), [gz-physics#850](https://github.com/gazebosim/gz-physics/issues/850), [gz-physics#851](https://github.com/gazebosim/gz-physics/issues/851), [gz-physics#854](https://github.com/gazebosim/gz-physics/issues/854), [gz-physics#856](https://github.com/gazebosim/gz-physics/issues/856)
 
 * Parsers
   * Fix null pointer dereference in XmlHelpers getValue* functions: [#2429](https://github.com/dartsim/dart/pull/2429)

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -237,7 +237,10 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
     }
   }
 
-  DART_ASSERT(isSymmetric(n, mA.data()));
+  if (!isSymmetric(n, mA.data())) {
+    dtwarn << "[BoxedLcpConstraintSolver::solveConstrainedGroup] LCP matrix is "
+              "not symmetric. Continuing to avoid assertion failure.\n";
+  }
 
   // Print LCP formulation
   //  dtdbg << "Before solve:" << std::endl;

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -237,10 +237,12 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
     }
   }
 
+#if !defined(NDEBUG)
   if (!isSymmetric(n, mA.data())) {
     dtwarn << "[BoxedLcpConstraintSolver::solveConstrainedGroup] LCP matrix is "
               "not symmetric. Continuing to avoid assertion failure.\n";
   }
+#endif
 
   // Print LCP formulation
   //  dtdbg << "Before solve:" << std::endl;

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1829,7 +1829,13 @@ void BodyNode::updateTransmittedForceFD()
   mF = mBiasForce;
   mF.noalias() += getArticulatedInertiaImplicit() * getSpatialAcceleration();
 
-  DART_ASSERT(!math::isNan(mF));
+  if (math::isNan(mF) || math::isInf(mF)) {
+    dtwarn << "[BodyNode::updateTransmittedForceFD] Non-finite transmitted "
+              "force detected for body ["
+           << getName()
+           << "]. Setting force to zero to avoid simulation instability.\n";
+    mF.setZero();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -1703,7 +1703,12 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaToDynamic(
   JacobianMatrix AIS = childArtInertia * getRelativeJacobianStatic();
   Eigen::Matrix6d PI = childArtInertia;
   PI.noalias() -= AIS * mInvProjArtInertia * AIS.transpose();
-  DART_ASSERT(!math::isNan(PI));
+  if (math::isNan(PI) || math::isInf(PI)) {
+    dtwarn << "[GenericJoint::addChildArtInertiaToDynamic] Non-finite "
+              "articulated inertia detected for joint ["
+           << this->getName() << "]. Skipping child inertia contribution.\n";
+    return;
+  }
 
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.
@@ -1809,7 +1814,14 @@ void GenericJoint<ConfigSpaceT>::updateInvProjArtInertiaDynamic(
   mInvProjArtInertia = math::inverse<ConfigSpaceT>(projAI);
 
   // Verification
-  DART_ASSERT(!math::isNan(mInvProjArtInertia));
+  if (math::isNan(mInvProjArtInertia) || math::isInf(mInvProjArtInertia)) {
+    dtwarn
+        << "[GenericJoint::updateInvProjArtInertiaDynamic] Non-finite inverse "
+           "projected articulated inertia detected for joint ["
+        << this->getName()
+        << "]. Setting inverse inertia to zero to avoid instability.\n";
+    mInvProjArtInertia.setZero();
+  }
 }
 
 //==============================================================================
@@ -1923,7 +1935,12 @@ void GenericJoint<ConfigSpaceT>::addChildBiasForceToDynamic(
   //    getInvProjArtInertiaImplicit() * mTotalForce;
 
   // Verification
-  DART_ASSERT(!math::isNan(beta));
+  if (math::isNan(beta) || math::isInf(beta)) {
+    dtwarn << "[GenericJoint::addChildBiasForceToDynamic] Non-finite bias "
+              "force detected for joint ["
+           << this->getName() << "]. Skipping bias force contribution.\n";
+    return;
+  }
 
   // Add child body's bias force to parent body's bias force. Note that mT
   // should be updated.
@@ -2170,7 +2187,14 @@ void GenericJoint<ConfigSpaceT>::updateAccelerationDynamic(
                * math::AdInvT(this->getRelativeTransform(), spatialAcc)));
 
   // Verification
-  DART_ASSERT(!math::isNan(getAccelerationsStatic()));
+  const Vector accelerations = getAccelerationsStatic();
+  if (math::isNan(accelerations) || math::isInf(accelerations)) {
+    dtwarn << "[GenericJoint::updateAccelerationDynamic] Non-finite joint "
+              "accelerations detected for joint ["
+           << this->getName()
+           << "]. Setting accelerations to zero to avoid instability.\n";
+    setAccelerationsStatic(Vector::Zero());
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -1759,7 +1759,12 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaImplicitToDynamic(
   JacobianMatrix AIS = childArtInertia * getRelativeJacobianStatic();
   Eigen::Matrix6d PI = childArtInertia;
   PI.noalias() -= AIS * mInvProjArtInertiaImplicit * AIS.transpose();
-  DART_ASSERT(!math::isNan(PI));
+  if (math::isNan(PI) || math::isInf(PI)) {
+    dtwarn << "[GenericJoint::addChildArtInertiaImplicitToDynamic] Non-finite "
+              "articulated inertia detected for joint ["
+           << this->getName() << "]. Skipping child inertia contribution.\n";
+    return;
+  }
 
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -12,6 +12,7 @@ dart_build_tests(
     test_Constraint.cpp
     test_Frames.cpp
     test_Friction.cpp
+    test_InvalidDynamicsInputs.cpp
     test_InverseKinematics.cpp
     test_NameManagement.cpp
     test_Signal.cpp

--- a/tests/integration/test_InvalidDynamicsInputs.cpp
+++ b/tests/integration/test_InvalidDynamicsInputs.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dart.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include <cmath>
+
+using namespace dart;
+using namespace dart::constraint;
+using namespace dart::dynamics;
+using namespace dart::simulation;
+
+namespace {
+
+SkeletonPtr createTwoLinkSkeleton(double childMass, double childInertia)
+{
+  auto skeleton = Skeleton::create("invalid_dynamics_skeleton");
+
+  auto rootPair = skeleton->createJointAndBodyNodePair<RevoluteJoint>();
+  auto* rootBody = rootPair.second;
+  rootBody->setMass(1.0);
+  rootBody->setMomentOfInertia(1.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+
+  auto childPair
+      = skeleton->createJointAndBodyNodePair<RevoluteJoint>(rootBody);
+  auto* childBody = childPair.second;
+  childBody->setMass(childMass);
+  childBody->setMomentOfInertia(
+      childInertia, childInertia, childInertia, 0.0, 0.0, 0.0);
+
+  return skeleton;
+}
+
+SkeletonPtr createBoxSkeleton(
+    const std::string& name,
+    const Eigen::Vector3d& size,
+    const Eigen::Vector3d& position,
+    double mass,
+    double inertia)
+{
+  auto skeleton = Skeleton::create(name);
+  auto pair = skeleton->createJointAndBodyNodePair<FreeJoint>();
+  auto* body = pair.second;
+
+  body->setMass(mass);
+  body->setMomentOfInertia(inertia, inertia, inertia, 0.0, 0.0, 0.0);
+
+  auto shape = std::make_shared<BoxShape>(size);
+  body->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+      shape);
+
+  Eigen::Vector6d positions = Eigen::Vector6d::Zero();
+  positions.tail<3>() = position;
+  skeleton->setPositions(positions);
+
+  return skeleton;
+}
+
+} // namespace
+
+TEST(InvalidDynamicsInputs, ZeroMassLeafDoesNotCrash)
+{
+  auto world = World::create();
+  auto skeleton = createTwoLinkSkeleton(0.0, 0.0);
+  world->addSkeleton(skeleton);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 5; ++i) {
+      world->step();
+    }
+  });
+
+  EXPECT_TRUE(skeleton->getPositions().allFinite());
+  EXPECT_TRUE(skeleton->getVelocities().allFinite());
+}
+
+TEST(InvalidDynamicsInputs, EpsilonMassLeafDoesNotCrash)
+{
+  constexpr double kEpsilonMass = 1e-300;
+  auto world = World::create();
+  auto skeleton = createTwoLinkSkeleton(kEpsilonMass, kEpsilonMass);
+  world->addSkeleton(skeleton);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 5; ++i) {
+      world->step();
+    }
+  });
+
+  EXPECT_TRUE(skeleton->getPositions().allFinite());
+  EXPECT_TRUE(skeleton->getVelocities().allFinite());
+}
+
+TEST(InvalidDynamicsInputs, ExtremeSpringDoesNotCrash)
+{
+  auto world = World::create();
+  auto skeleton = Skeleton::create("spring_overflow_skeleton");
+
+  auto pair = skeleton->createJointAndBodyNodePair<RevoluteJoint>();
+  auto* joint = pair.first;
+  auto* body = pair.second;
+  body->setMass(1.0);
+  body->setMomentOfInertia(1.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+
+  joint->setSpringStiffness(0, 1e300);
+  joint->setRestPosition(0, 1e10);
+  joint->setPosition(0, 0.0);
+
+  world->addSkeleton(skeleton);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 5; ++i) {
+      world->step();
+    }
+  });
+
+  EXPECT_TRUE(skeleton->getPositions().allFinite());
+  EXPECT_TRUE(skeleton->getVelocities().allFinite());
+}
+
+TEST(InvalidDynamicsInputs, ZeroMassContactDoesNotCrash)
+{
+  auto world = World::create();
+  world->setConstraintSolver(std::make_unique<BoxedLcpConstraintSolver>());
+
+  auto dynamicBox = createBoxSkeleton(
+      "dynamic_box",
+      Eigen::Vector3d(1.0, 1.0, 1.0),
+      Eigen::Vector3d::Zero(),
+      1.0,
+      1.0);
+  auto zeroMassBox = createBoxSkeleton(
+      "zero_mass_box",
+      Eigen::Vector3d(1.0, 1.0, 1.0),
+      Eigen::Vector3d(0.0, 0.0, 0.4),
+      0.0,
+      0.0);
+
+  world->addSkeleton(dynamicBox);
+  world->addSkeleton(zeroMassBox);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 5; ++i) {
+      world->step();
+    }
+  });
+
+  EXPECT_TRUE(dynamicBox->getPositions().allFinite());
+  EXPECT_TRUE(zeroMassBox->getPositions().allFinite());
+}


### PR DESCRIPTION
## Summary
- Replace asserts with warn-and-continue guards for non-finite articulated dynamics and non-symmetric LCP matrices.
- Add integration regression tests for zero/epsilon mass, extreme spring stiffness, and zero-mass contact paths.
- Note the behavior changes in CHANGELOG.md for gz-physics crash reports.

## Testing
- `pixi run lint`
- `pixi run test-unit` (fails: task not defined)
- `pixi run test-all` (interrupted; build stopped)

## References
- gazebosim/gz-physics#848
- gazebosim/gz-physics#849
- gazebosim/gz-physics#850
- gazebosim/gz-physics#851
- gazebosim/gz-physics#854
- gazebosim/gz-physics#856