### PR TITLE
Adopt C++20 ranges in collision constraints

### DIFF
--- a/dart/collision/dart/dart_collision_detector.cpp
+++ b/dart/collision/dart/dart_collision_detector.cpp
@@ -43,6 +43,10 @@
 #include "dart/dynamics/shape_frame.hpp"
 #include "dart/dynamics/sphere_shape.hpp"
 
+#include <ranges>
+
+#include <cstddef>
+
 namespace dart {
 namespace collision {
 
@@ -151,10 +155,10 @@ bool DARTCollisionDetector::collide(
   auto collisionFound = false;
   const auto& filter = option.collisionFilter;
 
-  for (auto i = 0u; i < objects.size() - 1; ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, objects.size() - 1)) {
     auto* collObj1 = objects[i];
 
-    for (auto j = i + 1u; j < objects.size(); ++j) {
+    for (const auto j : std::views::iota(i + 1, objects.size())) {
       auto* collObj2 = objects[j];
 
       if (filter && filter->ignoresCollision(collObj1, collObj2)) [[unlikely]] {
@@ -219,12 +223,8 @@ bool DARTCollisionDetector::collide(
   auto collisionFound = false;
   const auto& filter = option.collisionFilter;
 
-  for (auto i = 0u; i < objects1.size(); ++i) {
-    auto* collObj1 = objects1[i];
-
-    for (auto j = 0u; j < objects2.size(); ++j) {
-      auto* collObj2 = objects2[j];
-
+  for (auto* collObj1 : objects1) {
+    for (auto* collObj2 : objects2) {
       if (filter && filter->ignoresCollision(collObj1, collObj2)) {
         continue;
       }

--- a/dart/collision/fcl/fcl_collision_detector.cpp
+++ b/dart/collision/fcl/fcl_collision_detector.cpp
@@ -60,6 +60,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <ranges>
 #include <string>
 
 #include <cstdint>
@@ -552,9 +553,10 @@ template <typename BV>
   faces[4].set(1, 3, 2);
   faces[5].set(1, 4, 3);
 
-  for (unsigned int i = 0; i < points.size(); ++i) {
-    points[i] = pose * points[i];
-  }
+  std::ranges::transform(
+      points, points.begin(), [&](const fcl::Vector3& point) {
+        return pose * point;
+      });
 
   model->beginModel();
   model->addSubModel(points, faces);

--- a/dart/constraint/constraint_solver.cpp
+++ b/dart/constraint/constraint_solver.cpp
@@ -61,7 +61,9 @@
 #include <fmt/ostream.h>
 
 #include <algorithm>
+#include <iterator>
 #include <memory>
+#include <ranges>
 
 #include <cmath>
 
@@ -762,14 +764,17 @@ void ConstraintSolver::solvePositionConstrainedGroups()
   // Preserve velocity-impulse flags across the position pass.
   mImpulseAppliedStates.clear();
   mImpulseAppliedStates.reserve(mSkeletons.size());
-  for (const auto& skeleton : mSkeletons) {
-    mImpulseAppliedStates.push_back(skeleton->isImpulseApplied());
-  }
+  std::ranges::copy(
+      mSkeletons | std::views::transform([](const auto& skeleton) {
+        return skeleton->isImpulseApplied();
+      }),
+      std::back_inserter(mImpulseAppliedStates));
 
   for (auto& constraintGroup : mConstrainedGroups) {
     mPositionConstraints.clear();
     mPositionConstraints.reserve(constraintGroup.getNumConstraints());
-    for (std::size_t i = 0; i < constraintGroup.getNumConstraints(); ++i) {
+    for (const auto i : std::views::iota(
+             std::size_t{0}, constraintGroup.getNumConstraints())) {
       const ConstraintBasePtr& constraint = constraintGroup.getConstraint(i);
       if (std::dynamic_pointer_cast<ContactConstraint>(constraint)) {
         mPositionConstraints.push_back(constraint);
@@ -786,7 +791,7 @@ void ConstraintSolver::solvePositionConstrainedGroups()
     }
   }
 
-  for (std::size_t i = 0; i < mSkeletons.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, mSkeletons.size())) {
     mSkeletons[i]->setImpulseApplied(mImpulseAppliedStates[i]);
   }
 }

--- a/dart/constraint/soft_contact_constraint.cpp
+++ b/dart/constraint/soft_contact_constraint.cpp
@@ -45,8 +45,10 @@
 #include "dart/math/helpers.hpp"
 
 #include <iostream>
+#include <ranges>
 
 #include <cmath>
+#include <cstddef>
 
 #define DART_EPSILON 1e-6
 #define DART_ERROR_ALLOWANCE 0.0
@@ -195,7 +197,7 @@ SoftContactConstraint::SoftContactConstraint(
     Eigen::Vector3d bodyPoint1;
     Eigen::Vector3d bodyPoint2;
 
-    for (std::size_t i = 0; i < mContacts.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, mContacts.size())) {
       collision::Contact* ct = mContacts[i];
 
       // TODO(JS): Assumed that the number of tangent basis is 2.
@@ -284,7 +286,7 @@ SoftContactConstraint::SoftContactConstraint(
     Eigen::Vector3d bodyPoint1;
     Eigen::Vector3d bodyPoint2;
 
-    for (std::size_t i = 0; i < mContacts.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, mContacts.size())) {
       collision::Contact* ct = mContacts[i];
 
       bodyDirection1.noalias()
@@ -445,7 +447,7 @@ void SoftContactConstraint::getInformation(ConstraintInfo* _info)
   //----------------------------------------------------------------------------
   if (mIsFrictionOn) {
     std::size_t index = 0;
-    for (std::size_t i = 0; i < mContacts.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, mContacts.size())) {
       // Bias term, w, should be zero
       DART_ASSERT(_info->w[index] == 0.0);
       DART_ASSERT(_info->w[index + 1] == 0.0);
@@ -523,7 +525,7 @@ void SoftContactConstraint::getInformation(ConstraintInfo* _info)
   // Frictionless case
   //----------------------------------------------------------------------------
   else {
-    for (std::size_t i = 0; i < mContacts.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, mContacts.size())) {
       // Bias term, w, should be zero
       _info->w[i] = 0.0;
 
@@ -719,7 +721,7 @@ void SoftContactConstraint::applyImpulse(double* _lambda)
   if (mIsFrictionOn) {
     std::size_t index = 0;
 
-    for (std::size_t i = 0; i < mContacts.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, mContacts.size())) {
       //      std::cout << "_lambda1: " << _lambda[_idx] << std::endl;
       //      std::cout << "_lambda2: " << _lambda[_idx + 1] << std::endl;
       //      std::cout << "_lambda3: " << _lambda[_idx + 2] << std::endl;
@@ -816,7 +818,7 @@ void SoftContactConstraint::applyImpulse(double* _lambda)
   // Frictionless case
   //----------------------------------------------------------------------------
   else {
-    for (std::size_t i = 0; i < mContacts.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, mContacts.size())) {
       // Normal impulsive force
       //			pContactPts[i]->lambda[0] = _lambda[i];
 


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges utilities in collision and constraint internals.

## Motivation / Problem

- Continue the DART 7.0 C++20 cleanup by replacing manual index and transform loops in collision/constraint code with standard library ranges facilities where the behavior stays unchanged.

## Changes / Key Changes

- Use `std::views::iota` for indexed DART collision-pair traversal and soft-contact contact loops.
- Simplify cross-group DART collision traversal with direct range iteration.
- Use `std::ranges::transform` for FCL pyramid point transforms.
- Use a transform view and `std::ranges::copy` when preserving skeleton impulse flags across the position-constraint pass.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable