### PR TITLE
Packaging 6.16.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,27 @@
 
 ## DART 6
 
-### DART 6.16.7 (TBD)
+### [DART 6.16.7 (2026-02-10)](https://github.com/dartsim/dart/milestone/92?closed=1)
 
 * Build
 
-  * Added support for assimp 6.x while maintaining backward compatibility with assimp 5.x
+  * Added support for assimp 6.x while maintaining backward compatibility with assimp 5.x: [#2510](https://github.com/dartsim/dart/pull/2510)
+
+* Dynamics
+
+  * Reject non-finite transforms at Joint public API entry points and guard inertia propagation in kinematic joint variants: [#2497](https://github.com/dartsim/dart/pull/2497)
+
+* Math
+
+  * Enhance verifyTransform to also reject infinity values (previously only checked NaN): [#2497](https://github.com/dartsim/dart/pull/2497)
 
 * Optimizer
 
-  * Validate Problem and MultiObjectiveProblem dimension to prevent excessive allocation from huge inputs: [#2500](https://github.com/dartsim/dart/issues/2500)
+  * Validate Problem and MultiObjectiveProblem dimension to prevent excessive allocation from huge inputs: [#2503](https://github.com/dartsim/dart/pull/2503)
+
+* Parsers
+
+  * Replace MJCF parser DART_ASSERT with DART_WARN + identity fallback for non-finite transforms and rotations: [#2497](https://github.com/dartsim/dart/pull/2497)
 
 ### [DART 6.16.6 (2026-01-28)](https://github.com/dartsim/dart/milestone/91?closed=1)
 
@@ -21,16 +33,6 @@
 * Dynamics
 
   * Guard against non-finite articulated body computations from zero/epsilon mass or extreme spring values: [gz-physics#849](https://github.com/gazebosim/gz-physics/issues/849), [gz-physics#850](https://github.com/gazebosim/gz-physics/issues/850), [gz-physics#851](https://github.com/gazebosim/gz-physics/issues/851), [gz-physics#854](https://github.com/gazebosim/gz-physics/issues/854), [gz-physics#856](https://github.com/gazebosim/gz-physics/issues/856)
-
-  * Reject non-finite transforms at Joint public API entry points and guard inertia propagation in kinematic joint variants: [gz-physics#861](https://github.com/gazebosim/gz-physics/issues/861), [gz-physics#862](https://github.com/gazebosim/gz-physics/issues/862)
-
-* Parsers
-
-  * Replace MJCF parser DART_ASSERT with DART_WARN + identity fallback for non-finite transforms and rotations
-
-* Math
-
-  * Enhance verifyTransform to also reject infinity values (previously only checked NaN)
 
 ### [DART 6.16.5 (2026-01-21)](https://github.com/dartsim/dart/milestone/90?closed=1)
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.16.6</version>
+  <version>6.16.7</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.16.6"
+version = "6.16.7"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
## Summary
- Bump version to 6.16.7 in `package.xml` and `pixi.toml`
- Update CHANGELOG.md with release date (2026-02-10)
- Move #2497 changelog entries from 6.16.6 to 6.16.7 section (were incorrectly placed)

## Changes in 6.16.7
- Added support for assimp 6.x while maintaining backward compatibility with assimp 5.x (#2510)
- Reject non-finite transforms at Joint public API entry points and guard inertia propagation (#2497)
- Enhance verifyTransform to also reject infinity values (#2497)
- Validate Problem and MultiObjectiveProblem dimension (#2503)
- Replace MJCF parser DART_ASSERT with DART_WARN + identity fallback (#2497)