### PR TITLE
Adopt C++20 signed sizes in examples and tests

### DIFF
--- a/examples/atlas_puppet/main.cpp
+++ b/examples/atlas_puppet/main.cpp
@@ -38,6 +38,7 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <iterator>
 #include <string_view>
 
 using namespace dart::common;
@@ -100,7 +101,7 @@ public:
 
     if (enforceIdealPosture) {
       // Try to get the robot into the best possible posture
-      for (int i = 0; i < _x.size(); ++i) {
+      for (auto i = 0; i < std::ssize(_x); ++i) {
         if (mIdeal.size() <= i) {
           break;
         }
@@ -109,7 +110,7 @@ public:
       }
     } else {
       // Only adjust the posture if it is really bad
-      for (int i = 0; i < _x.size(); ++i) {
+      for (auto i = 0; i < std::ssize(_x); ++i) {
         if (mIdeal.size() <= i) {
           break;
         }

--- a/examples/hubo_puppet/main.cpp
+++ b/examples/hubo_puppet/main.cpp
@@ -42,6 +42,7 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <iterator>
 #include <span>
 
 using namespace dart::math;
@@ -99,7 +100,7 @@ public:
     mResultVector.setZero();
 
     if (enforceIdealPosture) {
-      for (int i = 0; i < _x.size(); ++i) {
+      for (auto i = 0; i < std::ssize(_x); ++i) {
         if (mIdeal.size() <= i) {
           break;
         }
@@ -107,7 +108,7 @@ public:
         mResultVector[i] = mWeights[i] * (_x[i] - mIdeal[i]);
       }
     } else {
-      for (int i = 0; i < _x.size(); ++i) {
+      for (auto i = 0; i < std::ssize(_x); ++i) {
         if (mIdeal.size() <= i) {
           break;
         }
@@ -583,7 +584,7 @@ public:
       testQ[4] = q5;
       testQ[5] = q6;
 
-      for (int k = 0; k < testQ.size(); ++k) {
+      for (auto k = 0; k < std::ssize(testQ); ++k) {
         if (fabs(testQ[k]) < zeroSize) {
           testQ[k] = 0;
         }

--- a/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
@@ -44,6 +44,8 @@
 #include <sstream>
 #include <string>
 
+#include <cstddef>
+
 namespace {
 
 using dart::math::LcpOptions;
@@ -227,7 +229,7 @@ void AddShockPropagationCounters(
     maxBlockSize = std::max(maxBlockSize, size);
   }
 
-  std::ptrdiff_t maxBlocksPerLayer = 0;
+  auto maxBlocksPerLayer = std::ptrdiff_t{0};
   if (!params.layers.empty()) {
     for (const auto& layer : params.layers) {
       maxBlocksPerLayer = std::max(maxBlocksPerLayer, std::ssize(layer));
@@ -337,8 +339,8 @@ static void BM_LcpCompare_ShockPropagation_Standard(benchmark::State& state)
 
   params.layers.clear();
   params.layers.reserve(params.blockSizes.size());
-  for (int i = 0; i < std::ssize(params.blockSizes); ++i) {
-    params.layers.push_back({i});
+  for (auto i = 0; i < std::ssize(params.blockSizes); ++i) {
+    params.layers.push_back({static_cast<int>(i)});
   }
 
   auto options = MakeBenchmarkOptions(100);

--- a/tests/integration/dynamics/dynamics_test_fixture.cpp
+++ b/tests/integration/dynamics/dynamics_test_fixture.cpp
@@ -48,6 +48,7 @@
 #include <Eigen/Dense>
 
 #include <iostream>
+#include <iterator>
 
 using namespace dart;
 using namespace simulation;
@@ -2216,7 +2217,7 @@ void DynamicsTest::testImpulseBasedDynamics(const common::Uri& uri)
 
       // Set random impulses
       VectorXd impulses = VectorXd::Zero(dof);
-      for (int k = 0; k < impulses.size(); ++k) {
+      for (auto k = 0; k < std::ssize(impulses); ++k) {
         impulses[k] = Random::uniform(lb, ub);
       }
       skel->setJointConstraintImpulses(impulses);

--- a/tests/integration/dynamics/test_forward_kinematics.cpp
+++ b/tests/integration/dynamics/test_forward_kinematics.cpp
@@ -39,6 +39,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <iterator>
 
 using namespace dart::test;
 
@@ -130,7 +131,7 @@ Eigen::MatrixXd finiteDifferenceJacobian(
     JacobianNode* node)
 {
   Eigen::MatrixXd J(3, q.size());
-  for (int i = 0; i < q.size(); ++i) {
+  for (auto i = 0; i < std::ssize(q); ++i) {
     const double dq = 1e-4;
 
     Eigen::VectorXd q_up = q;
@@ -165,7 +166,7 @@ Eigen::MatrixXd standardJacobian(
   Eigen::MatrixXd J = skeleton->getJacobian(node).bottomRows<3>();
 
   Eigen::MatrixXd reduced_J(3, q.size());
-  for (int i = 0; i < q.size(); ++i) {
+  for (auto i = 0; i < std::ssize(q); ++i) {
     reduced_J.col(i) = J.col(active_indices[i]);
   }
 

--- a/tests/integration/dynamics/test_meta_skeleton.cpp
+++ b/tests/integration/dynamics/test_meta_skeleton.cpp
@@ -45,6 +45,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <iterator>
 #include <unordered_set>
 
 using namespace dart;
@@ -151,7 +152,7 @@ TEST(MetaSkeleton, Referential)
       Eigen::VectorXd ddq = tree->getAccelerations();
 
       for (std::size_t k = 0; k < numIterations; ++k) {
-        for (int r = 0; r < q.size(); ++r) {
+        for (auto r = 0; r < std::ssize(q); ++r) {
           q[r] = math::Random::uniform<double>(-10, 10);
           dq[r] = math::Random::uniform<double>(-10, 10);
           ddq[r] = math::Random::uniform<double>(-10, 10);

--- a/tests/integration/simulation/test_world.cpp
+++ b/tests/integration/simulation/test_world.cpp
@@ -47,6 +47,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -442,7 +443,7 @@ TEST(World, Cloning)
 
         // Generate a random command vector
         Eigen::VectorXd commands = skel->getCommands();
-        for (int q = 0; q < commands.size(); ++q) {
+        for (auto q = 0; q < std::ssize(commands); ++q) {
           commands[q] = Random::uniform(-0.1, 0.1);
         }
 

--- a/tests/unit/dynamics/test_meta_skeleton.cpp
+++ b/tests/unit/dynamics/test_meta_skeleton.cpp
@@ -44,6 +44,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iterator>
 #include <vector>
 
 #include <cmath>
@@ -658,7 +659,7 @@ TEST(MetaSkeletonTests, MassMatrix)
   // Mass matrix should be positive semi-definite (all eigenvalues >= 0)
   Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(M);
   Eigen::VectorXd eigenvalues = eigensolver.eigenvalues();
-  for (int i = 0; i < eigenvalues.size(); ++i) {
+  for (auto i = 0; i < std::ssize(eigenvalues); ++i) {
     EXPECT_GE(eigenvalues[i], -1e-10); // Allow small numerical error
   }
 }


### PR DESCRIPTION
## Summary
- Use `std::ssize` for signed Eigen/container index loops in the Atlas and Hubo puppet examples.
- Apply the same signed-size cleanup in dynamics and simulation tests.
- Use signed-size counters in the LCP benchmark while preserving the required `int` cast at the solver-parameter API boundary.

## Motivation
Continue the C++20 modernization pass by replacing manual signed size comparisons and casts with standard library signed-size utilities.

## Changes
- Adds `<iterator>` where `std::ssize` is used.
- Converts local loop bounds and benchmark counters to use `std::ssize`.
- Keeps behavior unchanged and avoids changing public APIs.

## Testing
- `git diff --check`
- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`

## Breaking Changes
None.

## Related Issues
None.