### PR TITLE
Adopt C++20 bit_cast and math helpers

### DIFF
--- a/dart/dynamics/arrow_shape.cpp
+++ b/dart/dynamics/arrow_shape.cpp
@@ -34,6 +34,8 @@
 
 #include "dart/math/constants.hpp"
 
+#include <algorithm>
+
 namespace dart {
 namespace dynamics {
 
@@ -150,7 +152,7 @@ void ArrowShape::configureArrow(
   mProperties = _properties;
 
   mProperties.mHeadLengthScale
-      = std::max(0.0, std::min(1.0, mProperties.mHeadLengthScale));
+      = std::clamp(mProperties.mHeadLengthScale, 0.0, 1.0);
   mProperties.mMinHeadLength = std::max(0.0, mProperties.mMinHeadLength);
   mProperties.mMaxHeadLength = std::max(0.0, mProperties.mMaxHeadLength);
   mProperties.mHeadRadiusScale = std::max(1.0, mProperties.mHeadRadiusScale);

--- a/dart/dynamics/arrow_shape.cpp
+++ b/dart/dynamics/arrow_shape.cpp
@@ -152,7 +152,7 @@ void ArrowShape::configureArrow(
   mProperties = _properties;
 
   mProperties.mHeadLengthScale
-      = std::clamp(mProperties.mHeadLengthScale, 0.0, 1.0);
+      = std::max(0.0, std::min(1.0, mProperties.mHeadLengthScale));
   mProperties.mMinHeadLength = std::max(0.0, mProperties.mMinHeadLength);
   mProperties.mMaxHeadLength = std::max(0.0, mProperties.mMaxHeadLength);
   mProperties.mHeadRadiusScale = std::max(1.0, mProperties.mHeadRadiusScale);

--- a/dart/gui/interactive_frame.cpp
+++ b/dart/gui/interactive_frame.cpp
@@ -281,7 +281,7 @@ void InteractiveFrame::createStandardVisualizationShapes(
 {
   const auto pi = math::pi;
 
-  thickness = std::clamp(thickness, 0.0, 10.0);
+  thickness = std::min(10.0, std::max(0.0, thickness));
   std::size_t resolution = 72;
   double ring_outer_scale = 0.7 * size;
   double ring_inner_scale = ring_outer_scale * (1 - 0.1 * thickness);

--- a/dart/gui/interactive_frame.cpp
+++ b/dart/gui/interactive_frame.cpp
@@ -37,6 +37,8 @@
 #include "dart/dynamics/line_segment_shape.hpp"
 #include "dart/dynamics/mesh_shape.hpp"
 
+#include <algorithm>
+
 namespace dart {
 namespace gui {
 
@@ -279,7 +281,7 @@ void InteractiveFrame::createStandardVisualizationShapes(
 {
   const auto pi = math::pi;
 
-  thickness = std::min(10.0, std::max(0.0, thickness));
+  thickness = std::clamp(thickness, 0.0, 10.0);
   std::size_t resolution = 72;
   double ring_outer_scale = 0.7 * size;
   double ring_inner_scale = ring_outer_scale * (1 - 0.1 * thickness);

--- a/dart/gui/render/soft_mesh_shape_node.cpp
+++ b/dart/gui/render/soft_mesh_shape_node.cpp
@@ -207,7 +207,7 @@ static Eigen::Vector3d normalFromVertex(
   const Eigen::Vector3d n = dv1.cross(dv2);
 
   double weight = n.norm() / (dv1.norm() * dv2.norm());
-  weight = std::clamp(weight, -1.0, 1.0);
+  weight = std::max(-1.0, std::min(1.0, weight));
 
   return n.normalized() * asin(weight);
 }

--- a/dart/gui/render/soft_mesh_shape_node.cpp
+++ b/dart/gui/render/soft_mesh_shape_node.cpp
@@ -43,6 +43,8 @@
 #include <osg/Geode>
 #include <osg/Geometry>
 
+#include <algorithm>
+
 namespace dart {
 namespace gui {
 
@@ -205,7 +207,7 @@ static Eigen::Vector3d normalFromVertex(
   const Eigen::Vector3d n = dv1.cross(dv2);
 
   double weight = n.norm() / (dv1.norm() * dv2.norm());
-  weight = std::max(-1.0, std::min(1.0, weight));
+  weight = std::clamp(weight, -1.0, 1.0);
 
   return n.normalized() * asin(weight);
 }

--- a/dart/math/geometry.cpp
+++ b/dart/math/geometry.cpp
@@ -584,8 +584,7 @@ Eigen::Vector6d logMap(const Eigen::Isometry3d& _T)
   //    , beta = t*(1 + cos(t)) / (2*sin(t)), gamma = <w, p>*(1 - beta) / t^2
   //--------------------------------------------------------------------------
   double theta = std::acos(
-      std::max(
-          std::min(0.5 * (_T(0, 0) + _T(1, 1) + _T(2, 2) - 1.0), 1.0), -1.0));
+      std::clamp(0.5 * (_T(0, 0) + _T(1, 1) + _T(2, 2) - 1.0), -1.0, 1.0));
   double beta;
   double gamma;
   Eigen::Vector6d ret;

--- a/dart/simd/detail/avx2/operations.hpp
+++ b/dart/simd/detail/avx2/operations.hpp
@@ -36,7 +36,9 @@
 #include <dart/simd/detail/avx2/vec.hpp>
 #include <dart/simd/detail/avx2/vec_mask.hpp>
 
-#include <cstring>
+#include <bit>
+
+#include <cstddef>
 
 #if defined(DART_SIMD_AVX2)
 
@@ -530,8 +532,7 @@ frexpSimd(const Vec<float, 8>& v)
     v.store(vArr);
 
     for (std::size_t i = 0; i < 8; ++i) {
-      std::uint32_t b;
-      std::memcpy(&b, &vArr[i], sizeof(float));
+      std::uint32_t b = std::bit_cast<std::uint32_t>(vArr[i]);
 
       std::int32_t biasedExp
           = static_cast<std::int32_t>((b & 0x7F800000) >> 23);
@@ -550,14 +551,14 @@ frexpSimd(const Vec<float, 8>& v)
           continue;
         }
         float normalized = vArr[i] * 8388608.0f;
-        std::memcpy(&b, &normalized, sizeof(float));
+        b = std::bit_cast<std::uint32_t>(normalized);
         biasedExp = static_cast<std::int32_t>((b & 0x7F800000) >> 23);
         expAdjust = -23;
       }
 
       expArr[i] = biasedExp - 127 + expAdjust;
       std::uint32_t mantResult = (b & 0x807FFFFF) | 0x3F000000;
-      std::memcpy(&mantArr[i], &mantResult, sizeof(float));
+      mantArr[i] = std::bit_cast<float>(mantResult);
     }
     return {Vec<float, 8>::load(mantArr), Vec<std::int32_t, 8>::load(expArr)};
   }

--- a/dart/simd/detail/scalar/operations.hpp
+++ b/dart/simd/detail/scalar/operations.hpp
@@ -36,6 +36,7 @@
 #include <dart/simd/fwd.hpp>
 
 #include <algorithm>
+#include <bit>
 
 #include <cmath>
 #include <cstddef>
@@ -262,6 +263,18 @@ struct IntTypeFor<double>
 template <typename T>
 using int_type_for_t = typename IntTypeFor<T>::type;
 
+template <typename T>
+[[nodiscard]] DART_SIMD_INLINE int_type_for_t<T> toBits(T value) noexcept
+{
+  return std::bit_cast<int_type_for_t<T>>(value);
+}
+
+template <typename T>
+[[nodiscard]] DART_SIMD_INLINE T fromBits(int_type_for_t<T> bits) noexcept
+{
+  return std::bit_cast<T>(bits);
+}
+
 } // namespace detail
 
 template <typename T, std::size_t W>
@@ -274,11 +287,9 @@ template <typename T, std::size_t W>
   a.store(aArr);
   b.store(bArr);
   for (std::size_t i = 0; i < W; ++i) {
-    Int ai, bi;
-    std::memcpy(&ai, &aArr[i], sizeof(T));
-    std::memcpy(&bi, &bArr[i], sizeof(T));
-    Int ri = ai & bi;
-    std::memcpy(&rArr[i], &ri, sizeof(T));
+    const Int ai = detail::toBits(aArr[i]);
+    const Int bi = detail::toBits(bArr[i]);
+    rArr[i] = detail::fromBits<T>(ai & bi);
   }
   return Vec<T, W>::load(rArr);
 }
@@ -293,11 +304,9 @@ template <typename T, std::size_t W>
   a.store(aArr);
   b.store(bArr);
   for (std::size_t i = 0; i < W; ++i) {
-    Int ai, bi;
-    std::memcpy(&ai, &aArr[i], sizeof(T));
-    std::memcpy(&bi, &bArr[i], sizeof(T));
-    Int ri = ai | bi;
-    std::memcpy(&rArr[i], &ri, sizeof(T));
+    const Int ai = detail::toBits(aArr[i]);
+    const Int bi = detail::toBits(bArr[i]);
+    rArr[i] = detail::fromBits<T>(ai | bi);
   }
   return Vec<T, W>::load(rArr);
 }
@@ -312,11 +321,9 @@ template <typename T, std::size_t W>
   a.store(aArr);
   b.store(bArr);
   for (std::size_t i = 0; i < W; ++i) {
-    Int ai, bi;
-    std::memcpy(&ai, &aArr[i], sizeof(T));
-    std::memcpy(&bi, &bArr[i], sizeof(T));
-    Int ri = ai ^ bi;
-    std::memcpy(&rArr[i], &ri, sizeof(T));
+    const Int ai = detail::toBits(aArr[i]);
+    const Int bi = detail::toBits(bArr[i]);
+    rArr[i] = detail::fromBits<T>(ai ^ bi);
   }
   return Vec<T, W>::load(rArr);
 }
@@ -331,11 +338,9 @@ template <typename T, std::size_t W>
   a.store(aArr);
   b.store(bArr);
   for (std::size_t i = 0; i < W; ++i) {
-    Int ai, bi;
-    std::memcpy(&ai, &aArr[i], sizeof(T));
-    std::memcpy(&bi, &bArr[i], sizeof(T));
-    Int ri = ai & (~bi);
-    std::memcpy(&rArr[i], &ri, sizeof(T));
+    const Int ai = detail::toBits(aArr[i]);
+    const Int bi = detail::toBits(bArr[i]);
+    rArr[i] = detail::fromBits<T>(ai & (~bi));
   }
   return Vec<T, W>::load(rArr);
 }
@@ -503,8 +508,7 @@ frexpSimd(const Vec<float, W>& v)
   v.store(vArr);
 
   for (std::size_t i = 0; i < W; ++i) {
-    std::uint32_t bits;
-    std::memcpy(&bits, &vArr[i], sizeof(float));
+    std::uint32_t bits = std::bit_cast<std::uint32_t>(vArr[i]);
 
     std::int32_t biasedExp = static_cast<std::int32_t>((bits & expMask) >> 23);
     std::int32_t expAdjust = 0;
@@ -522,14 +526,14 @@ frexpSimd(const Vec<float, W>& v)
         continue;
       }
       float normalized = vArr[i] * 8388608.0f;
-      std::memcpy(&bits, &normalized, sizeof(float));
+      bits = std::bit_cast<std::uint32_t>(normalized);
       biasedExp = static_cast<std::int32_t>((bits & expMask) >> 23);
       expAdjust = -23;
     }
 
     expArr[i] = biasedExp - 127 + expAdjust;
     std::uint32_t mantissaBits = (bits & (signMask | mantissaMask)) | halfExp;
-    std::memcpy(&mantArr[i], &mantissaBits, sizeof(float));
+    mantArr[i] = std::bit_cast<float>(mantissaBits);
   }
   return {Vec<float, W>::load(mantArr), Vec<std::int32_t, W>::load(expArr)};
 }
