### PR TITLE
Adopt C++20 ranges in example and integration tests

### DIFF
--- a/examples/human_joint_limits/human_arm_joint_limit_constraint.cpp
+++ b/examples/human_joint_limits/human_arm_joint_limit_constraint.cpp
@@ -44,6 +44,7 @@
 
 #include <iostream>
 #include <limits>
+#include <ranges>
 
 #define DART_ERROR_ALLOWANCE 0.0
 #define DART_ERP 0.01
@@ -239,7 +240,7 @@ void HumanArmJointLimitConstraint::update()
         auto Wb = l->weights();
         vec_t W = *(Wb[0]);
         in_grad.assign(W.size() / out_grad.size(), 0);
-        for (size_t c = 0; c < in_grad.size(); c++) {
+        for (const auto c : std::views::iota(std::size_t{0}, in_grad.size())) {
           in_grad[c] = vectorize::dot(
               &out_grad[0], &W[c * out_grad.size()], out_grad.size());
         }
@@ -321,7 +322,7 @@ void HumanArmJointLimitConstraint::applyUnitImpulse(std::size_t index)
   const dynamics::SkeletonPtr& skeleton = mShldJoint->getSkeleton();
   skeleton->clearConstraintImpulses();
 
-  for (std::size_t i = 0; i < 3; i++) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
     mShldJoint->setConstraintImpulse(i, mJacobian[i]);
   }
   mElbowJoint->setConstraintImpulse(0, mJacobian[3]);
@@ -331,7 +332,7 @@ void HumanArmJointLimitConstraint::applyUnitImpulse(std::size_t index)
   skeleton->updateBiasImpulse(mLArmNode);
   skeleton->updateVelocityChange();
 
-  for (std::size_t i = 0; i < 3; i++) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
     mShldJoint->setConstraintImpulse(i, 0.0);
   }
   mElbowJoint->setConstraintImpulse(0, 0.0);
