### PR TITLE
fix: validate Problem dimension to prevent excessive allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
   - Ensure Bullet double-precision builds include `dart/collision/bullet/BulletInclude.hpp` before Bullet headers so `BT_USE_DOUBLE_PRECISION` is honored: [#2334](https://github.com/dartsim/dart/pull/2334).
 
 - LCP and Optimization
+  - Added dimension validation to `Problem::setDimension()` to reject dimensions exceeding `Problem::kMaxDimension` (1,000,000) with `InvalidArgumentException` instead of attempting multi-GB allocations that cause ASan aborts or `std::bad_alloc`. ([#2500](https://github.com/dartsim/dart/issues/2500))
   - Refactored the LCP solver stack under `dart::math::lcp` with unified APIs plus new solver implementations and ImGui dashboard support. ([#2202](https://github.com/dartsim/dart/pull/2202), [#2241](https://github.com/dartsim/dart/pull/2241), [#2318](https://github.com/dartsim/dart/pull/2318), [#2355](https://github.com/dartsim/dart/pull/2355))
   - Modernized the Dantzig solver and improved stability (C++20 optimizations, NaN fallback, warning suppression). ([#2081](https://github.com/dartsim/dart/pull/2081), [#2253](https://github.com/dartsim/dart/pull/2253), [#2111](https://github.com/dartsim/dart/pull/2111))
   - Fixed Lemke solver segfaults on macOS arm64 by avoiding Eigen stack allocations. ([#2462](https://github.com/dartsim/dart/pull/2462))

--- a/dart/math/optimization/problem.cpp
+++ b/dart/math/optimization/problem.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/math/optimization/problem.hpp"
 
+#include "dart/common/exception.hpp"
 #include "dart/common/logging.hpp"
 #include "dart/common/macros.hpp"
 #include "dart/math/helpers.hpp"
@@ -57,16 +58,25 @@ static T getVectorObjectIfAvailable(std::size_t _idx, std::span<const T> _vec)
 }
 
 //==============================================================================
-Problem::Problem(std::size_t _dim) : mDimension(0), mOptimumValue(0.0)
+Problem::Problem(std::size_t dim) : mDimension(0), mOptimumValue(0.0)
 {
-  setDimension(_dim);
+  setDimension(dim);
 }
 
 //==============================================================================
-void Problem::setDimension(std::size_t _dim)
+void Problem::setDimension(std::size_t dim)
 {
-  if (_dim != mDimension) {
-    mDimension = _dim;
+  DART_THROW_T_IF(
+      dim > kMaxDimension,
+      common::InvalidArgumentException,
+      "Problem dimension {} exceeds maximum allowed dimension {}. "
+      "This would allocate approximately {} MB across internal vectors.",
+      dim,
+      kMaxDimension,
+      (dim * 4 * sizeof(double)) / (1024 * 1024));
+
+  if (dim != mDimension) {
+    mDimension = dim;
 
     mInitialGuess = Eigen::VectorXd::Zero(mDimension);
 

--- a/dart/math/optimization/problem.hpp
+++ b/dart/math/optimization/problem.hpp
@@ -51,8 +51,15 @@ namespace math {
 class DART_API Problem
 {
 public:
+  /// @brief Maximum allowed dimension (~32 MB across 4 internal vectors).
+  /// @throws InvalidArgumentException from setDimension() if exceeded.
+  static constexpr std::size_t kMaxDimension = 1'000'000;
+
   /// @brief Constructor
-  explicit Problem(std::size_t _dim = 0);
+  ///
+  /// @param[in] dim Dimension of the problem. Must be <= kMaxDimension.
+  /// @throws InvalidArgumentException if dim exceeds kMaxDimension.
+  explicit Problem(std::size_t dim = 0);
 
   /// @brief Destructor
   virtual ~Problem() = default;
@@ -60,7 +67,10 @@ public:
   //--------------------------- Problem Setting --------------------------------
   /// @brief Set dimension. Note: Changing the dimension will clear out the
   /// initial guess and any seeds that have been added.
-  void setDimension(std::size_t _dim);
+  ///
+  /// @param[in] dim New dimension. Must be <= kMaxDimension.
+  /// @throws InvalidArgumentException if dim exceeds kMaxDimension.
+  void setDimension(std::size_t dim);
 
   /// @brief Get dimension
   std::size_t getDimension() const;


### PR DESCRIPTION
## Summary

- Add dimension validation to `Problem::setDimension()` to reject dimensions exceeding `Problem::kMaxDimension` (1,000,000), throwing `InvalidArgumentException` instead of attempting multi-GB allocations.

## Motivation / Problem

- Closes #2500
- `Problem::setDimension()` accepted any `std::size_t` without validation, passing it directly to four `Eigen::VectorXd` allocations. Huge dimensions (e.g., 488 billion from a bug, misconfiguration, or untrusted input) caused ASan `allocation-size-too-big` aborts or `std::bad_alloc` instead of a clear, catchable error.
- Note: The issue references `GenericMultiObjectiveProblem` / `MultiObjectiveProblem` which existed in DART 6.x but were removed in DART 7. The equivalent vulnerability on `main` is in `Problem::setDimension()`.

## Changes / Key Changes

- **`dart/math/optimization/problem.hpp`**: Added `static constexpr std::size_t kMaxDimension = 1'000'000` and documented throwing behavior on constructor/setter.
- **`dart/math/optimization/problem.cpp`**: Added `DART_THROW_T_IF` validation at the top of `setDimension()` using `InvalidArgumentException`. Fires before any allocation, preserving previous dimension on rejection.
- **`tests/unit/math/optimization/test_problem.cpp`**: 4 new tests covering rejection of excessive dimensions (kMaxDimension+1, SIZE_MAX), constructor rejection, boundary acceptance at kMaxDimension, and zero-dimension regression.
- **`CHANGELOG.md`**: Documented fix under "LCP and Optimization".

## Testing

- `pixi run lint` — pass
- `pixi run build` — pass (395/395)
- `ctest -R UNIT_math_optimization_Problem` — 23/23 tests pass (19 existing + 4 new)

## Breaking Changes

- [x] Technically breaking: code that previously passed dimensions > 1,000,000 to `Problem` will now throw `InvalidArgumentException`. In practice, no realistic optimization problem uses dimensions this large, and such values were always bugs or misconfiguration.

## Related Issues / PRs (backports)

- Closes #2500
- A separate PR for `release-6.16` would be needed to fix `MultiObjectiveProblem::setSolutionDimension()` and `GenericMultiObjectiveProblem` constructor there.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable — N/A, `setDimension` is already bound; validation is in C++ layer