### PR TITLE
fix: silently handle slip compliance sentinel value (-1.0) [6.16]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## DART 6
 
+### [DART 6.16.6 (TBD)](https://github.com/dartsim/dart/milestone/91?closed=1)
+
+* Constraint
+
+  * Fix slip compliance validation to silently handle the -1.0 sentinel value (meaning "use default") instead of logging spurious warnings: [gz-sim#3289](https://github.com/gazebosim/gz-sim/issues/3289)
+
 ### [DART 6.16.5 (2026-01-21)](https://github.com/dartsim/dart/milestone/90?closed=1)
 
 * Constraint

--- a/dart/constraint/ContactSurface.cpp
+++ b/dart/constraint/ContactSurface.cpp
@@ -297,13 +297,21 @@ double DefaultContactSurfaceHandler::computePrimarySlipCompliance(
   }
 
   const double slipCompliance = dynamicAspect->getPrimarySlipCompliance();
-  if (!std::isfinite(slipCompliance) || slipCompliance < 0.0) {
+
+  // Negative values (including the -1.0 sentinel) mean "use default".
+  // This is by design - see ShapeFrame.hpp documentation.
+  if (slipCompliance < 0.0) {
+    return DART_DEFAULT_SLIP_COMPLIANCE;
+  }
+
+  if (!std::isfinite(slipCompliance)) {
     dtwarn << "[ContactConstraint] Invalid primary slip compliance ("
            << slipCompliance << ") from ShapeNode [" << shapeNode->getName()
-           << "]. Slip compliance must be non-negative and finite. Using "
+           << "]. Slip compliance must be finite. Using "
            << "default value (" << DART_DEFAULT_SLIP_COMPLIANCE << ").\n";
     return DART_DEFAULT_SLIP_COMPLIANCE;
   }
+
   return slipCompliance;
 }
 
@@ -325,13 +333,21 @@ double DefaultContactSurfaceHandler::computeSecondarySlipCompliance(
   }
 
   const double slipCompliance = dynamicAspect->getSecondarySlipCompliance();
-  if (!std::isfinite(slipCompliance) || slipCompliance < 0.0) {
+
+  // Negative values (including the -1.0 sentinel) mean "use default".
+  // This is by design - see ShapeFrame.hpp documentation.
+  if (slipCompliance < 0.0) {
+    return DART_DEFAULT_SLIP_COMPLIANCE;
+  }
+
+  if (!std::isfinite(slipCompliance)) {
     dtwarn << "[ContactConstraint] Invalid secondary slip compliance ("
            << slipCompliance << ") from ShapeNode [" << shapeNode->getName()
-           << "]. Slip compliance must be non-negative and finite. Using "
+           << "]. Slip compliance must be finite. Using "
            << "default value (" << DART_DEFAULT_SLIP_COMPLIANCE << ").\n";
     return DART_DEFAULT_SLIP_COMPLIANCE;
   }
+
   return slipCompliance;
 }
 


### PR DESCRIPTION
## Summary

Fix slip compliance validation to silently handle the `-1.0` sentinel value instead of logging spurious warnings.

## Problem

PR #2435 added validation for contact surface parameters to prevent LCP solver crashes. However, the slip compliance parameters intentionally default to `-1.0` as a sentinel value meaning "use global default" (documented in `ShapeFrame.hpp`). The validation incorrectly treated this sentinel as an invalid value, causing massive warning spam:

- **gz-sim CI logs grew from ~4 MB to 1.5+ GB**
- Users see hundreds of warnings per second after upgrading to DART 6.16.5

## Solution

- Check negative values first and silently return the default (this handles the `-1.0` sentinel)
- Only warn for genuinely invalid NaN/Inf values (rare case from malformed SDF)

## Testing

- All existing unit tests pass (21 tests in `UNIT_constraint_ContactSurface`)
- `NegativePrimarySlipComplianceClampsToDefault` now produces no warning output
- `NaNPrimarySlipComplianceClampsToDefault` still produces a warning (correct behavior)

## Related Issues

- Fixes https://github.com/gazebosim/gz-sim/issues/3289
- Related to https://github.com/dartsim/dart/pull/2435