### PR TITLE
Adopt C++20 math and string utilities

### DIFF
--- a/dart/collision/dart/dart_collide.cpp
+++ b/dart/collision/dart/dart_collide.cpp
@@ -41,6 +41,7 @@
 #include "dart/math/helpers.hpp"
 
 #include <memory>
+#include <numeric>
 
 namespace dart {
 namespace collision {
@@ -144,8 +145,8 @@ DART_API void cullPoints(int n, double p[], int m, int i0, int iret[])
     cx = p[0];
     cy = p[1];
   } else if (n == 2) {
-    cx = 0.5 * (p[0] + p[2]);
-    cy = 0.5 * (p[1] + p[3]);
+    cx = std::midpoint(p[0], p[2]);
+    cy = std::midpoint(p[1], p[3]);
   } else {
     a = 0;
     cx = 0;
@@ -709,8 +710,8 @@ int dBoxBox(
     }
 
     {
-      point_vec << 0.5 * (pa[0] + pb[0]), 0.5 * (pa[1] + pb[1]),
-          0.5 * (pa[2] + pb[2]);
+      point_vec << std::midpoint(pa[0], pb[0]), std::midpoint(pa[1], pb[1]),
+          std::midpoint(pa[2], pb[2]);
       penetration = -s;
 
       Contact contact;

--- a/dart/dynamics/inverse_kinematics.cpp
+++ b/dart/dynamics/inverse_kinematics.cpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <numeric>
 #include <unordered_map>
 
 namespace dart {
@@ -524,7 +525,7 @@ Eigen::Vector6d InverseKinematics::TaskSpaceRegion::computeError()
     if (displacement[i] < min[i]) {
       if (mTaskSpaceP.mComputeErrorFromCenter) {
         if (std::isfinite(max[i])) {
-          error[i] = displacement[i] - (min[i] + max[i]) / 2.0;
+          error[i] = displacement[i] - std::midpoint(min[i], max[i]);
         } else {
           error[i] = displacement[i] - (min[i] + tolerance);
         }
@@ -534,7 +535,7 @@ Eigen::Vector6d InverseKinematics::TaskSpaceRegion::computeError()
     } else if (max[i] < displacement[i]) {
       if (mTaskSpaceP.mComputeErrorFromCenter) {
         if (std::isfinite(min[i])) {
-          error[i] = displacement[i] - (min[i] + max[i]) / 2.0;
+          error[i] = displacement[i] - std::midpoint(min[i], max[i]);
         } else {
           error[i] = displacement[i] - (max[i] - tolerance);
         }

--- a/dart/math/constants.hpp
+++ b/dart/math/constants.hpp
@@ -33,36 +33,19 @@
 #ifndef DART_MATH_CONSTANTS_HPP_
 #define DART_MATH_CONSTANTS_HPP_
 
-#include <limits>
-
-#if defined(__has_include)
-  #if __has_include(<numbers>)
-    #include <numbers>
-    #if defined(__cpp_lib_math_constants) && __cpp_lib_math_constants >= 201907L
-      #define DART_MATH_HAS_STD_NUMBERS 1
-    #endif
-  #endif
-#endif
-
-#ifndef DART_MATH_HAS_STD_NUMBERS
-  #define DART_MATH_HAS_STD_NUMBERS 0
-#endif
-
 #include "dart/common/deprecated.hpp"
 #include "dart/common/diagnostics.hpp"
+
+#include <limits>
+#include <numbers>
 
 namespace dart {
 namespace math {
 
 namespace detail {
 
-#if DART_MATH_HAS_STD_NUMBERS
 inline constexpr long double pi_ld = std::numbers::pi_v<long double>;
 inline constexpr long double phi_ld = std::numbers::phi_v<long double>;
-#else
-inline constexpr long double pi_ld = 3.141592653589793238462643383279502884L;
-inline constexpr long double phi_ld = 1.618033988749894848204586834365638118L;
-#endif
 
 inline constexpr long double two_pi_ld = 2.0L * pi_ld;
 inline constexpr long double half_pi_ld = 0.5L * pi_ld;
@@ -172,7 +155,5 @@ DART_SUPPRESS_DEPRECATED_END
 
 } // namespace math
 } // namespace dart
-
-#undef DART_MATH_HAS_STD_NUMBERS
 
 #endif // DART_MATH_CONSTANTS_HPP_

--- a/dart/math/geometry.cpp
+++ b/dart/math/geometry.cpp
@@ -591,9 +591,12 @@ Eigen::Vector6d logMap(const Eigen::Isometry3d& _T)
   Eigen::Vector6d ret;
 
   if (theta > pi - DART_EPSILON) {
-    const double c1 = 0.10132118364234; // 1 / pi^2
-    const double c2 = 0.01507440267955; // 1 / 4 / pi - 2 / pi^3
-    const double c3 = 0.00546765085347; // 3 / pi^4 - 1 / 4 / pi^2
+    constexpr double invPi = 1.0 / pi;
+    constexpr double invPiSquared = invPi * invPi;
+    constexpr double c1 = invPiSquared;
+    constexpr double c2 = 0.25 * invPi - 2.0 * invPiSquared * invPi;
+    constexpr double c3
+        = 3.0 * invPiSquared * invPiSquared - 0.25 * invPiSquared;
 
     double phi = pi - theta;
     double delta = 0.5 + 0.125 * phi * phi;

--- a/dart/simd/detail/math/constants.hpp
+++ b/dart/simd/detail/math/constants.hpp
@@ -35,6 +35,7 @@
 #include <dart/simd/config.hpp>
 
 #include <limits>
+#include <numbers>
 #include <type_traits>
 
 namespace dart::simd {
@@ -65,28 +66,28 @@ struct MathConstants
       "MathConstants requires floating point type");
 
   // Pi and related constants
-  static constexpr T pi = T(3.14159265358979323846264338327950288);
-  static constexpr T twoPi = T(6.28318530717958647692528676655900577);
-  static constexpr T halfPi = T(1.57079632679489661923132169163975144);
-  static constexpr T quarterPi = T(0.78539816339744830961566084581987572);
-  static constexpr T invPi = T(0.31830988618379067153776752674502872);
-  static constexpr T invTwoPi = T(0.15915494309189533576888376337251436);
-  static constexpr T twoOverPi = T(0.63661977236758134307553505349005745);
-  static constexpr T fourOverPi = T(1.27323954473516268615107010698011489);
+  static constexpr T pi = std::numbers::pi_v<T>;
+  static constexpr T twoPi = T(2) * std::numbers::pi_v<T>;
+  static constexpr T halfPi = std::numbers::pi_v<T> / T(2);
+  static constexpr T quarterPi = std::numbers::pi_v<T> / T(4);
+  static constexpr T invPi = std::numbers::inv_pi_v<T>;
+  static constexpr T invTwoPi = std::numbers::inv_pi_v<T> / T(2);
+  static constexpr T twoOverPi = T(2) * std::numbers::inv_pi_v<T>;
+  static constexpr T fourOverPi = T(4) * std::numbers::inv_pi_v<T>;
 
   // e and related constants
-  static constexpr T e = T(2.71828182845904523536028747135266250);
-  static constexpr T log2E = T(1.44269504088896340735992468100189214);
-  static constexpr T log10E = T(0.43429448190325182765112891891660508);
-  static constexpr T ln2 = T(0.69314718055994530941723212145817657);
-  static constexpr T ln10 = T(2.30258509299404568401799145468436421);
-  static constexpr T invLn2 = T(1.44269504088896340735992468100189214);
+  static constexpr T e = std::numbers::e_v<T>;
+  static constexpr T log2E = std::numbers::log2e_v<T>;
+  static constexpr T log10E = std::numbers::log10e_v<T>;
+  static constexpr T ln2 = std::numbers::ln2_v<T>;
+  static constexpr T ln10 = std::numbers::ln10_v<T>;
+  static constexpr T invLn2 = std::numbers::log2e_v<T>;
 
   // Square roots
-  static constexpr T sqrt2 = T(1.41421356237309504880168872420969808);
-  static constexpr T invSqrt2 = T(0.70710678118654752440084436210484904);
+  static constexpr T sqrt2 = std::numbers::sqrt2_v<T>;
+  static constexpr T invSqrt2 = T(1) / std::numbers::sqrt2_v<T>;
   static constexpr T sqrtPi = T(1.77245385090551602729816748334114518);
-  static constexpr T invSqrtPi = T(0.56418958354775628694807945156077259);
+  static constexpr T invSqrtPi = std::numbers::inv_sqrtpi_v<T>;
   static constexpr T sqrt2Pi = T(2.50662827463100050241576528481104525);
 
   // Special values

--- a/dart/utils/http_resource_retriever.cpp
+++ b/dart/utils/http_resource_retriever.cpp
@@ -39,6 +39,7 @@
 #include <iomanip>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
@@ -255,11 +256,8 @@ std::filesystem::path HttpResourceRetriever::buildCachePath(
   // Drop fragments when building the cache key.
   if (uri.mFragment) {
     const auto fragment = "#" + uri.mFragment.get_value_or("");
-    if (!fragment.empty() && url.size() >= fragment.size()) {
-      if (url.compare(url.size() - fragment.size(), fragment.size(), fragment)
-          == 0) {
-        url.erase(url.size() - fragment.size());
-      }
+    if (!fragment.empty() && url.ends_with(fragment)) {
+      url.erase(url.size() - fragment.size());
     }
   }
 

--- a/dart/utils/sdf/sdf_parser.cpp
+++ b/dart/utils/sdf/sdf_parser.cpp
@@ -73,6 +73,7 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <numeric>
 #include <span>
 #include <sstream>
 #include <stdexcept>
@@ -1773,7 +1774,7 @@ static bool readAxisElement(
   // position instead of assuming zero
   if (0.0 < lower || upper < 0.0) {
     if (std::isfinite(lower) && std::isfinite(upper)) {
-      initial = (lower + upper) / 2.0;
+      initial = std::midpoint(lower, upper);
     } else if (std::isfinite(lower)) {
       initial = lower;
     } else if (std::isfinite(upper)) {

--- a/dart/utils/urdf/urdf_parser.cpp
+++ b/dart/utils/urdf/urdf_parser.cpp
@@ -58,6 +58,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <numeric>
 #include <unordered_map>
 
 #include <cmath>
@@ -673,7 +674,7 @@ dynamics::BodyNode* UrdfParser::createDartJointAndNode(
       if (std::isfinite(_jt->limits->lower)
           && std::isfinite(_jt->limits->upper)) {
         singleDof.mInitialPositions[0]
-            = (_jt->limits->lower + _jt->limits->upper) / 2.0;
+            = std::midpoint(_jt->limits->lower, _jt->limits->upper);
       } else if (std::isfinite(_jt->limits->lower)) {
         singleDof.mInitialPositions[0] = _jt->limits->lower;
       } else if (std::isfinite(_jt->limits->upper)) {
@@ -759,7 +760,7 @@ dynamics::BodyNode* UrdfParser::createDartJointAndNode(
           if (std::isfinite(_jt->limits->lower)
               && std::isfinite(_jt->limits->upper)) {
             properties.mInitialPositions.setConstant(
-                (_jt->limits->lower + _jt->limits->upper) / 2.0);
+                std::midpoint(_jt->limits->lower, _jt->limits->upper));
           } else if (std::isfinite(_jt->limits->lower)) {
             properties.mInitialPositions.setConstant(_jt->limits->lower);
           } else if (std::isfinite(_jt->limits->upper)) {
@@ -819,7 +820,7 @@ dynamics::BodyNode* UrdfParser::createDartJointAndNode(
           if (std::isfinite(_jt->limits->lower)
               && std::isfinite(_jt->limits->upper)) {
             properties.mInitialPositions.setConstant(
-                (_jt->limits->lower + _jt->limits->upper) / 2.0);
+                std::midpoint(_jt->limits->lower, _jt->limits->upper));
           } else if (std::isfinite(_jt->limits->lower)) {
             properties.mInitialPositions.setConstant(_jt->limits->lower);
           } else if (std::isfinite(_jt->limits->upper)) {

--- a/examples/rigid_loop/main.cpp
+++ b/examples/rigid_loop/main.cpp
@@ -93,10 +93,10 @@ int main()
 
   Eigen::VectorXd initPose(dof);
   initPose.setZero();
-  initPose[20] = 3.14159 * 0.4;
-  initPose[23] = 3.14159 * 0.4;
-  initPose[26] = 3.14159 * 0.4;
-  initPose[29] = 3.14159 * 0.4;
+  initPose[20] = 0.4 * pi;
+  initPose[23] = 0.4 * pi;
+  initPose[26] = 0.4 * pi;
+  initPose[29] = 0.4 * pi;
   myWorld->getSkeleton(0)->setPositions(initPose);
 
   // create a ball joint constraint

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
@@ -42,6 +42,8 @@
 #include <dart/dynamics/simple_frame.hpp>
 #include <dart/dynamics/sphere_shape.hpp>
 
+#include <dart/math/constants.hpp>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>
@@ -96,7 +98,7 @@ const Eigen::Vector3d kContainerEllipsoidRadii(2.0, 1.5, 1.0);
 const double kContainerCylinderRadius = 2.0;
 const double kContainerCylinderHeight = 4.0;
 const double kContainmentOffset = 0.2;
-const double kYawQuarterTurn = 0.25 * 3.141592653589793;
+const double kYawQuarterTurn = 0.25 * dart::math::pi;
 
 const std::vector<ShapeSpec> kShapeSpecs = {
     {ShapeKind::Box, "box"},

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
@@ -30,6 +30,8 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <dart/math/constants.hpp>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <fcl/fcl.h>
@@ -85,7 +87,7 @@ const Eigen::Vector3d kContainerEllipsoidRadii(2.0, 1.5, 1.0);
 constexpr double kContainerCylinderRadius = 2.0;
 constexpr double kContainerCylinderHeight = 4.0;
 constexpr double kContainmentOffset = 0.2;
-constexpr double kYawQuarterTurn = 0.25 * 3.141592653589793;
+constexpr double kYawQuarterTurn = 0.25 * dart::math::pi;
 
 const std::vector<ShapeSpec> kShapeSpecs = {
     {ShapeKind::Box, "box"},

--- a/tests/integration/dynamics/test_joints.cpp
+++ b/tests/integration/dynamics/test_joints.cpp
@@ -60,6 +60,7 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <numeric>
 
 using namespace dart;
 using namespace dart::math;
@@ -470,7 +471,7 @@ void testCommandLimits(dynamics::Joint* joint)
 {
   const double lower = -5.0;
   const double upper = +5.0;
-  const double mid = 0.5 * (lower + upper);
+  const double mid = std::midpoint(lower, upper);
   const double lessThanLower = -10.0;
   const double greaterThanUpper = +10.0;
 

--- a/tests/integration/simulation/test_world.cpp
+++ b/tests/integration/simulation/test_world.cpp
@@ -707,10 +707,10 @@ simulation::WorldPtr createWorld()
 
   const auto dof = world->getSkeleton(0)->getNumDofs();
   Eigen::VectorXd initPose = Eigen::VectorXd::Zero(static_cast<int>(dof));
-  initPose[20] = 3.14159 * 0.4;
-  initPose[23] = 3.14159 * 0.4;
-  initPose[26] = 3.14159 * 0.4;
-  initPose[29] = 3.14159 * 0.4;
+  initPose[20] = 0.4 * dart::math::pi;
+  initPose[23] = 0.4 * dart::math::pi;
+  initPose[26] = 0.4 * dart::math::pi;
+  initPose[29] = 0.4 * dart::math::pi;
   world->getSkeleton(0)->setPositions(initPose);
 
   // Create a ball joint constraint
@@ -739,10 +739,10 @@ simulation::WorldPtr createWorldWithRevoluteConstraint()
 
   const auto dof = world->getSkeleton(0)->getNumDofs();
   Eigen::VectorXd initPose = Eigen::VectorXd::Zero(static_cast<int>(dof));
-  initPose[20] = 3.14159 * 0.4;
-  initPose[23] = 3.14159 * 0.4;
-  initPose[26] = 3.14159 * 0.4;
-  initPose[29] = 3.14159 * 0.4;
+  initPose[20] = 0.4 * dart::math::pi;
+  initPose[23] = 0.4 * dart::math::pi;
+  initPose[26] = 0.4 * dart::math::pi;
+  initPose[29] = 0.4 * dart::math::pi;
   world->getSkeleton(0)->setPositions(initPose);
 
   BodyNode* bd1 = world->getSkeleton(0)->getBodyNode("link 6");

--- a/tests/unit/collision/test_convex_mesh_shape_collision.cpp
+++ b/tests/unit/collision/test_convex_mesh_shape_collision.cpp
@@ -39,6 +39,7 @@
 #include "dart/dynamics/free_joint.hpp"
 #include "dart/dynamics/simple_frame.hpp"
 #include "dart/dynamics/skeleton.hpp"
+#include "dart/math/constants.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -72,7 +73,7 @@ using dart::dynamics::ConvexMeshShape;
 
 namespace {
 
-constexpr double kPi = 3.141592653589793;
+constexpr double kPi = dart::math::pi;
 
 struct TestFCLDetector : public FCLCollisionDetector
 {

--- a/tests/unit/constraint/test_constraint_solver.cpp
+++ b/tests/unit/constraint/test_constraint_solver.cpp
@@ -15,6 +15,7 @@
 
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <type_traits>
 #include <vector>
 
@@ -1213,7 +1214,8 @@ void setFrictionCoefficients(
       }
       dynamicsAspect->setPrimaryFrictionCoeff(primaryCoeff);
       dynamicsAspect->setSecondaryFrictionCoeff(secondaryCoeff);
-      dynamicsAspect->setFrictionCoeff(0.5 * (primaryCoeff + secondaryCoeff));
+      dynamicsAspect->setFrictionCoeff(
+          std::midpoint(primaryCoeff, secondaryCoeff));
     }
   }
 }

--- a/tests/unit/utils/test_http_resource_retriever.cpp
+++ b/tests/unit/utils/test_http_resource_retriever.cpp
@@ -66,11 +66,8 @@ std::filesystem::path computeCachePath(
   std::string url = uri.toString();
   if (uri.mFragment) {
     const auto fragment = "#" + uri.mFragment.get_value_or("");
-    if (!fragment.empty() && url.size() >= fragment.size()) {
-      if (url.compare(url.size() - fragment.size(), fragment.size(), fragment)
-          == 0) {
-        url.erase(url.size() - fragment.size());
-      }
+    if (!fragment.empty() && url.ends_with(fragment)) {
+      url.erase(url.size() - fragment.size());
     }
   }
 

--- a/tutorials/tutorial_wholebody_ik_finished/main.cpp
+++ b/tutorials/tutorial_wholebody_ik_finished/main.cpp
@@ -87,17 +87,15 @@ public:
 
   void resetToStandingPose()
   {
+    constexpr double degToRad = pi / 180.0;
+
     // Reset to standing configuration
-    mRobot->getDof("r_leg_hpy")
-        ->setPosition(-45.0 * constantsd::pi() / 180.0);
-    mRobot->getDof("r_leg_kny")->setPosition(90.0 * constantsd::pi() / 180.0);
-    mRobot->getDof("r_leg_aky")
-        ->setPosition(-45.0 * constantsd::pi() / 180.0);
-    mRobot->getDof("l_leg_hpy")
-        ->setPosition(-45.0 * constantsd::pi() / 180.0);
-    mRobot->getDof("l_leg_kny")->setPosition(90.0 * constantsd::pi() / 180.0);
-    mRobot->getDof("l_leg_aky")
-        ->setPosition(-45.0 * constantsd::pi() / 180.0);
+    mRobot->getDof("r_leg_hpy")->setPosition(-45.0 * degToRad);
+    mRobot->getDof("r_leg_kny")->setPosition(90.0 * degToRad);
+    mRobot->getDof("r_leg_aky")->setPosition(-45.0 * degToRad);
+    mRobot->getDof("l_leg_hpy")->setPosition(-45.0 * degToRad);
+    mRobot->getDof("l_leg_kny")->setPosition(90.0 * degToRad);
+    mRobot->getDof("l_leg_aky")->setPosition(-45.0 * degToRad);
 
     std::cout << "Reset to standing pose" << std::endl;
   }
@@ -138,16 +136,17 @@ SkeletonPtr loadAtlasRobot()
   }
 
   // Set up initial standing pose
-  atlas->getDof("r_leg_hpy")->setPosition(-45.0 * constantsd::pi() / 180.0);
-  atlas->getDof("r_leg_kny")->setPosition(90.0 * constantsd::pi() / 180.0);
-  atlas->getDof("r_leg_aky")->setPosition(-45.0 * constantsd::pi() / 180.0);
-  atlas->getDof("l_leg_hpy")->setPosition(-45.0 * constantsd::pi() / 180.0);
-  atlas->getDof("l_leg_kny")->setPosition(90.0 * constantsd::pi() / 180.0);
-  atlas->getDof("l_leg_aky")->setPosition(-45.0 * constantsd::pi() / 180.0);
+  constexpr double degToRad = pi / 180.0;
+  atlas->getDof("r_leg_hpy")->setPosition(-45.0 * degToRad);
+  atlas->getDof("r_leg_kny")->setPosition(90.0 * degToRad);
+  atlas->getDof("r_leg_aky")->setPosition(-45.0 * degToRad);
+  atlas->getDof("l_leg_hpy")->setPosition(-45.0 * degToRad);
+  atlas->getDof("l_leg_kny")->setPosition(90.0 * degToRad);
+  atlas->getDof("l_leg_aky")->setPosition(-45.0 * degToRad);
 
   // Prevent knees from bending backwards
-  atlas->getDof("r_leg_kny")->setPositionLowerLimit(10.0 * constantsd::pi() / 180.0);
-  atlas->getDof("l_leg_kny")->setPositionLowerLimit(10.0 * constantsd::pi() / 180.0);
+  atlas->getDof("r_leg_kny")->setPositionLowerLimit(10.0 * degToRad);
+  atlas->getDof("l_leg_kny")->setPositionLowerLimit(10.0 * degToRad);
 
   return atlas;
 }
@@ -272,8 +271,7 @@ void runHeadlessDemo(
             << " samples..." << std::endl;
   for (std::size_t i = 0; i < steps; ++i) {
     const double phase
-        = static_cast<double>(i) / static_cast<double>(steps)
-          * 2.0 * constantsd::pi();
+        = static_cast<double>(i) / static_cast<double>(steps) * two_pi;
     Eigen::Vector3d leftOffset(
         radius * std::cos(phase), 0.0, radius * std::sin(phase));
     Eigen::Vector3d rightOffset(
@@ -392,9 +390,9 @@ int main()
     const std::string arg = argv[i];
     if (arg == "--headless") {
       headless = true;
-    } else if (arg.rfind("--steps=", 0) == 0) {
+    } else if (arg.starts_with("--steps=")) {
       headlessSteps = std::stoul(arg.substr(8));
-    } else if (arg.rfind("--radius=", 0) == 0) {
+    } else if (arg.starts_with("--radius=")) {
       trajectoryRadius = std::stod(arg.substr(9));
     }
   }


### PR DESCRIPTION
## Description
- use C++20 `std::numbers` for standard math constants and derive remaining thresholds from those constants
- replace ad hoc prefix/suffix checks with C++20 string APIs
- use `std::midpoint` for scalar midpoint/centering calculations in collision, IK, and parser defaults

## Testing
- pixi run test-all