### PR TITLE
Adopt C++20 reverse views for traversal

### DIFF
--- a/dart/collision/ode/ode_collision_detector.cpp
+++ b/dart/collision/ode/ode_collision_detector.cpp
@@ -57,6 +57,7 @@
 #include <algorithm>
 #include <deque>
 #include <functional>
+#include <ranges>
 #include <utility>
 
 namespace dart {
@@ -463,10 +464,11 @@ void reportContacts(
     return;
   }
 
-  for (auto it = pastContacsVec.rbegin();
-       it != pastContacsVec.rend() && missing > 0u;
-       ++it) {
-    auto past_cont = *it;
+  for (const auto& past_cont : std::views::reverse(pastContacsVec)) {
+    if (missing == 0u) {
+      break;
+    }
+
     for (const auto& curr_cont : results_vec_copy) {
       const auto res_pair
           = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);

--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -36,6 +36,7 @@
 #include <dart/common/lockable_reference.hpp>
 
 #include <iterator>
+#include <ranges>
 #include <type_traits>
 
 namespace dart {
@@ -141,8 +142,8 @@ void MultiLockableReference<Lockable>::unlock() noexcept
     return;
   }
 
-  for (auto it = mLockables.rbegin(); it != mLockables.rend(); ++it) {
-    (*it)->unlock();
+  for (auto* lockable : std::views::reverse(mLockables)) {
+    lockable->unlock();
   }
 }
 

--- a/dart/dynamics/body_node.cpp
+++ b/dart/dynamics/body_node.cpp
@@ -45,6 +45,7 @@
 #include "dart/math/helpers.hpp"
 
 #include <algorithm>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -1122,12 +1123,10 @@ const std::vector<const DegreeOfFreedom*> BodyNode::getChainDofs() const
   std::vector<BodyNode*> bn_chain = criteria.satisfy();
   std::vector<const DegreeOfFreedom*> dofs;
   dofs.reserve(getNumDependentGenCoords());
-  for (std::vector<BodyNode*>::reverse_iterator rit = bn_chain.rbegin();
-       rit != bn_chain.rend();
-       ++rit) {
-    std::size_t nDofs = (*rit)->getParentJoint()->getNumDofs();
+  for (auto* bodyNode : std::views::reverse(bn_chain)) {
+    std::size_t nDofs = bodyNode->getParentJoint()->getNumDofs();
     for (std::size_t i = 0; i < nDofs; ++i) {
-      dofs.push_back((*rit)->getParentJoint()->getDof(i));
+      dofs.push_back(bodyNode->getParentJoint()->getDof(i));
     }
   }
 

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -52,6 +52,7 @@
 #include <algorithm>
 #include <iterator>
 #include <queue>
+#include <ranges>
 #include <span>
 #include <string>
 #include <vector>
@@ -2918,11 +2919,9 @@ std::vector<BodyNode*> Skeleton::extractBodyNodeTree(BodyNode* _bodyNode)
 {
   std::vector<BodyNode*> tree = constructBodyNodeTree(_bodyNode);
 
-  // Go backwards to minimize the number of shifts needed
-  std::vector<BodyNode*>::reverse_iterator rit;
   // Go backwards to minimize the amount of element shifting in the vectors
-  for (rit = tree.rbegin(); rit != tree.rend(); ++rit) {
-    unregisterBodyNode(*rit);
+  for (auto* bodyNode : std::views::reverse(tree)) {
+    unregisterBodyNode(bodyNode);
   }
 
   for (std::size_t i = 0; i < mSkelCache.mBodyNodes.size(); ++i) {
@@ -2978,11 +2977,8 @@ void Skeleton::updateCacheDimensions(std::size_t _treeIdx)
 void Skeleton::updateArticulatedInertia(std::size_t _tree) const
 {
   DataCache& cache = mTreeCache[_tree];
-  for (std::vector<BodyNode*>::const_reverse_iterator it
-       = cache.mBodyNodes.rbegin();
-       it != cache.mBodyNodes.rend();
-       ++it) {
-    (*it)->updateArtInertia(mAspectProperties.mTimeStep);
+  for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+    bodyNode->updateArtInertia(mAspectProperties.mTimeStep);
   }
 
   cache.mDirty.mArticulatedInertia = false;
@@ -3037,14 +3033,11 @@ void Skeleton::updateMassMatrix(std::size_t _treeIdx) const
     }
 
     // Mass matrix
-    for (std::vector<BodyNode*>::const_reverse_iterator it
-         = cache.mBodyNodes.rbegin();
-         it != cache.mBodyNodes.rend();
-         ++it) {
-      (*it)->aggregateMassMatrix(cache.mM, j);
-      std::size_t localDof = (*it)->mParentJoint->getNumDofs();
+    for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+      bodyNode->aggregateMassMatrix(cache.mM, j);
+      std::size_t localDof = bodyNode->mParentJoint->getNumDofs();
       if (localDof > 0) {
-        std::size_t iStart = (*it)->mParentJoint->getIndexInTree(0);
+        std::size_t iStart = bodyNode->mParentJoint->getIndexInTree(0);
 
         if (iStart + localDof < j) {
           break;
@@ -3130,15 +3123,12 @@ void Skeleton::updateAugMassMatrix(std::size_t _treeIdx) const
     }
 
     // Augmented Mass matrix
-    for (std::vector<BodyNode*>::const_reverse_iterator it
-         = cache.mBodyNodes.rbegin();
-         it != cache.mBodyNodes.rend();
-         ++it) {
-      (*it)->aggregateAugMassMatrix(
+    for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+      bodyNode->aggregateAugMassMatrix(
           cache.mAugM, j, mAspectProperties.mTimeStep);
-      std::size_t localDof = (*it)->mParentJoint->getNumDofs();
+      std::size_t localDof = bodyNode->mParentJoint->getNumDofs();
       if (localDof > 0) {
-        std::size_t iStart = (*it)->mParentJoint->getIndexInTree(0);
+        std::size_t iStart = bodyNode->mParentJoint->getIndexInTree(0);
 
         if (iStart + localDof < j) {
           break;
@@ -3218,11 +3208,8 @@ void Skeleton::updateInvMassMatrix(std::size_t _treeIdx) const
     cache.mDofs[j]->setForce(1.0);
 
     // Prepare cache data
-    for (std::vector<BodyNode*>::const_reverse_iterator it
-         = cache.mBodyNodes.rbegin();
-         it != cache.mBodyNodes.rend();
-         ++it) {
-      (*it)->updateInvMassMatrix();
+    for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+      bodyNode->updateInvMassMatrix();
     }
 
     // Inverse of mass matrix
@@ -3312,11 +3299,8 @@ void Skeleton::updateInvAugMassMatrix(std::size_t _treeIdx) const
     cache.mDofs[j]->setForce(1.0);
 
     // Prepare cache data
-    for (std::vector<BodyNode*>::const_reverse_iterator it
-         = cache.mBodyNodes.rbegin();
-         it != cache.mBodyNodes.rend();
-         ++it) {
-      (*it)->updateInvAugMassMatrix();
+    for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+      bodyNode->updateInvAugMassMatrix();
     }
 
     // Inverse of augmented mass matrix
@@ -3397,11 +3381,8 @@ void Skeleton::updateCoriolisForces(std::size_t _treeIdx) const
     (*it)->updateCombinedVector();
   }
 
-  for (std::vector<BodyNode*>::const_reverse_iterator it
-       = cache.mBodyNodes.rbegin();
-       it != cache.mBodyNodes.rend();
-       ++it) {
-    (*it)->aggregateCoriolisForceVector(cache.mCvec);
+  for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+    bodyNode->aggregateCoriolisForceVector(cache.mCvec);
   }
 
   cache.mDirty.mCoriolisForces = false;
@@ -3445,11 +3426,8 @@ void Skeleton::updateGravityForces(std::size_t _treeIdx) const
 
   cache.mG.setZero();
 
-  for (std::vector<BodyNode*>::const_reverse_iterator it
-       = cache.mBodyNodes.rbegin();
-       it != cache.mBodyNodes.rend();
-       ++it) {
-    (*it)->aggregateGravityForceVector(cache.mG, mAspectProperties.mGravity);
+  for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+    bodyNode->aggregateGravityForceVector(cache.mG, mAspectProperties.mGravity);
   }
 
   cache.mDirty.mGravityForces = false;
@@ -3499,11 +3477,8 @@ void Skeleton::updateCoriolisAndGravityForces(std::size_t _treeIdx) const
     (*it)->updateCombinedVector();
   }
 
-  for (std::vector<BodyNode*>::const_reverse_iterator it
-       = cache.mBodyNodes.rbegin();
-       it != cache.mBodyNodes.rend();
-       ++it) {
-    (*it)->aggregateCombinedVector(cache.mCg, mAspectProperties.mGravity);
+  for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+    bodyNode->aggregateCombinedVector(cache.mCg, mAspectProperties.mGravity);
   }
 
   cache.mDirty.mCoriolisAndGravityForces = false;
@@ -3548,11 +3523,8 @@ void Skeleton::updateExternalForces(std::size_t _treeIdx) const
   // Clear external force.
   cache.mFext.setZero();
 
-  for (std::vector<BodyNode*>::const_reverse_iterator itr
-       = cache.mBodyNodes.rbegin();
-       itr != cache.mBodyNodes.rend();
-       ++itr) {
-    (*itr)->aggregateExternalForces(cache.mFext);
+  for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+    bodyNode->aggregateExternalForces(cache.mFext);
   }
 
   // TODO(JS): Not implemented yet
@@ -3621,11 +3593,9 @@ const Eigen::VectorXd& Skeleton::computeConstraintForces(DataCache& cache) const
   DART_ASSERT(static_cast<std::size_t>(cache.mFc.size()) == dof);
 
   // Body constraint impulses
-  for (std::vector<BodyNode*>::reverse_iterator it = cache.mBodyNodes.rbegin();
-       it != cache.mBodyNodes.rend();
-       ++it) {
-    (*it)->aggregateSpatialToGeneralized(
-        cache.mFc, (*it)->getConstraintImpulse());
+  for (auto* bodyNode : std::views::reverse(cache.mBodyNodes)) {
+    bodyNode->aggregateSpatialToGeneralized(
+        cache.mFc, bodyNode->getConstraintImpulse());
   }
 
   // Joint constraint impulses
@@ -3854,10 +3824,8 @@ void Skeleton::computeForwardDynamics()
   // Note: Articulated Inertias will be updated automatically when
   // getArtInertiaImplicit() is called in BodyNode::updateBiasForce()
 
-  for (auto it = mSkelCache.mBodyNodes.rbegin();
-       it != mSkelCache.mBodyNodes.rend();
-       ++it) {
-    (*it)->updateBiasForce(
+  for (auto* bodyNode : std::views::reverse(mSkelCache.mBodyNodes)) {
+    bodyNode->updateBiasForce(
         mAspectProperties.mGravity, mAspectProperties.mTimeStep);
   }
 
@@ -3879,12 +3847,10 @@ void Skeleton::computeInverseDynamics(
   }
 
   // Backward recursion
-  for (auto it = mSkelCache.mBodyNodes.rbegin();
-       it != mSkelCache.mBodyNodes.rend();
-       ++it) {
-    (*it)->updateTransmittedForceID(
+  for (auto* bodyNode : std::views::reverse(mSkelCache.mBodyNodes)) {
+    bodyNode->updateTransmittedForceID(
         mAspectProperties.mGravity, _withExternalForces);
-    (*it)->updateJointForceID(
+    bodyNode->updateJointForceID(
         mAspectProperties.mTimeStep, _withDampingForces, _withSpringForces);
   }
 }
@@ -4117,10 +4083,8 @@ void Skeleton::computePositionVelocityChanges()
   }
 
   // Backward recursion
-  for (auto it = mSkelCache.mBodyNodes.rbegin();
-       it != mSkelCache.mBodyNodes.rend();
-       ++it) {
-    (*it)->updateBiasImpulseFromPositionImpulse();
+  for (auto* bodyNode : std::views::reverse(mSkelCache.mBodyNodes)) {
+    bodyNode->updateBiasImpulseFromPositionImpulse();
   }
 
   // Forward recursion
@@ -4183,10 +4147,8 @@ void Skeleton::computeImpulseForwardDynamics()
   // BodyNode::getArticulatedInertia()
 
   // Backward recursion
-  for (auto it = mSkelCache.mBodyNodes.rbegin();
-       it != mSkelCache.mBodyNodes.rend();
-       ++it) {
-    (*it)->updateBiasImpulse();
+  for (auto* bodyNode : std::views::reverse(mSkelCache.mBodyNodes)) {
+    bodyNode->updateBiasImpulse();
   }
 
   // Forward recursion


### PR DESCRIPTION
## Summary

- Replace hand-written reverse iterator loops with C++20 reverse views in traversal code.
- Keep traversal order and behavior unchanged while simplifying loop structure.

## Motivation / Problem

- DART targets C++20, so `std::views::reverse` can express reverse traversal directly.
- This removes manual `rbegin()` / `rend()` boilerplate in collision, locking, body-node, and skeleton code.

## Changes / Key Changes

- Updated ODE collision result pruning to use reverse views for newest-to-oldest contact traversal.
- Updated lockable reference and body-node traversal loops to use `std::views::reverse`.
- Simplified reverse skeleton traversal paths that previously used explicit reverse iterators.

## Testing

- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
