### PR TITLE
Adopt C++20 type predicates in core helpers

### DIFF
--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -35,6 +35,7 @@
 
 #include <dart/common/lockable_reference.hpp>
 
+#include <concepts>
 #include <iterator>
 #include <type_traits>
 
@@ -98,7 +99,7 @@ MultiLockableReference<Lockable>::MultiLockableReference(
       = std::remove_pointer_t<std::remove_cvref_t<IteratorValueType>>;
 
   static_assert(
-      std::is_same_v<Lockable, IteratorLockable>,
+      std::same_as<Lockable, IteratorLockable>,
       "Lockable of this class and the lockable of InputIterator are not the "
       "same.");
 }

--- a/dart/common/detail/logging-impl.hpp
+++ b/dart/common/detail/logging-impl.hpp
@@ -40,6 +40,7 @@
 #if DART_HAVE_spdlog
   #include <spdlog/spdlog.h>
 
+  #include <concepts>
   #include <type_traits>
   #include <utility>
   // Check if spdlog is using fmt or std::format backend
@@ -90,8 +91,8 @@ auto normalize(T&& arg)
   if constexpr (std::is_pointer_v<Decayed>) {
     using Pointee = std::remove_cv_t<std::remove_pointer_t<Decayed>>;
     if constexpr (
-        !std::is_same_v<Pointee, char> && !std::is_same_v<Pointee, signed char>
-        && !std::is_same_v<Pointee, unsigned char>) {
+        !std::same_as<Pointee, char> && !std::same_as<Pointee, signed char>
+        && !std::same_as<Pointee, unsigned char>) {
       return fmt::ptr(arg);
     } else {
       return std::forward<T>(arg);
@@ -101,8 +102,8 @@ auto normalize(T&& arg)
         = std::remove_reference_t<decltype(std::declval<Decayed&>().get())>;
     using Pointee = std::remove_cv_t<std::remove_pointer_t<RawPointer>>;
     if constexpr (
-        !std::is_same_v<Pointee, char> && !std::is_same_v<Pointee, signed char>
-        && !std::is_same_v<Pointee, unsigned char>) {
+        !std::same_as<Pointee, char> && !std::same_as<Pointee, signed char>
+        && !std::same_as<Pointee, unsigned char>) {
       return fmt::ptr(arg.get());
     } else {
       return std::forward<T>(arg);

--- a/dart/common/detail/stopwatch-impl.hpp
+++ b/dart/common/detail/stopwatch-impl.hpp
@@ -32,6 +32,8 @@
 
 #include <dart/common/stopwatch.hpp>
 
+#include <concepts>
+
 namespace dart::common {
 
 namespace {
@@ -56,10 +58,10 @@ Stopwatch<UnitType, ClockType>::Stopwatch(bool start)
   : mStart(ClockType::now()), mElapsed(0), mPaused(!start)
 {
   // clang-format off
-  static_assert(std::is_same_v<UnitType, std::chrono::seconds>
-      || std::is_same_v<UnitType, std::chrono::milliseconds>
-      || std::is_same_v<UnitType, std::chrono::microseconds>
-      || std::is_same_v<UnitType, std::chrono::nanoseconds>,
+  static_assert(std::same_as<UnitType, std::chrono::seconds>
+      || std::same_as<UnitType, std::chrono::milliseconds>
+      || std::same_as<UnitType, std::chrono::microseconds>
+      || std::same_as<UnitType, std::chrono::nanoseconds>,
       "Invalid unit");
   // clang-format on
 }
@@ -114,13 +116,13 @@ void Stopwatch<UnitType, ClockType>::reset()
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
+  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
     return duration().count() * 1e-9;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
     return duration().count() * 1e-6;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
     return duration().count() * 1e-3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
     return duration().count();
   }
 }
@@ -129,13 +131,13 @@ double Stopwatch<UnitType, ClockType>::elapsedS() const
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedMS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
+  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
     return duration().count() * 1e-6;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
     return duration().count() * 1e-3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
     return duration().count();
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
     return duration().count() * 1e+3;
     ;
   }
@@ -145,13 +147,13 @@ double Stopwatch<UnitType, ClockType>::elapsedMS() const
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedUS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
+  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
     return duration().count() * 1e-3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
     return duration().count();
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
     return duration().count() * 1e+3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
     return duration().count() * 1e+6;
     ;
   }
@@ -161,13 +163,13 @@ double Stopwatch<UnitType, ClockType>::elapsedUS() const
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedNS() const
 {
-  if constexpr (std::is_same_v<UnitType, std::chrono::nanoseconds>) {
+  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
     return duration().count();
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::microseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
     return duration().count() * 1e+3;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::milliseconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
     return duration().count() * 1e+6;
-  } else if constexpr (std::is_same_v<UnitType, std::chrono::seconds>) {
+  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
     return duration().count() * 1e+9;
   }
 }
@@ -203,17 +205,17 @@ void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
   print_duration_if_non_zero(os, s, "s ");
   t -= s;
 
-  if constexpr (!std::is_same_v<UnitType, std::chrono::seconds>) {
+  if constexpr (!std::same_as<UnitType, std::chrono::seconds>) {
     const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t);
     print_duration_if_non_zero(os, ms, "ms ");
     t -= ms;
 
-    if constexpr (!std::is_same_v<UnitType, std::chrono::milliseconds>) {
+    if constexpr (!std::same_as<UnitType, std::chrono::milliseconds>) {
       const auto us = std::chrono::duration_cast<std::chrono::microseconds>(t);
       print_duration_if_non_zero(os, us, "us ");
       t -= us;
 
-      if constexpr (!std::is_same_v<UnitType, std::chrono::microseconds>) {
+      if constexpr (!std::same_as<UnitType, std::chrono::microseconds>) {
         const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t);
         print_duration_if_non_zero(os, ns, "ns ");
         if (us == std::chrono::nanoseconds::zero()) {

--- a/dart/constraint/detail/constraint_solver-impl.hpp
+++ b/dart/constraint/detail/constraint_solver-impl.hpp
@@ -35,13 +35,15 @@
 
 #include <dart/constraint/constraint_solver.hpp>
 
+#include <concepts>
+
 namespace dart::constraint {
 
 //==============================================================================
 template <typename Func>
 void ConstraintSolver::eachConstraint(Func func) const
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, const ConstraintBase*>,
                     bool>) {
     for (auto i = 0u; i < getNumConstraints(); ++i) {
@@ -60,7 +62,7 @@ void ConstraintSolver::eachConstraint(Func func) const
 template <typename Func>
 void ConstraintSolver::eachConstraint(Func func)
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, ConstraintBase*>,
                     bool>) {
     for (auto i = 0u; i < getNumConstraints(); ++i) {

--- a/dart/dynamics/detail/basic_node_manager.hpp
+++ b/dart/dynamics/detail/basic_node_manager.hpp
@@ -41,6 +41,7 @@
 #include <dart/common/empty.hpp>
 #include <dart/common/name_manager.hpp>
 
+#include <concepts>
 #include <map>
 #include <typeindex>
 #include <unordered_set>
@@ -299,7 +300,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func) const                                       \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, const AspectName*>,           \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
@@ -315,7 +316,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func)                                             \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, AspectName*>,                 \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
@@ -363,7 +364,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func) const                \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, const AspectName*>,           \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
@@ -379,7 +380,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func)                      \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, AspectName*>,                 \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
@@ -407,7 +408,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func) const                                       \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, const AspectName*>,           \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
@@ -423,7 +424,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func)                                             \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, AspectName*>,                 \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
@@ -458,7 +459,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func) const                \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, const AspectName*>,           \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
@@ -474,7 +475,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func)                      \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
+    if constexpr (std::same_as<                                                \
                       std::invoke_result_t<Func, AspectName*>,                 \
                       bool>) {                                                 \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \

--- a/dart/dynamics/detail/body_node.hpp
+++ b/dart/dynamics/detail/body_node.hpp
@@ -37,6 +37,7 @@
 #include <dart/dynamics/shape_node.hpp>
 #include <dart/dynamics/skeleton.hpp>
 
+#include <concepts>
 #include <utility>
 
 namespace dart {
@@ -298,7 +299,7 @@ void BodyNode::removeAllShapeNodesWith()
 template <typename AspectT, typename Func>
 void BodyNode::eachShapeNodeWith(Func func) const
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, const ShapeNode*>,
                     bool>) {
     for (auto i = 0u; i < getNumShapeNodes(); ++i) {
@@ -323,7 +324,7 @@ void BodyNode::eachShapeNodeWith(Func func) const
 template <typename AspectT, typename Func>
 void BodyNode::eachShapeNodeWith(Func func)
 {
-  if constexpr (std::is_same_v<std::invoke_result_t<Func, ShapeNode*>, bool>) {
+  if constexpr (std::same_as<std::invoke_result_t<Func, ShapeNode*>, bool>) {
     for (auto i = 0u; i < getNumShapeNodes(); ++i) {
       ShapeNode* shapeNode = getShapeNode(i);
       if (shapeNode->has<AspectT>()) {

--- a/dart/dynamics/detail/meta_skeleton-impl.hpp
+++ b/dart/dynamics/detail/meta_skeleton-impl.hpp
@@ -35,13 +35,15 @@
 
 #include <dart/dynamics/meta_skeleton.hpp>
 
+#include <concepts>
+
 namespace dart::dynamics {
 
 //==============================================================================
 template <typename Func>
 void MetaSkeleton::eachBodyNode(Func func) const
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, const dynamics::BodyNode*>,
                     bool>) {
     for (auto i = 0u; i < getNumBodyNodes(); ++i) {
@@ -60,7 +62,7 @@ void MetaSkeleton::eachBodyNode(Func func) const
 template <typename Func>
 void MetaSkeleton::eachBodyNode(Func func)
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, dynamics::BodyNode*>,
                     bool>) {
     for (auto i = 0u; i < getNumBodyNodes(); ++i) {
@@ -79,7 +81,7 @@ void MetaSkeleton::eachBodyNode(Func func)
 template <typename Func>
 void MetaSkeleton::eachJoint(Func func) const
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, const dynamics::Joint*>,
                     bool>) {
     for (auto i = 0u; i < getNumJoints(); ++i) {
@@ -98,7 +100,7 @@ void MetaSkeleton::eachJoint(Func func) const
 template <typename Func>
 void MetaSkeleton::eachJoint(Func func)
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, dynamics::Joint*>,
                     bool>) {
     for (auto i = 0u; i < getNumJoints(); ++i) {
@@ -117,7 +119,7 @@ void MetaSkeleton::eachJoint(Func func)
 template <typename Func>
 void MetaSkeleton::eachDof(Func func) const
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::
                         invoke_result_t<Func, const dynamics::DegreeOfFreedom*>,
                     bool>) {
@@ -137,7 +139,7 @@ void MetaSkeleton::eachDof(Func func) const
 template <typename Func>
 void MetaSkeleton::eachDof(Func func)
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, dynamics::DegreeOfFreedom*>,
                     bool>) {
     for (auto i = 0u; i < getNumDofs(); ++i) {

--- a/dart/dynamics/detail/skeleton.hpp
+++ b/dart/dynamics/detail/skeleton.hpp
@@ -35,6 +35,7 @@
 
 #include <dart/dynamics/skeleton.hpp>
 
+#include <concepts>
 #include <type_traits>
 
 namespace dart {
@@ -84,10 +85,10 @@ std::pair<JointType*, NodeType*> Skeleton::createJointAndBodyNodePair(
 {
   JointType* joint = new JointType(_jointProperties);
   NodeType* node;
-  if constexpr (std::is_same_v<NodeType, BodyNode>) {
+  if constexpr (std::same_as<NodeType, BodyNode>) {
     void* mem = allocateBodyNodeMemory(BodyNodePoolKind::Body);
     node = new (mem) NodeType(_parent, joint, _bodyProperties);
-  } else if constexpr (std::is_same_v<NodeType, SoftBodyNode>) {
+  } else if constexpr (std::same_as<NodeType, SoftBodyNode>) {
     void* mem = allocateBodyNodeMemory(BodyNodePoolKind::Soft);
     node = new (mem) NodeType(_parent, joint, _bodyProperties);
   } else {

--- a/dart/math/helpers.hpp
+++ b/dart/math/helpers.hpp
@@ -186,13 +186,9 @@ namespace detail {
 template <typename Float>
 using FloatByteArray = std::array<std::byte, sizeof(Float)>;
 
-template <typename Float>
+template <std::floating_point Float>
 inline bool valueEqualFloating(Float lhs, Float rhs)
 {
-  static_assert(
-      std::is_floating_point_v<Float>,
-      "valueEqualFloating expects floating point");
-
   if (std::isnan(lhs) || std::isnan(rhs)) {
     return false;
   }

--- a/dart/simulation/detail/world-impl.hpp
+++ b/dart/simulation/detail/world-impl.hpp
@@ -42,6 +42,7 @@
 #include <dart/simulation/world.hpp>
 
 #include <algorithm>
+#include <concepts>
 
 namespace dart {
 namespace simulation {
@@ -57,7 +58,7 @@ WorldPtr World::create(Args&&... args)
 template <typename Func>
 void World::eachSkeleton(Func func) const
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, const dynamics::Skeleton*>,
                     bool>) {
     (void)std::ranges::all_of(
@@ -73,7 +74,7 @@ void World::eachSkeleton(Func func) const
 template <typename Func>
 void World::eachSkeleton(Func func)
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, dynamics::Skeleton*>,
                     bool>) {
     (void)std::ranges::all_of(
@@ -89,7 +90,7 @@ void World::eachSkeleton(Func func)
 template <typename Func>
 void World::eachSimpleFrame(Func func) const
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, const dynamics::SimpleFrame*>,
                     bool>) {
     (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {
@@ -106,7 +107,7 @@ void World::eachSimpleFrame(Func func) const
 template <typename Func>
 void World::eachSimpleFrame(Func func)
 {
-  if constexpr (std::is_same_v<
+  if constexpr (std::same_as<
                     std::invoke_result_t<Func, dynamics::SimpleFrame*>,
                     bool>) {
     (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {

--- a/dart/simulation/experimental/common/type_list.hpp
+++ b/dart/simulation/experimental/common/type_list.hpp
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <type_traits>
 
 namespace dart::simulation::experimental {
@@ -65,7 +66,7 @@ struct Contains;
 
 template <typename T, typename... Types>
 struct Contains<T, TypeList<Types...>>
-  : std::bool_constant<(std::is_same_v<T, Types> || ...)>
+  : std::bool_constant<(std::same_as<T, Types> || ...)>
 {
 };
 

--- a/dart/simulation/experimental/io/auto_serialization.hpp
+++ b/dart/simulation/experimental/io/auto_serialization.hpp
@@ -37,6 +37,7 @@
 
 #include <boost/pfr.hpp>
 
+#include <concepts>
 #include <iostream>
 #include <type_traits>
 
@@ -89,20 +90,20 @@ void autoSerialize(
     using FieldType = std::remove_cvref_t<decltype(field)>;
 
     // Handle different field types
-    if constexpr (std::is_same_v<FieldType, std::string>) {
+    if constexpr (std::same_as<FieldType, std::string>) {
       writeString(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
       writeVector3d(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Isometry3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Isometry3d>) {
       writeIsometry3d(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Quaterniond>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
       writePOD(out, field.w());
       writePOD(out, field.x());
       writePOD(out, field.y());
       writePOD(out, field.z());
-    } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
       writeVectorXd(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Matrix3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix3d>) {
       // Write 3x3 matrix (symmetric, so store 6 unique values)
       for (int i = 0; i < 3; ++i) {
         for (int j = i; j < 3; ++j) {
@@ -127,22 +128,22 @@ void autoDeserialize(std::istream& in, T& component)
     using FieldType = std::remove_cvref_t<decltype(field)>;
 
     // Handle different field types
-    if constexpr (std::is_same_v<FieldType, std::string>) {
+    if constexpr (std::same_as<FieldType, std::string>) {
       readString(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
       readVector3d(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Isometry3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Isometry3d>) {
       readIsometry3d(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Quaterniond>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
       double w, x, y, z;
       readPOD(in, w);
       readPOD(in, x);
       readPOD(in, y);
       readPOD(in, z);
       field = Eigen::Quaterniond(w, x, y, z);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
       readVectorXd(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Matrix3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix3d>) {
       // Read 3x3 symmetric matrix
       for (int i = 0; i < 3; ++i) {
         for (int j = i; j < 3; ++j) {
@@ -177,14 +178,14 @@ void autoSerialize(
   boost::pfr::for_each_field(component, [&](const auto& field) {
     using FieldType = std::remove_cvref_t<decltype(field)>;
 
-    if constexpr (std::is_same_v<FieldType, entt::entity>) {
+    if constexpr (std::same_as<FieldType, entt::entity>) {
       // Single entity field - always remap
       std::uint32_t mappedId
           = (field != entt::null)
                 ? static_cast<std::uint32_t>(entityMap.at(field))
                 : static_cast<std::uint32_t>(entt::null);
       writePOD(out, mappedId);
-    } else if constexpr (std::is_same_v<FieldType, std::vector<entt::entity>>) {
+    } else if constexpr (std::same_as<FieldType, std::vector<entt::entity>>) {
       // Vector of entities - always remap each
       std::size_t count = field.size();
       writePOD(out, count);
@@ -195,21 +196,21 @@ void autoSerialize(
                   : static_cast<std::uint32_t>(entt::null);
         writePOD(out, mappedId);
       }
-    } else if constexpr (std::is_same_v<FieldType, std::string>) {
+    } else if constexpr (std::same_as<FieldType, std::string>) {
       writeString(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
       writeVector3d(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Isometry3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Isometry3d>) {
       writeIsometry3d(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
       writeVectorXd(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Matrix3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix3d>) {
       for (int i = 0; i < 3; ++i) {
         for (int j = i; j < 3; ++j) {
           writePOD(out, field(i, j));
         }
       }
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Quaterniond>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
       writePOD(out, field.w());
       writePOD(out, field.x());
       writePOD(out, field.y());
@@ -230,12 +231,12 @@ void autoDeserialize(std::istream& in, T& component)
   boost::pfr::for_each_field(component, [&](auto& field) {
     using FieldType = std::remove_cvref_t<decltype(field)>;
 
-    if constexpr (std::is_same_v<FieldType, entt::entity>) {
+    if constexpr (std::same_as<FieldType, entt::entity>) {
       // Read entity ID (will be remapped in second pass)
       std::uint32_t entityId;
       readPOD(in, entityId);
       field = static_cast<entt::entity>(entityId);
-    } else if constexpr (std::is_same_v<FieldType, std::vector<entt::entity>>) {
+    } else if constexpr (std::same_as<FieldType, std::vector<entt::entity>>) {
       // Read vector of entities
       std::size_t count;
       readPOD(in, count);
@@ -245,15 +246,15 @@ void autoDeserialize(std::istream& in, T& component)
         readPOD(in, entityId);
         entity = static_cast<entt::entity>(entityId);
       }
-    } else if constexpr (std::is_same_v<FieldType, std::string>) {
+    } else if constexpr (std::same_as<FieldType, std::string>) {
       readString(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
       readVector3d(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Isometry3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Isometry3d>) {
       readIsometry3d(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
       readVectorXd(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Matrix3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix3d>) {
       for (int i = 0; i < 3; ++i) {
         for (int j = i; j < 3; ++j) {
           readPOD(in, field(i, j));
@@ -285,13 +286,13 @@ void autoSerialize(
   boost::pfr::for_each_field(value, [&](const auto& field) {
     using FieldType = std::remove_cvref_t<decltype(field)>;
 
-    if constexpr (std::is_same_v<FieldType, std::string>) {
+    if constexpr (std::same_as<FieldType, std::string>) {
       writeString(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
       writeVectorXd(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
       writeVector3d(out, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Matrix3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix3d>) {
       for (int i = 0; i < 3; ++i) {
         for (int j = i; j < 3; ++j) {
           writePOD(out, field(i, j));
@@ -314,13 +315,13 @@ void autoDeserialize(std::istream& in, T& value)
   boost::pfr::for_each_field(value, [&](auto& field) {
     using FieldType = std::remove_cvref_t<decltype(field)>;
 
-    if constexpr (std::is_same_v<FieldType, std::string>) {
+    if constexpr (std::same_as<FieldType, std::string>) {
       readString(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
       readVectorXd(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
       readVector3d(in, field);
-    } else if constexpr (std::is_same_v<FieldType, Eigen::Matrix3d>) {
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix3d>) {
       for (int i = 0; i < 3; ++i) {
         for (int j = i; j < 3; ++j) {
           readPOD(in, field(i, j));

--- a/dart/simulation/experimental/space/auto_mapper.hpp
+++ b/dart/simulation/experimental/space/auto_mapper.hpp
@@ -40,6 +40,7 @@
 #include <boost/pfr.hpp>
 #include <entt/entt.hpp>
 
+#include <concepts>
 #include <span>
 #include <type_traits>
 
@@ -61,7 +62,7 @@ size_t extractFieldToVector(
     vec[offset] = static_cast<double>(field);
     count = 1;
   } else if constexpr (
-      std::is_same_v<FieldType, Eigen::Isometry3d>
+      std::same_as<FieldType, Eigen::Isometry3d>
       || std::is_base_of_v<
           Eigen::Transform<double, 3, Eigen::Isometry>,
           FieldType>) {
@@ -77,21 +78,21 @@ size_t extractFieldToVector(
     vec[offset + 5] = rotation.y();
     vec[offset + 6] = rotation.z();
     count = 7;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Vector2d>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Vector2d>) {
     vec[offset + 0] = field.x();
     vec[offset + 1] = field.y();
     count = 2;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
     vec[offset + 0] = field.x();
     vec[offset + 1] = field.y();
     vec[offset + 2] = field.z();
     count = 3;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
     for (Eigen::Index i = 0; i < field.size(); ++i) {
       vec[offset + i] = field[i];
     }
     count = field.size();
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Quaterniond>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
     vec[offset + 0] = field.w();
     vec[offset + 1] = field.x();
     vec[offset + 2] = field.y();
@@ -123,7 +124,7 @@ size_t injectVectorToField(
     field = static_cast<FieldType>(vec[offset]);
     count = 1;
   } else if constexpr (
-      std::is_same_v<FieldType, Eigen::Isometry3d>
+      std::same_as<FieldType, Eigen::Isometry3d>
       || std::is_base_of_v<
           Eigen::Transform<double, 3, Eigen::Isometry>,
           FieldType>) {
@@ -135,21 +136,21 @@ size_t injectVectorToField(
     field.translation() = translation;
     field.linear() = rotation.toRotationMatrix();
     count = 7;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Vector2d>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Vector2d>) {
     field.x() = vec[offset + 0];
     field.y() = vec[offset + 1];
     count = 2;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
     field.x() = vec[offset + 0];
     field.y() = vec[offset + 1];
     field.z() = vec[offset + 2];
     count = 3;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
     for (Eigen::Index i = 0; i < field.size(); ++i) {
       field[i] = vec[offset + i];
     }
     count = field.size();
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Quaterniond>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
     field.w() = vec[offset + 0];
     field.x() = vec[offset + 1];
     field.y() = vec[offset + 2];
@@ -176,15 +177,15 @@ constexpr size_t getFieldDimension()
 
   if constexpr (std::is_arithmetic_v<FieldType> || std::is_enum_v<FieldType>) {
     return 1;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Vector2d>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Vector2d>) {
     return 2;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Vector3d>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Vector3d>) {
     return 3;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Quaterniond>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
     return 4;
-  } else if constexpr (std::is_same_v<FieldType, Eigen::Isometry3d>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::Isometry3d>) {
     return 7; // Translation (3) + Quaternion (4)
-  } else if constexpr (std::is_same_v<FieldType, Eigen::VectorXd>) {
+  } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
     return 0; // Dynamic size - must be computed at runtime
   } else if constexpr (std::is_aggregate_v<FieldType>) {
     // Nested aggregate struct - sum dimensions of all fields

--- a/tests/unit/math/test_convhull.cpp
+++ b/tests/unit/math/test_convhull.cpp
@@ -34,6 +34,7 @@
 
 #include <gtest/gtest.h>
 
+#include <concepts>
 #include <iterator>
 #include <set>
 #include <span>
@@ -404,7 +405,7 @@ TYPED_TEST(ConvexHullTest, NoInternalVertices)
   // For double precision, internal point should definitely not be on hull
   // For float precision with noise, it might rarely appear on hull due to
   // perturbation
-  if (std::is_same<Scalar, double>::value) {
+  if constexpr (std::same_as<Scalar, double>) {
     EXPECT_FALSE(usedVertices.contains(8))
         << "Internal point should not be on the convex hull (double precision)";
   }


### PR DESCRIPTION
## Summary

- Adopt C++20 type predicates in core helper templates and traversal callbacks.
- Replace type-trait equality checks with `std::same_as` where the code already branches on exact types.
- Constrain `valueEqualFloating` with `std::floating_point` instead of a function-body static assertion.

## Motivation / Problem

- DART 7 targets C++20, so these helper templates can express compile-time requirements directly with standard C++20 concepts.
- The changes reduce trait boilerplate while preserving existing behavior.

## Changes / Key Changes

- Updated common, constraint, dynamics, simulation, and simulation-experimental helper templates from `std::is_same_v` to `std::same_as`.
- Updated `dart::math::detail::valueEqualFloating` to use a `std::floating_point` template constraint.
- Updated the convex hull typed test to use `if constexpr (std::same_as<...>)`.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- C++20 modernization for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable