### PR TITLE
Adopt C++20 ranges in dynamics traversal helpers

### DIFF
--- a/dart/dynamics/chain.cpp
+++ b/dart/dynamics/chain.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/macros.hpp"
 #include "dart/dynamics/free_joint.hpp"
 
+#include <ranges>
+
 namespace dart {
 namespace dynamics {
 
@@ -210,7 +212,9 @@ bool Chain::isStillChain() const
 
   // Make sure there are no Branches and no parent FreeJoints on the BodyNodes
   // on the inside of the chain
-  for (std::size_t i = 1; i < mBodyNodes.size() - 1; ++i) {
+  const auto interiorEnd
+      = mBodyNodes.size() > 2 ? mBodyNodes.size() - 1 : std::size_t{1};
+  for (const auto i : std::views::iota(std::size_t{1}, interiorEnd)) {
     if (mBodyNodes[i]->getNumChildBodyNodes() > 1) {
       return false;
     }

--- a/dart/dynamics/node.cpp
+++ b/dart/dynamics/node.cpp
@@ -36,6 +36,7 @@
 #include "dart/dynamics/body_node.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 #define REPORT_INVALID_NODE(func)                                              \
   DART_ERROR(                                                                  \
@@ -285,7 +286,7 @@ void Node::stageForRemoval()
   destructors.erase(destructor_iter);
 
   // Reset all the Node indices that have been altered
-  for (std::size_t i = mIndexInBodyNode; i < nodes.size(); ++i) {
+  for (const auto i : std::views::iota(mIndexInBodyNode, nodes.size())) {
     nodes[i]->mIndexInBodyNode = i;
   }
 

--- a/dart/dynamics/referential_skeleton.cpp
+++ b/dart/dynamics/referential_skeleton.cpp
@@ -39,6 +39,7 @@
 #include "dart/dynamics/soft_body_node.hpp"
 
 #include <algorithm>
+#include <ranges>
 #include <span>
 
 namespace dart {
@@ -136,9 +137,7 @@ static std::vector<T2>& convertVector(
     std::span<const T1> t1_vec, std::vector<T2>& t2_vec)
 {
   t2_vec.resize(t1_vec.size());
-  for (std::size_t i = 0; i < t1_vec.size(); ++i) {
-    t2_vec[i] = t1_vec[i];
-  }
+  std::ranges::copy(t1_vec, t2_vec.begin());
   return t2_vec;
 }
 
@@ -1262,7 +1261,7 @@ void ReferentialSkeleton::unregisterBodyNode(
   mBodyNodes.erase(mBodyNodes.begin() + bnIndex);
   indexing.mBodyNodeIndex = INVALID_INDEX;
 
-  for (std::size_t i = bnIndex; i < mBodyNodes.size(); ++i) {
+  for (const auto i : std::views::iota(bnIndex, mBodyNodes.size())) {
     // Re-index all the BodyNodes in this ReferentialSkeleton which came after
     // the one that was removed.
     IndexMap& alteredIndexing = mIndexMap[mBodyNodes[i]];
@@ -1270,7 +1269,8 @@ void ReferentialSkeleton::unregisterBodyNode(
   }
 
   if (_unregisterDofs) {
-    for (std::size_t i = 0; i < indexing.mDofIndices.size(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, indexing.mDofIndices.size())) {
       if (indexing.mDofIndices[i] != INVALID_INDEX) {
         unregisterDegreeOfFreedom(_bn, i);
       }
@@ -1318,7 +1318,7 @@ void ReferentialSkeleton::unregisterJoint(BodyNode* _child)
   mJoints.erase(mJoints.begin() + jointIndex);
   it->second.mJointIndex = INVALID_INDEX;
 
-  for (std::size_t i = jointIndex; i < mJoints.size(); ++i) {
+  for (const auto i : std::views::iota(jointIndex, mJoints.size())) {
     // Re-index all of the Joints in this ReferentialSkeleton which came after
     // the Joint that was removed.
     JointPtr alteredJoint = mJoints[i];
@@ -1370,7 +1370,7 @@ void ReferentialSkeleton::unregisterDegreeOfFreedom(
   mDofs.erase(mDofs.begin() + dofIndex);
   it->second.mDofIndices[_localIndex] = INVALID_INDEX;
 
-  for (std::size_t i = dofIndex; i < mDofs.size(); ++i) {
+  for (const auto i : std::views::iota(dofIndex, mDofs.size())) {
     // Re-index all the DOFs in this ReferentialSkeleton which came after the
     // DOF that was removed.
     DegreeOfFreedomPtr dof = mDofs[i];
@@ -1472,13 +1472,8 @@ bool ReferentialSkeleton::IndexMap::isExpired() const
     return false;
   }
 
-  for (std::size_t i = 0; i < mDofIndices.size(); ++i) {
-    if (mDofIndices[i] != INVALID_INDEX) {
-      return false;
-    }
-  }
-
-  return true;
+  return !std::ranges::any_of(
+      mDofIndices, [](const auto index) { return index != INVALID_INDEX; });
 }
 
 } // namespace dynamics


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges in dynamics traversal helper loops.

## Motivation / Problem

- Continue the DART 7.0 C++20 modernization by replacing index-only loops with standard range utilities where that keeps behavior unchanged.

## Changes / Key Changes

- Use `std::views::iota` for reindexing and traversal loops in dynamics helpers.
- Use `std::ranges::copy` and `std::ranges::any_of` for vector conversion and expiration checks.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
