### PR TITLE
Use C++20 range algorithms for cleanup

### DIFF
--- a/dart/collision/collision_filter.cpp
+++ b/dart/collision/collision_filter.cpp
@@ -36,6 +36,8 @@
 #include "dart/common/macros.hpp"
 #include "dart/dynamics/body_node.hpp"
 
+#include <algorithm>
+
 namespace dart {
 namespace collision {
 
@@ -73,13 +75,9 @@ void CompositeCollisionFilter::removeAllCollisionFilters()
 bool CompositeCollisionFilter::ignoresCollision(
     const CollisionObject* object1, const CollisionObject* object2) const
 {
-  for (const auto* filter : mFilters) {
-    if (filter->ignoresCollision(object1, object2)) {
-      return true;
-    }
-  }
-
-  return false;
+  return std::ranges::any_of(mFilters, [object1, object2](const auto* filter) {
+    return filter->ignoresCollision(object1, object2);
+  });
 }
 
 //==============================================================================

--- a/dart/collision/detail/unordered_pairs.hpp
+++ b/dart/collision/detail/unordered_pairs.hpp
@@ -80,12 +80,8 @@ void UnorderedPairs<T>::addPair(const T* left, const T* right)
     std::swap(less, greater);
   }
 
-  // Call insert in case an entry for bodyNodeLess doesn't exist. If it doesn't
-  // exist, it will be initialized with an empty set. If it does already exist,
-  // we will just get an iterator to the existing entry.
-  const auto itLess
-      = mList.insert(std::make_pair(less, std::unordered_set<const T*>()))
-            .first;
+  // Create an empty set when the lower pointer has no existing entry.
+  const auto itLess = mList.try_emplace(less).first;
 
   // Insert bodyNodeGreater into the set corresponding to bodyNodeLess. If the
   // pair already existed, this will do nothing.
@@ -139,16 +135,7 @@ bool UnorderedPairs<T>::contains(const T* left, const T* right) const
   }
 
   const auto resultLeft = mList.find(less);
-  const bool foundLeft = (resultLeft != mList.end());
-  if (foundLeft) {
-    auto& associatedRights = resultLeft->second;
-
-    if (associatedRights.contains(greater)) {
-      return true;
-    }
-  }
-
-  return false;
+  return resultLeft != mList.end() && resultLeft->second.contains(greater);
 }
 
 } // namespace detail

--- a/dart/constraint/coupler_constraint.cpp
+++ b/dart/constraint/coupler_constraint.cpp
@@ -70,8 +70,8 @@ CouplerConstraint::CouplerConstraint(
   DART_ASSERT(joint->getNumDofs() <= mMimicProps.size());
   DART_ASSERT(mBodyNode);
 
-  std::fill(mLifeTime, mLifeTime + 6, 0);
-  std::fill(mActive, mActive + 6, false);
+  std::ranges::fill(mLifeTime, 0);
+  std::ranges::fill(mActive, false);
 }
 
 //==============================================================================

--- a/dart/constraint/joint_coulomb_friction_constraint.cpp
+++ b/dart/constraint/joint_coulomb_friction_constraint.cpp
@@ -38,6 +38,7 @@
 #include "dart/dynamics/joint.hpp"
 #include "dart/dynamics/skeleton.hpp"
 
+#include <algorithm>
 #include <iostream>
 
 #define DART_CFM 1e-9
@@ -58,19 +59,8 @@ JointCoulombFrictionConstraint::JointCoulombFrictionConstraint(
   DART_ASSERT(_joint);
   DART_ASSERT(mBodyNode);
 
-  mLifeTime[0] = 0;
-  mLifeTime[1] = 0;
-  mLifeTime[2] = 0;
-  mLifeTime[3] = 0;
-  mLifeTime[4] = 0;
-  mLifeTime[5] = 0;
-
-  mActive[0] = false;
-  mActive[1] = false;
-  mActive[2] = false;
-  mActive[3] = false;
-  mActive[4] = false;
-  mActive[5] = false;
+  std::ranges::fill(mLifeTime, 0);
+  std::ranges::fill(mActive, false);
 }
 
 //==============================================================================
@@ -276,13 +266,7 @@ dynamics::SkeletonPtr JointCoulombFrictionConstraint::getRootSkeleton() const
 //==============================================================================
 bool JointCoulombFrictionConstraint::isActive() const
 {
-  for (std::size_t i = 0; i < 6; ++i) {
-    if (mActive[i]) {
-      return true;
-    }
-  }
-
-  return false;
+  return std::ranges::any_of(mActive, [](bool active) { return active; });
 }
 
 } // namespace constraint

--- a/dart/dynamics/body_node.cpp
+++ b/dart/dynamics/body_node.cpp
@@ -1056,10 +1056,7 @@ Marker* BodyNode::createMarker(const Marker::BasicProperties& properties)
 //==============================================================================
 bool BodyNode::dependsOn(std::size_t _genCoordIndex) const
 {
-  return std::binary_search(
-      mDependentGenCoordIndices.begin(),
-      mDependentGenCoordIndices.end(),
-      _genCoordIndex);
+  return std::ranges::binary_search(mDependentGenCoordIndices, _genCoordIndex);
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/body_node_pool.hpp
+++ b/dart/dynamics/detail/body_node_pool.hpp
@@ -35,6 +35,7 @@
 
 #include <dart/common/memory_allocator.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <new>
 #include <vector>
@@ -232,15 +233,11 @@ bool BodyNodePool<T>::owns(const void* ptr) const noexcept
 
   const auto* bytePtr = static_cast<const std::byte*>(ptr);
   const std::size_t chunkBytes = mSlotsPerChunk * kSlotSize;
-  for (const auto& chunk : mChunks) {
+  return std::ranges::any_of(mChunks, [bytePtr, chunkBytes](const auto& chunk) {
     const std::byte* begin = chunk->mData;
     const std::byte* end = begin + chunkBytes;
-    if (bytePtr >= begin && bytePtr < end) {
-      return true;
-    }
-  }
-
-  return false;
+    return bytePtr >= begin && bytePtr < end;
+  });
 }
 
 //==============================================================================

--- a/dart/dynamics/ik_fast.cpp
+++ b/dart/dynamics/ik_fast.cpp
@@ -38,6 +38,8 @@
 #include "dart/dynamics/ikfast.h"
 #include "dart/dynamics/revolute_joint.hpp"
 
+#include <algorithm>
+
 namespace dart {
 namespace dynamics {
 
@@ -210,14 +212,11 @@ bool checkDofMapValidity(
   const auto& dependentDofs = ik->getNode()->getDependentDofs();
 
   for (const auto& dof : dofMap) {
-    bool found = false;
-    for (auto dependentDof : dependentDofs) {
-      const auto dependentDofIndex = dependentDof->getIndexInSkeleton();
-      if (dof == dependentDofIndex) {
-        found = true;
-        break;
-      }
-    }
+    const bool found
+        = std::ranges::any_of(dependentDofs, [dof](auto dependentDof) {
+            const auto dependentDofIndex = dependentDof->getIndexInSkeleton();
+            return dof == dependentDofIndex;
+          });
 
     if (!found) {
       DART_ERROR(

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -458,10 +458,7 @@ Skeleton::~Skeleton()
     } else {
       // Either heap-allocated or from a borrowed chunk (cross-skeleton move).
       // Call destructor explicitly, then free if heap-allocated.
-      bool isHeap = std::find(
-                        mHeapAllocatedBodyNodes.begin(),
-                        mHeapAllocatedBodyNodes.end(),
-                        bn)
+      bool isHeap = std::ranges::find(mHeapAllocatedBodyNodes, bn)
                     != mHeapAllocatedBodyNodes.end();
       if (isHeap) {
         delete bn;

--- a/dart/simulation/detail/world-impl.hpp
+++ b/dart/simulation/detail/world-impl.hpp
@@ -61,7 +61,7 @@ void World::eachSkeleton(Func func) const
                     std::invoke_result_t<Func, const dynamics::Skeleton*>,
                     bool>) {
     (void)std::ranges::all_of(
-        mSkeletons, [&func](const auto& skel) { return func(skel.get()); });
+        mSkeletons, [&func](auto skel) { return func(skel.get()); });
   } else {
     for (auto skel : mSkeletons) {
       func(skel.get());
@@ -77,7 +77,7 @@ void World::eachSkeleton(Func func)
                     std::invoke_result_t<Func, dynamics::Skeleton*>,
                     bool>) {
     (void)std::ranges::all_of(
-        mSkeletons, [&func](const auto& skel) { return func(skel.get()); });
+        mSkeletons, [&func](auto skel) { return func(skel.get()); });
   } else {
     for (auto skel : mSkeletons) {
       func(skel.get());
@@ -92,7 +92,7 @@ void World::eachSimpleFrame(Func func) const
   if constexpr (std::is_same_v<
                     std::invoke_result_t<Func, const dynamics::SimpleFrame*>,
                     bool>) {
-    (void)std::ranges::all_of(mSimpleFrames, [&func](const auto& simpleFrame) {
+    (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {
       return func(simpleFrame.get());
     });
   } else {
@@ -109,7 +109,7 @@ void World::eachSimpleFrame(Func func)
   if constexpr (std::is_same_v<
                     std::invoke_result_t<Func, dynamics::SimpleFrame*>,
                     bool>) {
-    (void)std::ranges::all_of(mSimpleFrames, [&func](const auto& simpleFrame) {
+    (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {
       return func(simpleFrame.get());
     });
   } else {

--- a/dart/simulation/detail/world-impl.hpp
+++ b/dart/simulation/detail/world-impl.hpp
@@ -41,6 +41,8 @@
 
 #include <dart/simulation/world.hpp>
 
+#include <algorithm>
+
 namespace dart {
 namespace simulation {
 
@@ -58,11 +60,8 @@ void World::eachSkeleton(Func func) const
   if constexpr (std::is_same_v<
                     std::invoke_result_t<Func, const dynamics::Skeleton*>,
                     bool>) {
-    for (auto skel : mSkeletons) {
-      if (!func(skel.get())) {
-        return;
-      }
-    }
+    (void)std::ranges::all_of(
+        mSkeletons, [&func](const auto& skel) { return func(skel.get()); });
   } else {
     for (auto skel : mSkeletons) {
       func(skel.get());
@@ -77,11 +76,8 @@ void World::eachSkeleton(Func func)
   if constexpr (std::is_same_v<
                     std::invoke_result_t<Func, dynamics::Skeleton*>,
                     bool>) {
-    for (auto skel : mSkeletons) {
-      if (!func(skel.get())) {
-        return;
-      }
-    }
+    (void)std::ranges::all_of(
+        mSkeletons, [&func](const auto& skel) { return func(skel.get()); });
   } else {
     for (auto skel : mSkeletons) {
       func(skel.get());
@@ -96,11 +92,9 @@ void World::eachSimpleFrame(Func func) const
   if constexpr (std::is_same_v<
                     std::invoke_result_t<Func, const dynamics::SimpleFrame*>,
                     bool>) {
-    for (auto simpleFrame : mSimpleFrames) {
-      if (!func(simpleFrame.get())) {
-        return;
-      }
-    }
+    (void)std::ranges::all_of(mSimpleFrames, [&func](const auto& simpleFrame) {
+      return func(simpleFrame.get());
+    });
   } else {
     for (auto simpleFrame : mSimpleFrames) {
       func(simpleFrame.get());
@@ -115,11 +109,9 @@ void World::eachSimpleFrame(Func func)
   if constexpr (std::is_same_v<
                     std::invoke_result_t<Func, dynamics::SimpleFrame*>,
                     bool>) {
-    for (auto simpleFrame : mSimpleFrames) {
-      if (!func(simpleFrame.get())) {
-        return;
-      }
-    }
+    (void)std::ranges::all_of(mSimpleFrames, [&func](const auto& simpleFrame) {
+      return func(simpleFrame.get());
+    });
   } else {
     for (auto simpleFrame : mSimpleFrames) {
       func(simpleFrame.get());

--- a/dart/utils/composite_resource_retriever.cpp
+++ b/dart/utils/composite_resource_retriever.cpp
@@ -36,6 +36,7 @@
 #include "dart/common/logging.hpp"
 #include "dart/common/uri.hpp"
 
+#include <algorithm>
 #include <iostream>
 
 namespace dart {
@@ -76,13 +77,11 @@ bool CompositeResourceRetriever::addSchemaRetriever(
 //==============================================================================
 bool CompositeResourceRetriever::exists(const common::Uri& uri)
 {
-  for (const common::ResourceRetrieverPtr& resourceRetriever :
-       getRetrievers(uri)) {
-    if (resourceRetriever->exists(uri)) {
-      return true;
-    }
-  }
-  return false;
+  return std::ranges::any_of(
+      getRetrievers(uri),
+      [&uri](const common::ResourceRetrieverPtr& resourceRetriever) {
+        return resourceRetriever->exists(uri);
+      });
 }
 
 //==============================================================================

--- a/dart/utils/mjcf/detail/utils.cpp
+++ b/dart/utils/mjcf/detail/utils.cpp
@@ -37,6 +37,8 @@
 #include "dart/utils/dart_resource_retriever.hpp"
 #include "dart/utils/xml_helpers.hpp"
 
+#include <algorithm>
+
 namespace dart {
 namespace utils {
 namespace MjcfParser {
@@ -252,14 +254,8 @@ void warnUnknownElements(
   const tinyxml2::XMLElement* child = parentElement->FirstChildElement();
   while (child != nullptr) {
     const std::string childName = child->Name();
-
-    bool known = false;
-    for (const auto& name : knownChildNames) {
-      if (childName == name) {
-        known = true;
-        break;
-      }
-    }
+    const bool known = std::ranges::find(knownChildNames, childName)
+                       != knownChildNames.end();
 
     if (!known) {
       DART_WARN(
@@ -281,14 +277,8 @@ void warnUnknownAttributes(
   const tinyxml2::XMLAttribute* attr = element->FirstAttribute();
   while (attr != nullptr) {
     const std::string attrName = attr->Name();
-
-    bool known = false;
-    for (const auto& name : knownAttrNames) {
-      if (attrName == name) {
-        known = true;
-        break;
-      }
-    }
+    const bool known
+        = std::ranges::find(knownAttrNames, attrName) != knownAttrNames.end();
 
     if (!known) {
       DART_WARN(

--- a/dart/utils/package_resource_retriever.cpp
+++ b/dart/utils/package_resource_retriever.cpp
@@ -37,6 +37,7 @@
 #include "dart/common/logging.hpp"
 #include "dart/common/uri.hpp"
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 
@@ -80,23 +81,20 @@ bool PackageResourceRetriever::exists(const common::Uri& uri)
     return false;
   }
 
-  for (const std::string& packagePath : getPackagePaths(packageName)) {
-    const std::string resolvedUri = packagePath + relativePath;
-    common::Uri fileUri;
-    if (!fileUri.fromStringOrPath(resolvedUri)) {
-      DART_WARN(
-          "Failed to parse resolved URI '{}' for package '{}'.",
-          resolvedUri,
-          packageName);
-      continue;
-    }
+  return std::ranges::any_of(
+      getPackagePaths(packageName), [&](const auto& packagePath) {
+        const std::string resolvedUri = packagePath + relativePath;
+        common::Uri fileUri;
+        if (!fileUri.fromStringOrPath(resolvedUri)) {
+          DART_WARN(
+              "Failed to parse resolved URI '{}' for package '{}'.",
+              resolvedUri,
+              packageName);
+          return false;
+        }
 
-    if (mLocalRetriever->exists(fileUri)) {
-      return true;
-    }
-  }
-
-  return false;
+        return mLocalRetriever->exists(fileUri);
+      });
 }
 
 //==============================================================================

--- a/tests/integration/simulation/test_world.cpp
+++ b/tests/integration/simulation/test_world.cpp
@@ -38,6 +38,7 @@
 #include "dart/common/macros.hpp"
 #include "dart/dynamics/body_node.hpp"
 #include "dart/dynamics/revolute_joint.hpp"
+#include "dart/dynamics/simple_frame.hpp"
 #include "dart/dynamics/skeleton.hpp"
 #include "dart/io/read.hpp"
 #include "dart/math/geometry.hpp"
@@ -46,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -267,6 +269,118 @@ TEST(World, RemoveSkeletonAndAllSkeletons)
   const auto removed = world->removeAllSkeletons();
   EXPECT_EQ(removed.size(), 1u);
   EXPECT_EQ(world->getNumSkeletons(), 0u);
+}
+
+//==============================================================================
+TEST(World, EachSkeletonKeepsRemovedSkeletonAliveDuringBoolCallback)
+{
+  {
+    auto world = World::create();
+    auto skeleton = Skeleton::create("skeleton");
+    skeleton->createJointAndBodyNodePair<RevoluteJoint>();
+    std::weak_ptr<Skeleton> weakSkeleton = skeleton;
+
+    world->addSkeleton(skeleton);
+    skeleton.reset();
+
+    bool visited = false;
+    world->eachSkeleton([&](Skeleton* skel) -> bool {
+      visited = true;
+      world->removeAllSkeletons();
+      const auto keptAlive = weakSkeleton.lock();
+      EXPECT_NE(nullptr, keptAlive);
+      if (keptAlive) {
+        EXPECT_EQ(skel, keptAlive.get());
+        EXPECT_EQ("skeleton", keptAlive->getName());
+      }
+      return false;
+    });
+
+    EXPECT_TRUE(visited);
+    EXPECT_TRUE(weakSkeleton.expired());
+  }
+
+  {
+    auto world = World::create();
+    auto skeleton = Skeleton::create("skeleton");
+    skeleton->createJointAndBodyNodePair<RevoluteJoint>();
+    std::weak_ptr<Skeleton> weakSkeleton = skeleton;
+
+    world->addSkeleton(skeleton);
+    skeleton.reset();
+
+    bool visited = false;
+    const auto& constWorld = *world;
+    constWorld.eachSkeleton([&](const Skeleton* skel) -> bool {
+      visited = true;
+      world->removeAllSkeletons();
+      const auto keptAlive = weakSkeleton.lock();
+      EXPECT_NE(nullptr, keptAlive);
+      if (keptAlive) {
+        EXPECT_EQ(skel, keptAlive.get());
+        EXPECT_EQ("skeleton", keptAlive->getName());
+      }
+      return false;
+    });
+
+    EXPECT_TRUE(visited);
+    EXPECT_TRUE(weakSkeleton.expired());
+  }
+}
+
+//==============================================================================
+TEST(World, EachSimpleFrameKeepsRemovedFrameAliveDuringBoolCallback)
+{
+  {
+    auto world = World::create();
+    auto frame = SimpleFrame::createShared(Frame::World(), "frame");
+    std::weak_ptr<SimpleFrame> weakFrame = frame;
+
+    world->addSimpleFrame(frame);
+    frame.reset();
+
+    bool visited = false;
+    world->eachSimpleFrame([&](SimpleFrame* simpleFrame) -> bool {
+      visited = true;
+      world->removeAllSimpleFrames();
+      const auto keptAlive = weakFrame.lock();
+      EXPECT_NE(nullptr, keptAlive);
+      if (keptAlive) {
+        EXPECT_EQ(simpleFrame, keptAlive.get());
+        EXPECT_EQ("frame", keptAlive->getName());
+      }
+      return false;
+    });
+
+    EXPECT_TRUE(visited);
+    EXPECT_TRUE(weakFrame.expired());
+  }
+
+  {
+    auto world = World::create();
+    auto frame = SimpleFrame::createShared(Frame::World(), "frame");
+    std::weak_ptr<SimpleFrame> weakFrame = frame;
+
+    world->addSimpleFrame(frame);
+    frame.reset();
+
+    bool visited = false;
+    const auto& constWorld = *world;
+    constWorld.eachSimpleFrame([&](const SimpleFrame* simpleFrame) -> bool {
+      visited = true;
+      world->removeAllSimpleFrames();
+      const auto keptAlive = weakFrame.lock();
+      EXPECT_NE(nullptr, keptAlive);
+      if (keptAlive) {
+        EXPECT_EQ(simpleFrame, keptAlive.get());
+        EXPECT_EQ("frame", keptAlive->getName());
+      }
+      return false;
+    });
+
+    EXPECT_TRUE(visited);
+    EXPECT_TRUE(weakFrame.expired());
+  }
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Replace small hand-written short-circuit loops with C++20 range algorithms in simulation, collision, resource lookup, MJCF parsing, IK setup, and allocator ownership checks.
- Simplify unordered collision-pair insertion with standard associative-container insertion.

## Motivation / Problem

- DART 7.0 is C++20-based, but a few simple search and predicate loops still used older STL idioms.
- These paths can be expressed more directly with standard library algorithms while preserving behavior.

## Changes / Key Changes

- Use `std::ranges::all_of` for callback early-stop helpers in `World::eachSkeleton()` and `World::eachSimpleFrame()`.
- Use `std::ranges::any_of` for collision-filter, resource-retriever, IK DOF-map, and body-node-pool membership checks.
- Use `std::ranges::find` for MJCF known-name checks.
- Use `try_emplace()` and a direct `contains()` return in unordered collision pairs.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
