### PR TITLE
Fix spdlog/fmt runtime logging (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
   * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds
 
-  * Fix spdlog/fmt 12 builds by treating DART logging format parameters as runtime format strings. ([#2538](https://github.com/dartsim/dart/issues/2538))
+  * Fix spdlog/fmt 12 builds by treating DART logging format parameters as runtime format strings. ([#2540](https://github.com/dartsim/dart/pull/2540), [#2538](https://github.com/dartsim/dart/issues/2538))
 
 * Simulation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
   * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds
 
+  * Fix spdlog/fmt 12 builds by treating DART logging format parameters as runtime format strings. ([#2538](https://github.com/dartsim/dart/issues/2538))
+
 * Simulation
 
   * Reject NaN, infinite, zero, and negative `World::setTimeStep()` values to prevent invalid timesteps from reaching the ODE LCP solver. ([#2532](https://github.com/dartsim/dart/pull/2532), [#2531](https://github.com/dartsim/dart/issues/2531))

--- a/dart/common/detail/Logging-impl.hpp
+++ b/dart/common/detail/Logging-impl.hpp
@@ -37,12 +37,7 @@
 
 #if DART_HAVE_spdlog
   #include <spdlog/spdlog.h>
-  #if defined(SPDLOG_USE_STD_FORMAT)
-    #define DART_SPDLOG_RUNTIME(str) str
-  #else
-    #include <spdlog/fmt/fmt.h>
-    #define DART_SPDLOG_RUNTIME(str) fmt::runtime(str)
-  #endif
+  #define DART_SPDLOG_RUNTIME(str) SPDLOG_FMT_RUNTIME(str)
 #else
   #include <iostream>
   #include <string>

--- a/dart/common/detail/Logging-impl.hpp
+++ b/dart/common/detail/Logging-impl.hpp
@@ -37,6 +37,12 @@
 
 #if DART_HAVE_spdlog
   #include <spdlog/spdlog.h>
+  #if defined(SPDLOG_USE_STD_FORMAT)
+    #define DART_SPDLOG_RUNTIME(str) str
+  #else
+    #include <spdlog/fmt/fmt.h>
+    #define DART_SPDLOG_RUNTIME(str) fmt::runtime(str)
+  #endif
 #else
   #include <iostream>
   #include <string>
@@ -80,7 +86,7 @@ template <typename S, typename... Args>
 void trace(const S& format_str, [[maybe_unused]] Args&&... args)
 {
 #if DART_HAVE_spdlog
-  spdlog::trace(format_str, std::forward<Args>(args)...);
+  spdlog::trace(DART_SPDLOG_RUNTIME(format_str), std::forward<Args>(args)...);
 #else
   detail::print(
       std::cout, "[trace]", format_str, 38, std::forward<Args>(args)...);
@@ -92,7 +98,7 @@ template <typename S, typename... Args>
 void debug(const S& format_str, [[maybe_unused]] Args&&... args)
 {
 #if DART_HAVE_spdlog
-  spdlog::debug(format_str, std::forward<Args>(args)...);
+  spdlog::debug(DART_SPDLOG_RUNTIME(format_str), std::forward<Args>(args)...);
 #else
   detail::print(
       std::cout, "[debug]", format_str, 36, std::forward<Args>(args)...);
@@ -104,7 +110,7 @@ template <typename S, typename... Args>
 void info(const S& format_str, [[maybe_unused]] Args&&... args)
 {
 #if DART_HAVE_spdlog
-  spdlog::info(format_str, std::forward<Args>(args)...);
+  spdlog::info(DART_SPDLOG_RUNTIME(format_str), std::forward<Args>(args)...);
 #else
   detail::print(
       std::cout, "[info]", format_str, 32, std::forward<Args>(args)...);
@@ -116,7 +122,7 @@ template <typename S, typename... Args>
 void warn(const S& format_str, [[maybe_unused]] Args&&... args)
 {
 #if DART_HAVE_spdlog
-  spdlog::warn(format_str, std::forward<Args>(args)...);
+  spdlog::warn(DART_SPDLOG_RUNTIME(format_str), std::forward<Args>(args)...);
 #else
   detail::print(
       std::cerr, "[warn]", format_str, 33, std::forward<Args>(args)...);
@@ -128,7 +134,7 @@ template <typename S, typename... Args>
 void error(const S& format_str, [[maybe_unused]] Args&&... args)
 {
 #if DART_HAVE_spdlog
-  spdlog::error(format_str, std::forward<Args>(args)...);
+  spdlog::error(DART_SPDLOG_RUNTIME(format_str), std::forward<Args>(args)...);
 #else
   detail::print(
       std::cerr, "[error]", format_str, 31, std::forward<Args>(args)...);
@@ -140,7 +146,8 @@ template <typename S, typename... Args>
 void fatal(const S& format_str, [[maybe_unused]] Args&&... args)
 {
 #if DART_HAVE_spdlog
-  spdlog::critical(format_str, std::forward<Args>(args)...);
+  spdlog::critical(
+      DART_SPDLOG_RUNTIME(format_str), std::forward<Args>(args)...);
 #else
   detail::print(
       std::cerr, "[fatal]", format_str, 35, std::forward<Args>(args)...);

--- a/tests/unit/common/test_Logging.cpp
+++ b/tests/unit/common/test_Logging.cpp
@@ -38,6 +38,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 using namespace dart;
 
 //==============================================================================
@@ -56,6 +58,18 @@ TEST(LoggingTest, Arguments)
 {
   [[maybe_unused]] int val = 10;
   DART_INFO("Log with param '{}' and '{}'", 1, val);
+}
+
+//==============================================================================
+TEST(LoggingTest, RuntimeFormatString)
+{
+  const std::string format = "Runtime format string {}";
+  dart::common::trace(format, 42);
+  dart::common::debug(format, 42);
+  dart::common::info(format, 42);
+  dart::common::warn(format, 42);
+  dart::common::error(format, 42);
+  dart::common::fatal(format, 42);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Wrap DART logging format strings with spdlog's `SPDLOG_FMT_RUNTIME(...)` compatibility macro.
- Add release-branch logging coverage for runtime `std::string` format strings.
- Document the DART 6.16.8 build compatibility fix.

## Motivation / Problem

- #2538 reports that DART 6.16.7 fails to build with newer spdlog/fmt combinations because DART forwards logging format parameters to spdlog as non-compile-time values.
- `main` has the corresponding DART 7 fix in #2542, while this PR applies the release-6.16-side fix.

## Why CI Missed This

- The release-6.16 Pixi environment currently pins `fmt >=11.1.4,<12` while the report uses fmt 12.1.0 with spdlog 1.17.0.
- Existing CI did compile and run logging tests, but only against the pinned dependency set. That made the API path look healthy while missing fmt 12's stricter compile-time format-string enforcement.
- A normal regression test under the same pinned dependencies is useful for API intent, but it is not sufficient to catch this class of dependency-forward breakage by itself.

## Long-Term Test Strategy

- Keep the new `LoggingTest.RuntimeFormatString` unit test as the local API regression for runtime format-string support.
- Add a scalable dependency-forward CI job or smoke workflow that builds at least the common logging target against newer supported system dependencies, especially latest compatible spdlog/fmt pairs.
- Prefer a focused compatibility smoke target over duplicating the full CI matrix: it should compile a representative logging call such as `dart::common::info(std::string, ...)` and run `UNIT_common_Logging` with the forward dependency set.
- Keep the regular locked Pixi CI as the reproducible baseline, and use the forward-compatibility job to catch breakage caused by ecosystem upgrades before downstream packagers hit it.

## Changes / Key Changes

- Add `DART_SPDLOG_RUNTIME(...)` through spdlog's `SPDLOG_FMT_RUNTIME(...)` macro so fmt-backed builds get runtime format handling without assuming a minimum fmt runtime API newer than DART's supported dependency range.
- Apply the wrapper to all DART common logging level functions.
- Add a `LoggingTest.RuntimeFormatString` regression case.

## Testing

- `git diff --check`
- Header compile smoke test for `dart::common::info(std::string, ...)`
- `cmake --build build/default/cpp/Release --target UNIT_common_Logging`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R UNIT_common_Logging`
- `pixi run lint`
- `pixi run test`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2538
- Main / DART 7 PR: #2542

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable