### PR TITLE
Adopt C++20 derived type constraints

### DIFF
--- a/dart/common/detail/composite_data.hpp
+++ b/dart/common/detail/composite_data.hpp
@@ -37,7 +37,9 @@
 
 #include <Eigen/Core>
 
+#include <concepts>
 #include <map>
+#include <type_traits>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_set>
@@ -77,8 +79,7 @@ template <class AspectT>
 struct GetAspect
 {
   using Type =
-      typename GetAspectImpl<AspectT, std::is_base_of<Aspect, AspectT>::value>::
-          Type;
+      typename GetAspectImpl<AspectT, std::derived_from<AspectT, Aspect>>::Type;
 };
 
 //==============================================================================
@@ -231,19 +232,19 @@ public:
   template <typename Arg>
   struct ConvertIfData
   {
-    using Type = typename std::conditional<
-        std::is_base_of<typename Base::Data, Arg>::value,
+    using Type = std::conditional_t<
+        std::derived_from<Arg, typename Base::Data>,
         typename Base::Data,
-        Arg>::type;
+        Arg>;
   };
 
   template <typename Arg>
   struct ConvertIfComposite
   {
-    using Type = typename std::conditional<
-        std::is_base_of<CompositeType, Arg>::value,
+    using Type = std::conditional_t<
+        std::derived_from<Arg, CompositeType>,
         CompositeType,
-        Arg>::type;
+        Arg>;
   };
 
   // To get byte-aligned Eigen vectors

--- a/dart/common/detail/embedded_aspect.hpp
+++ b/dart/common/detail/embedded_aspect.hpp
@@ -38,6 +38,9 @@
 #include <dart/common/aspect.hpp>
 #include <dart/common/stl_helpers.hpp>
 
+#include <concepts>
+#include <type_traits>
+
 namespace dart {
 namespace common {
 namespace detail {
@@ -106,8 +109,8 @@ public:
   template <typename T>
   struct ConvertIfState
   {
-    using type = typename std::
-        conditional<std::is_base_of<StateData, T>::value, StateData, T>::type;
+    using type
+        = std::conditional_t<std::derived_from<T, StateData>, StateData, T>;
   };
 
   /// Construct this Aspect without affecting the State.
@@ -275,10 +278,8 @@ public:
   template <typename T>
   struct ConvertIfProperties
   {
-    using type = typename std::conditional<
-        std::is_base_of<PropertiesData, T>::value,
-        PropertiesData,
-        T>::type;
+    using type = std::
+        conditional_t<std::derived_from<T, PropertiesData>, PropertiesData, T>;
   };
 
   /// Construct this Aspect without affecting the Properties.

--- a/dart/dynamics/entity_node.hpp
+++ b/dart/dynamics/entity_node.hpp
@@ -35,6 +35,8 @@
 
 #include <dart/dynamics/detail/entity_node_aspect.hpp>
 
+#include <concepts>
+
 namespace dart {
 namespace dynamics {
 
@@ -42,7 +44,7 @@ namespace dynamics {
 template <class Base>
 class EntityNode
   : public detail::
-        EntityNodeBase<Base, std::is_base_of<common::Composite, Base>::value>
+        EntityNodeBase<Base, std::derived_from<Base, common::Composite>>
 {
 public:
   using NameAspect = typename detail::EntityNodeAspectBase<Base>::Aspect;
@@ -50,9 +52,8 @@ public:
   /// Forwarding constructor
   template <typename... Args>
   EntityNode(Args&&... args)
-    : detail::
-          EntityNodeBase<Base, std::is_base_of<common::Composite, Base>::value>(
-              std::forward<Args>(args)...)
+    : detail::EntityNodeBase<Base, std::derived_from<Base, common::Composite>>(
+          std::forward<Args>(args)...)
   {
     this->template createAspect<NameAspect>();
   }

--- a/python/dartpy/common/type_casters.hpp
+++ b/python/dartpy/common/type_casters.hpp
@@ -4,6 +4,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include <concepts>
 #include <type_traits>
 
 #include "dart/dynamics/frame.hpp"
@@ -186,11 +187,10 @@ struct type_caster<dart::dynamics::Joint>
 };
 
 template <typename JointT>
-struct type_caster<
-    JointT,
-    std::enable_if_t<
-        std::is_base_of_v<dart::dynamics::Joint, JointT>
-        && !std::is_same_v<dart::dynamics::Joint, JointT>>>
+  requires(
+      std::derived_from<JointT, dart::dynamics::Joint>
+      && !std::same_as<JointT, dart::dynamics::Joint>)
+struct type_caster<JointT, int>
     : polymorphic_type_caster<JointT>
 {
   template <typename T>


### PR DESCRIPTION
## Summary

- Adopt C++20 `std::derived_from` for core derived-type routing in composite/aspect helpers.
- Replace the nanobind joint caster SFINAE specialization with a constrained C++20 partial specialization.

## Motivation / Problem

- DART now targets C++20, so template constraints can express derived-type requirements directly instead of encoding them through legacy `std::is_base_of` and `std::enable_if_t` plumbing.

## Changes / Key Changes

- Use `std::derived_from` for `EntityNode` base selection and composite/aspect data conversion helpers.
- Use `std::conditional_t` while touching the same type-routing helpers.
- Use `std::derived_from` and `std::same_as` in the Python joint caster specialization.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-py`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable