### PR TITLE
Adopt C++20 ranges in remaining examples

### DIFF
--- a/examples/biped_stand/main.cpp
+++ b/examples/biped_stand/main.cpp
@@ -37,6 +37,9 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <algorithm>
+#include <ranges>
+
 using namespace dart;
 
 //==============================================================================
@@ -70,14 +73,14 @@ public:
     mDesiredDofs = mBiped->getPositions();
 
     // using SPD results in simple Kp coefficients
-    for (int i = 0; i < 6; i++) {
+    for (const auto i : std::views::iota(0, 6)) {
       mKp(i, i) = 0.0;
       mKd(i, i) = 0.0;
     }
-    for (int i = 6; i < nDof; i++) {
+    for (const auto i : std::views::iota(6, std::max(6, nDof))) {
       mKp(i, i) = 400.0;
     }
-    for (int i = 6; i < nDof; i++) {
+    for (const auto i : std::views::iota(6, std::max(6, nDof))) {
       mKd(i, i) = 40.0;
     }
 
@@ -154,7 +157,7 @@ public:
     }
 
     // Just to make sure no illegal torque is used
-    for (int i = 0; i < 6; i++) {
+    for (const auto i : std::views::iota(0, 6)) {
       mTorques[i] = 0.0;
     }
 

--- a/examples/box_stacking/main.cpp
+++ b/examples/box_stacking/main.cpp
@@ -43,6 +43,7 @@
 #include <CLI/CLI.hpp>
 
 #include <iostream>
+#include <ranges>
 
 using namespace dart;
 
@@ -83,7 +84,7 @@ std::vector<dynamics::SkeletonPtr> createBoxStack(
 {
   std::vector<dynamics::SkeletonPtr> boxSkels(numBoxes);
 
-  for (auto i = 0u; i < numBoxes; ++i) {
+  for (const auto i : std::views::iota(std::size_t{0}, numBoxes)) {
     boxSkels[i] = createBox(
         Eigen::Vector3d(0.0, 0.0, heightFromGround + 0.25 + i * 0.5));
   }

--- a/examples/boxes/main.cpp
+++ b/examples/boxes/main.cpp
@@ -38,6 +38,8 @@
 
 #include <osgShadow/ShadowMap>
 
+#include <ranges>
+
 using namespace dart;
 using dart::simulation::CollisionDetectorType;
 
@@ -83,9 +85,9 @@ int main()
 
   // Create dim x dim x dim boxes
   auto dim = 5;
-  for (auto i = 0; i < dim; ++i) {
-    for (auto j = 0; j < dim; ++j) {
-      for (auto k = 0; k < dim; ++k) {
+  for (const auto i : std::views::iota(0, dim)) {
+    for (const auto j : std::views::iota(0, dim)) {
+      for (const auto k : std::views::iota(0, dim)) {
         auto x = i - dim / 2;
         auto y = j - dim / 2;
         auto z = k + 5;

--- a/examples/heightmap/main.cpp
+++ b/examples/heightmap/main.cpp
@@ -49,6 +49,7 @@
 
 #include <CLI/CLI.hpp>
 
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -80,8 +81,8 @@ typename HeightmapShape<S>::HeightField generateHeightField(
     std::size_t xResolution, std::size_t yResolution, S zMin, S zMax)
 {
   typename HeightmapShape<S>::HeightField data(yResolution, xResolution);
-  for (auto i = 0u; i < yResolution; ++i) {
-    for (auto j = 0u; j < xResolution; ++j) {
+  for (const auto i : std::views::iota(std::size_t{0}, yResolution)) {
+    for (const auto j : std::views::iota(std::size_t{0}, xResolution)) {
       data(i, j) = math::Random::uniform(zMin, zMax);
     }
   }
@@ -230,8 +231,8 @@ void addAlignmentBallGrid(
 
   const double step = (count == 1u) ? 0.0 : (2.0 * halfExtent) / (count - 1u);
   std::size_t index = 0u;
-  for (std::size_t row = 0u; row < count; ++row) {
-    for (std::size_t col = 0u; col < count; ++col) {
+  for (const auto row : std::views::iota(std::size_t{0}, count)) {
+    for (const auto col : std::views::iota(std::size_t{0}, count)) {
       const double x = center.x() - halfExtent + step * row;
       const double y = center.y() - halfExtent + step * col;
       const double z = dropHeight;

--- a/examples/joint_constraints/controller.cpp
+++ b/examples/joint_constraints/controller.cpp
@@ -32,6 +32,9 @@
 
 #include "controller.hpp"
 
+#include <algorithm>
+#include <ranges>
+
 using namespace dart;
 using namespace dynamics;
 using namespace math;
@@ -52,26 +55,26 @@ Controller::Controller(
 
   mTorques.resize(nDof);
   mDesiredDofs.resize(nDof);
-  for (int i = 0; i < nDof; i++) {
+  for (const auto i : std::views::iota(0, nDof)) {
     mTorques[i] = 0.0;
     mDesiredDofs[i] = mSkel->getPosition(i);
   }
 
   // using SPD results in simple Kp coefficients
-  for (int i = 0; i < 6; i++) {
+  for (const auto i : std::views::iota(0, 6)) {
     mKp(i, i) = 0.0;
     mKd(i, i) = 0.0;
   }
-  for (int i = 6; i < 22; i++) {
+  for (const auto i : std::views::iota(6, 22)) {
     mKp(i, i) = 200.0; // lower body + lower back
   }
-  for (int i = 22; i < nDof; i++) {
+  for (const auto i : std::views::iota(22, std::max(22, nDof))) {
     mKp(i, i) = 20.0;
   }
-  for (int i = 6; i < 22; i++) {
+  for (const auto i : std::views::iota(6, 22)) {
     mKd(i, i) = 100.0;
   }
-  for (int i = 22; i < nDof; i++) {
+  for (const auto i : std::views::iota(22, std::max(22, nDof))) {
     mKd(i, i) = 10.0;
   }
 
@@ -107,7 +110,7 @@ void Controller::computeTorques(
   }
 
   // Just to make sure no illegal torque is used
-  for (int i = 0; i < 6; i++) {
+  for (const auto i : std::views::iota(0, 6)) {
     mTorques[i] = 0.0;
   }
 

--- a/examples/operational_space_control/main.cpp
+++ b/examples/operational_space_control/main.cpp
@@ -38,6 +38,8 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <ranges>
+
 using namespace dart::common;
 using namespace dart::dynamics;
 using namespace dart::math;
@@ -55,12 +57,12 @@ public:
     // Setup gain matrices
     std::size_t dofs = mEndEffector->getNumDependentGenCoords();
     mKp.setZero();
-    for (std::size_t i = 0; i < 3; ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
       mKp(i, i) = 50.0;
     }
 
     mKd.setZero(dofs, dofs);
-    for (std::size_t i = 0; i < dofs; ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, dofs)) {
       mKd(i, i) = 5.0;
     }
 
@@ -159,7 +161,7 @@ public:
 
   void clearConstraints()
   {
-    for (std::size_t i = 0; i < 3; ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
       mConstrained[i] = false;
     }
   }
@@ -219,7 +221,7 @@ public:
     }
 
     std::size_t constraintDofs = 0;
-    for (std::size_t i = 0; i < 3; ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
       if (mConstrained[i]) {
         ++constraintDofs;
       }
@@ -229,7 +231,7 @@ public:
       mDnD->unconstrain();
     } else if (constraintDofs == 1) {
       Eigen::Vector3d v(Eigen::Vector3d::Zero());
-      for (std::size_t i = 0; i < 3; ++i) {
+      for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
         if (mConstrained[i]) {
           v[i] = 1.0;
         }
@@ -238,7 +240,7 @@ public:
       mDnD->constrainToLine(v);
     } else if (constraintDofs == 2) {
       Eigen::Vector3d v(Eigen::Vector3d::Zero());
-      for (std::size_t i = 0; i < 3; ++i) {
+      for (const auto i : std::views::iota(std::size_t{0}, std::size_t{3})) {
         if (!mConstrained[i]) {
           v[i] = 1.0;
         }

--- a/examples/rigid_chain/main.cpp
+++ b/examples/rigid_chain/main.cpp
@@ -39,6 +39,8 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <ranges>
+
 class RigidChainWorldNode : public dart::gui::RealTimeWorldNode
 {
 public:
@@ -61,7 +63,7 @@ private:
     int nDof = mWorld->getSkeleton(0)->getNumDofs();
     // add damping to each joint; twist-dof has smaller damping
     Eigen::VectorXd damping = -0.01 * mWorld->getSkeleton(0)->getVelocities();
-    for (int i = 0; i < nDof; i++) {
+    for (const auto i : std::views::iota(0, nDof)) {
       if (i % 3 == 1) {
         damping[i] *= 0.1;
       }
@@ -84,7 +86,7 @@ int main()
 
   int dof = myWorld->getSkeleton(0)->getNumDofs();
   Eigen::VectorXd initPose(dof);
-  for (int i = 0; i < dof; i++) {
+  for (const auto i : std::views::iota(0, dof)) {
     initPose[i] = dart::math::Random::uniform(-0.5, 0.5);
   }
   myWorld->getSkeleton(0)->setPositions(initPose);

--- a/examples/rigid_loop/main.cpp
+++ b/examples/rigid_loop/main.cpp
@@ -39,6 +39,8 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <ranges>
+
 using namespace dart;
 using namespace math;
 using namespace dynamics;
@@ -65,7 +67,7 @@ private:
     int nDof = mWorld->getSkeleton(0)->getNumDofs();
     // add damping to each joint; twist-dof has smaller damping
     Eigen::VectorXd damping = -0.01 * mWorld->getSkeleton(0)->getVelocities();
-    for (int i = 0; i < nDof; i++) {
+    for (const auto i : std::views::iota(0, nDof)) {
       if (i % 3 == 1) {
         damping[i] *= 0.1;
       }


### PR DESCRIPTION
## Summary

- Adopt `std::views::iota` for straightforward index loops in remaining example programs.
- Leave mutating argument-parser loops unchanged.

## Motivation / Problem

- Continue the main-branch C++20 modernization by replacing simple hand-written counted loops with standard C++20 range views where it improves consistency.

## Changes / Key Changes

- Add `<ranges>` to affected examples and convert fixed and dynamic index loops to `std::views::iota`.
- Guard nonzero-start dynamic iota ranges where needed so the end bound is not smaller than the start.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for DART 7.0 main.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable