### PR TITLE
Adopt C++20 ranges for MJCF error aggregation

### DIFF
--- a/dart/utils/mjcf/detail/actuator.cpp
+++ b/dart/utils/mjcf/detail/actuator.cpp
@@ -85,7 +85,7 @@ Errors Actuator::read(tinyxml2::XMLElement* element, const Defaults& defaults)
     }
 
     const Errors appendErrors = appendActuatorAttributes(attrs, child);
-    errors.insert(errors.end(), appendErrors.begin(), appendErrors.end());
+    appendErrorRange(errors, appendErrors);
 
     if (attrs.mJoint.empty()) {
       errors.push_back(Error(

--- a/dart/utils/mjcf/detail/asset.cpp
+++ b/dart/utils/mjcf/detail/asset.cpp
@@ -129,7 +129,7 @@ Errors Asset::read(tinyxml2::XMLElement* element)
   while (meshElements.next()) {
     Mesh mesh = Mesh();
     const auto bodyErrors = mesh.read(meshElements.get());
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
 
     if (bodyErrors.empty()) {
       mMeshes.emplace_back(std::move(mesh));
@@ -141,7 +141,7 @@ Errors Asset::read(tinyxml2::XMLElement* element)
   while (textureElements.next()) {
     Texture texture = Texture();
     const auto textureErrors = texture.read(textureElements.get());
-    errors.insert(errors.end(), textureErrors.begin(), textureErrors.end());
+    appendErrorRange(errors, textureErrors);
 
     if (textureErrors.empty()) {
       mTextures.emplace_back(std::move(texture));
@@ -153,7 +153,7 @@ Errors Asset::read(tinyxml2::XMLElement* element)
   while (materialElements.next()) {
     Material material = Material();
     const auto materialErrors = material.read(materialElements.get());
-    errors.insert(errors.end(), materialErrors.begin(), materialErrors.end());
+    appendErrorRange(errors, materialErrors);
 
     if (materialErrors.empty()) {
       mMaterials.emplace_back(std::move(material));
@@ -172,7 +172,7 @@ Errors Asset::preprocess(const Compiler& compiler)
 
   for (Mesh& mesh : mMeshes) {
     const Errors meshErrors = mesh.preprocess(compiler);
-    errors.insert(errors.end(), meshErrors.begin(), meshErrors.end());
+    appendErrorRange(errors, meshErrors);
   }
 
   return errors;
@@ -187,7 +187,7 @@ Errors Asset::compile(const Compiler& compiler)
     mMeshMap[mesh.getName()] = &mesh;
 
     const Errors meshErrors = mesh.compile(compiler);
-    errors.insert(errors.end(), meshErrors.begin(), meshErrors.end());
+    appendErrorRange(errors, meshErrors);
   }
 
   for (Texture& texture : mTextures) {
@@ -208,7 +208,7 @@ Errors Asset::postprocess(const Compiler& compiler)
 
   for (Mesh& mesh : mMeshes) {
     const Errors meshErrors = mesh.postprocess(compiler);
-    errors.insert(errors.end(), meshErrors.begin(), meshErrors.end());
+    appendErrorRange(errors, meshErrors);
   }
 
   return errors;

--- a/dart/utils/mjcf/detail/body.cpp
+++ b/dart/utils/mjcf/detail/body.cpp
@@ -75,7 +75,7 @@ Errors Body::read(
 
   // Read attributes
   const Errors attrErrors = appendBodyAttributes(mAttributes, element, size);
-  errors.insert(errors.end(), attrErrors.begin(), attrErrors.end());
+  appendErrorRange(errors, attrErrors);
 
   // Read <inertial>
   if (hasElement(element, "inertial")) {
@@ -83,7 +83,7 @@ Errors Body::read(
     DART_ASSERT(inertialElement);
     mAttributes.mInertial = Inertial();
     const Errors inertialErrors = mAttributes.mInertial->read(inertialElement);
-    errors.insert(errors.end(), inertialErrors.begin(), inertialErrors.end());
+    appendErrorRange(errors, inertialErrors);
   }
 
   // Read multiple <joint>
@@ -92,7 +92,7 @@ Errors Body::read(
     Joint joint = Joint();
     const Errors jointErrors = joint.read(
         jointElements.get(), defaults, currentDefault->getJointAttributes());
-    errors.insert(errors.end(), jointErrors.begin(), jointErrors.end());
+    appendErrorRange(errors, jointErrors);
     mJoints.emplace_back(std::move(joint));
   }
 
@@ -156,7 +156,7 @@ Errors Body::read(
     Geom geom = Geom();
     const Errors geomErrors = geom.read(
         geomElements.get(), defaults, currentDefault->getGeomAttributes());
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
     mGeoms.emplace_back(std::move(geom));
   }
 
@@ -165,7 +165,7 @@ Errors Body::read(
   while (siteElements.next()) {
     Site site = Site();
     const Errors siteErrors = site.read(siteElements.get());
-    errors.insert(errors.end(), siteErrors.begin(), siteErrors.end());
+    appendErrorRange(errors, siteErrors);
     mSites.emplace_back(std::move(site));
   }
 
@@ -174,7 +174,7 @@ Errors Body::read(
   while (cameraElements.next()) {
     Camera camera = Camera();
     const Errors cameraErrors = camera.read(cameraElements.get());
-    errors.insert(errors.end(), cameraErrors.begin(), cameraErrors.end());
+    appendErrorRange(errors, cameraErrors);
     mCameras.emplace_back(std::move(camera));
   }
 
@@ -183,7 +183,7 @@ Errors Body::read(
   while (lightElements.next()) {
     Light light = Light();
     const Errors lightErrors = light.read(lightElements.get());
-    errors.insert(errors.end(), lightErrors.begin(), lightErrors.end());
+    appendErrorRange(errors, lightErrors);
     mLights.emplace_back(std::move(light));
   }
 
@@ -193,7 +193,7 @@ Errors Body::read(
     Body childBody = Body();
     const Errors bodyErrors
         = childBody.read(bodyElements.get(), size, defaults, currentDefault);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
     mChildBodies.emplace_back(std::move(childBody));
   }
 
@@ -219,22 +219,22 @@ Errors Body::preprocess(const Compiler& compiler)
 
   for (Geom& geom : mGeoms) {
     const Errors geomErrors = geom.preprocess(compiler, true);
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
   }
 
   for (Site& site : mSites) {
     const Errors siteErrors = site.preprocess(compiler);
-    errors.insert(errors.end(), siteErrors.begin(), siteErrors.end());
+    appendErrorRange(errors, siteErrors);
   }
 
   for (Joint& joint : mJoints) {
     const Errors jointErrors = joint.preprocess(compiler);
-    errors.insert(errors.end(), jointErrors.begin(), jointErrors.end());
+    appendErrorRange(errors, jointErrors);
   }
 
   for (Body& body : mChildBodies) {
     const Errors bodyErrors = body.preprocess(compiler);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
   }
 
   return errors;
@@ -249,7 +249,7 @@ Errors Body::compile(const Compiler& compiler)
   if (mAttributes.mInertial) {
     mInertial = *mAttributes.mInertial;
     const Errors inertialErrors = mInertial.compile(compiler);
-    errors.insert(errors.end(), inertialErrors.begin(), inertialErrors.end());
+    appendErrorRange(errors, inertialErrors);
   } else {
     for (const Geom& geom : mGeoms) {
       if (geom.getType() == GeomType::MESH) {
@@ -269,22 +269,22 @@ Errors Body::compile(const Compiler& compiler)
 
   for (Geom& geom : mGeoms) {
     const Errors geomErrors = geom.compile(compiler);
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
   }
 
   for (Site& site : mSites) {
     const Errors siteErrors = site.compile(compiler);
-    errors.insert(errors.end(), siteErrors.begin(), siteErrors.end());
+    appendErrorRange(errors, siteErrors);
   }
 
   for (Joint& joint : mJoints) {
     const Errors jointErrors = joint.compile(compiler);
-    errors.insert(errors.end(), jointErrors.begin(), jointErrors.end());
+    appendErrorRange(errors, jointErrors);
   }
 
   for (Body& body : mChildBodies) {
     const Errors bodyErrors = body.compile(compiler);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
   }
 
   return errors;
@@ -368,22 +368,22 @@ Errors Body::postprocess(const Body* parent, const Compiler& compiler)
 
   for (Geom& geom : mGeoms) {
     const Errors geomErrors = geom.postprocess(this, compiler);
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
   }
 
   for (Site& site : mSites) {
     const Errors siteErrors = site.postprocess(this, compiler);
-    errors.insert(errors.end(), siteErrors.begin(), siteErrors.end());
+    appendErrorRange(errors, siteErrors);
   }
 
   for (Joint& joint : mJoints) {
     const Errors jointErrors = joint.postprocess(this, compiler);
-    errors.insert(errors.end(), jointErrors.begin(), jointErrors.end());
+    appendErrorRange(errors, jointErrors);
   }
 
   for (Body& body : mChildBodies) {
     const Errors bodyErrors = body.postprocess(this, compiler);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
   }
 
   return errors;

--- a/dart/utils/mjcf/detail/body_attributes.cpp
+++ b/dart/utils/mjcf/detail/body_attributes.cpp
@@ -74,8 +74,7 @@ Errors appendBodyAttributes(
 
   // Check if multiple orientation representations present
   const Errors orientationErrors = checkOrientationValidity(element);
-  errors.insert(
-      errors.end(), orientationErrors.begin(), orientationErrors.end());
+  appendErrorRange(errors, orientationErrors);
 
   // quat
   if (hasAttribute(element, "quat")) {
@@ -140,7 +139,7 @@ Errors appendBodyAttributes(
     DART_ASSERT(inertialElement);
     attributes.mInertial = Inertial();
     const Errors inertialErrors = attributes.mInertial->read(inertialElement);
-    errors.insert(errors.end(), inertialErrors.begin(), inertialErrors.end());
+    appendErrorRange(errors, inertialErrors);
   }
 
   return errors;

--- a/dart/utils/mjcf/detail/default.cpp
+++ b/dart/utils/mjcf/detail/default.cpp
@@ -108,32 +108,32 @@ Errors Default::read(tinyxml2::XMLElement* element, const Default* parent)
   if (hasElement(element, "motor")) {
     const Errors e = appendActuatorAttributes(
         mMotorAttributes, getElement(element, "motor"));
-    errors.insert(errors.end(), e.begin(), e.end());
+    appendErrorRange(errors, e);
   }
 
   if (hasElement(element, "position")) {
     const Errors e = appendActuatorAttributes(
         mPositionAttributes, getElement(element, "position"));
-    errors.insert(errors.end(), e.begin(), e.end());
+    appendErrorRange(errors, e);
   }
 
   if (hasElement(element, "velocity")) {
     const Errors e = appendActuatorAttributes(
         mVelocityAttributes, getElement(element, "velocity"));
-    errors.insert(errors.end(), e.begin(), e.end());
+    appendErrorRange(errors, e);
   }
 
   if (hasElement(element, "general")) {
     const Errors e = appendActuatorAttributes(
         mGeneralAttributes, getElement(element, "general"));
-    errors.insert(errors.end(), e.begin(), e.end());
+    appendErrorRange(errors, e);
   }
 
   if (hasElement(element, "geom")) {
     auto geomElement = getElement(element, "geom");
     const Errors geomErrors
         = appendGeomAttributes(mGeomAttributes, geomElement);
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
   }
 
   // Read <joint>
@@ -141,7 +141,7 @@ Errors Default::read(tinyxml2::XMLElement* element, const Default* parent)
     auto jointElement = getElement(element, "joint");
     const Errors jointErrors
         = appendJointAttributes(mJointAttributes, jointElement);
-    errors.insert(errors.end(), jointErrors.begin(), jointErrors.end());
+    appendErrorRange(errors, jointErrors);
   }
 
   // Read <mesh>
@@ -149,7 +149,7 @@ Errors Default::read(tinyxml2::XMLElement* element, const Default* parent)
     auto meshElement = getElement(element, "mesh");
     const Errors meshErrors
         = appendMeshAttributes(mMeshAttributes, meshElement);
-    errors.insert(errors.end(), meshErrors.begin(), meshErrors.end());
+    appendErrorRange(errors, meshErrors);
   }
 
   // Read <mesh>
@@ -160,7 +160,7 @@ Errors Default::read(tinyxml2::XMLElement* element, const Default* parent)
       auto weldElement = getElement(equalityElement, "weld");
       const Errors weldErrors
           = appendWeldAttributes(mWeldAttributes, weldElement);
-      errors.insert(errors.end(), weldErrors.begin(), weldErrors.end());
+      appendErrorRange(errors, weldErrors);
     }
   }
 
@@ -237,7 +237,7 @@ Errors Defaults::read(tinyxml2::XMLElement* element, const Default* parent)
   auto newDefault = Default();
   const Errors defaultErrors = newDefault.read(element, parent);
   if (!defaultErrors.empty()) {
-    errors.insert(errors.end(), defaultErrors.begin(), defaultErrors.end());
+    appendErrorRange(errors, defaultErrors);
     return errors;
   }
   mDefaultMap[className] = newDefault;
@@ -247,7 +247,7 @@ Errors Defaults::read(tinyxml2::XMLElement* element, const Default* parent)
   while (defaultElements.next()) {
     const Errors defaultErrors = read(defaultElements.get(), &newDefault);
     if (!defaultErrors.empty()) {
-      errors.insert(errors.end(), defaultErrors.begin(), defaultErrors.end());
+      appendErrorRange(errors, defaultErrors);
       return errors;
     }
   }

--- a/dart/utils/mjcf/detail/equality.cpp
+++ b/dart/utils/mjcf/detail/equality.cpp
@@ -69,7 +69,7 @@ Errors Equality::read(tinyxml2::XMLElement* element, const Defaults& defaults)
   while (weldElements.next()) {
     Weld weld = Weld();
     const Errors bodyErrors = weld.read(weldElements.get(), defaults);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
     mWelds.emplace_back(std::move(weld));
   }
 

--- a/dart/utils/mjcf/detail/error.hpp
+++ b/dart/utils/mjcf/detail/error.hpp
@@ -35,7 +35,12 @@
 
 #include <dart/utils/export.hpp>
 
+#include <algorithm>
+#include <concepts>
+#include <iterator>
+#include <ranges>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace dart {
@@ -87,6 +92,28 @@ private:
 };
 
 using Errors = std::vector<Error>;
+
+template <typename Range>
+concept ErrorRange = std::ranges::input_range<Range>
+                     && std::same_as<
+                         std::remove_cvref_t<std::ranges::range_value_t<Range>>,
+                         Error>;
+
+template <ErrorRange Range>
+void appendErrorRange(Errors& errors, Range&& newErrors)
+{
+  if constexpr (std::ranges::sized_range<Range>) {
+    errors.reserve(errors.size() + std::ranges::size(newErrors));
+  }
+
+  if constexpr (
+      std::is_rvalue_reference_v<Range&&>
+      && !std::is_const_v<std::remove_reference_t<Range>>) {
+    std::ranges::move(newErrors, std::back_inserter(errors));
+  } else {
+    std::ranges::copy(newErrors, std::back_inserter(errors));
+  }
+}
 
 } // namespace detail
 } // namespace MjcfParser

--- a/dart/utils/mjcf/detail/geom.cpp
+++ b/dart/utils/mjcf/detail/geom.cpp
@@ -79,7 +79,7 @@ Errors Geom::read(
 
   // Read attributes
   const Errors attrErrors = appendGeomAttributes(mAttributes, element);
-  errors.insert(errors.end(), attrErrors.begin(), attrErrors.end());
+  appendErrorRange(errors, attrErrors);
 
   return errors;
 }

--- a/dart/utils/mjcf/detail/geom_attributes.cpp
+++ b/dart/utils/mjcf/detail/geom_attributes.cpp
@@ -178,8 +178,7 @@ Errors appendGeomAttributes(
 
   // Check if multiple orientation representations present
   const Errors orientationErrors = checkOrientationValidity(element);
-  errors.insert(
-      errors.end(), orientationErrors.begin(), orientationErrors.end());
+  appendErrorRange(errors, orientationErrors);
 
   // quat
   if (hasAttribute(element, "quat")) {

--- a/dart/utils/mjcf/detail/inertial.cpp
+++ b/dart/utils/mjcf/detail/inertial.cpp
@@ -64,8 +64,7 @@ Errors Inertial::read(tinyxml2::XMLElement* element)
 
   // Check if multiple orientation representations present
   const Errors orientationErrors = checkOrientationValidity(element);
-  errors.insert(
-      errors.end(), orientationErrors.begin(), orientationErrors.end());
+  appendErrorRange(errors, orientationErrors);
 
   // quat
   if (hasAttribute(element, "quat")) {

--- a/dart/utils/mjcf/detail/joint.cpp
+++ b/dart/utils/mjcf/detail/joint.cpp
@@ -72,7 +72,7 @@ Errors Joint::read(
 
   // Read attributes
   const Errors attrErrors = appendJointAttributes(mAttributes, element);
-  errors.insert(errors.end(), attrErrors.begin(), attrErrors.end());
+  appendErrorRange(errors, attrErrors);
 
   return errors;
 }

--- a/dart/utils/mjcf/detail/mesh.cpp
+++ b/dart/utils/mjcf/detail/mesh.cpp
@@ -67,7 +67,7 @@ Errors Mesh::read(tinyxml2::XMLElement* element)
 
   // Read attributes
   const Errors attrErrors = appendMeshAttributes(mAttributes, element);
-  errors.insert(errors.end(), attrErrors.begin(), attrErrors.end());
+  appendErrorRange(errors, attrErrors);
 
   return errors;
 }

--- a/dart/utils/mjcf/detail/mujoco_model.cpp
+++ b/dart/utils/mjcf/detail/mujoco_model.cpp
@@ -61,7 +61,7 @@ Errors MujocoModel::read(
 
   // Handle <include>s
   const Errors includeErrors = handleInclude(element, baseUri, retriever);
-  errors.insert(errors.end(), includeErrors.begin(), includeErrors.end());
+  appendErrorRange(errors, includeErrors);
 
   warnUnknownElements(
       element,
@@ -87,7 +87,7 @@ Errors MujocoModel::read(
     auto compilerElement = getElement(element, "compiler");
     DART_ASSERT(compilerElement);
     const auto compilerErrors = mCompiler.read(compilerElement);
-    errors.insert(errors.end(), compilerErrors.begin(), compilerErrors.end());
+    appendErrorRange(errors, compilerErrors);
   }
   mCompiler.setBaseUri(baseUri);
   mCompiler.setResourceRetriever(retriever);
@@ -97,7 +97,7 @@ Errors MujocoModel::read(
     auto optionElement = getElement(element, "option");
     DART_ASSERT(optionElement);
     const auto optionErrors = mOption.read(optionElement);
-    errors.insert(errors.end(), optionErrors.begin(), optionErrors.end());
+    appendErrorRange(errors, optionErrors);
   }
 
   // Read <size>
@@ -105,7 +105,7 @@ Errors MujocoModel::read(
     auto sizeElement = getElement(element, "size");
     DART_ASSERT(sizeElement);
     const auto sizeErrors = mSize.read(sizeElement);
-    errors.insert(errors.end(), sizeErrors.begin(), sizeErrors.end());
+    appendErrorRange(errors, sizeErrors);
   }
 
   // Read <asset>
@@ -113,7 +113,7 @@ Errors MujocoModel::read(
     auto assetElement = getElement(element, "asset");
     DART_ASSERT(assetElement);
     const auto assetErrors = mAsset.read(assetElement);
-    errors.insert(errors.end(), assetErrors.begin(), assetErrors.end());
+    appendErrorRange(errors, assetErrors);
   }
 
   // Read <default>
@@ -121,7 +121,7 @@ Errors MujocoModel::read(
     auto defaultElement = getElement(element, "default");
     DART_ASSERT(defaultElement);
     const auto defaultErrors = mDefaults.read(defaultElement, nullptr);
-    errors.insert(errors.end(), defaultErrors.begin(), defaultErrors.end());
+    appendErrorRange(errors, defaultErrors);
   }
 
   // Read <worldbody>
@@ -136,7 +136,7 @@ Errors MujocoModel::read(
         mDefaults.getRootDefault(),
         baseUri,
         retriever);
-    errors.insert(errors.end(), worldbodyErrors.begin(), worldbodyErrors.end());
+    appendErrorRange(errors, worldbodyErrors);
   }
 
   // Read <actuator>
@@ -144,7 +144,7 @@ Errors MujocoModel::read(
     auto actuatorElement = getElement(element, "actuator");
     DART_ASSERT(actuatorElement);
     const auto actuatorErrors = mActuator.read(actuatorElement, mDefaults);
-    errors.insert(errors.end(), actuatorErrors.begin(), actuatorErrors.end());
+    appendErrorRange(errors, actuatorErrors);
   }
 
   // Read <contact>
@@ -152,47 +152,33 @@ Errors MujocoModel::read(
     auto contactElement = getElement(element, "contact");
     DART_ASSERT(contactElement);
     const auto contactErrors = mContact.read(contactElement);
-    errors.insert(errors.end(), contactErrors.begin(), contactErrors.end());
+    appendErrorRange(errors, contactErrors);
   }
 
   const Errors assetPreprocessErrors = mAsset.preprocess(mCompiler);
-  errors.insert(
-      errors.end(), assetPreprocessErrors.begin(), assetPreprocessErrors.end());
+  appendErrorRange(errors, assetPreprocessErrors);
 
   const Errors assetCompileErrors = mAsset.compile(mCompiler);
-  errors.insert(
-      errors.end(), assetCompileErrors.begin(), assetCompileErrors.end());
+  appendErrorRange(errors, assetCompileErrors);
 
   const Errors assetPostprocessErrors = mAsset.postprocess(mCompiler);
-  errors.insert(
-      errors.end(),
-      assetPostprocessErrors.begin(),
-      assetPostprocessErrors.end());
+  appendErrorRange(errors, assetPostprocessErrors);
 
   const Errors worldbodyPreprocessErrors = mWorldbody.preprocess(mCompiler);
-  errors.insert(
-      errors.end(),
-      worldbodyPreprocessErrors.begin(),
-      worldbodyPreprocessErrors.end());
+  appendErrorRange(errors, worldbodyPreprocessErrors);
 
   const Errors worldbodyCompileErrors = mWorldbody.compile(mCompiler);
-  errors.insert(
-      errors.end(),
-      worldbodyCompileErrors.begin(),
-      worldbodyCompileErrors.end());
+  appendErrorRange(errors, worldbodyCompileErrors);
 
   const Errors worldbodyPostprocessErrors = mWorldbody.postprocess(mCompiler);
-  errors.insert(
-      errors.end(),
-      worldbodyPostprocessErrors.begin(),
-      worldbodyPostprocessErrors.end());
+  appendErrorRange(errors, worldbodyPostprocessErrors);
 
   // Read <equality>
   if (hasElement(element, "equality")) {
     auto equalityElement = getElement(element, "equality");
     DART_ASSERT(equalityElement);
     const auto equalityErrors = mEquality.read(equalityElement, mDefaults);
-    errors.insert(errors.end(), equalityErrors.begin(), equalityErrors.end());
+    appendErrorRange(errors, equalityErrors);
   }
 
   return errors;
@@ -231,7 +217,7 @@ Errors MujocoModel::read(
 
   // Parse <mujoco> element
   const Errors readErrors = read(mujocoElement, uri, retriever);
-  errors.insert(errors.end(), readErrors.begin(), readErrors.end());
+  appendErrorRange(errors, readErrors);
 
   return errors;
 }

--- a/dart/utils/mjcf/detail/site.cpp
+++ b/dart/utils/mjcf/detail/site.cpp
@@ -117,8 +117,7 @@ Errors Site::read(tinyxml2::XMLElement* element)
 
   // Check if multiple orientation representations present
   const Errors orientationErrors = checkOrientationValidity(element);
-  errors.insert(
-      errors.end(), orientationErrors.begin(), orientationErrors.end());
+  appendErrorRange(errors, orientationErrors);
 
   // quat
   if (hasAttribute(element, "quat")) {

--- a/dart/utils/mjcf/detail/utils.cpp
+++ b/dart/utils/mjcf/detail/utils.cpp
@@ -249,11 +249,11 @@ std::vector<dynamics::BodyNode*> getBodyNodes(
 //==============================================================================
 void warnUnknownElements(
     const tinyxml2::XMLElement* parentElement,
-    const std::vector<std::string>& knownChildNames)
+    std::initializer_list<std::string_view> knownChildNames)
 {
   const tinyxml2::XMLElement* child = parentElement->FirstChildElement();
   while (child != nullptr) {
-    const std::string childName = child->Name();
+    const std::string_view childName = child->Name();
     const bool known = std::ranges::find(knownChildNames, childName)
                        != knownChildNames.end();
 
@@ -272,11 +272,11 @@ void warnUnknownElements(
 //==============================================================================
 void warnUnknownAttributes(
     const tinyxml2::XMLElement* element,
-    const std::vector<std::string>& knownAttrNames)
+    std::initializer_list<std::string_view> knownAttrNames)
 {
   const tinyxml2::XMLAttribute* attr = element->FirstAttribute();
   while (attr != nullptr) {
-    const std::string attrName = attr->Name();
+    const std::string_view attrName = attr->Name();
     const bool known
         = std::ranges::find(knownAttrNames, attrName) != knownAttrNames.end();
 

--- a/dart/utils/mjcf/detail/utils.hpp
+++ b/dart/utils/mjcf/detail/utils.hpp
@@ -42,6 +42,7 @@
 #include <Eigen/Core>
 #include <tinyxml2.h>
 
+#include <initializer_list>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -86,13 +87,13 @@ DART_UTILS_API std::vector<dynamics::BodyNode*> getBodyNodes(
 /// @c knownChildNames.
 DART_UTILS_API void warnUnknownElements(
     const tinyxml2::XMLElement* parentElement,
-    const std::vector<std::string>& knownChildNames);
+    std::initializer_list<std::string_view> knownChildNames);
 
 /// Logs warnings about attributes of @c element that are not in
 /// @c knownAttrNames.
 DART_UTILS_API void warnUnknownAttributes(
     const tinyxml2::XMLElement* element,
-    const std::vector<std::string>& knownAttrNames);
+    std::initializer_list<std::string_view> knownAttrNames);
 
 } // namespace detail
 } // namespace MjcfParser

--- a/dart/utils/mjcf/detail/weld.cpp
+++ b/dart/utils/mjcf/detail/weld.cpp
@@ -116,7 +116,7 @@ Errors Weld::read(tinyxml2::XMLElement* element, const Defaults& defaults)
 
   // Read attributes
   const Errors attrErrors = appendWeldAttributes(mAttributes, element);
-  errors.insert(errors.end(), attrErrors.begin(), attrErrors.end());
+  appendErrorRange(errors, attrErrors);
 
   if (mAttributes.mName) {
     mName = *mAttributes.mName;

--- a/dart/utils/mjcf/detail/worldbody.cpp
+++ b/dart/utils/mjcf/detail/worldbody.cpp
@@ -78,7 +78,7 @@ Errors Worldbody::read(
 
   // Handle multiple <include>
   const Errors includeErrors = handleInclude(element, baseUri, retriever);
-  errors.insert(errors.end(), includeErrors.begin(), includeErrors.end());
+  appendErrorRange(errors, includeErrors);
 
   warnUnknownElements(element, {"body", "geom", "site", "include"});
 
@@ -88,7 +88,7 @@ Errors Worldbody::read(
     Geom geom = Geom();
     const auto geomErrors = geom.read(
         geomElements.get(), defaults, currentDefault->getGeomAttributes());
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
 
     if (geomErrors.empty()) {
       mGeoms.emplace_back(std::move(geom));
@@ -100,7 +100,7 @@ Errors Worldbody::read(
   while (siteElements.next()) {
     Site site = Site();
     const auto siteErrors = site.read(geomElements.get());
-    errors.insert(errors.end(), siteErrors.begin(), siteErrors.end());
+    appendErrorRange(errors, siteErrors);
 
     if (siteErrors.empty()) {
       mSites.emplace_back(std::move(site));
@@ -113,7 +113,7 @@ Errors Worldbody::read(
     Body rootBody = Body();
     const auto bodyErrors
         = rootBody.read(bodyElements.get(), size, defaults, currentDefault);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
 
     if (bodyErrors.empty()) {
       mRootBodies.emplace_back(std::move(rootBody));
@@ -130,12 +130,12 @@ Errors Worldbody::preprocess(const Compiler& compiler)
 
   for (Geom& geom : mGeoms) {
     const Errors geomErrors = geom.preprocess(compiler);
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
   }
 
   for (Body& body : mRootBodies) {
     const Errors bodyErrors = body.preprocess(compiler);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
   }
 
   return errors;
@@ -148,12 +148,12 @@ Errors Worldbody::compile(const Compiler& compiler)
 
   for (Geom& geom : mGeoms) {
     const Errors geomErrors = geom.compile(compiler);
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
   }
 
   for (Body& body : mRootBodies) {
     const Errors bodyErrors = body.compile(compiler);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
   }
 
   return errors;
@@ -166,12 +166,12 @@ Errors Worldbody::postprocess(const Compiler& compiler)
 
   for (Geom& geom : mGeoms) {
     const Errors geomErrors = geom.postprocess(nullptr, compiler);
-    errors.insert(errors.end(), geomErrors.begin(), geomErrors.end());
+    appendErrorRange(errors, geomErrors);
   }
 
   for (Body& body : mRootBodies) {
     const Errors bodyErrors = body.postprocess(nullptr, compiler);
-    errors.insert(errors.end(), bodyErrors.begin(), bodyErrors.end());
+    appendErrorRange(errors, bodyErrors);
   }
 
   return errors;


### PR DESCRIPTION
## Summary

- Adds a constrained C++20 ranges helper for aggregating MJCF parser errors.
- Replaces repeated `errors.insert(errors.end(), range.begin(), range.end())` call sites across the MJCF detail parser.
- Changes MJCF unknown-element/attribute warning helpers to consume string-view initializer lists instead of temporary string vectors.

## Motivation / Problem

- The MJCF parser repeated the same iterator-pair error append pattern across many files.
- The unknown-name warning helpers allocated temporary `std::vector<std::string>` values for fixed string-literal name lists.

## Changes / Key Changes

- Introduced `ErrorRange` and `appendErrorRange()` in `dart/utils/mjcf/detail/error.hpp`.
- Updated MJCF parser detail files to use the new helper for error aggregation.
- Updated warning helper signatures and implementation to use `std::initializer_list<std::string_view>` with ranges lookup.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
