### PR TITLE
Use C++20 ranges in SIMD dynamic helpers

### DIFF
--- a/dart/simd/dynamic/matrix.hpp
+++ b/dart/simd/dynamic/matrix.hpp
@@ -39,6 +39,8 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
+
 namespace dart::simd {
 
 template <typename T>
@@ -110,7 +112,7 @@ public:
 
   void setZero()
   {
-    std::fill(data_.begin(), data_.end(), T(0));
+    std::ranges::fill(data_, T(0));
   }
 
   void setIdentity()
@@ -291,7 +293,7 @@ public:
   {
     DynamicMatrix result(
         static_cast<std::size_t>(m.rows()), static_cast<std::size_t>(m.cols()));
-    std::copy(m.data(), m.data() + m.size(), result.data_.data());
+    std::ranges::copy_n(m.data(), m.size(), result.data_.data());
     return result;
   }
 };

--- a/dart/simd/dynamic/vector.hpp
+++ b/dart/simd/dynamic/vector.hpp
@@ -38,6 +38,7 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
 #include <initializer_list>
 #include <numeric>
 
@@ -269,7 +270,7 @@ public:
   [[nodiscard]] static DynamicVector fromEigen(const Eigen::VectorX<T>& v)
   {
     DynamicVector result(static_cast<std::size_t>(v.size()));
-    std::copy(v.data(), v.data() + v.size(), result.data_.data());
+    std::ranges::copy_n(v.data(), v.size(), result.data_.data());
     return result;
   }
 };


### PR DESCRIPTION
## Summary

- Use C++20 ranges algorithms in the SIMD dynamic vector/matrix helpers.

## Motivation / Problem

- DART 7 uses C++20, so small container-wide algorithm calls can use ranges forms directly and avoid repeated iterator-pair spelling.

## Changes / Key Changes

- Added direct `<algorithm>` includes for the dynamic SIMD helper headers.
- Replaced `std::fill(begin, end, value)` with `std::ranges::fill` for dynamic matrix zeroing.
- Replaced Eigen-data pointer-pair `std::copy` calls with `std::ranges::copy_n` in `fromEigen()` helpers.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
