### PR TITLE
Adopt C++20 using enum in remaining switches

### DIFF
--- a/dart/dynamics/ball_joint.hpp
+++ b/dart/dynamics/ball_joint.hpp
@@ -119,12 +119,14 @@ public:
   static Eigen::Vector3d convertToPositions(
       const RotationType& _rotation, CoordinateChart chart)
   {
+    using enum CoordinateChart;
+
     switch (chart) {
-      case CoordinateChart::EXP_MAP:
+      case EXP_MAP:
         return math::logMap(_rotation);
-      case CoordinateChart::EULER_XYZ:
+      case EULER_XYZ:
         return math::matrixToEulerXYZ(_rotation);
-      case CoordinateChart::EULER_ZYX:
+      case EULER_ZYX:
         return math::matrixToEulerZYX(_rotation);
       default:
         DART_WARN(

--- a/dart/dynamics/euler_joint.hpp
+++ b/dart/dynamics/euler_joint.hpp
@@ -107,10 +107,12 @@ public:
   static Eigen::Vector3d convertToPositions(
       const RotationType& _rotation, AxisOrder _ordering)
   {
+    using enum AxisOrder;
+
     switch (_ordering) {
-      case AxisOrder::XYZ:
+      case XYZ:
         return math::matrixToEulerXYZ(_rotation);
-      case AxisOrder::ZYX:
+      case ZYX:
         return math::matrixToEulerZYX(_rotation);
       default:
         DART_WARN(

--- a/dart/gui/grid_visual.cpp
+++ b/dart/gui/grid_visual.cpp
@@ -278,18 +278,20 @@ void setVertices(
   int axis1 = 0;
   int axis2 = 1;
 
+  using enum GridVisual::PlaneType;
+
   switch (planeType) {
-    case GridVisual::PlaneType::XY: {
+    case XY: {
       axis1 = 0;
       axis2 = 1;
       break;
     }
-    case GridVisual::PlaneType::YZ: {
+    case YZ: {
       axis1 = 1;
       axis2 = 2;
       break;
     }
-    case GridVisual::PlaneType::ZX: {
+    case ZX: {
       axis1 = 2;
       axis2 = 0;
       break;
@@ -502,18 +504,20 @@ void GridVisual::refresh()
     static const ::osg::Vec4 yAxisLineColor(0.1f, 0.9f, 0.1f, 1.0f);
     static const ::osg::Vec4 zAxisLineColor(0.1f, 0.1f, 0.9f, 1.0f);
 
+    using enum GridVisual::PlaneType;
+
     switch (mPlaneType) {
-      case GridVisual::PlaneType::XY: {
+      case XY: {
         mAxisLineColor->at(0) = xAxisLineColor;
         mAxisLineColor->at(2) = yAxisLineColor;
         break;
       }
-      case GridVisual::PlaneType::YZ: {
+      case YZ: {
         mAxisLineColor->at(0) = yAxisLineColor;
         mAxisLineColor->at(2) = zAxisLineColor;
         break;
       }
-      case GridVisual::PlaneType::ZX: {
+      case ZX: {
         mAxisLineColor->at(0) = zAxisLineColor;
         mAxisLineColor->at(2) = xAxisLineColor;
         break;

--- a/dart/simulation/experimental/comps/joint.hpp
+++ b/dart/simulation/experimental/comps/joint.hpp
@@ -200,22 +200,24 @@ struct Joint
 
   [[nodiscard]] std::size_t getDOF() const
   {
+    using enum JointType;
+
     switch (type) {
-      case JointType::Fixed:
+      case Fixed:
         return 0;
-      case JointType::Revolute:
+      case Revolute:
         return 1;
-      case JointType::Prismatic:
+      case Prismatic:
         return 1;
-      case JointType::Screw:
+      case Screw:
         return 1;
-      case JointType::Universal:
+      case Universal:
         return 2;
-      case JointType::Ball:
+      case Ball:
         return 3;
-      case JointType::Planar:
+      case Planar:
         return 3;
-      case JointType::Free:
+      case Free:
         return 6;
       default:
         return 0;

--- a/dart/utils/mjcf/mjcf_parser.cpp
+++ b/dart/utils/mjcf/mjcf_parser.cpp
@@ -467,29 +467,31 @@ dynamics::ShapePtr createShape(const GeomOrSite& geomOrSite)
 {
   dynamics::ShapePtr shape = nullptr;
 
+  using enum detail::GeomType;
+
   switch (geomOrSite.getType()) {
-    case detail::GeomType::SPHERE: {
+    case SPHERE: {
       shape = std::make_shared<dynamics::SphereShape>(
           geomOrSite.getSphereRadius());
       break;
     }
-    case detail::GeomType::CAPSULE: {
+    case CAPSULE: {
       shape = std::make_shared<dynamics::CapsuleShape>(
           geomOrSite.getCapsuleRadius(), geomOrSite.getCapsuleLength());
       break;
     }
-    case detail::GeomType::ELLIPSOID: {
+    case ELLIPSOID: {
       // DART takes diameters while MJCF has radii
       shape = std::make_shared<dynamics::EllipsoidShape>(
           geomOrSite.getEllipsoidDiameters());
       break;
     }
-    case detail::GeomType::CYLINDER: {
+    case CYLINDER: {
       shape = std::make_shared<dynamics::CylinderShape>(
           geomOrSite.getCylinderRadius(), geomOrSite.getCylinderLength());
       break;
     }
-    case detail::GeomType::BOX: {
+    case BOX: {
       // DART takes full-sizes while MJCF has half-sizes
       shape = std::make_shared<dynamics::BoxShape>(geomOrSite.getBoxSize());
       break;
@@ -508,8 +510,10 @@ dynamics::ShapePtr createShape(
 {
   dynamics::ShapePtr shape = nullptr;
 
+  using enum detail::GeomType;
+
   switch (geom.getType()) {
-    case detail::GeomType::PLANE: {
+    case PLANE: {
       // TODO(JS): Needs to properly parse PLANE.
       Eigen::Vector3d size;
       size.head<2>() = 2.0 * geom.getPlaneHalfSize();
@@ -517,11 +521,11 @@ dynamics::ShapePtr createShape(
       shape = std::make_shared<dynamics::BoxShape>(size);
       break;
     }
-    case detail::GeomType::HFIELD: {
+    case HFIELD: {
       DART_ERROR("[MjcfParser] Not implemented for 'HFIELD' geom type.");
       break;
     }
-    case detail::GeomType::MESH: {
+    case MESH: {
       const detail::Mesh* mjcfMesh = mjcfAsset.getMesh(geom.getMesh());
       DART_ASSERT(mjcfMesh);
       shape = mjcfMesh->getMeshShape();
@@ -790,17 +794,19 @@ simulation::WorldPtr createWorld(
       continue;
     }
 
+    using enum detail::ActuatorType;
+
     switch (entry.mType) {
-      case detail::ActuatorType::MOTOR:
+      case MOTOR:
         dartJoint->setActuatorType(dynamics::Joint::FORCE);
         break;
-      case detail::ActuatorType::POSITION:
+      case POSITION:
         dartJoint->setActuatorType(dynamics::Joint::SERVO);
         break;
-      case detail::ActuatorType::VELOCITY:
+      case VELOCITY:
         dartJoint->setActuatorType(dynamics::Joint::VELOCITY);
         break;
-      case detail::ActuatorType::GENERAL:
+      case GENERAL:
         // General actuator — default to FORCE, log for transparency
         dartJoint->setActuatorType(dynamics::Joint::FORCE);
         DART_WARN(

--- a/tests/unit/math/lcp/test_all_solvers_smoke.cpp
+++ b/tests/unit/math/lcp/test_all_solvers_smoke.cpp
@@ -146,12 +146,14 @@ std::vector<SolverTestCase> createAllSolvers()
 
 bool canSolve(const SolverTestCase& solver, const FactoryProblem& problem)
 {
+  using enum ProblemCategory;
+
   switch (problem.category) {
-    case ProblemCategory::Standard:
+    case Standard:
       return solver.supportsStandard;
-    case ProblemCategory::Boxed:
+    case Boxed:
       return solver.supportsBoxed;
-    case ProblemCategory::BoxedFriction:
+    case BoxedFriction:
       return solver.supportsFindex;
   }
   return false;


### PR DESCRIPTION
## Summary

- Adopt C++20 `using enum` in remaining scoped-enum switch helpers not already covered by open PRs.

## Motivation / Problem

- Continue the DART 7.0 C++20 modernization by reducing repeated enum qualification in localized switch scopes.

## Changes / Key Changes

- Shorten remaining `JointType`, `GeomType`, `ActuatorType`, `PlaneType`, `AxisOrder`, `CoordinateChart`, and LCP problem-category switch labels with `using enum`.
- Keep each `using enum` declaration scoped immediately beside the switch using it.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up C++20 adoption work for DART 7.0 main.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable