### PR TITLE
Adopt C++20 ranges in tutorials and examples

### DIFF
--- a/examples/atlas_simbicon/controller.cpp
+++ b/examples/atlas_simbicon/controller.cpp
@@ -37,6 +37,8 @@
 #include "state_machine.hpp"
 #include "terminal_condition.hpp"
 
+#include <ranges>
+
 using namespace std;
 
 using namespace Eigen;
@@ -231,7 +233,8 @@ void Controller::printDebugInfo() const
             << " NUM DOF   : " << mAtlasRobot->getNumDofs() << std::endl
             << " NUM JOINTS: " << mAtlasRobot->getNumBodyNodes() << std::endl;
 
-  for (std::size_t i = 0; i < mAtlasRobot->getNumBodyNodes(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, mAtlasRobot->getNumBodyNodes())) {
     Joint* joint = mAtlasRobot->getJoint(i);
     BodyNode* body = mAtlasRobot->getBodyNode(i);
     BodyNode* parentBody = mAtlasRobot->getBodyNode(i)->getParentBodyNode();
@@ -948,10 +951,12 @@ StateMachine* Controller::_createRunningStateMachine()
 //==============================================================================
 void Controller::_setJointDamping()
 {
-  for (std::size_t i = 1; i < mAtlasRobot->getNumBodyNodes(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{1}, mAtlasRobot->getNumBodyNodes())) {
     Joint* joint = mAtlasRobot->getJoint(i);
     if (joint->getNumDofs() > 0) {
-      for (std::size_t j = 0; j < joint->getNumDofs(); ++j) {
+      for (const auto j :
+           std::views::iota(std::size_t{0}, joint->getNumDofs())) {
         joint->setDampingCoefficient(j, 80.0);
       }
     }

--- a/examples/atlas_simbicon/terminal_condition.cpp
+++ b/examples/atlas_simbicon/terminal_condition.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/macros.hpp"
 #include "state.hpp"
 
+#include <ranges>
+
 // Macro for functions not implemented yet
 #define NOT_YET(FUNCTION)                                                      \
   std::cout << #FUNCTION << "Not implemented yet." << std::endl;
@@ -93,7 +95,8 @@ bool BodyContactCondition::isSatisfied()
 {
   SoftBodyNode* soft = dynamic_cast<SoftBodyNode*>(mBodyNode);
   if (soft) {
-    for (std::size_t i = 0; i < soft->getNumPointMasses(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, soft->getNumPointMasses())) {
       PointMass* pm = soft->getPointMass(i);
       if (pm->isColliding()) {
         return true;

--- a/examples/g1_puppet/main.cpp
+++ b/examples/g1_puppet/main.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -402,7 +403,8 @@ SkeletonPtr loadG1(
 
 void enableDragAndDrop(dart::gui::Viewer& viewer, const SkeletonPtr& robot)
 {
-  for (std::size_t i = 0; i < robot->getNumBodyNodes(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, robot->getNumBodyNodes())) {
     viewer.enableDragAndDrop(robot->getBodyNode(i), false, false);
   }
 }

--- a/examples/hybrid_dynamics/main.cpp
+++ b/examples/hybrid_dynamics/main.cpp
@@ -40,6 +40,7 @@
 #include <dart/io/read.hpp>
 
 #include <iostream>
+#include <ranges>
 
 using namespace dart::common;
 using namespace dart::dynamics;
@@ -149,7 +150,8 @@ int main(int /*argc*/, char* /*argv*/[])
 
   Joint* joint0 = skel->getJoint(0);
   joint0->setActuatorType(Joint::PASSIVE);
-  for (std::size_t i = 1; i < skel->getNumBodyNodes(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{1}, skel->getNumBodyNodes())) {
     Joint* joint = skel->getJoint(i);
     joint->setActuatorType(Joint::VELOCITY);
   }

--- a/examples/rigid_shapes/main.cpp
+++ b/examples/rigid_shapes/main.cpp
@@ -50,6 +50,7 @@
 #include <fcl/config.h>
 
 #include <iostream>
+#include <ranges>
 #include <span>
 #include <string>
 #include <vector>
@@ -94,7 +95,8 @@ bool updateGroundThickness(const WorldPtr& world, double thickness)
 
   SkeletonPtr groundSkeleton = world->getSkeleton("ground skeleton");
   if (!groundSkeleton) {
-    for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, world->getNumSkeletons())) {
       auto skeleton = world->getSkeleton(i);
       if (skeleton && skeleton->getBodyNode("ground")) {
         groundSkeleton = skeleton;

--- a/examples/simulation_event_handler/main.cpp
+++ b/examples/simulation_event_handler/main.cpp
@@ -39,6 +39,7 @@
 #include <dart/all.hpp>
 
 #include <iostream>
+#include <ranges>
 
 using namespace dart::common;
 using namespace dart::dynamics;
@@ -380,7 +381,8 @@ int main()
   std::cout << "\n=== Simulation Event Handler Demo ===" << std::endl;
   std::cout << "World created with " << world->getNumSkeletons()
             << " skeletons:" << std::endl;
-  for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, world->getNumSkeletons())) {
     std::cout << "  " << (i + 1) << ". " << world->getSkeleton(i)->getName()
               << std::endl;
   }

--- a/examples/simulation_event_handler/simulation_event_handler.cpp
+++ b/examples/simulation_event_handler/simulation_event_handler.cpp
@@ -41,6 +41,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <ranges>
 
 using namespace dart::common;
 using namespace dart::dynamics;
@@ -440,7 +441,8 @@ void SimulationEventHandler::resetSimulation()
   }
 
   // Reset all skeletons to initial state
-  for (std::size_t i = 0; i < mWorld->getNumSkeletons(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, mWorld->getNumSkeletons())) {
     auto skel = mWorld->getSkeleton(i);
     skel->resetPositions();
     skel->resetVelocities();
@@ -549,10 +551,12 @@ std::vector<BodyNodePtr> SimulationEventHandler::getRigidBodies()
     return rigidBodies;
   }
 
-  for (std::size_t i = 0; i < mWorld->getNumSkeletons(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, mWorld->getNumSkeletons())) {
     auto skel = mWorld->getSkeleton(i);
 
-    for (std::size_t j = 0; j < skel->getNumBodyNodes(); ++j) {
+    for (const auto j :
+         std::views::iota(std::size_t{0}, skel->getNumBodyNodes())) {
       auto body = skel->getBodyNode(j);
       auto joint = body->getParentJoint();
 

--- a/examples/tinkertoy/tinkertoy_world_node.hpp
+++ b/examples/tinkertoy/tinkertoy_world_node.hpp
@@ -39,6 +39,8 @@
 
 #include <dart/all.hpp>
 
+#include <ranges>
+
 const double DefaultBlockLength = 0.5;
 const double DefaultBlockWidth = 0.075;
 const double DefaultJointRadius = 1.5 * DefaultBlockWidth / 2.0;
@@ -175,7 +177,8 @@ public:
     }
 
     dart::dynamics::SkeletonPtr temporary = mPickedNode->remove();
-    for (size_t i = 0; i < temporary->getNumBodyNodes(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, temporary->getNumBodyNodes())) {
       mViewer->disableDragAndDrop(
           mViewer->enableDragAndDrop(temporary->getBodyNode(i)));
     }
@@ -258,7 +261,7 @@ public:
     joint->setName("joint_#" + std::to_string(skel->getNumJoints()));
 
     joint->setTransformFromParentBodyNode(relTf);
-    for (size_t i = 0; i < joint->getNumDofs(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, joint->getNumDofs())) {
       joint->getDof(i)->setDampingCoefficient(DefaultDamping);
     }
 

--- a/examples/wam_ikfast/helpers.cpp
+++ b/examples/wam_ikfast/helpers.cpp
@@ -38,6 +38,7 @@
 
 #include <dart/io/read.hpp>
 
+#include <ranges>
 #include <sstream>
 
 //==============================================================================
@@ -134,11 +135,13 @@ void enableDragAndDrops(
     dart::gui::Viewer& viewer, const dart::dynamics::SkeletonPtr& wam)
 {
   // Turn on drag-and-drop for the whole Skeleton
-  for (std::size_t i = 0; i < wam->getNumBodyNodes(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, wam->getNumBodyNodes())) {
     viewer.enableDragAndDrop(wam->getBodyNode(i), false, false);
   }
 
-  for (std::size_t i = 0; i < wam->getNumEndEffectors(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, wam->getNumEndEffectors())) {
     dart::dynamics::EndEffector* ee = wam->getEndEffector(i);
     if (!ee->getIK()) {
       continue;

--- a/examples/wam_ikfast/input_handler.cpp
+++ b/examples/wam_ikfast/input_handler.cpp
@@ -34,6 +34,8 @@
 
 #include "wam_world.hpp"
 
+#include <ranges>
+
 //==============================================================================
 InputHandler::InputHandler(
     dart::gui::Viewer* viewer,
@@ -50,7 +52,8 @@ void InputHandler::initialize()
 {
   mRestConfig = mWam->getPositions();
 
-  for (std::size_t i = 0; i < mWam->getNumEndEffectors(); ++i) {
+  for (const auto i :
+       std::views::iota(std::size_t{0}, mWam->getNumEndEffectors())) {
     const InverseKinematicsPtr ik = mWam->getEndEffector(i)->getIK();
     if (ik) {
       mDefaultBounds.push_back(ik->getErrorMethod().getBounds());
@@ -71,7 +74,8 @@ bool InputHandler::handle(
 
   if (::osgGA::GUIEventAdapter::KEYDOWN == ea.getEventType()) {
     if (ea.getKey() == 'p' || ea.getKey() == 'P') {
-      for (std::size_t i = 0; i < mWam->getNumDofs(); ++i) {
+      for (const auto i :
+           std::views::iota(std::size_t{0}, mWam->getNumDofs())) {
         std::cout << mWam->getDof(i)->getName() << ": "
                   << mWam->getDof(i)->getPosition() << std::endl;
       }

--- a/tutorials/tutorial_biped/main.cpp
+++ b/tutorials/tutorial_biped/main.cpp
@@ -39,6 +39,8 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <ranges>
+
 const double default_speed_increment = 0.5;
 
 [[maybe_unused]] const int default_ik_iterations = 4500;
@@ -73,7 +75,7 @@ public:
       mKd(i, i) = 0.0;
     }
 
-    for (std::size_t i = 6; i < biped->getNumDofs(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{6}, biped->getNumDofs())) {
       mKp(i, i) = 1000;
       mKd(i, i) = 50;
     }

--- a/tutorials/tutorial_biped_finished/main.cpp
+++ b/tutorials/tutorial_biped_finished/main.cpp
@@ -39,6 +39,8 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <ranges>
+
 const double default_speed_increment = 0.5;
 
 const int default_ik_iterations = 4500;
@@ -73,7 +75,8 @@ public:
       mKd(i, i) = 0.0;
     }
 
-    for (std::size_t i = 6; i < mBiped->getNumDofs(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{6}, mBiped->getNumDofs())) {
       mKp(i, i) = 1000;
       mKd(i, i) = 50;
     }
@@ -185,7 +188,8 @@ public:
     // snippet:cpp-biped-lesson6-wheel-commands-start
     int wheelFirstIndex
         = mBiped->getDof("joint_front_left_1")->getIndexInSkeleton();
-    for (std::size_t i = wheelFirstIndex; i < mBiped->getNumDofs(); ++i) {
+    for (const auto i : std::views::iota(
+             static_cast<std::size_t>(wheelFirstIndex), mBiped->getNumDofs())) {
       mKp(i, i) = 0.0;
       mKd(i, i) = 0.0;
     }
@@ -343,7 +347,7 @@ SkeletonPtr loadBiped()
 
   // Set joint limits
   // snippet:cpp-biped-lesson1-limits-start
-  for (std::size_t i = 0; i < biped->getNumJoints(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, biped->getNumJoints())) {
     biped->getJoint(i)->setLimitEnforcement(true);
   }
   // snippet:cpp-biped-lesson1-limits-end

--- a/tutorials/tutorial_collisions/main.cpp
+++ b/tutorials/tutorial_collisions/main.cpp
@@ -35,6 +35,7 @@
 #include <dart/all.hpp>
 
 #include <random>
+#include <ranges>
 
 [[maybe_unused]] const double default_shape_density = 1000;  // kg/m^3
 [[maybe_unused]] const double default_shape_height = 0.1;    // m
@@ -203,7 +204,8 @@ protected:
   /// it, if one existed
   void removeSkeleton(const SkeletonPtr& skel)
   {
-    for (std::size_t i = 0; i < mJointConstraints.size(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, mJointConstraints.size())) {
       const dart::constraint::DynamicJointConstraintPtr& constraint
           = mJointConstraints[i];
 

--- a/tutorials/tutorial_collisions_finished/main.cpp
+++ b/tutorials/tutorial_collisions_finished/main.cpp
@@ -35,6 +35,7 @@
 #include <dart/all.hpp>
 
 #include <random>
+#include <ranges>
 
 const double default_shape_density = 1000;  // kg/m^3
 const double default_shape_height = 0.1;    // m
@@ -78,7 +79,7 @@ void setupRing(const SkeletonPtr& ring)
 {
   // snippet:cpp-collisions-lesson4a-ring-stiffness-start
   // Set the spring and damping coefficients for the degrees of freedom
-  for (std::size_t i = 6; i < ring->getNumDofs(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{6}, ring->getNumDofs())) {
     DegreeOfFreedom* dof = ring->getDof(i);
     dof->setSpringStiffness(ring_spring_stiffness);
     dof->setDampingCoefficient(ring_damping_coefficient);
@@ -91,7 +92,7 @@ void setupRing(const SkeletonPtr& ring)
   double angle = 2 * dart::math::pi / numEdges;
 
   // Set the BallJoints so that they have the correct rest position angle
-  for (std::size_t i = 1; i < ring->getNumJoints(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{1}, ring->getNumJoints())) {
     Joint* joint = ring->getJoint(i);
     Eigen::AngleAxisd rotation(angle, Eigen::Vector3d(0, 1, 0));
     Eigen::Vector3d restPos
@@ -105,7 +106,7 @@ void setupRing(const SkeletonPtr& ring)
 
   // snippet:cpp-collisions-lesson4c-ring-rest-state-start
   // Set the Joints to be in their rest positions
-  for (std::size_t i = 6; i < ring->getNumDofs(); ++i) {
+  for (const auto i : std::views::iota(std::size_t{6}, ring->getNumDofs())) {
     DegreeOfFreedom* dof = ring->getDof(i);
     dof->setPosition(dof->getRestPosition());
   }
@@ -290,7 +291,8 @@ protected:
   /// it, if one existed
   void removeSkeleton(const SkeletonPtr& skel)
   {
-    for (std::size_t i = 0; i < mJointConstraints.size(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, mJointConstraints.size())) {
       const dart::constraint::DynamicJointConstraintPtr& constraint
           = mJointConstraints[i];
 
@@ -417,7 +419,7 @@ BodyNode* addRigidBody(
   // Set damping to make the simulation more stable
   if (parent) {
     Joint* joint = bn->getParentJoint();
-    for (std::size_t i = 0; i < joint->getNumDofs(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, joint->getNumDofs())) {
       joint->getDof(i)->setDampingCoefficient(default_damping_coefficient);
     }
   }

--- a/tutorials/tutorial_multi_pendulum/main.cpp
+++ b/tutorials/tutorial_multi_pendulum/main.cpp
@@ -36,6 +36,8 @@
 
 #include <dart/all.hpp>
 
+#include <ranges>
+
 const double default_height = 1.0; // m
 const double default_width = 0.2;  // m
 const double default_depth = 0.2;  // m
@@ -161,7 +163,8 @@ public:
 
     if (!mBodyForce) {
       // Apply joint torques based on user input, and color the Joint shape red
-      for (std::size_t i = 0; i < mPendulum->getNumDofs(); ++i) {
+      for (const auto i :
+           std::views::iota(std::size_t{0}, mPendulum->getNumDofs())) {
         if (mForceCountDown[i] > 0) {
           // snippet:lesson1b-joint-force-start
           // Lesson 1b implementation lives in the finished tutorial.
@@ -172,7 +175,8 @@ public:
       }
     } else {
       // Apply body forces based on user input, and color the body shape red
-      for (std::size_t i = 0; i < mPendulum->getNumBodyNodes(); ++i) {
+      for (const auto i :
+           std::views::iota(std::size_t{0}, mPendulum->getNumBodyNodes())) {
         if (mForceCountDown[i] > 0) {
           // snippet:lesson1c-body-force-start
           // Lesson 1c implementation lives in the finished tutorial.

--- a/tutorials/tutorial_multi_pendulum_finished/main.cpp
+++ b/tutorials/tutorial_multi_pendulum_finished/main.cpp
@@ -36,6 +36,8 @@
 
 #include <dart/all.hpp>
 
+#include <ranges>
+
 const double default_height = 1.0; // m
 const double default_width = 0.2;  // m
 const double default_depth = 0.2;  // m
@@ -106,7 +108,8 @@ public:
   void changeRestPosition(double delta)
   {
     // snippet:cpp-lesson2a-rest-position-start
-    for (std::size_t i = 0; i < mPendulum->getNumDofs(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, mPendulum->getNumDofs())) {
       DegreeOfFreedom* dof = mPendulum->getDof(i);
       double q0 = dof->getRestPosition() + delta;
 
@@ -129,7 +132,8 @@ public:
   void changeStiffness(double delta)
   {
     // snippet:cpp-lesson2b-stiffness-start
-    for (std::size_t i = 0; i < mPendulum->getNumDofs(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, mPendulum->getNumDofs())) {
       DegreeOfFreedom* dof = mPendulum->getDof(i);
       double stiffness = dof->getSpringStiffness() + delta;
       if (stiffness < 0.0) {
@@ -143,7 +147,8 @@ public:
   void changeDamping(double delta)
   {
     // snippet:cpp-lesson2c-damping-start
-    for (std::size_t i = 0; i < mPendulum->getNumDofs(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, mPendulum->getNumDofs())) {
       DegreeOfFreedom* dof = mPendulum->getDof(i);
       double damping = dof->getDampingCoefficient() + delta;
       if (damping < 0.0) {
@@ -192,7 +197,8 @@ public:
   {
     // Reset all the shapes to be Blue
     // snippet:cpp-lesson1a-reset-start
-    for (std::size_t i = 0; i < mPendulum->getNumBodyNodes(); ++i) {
+    for (const auto i :
+         std::views::iota(std::size_t{0}, mPendulum->getNumBodyNodes())) {
       BodyNode* bn = mPendulum->getBodyNode(i);
 
       // If we have three visualization shapes, that means the arrow is
@@ -212,7 +218,8 @@ public:
 
     if (!mBodyForce) {
       // Apply joint torques based on user input, and color the Joint shape red
-      for (std::size_t i = 0; i < mPendulum->getNumDofs(); ++i) {
+      for (const auto i :
+           std::views::iota(std::size_t{0}, mPendulum->getNumDofs())) {
         if (mForceCountDown[i] > 0) {
           // snippet:cpp-lesson1b-joint-force-start
           DegreeOfFreedom* dof = mPendulum->getDof(i);
@@ -228,7 +235,8 @@ public:
       }
     } else {
       // Apply body forces based on user input, and color the body shape red
-      for (std::size_t i = 0; i < mPendulum->getNumBodyNodes(); ++i) {
+      for (const auto i :
+           std::views::iota(std::size_t{0}, mPendulum->getNumBodyNodes())) {
         if (mForceCountDown[i] > 0) {
           // snippet:cpp-lesson1c-body-force-start
           BodyNode* bn = mPendulum->getBodyNode(i);


### PR DESCRIPTION
## Summary

- Adopt `std::views::iota` for index-based traversal in tutorials and selected examples.
- Keep the changes mechanical and limited to loops over DART count APIs or container sizes.

## Motivation / Problem

- Continue the DART 7.0 C++20 adoption effort by replacing hand-written index loops with standard range views where that improves clarity without changing behavior.

## Changes / Key Changes

- Update tutorial loops over skeleton, joint, body-node, and DOF counts to use `std::views::iota`.
- Update example helper and event-handler loops over DART object counts to use `std::views::iota`.
- Add `<ranges>` includes where required.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of the DART 7.0 C++20 adoption series.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
