### PR TITLE
Use C++20 starts_with in examples

### DIFF
--- a/examples/atlas_puppet/main.cpp
+++ b/examples/atlas_puppet/main.cpp
@@ -38,6 +38,8 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <string_view>
+
 using namespace dart::common;
 using namespace dart::dynamics;
 using namespace dart::simulation;
@@ -288,8 +290,10 @@ public:
 
     mLegs.reserve(12);
     for (std::size_t i = 0; i < mAtlas->getNumDofs(); ++i) {
-      if (mAtlas->getDof(i)->getName().substr(1, 5) == "_leg_") {
-        mLegs.push_back(mAtlas->getDof(i)->getIndexInSkeleton());
+      const auto* dof = mAtlas->getDof(i);
+      const std::string_view name = dof->getName();
+      if (name.size() > 1 && name.substr(1).starts_with("_leg_")) {
+        mLegs.push_back(dof->getIndexInSkeleton());
       }
     }
     // We should also adjust the pelvis when detangling the legs

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -1162,8 +1162,8 @@ SkeletonPtr createHubo()
 
   for (std::size_t i = 0; i < hubo->getNumBodyNodes(); ++i) {
     BodyNode* bn = hubo->getBodyNode(i);
-    if (bn->getName().substr(0, 7) == "Body_LF"
-        || bn->getName().substr(0, 7) == "Body_RF") {
+    const auto& name = bn->getName();
+    if (name.starts_with("Body_LF") || name.starts_with("Body_RF")) {
       bn->remove();
       --i;
     }


### PR DESCRIPTION
## Summary

- Replace substring-based string prefix checks in examples with C++20 `starts_with` usage.

## Motivation / Problem

- Avoid temporary substring allocations and make prefix intent explicit in example code.

## Changes / Key Changes

- Use `std::string::starts_with` when filtering Hubo body names.
- Use `std::string_view` with `starts_with` for the Atlas leg DOF name match while preserving the existing offset-based match.

## Testing

- `pixi run lint`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable