### PR TITLE
Adopt C++20 using enum in switch helpers

### DIFF
--- a/dart/common/local_resource.cpp
+++ b/dart/common/local_resource.cpp
@@ -163,15 +163,16 @@ bool LocalResource::seek(ptrdiff_t _offset, SeekType _mode)
 {
   int origin;
   switch (_mode) {
-    case Resource::SEEKTYPE_CUR:
+    using enum Resource::SeekType;
+    case SEEKTYPE_CUR:
       origin = SEEK_CUR;
       break;
 
-    case Resource::SEEKTYPE_END:
+    case SEEKTYPE_END:
       origin = SEEK_END;
       break;
 
-    case Resource::SEEKTYPE_SET:
+    case SEEKTYPE_SET:
       origin = SEEK_SET;
       break;
 

--- a/dart/common/memory_manager.cpp
+++ b/dart/common/memory_manager.cpp
@@ -117,9 +117,10 @@ FrameAllocator& MemoryManager::getFrameAllocator()
 void* MemoryManager::allocate(Type type, size_t bytes)
 {
   switch (type) {
-    case Type::Base:
+    using enum Type;
+    case Base:
       return mBaseAllocator.allocate(bytes);
-    case Type::Free:
+    case Free:
       if (mUseDebugAllocators) {
         DART_ASSERT(mFreeListAllocatorWithDebug != nullptr);
         return mFreeListAllocatorWithDebug->allocate(bytes);
@@ -127,7 +128,7 @@ void* MemoryManager::allocate(Type type, size_t bytes)
 
       DART_ASSERT(mFreeListAllocator != nullptr);
       return mFreeListAllocator->allocate(bytes);
-    case Type::Pool:
+    case Pool:
       if (mUseDebugAllocators) {
         DART_ASSERT(mPoolAllocatorWithDebug != nullptr);
         return mPoolAllocatorWithDebug->allocate(bytes);
@@ -135,7 +136,7 @@ void* MemoryManager::allocate(Type type, size_t bytes)
 
       DART_ASSERT(mPoolAllocator != nullptr);
       return mPoolAllocator->allocate(bytes);
-    case Type::Frame:
+    case Frame:
       DART_ASSERT(mFrameAllocator != nullptr);
       return mFrameAllocator->allocate(bytes);
   }
@@ -158,10 +159,11 @@ void* MemoryManager::allocateUsingPool(size_t bytes)
 void MemoryManager::deallocate(Type type, void* pointer, size_t bytes)
 {
   switch (type) {
-    case Type::Base:
+    using enum Type;
+    case Base:
       mBaseAllocator.deallocate(pointer, bytes);
       break;
-    case Type::Free:
+    case Free:
       if (mUseDebugAllocators) {
         DART_ASSERT(mFreeListAllocatorWithDebug != nullptr);
         mFreeListAllocatorWithDebug->deallocate(pointer, bytes);
@@ -171,7 +173,7 @@ void MemoryManager::deallocate(Type type, void* pointer, size_t bytes)
       DART_ASSERT(mFreeListAllocator != nullptr);
       mFreeListAllocator->deallocate(pointer, bytes);
       break;
-    case Type::Pool:
+    case Pool:
       if (mUseDebugAllocators) {
         DART_ASSERT(mPoolAllocatorWithDebug != nullptr);
         mPoolAllocatorWithDebug->deallocate(pointer, bytes);
@@ -181,7 +183,7 @@ void MemoryManager::deallocate(Type type, void* pointer, size_t bytes)
       DART_ASSERT(mPoolAllocator != nullptr);
       mPoolAllocator->deallocate(pointer, bytes);
       break;
-    case Type::Frame:
+    case Frame:
       DART_ASSERT(mFrameAllocator != nullptr);
       mFrameAllocator->deallocate(pointer, bytes);
       break;

--- a/dart/dynamics/detail/planar_joint_aspect.cpp
+++ b/dart/dynamics/detail/planar_joint_aspect.cpp
@@ -41,16 +41,17 @@ namespace detail {
 PlanarJointUniqueProperties::PlanarJointUniqueProperties(PlaneType _planeType)
 {
   switch (_planeType) {
-    case PlaneType::ARBITRARY:
-    case PlaneType::XY:
+    using enum PlaneType;
+    case ARBITRARY:
+    case XY:
       setXYPlane();
       mPlaneType
           = _planeType; // In case the PlaneType was supposed to be arbitrary
       break;
-    case PlaneType::YZ:
+    case YZ:
       setYZPlane();
       break;
-    case PlaneType::ZX:
+    case ZX:
       setZXPlane();
       break;
   }
@@ -68,16 +69,17 @@ PlanarJointUniqueProperties::PlanarJointUniqueProperties(
     const PlanarJointUniqueProperties& other)
 {
   switch (other.mPlaneType) {
-    case PlaneType::ARBITRARY:
+    using enum PlaneType;
+    case ARBITRARY:
       setArbitraryPlane(other.mTransAxis1, other.mTransAxis2);
       break;
-    case PlaneType::XY:
+    case XY:
       setXYPlane();
       break;
-    case PlaneType::YZ:
+    case YZ:
       setYZPlane();
       break;
-    case PlaneType::ZX:
+    case ZX:
       setZXPlane();
       break;
   }
@@ -89,16 +91,17 @@ PlanarJointUniqueProperties& PlanarJointUniqueProperties::operator=(
 {
   if (this != &other) {
     switch (other.mPlaneType) {
-      case PlaneType::ARBITRARY:
+      using enum PlaneType;
+      case ARBITRARY:
         setArbitraryPlane(other.mTransAxis1, other.mTransAxis2);
         break;
-      case PlaneType::XY:
+      case XY:
         setXYPlane();
         break;
-      case PlaneType::YZ:
+      case YZ:
         setYZPlane();
         break;
-      case PlaneType::ZX:
+      case ZX:
         setZXPlane();
         break;
     }

--- a/dart/dynamics/detail/translational_joint2_d_aspect.cpp
+++ b/dart/dynamics/detail/translational_joint2_d_aspect.cpp
@@ -42,16 +42,17 @@ TranslationalJoint2DUniqueProperties::TranslationalJoint2DUniqueProperties(
     PlaneType planeType)
 {
   switch (planeType) {
-    case PlaneType::ARBITRARY:
-    case PlaneType::XY:
+    using enum PlaneType;
+    case ARBITRARY:
+    case XY:
       setXYPlane();
       mPlaneType
           = planeType; // In case the PlaneType was supposed to be arbitrary
       break;
-    case PlaneType::YZ:
+    case YZ:
       setYZPlane();
       break;
-    case PlaneType::ZX:
+    case ZX:
       setZXPlane();
       break;
   }
@@ -76,16 +77,17 @@ TranslationalJoint2DUniqueProperties::TranslationalJoint2DUniqueProperties(
     const TranslationalJoint2DUniqueProperties& other)
 {
   switch (other.mPlaneType) {
-    case PlaneType::ARBITRARY:
+    using enum PlaneType;
+    case ARBITRARY:
       setArbitraryPlane(other.mTransAxes);
       break;
-    case PlaneType::XY:
+    case XY:
       setXYPlane();
       break;
-    case PlaneType::YZ:
+    case YZ:
       setYZPlane();
       break;
-    case PlaneType::ZX:
+    case ZX:
       setZXPlane();
       break;
   }
@@ -98,16 +100,17 @@ TranslationalJoint2DUniqueProperties::operator=(
 {
   if (this != &other) {
     switch (other.mPlaneType) {
-      case PlaneType::ARBITRARY:
+      using enum PlaneType;
+      case ARBITRARY:
         setArbitraryPlane(other.mTransAxes);
         break;
-      case PlaneType::XY:
+      case XY:
         setXYPlane();
         break;
-      case PlaneType::YZ:
+      case YZ:
         setYZPlane();
         break;
-      case PlaneType::ZX:
+      case ZX:
         setZXPlane();
         break;
     }

--- a/dart/dynamics/euler_joint.cpp
+++ b/dart/dynamics/euler_joint.cpp
@@ -158,9 +158,10 @@ Eigen::Matrix3d EulerJoint::convertToRotation(
     const Eigen::Vector3d& _positions, AxisOrder _ordering)
 {
   switch (_ordering) {
-    case AxisOrder::XYZ:
+    using enum AxisOrder;
+    case XYZ:
       return math::eulerXYZToMatrix(_positions);
-    case AxisOrder::ZYX:
+    case ZYX:
       return math::eulerZYXToMatrix(_positions);
     default: {
       DART_ERROR(
@@ -200,7 +201,8 @@ Eigen::Matrix<double, 6, 3> EulerJoint::getRelativeJacobianStatic(
   Eigen::Vector6d J2 = Eigen::Vector6d::Zero();
 
   switch (getAxisOrder()) {
-    case AxisOrder::XYZ: {
+    using enum AxisOrder;
+    case XYZ: {
       //------------------------------------------------------------------------
       // S = [    c1*c2, s2,  0
       //       -(c1*s2), c2,  0
@@ -224,7 +226,7 @@ Eigen::Matrix<double, 6, 3> EulerJoint::getRelativeJacobianStatic(
 
       break;
     }
-    case AxisOrder::ZYX: {
+    case ZYX: {
       //------------------------------------------------------------------------
       // S = [   -s1,    0,   1
       //       s2*c1,   c2,   0
@@ -301,12 +303,13 @@ void EulerJoint::updateDegreeOfFreedomNames()
 {
   std::vector<std::string> affixes;
   switch (getAxisOrder()) {
-    case AxisOrder::ZYX:
+    using enum AxisOrder;
+    case ZYX:
       affixes.push_back("_z");
       affixes.push_back("_y");
       affixes.push_back("_x");
       break;
-    case AxisOrder::XYZ:
+    case XYZ:
       affixes.push_back("_x");
       affixes.push_back("_y");
       affixes.push_back("_z");

--- a/dart/dynamics/planar_joint.cpp
+++ b/dart/dynamics/planar_joint.cpp
@@ -257,19 +257,20 @@ void PlanarJoint::updateDegreeOfFreedomNames()
 {
   std::vector<std::string> affixes;
   switch (mAspectProperties.mPlaneType) {
-    case PlaneType::XY:
+    using enum PlaneType;
+    case XY:
       affixes.push_back("_x");
       affixes.push_back("_y");
       break;
-    case PlaneType::YZ:
+    case YZ:
       affixes.push_back("_y");
       affixes.push_back("_z");
       break;
-    case PlaneType::ZX:
+    case ZX:
       affixes.push_back("_z");
       affixes.push_back("_x");
       break;
-    case PlaneType::ARBITRARY:
+    case ARBITRARY:
       affixes.push_back("_1");
       affixes.push_back("_2");
       break;

--- a/dart/io/read.cpp
+++ b/dart/io/read.cpp
@@ -96,18 +96,20 @@ std::string getLowercaseExtension(const common::Uri& uri)
 
 std::optional<ModelFormat> inferFormatFromExtension(const common::Uri& uri)
 {
+  using enum ModelFormat;
+
   const auto ext = getLowercaseExtension(uri);
   if (ext == ".skel") {
-    return ModelFormat::Skel;
+    return Skel;
   }
   if (ext == ".sdf" || ext == ".world") {
-    return ModelFormat::Sdf;
+    return Sdf;
   }
   if (ext == ".urdf") {
-    return ModelFormat::Urdf;
+    return Urdf;
   }
   if (ext == ".mjcf") {
-    return ModelFormat::Mjcf;
+    return Mjcf;
   }
 
   // Extensions like ".xml" are ambiguous across multiple formats.
@@ -241,9 +243,10 @@ simulation::WorldPtr readWorld(
     const common::Uri& uri, const ReadOptions& options)
 {
   const auto resolved = resolveOptions(options);
+  using enum ModelFormat;
 
   ModelFormat format = resolved.format;
-  if (format == ModelFormat::Auto) {
+  if (format == Auto) {
     const auto inferred = inferFormat(uri, resolved.resourceRetriever);
     if (!inferred) {
       DART_ERROR(
@@ -255,9 +258,9 @@ simulation::WorldPtr readWorld(
   }
 
   switch (format) {
-    case ModelFormat::Skel:
+    case Skel:
       return utils::SkelParser::readWorld(uri, resolved.resourceRetriever);
-    case ModelFormat::Sdf:
+    case Sdf:
 #if DART_HAS_SDFORMAT
     {
       auto sdfOptions = utils::SdfParser::Options(resolved.resourceRetriever);
@@ -274,10 +277,10 @@ simulation::WorldPtr readWorld(
           uri.toString());
       return nullptr;
 #endif
-    case ModelFormat::Mjcf:
+    case Mjcf:
       return utils::MjcfParser::readWorld(
           uri, utils::MjcfParser::Options(resolved.resourceRetriever));
-    case ModelFormat::Urdf:
+    case Urdf:
 #if DART_IO_HAS_URDF
       return readUrdfWorld(uri, resolved);
 #else
@@ -287,7 +290,7 @@ simulation::WorldPtr readWorld(
           uri.toString());
       return nullptr;
 #endif
-    case ModelFormat::Auto:
+    case Auto:
       break;
   }
 
@@ -302,9 +305,10 @@ dynamics::SkeletonPtr readSkeleton(
     const common::Uri& uri, const ReadOptions& options)
 {
   const auto resolved = resolveOptions(options);
+  using enum ModelFormat;
 
   ModelFormat format = resolved.format;
-  if (format == ModelFormat::Auto) {
+  if (format == Auto) {
     const auto inferred = inferFormat(uri, resolved.resourceRetriever);
     if (!inferred) {
       DART_ERROR(
@@ -317,7 +321,7 @@ dynamics::SkeletonPtr readSkeleton(
   }
 
   switch (format) {
-    case ModelFormat::Skel: {
+    case Skel: {
       const auto world
           = utils::SkelParser::readWorld(uri, resolved.resourceRetriever);
       if (world) {
@@ -338,7 +342,7 @@ dynamics::SkeletonPtr readSkeleton(
 
       return utils::SkelParser::readSkeleton(uri, resolved.resourceRetriever);
     }
-    case ModelFormat::Sdf:
+    case Sdf:
 #if DART_HAS_SDFORMAT
     {
       auto sdfOptions = utils::SdfParser::Options(resolved.resourceRetriever);
@@ -355,7 +359,7 @@ dynamics::SkeletonPtr readSkeleton(
           uri.toString());
       return nullptr;
 #endif
-    case ModelFormat::Urdf:
+    case Urdf:
 #if DART_IO_HAS_URDF
       return readUrdfSkeleton(uri, resolved);
 #else
@@ -365,13 +369,13 @@ dynamics::SkeletonPtr readSkeleton(
           uri.toString());
       return nullptr;
 #endif
-    case ModelFormat::Mjcf:
+    case Mjcf:
       DART_ERROR(
           "[dart::io::readSkeleton] MJCF does not support direct skeleton "
           "parsing. URI=[{}]",
           uri.toString());
       return nullptr;
-    case ModelFormat::Auto:
+    case Auto:
       break;
   }
 

--- a/dart/math/lcp/lcp_types.cpp
+++ b/dart/math/lcp/lcp_types.cpp
@@ -39,19 +39,20 @@ namespace math {
 std::string toString(LcpSolverStatus status)
 {
   switch (status) {
-    case LcpSolverStatus::Success:
+    using enum LcpSolverStatus;
+    case Success:
       return "Success";
-    case LcpSolverStatus::Failed:
+    case Failed:
       return "Failed";
-    case LcpSolverStatus::MaxIterations:
+    case MaxIterations:
       return "MaxIterations";
-    case LcpSolverStatus::NumericalError:
+    case NumericalError:
       return "NumericalError";
-    case LcpSolverStatus::InvalidProblem:
+    case InvalidProblem:
       return "InvalidProblem";
-    case LcpSolverStatus::Degenerate:
+    case Degenerate:
       return "Degenerate";
-    case LcpSolverStatus::NotSolved:
+    case NotSolved:
       return "NotSolved";
     default:
       return "Unknown";

--- a/dart/utils/xml_helpers.cpp
+++ b/dart/utils/xml_helpers.cpp
@@ -611,43 +611,44 @@ tinyxml2::XMLElement* getElement(
 std::string toString(tinyxml2::XMLError errorCode)
 {
   switch (errorCode) {
-    case tinyxml2::XMLError::XML_SUCCESS:
+    using enum tinyxml2::XMLError;
+    case XML_SUCCESS:
       return "XML_SUCCESS";
-    case tinyxml2::XMLError::XML_NO_ATTRIBUTE:
+    case XML_NO_ATTRIBUTE:
       return "XML_NO_ATTRIBUTE";
-    case tinyxml2::XMLError::XML_WRONG_ATTRIBUTE_TYPE:
+    case XML_WRONG_ATTRIBUTE_TYPE:
       return "XML_WRONG_ATTRIBUTE_TYPE";
-    case tinyxml2::XMLError::XML_ERROR_FILE_NOT_FOUND:
+    case XML_ERROR_FILE_NOT_FOUND:
       return "XML_ERROR_FILE_NOT_FOUND";
-    case tinyxml2::XMLError::XML_ERROR_FILE_COULD_NOT_BE_OPENED:
+    case XML_ERROR_FILE_COULD_NOT_BE_OPENED:
       return "XML_ERROR_FILE_COULD_NOT_BE_OPENED";
-    case tinyxml2::XMLError::XML_ERROR_FILE_READ_ERROR:
+    case XML_ERROR_FILE_READ_ERROR:
       return "XML_ERROR_FILE_READ_ERROR";
-    case tinyxml2::XMLError::XML_ERROR_PARSING_ELEMENT:
+    case XML_ERROR_PARSING_ELEMENT:
       return "XML_ERROR_PARSING_ELEMENT";
-    case tinyxml2::XMLError::XML_ERROR_PARSING_ATTRIBUTE:
+    case XML_ERROR_PARSING_ATTRIBUTE:
       return "XML_ERROR_PARSING_ATTRIBUTE";
-    case tinyxml2::XMLError::XML_ERROR_PARSING_TEXT:
+    case XML_ERROR_PARSING_TEXT:
       return "XML_ERROR_PARSING_TEXT";
-    case tinyxml2::XMLError::XML_ERROR_PARSING_CDATA:
+    case XML_ERROR_PARSING_CDATA:
       return "XML_ERROR_PARSING_CDATA";
-    case tinyxml2::XMLError::XML_ERROR_PARSING_COMMENT:
+    case XML_ERROR_PARSING_COMMENT:
       return "XML_ERROR_PARSING_COMMENT";
-    case tinyxml2::XMLError::XML_ERROR_PARSING_DECLARATION:
+    case XML_ERROR_PARSING_DECLARATION:
       return "XML_ERROR_PARSING_DECLARATION";
-    case tinyxml2::XMLError::XML_ERROR_PARSING_UNKNOWN:
+    case XML_ERROR_PARSING_UNKNOWN:
       return "XML_ERROR_PARSING_UNKNOWN";
-    case tinyxml2::XMLError::XML_ERROR_EMPTY_DOCUMENT:
+    case XML_ERROR_EMPTY_DOCUMENT:
       return "XML_ERROR_EMPTY_DOCUMENT";
-    case tinyxml2::XMLError::XML_ERROR_MISMATCHED_ELEMENT:
+    case XML_ERROR_MISMATCHED_ELEMENT:
       return "XML_ERROR_MISMATCHED_ELEMENT";
-    case tinyxml2::XMLError::XML_ERROR_PARSING:
+    case XML_ERROR_PARSING:
       return "XML_ERROR_PARSING";
-    case tinyxml2::XMLError::XML_CAN_NOT_CONVERT_TEXT:
+    case XML_CAN_NOT_CONVERT_TEXT:
       return "XML_CAN_NOT_CONVERT_TEXT";
-    case tinyxml2::XMLError::XML_NO_TEXT_NODE:
+    case XML_NO_TEXT_NODE:
       return "XML_NO_TEXT_NODE";
-    case tinyxml2::XMLError::XML_ERROR_COUNT:
+    case XML_ERROR_COUNT:
       return "XML_ERROR_COUNT";
     default:
       return "Unknown error";

--- a/examples/unified_loading/main.cpp
+++ b/examples/unified_loading/main.cpp
@@ -75,15 +75,16 @@ std::string toLower(std::string_view value)
 const char* formatToString(dart::io::ModelFormat format)
 {
   switch (format) {
-    case dart::io::ModelFormat::Auto:
+    using enum dart::io::ModelFormat;
+    case Auto:
       return "auto";
-    case dart::io::ModelFormat::Skel:
+    case Skel:
       return "skel";
-    case dart::io::ModelFormat::Sdf:
+    case Sdf:
       return "sdf";
-    case dart::io::ModelFormat::Urdf:
+    case Urdf:
       return "urdf";
-    case dart::io::ModelFormat::Mjcf:
+    case Mjcf:
       return "mjcf";
   }
   return "unknown";
@@ -92,9 +93,10 @@ const char* formatToString(dart::io::ModelFormat format)
 const char* rootJointTypeToString(dart::io::RootJointType type)
 {
   switch (type) {
-    case dart::io::RootJointType::Floating:
+    using enum dart::io::RootJointType;
+    case Floating:
       return "floating";
-    case dart::io::RootJointType::Fixed:
+    case Fixed:
       return "fixed";
   }
   return "unknown";


### PR DESCRIPTION
## Summary

- Adopt C++20 `using enum` in enum-heavy switch helpers across IO, dynamics, math, XML, and the unified loading example.

## Motivation / Problem

- Repeated scoped enum qualifiers make dense switch helpers harder to scan now that the project builds as C++20.

## Changes / Key Changes

- Use function- or switch-local `using enum` declarations for `ModelFormat`, `RootJointType`, `MemoryManager::Type`, `Resource::SeekType`, `LcpSolverStatus`, `PlaneType`, `AxisOrder`, and `tinyxml2::XMLError`.
- Keep behavior unchanged while reducing qualified case-label noise.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption for DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
