### PR TITLE
Adopt C++20 standard concepts in numeric helpers

### DIFF
--- a/dart/simd/detail/scalar/operations.hpp
+++ b/dart/simd/detail/scalar/operations.hpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <concepts>
 
 #include <cmath>
 #include <cstddef>
@@ -346,7 +347,7 @@ template <typename T, std::size_t W>
 }
 
 template <typename T, std::size_t W>
-  requires std::is_integral_v<T>
+  requires std::integral<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitAnd(
     const Vec<T, W>& a, const Vec<T, W>& b)
 {
@@ -360,7 +361,7 @@ template <typename T, std::size_t W>
 }
 
 template <typename T, std::size_t W>
-  requires std::is_integral_v<T>
+  requires std::integral<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitOr(
     const Vec<T, W>& a, const Vec<T, W>& b)
 {
@@ -374,7 +375,7 @@ template <typename T, std::size_t W>
 }
 
 template <typename T, std::size_t W>
-  requires std::is_integral_v<T>
+  requires std::integral<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitXor(
     const Vec<T, W>& a, const Vec<T, W>& b)
 {
@@ -388,7 +389,7 @@ template <typename T, std::size_t W>
 }
 
 template <typename T, std::size_t W>
-  requires std::is_integral_v<T>
+  requires std::integral<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitNot(const Vec<T, W>& v)
 {
   alignas(64) T vArr[W], rArr[W];
@@ -400,7 +401,7 @@ template <typename T, std::size_t W>
 }
 
 template <int N, typename T, std::size_t W>
-  requires std::is_integral_v<T>
+  requires std::integral<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> shiftLeft(const Vec<T, W>& v)
 {
   alignas(64) T vArr[W], rArr[W];
@@ -412,7 +413,7 @@ template <int N, typename T, std::size_t W>
 }
 
 template <int N, typename T, std::size_t W>
-  requires std::is_integral_v<T>
+  requires std::integral<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> shiftRight(const Vec<T, W>& v)
 {
   alignas(64) T vArr[W], rArr[W];

--- a/dart/simd/geometry/batch.hpp
+++ b/dart/simd/geometry/batch.hpp
@@ -39,6 +39,7 @@
 #include <dart/simd/memory.hpp>
 
 #include <array>
+#include <concepts>
 
 namespace dart::simd {
 

--- a/dart/simd/geometry/isometry3.hpp
+++ b/dart/simd/geometry/isometry3.hpp
@@ -36,6 +36,8 @@
 
 #include <Eigen/Geometry>
 
+#include <concepts>
+
 namespace dart::simd {
 
 template <FloatType T>

--- a/dart/simd/geometry/matrix3x3.hpp
+++ b/dart/simd/geometry/matrix3x3.hpp
@@ -36,6 +36,8 @@
 
 #include <Eigen/Core>
 
+#include <concepts>
+
 #include <cmath>
 
 namespace dart::simd {

--- a/dart/simd/geometry/matrix4x4.hpp
+++ b/dart/simd/geometry/matrix4x4.hpp
@@ -37,6 +37,8 @@
 
 #include <Eigen/Core>
 
+#include <concepts>
+
 #include <cmath>
 
 namespace dart::simd {

--- a/dart/simd/geometry/quaternion.hpp
+++ b/dart/simd/geometry/quaternion.hpp
@@ -37,6 +37,8 @@
 
 #include <Eigen/Geometry>
 
+#include <concepts>
+
 #include <cmath>
 
 namespace dart::simd {

--- a/dart/simd/geometry/vector3.hpp
+++ b/dart/simd/geometry/vector3.hpp
@@ -67,6 +67,8 @@
 
 #include <Eigen/Core>
 
+#include <concepts>
+
 #include <cmath>
 
 namespace dart::simd {

--- a/dart/simd/geometry/vector4.hpp
+++ b/dart/simd/geometry/vector4.hpp
@@ -36,6 +36,8 @@
 
 #include <Eigen/Core>
 
+#include <concepts>
+
 #include <cmath>
 
 namespace dart::simd {


### PR DESCRIPTION
## Summary
- Replace numeric type-trait predicates with C++20 standard concepts in SIMD geometry helpers and scalar SIMD operations.
- Use `std::floating_point` in math helper static assertions.
- Restore macOS libc++ portability by avoiding `std::jthread` in profiling tests and the parallel-world benchmark.
- Add direct `<concepts>` includes where concepts are now referenced.

## Motivation
C++20 concepts express template requirements directly and make these numeric constraints easier to read than equivalent `std::is_*` trait expressions. The profiling-thread change keeps the branch buildable on CI platforms whose standard library does not yet provide `std::jthread`.

## Changes
- Converted float/double-only static assertions to `std::same_as`.
- Converted floating-point and integral `requires` clauses to `std::floating_point` and `std::integral`.
- Converted math helper floating-point static assertions to `std::floating_point`.
- Replaced `std::jthread` with `std::thread` plus explicit joins in profiling coverage and the dynamics cache benchmark.

## Testing
- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`

## Breaking Changes
None.

## Related Issues
None.
