### PR TITLE
Simplify filesystem compatibility wrapper

### DIFF
--- a/dart/common/filesystem.hpp
+++ b/dart/common/filesystem.hpp
@@ -28,85 +28,14 @@
 #ifndef DART_COMMON_FILESYSTEM_HPP_
 #define DART_COMMON_FILESYSTEM_HPP_
 
-#include <dart/common/platform.hpp>
-
-#if !defined(DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL)
-
-  // Check for feature test macro for <filesystem>
-  #if defined(__cpp_lib_filesystem)
-    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
-
-  // Check for feature test macro for <experimental/filesystem>
-  #elif defined(__cpp_lib_experimental_filesystem)
-    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
-
-  // We can't check if headers exist...
-  // Let's assume experimental to be safe
-  #elif !defined(__has_include)
-    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
-
-  // Check if the header "<filesystem>" exists
-  #elif __has_include(<filesystem>)
-
-    // If we're compiling on Visual Studio and are not compiling with C++17, we
-    // need to use experimental
-    #ifdef _MSC_VER
-
-      // Check and include header that defines "_HAS_CXX17"
-      #if __has_include(<yvals_core.h>)
-        #include <yvals_core.h>
-
-        // Check for enabled C++17 support
-        #if defined(_HAS_CXX17) && _HAS_CXX17
-          // We're using C++17, so let's use the normal version
-          #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
-        #endif
-      #endif
-
-      // If the marco isn't defined yet, that means any of the other VS specific
-      // checks failed, so we need to use experimental
-      #ifndef DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
-        #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
-      #endif
-
-    // Not on Visual Studio. Let's use the normal version
-    #else // #ifdef _MSC_VER
-      #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
-    #endif
-
-  // Check if the header "<filesystem>" exists
-  #elif __has_include(<experimental/filesystem>)
-    #define DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
-
-  // Fail if neither header is available with a nice error message
-  #else
-    #error Could not find system header "<filesystem>" or "<experimental/filesystem>"
-  #endif
-
-  // We previously determined that we need the experimental version
-  #if DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
-    // Include it
-    #include <experimental/filesystem>
+#include <filesystem>
+#include <system_error>
 
 namespace dart::common {
 
-namespace filesystem = ::std::experimental::filesystem;
-using error_code = ::std::error_code;
-
-} // namespace dart::common
-
-  // We have a decent compiler and can use the normal version
-  #else
-    // Include it
-    #include <filesystem>
-
-namespace dart::common {
 namespace filesystem = ::std::filesystem;
 using error_code = ::std::error_code;
+
 } // namespace dart::common
-
-  #endif
-
-#endif // #ifndef DART_INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
 
 #endif // #ifndef DART_COMMON_FILESYSTEM_HPP_


### PR DESCRIPTION
## Summary

- Simplifies the DART filesystem compatibility wrapper now that the project builds as C++20.

## Motivation / Problem

- The wrapper still carried fallback detection for `<experimental/filesystem>` and pre-C++17 standard library behavior that is no longer needed on the main branch.

## Changes / Key Changes

- Includes `<filesystem>` directly.
- Keeps the existing `dart::common::filesystem` and `dart::common::error_code` aliases intact.
- Removes the legacy experimental filesystem macro/detection path.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
