### PR TITLE
Use C++20 ranges reverse in linkage

### DIFF
--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -346,7 +346,7 @@ void Linkage::Criteria::expandToTarget(
     trimBodyNodes(newBns, _target.mChain, true);
   } else if (target_bn->descendsFrom(start_bn)) {
     newBns = climbToTarget(target_bn, start_bn);
-    std::reverse(newBns.begin(), newBns.end());
+    std::ranges::reverse(newBns);
     trimBodyNodes(newBns, _target.mChain, false);
   } else {
     newBns = climbToCommonRoot(_start, _target, _target.mChain);
@@ -416,7 +416,7 @@ std::vector<BodyNode*> Linkage::Criteria::climbToCommonRoot(
   }
 
   std::vector<BodyNode*> bnTarget = climbToTarget(target_bn, root);
-  std::reverse(bnTarget.begin(), bnTarget.end());
+  std::ranges::reverse(bnTarget);
   trimBodyNodes(bnTarget, _chain, false);
 
   std::vector<BodyNode*> bnAll;


### PR DESCRIPTION
## Summary

- Use C++20 `std::ranges::reverse` in linkage body-node path handling.

## Motivation / Problem

- DART 7 uses C++20, so container-wide reverse calls can use the range algorithm form instead of spelling begin/end pairs.

## Changes / Key Changes

- Replaced two iterator-pair `std::reverse` calls in `Linkage::Criteria` with `std::ranges::reverse`.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
