### PR TITLE
fix: DART 6.16 iterator invalidation SEGFAULT in Subject/Observer notification loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   * Fix SEGV in ImFontAtlas::AddFontFromMemoryCompressedTTF when null pointer is passed as compressed font data: [#2516](https://github.com/dartsim/dart/issues/2516)
 
+* Common
+
+  * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds
+
 ### [DART 6.16.7 (2026-02-10)](https://github.com/dartsim/dart/milestone/92?closed=1)
 
 * Build

--- a/dart/common/Observer.cpp
+++ b/dart/common/Observer.cpp
@@ -60,7 +60,7 @@ void Observer::handleDestructionNotification(const Subject*)
 //==============================================================================
 void Observer::addSubject(const Subject* _subject)
 {
-  if (nullptr == _subject || _subject->mNotifying)
+  if (nullptr == _subject)
     return;
 
   if (mSubjects.find(_subject) != mSubjects.end())

--- a/dart/common/Observer.cpp
+++ b/dart/common/Observer.cpp
@@ -40,12 +40,8 @@ namespace common {
 //==============================================================================
 Observer::~Observer()
 {
-  std::set<const Subject*>::iterator it = mSubjects.begin(),
-                                     end = mSubjects.end();
-  while (it != end)
-    (*(it++))->removeObserver(this);
-  // We do this tricky iterator method to deal with the fact that mObservers
-  // will be changing as we go through the loop
+  while (!mSubjects.empty())
+    removeSubject(*mSubjects.begin());
 }
 
 //==============================================================================
@@ -90,11 +86,8 @@ void Observer::removeSubject(const Subject* _subject)
 //==============================================================================
 void Observer::removeAllSubjects()
 {
-  std::set<const Subject*>::iterator it = mSubjects.begin(),
-                                     end = mSubjects.end();
-
-  while (it != end)
-    removeSubject(*(it++));
+  while (!mSubjects.empty())
+    removeSubject(*mSubjects.begin());
 }
 
 } // namespace common

--- a/dart/common/Observer.cpp
+++ b/dart/common/Observer.cpp
@@ -60,7 +60,7 @@ void Observer::handleDestructionNotification(const Subject*)
 //==============================================================================
 void Observer::addSubject(const Subject* _subject)
 {
-  if (nullptr == _subject)
+  if (nullptr == _subject || _subject->mNotifying)
     return;
 
   if (mSubjects.find(_subject) != mSubjects.end())

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -46,13 +46,17 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  // Swap into a local to avoid iterator invalidation: callbacks may mutate
-  // mObservers (e.g. an observer destroys a sibling, or re-registers). The
-  // swap guarantees we iterate only the original set and cannot loop forever.
-  std::set<Observer*> observers;
-  observers.swap(mObservers);
-  for (Observer* observer : observers)
+  // Drain from the beginning: erase each observer before invoking its callback
+  // so that if the callback destroys a sibling observer (whose destructor calls
+  // removeObserver), the sibling is safely erased from mObservers without
+  // invalidating any iterator. A swap-into-local alternative is unsafe here
+  // because it leaves dangling pointers in the local set when siblings are
+  // destroyed.
+  while (!mObservers.empty()) {
+    Observer* observer = *mObservers.begin();
+    mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);
+  }
 }
 
 //==============================================================================

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -46,25 +46,19 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  // Drain from the beginning: erase each observer before invoking its callback
-  // so that if the callback destroys a sibling observer (whose destructor calls
-  // removeObserver), the sibling is safely erased from mObservers without
-  // invalidating any iterator. A swap-into-local alternative is unsafe here
-  // because it leaves dangling pointers in the local set when siblings are
-  // destroyed. The iteration cap prevents infinite loops if a callback
-  // re-registers an observer on this (dying) subject.
-  const auto maxIterations = mObservers.size();
-  for (std::size_t i = 0; i < maxIterations && !mObservers.empty(); ++i) {
+  mNotifying = true;
+  while (!mObservers.empty()) {
     Observer* observer = *mObservers.begin();
     mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);
   }
+  mNotifying = false;
 }
 
 //==============================================================================
 void Subject::addObserver(Observer* _observer) const
 {
-  if (nullptr == _observer)
+  if (nullptr == _observer || mNotifying)
     return;
 
   if (mObservers.find(_observer) != mObservers.end())

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -46,13 +46,11 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  mNotifying = true;
   while (!mObservers.empty()) {
     Observer* observer = *mObservers.begin();
     mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);
   }
