### PR TITLE
Adopt C++20 ranges algorithms in utility code

### DIFF
--- a/dart/common/uri.cpp
+++ b/dart/common/uri.cpp
@@ -35,6 +35,7 @@
 #include "dart/common/logging.hpp"
 #include "dart/common/macros.hpp"
 
+#include <algorithm>
 #include <regex>
 #include <sstream>
 #include <string_view>
@@ -255,7 +256,7 @@ bool Uri::fromPath(std::string_view path)
 #ifdef _WIN32
   // Replace backslashes (from Windows paths) with forward slashes.
   std::string unixPath = pathString;
-  std::replace(std::begin(unixPath), std::end(unixPath), '\\', '/');
+  std::ranges::replace(unixPath, '\\', '/');
 
   return fromString(fileScheme + "/" + pathString);
 #else

--- a/dart/utils/composite_resource_retriever.cpp
+++ b/dart/utils/composite_resource_retriever.cpp
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <iterator>
 
 namespace dart {
 namespace utils {
@@ -130,14 +131,10 @@ CompositeResourceRetriever::getRetrievers(const common::Uri& uri) const
 
   const auto it = mResourceRetrievers.find(schema);
   if (it != std::end(mResourceRetrievers)) {
-    retrievers.insert(
-        std::end(retrievers), std::begin(it->second), std::end(it->second));
+    std::ranges::copy(it->second, std::back_inserter(retrievers));
   }
 
-  retrievers.insert(
-      std::end(retrievers),
-      std::begin(mDefaultResourceRetrievers),
-      std::end(mDefaultResourceRetrievers));
+  std::ranges::copy(mDefaultResourceRetrievers, std::back_inserter(retrievers));
 
   DART_WARN_IF(
       retrievers.empty(),

--- a/dart/utils/mesh_loader.hpp
+++ b/dart/utils/mesh_loader.hpp
@@ -261,8 +261,9 @@ typename MeshLoader<S>::aiScenePtr MeshLoader<S>::loadScene(
     }
 
     std::string extension(path.substr(extensionIndex));
-    std::transform(
-        extension.begin(), extension.end(), extension.begin(), ::tolower);
+    std::ranges::transform(extension, extension.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
     return extension == ".dae" || extension == ".zae";
   };
 

--- a/examples/speed_test/main.cpp
+++ b/examples/speed_test/main.cpp
@@ -35,6 +35,7 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <numeric>
 
@@ -162,11 +163,8 @@ void print_results(const std::vector<double>& result)
   double mean = sum / result.size();
   std::cout << "Average: " << mean << "\n";
   std::vector<double> diff(result.size());
-  std::transform(
-      result.begin(),
-      result.end(),
-      diff.begin(),
-      std::bind(std::minus<double>(), mean, std::placeholders::_1));
+  std::ranges::transform(
+      result, diff.begin(), [mean](double value) { return mean - value; });
   double stddev = std::sqrt(
       std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0)
       / result.size());

--- a/tests/integration/io/test_mjcf_parser.cpp
+++ b/tests/integration/io/test_mjcf_parser.cpp
@@ -1478,7 +1478,7 @@ TEST(MjcfParserTest, ComplexMjcfCoversDetails)
 
   const std::string meshFileName = meshPath.filename().string();
   std::string meshDirStr = tempDir.string();
-  std::replace(meshDirStr.begin(), meshDirStr.end(), '\\', '/');
+  std::ranges::replace(meshDirStr, '\\', '/');
   std::string xml = R"(
 <?xml version="1.0" ?>
 <mujoco model="complex_mjcf">
@@ -1617,7 +1617,7 @@ TEST(MjcfParserTest, CustomModelParsesBodiesGeomsAndActuators)
 
   const std::string meshFileName = meshPath.filename().string();
   std::string meshDirStr = tempDir.string();
-  std::replace(meshDirStr.begin(), meshDirStr.end(), '\\', '/');
+  std::ranges::replace(meshDirStr, '\\', '/');
   std::string xml = R"(
 <?xml version="1.0" ?>
 <mujoco model="custom_parser">

--- a/tests/integration/io/test_sdf_parser.cpp
+++ b/tests/integration/io/test_sdf_parser.cpp
@@ -65,6 +65,7 @@
 #include <sstream>
 #include <string>
 
+#include <cctype>
 #include <cstring>
 
 #if DART_HAVE_spdlog
@@ -911,8 +912,9 @@ TEST(SdfParser, WarnsOnTinyMassAndDefaultsInertia)
     EXPECT_TRUE(hasSmallMassWarning)
         << "Expected warning about tiny mass clamping in logs: " << logs;
     std::string logsLower = logs;
-    std::transform(
-        logsLower.begin(), logsLower.end(), logsLower.begin(), ::tolower);
+    std::ranges::transform(logsLower, logsLower.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
     EXPECT_NE(logsLower.find("clamping to"), std::string::npos)
         << "Expected warning about tiny mass clamping in logs: " << logs;
     EXPECT_NE(logs.find("defines <mass> but no <inertia>"), std::string::npos)

--- a/tests/integration/io/test_skel_parser.cpp
+++ b/tests/integration/io/test_skel_parser.cpp
@@ -1237,7 +1237,7 @@ TEST(SkelParser, ReadWorldFromFileMeshShape)
   meshFile.close();
 
   std::string meshPathStr = meshPath.string();
-  std::replace(meshPathStr.begin(), meshPathStr.end(), '\\', '/');
+  std::ranges::replace(meshPathStr, '\\', '/');
   const std::string skelXml = std::string(R"(<skel version="1.0">
   <world name="world">
     <skeleton name="skel">
@@ -2191,7 +2191,7 @@ TEST(SkelParser, WorldXmlParsesJointAndShapeVariants)
 
   // Use absolute path with forward slashes so Windows resolves the mesh file
   std::string meshPathStr = meshPath.string();
-  std::replace(meshPathStr.begin(), meshPathStr.end(), '\\', '/');
+  std::ranges::replace(meshPathStr, '\\', '/');
 
   const std::string skelXml = std::string(R"(
 <skel version="1.0">
@@ -4001,7 +4001,7 @@ TEST(SkelParser, ParsesRigidShapeVariantsFromXml)
 
   // Use absolute path with forward slashes so Windows resolves the mesh file
   std::string meshPathStr = meshPath.string();
-  std::replace(meshPathStr.begin(), meshPathStr.end(), '\\', '/');
+  std::ranges::replace(meshPathStr, '\\', '/');
 
   const auto skelPath = tempDir / "shapes.skel";
   const std::string skelXml = std::string(R"(<?xml version="1.0" ?>

--- a/tests/unit/math/lcp/test_lcp_validation_and_solvers.cpp
+++ b/tests/unit/math/lcp/test_lcp_validation_and_solvers.cpp
@@ -35,6 +35,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <limits>
 #include <string>
 #include <vector>
@@ -1103,8 +1104,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, p, q, Eigen::RowMajor> Be;
   Eigen::Matrix<double, q, r, Eigen::RowMajor> Ce;
-  std::copy(B.begin(), B.end(), Be.data());
-  std::copy(C.begin(), C.end(), Ce.data());
+  std::ranges::copy(B, Be.data());
+  std::ranges::copy(C, Ce.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected0 = Be * Ce;
   for (int i = 0; i < p * r; ++i) {
     EXPECT_NEAR(A0[static_cast<std::size_t>(i)], expected0.data()[i], 1e-12);
@@ -1117,8 +1118,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, q, p, Eigen::RowMajor> Be1;
   Eigen::Matrix<double, q, r, Eigen::RowMajor> Ce1;
-  std::copy(B1.begin(), B1.end(), Be1.data());
-  std::copy(C1.begin(), C1.end(), Ce1.data());
+  std::ranges::copy(B1, Be1.data());
+  std::ranges::copy(C1, Ce1.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected1
       = Be1.transpose() * Ce1;
   for (int i = 0; i < p * r; ++i) {
@@ -1132,8 +1133,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, p, q, Eigen::RowMajor> Be2;
   Eigen::Matrix<double, r, q, Eigen::RowMajor> Ce2;
-  std::copy(B2.begin(), B2.end(), Be2.data());
-  std::copy(C2.begin(), C2.end(), Ce2.data());
+  std::ranges::copy(B2, Be2.data());
+  std::ranges::copy(C2, Ce2.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected2
       = Be2 * Ce2.transpose();
   for (int i = 0; i < p * r; ++i) {


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges algorithms for utility and parser-adjacent code paths.
- Replace iterator-pair `std::copy`, `std::replace`, and `std::transform` call sites where the range form is clearer.

## Motivation / Problem

- DART 7 targets C++20, so these call sites can use the standard ranges algorithm overloads directly.
- The changes reduce iterator boilerplate while preserving existing behavior.

## Changes / Key Changes

- Use `std::ranges::replace` for path separator normalization in URI and parser tests.
- Use `std::ranges::copy` for vector-to-Eigen test matrix setup and resource retriever aggregation.
- Use `std::ranges::transform` for lowercase conversion and speed-test deviation calculation.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 modernization for DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable