### PR TITLE
Adopt C++20 construct_at in allocators

### DIFF
--- a/dart/common/detail/memory_allocator-impl.hpp
+++ b/dart/common/detail/memory_allocator-impl.hpp
@@ -56,29 +56,27 @@ T* MemoryAllocator::construct(Args&&... args) noexcept
 
   // Call constructor. Return nullptr if failed.
   try {
-    new (object) T(std::forward<Args>(args)...);
+    return std::construct_at(
+        static_cast<T*>(object), std::forward<Args>(args)...);
   } catch (...) {
     deallocate(object, sizeof(T));
     return nullptr;
   }
-
-  return reinterpret_cast<T*>(object);
 }
 
 //==============================================================================
 template <typename T, typename... Args>
 T* MemoryAllocator::constructAt(void* pointer, Args&&... args)
 {
-  return ::new (const_cast<void*>(static_cast<const volatile void*>(pointer)))
-      T(std::forward<Args>(args)...);
+  return std::construct_at(
+      static_cast<T*>(pointer), std::forward<Args>(args)...);
 }
 
 //==============================================================================
 template <typename T, typename... Args>
 T* MemoryAllocator::constructAt(T* pointer, Args&&... args)
 {
-  return ::new (const_cast<void*>(static_cast<const volatile void*>(pointer)))
-      T(std::forward<Args>(args)...);
+  return std::construct_at(pointer, std::forward<Args>(args)...);
 }
 
 //==============================================================================
@@ -88,7 +86,7 @@ void MemoryAllocator::destroy(T* object) noexcept
   if (!object) {
     return;
   }
-  object->~T();
+  std::destroy_at(object);
   deallocate(object, sizeof(T));
 }
 

--- a/dart/common/detail/memory_manager-impl.hpp
+++ b/dart/common/detail/memory_manager-impl.hpp
@@ -49,13 +49,12 @@ T* MemoryManager::construct(Type type, Args&&... args) noexcept
 
   // Call constructor. Return nullptr if failed.
   try {
-    new (object) T(std::forward<Args>(args)...);
+    return std::construct_at(
+        static_cast<T*>(object), std::forward<Args>(args)...);
   } catch (...) {
     deallocate(type, object, sizeof(T));
     return nullptr;
   }
-
-  return reinterpret_cast<T*>(object);
 }
 
 //==============================================================================
@@ -86,7 +85,7 @@ void MemoryManager::destroy(Type type, T* object) noexcept
   if (!object) {
     return;
   }
-  object->~T();
+  std::destroy_at(object);
   deallocate(type, object, sizeof(T));
 }
 

--- a/dart/common/frame_allocator.hpp
+++ b/dart/common/frame_allocator.hpp
@@ -39,6 +39,7 @@
 #include <dart/export.hpp>
 
 #include <algorithm>
+#include <memory>
 #include <new>
 #include <stdexcept>
 #include <utility>
@@ -145,7 +146,8 @@ public:
     if (memory == nullptr) {
       return nullptr;
     }
-    return new (memory) T(std::forward<Args>(args)...);
+    return std::construct_at(
+        static_cast<T*>(memory), std::forward<Args>(args)...);
   }
 
   [[nodiscard]] size_t capacity() const noexcept;

--- a/dart/common/free_list_allocator.cpp
+++ b/dart/common/free_list_allocator.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/logging.hpp"
 #include "dart/common/macros.hpp"
 
+#include <memory>
+
 namespace dart::common {
 
 //==============================================================================
@@ -63,7 +65,7 @@ FreeListAllocator::~FreeListAllocator()
       DART_ASSERT(!curr->mIsAllocated); // pointers should already be freed
       MemoryBlockHeader* next = curr->mNext;
 
-      curr->~MemoryBlockHeader();
+      std::destroy_at(curr);
       curr = next;
     }
   }
@@ -301,12 +303,12 @@ void FreeListAllocator::MemoryBlockHeader::split(size_t sizeToSplit)
 
   unsigned char* new_block_addr
       = asCharPtr() + sizeof(MemoryBlockHeader) + sizeToSplit;
-  MemoryBlockHeader* new_block
-      = new (static_cast<void*>(new_block_addr)) MemoryBlockHeader(
-          mSize - sizeof(MemoryBlockHeader) - sizeToSplit,
-          this,
-          mNext,
-          mIsNextContiguous);
+  MemoryBlockHeader* new_block = std::construct_at(
+      reinterpret_cast<MemoryBlockHeader*>(new_block_addr),
+      mSize - sizeof(MemoryBlockHeader) - sizeToSplit,
+      this,
+      mNext,
+      mIsNextContiguous);
   mNext = new_block;
   if (new_block->mNext) {
     new_block->mNext->mPrev = new_block;
@@ -336,7 +338,7 @@ void FreeListAllocator::MemoryBlockHeader::merge(MemoryBlockHeader* other)
   }
   mIsNextContiguous = other->mIsNextContiguous;
 
-  other->~MemoryBlockHeader(); // TODO(JS): Need this?
+  std::destroy_at(other); // TODO(JS): Need this?
 
   DART_ASSERT(isValid());
 }

--- a/dart/common/memory_allocator.hpp
+++ b/dart/common/memory_allocator.hpp
@@ -40,6 +40,7 @@
 #include <dart/export.hpp>
 
 #include <iostream>
+#include <memory>
 #include <string_view>
 
 #include <cstddef>


### PR DESCRIPTION
## Summary

- Adopt C++20 object lifetime helpers in the common allocator code.
- Replace direct placement-new and destructor calls with `std::construct_at` and `std::destroy_at` where the code already manages raw storage.

## Motivation / Problem

- The allocator layer manually constructs and destroys objects in raw storage.
- C++20 provides standard helpers that make those lifetime operations explicit while preserving the existing allocation behavior.

## Changes / Key Changes

- Use `std::construct_at` in `MemoryAllocator`, `MemoryManager`, `FrameAllocator`, and free-list block splitting.
- Use `std::destroy_at` for allocator-owned object destruction and free-list block header cleanup.
- Add the required `<memory>` includes where those helpers are used.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable