### PR TITLE
fix: DART 7 iterator invalidation SEGFAULT in Subject/Observer notification loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
   - Removed the legacy optional shim. ([#2137](https://github.com/dartsim/dart/pull/2137))
   - Removed the final compatibility headers that only re-included their replacements (`dart/collision/Option.hpp`, `dart/collision/Result.hpp`, and `dart/dynamics/MultiSphereShape.hpp`) and scrubbed the remaining deprecated documentation strings.
   - Removed the remaining 6.13 compatibility shims: deleted `dart/utils/urdf/URDFTypes.hpp`, the Eigen alias typedefs in `math/MathTypes.hpp`, the `dart7::comps::NameComponent` alias, and the legacy `dInfinity`/`dPAD` helpers, and tightened `SkelParser` plane parsing to treat `<point>` as an error.
+  - Fixed iterator invalidation in `Subject::sendDestructionNotification()`, `Observer::~Observer()`, and `Observer::removeAllSubjects()` that caused non-deterministic SEGFAULT on macOS arm64 Debug builds when an observer callback mutated the observer/subject set during iteration.
 
 - dartpy
   - Added bindings for `dynamics::EndEffector` (including the `Support` aspect) and exposed `BodyNode::createEndEffector`/`getEndEffector` plus the `Skeleton::getEndEffector` overloads to unblock the Atlas puppet Python example and IK tests.

--- a/dart/common/observer.cpp
+++ b/dart/common/observer.cpp
@@ -61,7 +61,7 @@ void Observer::handleDestructionNotification(const Subject*)
 //==============================================================================
 void Observer::addSubject(const Subject* _subject)
 {
-  if (nullptr == _subject || _subject->mNotifying) {
+  if (nullptr == _subject) {
     return;
   }
 

--- a/dart/common/observer.cpp
+++ b/dart/common/observer.cpp
@@ -40,13 +40,9 @@ namespace common {
 //==============================================================================
 Observer::~Observer()
 {
-  std::set<const Subject*>::iterator it = mSubjects.begin(),
-                                     end = mSubjects.end();
-  while (it != end) {
-    (*(it++))->removeObserver(this);
+  while (!mSubjects.empty()) {
+    removeSubject(*mSubjects.begin());
   }
-  // We do this tricky iterator method to deal with the fact that mObservers
-  // will be changing as we go through the loop
 }
 
 //==============================================================================
@@ -95,11 +91,8 @@ void Observer::removeSubject(const Subject* _subject)
 //==============================================================================
 void Observer::removeAllSubjects()
 {
-  std::set<const Subject*>::iterator it = mSubjects.begin(),
-                                     end = mSubjects.end();
-
-  while (it != end) {
-    removeSubject(*(it++));
+  while (!mSubjects.empty()) {
+    removeSubject(*mSubjects.begin());
   }
 }
 

--- a/dart/common/observer.cpp
+++ b/dart/common/observer.cpp
@@ -61,7 +61,7 @@ void Observer::handleDestructionNotification(const Subject*)
 //==============================================================================
 void Observer::addSubject(const Subject* _subject)
 {
-  if (nullptr == _subject) {
+  if (nullptr == _subject || _subject->mNotifying) {
     return;
   }
 

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -58,7 +58,7 @@ void Subject::sendDestructionNotification() const
 //==============================================================================
 void Subject::addObserver(Observer* _observer) const
 {
-  if (nullptr == _observer || mNotifying) {
+  if (nullptr == _observer) {
     return;
   }
 

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -46,12 +46,15 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  // Swap into a local to avoid iterator invalidation: callbacks may mutate
-  // mObservers (e.g. an observer destroys a sibling, or re-registers). The
-  // swap guarantees we iterate only the original set and cannot loop forever.
-  std::set<Observer*> observers;
-  observers.swap(mObservers);
-  for (Observer* observer : observers) {
+  // Drain from the beginning: erase each observer before invoking its callback
+  // so that if the callback destroys a sibling observer (whose destructor calls
+  // removeObserver), the sibling is safely erased from mObservers without
+  // invalidating any iterator. A swap-into-local alternative is unsafe here
+  // because it leaves dangling pointers in the local set when siblings are
+  // destroyed.
+  while (!mObservers.empty()) {
+    Observer* observer = *mObservers.begin();
+    mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);
   }
 }

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -46,13 +46,14 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  std::set<Observer*>::iterator sub = mObservers.begin(),
-                                end = mObservers.end();
-  while (sub != end) {
-    (*(sub++))->receiveDestructionNotification(this);
+  // Drain from the beginning to avoid iterator invalidation: callbacks may
+  // mutate mObservers (e.g. an observer removes another observer during
+  // notification), so we cannot rely on cached end-iterators or post-increment.
+  while (!mObservers.empty()) {
+    Observer* observer = *mObservers.begin();
+    mObservers.erase(mObservers.begin());
+    observer->receiveDestructionNotification(this);
   }
-  // We do this tricky iterator method to deal with the fact that mObservers
-  // will be changing as we go through the loop
 }
 
 //==============================================================================

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -46,12 +46,12 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  // Drain from the beginning to avoid iterator invalidation: callbacks may
-  // mutate mObservers (e.g. an observer removes another observer during
-  // notification), so we cannot rely on cached end-iterators or post-increment.
-  while (!mObservers.empty()) {
-    Observer* observer = *mObservers.begin();
-    mObservers.erase(mObservers.begin());
+  // Swap into a local to avoid iterator invalidation: callbacks may mutate
+  // mObservers (e.g. an observer destroys a sibling, or re-registers). The
+  // swap guarantees we iterate only the original set and cannot loop forever.
+  std::set<Observer*> observers;
+  observers.swap(mObservers);
+  for (Observer* observer : observers) {
     observer->receiveDestructionNotification(this);
   }
 }

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -46,13 +46,11 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  mNotifying = true;
   while (!mObservers.empty()) {
     Observer* observer = *mObservers.begin();
     mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);
   }
-  mNotifying = false;
 }
 
 //==============================================================================

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -46,9 +46,23 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  while (!mObservers.empty()) {
-    Observer* observer = *mObservers.begin();
-    mObservers.erase(mObservers.begin());
+  // Snapshot the observer list so that mutations during callbacks (peer
+  // destruction, re-subscription) cannot cause iterator invalidation or
+  // infinite loops.  mObservers keeps tracking live registrations so that
+  // removeObserver() from a peer's destructor still works correctly.
+  //
+  // Note: observers that re-subscribe during their callback will be
+  // registered again in mObservers after this function returns.  This is
+  // harmless when called from ~Subject() because the object destructs
+  // immediately after.
+  auto snapshot = mObservers;
+  for (Observer* observer : snapshot) {
+    // Skip observers that were already removed by an earlier callback
+    // (e.g. a peer's destructor called removeObserver on this subject).
+    if (!mObservers.contains(observer)) {
+      continue;
+    }
+    mObservers.erase(observer);
     observer->receiveDestructionNotification(this);
   }
 }

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -46,25 +46,19 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  // Drain from the beginning: erase each observer before invoking its callback
-  // so that if the callback destroys a sibling observer (whose destructor calls
-  // removeObserver), the sibling is safely erased from mObservers without
-  // invalidating any iterator. A swap-into-local alternative is unsafe here
-  // because it leaves dangling pointers in the local set when siblings are
-  // destroyed. The iteration cap prevents infinite loops if a callback
-  // re-registers an observer on this (dying) subject.
-  const auto maxIterations = mObservers.size();
-  for (std::size_t i = 0; i < maxIterations && !mObservers.empty(); ++i) {
+  mNotifying = true;
+  while (!mObservers.empty()) {
     Observer* observer = *mObservers.begin();
     mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);
   }
+  mNotifying = false;
 }
 
 //==============================================================================
 void Subject::addObserver(Observer* _observer) const
 {
-  if (nullptr == _observer) {
+  if (nullptr == _observer || mNotifying) {
     return;
   }
 

--- a/dart/common/subject.cpp
+++ b/dart/common/subject.cpp
@@ -51,8 +51,10 @@ void Subject::sendDestructionNotification() const
   // removeObserver), the sibling is safely erased from mObservers without
   // invalidating any iterator. A swap-into-local alternative is unsafe here
   // because it leaves dangling pointers in the local set when siblings are
-  // destroyed.
-  while (!mObservers.empty()) {
+  // destroyed. The iteration cap prevents infinite loops if a callback
+  // re-registers an observer on this (dying) subject.
+  const auto maxIterations = mObservers.size();
+  for (std::size_t i = 0; i < maxIterations && !mObservers.empty(); ++i) {
     Observer* observer = *mObservers.begin();
     mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);

--- a/dart/common/subject.hpp
+++ b/dart/common/subject.hpp
@@ -78,6 +78,11 @@ protected:
 
   /// List of current Observers
   mutable std::set<Observer*> mObservers;
+
+  /// True while sendDestructionNotification() is draining mObservers.
+  /// Prevents re-registration during notification (which would cause an
+  /// infinite drain loop or skip original observers).
+  mutable bool mNotifying{false};
 };
 
 } // namespace common

--- a/dart/common/subject.hpp
+++ b/dart/common/subject.hpp
@@ -78,11 +78,6 @@ protected:
 
   /// List of current Observers
   mutable std::set<Observer*> mObservers;
-
-  /// True while sendDestructionNotification() is draining mObservers.
-  /// Prevents re-registration during notification (which would cause an
-  /// infinite drain loop or skip original observers).
-  mutable bool mNotifying{false};
 };
 
 } // namespace common

--- a/tests/unit/common/test_subject_observer.cpp
+++ b/tests/unit/common/test_subject_observer.cpp
@@ -639,8 +639,12 @@ TEST(SubjectObserverTests, ReconnectAfterNotification)
 
 //==============================================================================
 // Regression: destroying a sibling observer during sendDestructionNotification
-// invalidated the iterator (SEGFAULT on macOS arm64 Debug). The drain-from-
-// begin fix makes this safe.
+// invalidated the iterator (SEGFAULT on macOS arm64 Debug). The swap-into-
+// local fix makes this safe.
+//
+// Both observers are heap-allocated and each holds a destroy-handle to the
+// other. Whichever is notified first destroys its peer, exercising the
+// iterator-invalidation path regardless of std::set pointer ordering.
 class PeerDestroyingObserver : public Observer
 {
 public:
@@ -649,7 +653,7 @@ public:
     addSubject(subject);
   }
 
-  void setPeerToDestroy(std::unique_ptr<TestObserver>* peerOwner)
+  void setPeerToDestroy(std::unique_ptr<PeerDestroyingObserver>* peerOwner)
   {
     mPeerOwner = peerOwner;
   }
@@ -668,14 +672,13 @@ protected:
   void handleDestructionNotification(const Subject*) override
   {
     ++mNotificationCount;
-    if (mPeerOwner) {
+    if (mPeerOwner && *mPeerOwner) {
       mPeerOwner->reset();
-      mPeerOwner = nullptr;
     }
   }
 
 private:
-  std::unique_ptr<TestObserver>* mPeerOwner = nullptr;
+  std::unique_ptr<PeerDestroyingObserver>* mPeerOwner = nullptr;
   int mNotificationCount = 0;
 };
 
@@ -683,21 +686,22 @@ private:
 TEST(SubjectObserverTests, ObserverDestroysPeerDuringNotification)
 {
   TestSubject subject;
-  PeerDestroyingObserver observerA;
-  auto observerB = std::make_unique<TestObserver>();
+  auto observerA = std::make_unique<PeerDestroyingObserver>();
+  auto observerB = std::make_unique<PeerDestroyingObserver>();
 
-  observerA.track(&subject);
+  observerA->track(&subject);
   observerB->track(&subject);
   EXPECT_EQ(subject.observerCount(), 2u);
 
-  observerA.setPeerToDestroy(&observerB);
+  // Each observer holds a destroy-handle to the other, so whichever is
+  // notified first will destroy its peer — exercising the invalidation
+  // path regardless of pointer ordering in std::set.
+  observerA->setPeerToDestroy(&observerB);
+  observerB->setPeerToDestroy(&observerA);
 
-  // A's callback destroys B, whose destructor calls removeObserver on
-  // the subject. Before the fix this corrupted the iterator.
   subject.notify();
 
-  EXPECT_EQ(observerB, nullptr);
   EXPECT_EQ(subject.observerCount(), 0u);
-  EXPECT_EQ(observerA.subjectCount(), 0u);
-  EXPECT_EQ(observerA.notificationCount(), 1);
+  // Exactly one was destroyed by the other's callback
+  EXPECT_TRUE(!observerA || !observerB);
 }

--- a/tests/unit/common/test_subject_observer.cpp
+++ b/tests/unit/common/test_subject_observer.cpp
@@ -705,3 +705,61 @@ TEST(SubjectObserverTests, ObserverDestroysPeerDuringNotification)
   // Exactly one was destroyed by the other's callback
   EXPECT_TRUE(!observerA || !observerB);
 }
+
+//==============================================================================
+// Regression: an observer that re-subscribes to the dying subject inside its
+// destruction callback would cause the old drain loop to never terminate.
+// The snapshot-based approach notifies only the original observers and ignores
+// re-subscriptions made during the notification pass.
+class ResubscribingObserver : public Observer
+{
+public:
+  void track(TestSubject* subject)
+  {
+    mSubjectPtr = subject;
+    addSubject(subject);
+  }
+
+  std::size_t subjectCount() const
+  {
+    return mSubjects.size();
+  }
+
+  int notificationCount() const
+  {
+    return mNotificationCount;
+  }
+
+protected:
+  void handleDestructionNotification(const Subject*) override
+  {
+    ++mNotificationCount;
+    // Attempt to re-subscribe — must NOT cause an infinite loop
+    if (mSubjectPtr) {
+      addSubject(mSubjectPtr);
+    }
+  }
+
+private:
+  TestSubject* mSubjectPtr = nullptr;
+  int mNotificationCount = 0;
+};
+
+//==============================================================================
+TEST(SubjectObserverTests, ResubscribeDuringDestructionNotificationTerminates)
+{
+  TestSubject subject;
+  ResubscribingObserver observer;
+
+  observer.track(&subject);
+  EXPECT_EQ(subject.observerCount(), 1u);
+
+  // With the old drain loop this would hang forever.
+  // With the snapshot fix it terminates and notifies exactly once.
+  subject.notify();
+
+  EXPECT_EQ(observer.notificationCount(), 1);
+  // Re-subscription during notification silently succeeds — the observer
+  // is registered again in mObservers after the notification pass.
+  EXPECT_EQ(subject.observerCount(), 1u);
+}

--- a/tests/unit/common/test_subject_observer.cpp
+++ b/tests/unit/common/test_subject_observer.cpp
@@ -636,3 +636,68 @@ TEST(SubjectObserverTests, ReconnectAfterNotification)
   subject.notify();
   EXPECT_EQ(observer.notificationCount(), 2);
 }
+
+//==============================================================================
+// Regression: destroying a sibling observer during sendDestructionNotification
+// invalidated the iterator (SEGFAULT on macOS arm64 Debug). The drain-from-
+// begin fix makes this safe.
+class PeerDestroyingObserver : public Observer
+{
+public:
+  void track(TestSubject* subject)
+  {
+    addSubject(subject);
+  }
+
+  void setPeerToDestroy(std::unique_ptr<TestObserver>* peerOwner)
+  {
+    mPeerOwner = peerOwner;
+  }
+
+  std::size_t subjectCount() const
+  {
+    return mSubjects.size();
+  }
+
+  int notificationCount() const
+  {
+    return mNotificationCount;
+  }
+
+protected:
+  void handleDestructionNotification(const Subject*) override
+  {
+    ++mNotificationCount;
+    if (mPeerOwner) {
+      mPeerOwner->reset();
+      mPeerOwner = nullptr;
+    }
+  }
+
+private:
+  std::unique_ptr<TestObserver>* mPeerOwner = nullptr;
+  int mNotificationCount = 0;
+};
+
+//==============================================================================
+TEST(SubjectObserverTests, ObserverDestroysPeerDuringNotification)
+{
+  TestSubject subject;
+  PeerDestroyingObserver observerA;
+  auto observerB = std::make_unique<TestObserver>();
+
+  observerA.track(&subject);
+  observerB->track(&subject);
+  EXPECT_EQ(subject.observerCount(), 2u);
+
+  observerA.setPeerToDestroy(&observerB);
+
+  // A's callback destroys B, whose destructor calls removeObserver on
+  // the subject. Before the fix this corrupted the iterator.
+  subject.notify();
+
+  EXPECT_EQ(observerB, nullptr);
+  EXPECT_EQ(subject.observerCount(), 0u);
+  EXPECT_EQ(observerA.subjectCount(), 0u);
+  EXPECT_EQ(observerA.notificationCount(), 1);
+}


### PR DESCRIPTION
## Summary

- Fix non-deterministic SEGFAULT in Subject/Observer destruction notification caused by iterator invalidation when callbacks mutate the observer/subject set during iteration.

## Motivation / Problem

- macOS arm64 Debug builds exhibited intermittent crashes in `UNIT_common_subject_observer` and `UNIT_dynamics_WeldJointMerge` due to undefined behavior in `Subject::sendDestructionNotification()`, `Observer::~Observer()`, and `Observer::removeAllSubjects()`.
- The root cause: cached end-iterators became invalid when an observer's callback destroyed a sibling observer (removing it from `mObservers`) or when `removeAllSubjects()` called `removeSubject()` which erased from `mSubjects`.

## Changes / Key Changes

- **`dart/common/subject.cpp`**: Replace post-increment iteration in `sendDestructionNotification()` with drain-from-begin pattern that pre-erases each observer before invoking its callback.
- **`dart/common/observer.cpp`**: Replace post-increment iteration in `~Observer()` and `removeAllSubjects()` with drain-from-begin pattern using `removeSubject(*mSubjects.begin())`.
- **Regression test**: Added `ObserverDestroysPeerDuringNotification` test that destroys a sibling observer during the notification callback — the exact scenario that triggered the SEGFAULT.
- **CHANGELOG.md**: Updated under Core section.

## Testing

- `pixi run lint` — passed
- `pixi run build` — passed
- `pixi run test-unit` — all 249 tests passed (13 `Not Run` are pre-existing simulation-experimental missing executables)
- `UNIT_common_subject_observer` — passed (includes new regression test)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Related to #2516 (discovered during investigation of arm64 Debug CI failures)
- Backport PR for `release-6.16` to follow

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes — N/A (no new public API)
- [ ] Add Python bindings (dartpy) if applicable — N/A