### PR TITLE
Adopt C++20 span range construction

### DIFF
--- a/dart/collision/collision_result.cpp
+++ b/dart/collision/collision_result.cpp
@@ -74,7 +74,7 @@ const Contact& CollisionResult::getContact(std::size_t index) const
 //==============================================================================
 std::span<const Contact> CollisionResult::getContacts() const
 {
-  return std::span<const Contact>(mContacts);
+  return mContacts;
 }
 
 //==============================================================================

--- a/dart/common/detail/cloneable.hpp
+++ b/dart/common/detail/cloneable.hpp
@@ -637,7 +637,7 @@ std::vector<T>& CloneableVector<T>::getVector()
 template <typename T>
 std::span<const T> CloneableVector<T>::getVector() const
 {
-  return std::span<const T>(mVector);
+  return mVector;
 }
 
 } // namespace common

--- a/dart/dynamics/hierarchical_ik.cpp
+++ b/dart/dynamics/hierarchical_ik.cpp
@@ -244,7 +244,7 @@ std::span<const Eigen::MatrixXd> HierarchicalIK::computeNullSpaces() const
   // indexing and changes in Joint / BodyNode properties.
 
   if (!recompute) {
-    return std::span<const Eigen::MatrixXd>(mNullSpaceCache);
+    return mNullSpaceCache;
   }
 
   const IKHierarchy& hierarchy = getIKHierarchy();
@@ -300,7 +300,7 @@ std::span<const Eigen::MatrixXd> HierarchicalIK::computeNullSpaces() const
     }
   }
 
-  return std::span<const Eigen::MatrixXd>(mNullSpaceCache);
+  return mNullSpaceCache;
 }
 
 //==============================================================================

--- a/dart/dynamics/ik_fast.cpp
+++ b/dart/dynamics/ik_fast.cpp
@@ -263,13 +263,13 @@ std::span<const std::size_t> IkFast::getDofs() const
     }
   }
 
-  return std::span<const std::size_t>(mDofs);
+  return mDofs;
 }
 
 //==============================================================================
 std::span<const std::size_t> IkFast::getFreeDofs() const
 {
-  return std::span<const std::size_t>(mFreeDofs);
+  return mFreeDofs;
 }
 
 //==============================================================================
@@ -401,8 +401,7 @@ IkFast::computeSolutions(const Eigen::Isometry3d& desiredBodyTf)
           "This analytical IK was not able to configure properly, so it will "
           "not be able to compute solutions. Returning an empty list of "
           "solutions.");
-      return std::span<const InverseKinematics::Analytical::Solution>(
-          mSolutions);
+      return mSolutions;
     }
   }
 
@@ -432,7 +431,7 @@ IkFast::computeSolutions(const Eigen::Isometry3d& desiredBodyTf)
         mSolutions);
   }
 
-  return std::span<const InverseKinematics::Analytical::Solution>(mSolutions);
+  return mSolutions;
 }
 
 //==============================================================================

--- a/dart/dynamics/inverse_kinematics.cpp
+++ b/dart/dynamics/inverse_kinematics.cpp
@@ -1061,7 +1061,7 @@ std::span<const IK::Analytical::Solution> IK::Analytical::getSolutions(
 
   setPositions(mRestoreConfigCache);
 
-  return std::span<const IK::Analytical::Solution>(mSolutions);
+  return mSolutions;
 }
 
 //==============================================================================
@@ -1395,13 +1395,13 @@ void InverseKinematics::setDofs(std::span<const std::size_t> _dofs)
 //==============================================================================
 std::span<const std::size_t> InverseKinematics::getDofs() const
 {
-  return std::span<const std::size_t>(mDofs);
+  return mDofs;
 }
 
 //==============================================================================
 std::span<const int> InverseKinematics::getDofMap() const
 {
-  return std::span<const int>(mDofMap);
+  return mDofMap;
 }
 
 //==============================================================================

--- a/dart/dynamics/joint.cpp
+++ b/dart/dynamics/joint.cpp
@@ -497,7 +497,7 @@ double Joint::getMimicOffset(std::size_t index) const
 //==============================================================================
 std::span<const MimicDofProperties> Joint::getMimicDofProperties() const
 {
-  return std::span<const MimicDofProperties>(mAspectProperties.mMimicDofProps);
+  return mAspectProperties.mMimicDofProps;
 }
 
 //==============================================================================

--- a/dart/dynamics/line_segment_shape.cpp
+++ b/dart/dynamics/line_segment_shape.cpp
@@ -218,7 +218,7 @@ const Eigen::Vector3d& LineSegmentShape::getVertex(std::size_t _idx) const
 //==============================================================================
 std::span<const Eigen::Vector3d> LineSegmentShape::getVertices() const
 {
-  return std::span<const Eigen::Vector3d>(mVertices);
+  return mVertices;
 }
 
 //==============================================================================
@@ -287,7 +287,7 @@ void LineSegmentShape::removeConnection(std::size_t _connectionIdx)
 //==============================================================================
 std::span<const Eigen::Vector2i> LineSegmentShape::getConnections() const
 {
-  return std::span<const Eigen::Vector2i>(mConnections);
+  return mConnections;
 }
 
 //==============================================================================

--- a/dart/dynamics/point_cloud_shape.cpp
+++ b/dart/dynamics/point_cloud_shape.cpp
@@ -135,7 +135,7 @@ void PointCloudShape::addPoints(const ::octomap::Pointcloud& pointCloud)
 //==============================================================================
 std::span<const Eigen::Vector3d> PointCloudShape::getPoints() const
 {
-  return std::span<const Eigen::Vector3d>(mPoints);
+  return mPoints;
 }
 
 //==============================================================================
@@ -214,7 +214,7 @@ void PointCloudShape::setColors(std::span<const Eigen::Vector4d> colors)
 //==============================================================================
 std::span<const Eigen::Vector4d> PointCloudShape::getColors() const
 {
-  return std::span<const Eigen::Vector4d>(mColors);
+  return mColors;
 }
 
 //==============================================================================

--- a/dart/dynamics/soft_body_node.cpp
+++ b/dart/dynamics/soft_body_node.cpp
@@ -258,7 +258,7 @@ const PointMass* SoftBodyNode::getPointMass(std::size_t _idx) const
 //==============================================================================
 std::span<PointMass* const> SoftBodyNode::getPointMasses() const
 {
-  return std::span<PointMass* const>(mPointMasses);
+  return mPointMasses;
 }
 
 //==============================================================================

--- a/dart/gui/default_event_handler.cpp
+++ b/dart/gui/default_event_handler.cpp
@@ -164,16 +164,16 @@ std::span<const PickInfo> DefaultEventHandler::getButtonPicks(
     MouseButton button, MouseButtonEvent event) const
 {
   if (BUTTON_NOTHING == event) {
-    return std::span<const PickInfo>(mMovePicks);
+    return mMovePicks;
   }
 
-  return std::span<const PickInfo>(mButtonPicks[button][event]);
+  return mButtonPicks[button][event];
 }
 
 //==============================================================================
 std::span<const PickInfo> DefaultEventHandler::getMovePicks() const
 {
-  return std::span<const PickInfo>(mMovePicks);
+  return mMovePicks;
 }
 
 //==============================================================================

--- a/dart/gui/drag_and_drop.cpp
+++ b/dart/gui/drag_and_drop.cpp
@@ -714,7 +714,7 @@ void BodyNodeDnD::move()
       }
     }
 
