### PR TITLE
Adopt C++20 ranges in GUI render helpers

### DIFF
--- a/dart/gui/im_gui_handler.cpp
+++ b/dart/gui/im_gui_handler.cpp
@@ -47,8 +47,10 @@
 #include <osg/RenderInfo>
 
 #include <algorithm>
+#include <ranges>
 
 #include <cmath>
+#include <cstddef>
 
 namespace dart {
 namespace gui {
@@ -668,7 +670,7 @@ void ImGuiHandler::newFrame(::osg::RenderInfo& renderInfo)
   mTime = currentTime;
   DART_ASSERT(mTime >= 0.0);
 
-  for (auto i = 0u; i < mMousePressed.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, mMousePressed.size())) {
     io.MouseDown[i] = mMousePressed[i];
   }
 

--- a/dart/gui/render/line_segment_shape_node.cpp
+++ b/dart/gui/render/line_segment_shape_node.cpp
@@ -44,6 +44,10 @@
 #include <osg/LineWidth>
 #include <osg/ShapeDrawable>
 
+#include <ranges>
+
+#include <cstddef>
+
 namespace dart {
 namespace gui {
 
@@ -213,8 +217,7 @@ void LineSegmentShapeDrawable::refresh(bool firstTime)
     mElements->clear();
     mElements->reserve(2 * connections.size());
 
-    for (std::size_t i = 0; i < connections.size(); ++i) {
-      const Eigen::Vector2i& c = connections[i];
+    for (const Eigen::Vector2i& c : connections) {
       mElements->push_back(static_cast<unsigned int>(c[0]));
       mElements->push_back(static_cast<unsigned int>(c[1]));
     }
@@ -233,7 +236,7 @@ void LineSegmentShapeDrawable::refresh(bool firstTime)
       mVertices->resize(vertices.size());
     }
 
-    for (std::size_t i = 0; i < vertices.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, vertices.size())) {
       (*mVertices)[i] = eigToOsgVec3(vertices[i]);
     }
 

--- a/dart/gui/render/multi_sphere_shape_node.cpp
+++ b/dart/gui/render/multi_sphere_shape_node.cpp
@@ -45,6 +45,10 @@
 #include <osg/Light>
 #include <osg/Material>
 
+#include <ranges>
+
+#include <cstddef>
+
 namespace dart {
 namespace gui {
 
@@ -233,7 +237,7 @@ void MultiSphereShapeDrawable::refresh(bool firstTime)
     // Convert the convex hull to OSG data types
     mVertices->resize(meshVertices.size());
     mNormals->resize(meshVertices.size());
-    for (auto i = 0u; i < meshVertices.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, meshVertices.size())) {
       const auto& v = meshVertices[i];
       const auto& n = meshNormals[i];
       (*mVertices)[i] = ::osg::Vec3(v[0], v[1], v[2]);
@@ -245,7 +249,8 @@ void MultiSphereShapeDrawable::refresh(bool firstTime)
     ::osg::ref_ptr<::osg::DrawElementsUInt> drawElements
         = new ::osg::DrawElementsUInt(GL_TRIANGLES);
     drawElements->resize(3 * meshTriangles.size());
-    for (auto i = 0u; i < meshTriangles.size(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, meshTriangles.size())) {
       const auto& triangle = meshTriangles[i];
       (*drawElements)[3 * i] = triangle[0];
       (*drawElements)[3 * i + 1] = triangle[1];

--- a/dart/gui/render/point_cloud_shape_node.cpp
+++ b/dart/gui/render/point_cloud_shape_node.cpp
@@ -47,7 +47,10 @@
 #include <osg/ShapeDrawable>
 #include <osg/Texture2D>
 
+#include <ranges>
 #include <span>
+
+#include <cstddef>
 
 namespace dart {
 namespace gui {
@@ -484,7 +487,7 @@ public:
         = shouldUseVisualAspectColor(points, colors, colorMode);
 
     mVertices->resize(points.size());
-    for (auto i = 0u; i < points.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, points.size())) {
       const auto& point = points[i];
       mVertices->at(i).set(
           static_cast<float>(point.x()),
@@ -513,7 +516,7 @@ public:
       mGeometry->setColorArray(mColors, ::osg::Array::BIND_OVERALL);
     } else if (colorMode == dynamics::PointCloudShape::BIND_PER_POINT) {
       mColors->resize(colors.size());
-      for (auto i = 0u; i < colors.size(); ++i) {
+      for (const auto i : std::views::iota(std::size_t{0}, colors.size())) {
         const auto& color = colors[i];
         mColors->at(i).set(
             static_cast<float>(color[0]),

--- a/dart/gui/support_polygon_visual.cpp
+++ b/dart/gui/support_polygon_visual.cpp
@@ -39,6 +39,10 @@
 #include "dart/dynamics/sphere_shape.hpp"
 #include "dart/math/helpers.hpp"
 
+#include <ranges>
+
+#include <cstddef>
+
 namespace dart {
 namespace gui {
 
@@ -259,7 +263,7 @@ void SupportPolygonVisual::refresh()
   if (mDisplayPolygon) {
     mVertices->resize(poly.size());
     mFaces->resize(poly.size());
-    for (std::size_t i = 0; i < poly.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, poly.size())) {
       const Eigen::Vector3d& v = axes.first * poly[i][0]
                                  + axes.second * poly[i][1] + up * mElevation;
       (*mVertices)[i] = ::osg::Vec3(v[0], v[1], v[2]);
@@ -307,8 +311,7 @@ void SupportPolygonVisual::refresh()
       const auto bns = skel->getTreeBodyNodes(mTreeIndex);
 
       double mass = 0.0;
-      for (std::size_t i = 0; i < bns.size(); ++i) {
-        dart::dynamics::BodyNode* bn = bns[i];
+      for (dart::dynamics::BodyNode* bn : bns) {
         com += bn->getMass() * bn->getCOM();
         mass += bn->getMass();
       }


### PR DESCRIPTION
## Summary

- Adopt C++20 range-based iteration in selected GUI and render helper loops.

## Motivation / Problem

- Continue simplifying DART 7.0 internals with standard C++20 facilities where they preserve behavior and reduce manual index/control-flow boilerplate.

## Changes / Key Changes

- Use `std::views::iota` for index-based updates that write to parallel GUI/render arrays.
- Replace manual index loops with range-for loops where the index was unused.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
