### PR TITLE
Adopt C++20 helpers in factory templates

### DIFF
--- a/dart/common/detail/factory-impl.hpp
+++ b/dart/common/detail/factory-impl.hpp
@@ -37,6 +37,8 @@
 #include <dart/common/logging.hpp>
 #include <dart/common/memory.hpp>
 
+#include <ranges>
+
 namespace dart {
 namespace common {
 
@@ -153,8 +155,8 @@ template <typename KeyT, typename BaseT, typename HeldT, typename... Args>
 std::unordered_set<KeyT> Factory<KeyT, BaseT, HeldT, Args...>::getKeys() const
 {
   std::unordered_set<KeyT> keys;
-  for (const auto& entry : mCreatorMap) {
-    keys.insert(entry.first);
+  for (const auto& key : std::views::keys(mCreatorMap)) {
+    keys.insert(key);
   }
 
   return keys;

--- a/dart/common/factory.hpp
+++ b/dart/common/factory.hpp
@@ -38,6 +38,7 @@
 
 #include <functional>
 #include <memory>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -67,10 +68,8 @@ public:
   using This = Factory<KeyT, BaseT, HeldT>;
   using Creator = std::function<HeldT(Args...)>;
   template <typename Key>
-  using HashType = typename std::conditional<
-      std::is_enum<Key>::value,
-      EnumClassHash,
-      std::hash<Key>>::type;
+  using HashType
+      = std::conditional_t<std::is_enum_v<Key>, EnumClassHash, std::hash<Key>>;
   using CreatorMap = std::unordered_map<KeyT, Creator, HashType<KeyT>>;
 
   /// Default constructor.


### PR DESCRIPTION
## Summary

- Modernize factory type traits with C++20 variable and alias helpers.
- Use `std::views::keys` when collecting registered factory keys.

## Motivation / Problem

- Continue the C++20 adoption sweep on `main` while keeping template utility code straightforward.

## Changes / Key Changes

- Replace `std::conditional<...>::type` and `std::is_enum<...>::value` with `std::conditional_t` and `std::is_enum_v`.
- Iterate creator-map keys directly via `std::views::keys` in `Factory::getKeys()`.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of the C++20 adoption work for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable