### PR TITLE
Use C++20 numbers for benchmark pi

### DIFF
--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -65,6 +65,7 @@
 #include <benchmark/benchmark.h>
 
 #include <atomic>
+#include <numbers>
 #include <queue>
 #include <thread>
 #include <vector>
@@ -284,7 +285,7 @@ SkeletonPtr makeStar(int N, const std::string& prefix = "star")
     auto [cj, cb] = skel->createJointAndBodyNodePair<JointType>(
         rootBody, cjprops, cbprops);
 
-    const double angle = 2.0 * M_PI * i / (N - 1);
+    const double angle = 2.0 * std::numbers::pi_v<double> * i / (N - 1);
     cj->setTransformFromParentBodyNode(
         Eigen::Isometry3d(
             Eigen::Translation3d(


### PR DESCRIPTION
## Summary

- Replace the dynamics cache benchmark's `M_PI` use with the standard C++20 `std::numbers::pi_v<double>` constant.

## Motivation / Problem

- `M_PI` is a non-standard macro, while DART now builds as C++20 and can use the standard library's numeric constants directly.

## Changes / Key Changes

- Include `<numbers>` in `tests/benchmark/dynamics/bm_dynamics_cache.cpp`.
- Use `std::numbers::pi_v<double>` when generating the star benchmark angles.

## Testing

- `pixi run lint`
- `pixi run bash -lc 'BUILD_TYPE=Release CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/${BUILD_TYPE} python scripts/cmake_build.py --target bm_dynamics_cache'`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
