### PR TITLE
fix: validate Problem and MultiObjectiveProblem dimension (backport #2500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## DART 6
 
+### DART 6.16.7 (TBD)
+
+* Optimizer
+
+  * Validate Problem and MultiObjectiveProblem dimension to prevent excessive allocation from huge inputs: [#2500](https://github.com/dartsim/dart/issues/2500)
+
 ### [DART 6.16.6 (2026-01-28)](https://github.com/dartsim/dart/milestone/91?closed=1)
 
 * Constraint

--- a/dart/optimizer/MultiObjectiveProblem.cpp
+++ b/dart/optimizer/MultiObjectiveProblem.cpp
@@ -40,6 +40,8 @@
 #include <algorithm>
 #include <limits>
 #include <numeric>
+#include <stdexcept>
+#include <string>
 
 namespace dart {
 namespace optimizer {
@@ -66,6 +68,13 @@ MultiObjectiveProblem::MultiObjectiveProblem(
 void MultiObjectiveProblem::setSolutionDimension(
     std::size_t dim, std::size_t integerDim)
 {
+  if (dim > kMaxDimension) {
+    throw std::invalid_argument(
+        "[MultiObjectiveProblem::setSolutionDimension] Requested dimension ("
+        + std::to_string(dim) + ") exceeds the maximum allowed dimension ("
+        + std::to_string(kMaxDimension) + ").");
+  }
+
   if (dim == mDimension && integerDim == mIntegerDimension)
     return;
 

--- a/dart/optimizer/MultiObjectiveProblem.hpp
+++ b/dart/optimizer/MultiObjectiveProblem.hpp
@@ -47,7 +47,16 @@ namespace optimizer {
 class MultiObjectiveProblem
 {
 public:
+  /// Maximum allowed dimension for a MultiObjectiveProblem.
+  ///
+  /// Requesting a dimension above this limit throws std::invalid_argument.
+  /// The value (1 000 000) keeps peak allocation under ~16 MB (two
+  /// VectorXd of 8 bytes each).
+  static constexpr std::size_t kMaxDimension = 1'000'000;
+
   /// Constructor
+  ///
+  /// \throws std::invalid_argument if \p dim exceeds kMaxDimension.
   explicit MultiObjectiveProblem(std::size_t dim, std::size_t integerDim = 0u);
 
   /// Destructor
@@ -72,6 +81,7 @@ public:
   ///
   /// \param[in] dim Total dimension of the solution.
   /// \param[in] integerDim The dimension of integer part in the solution.
+  /// \throws std::invalid_argument if \p dim exceeds kMaxDimension.
   virtual void setSolutionDimension(
       std::size_t dim, std::size_t integerDim = 0u);
 

--- a/dart/optimizer/Problem.cpp
+++ b/dart/optimizer/Problem.cpp
@@ -39,6 +39,8 @@
 
 #include <algorithm>
 #include <limits>
+#include <stdexcept>
+#include <string>
 
 namespace dart {
 namespace optimizer {
@@ -64,6 +66,13 @@ Problem::Problem(std::size_t _dim) : mDimension(0), mOptimumValue(0.0)
 //==============================================================================
 void Problem::setDimension(std::size_t _dim)
 {
+  if (_dim > kMaxDimension) {
+    throw std::invalid_argument(
+        "[Problem::setDimension] Requested dimension (" + std::to_string(_dim)
+        + ") exceeds the maximum allowed dimension ("
+        + std::to_string(kMaxDimension) + ").");
+  }
+
   if (_dim != mDimension) {
     mDimension = _dim;
 

--- a/dart/optimizer/Problem.hpp
+++ b/dart/optimizer/Problem.hpp
@@ -48,7 +48,16 @@ namespace optimizer {
 class Problem
 {
 public:
+  /// Maximum allowed dimension for a Problem.
+  ///
+  /// Requesting a dimension above this limit throws std::invalid_argument.
+  /// The value (1 000 000) keeps peak allocation under ~32 MB (four
+  /// VectorXd of 8 bytes each).
+  static constexpr std::size_t kMaxDimension = 1'000'000;
+
   /// \brief Constructor
+  ///
+  /// \throws std::invalid_argument if \p _dim exceeds kMaxDimension.
   explicit Problem(std::size_t _dim = 0);
 
   /// \brief Destructor
@@ -57,6 +66,8 @@ public:
   //--------------------------- Problem Setting --------------------------------
   /// \brief Set dimension. Note: Changing the dimension will clear out the
   /// initial guess and any seeds that have been added.
+  ///
+  /// \throws std::invalid_argument if \p _dim exceeds kMaxDimension.
   void setDimension(std::size_t _dim);
 
   /// \brief Get dimension

--- a/tests/integration/test_Optimizer.cpp
+++ b/tests/integration/test_Optimizer.cpp
@@ -65,6 +65,35 @@ using namespace dart::optimizer;
 using namespace dart::dynamics;
 
 //==============================================================================
+TEST(Optimizer, SetDimensionRejectsExcessiveDimension)
+{
+  Problem prob;
+  EXPECT_THROW(
+      prob.setDimension(Problem::kMaxDimension + 1), std::invalid_argument);
+}
+
+//==============================================================================
+TEST(Optimizer, ConstructorRejectsExcessiveDimension)
+{
+  EXPECT_THROW(Problem(Problem::kMaxDimension + 1), std::invalid_argument);
+}
+
+//==============================================================================
+TEST(Optimizer, SetDimensionAcceptsMaxDimension)
+{
+  Problem prob;
+  EXPECT_NO_THROW(prob.setDimension(Problem::kMaxDimension));
+  EXPECT_EQ(prob.getDimension(), Problem::kMaxDimension);
+}
+
+//==============================================================================
+TEST(Optimizer, ZeroDimensionRemainsValid)
+{
+  Problem prob(0);
+  EXPECT_EQ(prob.getDimension(), 0u);
+}
+
+//==============================================================================
 /// \brief class SampleObjFunc
 class SampleObjFunc : public Function
 {


### PR DESCRIPTION
## Summary

Backport of #2502 to `release-6.16`. Adds dimension validation to `Problem::setDimension()` and `MultiObjectiveProblem::setSolutionDimension()` to prevent excessive memory allocation from huge dimension values.

- Add `kMaxDimension = 1'000'000` constant to both `Problem` and `MultiObjectiveProblem`
- Throw `std::invalid_argument` before allocation when dimension exceeds the limit
- `GenericMultiObjectiveProblem` is also protected (its constructor delegates to `setSolutionDimension()`)
- Add 10 new tests covering rejection, boundary, and zero-dimension cases
- Update CHANGELOG for 6.16.7

Closes #2500