### PR TITLE
Adopt C++20 size and allocation helpers

### DIFF
--- a/dart/constraint/constraint_solver.cpp
+++ b/dart/constraint/constraint_solver.cpp
@@ -61,6 +61,7 @@
 #include <fmt/ostream.h>
 
 #include <algorithm>
+#include <memory>
 
 #include <cmath>
 
@@ -1254,7 +1255,7 @@ void ConstraintSolver::print(
   }
   std::cout << std::endl;
 
-  auto* Ax = new double[n];
+  auto Ax = std::make_unique_for_overwrite<double[]>(n);
   for (std::size_t i = 0; i < n; ++i) {
     Ax[i] = 0.0;
   }
@@ -1275,8 +1276,6 @@ void ConstraintSolver::print(
     std::cout << b[i] + w[i] << " ";
   }
   std::cout << std::endl;
-
-  delete[] Ax;
 }
 
 } // namespace constraint

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -108,7 +108,7 @@ public:
     if (next < 0) {
       return false;
     }
-    if (static_cast<std::size_t>(next) > mData.size()) {
+    if (next > std::ssize(mData)) {
       return false;
     }
 

--- a/dart/math/lcp/pivoting/dantzig/lcp.cpp
+++ b/dart/math/lcp/pivoting/dantzig/lcp.cpp
@@ -201,14 +201,14 @@ bool SolveLCP(
     const int nskip = padding(n);
     const std::size_t nSize = static_cast<std::size_t>(n);
     const std::size_t nskipSize = static_cast<std::size_t>(nskip);
-    auto d = std::make_unique<Scalar[]>(n);
+    auto d = std::make_unique_for_overwrite<Scalar[]>(nSize);
     SetZero(d.get(), n);
 
     std::unique_ptr<Scalar[]> A_storage;
     Scalar* A_work = nullptr;
 
     if (n != nskip) {
-      A_storage.reset(new Scalar[nSize * nskipSize]);
+      A_storage = std::make_unique_for_overwrite<Scalar[]>(nSize * nskipSize);
       for (int i = 0; i < n; ++i) {
         const std::size_t rowOffset = static_cast<std::size_t>(i) * nskipSize;
         memcpy(&A_storage[rowOffset], &A[rowOffset], nSize * sizeof(Scalar));
@@ -233,7 +233,7 @@ bool SolveLCP(
   Scalar* A_work = nullptr;
 
   if (n != nskip) {
-    A_storage.reset(new Scalar[nSize * nskipSize]);
+    A_storage = std::make_unique_for_overwrite<Scalar[]>(nSize * nskipSize);
     for (int i = 0; i < n; ++i) {
       const std::size_t rowOffset = static_cast<std::size_t>(i) * nskipSize;
       memcpy(&A_storage[rowOffset], &A[rowOffset], nSize * sizeof(Scalar));
@@ -251,7 +251,7 @@ bool SolveLCP(
   std::unique_ptr<Scalar[]> wStorage;
   Scalar* w = outer_w;
   if (!w) {
-    wStorage.reset(new Scalar[n]);
+    wStorage = std::make_unique_for_overwrite<Scalar[]>(n);
     w = wStorage.get();
   }
   auto delta_w = std::make_unique<Scalar[]>(n);

--- a/examples/lcp_physics/main.cpp
+++ b/examples/lcp_physics/main.cpp
@@ -45,6 +45,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <random>
 #include <sstream>
 #include <string>
@@ -631,7 +632,7 @@ private:
     if (ImGui::CollapsingHeader("Scenario", ImGuiTreeNodeFlags_DefaultOpen)) {
       int prevScenario = mCurrentScenario;
 
-      for (int i = 0; i < static_cast<int>(mScenarios.size()); ++i) {
+      for (int i = 0; i < std::ssize(mScenarios); ++i) {
         if (ImGui::RadioButton(
                 mScenarios[i].name.c_str(), &mCurrentScenario, i)) {
           if (prevScenario != mCurrentScenario) {
@@ -650,7 +651,7 @@ private:
     if (ImGui::CollapsingHeader("LCP Solver", ImGuiTreeNodeFlags_DefaultOpen)) {
       int prevSolver = mCurrentSolver;
 
-      for (int i = 0; i < static_cast<int>(mSolvers.size()); ++i) {
+      for (int i = 0; i < std::ssize(mSolvers); ++i) {
         if (ImGui::RadioButton(mSolvers[i].name.c_str(), &mCurrentSolver, i)) {
           if (prevSolver != mCurrentSolver) {
             applySolver(mWorld, mSolvers[mCurrentSolver].type);
@@ -697,7 +698,7 @@ private:
         ImGui::PlotLines(
             "##steptime",
             history.data(),
-            static_cast<int>(history.size()),
+            static_cast<int>(std::ssize(history)),
             0,
             nullptr,
             0.0f,
@@ -708,7 +709,7 @@ private:
         for (float t : history) {
           avgTime += t;
         }
-        avgTime /= static_cast<float>(history.size());
+        avgTime /= static_cast<float>(std::ssize(history));
         ImGui::Text("Avg: %.2f ms, Max: %.2f ms", avgTime, maxTime / 1.2f);
       }
     }
@@ -815,7 +816,7 @@ void listSolvers()
 int parseScenario(const std::string& name)
 {
   auto scenarios = GetScenarios();
-  for (int i = 0; i < static_cast<int>(scenarios.size()); ++i) {
+  for (int i = 0; i < std::ssize(scenarios); ++i) {
     std::string lowerName = scenarios[i].name;
     std::ranges::transform(lowerName, lowerName.begin(), ::tolower);
     std::string lowerInput = name;
@@ -830,7 +831,7 @@ int parseScenario(const std::string& name)
 int parseSolver(const std::string& name)
 {
   auto solvers = GetSolvers();
-  for (int i = 0; i < static_cast<int>(solvers.size()); ++i) {
+  for (int i = 0; i < std::ssize(solvers); ++i) {
     std::string lowerName = solvers[i].name;
     std::ranges::transform(lowerName, lowerName.begin(), ::tolower);
     std::string lowerInput = name;

--- a/tests/benchmark/common/bm_allocators_comparative.cpp
+++ b/tests/benchmark/common/bm_allocators_comparative.cpp
@@ -233,7 +233,7 @@ static void BM_Stack_StdPmr(benchmark::State& state)
   const auto size = static_cast<size_t>(state.range(0));
   const auto count = static_cast<size_t>(state.range(1));
   const size_t arenaSize = count * (size + 32) + 4096;
-  auto backing = std::make_unique<char[]>(arenaSize);
+  auto backing = std::make_unique_for_overwrite<char[]>(arenaSize);
 
   for (auto _ : state) {
     // Reconstruct each iteration (monotonic_buffer_resource has no reset())
@@ -598,7 +598,7 @@ static void BM_FrameBulk_StdPmr(benchmark::State& state)
 {
   const auto count = static_cast<size_t>(state.range(0));
   const size_t arenaSize = count * 512 + 4096;
-  auto backing = std::make_unique<char[]>(arenaSize);
+  auto backing = std::make_unique_for_overwrite<char[]>(arenaSize);
 
   lcgState = 55u;
   for (auto _ : state) {
@@ -691,7 +691,7 @@ static void BM_StlVector_StdPmr(benchmark::State& state)
 {
   const auto n = static_cast<size_t>(state.range(0));
   const size_t arenaSize = n * sizeof(int) * 4 + 4096;
-  auto backing = std::make_unique<char[]>(arenaSize);
+  auto backing = std::make_unique_for_overwrite<char[]>(arenaSize);
 
   for (auto _ : state) {
     std::pmr::monotonic_buffer_resource mono(

--- a/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
@@ -38,6 +38,7 @@
 #include <Eigen/Dense>
 #include <benchmark/benchmark.h>
 
+#include <iterator>
 #include <limits>
 #include <random>
 #include <sstream>
@@ -215,8 +216,8 @@ void AddShockPropagationCounters(
     benchmark::State& state,
     const dart::math::ShockPropagationSolver::Parameters& params)
 {
-  const int blockCount = static_cast<int>(params.blockSizes.size());
-  int layerCount = static_cast<int>(params.layers.size());
+  const auto blockCount = std::ssize(params.blockSizes);
+  auto layerCount = std::ssize(params.layers);
   if (layerCount == 0 && blockCount > 0) {
     layerCount = 1;
   }
@@ -226,11 +227,10 @@ void AddShockPropagationCounters(
     maxBlockSize = std::max(maxBlockSize, size);
   }
 
-  int maxBlocksPerLayer = 0;
+  std::ptrdiff_t maxBlocksPerLayer = 0;
   if (!params.layers.empty()) {
     for (const auto& layer : params.layers) {
-      maxBlocksPerLayer
-          = std::max(maxBlocksPerLayer, static_cast<int>(layer.size()));
+      maxBlocksPerLayer = std::max(maxBlocksPerLayer, std::ssize(layer));
     }
   } else {
     maxBlocksPerLayer = blockCount;
@@ -337,7 +337,7 @@ static void BM_LcpCompare_ShockPropagation_Standard(benchmark::State& state)
 
   params.layers.clear();
   params.layers.reserve(params.blockSizes.size());
-  for (int i = 0; i < static_cast<int>(params.blockSizes.size()); ++i) {
+  for (int i = 0; i < std::ssize(params.blockSizes); ++i) {
     params.layers.push_back({i});
   }
 

--- a/tests/integration/io/test_mjcf_parser.cpp
+++ b/tests/integration/io/test_mjcf_parser.cpp
@@ -43,6 +43,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <string>
 
@@ -72,15 +73,15 @@ public:
 
   bool seek(ptrdiff_t offset, SeekType origin) override
   {
-    std::size_t base = 0;
+    ptrdiff_t base = 0;
     if (origin == SEEKTYPE_CUR) {
-      base = mOffset;
+      base = static_cast<ptrdiff_t>(mOffset);
     } else if (origin == SEEKTYPE_END) {
-      base = mData.size();
+      base = std::ssize(mData);
     }
 
-    const auto next = static_cast<long long>(base) + offset;
-    if (next < 0 || next > static_cast<long long>(mData.size())) {
+    const auto next = base + offset;
+    if (next < 0 || next > std::ssize(mData)) {
       return false;
     }
 

--- a/tests/integration/io/test_sdf_parser.cpp
+++ b/tests/integration/io/test_sdf_parser.cpp
@@ -60,6 +60,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <sstream>
 #include <string>
@@ -98,15 +99,15 @@ public:
 
   bool seek(ptrdiff_t offset, SeekType origin) override
   {
-    std::size_t base = 0;
+    ptrdiff_t base = 0;
     if (origin == SEEKTYPE_CUR) {
-      base = mOffset;
+      base = static_cast<ptrdiff_t>(mOffset);
     } else if (origin == SEEKTYPE_END) {
-      base = mData.size();
+      base = std::ssize(mData);
     }
 
-    const auto next = static_cast<long long>(base) + offset;
-    if (next < 0 || next > static_cast<long long>(mData.size())) {
+    const auto next = base + offset;
+    if (next < 0 || next > std::ssize(mData)) {
       return false;
     }
 

--- a/tests/integration/io/test_urdf_parser.cpp
+++ b/tests/integration/io/test_urdf_parser.cpp
@@ -59,6 +59,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <map>
 #include <string>
 
@@ -90,15 +91,15 @@ public:
 
   bool seek(ptrdiff_t offset, SeekType origin) override
   {
-    std::size_t base = 0;
+    ptrdiff_t base = 0;
     if (origin == SEEKTYPE_CUR) {
-      base = mOffset;
+      base = static_cast<ptrdiff_t>(mOffset);
     } else if (origin == SEEKTYPE_END) {
-      base = mData.size();
+      base = std::ssize(mData);
     }
 
-    const auto next = static_cast<long long>(base) + offset;
-    if (next < 0 || next > static_cast<long long>(mData.size())) {
+    const auto next = base + offset;
+    if (next < 0 || next > std::ssize(mData)) {
       return false;
     }
 

--- a/tests/integration/optimization/test_inverse_kinematics.cpp
+++ b/tests/integration/optimization/test_inverse_kinematics.cpp
@@ -39,6 +39,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <iterator>
 #include <span>
 #include <string_view>
 #include <vector>
@@ -70,7 +71,7 @@ public:
   std::span<const Solution> computeSolutions(const Eigen::Isometry3d&) override
   {
     mSolutions.clear();
-    const int dofCount = static_cast<int>(mDofs.size());
+    const auto dofCount = std::ssize(mDofs);
     Eigen::VectorXd config = Eigen::VectorXd::Zero(dofCount);
     mSolutions.emplace_back(config, VALID);
 

--- a/tests/unit/common/test_resource.cpp
+++ b/tests/unit/common/test_resource.cpp
@@ -38,6 +38,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -70,15 +71,15 @@ public:
 
   bool seek(ptrdiff_t offset, SeekType origin) override
   {
-    std::size_t base = 0;
+    ptrdiff_t base = 0;
     if (origin == SEEKTYPE_CUR) {
-      base = mCursor;
+      base = static_cast<ptrdiff_t>(mCursor);
     } else if (origin == SEEKTYPE_END) {
-      base = mData.size();
+      base = std::ssize(mData);
     }
 
-    const auto next = static_cast<long long>(base) + offset;
-    if (next < 0 || next > static_cast<long long>(mData.size())) {
+    const auto next = base + offset;
+    if (next < 0 || next > std::ssize(mData)) {
       return false;
     }
 

--- a/tests/unit/dynamics/test_inverse_kinematics.cpp
+++ b/tests/unit/dynamics/test_inverse_kinematics.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <span>
@@ -93,8 +94,7 @@ public:
   {
     (void)desiredTf;
     mSolutions.clear();
-    Eigen::VectorXd config
-        = Eigen::VectorXd::Zero(static_cast<int>(mDofs.size()));
+    Eigen::VectorXd config = Eigen::VectorXd::Zero(std::ssize(mDofs));
     if (!mDofs.empty()) {
       config[0]
           = mIK->getNode()->getSkeleton()->getDof(mDofs[0])->getPosition();
@@ -160,7 +160,7 @@ TEST(InverseKinematics, ConfigurationAndClone)
   auto& gradient = ik->getGradientMethod();
   gradient.setComponentWiseClamp(0.25);
   gradient.setComponentWeights(
-      Eigen::VectorXd::Constant(static_cast<int>(ik->getDofs().size()), 1.0));
+      Eigen::VectorXd::Constant(std::ssize(ik->getDofs()), 1.0));
   EXPECT_EQ(gradient.getMethodName().empty(), false);
 
   auto clone = ik->clone(fixture.root);
@@ -190,7 +190,7 @@ TEST(InverseKinematics, FindSolutionPaths)
 
   solution.resize(0);
   ik->findSolution(solution);
-  EXPECT_EQ(solution.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(solution.size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, SolveAllowIncompleteFalse)
@@ -233,9 +233,9 @@ TEST(InverseKinematics, FindSolutionUsesProvidedConfig)
   ik->setSolver(solver);
 
   Eigen::VectorXd config
-      = Eigen::VectorXd::Constant(static_cast<int>(ik->getDofs().size()), 0.1);
+      = Eigen::VectorXd::Constant(std::ssize(ik->getDofs()), 0.1);
   ik->findSolution(config);
-  EXPECT_EQ(config.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(config.size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, TaskSpaceRegionReferenceFrameError)
@@ -330,16 +330,16 @@ TEST(InverseKinematics, SolveWithJacobianMethods)
   dls.setDampingCoefficient(0.15);
   Eigen::VectorXd dlsSolution;
   EXPECT_TRUE(ik->findSolution(dlsSolution) || dlsSolution.size() > 0);
-  EXPECT_EQ(dlsSolution.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(dlsSolution.size(), std::ssize(ik->getDofs()));
 
   auto& transpose
       = ik->setGradientMethod<InverseKinematics::JacobianTranspose>();
   transpose.setComponentWiseClamp(0.05);
   transpose.setComponentWeights(
-      Eigen::VectorXd::Constant(static_cast<int>(ik->getDofs().size()), 0.8));
+      Eigen::VectorXd::Constant(std::ssize(ik->getDofs()), 0.8));
   Eigen::VectorXd jtSolution;
   EXPECT_TRUE(ik->findSolution(jtSolution) || jtSolution.size() > 0);
-  EXPECT_EQ(jtSolution.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(jtSolution.size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, AnalyticalGradientAndWeights)
@@ -366,8 +366,7 @@ TEST(InverseKinematics, AnalyticalGradientAndWeights)
 
   const auto solutions = analyticalPtr->getSolutions();
   ASSERT_EQ(solutions.size(), 1u);
-  EXPECT_EQ(
-      solutions[0].mConfig.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(solutions[0].mConfig.size(), std::ssize(ik->getDofs()));
 
   Eigen::VectorXd q = ik->getPositions();
   Eigen::VectorXd grad = Eigen::VectorXd::Zero(q.size());
@@ -482,7 +481,7 @@ TEST(InverseKinematics, AnalyticalExtraDofsAndGradientCaching)
   analytical.setExtraErrorLengthClamp(0.2);
   analytical.setComponentWiseClamp(0.05);
   analytical.setComponentWeights(
-      Eigen::VectorXd::Constant(static_cast<int>(ik->getDofs().size()), 1.0));
+      Eigen::VectorXd::Constant(std::ssize(ik->getDofs()), 1.0));
 
   Eigen::VectorXd q = ik->getPositions();
   Eigen::VectorXd grad = Eigen::VectorXd::Zero(q.size());
@@ -501,9 +500,7 @@ TEST(InverseKinematics, AnalyticalExtraDofsAndGradientCaching)
       analytical.getExtraDofUtilization(),
       InverseKinematics::Analytical::PRE_ANALYTICAL);
   EXPECT_DOUBLE_EQ(analytical.getComponentWiseClamp(), 0.05);
-  EXPECT_EQ(
-      analytical.getComponentWeights().size(),
-      static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(analytical.getComponentWeights().size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, ObjectiveAndConstraintEvaluation)
@@ -575,7 +572,7 @@ TEST(InverseKinematics, ResetProblemAndSolveAndApply)
   ASSERT_NE(problem, nullptr);
 
   const auto dofs = ik->getDofs();
-  Eigen::VectorXd seed = Eigen::VectorXd::Zero(static_cast<int>(dofs.size()));
+  Eigen::VectorXd seed = Eigen::VectorXd::Zero(std::ssize(dofs));
   problem->addSeed(seed);
   EXPECT_EQ(problem->getSeeds().size(), 1u);
 
@@ -591,7 +588,7 @@ TEST(InverseKinematics, ResetProblemAndSolveAndApply)
   ik->setOffset(Eigen::Vector3d(0.1, 0.0, 0.0));
   const auto jac = ik->computeJacobian();
   EXPECT_EQ(jac.rows(), 6);
-  EXPECT_EQ(jac.cols(), static_cast<int>(dofs.size()));
+  EXPECT_EQ(jac.cols(), std::ssize(dofs));
 
   ik->setOffset(Eigen::Vector3d::Zero());
   auto solver = std::make_shared<math::GradientDescentSolver>();
@@ -603,7 +600,7 @@ TEST(InverseKinematics, ResetProblemAndSolveAndApply)
 
   Eigen::VectorXd positions;
   EXPECT_TRUE(ik->solveAndApply(positions, false));
-  EXPECT_EQ(positions.size(), static_cast<int>(dofs.size()));
+  EXPECT_EQ(positions.size(), std::ssize(dofs));
 }
 
 TEST(HierarchicalIK, CompositeAndWholeBody)
@@ -973,7 +970,7 @@ TEST(InverseKinematics, AccessorsAndConfiguration)
       = ik->setGradientMethod<InverseKinematics::JacobianTranspose>();
   transpose.setComponentWiseClamp(0.1);
   transpose.setComponentWeights(
-      Eigen::VectorXd::Constant(static_cast<int>(ik->getDofs().size()), 1.0));
+      Eigen::VectorXd::Constant(std::ssize(ik->getDofs()), 1.0));
 
   Eigen::VectorXd grad = Eigen::VectorXd::Zero(q.size());
   Eigen::Map<Eigen::VectorXd> gradMap(grad.data(), grad.size());
@@ -992,7 +989,7 @@ TEST(InverseKinematics, AccessorsAndConfiguration)
 
   Eigen::VectorXd solution;
   EXPECT_TRUE(ik->findSolution(solution) || solution.size() > 0);
-  EXPECT_EQ(solution.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(solution.size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, ConstAccessorsAndProblemSetup)
@@ -1074,7 +1071,7 @@ TEST(InverseKinematics, ConstAccessorsAndProblemSetup)
 
   Eigen::VectorXd solution;
   ik->solveAndApply(solution, true);
-  EXPECT_EQ(solution.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(solution.size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, AnalyticalConfigurationAndClone)
@@ -1392,8 +1389,7 @@ TEST(InverseKinematics, ErrorMethodDesiredTransformAndAnalyticalSolutions)
   auto& analytical = ik->setGradientMethod<DummyAnalytical>();
   const auto solutions = analytical.getSolutions();
   ASSERT_EQ(solutions.size(), 1u);
-  EXPECT_EQ(
-      solutions[0].mConfig.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(solutions[0].mConfig.size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, TaskSpaceRegionCenterBoundsAndOffset)
@@ -1544,7 +1540,7 @@ TEST(InverseKinematics, EndEffectorCreateIkSolveGradientDescent)
 
   Eigen::VectorXd solution;
   ik->solveAndApply(solution, true);
-  EXPECT_EQ(solution.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(solution.size(), std::ssize(ik->getDofs()));
 }
 
 TEST(InverseKinematics, EndEffectorCreateIkSolveAnalytical)
@@ -1567,7 +1563,7 @@ TEST(InverseKinematics, EndEffectorCreateIkSolveAnalytical)
 
   Eigen::VectorXd positions;
   ik->solveAndApply(positions, true);
-  EXPECT_EQ(positions.size(), static_cast<int>(ik->getDofs().size()));
+  EXPECT_EQ(positions.size(), std::ssize(ik->getDofs()));
   EXPECT_NE(ik->getAnalytical(), nullptr);
 }
 

--- a/tests/unit/dynamics/test_mesh_shape.cpp
+++ b/tests/unit/dynamics/test_mesh_shape.cpp
@@ -139,7 +139,7 @@ public:
     if (next < 0) {
       return false;
     }
-    if (static_cast<std::size_t>(next) > mData.size()) {
+    if (next > std::ssize(mData)) {
       return false;
     }
 

--- a/tests/unit/dynamics/test_skeleton_accessors.cpp
+++ b/tests/unit/dynamics/test_skeleton_accessors.cpp
@@ -65,6 +65,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <iterator>
 #include <memory>
 #include <vector>
 
@@ -3894,8 +3895,8 @@ TEST(SkeletonAccessors, MultiTreeMassMatricesAndCaches)
 
   const auto& M0 = skeleton->getMassMatrix(0);
   const auto& M1 = skeleton->getMassMatrix(1);
-  EXPECT_EQ(M0.rows(), static_cast<int>(tree0Dofs.size()));
-  EXPECT_EQ(M1.cols(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(M0.rows(), std::ssize(tree0Dofs));
+  EXPECT_EQ(M1.cols(), std::ssize(tree1Dofs));
   EXPECT_TRUE(M0.allFinite());
   EXPECT_TRUE(M1.allFinite());
 

--- a/tests/unit/dynamics/test_skeleton_properties.cpp
+++ b/tests/unit/dynamics/test_skeleton_properties.cpp
@@ -45,6 +45,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <iterator>
 #include <vector>
 
 using namespace dart::dynamics;
@@ -200,9 +201,9 @@ TEST(SkeletonConfiguration, GetConfigWithIndicesAndCommands)
       indices,
       Skeleton::CONFIG_COMMANDS | Skeleton::CONFIG_FORCES
           | Skeleton::CONFIG_ACCELERATIONS);
-  EXPECT_EQ(config.mCommands.size(), static_cast<int>(indices.size()));
-  EXPECT_EQ(config.mForces.size(), static_cast<int>(indices.size()));
-  EXPECT_EQ(config.mAccelerations.size(), static_cast<int>(indices.size()));
+  EXPECT_EQ(config.mCommands.size(), std::ssize(indices));
+  EXPECT_EQ(config.mForces.size(), std::ssize(indices));
+  EXPECT_EQ(config.mAccelerations.size(), std::ssize(indices));
   EXPECT_EQ(config.mPositions.size(), 0);
   EXPECT_EQ(config.mVelocities.size(), 0);
 }
@@ -347,66 +348,66 @@ TEST(SkeletonProperties, TreeLevelMassMatrixGetters)
   const auto tree1Dofs = skeleton->getTreeDofs(1);
 
   const auto& mass0 = skeleton->getMassMatrix(0);
-  EXPECT_EQ(mass0.rows(), static_cast<int>(tree0Dofs.size()));
-  EXPECT_EQ(mass0.cols(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(mass0.rows(), std::ssize(tree0Dofs));
+  EXPECT_EQ(mass0.cols(), std::ssize(tree0Dofs));
 
   const auto& augMass0 = skeleton->getAugMassMatrix(0);
-  EXPECT_EQ(augMass0.rows(), static_cast<int>(tree0Dofs.size()));
-  EXPECT_EQ(augMass0.cols(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(augMass0.rows(), std::ssize(tree0Dofs));
+  EXPECT_EQ(augMass0.cols(), std::ssize(tree0Dofs));
 
   const auto& invMass0 = skeleton->getInvMassMatrix(0);
-  EXPECT_EQ(invMass0.rows(), static_cast<int>(tree0Dofs.size()));
-  EXPECT_EQ(invMass0.cols(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(invMass0.rows(), std::ssize(tree0Dofs));
+  EXPECT_EQ(invMass0.cols(), std::ssize(tree0Dofs));
 
   const auto& invAugMass0 = skeleton->getInvAugMassMatrix(0);
-  EXPECT_EQ(invAugMass0.rows(), static_cast<int>(tree0Dofs.size()));
-  EXPECT_EQ(invAugMass0.cols(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(invAugMass0.rows(), std::ssize(tree0Dofs));
+  EXPECT_EQ(invAugMass0.cols(), std::ssize(tree0Dofs));
 
   const auto& coriolis0 = skeleton->getCoriolisForces(0);
-  EXPECT_EQ(coriolis0.size(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(coriolis0.size(), std::ssize(tree0Dofs));
 
   const auto& gravity0 = skeleton->getGravityForces(0);
-  EXPECT_EQ(gravity0.size(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(gravity0.size(), std::ssize(tree0Dofs));
 
   const auto& cg0 = skeleton->getCoriolisAndGravityForces(0);
-  EXPECT_EQ(cg0.size(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(cg0.size(), std::ssize(tree0Dofs));
 
   const auto& ext0 = skeleton->getExternalForces(0);
-  EXPECT_EQ(ext0.size(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(ext0.size(), std::ssize(tree0Dofs));
 
   const auto& constraint0 = skeleton->getConstraintForces(0);
-  EXPECT_EQ(constraint0.size(), static_cast<int>(tree0Dofs.size()));
+  EXPECT_EQ(constraint0.size(), std::ssize(tree0Dofs));
 
   const auto& mass1 = skeleton->getMassMatrix(1);
-  EXPECT_EQ(mass1.rows(), static_cast<int>(tree1Dofs.size()));
-  EXPECT_EQ(mass1.cols(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(mass1.rows(), std::ssize(tree1Dofs));
+  EXPECT_EQ(mass1.cols(), std::ssize(tree1Dofs));
 
   const auto& augMass1 = skeleton->getAugMassMatrix(1);
-  EXPECT_EQ(augMass1.rows(), static_cast<int>(tree1Dofs.size()));
-  EXPECT_EQ(augMass1.cols(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(augMass1.rows(), std::ssize(tree1Dofs));
+  EXPECT_EQ(augMass1.cols(), std::ssize(tree1Dofs));
 
   const auto& invMass1 = skeleton->getInvMassMatrix(1);
-  EXPECT_EQ(invMass1.rows(), static_cast<int>(tree1Dofs.size()));
-  EXPECT_EQ(invMass1.cols(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(invMass1.rows(), std::ssize(tree1Dofs));
+  EXPECT_EQ(invMass1.cols(), std::ssize(tree1Dofs));
 
   const auto& invAugMass1 = skeleton->getInvAugMassMatrix(1);
-  EXPECT_EQ(invAugMass1.rows(), static_cast<int>(tree1Dofs.size()));
-  EXPECT_EQ(invAugMass1.cols(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(invAugMass1.rows(), std::ssize(tree1Dofs));
+  EXPECT_EQ(invAugMass1.cols(), std::ssize(tree1Dofs));
 
   const auto& coriolis1 = skeleton->getCoriolisForces(1);
-  EXPECT_EQ(coriolis1.size(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(coriolis1.size(), std::ssize(tree1Dofs));
 
   const auto& gravity1 = skeleton->getGravityForces(1);
-  EXPECT_EQ(gravity1.size(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(gravity1.size(), std::ssize(tree1Dofs));
 
   const auto& cg1 = skeleton->getCoriolisAndGravityForces(1);
-  EXPECT_EQ(cg1.size(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(cg1.size(), std::ssize(tree1Dofs));
 
   const auto& ext1 = skeleton->getExternalForces(1);
-  EXPECT_EQ(ext1.size(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(ext1.size(), std::ssize(tree1Dofs));
 
   const auto& constraint1 = skeleton->getConstraintForces(1);
-  EXPECT_EQ(constraint1.size(), static_cast<int>(tree1Dofs.size()));
+  EXPECT_EQ(constraint1.size(), std::ssize(tree1Dofs));
 
   Eigen::VectorXd positions = skeleton->getPositions();
   positions[0] += 0.2;

--- a/tests/unit/math/lcp/test_lcp_comparison_harness.cpp
+++ b/tests/unit/math/lcp/test_lcp_comparison_harness.cpp
@@ -34,6 +34,8 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include <iterator>
+
 namespace {
 
 using dart::math::LcpOptions;
@@ -156,7 +158,7 @@ TEST(LcpComparisonHarness, ShockPropagationOnStandardFixtures)
       continue;
     }
 
-    const int n = static_cast<int>(fixture.problem.b.size());
+    const int n = static_cast<int>(std::ssize(fixture.problem.b));
 
     dart::math::ShockPropagationSolver::Parameters params;
     params.blockSizes = {n};
@@ -181,7 +183,7 @@ TEST(LcpComparisonHarness, ShockPropagationOnFrictionIndexFixtures)
   dart::math::ShockPropagationSolver solver;
 
   for (const auto& fixture : dart::test::getFrictionIndexFixtures()) {
-    const int n = static_cast<int>(fixture.problem.b.size());
+    const int n = static_cast<int>(std::ssize(fixture.problem.b));
     if (n % 3 != 0) {
       continue;
     }
@@ -319,7 +321,7 @@ TEST(LcpComparisonHarness, BgsOnStandardFixtureWithExplicitBlocks)
     if (fixture.kind != dart::test::LcpFixtureKind::Standard) {
       continue;
     }
-    const int n = static_cast<int>(fixture.problem.b.size());
+    const int n = static_cast<int>(std::ssize(fixture.problem.b));
     if (n > 3) {
       continue;
     }
@@ -366,7 +368,7 @@ TEST(LcpComparisonHarness, BlockedJacobiOnStandardFixtureWithExplicitBlocks)
     if (fixture.kind != dart::test::LcpFixtureKind::Standard) {
       continue;
     }
-    const int n = static_cast<int>(fixture.problem.b.size());
+    const int n = static_cast<int>(std::ssize(fixture.problem.b));
     if (n > 3) {
       continue;
     }

--- a/tests/unit/math/test_convhull.cpp
+++ b/tests/unit/math/test_convhull.cpp
@@ -34,6 +34,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include <set>
 #include <span>
 #include <unordered_set>
@@ -173,7 +174,7 @@ TYPED_TEST(ConvexHullTest, Cube)
   std::set<int> usedVertices;
   for (const auto& idx : faces) {
     ASSERT_GE(idx, 0) << "Vertex index must be non-negative";
-    ASSERT_LT(idx, static_cast<int>(vertices.size()))
+    ASSERT_LT(idx, std::ssize(vertices))
         << "Vertex index must be < number of vertices";
     usedVertices.insert(idx);
   }
@@ -245,7 +246,7 @@ TYPED_TEST(ConvexHullTest, Octahedron)
   std::set<int> usedVertices;
   for (const auto& idx : faces) {
     ASSERT_GE(idx, 0) << "Vertex index must be non-negative";
-    ASSERT_LT(idx, static_cast<int>(vertices.size()))
+    ASSERT_LT(idx, std::ssize(vertices))
         << "Vertex index must be < number of vertices";
     usedVertices.insert(idx);
   }
@@ -334,7 +335,7 @@ TYPED_TEST(ConvexHullTest, AllFaceIndicesValid)
   // All face indices must be valid
   for (const auto& idx : faces) {
     EXPECT_GE(idx, 0) << "Face index must be non-negative";
-    EXPECT_LT(idx, static_cast<int>(vertices.size()))
+    EXPECT_LT(idx, std::ssize(vertices))
         << "Face index must be < number of vertices";
   }
 }


### PR DESCRIPTION
## Summary

- Adopt C++20 signed-size and allocation helpers across a larger focused sweep.

## Motivation / Problem

- Prefer standard C++20 library utilities over repeated casts and manual array ownership when the surrounding code already uses signed indexes or fully overwrites scratch storage.

## Changes / Key Changes

- Use `std::ssize` for signed container sizes in resource seek bounds, tests, benchmarks, and the LCP physics example.
- Use `std::make_unique_for_overwrite` for scratch buffers that are immediately filled or used as raw backing storage.
- Replace a manual `new[]`/`delete[]` diagnostic buffer with `std::unique_ptr` ownership.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable