### PR TITLE
Simplify primitive shape math and NEON setup

### DIFF
--- a/dart/dynamics/box_shape.cpp
+++ b/dart/dynamics/box_shape.cpp
@@ -34,8 +34,6 @@
 
 #include "dart/common/macros.hpp"
 
-#include <cmath>
-
 namespace dart {
 namespace dynamics {
 
@@ -78,9 +76,10 @@ Eigen::Matrix3d BoxShape::computeInertia(
 {
   Eigen::Matrix3d inertia = Eigen::Matrix3d::Identity();
 
-  inertia(0, 0) = mass / 12.0 * (std::pow(size[1], 2) + std::pow(size[2], 2));
-  inertia(1, 1) = mass / 12.0 * (std::pow(size[0], 2) + std::pow(size[2], 2));
-  inertia(2, 2) = mass / 12.0 * (std::pow(size[0], 2) + std::pow(size[1], 2));
+  const auto sizeSquared = size.cwiseProduct(size);
+  inertia(0, 0) = mass / 12.0 * (sizeSquared[1] + sizeSquared[2]);
+  inertia(1, 1) = mass / 12.0 * (sizeSquared[0] + sizeSquared[2]);
+  inertia(2, 2) = mass / 12.0 * (sizeSquared[0] + sizeSquared[1]);
 
   return inertia;
 }

--- a/dart/dynamics/cone_shape.cpp
+++ b/dart/dynamics/cone_shape.cpp
@@ -37,8 +37,6 @@
 #include "dart/dynamics/sphere_shape.hpp"
 #include "dart/math/helpers.hpp"
 
-#include <cmath>
-
 namespace dart {
 namespace dynamics {
 
@@ -100,7 +98,7 @@ void ConeShape::setHeight(double height)
 //==============================================================================
 double ConeShape::computeVolume(double radius, double height)
 {
-  return (1.0 / 3.0) * math::pi * std::pow(radius, 2) * height;
+  return (1.0 / 3.0) * math::pi * radius * radius * height;
 }
 
 //==============================================================================

--- a/dart/dynamics/cylinder_shape.cpp
+++ b/dart/dynamics/cylinder_shape.cpp
@@ -35,8 +35,6 @@
 #include "dart/common/macros.hpp"
 #include "dart/math/helpers.hpp"
 
-#include <cmath>
-
 namespace dart {
 namespace dynamics {
 
@@ -98,7 +96,7 @@ void CylinderShape::setHeight(double _height)
 //==============================================================================
 double CylinderShape::computeVolume(double radius, double height)
 {
-  return math::pi * std::pow(radius, 2) * height;
+  return math::pi * radius * radius * height;
 }
 
 //==============================================================================
@@ -107,10 +105,11 @@ Eigen::Matrix3d CylinderShape::computeInertia(
 {
   Eigen::Matrix3d inertia = Eigen::Matrix3d::Zero();
 
-  inertia(0, 0)
-      = mass * (3.0 * std::pow(radius, 2) + std::pow(height, 2)) / 12.0;
+  const auto radiusSquared = radius * radius;
+  const auto heightSquared = height * height;
+  inertia(0, 0) = mass * (3.0 * radiusSquared + heightSquared) / 12.0;
   inertia(1, 1) = inertia(0, 0);
-  inertia(2, 2) = 0.5 * mass * radius * radius;
+  inertia(2, 2) = 0.5 * mass * radiusSquared;
 
   return inertia;
 }

--- a/dart/dynamics/ellipsoid_shape.cpp
+++ b/dart/dynamics/ellipsoid_shape.cpp
@@ -116,9 +116,10 @@ Eigen::Matrix3d EllipsoidShape::computeInertia(
   Eigen::Matrix3d inertia = Eigen::Matrix3d::Identity();
 
   const auto coeff = mass / 20.0;
-  const auto AA = std::pow(diameters[0], 2);
-  const auto BB = std::pow(diameters[1], 2);
-  const auto CC = std::pow(diameters[2], 2);
+  const auto diametersSquared = diameters.cwiseProduct(diameters);
+  const auto AA = diametersSquared[0];
+  const auto BB = diametersSquared[1];
+  const auto CC = diametersSquared[2];
 
   inertia(0, 0) = coeff * (BB + CC);
   inertia(1, 1) = coeff * (AA + CC);

--- a/dart/dynamics/sphere_shape.cpp
+++ b/dart/dynamics/sphere_shape.cpp
@@ -94,7 +94,8 @@ double SphereShape::getRadius() const
 //==============================================================================
 double SphereShape::computeVolume(double radius)
 {
-  return math::pi * 4.0 / 3.0 * std::pow(radius, 3);
+  const auto radiusSquared = radius * radius;
+  return math::pi * 4.0 / 3.0 * radiusSquared * radius;
 }
 
 //==============================================================================
@@ -102,7 +103,7 @@ Eigen::Matrix3d SphereShape::computeInertia(double radius, double mass)
 {
   Eigen::Matrix3d inertia = Eigen::Matrix3d::Identity();
 
-  inertia(0, 0) = 2.0 / 5.0 * mass * std::pow(radius, 2);
+  inertia(0, 0) = 2.0 / 5.0 * mass * radius * radius;
   inertia(1, 1) = inertia(0, 0);
   inertia(2, 2) = inertia(0, 0);
 

--- a/dart/simd/detail/neon/vec.hpp
+++ b/dart/simd/detail/neon/vec.hpp
@@ -34,6 +34,8 @@
 
 #include <dart/simd/config.hpp>
 
+#include <array>
+
 #include <cstddef>
 #include <cstdint>
 
@@ -69,8 +71,8 @@ struct Vec<float, 4>
 
   DART_SIMD_INLINE static Vec set(float v0, float v1, float v2, float v3)
   {
-    alignas(16) float tmp[4] = {v0, v1, v2, v3};
-    return Vec(vld1q_f32(tmp));
+    alignas(16) const auto tmp = std::to_array<float>({v0, v1, v2, v3});
+    return Vec(vld1q_f32(tmp.data()));
   }
 
   DART_SIMD_INLINE static Vec load(const float* ptr)
@@ -182,8 +184,8 @@ struct Vec<double, 2>
 
   DART_SIMD_INLINE static Vec set(double v0, double v1)
   {
-    alignas(16) double tmp[2] = {v0, v1};
-    return Vec(vld1q_f64(tmp));
+    alignas(16) const auto tmp = std::to_array<double>({v0, v1});
+    return Vec(vld1q_f64(tmp.data()));
   }
 
   DART_SIMD_INLINE static Vec load(const double* ptr)


### PR DESCRIPTION
## Summary

- Simplify primitive shape inertia and volume helpers by replacing fixed-exponent `std::pow` calls with direct multiplication or Eigen coefficient-wise products.
- Use C++20 `std::to_array` for the NEON `Vec::set()` temporary buffers.
- Remove no-longer-needed `<cmath>` includes from primitive shape implementations.

## Motivation / Problem

- Fixed powers such as square and cube are clearer and cheaper as direct multiplications.
- The NEON setup code can use a standard C++20 fixed-size array helper instead of manually initialized raw arrays.

## Changes / Key Changes

- Updated box, cone, cylinder, sphere, and ellipsoid shape math helpers.
- Updated NEON SIMD set helpers to build aligned `std::array` temporaries with `std::to_array`.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
