### PR TITLE
Address CodeQL alerts and add PR workflow

### DIFF
--- a/.claude/commands/dart-pr.md
+++ b/.claude/commands/dart-pr.md
@@ -1,0 +1,85 @@
+---
+description: create a branch, commit, push, and open a DART pull request
+agent: build
+---
+
+Prepare or open a DART pull request: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ai-tools.md
+@.github/PULL_REQUEST_TEMPLATE.md
+
+## Recent PR Patterns
+
+When the expected PR style is unclear, inspect recently merged PRs before
+drafting the title or body:
+
+```bash
+gh pr list --repo dartsim/dart --state merged --base main --limit 10 \
+  --json number,title,body,mergedAt
+```
+
+Use these practices:
+
+- Keep titles plain, scoped, and outcome-focused. Do not add agent prefixes.
+- Fill the PR template with concrete Summary, Motivation, Changes, Testing,
+  Breaking Changes, and Related Issues details.
+- In Testing, list exact commands, targets, or test names that ran.
+- For CI, performance, or infrastructure work, include evidence such as CI run
+  observations, timing, reruns, benchmark output, or why a skipped check is
+  expected.
+- Mark non-applicable checklist items as "N/A" with a short reason.
+- Mention related PRs, issues, backports, and follow-ups explicitly, including
+  "None" when there is no related work.
+
+## Workflow
+
+1. Inspect scope:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   ```
+2. Exclude unrelated dirty files unless the user explicitly includes them.
+3. Choose the target branch and milestone:
+
+   | Target         | Milestone     |
+   | -------------- | ------------- |
+   | `main`         | `DART 7.0`    |
+   | `release-6.16` | `DART 6.16.x` |
+
+4. For bug fixes, use the dual-PR flow: fix `release-6.16` first, then
+   cherry-pick or reapply to `main`.
+5. Before every commit, run:
+   ```bash
+   pixi run lint
+   ```
+   Also run `pixi run build` for C++ or Python changes and focused tests for
+   behavior changes.
+6. Create or update a topic branch when needed:
+   ```bash
+   git checkout -b <type>/<topic> origin/<target-branch>
+   ```
+7. Commit only intended files with a plain descriptive commit title.
+8. Push and open a draft PR:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --draft --base <target-branch> --milestone "<milestone>" \
+     --title "<plain title>" --body-file <filled-template-file>
+   ```
+9. If `CHANGELOG.md` needs the PR number, add the changelog entry in a
+   follow-up commit after opening the draft PR.
+10. Monitor CI:
+    ```bash
+    gh pr checks <PR_NUMBER>
+    ```
+
+## AI Review Comments
+
+Never reply to AI-generated review comments from bot users such as
+`chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
+Push fixes silently and ask for a new AI review with `@codex review` only when
+needed.

--- a/.codex/skills/dart-pr/SKILL.md
+++ b/.codex/skills/dart-pr/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: dart-pr
+description: "DART PR: create a branch, commit, push, and open a DART pull request"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-pr
+
+Use this skill in Codex when you want the same workflow that Claude Code and
+OpenCode expose as `/dart-pr`.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-pr <arguments>`
+- Codex: `$dart-pr <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Prepare or open a DART pull request: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ai-tools.md
+@.github/PULL_REQUEST_TEMPLATE.md
+
+## Recent PR Patterns
+
+When the expected PR style is unclear, inspect recently merged PRs before
+drafting the title or body:
+
+```bash
+gh pr list --repo dartsim/dart --state merged --base main --limit 10 \
+  --json number,title,body,mergedAt
+```
+
+Use these practices:
+
+- Keep titles plain, scoped, and outcome-focused. Do not add agent prefixes.
+- Fill the PR template with concrete Summary, Motivation, Changes, Testing,
+  Breaking Changes, and Related Issues details.
+- In Testing, list exact commands, targets, or test names that ran.
+- For CI, performance, or infrastructure work, include evidence such as CI run
+  observations, timing, reruns, benchmark output, or why a skipped check is
+  expected.
+- Mark non-applicable checklist items as "N/A" with a short reason.
+- Mention related PRs, issues, backports, and follow-ups explicitly, including
+  "None" when there is no related work.
+
+## Workflow
+
+1. Inspect scope:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   ```
+2. Exclude unrelated dirty files unless the user explicitly includes them.
+3. Choose the target branch and milestone:
+
+   | Target         | Milestone     |
+   | -------------- | ------------- |
+   | `main`         | `DART 7.0`    |
+   | `release-6.16` | `DART 6.16.x` |
+
+4. For bug fixes, use the dual-PR flow: fix `release-6.16` first, then
+   cherry-pick or reapply to `main`.
+5. Before every commit, run:
+   ```bash
+   pixi run lint
+   ```
+   Also run `pixi run build` for C++ or Python changes and focused tests for
+   behavior changes.
+6. Create or update a topic branch when needed:
+   ```bash
+   git checkout -b <type>/<topic> origin/<target-branch>
+   ```
+7. Commit only intended files with a plain descriptive commit title.
+8. Push and open a draft PR:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --draft --base <target-branch> --milestone "<milestone>" \
+     --title "<plain title>" --body-file <filled-template-file>
+   ```
+9. If `CHANGELOG.md` needs the PR number, add the changelog entry in a
+   follow-up commit after opening the draft PR.
+10. Monitor CI:
+    ```bash
+    gh pr checks <PR_NUMBER>
+    ```
+
+## AI Review Comments
+
+Never reply to AI-generated review comments from bot users such as
+`chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
+Push fixes silently and ask for a new AI review with `@codex review` only when
+needed.

