### PR TITLE
Fix SEGV in ImFontAtlas font loading with null pointer input (DART 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
   - Documented SKEL as a legacy format.
 
 - GUI and Rendering
+  - Fix SEGV in `ImFontAtlas::AddFontFromMemoryCompressedTTF` when null pointer is passed as compressed font data. ([#2516](https://github.com/dartsim/dart/issues/2516))
   - Added headless rendering support via `ViewerConfig` and pbuffer graphics context for CI pipelines and batch frame capture. Includes `Viewer::captureBuffer()` for raw RGBA pixel readback and a new `headless-rendering` CI job. ([#2466](https://github.com/dartsim/dart/pull/2466))
   - Added `ImGuiViewer` construction from `ViewerConfig` to support headless ImGui rendering and example frame capture workflows.
   - GUI naming updates and backend cleanup (including the osg suffix removal). ([#2209](https://github.com/dartsim/dart/pull/2209), [#2257](https://github.com/dartsim/dart/pull/2257))

--- a/cmake/dart_find_dependencies.cmake
+++ b/cmake/dart_find_dependencies.cmake
@@ -237,6 +237,9 @@ if(DART_BUILD_GUI)
       GIT_TAG        ${IMGUI_TARGET_VERSION}
       GIT_SHALLOW    TRUE
       SOURCE_DIR     "${CMAKE_BINARY_DIR}/_deps/imgui-src"
+      PATCH_COMMAND  ${CMAKE_COMMAND}
+        -DIMGUI_SOURCE_DIR=${CMAKE_BINARY_DIR}/_deps/imgui-src
+        -P ${CMAKE_CURRENT_LIST_DIR}/patches/imgui_null_font_guard.cmake
     )
 
     # Populate imgui using the modern helper (avoids CMP0169 warnings)

--- a/cmake/patches/imgui_null_font_guard.cmake
+++ b/cmake/patches/imgui_null_font_guard.cmake
@@ -63,5 +63,15 @@ string(REPLACE
   content "${content}"
 )
 
+# Verify all three patches were applied (detect source drift from ImGui updates)
+string(FIND "${content}" "DART patch" _patch_found)
+if(_patch_found EQUAL -1)
+  message(FATAL_ERROR
+    "ImGui null-pointer patch failed: none of the expected patterns were found "
+    "in ${file}. The ImGui source may have changed. Update the patch patterns "
+    "to match the current ImGui version."
+  )
+endif()
+
 file(WRITE "${file}" "${content}")
 message(STATUS "Patched imgui_draw.cpp with null pointer guards (issue #2516)")

--- a/cmake/patches/imgui_null_font_guard.cmake
+++ b/cmake/patches/imgui_null_font_guard.cmake
@@ -34,7 +34,6 @@ string(REPLACE
     font_cfg.FontData = ttf_data;"
   "IM_ASSERT(!Locked && \"Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!\");
     // [DART patch] Guard against null/empty input (issue #2516)
-    IM_ASSERT(ttf_data != NULL && \"ttf_data is NULL!\");
     if (ttf_data == NULL || ttf_size <= 0)
         return NULL;
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
@@ -47,7 +46,6 @@ string(REPLACE
 string(REPLACE
   "const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);"
   "// [DART patch] Guard against null/empty input to prevent SEGV in stb_decompress (issue #2516)
-    IM_ASSERT(compressed_ttf_data != NULL && \"compressed_ttf_data is NULL!\");
     if (compressed_ttf_data == NULL || compressed_ttf_size <= 0)
         return NULL;
 
@@ -59,7 +57,6 @@ string(REPLACE
 string(REPLACE
   "int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;"
   "// [DART patch] Guard against null input (issue #2516)
-    IM_ASSERT(compressed_ttf_data_base85 != NULL && \"compressed_ttf_data_base85 is NULL!\");
     if (compressed_ttf_data_base85 == NULL)
         return NULL;
     int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;"

--- a/cmake/patches/imgui_null_font_guard.cmake
+++ b/cmake/patches/imgui_null_font_guard.cmake
@@ -1,0 +1,70 @@
+# Patch: Add null pointer validation to ImGui font loading functions
+# Fixes: https://github.com/dartsim/dart/issues/2516
+#
+# ImGui v1.84.2 does not validate input pointers in AddFontFromMemory*
+# functions, causing SEGV when nullptr is passed (e.g., from a failed
+# resource load). This patch adds early-return guards.
+#
+# Usage: cmake -DIMGUI_SOURCE_DIR=<path> -P imgui_null_font_guard.cmake
+
+if(NOT DEFINED IMGUI_SOURCE_DIR)
+  message(FATAL_ERROR "IMGUI_SOURCE_DIR must be set")
+endif()
+
+set(file "${IMGUI_SOURCE_DIR}/imgui_draw.cpp")
+
+if(NOT EXISTS "${file}")
+  message(FATAL_ERROR "imgui_draw.cpp not found at ${file}")
+endif()
+
+file(READ "${file}" content)
+
+# Guard: only patch once (idempotent)
+string(FIND "${content}" "DART patch" already_patched)
+if(NOT already_patched EQUAL -1)
+  message(STATUS "imgui_draw.cpp already patched, skipping")
+  return()
+endif()
+
+# Patch AddFontFromMemoryTTF
+string(REPLACE
+  "IM_ASSERT(!Locked && \"Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!\");
+    ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
+    IM_ASSERT(font_cfg.FontData == NULL);
+    font_cfg.FontData = ttf_data;"
+  "IM_ASSERT(!Locked && \"Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!\");
+    // [DART patch] Guard against null/empty input (issue #2516)
+    IM_ASSERT(ttf_data != NULL && \"ttf_data is NULL!\");
+    if (ttf_data == NULL || ttf_size <= 0)
+        return NULL;
+    ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
+    IM_ASSERT(font_cfg.FontData == NULL);
+    font_cfg.FontData = ttf_data;"
+  content "${content}"
+)
+
+# Patch AddFontFromMemoryCompressedTTF
+string(REPLACE
+  "const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);"
+  "// [DART patch] Guard against null/empty input to prevent SEGV in stb_decompress (issue #2516)
+    IM_ASSERT(compressed_ttf_data != NULL && \"compressed_ttf_data is NULL!\");
+    if (compressed_ttf_data == NULL || compressed_ttf_size <= 0)
+        return NULL;
+
+    const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);"
+  content "${content}"
+)
+
+# Patch AddFontFromMemoryCompressedBase85TTF
+string(REPLACE
+  "int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;"
+  "// [DART patch] Guard against null input (issue #2516)
+    IM_ASSERT(compressed_ttf_data_base85 != NULL && \"compressed_ttf_data_base85 is NULL!\");
+    if (compressed_ttf_data_base85 == NULL)
+        return NULL;
+    int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;"
+  content "${content}"
+)
+
+file(WRITE "${file}" "${content}")
+message(STATUS "Patched imgui_draw.cpp with null pointer guards (issue #2516)")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -249,9 +249,12 @@ if(TARGET dart-gui)
   dart_add_test("unit" UNIT_gui_HeightmapShapeNode gui/test_heightmap_shape_node.cpp)
   dart_add_test(
     "unit" UNIT_gui_ImGuiWindowScaling gui/test_im_gui_window_scaling.cpp)
-  dart_add_test(
-    "unit" UNIT_gui_ImGuiNullFontGuard gui/test_imgui_null_font_guard.cpp)
-  target_link_libraries(UNIT_gui_ImGuiNullFontGuard dart-gui)
+  # Null font guard test only works with fetched (patched) ImGui, not system ImGui
+  if(NOT DART_USE_SYSTEM_IMGUI)
+    dart_add_test(
+      "unit" UNIT_gui_ImGuiNullFontGuard gui/test_imgui_null_font_guard.cpp)
+    target_link_libraries(UNIT_gui_ImGuiNullFontGuard dart-gui)
+  endif()
   dart_add_test(
     "unit" UNIT_gui_HeadlessViewer gui/test_headless_viewer.cpp)
   target_link_libraries(UNIT_gui_HeadlessViewer dart-gui)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -250,6 +250,9 @@ if(TARGET dart-gui)
   dart_add_test(
     "unit" UNIT_gui_ImGuiWindowScaling gui/test_im_gui_window_scaling.cpp)
   dart_add_test(
+    "unit" UNIT_gui_ImGuiNullFontGuard gui/test_imgui_null_font_guard.cpp)
+  target_link_libraries(UNIT_gui_ImGuiNullFontGuard dart-gui)
+  dart_add_test(
     "unit" UNIT_gui_HeadlessViewer gui/test_headless_viewer.cpp)
   target_link_libraries(UNIT_gui_HeadlessViewer dart-gui)
   # System ImGui builds can depend on SDL3, which is not available in ASAN CI.

--- a/tests/unit/gui/test_imgui_null_font_guard.cpp
+++ b/tests/unit/gui/test_imgui_null_font_guard.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/gui/include_im_gui.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(Issue2516, AddFontFromMemoryCompressedTTF_NullData)
+{
+  ImFontAtlas atlas;
+
+  ImFont* font = atlas.AddFontFromMemoryCompressedTTF(
+      nullptr, 0, 16.0f, nullptr, nullptr);
+
+  EXPECT_EQ(font, nullptr);
+}
+
+TEST(Issue2516, AddFontFromMemoryTTF_NullData)
+{
+  ImFontAtlas atlas;
+
+  ImFont* font
+      = atlas.AddFontFromMemoryTTF(nullptr, 0, 16.0f, nullptr, nullptr);
+
+  EXPECT_EQ(font, nullptr);
+}
+
+TEST(Issue2516, AddFontFromMemoryCompressedBase85TTF_NullData)
+{
+  ImFontAtlas atlas;
+
+  ImFont* font = atlas.AddFontFromMemoryCompressedBase85TTF(
+      nullptr, 16.0f, nullptr, nullptr);
+
+  EXPECT_EQ(font, nullptr);
+}


### PR DESCRIPTION
## Summary

- Fix segmentation fault in `ImFontAtlas::AddFontFromMemoryCompressedTTF` when `nullptr` is passed as `compressed_ttf_data`

## Motivation / Problem

- When `AddFontFromMemoryCompressedTTF` is called with a null pointer (e.g., from a failed resource load), `stb_decompress_length()` dereferences the null pointer and causes a SEGV crash (reading address `0x8`). This was reported in #2516 with a full ASan stack trace.

## Changes / Key Changes

- Added CMake patch script `cmake/patches/imgui_null_font_guard.cmake` that applies null pointer validation to three ImGui font loading functions during FetchContent population:
  - `AddFontFromMemoryCompressedTTF` — checks `compressed_ttf_data != NULL && compressed_ttf_size > 0`
  - `AddFontFromMemoryTTF` — checks `ttf_data != NULL && ttf_size > 0`
  - `AddFontFromMemoryCompressedBase85TTF` — checks `compressed_ttf_data_base85 != NULL`
- Each function now returns `NULL` gracefully instead of crashing
- Patch is idempotent (safe to re-run)
- Added `PATCH_COMMAND` to `FetchContent_Declare(imgui)` in `cmake/dart_find_dependencies.cmake`

**Note:** When `DART_USE_SYSTEM_IMGUI=ON`, the system-installed ImGui is used directly and this patch is not applied. The fix depends on the system package being updated upstream.

## Testing

- Added unit test `test_imgui_null_font_guard.cpp` with 3 test cases verifying each function returns `nullptr` without crashing
- Built with `DART_USE_SYSTEM_IMGUI=OFF` and ran tests: all 3 pass

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2516
- Companion PR for `release-6.16`: #2517

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable