### PR TITLE
Adopt C++20 concepts in SIMD templates

### DIFF
--- a/dart/simd/detail/math/constants.hpp
+++ b/dart/simd/detail/math/constants.hpp
@@ -34,6 +34,7 @@
 
 #include <dart/simd/config.hpp>
 
+#include <concepts>
 #include <limits>
 #include <numbers>
 #include <type_traits>
@@ -58,13 +59,9 @@ struct HasFullIntegerSimd<8> : std::false_type
 
 /// Mathematical constants for SIMD operations
 /// All constants are provided as constexpr template variables for float/double
-template <typename T>
+template <std::floating_point T>
 struct MathConstants
 {
-  static_assert(
-      std::is_floating_point_v<T>,
-      "MathConstants requires floating point type");
-
   // Pi and related constants
   static constexpr T pi = std::numbers::pi_v<T>;
   static constexpr T twoPi = T(2) * std::numbers::pi_v<T>;
@@ -103,7 +100,7 @@ struct MathConstants
   // These are used for argument reduction: x = x - n * (c1 + c2 + c3)
   // where c1 + c2 + c3 = pi/2 with high precision
   static constexpr T pio2_1 = []() {
-    if constexpr (std::is_same_v<T, float>) {
+    if constexpr (std::same_as<T, float>) {
       return T(0.78515625);
     } else {
       return T(7.85398125648498535156e-1);
@@ -111,7 +108,7 @@ struct MathConstants
   }();
 
   static constexpr T pio2_2 = []() {
-    if constexpr (std::is_same_v<T, float>) {
+    if constexpr (std::same_as<T, float>) {
       return T(2.4187564849853515625e-4);
     } else {
       return T(3.77489470793079817668e-8);
@@ -119,7 +116,7 @@ struct MathConstants
   }();
 
   static constexpr T pio2_3 = []() {
-    if constexpr (std::is_same_v<T, float>) {
+    if constexpr (std::same_as<T, float>) {
       return T(3.77489497744594108e-8);
     } else {
       return T(2.69515142907905952645e-15);
@@ -128,7 +125,7 @@ struct MathConstants
 
   // Range reduction constants for exp
   static constexpr T expHi = []() {
-    if constexpr (std::is_same_v<T, float>) {
+    if constexpr (std::same_as<T, float>) {
       return T(88.3762626647949f);
     } else {
       return T(709.43613930310391424428);
@@ -136,7 +133,7 @@ struct MathConstants
   }();
 
   static constexpr T expLo = []() {
-    if constexpr (std::is_same_v<T, float>) {
+    if constexpr (std::same_as<T, float>) {
       return T(-88.3762626647949f);
     } else {
       return T(-709.43613930310391424428);
@@ -145,7 +142,7 @@ struct MathConstants
 
   // Log constants
   static constexpr T logLo = []() {
-    if constexpr (std::is_same_v<T, float>) {
+    if constexpr (std::same_as<T, float>) {
       return T(1.1754943508e-38f); // FLT_MIN
     } else {
       return T(2.2250738585072014e-308); // DBL_MIN
@@ -154,43 +151,43 @@ struct MathConstants
 };
 
 // Convenience aliases
-template <typename T>
+template <std::floating_point T>
 inline constexpr T Pi = MathConstants<T>::pi;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T TwoPi = MathConstants<T>::twoPi;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T HalfPi = MathConstants<T>::halfPi;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T InvPi = MathConstants<T>::invPi;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T FourOverPi = MathConstants<T>::fourOverPi;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T E = MathConstants<T>::e;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T Ln2 = MathConstants<T>::ln2;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T InvLn2 = MathConstants<T>::invLn2;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T Log2E = MathConstants<T>::log2E;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T Sqrt2 = MathConstants<T>::sqrt2;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T InvSqrt2 = MathConstants<T>::invSqrt2;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T Infinity = MathConstants<T>::infinity;
 
-template <typename T>
+template <std::floating_point T>
 inline constexpr T NaN = MathConstants<T>::nan;
 
 } // namespace dart::simd

--- a/dart/simd/detail/scalar/operations.hpp
+++ b/dart/simd/detail/scalar/operations.hpp
@@ -265,7 +265,7 @@ using int_type_for_t = typename IntTypeFor<T>::type;
 } // namespace detail
 
 template <typename T, std::size_t W>
-  requires std::is_floating_point_v<T>
+  requires std::floating_point<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitAnd(
     const Vec<T, W>& a, const Vec<T, W>& b)
 {
@@ -284,7 +284,7 @@ template <typename T, std::size_t W>
 }
 
 template <typename T, std::size_t W>
-  requires std::is_floating_point_v<T>
+  requires std::floating_point<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitOr(
     const Vec<T, W>& a, const Vec<T, W>& b)
 {
@@ -303,7 +303,7 @@ template <typename T, std::size_t W>
 }
 
 template <typename T, std::size_t W>
-  requires std::is_floating_point_v<T>
+  requires std::floating_point<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitXor(
     const Vec<T, W>& a, const Vec<T, W>& b)
 {
@@ -322,7 +322,7 @@ template <typename T, std::size_t W>
 }
 
 template <typename T, std::size_t W>
-  requires std::is_floating_point_v<T>
+  requires std::floating_point<T>
 [[nodiscard]] DART_SIMD_INLINE Vec<T, W> bitAndnot(
     const Vec<T, W>& a, const Vec<T, W>& b)
 {

--- a/dart/simd/dynamic/matrix.hpp
+++ b/dart/simd/dynamic/matrix.hpp
@@ -41,13 +41,9 @@
 
 namespace dart::simd {
 
-template <typename T>
+template <FloatType T>
 class DynamicMatrix
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "DynamicMatrix only supports float or double");
-
 public:
   using scalar_type = T;
   static constexpr std::size_t simd_width = preferred_width_v<T>;

--- a/dart/simd/dynamic/vector.hpp
+++ b/dart/simd/dynamic/vector.hpp
@@ -46,13 +46,9 @@
 
 namespace dart::simd {
 
-template <typename T>
+template <FloatType T>
 class DynamicVector
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "DynamicVector only supports float or double");
-
 public:
   using scalar_type = T;
   static constexpr std::size_t simd_width = preferred_width_v<T>;

--- a/dart/simd/geometry/batch.hpp
+++ b/dart/simd/geometry/batch.hpp
@@ -54,13 +54,10 @@ namespace dart::simd {
 /// - m00, m10, m20 = column 0
 /// - m01, m11, m21 = column 1
 /// - m02, m12, m22 = column 2
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 struct Matrix3x3SoA
 {
   static_assert(N >= 1 && N <= 16, "N must be between 1 and 16");
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Matrix3x3SoA only supports float or double");
 
   // Column 0
   Vec<T, N> m00, m10, m20;
@@ -241,13 +238,10 @@ using Matrix3x3SoAd4 = Matrix3x3SoA<double, 4>;
 // =============================================================================
 
 /// @brief SoA layout for N 4x4 matrices
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 struct Matrix4x4SoA
 {
   static_assert(N >= 1 && N <= 16, "N must be between 1 and 16");
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Matrix4x4SoA only supports float or double");
 
   // Column 0
   Vec<T, N> m00, m10, m20, m30;
@@ -437,13 +431,10 @@ using Matrix4x4SoAd4 = Matrix4x4SoA<double, 4>;
 // =============================================================================
 
 /// @brief SoA layout for N 3D vectors - extends EigenSoA3 with more operations
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 struct Vector3SoA
 {
   static_assert(N >= 1 && N <= 16, "N must be between 1 and 16");
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Vector3SoA only supports float or double");
 
   Vec<T, N> x, y, z;
 
@@ -529,7 +520,7 @@ struct Vector3SoA
 };
 
 /// Batch dot product: returns N dot products
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 [[nodiscard]] inline Vec<T, N> dot(
     const Vector3SoA<T, N>& a, const Vector3SoA<T, N>& b) noexcept
 {
@@ -537,7 +528,7 @@ template <typename T, std::size_t N>
 }
 
 /// Batch cross product: returns N cross products
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 [[nodiscard]] inline Vector3SoA<T, N> cross(
     const Vector3SoA<T, N>& a, const Vector3SoA<T, N>& b) noexcept
 {
@@ -548,7 +539,7 @@ template <typename T, std::size_t N>
 }
 
 /// Batch squared norm: returns N squared norms
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 [[nodiscard]] inline Vec<T, N> squaredNorm(const Vector3SoA<T, N>& v) noexcept
 {
   return fmadd(v.x, v.x, fmadd(v.y, v.y, v.z * v.z));
@@ -556,7 +547,7 @@ template <typename T, std::size_t N>
 
 /// Batch normalize: returns N normalized vectors
 /// Returns zero for zero-length vectors (matching scalar Vector3::normalized())
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 [[nodiscard]] inline Vector3SoA<T, N> normalize(
     const Vector3SoA<T, N>& v) noexcept
 {
@@ -571,7 +562,7 @@ template <typename T, std::size_t N>
 }
 
 /// Batch outer product: returns N outer products (3x3 matrices)
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 [[nodiscard]] inline Matrix3x3SoA<T, N> outer(
     const Vector3SoA<T, N>& a, const Vector3SoA<T, N>& b) noexcept
 {
@@ -593,7 +584,7 @@ template <typename T, std::size_t N>
 
 /// Batch reflect: v - 2*(v·n)*n for each of N vectors
 /// Assumes n is normalized
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 [[nodiscard]] inline Vector3SoA<T, N> reflect(
     const Vector3SoA<T, N>& v, const Vector3SoA<T, N>& n) noexcept
 {
@@ -605,7 +596,7 @@ template <typename T, std::size_t N>
 
 /// Batch project: (a·b / b·b) * b for each of N vectors
 /// Returns zero when b is zero-length (avoiding division by zero)
-template <typename T, std::size_t N>
+template <FloatType T, std::size_t N>
 [[nodiscard]] inline Vector3SoA<T, N> project(
     const Vector3SoA<T, N>& a, const Vector3SoA<T, N>& b) noexcept
 {

--- a/dart/simd/geometry/isometry3.hpp
+++ b/dart/simd/geometry/isometry3.hpp
@@ -38,13 +38,9 @@
 
 namespace dart::simd {
 
-template <typename T>
+template <FloatType T>
 struct Isometry3
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Isometry3 only supports float or double");
-
   Quaternion<T> rotation;
   Vector3<T> translation;
 
@@ -127,7 +123,7 @@ struct Isometry3
   }
 };
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Isometry3<T> lerp(
     const Isometry3<T>& a, const Isometry3<T>& b, T t)
 {

--- a/dart/simd/geometry/matrix3x3.hpp
+++ b/dart/simd/geometry/matrix3x3.hpp
@@ -46,13 +46,9 @@ namespace dart::simd {
 /// Column-major storage matches Eigen's default and is optimal for mat-vec.
 ///
 /// @tparam T Scalar type (float or double)
-template <typename T>
+template <FloatType T>
 struct Matrix3x3
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Matrix3x3 only supports float or double");
-
   Vec<T, 4> col0, col1, col2;
 
   Matrix3x3() = default;
@@ -245,7 +241,7 @@ struct Matrix3x3
 
     T det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
 
-    constexpr T eps = std::is_same_v<T, float> ? T(1e-6) : T(1e-12);
+    constexpr T eps = std::same_as<T, float> ? T(1e-6) : T(1e-12);
     if (std::abs(det) < eps) {
       return false;
     }
@@ -281,7 +277,7 @@ struct Matrix3x3
 
 /// Outer product: produces a 3x3 matrix from two vectors
 /// result[i][j] = a[i] * b[j]
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Matrix3x3<T> outer(
     const Vector3<T>& a, const Vector3<T>& b)
 {

--- a/dart/simd/geometry/matrix4x4.hpp
+++ b/dart/simd/geometry/matrix4x4.hpp
@@ -47,13 +47,9 @@ namespace dart::simd {
 /// Column-major storage matches Eigen's default.
 ///
 /// @tparam T Scalar type (float or double)
-template <typename T>
+template <FloatType T>
 struct Matrix4x4
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Matrix4x4 only supports float or double");
-
   Vec<T, 4> col0, col1, col2, col3;
 
   Matrix4x4() = default;
@@ -341,7 +337,7 @@ struct Matrix4x4
 
     T det = s0 * c5 - s1 * c4 + s2 * c3 + s3 * c2 - s4 * c1 + s5 * c0;
 
-    constexpr T eps = std::is_same_v<T, float> ? T(1e-6) : T(1e-12);
+    constexpr T eps = std::same_as<T, float> ? T(1e-6) : T(1e-12);
     if (std::abs(det) < eps) {
       return false;
     }
@@ -387,7 +383,7 @@ struct Matrix4x4
 };
 
 /// Outer product: produces a 4x4 matrix from two vectors
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Matrix4x4<T> outer(
     const Vector4<T>& a, const Vector4<T>& b)
 {

--- a/dart/simd/geometry/quaternion.hpp
+++ b/dart/simd/geometry/quaternion.hpp
@@ -42,13 +42,9 @@
 namespace dart::simd {
 
 // Storage: [x, y, z, w] matching Eigen::Quaternion internal order
-template <typename T>
+template <FloatType T>
 struct Quaternion
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Quaternion only supports float or double");
-
   Vec<T, 4> data;
 
   Quaternion() = default;
@@ -231,14 +227,14 @@ struct Quaternion
   }
 };
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE T
 dot(const Quaternion<T>& a, const Quaternion<T>& b)
 {
   return hsum(a.data * b.data);
 }
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Quaternion<T> slerp(
     const Quaternion<T>& a, const Quaternion<T>& b, T t)
 {

--- a/dart/simd/geometry/vector3.hpp
+++ b/dart/simd/geometry/vector3.hpp
@@ -78,13 +78,9 @@ namespace dart::simd {
 /// operations while maintaining a 3D vector interface.
 ///
 /// @tparam T Scalar type (float or double)
-template <typename T>
+template <FloatType T>
 struct Vector3
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Vector3 only supports float or double");
-
   /// Internal storage: [x, y, z, 0]
   Vec<T, 4> data;
 
@@ -311,7 +307,7 @@ struct Vector3
 // =============================================================================
 
 /// Dot product
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE T dot(const Vector3<T>& a, const Vector3<T>& b)
 {
   Vec<T, 4> prod = a.data * b.data;
@@ -319,7 +315,7 @@ template <typename T>
 }
 
 /// Cross product
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector3<T> cross(
     const Vector3<T>& a, const Vector3<T>& b)
 {
@@ -331,7 +327,7 @@ template <typename T>
 }
 
 /// Component-wise minimum
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector3<T> min(
     const Vector3<T>& a, const Vector3<T>& b)
 {
@@ -339,7 +335,7 @@ template <typename T>
 }
 
 /// Component-wise maximum
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector3<T> max(
     const Vector3<T>& a, const Vector3<T>& b)
 {
@@ -347,14 +343,14 @@ template <typename T>
 }
 
 /// Component-wise absolute value
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector3<T> abs(const Vector3<T>& v)
 {
   return Vector3<T>(abs(v.data));
 }
 
 /// Linear interpolation: a + t * (b - a)
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector3<T> lerp(
     const Vector3<T>& a, const Vector3<T>& b, T t)
 {
@@ -362,7 +358,7 @@ template <typename T>
 }
 
 /// Distance between two points
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE T
 distance(const Vector3<T>& a, const Vector3<T>& b)
 {
@@ -370,7 +366,7 @@ distance(const Vector3<T>& a, const Vector3<T>& b)
 }
 
 /// Squared distance between two points (faster)
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE T
 squaredDistance(const Vector3<T>& a, const Vector3<T>& b)
 {
@@ -378,7 +374,7 @@ squaredDistance(const Vector3<T>& a, const Vector3<T>& b)
 }
 
 /// Reflect vector v around normal n (n must be normalized)
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector3<T> reflect(
     const Vector3<T>& v, const Vector3<T>& n)
 {
@@ -386,7 +382,7 @@ template <typename T>
 }
 
 /// Project vector a onto vector b
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector3<T> project(
     const Vector3<T>& a, const Vector3<T>& b)
 {

--- a/dart/simd/geometry/vector4.hpp
+++ b/dart/simd/geometry/vector4.hpp
@@ -42,13 +42,9 @@ namespace dart::simd {
 
 /// @brief SIMD-backed 4D vector using native Vec<T, 4> storage
 /// @tparam T Scalar type (float or double)
-template <typename T>
+template <FloatType T>
 struct Vector4
 {
-  static_assert(
-      std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Vector4 only supports float or double");
-
   Vec<T, 4> data;
 
   Vector4() = default;
@@ -199,33 +195,33 @@ struct Vector4
   }
 };
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE T dot(const Vector4<T>& a, const Vector4<T>& b)
 {
   return hsum(a.data * b.data);
 }
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector4<T> min(
     const Vector4<T>& a, const Vector4<T>& b)
 {
   return Vector4<T>(min(a.data, b.data));
 }
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector4<T> max(
     const Vector4<T>& a, const Vector4<T>& b)
 {
   return Vector4<T>(max(a.data, b.data));
 }
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector4<T> abs(const Vector4<T>& v)
 {
   return Vector4<T>(abs(v.data));
 }
 
-template <typename T>
+template <FloatType T>
 [[nodiscard]] DART_SIMD_INLINE Vector4<T> lerp(
     const Vector4<T>& a, const Vector4<T>& b, T t)
 {

--- a/tests/unit/simd/test_math.cpp
+++ b/tests/unit/simd/test_math.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 
+#include <concepts>
 #include <limits>
 #include <random>
 #include <vector>
@@ -60,7 +61,7 @@ protected:
   // Tolerance for transcendental functions (looser than basic ops)
   static constexpr scalar_type tolerance()
   {
-    if constexpr (std::is_same_v<scalar_type, float>) {
+    if constexpr (std::same_as<scalar_type, float>) {
       return 1e-5f;
     } else {
       return 1e-12;
@@ -70,7 +71,7 @@ protected:
   // Even looser tolerance for functions with higher error accumulation
   static constexpr scalar_type looseTolerance()
   {
-    if constexpr (std::is_same_v<scalar_type, float>) {
+    if constexpr (std::same_as<scalar_type, float>) {
       return 1e-4f;
     } else {
       return 1e-10;

--- a/tests/unit/simd/test_operations_scalar.cpp
+++ b/tests/unit/simd/test_operations_scalar.cpp
@@ -34,6 +34,8 @@
 
 #include <gtest/gtest.h>
 
+#include <concepts>
+
 #include <cmath>
 
 namespace dart::simd {
@@ -49,7 +51,7 @@ protected:
 
   static constexpr scalar_type tolerance()
   {
-    if constexpr (std::is_same_v<scalar_type, float>) {
+    if constexpr (std::same_as<scalar_type, float>) {
       return 1e-5f;
     } else {
       return 1e-12;

--- a/tests/unit/simd/test_vec_scalar.cpp
+++ b/tests/unit/simd/test_vec_scalar.cpp
@@ -34,6 +34,7 @@
 
 #include <gtest/gtest.h>
 
+#include <concepts>
 #include <limits>
 
 #include <cmath>
@@ -50,9 +51,9 @@ protected:
 
   static constexpr scalar_type tolerance()
   {
-    if constexpr (std::is_same_v<scalar_type, float>) {
+    if constexpr (std::same_as<scalar_type, float>) {
       return 1e-6f;
-    } else if constexpr (std::is_same_v<scalar_type, double>) {
+    } else if constexpr (std::same_as<scalar_type, double>) {
       return 1e-15;
     } else {
       return scalar_type{0};
@@ -61,7 +62,7 @@ protected:
 
   void expect_near(scalar_type a, scalar_type b)
   {
-    if constexpr (std::is_floating_point_v<scalar_type>) {
+    if constexpr (std::floating_point<scalar_type>) {
       EXPECT_NEAR(a, b, tolerance());
     } else {
       EXPECT_EQ(a, b);


### PR DESCRIPTION
## Summary

- Adopt C++20 concepts across SIMD scalar, dynamic, and geometry templates.

## Motivation / Problem

- SIMD headers already define local C++20 concepts, but several core templates still used legacy type-trait assertions and predicates.

## Changes / Key Changes

- Constrain float-only SIMD dynamic and geometry templates with the existing `FloatType` concept.
- Constrain SIMD math constants with `std::floating_point`.
- Replace remaining SIMD `is_same_v` and `is_floating_point_v` checks with `std::same_as` and `std::floating_point`.
- Update SIMD unit tests to use the same C++20 predicates.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- C++20 modernization for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
