### PR TITLE
Adopt C++20 ranges in GUI scene nodes

### DIFF
--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -52,11 +52,14 @@
 #include <osgDB/ReadFile>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <map>
+#include <span>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
@@ -772,17 +775,19 @@ void MeshShapeGeometry::extractData(bool firstTime)
 
   if (mShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_ELEMENTS)
       || firstTime) {
-    ::osg::ref_ptr<::osg::DrawElementsUInt> elements[3];
-    elements[0] = new ::osg::DrawElementsUInt(GL_POINTS);
-    elements[1] = new ::osg::DrawElementsUInt(GL_LINES);
-    elements[2] = new ::osg::DrawElementsUInt(GL_TRIANGLES);
+    const std::array<::osg::ref_ptr<::osg::DrawElementsUInt>, 3> elements{
+        new ::osg::DrawElementsUInt(GL_POINTS),
+        new ::osg::DrawElementsUInt(GL_LINES),
+        new ::osg::DrawElementsUInt(GL_TRIANGLES)};
 
     std::vector<Eigen::Vector3d> vertices;
-    vertices.reserve(mAiMesh->mNumVertices);
-    for (std::size_t i = 0; i < mAiMesh->mNumVertices; ++i) {
-      const aiVector3D& vertex = mAiMesh->mVertices[i];
-      vertices.emplace_back(vertex.x, vertex.y, vertex.z);
-    }
+    const std::span<const aiVector3D> aiVertices{
+        mAiMesh->mVertices, mAiMesh->mNumVertices};
+    vertices.reserve(aiVertices.size());
+    std::ranges::transform(
+        aiVertices, std::back_inserter(vertices), [](const aiVector3D& vertex) {
+          return Eigen::Vector3d(vertex.x, vertex.y, vertex.z);
+        });
 
     std::vector<std::size_t> polygon;
     std::vector<
@@ -790,34 +795,29 @@ void MeshShapeGeometry::extractData(bool firstTime)
         Eigen::aligned_allocator<Eigen::Matrix<std::size_t, 3, 1>>>
         triangles;
 
-    for (std::size_t i = 0; i < mAiMesh->mNumFaces; ++i) {
-      const aiFace& face = mAiMesh->mFaces[i];
-
+    const std::span<const aiFace> aiFaces{mAiMesh->mFaces, mAiMesh->mNumFaces};
+    for (const aiFace& face : aiFaces) {
       if (face.mNumIndices == 0) {
         continue;
       }
 
+      const std::span<const unsigned int> faceIndices{
+          face.mIndices, face.mNumIndices};
+
       if (face.mNumIndices < 3) {
-        ::osg::DrawElementsUInt* elem = elements[face.mNumIndices - 1];
-        for (std::size_t j = 0; j < face.mNumIndices; ++j) {
-          elem->push_back(face.mIndices[j]);
-        }
+        std::ranges::copy(
+            faceIndices, std::back_inserter(*elements[face.mNumIndices - 1]));
         continue;
       }
 
       if (face.mNumIndices == 3) {
-        ::osg::DrawElementsUInt* elem = elements[2];
-        for (std::size_t j = 0; j < face.mNumIndices; ++j) {
-          elem->push_back(face.mIndices[j]);
-        }
+        std::ranges::copy(faceIndices, std::back_inserter(*elements[2]));
         continue;
       }
 
       polygon.clear();
-      polygon.reserve(face.mNumIndices);
-      for (std::size_t j = 0; j < face.mNumIndices; ++j) {
-        polygon.push_back(face.mIndices[j]);
-      }
+      polygon.reserve(faceIndices.size());
+      std::ranges::copy(faceIndices, std::back_inserter(polygon));
 
       triangles.clear();
       if (!dart::math::detail::triangulateFaceEarClipping(
@@ -840,9 +840,9 @@ void MeshShapeGeometry::extractData(bool firstTime)
       }
     }
 
-    for (std::size_t i = 0; i < 3; ++i) {
-      if (elements[i]->size() > 0) {
-        addPrimitiveSet(elements[i]);
+    for (const auto& element : elements) {
+      if (!element->empty()) {
+        addPrimitiveSet(element);
       }
     }
   }

--- a/dart/gui/viewer.cpp
+++ b/dart/gui/viewer.cpp
@@ -48,7 +48,9 @@
 #include <osg/OperationThread>
 #include <osgDB/WriteFile>
 
+#include <algorithm>
 #include <iomanip>
+#include <ranges>
 
 namespace dart {
 namespace gui {
@@ -563,18 +565,11 @@ void Viewer::removeWorldNode(std::shared_ptr<dart::simulation::World> _oldWorld)
 WorldNode* Viewer::getWorldNode(
     std::shared_ptr<dart::simulation::World> _world) const
 {
-  auto it = mWorldNodes.cbegin();
-  auto end = mWorldNodes.cend();
-  WorldNode* node = nullptr;
-  for (; it != end; ++it) {
-    WorldNode* checkNode = it->first;
-    if (checkNode->getWorld() == _world) {
-      node = checkNode;
-      break;
-    }
-  }
+  const auto it = std::ranges::find_if(mWorldNodes, [&](const auto& nodePair) {
+    return nodePair.first->getWorld() == _world;
+  });
 
-  return node;
+  return it != mWorldNodes.cend() ? it->first : nullptr;
 }
 
 //==============================================================================
@@ -791,21 +786,13 @@ static sfs_dnd::iterator getSimpleFrameShapeDnDFromMultimap(
 {
   using namespace sfs_dnd;
 
-  std::pair<iterator, iterator> range = map.equal_range(_shape);
-  iterator it = range.first, end = range.second;
-  while (it != map.end()) {
-    SimpleFrameShapeDnD* dnd = it->second;
-    if (dnd->getSimpleFrame() == _frame) {
-      return it;
-    }
+  auto [first, last] = map.equal_range(_shape);
+  auto shapeDnDs = std::ranges::subrange(first, last);
+  auto it = std::ranges::find_if(shapeDnDs, [_frame](const auto& entry) {
+    return entry.second->getSimpleFrame() == _frame;
+  });
 
-    if (it == end) {
-      break;
-    }
-    ++it;
-  }
-
-  return map.end();
+  return it != shapeDnDs.end() ? it : map.end();
 }
 
 //==============================================================================
@@ -991,23 +978,19 @@ void Viewer::updateViewer()
 //==============================================================================
 void Viewer::updateDragAndDrops()
 {
-  for (auto& dnd_pair : mSimpleFrameDnDMap) {
-    SimpleFrameDnD* dnd = dnd_pair.second;
+  for (SimpleFrameDnD* dnd : std::views::values(mSimpleFrameDnDMap)) {
     dnd->update();
   }
 
-  for (auto& dnd_pair : mSimpleFrameShapeDnDMap) {
-    SimpleFrameShapeDnD* dnd = dnd_pair.second;
+  for (SimpleFrameShapeDnD* dnd : std::views::values(mSimpleFrameShapeDnDMap)) {
     dnd->update();
   }
 
-  for (auto& dnd_pair : mInteractiveFrameDnDMap) {
-    InteractiveFrameDnD* dnd = dnd_pair.second;
+  for (InteractiveFrameDnD* dnd : std::views::values(mInteractiveFrameDnDMap)) {
     dnd->update();
   }
 
-  for (auto& dnd_pair : mBodyNodeDnDMap) {
-    BodyNodeDnD* dnd = dnd_pair.second;
+  for (BodyNodeDnD* dnd : std::views::values(mBodyNodeDnDMap)) {
     dnd->update();
   }
 }

--- a/dart/gui/world_node.cpp
+++ b/dart/gui/world_node.cpp
@@ -44,6 +44,7 @@
 #include <osgShadow/ShadowedScene>
 
 #include <deque>
+#include <ranges>
 
 namespace dart {
 namespace gui {
@@ -112,8 +113,7 @@ void WorldNode::setWorld(std::shared_ptr<dart::simulation::World> newWorld)
 //==============================================================================
 void WorldNode::clearAllShapeFrameNodes()
 {
-  for (auto& node_pair : mFrameToNode) {
-    ShapeFrameNode* node = node_pair.second;
+  for (ShapeFrameNode* node : std::views::values(mFrameToNode)) {
     if (node) {
       mNormalGroup->removeChild(node);
       mShadowedGroup->removeChild(node);
@@ -214,33 +214,24 @@ void WorldNode::setupViewer()
 //==============================================================================
 void WorldNode::clearChildUtilizationFlags()
 {
-  for (auto& node_pair : mFrameToNode) {
-    node_pair.second->clearUtilization();
+  for (ShapeFrameNode* node : std::views::values(mFrameToNode)) {
+    node->clearUtilization();
   }
 }
 
 //==============================================================================
 void WorldNode::clearUnusedNodes()
 {
-  std::vector<dart::dynamics::Frame*> unused;
-  unused.reserve(mFrameToNode.size());
-
-  // Find unused ShapeFrameNodes
-  for (auto& node_pair : mFrameToNode) {
-    ShapeFrameNode* node = node_pair.second;
-    if (node && !node->wasUtilized()) {
-      unused.push_back(node_pair.first);
+  std::erase_if(mFrameToNode, [&](const auto& nodePair) {
+    ShapeFrameNode* node = nodePair.second;
+    if (!node || node->wasUtilized()) {
+      return false;
     }
-  }
 
-  // Clear unused ShapeFrameNodes
-  for (dart::dynamics::Frame* frame : unused) {
-    NodeMap::iterator it = mFrameToNode.find(frame);
-    ShapeFrameNode* node = it->second;
     mNormalGroup->removeChild(node);
     mShadowedGroup->removeChild(node);
-    mFrameToNode.erase(it);
-  }
+    return true;
+  });
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges and views in GUI scene-node traversal and lookups.
- Use `std::erase_if` for stale GUI frame-node cleanup.
- Use `std::span` plus ranges algorithms when reading Assimp mesh arrays.

## Motivation / Problem

- Continue the main-branch C++20 modernization pass with behavior-preserving simplifications in GUI code.
- Remove manual iterator and temporary-container cleanup patterns where C++20 standard library helpers express the intent directly.

## Changes / Key Changes

- Replaced manual world-node lookup and drag-and-drop map value loops with `std::ranges`/`std::views`.
- Replaced two-pass unused shape-frame cleanup with `std::erase_if`.
- Reworked mesh primitive extraction to range over `std::span` views of Assimp vertices, faces, and face indices.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `git diff --check`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Supersedes #2578, where GitHub did not publish `refs/pull/2578/head` for ReadTheDocs to fetch.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