-    mIK->setDofs(std::span<const std::size_t>(dofs));
+    mIK->setDofs(dofs);
   } else {
     if (mUseWholeBody) {
       mIK->useWholeBody();

--- a/dart/gui/polyhedron_visual.cpp
+++ b/dart/gui/polyhedron_visual.cpp
@@ -131,7 +131,7 @@ void PolyhedronVisual::setVertices(
 //==============================================================================
 std::span<const Eigen::Vector3d> PolyhedronVisual::getVertices() const
 {
-  return std::span<const Eigen::Vector3d>(mVertices);
+  return mVertices;
 }
 
 //==============================================================================
@@ -309,8 +309,8 @@ void PolyhedronVisual::updateGeometry()
     return;
   }
 
-  auto result = dart::math::computeConvexHull3D<double, std::size_t>(
-      std::span<const Eigen::Vector3d>(mVertices), true);
+  auto result
+      = dart::math::computeConvexHull3D<double, std::size_t>(mVertices, true);
 
   auto hullVertices = std::move(std::get<0>(result));
   auto hullTriangles = std::move(std::get<1>(result));

--- a/dart/math/optimization/problem.cpp
+++ b/dart/math/optimization/problem.cpp
@@ -174,7 +174,7 @@ std::vector<Eigen::VectorXd>& Problem::getSeeds()
 //==============================================================================
 std::span<const Eigen::VectorXd> Problem::getSeeds() const
 {
-  return std::span<const Eigen::VectorXd>(mSeeds);
+  return mSeeds;
 }
 
 //==============================================================================

--- a/dart/utils/package_resource_retriever.cpp
+++ b/dart/utils/package_resource_retriever.cpp
@@ -165,14 +165,14 @@ std::span<const std::string> PackageResourceRetriever::getPackagePaths(
   // Lookup the corresponding package path.
   const auto it = mPackageMap.find(packageNameString);
   if (it != std::end(mPackageMap)) {
-    return std::span<const std::string>(it->second);
+    return it->second;
   } else {
     DART_WARN(
         "{}{}{}",
         "Unable to resolvepath to package '",
         packageNameString,
         "'. Did you call addPackageDirectory(~) for this package name?\n");
-    return std::span<const std::string>(empty_placeholder);
+    return empty_placeholder;
   }
 }
 

--- a/dart/utils/sdf/sdf_parser.cpp
+++ b/dart/utils/sdf/sdf_parser.cpp
@@ -989,8 +989,7 @@ void applyMimicConstraints(
       continue;
     }
 
-    joint->setMimicJointDofs(
-        std::span<const dynamics::MimicDofProperties>(props));
+    joint->setMimicJointDofs(props);
     joint->setActuatorType(dynamics::Joint::MIMIC);
     joint->setUseCouplerConstraint(useCoupler);
   }

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -207,7 +207,7 @@ public:
         DART_WARN(
             "This analytical IK was not able to configure properly, so it will "
             "not be able to compute solutions");
-        return {mSolutions.data(), mSolutions.size()};
+        return mSolutions;
       }
     }
 
@@ -217,13 +217,13 @@ public:
           "Attempting to perform an IK on a limb that no longer exists [{}]!",
           getMethodName());
       DART_ASSERT(false);
-      return {mSolutions.data(), mSolutions.size()};
+      return mSolutions;
     }
 
     if (nullptr == mWristEnd) {
       DART_ERROR("Attempting to perform IK without a wrist!");
       DART_ASSERT(false);
-      return {mSolutions.data(), mSolutions.size()};
+      return mSolutions;
     }
 
     const std::size_t SP = 0;
@@ -346,7 +346,7 @@ public:
 
     checkSolutionJointLimits();
 
-    return {mSolutions.data(), mSolutions.size()};
+    return mSolutions;
   }
 
   std::span<const std::size_t> getDofs() const override
@@ -355,7 +355,7 @@ public:
       configure();
     }
 
-    return {mDofs.data(), mDofs.size()};
+    return mDofs;
   }
 
   const double zeroSize = 1e-8;
@@ -489,7 +489,7 @@ public:
         DART_WARN(
             "This analytical IK was not able to configure properly, so it will "
             "not be able to compute solutions");
-        return {mSolutions.data(), mSolutions.size()};
+        return mSolutions;
       }
     }
 
@@ -497,7 +497,7 @@ public:
     if (nullptr == base) {
       DART_ERROR("Attempting to perform IK on a limb that no longer exists!");
       DART_ASSERT(false);
-      return {mSolutions.data(), mSolutions.size()};
+      return mSolutions;
     }
 
     double nx, ny, sx, sy, ax, ay, az, px, py, pz;
@@ -595,7 +595,7 @@ public:
 
     checkSolutionJointLimits();
 
-    return {mSolutions.data(), mSolutions.size()};
+    return mSolutions;
   }
 
   std::span<const std::size_t> getDofs() const override
@@ -604,7 +604,7 @@ public:
       configure();
     }
 
-    return {mDofs.data(), mDofs.size()};
+    return mDofs;
   }
 
   const double zeroSize = 1e-8;

--- a/examples/mimic_pendulums/main.cpp
+++ b/examples/mimic_pendulums/main.cpp
@@ -203,8 +203,7 @@ void retargetMimicsToBaseline(
         // Leave the baseline uncoupled so it serves as the reference.
         std::vector<dart::dynamics::MimicDofProperties> clearedProps(
             joint->getNumDofs());
-        joint->setMimicJointDofs(
-            std::span<const dart::dynamics::MimicDofProperties>(clearedProps));
+        joint->setMimicJointDofs(clearedProps);
         joint->setActuatorType(dart::dynamics::Joint::FORCE);
         joint->setUseCouplerConstraint(false);
         continue;

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -147,7 +147,7 @@ public:
     // Update point cloud colors
     auto colors = generatePointCloudColors(pointCloud);
     DART_ASSERT(pointCloud.size() == colors.size());
-    mPointCloudShape->setColors(std::span<const Eigen::Vector4d>(colors));
+    mPointCloudShape->setColors(colors);
 
     // Update voxel
     mVoxelGridShape->updateOccupancy(pointCloud, sensorPos);

--- a/examples/polyhedron_visual/main.cpp
+++ b/examples/polyhedron_visual/main.cpp
@@ -61,7 +61,7 @@ int main()
 
   // Attach the polyhedron visual and customize its colors.
   auto polyhedron = new dart::gui::PolyhedronVisual();
-  polyhedron->setVertices(std::span<const Eigen::Vector3d>(vertices));
+  polyhedron->setVertices(vertices);
   polyhedron->setSurfaceColor(Eigen::Vector4d(0.1, 0.8, 0.6, 0.5));
   polyhedron->setWireframeColor(Eigen::Vector4d(0.05, 0.05, 0.05, 1.0));
   viewer.addAttachment(polyhedron);

--- a/python/dartpy/dynamics/joint.cpp
+++ b/python/dartpy/dynamics/joint.cpp
@@ -102,7 +102,7 @@ void defJoint(nb::module_& m)
       .def(
           "setActuatorTypes",
           [](Joint& self, const std::vector<ActuatorType>& actuatorTypes) {
-            self.setActuatorTypes(std::span<const ActuatorType>(actuatorTypes));
+            self.setActuatorTypes(actuatorTypes);
           },
           nb::arg("actuator_types"))
       .def(

--- a/python/dartpy/gui/viewer_attachment.cpp
+++ b/python/dartpy/gui/viewer_attachment.cpp
@@ -74,7 +74,7 @@ void defPolyhedronVisual(nb::module_& m)
           "setVertices",
           [](PolyhedronVisual& self,
              const std::vector<Eigen::Vector3d>& vertices) {
-            self.setVertices(std::span<const Eigen::Vector3d>(vertices));
+            self.setVertices(vertices);
           })
       .def(
           "setVerticesMatrix",

--- a/tests/benchmark/unit/bm_convhull.cpp
+++ b/tests/benchmark/unit/bm_convhull.cpp
@@ -63,7 +63,7 @@ std::vector<Eigen::Matrix<S, 3, 1>> generateRandomPoints(
 template <typename T>
 std::span<const T> asSpan(const std::vector<T>& values)
 {
-  return std::span<const T>(values);
+  return values;
 }
 
 //==============================================================================

--- a/tests/integration/simulation/test_mimic_constraint.cpp
+++ b/tests/integration/simulation/test_mimic_constraint.cpp
@@ -163,8 +163,7 @@ void retargetMimicJoints(const WorldPtr& world, const std::string& baselineName)
       if (skeleton == baseline) {
         std::vector<dart::dynamics::MimicDofProperties> clearedProps(
             joint->getNumDofs());
-        joint->setMimicJointDofs(
-            std::span<const dart::dynamics::MimicDofProperties>(clearedProps));
+        joint->setMimicJointDofs(clearedProps);
         joint->setActuatorType(dart::dynamics::Joint::FORCE);
         joint->setUseCouplerConstraint(false);
         continue;

--- a/tests/unit/dynamics/test_inverse_kinematics.cpp
+++ b/tests/unit/dynamics/test_inverse_kinematics.cpp
@@ -390,7 +390,7 @@ TEST(InverseKinematics, JacobianDlsGradientAndDofs)
 
   const auto dofs = ik->getDofs();
   ASSERT_GT(dofs.size(), 0u);
-  ik->setDofs(std::span<const std::size_t>(dofs.data(), 1u));
+  ik->setDofs(dofs.first(1u));
   EXPECT_EQ(ik->getDofs().size(), 1u);
 
   Eigen::VectorXd q = ik->getPositions();
@@ -940,8 +940,7 @@ TEST(InverseKinematics, AccessorsAndConfiguration)
   if (wholeBodyDofs.size() > 1) {
     subsetDofs.push_back(wholeBodyDofs[1]);
   }
-  ik->setDofs(
-      std::span<const std::size_t>(subsetDofs.data(), subsetDofs.size()));
+  ik->setDofs(subsetDofs);
   EXPECT_EQ(ik->getDofs().size(), subsetDofs.size());
 
   auto& tsr = ik->setErrorMethod<InverseKinematics::TaskSpaceRegion>();

--- a/tests/unit/math/test_convhull.cpp
+++ b/tests/unit/math/test_convhull.cpp
@@ -89,7 +89,7 @@ TYPED_TEST(ConvexHullTest, EmptyInput)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   EXPECT_EQ(numFaces, 0);
   EXPECT_TRUE(faces.empty());
@@ -109,7 +109,7 @@ TYPED_TEST(ConvexHullTest, TooFewVertices)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   EXPECT_EQ(numFaces, 0);
   EXPECT_TRUE(faces.empty());
@@ -129,7 +129,7 @@ TYPED_TEST(ConvexHullTest, Tetrahedron)
 
   std::vector<int> faces;
   int numFaces = 0;
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // A tetrahedron should have exactly 4 triangular faces
   ASSERT_EQ(numFaces, 4) << "Tetrahedron must have exactly 4 faces";
@@ -163,7 +163,7 @@ TYPED_TEST(ConvexHullTest, Cube)
 
   std::vector<int> faces;
   int numFaces = 0;
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // A cube has 6 square faces, each split into 2 triangles = 12 faces
   ASSERT_EQ(numFaces, 12) << "Cube must have exactly 12 triangular faces";
@@ -201,7 +201,7 @@ TYPED_TEST(ConvexHullTest, CubeWithInternalPoint)
 
   std::vector<int> faces;
   int numFaces = 0;
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // Should produce cube hull (12 faces) or slightly more if noise perturbs
   // internal point For double precision: exactly 12 faces For float precision:
@@ -235,7 +235,7 @@ TYPED_TEST(ConvexHullTest, Octahedron)
 
   std::vector<int> faces;
   int numFaces = 0;
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // An octahedron has exactly 8 triangular faces
   ASSERT_EQ(numFaces, 8) << "Octahedron must have exactly 8 faces";
@@ -271,7 +271,7 @@ TYPED_TEST(ConvexHullTest, CoplanarPoints)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // Should handle degenerate case gracefully (may succeed or fail)
   // At minimum, should not crash or produce invalid results
@@ -299,7 +299,7 @@ TYPED_TEST(ConvexHullTest, DuplicateVertices)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // Implementation adds noise to avoid degeneracy, so duplicates become
   // slightly different points. Should produce valid hull (4-6 faces)
@@ -329,7 +329,7 @@ TYPED_TEST(ConvexHullTest, AllFaceIndicesValid)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // All face indices must be valid
   for (const auto& idx : faces) {
@@ -358,7 +358,7 @@ TYPED_TEST(ConvexHullTest, AllFacesAreTriangles)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // Number of indices must be exactly 3 * numFaces
   EXPECT_EQ(faces.size(), static_cast<size_t>(numFaces * 3))
@@ -387,7 +387,7 @@ TYPED_TEST(ConvexHullTest, NoInternalVertices)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // The internal point (vertex 8) should NOT appear in any face
   // (unless noise perturbation pushes it outside, which is less likely with
@@ -424,7 +424,7 @@ TYPED_TEST(ConvexHullTest, ConsistentWindingOrder)
   std::vector<int> faces;
   int numFaces = 0;
 
-  convexHull3dBuild(std::span<const Vector3>(vertices), faces, numFaces);
+  convexHull3dBuild(std::span<const Vector3>{vertices}, faces, numFaces);
 
   // Compute centroid
   Vector3 centroid = Vector3::Zero();

--- a/tests/unit/math/test_geometry.cpp
+++ b/tests/unit/math/test_geometry.cpp
@@ -226,8 +226,7 @@ TEST(Geometry, ComputeConvexHullUsesSortedAngles)
   points.emplace_back(0.0, 1.0);
 
   std::vector<std::size_t> indices;
-  const auto hull
-      = computeConvexHull(indices, std::span<const Eigen::Vector2d>(points));
+  const auto hull = computeConvexHull(indices, points);
 
   EXPECT_EQ(hull.size(), 3u);
   EXPECT_EQ(indices.size(), 3u);
@@ -242,8 +241,7 @@ TEST(Geometry, ComputeConvexHullCollinearDuplicates)
   points.emplace_back(3.0, 3.0);
 
   std::vector<std::size_t> indices;
-  const auto hull
-      = computeConvexHull(indices, std::span<const Eigen::Vector2d>(points));
+  const auto hull = computeConvexHull(indices, points);
 
   ASSERT_EQ(hull.size(), 2u);
   ASSERT_EQ(indices.size(), 2u);
@@ -261,8 +259,7 @@ TEST(Geometry, ComputeConvexHullDropsInteriorPoint)
   points.emplace_back(1.0, 1.0); // interior point
 
   std::vector<std::size_t> indices;
-  const auto hull
-      = computeConvexHull(indices, std::span<const Eigen::Vector2d>(points));
+  const auto hull = computeConvexHull(indices, points);
 
   EXPECT_EQ(hull.size(), 4u);
   EXPECT_EQ(indices.size(), 4u);
@@ -870,8 +867,7 @@ TEST(Geometry, ComputeConvexHullBacktracksRightTurn)
   points.emplace_back(0.0, 2.0);
 
   std::vector<std::size_t> indices;
-  const auto hull
-      = computeConvexHull(indices, std::span<const Eigen::Vector2d>(points));
+  const auto hull = computeConvexHull(indices, points);
 
   bool hasInterior = false;
   for (const auto& p : hull) {
@@ -1863,7 +1859,7 @@ TEST(Geometry, ComputeConvexHullWrapper)
   points.emplace_back(1.0, 1.0);
   points.emplace_back(0.0, 1.0);
 
-  const auto hull = computeConvexHull(std::span<const Eigen::Vector2d>(points));
+  const auto hull = computeConvexHull(points);
   EXPECT_EQ(hull.size(), 4u);
 }
 
@@ -1916,8 +1912,7 @@ TEST(Geometry, ComputeConvexHullRightTurnBacktrack)
   points.emplace_back(0.0, 2.0);
 
   std::vector<std::size_t> indices;
-  const auto hull
-      = computeConvexHull(indices, std::span<const Eigen::Vector2d>(points));
+  const auto hull = computeConvexHull(indices, points);
 
   EXPECT_EQ(hull.size(), 4u);
   EXPECT_EQ(indices.size(), 4u);

--- a/tests/unit/simulation/experimental/space/test_auto_mapper.cpp
+++ b/tests/unit/simulation/experimental/space/test_auto_mapper.cpp
@@ -241,7 +241,7 @@ TEST(AutoMapper, RoundTripMultipleFields)
   vec1[3] = 40.0;
 
   // Inject back
-  mapper.fromVector(registry, std::span<const double>(vec1));
+  mapper.fromVector(registry, vec1);
 
   // Verify
   const auto& modified = registry.get<JointState>(entity);
@@ -282,7 +282,7 @@ TEST(AutoMapper, NestedStructs)
   vec[0] = 10.0;
   vec[1] = 20.0;
   vec[2] = 30.0;
-  mapper.fromVector(registry, std::span<const double>(vec));
+  mapper.fromVector(registry, vec);
 
   // Verify
   const auto& modified = registry.get<NestedData>(entity);

--- a/tests/unit/simulation/experimental/space/test_state_space.cpp
+++ b/tests/unit/simulation/experimental/space/test_state_space.cpp
@@ -100,7 +100,7 @@ TEST(StateSpace, AddMultipleScalarsHelper)
 {
   StateSpace space;
   const std::vector<std::string> names = {"x", "y", "z"};
-  space.addVariables(std::span<const std::string>(names), -1.0, 1.0);
+  space.addVariables(names, -1.0, 1.0);
 
   EXPECT_EQ(space.getDimension(), 3);
   EXPECT_EQ(space.getNumVariables(), 3);

--- a/tests/unit/simulation/experimental/space/test_vector_mapper.cpp
+++ b/tests/unit/simulation/experimental/space/test_vector_mapper.cpp
@@ -168,7 +168,7 @@ TEST(VectorMapper, RoundTripWithPositionMapper)
   }
 
   // Write back
-  mapper.fromVector(registry, std::span<const double>(vec2));
+  mapper.fromVector(registry, vec2);
 
   // Verify modifications - all values should be 10x original
   const auto& pos1 = registry.get<Position>(entity1);
@@ -336,9 +336,7 @@ TEST(VectorMapper, InputVectorTooSmall)
   entt::registry registry;
   std::vector<double> tooSmall(3); // Should be at least 5
 
-  EXPECT_THROW(
-      mapper.fromVector(registry, std::span<const double>(tooSmall)),
-      std::invalid_argument);
+  EXPECT_THROW(mapper.fromVector(registry, tooSmall), std::invalid_argument);
 }
 
 TEST(VectorMapper, NoMapperFillsZeros)


### PR DESCRIPTION
## Summary

- Use C++20 `std::span` range construction/conversion across span-returning APIs, bindings, examples, and tests.

## Motivation / Problem

- Several call sites manually rebuilt spans from `data()`/`size()` or explicitly wrapped contiguous containers before passing them to `std::span` parameters.
- C++20 allows these conversions directly for compatible contiguous ranges, reducing boilerplate while preserving behavior.

## Changes / Key Changes

- Return existing contiguous containers directly from `std::span`-returning accessors where lifetime and constness already match.
- Pass vectors and arrays directly to APIs taking `std::span` instead of redundant `std::span(...)` wrappers.
- Keep explicit brace span construction in template calls where span type deduction is still required.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable

No changelog, tests, docs, or binding additions are needed because this is an internal refactor with no behavior or API change.