@@ -348,7 +349,7 @@ void HumanArmJointLimitConstraint::getVelocityChange(
 
   if (mShldJoint->getSkeleton()->isImpulseApplied()) {
     Eigen::Vector4d delq_d;
-    for (std::size_t i = 0; i < 3; i++) {
+    for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
       delq_d[i] = mShldJoint->getVelocityChange(i);
     }
     delq_d[3] = mElbowJoint->getVelocityChange(0);
@@ -383,7 +384,7 @@ void HumanArmJointLimitConstraint::applyImpulse(double* lambda)
   auto con_force = lambda[0];
   mOldX = con_force;
 
-  for (std::size_t i = 0; i < 3; i++) {
+  for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
     mShldJoint->setConstraintImpulse(
         i, mShldJoint->getConstraintImpulse(i) + mJacobian[i] * con_force);
   }

--- a/examples/human_joint_limits/human_leg_joint_limit_constraint.cpp
+++ b/examples/human_joint_limits/human_leg_joint_limit_constraint.cpp
@@ -44,6 +44,7 @@
 
 #include <iostream>
 #include <limits>
+#include <ranges>
 
 #define DART_ERROR_ALLOWANCE 0.0
 #define DART_ERP 0.01
@@ -245,7 +246,7 @@ void HumanLegJointLimitConstraint::update()
         auto Wb = l->weights();
         vec_t W = *(Wb[0]);
         in_grad.assign(W.size() / out_grad.size(), 0);
-        for (size_t c = 0; c < in_grad.size(); c++) {
+        for (const auto c : std::views::iota(std::size_t{0}, in_grad.size())) {
           in_grad[c] = vectorize::dot(
               &out_grad[0], &W[c * out_grad.size()], out_grad.size());
         }

--- a/examples/soft_bodies/main.cpp
+++ b/examples/soft_bodies/main.cpp
@@ -39,6 +39,8 @@
 
 #include <osgViewer/Viewer>
 
+#include <ranges>
+
 using namespace dart::dynamics;
 
 class RecordingWorld : public dart::gui::RealTimeWorldNode
@@ -56,13 +58,15 @@ public:
     TimeSlice slice;
     slice.reserve(mWorld->getNumSkeletons());
 
-    for (std::size_t i = 0; i < mWorld->getNumSkeletons(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, mWorld->getNumSkeletons())) {
       const SkeletonPtr& skeleton = mWorld->getSkeleton(i);
       State state;
       state.mConfig = skeleton->getConfiguration();
       state.mAspectStates.reserve(skeleton->getNumBodyNodes());
 
-      for (std::size_t j = 0; j < skeleton->getNumBodyNodes(); ++j) {
+      for (const auto j :
+           std::views::iota(std::size_t{0}, skeleton->getNumBodyNodes())) {
         BodyNode* bn = skeleton->getBodyNode(j);
         state.mAspectStates.push_back(bn->getCompositeState());
       }
@@ -98,13 +102,14 @@ public:
     std::cout << "Moving to time step #" << index << std::endl;
 
     const TimeSlice& slice = mHistory[index];
-    for (std::size_t i = 0; i < slice.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, slice.size())) {
       const State& state = slice[i];
       const SkeletonPtr& skeleton = mWorld->getSkeleton(i);
 
       skeleton->setConfiguration(state.mConfig);
 
-      for (std::size_t j = 0; j < skeleton->getNumBodyNodes(); ++j) {
+      for (const auto j :
+           std::views::iota(std::size_t{0}, skeleton->getNumBodyNodes())) {
         BodyNode* bn = skeleton->getBodyNode(j);
         bn->setCompositeState(state.mAspectStates[j]);
       }

--- a/tests/integration/dynamics/test_atlas_ik.cpp
+++ b/tests/integration/dynamics/test_atlas_ik.cpp
@@ -42,6 +42,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <ranges>
 
 using namespace Eigen;
 using namespace dart;
@@ -154,7 +155,7 @@ TEST(AtlasIK, TightBoundsProduceNonZeroError)
   // Compute error manually using the correct DOFs
   const auto dofs = ik->getDofs();
   Eigen::VectorXd q(dofs.size());
-  for (std::size_t i = 0; i < dofs.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, dofs.size())) {
     q[i] = atlas->getDof(dofs[i])->getPosition();
   }
 

--- a/tests/integration/dynamics/test_soft_dynamics.cpp
+++ b/tests/integration/dynamics/test_soft_dynamics.cpp
@@ -48,6 +48,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -540,7 +541,8 @@ TEST(SoftDynamics, StepSoftBodyExercisesPhysicsPaths)
 
   dynamics::SoftBodyNode* softBody = nullptr;
   dynamics::SkeletonPtr softSkel;
-  for (std::size_t s = 0; s < world->getNumSkeletons(); ++s) {
+  for (const auto s :
+       std::views::iota(std::size_t{0}, world->getNumSkeletons())) {
     auto skel = world->getSkeleton(s);
     if (skel->getNumSoftBodyNodes() > 0) {
       softBody = skel->getSoftBodyNode(0);
@@ -566,7 +568,8 @@ TEST(SoftDynamics, GravityToggleAndExternalForce)
 
   dynamics::SoftBodyNode* softBody = nullptr;
   dynamics::SkeletonPtr softSkel;
-  for (std::size_t s = 0; s < world->getNumSkeletons(); ++s) {
+  for (const auto s :
+       std::views::iota(std::size_t{0}, world->getNumSkeletons())) {
     auto skel = world->getSkeleton(s);
     if (skel->getNumSoftBodyNodes() > 0) {
       softBody = skel->getSoftBodyNode(0);
@@ -585,7 +588,8 @@ TEST(SoftDynamics, GravityToggleAndExternalForce)
   world->step();
   EXPECT_TRUE(softSkel->getPositions().array().isFinite().all());
 
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     auto* pm = softBody->getPointMass(i);
     pm->addExtForce(Eigen::Vector3d(0.0, 0.0, 0.1));
   }
@@ -659,7 +663,8 @@ TEST(SoftDynamics, MultipleSoftSkeletonsInteract)
     world->step();
   }
 
-  for (std::size_t s = 0; s < world->getNumSkeletons(); ++s) {
+  for (const auto s :
+       std::views::iota(std::size_t{0}, world->getNumSkeletons())) {
     auto skel = world->getSkeleton(s);
     EXPECT_TRUE(skel->getPositions().array().isFinite().all());
   }

--- a/tests/integration/utils/test_aspect.cpp
+++ b/tests/integration/utils/test_aspect.cpp
@@ -52,6 +52,7 @@
 
 #include <gtest/gtest.h>
 
+#include <ranges>
 #include <vector>
 
 #include <cstddef>
@@ -381,7 +382,8 @@ static std::vector<LifecycleEvent> lifecycleEvents;
 static std::size_t findLifecycleEventIndex(
     const int tag, const int id, const LifecycleEvent::Type type)
 {
-  for (std::size_t i = 0; i < lifecycleEvents.size(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, lifecycleEvents.size())) {
     const auto& event = lifecycleEvents[i];
     if (event.tag == tag && event.id == id && event.type == type) {
       return i;
@@ -596,7 +598,7 @@ TEST(Aspect, MatchAspectsNotifiesRemovedLifecycle)
   EXPECT_LT(loseAspect2Index, destroyAspect2Index);
 
   bool sawSetAfter = false;
-  for (std::size_t i = eventsBefore; i < lifecycleEvents.size(); ++i) {
+  for (const auto i : std::views::iota(eventsBefore, lifecycleEvents.size())) {
     if (lifecycleEvents[i].tag == 1
         && lifecycleEvents[i].type == LifecycleEvent::Type::SetComposite) {
       sawSetAfter = true;

--- a/tests/integration/utils/test_concurrency.cpp
+++ b/tests/integration/utils/test_concurrency.cpp
@@ -39,6 +39,7 @@
 
 #include <chrono>
 #include <future>
+#include <ranges>
 
 using namespace dart;
 using namespace dynamics;
@@ -69,7 +70,7 @@ TEST(Concurrency, FrameDeletion)
         std::async(std::launch::async, &createAndDestroyFrames, i));
   }
 
-  for (std::size_t i = 0; i < futures.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, futures.size())) {
     EXPECT_EQ(Frame::World()->getNumChildEntities(), 0);
     EXPECT_EQ(Frame::World()->getNumChildFrames(), 0);
     futures[i].get();

--- a/tests/integration/utils/test_frames.cpp
+++ b/tests/integration/utils/test_frames.cpp
@@ -39,6 +39,8 @@
 
 #include <gtest/gtest.h>
 
+#include <ranges>
+
 using namespace dart;
 using namespace dart::dynamics;
 using namespace dart::math;
@@ -68,7 +70,7 @@ void randomize_transform(
 
 void randomize_transforms(common::aligned_vector<Eigen::Isometry3d>& tfs)
 {
-  for (std::size_t i = 0; i < tfs.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, tfs.size())) {
     randomize_transform(tfs[i]);
   }
 }
@@ -157,15 +159,15 @@ TEST(Frames, ForwardKinematicsChain)
 
   randomize_transforms(tfs);
 
-  for (std::size_t i = 0; i < frames.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
     SimpleFrame* F = frames[i];
     F->setRelativeTransform(tfs[i]);
   }
 
-  for (std::size_t i = 0; i < frames.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
     Frame* F = frames[i];
     Eigen::Isometry3d expectation(Eigen::Isometry3d::Identity());
-    for (std::size_t j = 0; j <= i; ++j) {
+    for (const auto j : std::views::iota(std::size_t{0}, i + 1)) {
       expectation = expectation * tfs[j];
     }
 
@@ -174,13 +176,13 @@ TEST(Frames, ForwardKinematicsChain)
   }
 
   randomize_transforms(tfs);
-  for (std::size_t i = 0; i < frames.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
     SimpleFrame* F = frames[i];
     F->setRelativeTransform(tfs[i]);
   }
 
   Eigen::Isometry3d expectation(Eigen::Isometry3d::Identity());
-  for (std::size_t j = 0; j < frames.size(); ++j) {
+  for (const auto j : std::views::iota(std::size_t{0}, frames.size())) {
     expectation = expectation * tfs[j];
   }
 
@@ -193,7 +195,7 @@ TEST(Frames, ForwardKinematicsChain)
     common::aligned_vector<Eigen::Vector6d> v_rels(frames.size());
     common::aligned_vector<Eigen::Vector6d> v_total(frames.size());
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       v_rels[i] = random_vec<6>();
 
       SimpleFrame* F = frames[i];
@@ -211,7 +213,7 @@ TEST(Frames, ForwardKinematicsChain)
       }
     }
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       SimpleFrame* F = frames[i];
 
       Eigen::Vector6d v_actual = F->getSpatialVelocity();
@@ -228,7 +230,7 @@ TEST(Frames, ForwardKinematicsChain)
     std::vector<Eigen::Vector3d> v_total(frames.size());
     std::vector<Eigen::Vector3d> w_total(frames.size());
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       v_rels[i] = random_vec<3>();
       w_rels[i] = random_vec<3>();
 
@@ -263,7 +265,7 @@ TEST(Frames, ForwardKinematicsChain)
       }
     }
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       SimpleFrame* F = frames[i];
       Eigen::Vector3d v_actual = F->getLinearVelocity();
       Eigen::Vector3d w_actual = F->getAngularVelocity();
@@ -283,7 +285,7 @@ TEST(Frames, ForwardKinematicsChain)
     common::aligned_vector<Eigen::Vector6d> v_total(frames.size());
     common::aligned_vector<Eigen::Vector6d> a_total(frames.size());
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       v_rels[i] = random_vec<6>();
       a_rels[i] = random_vec<6>();
 
@@ -309,7 +311,7 @@ TEST(Frames, ForwardKinematicsChain)
       }
     }
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       SimpleFrame* F = frames[i];
 
       Eigen::Vector6d a_actual = F->getSpatialAcceleration();
@@ -318,7 +320,7 @@ TEST(Frames, ForwardKinematicsChain)
     }
 
     // Test relative computations
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       Frame* F = frames[i];
       Frame* P = F->getParentFrame();
 
@@ -330,7 +332,7 @@ TEST(Frames, ForwardKinematicsChain)
     }
 
     // Test offset computations
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       Eigen::Vector3d offset = random_vec<3>();
       Frame* F = frames[i];
 
@@ -383,7 +385,7 @@ TEST(Frames, ForwardKinematicsChain)
     std::vector<Eigen::Vector3d> a_total(frames.size());
     std::vector<Eigen::Vector3d> alpha_total(frames.size());
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       v_rels[i] = random_vec<3>();
       w_rels[i] = random_vec<3>();
       a_rels[i] = random_vec<3>();
@@ -447,7 +449,7 @@ TEST(Frames, ForwardKinematicsChain)
       }
     }
 
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       SimpleFrame* F = frames[i];
       Eigen::Vector3d v_actual = F->getLinearVelocity();
       Eigen::Vector3d w_actual = F->getAngularVelocity();
@@ -461,7 +463,7 @@ TEST(Frames, ForwardKinematicsChain)
     }
 
     // Test relative computations
-    for (std::size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, frames.size())) {
       SimpleFrame* F = frames[i];
       Frame* P = F->getParentFrame();
       Eigen::Vector3d v_rel = F->getLinearVelocity(P, P);
@@ -480,7 +482,7 @@ TEST(Frames, ForwardKinematicsChain)
 void randomize_target_values(
     const std::vector<SimpleFrame*>& targets, bool spatial)
 {
-  for (std::size_t i = 0; i < targets.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, targets.size())) {
     SimpleFrame* T = targets[i];
 
     Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
@@ -506,7 +508,7 @@ void set_relative_values(
     const std::vector<SimpleFrame*>& followers,
     bool spatial)
 {
-  for (std::size_t i = 0; i < targets.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, targets.size())) {
     Frame* T = targets[i];
     SimpleFrame* F = followers[i];
     Frame* P = F->getParentFrame();
@@ -530,7 +532,7 @@ void check_world_values(
     const std::vector<SimpleFrame*>& followers,
     double tolerance)
 {
-  for (std::size_t i = 0; i < targets.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, targets.size())) {
     Frame* T = targets[i];
     Frame* F = followers[i];
 
@@ -572,7 +574,7 @@ void check_values(
     const Frame* inCoordinatesOf,
     double tolerance)
 {
-  for (std::size_t i = 0; i < targets.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, targets.size())) {
     Frame* T = targets[i];
     Frame* F = followers[i];
 
@@ -624,7 +626,7 @@ void check_offset_computations(
     const Frame* inCoordinatesOf,
     double tolerance)
 {
-  for (std::size_t i = 0; i < targets.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, targets.size())) {
     Frame* T = targets[i];
     Frame* F = followers[i];
 
@@ -755,9 +757,9 @@ void test_relative_values(bool spatial_targets, bool spatial_followers)
   check_world_values(targets, followers, tolerance);
 
   // Check every combination of relative values
-  for (std::size_t i = 0; i < targets.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, targets.size())) {
     Frame* T = targets[i];
-    for (std::size_t j = 0; j < followers.size(); ++j) {
+    for (const auto j : std::views::iota(std::size_t{0}, followers.size())) {
       Frame* F = followers[j];
 
       check_values(targets, followers, T, F, tolerance);
@@ -767,8 +769,8 @@ void test_relative_values(bool spatial_targets, bool spatial_followers)
   }
 
   // Test SimpleFrame::setTransform()
-  for (std::size_t i = 0; i < followers.size(); ++i) {
-    for (std::size_t j = 0; j < followers.size(); ++j) {
+  for (const auto i : std::views::iota(std::size_t{0}, followers.size())) {
+    for (const auto j : std::views::iota(std::size_t{0}, followers.size())) {
       SimpleFrame* F = followers[i];
       SimpleFrame* T = followers[j];
       Eigen::Isometry3d tf;

--- a/tests/unit/dynamics/test_body_node_external_force.cpp
+++ b/tests/unit/dynamics/test_body_node_external_force.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <ranges>
 
 using namespace dart;
 using namespace dart::dynamics;
@@ -227,7 +228,7 @@ TEST(BodyNodeExternalForce, SimulationDoesNotCrashWithNaNForce)
 
   // Positions should still be valid (no NaN propagation)
   Eigen::VectorXd positions = skel->getPositions();
-  for (Eigen::Index i = 0; i < positions.size(); ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, positions.size())) {
     EXPECT_FALSE(std::isnan(positions[i]))
         << "Position " << i << " should not be NaN";
   }

--- a/tests/unit/dynamics/test_joint_command.cpp
+++ b/tests/unit/dynamics/test_joint_command.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <ranges>
 
 using namespace dart;
 using namespace dart::dynamics;
@@ -163,13 +164,13 @@ TEST(JointCommand, SimulationDoesNotCrashWithInfAccelerationCommand)
   });
 
   Eigen::VectorXd positions = skel->getPositions();
-  for (Eigen::Index i = 0; i < positions.size(); ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, positions.size())) {
     EXPECT_TRUE(std::isfinite(positions[i]))
         << "Position " << i << " should be finite after simulation";
   }
 
   Eigen::VectorXd velocities = skel->getVelocities();
-  for (Eigen::Index i = 0; i < velocities.size(); ++i) {
+  for (const auto i : std::views::iota(Eigen::Index{0}, velocities.size())) {
     EXPECT_TRUE(std::isfinite(velocities[i]))
         << "Velocity " << i << " should be finite after simulation";
   }

--- a/tests/unit/dynamics/test_multi_sphere_convex_hull_shape.cpp
+++ b/tests/unit/dynamics/test_multi_sphere_convex_hull_shape.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <ranges>
+
 using namespace dart::dynamics;
 
 //==============================================================================
@@ -255,7 +257,8 @@ TEST(MultiSphereConvexHullShapeTest, Clone)
   const auto& originalSpheres = shape->getSpheres();
   const auto& clonedSpheres = clonedShape->getSpheres();
 
-  for (std::size_t i = 0; i < originalSpheres.size(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, originalSpheres.size())) {
     EXPECT_DOUBLE_EQ(clonedSpheres[i].first, originalSpheres[i].first);
     EXPECT_TRUE(clonedSpheres[i].second.isApprox(originalSpheres[i].second));
   }

--- a/tests/unit/dynamics/test_skeleton_properties.cpp
+++ b/tests/unit/dynamics/test_skeleton_properties.cpp
@@ -46,6 +46,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 #include <vector>
 
 using namespace dart::dynamics;
@@ -258,7 +259,7 @@ TEST(SkeletonConfiguration, UpdatesSelectedDofs)
   const Eigen::VectorXd updatedPositions = skeleton->getPositions();
   const Eigen::VectorXd updatedVelocities = skeleton->getVelocities();
 
-  for (std::size_t i = 0; i < indices.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, indices.size())) {
     EXPECT_DOUBLE_EQ(updatedPositions[indices[i]], positions[i]);
     EXPECT_DOUBLE_EQ(updatedVelocities[indices[i]], velocities[i]);
   }

--- a/tests/unit/dynamics/test_soft_body_node.cpp
+++ b/tests/unit/dynamics/test_soft_body_node.cpp
@@ -5,6 +5,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include <ranges>
 #include <vector>
 
 #include <cmath>
@@ -294,7 +295,7 @@ TEST(SoftBodyNode, PointMassSpan)
   auto pointMasses = softBody->getPointMasses();
   EXPECT_EQ(pointMasses.size(), softBody->getNumPointMasses());
 
-  for (std::size_t i = 0; i < pointMasses.size(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, pointMasses.size())) {
     EXPECT_EQ(pointMasses[i], softBody->getPointMass(i));
   }
 }
@@ -533,7 +534,8 @@ TEST(SoftBodyNode, MultiStepSimulation)
   }
 
   // All point masses should have finite positions
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     auto* pm = softBody->getPointMass(i);
     EXPECT_TRUE(pm->getPositions().array().isFinite().all());
     EXPECT_TRUE(pm->getVelocities().array().isFinite().all());
@@ -551,7 +553,8 @@ TEST(SoftBodyNode, WorldStepWithDampingAndConstraints)
   skeleton->setPositions(Eigen::VectorXd::Zero(dofs));
   skeleton->setVelocities(Eigen::VectorXd::Zero(dofs));
 
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     auto* pm = softBody->getPointMass(i);
     pm->setVelocities(Eigen::Vector3d(0.2, -0.1, 0.05));
     pm->setConstraintImpulse(Eigen::Vector3d::UnitX(), false);
@@ -563,7 +566,8 @@ TEST(SoftBodyNode, WorldStepWithDampingAndConstraints)
   world->setTimeStep(1e-3);
   world->step();
 
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     const auto* pm = softBody->getPointMass(i);
     EXPECT_TRUE(pm->getForces().array().isFinite().all());
     EXPECT_TRUE(pm->getConstraintImpulses().array().isFinite().all());
@@ -669,7 +673,8 @@ TEST(SoftBodyNode, ChildBodyNodeDynamicsPaths)
   skeleton->setPositions(positions);
   skeleton->setVelocities(velocities);
 
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     auto* pm = softBody->getPointMass(i);
     ASSERT_NE(pm, nullptr);
     pm->setVelocities(Eigen::Vector3d(0.1, -0.2, 0.05));
@@ -730,7 +735,8 @@ TEST(SoftBodyNode, DerivativeUpdatesWithWorldStep)
   skeleton->setVelocities(Eigen::VectorXd::LinSpaced(dofs, 0.1, 0.2));
   skeleton->setAccelerations(Eigen::VectorXd::Constant(dofs, -0.05));
 
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     auto* pm = softBody->getPointMass(i);
     ASSERT_NE(pm, nullptr);
     pm->setVelocities(Eigen::Vector3d(0.1, -0.2, 0.3));
@@ -959,7 +965,8 @@ TEST(SoftBodyNode, BiasImpulseAndConstrainedTermUpdates)
       0.08);
 
   softBody->setConstraintImpulse(Eigen::Vector6d::Ones());
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     auto* pm = softBody->getPointMass(i);
     pm->setConstraintImpulse(Eigen::Vector3d::UnitX());
     pm->setVelocityChange(0, 0.1);
@@ -969,7 +976,8 @@ TEST(SoftBodyNode, BiasImpulseAndConstrainedTermUpdates)
   skeleton->updateVelocityChange();
   skeleton->computePositionVelocityChanges();
 
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     const auto* pm = softBody->getPointMass(i);
     EXPECT_TRUE(pm->getVelocities().array().isFinite().all());
     EXPECT_TRUE(pm->getAccelerations().array().isFinite().all());

--- a/tests/unit/dynamics/test_soft_mesh_shape.cpp
+++ b/tests/unit/dynamics/test_soft_mesh_shape.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <ranges>
+
 #include <cmath>
 
 using namespace dart;
@@ -176,7 +178,8 @@ TEST(SoftMeshShapeTest, TriMeshVerticesMatchPointMasses)
 
   const auto& vertices = triMesh->getVertices();
 
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     PointMass* pm = softBody->getPointMass(i);
     Eigen::Vector3d restingPos = pm->getRestingPosition();
     EXPECT_TRUE(vertices[i].isApprox(restingPos, 1e-10))
@@ -287,7 +290,8 @@ TEST(SoftMeshShapeTest, MultiplePointMassUpdates)
   ASSERT_NE(triMesh, nullptr);
 
   std::vector<Eigen::Vector3d> expectedPositions;
-  for (std::size_t i = 0; i < softBody->getNumPointMasses(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, softBody->getNumPointMasses())) {
     PointMass* pm = softBody->getPointMass(i);
     Eigen::Vector3d restingPos = pm->getRestingPosition();
     Eigen::Vector3d displacement(
@@ -301,7 +305,8 @@ TEST(SoftMeshShapeTest, MultiplePointMassUpdates)
   softMeshShape->update();
 
   const auto& vertices = triMesh->getVertices();
-  for (std::size_t i = 0; i < expectedPositions.size(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, expectedPositions.size())) {
     EXPECT_TRUE(vertices[i].isApprox(expectedPositions[i], 1e-10))
         << "Vertex " << i << " not updated correctly";
   }


### PR DESCRIPTION
## Summary

- Adopt `std::views::iota` in non-overlapping example, integration-test, and unit-test index loops.
- Keep generated IKFast code and files already owned by open PRs untouched.

## Motivation / Problem

- Continue the DART 7.0 C++20 migration by replacing hand-written index loops where the index is still needed for cross-container or API access.

## Changes / Key Changes

- Updated human joint limit and soft-body example loops to use C++20 range views.
- Updated integration tests for Atlas IK, soft dynamics, aspects, concurrency, and frame utilities.
- Updated dynamics unit tests for external force, joint command, multi-sphere hulls, skeleton properties, soft body nodes, and soft mesh shapes.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: internal refactor only)
- [x] Add unit tests for new functionality (not applicable: no behavior change)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)