### PR TITLE
Adopt C++20 concepts for callback helpers

### DIFF
--- a/dart/common/detail/callback_traits.hpp
+++ b/dart/common/detail/callback_traits.hpp
@@ -30,49 +30,18 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_CONSTRAINT_DETAIL_CONSTRAINTSOVER_IMPL_HPP_
-#define DART_CONSTRAINT_DETAIL_CONSTRAINTSOVER_IMPL_HPP_
+#ifndef DART_COMMON_DETAIL_CALLBACK_TRAITS_HPP_
+#define DART_COMMON_DETAIL_CALLBACK_TRAITS_HPP_
 
-#include <dart/constraint/constraint_solver.hpp>
+#include <concepts>
+#include <type_traits>
 
-#include <dart/common/detail/callback_traits.hpp>
-
-namespace dart::constraint {
-
-//==============================================================================
-template <typename Func>
-void ConstraintSolver::eachConstraint(Func func) const
-{
-  if constexpr (common::detail::ReturnsBool<Func, const ConstraintBase*>) {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      if (!func(getConstraint(i))) {
-        return;
-      }
-    }
-  } else {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      func(getConstraint(i));
-    }
-  }
-}
+namespace dart::common::detail {
 
 //==============================================================================
-template <typename Func>
-void ConstraintSolver::eachConstraint(Func func)
-{
-  if constexpr (common::detail::ReturnsBool<Func, ConstraintBase*>) {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      if (!func(getConstraint(i))) {
-        return;
-      }
-    }
-  } else {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      func(getConstraint(i));
-    }
-  }
-}
+template <typename Func, typename... Args>
+concept ReturnsBool = std::same_as<std::invoke_result_t<Func, Args...>, bool>;
 
-} // namespace dart::constraint
+} // namespace dart::common::detail
 
-#endif // DART_CONSTRAINT_DETAIL_CONSTRAINTSOVER_IMPL_HPP_
+#endif // DART_COMMON_DETAIL_CALLBACK_TRAITS_HPP_

--- a/dart/common/detail/stopwatch-impl.hpp
+++ b/dart/common/detail/stopwatch-impl.hpp
@@ -32,9 +32,18 @@
 
 #include <dart/common/stopwatch.hpp>
 
+#include <concepts>
+
 namespace dart::common {
 
 namespace {
+//==============================================================================
+template <typename UnitType>
+concept StopwatchUnit = std::same_as<UnitType, std::chrono::seconds>
+                        || std::same_as<UnitType, std::chrono::milliseconds>
+                        || std::same_as<UnitType, std::chrono::microseconds>
+                        || std::same_as<UnitType, std::chrono::nanoseconds>;
+
 //==============================================================================
 template <class duration_t>
 void print_duration_if_non_zero(
@@ -55,13 +64,7 @@ template <typename UnitType, typename ClockType>
 Stopwatch<UnitType, ClockType>::Stopwatch(bool start)
   : mStart(ClockType::now()), mElapsed(0), mPaused(!start)
 {
-  // clang-format off
-  static_assert(std::is_same_v<UnitType, std::chrono::seconds>
-      || std::is_same_v<UnitType, std::chrono::milliseconds>
-      || std::is_same_v<UnitType, std::chrono::microseconds>
-      || std::is_same_v<UnitType, std::chrono::nanoseconds>,
-      "Invalid unit");
-  // clang-format on
+  static_assert(StopwatchUnit<UnitType>, "Invalid unit");
 }
 
 //==============================================================================
@@ -114,62 +117,28 @@ void Stopwatch<UnitType, ClockType>::reset()
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
-    return duration().count() * 1e-9;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
-    return duration().count() * 1e-6;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
-    return duration().count() * 1e-3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
-    return duration().count();
-  }
+  return std::chrono::duration<double>(duration()).count();
 }
 
 //==============================================================================
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedMS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
-    return duration().count() * 1e-6;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
-    return duration().count() * 1e-3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
-    return duration().count();
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
-    return duration().count() * 1e+3;
-    ;
-  }
+  return std::chrono::duration<double, std::milli>(duration()).count();
 }
 
 //==============================================================================
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedUS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
-    return duration().count() * 1e-3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
-    return duration().count();
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
-    return duration().count() * 1e+3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
-    return duration().count() * 1e+6;
-    ;
-  }
+  return std::chrono::duration<double, std::micro>(duration()).count();
 }
 
 //==============================================================================
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedNS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
-    return duration().count();
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
-    return duration().count() * 1e+3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
-    return duration().count() * 1e+6;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
-    return duration().count() * 1e+9;
-  }
+  return std::chrono::duration<double, std::nano>(duration()).count();
 }
 
 //==============================================================================
@@ -203,17 +172,17 @@ void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
   print_duration_if_non_zero(os, s, "s ");
   t -= s;
 
-  if constexpr (!std::is_same_v<UnitType, std::chrono::seconds>) {
+  if constexpr (!std::same_as<UnitType, std::chrono::seconds>) {
     const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t);
     print_duration_if_non_zero(os, ms, "ms ");
     t -= ms;
 
-    if constexpr (!std::is_same_v<UnitType, std::chrono::milliseconds>) {
+    if constexpr (!std::same_as<UnitType, std::chrono::milliseconds>) {
       const auto us = std::chrono::duration_cast<std::chrono::microseconds>(t);
       print_duration_if_non_zero(os, us, "us ");
       t -= us;
 
-      if constexpr (!std::is_same_v<UnitType, std::chrono::microseconds>) {
+      if constexpr (!std::same_as<UnitType, std::chrono::microseconds>) {
         const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t);
         print_duration_if_non_zero(os, ns, "ns ");
         if (us == std::chrono::nanoseconds::zero()) {

--- a/dart/dynamics/detail/basic_node_manager.hpp
+++ b/dart/dynamics/detail/basic_node_manager.hpp
@@ -38,6 +38,7 @@
 #include <dart/dynamics/node.hpp>
 
 #include <dart/common/class_with_virtual_base.hpp>
+#include <dart/common/detail/callback_traits.hpp>
 #include <dart/common/empty.hpp>
 #include <dart/common/name_manager.hpp>
 
@@ -299,9 +300,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func) const                                       \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -315,9 +314,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func)                                             \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -363,9 +360,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func) const                \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \
@@ -379,9 +374,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func)                      \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \
@@ -407,9 +400,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func) const                                       \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -423,9 +414,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func)                                             \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -458,9 +447,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func) const                \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \
@@ -474,9 +461,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func)                      \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \

--- a/dart/dynamics/detail/body_node.hpp
+++ b/dart/dynamics/detail/body_node.hpp
@@ -37,6 +37,8 @@
 #include <dart/dynamics/shape_node.hpp>
 #include <dart/dynamics/skeleton.hpp>
 
