### PR TITLE
Adopt C++20 comparison utilities

### DIFF
--- a/dart/dynamics/ball_joint.cpp
+++ b/dart/dynamics/ball_joint.cpp
@@ -39,6 +39,7 @@
 
 #include <array>
 #include <string>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -237,8 +238,8 @@ void BallJoint::integratePositions(
     double dt,
     Eigen::VectorXd& result) const
 {
-  if (static_cast<std::size_t>(q0.size()) != getNumDofs()
-      || static_cast<std::size_t>(v.size()) != getNumDofs()) {
+  if (!std::cmp_equal(q0.size(), getNumDofs())
+      || !std::cmp_equal(v.size(), getNumDofs())) {
     DART_ERROR(
         "q0's size [{}] and v's size [{}] must both equal the dof [{}] for "
         "Joint [{}].",

--- a/dart/dynamics/detail/generic_joint.hpp
+++ b/dart/dynamics/detail/generic_joint.hpp
@@ -45,6 +45,7 @@
 #include <dart/math/helpers.hpp>
 
 #include <sstream>
+#include <utility>
 
 #include <cmath>
 
@@ -494,7 +495,7 @@ double GenericJoint<ConfigSpaceT>::getCommand(size_t index) const
 template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
 {
-  if (static_cast<size_t>(commands.size()) != getNumDofs()) {
+  if (!std::cmp_equal(commands.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setCommands, commands);
     return;
   }
@@ -557,7 +558,7 @@ double GenericJoint<ConfigSpaceT>::getPosition(size_t index) const
 template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setPositions(const Eigen::VectorXd& positions)
 {
-  if (static_cast<size_t>(positions.size()) != getNumDofs()) {
+  if (!std::cmp_equal(positions.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setPositions, positions);
     return;
   }
@@ -602,7 +603,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setPositionLowerLimits(
     const Eigen::VectorXd& lowerLimits)
 {
-  if (static_cast<size_t>(lowerLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(lowerLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setPositionLowerLimits, lowerLimits);
     return;
   }
@@ -647,7 +648,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setPositionUpperLimits(
     const Eigen::VectorXd& upperLimits)
 {
-  if (static_cast<size_t>(upperLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(upperLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setPositionUpperLimits, upperLimits);
     return;
   }
@@ -724,7 +725,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setInitialPositions(
     const Eigen::VectorXd& initial)
 {
-  if (static_cast<size_t>(initial.size()) != getNumDofs()) {
+  if (!std::cmp_equal(initial.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setInitialPositions, initial);
     return;
   }
@@ -846,7 +847,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setVelocities(
     const Eigen::VectorXd& velocities)
 {
-  if (static_cast<size_t>(velocities.size()) != getNumDofs()) {
+  if (!std::cmp_equal(velocities.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setVelocities, velocities);
     return;
   }
@@ -897,7 +898,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setVelocityLowerLimits(
     const Eigen::VectorXd& lowerLimits)
 {
-  if (static_cast<size_t>(lowerLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(lowerLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setVelocityLowerLimits, lowerLimits);
     return;
   }
@@ -942,7 +943,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setVelocityUpperLimits(
     const Eigen::VectorXd& upperLimits)
 {
-  if (static_cast<size_t>(upperLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(upperLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setVelocityUpperLimits, upperLimits);
     return;
   }
@@ -1006,7 +1007,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setInitialVelocities(
     const Eigen::VectorXd& initial)
 {
-  if (static_cast<size_t>(initial.size()) != getNumDofs()) {
+  if (!std::cmp_equal(initial.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setInitialVelocities, initial);
     return;
   }
@@ -1064,7 +1065,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setAccelerations(
     const Eigen::VectorXd& accelerations)
 {
-  if (static_cast<size_t>(accelerations.size()) != getNumDofs()) {
+  if (!std::cmp_equal(accelerations.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setAccelerations, accelerations);
     return;
   }
@@ -1115,7 +1116,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setAccelerationLowerLimits(
     const Eigen::VectorXd& lowerLimits)
 {
-  if (static_cast<size_t>(lowerLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(lowerLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setAccelerationLowerLimits, lowerLimits);
     return;
   }
@@ -1159,7 +1160,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setAccelerationUpperLimits(
     const Eigen::VectorXd& upperLimits)
 {
-  if (static_cast<size_t>(upperLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(upperLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setAccelerationUpperLimits, upperLimits);
     return;
   }
@@ -1213,7 +1214,7 @@ double GenericJoint<ConfigSpaceT>::getForce(size_t index) const
 template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setForces(const Eigen::VectorXd& forces)
 {
-  if (static_cast<size_t>(forces.size()) != getNumDofs()) {
+  if (!std::cmp_equal(forces.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setForces, forces);
     return;
   }
@@ -1263,7 +1264,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setForceLowerLimits(
     const Eigen::VectorXd& lowerLimits)
 {
-  if (static_cast<size_t>(lowerLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(lowerLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setForceLowerLimits, lowerLimits);
     return;
   }
@@ -1307,7 +1308,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setForceUpperLimits(
     const Eigen::VectorXd& upperLimits)
 {
-  if (static_cast<size_t>(upperLimits.size()) != getNumDofs()) {
+  if (!std::cmp_equal(upperLimits.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setForceUpperLimits, upperLimits);
     return;
   }
@@ -1419,8 +1420,8 @@ void GenericJoint<ConfigSpaceT>::integratePositions(
     double dt,
     Eigen::VectorXd& result) const
 {
-  if (static_cast<std::size_t>(q0.size()) != getNumDofs()
-      || static_cast<std::size_t>(v.size()) != getNumDofs()) {
+  if (!std::cmp_equal(q0.size(), getNumDofs())
+      || !std::cmp_equal(v.size(), getNumDofs())) {
     DART_ERROR(
         "q0's size [{}] and v's size [{}] must both equal the dof [{}] for "
         "Joint [{}].",
@@ -1460,8 +1461,8 @@ template <class ConfigSpaceT>
 Eigen::VectorXd GenericJoint<ConfigSpaceT>::getPositionDifferences(
     const Eigen::VectorXd& q2, const Eigen::VectorXd& q1) const
 {
-  if (static_cast<size_t>(q1.size()) != getNumDofs()
-      || static_cast<size_t>(q2.size()) != getNumDofs()) {
+  if (!std::cmp_equal(q1.size(), getNumDofs())
+      || !std::cmp_equal(q2.size(), getNumDofs())) {
     DART_ERROR(
         "q1's size [{}] or q2's size [{}] must both equal the dof [{}] for "
         "Joint [{}].",
@@ -1549,7 +1550,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setRestPositions(
     const Eigen::VectorXd& restPositions)
 {
-  if (static_cast<size_t>(restPositions.size()) != getNumDofs()) {
+  if (!std::cmp_equal(restPositions.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setRestPositions, restPositions);
     return;
   }
@@ -1604,7 +1605,7 @@ template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setDampingCoefficients(
     const Eigen::VectorXd& dampingCoefficients)
 {
-  if (static_cast<size_t>(dampingCoefficients.size()) != getNumDofs()) {
+  if (!std::cmp_equal(dampingCoefficients.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(
         setDampingCoefficients, dampingCoefficients);
     return;
@@ -1671,7 +1672,7 @@ double GenericJoint<ConfigSpaceT>::getCoulombFriction(size_t index) const
 template <class ConfigSpaceT>
 void GenericJoint<ConfigSpaceT>::setFrictions(const Eigen::VectorXd& frictions)
 {
-  if (static_cast<size_t>(frictions.size()) != getNumDofs()) {
+  if (!std::cmp_equal(frictions.size(), getNumDofs())) {
     GenericJoint_REPORT_DIM_MISMATCH(setFrictions, frictions);
     return;
   }

--- a/dart/dynamics/free_joint.cpp
+++ b/dart/dynamics/free_joint.cpp
@@ -39,6 +39,7 @@
 
 #include <array>
 #include <string>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -713,8 +714,8 @@ void FreeJoint::integratePositions(
     double dt,
     Eigen::VectorXd& result) const
 {
-  if (static_cast<std::size_t>(q0.size()) != getNumDofs()
-      || static_cast<std::size_t>(v.size()) != getNumDofs()) {
+  if (!std::cmp_equal(q0.size(), getNumDofs())
+      || !std::cmp_equal(v.size(), getNumDofs())) {
     DART_ERROR(
         "q0's size [{}] and v's size [{}] must both equal the dof [{}] for "
         "Joint [{}].",

--- a/dart/dynamics/hierarchical_ik.cpp
+++ b/dart/dynamics/hierarchical_ik.cpp
@@ -39,6 +39,8 @@
 #include "dart/dynamics/skeleton.hpp"
 #include "dart/math/optimization/gradient_descent_solver.hpp"
 
+#include <utility>
+
 namespace dart {
 namespace dynamics {
 
@@ -227,7 +229,7 @@ std::span<const Eigen::MatrixXd> HierarchicalIK::computeNullSpaces() const
   bool recompute = false;
   const ConstSkeletonPtr& skel = getSkeleton();
   const std::size_t nDofs = skel->getNumDofs();
-  if (static_cast<std::size_t>(mLastPositions.size()) != nDofs) {
+  if (!std::cmp_equal(mLastPositions.size(), nDofs)) {
     recompute = true;
   } else {
     for (std::size_t i = 0; i < nDofs; ++i) {

--- a/dart/dynamics/ik_fast.cpp
+++ b/dart/dynamics/ik_fast.cpp
@@ -39,6 +39,7 @@
 #include "dart/dynamics/revolute_joint.hpp"
 
 #include <algorithm>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -356,7 +357,7 @@ void IkFast::configure() const
   const auto ikFastNumFreeJoints = getNumFreeParameters();
   const auto ikFastNumNonFreeJoints = ikFastNumJoints - ikFastNumFreeJoints;
 
-  if (static_cast<std::size_t>(ikFastNumNonFreeJoints) != mDofs.size()) {
+  if (!std::cmp_equal(ikFastNumNonFreeJoints, mDofs.size())) {
     DART_ERROR(
         "Failed to configure. Received a joint map of size '{}' but the actual "
         "dofs IkFast is '{}'.",
@@ -365,7 +366,7 @@ void IkFast::configure() const
     return;
   }
 
-  if (static_cast<std::size_t>(ikFastNumFreeJoints) != mFreeDofs.size()) {
+  if (!std::cmp_equal(ikFastNumFreeJoints, mFreeDofs.size())) {
     DART_ERROR(
         "Failed to configure. Received a free joint map of size '{}' but the "
         "actual dofs IkFast is '{}'.",
@@ -440,7 +441,7 @@ Eigen::Isometry3d IkFast::computeFk(const Eigen::VectorXd& parameters)
 {
   const std::size_t ikFastNumNonFreeJoints
       = getNumJoints2() - getNumFreeParameters2();
-  if (static_cast<std::size_t>(parameters.size()) != ikFastNumNonFreeJoints) {
+  if (!std::cmp_equal(parameters.size(), ikFastNumNonFreeJoints)) {
     DART_WARN(
         "The dimension of given joint positions doesn't agree with the number "
         "of joints of this IkFast solver. Returning identity.");

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -108,7 +108,7 @@ public:
     if (next < 0) {
       return false;
     }
-    if (next > std::ssize(mData)) {
+    if (std::cmp_greater(next, mData.size())) {
       return false;
     }
 

--- a/dart/dynamics/meta_skeleton.cpp
+++ b/dart/dynamics/meta_skeleton.cpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -144,7 +145,7 @@ static void setAllValuesFromVector(
     const std::string& _vname)
 {
   std::size_t nDofs = skel->getNumDofs();
-  if (_values.size() != static_cast<int>(skel->getNumDofs())) {
+  if (!std::cmp_equal(_values.size(), skel->getNumDofs())) {
     DART_ERROR(
         "Invalid number of entries ({}) in {} for MetaSkeleton named [{}] "
         "({}). Must be equal to ({}). Nothing will be set!",

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -54,6 +54,7 @@
 #include <queue>
 #include <span>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define SET_ALL_FLAGS(X)                                                       \
@@ -72,7 +73,7 @@
 #define CHECK_CONFIG_VECTOR_SIZE(V)                                            \
   if (V.size() > 0) {                                                          \
     if (nonzero_size != INVALID_INDEX                                          \
-        && V.size() != static_cast<int>(nonzero_size)) {                       \
+        && !std::cmp_equal(V.size(), nonzero_size)) {                          \
       DART_ERROR(                                                              \
           "Mismatch in size of vector [{}] "                                   \
           "(expected {} | found {})",                                          \
@@ -1631,7 +1632,7 @@ void Skeleton::integratePositions(
     return;
   }
 
-  if (velocityChanges.size() != static_cast<Eigen::Index>(getNumDofs())) {
+  if (!std::cmp_equal(velocityChanges.size(), getNumDofs())) {
     DART_ASSERT(false);
     integratePositions(_dt);
     return;
@@ -1681,8 +1682,8 @@ void Skeleton::integrateVelocities(double _dt)
 Eigen::VectorXd Skeleton::getPositionDifferences(
     const Eigen::VectorXd& _q2, const Eigen::VectorXd& _q1) const
 {
-  if (static_cast<std::size_t>(_q2.size()) != getNumDofs()
-      || static_cast<std::size_t>(_q1.size()) != getNumDofs()) {
+  if (!std::cmp_equal(_q2.size(), getNumDofs())
+      || !std::cmp_equal(_q1.size(), getNumDofs())) {
     DART_ERROR(
         "Skeleton::getPositionsDifference: q1's size[{}] or q2's size[{}is "
         "different with the dof [{}].",
@@ -1713,8 +1714,8 @@ Eigen::VectorXd Skeleton::getPositionDifferences(
 Eigen::VectorXd Skeleton::getVelocityDifferences(
     const Eigen::VectorXd& _dq2, const Eigen::VectorXd& _dq1) const
 {
-  if (static_cast<std::size_t>(_dq2.size()) != getNumDofs()
-      || static_cast<std::size_t>(_dq1.size()) != getNumDofs()) {
+  if (!std::cmp_equal(_dq2.size(), getNumDofs())
+      || !std::cmp_equal(_dq1.size(), getNumDofs())) {
     DART_ERROR(
         "Skeleton::getPositionsDifference: dq1's size[{}] or dq2's size[{}is "
         "different with the dof [{}].",
@@ -3383,7 +3384,7 @@ void Skeleton::updateCoriolisForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(cache.mCvec.size()) == dof);
+  DART_ASSERT(std::cmp_equal(cache.mCvec.size(), dof));
   if (dof == 0) {
     cache.mDirty.mCoriolisForces = false;
     return;
@@ -3411,7 +3412,7 @@ void Skeleton::updateCoriolisForces(std::size_t _treeIdx) const
 void Skeleton::updateCoriolisForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mCvec.size()) == dof);
+  DART_ASSERT(std::cmp_equal(mSkelCache.mCvec.size(), dof));
   if (dof == 0) {
     mSkelCache.mDirty.mCoriolisForces = false;
     return;
@@ -3437,7 +3438,7 @@ void Skeleton::updateGravityForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(cache.mG.size()) == dof);
+  DART_ASSERT(std::cmp_equal(cache.mG.size(), dof));
   if (dof == 0) {
     cache.mDirty.mGravityForces = false;
     return;
@@ -3459,7 +3460,7 @@ void Skeleton::updateGravityForces(std::size_t _treeIdx) const
 void Skeleton::updateGravityForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mG.size()) == dof);
+  DART_ASSERT(std::cmp_equal(mSkelCache.mG.size(), dof));
   if (dof == 0) {
     mSkelCache.mDirty.mGravityForces = false;
     return;
@@ -3485,7 +3486,7 @@ void Skeleton::updateCoriolisAndGravityForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(cache.mCg.size()) == dof);
+  DART_ASSERT(std::cmp_equal(cache.mCg.size(), dof));
   if (dof == 0) {
     cache.mDirty.mCoriolisAndGravityForces = false;
     return;
@@ -3513,7 +3514,7 @@ void Skeleton::updateCoriolisAndGravityForces(std::size_t _treeIdx) const
 void Skeleton::updateCoriolisAndGravityForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mCg.size()) == dof);
+  DART_ASSERT(std::cmp_equal(mSkelCache.mCg.size(), dof));
   if (dof == 0) {
     mSkelCache.mDirty.mCoriolisAndGravityForces = false;
     return;
@@ -3539,7 +3540,7 @@ void Skeleton::updateExternalForces(std::size_t _treeIdx) const
 {
   DataCache& cache = mTreeCache[_treeIdx];
   std::size_t dof = cache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(cache.mFext.size()) == dof);
+  DART_ASSERT(std::cmp_equal(cache.mFext.size(), dof));
   if (dof == 0) {
     cache.mDirty.mExternalForces = false;
     return;
@@ -3593,7 +3594,7 @@ void Skeleton::updateExternalForces(std::size_t _treeIdx) const
 void Skeleton::updateExternalForces() const
 {
   std::size_t dof = mSkelCache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(mSkelCache.mFext.size()) == dof);
+  DART_ASSERT(std::cmp_equal(mSkelCache.mFext.size(), dof));
   if (dof == 0) {
     mSkelCache.mDirty.mExternalForces = false;
     return;
@@ -3618,7 +3619,7 @@ void Skeleton::updateExternalForces() const
 const Eigen::VectorXd& Skeleton::computeConstraintForces(DataCache& cache) const
 {
   const std::size_t dof = cache.mDofs.size();
-  DART_ASSERT(static_cast<std::size_t>(cache.mFc.size()) == dof);
+  DART_ASSERT(std::cmp_equal(cache.mFc.size(), dof));
 
   // Body constraint impulses
   for (std::vector<BodyNode*>::reverse_iterator it = cache.mBodyNodes.rbegin();

--- a/dart/dynamics/soft_body_node.cpp
+++ b/dart/dynamics/soft_body_node.cpp
@@ -45,6 +45,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <cmath>
@@ -113,14 +114,11 @@ void SoftBodyNodeUniqueProperties::addFace(const Eigen::Vector3i& _newFace)
   DART_ASSERT(_newFace[1] != _newFace[2]);
   DART_ASSERT(_newFace[2] != _newFace[0]);
   DART_ASSERT(
-      0 <= _newFace[0]
-      && static_cast<std::size_t>(_newFace[0]) < mPointProps.size());
+      0 <= _newFace[0] && std::cmp_less(_newFace[0], mPointProps.size()));
   DART_ASSERT(
-      0 <= _newFace[1]
-      && static_cast<std::size_t>(_newFace[1]) < mPointProps.size());
+      0 <= _newFace[1] && std::cmp_less(_newFace[1], mPointProps.size()));
   DART_ASSERT(
-      0 <= _newFace[2]
-      && static_cast<std::size_t>(_newFace[2]) < mPointProps.size());
+      0 <= _newFace[2] && std::cmp_less(_newFace[2], mPointProps.size()));
   mFaces.push_back(_newFace);
 }
 

--- a/dart/math/optimization/problem.cpp
+++ b/dart/math/optimization/problem.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <limits>
 #include <span>
+#include <utility>
 
 namespace dart {
 namespace math {
@@ -100,11 +101,9 @@ std::size_t Problem::getDimension() const
 //==============================================================================
 void Problem::setInitialGuess(const Eigen::VectorXd& _initGuess)
 {
-  DART_ASSERT(
-      static_cast<std::size_t>(_initGuess.size()) == mDimension
-      && "Invalid size.");
+  DART_ASSERT(std::cmp_equal(_initGuess.size(), mDimension) && "Invalid size.");
 
-  if (_initGuess.size() != static_cast<int>(mDimension)) {
+  if (!std::cmp_equal(_initGuess.size(), mDimension)) {
     DART_ERROR(
         "Attempting to set the initial guess of a Problem of dimension [{}] to "
         "a vector of dimension [{}]. This initial guess will not be used!",
@@ -125,7 +124,7 @@ const Eigen::VectorXd& Problem::getInitialGuess() const
 //==============================================================================
 void Problem::addSeed(const Eigen::VectorXd& _seed)
 {
-  if (_seed.size() == static_cast<int>(mDimension)) {
+  if (std::cmp_equal(_seed.size(), mDimension)) {
     mSeeds.push_back(_seed);
   } else {
     DART_WARN(
@@ -186,8 +185,7 @@ void Problem::clearAllSeeds()
 //==============================================================================
 void Problem::setLowerBounds(const Eigen::VectorXd& _lb)
 {
-  DART_ASSERT(
-      static_cast<std::size_t>(_lb.size()) == mDimension && "Invalid size.");
+  DART_ASSERT(std::cmp_equal(_lb.size(), mDimension) && "Invalid size.");
   mLowerBounds = _lb;
 }
 
@@ -200,8 +198,7 @@ const Eigen::VectorXd& Problem::getLowerBounds() const
 //==============================================================================
 void Problem::setUpperBounds(const Eigen::VectorXd& _ub)
 {
-  DART_ASSERT(
-      static_cast<std::size_t>(_ub.size()) == mDimension && "Invalid size.");
+  DART_ASSERT(std::cmp_equal(_ub.size(), mDimension) && "Invalid size.");
   mUpperBounds = _ub;
 }
 
@@ -307,9 +304,7 @@ double Problem::getOptimumValue() const
 //==============================================================================
 void Problem::setOptimalSolution(const Eigen::VectorXd& _optParam)
 {
-  DART_ASSERT(
-      static_cast<std::size_t>(_optParam.size()) == mDimension
-      && "Invalid size.");
+  DART_ASSERT(std::cmp_equal(_optParam.size(), mDimension) && "Invalid size.");
   mOptimalSolution = _optParam;
 }
 

--- a/dart/simulation/experimental/space/vector_mapper.cpp
+++ b/dart/simulation/experimental/space/vector_mapper.cpp
@@ -36,6 +36,7 @@
 
 #include <format>
 #include <stdexcept>
+#include <utility>
 
 namespace dart::simulation::experimental {
 
@@ -91,7 +92,7 @@ void VectorMapper::toVector(
 void VectorMapper::toEigen(
     const entt::registry& registry, Eigen::VectorXd& output) const
 {
-  if (static_cast<size_t>(output.size()) < m_space.getDimension()) {
+  if (std::cmp_less(output.size(), m_space.getDimension())) {
     throw std::invalid_argument(
         std::format(
             "Output vector size ({}) < required dimension ({})",
@@ -137,7 +138,7 @@ void VectorMapper::fromVector(
 void VectorMapper::fromEigen(
     entt::registry& registry, const Eigen::VectorXd& vec)
 {
-  if (static_cast<size_t>(vec.size()) < m_space.getDimension()) {
+  if (std::cmp_less(vec.size(), m_space.getDimension())) {
     throw std::invalid_argument(
         std::format(
             "Input vector size ({}) < required dimension ({})",

--- a/dart/simulation/world.cpp
+++ b/dart/simulation/world.cpp
@@ -57,6 +57,7 @@
 
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <cmath>
@@ -611,7 +612,7 @@ bool World::hasSkeleton(std::string_view skeletonName) const
 //==============================================================================
 int World::getIndex(int _index) const
 {
-  if (_index < 0 || static_cast<std::size_t>(_index) >= mIndices.size()) {
+  if (_index < 0 || std::cmp_greater_equal(_index, mIndices.size())) {
     DART_ERROR(
         "World::getIndex: index [{}] is out of range. Valid range is [0, {}).",
         _index,

--- a/examples/atlas_simbicon/state.cpp
+++ b/examples/atlas_simbicon/state.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/macros.hpp"
 #include "terminal_condition.hpp"
 
+#include <utility>
+
 // Macro for functions not implemented yet
 #define NOT_YET(FUNCTION)                                                      \
   std::cout << #FUNCTION << "Not implemented yet." << std::endl;
@@ -643,7 +645,7 @@ double State::getDerivativeGain(int _idx) const
 void State::setFeedbackSagittalCOMDistance(std::size_t _index, double _val)
 {
   DART_ASSERT(
-      static_cast<int>(_index) <= mSagittalCd.size() && "Invalid index.");
+      std::cmp_less_equal(_index, mSagittalCd.size()) && "Invalid index.");
 
   mSagittalCd[_index] = _val;
 }
@@ -652,7 +654,7 @@ void State::setFeedbackSagittalCOMDistance(std::size_t _index, double _val)
 void State::setFeedbackSagittalCOMVelocity(std::size_t _index, double _val)
 {
   DART_ASSERT(
-      static_cast<int>(_index) <= mSagittalCv.size() && "Invalid index.");
+      std::cmp_less_equal(_index, mSagittalCv.size()) && "Invalid index.");
 
   mSagittalCv[_index] = _val;
 }
@@ -661,7 +663,7 @@ void State::setFeedbackSagittalCOMVelocity(std::size_t _index, double _val)
 void State::setFeedbackCoronalCOMDistance(std::size_t _index, double _val)
 {
   DART_ASSERT(
-      static_cast<int>(_index) <= mCoronalCd.size() && "Invalid index.");
+      std::cmp_less_equal(_index, mCoronalCd.size()) && "Invalid index.");
 
   mCoronalCd[_index] = _val;
 }
@@ -670,7 +672,7 @@ void State::setFeedbackCoronalCOMDistance(std::size_t _index, double _val)
 void State::setFeedbackCoronalCOMVelocity(std::size_t _index, double _val)
 {
   DART_ASSERT(
-      static_cast<int>(_index) <= mCoronalCv.size() && "Invalid index.");
+      std::cmp_less_equal(_index, mCoronalCv.size()) && "Invalid index.");
 
   mCoronalCv[_index] = _val;
 }

--- a/tests/integration/dynamics/test_skeleton.cpp
+++ b/tests/integration/dynamics/test_skeleton.cpp
@@ -45,6 +45,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <utility>
 
 using namespace dart;
 using namespace math;
@@ -837,7 +838,7 @@ TEST(Skeleton, Configurations)
 
   c2 = twoLink->getConfiguration(Skeleton::CONFIG_VELOCITIES);
   EXPECT_TRUE(c2.mPositions.size() == 0);
-  EXPECT_TRUE(c2.mVelocities.size() == static_cast<int>(twoLink->getNumDofs()));
+  EXPECT_TRUE(std::cmp_equal(c2.mVelocities.size(), twoLink->getNumDofs()));
   EXPECT_TRUE(c2.mAccelerations.size() == 0);
 }
 

--- a/tests/unit/dynamics/test_generic_joints.cpp
+++ b/tests/unit/dynamics/test_generic_joints.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <limits>
 #include <string>
+#include <utility>
 
 using namespace dart;
 using namespace dart::dynamics;
@@ -698,7 +699,7 @@ void exerciseConstOverloads(const std::string& name)
   typename JointType::Vector q2Static = q2;
   const auto diffStatic
       = constJoint->getPositionDifferencesStatic(q2Static, q1Static);
-  EXPECT_EQ(static_cast<Eigen::Index>(diffStatic.size()), ndofs);
+  EXPECT_TRUE(std::cmp_equal(diffStatic.size(), ndofs));
 
   const auto jac = constJoint->getRelativeJacobian();
   EXPECT_EQ(jac.cols(), ndofs);

--- a/tests/unit/dynamics/test_mesh_shape.cpp
+++ b/tests/unit/dynamics/test_mesh_shape.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <system_error>
 #include <unordered_map>
+#include <utility>
 
 #include <cmath>
 #include <cstring>
@@ -139,7 +140,7 @@ public:
     if (next < 0) {
       return false;
     }
-    if (next > std::ssize(mData)) {
+    if (std::cmp_greater(next, mData.size())) {
       return false;
     }
 


### PR DESCRIPTION
## Summary

- Replace signed/unsigned size casts with C++20 comparison helpers across dynamics, optimization, simulation, and related tests/examples.
- Use `std::cmp_equal`, `std::cmp_less`, and `std::cmp_greater_equal` for Eigen/container size checks and index validation.

## Motivation / Problem

- The codebase is C++20, so standard comparison helpers can express mixed signedness checks without manual casts.
- This keeps dimension and bounds checks warning-resistant while preserving the existing control flow.

## Changes / Key Changes

- Modernize dimension checks in generic joints, ball/free joints, skeleton, hierarchical IK, IkFast, and meta skeleton code.
- Modernize optimization problem vector-size validation and simulation world/vector-mapper bounds checks.
- Update matching tests and the Atlas Simbicon example to use the same C++20 comparison helpers.

## Testing

- `git diff --check`
- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 modernization PR for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable