### PR TITLE
Adopt C++20 ranges in mesh helpers

### DIFF
--- a/dart/math/detail/geometry-impl.hpp
+++ b/dart/math/detail/geometry-impl.hpp
@@ -36,7 +36,10 @@
 #include <dart/math/detail/convhull.hpp>
 #include <dart/math/geometry.hpp>
 
+#include <ranges>
 #include <unordered_map>
+
+#include <cstddef>
 
 namespace dart {
 namespace math {
@@ -60,13 +63,13 @@ discardUnusedVertices(
       Eigen::aligned_allocator<Eigen::Matrix<Index, 3, 1>>>();
   newTriangles.resize(triangles.size());
   auto indexMap = std::unordered_map<Index, Index>();
-  auto newIndex = 0;
+  auto newIndex = Index{0};
 
-  for (auto i = 0u; i < triangles.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, triangles.size())) {
     const auto& triangle = triangles[i];
     auto& newTriangle = newTriangles[i];
 
-    for (auto j = 0u; j < 3; ++j) {
+    for (const auto j : std::views::iota(0, 3)) {
       const auto result
           = indexMap.insert(std::make_pair(triangle[j], newIndex));
       const bool& inserted = result.second;

--- a/dart/math/detail/polygon_mesh-impl.hpp
+++ b/dart/math/detail/polygon_mesh-impl.hpp
@@ -36,7 +36,9 @@
 #include <dart/math/polygon_mesh.hpp>
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
+#include <ranges>
 #include <span>
 #include <utility>
 
@@ -165,15 +167,15 @@ bool triangulateFaceEarClipping(
   }
   const bool isCCW = area2 > 0.0;
 
-  std::vector<std::size_t> polygon(count);
-  for (std::size_t i = 0; i < count; ++i) {
-    polygon[i] = i;
-  }
+  std::vector<std::size_t> polygon;
+  polygon.reserve(count);
+  std::ranges::copy(
+      std::views::iota(std::size_t{0}, count), std::back_inserter(polygon));
 
   bool removedColinear = true;
   while (removedColinear && polygon.size() > 3) {
     removedColinear = false;
-    for (std::size_t i = 0; i < polygon.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, polygon.size())) {
       const std::size_t prev
           = polygon[(i + polygon.size() - 1) % polygon.size()];
       const std::size_t curr = polygon[i];
@@ -217,7 +219,7 @@ bool triangulateFaceEarClipping(
 
   while (polygon.size() > 3 && iterations < maxIterations) {
     bool earFound = false;
-    for (std::size_t i = 0; i < polygon.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, polygon.size())) {
       const std::size_t prev
           = polygon[(i + polygon.size() - 1) % polygon.size()];
       const std::size_t curr = polygon[i];
@@ -227,17 +229,13 @@ bool triangulateFaceEarClipping(
         continue;
       }
 
-      bool hasInteriorPoint = false;
-      for (std::size_t j = 0; j < polygon.size(); ++j) {
-        const std::size_t idx = polygon[j];
-        if (idx == prev || idx == curr || idx == next) {
-          continue;
-        }
-        if (containsPoint(prev, curr, next, idx)) {
-          hasInteriorPoint = true;
-          break;
-        }
-      }
+      const bool hasInteriorPoint
+          = std::ranges::any_of(polygon, [&](std::size_t idx) {
+              if (idx == prev || idx == curr || idx == next) {
+                return false;
+              }
+              return containsPoint(prev, curr, next, idx);
+            });
       if (hasInteriorPoint) {
         continue;
       }
@@ -408,7 +406,7 @@ typename PolygonMesh<S>::TriMeshType PolygonMesh<S>::triangulate() const
             std::span<const Vector3>{this->mVertices},
             triangles)) {
       const Index v0 = face[0];
-      for (std::size_t i = 1; i + 1 < face.size(); ++i) {
+      for (const auto i : std::views::iota(std::size_t{1}, face.size() - 1)) {
         triMesh.addTriangle(v0, face[i], face[i + 1]);
       }
       continue;

--- a/dart/math/detail/tri_mesh-impl.hpp
+++ b/dart/math/detail/tri_mesh-impl.hpp
@@ -38,7 +38,11 @@
 
 #include <Eigen/Geometry>
 
+#include <algorithm>
+#include <ranges>
 #include <span>
+
+#include <cstddef>
 
 namespace dart {
 namespace math {
@@ -133,8 +137,8 @@ void TriMesh<S>::computeVertexNormals()
   this->mVertexNormals.clear();
   this->mVertexNormals.resize(this->mVertices.size(), Vector3::Zero());
 
-  for (auto i = 0u; i < mTriangles.size(); ++i) {
-    auto& triangle = mTriangles[i];
+  for (const auto i : std::views::iota(std::size_t{0}, mTriangles.size())) {
+    const auto& triangle = mTriangles[i];
     this->mVertexNormals[triangle[0]] += mTriangleNormals[i];
     this->mVertexNormals[triangle[1]] += mTriangleNormals[i];
     this->mVertexNormals[triangle[2]] += mTriangleNormals[i];
@@ -213,9 +217,10 @@ TriMesh<S>& TriMesh<S>::operator+=(const TriMesh& other)
 
   const Triangle offset = Triangle::Constant(oldNumVertices);
   mTriangles.resize(mTriangles.size() + other.mTriangles.size());
-  for (auto i = 0u; i < other.mTriangles.size(); ++i) {
-    mTriangles[i + oldNumTriangles] = other.mTriangles[i] + offset;
-  }
+  std::ranges::transform(
+      other.mTriangles,
+      mTriangles.begin() + static_cast<std::ptrdiff_t>(oldNumTriangles),
+      [&](const Triangle& triangle) { return triangle + offset; });
 
   return *this;
 }
@@ -243,14 +248,14 @@ void TriMesh<S>::computeTriangleNormals()
 {
   mTriangleNormals.resize(mTriangles.size());
 
-  for (auto i = 0u; i < mTriangles.size(); ++i) {
-    auto& triangle = mTriangles[i];
-    const Vector3 v01
-        = this->mVertices[triangle[1]] - this->mVertices[triangle[0]];
-    const Vector3 v02
-        = this->mVertices[triangle[2]] - this->mVertices[triangle[0]];
-    mTriangleNormals[i] = v01.cross(v02);
-  }
+  std::ranges::transform(
+      mTriangles, mTriangleNormals.begin(), [&](const Triangle& triangle) {
+        const Vector3 v01
+            = this->mVertices[triangle[1]] - this->mVertices[triangle[0]];
+        const Vector3 v02
+            = this->mVertices[triangle[2]] - this->mVertices[triangle[0]];
+        return v01.cross(v02);
+      });
 
   normalizeTriangleNormals();
 }


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges algorithms and views in math mesh helpers.

## Motivation / Problem

- Continue the DART 7.0 C++20 cleanup by replacing small hand-written index and transform loops with standard library facilities where they preserve the existing behavior.

## Changes / Key Changes

- Use `std::views::iota` for mesh index iteration.
- Use `std::ranges::transform` for triangle offsetting and normal generation.
- Use `std::ranges::copy` and `std::ranges::any_of` in polygon triangulation helpers.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable