### PR TITLE
Use C++20 ranges transform for string cleanup

### DIFF
--- a/dart/common/string.cpp
+++ b/dart/common/string.cpp
@@ -46,7 +46,7 @@ std::string toUpper(std::string str)
 //==============================================================================
 void toUpperInPlace(std::string& str)
 {
-  std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+  std::ranges::transform(str, str.begin(), ::toupper);
 }
 
 //==============================================================================
@@ -59,7 +59,7 @@ std::string toLower(std::string str)
 //==============================================================================
 void toLowerInPlace(std::string& str)
 {
-  std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+  std::ranges::transform(str, str.begin(), ::tolower);
 }
 
 //==============================================================================

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -1552,8 +1552,7 @@ bool hasColladaExtension(std::string_view path)
   }
 
   std::string extension(path.substr(extensionIndex));
-  std::transform(
-      extension.begin(), extension.end(), extension.begin(), ::tolower);
+  std::ranges::transform(extension, extension.begin(), ::tolower);
   return extension == ".dae" || extension == ".zae";
 }
 

--- a/dart/utils/sdf/detail/sdf_helpers.cpp
+++ b/dart/utils/sdf/detail/sdf_helpers.cpp
@@ -34,6 +34,8 @@
 
 #include <dart/common/uri.hpp>
 
+#include <algorithm>
+
 #include <cmath>
 
 #if __has_include(<gz/math/Quaternion.hh>)
@@ -62,10 +64,9 @@ double sanitizeParsedValue(double value)
 std::string toLowerCopy(std::string_view text)
 {
   std::string lower(text);
-  std::transform(
-      lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
-        return static_cast<char>(std::tolower(c));
-      });
+  std::ranges::transform(lower, lower.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
   return lower;
 }
 

--- a/examples/lcp_physics/main.cpp
+++ b/examples/lcp_physics/main.cpp
@@ -817,11 +817,9 @@ int parseScenario(const std::string& name)
   auto scenarios = GetScenarios();
   for (int i = 0; i < static_cast<int>(scenarios.size()); ++i) {
     std::string lowerName = scenarios[i].name;
-    std::transform(
-        lowerName.begin(), lowerName.end(), lowerName.begin(), ::tolower);
+    std::ranges::transform(lowerName, lowerName.begin(), ::tolower);
     std::string lowerInput = name;
-    std::transform(
-        lowerInput.begin(), lowerInput.end(), lowerInput.begin(), ::tolower);
+    std::ranges::transform(lowerInput, lowerInput.begin(), ::tolower);
     if (lowerName.find(lowerInput) != std::string::npos) {
       return i;
     }
@@ -834,11 +832,9 @@ int parseSolver(const std::string& name)
   auto solvers = GetSolvers();
   for (int i = 0; i < static_cast<int>(solvers.size()); ++i) {
     std::string lowerName = solvers[i].name;
-    std::transform(
-        lowerName.begin(), lowerName.end(), lowerName.begin(), ::tolower);
+    std::ranges::transform(lowerName, lowerName.begin(), ::tolower);
     std::string lowerInput = name;
-    std::transform(
-        lowerInput.begin(), lowerInput.end(), lowerInput.begin(), ::tolower);
+    std::ranges::transform(lowerInput, lowerInput.begin(), ::tolower);
     if (lowerName.find(lowerInput) != std::string::npos) {
       return i;
     }


### PR DESCRIPTION
## Summary

- Use C++20 `std::ranges::transform` for behavior-preserving string case cleanup.

## Motivation / Problem

- DART 7 requires C++20, and these call sites can be expressed directly as ranges algorithms instead of iterator-pair transforms.

## Changes / Key Changes

- Updated common string case helpers to use `std::ranges::transform`.
- Updated Collada extension normalization, SDF lower-copy helper, and LCP example argument parsing to use ranges transforms.
- Added a direct `<algorithm>` include in the SDF helper implementation for ranges algorithm use.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
