### PR TITLE
Adopt C++20 signed size utilities

### DIFF
--- a/dart/dynamics/inverse_kinematics.cpp
+++ b/dart/dynamics/inverse_kinematics.cpp
@@ -249,7 +249,7 @@ const Eigen::Vector6d& InverseKinematics::ErrorMethod::evalError(
 
   if (_q.size() == mLastPositions.size()) {
     bool repeat = true;
-    for (int i = 0; i < mLastPositions.size(); ++i) {
+    for (int i = 0; i < std::ssize(mLastPositions); ++i) {
       if (_q[i] != mLastPositions[i]) {
         repeat = false;
         break;
@@ -643,7 +643,7 @@ void InverseKinematics::GradientMethod::evalGradient(
 
   if (_q.size() == mLastPositions.size()) {
     bool repeat = true;
-    for (int i = 0; i < mLastPositions.size(); ++i) {
+    for (int i = 0; i < std::ssize(mLastPositions); ++i) {
       if (_q[i] != mLastPositions[i]) {
         repeat = false;
         break;
@@ -673,7 +673,7 @@ const std::string& InverseKinematics::GradientMethod::getMethodName() const
 void InverseKinematics::GradientMethod::clampGradient(
     Eigen::VectorXd& _grad) const
 {
-  for (int i = 0; i < _grad.size(); ++i) {
+  for (int i = 0; i < std::ssize(_grad); ++i) {
     if (std::abs(_grad[i]) > mGradientP.mComponentWiseClamp) {
       _grad[i] = _grad[i] > 0 ? mGradientP.mComponentWiseClamp
                               : -mGradientP.mComponentWiseClamp;

--- a/dart/math/optimization/gradient_descent_solver.cpp
+++ b/dart/math/optimization/gradient_descent_solver.cpp
@@ -38,6 +38,8 @@
 #include "dart/math/optimization/problem.hpp"
 
 #include <iostream>
+#include <iterator>
+#include <utility>
 
 namespace dart {
 namespace math {
@@ -432,11 +434,11 @@ void GradientDescentSolver::randomizeConfiguration(Eigen::VectorXd& _x)
     return;
   }
 
-  if (_x.size() < static_cast<int>(mProperties.mProblem->getDimension())) {
+  if (std::cmp_less(_x.size(), mProperties.mProblem->getDimension())) {
     _x = Eigen::VectorXd::Zero(mProperties.mProblem->getDimension());
   }
 
-  for (int i = 0; i < _x.size(); ++i) {
+  for (int i = 0; i < std::ssize(_x); ++i) {
     double lower = mProperties.mProblem->getLowerBounds()[i];
     double upper = mProperties.mProblem->getUpperBounds()[i];
     double step = upper - lower;
@@ -456,7 +458,7 @@ void GradientDescentSolver::clampToBoundary(Eigen::VectorXd& _x)
     return;
   }
 
-  if (_x.size() != static_cast<int>(mProperties.mProblem->getDimension())) {
+  if (!std::cmp_equal(_x.size(), mProperties.mProblem->getDimension())) {
     DART_ERROR(
         "Mismatch between configuration size [{}] and the dimension of the "
         "Problem [{}]",
@@ -469,7 +471,7 @@ void GradientDescentSolver::clampToBoundary(Eigen::VectorXd& _x)
   DART_ASSERT(mProperties.mProblem->getLowerBounds().size() == _x.size());
   DART_ASSERT(mProperties.mProblem->getUpperBounds().size() == _x.size());
 
-  for (int i = 0; i < _x.size(); ++i) {
+  for (int i = 0; i < std::ssize(_x); ++i) {
     _x[i] = math::clip(
         _x[i],
         mProperties.mProblem->getLowerBounds()[i],

--- a/tests/unit/dynamics/test_linkage.cpp
+++ b/tests/unit/dynamics/test_linkage.cpp
@@ -43,6 +43,8 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
+
 using namespace dart;
 using namespace dart::dynamics;
 
@@ -501,13 +503,13 @@ TEST(LinkageTests, PositionOperations)
   Eigen::VectorXd result = linkage->getPositions();
   EXPECT_EQ(result.size(), static_cast<int>(linkage->getNumDofs()));
 
-  for (int i = 0; i < result.size(); ++i) {
+  for (int i = 0; i < std::ssize(result); ++i) {
     EXPECT_DOUBLE_EQ(result[i], 1.0);
   }
 
   linkage->resetPositions();
   result = linkage->getPositions();
-  for (int i = 0; i < result.size(); ++i) {
+  for (int i = 0; i < std::ssize(result); ++i) {
     EXPECT_DOUBLE_EQ(result[i], 0.0);
   }
 }
@@ -528,13 +530,13 @@ TEST(LinkageTests, VelocityOperations)
   linkage->setVelocities(velocities);
 
   Eigen::VectorXd result = linkage->getVelocities();
-  for (int i = 0; i < result.size(); ++i) {
+  for (int i = 0; i < std::ssize(result); ++i) {
     EXPECT_DOUBLE_EQ(result[i], 2.0);
   }
 
   linkage->resetVelocities();
   result = linkage->getVelocities();
-  for (int i = 0; i < result.size(); ++i) {
+  for (int i = 0; i < std::ssize(result); ++i) {
     EXPECT_DOUBLE_EQ(result[i], 0.0);
   }
 }

--- a/tests/unit/dynamics/test_skeleton_accessors.cpp
+++ b/tests/unit/dynamics/test_skeleton_accessors.cpp
@@ -2749,11 +2749,10 @@ TEST(SkeletonConfiguration, ConfigurationFlagsAndSegments)
 
   const auto config = skeleton->getConfiguration(
       indices, Skeleton::CONFIG_POSITIONS | Skeleton::CONFIG_FORCES);
-  EXPECT_EQ(
-      config.mPositions.size(), static_cast<Eigen::Index>(indices.size()));
+  EXPECT_EQ(config.mPositions.size(), std::ssize(indices));
   EXPECT_EQ(config.mVelocities.size(), 0);
   EXPECT_EQ(config.mAccelerations.size(), 0);
-  EXPECT_EQ(config.mForces.size(), static_cast<Eigen::Index>(indices.size()));
+  EXPECT_EQ(config.mForces.size(), std::ssize(indices));
   EXPECT_EQ(config.mCommands.size(), 0);
   EXPECT_TRUE(config.mPositions.isApprox(posSubset));
   EXPECT_TRUE(config.mForces.isApprox(forceSubset));

--- a/tests/unit/math/lcp/test_lcp_newton_solvers.cpp
+++ b/tests/unit/math/lcp/test_lcp_newton_solvers.cpp
@@ -40,6 +40,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include <limits>
 
 #include <cmath>
@@ -183,7 +184,7 @@ LcpProblem makeInfeasibleProblem()
 void expectDiagonalSolution(const Eigen::VectorXd& x, double expected)
 {
   EXPECT_TRUE(x.array().isFinite().all());
-  for (Eigen::Index i = 0; i < x.size(); ++i) {
+  for (Eigen::Index i = 0; i < std::ssize(x); ++i) {
     EXPECT_NEAR(x[i], expected, 1e-6);
   }
 }
@@ -239,7 +240,7 @@ TEST(FischerBurmeisterNewtonSolver, SolveBoxedProblem)
 
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     EXPECT_GE(x[i], -1e-6);
     EXPECT_LE(x[i], 0.6 + 1e-6);
   }
@@ -359,7 +360,7 @@ TEST(PenalizedFischerBurmeisterNewtonSolver, SolveBoxedProblem)
 
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     EXPECT_GE(x[i], -1e-6);
     EXPECT_LE(x[i], 0.6 + 1e-6);
   }
@@ -468,7 +469,7 @@ TEST(MinimumMapNewtonSolver, SolveSpdProblem)
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
   const Eigen::VectorXd expected = problem.A.ldlt().solve(problem.b);
-  for (int i = 0; i < expected.size(); ++i) {
+  for (int i = 0; i < std::ssize(expected); ++i) {
     EXPECT_NEAR(x[i], expected[i], 1e-5);
   }
 }
@@ -486,7 +487,7 @@ TEST(MinimumMapNewtonSolver, SolveBoxedProblem)
 
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     EXPECT_GE(x[i], -1e-6);
     EXPECT_LE(x[i], 0.6 + 1e-6);
   }
@@ -655,7 +656,7 @@ TEST(InteriorPointSolver, SolveDiagonalProblem)
 
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     EXPECT_NEAR(x[i], 0.5, 1e-4);
   }
 }
@@ -674,7 +675,7 @@ TEST(InteriorPointSolver, SolveSpdProblem)
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
   const Eigen::VectorXd expected = problem.A.ldlt().solve(problem.b);
-  for (int i = 0; i < expected.size(); ++i) {
+  for (int i = 0; i < std::ssize(expected); ++i) {
     EXPECT_NEAR(x[i], expected[i], 1e-4);
   }
 }
@@ -692,7 +693,7 @@ TEST(InteriorPointSolver, SolveBoxedProblem)
 
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     EXPECT_GE(x[i], -1e-6);
     EXPECT_LE(x[i], 0.6 + 1e-6);
   }
@@ -802,7 +803,7 @@ TEST(LemkeSolver, SolveSpdProblem)
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
   const Eigen::VectorXd expected = problem.A.ldlt().solve(problem.b);
-  for (int i = 0; i < expected.size(); ++i) {
+  for (int i = 0; i < std::ssize(expected); ++i) {
     EXPECT_NEAR(x[i], expected[i], 1e-5);
   }
 }
@@ -820,7 +821,7 @@ TEST(LemkeSolver, SolveBoxedProblem)
 
   EXPECT_EQ(result.status, LcpSolverStatus::Success);
   EXPECT_TRUE(x.array().isFinite().all());
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     EXPECT_GE(x[i], -1e-6);
     EXPECT_LE(x[i], 0.6 + 1e-6);
   }

--- a/tests/unit/math/lcp/test_lcp_projection_solvers.cpp
+++ b/tests/unit/math/lcp/test_lcp_projection_solvers.cpp
@@ -42,6 +42,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include <limits>
 
 #include <cmath>
@@ -172,7 +173,7 @@ LcpProblem makeLargeCoupledProblem(int n)
 
 void ExpectNonnegative(const Eigen::VectorXd& x, double tol)
 {
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     EXPECT_GE(x[i], -tol);
   }
 }
@@ -183,7 +184,7 @@ void ExpectBoxed(
     const Eigen::VectorXd& hi,
     double tol)
 {
-  for (int i = 0; i < x.size(); ++i) {
+  for (int i = 0; i < std::ssize(x); ++i) {
     if (std::isfinite(lo[i])) {
       EXPECT_GE(x[i], lo[i] - tol);
     }

--- a/tests/unit/math/optimization/test_gradient_descent_solver.cpp
+++ b/tests/unit/math/optimization/test_gradient_descent_solver.cpp
@@ -36,6 +36,8 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
+
 using namespace dart::math;
 
 namespace {
@@ -65,7 +67,7 @@ public:
   double eval(const Eigen::VectorXd& x) override
   {
     double sum = 0.0;
-    for (int i = 0; i < x.size() - 1; ++i) {
+    for (int i = 0; i < std::ssize(x) - 1; ++i) {
       double t1 = x[i + 1] - x[i] * x[i];
       double t2 = 1.0 - x[i];
       sum += 100.0 * t1 * t1 + t2 * t2;
@@ -77,7 +79,7 @@ public:
       const Eigen::VectorXd& x, Eigen::Map<Eigen::VectorXd> grad) override
   {
     grad.setZero();
-    for (int i = 0; i < x.size() - 1; ++i) {
+    for (int i = 0; i < std::ssize(x) - 1; ++i) {
       double t1 = x[i + 1] - x[i] * x[i];
       grad[i] += -400.0 * x[i] * t1 - 2.0 * (1.0 - x[i]);
       grad[i + 1] += 200.0 * t1;


### PR DESCRIPTION
## Summary

- Adopt `std::ssize` for signed loop bounds and size expectations in inverse kinematics, skeleton, LCP, optimization, and convex hull test code.
- Use C++20 comparison utilities in the gradient descent solver to avoid signed/unsigned casts when validating problem dimensions.

## Motivation / Problem

- The codebase is now C++20, so signed size handling can use standard library helpers instead of local casts and manual signed conversions.
- This reduces warning-prone size conversions while preserving existing behavior.

## Changes / Key Changes

- Replace integer loop bounds over standard containers with `std::ssize(...)` where loop indices are intentionally signed.
- Replace gradient descent dimension checks with `std::cmp_less` and `std::cmp_equal`.
- Keep external API casts where the receiving API explicitly requires `int`.

## Testing

- `git diff --check`
- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 modernization PR for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable