### PR TITLE
Adopt C++20 solver math helpers

### DIFF
--- a/dart/math/detail/convhull-impl.hpp
+++ b/dart/math/detail/convhull-impl.hpp
@@ -169,8 +169,8 @@ template <typename S>
   c[1] = dz1 * dx2 - dx1 * dz2;
   c[2] = dx1 * dy2 - dy1 * dx2;
 
-  // Normalize (use x*x instead of pow for speed)
-  const S normC = std::sqrt(c[0] * c[0] + c[1] * c[1] + c[2] * c[2]);
+  // Normalize.
+  const S normC = std::hypot(c[0], c[1], c[2]);
   const S invNormC = static_cast<S>(1.0) / normC;
   c[0] *= invNormC;
   c[1] *= invNormC;

--- a/dart/math/lcp/newton/fischer_burmeister_newton_solver.cpp
+++ b/dart/math/lcp/newton/fischer_burmeister_newton_solver.cpp
@@ -41,6 +41,8 @@
 #include <iterator>
 #include <limits>
 
+#include <cmath>
+
 namespace dart::math {
 namespace {
 
@@ -74,7 +76,7 @@ void computeFbFunction(
   for (Eigen::Index i = 0; i < n; ++i) {
     const double xi = x[i];
     const double yi = y[i];
-    const double r = std::sqrt(xi * xi + yi * yi + epsilon * epsilon);
+    const double r = std::hypot(xi, yi, epsilon);
     const double invR = (r > 0.0) ? (1.0 / r) : 0.0;
     phi[i] = r - xi - yi;
     p[i] = xi * invR - 1.0;

--- a/dart/math/lcp/newton/penalized_fischer_burmeister_newton_solver.cpp
+++ b/dart/math/lcp/newton/penalized_fischer_burmeister_newton_solver.cpp
@@ -79,7 +79,7 @@ void computePenalizedFbFunction(
   for (Eigen::Index i = 0; i < n; ++i) {
     const double xi = x[i];
     const double yi = y[i];
-    const double r = std::sqrt(xi * xi + yi * yi + epsilon * epsilon);
+    const double r = std::hypot(xi, yi, epsilon);
     const double invR = (r > 0.0) ? (1.0 / r) : 0.0;
     const double maxY = std::max(0.0, yi);
 

--- a/dart/math/lcp/other/staggering_solver.cpp
+++ b/dart/math/lcp/other/staggering_solver.cpp
@@ -210,7 +210,7 @@ LcpResult StaggeringSolver::solve(
       = [&](std::span<const int> indices, const Eigen::VectorXd& values) {
           for (int k = 0; k < std::ssize(indices); ++k) {
             const int idx = indices[k];
-            double updated = x[idx] + relaxation * (values[k] - x[idx]);
+            double updated = std::lerp(x[idx], values[k], relaxation);
             if (std::isfinite(lo[idx])) {
               updated = std::max(updated, lo[idx]);
             }
@@ -227,7 +227,7 @@ LcpResult StaggeringSolver::solve(
                                     const Eigen::VectorXd& hiEff) {
     for (int k = 0; k < std::ssize(indices); ++k) {
       const int idx = indices[k];
-      double updated = x[idx] + relaxation * (values[k] - x[idx]);
+      double updated = std::lerp(x[idx], values[k], relaxation);
       if (std::isfinite(loEff[idx])) {
         updated = std::max(updated, loEff[idx]);
       }

--- a/dart/math/lcp/projection/apgd_solver.cpp
+++ b/dart/math/lcp/projection/apgd_solver.cpp
@@ -202,7 +202,7 @@ LcpResult ApgdSolver::solve(
       }
 
       const double oldX = xdata[idx];
-      newX = oldX + relaxation * (newX - oldX);
+      newX = std::lerp(oldX, newX, relaxation);
 
       if (findexData[idx] >= 0) {
         const double hiTmp = std::abs(

--- a/dart/math/lcp/projection/jacobi_solver.cpp
+++ b/dart/math/lcp/projection/jacobi_solver.cpp
@@ -201,7 +201,7 @@ LcpResult JacobiSolver::solve(
       const double diag = A(i, i);
       if (std::isfinite(diag) && std::abs(diag) >= params->epsilonForDivision) {
         const double step = x[i] - w[i] / diag;
-        value = x[i] + relaxation * (step - x[i]);
+        value = std::lerp(x[i], step, relaxation);
       }
 
       if (std::isfinite(loEff[i])) {

--- a/dart/math/lcp/projection/pgs_solver.cpp
+++ b/dart/math/lcp/projection/pgs_solver.cpp
@@ -170,7 +170,7 @@ LcpResult PgsSolver::solve(
 
     newX /= Adata[static_cast<std::size_t>(nSkip * i + i)];
 
-    newX = oldX + relaxation * (newX - oldX);
+    newX = std::lerp(oldX, newX, relaxation);
 
     if (findexData[static_cast<std::size_t>(i)] >= 0) {
       const double hiTmp = std::abs(
@@ -242,7 +242,7 @@ LcpResult PgsSolver::solve(
           newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
         }
 
-        newX = oldX + relaxation * (newX - oldX);
+        newX = std::lerp(oldX, newX, relaxation);
 
         if (findexData[static_cast<std::size_t>(index)] >= 0) {
           const double hiTmp = std::abs(

--- a/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
+++ b/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
@@ -234,7 +234,7 @@ LcpResult RedBlackGaussSeidelSolver::solve(
     if (std::isfinite(diag) && std::abs(diag) >= params->epsilonForDivision) {
       const double residualEntry = A.row(i).dot(xRead) - b[i];
       const double step = xRead[i] - residualEntry / diag;
-      value = xRead[i] + relaxation * (step - xRead[i]);
+      value = std::lerp(xRead[i], step, relaxation);
     } else {
       value = 0.0;
     }

--- a/dart/math/lcp/projection/symmetric_psor_solver.cpp
+++ b/dart/math/lcp/projection/symmetric_psor_solver.cpp
@@ -221,7 +221,7 @@ LcpResult SymmetricPsorSolver::solve(
     if (std::isfinite(diag) && std::abs(diag) >= params->epsilonForDivision) {
       const double residualEntry = A.row(i).dot(x) - b[i];
       const double step = x[i] - residualEntry / diag;
-      value = x[i] + relaxation * (step - x[i]);
+      value = std::lerp(x[i], step, relaxation);
     } else {
       value = 0.0;
     }

--- a/dart/math/lcp/projection/tgs_solver.cpp
+++ b/dart/math/lcp/projection/tgs_solver.cpp
@@ -175,7 +175,7 @@ LcpResult TgsSolver::solve(
       newX *= invDiag[idx];
 
       const double oldX = xdata[idx];
-      newX = oldX + relaxation * (newX - oldX);
+      newX = std::lerp(oldX, newX, relaxation);
 
       double loVal = loData[idx];
       double hiVal = hiData[idx];


### PR DESCRIPTION
## Summary

- use `std::lerp` for scalar relaxation updates in LCP projection and staggering solvers
- use `std::hypot` for Euclidean norms in LCP Newton solvers and convex hull normalization
- replace hand-expanded scalar interpolation and norm idioms with standard C++20 library helpers

## Motivation

This continues the C++20 adoption work for DART 7.0 by simplifying solver math code where the standard library now provides clearer, well-tested helpers.

## Changes

- Updated scalar relaxation assignments in APGD, Jacobi, PGS, red-black Gauss-Seidel, symmetric PSOR, TGS, and staggering solvers to use `std::lerp`.
- Updated Fischer-Burmeister Newton residual norms to use `std::hypot`.
- Updated convex hull vector normalization to use the three-argument `std::hypot` overload.

## Testing

- [x] `pixi run lint`
- [x] `pixi run build`
- [x] `pixi run test-unit`
- [x] `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues

None.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have run the required local checks.
- [x] I have updated documentation where applicable. N/A, implementation-only cleanup.
- [x] I have updated `CHANGELOG.md` where applicable. N/A, internal cleanup with no user-facing behavior change.
