### PR TITLE
Adopt C++20 concepts in simulation mapping

### DIFF
--- a/dart/simulation/experimental/space/auto_mapper.hpp
+++ b/dart/simulation/experimental/space/auto_mapper.hpp
@@ -48,6 +48,15 @@
 
 namespace dart::simulation::experimental::space {
 
+namespace detail {
+
+template <typename T>
+concept IsometryField
+    = std::same_as<T, Eigen::Isometry3d>
+      || std::derived_from<T, Eigen::Transform<double, 3, Eigen::Isometry>>;
+
+} // namespace detail
+
 /// Automatically extract scalars from a field for vector mapping
 /// Handles POD types, Eigen vectors, and nested structs
 template <typename Field>
@@ -61,11 +70,7 @@ size_t extractFieldToVector(
     // Scalar types (double, float, int, etc.)
     vec[offset] = static_cast<double>(field);
     count = 1;
-  } else if constexpr (
-      std::same_as<FieldType, Eigen::Isometry3d>
-      || std::is_base_of_v<
-          Eigen::Transform<double, 3, Eigen::Isometry>,
-          FieldType>) {
+  } else if constexpr (detail::IsometryField<FieldType>) {
     // Extract translation (3) + rotation as quaternion (4)
     // Handle early to avoid confusion with other Eigen types
     auto translation = field.translation();
@@ -123,11 +128,7 @@ size_t injectVectorToField(
   if constexpr (std::is_arithmetic_v<FieldType>) {
     field = static_cast<FieldType>(vec[offset]);
     count = 1;
-  } else if constexpr (
-      std::same_as<FieldType, Eigen::Isometry3d>
-      || std::is_base_of_v<
-          Eigen::Transform<double, 3, Eigen::Isometry>,
-          FieldType>) {
+  } else if constexpr (detail::IsometryField<FieldType>) {
     // Handle Isometry3d (before other Eigen types)
     Eigen::Vector3d translation(
         vec[offset + 0], vec[offset + 1], vec[offset + 2]);

--- a/dart/simulation/experimental/space/component_mapper.hpp
+++ b/dart/simulation/experimental/space/component_mapper.hpp
@@ -35,11 +35,27 @@
 #include <Eigen/Core>
 #include <entt/entt.hpp>
 
+#include <concepts>
 #include <functional>
 #include <span>
+#include <type_traits>
 #include <vector>
 
 namespace dart::simulation::experimental {
+
+namespace detail {
+
+template <typename Field>
+concept ArithmeticField = std::is_arithmetic_v<std::remove_cvref_t<Field>>;
+
+template <typename Field>
+concept EigenVectorField = requires(Field field, Eigen::Index i) {
+  { field.size() } -> std::convertible_to<Eigen::Index>;
+  field.data();
+  field[i];
+};
+
+} // namespace detail
 
 /// Abstract interface for extracting component data to/from flat vectors
 ///
@@ -161,15 +177,12 @@ public:
       const Field& field = component.*m_fieldPtr;
 
       // Handle scalar field
-      if constexpr (std::is_arithmetic_v<Field>) {
+      if constexpr (detail::ArithmeticField<Field>) {
         vec[offset + count] = static_cast<double>(field);
         ++count;
       }
       // Handle Eigen vectors
-      else if constexpr (requires {
-                           field.size();
-                           field.data();
-                         }) {
+      else if constexpr (detail::EigenVectorField<Field>) {
         for (Eigen::Index i = 0; i < field.size(); ++i) {
           vec[offset + count] = field[i];
           ++count;
@@ -193,15 +206,12 @@ public:
       Field& field = component.*m_fieldPtr;
 
       // Handle scalar field
-      if constexpr (std::is_arithmetic_v<Field>) {
+      if constexpr (detail::ArithmeticField<Field>) {
         field = static_cast<Field>(vec[offset + count]);
         ++count;
       }
       // Handle Eigen vectors
-      else if constexpr (requires {
-                           field.size();
-                           field.data();
-                         }) {
+      else if constexpr (detail::EigenVectorField<Field>) {
         for (Eigen::Index i = 0; i < field.size(); ++i) {
           field[i] = vec[offset + count];
           ++count;


### PR DESCRIPTION
## Summary

- use C++20 standard concepts for simulation-experimental type-list membership and serialization type dispatch
- replace repeated ad hoc mapper `requires` checks with named field concepts
- use `std::same_as` and `std::derived_from` for auto-mapper field classification

## Motivation

This continues the DART 7.0 C++20 adoption work by making simulation-experimental mapping and serialization type dispatch more direct and declarative without changing serialized formats or mapper behavior.

## Changes

- Updated `TypeList` membership to use `std::same_as`.
- Updated auto-serialization field dispatch to use `std::same_as`.
- Added named mapper field concepts for arithmetic and Eigen-vector-like fields.
- Replaced the auto-mapper isometry type trait chain with a `std::same_as` / `std::derived_from` concept.

## Testing

- [x] `pixi run lint`
- [x] `pixi run build`
- [x] `pixi run test-unit`
- [x] `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues

None.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have run the required local checks.
- [x] I have updated documentation where applicable. N/A, implementation-only cleanup.
- [x] I have updated `CHANGELOG.md` where applicable. N/A, internal cleanup with no user-facing behavior change.