-  mNotifying = false;
 }
 
 //==============================================================================

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -46,14 +46,13 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  // Drain from the beginning to avoid iterator invalidation: callbacks may
-  // mutate mObservers (e.g. an observer removes another observer during
-  // notification), so we cannot rely on cached end-iterators or post-increment.
-  while (!mObservers.empty()) {
-    Observer* observer = *mObservers.begin();
-    mObservers.erase(mObservers.begin());
+  // Swap into a local to avoid iterator invalidation: callbacks may mutate
+  // mObservers (e.g. an observer destroys a sibling, or re-registers). The
+  // swap guarantees we iterate only the original set and cannot loop forever.
+  std::set<Observer*> observers;
+  observers.swap(mObservers);
+  for (Observer* observer : observers)
     observer->receiveDestructionNotification(this);
-  }
 }
 
 //==============================================================================

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -58,7 +58,7 @@ void Subject::sendDestructionNotification() const
 //==============================================================================
 void Subject::addObserver(Observer* _observer) const
 {
-  if (nullptr == _observer || mNotifying)
+  if (nullptr == _observer)
     return;
 
   if (mObservers.find(_observer) != mObservers.end())

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -46,12 +46,14 @@ Subject::~Subject()
 //==============================================================================
 void Subject::sendDestructionNotification() const
 {
-  std::set<Observer*>::iterator sub = mObservers.begin(),
-                                end = mObservers.end();
-  while (sub != end)
-    (*(sub++))->receiveDestructionNotification(this);
-  // We do this tricky iterator method to deal with the fact that mObservers
-  // will be changing as we go through the loop
+  // Drain from the beginning to avoid iterator invalidation: callbacks may
+  // mutate mObservers (e.g. an observer removes another observer during
+  // notification), so we cannot rely on cached end-iterators or post-increment.
+  while (!mObservers.empty()) {
+    Observer* observer = *mObservers.begin();
+    mObservers.erase(mObservers.begin());
+    observer->receiveDestructionNotification(this);
+  }
 }
 
 //==============================================================================

--- a/dart/common/Subject.cpp
+++ b/dart/common/Subject.cpp
@@ -51,8 +51,10 @@ void Subject::sendDestructionNotification() const
   // removeObserver), the sibling is safely erased from mObservers without
   // invalidating any iterator. A swap-into-local alternative is unsafe here
   // because it leaves dangling pointers in the local set when siblings are
-  // destroyed.
-  while (!mObservers.empty()) {
+  // destroyed. The iteration cap prevents infinite loops if a callback
+  // re-registers an observer on this (dying) subject.
+  const auto maxIterations = mObservers.size();
+  for (std::size_t i = 0; i < maxIterations && !mObservers.empty(); ++i) {
     Observer* observer = *mObservers.begin();
     mObservers.erase(mObservers.begin());
     observer->receiveDestructionNotification(this);

--- a/dart/common/Subject.hpp
+++ b/dart/common/Subject.hpp
@@ -76,11 +76,6 @@ protected:
 
   /// List of current Observers
   mutable std::set<Observer*> mObservers;
-
-  /// True while sendDestructionNotification() is draining mObservers.
-  /// Prevents re-registration during notification (which would cause an
-  /// infinite drain loop or skip original observers).
-  mutable bool mNotifying{false};
 };
 
 } // namespace common

--- a/dart/common/Subject.hpp
+++ b/dart/common/Subject.hpp
@@ -76,6 +76,11 @@ protected:
 
   /// List of current Observers
   mutable std::set<Observer*> mObservers;
+
+  /// True while sendDestructionNotification() is draining mObservers.
+  /// Prevents re-registration during notification (which would cause an
+  /// infinite drain loop or skip original observers).
+  mutable bool mNotifying{false};
 };
 
 } // namespace common

--- a/tests/unit/common/test_SubjectObserver.cpp
+++ b/tests/unit/common/test_SubjectObserver.cpp
@@ -150,8 +150,12 @@ TEST(SubjectObserverTests, MultipleObserversReceiveNotifications)
 
 //==============================================================================
 // Regression: destroying a sibling observer during sendDestructionNotification
-// invalidated the iterator (SEGFAULT on macOS arm64 Debug). The drain-from-
-// begin fix makes this safe.
+// invalidated the iterator (SEGFAULT on macOS arm64 Debug). The swap-into-
+// local fix makes this safe.
+//
+// Both observers are heap-allocated and each holds a destroy-handle to the
+// other. Whichever is notified first destroys its peer, exercising the
+// iterator-invalidation path regardless of std::set pointer ordering.
 class PeerDestroyingObserver : public Observer
 {
 public:
@@ -160,7 +164,7 @@ public:
     addSubject(subject);
   }
 