+#include <dart/common/detail/callback_traits.hpp>
+
 #include <utility>
 
 namespace dart {
@@ -298,9 +300,7 @@ void BodyNode::removeAllShapeNodesWith()
 template <typename AspectT, typename Func>
 void BodyNode::eachShapeNodeWith(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const ShapeNode*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const ShapeNode*>) {
     for (auto i = 0u; i < getNumShapeNodes(); ++i) {
       const ShapeNode* shapeNode = getShapeNode(i);
       if (shapeNode->has<AspectT>()) {
@@ -323,7 +323,7 @@ void BodyNode::eachShapeNodeWith(Func func) const
 template <typename AspectT, typename Func>
 void BodyNode::eachShapeNodeWith(Func func)
 {
-  if constexpr (std::is_same_v<std::invoke_result_t<Func, ShapeNode*>, bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, ShapeNode*>) {
     for (auto i = 0u; i < getNumShapeNodes(); ++i) {
       ShapeNode* shapeNode = getShapeNode(i);
       if (shapeNode->has<AspectT>()) {

--- a/dart/dynamics/detail/meta_skeleton-impl.hpp
+++ b/dart/dynamics/detail/meta_skeleton-impl.hpp
@@ -35,15 +35,15 @@
 
 #include <dart/dynamics/meta_skeleton.hpp>
 
+#include <dart/common/detail/callback_traits.hpp>
+
 namespace dart::dynamics {
 
 //==============================================================================
 template <typename Func>
 void MetaSkeleton::eachBodyNode(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::BodyNode*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const dynamics::BodyNode*>) {
     for (auto i = 0u; i < getNumBodyNodes(); ++i) {
       if (!func(getBodyNode(i))) {
         return;
@@ -60,9 +60,7 @@ void MetaSkeleton::eachBodyNode(Func func) const
 template <typename Func>
 void MetaSkeleton::eachBodyNode(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::BodyNode*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::BodyNode*>) {
     for (auto i = 0u; i < getNumBodyNodes(); ++i) {
       if (!func(getBodyNode(i))) {
         return;
@@ -79,9 +77,7 @@ void MetaSkeleton::eachBodyNode(Func func)
 template <typename Func>
 void MetaSkeleton::eachJoint(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::Joint*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const dynamics::Joint*>) {
     for (auto i = 0u; i < getNumJoints(); ++i) {
       if (!func(getJoint(i))) {
         return;
@@ -98,9 +94,7 @@ void MetaSkeleton::eachJoint(Func func) const
 template <typename Func>
 void MetaSkeleton::eachJoint(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::Joint*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::Joint*>) {
     for (auto i = 0u; i < getNumJoints(); ++i) {
       if (!func(getJoint(i))) {
         return;
@@ -117,10 +111,8 @@ void MetaSkeleton::eachJoint(Func func)
 template <typename Func>
 void MetaSkeleton::eachDof(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::
-                        invoke_result_t<Func, const dynamics::DegreeOfFreedom*>,
-                    bool>) {
+  if constexpr (common::detail::
+                    ReturnsBool<Func, const dynamics::DegreeOfFreedom*>) {
     for (auto i = 0u; i < getNumDofs(); ++i) {
       if (!func(getDof(i))) {
         return;
@@ -137,9 +129,7 @@ void MetaSkeleton::eachDof(Func func) const
 template <typename Func>
 void MetaSkeleton::eachDof(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::DegreeOfFreedom*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::DegreeOfFreedom*>) {
     for (auto i = 0u; i < getNumDofs(); ++i) {
       if (!func(getDof(i))) {
         return;

--- a/dart/dynamics/detail/skeleton.hpp
+++ b/dart/dynamics/detail/skeleton.hpp
@@ -35,7 +35,7 @@
 
 #include <dart/dynamics/skeleton.hpp>
 
-#include <type_traits>
+#include <concepts>
 
 namespace dart {
 namespace dynamics {
@@ -84,10 +84,10 @@ std::pair<JointType*, NodeType*> Skeleton::createJointAndBodyNodePair(
 {
   JointType* joint = new JointType(_jointProperties);
   NodeType* node;
-  if constexpr (std::is_same_v<NodeType, BodyNode>) {
+  if constexpr (std::same_as<NodeType, BodyNode>) {
     void* mem = allocateBodyNodeMemory(BodyNodePoolKind::Body);
     node = new (mem) NodeType(_parent, joint, _bodyProperties);
-  } else if constexpr (std::is_same_v<NodeType, SoftBodyNode>) {
+  } else if constexpr (std::same_as<NodeType, SoftBodyNode>) {
     void* mem = allocateBodyNodeMemory(BodyNodePoolKind::Soft);
     node = new (mem) NodeType(_parent, joint, _bodyProperties);
   } else {

--- a/dart/simulation/detail/world-impl.hpp
+++ b/dart/simulation/detail/world-impl.hpp
@@ -41,6 +41,8 @@
 
 #include <dart/simulation/world.hpp>
 
+#include <dart/common/detail/callback_traits.hpp>
+
 #include <algorithm>
 
 namespace dart {
@@ -57,9 +59,7 @@ WorldPtr World::create(Args&&... args)
 template <typename Func>
 void World::eachSkeleton(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::Skeleton*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const dynamics::Skeleton*>) {
     (void)std::ranges::all_of(
         mSkeletons, [&func](auto skel) { return func(skel.get()); });
   } else {
@@ -73,9 +73,7 @@ void World::eachSkeleton(Func func) const
 template <typename Func>
 void World::eachSkeleton(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::Skeleton*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::Skeleton*>) {
     (void)std::ranges::all_of(
         mSkeletons, [&func](auto skel) { return func(skel.get()); });
   } else {
@@ -89,9 +87,8 @@ void World::eachSkeleton(Func func)
 template <typename Func>
 void World::eachSimpleFrame(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::SimpleFrame*>,
-                    bool>) {
+  if constexpr (common::detail::
+                    ReturnsBool<Func, const dynamics::SimpleFrame*>) {
     (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {
       return func(simpleFrame.get());
     });
@@ -106,9 +103,7 @@ void World::eachSimpleFrame(Func func) const
 template <typename Func>
 void World::eachSimpleFrame(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::SimpleFrame*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::SimpleFrame*>) {
     (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {
       return func(simpleFrame.get());
     });


### PR DESCRIPTION
## Summary

Adopt C++20 concepts in callback/type helper code.

## Motivation

The callback iteration helpers were still using repeated `std::is_same_v<std::invoke_result_t<...>, bool>` checks. C++20 concepts make those type predicates clearer and easier to reuse.

## Changes

- Add `dart::common::detail::ReturnsBool` as a shared C++20 concept for callback early-exit detection.
- Use the concept across constraint, dynamics, and simulation callback helpers.
- Replace remaining exact-type dispatch in skeleton helpers with `std::same_as`.
- Simplify `Stopwatch` unit validation with a concept and use chrono duration conversions for elapsed time helpers.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

None.

## Related Issues

None.

## Checklist

- [x] Tests added or updated where needed
- [x] Documentation updated where needed
- [x] CHANGELOG updated if user-facing
