### PR TITLE
feat: add hierarchical memory management with cache-friendly allocators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ profiling/*.txt
 # Sisyphus agent artifacts
 .sisyphus/
 
+# Benchmark result artifacts
+.benchmark_results/
+
 # Coverage files
 *.info
 *.gcda

--- a/dart/common/detail/memory_manager-impl.hpp
+++ b/dart/common/detail/memory_manager-impl.hpp
@@ -73,6 +73,13 @@ T* MemoryManager::constructUsingPool(Args&&... args) noexcept
 }
 
 //==============================================================================
+template <typename T, typename... Args>
+T* MemoryManager::constructUsingFrame(Args&&... args) noexcept
+{
+  return construct<T, Args...>(Type::Frame, std::forward<Args>(args)...);
+}
+
+//==============================================================================
 template <typename T>
 void MemoryManager::destroy(Type type, T* object) noexcept
 {
@@ -95,6 +102,13 @@ template <typename T>
 void MemoryManager::destroyUsingPool(T* pointer) noexcept
 {
   destroy(Type::Pool, pointer);
+}
+
+//==============================================================================
+template <typename T>
+void MemoryManager::destroyUsingFrame(T* pointer) noexcept
+{
+  destroy(Type::Frame, pointer);
 }
 
 } // namespace dart::common

--- a/dart/common/frame_allocator.cpp
+++ b/dart/common/frame_allocator.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/common/frame_allocator.hpp"
+
+#include <algorithm>
+
+#include <cstdint>
+
+namespace dart::common {
+
+//==============================================================================
+FrameAllocator::FrameAllocator(
+    MemoryAllocator& baseAllocator, size_t initialCapacity)
+  : mBaseAllocator(baseAllocator),
+    mBuffer(static_cast<char*>(baseAllocator.allocate(initialCapacity))),
+    mCapacity(mBuffer ? initialCapacity : 0),
+    mOffset(0)
+{
+}
+
+//==============================================================================
+FrameAllocator::~FrameAllocator()
+{
+  for (const auto& entry : mOverflowAllocations) {
+    mBaseAllocator.deallocate(entry.ptr, entry.allocatedSize);
+  }
+  mOverflowAllocations.clear();
+  if (mBuffer) {
+    mBaseAllocator.deallocate(mBuffer, mCapacity);
+  }
+}
+
+//==============================================================================
+const MemoryAllocator& FrameAllocator::getBaseAllocator() const
+{
+  return mBaseAllocator;
+}
+
+//==============================================================================
+MemoryAllocator& FrameAllocator::getBaseAllocator()
+{
+  return mBaseAllocator;
+}
+
+//==============================================================================
+void* FrameAllocator::allocate(size_t bytes) noexcept
+{
+  return allocateAligned(bytes, 32);
+}
+
+//==============================================================================
+void FrameAllocator::deallocate(void* /*pointer*/, size_t /*bytes*/)
+{
+  // Arena semantics: memory is freed in bulk on reset()
+}
+
+//==============================================================================
+void FrameAllocator::print(std::ostream& os, int indent) const
+{
+  const std::string spaces(indent, ' ');
+  os << spaces << "[FrameAllocator] capacity: " << mCapacity
+     << " used: " << mOffset << " overflow: " << mOverflowAllocations.size()
+     << "\n";
+}
+
+//==============================================================================
+void* FrameAllocator::allocateAligned(size_t bytes, size_t alignment) noexcept
+{
+  if (bytes == 0 || alignment == 0) {
+    return nullptr;
+  }
+
+  // Align based on the actual memory address, not just the offset, since the
+  // buffer base may not be aligned to the requested alignment.
+  const auto currentAddr = reinterpret_cast<uintptr_t>(mBuffer) + mOffset;
+  const auto alignedAddr = (currentAddr + alignment - 1) & ~(alignment - 1);
+  const auto alignedOffset
+      = static_cast<size_t>(alignedAddr - reinterpret_cast<uintptr_t>(mBuffer));
+
+  if (alignedOffset + bytes <= mCapacity) {
+    mOffset = alignedOffset + bytes;
+    return mBuffer + alignedOffset;
+  }
+
+  // Over-allocate to guarantee alignment within the raw block
+  const size_t totalSize = bytes + alignment;
+  void* raw = mBaseAllocator.allocate(totalSize);
+  if (!raw) {
+    return nullptr;
+  }
+
+  const auto rawAddr = reinterpret_cast<uintptr_t>(raw);
+  const auto overflowAligned = (rawAddr + alignment - 1) & ~(alignment - 1);
+  void* pointer = reinterpret_cast<void*>(overflowAligned);
+
+  mOverflowAllocations.push_back({raw, totalSize});
+  return pointer;
+}
+
+//==============================================================================
+void FrameAllocator::reset() noexcept
+{
+  if (!mOverflowAllocations.empty()) {
+    size_t totalOverflow = 0;
+    for (const auto& entry : mOverflowAllocations) {
+      mBaseAllocator.deallocate(entry.ptr, entry.allocatedSize);
+      totalOverflow += entry.allocatedSize;
+    }
+    mOverflowAllocations.clear();
+
+    const size_t needed = mOffset + totalOverflow;
+    const size_t newCapacity = std::max(mCapacity * 2, needed + 256);
+    void* newBuffer = mBaseAllocator.allocate(newCapacity);
+    if (newBuffer) {
+      if (mBuffer) {
+        mBaseAllocator.deallocate(mBuffer, mCapacity);
+      }
+      mBuffer = static_cast<char*>(newBuffer);
+      mCapacity = newCapacity;
+    }
+  }
+
+  mOffset = 0;
+}
+
+//==============================================================================
+size_t FrameAllocator::capacity() const noexcept
+{
+  return mCapacity;
+}
+
+//==============================================================================
+size_t FrameAllocator::used() const noexcept
+{
+  return mOffset;
+}
+
+//==============================================================================
+size_t FrameAllocator::overflowCount() const noexcept
+{
+  return mOverflowAllocations.size();
+}
+
+} // namespace dart::common

--- a/dart/common/frame_allocator.hpp
+++ b/dart/common/frame_allocator.hpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COMMON_FRAMEALLOCATOR_HPP_
+#define DART_COMMON_FRAMEALLOCATOR_HPP_
+
+#include <dart/common/memory_allocator.hpp>
+#include <dart/common/memory_allocator_debugger.hpp>
+
+#include <dart/export.hpp>
+
+#include <algorithm>
+#include <new>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <cstddef>
+
+namespace dart::common {
+
+class DART_API FrameAllocator : public MemoryAllocator
+{
+public:
+  using Debug = MemoryAllocatorDebugger<FrameAllocator>;
+
+  /// Constructor
+  ///
+  /// @param[in] baseAllocator: (optional) Base memory allocator.
+  /// @param[in] initialCapacity: (optional) Bytes to initially allocate.
+  explicit FrameAllocator(
+      MemoryAllocator& baseAllocator = MemoryAllocator::GetDefault(),
+      size_t initialCapacity = 65536);
+
+  ~FrameAllocator() override;
+
+  FrameAllocator(const FrameAllocator&) = delete;
+  FrameAllocator& operator=(const FrameAllocator&) = delete;
+  FrameAllocator(FrameAllocator&&) = delete;
+  FrameAllocator& operator=(FrameAllocator&&) = delete;
+
+  DART_STRING_TYPE(FrameAllocator);
+
+  [[nodiscard]] const MemoryAllocator& getBaseAllocator() const;
+  [[nodiscard]] MemoryAllocator& getBaseAllocator();
+
+  [[nodiscard]] void* allocate(size_t bytes) noexcept override;
+  void deallocate(void* pointer, size_t bytes) override;
+  void print(std::ostream& os = std::cout, int indent = 0) const override;
+
+  [[nodiscard]] void* allocateAligned(
+      size_t bytes, size_t alignment = 32) noexcept;
+
+  void reset() noexcept;
+
+  template <typename T, typename... Args>
+  [[nodiscard]] T* construct(Args&&... args)
+  {
+    const size_t alignment = std::max<size_t>(alignof(T), 32);
+    void* memory = allocateAligned(sizeof(T), alignment);
+    if (memory == nullptr) {
+      return nullptr;
+    }
+    return new (memory) T(std::forward<Args>(args)...);
+  }
+
+  [[nodiscard]] size_t capacity() const noexcept;
+
+  [[nodiscard]] size_t used() const noexcept;
+
+  [[nodiscard]] size_t overflowCount() const noexcept;
+
+private:
+  struct OverflowEntry
+  {
+    void* ptr;
+    size_t allocatedSize;
+  };
+
+  MemoryAllocator& mBaseAllocator;
+  char* mBuffer;
+  size_t mCapacity;
+  size_t mOffset;
+  std::vector<OverflowEntry> mOverflowAllocations;
+};
+
+/// STL-compatible allocator adapter for FrameAllocator.
+/// Allocated memory is freed only on FrameAllocator::reset(), not on
+/// individual deallocate() calls.
+template <typename T>
+class FrameStlAllocator
+{
+public:
+  using value_type = T;
+
+  explicit FrameStlAllocator(FrameAllocator& arena) noexcept : mArena(&arena) {}
+
+  template <typename U>
+  FrameStlAllocator(const FrameStlAllocator<U>& other) noexcept
+    : mArena(other.mArena)
+  {
+  }
+
+  [[nodiscard]] T* allocate(std::size_t n)
+  {
+    void* p = mArena->allocateAligned(n * sizeof(T), alignof(T));
+    if (!p) {
+      throw std::bad_alloc();
+    }
+    return static_cast<T*>(p);
+  }
+
+  void deallocate(T*, std::size_t) noexcept
+  {
+    // Arena semantics: memory freed on reset()
+  }
+
+  template <typename U>
+  bool operator==(const FrameStlAllocator<U>& other) const noexcept
+  {
+    return mArena == other.mArena;
+  }
+
+private:
+  template <typename U>
+  friend class FrameStlAllocator;
+  FrameAllocator* mArena;
+};
+
+} // namespace dart::common
+
+#endif // DART_COMMON_FRAMEALLOCATOR_HPP_

--- a/dart/constraint/constraint_solver.hpp
+++ b/dart/constraint/constraint_solver.hpp
@@ -44,6 +44,7 @@
 #include <dart/math/lcp/lcp_solver.hpp>
 
 #include <dart/common/deprecated.hpp>
+#include <dart/common/frame_allocator.hpp>
 
 #include <dart/export.hpp>
 
@@ -74,7 +75,7 @@ public:
   ConstraintSolver(const ConstraintSolver& other) = delete;
 
   /// Destructor
-  virtual ~ConstraintSolver() = default;
+  virtual ~ConstraintSolver();
 
   /// Add single skeleton
   void addSkeleton(const dynamics::SkeletonPtr& skeleton);
@@ -145,6 +146,8 @@ public:
 
   /// Get time step
   double getTimeStep() const;
+
+  void setFrameAllocator(common::FrameAllocator* alloc);
 
   /// Set collision detector
   void setCollisionDetector(
@@ -356,6 +359,14 @@ protected:
   Eigen::VectorXi mFIndex;
   Eigen::VectorXi mFIndexBackup;
   Eigen::VectorXi mOffset;
+
+  std::unique_ptr<common::FrameAllocator> mOwnedFrameAllocator;
+  common::FrameAllocator* mFrameAllocator = nullptr;
+
+  /// Persistent containers (reused across steps to avoid per-step allocation)
+  std::vector<collision::Contact*> mContactPtrs;
+  std::vector<bool> mImpulseAppliedStates;
+  std::vector<ConstraintBasePtr> mPositionConstraints;
 };
 
 } // namespace constraint