-  void setPeerToDestroy(std::unique_ptr<TestObserver>* peerOwner)
+  void setPeerToDestroy(std::unique_ptr<PeerDestroyingObserver>* peerOwner)
   {
     mPeerOwner = peerOwner;
   }
@@ -179,14 +183,13 @@ protected:
   void handleDestructionNotification(const Subject*) override
   {
     ++mNotificationCount;
-    if (mPeerOwner) {
+    if (mPeerOwner && *mPeerOwner) {
       mPeerOwner->reset();
-      mPeerOwner = nullptr;
     }
   }
 
 private:
-  std::unique_ptr<TestObserver>* mPeerOwner = nullptr;
+  std::unique_ptr<PeerDestroyingObserver>* mPeerOwner = nullptr;
   int mNotificationCount = 0;
 };
 
@@ -194,21 +197,22 @@ private:
 TEST(SubjectObserverTests, ObserverDestroysPeerDuringNotification)
 {
   TestSubject subject;
-  PeerDestroyingObserver observerA;
-  auto observerB = std::make_unique<TestObserver>();
+  auto observerA = std::make_unique<PeerDestroyingObserver>();
+  auto observerB = std::make_unique<PeerDestroyingObserver>();
 
-  observerA.track(&subject);
+  observerA->track(&subject);
   observerB->track(&subject);
   EXPECT_EQ(subject.observerCount(), 2u);
 
-  observerA.setPeerToDestroy(&observerB);
+  // Each observer holds a destroy-handle to the other, so whichever is
+  // notified first will destroy its peer — exercising the invalidation
+  // path regardless of pointer ordering in std::set.
+  observerA->setPeerToDestroy(&observerB);
+  observerB->setPeerToDestroy(&observerA);
 
-  // A's callback destroys B, whose destructor calls removeObserver on
-  // the subject. Before the fix this corrupted the iterator.
   subject.notify();
 
-  EXPECT_EQ(observerB, nullptr);
   EXPECT_EQ(subject.observerCount(), 0u);
-  EXPECT_EQ(observerA.subjectCount(), 0u);
-  EXPECT_EQ(observerA.notificationCount(), 1);
+  // Exactly one was destroyed by the other's callback
+  EXPECT_TRUE(!observerA || !observerB);
 }

--- a/tests/unit/common/test_SubjectObserver.cpp
+++ b/tests/unit/common/test_SubjectObserver.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/common/Observer.hpp"
+#include "dart/common/Subject.hpp"
+#include "dart/common/sub_ptr.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace dart;
+using namespace dart::common;
+
+namespace {
+
+class TestSubject : public Subject
+{
+public:
+  void notify()
+  {
+    sendDestructionNotification();
+  }
+
+  std::size_t observerCount() const
+  {
+    return mObservers.size();
+  }
+};
+
+class TestObserver : public Observer
+{
+public:
+  void track(TestSubject* subject)
+  {
+    addSubject(subject);
+  }
+
+  std::size_t subjectCount() const
+  {
+    return mSubjects.size();
+  }
+
+  int notificationCount() const
+  {
+    return mNotificationCount;
+  }
+
+protected:
+  void handleDestructionNotification(const Subject*) override
+  {
+    ++mNotificationCount;
+  }
+
+private:
+  int mNotificationCount = 0;
+};
+
+} // namespace
+
+//==============================================================================
+TEST(SubjectObserverTests, BasicNotification)
+{
+  TestObserver observer;
+  TestSubject subject;
+
+  observer.track(&subject);
+  EXPECT_EQ(observer.subjectCount(), 1u);
+  EXPECT_EQ(subject.observerCount(), 1u);
+
+  subject.notify();
+  EXPECT_EQ(observer.subjectCount(), 0u);
+  EXPECT_EQ(subject.observerCount(), 0u);
+  EXPECT_EQ(observer.notificationCount(), 1);
+}
+
+//==============================================================================
+TEST(SubjectObserverTests, ObserverDestructorDetaches)
+{
+  TestSubject subject;
+  {
+    TestObserver observer;
+    observer.track(&subject);
+    EXPECT_EQ(subject.observerCount(), 1u);
+  }
+  EXPECT_EQ(subject.observerCount(), 0u);
+}
+
+//==============================================================================
+TEST(SubjectObserverTests, SubjectDestructorNotifiesObserver)
+{
+  TestObserver observer;
+  {
+    auto subject = std::make_unique<TestSubject>();
+    observer.track(subject.get());
+    EXPECT_EQ(observer.subjectCount(), 1u);
+  }
+  EXPECT_EQ(observer.subjectCount(), 0u);
+  EXPECT_EQ(observer.notificationCount(), 1);
+}
+
+//==============================================================================
+TEST(SubjectObserverTests, MultipleObserversReceiveNotifications)
+{
+  TestObserver observer1;
+  TestObserver observer2;
+  TestObserver observer3;
+
+  {
+    TestSubject subject;
+    observer1.track(&subject);
+    observer2.track(&subject);
+    observer3.track(&subject);
+    EXPECT_EQ(subject.observerCount(), 3u);
+  }
+
+  EXPECT_EQ(observer1.notificationCount(), 1);
+  EXPECT_EQ(observer2.notificationCount(), 1);
+  EXPECT_EQ(observer3.notificationCount(), 1);
+}
+
+//==============================================================================
+// Regression: destroying a sibling observer during sendDestructionNotification
+// invalidated the iterator (SEGFAULT on macOS arm64 Debug). The drain-from-
+// begin fix makes this safe.
+class PeerDestroyingObserver : public Observer
+{
+public:
+  void track(TestSubject* subject)
+  {
+    addSubject(subject);
+  }
+
+  void setPeerToDestroy(std::unique_ptr<TestObserver>* peerOwner)
+  {
+    mPeerOwner = peerOwner;
+  }
+
+  std::size_t subjectCount() const
+  {
+    return mSubjects.size();
+  }
+
+  int notificationCount() const
+  {
+    return mNotificationCount;
+  }
+
+protected:
+  void handleDestructionNotification(const Subject*) override
+  {
+    ++mNotificationCount;
+    if (mPeerOwner) {
+      mPeerOwner->reset();
+      mPeerOwner = nullptr;
+    }
+  }
+
+private:
+  std::unique_ptr<TestObserver>* mPeerOwner = nullptr;
+  int mNotificationCount = 0;
+};
+
+//==============================================================================
+TEST(SubjectObserverTests, ObserverDestroysPeerDuringNotification)
+{
+  TestSubject subject;
+  PeerDestroyingObserver observerA;
+  auto observerB = std::make_unique<TestObserver>();
+
+  observerA.track(&subject);
+  observerB->track(&subject);
+  EXPECT_EQ(subject.observerCount(), 2u);
+
+  observerA.setPeerToDestroy(&observerB);
+
+  // A's callback destroys B, whose destructor calls removeObserver on
+  // the subject. Before the fix this corrupted the iterator.
+  subject.notify();
+
+  EXPECT_EQ(observerB, nullptr);
+  EXPECT_EQ(subject.observerCount(), 0u);
+  EXPECT_EQ(observerA.subjectCount(), 0u);
+  EXPECT_EQ(observerA.notificationCount(), 1);
+}


### PR DESCRIPTION
## Summary

- Fix non-deterministic SEGFAULT in Subject/Observer destruction notification caused by iterator invalidation when callbacks mutate the observer/subject set during iteration.

## Motivation / Problem

- macOS arm64 Debug builds exhibited intermittent crashes in `UNIT_common_subject_observer` and `UNIT_dynamics_WeldJointMerge` due to undefined behavior in `Subject::sendDestructionNotification()`, `Observer::~Observer()`, and `Observer::removeAllSubjects()`.
- The root cause: cached end-iterators became invalid when an observer's callback destroyed a sibling observer (removing it from `mObservers`) or when `removeAllSubjects()` called `removeSubject()` which erased from `mSubjects`.

## Changes / Key Changes

- **`dart/common/Subject.cpp`**: Replace post-increment iteration in `sendDestructionNotification()` with drain-from-begin pattern that pre-erases each observer before invoking its callback.
- **`dart/common/Observer.cpp`**: Replace post-increment iteration in `~Observer()` and `removeAllSubjects()` with drain-from-begin pattern using `removeSubject(*mSubjects.begin())`.
- **Regression test**: Added `test_SubjectObserver.cpp` with `ObserverDestroysPeerDuringNotification` test.
- **CHANGELOG.md**: Updated under 6.16.8 Common section.

## Testing

- Verified build and all unit tests pass on main branch (identical logic).
- `UNIT_common_subject_observer` passes including the new regression test.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Main branch PR: #2519
- Related to #2516 (discovered during investigation of arm64 Debug CI failures)

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes — N/A (no new public API)
- [ ] Add Python bindings (dartpy) if applicable — N/A