### PR TITLE
Modernize C++20 cleanup patterns

### DIFF
--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -35,6 +35,9 @@
 
 #include <dart/common/lockable_reference.hpp>
 
+#include <iterator>
+#include <type_traits>
+
 namespace dart {
 namespace common {
 
@@ -91,11 +94,11 @@ MultiLockableReference<Lockable>::MultiLockableReference(
 {
   using IteratorValueType =
       typename std::iterator_traits<InputIterator>::value_type;
-  using IteratorLockable = typename std::remove_pointer<
-      typename std::remove_reference<IteratorValueType>::type>::type;
+  using IteratorLockable
+      = std::remove_pointer_t<std::remove_cvref_t<IteratorValueType>>;
 
   static_assert(
-      std::is_same<Lockable, IteratorLockable>::value,
+      std::is_same_v<Lockable, IteratorLockable>,
       "Lockable of this class and the lockable of InputIterator are not the "
       "same.");
 }

--- a/dart/common/detail/memory-impl.hpp
+++ b/dart/common/detail/memory-impl.hpp
@@ -39,6 +39,7 @@
 #include <Eigen/StdVector>
 
 #include <memory>
+#include <type_traits>
 
 namespace dart {
 namespace common {
@@ -47,7 +48,7 @@ namespace common {
 template <typename _Tp, typename... _Args>
 std::shared_ptr<_Tp> make_aligned_shared(_Args&&... __args)
 {
-  using _Tp_nc = typename std::remove_const<_Tp>::type;
+  using _Tp_nc = std::remove_const_t<_Tp>;
 
   return std::allocate_shared<_Tp>(
       Eigen::aligned_allocator<_Tp_nc>(), std::forward<_Args>(__args)...);

--- a/dart/math/detail/random-impl.hpp
+++ b/dart/math/detail/random-impl.hpp
@@ -33,6 +33,7 @@
 #include <dart/math/random.hpp>
 
 #include <concepts>
+#include <type_traits>
 
 namespace dart {
 namespace math {
@@ -46,15 +47,18 @@ namespace detail {
 /// Reference:
 /// https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
 template <typename T>
+using UniformIntType = std::remove_cvref_t<T>;
+
+template <typename T>
 concept UniformIntCompatible
-    = std::same_as<std::remove_cv_t<T>, short>
-      || std::same_as<std::remove_cv_t<T>, int>
-      || std::same_as<std::remove_cv_t<T>, long>
-      || std::same_as<std::remove_cv_t<T>, long long>
-      || std::same_as<std::remove_cv_t<T>, unsigned short>
-      || std::same_as<std::remove_cv_t<T>, unsigned int>
-      || std::same_as<std::remove_cv_t<T>, unsigned long>
-      || std::same_as<std::remove_cv_t<T>, unsigned long long>;
+    = std::same_as<UniformIntType<T>, short>
+      || std::same_as<UniformIntType<T>, int>
+      || std::same_as<UniformIntType<T>, long>
+      || std::same_as<UniformIntType<T>, long long>
+      || std::same_as<UniformIntType<T>, unsigned short>
+      || std::same_as<UniformIntType<T>, unsigned int>
+      || std::same_as<UniformIntType<T>, unsigned long>
+      || std::same_as<UniformIntType<T>, unsigned long long>;
 
 /// Check whether T is derived from Eigen::MatrixBase
 template <typename T>
@@ -220,7 +224,7 @@ struct UniformImpl;
 
 //==============================================================================
 template <typename T>
-  requires std::is_arithmetic_v<T>
+  requires(std::floating_point<T> || UniformIntCompatible<T>)
 struct UniformImpl<T>
 {
   static T run(T min, T max)
@@ -279,7 +283,7 @@ struct NormalImpl;
 
 //==============================================================================
 template <typename T>
-  requires std::is_arithmetic_v<T>
+  requires(std::floating_point<T> || UniformIntCompatible<T>)
 struct NormalImpl<T>
 {
   static T run(T min, T max)

--- a/dart/simulation/experimental/space/vector_mapper.cpp
+++ b/dart/simulation/experimental/space/vector_mapper.cpp
@@ -145,13 +145,9 @@ void VectorMapper::fromEigen(
             m_space.getDimension()));
   }
 
-  // Convert Eigen to std::vector
-  std::vector<double> temp(vec.size());
-  for (Eigen::Index i = 0; i < vec.size(); ++i) {
-    temp[i] = vec[i];
-  }
-
-  fromVector(registry, std::span<const double>(temp));
+  fromVector(
+      registry,
+      std::span<const double>(vec.data(), static_cast<size_t>(vec.size())));
 }
 
 void VectorMapper::addMapper(

--- a/python/dartpy/common/type_casters.hpp
+++ b/python/dartpy/common/type_casters.hpp
@@ -4,6 +4,8 @@
 
 #include <nanobind/nanobind.h>
 
+#include <type_traits>
+
 #include "dart/dynamics/frame.hpp"
 #include "dart/dynamics/jacobian_node.hpp"
 #include "dart/dynamics/joint.hpp"
@@ -53,7 +55,7 @@ struct polymorphic_type_caster : type_caster_base_tag {
   NB_INLINE static handle from_cpp(
       T&& value, rv_policy policy, cleanup_list* cleanup) noexcept
   {
-    using BareT = std::remove_reference_t<std::remove_cv_t<T>>;
+    using BareT = std::remove_cvref_t<T>;
 
     if constexpr (std::is_pointer_v<BareT>) {
       Type* ptr = (Type*) value;
@@ -134,7 +136,7 @@ struct type_caster<dart::dynamics::BodyNode>
   NB_INLINE static handle from_cpp(
       T&& value, rv_policy policy, cleanup_list* cleanup) noexcept
   {
-    using BareT = std::remove_cv_t<std::remove_reference_t<T>>;
+    using BareT = std::remove_cvref_t<T>;
     if constexpr (std::is_pointer_v<BareT>
                   || std::is_lvalue_reference_v<T>) {
       if (policy != rv_policy::reference_internal)
@@ -153,7 +155,7 @@ struct type_caster<dart::dynamics::JacobianNode>
   NB_INLINE static handle from_cpp(
       T&& value, rv_policy policy, cleanup_list* cleanup) noexcept
   {
-    using BareT = std::remove_cv_t<std::remove_reference_t<T>>;
+    using BareT = std::remove_cvref_t<T>;
     if constexpr (std::is_pointer_v<BareT>
                   || std::is_lvalue_reference_v<T>) {
       if (policy != rv_policy::reference_internal)
@@ -172,7 +174,7 @@ struct type_caster<dart::dynamics::Joint>
   NB_INLINE static handle from_cpp(
       T&& value, rv_policy policy, cleanup_list* cleanup) noexcept
   {
-    using BareT = std::remove_cv_t<std::remove_reference_t<T>>;
+    using BareT = std::remove_cvref_t<T>;
     if constexpr (std::is_pointer_v<BareT>
                   || std::is_lvalue_reference_v<T>) {
       if (policy != rv_policy::reference_internal)


### PR DESCRIPTION
## Summary

- Modernizes a few low-risk C++20 cleanup patterns across math, common, simulation-experimental, and dartpy support code.

## Motivation / Problem

- DART 7 targets C++20, and several small areas still used older type-trait spellings or an avoidable Eigen-to-vector copy.
- This keeps the existing behavior while making constraints and forwarding code easier to read.

## Changes / Key Changes

- Tightened `Random` scalar implementation constraints with C++20 concepts while preserving the accepted integer distribution types.
- Replaced older nested type-trait forms with `std::remove_cvref_t`, `std::remove_const_t`, and `_v` trait helpers.
- Removed a temporary vector allocation in `VectorMapper::fromEigen` by passing a `std::span` over Eigen's contiguous storage.

## Testing

- `pixi run lint`
- `pixi run build`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R "^(UNIT_math_Random|test_vector_mapper|UNIT_common_(MemoryManager|StlAllocator|PoolAllocator|FreeListAllocator|CAllocator))$"`
- `pixi run test-py`
- `pixi run test`
- `pixi run test-simulation-experimental`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- N/A

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
