### PR TITLE
Adopt C++20 ranges in URDF and SDF parsers

### DIFF
--- a/dart/utils/sdf/sdf_parser.cpp
+++ b/dart/utils/sdf/sdf_parser.cpp
@@ -66,14 +66,17 @@
 #include <Eigen/StdVector>
 #include <sdf/sdf.hh>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <numeric>
+#include <ranges>
 #include <span>
 #include <sstream>
 #include <stdexcept>
@@ -938,8 +941,7 @@ NextResult getNextJointAndNodePair(
 void applyMimicConstraints(
     const dynamics::SkeletonPtr& skeleton, const JointMap& sdfJoints)
 {
-  for (const auto& entry : sdfJoints) {
-    const auto& jointInfo = entry.second;
+  for (const auto& jointInfo : sdfJoints | std::views::values) {
     if (jointInfo.mimicInfos.empty()) {
       continue;
     }
@@ -951,9 +953,10 @@ void applyMimicConstraints(
 
     const auto existingProps = joint->getMimicDofProperties();
     std::vector<dynamics::MimicDofProperties> props(joint->getNumDofs());
-    for (std::size_t i = 0; i < existingProps.size() && i < props.size(); ++i) {
-      props[i] = existingProps[i];
-    }
+    std::ranges::copy_n(
+        existingProps.begin(),
+        std::min(existingProps.size(), props.size()),
+        props.begin());
 
     bool applied = false;
     bool useCoupler = false;
@@ -1612,18 +1615,16 @@ SDFJoint readJoint(
   // Mimic metadata (captured before joint creation)
   if (hasElement(_jointElement, "axis")) {
     const ElementPtr& axisElement = getElement(_jointElement, "axis");
-    const auto mimics = readMimicElements(axisElement);
-    newJoint.mimicInfos.insert(
-        newJoint.mimicInfos.end(), mimics.begin(), mimics.end());
+    auto mimics = readMimicElements(axisElement);
+    std::ranges::move(mimics, std::back_inserter(newJoint.mimicInfos));
   }
   if (hasElement(_jointElement, "axis2")) {
     const ElementPtr& axis2Element = getElement(_jointElement, "axis2");
     auto mimics = readMimicElements(axis2Element);
-    for (auto& m : mimics) {
-      m.referenceDof = 1u; // axis2 maps to the second DoF
-    }
-    newJoint.mimicInfos.insert(
-        newJoint.mimicInfos.end(), mimics.begin(), mimics.end());
+    std::ranges::for_each(mimics, [](auto& mimic) {
+      mimic.referenceDof = 1u; // axis2 maps to the second DoF
+    });
+    std::ranges::move(mimics, std::back_inserter(newJoint.mimicInfos));
   }
 
   //--------------------------------------------------------------------------

--- a/dart/utils/urdf/urdf_parser.cpp
+++ b/dart/utils/urdf/urdf_parser.cpp
@@ -55,10 +55,12 @@
 
 #include <tinyxml2.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <numeric>
+#include <ranges>
 #include <unordered_map>
 
 #include <cmath>
@@ -201,8 +203,7 @@ simulation::WorldPtr UrdfParser::parseWorldString(
 
   simulation::WorldPtr world = simulation::World::create();
 
-  for (std::size_t i = 0; i < worldInterface->models.size(); ++i) {
-    const urdf_parsing::Entity& entity = worldInterface->models[i];
+  for (const urdf_parsing::Entity& entity : worldInterface->models) {
     std::string modelContent;
     readFileToString(resourceRetriever, entity.uri, modelContent);
     ParseContext context;
@@ -211,15 +212,13 @@ simulation::WorldPtr UrdfParser::parseWorldString(
         entity.model.get(), entity.uri, resourceRetriever, mOptions, &context);
 
     if (!skeleton) {
-      DART_WARN(
-          "Robot {} was not correctly parsed!",
-          worldInterface->models[i].model->getName());
+      DART_WARN("Robot {} was not correctly parsed!", entity.model->getName());
       continue;
     }
 
     // Initialize position and RPY
     dynamics::Joint* rootJoint = skeleton->getRootBodyNode()->getParentJoint();
-    Eigen::Isometry3d transform = toEigen(worldInterface->models[i].origin);
+    Eigen::Isometry3d transform = toEigen(entity.origin);
 
     if (dynamic_cast<dynamics::FreeJoint*>(rootJoint)) {
       rootJoint->setPositions(
@@ -258,17 +257,18 @@ dynamics::SkeletonPtr UrdfParser::modelInterfaceToSkeleton(
         "the URDF standard. Please consider changing the robot model as a "
         "single tree robot.");
 
-    for (std::size_t i = 0; i < root->child_links.size(); i++) {
-      if (!createSkeletonRecursive(
-              model,
-              skeleton,
-              root->child_links[i].get(),
-              nullptr,
-              baseUri,
-              resourceRetriever,
-              options)) {
-        return nullptr;
-      }
+    const auto createChildSkeleton = [&](const auto& childLink) {
+      return createSkeletonRecursive(
+          model,
+          skeleton,
+          childLink.get(),
+          nullptr,
+          baseUri,
+          resourceRetriever,
+          options);
+    };
+    if (!std::ranges::all_of(root->child_links, createChildSkeleton)) {
+      return nullptr;
     }
   } else {
     if (!createSkeletonRecursive(
@@ -284,9 +284,9 @@ dynamics::SkeletonPtr UrdfParser::modelInterfaceToSkeleton(
   }
 
   // Find mimic joints
-  for (std::size_t i = 0; i < root->child_links.size(); i++) {
-    addMimicJointsRecursive(model, skeleton, root->child_links[i].get());
-  }
+  std::ranges::for_each(root->child_links, [&](const auto& childLink) {
+    addMimicJointsRecursive(model, skeleton, childLink.get());
+  });
 
   const std::vector<TransmissionInfo> empty;
   const auto& transmissions
@@ -334,19 +334,16 @@ bool UrdfParser::createSkeletonRecursive(
     return false;
   }
 
-  for (std::size_t i = 0; i < lk->child_links.size(); ++i) {
-    if (!createSkeletonRecursive(
-            model,
-            skel,
-            lk->child_links[i].get(),
-            node,
-            baseUri,
-            resourceRetriever,
-            options)) {
-      return false;
-    }
-  }
-  return true;
+  return std::ranges::all_of(lk->child_links, [&](const auto& childLink) {
+    return createSkeletonRecursive(
+        model,
+        skel,
+        childLink.get(),
+        node,
+        baseUri,
+        resourceRetriever,
+        options);
+  });
 }
 
 bool UrdfParser::addMimicJointsRecursive(
@@ -386,13 +383,9 @@ bool UrdfParser::addMimicJointsRecursive(
     joint->setMimicJoint(mimicJoint, multiplier, offset);
   }
 
-  for (std::size_t i = 0; i < _lk->child_links.size(); ++i) {
-    if (!addMimicJointsRecursive(model, _skel, _lk->child_links[i].get())) {
-      return false;
-    }
-  }
-
-  return true;
+  return std::ranges::all_of(_lk->child_links, [&](const auto& childLink) {
+    return addMimicJointsRecursive(model, _skel, childLink.get());
+  });
 }
 
 //==============================================================================
@@ -507,13 +500,13 @@ void UrdfParser::applyTransmissions(
     grouped[tx.mActuatorName].push_back(tx);
   }
 
-  for (const auto& actuatorPair : grouped) {
-    const auto& entries = actuatorPair.second;
+  for (const auto& [actuatorName, entries] : grouped) {
     if (entries.size() < 2) {
       continue;
     }
 
     std::vector<std::pair<const TransmissionInfo*, dynamics::Joint*>> valid;
+    valid.reserve(entries.size());
     for (const auto& tx : entries) {
       auto* joint = skel->getJoint(tx.mJointName);
       if (!joint) {
@@ -529,7 +522,7 @@ void UrdfParser::applyTransmissions(
         DART_WARN(
             "[UrdfParser] Transmission [{}] targets joint [{}] with {} DoFs; "
             "only single-DoF joints are supported for transmission coupling.",
-            actuatorPair.first,
+            actuatorName,
             tx.mJointName,
             joint->getNumDofs());
         continue;
@@ -539,7 +532,7 @@ void UrdfParser::applyTransmissions(
         DART_WARN(
             "[UrdfParser] Transmission [{}] targets joint [{}] that already "
             "has a mimic actuator; skipping to avoid conflict.",
-            actuatorPair.first,
+            actuatorName,
             tx.mJointName);
         continue;
       }
@@ -555,9 +548,8 @@ void UrdfParser::applyTransmissions(
     dynamics::Joint* referenceJoint = valid.front().second;
     const double referenceReduction = referenceInfo->mMechanicalReduction;
 
-    for (std::size_t i = 1; i < valid.size(); ++i) {
-      const auto* followerInfo = valid[i].first;
-      dynamics::Joint* followerJoint = valid[i].second;
+    for (const auto& [followerInfo, followerJoint] :
+         valid | std::views::drop(1)) {
       const double followerReduction = followerInfo->mMechanicalReduction;
 
       const double multiplier = referenceReduction / followerReduction;
@@ -567,7 +559,7 @@ void UrdfParser::applyTransmissions(
             "actuator [{}]; skipping follower.",
             referenceJoint->getName(),
             followerJoint->getName(),
-            actuatorPair.first);
+            actuatorName);
         continue;
       }
 
@@ -925,7 +917,7 @@ bool UrdfParser::createShapeNodes(
     const common::ResourceRetrieverPtr& resourceRetriever)
 {
   // Set visual information
-  for (auto visual : lk->visual_array) {
+  for (const auto& visual : lk->visual_array) {
     dynamics::ShapePtr shape
         = createShape(visual.get(), baseUri, resourceRetriever);
 
@@ -943,7 +935,7 @@ bool UrdfParser::createShapeNodes(
   }
 
   // Set collision information
-  for (auto collision : lk->collision_array) {
+  for (const auto& collision : lk->collision_array) {
     dynamics::ShapePtr shape
         = createShape(collision.get(), baseUri, resourceRetriever);
 


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges helpers in URDF world, skeleton, mimic-joint, and transmission traversal.
- Use C++20 ranges algorithms in SDF mimic constraint parsing and property copying.
- Avoid shared pointer copies in URDF visual and collision shape traversal.

## Motivation / Problem

- Modernizing parser traversal makes the intent of recursive and grouped operations clearer while staying behavior-preserving.

## Changes / Key Changes

- Replaced manual index loops with range-for, `std::ranges::all_of`, and `std::ranges::for_each` where traversal intent is explicit.
- Used structured bindings plus `std::views::drop` for transmission followers.
- Used `std::views::values`, `std::ranges::copy_n`, and `std::ranges::move` in SDF mimic metadata handling.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `git diff --check`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: refactor only)
- [x] Add unit tests for new functionality (not applicable: behavior-preserving refactor)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
