### PR TITLE
Adopt C++20 source_location for diagnostics

### DIFF
--- a/dart/common/detail/logging-impl.hpp
+++ b/dart/common/detail/logging-impl.hpp
@@ -207,6 +207,14 @@ inline std::string makeLogPrefix(
   return {};
 }
 
+inline std::string makeLogPrefix(const std::source_location& location)
+{
+  return makeLogPrefix(
+      location.file_name(),
+      static_cast<int>(location.line()),
+      location.function_name());
+}
+
 #if DART_HAVE_spdlog
 inline constexpr spdlog::level::level_enum toSpdlogLevel(LogLevel level)
 {
@@ -302,6 +310,21 @@ void log(
       toAnsiColor(level),
       std::forward<Args>(args)...);
 #endif
+}
+
+template <typename S, typename... Args>
+void log(
+    LogLevel level,
+    const std::source_location& location,
+    const S& format_str,
+    Args&&... args)
+{
+  log(level,
+      location.file_name(),
+      static_cast<int>(location.line()),
+      location.function_name(),
+      format_str,
+      std::forward<Args>(args)...);
 }
 
 } // namespace detail

--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -570,12 +570,6 @@ void Profiler::clearNode(ProfileNode& node)
 }
 
 ProfileScope::ProfileScope(
-    std::string_view name, const std::source_location& location)
-  : ProfileScope(name, location.file_name(), static_cast<int>(location.line()))
-{
-}
-
-ProfileScope::ProfileScope(
     std::string_view name, std::string_view file, int line)
   : m_record(Profiler::threadRecord())
 {

--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -570,6 +570,12 @@ void Profiler::clearNode(ProfileNode& node)
 }
 
 ProfileScope::ProfileScope(
+    std::string_view name, const std::source_location& location)
+  : ProfileScope(name, location.file_name(), static_cast<int>(location.line()))
+{
+}
+
+ProfileScope::ProfileScope(
     std::string_view name, std::string_view file, int line)
   : m_record(Profiler::threadRecord())
 {

--- a/dart/common/detail/profiler.hpp
+++ b/dart/common/detail/profiler.hpp
@@ -146,7 +146,11 @@ class DART_API ProfileScope
 public:
   explicit ProfileScope(
       std::string_view name,
-      const std::source_location& location = std::source_location::current());
+      const std::source_location& location = std::source_location::current())
+    : ProfileScope(
+          name, location.file_name(), static_cast<int>(location.line()))
+  {
+  }
   explicit ProfileScope(std::string_view name, std::string_view file, int line);
   ~ProfileScope();
 