@@ -548,9 +552,7 @@ template <std::size_t W>
     } else {
       std::uint32_t pow2Bits = static_cast<std::uint32_t>(expArr[i] + 0x7f)
                                << 23;
-      float pow2;
-      std::memcpy(&pow2, &pow2Bits, sizeof(float));
-      rArr[i] = xArr[i] * pow2;
+      rArr[i] = xArr[i] * std::bit_cast<float>(pow2Bits);
     }
   }
   return Vec<float, W>::load(rArr);

--- a/dart/simd/detail/sse42/operations.hpp
+++ b/dart/simd/detail/sse42/operations.hpp
@@ -36,7 +36,9 @@
 #include <dart/simd/detail/sse42/vec.hpp>
 #include <dart/simd/detail/sse42/vec_mask.hpp>
 
-#include <cstring>
+#include <bit>
+
+#include <cstddef>
 
 #if defined(DART_SIMD_SSE42)
 
@@ -551,8 +553,7 @@ frexpSimd(const Vec<float, 4>& v)
     v.store(vArr);
 
     for (std::size_t i = 0; i < 4; ++i) {
-      std::uint32_t b;
-      std::memcpy(&b, &vArr[i], sizeof(float));
+      std::uint32_t b = std::bit_cast<std::uint32_t>(vArr[i]);
 
       std::int32_t biasedExp
           = static_cast<std::int32_t>((b & 0x7F800000) >> 23);
@@ -571,14 +572,14 @@ frexpSimd(const Vec<float, 4>& v)
           continue;
         }
         float normalized = vArr[i] * 8388608.0f;
