### PR TITLE
Adopt C++20 ranges in common math helpers

### DIFF
--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -39,6 +39,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
@@ -380,7 +381,7 @@ void Profiler::printNode(
         return lhs->inclusiveNs > rhs->inclusiveNs;
       });
 
-  for (std::size_t idx = 0; idx < children.size(); ++idx) {
+  for (const auto idx : std::views::iota(std::size_t{0}, children.size())) {
     const auto* child = children[idx];
     const auto pct = percentage(child->inclusiveNs, threadTotalNs);
     if (pct < minPercent && child->inclusiveNs < 1'000'000) {
@@ -500,7 +501,7 @@ void Profiler::printSummary(std::ostream& os)
     const std::size_t hotLabelWidth
         = std::clamp<std::size_t>(maxHotLabel, 16, 48);
 
-    for (std::size_t i = 0; i < hotspotCount; ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, hotspotCount)) {
       const auto& entry = hotspots[i];
       const auto pct = percentage(entry.inclusiveNs, totalNs);
       const bool isHot = (i < 3) || (pct >= 20.0);

--- a/dart/common/pool_allocator.cpp
+++ b/dart/common/pool_allocator.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/logging.hpp"
 #include "dart/common/macros.hpp"
 
+#include <ranges>
+
 #include <cstring>
 
 namespace dart::common {
@@ -48,13 +50,15 @@ PoolAllocator::PoolAllocator(MemoryAllocator& baseAllocator)
       "sizeof(MemoryUnit) should be equal to or greater than 8.");
 
   if (!mInitialized) {
-    for (auto i = 0u; i < HEAP_COUNT; ++i) {
+    for (const auto i :
+         std::views::iota(0u, static_cast<unsigned>(HEAP_COUNT))) {
       mUnitSizes[i] = (i + 1) * 8;
     }
 
     auto j = 0u;
     mMapSizeToHeapIndex[0] = -1;
-    for (auto i = 1u; i <= MAX_UNIT_SIZE; ++i) {
+    for (const auto i :
+         std::views::iota(1u, static_cast<unsigned>(MAX_UNIT_SIZE) + 1u)) {
       if (i <= mUnitSizes[j]) {
         mMapSizeToHeapIndex[i] = j;
       } else {
@@ -78,7 +82,7 @@ PoolAllocator::PoolAllocator(MemoryAllocator& baseAllocator)
 //==============================================================================
 PoolAllocator::~PoolAllocator()
 {
-  for (int i = 0; i < mCurrentMemoryBlockIndex; ++i) {
+  for (const auto i : std::views::iota(0, mCurrentMemoryBlockIndex)) {
     mBaseAllocator.deallocate(mMemoryBlocks[i].mMemoryUnits, BLOCK_SIZE);
   }
   mBaseAllocator.deallocate(
@@ -126,7 +130,8 @@ void* PoolAllocator::allocateSlow(int heapIndex) noexcept
   const unsigned int unitCount = BLOCK_SIZE / unitSize;
   DART_ASSERT(unitCount > 0);
   auto* memoryUnitsBeginChar = reinterpret_cast<char*>(newBlock->mMemoryUnits);
-  for (size_t i = 0u; i < unitCount - 1; ++i) {
+  for (const auto i : std::views::iota(
+           std::size_t{0}, static_cast<std::size_t>(unitCount - 1))) {
     auto* unit
         = reinterpret_cast<MemoryUnit*>(memoryUnitsBeginChar + unitSize * i);
     auto* nextUnit = reinterpret_cast<MemoryUnit*>(

--- a/dart/math/detail/random-impl.hpp
+++ b/dart/math/detail/random-impl.hpp
@@ -33,6 +33,7 @@
 #include <dart/math/random.hpp>
 
 #include <concepts>
+#include <ranges>
 #include <type_traits>
 
 namespace dart {
@@ -137,8 +138,8 @@ struct UniformMatrixImpl<Derived>
     const auto minEval = min.eval();
     const auto maxEval = max.eval();
     typename Derived::PlainObject result(minEval.rows(), minEval.cols());
-    for (Eigen::Index i = 0; i < minEval.rows(); ++i) {
-      for (Eigen::Index j = 0; j < minEval.cols(); ++j) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, minEval.rows())) {
+      for (const auto j : std::views::iota(Eigen::Index{0}, minEval.cols())) {
         result(i, j) = Random::uniform<typename Derived::Scalar>(
             minEval(i, j), maxEval(i, j));
       }
@@ -162,7 +163,7 @@ struct UniformMatrixImpl<Derived>
     const auto minEval = min.eval();
     const auto maxEval = max.eval();
     typename Derived::PlainObject result(minEval.size());
-    for (Eigen::Index i = 0; i < minEval.size(); ++i) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, minEval.size())) {
       result[i]
           = Random::uniform<typename Derived::Scalar>(minEval[i], maxEval[i]);
     }
@@ -185,8 +186,8 @@ struct UniformMatrixImpl<Derived>
     const auto minEval = min.eval();
     const auto maxEval = max.eval();
     typename Derived::PlainObject result;
-    for (Eigen::Index i = 0; i < minEval.rows(); ++i) {
-      for (Eigen::Index j = 0; j < minEval.cols(); ++j) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, minEval.rows())) {
+      for (const auto j : std::views::iota(Eigen::Index{0}, minEval.cols())) {
         result(i, j) = Random::uniform<typename Derived::Scalar>(
             minEval(i, j), maxEval(i, j));
       }
@@ -210,7 +211,7 @@ struct UniformMatrixImpl<Derived>
     const auto minEval = min.eval();
     const auto maxEval = max.eval();
     typename Derived::PlainObject result;
-    for (Eigen::Index i = 0; i < minEval.size(); ++i) {
+    for (const auto i : std::views::iota(Eigen::Index{0}, minEval.size())) {
       result[i]
           = Random::uniform<typename Derived::Scalar>(minEval[i], maxEval[i]);
     }


### PR DESCRIPTION
## Summary

- Adopt `std::views::iota` for index-based loops in common profiling, pool allocation, and random matrix helpers.

## Motivation / Problem

- Continue the DART 7.0 C++20 adoption sweep by replacing manual counter loops where the index value is still needed.

## Changes / Key Changes

- Use C++20 iota views when walking profiler child/hotspot indices.
- Use iota views for pool allocator heap setup, block release, and free-list linking.
- Use Eigen-indexed iota views for uniform random matrix/vector generation.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of the ongoing C++20 adoption work for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
