### PR TITLE
Adopt C++20 helpers in legacy tests

### DIFF
--- a/examples/atlas_simbicon/state_machine.cpp
+++ b/examples/atlas_simbicon/state_machine.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/macros.hpp"
 #include "state.hpp"
 
+#include <algorithm>
+
 // Macro for functions not implemented yet
 #define NOT_YET(FUNCTION)                                                      \
   std::cout << #FUNCTION << "Not implemented yet." << std::endl;
@@ -60,10 +62,7 @@ StateMachine::StateMachine(const std::string& _name)
 //==============================================================================
 StateMachine::~StateMachine()
 {
-  for (vector<State*>::iterator it = mStates.begin(); it != mStates.end();
-       ++it) {
-    delete *it;
-  }
+  std::ranges::for_each(mStates, [](State* state) { delete state; });
 }
 
 //==============================================================================
@@ -190,14 +189,7 @@ void StateMachine::setVerbosity(bool verbosity)
 //==============================================================================
 bool StateMachine::_containState(const State* _state) const
 {
-  for (vector<State*>::const_iterator it = mStates.begin(); it != mStates.end();
-       ++it) {
-    if (*it == _state) {
-      return true;
-    }
-  }
-
-  return false;
+  return std::ranges::find(mStates, _state) != mStates.end();
 }
 
 //==============================================================================
@@ -209,15 +201,9 @@ bool StateMachine::_containState(const string& _name) const
 //==============================================================================
 State* StateMachine::_findState(const string& _name) const
 {
-  State* state = nullptr;
+  const auto it = std::ranges::find_if(mStates, [&_name](const State* state) {
+    return state->getName() == _name;
+  });
 
-  for (vector<State*>::const_iterator it = mStates.begin(); it != mStates.end();
-       ++it) {
-    if ((*it)->getName() == _name) {
-      state = *it;
-      break;
-    }
-  }
-
-  return state;
+  return it == mStates.end() ? nullptr : *it;
 }

--- a/tests/unit/collision/test_dart_collide.cpp
+++ b/tests/unit/collision/test_dart_collide.cpp
@@ -14,6 +14,7 @@
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <memory>
 
 #include <cmath>
@@ -701,41 +702,47 @@ TEST(DARTCollide, CylinderPlaneAllNegativeDepths)
 
 TEST(DARTCollideHelpers, CullPointsAndIntersectRectQuad)
 {
-  int iret[4] = {-1, -1, -1, -1};
+  auto iret = std::to_array<int>({-1, -1, -1, -1});
 
-  double single[2] = {1.0, 2.0};
-  cullPoints(1, single, 1, 0, iret);
+  auto single = std::to_array<double>({1.0, 2.0});
+  cullPoints(1, single.data(), 1, 0, iret.data());
   EXPECT_EQ(iret[0], 0);
 
-  double segment[4] = {0.0, 0.0, 1.0, 0.0};
-  cullPoints(2, segment, 2, 0, iret);
+  auto segment = std::to_array<double>({0.0, 0.0, 1.0, 0.0});
+  cullPoints(2, segment.data(), 2, 0, iret.data());
   EXPECT_EQ(iret[0], 0);
   EXPECT_EQ(iret[1], 1);
 
-  double quad[8] = {0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0};
-  cullPoints(4, quad, 3, 0, iret);
+  auto quad = std::to_array<double>({0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0});
+  cullPoints(4, quad.data(), 3, 0, iret.data());
   for (int i = 0; i < 3; ++i) {
     EXPECT_GE(iret[i], 0);
     EXPECT_LT(iret[i], 4);
   }
 
-  double h[2] = {1.0, 1.0};
-  double inside[8] = {0.5, 0.5, -0.5, 0.5, -0.5, -0.5, 0.5, -0.5};
-  double ret[16] = {};
-  const int insideCount = intersectRectQuad(h, inside, ret);
+  auto h = std::to_array<double>({1.0, 1.0});
+  auto inside
+      = std::to_array<double>({0.5, 0.5, -0.5, 0.5, -0.5, -0.5, 0.5, -0.5});
+  std::array<double, 16> ret{};
+  const int insideCount
+      = intersectRectQuad(h.data(), inside.data(), ret.data());
   EXPECT_EQ(insideCount, 4);
 
-  double outside[8] = {3.0, 3.0, 4.0, 3.0, 4.0, 4.0, 3.0, 4.0};
-  const int outsideCount = intersectRectQuad(h, outside, ret);
+  auto outside
+      = std::to_array<double>({3.0, 3.0, 4.0, 3.0, 4.0, 4.0, 3.0, 4.0});
+  const int outsideCount
+      = intersectRectQuad(h.data(), outside.data(), ret.data());
   EXPECT_EQ(outsideCount, 0);
 }
 
 TEST(DARTCollideHelpers, IntersectRectQuadOverflow)
 {
-  double h[2] = {1.0, 1.0};
-  double ret[16] = {};
-  double overflowQuad[8] = {2.0, 2.0, -2.0, 2.0, 2.0, -2.0, -2.0, -2.0};
-  const int count = intersectRectQuad(h, overflowQuad, ret);
+  auto h = std::to_array<double>({1.0, 1.0});
+  std::array<double, 16> ret{};
+  auto overflowQuad
+      = std::to_array<double>({2.0, 2.0, -2.0, 2.0, 2.0, -2.0, -2.0, -2.0});
+  const int count
+      = intersectRectQuad(h.data(), overflowQuad.data(), ret.data());
   EXPECT_GE(count, 0);
   EXPECT_LE(count, 8);
 }

--- a/tests/unit/constraint/test_joint_limit_constraint.cpp
+++ b/tests/unit/constraint/test_joint_limit_constraint.cpp
@@ -37,6 +37,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
 #include <memory>
 
 #include <cmath>
@@ -247,18 +249,15 @@ TEST(JointLimitConstraintTests, GetInformation)
   ASSERT_TRUE(constraint.isActive());
 
   constraint::ConstraintInfo info;
-  double lo[6], hi[6], b[6], w[6], x[6];
-  int findex[6];
-  for (int i = 0; i < 6; ++i) {
-    lo[i] = hi[i] = b[i] = w[i] = x[i] = 0.0;
-    findex[i] = -1;
-  }
-  info.lo = lo;
-  info.hi = hi;
-  info.b = b;
-  info.w = w;
-  info.x = x;
-  info.findex = findex;
+  std::array<double, 6> lo{}, hi{}, b{}, w{}, x{};
+  std::array<int, 6> findex;
+  std::ranges::fill(findex, -1);
+  info.lo = lo.data();
+  info.hi = hi.data();
+  info.b = b.data();
+  info.w = w.data();
+  info.x = x.data();
+  info.findex = findex.data();
   info.invTimeStep = 1000.0;
 
   // Ensure non-zero error allowance
@@ -284,13 +283,13 @@ TEST(JointLimitConstraintTests, ApplyImpulseAndVelocityChange)
   skeleton->computeForwardDynamics();
   constraint.update();
 
-  double delVel[6] = {0, 0, 0, 0, 0, 0};
+  std::array<double, 6> delVel{};
   constraint.applyUnitImpulse(0);
   skeleton->computeImpulseForwardDynamics();
-  constraint.getVelocityChange(delVel, true);
+  constraint.getVelocityChange(delVel.data(), true);
 
-  double lambda[1] = {1.0};
-  constraint.applyImpulse(lambda);
+  auto lambda = std::to_array<double>({1.0});
+  constraint.applyImpulse(lambda.data());
 
   constraint.excite();
   constraint.unexcite();
@@ -381,18 +380,15 @@ TEST(JointLimitConstraintTests, GetInformationForVelocityViolation)
   ASSERT_TRUE(constraint.isActive());
 
   constraint::ConstraintInfo info;
-  double lo[6], hi[6], b[6], w[6], x[6];
-  int findex[6];
-  for (int i = 0; i < 6; ++i) {
-    lo[i] = hi[i] = b[i] = w[i] = x[i] = 0.0;
-    findex[i] = -1;
-  }
-  info.lo = lo;
-  info.hi = hi;
-  info.b = b;
-  info.w = w;
-  info.x = x;
-  info.findex = findex;
+  std::array<double, 6> lo{}, hi{}, b{}, w{}, x{};
+  std::array<int, 6> findex;
+  std::ranges::fill(findex, -1);
+  info.lo = lo.data();
+  info.hi = hi.data();
+  info.b = b.data();
+  info.w = w.data();
+  info.x = x.data();
+  info.findex = findex.data();
   info.invTimeStep = 1000.0;
 
   constraint.getInformation(&info);
@@ -415,13 +411,13 @@ TEST(
   constraint.update();
   ASSERT_TRUE(constraint.isActive());
 
-  double delVel[6] = {0, 0, 0, 0, 0, 0};
+  std::array<double, 6> delVel{};
   constraint.applyUnitImpulse(0);
   skeleton->computeImpulseForwardDynamics();
-  constraint.getVelocityChange(delVel, true);
+  constraint.getVelocityChange(delVel.data(), true);
 
-  double lambda[1] = {1.0};
-  constraint.applyImpulse(lambda);
+  auto lambda = std::to_array<double>({1.0});
+  constraint.applyImpulse(lambda.data());
 }
 
 TEST(JointLimitConstraintTests, UpperVelocityViolation)
@@ -449,10 +445,10 @@ TEST(JointLimitConstraintTests, GetVelocityChangeWithoutCfm)
   constraint.update();
   ASSERT_TRUE(constraint.isActive());
 
-  double delVel[6] = {0, 0, 0, 0, 0, 0};
+  std::array<double, 6> delVel{};
   constraint.applyUnitImpulse(0);
   skeleton->computeImpulseForwardDynamics();
-  constraint.getVelocityChange(delVel, false);
+  constraint.getVelocityChange(delVel.data(), false);
 }
 
 TEST(JointLimitConstraintTests, GetVelocityChangeWhenImpulseNotApplied)
@@ -469,8 +465,8 @@ TEST(JointLimitConstraintTests, GetVelocityChangeWhenImpulseNotApplied)
 
   skeleton->setImpulseApplied(false);
 
-  double delVel[6] = {0, 0, 0, 0, 0, 0};
-  constraint.getVelocityChange(delVel, false);
+  std::array<double, 6> delVel{};
+  constraint.getVelocityChange(delVel.data(), false);
 
   EXPECT_DOUBLE_EQ(delVel[0], 0.0);
 }


### PR DESCRIPTION
## Summary

- Use C++20 ranges algorithms in the atlas Simbicon state machine.
- Replace raw fixed test buffers with `std::array` and `std::to_array` where C APIs still require pointers.

## Motivation / Problem

- Continue the C++20 adoption sweep on `main` by modernizing remaining untouched legacy test/example code.

## Changes / Key Changes

- Replace explicit iterator search loops with `std::ranges::for_each`, `std::ranges::find`, and `std::ranges::find_if`.
- Use `std::to_array` for fixed collision-helper inputs and impulse vectors.
- Use `std::array` storage plus `.data()` for APIs that still expose pointer-based contracts.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of the C++20 adoption work for `main` / DART 7.0.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable