### PR TITLE
Adopt C++20 ranges in dynamics core loops

### DIFF
--- a/dart/dynamics/group.cpp
+++ b/dart/dynamics/group.cpp
@@ -38,6 +38,8 @@
 #include "dart/dynamics/degree_of_freedom.hpp"
 #include "dart/dynamics/joint.hpp"
 
+#include <ranges>
+
 namespace dart {
 namespace dynamics {
 
@@ -280,7 +282,8 @@ bool Group::addComponent(BodyNode* _bn, bool _warning)
 
   added |= addBodyNode(_bn, false);
 
-  for (std::size_t i = 0; i < _bn->getParentJoint()->getNumDofs(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, _bn->getParentJoint()->getNumDofs())) {
     added |= addDof(_bn->getParentJoint()->getDof(i), false);
   }
 
@@ -328,7 +331,8 @@ bool Group::removeComponent(BodyNode* _bn, bool _warning)
 
   removed |= removeBodyNode(_bn, false);
 
-  for (std::size_t i = 0; i < _bn->getParentJoint()->getNumDofs(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, _bn->getParentJoint()->getNumDofs())) {
     removed |= removeDof(_bn->getParentJoint()->getDof(i), false);
   }
 
@@ -467,7 +471,8 @@ bool Group::addJoint(Joint* _joint, bool _addDofs, bool _warning)
   }
 
   if (_addDofs) {
-    for (std::size_t i = 0; i < _joint->getNumDofs(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, _joint->getNumDofs())) {
       added |= addDof(_joint->getDof(i), false, false);
     }
   }
@@ -533,7 +538,8 @@ bool Group::removeJoint(Joint* _joint, bool _removeDofs, bool _warning)
   }
 
   if (_removeDofs) {
-    for (std::size_t i = 0; i < _joint->getNumDofs(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, _joint->getNumDofs())) {
       removed |= removeDof(_joint->getDof(i), false, false);
     }
   }
@@ -667,7 +673,7 @@ bool Group::removeDof(DegreeOfFreedom* _dof, bool _cleanupJoint, bool _warning)
     // Check whether any DOFs belonging to the Joint are remaining in the Group
     bool performCleanup = true;
     Joint* joint = _dof->getJoint();
-    for (std::size_t i = 0; i < joint->getNumDofs(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, joint->getNumDofs())) {
       if (getIndexOf(joint->getDof(i), false) == INVALID_INDEX) {
         performCleanup = false;
         break;
@@ -727,15 +733,16 @@ Group::Group(
   addBodyNodes(bodyNodes);
 
   if (includeDofs || includeJoints) {
-    for (std::size_t i = 0; i < bodyNodes.size(); ++i) {
-      Joint* joint = bodyNodes[i]->getParentJoint();
+    for (BodyNode* bodyNode : bodyNodes) {
+      Joint* joint = bodyNode->getParentJoint();
 
       if (includeJoints) {
         addJoint(joint, false);
       }
 
       if (includeDofs) {
-        for (std::size_t j = 0; j < joint->getNumDofs(); ++j) {
+        for (const auto j :
+             std::views::iota(std::size_t{0}, joint->getNumDofs())) {
           addDof(joint->getDof(j));
         }
       }
@@ -754,8 +761,7 @@ Group::Group(
   addDofs(dofs, includeJoints);
 
   if (includeBodyNodes) {
-    for (std::size_t i = 0; i < dofs.size(); ++i) {
-      DegreeOfFreedom* dof = dofs[i];
+    for (DegreeOfFreedom* dof : dofs) {
       addBodyNode(dof->getChildBodyNode(), false);
     }
   }
@@ -767,15 +773,18 @@ Group::Group(const std::string& _name, const MetaSkeletonPtr& _metaSkeleton)
   setName(_name);
 
   if (_metaSkeleton) {
-    for (std::size_t i = 0; i < _metaSkeleton->getNumBodyNodes(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, _metaSkeleton->getNumBodyNodes())) {
       addBodyNode(_metaSkeleton->getBodyNode(i));
     }
 
-    for (std::size_t i = 0; i < _metaSkeleton->getNumJoints(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, _metaSkeleton->getNumJoints())) {
       addJoint(_metaSkeleton->getJoint(i), false);
     }
 
-    for (std::size_t i = 0; i < _metaSkeleton->getNumDofs(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, _metaSkeleton->getNumDofs())) {
       addDof(_metaSkeleton->getDof(i), false);
     }
   }

--- a/dart/dynamics/inertia.cpp
+++ b/dart/dynamics/inertia.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/logging.hpp"
 #include "dart/math/geometry.hpp"
 
+#include <ranges>
+
 namespace dart {
 namespace dynamics {
 
@@ -148,7 +150,7 @@ void Inertia::setMoment(const Eigen::Matrix3d& _moment)
       "Passing in an invalid moment of inertia matrix. Results might not by "
       "physically accurate or meaningful.");
 
-  for (std::size_t i = 0; i < 3; ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
     mMoment[i] = _moment(i, i);
   }
 
@@ -182,7 +184,7 @@ void Inertia::setMoment(
 Eigen::Matrix3d Inertia::getMoment() const
 {
   Eigen::Matrix3d I;
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : std::views::iota(0, 3)) {
     I(i, i) = mMoment[i];
   }
 
@@ -239,7 +241,7 @@ bool Inertia::verifyMoment(
     const Eigen::Matrix3d& _moment, bool _printWarnings, double _tolerance)
 {
   bool valid = true;
-  for (int i = 0; i < 3; ++i) {
+  for (const auto i : std::views::iota(0, 3)) {
     if (_moment(i, i) <= 0) {
       valid = false;
       DART_WARN_IF(
@@ -252,8 +254,8 @@ bool Inertia::verifyMoment(
     }
   }
 
-  for (int i = 0; i < 3; ++i) {
-    for (int j = i + 1; j < 3; ++j) {
+  for (const auto i : std::views::iota(0, 3)) {
+    for (const auto j : std::views::iota(i + 1, 3)) {
       if (std::abs(_moment(i, j) - _moment(j, i)) > _tolerance) {
         valid = false;
         DART_WARN_IF(
@@ -279,7 +281,7 @@ bool Inertia::verifySpatialTensor(
 {
   bool valid = true;
 
-  for (std::size_t i = 0; i < 6; ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{6})) {
     if (_spatial(i, i) <= 0) {
       valid = false;
       if (_printWarnings) {
@@ -296,8 +298,8 @@ bool Inertia::verifySpatialTensor(
   }
 
   // Off-diagonals of top left block
-  for (std::size_t i = 0; i < 3; ++i) {
-    for (std::size_t j = i + 1; j < 3; ++j) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
+    for (const auto j : std::views::iota(i + 1, std::size_t{3})) {
       if (std::abs(_spatial(i, j) - _spatial(j, i)) > _tolerance) {
         valid = false;
         DART_WARN(
@@ -314,8 +316,8 @@ bool Inertia::verifySpatialTensor(
   }
 
   // Off-diagonals of bottom right block
-  for (std::size_t i = 3; i < 6; ++i) {
-    for (std::size_t j = i + 1; j < 6; ++j) {
+  for (const auto i : std::views::iota(std::size_t{3}, std::size_t{6})) {
+    for (const auto j : std::views::iota(i + 1, std::size_t{6})) {
       if (_spatial(i, j) != 0) {
         valid = false;
         DART_WARN_IF(
@@ -339,8 +341,8 @@ bool Inertia::verifySpatialTensor(
   }
 
   // Diagonals of the bottom left and top right blocks
-  for (std::size_t k = 0; k < 2; ++k) {
-    for (std::size_t i = 0; i < 3; ++i) {
+  for (const auto k : std::views::iota(std::size_t{0}, std::size_t{2})) {
+    for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
       std::size_t i1 = k == 0 ? i + 3 : i;
       std::size_t i2 = k == 0 ? i : i + 3;
       if (_spatial(i1, i2) != 0) {
@@ -356,9 +358,9 @@ bool Inertia::verifySpatialTensor(
   }
 
   // Check skew-symmetry in bottom left and top right
-  for (std::size_t k = 0; k < 2; ++k) {
-    for (std::size_t i = 0; i < 3; ++i) {
-      for (std::size_t j = i + 1; j < 3; ++j) {
+  for (const auto k : std::views::iota(std::size_t{0}, std::size_t{2})) {
+    for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
+      for (const auto j : std::views::iota(i + 1, std::size_t{3})) {
         std::size_t i1 = k == 0 ? i + 3 : i;
         std::size_t j1 = k == 0 ? j : j + 3;
 
@@ -387,8 +389,8 @@ bool Inertia::verifySpatialTensor(
   // Note that we only need to check three of the components from each block,
   // because the last test ensures that both blocks are skew-symmetric
   // themselves
-  for (std::size_t i = 0; i < 3; ++i) {
-    for (std::size_t j = i + 1; j < 3; ++j) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
+    for (const auto j : std::views::iota(i + 1, std::size_t{3})) {
       std::size_t i1 = i;
       std::size_t j1 = j + 3;
 
@@ -456,7 +458,7 @@ void Inertia::computeParameters()
   mCenterOfMass[2] = -C(0, 1);
 
   Eigen::Matrix3d I = mSpatialTensor.block<3, 3>(0, 0) + mMass * C * C;
-  for (std::size_t i = 0; i < 3; ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
     mMoment[i] = I(i, i);
   }
 

--- a/dart/dynamics/point_mass.cpp
+++ b/dart/dynamics/point_mass.cpp
@@ -39,6 +39,8 @@
 #include "dart/math/geometry.hpp"
 #include "dart/math/helpers.hpp"
 
+#include <ranges>
+
 using namespace Eigen;
 
 namespace dart {
@@ -859,7 +861,8 @@ void PointMass::updateBiasForceFD(double _dt, const Eigen::Vector3d& _gravity)
   mAlpha = state.mForces - (kv + nN * ke) * getPositions()
            - (_dt * (kv + nN * ke) + kd) * getVelocities()
            - getMass() * getPartialAccelerations() - mB;
-  for (std::size_t i = 0; i < getNumConnectedPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, getNumConnectedPointMasses())) {
     const State& i_state = getConnectedPointMass(i)->getState();
     mAlpha += ke * (i_state.mPositions + _dt * i_state.mVelocities);
   }

--- a/dart/dynamics/weld_joint.cpp
+++ b/dart/dynamics/weld_joint.cpp
@@ -39,6 +39,7 @@
 #include "dart/math/geometry.hpp"
 #include "dart/math/helpers.hpp"
 
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -156,7 +157,8 @@ BodyNode* WeldJoint::merge()
   // Reparent grandchildren while keeping their world transforms intact.
   std::vector<BodyNode*> grandchildren;
   grandchildren.reserve(child->getNumChildBodyNodes());
-  for (std::size_t i = 0; i < child->getNumChildBodyNodes(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, child->getNumChildBodyNodes())) {
     grandchildren.push_back(child->getChildBodyNode(i));
   }
 


### PR DESCRIPTION
## Summary

- Adopt C++20 range-based iteration in selected dynamics core loops.

## Motivation / Problem

- Continue simplifying DART 7.0 internals with standard C++20 facilities in files not covered by existing C++20 adoption PRs.

## Changes / Key Changes

- Use `std::views::iota` for index-based BodyNode, Joint, DOF, inertia, and PointMass loops.
- Replace manual span indexing with range-for where the element is used directly.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
