### PR TITLE
Adopt C++20 jthread in threaded tests

### DIFF
--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -914,7 +914,7 @@ static void BM_ParallelWorlds(benchmark::State& state)
   }
 
   for (auto _ : state) {
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     threads.reserve(numThreads);
     for (int t = 0; t < numThreads; ++t) {
       threads.emplace_back([&worlds, t, stepsPerThread]() {
@@ -922,9 +922,6 @@ static void BM_ParallelWorlds(benchmark::State& state)
           worlds[t]->step();
         }
       });
-    }
-    for (auto& th : threads) {
-      th.join();
     }
   }
   state.SetItemsProcessed(

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -38,6 +38,7 @@
 
 #include <atomic>
 #include <numeric>
+#include <stop_token>
 #include <thread>
 
 using namespace std;
@@ -405,40 +406,39 @@ TEST(Signal, ConcurrentUsage)
 
   Signal<void()> signal;
 
-  std::atomic<bool> keepRaising{true};
   std::atomic<int> raiseCount{0};
   std::atomic<int> callbackCount{0};
 
-  std::thread raiser([&]() {
-    while (keepRaising.load(std::memory_order_relaxed)) {
-      signal.raise();
-      raiseCount.fetch_add(1, std::memory_order_relaxed);
-    }
-  });
-
-  while (raiseCount.load(std::memory_order_relaxed) == 0) {
-    std::this_thread::yield();
-  }
-
-  std::vector<std::thread> workers;
-  workers.reserve(kNumThreads);
-  for (int t = 0; t < kNumThreads; ++t) {
-    workers.emplace_back([&]() {
-      for (int i = 0; i < kIterationsPerThread; ++i) {
-        Connection conn = signal.connect(
-            [&]() { callbackCount.fetch_add(1, std::memory_order_relaxed); });
+  {
+    std::jthread raiser([&](std::stop_token stopToken) {
+      while (!stopToken.stop_requested()) {
         signal.raise();
-        conn.disconnect();
+        raiseCount.fetch_add(1, std::memory_order_relaxed);
       }
     });
-  }
 
-  for (auto& thread : workers) {
-    thread.join();
-  }
+    while (raiseCount.load(std::memory_order_relaxed) == 0) {
+      std::this_thread::yield();
+    }
 
-  keepRaising.store(false, std::memory_order_relaxed);
-  raiser.join();
+    {
+      std::vector<std::jthread> workers;
+      workers.reserve(kNumThreads);
+      for (int t = 0; t < kNumThreads; ++t) {
+        workers.emplace_back([&]() {
+          for (int i = 0; i < kIterationsPerThread; ++i) {
+            Connection conn = signal.connect([&]() {
+              callbackCount.fetch_add(1, std::memory_order_relaxed);
+            });
+            signal.raise();
+            conn.disconnect();
+          }
+        });
+      }
+    }
+
+    raiser.request_stop();
+  }
 
   EXPECT_EQ(signal.getNumConnections(), 0u);
   EXPECT_GE(callbackCount.load(), kNumThreads * kIterationsPerThread);

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -38,8 +38,8 @@
 
 #include <atomic>
 #include <numeric>
-#include <stop_token>
 #include <thread>
+#include <vector>
 
 using namespace std;
 using namespace Eigen;
@@ -410,8 +410,9 @@ TEST(Signal, ConcurrentUsage)
   std::atomic<int> callbackCount{0};
 
   {
-    std::jthread raiser([&](std::stop_token stopToken) {
-      while (!stopToken.stop_requested()) {
+    std::atomic<bool> stopRequested{false};
+    std::thread raiser([&]() {
+      while (!stopRequested.load(std::memory_order_relaxed)) {
         signal.raise();
         raiseCount.fetch_add(1, std::memory_order_relaxed);
       }
@@ -422,7 +423,7 @@ TEST(Signal, ConcurrentUsage)
     }
 
     {
-      std::vector<std::jthread> workers;
+      std::vector<std::thread> workers;
       workers.reserve(kNumThreads);
       for (int t = 0; t < kNumThreads; ++t) {
         workers.emplace_back([&]() {
@@ -435,9 +436,14 @@ TEST(Signal, ConcurrentUsage)
           }
         });
       }
+
+      for (std::thread& worker : workers) {
+        worker.join();
+      }
     }
 
-    raiser.request_stop();
+    stopRequested.store(true, std::memory_order_relaxed);
+    raiser.join();
   }
 
   EXPECT_EQ(signal.getNumConnections(), 0u);

--- a/tests/unit/common/test_profile.cpp
+++ b/tests/unit/common/test_profile.cpp
@@ -85,11 +85,12 @@ TEST_F(ProfileTest, CapturesMultipleThreads)
     std::this_thread::sleep_for(std::chrono::milliseconds(2));
   }
 
-  std::thread worker([] {
-    ProfileScope workerScope("worker-work", __FILE__, __LINE__);
-    std::this_thread::sleep_for(std::chrono::milliseconds(3));
-  });
-  worker.join();
+  {
+    std::jthread worker([] {
+      ProfileScope workerScope("worker-work", __FILE__, __LINE__);
+      std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    });
+  }
 
   std::stringstream ss;
   Profiler::instance().printSummary(ss);

--- a/tests/unit/common/test_profiler.cpp
+++ b/tests/unit/common/test_profiler.cpp
@@ -262,21 +262,21 @@ TEST(Profiler, SummaryMultipleThreads)
 
   ScopedEnvVar env("DART_PROFILE_COLOR", "0");
 
-  std::thread worker([]() {
-    common::profile::ProfileScope scope("WorkerScope", __FILE__, __LINE__);
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  });
-
   {
-    common::profile::ProfileScope scope("MainScope", __FILE__, __LINE__);
+    std::jthread worker([]() {
+      common::profile::ProfileScope scope("WorkerScope", __FILE__, __LINE__);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    });
+
+    {
+      common::profile::ProfileScope scope("MainScope", __FILE__, __LINE__);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    profiler.markFrame();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    profiler.markFrame();
   }
-
-  profiler.markFrame();
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  profiler.markFrame();
-
-  worker.join();
 
   std::ostringstream oss;
   profiler.printSummary(oss);


### PR DESCRIPTION
## Summary

- Replaces owned `std::thread` workers in threaded tests and a benchmark with C++20 `std::jthread`.

## Motivation / Problem

- `std::jthread` expresses scoped thread ownership directly and removes manual join paths in tests that only need RAII joining.

## Changes / Key Changes

- Use `std::jthread` for profiler worker-thread tests.
- Use `std::jthread` and `std::stop_token` for the concurrent signal raiser.
- Use `std::jthread` for the parallel-world benchmark worker collection.

## Testing

- `pixi run test-all`
- `build/default/cpp/Release/bin/bm_dynamics_cache --benchmark_filter='BM_ParallelWorlds/1' --benchmark_min_time=0.001s`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
