### PR TITLE
Adopt C++20 clamp and hypot helpers

### DIFF
--- a/dart/collision/dart/dart_collide.cpp
+++ b/dart/collision/dart/dart_collide.cpp
@@ -43,6 +43,8 @@
 #include <memory>
 #include <numeric>
 
+#include <cmath>
+
 namespace dart {
 namespace collision {
 
@@ -556,7 +558,7 @@ int dBoxBox(
 #undef TST
 #define TST(expr1, expr2, n1, n2, n3, cc)                                      \
   s2 = std::abs(expr1) - (expr2);                                              \
-  l = sqrt((n1) * (n1) + (n2) * (n2) + (n3) * (n3));                           \
+  l = std::hypot((n1), (n2), (n3));                                            \
   if (l > 0) {                                                                 \
     s2 /= l;                                                                   \
     if (s2 * fudge_factor > s) {                                               \
@@ -1289,7 +1291,7 @@ int collideCylinderSphere(
 {
   Eigen::Vector3d center = T0.inverse() * T1.translation();
 
-  double dist = sqrt(center[0] * center[0] + center[1] * center[1]);
+  double dist = std::hypot(center[0], center[1]);
 
   if (dist < cyl_rad && std::abs(center[2]) < half_height + sphere_rad) {
     Contact contact;

--- a/dart/math/lcp/other/interior_point_solver.cpp
+++ b/dart/math/lcp/other/interior_point_solver.cpp
@@ -79,7 +79,7 @@ double computeStepSize(
 
 double clampValue(double value, double lo, double hi)
 {
-  return std::min(std::max(value, lo), hi);
+  return std::clamp(value, lo, hi);
 }
 
 } // namespace
@@ -171,7 +171,7 @@ LcpResult InteriorPointSolver::solve(
   const double stepScale = clampValue(params->stepScale, 1e-3, 1.0);
 
   const double initScale = std::max(1.0, vectorInfinityNorm(b));
-  const double minVal = std::max(1e-8, std::min(1.0, 1e-6 * initScale));
+  const double minVal = std::clamp(1e-6 * initScale, 1e-8, 1.0);
 
   if (x.size() != n || !options.warmStart || !x.allFinite()) {
     x = Eigen::VectorXd::Constant(n, minVal);

--- a/tests/benchmark/simd/bm_simd.cpp
+++ b/tests/benchmark/simd/bm_simd.cpp
@@ -38,6 +38,8 @@
 #include <random>
 #include <vector>
 
+#include <cmath>
+
 using namespace dart::simd;
 
 namespace {
@@ -1851,7 +1853,7 @@ static void BM_Vector3Reflect_Batch_DART_f32(benchmark::State& state)
     vz[i] = dist(gen);
     // Pre-normalize the normals
     float nnx = dist(gen), nny = dist(gen), nnz = dist(gen);
-    float len = std::sqrt(nnx * nnx + nny * nny + nnz * nnz);
+    float len = std::hypot(nnx, nny, nnz);
     nx[i] = nnx / len;
     ny[i] = nny / len;
     nz[i] = nnz / len;


### PR DESCRIPTION
## Summary

- Use `std::clamp` for remaining scalar bound normalization in the interior-point LCP solver.
- Use `std::hypot` for Euclidean norm calculations in DART collision helpers and SIMD benchmarks.
- Replace hand-expanded clamp/norm expressions with C++20 standard library helpers.

## Motivation

This continues the DART 7.0 C++20 adoption work by removing handwritten scalar math idioms in remaining non-overlapping paths.

## Changes

- Updated interior-point LCP solver scalar bound clamping to use `std::clamp`.
- Updated DART collision norm calculations to use the two- and three-argument `std::hypot` overloads.
- Updated SIMD benchmark normal pre-normalization to use `std::hypot`.

## Testing

- [x] `pixi run lint`
- [x] `pixi run build`
- [x] `pixi run test-unit`
- [x] `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues

None.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have run the required local checks.
- [x] I have updated documentation where applicable. N/A, implementation-only cleanup.
- [x] I have updated `CHANGELOG.md` where applicable. N/A, internal cleanup with no user-facing behavior change.