### PR TITLE
Use C++20 contains in profiling tests

### DIFF
--- a/tests/unit/simulation/experimental/common/test_diagnostics_profiling.cpp
+++ b/tests/unit/simulation/experimental/common/test_diagnostics_profiling.cpp
@@ -164,7 +164,7 @@ TEST(Profiling, ProfileStats_Record_AddsEntries)
 
   const auto& entries = ProfileStats::entries();
   EXPECT_EQ(entries.size(), 1);
-  EXPECT_TRUE(entries.find("test_entry") != entries.end());
+  EXPECT_TRUE(entries.contains("test_entry"));
 
   ProfileStats::reset();
 }
@@ -178,8 +178,8 @@ TEST(Profiling, ProfileStats_Entries_RetrievesRecordedEntries)
 
   const auto& entries = ProfileStats::entries();
   EXPECT_EQ(entries.size(), 2);
-  EXPECT_TRUE(entries.find("entry1") != entries.end());
-  EXPECT_TRUE(entries.find("entry2") != entries.end());
+  EXPECT_TRUE(entries.contains("entry1"));
+  EXPECT_TRUE(entries.contains("entry2"));
 
   ProfileStats::reset();
 }
@@ -314,7 +314,7 @@ TEST(Profiling, ScopedTimer_ReportsToProfileStats)
   }
 
   const auto& entries = ProfileStats::entries();
-  EXPECT_TRUE(entries.find("report_test") != entries.end());
+  EXPECT_TRUE(entries.contains("report_test"));
 
   ProfileStats::reset();
 }
@@ -348,7 +348,7 @@ TEST(Profiling, ScopedTimer_StringViewName)
   }
 
   const auto& entries = ProfileStats::entries();
-  EXPECT_TRUE(entries.find("string_view_test") != entries.end());
+  EXPECT_TRUE(entries.contains("string_view_test"));
 
   ProfileStats::reset();
 }


### PR DESCRIPTION
## Summary
- Use C++20 `contains` for profile-stat membership assertions.

## Motivation / Problem
- Membership-only `find() != end()` checks are more verbose than the C++20 associative-container API.

## Changes / Key Changes
- Replace five `ProfileStats::entries()` membership assertions with `contains`.
- Keep iterator-based `find` checks where tests inspect the recorded entry.

## Testing
- `pixi run test-all`

## Breaking Changes
- [x] None

## Related Issues / PRs (backports)
- None

---
#### Checklist
- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
