### PR TITLE
Adopt C++20 iota views in LCP solvers

### DIFF
--- a/dart/math/lcp/other/shock_propagation_solver.cpp
+++ b/dart/math/lcp/other/shock_propagation_solver.cpp
@@ -39,7 +39,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
-#include <numeric>
+#include <ranges>
 #include <span>
 #include <string>
 #include <utility>
@@ -171,11 +171,8 @@ bool buildBlocks(
 
     int offset = 0;
     for (const int size : params.blockSizes) {
-      std::vector<int> indices;
-      indices.reserve(static_cast<std::size_t>(size));
-      for (int i = 0; i < size; ++i) {
-        indices.push_back(offset + i);
-      }
+      const auto indexRange = std::views::iota(offset, offset + size);
+      std::vector<int> indices(indexRange.begin(), indexRange.end());
       offset += size;
 
       BlockData block;
@@ -196,8 +193,8 @@ bool buildBlocks(
     return true;
   }
 
-  std::vector<int> parent(n);
-  std::iota(parent.begin(), parent.end(), 0);
+  const auto problemIndices = std::views::iota(0, static_cast<int>(n));
+  std::vector<int> parent(problemIndices.begin(), problemIndices.end());
 
   auto findRoot = [&](int v) {
     while (parent[v] != v) {
@@ -266,8 +263,8 @@ bool buildLayerOrder(
   }
 
   if (params.layers.empty()) {
-    layers.emplace_back(numBlocks);
-    std::iota(layers.front().begin(), layers.front().end(), 0);
+    const auto blockIndices = std::views::iota(0, static_cast<int>(numBlocks));
+    layers.emplace_back(blockIndices.begin(), blockIndices.end());
     return true;
   }
 

--- a/dart/math/lcp/projection/bgs_solver.cpp
+++ b/dart/math/lcp/projection/bgs_solver.cpp
@@ -39,7 +39,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
-#include <numeric>
+#include <ranges>
 #include <span>
 #include <string>
 #include <utility>
@@ -171,11 +171,8 @@ bool buildBlocks(
 
     int offset = 0;
     for (const int size : params.blockSizes) {
-      std::vector<int> indices;
-      indices.reserve(static_cast<std::size_t>(size));
-      for (int i = 0; i < size; ++i) {
-        indices.push_back(offset + i);
-      }
+      const auto indexRange = std::views::iota(offset, offset + size);
+      std::vector<int> indices(indexRange.begin(), indexRange.end());
       offset += size;
 
       BlockData block;
@@ -196,8 +193,8 @@ bool buildBlocks(
     return true;
   }
 
-  std::vector<int> parent(n);
-  std::iota(parent.begin(), parent.end(), 0);
+  const auto problemIndices = std::views::iota(0, static_cast<int>(n));
+  std::vector<int> parent(problemIndices.begin(), problemIndices.end());
 
   auto findRoot = [&](int v) {
     while (parent[v] != v) {

--- a/dart/math/lcp/projection/blocked_jacobi_solver.cpp
+++ b/dart/math/lcp/projection/blocked_jacobi_solver.cpp
@@ -41,7 +41,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
-#include <numeric>
+#include <ranges>
 #include <span>
 #include <string>
 #include <utility>
@@ -173,11 +173,8 @@ bool buildBlocks(
 
     int offset = 0;
     for (const int size : params.blockSizes) {
-      std::vector<int> indices;
-      indices.reserve(static_cast<std::size_t>(size));
-      for (int i = 0; i < size; ++i) {
-        indices.push_back(offset + i);
-      }
+      const auto indexRange = std::views::iota(offset, offset + size);
+      std::vector<int> indices(indexRange.begin(), indexRange.end());
       offset += size;
 
       BlockData block;
@@ -198,8 +195,8 @@ bool buildBlocks(
     return true;
   }
 
-  std::vector<int> parent(n);
-  std::iota(parent.begin(), parent.end(), 0);
+  const auto problemIndices = std::views::iota(0, static_cast<int>(n));
+  std::vector<int> parent(problemIndices.begin(), problemIndices.end());
 
   auto findRoot = [&](int v) {
     while (parent[v] != v) {


### PR DESCRIPTION
## Summary

- Adopt C++20 `std::views::iota` for block and parent-index vector construction in LCP solvers.

## Motivation / Problem

- The affected solvers had local hand-written index loops and `std::iota` initialization that can be represented directly with C++20 range views.

## Changes / Key Changes

- Replace manual block-index vector construction with `std::views::iota`.
- Replace parent and layer index initialization with iota-view-backed vector construction.
- Swap unused `<numeric>` includes for `<ranges>`.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
