### PR TITLE
Adopt C++20 ranges and concepts in helpers

### DIFF
--- a/dart/simd/eigen/interop.hpp
+++ b/dart/simd/eigen/interop.hpp
@@ -38,14 +38,15 @@
 #include <Eigen/Core>
 
 #include <array>
+#include <concepts>
 #include <type_traits>
 
 namespace dart::simd {
 
 template <typename Derived>
-concept EigenDenseBase = std::is_base_of_v<
-    Eigen::DenseBase<std::remove_cvref_t<Derived>>,
-    std::remove_cvref_t<Derived>>;
+concept EigenDenseBase = std::derived_from<
+    std::remove_cvref_t<Derived>,
+    Eigen::DenseBase<std::remove_cvref_t<Derived>>>;
 
 template <typename Derived>
 concept EigenVectorXpr

--- a/dart/simulation/experimental/io/serializer.hpp
+++ b/dart/simulation/experimental/io/serializer.hpp
@@ -38,10 +38,12 @@
 
 #include <entt/entity/registry.hpp>
 
+#include <concepts>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 
 namespace dart::simulation::experimental::io {
@@ -153,17 +155,24 @@ private:
 //   static constexpr bool serializable = false;
 //
 // Default behavior (no serializable member): component IS serialized
-template <typename ComponentT, typename = void>
+namespace detail {
+
+template <typename ComponentT>
+concept HasSerializableFlag = requires {
+  { ComponentT::serializable } -> std::convertible_to<bool>;
+};
+
+} // namespace detail
+
+template <typename ComponentT>
 struct IsSerializable : std::true_type
 {
 };
 
 // Specialization for components with 'serializable' member
 template <typename ComponentT>
-struct IsSerializable<
-    ComponentT,
-    std::void_t<decltype(ComponentT::serializable)>>
-  : std::bool_constant<ComponentT::serializable>
+  requires detail::HasSerializableFlag<ComponentT>
+struct IsSerializable<ComponentT> : std::bool_constant<ComponentT::serializable>
 {
 };
 

--- a/python/dartpy/common/eigen_utils.hpp
+++ b/python/dartpy/common/eigen_utils.hpp
@@ -7,6 +7,7 @@
 #include <nanobind/stl/vector.h>
 
 #include <array>
+#include <ranges>
 #include <vector>
 
 namespace dart::python_nb {
@@ -44,13 +45,13 @@ inline Eigen::Vector3d vector3FromNumpy(const nanobind::ndarray<double>& array)
     const int64_t s1 = stride(1);
     if (array.shape(0) == 3 && array.shape(1) == 1) {
       Eigen::Vector3d out;
-      for (Eigen::Index i = 0; i < 3; ++i)
+      for (const auto i : std::views::iota(Eigen::Index{0}, Eigen::Index{3}))
         out[i] = base[i * s0 + 0 * s1];
       return out;
     }
     if (array.shape(0) == 1 && array.shape(1) == 3) {
       Eigen::Vector3d out;
-      for (Eigen::Index i = 0; i < 3; ++i)
+      for (const auto i : std::views::iota(Eigen::Index{0}, Eigen::Index{3}))
         out[i] = base[0 * s0 + i * s1];
       return out;
     }
@@ -76,8 +77,8 @@ inline Eigen::Matrix3d matrix3FromNumpy(const nanobind::ndarray<double>& array)
   };
   const int64_t s0 = stride(0);
   const int64_t s1 = stride(1);
-  for (Eigen::Index r = 0; r < 3; ++r)
-    for (Eigen::Index c = 0; c < 3; ++c)
+  for (const auto r : std::views::iota(Eigen::Index{0}, Eigen::Index{3}))
+    for (const auto c : std::views::iota(Eigen::Index{0}, Eigen::Index{3}))
       out(r, c) = base[r * s0 + c * s1];
   return out;
 }
@@ -89,10 +90,10 @@ inline Eigen::MatrixXd matrixFromArray(
     return Eigen::MatrixXd();
   const std::size_t cols = rows.front().size();
   Eigen::MatrixXd out(rows.size(), cols);
-  for (std::size_t r = 0; r < rows.size(); ++r) {
+  for (const auto r : std::views::iota(std::size_t{0}, rows.size())) {
     if (rows[r].size() != cols)
       throw nanobind::type_error("Matrix rows must have consistent length");
-    for (std::size_t c = 0; c < cols; ++c)
+    for (const auto c : std::views::iota(std::size_t{0}, cols))
       out(static_cast<Eigen::Index>(r), static_cast<Eigen::Index>(c))
           = rows[r][c];
   }
@@ -127,7 +128,7 @@ inline Eigen::VectorXd toVector(const nanobind::handle& value)
       Eigen::VectorXd out(array.shape(0));
       const double* base = array.data();
       const int64_t s0 = stride(0);
-      for (Eigen::Index i = 0; i < out.size(); ++i)
+      for (const auto i : std::views::iota(Eigen::Index{0}, out.size()))
         out[i] = base[i * s0];
       return out;
     }
@@ -136,7 +137,7 @@ inline Eigen::VectorXd toVector(const nanobind::handle& value)
       const double* base = array.data();
       const int64_t s0 = stride(0);
       const int64_t s1 = stride(1);
-      for (Eigen::Index i = 0; i < out.size(); ++i)
+      for (const auto i : std::views::iota(Eigen::Index{0}, out.size()))
         out[i] = base[i * s0 + 0 * s1];
       return out;
     }
@@ -145,7 +146,7 @@ inline Eigen::VectorXd toVector(const nanobind::handle& value)
       const double* base = array.data();
       const int64_t s0 = stride(0);
       const int64_t s1 = stride(1);
-      for (Eigen::Index i = 0; i < out.size(); ++i)
+      for (const auto i : std::views::iota(Eigen::Index{0}, out.size()))
         out[i] = base[0 * s0 + i * s1];
       return out;
     }
@@ -153,7 +154,7 @@ inline Eigen::VectorXd toVector(const nanobind::handle& value)
 
   std::vector<double> data = nanobind::cast<std::vector<double>>(value);
   Eigen::VectorXd out(data.size());
-  for (Eigen::Index i = 0; i < out.size(); ++i)
+  for (const auto i : std::views::iota(Eigen::Index{0}, out.size()))
     out[i] = data[static_cast<std::size_t>(i)];
   return out;
 }
@@ -167,8 +168,8 @@ inline Eigen::Matrix3d toMatrix3(const nanobind::handle& value)
   const auto nested
       = nanobind::cast<std::array<std::array<double, 3>, 3>>(value);
   Eigen::Matrix3d out;
-  for (int r = 0; r < 3; ++r)
-    for (int c = 0; c < 3; ++c)
+  for (const auto r : std::views::iota(std::size_t{0}, nested.size()))
+    for (const auto c : std::views::iota(std::size_t{0}, nested[r].size()))
       out(r, c) = nested[r][c];
   return out;
 }

--- a/python/dartpy/common/repr.hpp
+++ b/python/dartpy/common/repr.hpp
@@ -4,6 +4,7 @@
 #include <nanobind/stl/string.h>
 
 #include <iomanip>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -45,7 +46,7 @@ inline std::string format_repr(
   oss << type_name;
   if (!fields.empty()) {
     oss << "(";
-    for (std::size_t i = 0; i < fields.size(); ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, fields.size())) {
       if (i != 0) {
         oss << ", ";
       }

--- a/tests/unit/common/test_lockable_reference.cpp
+++ b/tests/unit/common/test_lockable_reference.cpp
@@ -34,11 +34,28 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <iterator>
 #include <mutex>
 #include <vector>
 
 using namespace dart;
 using namespace dart::common;
+
+namespace {
+
+std::vector<std::mutex*> makeMutexPointers(std::vector<std::mutex>& mutexes)
+{
+  std::vector<std::mutex*> mutexPtrs;
+  mutexPtrs.reserve(mutexes.size());
+  std::ranges::transform(
+      mutexes, std::back_inserter(mutexPtrs), [](auto& mutex) {
+        return &mutex;
+      });
+  return mutexPtrs;
+}
+
+} // namespace
 
 //==============================================================================
 TEST(SingleLockableReference, LockAndUnlock)
@@ -144,10 +161,7 @@ TEST(MultiLockableReference, LockAndUnlockMultipleMutexes)
 {
   auto holder = std::make_shared<int>(42);
   std::vector<std::mutex> mutexes(3);
-  std::vector<std::mutex*> mutexPtrs;
-  for (auto& m : mutexes) {
-    mutexPtrs.push_back(&m);
-  }
+  auto mutexPtrs = makeMutexPointers(mutexes);
 
   MultiLockableReference<std::mutex> lockRef(
       holder, mutexPtrs.begin(), mutexPtrs.end());
@@ -170,10 +184,7 @@ TEST(MultiLockableReference, TryLockSucceedsWhenAllUnlocked)
 {
   auto holder = std::make_shared<int>(42);
   std::vector<std::mutex> mutexes(2);
-  std::vector<std::mutex*> mutexPtrs;
-  for (auto& m : mutexes) {
-    mutexPtrs.push_back(&m);
-  }
+  auto mutexPtrs = makeMutexPointers(mutexes);
 
   MultiLockableReference<std::mutex> lockRef(
       holder, mutexPtrs.begin(), mutexPtrs.end());
@@ -186,10 +197,7 @@ TEST(MultiLockableReference, TryLockFailsWhenOneLocked)
 {
   auto holder = std::make_shared<int>(42);
   std::vector<std::mutex> mutexes(3);
-  std::vector<std::mutex*> mutexPtrs;
-  for (auto& m : mutexes) {
-    mutexPtrs.push_back(&m);
-  }
+  auto mutexPtrs = makeMutexPointers(mutexes);
 
   mutexes[1].lock();
 
@@ -205,10 +213,7 @@ TEST(MultiLockableReference, WorksWithStdLockGuard)
 {
   auto holder = std::make_shared<int>(42);
   std::vector<std::mutex> mutexes(2);
-  std::vector<std::mutex*> mutexPtrs;
-  for (auto& m : mutexes) {
-    mutexPtrs.push_back(&m);
-  }
+  auto mutexPtrs = makeMutexPointers(mutexes);
 
   MultiLockableReference<std::mutex> lockRef(
       holder, mutexPtrs.begin(), mutexPtrs.end());
@@ -229,10 +234,7 @@ TEST(MultiLockableReference, WorksWithStdLockGuard)
 TEST(MultiLockableReference, LockNoOpWhenHolderExpired)
 {
   std::vector<std::mutex> mutexes(2);
-  std::vector<std::mutex*> mutexPtrs;
-  for (auto& m : mutexes) {
-    mutexPtrs.push_back(&m);
-  }
+  auto mutexPtrs = makeMutexPointers(mutexes);
 
   MultiLockableReference<std::mutex>* lockRef = nullptr;
 
@@ -255,10 +257,7 @@ TEST(MultiLockableReference, LockNoOpWhenHolderExpired)
 TEST(MultiLockableReference, TryLockReturnsFalseWhenHolderExpired)
 {
   std::vector<std::mutex> mutexes(2);
-  std::vector<std::mutex*> mutexPtrs;
-  for (auto& m : mutexes) {
-    mutexPtrs.push_back(&m);
-  }
+  auto mutexPtrs = makeMutexPointers(mutexes);
 
   MultiLockableReference<std::mutex>* lockRef = nullptr;
 

--- a/tests/unit/constraint/test_constraint_solver.cpp
+++ b/tests/unit/constraint/test_constraint_solver.cpp
@@ -1686,7 +1686,7 @@ TEST(ConstraintSolver, EachConstraintConstAndNonConst)
 
   std::vector<constraint::ConstraintBase*> seen;
   solver.eachConstraint([&](auto constraint) {
-    using ConstraintType = std::decay_t<decltype(constraint)>;
+    using ConstraintType = std::remove_cvref_t<decltype(constraint)>;
     if constexpr (std::is_pointer_v<ConstraintType>) {
       seen.push_back(constraint);
     } else {

--- a/tests/unit/simulation/experimental/world/test_serialization.cpp
+++ b/tests/unit/simulation/experimental/world/test_serialization.cpp
@@ -46,7 +46,7 @@
 
 #include <gtest/gtest.h>
 
-#include <iterator>
+#include <ranges>
 #include <sstream>
 
 //==============================================================================
@@ -682,7 +682,7 @@ TEST(Serialization, StateSerializedCorrectly)
   auto& registry2 = world2.getRegistry();
   auto view
       = registry2.view<dart::simulation::experimental::comps::FreeFrameTag>();
-  EXPECT_EQ(std::distance(view.begin(), view.end()), 2)
+  EXPECT_EQ(std::ranges::distance(view), 2)
       << "Should have restored 2 FreeFrames";
 
   // Verify that FrameState components exist
@@ -845,7 +845,7 @@ TEST(Serialization, CloneDeepCopy)
   auto cloneView = cloneReg.view<
       dart::simulation::experimental::comps::Name,
       dart::simulation::experimental::comps::FreeFrameProperties>();
-  EXPECT_EQ(std::distance(cloneView.begin(), cloneView.end()), 2);
+  EXPECT_EQ(std::ranges::distance(cloneView), 2);
 
   for (auto entity : cloneView) {
     auto& props


### PR DESCRIPTION
## Summary

- Adopt C++20 concepts and range utilities in remaining helper code that is not already covered by open C++20 PRs.
- Keep the changes mechanical and behavior-preserving.

## Motivation / Problem

- Continue the DART 7.0 C++20 adoption effort across helper and test code while current PRs are waiting on CI.

## Changes / Key Changes

- Replace SFINAE serializable detection with a requires-constrained C++20 specialization.
- Use `std::derived_from` for Eigen expression concepts.
- Use `std::views::iota`, `std::ranges::transform`, and `std::ranges::distance` in Python binding helpers and tests.
- Prefer `std::remove_cvref_t` where only cv/ref stripping is needed.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of the DART 7.0 C++20 adoption series.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