--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -2,6 +2,8 @@
 #
 # Limit CodeQL analysis to first-party sources and ignore vendored or generated
 # content that lives under build artifacts or virtual environments.
+# C++ manual-build SARIF can still include dependency headers; codeql.yml filters
+# those external findings before upload.
 
 name: dart-codeql-config
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,3 +96,37 @@ jobs:
 
       - name: CodeQL Analyze
         uses: github/codeql-action/analyze@v4
+        with:
+          output: sarif-results
+          upload: failure-only
+
+      - name: Filter external dependency alerts
+        run: |
+          shopt -s nullglob
+          sarif_files=(sarif-results/*.sarif)
+
+          if (( ${#sarif_files[@]} == 0 )); then
+            echo "No CodeQL SARIF files found." >&2
+            exit 1
+          fi
+
+          for sarif in "${sarif_files[@]}"; do
+            tmp="${sarif}.tmp"
+            jq '
+              (.runs[]?.results) |= map(
+                select(
+                  (
+                    .locations[0].physicalLocation.artifactLocation.uri // ""
+                    | startswith(".pixi/")
+                  )
+                  | not
+                )
+              )
+            ' "$sarif" > "$tmp"
+            mv "$tmp" "$sarif"
+          done
+
+      - name: Upload filtered CodeQL results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-results

--- a/.opencode/command/dart-pr.md
+++ b/.opencode/command/dart-pr.md
@@ -1,0 +1,89 @@
+---
+description: create a branch, commit, push, and open a DART pull request
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Prepare or open a DART pull request: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ai-tools.md
+@.github/PULL_REQUEST_TEMPLATE.md
+
+## Recent PR Patterns
+
+When the expected PR style is unclear, inspect recently merged PRs before
+drafting the title or body:
+
+```bash
+gh pr list --repo dartsim/dart --state merged --base main --limit 10 \
+  --json number,title,body,mergedAt
+```
+
+Use these practices:
+
+- Keep titles plain, scoped, and outcome-focused. Do not add agent prefixes.
+- Fill the PR template with concrete Summary, Motivation, Changes, Testing,
+  Breaking Changes, and Related Issues details.
+- In Testing, list exact commands, targets, or test names that ran.
+- For CI, performance, or infrastructure work, include evidence such as CI run
+  observations, timing, reruns, benchmark output, or why a skipped check is
+  expected.
+- Mark non-applicable checklist items as "N/A" with a short reason.
+- Mention related PRs, issues, backports, and follow-ups explicitly, including
+  "None" when there is no related work.
+
+## Workflow
+
+1. Inspect scope:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   ```
+2. Exclude unrelated dirty files unless the user explicitly includes them.
+3. Choose the target branch and milestone:
+
+   | Target         | Milestone     |
+   | -------------- | ------------- |
+   | `main`         | `DART 7.0`    |
+   | `release-6.16` | `DART 6.16.x` |
+
+4. For bug fixes, use the dual-PR flow: fix `release-6.16` first, then
+   cherry-pick or reapply to `main`.
+5. Before every commit, run:
+   ```bash
+   pixi run lint
+   ```
+   Also run `pixi run build` for C++ or Python changes and focused tests for
+   behavior changes.
+6. Create or update a topic branch when needed:
+   ```bash
+   git checkout -b <type>/<topic> origin/<target-branch>
+   ```
+7. Commit only intended files with a plain descriptive commit title.
+8. Push and open a draft PR:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --draft --base <target-branch> --milestone "<milestone>" \
+     --title "<plain title>" --body-file <filled-template-file>
+   ```
+9. If `CHANGELOG.md` needs the PR number, add the changelog entry in a
+   follow-up commit after opening the draft PR.
+10. Monitor CI:
+    ```bash
+    gh pr checks <PR_NUMBER>
+    ```
+
+## AI Review Comments
+
+Never reply to AI-generated review comments from bot users such as
+`chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
+Push fixes silently and ask for a new AI review with `@codex review` only when
+needed.

--- a/dart/collision/ode/detail/ode_heightmap-impl.hpp
+++ b/dart/collision/ode/detail/ode_heightmap-impl.hpp
@@ -70,14 +70,14 @@ void setOdeHeightfieldDetails(
       odeHeightfieldId,
       heights,
       0,
-      (width - 1) * scale.x(),  // width (in meters)
-      (height - 1) * scale.y(), // height (in meters)
-      width,                    // width (sampling size)
-      height,                   // height (sampling size)
-      scale.z(),                // vertical scaling
-      0.0,                      // vertical offset
-      HF_THICKNESS,             // vertical thickness for closing the mesh
-      0);                       // wrap mode
+      static_cast<dReal>(width - 1) * static_cast<dReal>(scale.x()),
+      static_cast<dReal>(height - 1) * static_cast<dReal>(scale.y()),
+      width,        // width (sampling size)
+      height,       // height (sampling size)
+      scale.z(),    // vertical scaling
+      0.0,          // vertical offset
+      HF_THICKNESS, // vertical thickness for closing the mesh
+      0);           // wrap mode
 }
 
 //==============================================================================
@@ -106,14 +106,14 @@ void setOdeHeightfieldDetails(
       odeHeightfieldId,
       heights,
       0,
-      (width - 1) * scale.x(),  // width (in meters)
-      (height - 1) * scale.y(), // height (in meters)
-      width,                    // width (sampling size)
-      height,                   // height (sampling size)
-      scale.z(),                // vertical scaling
-      0.0,                      // vertical offset
-      HF_THICKNESS,             // vertical thickness for closing the mesh
-      0);                       // wrap mode
+      static_cast<dReal>(width - 1) * static_cast<dReal>(scale.x()),
+      static_cast<dReal>(height - 1) * static_cast<dReal>(scale.y()),
+      width,        // width (sampling size)
+      height,       // height (sampling size)
+      scale.z(),    // vertical scaling
+      0.0,          // vertical offset
+      HF_THICKNESS, // vertical thickness for closing the mesh
+      0);           // wrap mode
 }
 
 //==============================================================================

--- a/dart/dynamics/soft_body_node.cpp
+++ b/dart/dynamics/soft_body_node.cpp
@@ -1730,9 +1730,12 @@ SoftBodyNode::UniqueProperties SoftBodyNodeHelper::makeBoxProperties(
   //----------------------------------------------------------------------------
   // Faces
   //----------------------------------------------------------------------------
-  std::size_t nFacesX = 2 * (frags[1] - 1) * (frags[2] - 1);
-  std::size_t nFacesY = 2 * (frags[2] - 1) * (frags[0] - 1);
-  std::size_t nFacesZ = 2 * (frags[0] - 1) * (frags[1] - 1);
+  const std::size_t fragmentsX = static_cast<std::size_t>(frags[0]);
+  const std::size_t fragmentsY = static_cast<std::size_t>(frags[1]);
+  const std::size_t fragmentsZ = static_cast<std::size_t>(frags[2]);
+  std::size_t nFacesX = 2 * (fragmentsY - 1) * (fragmentsZ - 1);
+  std::size_t nFacesY = 2 * (fragmentsZ - 1) * (fragmentsX - 1);
+  std::size_t nFacesZ = 2 * (fragmentsX - 1) * (fragmentsY - 1);
   std::size_t nFaces = 2 * nFacesX + 2 * nFacesY + 2 * nFacesZ;
 
   std::vector<Eigen::Vector3i> faces(nFaces, Eigen::Vector3i::Zero());

--- a/dart/math/lcp/pivoting/dantzig/lcp.cpp
+++ b/dart/math/lcp/pivoting/dantzig/lcp.cpp
@@ -161,6 +161,8 @@ rows/columns and manipulate C.
 #include <memory>
 #include <vector>
 
+#include <cstddef>
+
 //***************************************************************************
 // code generation parameters
 
@@ -197,6 +199,8 @@ bool SolveLCP(
   // and return
   if (nub >= n) {
     const int nskip = padding(n);
+    const std::size_t nSize = static_cast<std::size_t>(n);
+    const std::size_t nskipSize = static_cast<std::size_t>(nskip);
     auto d = std::make_unique<Scalar[]>(n);
     SetZero(d.get(), n);
 
@@ -204,9 +208,10 @@ bool SolveLCP(
     Scalar* A_work = nullptr;
 
     if (n != nskip) {
-      A_storage.reset(new Scalar[n * nskip]);
+      A_storage.reset(new Scalar[nSize * nskipSize]);
       for (int i = 0; i < n; ++i) {
-        memcpy(&A_storage[i * nskip], &A[i * nskip], n * sizeof(Scalar));
+        const std::size_t rowOffset = static_cast<std::size_t>(i) * nskipSize;
+        memcpy(&A_storage[rowOffset], &A[rowOffset], nSize * sizeof(Scalar));
       }
       A_work = A_storage.get();
     } else {
@@ -221,14 +226,17 @@ bool SolveLCP(
   }
 
   const int nskip = padding(n);
+  const std::size_t nSize = static_cast<std::size_t>(n);
+  const std::size_t nskipSize = static_cast<std::size_t>(nskip);
 
   std::unique_ptr<Scalar[]> A_storage;
   Scalar* A_work = nullptr;
 
   if (n != nskip) {
-    A_storage.reset(new Scalar[n * nskip]);
+    A_storage.reset(new Scalar[nSize * nskipSize]);
     for (int i = 0; i < n; ++i) {
-      memcpy(&A_storage[i * nskip], &A[i * nskip], n * sizeof(Scalar));
+      const std::size_t rowOffset = static_cast<std::size_t>(i) * nskipSize;
+      memcpy(&A_storage[rowOffset], &A[rowOffset], nSize * sizeof(Scalar));
     }
     A_work = A_storage.get();
   } else {
@@ -238,7 +246,7 @@ bool SolveLCP(
   // Create PivotMatrix from work array
   PivotMatrix<Scalar> A_pivot(n, n, A_work, nskip);
 
-  auto L = std::make_unique<Scalar[]>(n * nskip);
+  auto L = std::make_unique<Scalar[]>(nSize * nskipSize);
   auto d = std::make_unique<Scalar[]>(n);
   std::unique_ptr<Scalar[]> wStorage;
   Scalar* w = outer_w;

--- a/dart/math/lcp/pivoting/dantzig/matrix-impl.hpp
+++ b/dart/math/lcp/pivoting/dantzig/matrix-impl.hpp
@@ -181,10 +181,12 @@ int dInvertPDMatrix(
                                 : SolveCholesky_size;
   DART_ASSERT(MaxCholesky_size % sizeof(Scalar) == 0);
   const int nskip = padding(n);
-  const int nskip_mul_n = nskip * n;
+  const size_t nSize = static_cast<size_t>(n);
+  const size_t nskipSize = static_cast<size_t>(nskip);
+  const size_t nskip_mul_n = nskipSize * nSize;
   // Compute sizes in Scalar units for proper alignment on ARM64
   const size_t MaxCholesky_scalars = MaxCholesky_size / sizeof(Scalar);
-  const size_t total_scalars = MaxCholesky_scalars + nskip + nskip_mul_n;
+  const size_t total_scalars = MaxCholesky_scalars + nskipSize + nskip_mul_n;
   std::vector<Scalar> tmp_storage;
   Scalar* tmp;
   if (tmpbuf) {

--- a/dart/math/lcp/pivoting/dantzig/matrix.hpp
+++ b/dart/math/lcp/pivoting/dantzig/matrix.hpp
@@ -264,18 +264,22 @@ inline constexpr size_t dEstimateSolveCholeskyTmpbufSize(int n)
 template <typename Scalar>
 inline constexpr size_t dEstimateInvertPDMatrixTmpbufSize(int n)
 {
+  const size_t nSize = static_cast<size_t>(n);
+  const size_t nskipSize = static_cast<size_t>(padding(n));
   size_t FactorCholesky_size = dEstimateFactorCholeskyTmpbufSize<Scalar>(n);
   size_t SolveCholesky_size = dEstimateSolveCholeskyTmpbufSize<Scalar>(n);
   size_t MaxCholesky_size = FactorCholesky_size > SolveCholesky_size
                                 ? FactorCholesky_size
                                 : SolveCholesky_size;
-  return padding(n) * (n + 1) * sizeof(Scalar) + MaxCholesky_size;
+  return nskipSize * (nSize + 1) * sizeof(Scalar) + MaxCholesky_size;
 }
 
 template <typename Scalar>
 inline constexpr size_t dEstimateIsPositiveDefiniteTmpbufSize(int n)
 {
-  return padding(n) * n * sizeof(Scalar)
+  const size_t nSize = static_cast<size_t>(n);
+  const size_t nskipSize = static_cast<size_t>(padding(n));
+  return nskipSize * nSize * sizeof(Scalar)
          + dEstimateFactorCholeskyTmpbufSize<Scalar>(n);
 }
 

--- a/tests/baseline/odelcpsolver/lcp.cpp
+++ b/tests/baseline/odelcpsolver/lcp.cpp
@@ -1124,19 +1124,21 @@ bool dSolveLCP (int n, dReal *A, dReal *x, dReal *b,
 size_t dEstimateSolveLCPMemoryReq(int n, bool outer_w_avail)
 {
   const int nskip = dPAD(n);
+  const size_t nSize = static_cast<size_t>(n);
+  const size_t nskipSize = static_cast<size_t>(nskip);
 
   size_t res = 0;
 
-  res += (sizeof(dReal) * (n * nskip)); // for L
-  res += 5 * (sizeof(dReal) * n); // for d, delta_w, delta_x, Dell, ell
+  res += (sizeof(dReal) * (nSize * nskipSize)); // for L
+  res += 5 * (sizeof(dReal) * nSize); // for d, delta_w, delta_x, Dell, ell
   if (!outer_w_avail) {
-    res += (sizeof(dReal) * n); // for w
+    res += (sizeof(dReal) * nSize); // for w
   }
 #ifdef ROWPTRS
-  res += (sizeof(dReal *) * n); // for Arows
+  res += (sizeof(dReal *) * nSize); // for Arows
 #endif
-  res += 2 * (sizeof(int) * n); // for p, C
-  res += (sizeof(bool) * n); // for state
+  res += 2 * (sizeof(int) * nSize); // for p, C
+  res += (sizeof(bool) * nSize); // for state
 
   // Use n instead of nC as nC varies at runtime while n is greater or equal to nC
   size_t lcp_transfer_req = dLCP::estimate_transfer_i_from_C_to_N_mem_req(n, nskip);

--- a/tests/baseline/odelcpsolver/matrix.h
+++ b/tests/baseline/odelcpsolver/matrix.h
@@ -218,15 +218,20 @@ PURE_INLINE size_t _dEstimateSolveCholeskyTmpbufSize(int n)
 
 PURE_INLINE size_t _dEstimateInvertPDMatrixTmpbufSize(int n)
 {
+  const size_t nSize = static_cast<size_t>(n);
+  const size_t nskipSize = static_cast<size_t>(dPAD(n));
   size_t FactorCholesky_size = _dEstimateFactorCholeskyTmpbufSize(n);
   size_t SolveCholesky_size = _dEstimateSolveCholeskyTmpbufSize(n);
   size_t MaxCholesky_size = FactorCholesky_size > SolveCholesky_size ? FactorCholesky_size : SolveCholesky_size;
-  return dPAD(n) * (n + 1) * sizeof(dReal) + MaxCholesky_size;
+  return nskipSize * (nSize + 1) * sizeof(dReal) + MaxCholesky_size;
 }
 
 PURE_INLINE size_t _dEstimateIsPositiveDefiniteTmpbufSize(int n)
 {
-  return dPAD(n) * n * sizeof(dReal) + _dEstimateFactorCholeskyTmpbufSize(n);
+  const size_t nSize = static_cast<size_t>(n);
+  const size_t nskipSize = static_cast<size_t>(dPAD(n));
+  return nskipSize * nSize * sizeof(dReal)
+         + _dEstimateFactorCholeskyTmpbufSize(n);
 }
 
 PURE_INLINE size_t _dEstimateLDLTAddTLTmpbufSize(int nskip)


### PR DESCRIPTION
## Summary

- Addresses the open first-party CodeQL integer-multiplication cast alerts by widening operands before multiplication in LCP, soft-body, heightmap, and ODE baseline code.
- Filters CodeQL SARIF results from `.pixi/` dependency headers before upload so vendored dependency findings do not stay open in the DART dashboard.
- Adds a `/dart-pr` workflow command for Claude Code/OpenCode and the generated `$dart-pr` Codex skill.

## Motivation / Problem

- The DART code-scanning dashboard has open `cpp/integer-multiplication-cast-to-long` alerts in first-party code and one external Bullet header under `.pixi/`.
- The arithmetic fixes make the intended widened multiplication explicit at the call sites instead of relying on a cast after the multiplication has already happened.
- The PR workflow helper fills the project-level gap for preparing, validating, pushing, and opening DART PRs, while keeping the source in `.claude/commands/` so it aligns with #2556.

## Changes / Key Changes

- Cast dimensions/counts to `std::size_t` or `size_t` before multiplications used for allocation, copy, and matrix indexing paths.
- Cast ODE heightmap dimensions to `dReal` before multiplication in both float and double data paths.
- Make CodeQL analysis write SARIF locally, filter `.pixi/` primary-location findings with `jq`, then upload the filtered SARIF.
- Add `.claude/commands/dart-pr.md` as the command source and sync `.opencode/command/dart-pr.md` plus `.codex/skills/dart-pr/SKILL.md`.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run sync-ai-commands --check`
- `pixi run lint-md`
- `pixi run lint-yaml`
- `pixi run lint-cpp`
- `git diff --check`
- Built focused test targets: `UNIT_collision_OdeHeightmap`, `UNIT_dynamics_SoftBodyNodeHelper`, `UNIT_math_lcp_math_lcp_dantzig_solver`, `UNIT_math_lcp_math_lcp_dantzig_vs_ode`, `UNIT_math_lcp_math_lcp_pivot_matrix`, `INTEGRATION_constraint_LcpSolverStability`, `INTEGRATION_dynamics_SoftDynamics`
- Ran focused `ctest` for those targets: 7/7 passed
- Temporary merge simulation against #2556 head `575d0a51d29d54d2d77717a0f09f9b86b03b8d7a`: clean

## Breaking Changes

- [x] None
- No API or expected runtime behavior changes.

## Related Issues / PRs (backports)

- Related: #2556
- Related: GitHub code-scanning alerts for `cpp/integer-multiplication-cast-to-long`
- Backports: None; targets `main` only.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (N/A: internal CodeQL/tooling cleanup and AI workflow helper; no user-facing API or behavior change)
- [x] Add unit tests for new functionality (N/A: no new runtime behavior; focused existing tests ran)
- [x] Document new methods and classes (N/A: no API additions)
- [x] Add Python bindings (dartpy) if applicable (N/A: no C++/Python API additions)
