### PR TITLE
Adopt C++20 ranges in remaining LCP solvers

### DIFF
--- a/dart/math/lcp/newton/boxed_semi_smooth_newton_solver.cpp
+++ b/dart/math/lcp/newton/boxed_semi_smooth_newton_solver.cpp
@@ -37,6 +37,7 @@
 #include <Eigen/Cholesky>
 
 #include <algorithm>
+#include <ranges>
 
 #include <cmath>
 
@@ -83,7 +84,7 @@ Eigen::VectorXd projectVector(
     const Eigen::VectorXd& hi)
 {
   Eigen::VectorXd result(x.size());
-  for (Eigen::Index i = 0; i < x.size(); ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, x.size())) {
     result[i] = project(x[i], lo[i], hi[i]);
   }
   return result;
@@ -170,7 +171,7 @@ LcpResult BoxedSemiSmoothNewtonSolver::solve(
 
   Eigen::VectorXd loEff = lo;
   Eigen::VectorXd hiEff = hi;
-  for (Eigen::Index i = 0; i < n; ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
     if (findex[i] >= 0) {
       loEff[i] = -std::numeric_limits<double>::infinity();
       hiEff[i] = std::numeric_limits<double>::infinity();
@@ -193,10 +194,10 @@ LcpResult BoxedSemiSmoothNewtonSolver::solve(
   bool converged = false;
   bool lineSearchFailed = false;
 
-  for (int iter = 0; iter < maxIterations; ++iter) {
+  for ([[maybe_unused]] const auto iter : std::views::iota(0, maxIterations)) {
     ++iterationsUsed;
 
-    for (Eigen::Index i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
       if (findex[i] >= 0) {
         const double fricLimit = std::abs(hi[i] * x[findex[i]]);
         loEff[i] = -fricLimit;
@@ -214,7 +215,7 @@ LcpResult BoxedSemiSmoothNewtonSolver::solve(
     }
 
     J.setZero();
-    for (Eigen::Index i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
       const double candidate = x[i] - w[i];
       const ConstraintState state
           = classifyPoint(candidate, w[i], loEff[i], hiEff[i], absTol);
@@ -225,7 +226,7 @@ LcpResult BoxedSemiSmoothNewtonSolver::solve(
           J(i, i) = 1.0;
           break;
         case ConstraintState::Interior:
-          for (Eigen::Index j = 0; j < n; ++j) {
+          for (const auto j : std::views::iota(Eigen::Index{0}, n)) {
             J(i, j) = A(i, j);
           }
           break;
@@ -254,7 +255,7 @@ LcpResult BoxedSemiSmoothNewtonSolver::solve(
     for (int ls = 0; ls < params->maxLineSearchSteps; ++ls) {
       Eigen::VectorXd xNew = projectVector(x + alpha * dx, loEff, hiEff);
 
-      for (Eigen::Index i = 0; i < n; ++i) {
+      for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
         if (findex[i] >= 0) {
           const double fricLimit = std::abs(hi[i] * xNew[findex[i]]);
           loEff[i] = -fricLimit;
@@ -287,7 +288,7 @@ LcpResult BoxedSemiSmoothNewtonSolver::solve(
     }
   }
 
-  for (Eigen::Index i = 0; i < n; ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
     if (findex[i] >= 0) {
       const double fricLimit = std::abs(hi[i] * x[findex[i]]);
       loEff[i] = -fricLimit;

--- a/dart/math/lcp/newton/minimum_map_newton_solver.cpp
+++ b/dart/math/lcp/newton/minimum_map_newton_solver.cpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+#include <ranges>
 #include <vector>
 
 namespace dart::math {
@@ -157,7 +158,7 @@ LcpResult MinimumMapNewtonSolver::solve(
   Eigen::VectorXd H(n);
   Eigen::VectorXd dx(n);
 
-  for (int iter = 0; iter < maxIterations; ++iter) {
+  for ([[maybe_unused]] const auto iter : std::views::iota(0, maxIterations)) {
     iterationsUsed = iter + 1;
 
     y = A * x - b;
@@ -180,7 +181,7 @@ LcpResult MinimumMapNewtonSolver::solve(
     active.reserve(static_cast<std::size_t>(n));
     freeSet.reserve(static_cast<std::size_t>(n));
 
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(0, static_cast<int>(n))) {
       if (y[i] < x[i]) {
         active.push_back(i);
       } else {
@@ -201,18 +202,18 @@ LcpResult MinimumMapNewtonSolver::solve(
       Eigen::VectorXd rhs(aSize);
       Eigen::VectorXd dxF(fSize);
 
-      for (int r = 0; r < aSize; ++r) {
+      for (const auto r : std::views::iota(0, static_cast<int>(aSize))) {
         const int i = active[r];
         rhs[r] = -y[i];
-        for (int c = 0; c < aSize; ++c) {
+        for (const auto c : std::views::iota(0, static_cast<int>(aSize))) {
           A_AA(r, c) = A(i, active[c]);
         }
-        for (int c = 0; c < fSize; ++c) {
+        for (const auto c : std::views::iota(0, static_cast<int>(fSize))) {
           A_AF(r, c) = A(i, freeSet[c]);
         }
       }
 
-      for (int c = 0; c < fSize; ++c) {
+      for (const auto c : std::views::iota(0, static_cast<int>(fSize))) {
         dxF[c] = dx[freeSet[c]];
       }
 
@@ -225,7 +226,7 @@ LcpResult MinimumMapNewtonSolver::solve(
         return result;
       }
 
-      for (int r = 0; r < aSize; ++r) {
+      for (const auto r : std::views::iota(0, static_cast<int>(aSize))) {
         dx[active[r]] = dxA[r];
       }
     }

--- a/dart/math/lcp/other/admm_solver.cpp
+++ b/dart/math/lcp/other/admm_solver.cpp
@@ -37,6 +37,7 @@
 #include <Eigen/Cholesky>
 
 #include <algorithm>
+#include <ranges>
 
 #include <cmath>
 
@@ -141,7 +142,7 @@ LcpResult AdmmSolver::solve(
 
     // z-update: z = clamp(x + y/rho, lo, hi) with findex handling
     Eigen::VectorXd xTilde = x + y / rho;
-    for (Eigen::Index i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
       double loVal = lo[i];
       double hiVal = hi[i];
       if (findex[i] >= 0) {

--- a/dart/math/lcp/other/mprgp_solver.cpp
+++ b/dart/math/lcp/other/mprgp_solver.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -240,13 +241,17 @@ LcpResult MprgpSolver::solve(
   std::vector<int> activePrev(n, 0);
   bool resetDirection = true;
 
-  for (int iter = 0; iter < maxIterations && !converged; ++iter) {
+  for (const auto iter : std::views::iota(0, maxIterations)) {
+    if (converged) {
+      break;
+    }
+
     iterationsUsed = iter + 1;
 
     w = A * x - b;
     pg = w;
 
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(0, static_cast<int>(n))) {
       if (x[i] <= 0.0 && w[i] > 0.0) {
         active[i] = 1;
         x[i] = 0.0;
@@ -274,7 +279,7 @@ LcpResult MprgpSolver::solve(
       p = -pg + beta * pPrev;
     }
 
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(0, static_cast<int>(n))) {
       if (active[i]) {
         p[i] = 0.0;
       }
@@ -301,7 +306,7 @@ LcpResult MprgpSolver::solve(
     }
 
     double alphaMax = std::numeric_limits<double>::infinity();
-    for (int i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(0, static_cast<int>(n))) {
       if (p[i] < 0.0) {
         alphaMax = std::min(alphaMax, -x[i] / p[i]);
       }

--- a/dart/math/lcp/other/sap_solver.cpp
+++ b/dart/math/lcp/other/sap_solver.cpp
@@ -37,6 +37,7 @@
 #include <Eigen/Cholesky>
 
 #include <algorithm>
+#include <ranges>
 
 #include <cmath>
 
@@ -51,7 +52,7 @@ double computeBarrierCost(
     double reg)
 {
   double cost = 0.0;
-  for (Eigen::Index i = 0; i < x.size(); ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, x.size())) {
     if (x[i] < lo[i]) {
       const double diff = lo[i] - x[i];
       cost += 0.5 * diff * diff / reg;
@@ -70,7 +71,7 @@ void computeBarrierGradient(
     double reg,
     Eigen::VectorXd& grad)
 {
-  for (Eigen::Index i = 0; i < x.size(); ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, x.size())) {
     if (x[i] < lo[i]) {
       grad[i] += (x[i] - lo[i]) / reg;
     } else if (x[i] > hi[i]) {
@@ -86,7 +87,7 @@ void addBarrierHessianDiagonal(
     double reg,
     Eigen::VectorXd& diagAdd)
 {
-  for (Eigen::Index i = 0; i < x.size(); ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, x.size())) {
     if (x[i] < lo[i] || x[i] > hi[i]) {
       diagAdd[i] += 1.0 / reg;
     }
@@ -165,7 +166,7 @@ LcpResult SapSolver::solve(
 
   Eigen::VectorXd loEff = lo;
   Eigen::VectorXd hiEff = hi;
-  for (Eigen::Index i = 0; i < n; ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
     if (findex[i] >= 0) {
       loEff[i] = -std::numeric_limits<double>::infinity();
       hiEff[i] = std::numeric_limits<double>::infinity();
@@ -178,7 +179,7 @@ LcpResult SapSolver::solve(
     x.setZero();
   }
 
-  for (Eigen::Index i = 0; i < n; ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
     x[i] = std::clamp(x[i], loEff[i], hiEff[i]);
   }
 
@@ -190,10 +191,10 @@ LcpResult SapSolver::solve(
   int iterationsUsed = 0;
   bool converged = false;
 
-  for (int iter = 0; iter < maxIterations; ++iter) {
+  for ([[maybe_unused]] const auto iter : std::views::iota(0, maxIterations)) {
     ++iterationsUsed;
 
-    for (Eigen::Index i = 0; i < n; ++i) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
       if (findex[i] >= 0) {
         const double fricLimit = std::abs(hi[i] * x[findex[i]]);
         loEff[i] = -fricLimit;
@@ -238,7 +239,7 @@ LcpResult SapSolver::solve(
     for (int ls = 0; ls < maxLs; ++ls) {
       xNew = x + alpha * dx;
 
-      for (Eigen::Index i = 0; i < n; ++i) {
+      for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
         if (findex[i] >= 0) {
           const double fricLimit = std::abs(hi[i] * xNew[findex[i]]);
           loEff[i] = -fricLimit;
@@ -259,7 +260,7 @@ LcpResult SapSolver::solve(
     x = x + alpha * dx;
   }
 
-  for (Eigen::Index i = 0; i < n; ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, n)) {
     if (findex[i] >= 0) {
       const double fricLimit = std::abs(hi[i] * x[findex[i]]);
       loEff[i] = -fricLimit;


### PR DESCRIPTION
## Summary

- Adopt C++20 range-based iteration in the remaining untouched LCP solver implementations.

## Motivation / Problem

- Continue simplifying DART 7.0 solver internals with standard C++20 facilities while avoiding overlap with the existing LCP-focused pull requests.

## Changes / Key Changes

- Use `std::views::iota` for Eigen-indexed loops in ADMM, SAP, and boxed semi-smooth Newton solvers.
- Use `std::views::iota` for active-set and matrix-copy loops in MPRGP and minimum-map Newton solvers.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
