### PR TITLE
Fix: reject non-finite transforms in public API and MJCF parser (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
 
   * Guard against non-finite articulated body computations from zero/epsilon mass or extreme spring values: [gz-physics#849](https://github.com/gazebosim/gz-physics/issues/849), [gz-physics#850](https://github.com/gazebosim/gz-physics/issues/850), [gz-physics#851](https://github.com/gazebosim/gz-physics/issues/851), [gz-physics#854](https://github.com/gazebosim/gz-physics/issues/854), [gz-physics#856](https://github.com/gazebosim/gz-physics/issues/856)
 
+  * Reject non-finite transforms at Joint public API entry points and guard inertia propagation in kinematic joint variants: [gz-physics#861](https://github.com/gazebosim/gz-physics/issues/861), [gz-physics#862](https://github.com/gazebosim/gz-physics/issues/862)
+
+* Parsers
+
+  * Replace MJCF parser DART_ASSERT with DART_WARN + identity fallback for non-finite transforms and rotations
+
+* Math
+
+  * Enhance verifyTransform to also reject infinity values (previously only checked NaN)
+
 ### [DART 6.16.5 (2026-01-21)](https://github.com/dartsim/dart/milestone/90?closed=1)
 
 * Constraint

--- a/dart/dynamics/BallJoint.cpp
+++ b/dart/dynamics/BallJoint.cpp
@@ -157,7 +157,12 @@ void BallJoint::updateRelativeTransform() const
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mR
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[BallJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -731,8 +731,9 @@ static bool checkSkeletonNodeAgreement(
 {
   if (nullptr == _newSkeleton) {
     dterr << "[BodyNode::" << _function << "] Attempting to " << _operation
-          << " a BodyNode tree starting " << "from [" << _bodyNode->getName()
-          << "] in the Skeleton named [" << _bodyNode->getSkeleton()->getName()
+          << " a BodyNode tree starting "
+          << "from [" << _bodyNode->getName() << "] in the Skeleton named ["
+          << _bodyNode->getSkeleton()->getName()
           << "] into a nullptr Skeleton.\n";
     return false;
   }

--- a/dart/dynamics/EulerJoint.cpp
+++ b/dart/dynamics/EulerJoint.cpp
@@ -327,7 +327,12 @@ void EulerJoint::updateRelativeTransform() const
        * convertToTransform(getPositionsStatic())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[EulerJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -635,7 +635,12 @@ void FreeJoint::updateRelativeTransform() const
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mQ
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[FreeJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -551,7 +551,13 @@ double Joint::getPotentialEnergy() const
 //==============================================================================
 void Joint::setTransformFromParentBodyNode(const Eigen::Isometry3d& _T)
 {
-  DART_ASSERT(math::verifyTransform(_T));
+  if (!math::verifyTransform(_T)) {
+    DART_WARN(
+        "[Joint::setTransformFromParentBodyNode] Non-finite transform "
+        "rejected for joint [{}]. Keeping existing transform.",
+        getName());
+    return;
+  }
   mAspectProperties.mT_ParentBodyToJoint = _T;
   notifyPositionUpdated();
 }
@@ -559,7 +565,13 @@ void Joint::setTransformFromParentBodyNode(const Eigen::Isometry3d& _T)
 //==============================================================================
 void Joint::setTransformFromChildBodyNode(const Eigen::Isometry3d& _T)
 {
-  DART_ASSERT(math::verifyTransform(_T));
+  if (!math::verifyTransform(_T)) {
+    DART_WARN(
+        "[Joint::setTransformFromChildBodyNode] Non-finite transform "
+        "rejected for joint [{}]. Keeping existing transform.",
+        getName());
+    return;
+  }
   mAspectProperties.mT_ChildBodyToJoint = _T;
   updateRelativeJacobian();
   notifyPositionUpdated();

--- a/dart/dynamics/PlanarJoint.cpp
+++ b/dart/dynamics/PlanarJoint.cpp
@@ -272,8 +272,12 @@ void PlanarJoint::updateRelativeTransform() const
        * math::expAngular(mAspectProperties.mRotAxis * positions[2])
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  // Verification
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[PlanarJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/PrismaticJoint.cpp
+++ b/dart/dynamics/PrismaticJoint.cpp
@@ -182,8 +182,12 @@ void PrismaticJoint::updateRelativeTransform() const
        * Eigen::Translation3d(getAxis() * getPositionsStatic())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  // Verification
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[PrismaticJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/RevoluteJoint.cpp
+++ b/dart/dynamics/RevoluteJoint.cpp
@@ -183,8 +183,12 @@ void RevoluteJoint::updateRelativeTransform() const
        * math::expAngular(getAxis() * getPositionsStatic())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  // Verification
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[RevoluteJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/ScrewJoint.cpp
+++ b/dart/dynamics/ScrewJoint.cpp
@@ -210,7 +210,12 @@ void ScrewJoint::updateRelativeTransform() const
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint
        * math::expMap(S * getPositionsStatic())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[ScrewJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/TranslationalJoint.cpp
+++ b/dart/dynamics/TranslationalJoint.cpp
@@ -122,8 +122,12 @@ void TranslationalJoint::updateRelativeTransform() const
        * Eigen::Translation3d(getPositionsStatic())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  // Verification
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[TranslationalJoint::updateRelativeTransform] Non-finite "
+              "relative transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/TranslationalJoint2D.cpp
+++ b/dart/dynamics/TranslationalJoint2D.cpp
@@ -228,8 +228,12 @@ void TranslationalJoint2D::updateRelativeTransform() const
            mAspectProperties.getTranslationalAxes() * positions)
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
 
-  // Verification
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[TranslationalJoint2D::updateRelativeTransform] Non-finite "
+              "relative transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/UniversalJoint.cpp
+++ b/dart/dynamics/UniversalJoint.cpp
@@ -195,7 +195,12 @@ void UniversalJoint::updateRelativeTransform() const
        * Eigen::AngleAxisd(positions[0], getAxis1())
        * Eigen::AngleAxisd(positions[1], getAxis2())
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
-  DART_ASSERT(math::verifyTransform(mT));
+  if (!math::verifyTransform(mT)) {
+    dtwarn << "[UniversalJoint::updateRelativeTransform] Non-finite relative "
+              "transform detected in '"
+           << this->getName() << "'. Using identity.\n";
+    mT = Eigen::Isometry3d::Identity();
+  }
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -47,9 +47,9 @@
 #define GenericJoint_REPORT_DIM_MISMATCH(func, arg)                            \
   {                                                                            \
     dterr << "[GenericJoint::" #func "] Mismatch beteween size of "            \
-          << #arg " [" << arg.size() << "] and the number of " << "DOFs ["     \
-          << getNumDofs() << "] for Joint named [" << this->getName()          \
-          << "].\n";                                                           \
+          << #arg " [" << arg.size() << "] and the number of "                 \
+          << "DOFs [" << getNumDofs() << "] for Joint named ["                 \
+          << this->getName() << "].\n";                                        \
     DART_ASSERT(false);                                                        \
   }
 

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -47,9 +47,9 @@
 #define GenericJoint_REPORT_DIM_MISMATCH(func, arg)                            \
   {                                                                            \
     dterr << "[GenericJoint::" #func "] Mismatch beteween size of "            \
-          << #arg " [" << arg.size() << "] and the number of "                 \
-          << "DOFs [" << getNumDofs() << "] for Joint named ["                 \
-          << this->getName() << "].\n";                                        \
+          << #arg " [" << arg.size() << "] and the number of " << "DOFs ["     \
+          << getNumDofs() << "] for Joint named [" << this->getName()          \
+          << "].\n";                                                           \
     DART_ASSERT(false);                                                        \
   }
 
@@ -1712,8 +1712,15 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaToDynamic(
 
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.
-  parentArtInertia
-      += math::transformInertia(this->getRelativeTransform().inverse(), PI);
+  const Eigen::Matrix6d contribution
+      = math::transformInertia(this->getRelativeTransform().inverse(), PI);
+  if (math::isNan(contribution) || math::isInf(contribution)) {
+    dtwarn << "[GenericJoint::addChildArtInertiaToDynamic] Non-finite "
+              "transformed inertia detected for joint ["
+           << this->getName() << "]. Skipping child inertia contribution.\n";
+    return;
+  }
+  parentArtInertia += contribution;
 }
 
 //==============================================================================
@@ -1723,8 +1730,15 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaToKinematic(
 {
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.
-  parentArtInertia += math::transformInertia(
+  const Eigen::Matrix6d contribution = math::transformInertia(
       this->getRelativeTransform().inverse(), childArtInertia);
+  if (math::isNan(contribution) || math::isInf(contribution)) {
+    dtwarn << "[GenericJoint::addChildArtInertiaToKinematic] Non-finite "
+              "transformed inertia detected for joint ["
+           << this->getName() << "]. Skipping child inertia contribution.\n";
+    return;
+  }
+  parentArtInertia += contribution;
 }
 
 //==============================================================================
@@ -1768,8 +1782,15 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaImplicitToDynamic(
 
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.
-  parentArtInertia
-      += math::transformInertia(this->getRelativeTransform().inverse(), PI);
+  const Eigen::Matrix6d contribution
+      = math::transformInertia(this->getRelativeTransform().inverse(), PI);
+  if (math::isNan(contribution) || math::isInf(contribution)) {
+    dtwarn << "[GenericJoint::addChildArtInertiaImplicitToDynamic] Non-finite "
+              "transformed inertia detected for joint ["
+           << this->getName() << "]. Skipping child inertia contribution.\n";
+    return;
+  }
+  parentArtInertia += contribution;
 }
 
 //==============================================================================
@@ -1779,8 +1800,16 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaImplicitToKinematic(
 {
   // Add child body's articulated inertia to parent body's articulated inertia.
   // Note that mT should be updated.
-  parentArtInertia += math::transformInertia(
+  const Eigen::Matrix6d contribution = math::transformInertia(
       this->getRelativeTransform().inverse(), childArtInertia);
+  if (math::isNan(contribution) || math::isInf(contribution)) {
+    dtwarn
+        << "[GenericJoint::addChildArtInertiaImplicitToKinematic] Non-finite "
+           "transformed inertia detected for joint ["
+        << this->getName() << "]. Skipping child inertia contribution.\n";
+    return;
+  }
+  parentArtInertia += contribution;
 }
 
 //==============================================================================

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -1663,7 +1663,8 @@ Eigen::Vector2d computeCentroidOfHull(const SupportPolygon& _convexHull)
              << "contains indices " << i - 1 << " -> " << i << ":\n"
              << i - 1 << ") " << p1.transpose() << " (" << a1 << " degrees)"
              << "\n"
-             << i << ") " << p2.transpose() << " (" << a2 << " degrees)" << "\n"
+             << i << ") " << p2.transpose() << " (" << a2 << " degrees)"
+             << "\n"
              << "0) " << p0.transpose() << "\n"
              << "(" << result << ") "
              << (PARALLEL == result

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -1531,7 +1531,10 @@ Eigen::Matrix3d computeRotation(
   result.col(++index % 3) = axis1;
   result.col(++index % 3) = axis2;
 
-  DART_ASSERT(verifyRotation(result));
+  if (!verifyRotation(result)) {
+    dtwarn << "[math::computeRotation] Non-finite rotation result.\n";
+    result = Eigen::Matrix3d::Identity();
+  }
 
   return result;
 }
@@ -1547,8 +1550,10 @@ Eigen::Isometry3d computeTransform(
   result.linear() = computeRotation(axis, axisType);
   result.translation() = translation;
 
-  // Verification
-  DART_ASSERT(verifyTransform(result));
+  if (!verifyTransform(result)) {
+    dtwarn << "[math::computeTransform] Non-finite transform result.\n";
+    result = Eigen::Isometry3d::Identity();
+  }
 
   return result;
 }

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -1473,7 +1473,7 @@ bool verifyRotation(const Eigen::Matrix3d& _T)
 
 bool verifyTransform(const Eigen::Isometry3d& _T)
 {
-  return !isNan(_T.matrix().topRows<3>())
+  return !isNan(_T.matrix().topRows<3>()) && !isInf(_T.matrix().topRows<3>())
          && std::abs(_T.linear().determinant() - 1.0) <= DART_EPSILON;
 }
 
@@ -1663,8 +1663,7 @@ Eigen::Vector2d computeCentroidOfHull(const SupportPolygon& _convexHull)
              << "contains indices " << i - 1 << " -> " << i << ":\n"
              << i - 1 << ") " << p1.transpose() << " (" << a1 << " degrees)"
              << "\n"
-             << i << ") " << p2.transpose() << " (" << a2 << " degrees)"
-             << "\n"
+             << i << ") " << p2.transpose() << " (" << a2 << " degrees)" << "\n"
              << "0) " << p0.transpose() << "\n"
              << "(" << result << ") "
              << (PARALLEL == result

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -232,7 +232,12 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
           mAttributes.mXYAxes,
           mAttributes.mZAxis,
           compiler);
-      DART_ASSERT(math::verifyTransform(mRelativeTransform));
+      if (!math::verifyTransform(mRelativeTransform)) {
+        DART_WARN(
+            "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
+            "The model file may contain extreme or invalid pose values.");
+        mRelativeTransform = Eigen::Isometry3d::Identity();
+      }
     } else {
       mWorldTransform.translation() = *mAttributes.mPos;
       mWorldTransform.linear() = compileRotation(
@@ -246,21 +251,43 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
         mInertial.setRelativeTransform(
             mWorldTransform.inverse() * mInertial.getWorldTransform());
       }
-      DART_ASSERT(math::verifyTransform(mWorldTransform));
+      if (!math::verifyTransform(mWorldTransform)) {
+        DART_WARN(
+            "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
+            "The model file may contain extreme or invalid pose values.");
+        mWorldTransform = Eigen::Isometry3d::Identity();
+      }
     }
   } else {
     if (compiler.getCoordinate() == Coordinate::LOCAL) {
       mRelativeTransform = mInertial.getRelativeTransform();
-      DART_ASSERT(math::verifyTransform(mRelativeTransform));
+      if (!math::verifyTransform(mRelativeTransform)) {
+        DART_WARN(
+            "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
+            "The model file may contain extreme or invalid pose values.");
+        mRelativeTransform = Eigen::Isometry3d::Identity();
+      }
     } else {
       mWorldTransform = mInertial.getWorldTransform();
       if (parent != nullptr) {
         mRelativeTransform
             = parent->getWorldTransform().inverse() * mWorldTransform;
-        DART_ASSERT(math::verifyTransform(mRelativeTransform));
+        if (!math::verifyTransform(mRelativeTransform)) {
+          DART_WARN(
+              "[MjcfBody] Non-finite transform detected while parsing MJCF "
+              "body. "
+              "The model file may contain extreme or invalid pose values.");
+          mRelativeTransform = Eigen::Isometry3d::Identity();
+        }
       } else {
         mRelativeTransform = mWorldTransform;
-        DART_ASSERT(math::verifyTransform(mRelativeTransform));
+        if (!math::verifyTransform(mRelativeTransform)) {
+          DART_WARN(
+              "[MjcfBody] Non-finite transform detected while parsing MJCF "
+              "body. "
+              "The model file may contain extreme or invalid pose values.");
+          mRelativeTransform = Eigen::Isometry3d::Identity();
+        }
       }
       mInertial.setRelativeTransform(Eigen::Isometry3d::Identity());
     }
@@ -358,7 +385,13 @@ const Site& Body::getSite(std::size_t index) const
 //==============================================================================
 void Body::setRelativeTransform(const Eigen::Isometry3d& tf)
 {
-  DART_ASSERT(math::verifyTransform(tf));
+  if (!math::verifyTransform(tf)) {
+    DART_WARN(
+        "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
+        "The model file may contain extreme or invalid pose values.");
+    mRelativeTransform = Eigen::Isometry3d::Identity();
+    return;
+  }
   mRelativeTransform = tf;
 }
 
@@ -371,7 +404,13 @@ const Eigen::Isometry3d& Body::getRelativeTransform() const
 //==============================================================================
 void Body::setWorldTransform(const Eigen::Isometry3d& tf)
 {
-  DART_ASSERT(math::verifyTransform(tf));
+  if (!math::verifyTransform(tf)) {
+    DART_WARN(
+        "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
+        "The model file may contain extreme or invalid pose values.");
+    mWorldTransform = Eigen::Isometry3d::Identity();
+    return;
+  }
   mWorldTransform = tf;
 }
 

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -266,9 +266,16 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
             "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
             "The model file may contain extreme or invalid pose values.");
         mRelativeTransform = Eigen::Isometry3d::Identity();
+        mInertial.setRelativeTransform(Eigen::Isometry3d::Identity());
       }
     } else {
       mWorldTransform = mInertial.getWorldTransform();
+      if (!math::verifyTransform(mWorldTransform)) {
+        DART_WARN(
+            "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
+            "The model file may contain extreme or invalid pose values.");
+        mWorldTransform = Eigen::Isometry3d::Identity();
+      }
       if (parent != nullptr) {
         mRelativeTransform
             = parent->getWorldTransform().inverse() * mWorldTransform;
@@ -281,13 +288,6 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
         }
       } else {
         mRelativeTransform = mWorldTransform;
-        if (!math::verifyTransform(mRelativeTransform)) {
-          DART_WARN(
-              "[MjcfBody] Non-finite transform detected while parsing MJCF "
-              "body. "
-              "The model file may contain extreme or invalid pose values.");
-          mRelativeTransform = Eigen::Isometry3d::Identity();
-        }
       }
       mInertial.setRelativeTransform(Eigen::Isometry3d::Identity());
     }

--- a/dart/utils/mjcf/detail/Body.cpp
+++ b/dart/utils/mjcf/detail/Body.cpp
@@ -247,15 +247,15 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
           mAttributes.mXYAxes,
           mAttributes.mZAxis,
           compiler);
-      if (mAttributes.mInertial) {
-        mInertial.setRelativeTransform(
-            mWorldTransform.inverse() * mInertial.getWorldTransform());
-      }
       if (!math::verifyTransform(mWorldTransform)) {
         DART_WARN(
             "[MjcfBody] Non-finite transform detected while parsing MJCF body. "
             "The model file may contain extreme or invalid pose values.");
         mWorldTransform = Eigen::Isometry3d::Identity();
+      }
+      if (mAttributes.mInertial) {
+        mInertial.setRelativeTransform(
+            mWorldTransform.inverse() * mInertial.getWorldTransform());
       }
     }
   } else {

--- a/dart/utils/mjcf/detail/Utils.cpp
+++ b/dart/utils/mjcf/detail/Utils.cpp
@@ -111,7 +111,12 @@ Eigen::Matrix3d compileRotation(
       angle = math::toRadian(angle);
     }
     rot = Eigen::AngleAxisd(angle, axis).toRotationMatrix();
-    DART_ASSERT(math::verifyRotation(rot));
+    if (!math::verifyRotation(rot)) {
+      DART_WARN(
+          "[MjcfUtils] Non-finite rotation detected while parsing MJCF data. "
+          "The model file may contain extreme or invalid orientation values.");
+      rot = Eigen::Matrix3d::Identity();
+    }
   } else if (euler) {
     Eigen::Vector3d angles = *euler;
     if (compiler.getAngle() == Angle::DEGREE) {
@@ -122,10 +127,24 @@ Eigen::Matrix3d compileRotation(
 
     if (compiler.getEulerSeq() == "xyz") {
       rot = math::eulerXYZToMatrix(angles);
-      DART_ASSERT(math::verifyRotation(rot));
+      if (!math::verifyRotation(rot)) {
+        DART_WARN(
+            "[MjcfUtils] Non-finite rotation detected while parsing MJCF "
+            "data. "
+            "The model file may contain extreme or invalid orientation "
+            "values.");
+        rot = Eigen::Matrix3d::Identity();
+      }
     } else if (compiler.getEulerSeq() == "zyx") {
       rot = math::eulerZYXToMatrix(angles);
-      DART_ASSERT(math::verifyRotation(rot));
+      if (!math::verifyRotation(rot)) {
+        DART_WARN(
+            "[MjcfUtils] Non-finite rotation detected while parsing MJCF "
+            "data. "
+            "The model file may contain extreme or invalid orientation "
+            "values.");
+        rot = Eigen::Matrix3d::Identity();
+      }
     } else {
       dterr << "[MjcfParser] Unsupported Euler angle sequence: '"
             << compiler.getEulerSeq() << "'. Please report this error. "
@@ -136,15 +155,30 @@ Eigen::Matrix3d compileRotation(
     rot.col(0) = (*xyAxes).head<3>().normalized();                    // X axis
     rot.col(1) = (*xyAxes).tail<3>().normalized();                    // Y axis
     rot.col(2).noalias() = rot.col(0).cross(rot.col(1)).normalized(); // Z axis
-    DART_ASSERT(math::verifyRotation(rot));
+    if (!math::verifyRotation(rot)) {
+      DART_WARN(
+          "[MjcfUtils] Non-finite rotation detected while parsing MJCF data. "
+          "The model file may contain extreme or invalid orientation values.");
+      rot = Eigen::Matrix3d::Identity();
+    }
   } else if (zAxis) {
     rot = Eigen::Quaterniond::FromTwoVectors(
               Eigen::Vector3d::UnitZ(), zAxis->normalized())
               .toRotationMatrix();
-    DART_ASSERT(math::verifyRotation(rot));
+    if (!math::verifyRotation(rot)) {
+      DART_WARN(
+          "[MjcfUtils] Non-finite rotation detected while parsing MJCF data. "
+          "The model file may contain extreme or invalid orientation values.");
+      rot = Eigen::Matrix3d::Identity();
+    }
   } else {
     rot = quat.normalized().toRotationMatrix();
-    DART_ASSERT(math::verifyRotation(rot));
+    if (!math::verifyRotation(rot)) {
+      DART_WARN(
+          "[MjcfUtils] Non-finite rotation detected while parsing MJCF data. "
+          "The model file may contain extreme or invalid orientation values.");
+      rot = Eigen::Matrix3d::Identity();
+    }
   }
 
   return rot;

--- a/tests/unit/dynamics/test_Joints.cpp
+++ b/tests/unit/dynamics/test_Joints.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dart.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include <cmath>
+
+using namespace dart;
+using namespace dart::dynamics;
+using namespace dart::simulation;
+
+TEST(Joints, NonFiniteTransformFromParentBodyNodeRejected)
+{
+  auto skel = Skeleton::create("test");
+  auto pair = skel->createJointAndBodyNodePair<RevoluteJoint>();
+  auto* joint = pair.first;
+
+  Eigen::Isometry3d goodTf = Eigen::Isometry3d::Identity();
+  goodTf.translation() = Eigen::Vector3d(1, 2, 3);
+  joint->setTransformFromParentBodyNode(goodTf);
+  EXPECT_TRUE(goodTf.isApprox(joint->getTransformFromParentBodyNode(), 1e-10));
+
+  Eigen::Isometry3d nanTf = Eigen::Isometry3d::Identity();
+  nanTf.translation()[0] = std::numeric_limits<double>::quiet_NaN();
+  joint->setTransformFromParentBodyNode(nanTf);
+  EXPECT_TRUE(goodTf.isApprox(joint->getTransformFromParentBodyNode(), 1e-10));
+
+  Eigen::Isometry3d infTf = Eigen::Isometry3d::Identity();
+  infTf.translation()[0] = std::numeric_limits<double>::infinity();
+  joint->setTransformFromParentBodyNode(infTf);
+  EXPECT_TRUE(goodTf.isApprox(joint->getTransformFromParentBodyNode(), 1e-10));
+
+  Eigen::Isometry3d badRotTf = Eigen::Isometry3d::Identity();
+  badRotTf.linear() << 2, 0, 0, 0, 2, 0, 0, 0, 2;
+  joint->setTransformFromParentBodyNode(badRotTf);
+  EXPECT_TRUE(goodTf.isApprox(joint->getTransformFromParentBodyNode(), 1e-10));
+}
+
+TEST(Joints, NonFiniteTransformFromChildBodyNodeRejected)
+{
+  auto skel = Skeleton::create("test");
+  auto pair = skel->createJointAndBodyNodePair<RevoluteJoint>();
+  auto* joint = pair.first;
+
+  Eigen::Isometry3d nanTf = Eigen::Isometry3d::Identity();
+  nanTf.translation()[0] = std::numeric_limits<double>::quiet_NaN();
+  joint->setTransformFromChildBodyNode(nanTf);
+  EXPECT_TRUE(Eigen::Isometry3d::Identity().isApprox(
+      joint->getTransformFromChildBodyNode(), 1e-10));
+}
+
+TEST(Joints, SimulationSurvivesOverflowTransforms)
+{
+  auto skel = Skeleton::create("overflow");
+  auto pair = skel->createJointAndBodyNodePair<FreeJoint>();
+  auto* body = pair.second;
+  body->setMass(1.0);
+
+  Eigen::Isometry3d extremeTf = Eigen::Isometry3d::Identity();
+  extremeTf.translation() = Eigen::Vector3d(1e308, 1e308, 1e308);
+  pair.first->setTransformFromParentBodyNode(extremeTf);
+
+  auto world = World::create();
+  world->addSkeleton(skel);
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_NO_THROW(world->step());
+  }
+}

--- a/tests/unit/math/test_Geometry.cpp
+++ b/tests/unit/math/test_Geometry.cpp
@@ -344,7 +344,9 @@ TEST(LIE_GROUP_OPERATORS, EXPONENTIAL_MAPPINGS)
       randomS[i] = Random::uniform(min, max);
 
     Eigen::Isometry3d T = math::expMap(randomS);
-    EXPECT_TRUE(math::verifyTransform(T));
+    // With extreme inputs (±1e128), the translation component may overflow to
+    // infinity while the rotation remains valid. Only verify the rotation part.
+    EXPECT_TRUE(math::verifyRotation(T.linear()));
   }
 }
 


### PR DESCRIPTION
## Summary

- Backport of #2496 to `release-6.16`.
- Guard against non-finite (NaN/Inf) transforms that cause assertion failures and crashes when SDF models contain extreme pose values (e.g., `1e308`) that overflow during matrix operations.
- Extends the guards from #2485 with additional coverage for public API entry points, MJCF parser, and the `verifyTransform` utility itself.

## Motivation / Problem

Gazebo users report crashes when SDF models contain extreme `<pose>` values like `1e308`. These values are finite doubles but overflow to infinity during matrix multiplication in the dynamics pipeline, hitting `DART_ASSERT` (which wraps `assert()`) and killing the process in debug builds.

The previous fix (#2485) guarded the internal dynamics pipeline. This PR adds:
1. **Public API guards** (Category A): `Joint::setTransformFromParent/ChildBodyNode` now rejects non-finite transforms at the entry point
2. **MJCF parser guards**: All `DART_ASSERT(verifyTransform/verifyRotation)` replaced with `DART_WARN` + identity fallback
3. **`verifyTransform` enhancement**: Now also checks for infinity (previously only NaN)
4. **Additional pipeline guards** (Category C): Inertia propagation in kinematic joint variants

## Changes / Key Changes

| File | Change |
|------|--------|
| `dart/dynamics/Joint.cpp` | `setTransformFromParent/ChildBodyNode`: reject + warn + keep previous |
| `dart/dynamics/BodyNode.cpp` | `updateTransform`, `updateArtInertia`: warn + safe fallback |
| `dart/dynamics/detail/GenericJoint.hpp` | Guard `transformInertia` output in all 4 inertia propagation functions |
| `dart/math/Geometry.cpp` | `verifyTransform` checks `!isInf()` in addition to `!isNan()` |
| `dart/utils/mjcf/detail/Body.cpp` | 7× `DART_ASSERT` → `DART_WARN` + identity fallback |
| `dart/utils/mjcf/detail/Utils.cpp` | 6× `DART_ASSERT` → `DART_WARN` + identity fallback |
| `tests/unit/dynamics/test_Joints.cpp` | 3 new tests: NaN/Inf/bad-rotation rejection, overflow simulation survival |
| `tests/unit/math/test_Geometry.cpp` | Fix `ExponentialMappings` test: use `verifyRotation` for extreme inputs where translation overflows |
| `CHANGELOG.md` | Entry under DART 6.16.7 |

## Testing

- `ctest --output-on-failure` — All 81/81 tests pass

## Breaking Changes

- [x] None

Behavior change: non-finite transforms are now rejected with a warning instead of crashing via `assert()`. This is strictly safer — previously the process would abort in debug builds.

## Related Issues / PRs

- Addresses: gazebosim/gz-physics#861, gazebosim/gz-physics#862
- Extends: #2485 (previous round of non-finite guards for release-6.16)
- Main branch PR: #2496

---

#### Checklist

- [x] Milestone set (DART 6.16.7)
- [x] CHANGELOG.md updated
- [x] Add unit tests for new functionality
- [ ] Add Python bindings (dartpy) if applicable — N/A (internal behavior change)