--- a/dart/dynamics/detail/body_node_pool.hpp
+++ b/dart/dynamics/detail/body_node_pool.hpp
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_DETAIL_BODY_NODE_POOL_HPP_
+#define DART_DYNAMICS_DETAIL_BODY_NODE_POOL_HPP_
+
+#include <dart/common/memory_allocator.hpp>
+
+#include <memory>
+#include <new>
+#include <vector>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace dart::dynamics::detail {
+
+//==============================================================================
+template <typename T>
+class BodyNodePool
+{
+public:
+  static_assert(alignof(T) <= 32, "BodyNodePool requires alignof(T) <= 32.");
+  static_assert(
+      sizeof(T) >= sizeof(void*),
+      "BodyNodePool requires sizeof(T) >= sizeof(void*).");
+
+  static constexpr std::size_t kSlotSize = ((sizeof(T) + 31) / 32) * 32;
+
+  explicit BodyNodePool(
+      common::MemoryAllocator& baseAllocator
+      = common::MemoryAllocator::GetDefault(),
+      std::size_t initialChunkCapacity = 64);
+  ~BodyNodePool(); // Calls clear()
+
+  // Non-copyable, non-movable (pool owns memory that live objects point into)
+  BodyNodePool(const BodyNodePool&) = delete;
+  BodyNodePool& operator=(const BodyNodePool&) = delete;
+  BodyNodePool(BodyNodePool&&) = delete;
+  BodyNodePool& operator=(BodyNodePool&&) = delete;
+
+  /// Allocate a raw slot (32-byte aligned, sizeof(T) usable bytes).
+  /// Does NOT construct an object. Caller must use placement new.
+  [[nodiscard]] void* allocate();
+
+  /// Return a slot to the free list. Does NOT call destructor.
+  /// Caller must explicitly destruct before calling this.
+  void deallocate(void* ptr) noexcept;
+
+  /// Returns true if ptr was allocated from this pool
+  [[nodiscard]] bool owns(const void* ptr) const noexcept;
+
+  /// Number of currently allocated (in-use) slots
+  [[nodiscard]] std::size_t size() const noexcept;
+
+  /// Total capacity across all chunks
+  [[nodiscard]] std::size_t capacity() const noexcept;
+
+private:
+  struct FreeNode
+  {
+    FreeNode* mNext;
+  };
+
+  struct Chunk
+  {
+    Chunk(common::MemoryAllocator& allocator, std::size_t slotCount);
+    ~Chunk();
+
+    std::byte* getSlot(std::size_t index) const;
+
+    common::MemoryAllocator& mAllocator;
+    void* mRawPtr;
+    std::byte* mData;
+    std::size_t mAllocatedSize;
+  };
+
+  void clear() noexcept;
+  void addChunk();
+
+  static constexpr std::size_t kDefaultSlotsPerChunk = 64;
+
+  common::MemoryAllocator& mBaseAllocator;
+  const std::size_t mSlotsPerChunk;
+  std::vector<std::shared_ptr<Chunk>> mChunks;
+  FreeNode* mFreeList;
+  std::size_t mSize;
+  std::size_t mNextSlotIndex;
+
+public:
+  /// Get the shared_ptr to the chunk owning ptr (for cross-skeleton moves).
+  /// Returns nullptr if ptr is not owned by this pool.
+  [[nodiscard]] std::shared_ptr<Chunk> getChunkFor(
+      const void* ptr) const noexcept;
+};
+
+//==============================================================================
+template <typename T>
+BodyNodePool<T>::Chunk::Chunk(
+    common::MemoryAllocator& allocator, std::size_t slotCount)
+  : mAllocator(allocator), mAllocatedSize(slotCount * kSlotSize + 32)
+{
+  mRawPtr = allocator.allocate(mAllocatedSize);
+  if (mRawPtr) {
+    auto raw = reinterpret_cast<std::uintptr_t>(mRawPtr);
+    auto aligned = (raw + 31) & ~std::uintptr_t{31};
+    mData = reinterpret_cast<std::byte*>(aligned);
+  } else {
+    mData = nullptr;
+  }
+}
+
+//==============================================================================
+template <typename T>
+BodyNodePool<T>::Chunk::~Chunk()
+{
+  if (mRawPtr) {
+    mAllocator.deallocate(mRawPtr, mAllocatedSize);
+  }
+}
+
+//==============================================================================
+template <typename T>
+std::byte* BodyNodePool<T>::Chunk::getSlot(std::size_t index) const
+{
+  return mData + (index * kSlotSize);
+}
+
+//==============================================================================
+template <typename T>
+BodyNodePool<T>::BodyNodePool(
+    common::MemoryAllocator& baseAllocator, std::size_t initialChunkCapacity)
+  : mBaseAllocator(baseAllocator),
+    mSlotsPerChunk(
+        initialChunkCapacity == 0 ? kDefaultSlotsPerChunk
+                                  : initialChunkCapacity),
+    mChunks(),
+    mFreeList(nullptr),
+    mSize(0),
+    mNextSlotIndex(0)
+{
+}
+
+//==============================================================================
+template <typename T>
+BodyNodePool<T>::~BodyNodePool()
+{
+  clear();
+}
+
+//==============================================================================
+template <typename T>
+void* BodyNodePool<T>::allocate()
+{
+  if (mFreeList != nullptr) {
+    FreeNode* node = mFreeList;
+    mFreeList = node->mNext;
+    ++mSize;
+    return node;
+  }
+
+  if (mChunks.empty() || mNextSlotIndex >= mSlotsPerChunk) {
+    addChunk();
+  }
+
+  void* slot = mChunks.back()->getSlot(mNextSlotIndex);
+  ++mNextSlotIndex;
+  ++mSize;
+  return slot;
+}
+
+//==============================================================================
+template <typename T>
+void BodyNodePool<T>::deallocate(void* ptr) noexcept
+{
+  if (ptr == nullptr) {
+    return;
+  }
+
+  FreeNode* node = static_cast<FreeNode*>(ptr);
+  node->mNext = mFreeList;
+  mFreeList = node;
+  --mSize;
+}
+
+//==============================================================================
+template <typename T>
+bool BodyNodePool<T>::owns(const void* ptr) const noexcept
+{
+  if (ptr == nullptr) {
+    return false;
+  }
+
+  const auto* bytePtr = static_cast<const std::byte*>(ptr);
+  const std::size_t chunkBytes = mSlotsPerChunk * kSlotSize;
+  for (const auto& chunk : mChunks) {
+    const std::byte* begin = chunk->mData;
+    const std::byte* end = begin + chunkBytes;
+    if (bytePtr >= begin && bytePtr < end) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+//==============================================================================
+template <typename T>
+std::size_t BodyNodePool<T>::size() const noexcept
+{
+  return mSize;
+}
+
+//==============================================================================
+template <typename T>
+std::size_t BodyNodePool<T>::capacity() const noexcept
+{
+  return mChunks.size() * mSlotsPerChunk;
+}
+
+//==============================================================================
+template <typename T>
+void BodyNodePool<T>::clear() noexcept
+{
+  mChunks.clear();
+  mFreeList = nullptr;
+  mSize = 0;
+  mNextSlotIndex = 0;
+}
+
+//==============================================================================
+template <typename T>
+void BodyNodePool<T>::addChunk()
+{
+  mChunks.emplace_back(std::make_shared<Chunk>(mBaseAllocator, mSlotsPerChunk));
+  mNextSlotIndex = 0;
+}
+
+//==============================================================================
+template <typename T>
+std::shared_ptr<typename BodyNodePool<T>::Chunk> BodyNodePool<T>::getChunkFor(
+    const void* ptr) const noexcept
+{
+  if (ptr == nullptr) {
+    return nullptr;
+  }
+
+  const auto* bytePtr = static_cast<const std::byte*>(ptr);
+  const std::size_t chunkBytes = mSlotsPerChunk * kSlotSize;
+  for (const auto& chunk : mChunks) {
+    const std::byte* begin = chunk->mData;
+    const std::byte* end = begin + chunkBytes;
+    if (bytePtr >= begin && bytePtr < end) {
+      return chunk;
+    }
+  }
+
+  return nullptr;
+}
+
+} // namespace dart::dynamics::detail
+
+#endif // DART_DYNAMICS_DETAIL_BODY_NODE_POOL_HPP_

--- a/dart/dynamics/detail/body_node_pool.hpp
+++ b/dart/dynamics/detail/body_node_pool.hpp
@@ -190,6 +190,9 @@ void* BodyNodePool<T>::allocate()
 
   if (mChunks.empty() || mNextSlotIndex >= mSlotsPerChunk) {
     addChunk();
+    if (mChunks.empty() || mChunks.back()->mData == nullptr) {
+      return nullptr;
+    }
   }
 
   void* slot = mChunks.back()->getSlot(mNextSlotIndex);

--- a/dart/simulation/world.hpp
+++ b/dart/simulation/world.hpp
@@ -51,6 +51,7 @@
 #include <dart/dynamics/simple_frame.hpp>
 #include <dart/dynamics/skeleton.hpp>
 
+#include <dart/common/memory_manager.hpp>
 #include <dart/common/name_manager.hpp>
 #include <dart/common/smart_pointer.hpp>
 #include <dart/common/subject.hpp>
@@ -86,6 +87,10 @@ struct WorldConfig final
 
   /// Preferred collision detector for the world.
   CollisionDetectorType collisionDetector = CollisionDetectorType::Fcl;
+
+  /// Optional base allocator for the world's memory manager.
+  /// If nullptr, MemoryAllocator::GetDefault() is used.
+  common::MemoryAllocator* baseAllocator = nullptr;
 
   WorldConfig() = default;
   explicit WorldConfig(std::string_view worldName)
@@ -325,6 +330,9 @@ public:
   /// Get the constraint solver
   const constraint::ConstraintSolver* getConstraintSolver() const;
 
+  [[nodiscard]] common::MemoryManager& getMemoryManager();
+  [[nodiscard]] const common::MemoryManager& getMemoryManager() const;
+
   /// Bake simulated current state and store it into mRecording
   void bake();
 
@@ -453,6 +461,8 @@ protected:
 
   /// Current simulation frame number
   int mFrame;
+
+  common::MemoryManager mMemoryManager;
 
   /// Constraint solver
   std::unique_ptr<constraint::ConstraintSolver> mConstraintSolver;

--- a/docs/design/hierarchical_allocator.md
+++ b/docs/design/hierarchical_allocator.md
@@ -1,0 +1,158 @@
+# Hierarchical Allocator Design: World-Level Memory Management
+
+## Status: PROPOSAL (not yet implemented)
+
+## 1. Current State
+
+### Existing Infrastructure
+
+- `MemoryAllocator` base class (`dart/common/memory_allocator.hpp`): `allocate(bytes)`, `deallocate(ptr, bytes)` -- virtual interface for all allocators
+- `MemoryManager` (`dart/common/memory_manager.hpp`): composite containing FreeListAllocator + PoolAllocator, accepts a base `MemoryAllocator&`
+- `PoolAllocator`: fast fixed-size pool (max 1024 bytes per object)
+- `FreeListAllocator`: arbitrary size allocations with coalescing
+
+Both exist but are **unused by dynamics or constraint modules**.
+
+### Recent Additions (Cache-Friendliness Optimizations)
+
+- `BodyNodePool<T>` (`dart/dynamics/detail/body_node_pool.hpp`): per-Skeleton contiguous pool for BodyNode allocation, 32-byte aligned slots
+- `FrameAllocator` (`dart/common/frame_allocator.hpp`): per-step bump allocator for constraint temporaries, supports aligned allocation
+
+Both are **standalone** -- they bypass MemoryManager and manage their own memory.
+
+## 2. Problem Statement
+
+Each component manages memory independently:
+
+- Skeleton creates its own BodyNodePool in the constructor
+- ConstraintSolver creates its own FrameAllocator as a member
+- No coordination or configuration from above
+
+This makes it impossible to:
+
+1. Configure memory strategy at the World level (e.g., pre-allocate for known workload)
+2. Share memory budgets across components
+3. Use custom allocators (e.g., arena per-thread for parallel simulation)
+4. Monitor total memory usage from a single point
+
+## 3. Proposed Architecture
+
+### Ownership Hierarchy
+
+```
+World
++-- MemoryManager (owned, configurable)
+|   +-- base: MemoryAllocator& (user-replaceable)
+|   +-- pool: PoolAllocator (for small objects)
+|   +-- free: FreeListAllocator (for large objects)
+|
++-- Skeleton 1 (receives MemoryManager* on addSkeleton)
+|   +-- BodyNodePool (allocates from MemoryManager's pool)
+|
++-- Skeleton 2
+|   +-- BodyNodePool (same MemoryManager)
+|
++-- ConstraintSolver (receives MemoryManager* on construction)
+    +-- FrameAllocator (allocates initial buffer from MemoryManager)
+```
+
+### API Sketch
+
+```cpp
+// World gains optional allocator configuration
+class World {
+public:
+  void setMemoryManager(std::shared_ptr<MemoryManager> manager);
+  MemoryManager& getMemoryManager();
+
+private:
+  std::shared_ptr<MemoryManager> mMemoryManager;
+};
+
+// Skeleton receives allocator at construction time
+class Skeleton {
+public:
+  static SkeletonPtr create(
+      const std::string& name,
+      MemoryManager* allocator = nullptr);  // nullptr = use default
+
+protected:
+  MemoryManager* mMemoryManager;  // non-owning, from World
+};
+
+// ConstraintSolver receives allocator configuration
+class ConstraintSolver {
+public:
+  void setMemoryManager(MemoryManager* manager);
+
+private:
+  MemoryManager* mMemoryManager;  // non-owning, from World
+};
+```
+
+### User-Level Usage
+
+```cpp
+// Default: zero configuration needed (backward compatible)
+auto world = World::create();
+world->addSkeleton(robot);  // uses default MemoryManager
+
+// Advanced: custom allocator for the entire world
+auto customAllocator = std::make_shared<MemoryManager>(myBaseAllocator);
+world->setMemoryManager(customAllocator);
+world->addSkeleton(robot);  // robot's pool uses customAllocator
+```
+
+## 4. Alignment Gap in MemoryAllocator
+
+### Current Issue
+
+```cpp
+// MemoryAllocator base class -- NO alignment parameter
+virtual void* allocate(size_t bytes) noexcept = 0;
+
+// FrameAllocator -- HAS alignment parameter
+void* allocate(size_t bytes, size_t alignment = 32);
+
+// BodyNodePool -- uses 32-byte aligned slots internally
+```
+
+The base interface cannot express alignment requirements, preventing FrameAllocator from deriving from MemoryAllocator.
+
+### Proposed Fix
+
+```cpp
+class MemoryAllocator {
+public:
+  virtual void* allocate(size_t bytes) noexcept = 0;           // existing
+  virtual void* allocate(size_t bytes, size_t alignment) noexcept;  // new
+};
+```
+
+Default: delegates to `allocate(bytes)` -- backward compatible for existing subclasses.
+
+## 5. Migration Path
+
+| Phase | Description                                                         | Status   |
+| ----- | ------------------------------------------------------------------- | -------- |
+| 1     | BodyNodePool and FrameAllocator standalone                          | **Done** |
+| 2     | World owns MemoryManager, passes to Skeleton and ConstraintSolver   | Planned  |
+| 3     | MemoryAllocator gains alignment; FrameAllocator derives from it     | Planned  |
+| 4     | Per-World memory budgets, thread-local allocators for parallel step | Future   |
+
+## 6. Benefits
+
+| Benefit                    | Description                                                 |
+| -------------------------- | ----------------------------------------------------------- |
+| Single configuration point | One `setMemoryManager()` call controls all allocation       |
+| Memory budgeting           | World-level tracking of total allocation                    |
+| Testability                | Inject mock allocators for deterministic testing            |
+| Thread safety              | Per-World allocators enable independent parallel simulation |
+| Custom placement           | Users can control memory locality (e.g., NUMA-aware)        |
+
+## 7. Non-Goals
+
+- GPU memory management (out of scope for CPU dynamics)
+- Custom allocators for Eigen internal temporaries
+- Replacing system malloc for non-DART allocations
+- Lock-free allocators (ConstraintSolver is single-threaded per-World)

--- a/docs/dev_tasks/hierarchical-allocator/README.md
+++ b/docs/dev_tasks/hierarchical-allocator/README.md
@@ -1,0 +1,161 @@
+# Hierarchical Allocator: World-Level Memory Management
+
+**Status**: IN PROGRESS (Phase 4 partially applied, code does not compile)
+**Branch**: working tree on `main` (no commits yet)
+**Started**: Previous session
+**Goal**: World owns MemoryManager → provides tailored allocators to components
+
+## Architecture (Agreed Design)
+
+```
+WorldConfig { MemoryAllocator* baseAllocator = nullptr; }
+    │
+    ▼
+World always creates MemoryManager(baseAllocator ?: GetDefault())
+    │
+    ├── MemoryManager owns:
+    │   ├── FreeListAllocator(baseAllocator)     [existing]
+    │   │     └── PoolAllocator(freeListAlloc)   [existing]
+    │   └── FrameAllocator(baseAllocator)        [NEW - sibling to FreeList]
+    │
+    ├── ConstraintSolver borrows FrameAllocator* from MemoryManager
+    │   └── Uses for per-step constraint allocation via FrameStlAllocator<T>
+    │
+    └── Skeleton borrows FreeListAllocator& from MemoryManager
+        └── BodyNodePool uses it as base for chunk allocation
+```
+
+**Key principles:**
+
+- `World::getMemoryManager()` always returns non-null reference
+- Components BORROW allocators (don't own them)
+- Cloned World/Skeleton get their own fresh allocators (same base allocator, independent state)
+- Without World, components fall back to default behavior
+
+## Completed Work (Phases 1-3)
+
+### New Files (untracked)
+
+| File                                                | Purpose                                                | Tests                 |
+| --------------------------------------------------- | ------------------------------------------------------ | --------------------- |
+| `dart/common/frame_allocator.hpp`                   | Bump allocator inheriting `MemoryAllocator`            | 9 unit tests          |
+| `dart/common/frame_allocator.cpp`                   | Implementation (uses baseAllocator for backing memory) | ↑                     |
+| `dart/dynamics/detail/body_node_pool.hpp`           | Per-Skeleton contiguous pool, 32-byte aligned          | 6 unit tests          |
+| `tests/unit/common/test_frame_allocator.cpp`        | FrameAllocator unit tests                              | registered ✓          |
+| `tests/unit/dynamics/test_body_node_pool.cpp`       | BodyNodePool unit tests                                | **NOT registered** ⚠️ |
+| `tests/benchmark/dynamics/bm_dynamics_cache.cpp`    | Comprehensive dynamics benchmarks                      | built ✓               |
+| `tests/benchmark/dynamics/bm_dynamics_cache_io.cpp` | Real robot model benchmarks (needs dart-io)            | built ✓               |
+| `docs/design/hierarchical_allocator.md`             | Design doc (outdated, predates current design)         | —                     |
+| `scripts/compare_benchmarks.py`                     | Benchmark comparison utility                           | —                     |
+
+### Modified Files (tracked, uncommitted)
+
+| File                                    | Phase | State                                                     |
+| --------------------------------------- | ----- | --------------------------------------------------------- |
+| `dart/dynamics/skeleton.hpp`            | 1     | ✅ Done: pool members, helpers                            |
+| `dart/dynamics/skeleton.cpp`            | 1     | ✅ Done: pool ctor/dtor/clone/move                        |
+| `dart/dynamics/detail/skeleton.hpp`     | 1     | ✅ Done: if-constexpr routing                             |
+| `dart/constraint/constraint_solver.hpp` | 4     | ⚠️ Partial: unique_ptr member, needs→borrowed ptr         |
+| `dart/constraint/constraint_solver.cpp` | 4     | 🔴 Broken: FrameStlAllocator ctor type mismatch           |
+| `dart/simulation/world.hpp`             | 4     | ⚠️ Partial: correct types declared                        |
+| `dart/simulation/world.cpp`             | 4     | 🔴 Broken: 5+ compile errors (see below)                  |
+| `tests/benchmark/CMakeLists.txt`        | 1     | ✅ Done                                                   |
+| `tests/unit/CMakeLists.txt`             | 1     | ⚠️ Partial: frame_allocator registered, pool test missing |
+| `scripts/run_cpp_benchmark.py`          | 1     | ✅ Done                                                   |
+| `.gitignore`                            | 1     | ✅ Done                                                   |
+
+### Files NOT YET Modified (need Phase 4)
+
+| File                             | Required Change                                              |
+| -------------------------------- | ------------------------------------------------------------ |
+| `dart/common/memory_manager.hpp` | Add `Frame` to Type enum, add FrameAllocator member + getter |
+| `dart/common/memory_manager.cpp` | Construct FrameAllocator in ctor, implement getter           |
+
+## Compile-Breaking Bugs (Current State)
+
+### world.cpp (5 errors)
+
+1. `config.memoryManager` → field doesn't exist, should derive from `config.baseAllocator`
+2. `mMemoryManager.get()` → value member, no `.get()` method
+3. `if (mMemoryManager)` → value member, no `operator bool`
+4. `mMemoryManager->getBaseAllocator()` → should use `.` not `->`
+5. `config.memoryManager = mMemoryManager` in clone() → wrong field name
+
+### constraint_solver.cpp (2 errors)
+
+1. `FrameStlAllocator<T>(mFrameAllocator)` at 6+ sites → passes `unique_ptr`, needs `FrameAllocator&`
+2. `mFrameAllocator.reset()` → destroys the unique_ptr (should call `mFrameAllocator->reset()` for arena reset)
+
+### Test registration (1 gap)
+
+1. `test_body_node_pool.cpp` exists but not in any CMakeLists.txt
+
+## Remaining Work (Ordered)
+
+### Step 1: Add FrameAllocator to MemoryManager
+
+- Add `Type::Frame` to enum in `memory_manager.hpp`
+- Add `unique_ptr<FrameAllocator>` + debug variant members
+- Add `getFrameAllocator()` getter
+- Construct in `MemoryManager::MemoryManager()` with debug wrapping
+- Add `allocateUsingFrame` / `deallocateUsingFrame` routing
+
+### Step 2: Fix world.cpp to match world.hpp
+
+- Constructor: `mMemoryManager(config.baseAllocator ? *config.baseAllocator : MemoryAllocator::GetDefault())`
+- `getMemoryManager()`: return `mMemoryManager;` (ref, not pointer)
+- Propagation: remove `if (mMemoryManager)` guards (always valid)
+- `addSkeleton()`: pass `&mMemoryManager.getBaseAllocator()` to skeleton
+- `setConstraintSolver()`: pass `&mMemoryManager.getFrameAllocator()` to solver
+- `clone()`: `config.baseAllocator = &mMemoryManager.getBaseAllocator();`
+
+### Step 3: Fix ConstraintSolver to borrow FrameAllocator
+
+- Change `unique_ptr<FrameAllocator> mFrameAllocator` → `FrameAllocator* mFrameAllocator = nullptr`
+- Remove FrameAllocator construction from ConstraintSolver ctor
+- Add `setFrameAllocator(FrameAllocator*)` (replaces `setBaseAllocator`)
+- Fix all 6 `FrameStlAllocator` sites: `FrameStlAllocator<T>(*mFrameAllocator)`
+- Fix `mFrameAllocator.reset()` → `mFrameAllocator->reset()` (arena reset, not ptr reset)
+- Add null-safety: standalone ConstraintSolver (no World) skips arena allocation
+
+### Step 4: Wire Skeleton to borrow base allocator from World
+
+- Add `MemoryAllocator* mBaseAllocator = nullptr` to Skeleton
+- Add `setBaseAllocator(MemoryAllocator*)` method
+- Make pool construction lazy: only when first BodyNode is created
+- Pool ctor passes `*mBaseAllocator` (or `GetDefault()` if null)
+- World::addSkeleton() calls `skeleton->setBaseAllocator(&memMgr.getBaseAllocator())`
+
+### Step 5: Register missing test + build verification
+
+- Add `test_body_node_pool.cpp` to `tests/unit/CMakeLists.txt`
+- `pixi run build` — must compile cleanly
+- `pixi run test-unit` — all 248+ tests must pass
+- `pixi run lint` — format check
+
+### Step 6: Update design doc + benchmarks
+
+- Update `docs/design/hierarchical_allocator.md` to match final architecture
+- Run benchmarks to verify no regressions from Phase 1-3 wins
+
+## Open Design Questions
+
+1. **FrameAllocator debug wrapping**: Follow existing pattern (debug variant in non-release)?
+   - Recommendation: YES, match FreeList/Pool pattern
+2. **Standalone ConstraintSolver fallback**: Create own FrameAllocator or skip arena?
+   - Recommendation: Create default FrameAllocator lazily if null when solve() called
+3. **Skeleton pool lazy vs eager**: Delay pool creation until first BodyNode?
+   - Recommendation: Eager with default allocator, swap allocator on setBaseAllocator
+4. **Pre-existing allocator bugs**: Fix in this PR or defer?
+   - Recommendation: DEFER — separate PR for FreeList/Pool alignment/overflow bugs
+
+## Benchmark Baselines (from Phases 1-3)
+
+- Lifecycle: -30-41% improvement (PRESERVE)
+- Contact WorldStep: -13% improvement (PRESERVE)
+- ParallelWorlds: -25-36% improvement (PRESERVE)
+- Small-skeleton FK: +13-54% regression (FIX via hierarchical refactor)
+- Small WorldStep: +65% regression (FIX via hierarchical refactor)
+
+Regressions were caused by inline allocators bloating sizeof(Skeleton/ConstraintSolver).
+Hierarchical design moves allocators OUT of components → should fix regressions.

--- a/docs/dev_tasks/hierarchical-allocator/RESUME.md
+++ b/docs/dev_tasks/hierarchical-allocator/RESUME.md
@@ -1,0 +1,37 @@
+# Resume: Hierarchical Allocator Task
+
+**Last session**: Audited all modified files, created comprehensive task tracking.
+
+## Current State: CODE DOES NOT COMPILE
+
+The working tree has partially-applied Phase 4 changes across 11 tracked files + 9 untracked files.
+Phase 1 (pools) and Phase 3 (FrameAllocator) code is complete and correct.
+Phase 4 (hierarchical wiring) is half-done with compile-breaking bugs.
+
+## To Continue
+
+Read `docs/dev_tasks/hierarchical-allocator/README.md` for the full task plan.
+
+**Immediate next step**: Execute Steps 1-5 from README.md in order:
+
+1. Add FrameAllocator to MemoryManager
+2. Fix world.cpp compile errors
+3. Fix ConstraintSolver to borrow FrameAllocator
+4. Wire Skeleton to borrow base allocator
+5. Register missing test + build verification
+
+## Key Files to Read First
+
+- `dart/common/memory_manager.hpp` + `.cpp` — needs FrameAllocator added
+- `dart/simulation/world.hpp` + `.cpp` — hpp is correct, cpp has 5 bugs
+- `dart/constraint/constraint_solver.hpp` + `.cpp` — needs ptr type change
+- `dart/common/frame_allocator.hpp` — the new allocator (inherits MemoryAllocator)
+
+## Build Commands
+
+```bash
+pixi run build        # Must pass after fixes
+pixi run test-unit    # 248+ tests must pass
+pixi run lint         # Format before commit
+pixi run test-all     # Full validation
+```

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -222,7 +222,7 @@ def format_markdown(
         "**Metric**: {} ({})".format(metric, aggregate),
         "",
         "| Benchmark | Baseline (\u00b5s) | Optimized (\u00b5s) "
-        "| \u0394 (\u00b5s) | Change |",
+        + "| \u0394 (\u00b5s) | Change |",
         "|-----------|--------------|----------------|--------|--------|",
     ]
 

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Compare two Google Benchmark JSON files and produce a comparison table."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+_UNIT_TO_NS = {"ns": 1.0, "us": 1e3, "ms": 1e6, "s": 1e9}
+_NS_TO_US = 1e-3
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare two Google Benchmark JSON files.",
+    )
+    parser.add_argument(
+        "baseline",
+        type=Path,
+        help="Baseline benchmark JSON file",
+    )
+    parser.add_argument(
+        "optimized",
+        type=Path,
+        help="Optimized benchmark JSON file",
+    )
+    parser.add_argument(
+        "--metric",
+        choices=["cpu_time", "real_time"],
+        default="cpu_time",
+        help="Time metric to compare (default: cpu_time)",
+    )
+    parser.add_argument(
+        "--aggregate",
+        choices=["median", "mean"],
+        default="median",
+        help="Aggregate type to use when repetitions exist (default: median)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file (default: stdout)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "csv"],
+        default="markdown",
+        dest="fmt",
+        help="Output format (default: markdown)",
+    )
+    return parser.parse_args(argv)
+
+
+def _to_ns(value: float, unit: str) -> float:
+    return value * _UNIT_TO_NS.get(unit, 1.0)
+
+
+def load_benchmarks(
+    filepath: Path,
+    metric: str,
+    aggregate: str,
+) -> tuple[dict, dict[str, float]]:
+    """Load benchmark JSON and return ``(context, {name: time_in_ns})``.
+
+    Prefers aggregate entries (median/mean) when available.  Falls back to
+    iteration entries, averaging when a benchmark has multiple repetitions.
+    """
+    with open(filepath) as f:
+        data = json.load(f)
+
+    context = data.get("context", {})
+    benchmarks = data.get("benchmarks", [])
+
+    if not benchmarks:
+        print(
+            "Error: no benchmarks in {}".format(filepath),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    agg_entries = [
+        b
+        for b in benchmarks
+        if b.get("run_type") == "aggregate" and b.get("aggregate_name") == aggregate
+    ]
+
+    if agg_entries:
+        result: dict[str, float] = {}
+        for b in agg_entries:
+            result[b["run_name"]] = _to_ns(b[metric], b.get("time_unit", "ns"))
+        return context, result
+
+    iter_entries = [b for b in benchmarks if b.get("run_type") == "iteration"]
+    if not iter_entries:
+        iter_entries = benchmarks
+
+    groups: dict[str, list[float]] = defaultdict(list)
+    for b in iter_entries:
+        name = b.get("run_name", b.get("name", "unknown"))
+        groups[name].append(_to_ns(b[metric], b.get("time_unit", "ns")))
+
+    return context, {n: sum(t) / len(t) for n, t in groups.items()}
+
+
+def _strip_aggregate_suffix(name: str) -> str:
+    for suffix in ("_mean", "_median", "_stddev", "_cv"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def compute_comparison(
+    baseline_times: dict[str, float],
+    optimized_times: dict[str, float],
+) -> list[dict]:
+    base_norm = {_strip_aggregate_suffix(k): v for k, v in baseline_times.items()}
+    opt_norm = {_strip_aggregate_suffix(k): v for k, v in optimized_times.items()}
+
+    all_names = set(base_norm.keys()) | set(opt_norm.keys())
+
+    rows: list[dict] = []
+    for name in sorted(all_names):
+        if name not in base_norm:
+            print(
+                "Warning: '{}' only in optimized, skipping".format(name),
+                file=sys.stderr,
+            )
+            continue
+        if name not in opt_norm:
+            print(
+                "Warning: '{}' only in baseline, skipping".format(name),
+                file=sys.stderr,
+            )
+            continue
+
+        base_ns = base_norm[name]
+        opt_ns = opt_norm[name]
+
+        if base_ns <= 0:
+            print(
+                "Warning: zero baseline for '{}', skipping".format(name),
+                file=sys.stderr,
+            )
+            continue
+
+        base_us = base_ns * _NS_TO_US
+        opt_us = opt_ns * _NS_TO_US
+        delta_us = opt_us - base_us
+        change_pct = (opt_ns - base_ns) / base_ns * 100.0
+
+        rows.append(
+            {
+                "name": name,
+                "baseline_us": base_us,
+                "optimized_us": opt_us,
+                "delta_us": delta_us,
+                "change_pct": change_pct,
+            }
+        )
+
+    rows.sort(key=lambda r: r["change_pct"])
+    return rows
+
+
+def geometric_mean_speedup(rows: list[dict]) -> float:
+    """``exp(mean(log(baseline_i / optimized_i)))`` for all valid pairs."""
+    log_ratios: list[float] = []
+    for r in rows:
+        if r["baseline_us"] > 0 and r["optimized_us"] > 0:
+            log_ratios.append(math.log(r["baseline_us"] / r["optimized_us"]))
+    if not log_ratios:
+        return 1.0
+    return math.exp(sum(log_ratios) / len(log_ratios))
+
+
+def _short_name(name: str) -> str:
+    idx = name.find("/min_time:")
+    if idx != -1:
+        return name[:idx]
+    return name
+
+
+def _fmt_change(pct: float) -> str:
+    if pct <= -1.0:
+        return "**{:.1f}%**".format(pct)
+    if pct >= 1.0:
+        return "**+{:.1f}%**".format(pct)
+    if pct >= 0:
+        return "+{:.1f}%".format(pct)
+    return "{:.1f}%".format(pct)
+
+
+def format_markdown(
+    rows: list[dict],
+    base_ctx: dict,
+    opt_ctx: dict,
+    metric: str,
+    aggregate: str,
+) -> str:
+    lines: list[str] = [
+        "## Benchmark Comparison",
+        "",
+        "**Baseline**: {} ({})".format(
+            base_ctx.get("date", "unknown"),
+            base_ctx.get("executable", "unknown"),
+        ),
+        "**Optimized**: {} ({})".format(
+            opt_ctx.get("date", "unknown"),
+            opt_ctx.get("executable", "unknown"),
+        ),
+        "**CPU**: {} \u00d7 {} MHz".format(
+            base_ctx.get("num_cpus", "?"),
+            base_ctx.get("mhz_per_cpu", "?"),
+        ),
+        "**Metric**: {} ({})".format(metric, aggregate),
+        "",
+        "| Benchmark | Baseline (\u00b5s) | Optimized (\u00b5s) "
+        "| \u0394 (\u00b5s) | Change |",
+        "|-----------|--------------|----------------|--------|--------|",
+    ]
+
+    for r in rows:
+        lines.append(
+            "| {} | {:.1f} | {:.1f} | {:.1f} | {} |".format(
+                _short_name(r["name"]),
+                r["baseline_us"],
+                r["optimized_us"],
+                r["delta_us"],
+                _fmt_change(r["change_pct"]),
+            )
+        )
+
+    n_total = len(rows)
+    n_improved = sum(1 for r in rows if r["change_pct"] < -1.0)
+    n_regressed = sum(1 for r in rows if r["change_pct"] > 1.0)
+    n_unchanged = n_total - n_improved - n_regressed
+    geo = geometric_mean_speedup(rows)
+
+    lines.extend(
+        [
+            "",
+            "### Summary",
+            "- **Compared**: {} benchmarks".format(n_total),
+            "- **Improved** (>1%): {}".format(n_improved),
+            "- **Regressed** (>1%): {}".format(n_regressed),
+            "- **Unchanged**: {}".format(n_unchanged),
+            "- **Geometric mean speedup**: {:.2f}x".format(geo),
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def format_csv(
+    rows: list[dict],
+    base_ctx: dict,
+    opt_ctx: dict,
+    metric: str,
+    aggregate: str,
+) -> str:
+    _ = base_ctx, opt_ctx, metric, aggregate
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "Benchmark",
+            "Baseline (us)",
+            "Optimized (us)",
+            "Delta (us)",
+            "Change (%)",
+        ]
+    )
+    for r in rows:
+        writer.writerow(
+            [
+                _short_name(r["name"]),
+                "{:.1f}".format(r["baseline_us"]),
+                "{:.1f}".format(r["optimized_us"]),
+                "{:.1f}".format(r["delta_us"]),
+                "{:.1f}".format(r["change_pct"]),
+            ]
+        )
+    return buf.getvalue()
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    if not args.baseline.exists():
+        print(
+            "Error: file not found: {}".format(args.baseline),
+            file=sys.stderr,
+        )
+        return 1
+    if not args.optimized.exists():
+        print(
+            "Error: file not found: {}".format(args.optimized),
+            file=sys.stderr,
+        )
+        return 1
+
+    base_ctx, base_times = load_benchmarks(args.baseline, args.metric, args.aggregate)
+    opt_ctx, opt_times = load_benchmarks(args.optimized, args.metric, args.aggregate)
+
+    rows = compute_comparison(base_times, opt_times)
+
+    if not rows:
+        print("Error: no matching benchmarks found", file=sys.stderr)
+        return 1
+
+    if args.fmt == "markdown":
+        text = format_markdown(rows, base_ctx, opt_ctx, args.metric, args.aggregate)
+    else:
+        text = format_csv(rows, base_ctx, opt_ctx, args.metric, args.aggregate)
+
+    if args.output:
+        args.output.write_text(text)
+        print("Output written to {}".format(args.output), file=sys.stderr)
+    else:
+        sys.stdout.write(text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/run_cpp_benchmark.py
+++ b/scripts/run_cpp_benchmark.py
@@ -19,6 +19,8 @@ CANONICAL_BENCHMARKS = {
     "dot_product": "BM_DOT_PRODUCT",
     "matrix_multiply": "BM_MATRIX_MULTIPLY",
     "simd": "bm_simd",
+    "dynamics_cache": "bm_dynamics_cache",
+    "dynamics_cache_io": "bm_dynamics_cache_io",
 }
 
 ALIASES = {
@@ -34,6 +36,8 @@ ALIASES = {
     "lcpsolver": "BM_LCPSOLVER",
     "lcp_solvers": "BM_LCPSOLVER_SOLVERS",
     "bm_simd": "bm_simd",
+    "bm_dynamics_cache": "bm_dynamics_cache",
+    "bm_dynamics_cache_io": "bm_dynamics_cache_io",
 }
 
 

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -67,6 +67,24 @@ if(TARGET dart-io)
   dart_format_add(dynamics/bm_kinematics.cpp)
 endif()
 
+add_executable(bm_dynamics_cache dynamics/bm_dynamics_cache.cpp)
+target_link_libraries(bm_dynamics_cache
+  dart
+  benchmark::benchmark
+  benchmark::benchmark_main
+)
+dart_format_add(dynamics/bm_dynamics_cache.cpp)
+
+if(TARGET dart-io)
+  add_executable(bm_dynamics_cache_io dynamics/bm_dynamics_cache_io.cpp)
+  target_link_libraries(bm_dynamics_cache_io
+    dart-io
+    benchmark::benchmark
+    benchmark::benchmark_main
+  )
+  dart_format_add(dynamics/bm_dynamics_cache_io.cpp)
+endif()
+
 # ==============================================================================
 # Component Benchmarks (organized in subdirectories)
 # ==============================================================================

--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -1,0 +1,1441 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// @file bm_dynamics_cache.cpp
+/// @brief Comprehensive dynamics benchmark suite for DART.
+///
+/// Benchmarks are parametric across:
+///   - Scale: 1 to 500 bodies
+///   - Topology: serial chain, binary tree, star
+///   - Joint type: Revolute, Ball, Free
+///   - Operation: FK, FD, ID, mass matrix, Coriolis+gravity, integration,
+///                World::step
+///   - Multi-skeleton: 1 to 100 skeletons in a world
+///   - Parallel worlds: 1 to 4 threads
+///
+/// Run all:     pixi run bm -- dynamics_cache
+/// Run subset:  pixi run bm -- dynamics_cache
+///                --benchmark_filter="BM_Serial.*Revolute.*ForwardDynamics"
+
+#include <dart/simulation/world.hpp>
+
+#include <dart/dynamics/ball_joint.hpp>
+#include <dart/dynamics/body_node.hpp>
+#include <dart/dynamics/box_shape.hpp>
+#include <dart/dynamics/free_joint.hpp>
+#include <dart/dynamics/inertia.hpp>
+#include <dart/dynamics/joint.hpp>
+#include <dart/dynamics/revolute_joint.hpp>
+#include <dart/dynamics/shape_node.hpp>
+#include <dart/dynamics/skeleton.hpp>
+#include <dart/dynamics/sphere_shape.hpp>
+#include <dart/dynamics/weld_joint.hpp>
+
+#include <dart/math/random.hpp>
+
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+
+// ============================================================================
+// Global allocation tracking for Section P (Allocation Metrics)
+// ============================================================================
+// These overrides are active for the entire benchmark binary. They add minimal
+// overhead (atomic increment) which is constant across baseline and optimized
+// runs, so relative comparisons remain valid.
+static std::atomic<int64_t> g_alloc_count{0};
+static std::atomic<int64_t> g_alloc_bytes{0};
+
+void* operator new(std::size_t size)
+{
+  g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+  g_alloc_bytes.fetch_add(
+      static_cast<int64_t>(size), std::memory_order_relaxed);
+  void* ptr = std::malloc(size);
+  if (!ptr) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void* operator new[](std::size_t size)
+{
+  g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+  g_alloc_bytes.fetch_add(
+      static_cast<int64_t>(size), std::memory_order_relaxed);
+  void* ptr = std::malloc(size);
+  if (!ptr) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void operator delete(void* ptr) noexcept
+{
+  std::free(ptr);
+}
+
+void operator delete[](void* ptr) noexcept
+{
+  std::free(ptr);
+}
+
+void operator delete(void* ptr, std::size_t) noexcept
+{
+  std::free(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t) noexcept
+{
+  std::free(ptr);
+}
+
+using namespace dart;
+using namespace dart::dynamics;
+using namespace dart::simulation;
+
+// ============================================================================
+// Section A: Skeleton Builder Helpers
+// ============================================================================
+
+/// Joint property helper: set transform offset so links are spaced apart.
+template <typename JointType>
+void setJointOffset(
+    typename JointType::Properties& /*props*/, [[maybe_unused]] int /*index*/)
+{
+  // Default: no special offset setup needed (Ball/Free joints don't use axis)
+}
+
+template <>
+void setJointOffset<RevoluteJoint>(
+    RevoluteJoint::Properties& props, int /*index*/)
+{
+  props.mAxis = Eigen::Vector3d::UnitZ();
+}
+
+/// Create body properties with uniform mass and inertia.
+inline BodyNode::Properties makeBodyProps(const std::string& name)
+{
+  BodyNode::Properties props;
+  props.mName = name;
+  props.mInertia.setMass(1.0);
+  props.mInertia.setMoment(0.1 * Eigen::Matrix3d::Identity());
+  return props;
+}
+
+/// Create body properties with specified mass and inertia scale.
+inline BodyNode::Properties makeBodyProps(
+    const std::string& name, double mass, double inertiaScale)
+{
+  BodyNode::Properties props;
+  props.mName = name;
+  props.mInertia.setMass(mass);
+  props.mInertia.setMoment(inertiaScale * Eigen::Matrix3d::Identity());
+  return props;
+}
+
+/// Build a serial chain (linear: body[i] is parent of body[i+1]).
+template <typename JointType>
+SkeletonPtr makeSerialChain(int N, const std::string& prefix = "serial")
+{
+  auto skel = Skeleton::create(prefix + "_" + std::to_string(N));
+  BodyNode* parent = nullptr;
+  for (int i = 0; i < N; ++i) {
+    typename JointType::Properties jprops;
+    jprops.mName = prefix + "_j" + std::to_string(i);
+    setJointOffset<JointType>(jprops, i);
+
+    auto bprops = makeBodyProps(prefix + "_b" + std::to_string(i));
+    auto [joint, body]
+        = skel->createJointAndBodyNodePair<JointType>(parent, jprops, bprops);
+
+    // Space links apart so geometry is non-degenerate
+    joint->setTransformFromParentBodyNode(
+        Eigen::Isometry3d(Eigen::Translation3d(0.0, 0.0, 0.1)));
+
+    parent = body;
+  }
+  return skel;
+}
+
+/// Build a binary tree (breadth-first). Total bodies >= N.
+template <typename JointType>
+SkeletonPtr makeBinaryTree(int N, const std::string& prefix = "btree")
+{
+  auto skel = Skeleton::create(prefix + "_" + std::to_string(N));
+
+  if (N <= 0) {
+    return skel;
+  }
+
+  // Create root
+  typename JointType::Properties jprops;
+  jprops.mName = prefix + "_j0";
+  setJointOffset<JointType>(jprops, 0);
+  auto bprops = makeBodyProps(prefix + "_b0");
+  auto [rootJoint, rootBody]
+      = skel->createJointAndBodyNodePair<JointType>(nullptr, jprops, bprops);
+  rootJoint->setTransformFromParentBodyNode(
+      Eigen::Isometry3d(Eigen::Translation3d(0.0, 0.0, 0.1)));
+
+  int count = 1;
+  std::queue<BodyNode*> frontier;
+  frontier.push(rootBody);
+
+  while (count < N && !frontier.empty()) {
+    BodyNode* parent = frontier.front();
+    frontier.pop();
+
+    // Create left child
+    if (count >= N) {
+      break;
+    }
+    typename JointType::Properties ljprops;
+    ljprops.mName = prefix + "_j" + std::to_string(count);
+    setJointOffset<JointType>(ljprops, count);
+    auto lbprops = makeBodyProps(prefix + "_b" + std::to_string(count));
+    auto [lj, lb]
+        = skel->createJointAndBodyNodePair<JointType>(parent, ljprops, lbprops);
+    lj->setTransformFromParentBodyNode(
+        Eigen::Isometry3d(Eigen::Translation3d(0.05, 0.0, 0.1)));
+    frontier.push(lb);
+    ++count;
+
+    // Create right child
+    if (count >= N) {
+      break;
+    }
+    typename JointType::Properties rjprops;
+    rjprops.mName = prefix + "_j" + std::to_string(count);
+    setJointOffset<JointType>(rjprops, count);
+    auto rbprops = makeBodyProps(prefix + "_b" + std::to_string(count));
+    auto [rj, rb]
+        = skel->createJointAndBodyNodePair<JointType>(parent, rjprops, rbprops);
+    rj->setTransformFromParentBodyNode(
+        Eigen::Isometry3d(Eigen::Translation3d(-0.05, 0.0, 0.1)));
+    frontier.push(rb);
+    ++count;
+  }
+  return skel;
+}
+
+/// Build a star topology (single root, N-1 children directly on root).
+template <typename JointType>
+SkeletonPtr makeStar(int N, const std::string& prefix = "star")
+{
+  auto skel = Skeleton::create(prefix + "_" + std::to_string(N));
+
+  if (N <= 0) {
+    return skel;
+  }
+
+  // Create root
+  typename JointType::Properties jprops;
+  jprops.mName = prefix + "_j0";
+  setJointOffset<JointType>(jprops, 0);
+  auto bprops = makeBodyProps(prefix + "_b0");
+  auto [rootJoint, rootBody]
+      = skel->createJointAndBodyNodePair<JointType>(nullptr, jprops, bprops);
+  rootJoint->setTransformFromParentBodyNode(
+      Eigen::Isometry3d(Eigen::Translation3d(0.0, 0.0, 0.1)));
+
+  // All remaining bodies are children of root
+  for (int i = 1; i < N; ++i) {
+    typename JointType::Properties cjprops;
+    cjprops.mName = prefix + "_j" + std::to_string(i);
+    setJointOffset<JointType>(cjprops, i);
+    auto cbprops = makeBodyProps(prefix + "_b" + std::to_string(i));
+    auto [cj, cb] = skel->createJointAndBodyNodePair<JointType>(
+        rootBody, cjprops, cbprops);
+
+    const double angle = 2.0 * M_PI * i / (N - 1);
+    cj->setTransformFromParentBodyNode(
+        Eigen::Isometry3d(
+            Eigen::Translation3d(
+                0.1 * std::cos(angle), 0.1 * std::sin(angle), 0.0)));
+  }
+  return skel;
+}
+
+/// Build a Unitree G1-like humanoid skeleton with 29 DOF.
+///
+/// Topology:
+///   - FreeJoint root "pelvis" (6 DOF)
+///   - Torso chain from pelvis: waist_yaw, waist_pitch, waist_roll (3 DOF)
+///   - Left arm from torso: 7 revolute joints (7 DOF)
+///   - Right arm from torso: 7 revolute joints (7 DOF)
+///   - Left leg from pelvis: 3 revolute joints (3 DOF)
+///   - Right leg from pelvis: 3 revolute joints (3 DOF)
+///   - Total: 6 + 3 + 7 + 7 + 3 + 3 = 29 DOF
+inline SkeletonPtr makeG1Humanoid()
+{
+  auto skel = Skeleton::create("g1_humanoid_29dof");
+  constexpr double kMass = 1.5;
+  constexpr double kInertia = 0.15;
+  const Eigen::Isometry3d offset(Eigen::Translation3d(0.0, 0.0, 0.1));
+
+  // Helper: append a chain of revolute joints to a parent body
+  auto addRevoluteChain
+      = [&](BodyNode* parent,
+            const std::vector<std::string>& jointNames) -> BodyNode* {
+    BodyNode* current = parent;
+    for (const auto& jname : jointNames) {
+      RevoluteJoint::Properties jprops;
+      jprops.mName = jname;
+      setJointOffset<RevoluteJoint>(jprops, 0);
+      auto bprops = makeBodyProps(jname + "_body", kMass, kInertia);
+      auto [joint, body] = skel->createJointAndBodyNodePair<RevoluteJoint>(
+          current, jprops, bprops);
+      joint->setTransformFromParentBodyNode(offset);
+      current = body;
+    }
+    return current;
+  };
+
+  // Root: FreeJoint pelvis (6 DOF)
+  FreeJoint::Properties pelvisJProps;
+  pelvisJProps.mName = "pelvis_joint";
+  auto pelvisProps = makeBodyProps("pelvis", kMass, kInertia);
+  auto [pelvisJoint, pelvis] = skel->createJointAndBodyNodePair<FreeJoint>(
+      nullptr, pelvisJProps, pelvisProps);
+  pelvisJoint->setTransformFromParentBodyNode(offset);
+
+  // Torso chain from pelvis (3 DOF)
+  BodyNode* torso
+      = addRevoluteChain(pelvis, {"waist_yaw", "waist_pitch", "waist_roll"});
+
+  // Left arm from torso (7 DOF)
+  addRevoluteChain(
+      torso,
+      {"l_shoulder_pitch",
+       "l_shoulder_roll",
+       "l_shoulder_yaw",
+       "l_elbow",
+       "l_wrist_roll",
+       "l_wrist_pitch",
+       "l_wrist_yaw"});
+
+  // Right arm from torso (7 DOF)
+  addRevoluteChain(
+      torso,
+      {"r_shoulder_pitch",
+       "r_shoulder_roll",
+       "r_shoulder_yaw",
+       "r_elbow",
+       "r_wrist_roll",
+       "r_wrist_pitch",
+       "r_wrist_yaw"});
+
+  // Left leg from pelvis (3 DOF)
+  addRevoluteChain(pelvis, {"l_hip", "l_knee", "l_ankle"});
+
+  // Right leg from pelvis (3 DOF)
+  addRevoluteChain(pelvis, {"r_hip", "r_knee", "r_ankle"});
+
+  return skel;
+}
+
+/// Randomize all DOF positions and velocities to defeat caching.
+inline void randomizeState(const SkeletonPtr& skel)
+{
+  for (std::size_t i = 0; i < skel->getNumDofs(); ++i) {
+    auto* dof = skel->getDof(i);
+    dof->setPosition(math::Random::uniform(-0.5, 0.5));
+    dof->setVelocity(math::Random::uniform(-1.0, 1.0));
+  }
+}
+
+/// Force all joints to mark their caches as dirty.
+inline void dirtyAllJoints(const SkeletonPtr& skel)
+{
+  for (std::size_t i = 0; i < skel->getNumJoints(); ++i) {
+    skel->getJoint(i)->notifyPositionUpdated();
+  }
+}
+
+/// Lightweight energy conservation sanity check.
+/// Uses zero-gravity world so total KE should be roughly conserved.
+/// Returns true if energy drift is within tolerance.
+inline bool checkEnergyConservation(
+    const SkeletonPtr& skel, int steps = 100, double toleranceFraction = 0.5)
+{
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d::Zero());
+  world->setTimeStep(0.001);
+  world->addSkeleton(skel->cloneSkeleton());
+
+  auto s = world->getSkeleton(0);
+  // Set some initial velocity
+  for (std::size_t i = 0; i < s->getNumDofs(); ++i) {
+    s->getDof(i)->setVelocity(0.1);
+  }
+
+  const double e0 = s->computeKineticEnergy() + s->computePotentialEnergy();
+  for (int i = 0; i < steps; ++i) {
+    world->step();
+  }
+  const double e1 = s->computeKineticEnergy() + s->computePotentialEnergy();
+
+  if (e0 == 0.0) {
+    return true;
+  }
+  return std::abs(e1 - e0) / std::abs(e0) < toleranceFraction;
+}
+
+// ============================================================================
+// Section B: Per-Operation Benchmark Templates
+// ============================================================================
+
+// Macro to define and register a benchmark for a single
+// (topology, joint type, operation) combination.
+//
+// TopologyTag  — name fragment: Serial, BinaryTree, Star
+// MakerFunc    — makeSerialChain, makeBinaryTree, makeStar
+// JointType    — RevoluteJoint, BallJoint, FreeJoint
+// JointTag     — Revolute, Ball, Free
+// OpTag        — ForwardKinematics, ForwardDynamics, etc.
+// OpBody       — the C++ statement(s) to benchmark
+
+// clang-format off
+#define DEFINE_DYNAMICS_BM(TopologyTag, MakerFunc, JointType, JointTag, OpTag, OpBody) \
+  static void BM_##TopologyTag##_##JointTag##_##OpTag(                                 \
+      benchmark::State& state)                                                          \
+  {                                                                                     \
+    const int N = static_cast<int>(state.range(0));                                     \
+    auto skel = MakerFunc<JointType>(N);                                                \
+    randomizeState(skel);                                                               \
+                                                                                        \
+    for (auto _ : state) {                                                              \
+      state.PauseTiming();                                                              \
+      dirtyAllJoints(skel);                                                             \
+      randomizeState(skel);                                                             \
+      state.ResumeTiming();                                                             \
+                                                                                        \
+      OpBody;                                                                           \
+    }                                                                                   \
+    state.SetItemsProcessed(                                                            \
+        static_cast<int64_t>(state.iterations()));                                      \
+    state.counters["bodies"]                                                            \
+        = static_cast<double>(skel->getNumBodyNodes());                                 \
+    state.counters["dofs"]                                                              \
+        = static_cast<double>(skel->getNumDofs());                                      \
+  }
+// clang-format on
+
+// Scale arguments for body count
+// Small: 1,5,10,20  Medium: 50,100  Large: 200,500
+#define BM_SCALE_ARGS                                                          \
+  Arg(1)->Arg(5)->Arg(10)->Arg(20)->Arg(50)->Arg(100)->Arg(200)
+
+// Full scale including 500 (some combos like Free/500 are very expensive)
+#define BM_SCALE_ARGS_FULL                                                     \
+  Arg(1)->Arg(5)->Arg(10)->Arg(20)->Arg(50)->Arg(100)->Arg(200)->Arg(500)
+
+// clang-format off
+#define BM_OPTS \
+  ->MinTime(0.3)
+// clang-format on
+
+// Register macro
+#define REGISTER_DYNAMICS_BM(TopologyTag, JointTag, OpTag)                     \
+  BENCHMARK(BM_##TopologyTag##_##JointTag##_##OpTag)->BM_SCALE_ARGS BM_OPTS
+
+// For operations that scale well (FK, integration), include 500
+#define REGISTER_DYNAMICS_BM_FULL(TopologyTag, JointTag, OpTag)                \
+  BENCHMARK(BM_##TopologyTag##_##JointTag##_##OpTag)->BM_SCALE_ARGS_FULL BM_OPTS
+
+// ============================================================================
+// Section C: Forward Kinematics Benchmarks
+// ============================================================================
+
+// --- Serial Chain ---
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    RevoluteJoint,
+    Revolute,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM_FULL(Serial, Revolute, ForwardKinematics);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    BallJoint,
+    Ball,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM_FULL(Serial, Ball, ForwardKinematics);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    FreeJoint,
+    Free,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM(Serial, Free, ForwardKinematics);
+
+// --- Binary Tree ---
+DEFINE_DYNAMICS_BM(
+    BinaryTree,
+    makeBinaryTree,
+    RevoluteJoint,
+    Revolute,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM_FULL(BinaryTree, Revolute, ForwardKinematics);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree,
+    makeBinaryTree,
+    BallJoint,
+    Ball,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM(BinaryTree, Ball, ForwardKinematics);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree,
+    makeBinaryTree,
+    FreeJoint,
+    Free,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM(BinaryTree, Free, ForwardKinematics);
+
+// --- Star ---
+DEFINE_DYNAMICS_BM(
+    Star,
+    makeStar,
+    RevoluteJoint,
+    Revolute,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM_FULL(Star, Revolute, ForwardKinematics);
+
+DEFINE_DYNAMICS_BM(
+    Star,
+    makeStar,
+    BallJoint,
+    Ball,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM(Star, Ball, ForwardKinematics);
+
+DEFINE_DYNAMICS_BM(
+    Star,
+    makeStar,
+    FreeJoint,
+    Free,
+    ForwardKinematics,
+    skel->computeForwardKinematics(true, true, true))
+REGISTER_DYNAMICS_BM(Star, Free, ForwardKinematics);
+
+// ============================================================================
+// Section D: Forward Dynamics Benchmarks (ABA)
+// ============================================================================
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    RevoluteJoint,
+    Revolute,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM_FULL(Serial, Revolute, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    BallJoint,
+    Ball,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM(Serial, Ball, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    FreeJoint,
+    Free,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM(Serial, Free, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree,
+    makeBinaryTree,
+    RevoluteJoint,
+    Revolute,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM_FULL(BinaryTree, Revolute, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree,
+    makeBinaryTree,
+    BallJoint,
+    Ball,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM(BinaryTree, Ball, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree,
+    makeBinaryTree,
+    FreeJoint,
+    Free,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM(BinaryTree, Free, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Star,
+    makeStar,
+    RevoluteJoint,
+    Revolute,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM_FULL(Star, Revolute, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Star,
+    makeStar,
+    BallJoint,
+    Ball,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM(Star, Ball, ForwardDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Star,
+    makeStar,
+    FreeJoint,
+    Free,
+    ForwardDynamics,
+    skel->computeForwardDynamics())
+REGISTER_DYNAMICS_BM(Star, Free, ForwardDynamics);
+
+// ============================================================================
+// Section E: Inverse Dynamics Benchmarks (RNEA)
+// ============================================================================
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    RevoluteJoint,
+    Revolute,
+    InverseDynamics,
+    skel->computeInverseDynamics(false, false, false))
+REGISTER_DYNAMICS_BM_FULL(Serial, Revolute, InverseDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    BallJoint,
+    Ball,
+    InverseDynamics,
+    skel->computeInverseDynamics(false, false, false))
+REGISTER_DYNAMICS_BM(Serial, Ball, InverseDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    FreeJoint,
+    Free,
+    InverseDynamics,
+    skel->computeInverseDynamics(false, false, false))
+REGISTER_DYNAMICS_BM(Serial, Free, InverseDynamics);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree,
+    makeBinaryTree,
+    RevoluteJoint,
+    Revolute,
+    InverseDynamics,
+    skel->computeInverseDynamics(false, false, false))
+REGISTER_DYNAMICS_BM(BinaryTree, Revolute, InverseDynamics);
+
+DEFINE_DYNAMICS_BM(
+    Star,
+    makeStar,
+    RevoluteJoint,
+    Revolute,
+    InverseDynamics,
+    skel->computeInverseDynamics(false, false, false))
+REGISTER_DYNAMICS_BM(Star, Revolute, InverseDynamics);
+
+// ============================================================================
+// Section F: Mass Matrix Benchmarks (CRB)
+// ============================================================================
+
+DEFINE_DYNAMICS_BM(
+    Serial, makeSerialChain, RevoluteJoint, Revolute, MassMatrix, {
+      auto m = skel->getMassMatrix();
+      benchmark::DoNotOptimize(m);
+    })
+REGISTER_DYNAMICS_BM_FULL(Serial, Revolute, MassMatrix);
+
+DEFINE_DYNAMICS_BM(Serial, makeSerialChain, BallJoint, Ball, MassMatrix, {
+  auto m = skel->getMassMatrix();
+  benchmark::DoNotOptimize(m);
+})
+REGISTER_DYNAMICS_BM(Serial, Ball, MassMatrix);
+
+DEFINE_DYNAMICS_BM(Serial, makeSerialChain, FreeJoint, Free, MassMatrix, {
+  auto m = skel->getMassMatrix();
+  benchmark::DoNotOptimize(m);
+})
+REGISTER_DYNAMICS_BM(Serial, Free, MassMatrix);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree, makeBinaryTree, RevoluteJoint, Revolute, MassMatrix, {
+      auto m = skel->getMassMatrix();
+      benchmark::DoNotOptimize(m);
+    })
+REGISTER_DYNAMICS_BM(BinaryTree, Revolute, MassMatrix);
+
+DEFINE_DYNAMICS_BM(Star, makeStar, RevoluteJoint, Revolute, MassMatrix, {
+  auto m = skel->getMassMatrix();
+  benchmark::DoNotOptimize(m);
+})
+REGISTER_DYNAMICS_BM(Star, Revolute, MassMatrix);
+
+// ============================================================================
+// Section G: Coriolis + Gravity Benchmarks
+// ============================================================================
+
+DEFINE_DYNAMICS_BM(
+    Serial, makeSerialChain, RevoluteJoint, Revolute, CoriolisGravity, {
+      auto f = skel->getCoriolisAndGravityForces();
+      benchmark::DoNotOptimize(f);
+    })
+REGISTER_DYNAMICS_BM_FULL(Serial, Revolute, CoriolisGravity);
+
+DEFINE_DYNAMICS_BM(Serial, makeSerialChain, BallJoint, Ball, CoriolisGravity, {
+  auto f = skel->getCoriolisAndGravityForces();
+  benchmark::DoNotOptimize(f);
+})
+REGISTER_DYNAMICS_BM(Serial, Ball, CoriolisGravity);
+
+DEFINE_DYNAMICS_BM(
+    BinaryTree, makeBinaryTree, RevoluteJoint, Revolute, CoriolisGravity, {
+      auto f = skel->getCoriolisAndGravityForces();
+      benchmark::DoNotOptimize(f);
+    })
+REGISTER_DYNAMICS_BM(BinaryTree, Revolute, CoriolisGravity);
+
+// ============================================================================
+// Section H: Integration Benchmarks
+// ============================================================================
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    RevoluteJoint,
+    Revolute,
+    Integration,
+    skel->integratePositions(0.001);
+    skel->integrateVelocities(0.001))
+REGISTER_DYNAMICS_BM_FULL(Serial, Revolute, Integration);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    BallJoint,
+    Ball,
+    Integration,
+    skel->integratePositions(0.001);
+    skel->integrateVelocities(0.001))
+REGISTER_DYNAMICS_BM_FULL(Serial, Ball, Integration);
+
+DEFINE_DYNAMICS_BM(
+    Serial,
+    makeSerialChain,
+    FreeJoint,
+    Free,
+    Integration,
+    skel->integratePositions(0.001);
+    skel->integrateVelocities(0.001))
+REGISTER_DYNAMICS_BM(Serial, Free, Integration);
+
+// ============================================================================
+// Section I: World::step() Benchmarks (full pipeline)
+// ============================================================================
+
+// World::step includes FK + FD + collision + constraints + integration.
+// We use a separate function (not the macro) because setup is more complex.
+
+using MakerFn = SkeletonPtr (*)(int, const std::string&);
+
+static void BM_WorldStep_Impl(benchmark::State& state, MakerFn maker)
+{
+  const int N = static_cast<int>(state.range(0));
+  auto skel = maker(N, "ws");
+  randomizeState(skel);
+
+  // Energy conservation sanity check (once, outside timed loop)
+  assert(checkEnergyConservation(skel, 50, 0.5));
+
+  // Create world for timed measurement (with gravity)
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(skel);
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+
+static void BM_Serial_Revolute_WorldStep(benchmark::State& state)
+{
+  BM_WorldStep_Impl(state, &makeSerialChain<RevoluteJoint>);
+}
+BENCHMARK(BM_Serial_Revolute_WorldStep)->BM_SCALE_ARGS_FULL BM_OPTS;
+
+static void BM_Serial_Ball_WorldStep(benchmark::State& state)
+{
+  BM_WorldStep_Impl(state, &makeSerialChain<BallJoint>);
+}
+BENCHMARK(BM_Serial_Ball_WorldStep)->BM_SCALE_ARGS BM_OPTS;
+
+static void BM_Serial_Free_WorldStep(benchmark::State& state)
+{
+  BM_WorldStep_Impl(state, &makeSerialChain<FreeJoint>);
+}
+BENCHMARK(BM_Serial_Free_WorldStep)->BM_SCALE_ARGS BM_OPTS;
+
+static void BM_BinaryTree_Revolute_WorldStep(benchmark::State& state)
+{
+  BM_WorldStep_Impl(state, &makeBinaryTree<RevoluteJoint>);
+}
+BENCHMARK(BM_BinaryTree_Revolute_WorldStep)->BM_SCALE_ARGS BM_OPTS;
+
+static void BM_Star_Revolute_WorldStep(benchmark::State& state)
+{
+  BM_WorldStep_Impl(state, &makeStar<RevoluteJoint>);
+}
+BENCHMARK(BM_Star_Revolute_WorldStep)->BM_SCALE_ARGS BM_OPTS;
+
+// ============================================================================
+// Section J: Multi-Skeleton World::step() Benchmarks
+// ============================================================================
+
+static void BM_MultiSkeleton_WorldStep(benchmark::State& state)
+{
+  const int numSkeletons = static_cast<int>(state.range(0));
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+
+  for (int i = 0; i < numSkeletons; ++i) {
+    auto skel = makeSerialChain<RevoluteJoint>(20, "ms" + std::to_string(i));
+    randomizeState(skel);
+    world->addSkeleton(skel);
+  }
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(
+      static_cast<int64_t>(state.iterations()) * numSkeletons);
+  state.counters["skeletons"] = numSkeletons;
+  state.counters["bodies_per_skel"] = 20;
+  state.counters["total_bodies"] = numSkeletons * 20;
+}
+BENCHMARK(BM_MultiSkeleton_WorldStep)
+    ->Arg(1)
+    ->Arg(5)
+    ->Arg(10)
+    ->Arg(25)
+    ->Arg(50)
+    ->Arg(100) BM_OPTS;
+
+// ============================================================================
+// Section K: Parallel Worlds Benchmark
+// ============================================================================
+
+static void BM_ParallelWorlds(benchmark::State& state)
+{
+  const int numThreads = static_cast<int>(state.range(0));
+  const int stepsPerThread = 10;
+
+  // Build independent worlds (one per thread) — outside timed loop
+  std::vector<WorldPtr> worlds(numThreads);
+  for (int t = 0; t < numThreads; ++t) {
+    worlds[t] = World::create("pw_" + std::to_string(t));
+    worlds[t]->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    worlds[t]->setTimeStep(0.001);
+    auto skel = makeSerialChain<RevoluteJoint>(20, "pw_s" + std::to_string(t));
+    randomizeState(skel);
+    worlds[t]->addSkeleton(skel);
+  }
+
+  for (auto _ : state) {
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+    for (int t = 0; t < numThreads; ++t) {
+      threads.emplace_back([&worlds, t, stepsPerThread]() {
+        for (int s = 0; s < stepsPerThread; ++s) {
+          worlds[t]->step();
+        }
+      });
+    }
+    for (auto& th : threads) {
+      th.join();
+    }
+  }
+  state.SetItemsProcessed(
+      static_cast<int64_t>(state.iterations()) * numThreads * stepsPerThread);
+  state.counters["threads"] = numThreads;
+  state.counters["steps_per_thread"] = stepsPerThread;
+}
+BENCHMARK(BM_ParallelWorlds)->Arg(1)->Arg(2)->Arg(4)->Arg(8) BM_OPTS;
+
+// ============================================================================
+// Section L: Unitree G1-like Humanoid Benchmarks (29 DOF)
+// ============================================================================
+
+static void BM_G1Humanoid_ForwardKinematics(benchmark::State& state)
+{
+  auto skel = makeG1Humanoid();
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+
+    skel->computeForwardKinematics(true, true, true);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_G1Humanoid_ForwardKinematics)->MinTime(0.3);
+
+static void BM_G1Humanoid_ForwardDynamics(benchmark::State& state)
+{
+  auto skel = makeG1Humanoid();
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+
+    skel->computeForwardDynamics();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_G1Humanoid_ForwardDynamics)->MinTime(0.3);
+
+static void BM_G1Humanoid_InverseDynamics(benchmark::State& state)
+{
+  auto skel = makeG1Humanoid();
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+
+    skel->computeInverseDynamics(false, false, false);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_G1Humanoid_InverseDynamics)->MinTime(0.3);
+
+static void BM_G1Humanoid_MassMatrix(benchmark::State& state)
+{
+  auto skel = makeG1Humanoid();
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+
+    auto m = skel->getMassMatrix();
+    benchmark::DoNotOptimize(m);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_G1Humanoid_MassMatrix)->MinTime(0.3);
+
+static void BM_G1Humanoid_WorldStep(benchmark::State& state)
+{
+  auto skel = makeG1Humanoid();
+  randomizeState(skel);
+  assert(checkEnergyConservation(skel, 50, 0.5));
+
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(skel);
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_G1Humanoid_WorldStep)->MinTime(0.3);
+
+// ============================================================================
+// Section N: Contact/Collision World::step() Benchmarks
+// ============================================================================
+
+static SkeletonPtr makeGroundPlane()
+{
+  auto ground = Skeleton::create("ground");
+  auto [joint, body] = ground->createJointAndBodyNodePair<WeldJoint>(nullptr);
+  joint->setName("ground_weld");
+  body->setName("ground_body");
+  auto shape = std::make_shared<BoxShape>(Eigen::Vector3d(10.0, 10.0, 0.1));
+  body->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+      shape);
+  return ground;
+}
+
+static void BM_Contact_StackedBoxes_WorldStep(benchmark::State& state)
+{
+  const int numBoxes = static_cast<int>(state.range(0));
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(makeGroundPlane());
+
+  for (int i = 0; i < numBoxes; ++i) {
+    auto box = Skeleton::create("box_" + std::to_string(i));
+    auto [joint, body] = box->createJointAndBodyNodePair<FreeJoint>(nullptr);
+    joint->setName("box_joint_" + std::to_string(i));
+    body->setName("box_body_" + std::to_string(i));
+
+    auto shape = std::make_shared<BoxShape>(Eigen::Vector3d(0.3, 0.3, 0.3));
+    body->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+        shape);
+
+    BodyNode::Properties props;
+    props.mInertia.setMass(1.0);
+    props.mInertia.setMoment(0.1 * Eigen::Matrix3d::Identity());
+    body->setInertia(props.mInertia);
+
+    Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+    tf.translation() = Eigen::Vector3d(0.0, 0.0, 0.2 + i * 0.35);
+    joint->setTransformFromParentBodyNode(tf);
+
+    world->addSkeleton(box);
+  }
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["num_skeletons"]
+      = static_cast<double>(world->getNumSkeletons());
+  state.counters["total_dofs"] = static_cast<double>(numBoxes * 6);
+}
+BENCHMARK(BM_Contact_StackedBoxes_WorldStep)
+    ->Arg(2)
+    ->Arg(5)
+    ->Arg(10)
+    ->Arg(20)
+    ->MinTime(0.1);
+
+static void BM_Contact_ChainOnGround_WorldStep(benchmark::State& state)
+{
+  const int N = static_cast<int>(state.range(0));
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(makeGroundPlane());
+
+  // Build a serial chain with collision spheres
+  auto skel = Skeleton::create("chain");
+  BodyNode* parent = nullptr;
+  for (int i = 0; i < N; ++i) {
+    RevoluteJoint::Properties jprops;
+    jprops.mName = "chain_j" + std::to_string(i);
+    jprops.mAxis = Eigen::Vector3d::UnitZ();
+
+    BodyNode::Properties bprops;
+    bprops.mName = "chain_b" + std::to_string(i);
+    bprops.mInertia.setMass(1.0);
+    bprops.mInertia.setMoment(0.1 * Eigen::Matrix3d::Identity());
+
+    auto [joint, body] = skel->createJointAndBodyNodePair<RevoluteJoint>(
+        parent, jprops, bprops);
+
+    Eigen::Isometry3d offset = Eigen::Isometry3d::Identity();
+    if (i == 0) {
+      offset.translation() = Eigen::Vector3d(0.0, 0.0, 1.0);
+    } else {
+      offset.translation() = Eigen::Vector3d(0.1, 0.0, 0.0);
+    }
+    joint->setTransformFromParentBodyNode(offset);
+
+    auto sphere = std::make_shared<SphereShape>(0.05);
+    body->createShapeNodeWith<CollisionAspect, DynamicsAspect>(sphere);
+
+    parent = body;
+  }
+  randomizeState(skel);
+  world->addSkeleton(skel);
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Contact_ChainOnGround_WorldStep)
+    ->Arg(5)
+    ->Arg(10)
+    ->Arg(20)
+    ->Arg(50)
+    ->MinTime(0.1);
+
+// ============================================================================
+// Section O: Skeleton Lifecycle Benchmarks (Create/Clone/Destroy)
+// ============================================================================
+
+static void BM_Lifecycle_Create_SerialChain(benchmark::State& state)
+{
+  const int N = static_cast<int>(state.range(0));
+  for (auto _ : state) {
+    auto skel = makeSerialChain<RevoluteJoint>(N, "lc_create");
+    benchmark::DoNotOptimize(skel.get());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(N);
+}
+BENCHMARK(BM_Lifecycle_Create_SerialChain)
+    ->Arg(1)
+    ->Arg(5)
+    ->Arg(10)
+    ->Arg(20)
+    ->Arg(50)
+    ->Arg(100)
+    ->Arg(200)
+    ->MinTime(0.1);
+
+static void BM_Lifecycle_Clone_SerialChain(benchmark::State& state)
+{
+  const int N = static_cast<int>(state.range(0));
+  auto skel = makeSerialChain<RevoluteJoint>(N, "lc_clone");
+  for (auto _ : state) {
+    auto clone = skel->cloneSkeleton();
+    benchmark::DoNotOptimize(clone.get());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(N);
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Lifecycle_Clone_SerialChain)
+    ->Arg(1)
+    ->Arg(5)
+    ->Arg(10)
+    ->Arg(20)
+    ->Arg(50)
+    ->Arg(100)
+    ->Arg(200)
+    ->MinTime(0.1);
+
+static void BM_Lifecycle_CreateDestroy_Repeated(benchmark::State& state)
+{
+  const int N = static_cast<int>(state.range(0));
+  for (auto _ : state) {
+    std::vector<SkeletonPtr> skels;
+    skels.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+      skels.push_back(
+          makeSerialChain<RevoluteJoint>(N, "lc_churn_" + std::to_string(i)));
+    }
+    skels.clear();
+    benchmark::ClobberMemory();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * 10);
+  state.counters["total_bodies"] = static_cast<double>(10 * N);
+}
+BENCHMARK(BM_Lifecycle_CreateDestroy_Repeated)
+    ->Arg(5)
+    ->Arg(10)
+    ->Arg(20)
+    ->Arg(50)
+    ->Arg(100)
+    ->MinTime(0.1);
+
+static void BM_Lifecycle_Clone_BinaryTree(benchmark::State& state)
+{
+  const int N = static_cast<int>(state.range(0));
+  auto skel = makeBinaryTree<RevoluteJoint>(N, "lc_btclone");
+  for (auto _ : state) {
+    auto clone = skel->cloneSkeleton();
+    benchmark::DoNotOptimize(clone.get());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Lifecycle_Clone_BinaryTree)
+    ->Arg(5)
+    ->Arg(10)
+    ->Arg(20)
+    ->Arg(50)
+    ->Arg(100)
+    ->MinTime(0.1);
+
+static void BM_Lifecycle_Clone_G1Humanoid(benchmark::State& state)
+{
+  auto skel = makeG1Humanoid();
+  for (auto _ : state) {
+    auto clone = skel->cloneSkeleton();
+    benchmark::DoNotOptimize(clone.get());
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Lifecycle_Clone_G1Humanoid)->MinTime(0.1);
+
+// ============================================================================
+// Section P: Allocation Metrics (Heap Allocation Counting)
+// ============================================================================
+// These benchmarks use the global operator new/delete overrides above to count
+// heap allocations per operation. The allocation COUNT is what matters -- it
+// shows how pool/arena allocation reduces heap pressure.
+
+static void BM_AllocMetrics_WorldStep_Serial20(benchmark::State& state)
+{
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  auto skel = makeSerialChain<RevoluteJoint>(20, "alloc_s20");
+  randomizeState(skel);
+  world->addSkeleton(skel);
+
+  // Warm up
+  world->step();
+
+  int64_t total_allocs = 0;
+  int64_t total_bytes = 0;
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto start_allocs = g_alloc_count.load(std::memory_order_relaxed);
+    auto start_bytes = g_alloc_bytes.load(std::memory_order_relaxed);
+    state.ResumeTiming();
+
+    world->step();
+
+    state.PauseTiming();
+    total_allocs = g_alloc_count.load(std::memory_order_relaxed) - start_allocs;
+    total_bytes = g_alloc_bytes.load(std::memory_order_relaxed) - start_bytes;
+    state.ResumeTiming();
+  }
+  state.counters["allocs_per_step"] = benchmark::Counter(
+      static_cast<double>(total_allocs), benchmark::Counter::kAvgIterations);
+  state.counters["bytes_per_step"] = benchmark::Counter(
+      static_cast<double>(total_bytes), benchmark::Counter::kAvgIterations);
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+}
+BENCHMARK(BM_AllocMetrics_WorldStep_Serial20)->MinTime(0.3);
+
+static void BM_AllocMetrics_WorldStep_G1Humanoid(benchmark::State& state)
+{
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  auto skel = makeG1Humanoid();
+  randomizeState(skel);
+  world->addSkeleton(skel);
+
+  world->step();
+
+  int64_t total_allocs = 0;
+  int64_t total_bytes = 0;
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto start_allocs = g_alloc_count.load(std::memory_order_relaxed);
+    auto start_bytes = g_alloc_bytes.load(std::memory_order_relaxed);
+    state.ResumeTiming();
+
+    world->step();
+
+    state.PauseTiming();
+    total_allocs
+        += g_alloc_count.load(std::memory_order_relaxed) - start_allocs;
+    total_bytes += g_alloc_bytes.load(std::memory_order_relaxed) - start_bytes;
+    state.ResumeTiming();
+  }
+  state.counters["allocs_per_step"] = benchmark::Counter(
+      static_cast<double>(total_allocs), benchmark::Counter::kAvgIterations);
+  state.counters["bytes_per_step"] = benchmark::Counter(
+      static_cast<double>(total_bytes), benchmark::Counter::kAvgIterations);
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+}
+BENCHMARK(BM_AllocMetrics_WorldStep_G1Humanoid)->MinTime(0.3);
+
+static void BM_AllocMetrics_WorldStep_Contact10(benchmark::State& state)
+{
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(makeGroundPlane());
+
+  for (int i = 0; i < 10; ++i) {
+    auto box = Skeleton::create("abox_" + std::to_string(i));
+    auto [joint, body] = box->createJointAndBodyNodePair<FreeJoint>(nullptr);
+    joint->setName("abox_j_" + std::to_string(i));
+    body->setName("abox_b_" + std::to_string(i));
+
+    auto shape = std::make_shared<BoxShape>(Eigen::Vector3d(0.3, 0.3, 0.3));
+    body->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+        shape);
+    Inertia inertia;
+    inertia.setMass(1.0);
+    inertia.setMoment(0.1 * Eigen::Matrix3d::Identity());
+    body->setInertia(inertia);
+
+    Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+    tf.translation() = Eigen::Vector3d(0.0, 0.0, 0.2 + i * 0.35);
+    joint->setTransform(tf);
+    world->addSkeleton(box);
+  }
+
+  // Warm up — let boxes settle
+  for (int i = 0; i < 10; ++i) {
+    world->step();
+  }
+
+  int64_t total_allocs = 0;
+  int64_t total_bytes = 0;
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto start_allocs = g_alloc_count.load(std::memory_order_relaxed);
+    auto start_bytes = g_alloc_bytes.load(std::memory_order_relaxed);
+    state.ResumeTiming();
+
+    world->step();
+
+    state.PauseTiming();
+    total_allocs
+        += g_alloc_count.load(std::memory_order_relaxed) - start_allocs;
+    total_bytes += g_alloc_bytes.load(std::memory_order_relaxed) - start_bytes;
+    state.ResumeTiming();
+  }
+  state.counters["allocs_per_step"] = benchmark::Counter(
+      static_cast<double>(total_allocs), benchmark::Counter::kAvgIterations);
+  state.counters["bytes_per_step"] = benchmark::Counter(
+      static_cast<double>(total_bytes), benchmark::Counter::kAvgIterations);
+  state.counters["num_skeletons"]
+      = static_cast<double>(world->getNumSkeletons());
+}
+BENCHMARK(BM_AllocMetrics_WorldStep_Contact10)->MinTime(0.3);
+
+static void BM_AllocMetrics_Create_Serial50(benchmark::State& state)
+{
+  int64_t total_allocs = 0;
+  int64_t total_bytes = 0;
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto start_allocs = g_alloc_count.load(std::memory_order_relaxed);
+    auto start_bytes = g_alloc_bytes.load(std::memory_order_relaxed);
+    state.ResumeTiming();
+
+    auto skel = makeSerialChain<RevoluteJoint>(50, "alloc_create");
+    benchmark::DoNotOptimize(skel.get());
+
+    state.PauseTiming();
+    total_allocs
+        += g_alloc_count.load(std::memory_order_relaxed) - start_allocs;
+    total_bytes += g_alloc_bytes.load(std::memory_order_relaxed) - start_bytes;
+    state.ResumeTiming();
+  }
+  state.counters["allocs_per_create"] = benchmark::Counter(
+      static_cast<double>(total_allocs), benchmark::Counter::kAvgIterations);
+  state.counters["bytes_per_create"] = benchmark::Counter(
+      static_cast<double>(total_bytes), benchmark::Counter::kAvgIterations);
+}
+BENCHMARK(BM_AllocMetrics_Create_Serial50)->MinTime(0.3);
+
+static void BM_AllocMetrics_Clone_Serial50(benchmark::State& state)
+{
+  auto skel = makeSerialChain<RevoluteJoint>(50, "alloc_clone");
+
+  int64_t total_allocs = 0;
+  int64_t total_bytes = 0;
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto start_allocs = g_alloc_count.load(std::memory_order_relaxed);
+    auto start_bytes = g_alloc_bytes.load(std::memory_order_relaxed);
+    state.ResumeTiming();
+
+    auto clone = skel->cloneSkeleton();
+    benchmark::DoNotOptimize(clone.get());
+
+    state.PauseTiming();
+    total_allocs
+        += g_alloc_count.load(std::memory_order_relaxed) - start_allocs;
+    total_bytes += g_alloc_bytes.load(std::memory_order_relaxed) - start_bytes;
+    state.ResumeTiming();
+  }
+  state.counters["allocs_per_clone"] = benchmark::Counter(
+      static_cast<double>(total_allocs), benchmark::Counter::kAvgIterations);
+  state.counters["bytes_per_clone"] = benchmark::Counter(
+      static_cast<double>(total_bytes), benchmark::Counter::kAvgIterations);
+}
+BENCHMARK(BM_AllocMetrics_Clone_Serial50)->MinTime(0.3);

--- a/tests/benchmark/dynamics/bm_dynamics_cache_io.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache_io.cpp
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// @file bm_dynamics_cache_io.cpp
+/// @brief Dynamics benchmarks using real robot models loaded via dart-io.
+///
+/// Separate binary from bm_dynamics_cache because this requires dart-io
+/// linkage.
+///
+/// Run:  pixi run bm -- dynamics_cache_io
+
+#include <dart/config.hpp>
+
+#include <dart/simulation/world.hpp>
+
+#include <dart/dynamics/degree_of_freedom.hpp>
+#include <dart/dynamics/joint.hpp>
+#include <dart/dynamics/skeleton.hpp>
+
+#include <dart/math/random.hpp>
+
+#include <dart/common/uri.hpp>
+
+#include <dart/io/read.hpp>
+
+#include <benchmark/benchmark.h>
+
+using namespace dart;
+using namespace dart::dynamics;
+using namespace dart::simulation;
+
+// ============================================================================
+// Helpers (mirrored from bm_dynamics_cache.cpp)
+// ============================================================================
+
+inline void randomizeState(const SkeletonPtr& skel)
+{
+  for (std::size_t i = 0; i < skel->getNumDofs(); ++i) {
+    auto* dof = skel->getDof(i);
+    dof->setPosition(math::Random::uniform(-0.5, 0.5));
+    dof->setVelocity(math::Random::uniform(-1.0, 1.0));
+  }
+}
+
+inline void dirtyAllJoints(const SkeletonPtr& skel)
+{
+  for (std::size_t i = 0; i < skel->getNumJoints(); ++i) {
+    skel->getJoint(i)->notifyPositionUpdated();
+  }
+}
+
+static SkeletonPtr loadModel(
+    const std::string& uri, const io::ReadOptions& options = io::ReadOptions())
+{
+  auto skel = dart::io::readSkeleton(common::Uri(uri), options);
+  if (skel) {
+    return skel;
+  }
+  auto world = dart::io::readWorld(common::Uri(uri), options);
+  if (world && world->getNumSkeletons() > 0) {
+    return world->getSkeleton(0);
+  }
+  return nullptr;
+}
+
+// Package directory options for URDFs that use package:// mesh URIs
+static io::ReadOptions wamOptions()
+{
+  io::ReadOptions opts;
+  opts.addPackageDirectory("herb_description", config::dataPath("urdf/wam"));
+  return opts;
+}
+
+static io::ReadOptions drchuboOptions()
+{
+  io::ReadOptions opts;
+  opts.addPackageDirectory("drchubo", config::dataPath("urdf/drchubo"));
+  return opts;
+}
+
+// ============================================================================
+// KR5 (6-DOF industrial arm)
+// ============================================================================
+
+static void BM_Robot_KR5_ForwardKinematics(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+  if (!skel) {
+    state.SkipWithError("Failed to load KR5 model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardKinematics(true, true, true);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_KR5_ForwardKinematics)->MinTime(0.1);
+
+static void BM_Robot_KR5_ForwardDynamics(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+  if (!skel) {
+    state.SkipWithError("Failed to load KR5 model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardDynamics();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_KR5_ForwardDynamics)->MinTime(0.1);
+
+static void BM_Robot_KR5_WorldStep(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+  if (!skel) {
+    state.SkipWithError("Failed to load KR5 model");
+    return;
+  }
+  randomizeState(skel);
+
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(skel);
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_KR5_WorldStep)->MinTime(0.1);
+
+// ============================================================================
+// WAM (7-DOF arm) — requires package directory for mesh resolution
+// ============================================================================
+
+static void BM_Robot_WAM_ForwardKinematics(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/urdf/wam/wam.urdf", wamOptions());
+  if (!skel) {
+    state.SkipWithError("Failed to load WAM model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardKinematics(true, true, true);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_WAM_ForwardKinematics)->MinTime(0.1);
+
+static void BM_Robot_WAM_ForwardDynamics(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/urdf/wam/wam.urdf", wamOptions());
+  if (!skel) {
+    state.SkipWithError("Failed to load WAM model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardDynamics();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_WAM_ForwardDynamics)->MinTime(0.1);
+
+static void BM_Robot_WAM_WorldStep(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/urdf/wam/wam.urdf", wamOptions());
+  if (!skel) {
+    state.SkipWithError("Failed to load WAM model");
+    return;
+  }
+  randomizeState(skel);
+
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(skel);
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_WAM_WorldStep)->MinTime(0.1);
+
+// ============================================================================
+// DRCHubo (~30 DOF humanoid) — requires package directory for mesh resolution
+// ============================================================================
+
+static void BM_Robot_DRCHubo_ForwardKinematics(benchmark::State& state)
+{
+  auto skel
+      = loadModel("dart://sample/urdf/drchubo/drchubo.urdf", drchuboOptions());
+  if (!skel) {
+    state.SkipWithError("Failed to load DRCHubo model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardKinematics(true, true, true);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_DRCHubo_ForwardKinematics)->MinTime(0.1);
+
+static void BM_Robot_DRCHubo_ForwardDynamics(benchmark::State& state)
+{
+  auto skel
+      = loadModel("dart://sample/urdf/drchubo/drchubo.urdf", drchuboOptions());
+  if (!skel) {
+    state.SkipWithError("Failed to load DRCHubo model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardDynamics();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_DRCHubo_ForwardDynamics)->MinTime(0.1);
+
+static void BM_Robot_DRCHubo_WorldStep(benchmark::State& state)
+{
+  auto skel
+      = loadModel("dart://sample/urdf/drchubo/drchubo.urdf", drchuboOptions());
+  if (!skel) {
+    state.SkipWithError("Failed to load DRCHubo model");
+    return;
+  }
+  randomizeState(skel);
+
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(skel);
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_DRCHubo_WorldStep)->MinTime(0.1);
+
+// ============================================================================
+// Atlas (humanoid, loaded via URDF in sdf directory)
+// ============================================================================
+
+static void BM_Robot_Atlas_ForwardKinematics(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
+  if (!skel) {
+    state.SkipWithError("Failed to load Atlas model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardKinematics(true, true, true);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_Atlas_ForwardKinematics)->MinTime(0.1);
+
+static void BM_Robot_Atlas_ForwardDynamics(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
+  if (!skel) {
+    state.SkipWithError("Failed to load Atlas model");
+    return;
+  }
+  randomizeState(skel);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    dirtyAllJoints(skel);
+    randomizeState(skel);
+    state.ResumeTiming();
+    skel->computeForwardDynamics();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_Atlas_ForwardDynamics)->MinTime(0.1);
+
+static void BM_Robot_Atlas_WorldStep(benchmark::State& state)
+{
+  auto skel = loadModel("dart://sample/sdf/atlas/atlas_v3_no_head.urdf");
+  if (!skel) {
+    state.SkipWithError("Failed to load Atlas model");
+    return;
+  }
+  randomizeState(skel);
+
+  auto world = World::create();
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world->setTimeStep(0.001);
+  world->addSkeleton(skel);
+
+  for (auto _ : state) {
+    world->step();
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+  state.counters["bodies"] = static_cast<double>(skel->getNumBodyNodes());
+  state.counters["dofs"] = static_cast<double>(skel->getNumDofs());
+}
+BENCHMARK(BM_Robot_Atlas_WorldStep)->MinTime(0.1);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ set(common_unit_sources
   common/test_composite.cpp
   common/test_exception.cpp
   common/test_factory.cpp
+  common/test_frame_allocator.cpp
   common/test_free_list_allocator.cpp
   common/test_local_resource.cpp
   common/test_local_resource_retriever.cpp
@@ -177,6 +178,8 @@ dart_add_test("unit" UNIT_dynamics_Entity dynamics/test_entity.cpp)
 if(TARGET dart-utils-urdf)
   dart_add_test("unit" UNIT_dynamics_CreateShapeNodeApi dynamics/test_create_shape_node_api.cpp)
 endif()
+
+dart_add_test("unit" UNIT_dynamics_BodyNodePool dynamics/test_body_node_pool.cpp)
 
 # ==============================================================================
 # Math Tests

--- a/tests/unit/common/test_frame_allocator.cpp
+++ b/tests/unit/common/test_frame_allocator.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../../helpers/gtest_utils.hpp"
+
+#include <dart/common/frame_allocator.hpp>
+#include <dart/common/memory_allocator.hpp>
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+using namespace dart::common;
+
+class FrameAllocatorTest : public ::testing::Test
+{
+};
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, Construction)
+{
+  FrameAllocator allocator;
+  EXPECT_EQ(allocator.capacity(), 65536u);
+  EXPECT_EQ(allocator.used(), 0u);
+  EXPECT_EQ(allocator.overflowCount(), 0u);
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, BasicAllocate)
+{
+  FrameAllocator allocator;
+  size_t previousUsed = 0;
+  const size_t sizes[] = {8, 64, 256, 1024};
+  for (size_t size : sizes) {
+    void* ptr = allocator.allocate(size);
+    EXPECT_NE(ptr, nullptr);
+    EXPECT_GT(allocator.used(), previousUsed);
+    previousUsed = allocator.used();
+  }
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, Alignment)
+{
+  FrameAllocator allocator;
+  const size_t alignments[] = {16, 32, 64};
+  for (size_t alignment : alignments) {
+    void* ptr = allocator.allocateAligned(32, alignment);
+    EXPECT_NE(ptr, nullptr);
+    const uintptr_t address = reinterpret_cast<uintptr_t>(ptr);
+    EXPECT_EQ(address % alignment, 0u);
+  }
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, Reset)
+{
+  FrameAllocator allocator;
+  void* first = allocator.allocate(64);
+  EXPECT_NE(first, nullptr);
+  EXPECT_GT(allocator.used(), 0u);
+
+  allocator.reset();
+  EXPECT_EQ(allocator.used(), 0u);
+  EXPECT_EQ(allocator.overflowCount(), 0u);
+
+  void* second = allocator.allocate(64);
+  EXPECT_EQ(first, second);
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, Overflow)
+{
+  FrameAllocator allocator(MemoryAllocator::GetDefault(), 256);
+  void* ptr = allocator.allocate(300);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(allocator.overflowCount(), 1u);
+
+  allocator.reset();
+  EXPECT_EQ(allocator.overflowCount(), 0u);
+  EXPECT_GE(allocator.capacity(), 556u);
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, OverflowMultiple)
+{
+  FrameAllocator allocator(MemoryAllocator::GetDefault(), 128);
+  for (int i = 0; i < 5; ++i) {
+    void* ptr = allocator.allocate(64);
+    EXPECT_NE(ptr, nullptr);
+  }
+  EXPECT_GE(allocator.overflowCount(), 1u);
+
+  allocator.reset();
+  EXPECT_EQ(allocator.overflowCount(), 0u);
+  EXPECT_GE(allocator.capacity(), 576u);
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, Construct)
+{
+  struct TestObj
+  {
+    TestObj(int x, double y) : a(x), b(y) {}
+
+    int a;
+    double b;
+  };
+
+  FrameAllocator allocator;
+  TestObj* obj = allocator.construct<TestObj>(42, 3.5);
+  ASSERT_NE(obj, nullptr);
+  EXPECT_EQ(obj->a, 42);
+  EXPECT_DOUBLE_EQ(obj->b, 3.5);
+
+  auto* vec = allocator.construct<Eigen::Vector3d>(1.0, 2.0, 3.0);
+  ASSERT_NE(vec, nullptr);
+  EXPECT_DOUBLE_EQ((*vec)(0), 1.0);
+  EXPECT_DOUBLE_EQ((*vec)(1), 2.0);
+  EXPECT_DOUBLE_EQ((*vec)(2), 3.0);
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, BaseAllocator)
+{
+  auto& defaultAlloc = MemoryAllocator::GetDefault();
+  FrameAllocator allocator(defaultAlloc, 512);
+
+  EXPECT_EQ(&allocator.getBaseAllocator(), &defaultAlloc);
+  EXPECT_EQ(allocator.capacity(), 512u);
+
+  void* ptr = allocator.allocate(64);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_GT(allocator.used(), 0u);
+}
+
+//=============================================================================
+TEST_F(FrameAllocatorTest, MultipleResets)
+{
+  FrameAllocator allocator(MemoryAllocator::GetDefault(), 128);
+  void* ptr = allocator.allocate(512);
+  EXPECT_NE(ptr, nullptr);
+  allocator.reset();
+  const size_t stableCapacity = allocator.capacity();
+
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_NE(allocator.allocate(32), nullptr);
+    EXPECT_NE(allocator.allocate(96), nullptr);
+    EXPECT_NE(allocator.allocate(128), nullptr);
+    allocator.reset();
+    EXPECT_EQ(allocator.capacity(), stableCapacity);
+  }
+}

--- a/tests/unit/dynamics/test_body_node_pool.cpp
+++ b/tests/unit/dynamics/test_body_node_pool.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/detail/body_node_pool.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include <cstdint>
+
+namespace {
+
+struct alignas(32) FakeBodyNode
+{
+  char data[1536];
+};
+
+using Pool = dart::dynamics::detail::BodyNodePool<FakeBodyNode>;
+
+} // namespace
+
+//==============================================================================
+TEST(BodyNodePoolTest, BasicAllocation)
+{
+  Pool pool;
+  std::vector<void*> pointers;
+  pointers.reserve(10);
+
+  for (int i = 0; i < 10; ++i) {
+    void* ptr = pool.allocate();
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(ptr) % 32, 0u);
+    pointers.push_back(ptr);
+  }
+
+  std::unordered_set<void*> uniquePtrs(pointers.begin(), pointers.end());
+  EXPECT_EQ(uniquePtrs.size(), pointers.size());
+}
+
+//==============================================================================
+TEST(BodyNodePoolTest, Deallocation)
+{
+  Pool pool;
+  void* p0 = pool.allocate();
+  void* p1 = pool.allocate();
+  void* p2 = pool.allocate();
+  void* p3 = pool.allocate();
+  void* p4 = pool.allocate();
+
+  pool.deallocate(p1);
+  pool.deallocate(p3);
+
+  void* r0 = pool.allocate();
+  void* r1 = pool.allocate();
+
+  EXPECT_EQ(r0, p3);
+  EXPECT_EQ(r1, p1);
+
+  pool.deallocate(p0);
+  pool.deallocate(p2);
+  pool.deallocate(p4);
+  pool.deallocate(r0);
+  pool.deallocate(r1);
+}
+
+//==============================================================================
+TEST(BodyNodePoolTest, GrowthPreservesPointers)
+{
+  Pool pool;
+  std::vector<void*> firstChunk;
+  firstChunk.reserve(64);
+
+  for (int i = 0; i < 64; ++i) {
+    void* ptr = pool.allocate();
+    firstChunk.push_back(ptr);
+    auto* bytes = static_cast<std::uint8_t*>(ptr);
+    bytes[0] = static_cast<std::uint8_t>(i);
+  }
+
+  std::vector<void*> laterAllocations;
+  laterAllocations.reserve(36);
+  for (int i = 0; i < 36; ++i) {
+    laterAllocations.push_back(pool.allocate());
+  }
+
+  for (int i = 0; i < 64; ++i) {
+    auto* bytes = static_cast<std::uint8_t*>(firstChunk[i]);
+    EXPECT_EQ(bytes[0], static_cast<std::uint8_t>(i));
+  }
+}
+
+//==============================================================================
+TEST(BodyNodePoolTest, OwnsCheck)
+{
+  Pool pool;
+  void* ptr = pool.allocate();
+  EXPECT_TRUE(pool.owns(ptr));
+
+  FakeBodyNode stackNode;
+  EXPECT_FALSE(pool.owns(&stackNode));
+
+  auto heapNode = std::make_unique<FakeBodyNode>();
+  EXPECT_FALSE(pool.owns(heapNode.get()));
+}
+
+//==============================================================================
+TEST(BodyNodePoolTest, SizeTracking)
+{
+  Pool pool;
+  EXPECT_EQ(pool.size(), 0u);
+
+  void* p0 = pool.allocate();
+  EXPECT_EQ(pool.size(), 1u);
+
+  void* p1 = pool.allocate();
+  EXPECT_EQ(pool.size(), 2u);
+
+  pool.deallocate(p0);
+  EXPECT_EQ(pool.size(), 1u);
+
+  pool.deallocate(p1);
+  EXPECT_EQ(pool.size(), 0u);
+}
+
+//==============================================================================
+TEST(BodyNodePoolTest, Alignment)
+{
+  Pool pool;
+  for (int i = 0; i < 500; ++i) {
+    void* ptr = pool.allocate();
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(ptr) % 32, 0u);
+  }
+}


### PR DESCRIPTION
## Summary

Add a three-tier allocator hierarchy (BodyNodePool, FrameAllocator, MemoryManager) to improve cache locality for dynamics simulation, wired through World → ConstraintSolver.

## Motivation / Problem

- Physics stepping allocates many small temporaries (constraint Jacobians, contact vectors) that scatter across the heap, causing cache misses
- BodyNodes within a Skeleton are individually heap-allocated, preventing spatial locality during forward dynamics traversal
- No unified memory management existed to allow configurable allocation strategies per World

## Changes / Key Changes

- **BodyNodePool** (`dart/dynamics/detail/body_node_pool.hpp`): Per-Skeleton contiguous memory pool for BodyNode storage with 32-byte alignment and O(1) index-based access
- **FrameAllocator** (`dart/common/frame_allocator.{hpp,cpp}`): Bump allocator for per-step constraint temporaries, inheriting from `MemoryAllocator` for polymorphic use. Resets each step with near-zero overhead.
- **MemoryManager** extended with `Type::Frame` enum, `getFrameAllocator()`, and frame-specific allocate/deallocate/construct/destroy methods
- **World** owns `MemoryManager` as a value member, propagates `FrameAllocator*` to `ConstraintSolver` via `setFrameAllocator()`
- **ConstraintSolver** borrows `FrameAllocator*` from World with an owned fallback for standalone use; all 6 `FrameStlAllocator` construction sites updated
- **Skeleton** updated with pool-based BodyNode storage and `if constexpr` routing in detail headers

### Architecture

```
World (owns MemoryManager)
├── MemoryManager
│   ├── FreeListAllocator(baseAllocator)
│   │     └── PoolAllocator(freeListAlloc)
│   └── FrameAllocator(baseAllocator)
├── ConstraintSolver (borrows FrameAllocator*)
│   └── Per-step bump allocation via FrameStlAllocator<T>
└── Skeleton
    └── BodyNodePool (contiguous, 32-byte aligned)
```

## Performance

Benchmarked on 64-core AMD (3700 MHz), comparing against `main` baseline. 339 benchmarks total: **213 improved, 75 regressed, 51 unchanged**. Geometric mean speedup: **1.04×**.

### Highlights (wins)

| Benchmark | Bodies | Baseline (µs) | Optimized (µs) | Change |
|-----------|--------|---------------|----------------|--------|
| Serial_Ball_WorldStep | 200 | 1445 | 650 | **-55%** |
| Serial_Ball_WorldStep | 100 | 495 | 256 | **-48%** |
| Serial_Ball_WorldStep | 50 | 262 | 157 | **-40%** |
| ParallelWorlds | 2 | 207 | 120 | **-42%** |
| ParallelWorlds | 8 | 692 | 482 | **-30%** |
| Lifecycle_Create_SerialChain | 200 | 9336 | 5574 | **-40%** |
| Lifecycle_Clone_SerialChain | 200 | 11984 | 7186 | **-40%** |
| Lifecycle_CreateDestroy_Repeated | 50 | 10009 | 5816 | **-42%** |
| Lifecycle_CreateDestroy_Repeated | 100 | 29210 | 19577 | **-33%** |
| Contact_StackedBoxes_WorldStep | 20 | 1868 | 1580 | **-15%** |
| Contact_ChainOnGround_WorldStep | 10 | 22 | 20 | **-11%** |
| G1Humanoid_ForwardDynamics | 24 | 36 | 32 | **-11%** |
| G1Humanoid_WorldStep | 24 | 42 | 38 | **-9%** |

### Regressions (trade-offs)

| Benchmark | Bodies | Baseline (µs) | Optimized (µs) | Change |
|-----------|--------|---------------|----------------|--------|
| Serial_Revolute_ForwardKinematics | 100 | 23 | 35 | **+53%** |
| Serial_Revolute_ForwardKinematics | 200 | 47 | 71 | **+50%** |
| Serial_Ball_ForwardKinematics | 100 | 25 | 30 | **+20%** |
| Serial_Revolute_MassMatrix | 50 | 168 | 184 | **+10%** |
| BinaryTree_Revolute_MassMatrix | 200 | 2584 | 2839 | **+10%** |

ForwardKinematics regressions are caused by increased `sizeof(Skeleton)` from the pool member displacing hot data in cache lines. MassMatrix regressions follow the same pattern. These trade-offs are acceptable given the much larger wins on dynamics-heavy workloads (WorldStep, lifecycle, contact) which dominate real simulation time.

## Testing

- `pixi run test-all` — **All 6 suites pass**: lint, build, 249 unit tests, simulation-experimental, Python tests, documentation
- New unit tests: `test_frame_allocator.cpp` (9 tests), `test_body_node_pool.cpp` (6 tests)
- New benchmarks: `bm_dynamics_cache.cpp`, `bm_dynamics_cache_io.cpp`

## Breaking Changes

- [x] `ConstraintSolver::setBaseAllocator()` replaced with `setFrameAllocator()` — internal API only, not exposed in Python bindings
- [x] `WorldConfig::memoryManager` replaced with `WorldConfig::baseAllocator` — simpler configuration surface

## Related Issues / PRs (backports)

- Main branch only (DART 7) — no backport needed

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [ ] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable