### PR TITLE
use modern imgui modifier key names

### DIFF
--- a/dart/gui/im_gui_handler.cpp
+++ b/dart/gui/im_gui_handler.cpp
@@ -130,16 +130,16 @@ ConvertedKey convertFromOSGKey(int key)
       return ImGuiKey_Escape;
     case KeySymbol::KEY_Control_L:
     case KeySymbol::KEY_Control_R:
-      return ImGuiKey_ModCtrl;
+      return ImGuiMod_Ctrl;
     case KeySymbol::KEY_Shift_L:
     case KeySymbol::KEY_Shift_R:
-      return ImGuiKey_ModShift;
+      return ImGuiMod_Shift;
     case KeySymbol::KEY_Alt_L:
     case KeySymbol::KEY_Alt_R:
-      return ImGuiKey_ModAlt;
+      return ImGuiMod_Alt;
     case KeySymbol::KEY_Super_L:
     case KeySymbol::KEY_Super_R:
-      return ImGuiKey_ModSuper;
+      return ImGuiMod_Super;
     case KeySymbol::KEY_A:
       return ImGuiKey_A;
     case KeySymbol::KEY_C:


### PR DESCRIPTION
## Summary

Switches over from `ImGuiKey_ModXXX` (deprecated in 1.89) to `ImGuiMod_XXX`. This _should_ be backwards compatible (i.e. building with older imgui still works)

<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

## Motivation / Problem

Building with imgui >= 1.92.6

<!-- Why is this change needed? What problem does it solve? -->

## Changes / Key Changes

- `ImGuiKey_ModXXX` -> `ImGuiMod_XXX`

<!-- High-level list of key changes. -->

## Testing

I sadly couldn't get pixi and/or this project's build tools set up, but it _does_ build as the corresponding package in nixpkgs (which I'm trying to fixup in the first place)

## Breaking Changes

none

<!-- If breaking changes exist, describe impact and migration steps. -->

## Related Issues / PRs (backports)

- also see https://github.com/dartsim/dart/pull/1872
- same PR but based on `release-6.16`: https://github.com/dartsim/dart/pull/2526 (files were renamed since then)

<!-- List issue links and any related/backport PRs. -->

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
