### PR TITLE
fix: Add FreeBSD support in shared library platform switches

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -19,17 +19,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check runner requirements (KVM and Docker)
-        id: prereqs
         run: |
           FAILED=false
 
           echo "=== Docker Diagnostics ==="
           if docker info > /dev/null 2>&1; then
             echo "Docker is accessible"
-            echo "docker_available=true" >> $GITHUB_OUTPUT
           else
             echo "::error::Docker not accessible - check socket permissions"
-            echo "docker_available=false" >> $GITHUB_OUTPUT
             FAILED=true
           fi
 
@@ -39,27 +36,24 @@ jobs:
           ls -la /dev/kvm 2>/dev/null || echo "/dev/kvm does not exist"
           if [ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
             echo "KVM is accessible"
-            echo "kvm_available=true" >> $GITHUB_OUTPUT
           else
             echo "::error::KVM not accessible"
-            echo "kvm_available=false" >> $GITHUB_OUTPUT
             FAILED=true
           fi
 
           if [ "$FAILED" = "true" ]; then
             echo ""
-            echo "::warning::FreeBSD CI requires both Docker and KVM — skipping tests on this runner"
+            echo "::error::FreeBSD CI requires both Docker and KVM"
             echo "Self-hosted runner setup: https://gist.github.com/jslee02/c0a6b0e4af18e4ecb2f2e8fb5b715f78"
+            exit 1
           fi
 
       - name: Setup pixi (CI)
-        if: steps.prereqs.outputs.kvm_available == 'true' && steps.prereqs.outputs.docker_available == 'true'
         uses: ./.github/actions/setup-pixi-ci
         with:
           pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Run FreeBSD repro tests
-        if: steps.prereqs.outputs.kvm_available == 'true' && steps.prereqs.outputs.docker_available == 'true'
         env:
           FREEBSD_VM_CPUS: "2"
           FREEBSD_VM_MEM: "4096"
@@ -95,12 +89,12 @@ jobs:
           exit 1
 
       - name: Show Docker container logs
-        if: always() && steps.prereqs.outputs.kvm_available == 'true' && steps.prereqs.outputs.docker_available == 'true'
+        if: always()
         run: |
           echo "=== Full Docker Container Logs ==="
           docker logs dart-freebsd-vm 2>&1 || true
           echo "==================================="
 
       - name: Stop FreeBSD VM
-        if: always() && steps.prereqs.outputs.kvm_available == 'true' && steps.prereqs.outputs.docker_available == 'true'
+        if: always()
         run: pixi run freebsd-stop

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -97,4 +97,4 @@ jobs:
 
       - name: Stop FreeBSD VM
         if: always()
-        run: pixi run freebsd-stop
+        run: pixi run freebsd-stop || true

--- a/dart/common/shared_library.cpp
+++ b/dart/common/shared_library.cpp
@@ -35,7 +35,7 @@
 #include "dart/common/detail/shared_library_manager.hpp"
 #include "dart/common/logging.hpp"
 
-#if DART_OS_LINUX || DART_OS_MACOS
+#if DART_OS_LINUX || DART_OS_MACOS || DART_OS_FREEBSD
 
   #include <dlfcn.h>
   #define DYNLIB_LOAD(a) dlopen(a, RTLD_LAZY | RTLD_GLOBAL)
@@ -128,7 +128,7 @@ void* SharedLibrary::getSymbol(std::string_view symbolName) const
 //==============================================================================
 std::string SharedLibrary::getLastError() const
 {
-#if DART_OS_LINUX || DART_OS_MACOS
+#if DART_OS_LINUX || DART_OS_MACOS || DART_OS_FREEBSD
   return std::string(dlerror());
 #elif DART_OS_WINDOWS
   LPTSTR lpMsgBuf;

--- a/dart/common/shared_library.hpp
+++ b/dart/common/shared_library.hpp
@@ -40,7 +40,7 @@
 #include <string>
 #include <string_view>
 
-#if DART_OS_LINUX
+#if DART_OS_LINUX || DART_OS_FREEBSD
 
   #define DYNLIB_HANDLE void*
 
@@ -56,7 +56,7 @@ using hInstance = HINSTANCE__*;
 
 #endif
 
-#if DART_OS_LINUX
+#if DART_OS_LINUX || DART_OS_FREEBSD
 static constexpr const char* DART_SHARED_LIB_EXTENSION = "so";
 #elif DART_OS_MACOS
 static constexpr const char* DART_SHARED_LIB_EXTENSION = "dylib";
@@ -66,7 +66,7 @@ static constexpr const char* DART_SHARED_LIB_EXTENSION = "dll";
   #error Unhandled platform
 #endif
 
-#if DART_OS_LINUX
+#if DART_OS_LINUX || DART_OS_FREEBSD
 static constexpr const char* DART_SHARED_LIB_PREFIX = "lib";
 #elif DART_OS_MACOS
 static constexpr const char* DART_SHARED_LIB_PREFIX = "lib";


### PR DESCRIPTION
## Summary

Addresses review feedback from #2513:

- **P1 (shared library)**: Add `DART_OS_FREEBSD` to all platform-conditional blocks in `shared_library.hpp` and `shared_library.cpp`. Without this, FreeBSD builds hit `#error Unhandled platform` and missing `DYNLIB_*` macros. FreeBSD uses the same `dlopen`/`dlsym`/`dlclose` API as Linux.

- **P2 (CI prereq enforcement)**: Restore `exit 1` when Docker/KVM prerequisites are missing in `ci_freebsd.yml`. The previous PR downgraded this to a warning, which silently skips tests and reports success. Now the job fails fast with a clear error, and redundant step output variables and `if`-guards are removed.

## Files Changed

| File | Change |
|------|--------|
| `dart/common/shared_library.hpp` | Add `DART_OS_FREEBSD` to `DYNLIB_HANDLE`, extension, and prefix conditionals |
| `dart/common/shared_library.cpp` | Add `DART_OS_FREEBSD` to `DYNLIB_LOAD/SYM/UNLOAD` and `getLastError()` conditionals |
| `.github/workflows/ci_freebsd.yml` | Restore `exit 1` on missing prereqs; remove unused outputs and `if`-guards |

## Testing

- C++ lint passes (`pixi run check-lint-cpp`)
- Python lint passes (`pixi run check-lint-py`)
- `shared_library.cpp` compiles clean (verified in build output)
- Full build failure is pre-existing (assimp header issue in local env), unrelated to these changes