-        std::memcpy(&b, &normalized, sizeof(float));
+        b = std::bit_cast<std::uint32_t>(normalized);
         biasedExp = static_cast<std::int32_t>((b & 0x7F800000) >> 23);
         expAdjust = -23;
       }
 
       expArr[i] = biasedExp - 127 + expAdjust;
       std::uint32_t mantResult = (b & 0x807FFFFF) | 0x3F000000;
-      std::memcpy(&mantArr[i], &mantResult, sizeof(float));
+      mantArr[i] = std::bit_cast<float>(mantResult);
     }
     return {Vec<float, 4>::load(mantArr), Vec<std::int32_t, 4>::load(expArr)};
   }

--- a/examples/coupler_constraint/main.cpp
+++ b/examples/coupler_constraint/main.cpp
@@ -65,6 +65,7 @@
 #include <vector>
 
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 
 using dart::dynamics::BodyNode;
@@ -77,6 +78,15 @@ using dart::simulation::World;
 using dart::simulation::WorldPtr;
 
 namespace {
+
+Eigen::Vector3d lerpColor(
+    const Eigen::Vector3d& a, const Eigen::Vector3d& b, double t)
+{
+  return Eigen::Vector3d(
+      std::lerp(a.x(), b.x(), t),
+      std::lerp(a.y(), b.y(), t),
+      std::lerp(a.z(), b.z(), t));
+}
 
 struct MimicAssembly
 {
@@ -453,11 +463,11 @@ private:
     if (pair.usesCoupler) {
       const Eigen::Vector3d good(0.6, 0.95, 0.4);
       const Eigen::Vector3d bad(1.0, 0.6, 0.2);
-      color = good + severity * (bad - good);
+      color = lerpColor(good, bad, severity);
     } else {
       const Eigen::Vector3d base(0.7, 0.7, 0.85);
       const Eigen::Vector3d alert(1.0, 0.4, 0.3);
-      color = base + severity * (alert - base);
+      color = lerpColor(base, alert, severity);
     }
     pair.linkVisual->setColor(color);
   }

--- a/tests/integration/collision/test_bullet_ellipsoid_rolling.cpp
+++ b/tests/integration/collision/test_bullet_ellipsoid_rolling.cpp
@@ -115,10 +115,9 @@ RollingResult runRollingTrial(
   double support = shape->getBoundingBox().getMax()[2];
   if (const auto ellipsoid = std::dynamic_pointer_cast<EllipsoidShape>(shape)) {
     const Eigen::Vector3d radii = ellipsoid->getRadii();
-    const double denom = std::pow(normal[0] / radii[0], 2)
-                         + std::pow(normal[1] / radii[1], 2)
-                         + std::pow(normal[2] / radii[2], 2);
-    support = 1.0 / std::sqrt(denom);
+    const double denom = std::hypot(
+        normal[0] / radii[0], normal[1] / radii[1], normal[2] / radii[2]);
+    support = 1.0 / denom;
   }
 
   Eigen::Isometry3d objectTf = Eigen::Isometry3d::Identity();

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
@@ -227,21 +227,20 @@ bool getExtentAlongDirection(
   if (const auto* ellipsoid
       = dynamic_cast<const dart::dynamics::EllipsoidShape*>(&shape)) {
     const Eigen::Vector3d radii = ellipsoid->getRadii();
-    extent = std::sqrt(
-        std::pow(radii.x() * dir.x(), 2) + std::pow(radii.y() * dir.y(), 2)
-        + std::pow(radii.z() * dir.z(), 2));
+    extent = std::hypot(
+        radii.x() * dir.x(), radii.y() * dir.y(), radii.z() * dir.z());
     return true;
   }
   if (const auto* cylinder
       = dynamic_cast<const dart::dynamics::CylinderShape*>(&shape)) {
-    const double xy = std::sqrt(dir.x() * dir.x() + dir.y() * dir.y());
+    const double xy = std::hypot(dir.x(), dir.y());
     extent = cylinder->getRadius() * xy
              + 0.5 * cylinder->getHeight() * std::abs(dir.z());
     return true;
   }
   if (const auto* cone
       = dynamic_cast<const dart::dynamics::ConeShape*>(&shape)) {
-    const double xy = std::sqrt(dir.x() * dir.x() + dir.y() * dir.y());
+    const double xy = std::hypot(dir.x(), dir.y());
     const double apex = 0.5 * cone->getHeight() * dir.z();
     const double base
         = -0.5 * cone->getHeight() * dir.z() + cone->getRadius() * xy;

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
@@ -212,18 +212,18 @@ bool getExtentAlongDirection(
       extent = kSphereRadius;
       return true;
     case ShapeKind::Cylinder: {
-      const double xy = std::sqrt(dir.x() * dir.x() + dir.y() * dir.y());
+      const double xy = std::hypot(dir.x(), dir.y());
       extent = kCylinderRadius * xy + 0.5 * kCylinderHeight * std::abs(dir.z());
       return true;
     }
     case ShapeKind::Ellipsoid:
-      extent = std::sqrt(
-          std::pow(kEllipsoidRadii.x() * dir.x(), 2)
-          + std::pow(kEllipsoidRadii.y() * dir.y(), 2)
-          + std::pow(kEllipsoidRadii.z() * dir.z(), 2));
+      extent = std::hypot(
+          kEllipsoidRadii.x() * dir.x(),
+          kEllipsoidRadii.y() * dir.y(),
+          kEllipsoidRadii.z() * dir.z());
       return true;
     case ShapeKind::Cone: {
-      const double xy = std::sqrt(dir.x() * dir.x() + dir.y() * dir.y());
+      const double xy = std::hypot(dir.x(), dir.y());
       const double apex = 0.5 * kConeHeight * dir.z();
       const double base = -0.5 * kConeHeight * dir.z() + kConeRadius * xy;
       extent = std::max(apex, base);
@@ -272,16 +272,16 @@ bool getContainerExtentAlongDirection(
       extent = kContainerSphereRadius;
       return true;
     case ShapeKind::Cylinder: {
-      const double xy = std::sqrt(dir.x() * dir.x() + dir.y() * dir.y());
+      const double xy = std::hypot(dir.x(), dir.y());
       extent = kContainerCylinderRadius * xy
                + 0.5 * kContainerCylinderHeight * std::abs(dir.z());
       return true;
     }
     case ShapeKind::Ellipsoid:
-      extent = std::sqrt(
-          std::pow(kContainerEllipsoidRadii.x() * dir.x(), 2)
-          + std::pow(kContainerEllipsoidRadii.y() * dir.y(), 2)
-          + std::pow(kContainerEllipsoidRadii.z() * dir.z(), 2));
+      extent = std::hypot(
+          kContainerEllipsoidRadii.x() * dir.x(),
+          kContainerEllipsoidRadii.y() * dir.y(),
+          kContainerEllipsoidRadii.z() * dir.z());
       return true;
     case ShapeKind::Cone:
     case ShapeKind::Plane:


### PR DESCRIPTION
## Summary

- Adopt `std::bit_cast` for SIMD scalar fallback bit reinterpretation.
- Use C++20 standard math helpers for small clamp, interpolation, and norm idioms.

## Motivation / Problem

- Manual byte-copy type punning obscures intent in SIMD bit operations.
- Hand-written clamp, interpolation, and Euclidean norm expressions are more verbose than the C++20 standard library equivalents.

## Changes / Key Changes

- Replaced floating-point SIMD fallback bit reinterpretation with `std::bit_cast` in scalar, SSE4.2, and AVX2 operation helpers.
- Replaced selected min/max bounds expressions with `std::clamp` where the bounds are constant and ordered.
- Used `std::lerp` for coupler example color interpolation.
- Used `std::hypot` for 2D and 3D norm calculations in collision integration tests.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: internal refactor only)
- [x] Add unit tests for new functionality (not applicable: no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)