--- a/dart/common/detail/profiler.hpp
+++ b/dart/common/detail/profiler.hpp
@@ -40,6 +40,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <source_location>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -143,6 +144,9 @@ private:
 class DART_API ProfileScope
 {
 public:
+  explicit ProfileScope(
+      std::string_view name,
+      const std::source_location& location = std::source_location::current());
   explicit ProfileScope(std::string_view name, std::string_view file, int line);
   ~ProfileScope();
 

--- a/dart/common/logging.hpp
+++ b/dart/common/logging.hpp
@@ -33,6 +33,8 @@
 #ifndef DART_COMMON_LOGGING_HPP_
 #define DART_COMMON_LOGGING_HPP_
 
+#include <source_location>
+
 #include <cstdint>
 
 // clang-format off
@@ -109,15 +111,20 @@ void log(
     const S& format_str,
     Args&&... args);
 
+template <typename S, typename... Args>
+void log(
+    LogLevel level,
+    const std::source_location& location,
+    const S& format_str,
+    Args&&... args);
+
 } // namespace dart::common::detail
 
 #if DART_ACTIVE_LOG_LEVEL <= DART_LOG_LEVEL_TRACE
   #define DART_TRACE(...)                                                      \
     ::dart::common::detail::log(                                               \
         ::dart::common::detail::LogLevel::Trace,                               \
-        __FILE__,                                                              \
-        __LINE__,                                                              \
-        __func__,                                                              \
+        ::std::source_location::current(),                                     \
         __VA_ARGS__)
   #define DART_TRACE_IF(condition, ...)                                        \
     do {                                                                       \
@@ -139,9 +146,7 @@ void log(
   #define DART_DEBUG(...)                                                      \
     ::dart::common::detail::log(                                               \
         ::dart::common::detail::LogLevel::Debug,                               \
-        __FILE__,                                                              \
-        __LINE__,                                                              \
-        __func__,                                                              \
+        ::std::source_location::current(),                                     \
         __VA_ARGS__)
   #define DART_DEBUG_IF(condition, ...)                                        \
     do {                                                                       \
@@ -163,9 +168,7 @@ void log(
   #define DART_INFO(...)                                                       \
     ::dart::common::detail::log(                                               \
         ::dart::common::detail::LogLevel::Info,                                \
-        __FILE__,                                                              \
-        __LINE__,                                                              \
-        __func__,                                                              \
+        ::std::source_location::current(),                                     \
         __VA_ARGS__)
   #define DART_INFO_IF(condition, ...)                                         \
     do {                                                                       \
@@ -187,9 +190,7 @@ void log(
   #define DART_WARN(...)                                                       \
     ::dart::common::detail::log(                                               \
         ::dart::common::detail::LogLevel::Warn,                                \
-        __FILE__,                                                              \
-        __LINE__,                                                              \
-        __func__,                                                              \
+        ::std::source_location::current(),                                     \
         __VA_ARGS__)
   #define DART_WARN_IF(condition, ...)                                         \
     do {                                                                       \
@@ -211,9 +212,7 @@ void log(
   #define DART_ERROR(...)                                                      \
     ::dart::common::detail::log(                                               \
         ::dart::common::detail::LogLevel::Error,                               \
-        __FILE__,                                                              \
-        __LINE__,                                                              \
-        __func__,                                                              \
+        ::std::source_location::current(),                                     \
         __VA_ARGS__)
   #define DART_ERROR_IF(condition, ...)                                        \
     do {                                                                       \
@@ -235,9 +234,7 @@ void log(
   #define DART_FATAL(...)                                                      \
     ::dart::common::detail::log(                                               \
         ::dart::common::detail::LogLevel::Fatal,                               \
-        __FILE__,                                                              \
-        __LINE__,                                                              \
-        __func__,                                                              \
+        ::std::source_location::current(),                                     \
         __VA_ARGS__)
   #define DART_FATAL_IF(condition, ...)                                        \
     do {                                                                       \

--- a/dart/common/profile.hpp
+++ b/dart/common/profile.hpp
@@ -100,12 +100,10 @@
       ::dart::common::profile::Profiler::instance().markFrame()
     #define DART_PROFILE_TEXT_SCOPED(name_literal)                             \
       ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(           \
-          _dart_profile_scope_)(                                               \
-          name_literal, __FILE__, static_cast<int>(__LINE__))
+          _dart_profile_scope_)(name_literal)
     #define DART_PROFILE_TEXT_SCOPED_F()                                       \
       ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(           \
-          _dart_profile_scope_func_)(                                          \
-          __func__, __FILE__, static_cast<int>(__LINE__))
+          _dart_profile_scope_func_)(__func__)
     #define DART_PROFILE_TEXT_DUMP()                                           \
       ::dart::common::profile::Profiler::instance().printSummary()
   #else

--- a/dart/simulation/experimental/common/logging.hpp
+++ b/dart/simulation/experimental/common/logging.hpp
@@ -262,21 +262,21 @@ inline std::string makeContext(const std::source_location& location)
       location.function_name());
 }
 
-template <typename Format, typename... Args>
+template <typename S, typename... Args>
 void log(
     LogLevel level,
     const char* file,
     int line,
     const char* function,
-    Format&& format,
+    const S& format,
     Args&&... args)
 {
   auto& logger = Logger::instance();
+  fmt::basic_string_view<char> fmt_view(format);
+  auto message = fmt::vformat(fmt_view, fmt::make_format_args(args...));
 #ifndef NDEBUG
   std::string prefix = makeContext(file, line, function);
   if (!prefix.empty()) {
-    auto message = fmt::format(
-        std::forward<Format>(format), std::forward<Args>(args)...);
     logger->log(toSpdlogLevel(level), "{}{}", prefix, message);
     return;
   }
@@ -285,24 +285,21 @@ void log(
   (void)line;
   (void)function;
 #endif
-  logger->log(
-      toSpdlogLevel(level),
-      std::forward<Format>(format),
-      std::forward<Args>(args)...);
+  logger->log(toSpdlogLevel(level), "{}", message);
 }
 
-template <typename Format, typename... Args>
+template <typename S, typename... Args>
 void log(
     LogLevel level,
     const std::source_location& location,
-    Format&& format,
+    const S& format,
     Args&&... args)
 {
   log(level,
       location.file_name(),
       static_cast<int>(location.line()),
       location.function_name(),
-      std::forward<Format>(format),
+      format,
       std::forward<Args>(args)...);
 }
 

--- a/dart/simulation/experimental/common/logging.hpp
+++ b/dart/simulation/experimental/common/logging.hpp
@@ -272,12 +272,17 @@ void log(
     Args&&... args)
 {
   auto& logger = Logger::instance();
+  const auto spdlogLevel = toSpdlogLevel(level);
+  if (!logger->should_log(spdlogLevel)) {
+    return;
+  }
+
   fmt::basic_string_view<char> fmt_view(format);
   auto message = fmt::vformat(fmt_view, fmt::make_format_args(args...));
 #ifndef NDEBUG
   std::string prefix = makeContext(file, line, function);
   if (!prefix.empty()) {
-    logger->log(toSpdlogLevel(level), "{}{}", prefix, message);
+    logger->log(spdlogLevel, "{}{}", prefix, message);
     return;
   }
 #else
@@ -285,7 +290,7 @@ void log(
   (void)line;
   (void)function;
 #endif
-  logger->log(toSpdlogLevel(level), "{}", message);
+  logger->log(spdlogLevel, "{}", message);
 }
 
 template <typename S, typename... Args>

--- a/dart/simulation/experimental/common/logging.hpp
+++ b/dart/simulation/experimental/common/logging.hpp
@@ -38,6 +38,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <source_location>
 #include <string>
 
 #define DART_EXPERIMENTAL_DETAIL_PP_CONCAT_IMPL(a, b) a##b
@@ -253,6 +254,14 @@ inline std::string makeContext(const char* file, int line, const char* function)
   return {};
 }
 
+inline std::string makeContext(const std::source_location& location)
+{
+  return makeContext(
+      location.file_name(),
+      static_cast<int>(location.line()),
+      location.function_name());
+}
+
 template <typename Format, typename... Args>
 void log(
     LogLevel level,
@@ -282,6 +291,21 @@ void log(
       std::forward<Args>(args)...);
 }
 
+template <typename Format, typename... Args>
+void log(
+    LogLevel level,
+    const std::source_location& location,
+    Format&& format,
+    Args&&... args)
+{
+  log(level,
+      location.file_name(),
+      static_cast<int>(location.line()),
+      location.function_name(),
+      std::forward<Format>(format),
+      std::forward<Args>(args)...);
+}
+
 } // namespace detail
 
 /// Initialize simulation-experimental logging with default settings
@@ -301,9 +325,7 @@ inline void initializeLogging()
 #ifndef NDEBUG
   detail::log(
       LogLevel::Info,
-      __FILE__,
-      __LINE__,
-      __func__,
+      std::source_location::current(),
       "simulation-experimental logging initialized");
 #endif
 }
@@ -326,49 +348,37 @@ inline LogLevel getLogLevel()
 #define DART_EXPERIMENTAL_TRACE(...)                                           \
   ::dart::simulation::experimental::common::detail::log(                       \
       ::dart::simulation::experimental::common::LogLevel::Trace,               \
-      __FILE__,                                                                \
-      __LINE__,                                                                \
-      __func__,                                                                \
+      ::std::source_location::current(),                                       \
       __VA_ARGS__)
 
 #define DART_EXPERIMENTAL_DEBUG(...)                                           \
   ::dart::simulation::experimental::common::detail::log(                       \
       ::dart::simulation::experimental::common::LogLevel::Debug,               \
-      __FILE__,                                                                \
-      __LINE__,                                                                \
-      __func__,                                                                \
+      ::std::source_location::current(),                                       \
       __VA_ARGS__)
 
 #define DART_EXPERIMENTAL_INFO(...)                                            \
   ::dart::simulation::experimental::common::detail::log(                       \
       ::dart::simulation::experimental::common::LogLevel::Info,                \
-      __FILE__,                                                                \
-      __LINE__,                                                                \
-      __func__,                                                                \
+      ::std::source_location::current(),                                       \
       __VA_ARGS__)
 
 #define DART_EXPERIMENTAL_WARN(...)                                            \
   ::dart::simulation::experimental::common::detail::log(                       \
       ::dart::simulation::experimental::common::LogLevel::Warn,                \
-      __FILE__,                                                                \
-      __LINE__,                                                                \
-      __func__,                                                                \
+      ::std::source_location::current(),                                       \
       __VA_ARGS__)
 
 #define DART_EXPERIMENTAL_ERROR(...)                                           \
   ::dart::simulation::experimental::common::detail::log(                       \
       ::dart::simulation::experimental::common::LogLevel::Error,               \
-      __FILE__,                                                                \
-      __LINE__,                                                                \
-      __func__,                                                                \
+      ::std::source_location::current(),                                       \
       __VA_ARGS__)
 
 #define DART_EXPERIMENTAL_CRITICAL(...)                                        \
   ::dart::simulation::experimental::common::detail::log(                       \
       ::dart::simulation::experimental::common::LogLevel::Critical,            \
-      __FILE__,                                                                \
-      __LINE__,                                                                \
-      __func__,                                                                \
+      ::std::source_location::current(),                                       \
       __VA_ARGS__)
 
 // Conditional logging

--- a/tests/unit/common/test_logging.cpp
+++ b/tests/unit/common/test_logging.cpp
@@ -39,6 +39,7 @@
 
 #include <iostream>
 #include <memory>
+#include <source_location>
 #include <sstream>
 #include <string>
 
@@ -238,6 +239,17 @@ TEST(LoggingTest, DetailHelpers)
   if (!partialPrefix.empty()) {
     EXPECT_NE(partialPrefix.find("file.cpp"), std::string::npos);
   }
+
+  const auto locationPrefix = makeLogPrefix(std::source_location::current());
+  if (!locationPrefix.empty()) {
+    EXPECT_NE(locationPrefix.find("test_logging.cpp"), std::string::npos);
+  }
+
+  dart::common::detail::log(
+      LogLevel::Info,
+      std::source_location::current(),
+      "source location detail log {}",
+      42);
 
   EXPECT_NE(toAnsiColor(LogLevel::Trace), 0);
   EXPECT_NE(toAnsiColor(LogLevel::Debug), 0);

--- a/tests/unit/common/test_profiler.cpp
+++ b/tests/unit/common/test_profiler.cpp
@@ -131,6 +131,28 @@ TEST(Profiler, ColorizedOutput)
   EXPECT_NE(output.find("\033["), std::string::npos);
 }
 
+TEST(Profiler, SourceLocationScope)
+{
+  auto& profiler = common::profile::Profiler::instance();
+  profiler.reset();
+
+  ScopedEnvVar env("DART_PROFILE_COLOR", "0");
+
+  {
+    common::profile::ProfileScope scope("SourceLocationScope");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  profiler.markFrame();
+
+  std::ostringstream oss;
+  profiler.printSummary(oss);
+
+  const std::string output = oss.str();
+  EXPECT_NE(output.find("SourceLocationScope"), std::string::npos);
+  EXPECT_NE(output.find("test_profiler.cpp"), std::string::npos);
+}
+
 TEST(Profiler, UseColorEnvVarVariants)
 {
   {

--- a/tests/unit/simulation/experimental/common/test_logging.cpp
+++ b/tests/unit/simulation/experimental/common/test_logging.cpp
@@ -34,6 +34,8 @@
 
 #include <gtest/gtest.h>
 
+#include <source_location>
+
 using namespace dart::simulation::experimental::common;
 
 // Test logging initialization
@@ -107,4 +109,20 @@ TEST(Logging, AllLevels)
   DART_EXPERIMENTAL_WARN("Warning message");
   DART_EXPERIMENTAL_ERROR("Error message");
   DART_EXPERIMENTAL_CRITICAL("Critical message");
+}
+
+TEST(Logging, SourceLocationDetailHelpers)
+{
+  initializeLogging();
+
+  const auto context = detail::makeContext(std::source_location::current());
+  if (!context.empty()) {
+    EXPECT_NE(context.find("test_logging.cpp"), std::string::npos);
+  }
+
+  detail::log(
+      LogLevel::Info,
+      std::source_location::current(),
+      "source location detail log {}",
+      42);
 }

--- a/tests/unit/simulation/experimental/common/test_logging.cpp
+++ b/tests/unit/simulation/experimental/common/test_logging.cpp
@@ -35,8 +35,29 @@
 #include <gtest/gtest.h>
 
 #include <source_location>
+#include <string_view>
 
 using namespace dart::simulation::experimental::common;
+
+namespace {
+
+struct CountingValue
+{
+  int* formatCount;
+};
+
+} // namespace
+
+template <>
+struct fmt::formatter<CountingValue> : fmt::formatter<std::string_view>
+{
+  template <typename FormatContext>
+  auto format(const CountingValue& value, FormatContext& ctx) const
+  {
+    ++*value.formatCount;
+    return fmt::formatter<std::string_view>::format("value", ctx);
+  }
+};
 
 // Test logging initialization
 TEST(Logging, Initialization)
@@ -109,6 +130,22 @@ TEST(Logging, AllLevels)
   DART_EXPERIMENTAL_WARN("Warning message");
   DART_EXPERIMENTAL_ERROR("Error message");
   DART_EXPERIMENTAL_CRITICAL("Critical message");
+}
+
+TEST(Logging, DisabledLevelsDoNotFormatArguments)
+{
+  initializeLogging();
+
+  setLogLevel(LogLevel::Error);
+
+  int formatCount = 0;
+  DART_EXPERIMENTAL_DEBUG("{}", CountingValue{&formatCount});
+  EXPECT_EQ(formatCount, 0);
+
+  DART_EXPERIMENTAL_ERROR("{}", CountingValue{&formatCount});
+  EXPECT_EQ(formatCount, 1);
+
+  setLogLevel(LogLevel::Info);
 }
 
 TEST(Logging, SourceLocationDetailHelpers)


### PR DESCRIPTION
## Summary

- Adopt `std::source_location` in DART diagnostic helpers so call-site file, line, and function metadata are captured by the standard library.
- Keep existing logging and profiling macro call sites source-compatible while moving metadata capture into helper APIs.

## Motivation / Problem

- DART now targets C++20, so diagnostics can use the standard call-site metadata facility instead of macro-expanded file/function/line plumbing.
- This reduces macro surface area and keeps logging/profiling helpers easier to maintain.

## Changes / Key Changes

- Added `std::source_location` parameters to common logging and profiler helper implementations.
- Updated profiling macros to forward a single source-location object through `DART_PROFILE_*` scopes.
- Applied the same source-location pattern to simulation-experimental logging macros.

## Testing

- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
