### PR TITLE
Use C++20 contains in membership tests

### DIFF
--- a/tests/integration/io/test_mjcf_parser.cpp
+++ b/tests/integration/io/test_mjcf_parser.cpp
@@ -117,7 +117,7 @@ public:
 
   bool exists(const common::Uri& uri) override
   {
-    return mFiles.count(uri.toString()) > 0;
+    return mFiles.contains(uri.toString());
   }
 
   common::ResourcePtr retrieve(const common::Uri& uri) override

--- a/tests/integration/io/test_sdf_parser.cpp
+++ b/tests/integration/io/test_sdf_parser.cpp
@@ -143,7 +143,7 @@ public:
 
   bool exists(const common::Uri& uri) override
   {
-    return mFiles.count(uri.toString()) > 0;
+    return mFiles.contains(uri.toString());
   }
 
   common::ResourcePtr retrieve(const common::Uri& uri) override

--- a/tests/integration/io/test_urdf_parser.cpp
+++ b/tests/integration/io/test_urdf_parser.cpp
@@ -135,7 +135,7 @@ public:
 
   bool exists(const common::Uri& uri) override
   {
-    return mFiles.count(uri.toString()) > 0;
+    return mFiles.contains(uri.toString());
   }
 
   common::ResourcePtr retrieve(const common::Uri& uri) override

--- a/tests/unit/dynamics/test_frame.cpp
+++ b/tests/unit/dynamics/test_frame.cpp
@@ -1066,8 +1066,8 @@ TEST(FrameTest, ChildFramesSets)
 
   const std::set<Frame*>& childFrames = parent->getChildFrames();
   EXPECT_EQ(childFrames.size(), 2u);
-  EXPECT_TRUE(childFrames.count(child1.get()) > 0);
-  EXPECT_TRUE(childFrames.count(child2.get()) > 0);
+  EXPECT_TRUE(childFrames.contains(child1.get()));
+  EXPECT_TRUE(childFrames.contains(child2.get()));
 
   const std::set<const Frame*> constChildFrames
       = static_cast<const Frame*>(parent.get())->getChildFrames();

--- a/tests/unit/dynamics/test_mesh_shape.cpp
+++ b/tests/unit/dynamics/test_mesh_shape.cpp
@@ -998,7 +998,7 @@ TEST(MeshShapeTest, TriMeshGetMeshPreservesMaterialIndices)
     expectedMaterialNames.insert("material_" + std::to_string(index));
   }
   for (const auto& name : usedMaterialNames) {
-    EXPECT_TRUE(expectedMaterialNames.count(name)) << materialSummary.str();
+    EXPECT_TRUE(expectedMaterialNames.contains(name)) << materialSummary.str();
   }
 
   std::error_code ec;

--- a/tests/unit/dynamics/test_skeleton_properties.cpp
+++ b/tests/unit/dynamics/test_skeleton_properties.cpp
@@ -263,7 +263,7 @@ TEST(SkeletonConfiguration, UpdatesSelectedDofs)
   }
 
   for (std::size_t i = 0; i < dofs; ++i) {
-    if (std::find(indices.begin(), indices.end(), i) == indices.end()) {
+    if (std::ranges::find(indices, i) == indices.end()) {
       EXPECT_DOUBLE_EQ(updatedPositions[i], 0.0);
       EXPECT_DOUBLE_EQ(updatedVelocities[i], 0.0);
     }

--- a/tests/unit/math/test_convhull.cpp
+++ b/tests/unit/math/test_convhull.cpp
@@ -214,7 +214,7 @@ TYPED_TEST(ConvexHullTest, CubeWithInternalPoint)
   // All 8 cube vertices should be used
   std::set<int> usedVertices(faces.begin(), faces.end());
   for (int i = 0; i < 8; ++i) {
-    EXPECT_GT(usedVertices.count(i), 0u)
+    EXPECT_TRUE(usedVertices.contains(i))
         << "Cube vertex " << i << " should be on the convex hull";
   }
 }
@@ -396,7 +396,7 @@ TYPED_TEST(ConvexHullTest, NoInternalVertices)
 
   // All 8 cube vertices must always be on the hull
   for (int i = 0; i < 8; ++i) {
-    EXPECT_GT(usedVertices.count(i), 0u)
+    EXPECT_TRUE(usedVertices.contains(i))
         << "Cube vertex " << i << " should be on the convex hull";
   }
 
@@ -404,7 +404,7 @@ TYPED_TEST(ConvexHullTest, NoInternalVertices)
   // For float precision with noise, it might rarely appear on hull due to
   // perturbation
   if (std::is_same<Scalar, double>::value) {
-    EXPECT_EQ(usedVertices.count(8), 0u)
+    EXPECT_FALSE(usedVertices.contains(8))
         << "Internal point should not be on the convex hull (double precision)";
   }
 }

--- a/tests/unit/sensor/test_sensor_manager.cpp
+++ b/tests/unit/sensor/test_sensor_manager.cpp
@@ -138,8 +138,8 @@ TEST(SensorManagerTest, RemoveAllSensors)
 
   EXPECT_EQ(manager.getNumSensors(), 0u);
   EXPECT_EQ(removed.size(), 2u);
-  EXPECT_TRUE(removed.count(sensor1) > 0);
-  EXPECT_TRUE(removed.count(sensor2) > 0);
+  EXPECT_TRUE(removed.contains(sensor1));
+  EXPECT_TRUE(removed.contains(sensor2));
 }
 
 TEST(SensorManagerTest, GetSensorByIndex)

--- a/tests/unit/simulation/test_world.cpp
+++ b/tests/unit/simulation/test_world.cpp
@@ -181,9 +181,9 @@ TEST(WorldTests, RemoveAllSkeletons)
 
   EXPECT_EQ(world->getNumSkeletons(), 0u);
   EXPECT_EQ(removed.size(), 3u);
-  EXPECT_TRUE(removed.count(skel1) > 0);
-  EXPECT_TRUE(removed.count(skel2) > 0);
-  EXPECT_TRUE(removed.count(skel3) > 0);
+  EXPECT_TRUE(removed.contains(skel1));
+  EXPECT_TRUE(removed.contains(skel2));
+  EXPECT_TRUE(removed.contains(skel3));
 }
 
 //==============================================================================
@@ -855,9 +855,9 @@ TEST(WorldTests, RemoveAllSensors)
 
   EXPECT_EQ(world->getNumSensors(), 0u);
   EXPECT_EQ(removed.size(), 3u);
-  EXPECT_TRUE(removed.count(sensor1) > 0);
-  EXPECT_TRUE(removed.count(sensor2) > 0);
-  EXPECT_TRUE(removed.count(sensor3) > 0);
+  EXPECT_TRUE(removed.contains(sensor1));
+  EXPECT_TRUE(removed.contains(sensor2));
+  EXPECT_TRUE(removed.contains(sensor3));
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Use C++20 `contains()` for associative-container membership checks in tests.
- Use `std::ranges::find` for the remaining vector membership check in skeleton configuration tests.

## Motivation / Problem

- These checks only test membership, so C++20 APIs express intent more directly than `count(...) > 0` or iterator-pair `std::find`.

## Changes / Key Changes

- Updated set/map membership checks in dynamics, math, sensor, simulation, and IO parser tests.
- Kept iterator-returning lookup patterns unchanged.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
