### PR TITLE
Fix invalid World timestep validation (DART 6.16)

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -43,8 +43,39 @@ jobs:
           FREEBSD_VM_MEM: "4096"
           FREEBSD_VM_BUILD_PARALLEL_LEVEL: "1"
           FREEBSD_VM_CTEST_TIMEOUT: "2400"
-        run: pixi run freebsd-test
+        run: |
+          set -euo pipefail
+          max_attempts=2
+          for attempt in $(seq 1 $max_attempts); do
+            echo "=== FreeBSD VM test attempt ${attempt}/${max_attempts} ==="
+            pixi run freebsd-stop || true
+            pixi run freebsd-test &
+            TEST_PID=$!
+            sleep 10
+            echo "=== Docker Container Logs (QEMU Startup) ==="
+            docker logs dart-freebsd-vm 2>&1 | head -50 || true
+            echo "=============================================="
+            if wait $TEST_PID; then
+              echo "FreeBSD tests passed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "::warning::FreeBSD VM test failed on attempt ${attempt}/${max_attempts}"
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "Retrying after cleanup..."
+              pixi run freebsd-stop || true
+              sleep 5
+            fi
+          done
+          echo "::error::FreeBSD VM tests failed after ${max_attempts} attempts"
+          exit 1
+
+      - name: Show Docker container logs
+        if: always()
+        run: |
+          echo "=== Full Docker Container Logs ==="
+          docker logs dart-freebsd-vm 2>&1 || true
+          echo "==================================="
 
       - name: Stop FreeBSD VM
         if: always()
-        run: pixi run freebsd-stop
+        run: pixi run freebsd-stop || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
   * Reject NaN, infinite, zero, and negative `World::setTimeStep()` values to prevent invalid timesteps from reaching the ODE LCP solver. ([#2532](https://github.com/dartsim/dart/pull/2532), [#2531](https://github.com/dartsim/dart/issues/2531))
 
+* Tooling and Docs
+
+  * Improve FreeBSD VM CI startup resilience with a longer SSH readiness window, fresh VM container startup, KVM group propagation, retry handling, and startup diagnostics. ([#2532](https://github.com/dartsim/dart/pull/2532))
+
 ### [DART 6.16.7 (2026-02-10)](https://github.com/dartsim/dart/milestone/92?closed=1)
 
 * Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
   * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds
 
+* Simulation
+
+  * Reject NaN, infinite, zero, and negative `World::setTimeStep()` values to prevent invalid timesteps from reaching the ODE LCP solver: [#2531](https://github.com/dartsim/dart/issues/2531)
+
 ### [DART 6.16.7 (2026-02-10)](https://github.com/dartsim/dart/milestone/92?closed=1)
 
 * Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 * Simulation
 
-  * Reject NaN, infinite, zero, and negative `World::setTimeStep()` values to prevent invalid timesteps from reaching the ODE LCP solver: [#2531](https://github.com/dartsim/dart/issues/2531)
+  * Reject NaN, infinite, zero, and negative `World::setTimeStep()` values to prevent invalid timesteps from reaching the ODE LCP solver. ([#2532](https://github.com/dartsim/dart/pull/2532), [#2531](https://github.com/dartsim/dart/issues/2531))
 
 ### [DART 6.16.7 (2026-02-10)](https://github.com/dartsim/dart/milestone/92?closed=1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 * Tooling and Docs
 
-  * Improve FreeBSD VM CI startup resilience with a longer SSH readiness window, fresh VM container startup, KVM group propagation, retry handling, and startup diagnostics. ([#2532](https://github.com/dartsim/dart/pull/2532))
+  * Improve FreeBSD VM CI startup resilience with a release image URL, fallback image downloads, a longer SSH readiness window, fresh VM container startup, KVM group propagation, retry handling, and startup diagnostics. ([#2532](https://github.com/dartsim/dart/pull/2532))
 
 ### [DART 6.16.7 (2026-02-10)](https://github.com/dartsim/dart/milestone/92?closed=1)
 

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -51,6 +51,8 @@
 #include <string>
 #include <vector>
 
+#include <cmath>
+
 namespace dart {
 namespace simulation {
 
@@ -133,8 +135,9 @@ WorldPtr World::clone() const
 //==============================================================================
 void World::setTimeStep(double _timeStep)
 {
-  if (_timeStep <= 0.0) {
-    dtwarn << "[World] Attempting to set negative timestep. Ignoring this "
+  if (!std::isfinite(_timeStep) || _timeStep <= 0.0) {
+    dtwarn << "[World] Attempting to set invalid timestep (" << _timeStep
+           << "). Ignoring this "
            << "request because it can lead to undefined behavior.\n";
     return;
   }

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -129,7 +129,7 @@ public:
   /// Get gravity
   const Eigen::Vector3d& getGravity() const;
 
-  /// Set time step
+  /// Set time step. Invalid (<= 0 or non-finite) values are ignored.
   void setTimeStep(double _timeStep);
 
   /// Get time step

--- a/docker/freebsd/entrypoint.py
+++ b/docker/freebsd/entrypoint.py
@@ -4,10 +4,21 @@ import subprocess
 import sys
 from pathlib import Path
 
-DEFAULT_IMAGE_URL = (
-    "https://download.freebsd.org/ftp/snapshots/VM-IMAGES/15.0-STABLE/"
-    "amd64/Latest/FreeBSD-15.0-STABLE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
-)
+DEFAULT_IMAGE_URLS = [
+    (
+        "https://download.freebsd.org/ftp/releases/VM-IMAGES/15.0-RELEASE/"
+        "amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
+    ),
+    (
+        "https://download.freebsd.org/ftp/snapshots/VM-IMAGES/15.1-PRERELEASE/"
+        "amd64/Latest/FreeBSD-15.1-PRERELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
+    ),
+    (
+        "https://download.freebsd.org/ftp/releases/VM-IMAGES/14.4-RELEASE/"
+        "amd64/Latest/FreeBSD-14.4-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
+    ),
+]
+DEFAULT_IMAGE_URL = ",".join(DEFAULT_IMAGE_URLS)
 DEFAULT_DISK_SIZE = "12G"
 
 
@@ -35,7 +46,32 @@ def is_xz_file(path):
         return handle.read(6) == b"\xfd7zXZ\x00"
 
 
-def ensure_image(vm_dir, image_url, image_xz, image_qcow2):
+def parse_image_urls(value):
+    urls = [url for url in value.replace(",", " ").split() if url]
+    return urls or DEFAULT_IMAGE_URLS
+
+
+def download_image(image_urls, image_xz):
+    failures = []
+    for image_url in image_urls:
+        print(f"Downloading FreeBSD image from {image_url}...")
+        result = subprocess.run(
+            ["curl", "-fL", image_url, "-o", str(image_xz)],
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        failures.append(f"{image_url} (curl exit {result.returncode})")
+        if image_xz.exists():
+            image_xz.unlink()
+
+    print("Failed to download any FreeBSD image:", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+    sys.exit(1)
+
+
+def ensure_image(vm_dir, image_urls, image_xz, image_qcow2):
     if image_xz.exists() and not is_xz_file(image_xz):
         print(f"Removing invalid FreeBSD archive at {image_xz}...")
         image_xz.unlink()
@@ -43,8 +79,7 @@ def ensure_image(vm_dir, image_url, image_xz, image_qcow2):
         print(f"Removing empty FreeBSD image at {image_qcow2}...")
         image_qcow2.unlink()
     if not image_xz.exists():
-        print(f"Downloading FreeBSD image from {image_url}...")
-        run(["curl", "-fL", image_url, "-o", str(image_xz)])
+        download_image(image_urls, image_xz)
     if not image_qcow2.exists():
         print("Extracting FreeBSD image...")
         run(["xz", "-d", "-c", str(image_xz)], stdout_path=image_qcow2)
@@ -128,7 +163,7 @@ def write_seed(vm_dir, ssh_key, user_data, meta_data, seed_img, user):
 
 def main():
     vm_dir = Path(os.getenv("FREEBSD_VM_DIR", "/vm"))
-    image_url = os.getenv("FREEBSD_VM_IMAGE_URL", DEFAULT_IMAGE_URL)
+    image_urls = parse_image_urls(os.getenv("FREEBSD_VM_IMAGE_URL", DEFAULT_IMAGE_URL))
     ssh_port = getenv_int("FREEBSD_VM_SSH_PORT", 10022)
     cpus = getenv_int("FREEBSD_VM_CPUS", 4)
     mem = getenv_int("FREEBSD_VM_MEM", 4096)
@@ -145,7 +180,7 @@ def main():
     meta_data = vm_dir / "meta-data"
     ssh_key = vm_dir / "id_ed25519"
 
-    ensure_image(vm_dir, image_url, image_xz, image_qcow2)
+    ensure_image(vm_dir, image_urls, image_xz, image_qcow2)
     ensure_overlay(image_qcow2, overlay_qcow2)
     resize_overlay(overlay_qcow2, disk_size)
     ensure_ssh_key(vm_dir, ssh_key)

--- a/scripts/freebsd.py
+++ b/scripts/freebsd.py
@@ -128,24 +128,25 @@ def container_running(container):
     return container in (result.stdout or "").splitlines()
 
 
+_ensure_started_state = {"started": False}
+
+
 def ensure_started(args):
-    key_path = ssh_key_path(vm_dir_path(args.vm_dir))
-    if container_running(args.container):
-        if not key_path.exists():
-            print(
-                "SSH key missing for the running FreeBSD VM; restarting to regenerate it.",
-                file=sys.stderr,
-            )
-            stop_container(args)
+    if _ensure_started_state["started"]:
+        if not container_running(args.container):
             start_container(args)
-    else:
-        start_container(args)
+            wait_for_ssh_key(args)
+            wait_for_ssh(args, user=args.user)
+        return
+    start_container(args)
     wait_for_ssh_key(args)
     wait_for_ssh(args, user=args.user)
+    _ensure_started_state["started"] = True
 
 
 def build_image(args):
-    run(
+    env = {**os.environ, "DOCKER_BUILDKIT": "0"}
+    subprocess.run(
         [
             "docker",
             "build",
@@ -154,7 +155,9 @@ def build_image(args):
             "-f",
             dockerfile_path(),
             docker_path(),
-        ]
+        ],
+        check=True,
+        env=env,
     )
 
 
@@ -166,12 +169,8 @@ def start_container(args):
     vm_dir.mkdir(parents=True, exist_ok=True)
     ensure_ssh_key(args)
 
-    if container_running(args.container):
-        print(f"Container '{args.container}' already running.")
-        return
-
-    if container_exists(args.container):
-        run(["docker", "rm", "-f", args.container])
+    # Always force-remove any existing container to ensure fresh state.
+    run(["docker", "rm", "-f", args.container], check=False)
 
     cmd = [
         "docker",
@@ -198,10 +197,17 @@ def start_container(args):
     if disk_size:
         cmd.extend(["-e", f"FREEBSD_VM_DISK_SIZE={disk_size}"])
 
-    if Path("/dev/kvm").exists():
-        cmd.extend(["--device", "/dev/kvm"])
+    kvm_path = Path("/dev/kvm")
+    if kvm_path.exists():
+        print("KVM detected on host, passing --device /dev/kvm to Docker")
+        kvm_gid = kvm_path.stat().st_gid
+        print(f"KVM device group ID: {kvm_gid}")
+        cmd.extend(["--device", "/dev/kvm", "--group-add", str(kvm_gid)])
+    else:
+        print("KVM not detected on host (/dev/kvm does not exist)")
 
     cmd.append(args.image)
+    print(f"Docker command: {' '.join(cmd)}")
     run(cmd)
 
 
@@ -238,11 +244,55 @@ def wait_for_ssh_key(args, timeout=120):
     sys.exit(1)
 
 
-def wait_for_ssh(args, user, timeout=300):
+def dump_vm_diagnostics(args):
+    print("=== FreeBSD VM Diagnostics ===", file=sys.stderr, flush=True)
+
+    result = run(
+        ["docker", "inspect", "-f", "{{.State.Status}}", args.container],
+        check=False,
+        capture=True,
+    )
+    status = (result.stdout or "").strip() if result.returncode == 0 else "unknown"
+    print(f"Container status: {status}", file=sys.stderr, flush=True)
+
+    print("--- Container logs (last 50 lines) ---", file=sys.stderr, flush=True)
+    run(["docker", "logs", "--tail", "50", args.container], check=False)
+
+    vm_dir = vm_dir_path(args.vm_dir)
+    serial_log = vm_dir / "serial.log"
+    if serial_log.exists():
+        size = serial_log.stat().st_size
+        print(
+            f"--- Serial log ({size} bytes, last 30 lines) ---",
+            file=sys.stderr,
+            flush=True,
+        )
+        try:
+            lines = serial_log.read_text(errors="replace").splitlines()
+            for line in lines[-30:]:
+                print(f"  {line}", file=sys.stderr, flush=True)
+        except Exception as exc:
+            print(f"  (could not read serial log: {exc})", file=sys.stderr, flush=True)
+    else:
+        print("--- Serial log: not found ---", file=sys.stderr, flush=True)
+
+    print("=== End Diagnostics ===", file=sys.stderr, flush=True)
+
+
+def wait_for_ssh(args, user, timeout=600):
     vm_dir = vm_dir_path(args.vm_dir)
     key_path = ssh_key_path(vm_dir)
     deadline = time.time() + timeout
     while time.time() < deadline:
+        if not container_running(args.container):
+            print(
+                f"Container '{args.container}' stopped unexpectedly.",
+                file=sys.stderr,
+                flush=True,
+            )
+            dump_vm_diagnostics(args)
+            sys.exit(1)
+
         result = subprocess.run(
             [
                 "ssh",
@@ -263,6 +313,8 @@ def wait_for_ssh(args, user, timeout=300):
         if result.returncode == 0:
             return
         time.sleep(5)
+
+    dump_vm_diagnostics(args)
     print(
         (
             "Timed out waiting for FreeBSD SSH to become ready. "

--- a/scripts/freebsd.py
+++ b/scripts/freebsd.py
@@ -41,10 +41,21 @@ DEFAULT_PACKAGES = [
     "ros-urdfdom",
     "ros-urdfdom_headers",
 ]
-DEFAULT_IMAGE_URL = (
-    "https://download.freebsd.org/ftp/snapshots/VM-IMAGES/15.0-STABLE/"
-    "amd64/Latest/FreeBSD-15.0-STABLE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
-)
+DEFAULT_IMAGE_URLS = [
+    (
+        "https://download.freebsd.org/ftp/releases/VM-IMAGES/15.0-RELEASE/"
+        "amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
+    ),
+    (
+        "https://download.freebsd.org/ftp/snapshots/VM-IMAGES/15.1-PRERELEASE/"
+        "amd64/Latest/FreeBSD-15.1-PRERELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
+    ),
+    (
+        "https://download.freebsd.org/ftp/releases/VM-IMAGES/14.4-RELEASE/"
+        "amd64/Latest/FreeBSD-14.4-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz"
+    ),
+]
+DEFAULT_IMAGE_URL = ",".join(DEFAULT_IMAGE_URLS)
 SSH_OPTIONS = [
     "-o",
     "StrictHostKeyChecking=no",
@@ -547,7 +558,14 @@ def parse_args():
         default=env_default_int("FREEBSD_VM_MEM", DEFAULT_MEM),
     )
     parser.add_argument("--user", default=DEFAULT_USER)
-    parser.add_argument("--image-url", default=DEFAULT_IMAGE_URL)
+    parser.add_argument(
+        "--image-url",
+        default=DEFAULT_IMAGE_URL,
+        help=(
+            "FreeBSD VM image URL. Multiple URLs can be comma- or "
+            "whitespace-separated; the VM launcher tries them in order."
+        ),
+    )
     parser.add_argument("--remote-dir", default=DEFAULT_REMOTE_DIR)
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -50,6 +50,8 @@
 #include "dart/simulation/simulation.hpp"
 #include "dart/utils/utils.hpp"
 
+#include <limits>
+
 using namespace dart;
 using namespace common;
 using namespace math;
@@ -1594,6 +1596,37 @@ TEST_F(Collision, CollisionOfPrescribedJoints)
     EXPECT_NEAR(joint6->getVelocity(0), 0.0, tol);
     EXPECT_NEAR(joint6->getAcceleration(0), 0.0, tol);
   }
+}
+
+//==============================================================================
+TEST_F(Collision, CollisionOfPrescribedJointsRejectsInvalidTimeStep)
+{
+  WorldPtr world = SkelParser::readWorld(
+      "dart://sample/skel/test/collision_of_prescribed_joints_test.skel");
+  ASSERT_TRUE(world != nullptr);
+
+  const double originalTimeStep = world->getTimeStep();
+  ASSERT_GT(originalTimeStep, 0.0);
+
+  const double invalidValues[]
+      = {std::numeric_limits<double>::quiet_NaN(),
+         std::numeric_limits<double>::infinity(),
+         -std::numeric_limits<double>::infinity(),
+         0.0,
+         -1.0};
+
+  for (double invalid : invalidValues) {
+    world->setTimeStep(invalid);
+    EXPECT_DOUBLE_EQ(world->getTimeStep(), originalTimeStep);
+  }
+
+  for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
+    EXPECT_DOUBLE_EQ(world->getSkeleton(i)->getTimeStep(), originalTimeStep);
+  }
+
+  EXPECT_DOUBLE_EQ(
+      world->getConstraintSolver()->getTimeStep(), originalTimeStep);
+  EXPECT_NO_THROW(world->step(false));
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Reject NaN, infinite, zero, and negative values passed to `World::setTimeStep()` on `release-6.16`.
- Add a regression test for the prescribed-joint collision world from #2531.
- Improve FreeBSD VM CI startup resilience after the PR hit repeated SSH readiness timeouts.
- Fix FreeBSD VM image downloads by moving to the 15.0 release image and adding fallback image URLs.
- Add DART 6.16.8 changelog entries.

## Motivation / Problem

- #2531 reports that NaN timesteps can propagate through `World::setTimeStep()` into the ODE LCP solver and trigger an assertion failure.
- The `main` branch already has equivalent boundary validation, but `release-6.16` only rejected non-positive values.
- CI FreeBSD first failed before DART build/test execution because the VM did not become SSH-ready within the old startup timeout.
- After the startup diagnostics landed, CI exposed that the old FreeBSD `15.0-STABLE` snapshot image URL now returns 404.

## Changes / Key Changes

- Use `std::isfinite()` in `World::setTimeStep()` before updating the world, skeletons, or constraint solver timestep.
- Keep the previous valid timestep when invalid values are supplied.
- Verify the reported prescribed-joint collision scene still steps after invalid timestep inputs are rejected.
- Add FreeBSD VM startup retries, a longer SSH readiness window, fresh container startup, KVM group propagation, and diagnostics on startup failure.
- Use the FreeBSD 15.0 release VM image by default and let the VM launcher try fallback image URLs if a mirror path disappears.

## Testing

- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target test_Collision`
- `./build/default/cpp/Release/tests/integration/test_Collision --gtest_filter=Collision.CollisionOfPrescribedJointsRejectsInvalidTimeStep`
- `python3 -m py_compile scripts/freebsd.py docker/freebsd/entrypoint.py`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2531
- Main / DART 7 tracking PR: #2533

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable