### PR TITLE
Adopt C++20 ranges string helpers

### DIFF
--- a/dart/common/uri.cpp
+++ b/dart/common/uri.cpp
@@ -35,6 +35,7 @@
 #include "dart/common/logging.hpp"
 #include "dart/common/macros.hpp"
 
+#include <algorithm>
 #include <regex>
 #include <sstream>
 #include <string_view>
@@ -255,7 +256,7 @@ bool Uri::fromPath(std::string_view path)
 #ifdef _WIN32
   // Replace backslashes (from Windows paths) with forward slashes.
   std::string unixPath = pathString;
-  std::replace(std::begin(unixPath), std::end(unixPath), '\\', '/');
+  std::ranges::replace(unixPath, '\\', '/');
 
   return fromString(fileScheme + "/" + pathString);
 #else

--- a/tests/integration/io/test_skel_parser.cpp
+++ b/tests/integration/io/test_skel_parser.cpp
@@ -1237,7 +1237,7 @@ TEST(SkelParser, ReadWorldFromFileMeshShape)
   meshFile.close();
 
   std::string meshPathStr = meshPath.string();
-  std::replace(meshPathStr.begin(), meshPathStr.end(), '\\', '/');
+  std::ranges::replace(meshPathStr, '\\', '/');
   const std::string skelXml = std::string(R"(<skel version="1.0">
   <world name="world">
     <skeleton name="skel">
@@ -2191,7 +2191,7 @@ TEST(SkelParser, WorldXmlParsesJointAndShapeVariants)
 
   // Use absolute path with forward slashes so Windows resolves the mesh file
   std::string meshPathStr = meshPath.string();
-  std::replace(meshPathStr.begin(), meshPathStr.end(), '\\', '/');
+  std::ranges::replace(meshPathStr, '\\', '/');
 
   const std::string skelXml = std::string(R"(
 <skel version="1.0">
@@ -4001,7 +4001,7 @@ TEST(SkelParser, ParsesRigidShapeVariantsFromXml)
 
   // Use absolute path with forward slashes so Windows resolves the mesh file
   std::string meshPathStr = meshPath.string();
-  std::replace(meshPathStr.begin(), meshPathStr.end(), '\\', '/');
+  std::ranges::replace(meshPathStr, '\\', '/');
 
   const auto skelPath = tempDir / "shapes.skel";
   const std::string skelXml = std::string(R"(<?xml version="1.0" ?>

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <numeric>
 #include <thread>
@@ -296,7 +297,7 @@ TEST(Signal, ReturnValues)
   signal1.connect(&quotient);
   signal1.connect(&sum);
   signal1.connect(&difference);
-  EXPECT_EQ(signal1(5, 3), *std::max_element(res.begin(), res.end()));
+  EXPECT_EQ(signal1(5, 3), *std::ranges::max_element(res));
 
   // signal_sum
   Signal<float(float, float), signal_sum> signal2;

--- a/tests/unit/common/test_uri.cpp
+++ b/tests/unit/common/test_uri.cpp
@@ -683,7 +683,7 @@ TEST(UriHelpers, UriComponent_ArrowOperator)
 {
   UriComponent component("test_value");
   EXPECT_EQ(component->length(), 10u);
-  EXPECT_EQ(component->substr(0, 4), "test");
+  EXPECT_TRUE(component->starts_with("test"));
 }
 
 TEST(UriHelpers, getPath_ReturnsPathComponent)


### PR DESCRIPTION
## Summary

- use `std::ranges::replace` for whole-string path separator normalization
- use `std::ranges::max_element` for full-range signal result checks
- use `std::string::starts_with` in the URI component test

## Motivation

This continues the DART 7.0 C++20 modernization work by replacing iterator-pair and substring idioms with direct standard-library helpers where the whole range or prefix semantics are explicit.

## Changes

- Updated Windows path separator normalization in URI and SKEL parser tests to use ranges algorithms.
- Updated the signal return-value integration test to use a ranges algorithm overload.
- Updated the URI component arrow-operator test to use the C++20 prefix helper.

## Testing

- [x] `pixi run lint`
- [x] `pixi run build`
- [x] `pixi run test-unit`
- [x] `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues

None.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have run the required local checks.
- [x] I have updated documentation where applicable. N/A, implementation-only cleanup.
- [x] I have updated `CHANGELOG.md` where applicable. N/A, internal cleanup with no user-facing behavior change.
