### PR TITLE
Adopt std::format in dartpy repr bindings

### DIFF
--- a/python/dartpy/collision/collision_option.cpp
+++ b/python/dartpy/collision/collision_option.cpp
@@ -8,7 +8,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>
 
-#include <format>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -60,7 +60,7 @@ void defCollisionOption(nb::module_& m)
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("enable_contact", repr_bool(self.enableContact));
         fields.emplace_back(
-            "max_contacts", std::format("{}", self.maxNumContacts));
+            "max_contacts", std::to_string(self.maxNumContacts));
         fields.emplace_back(
             "allow_negative_penetration_depth_contacts",
             repr_bool(self.allowNegativePenetrationDepthContacts));

--- a/python/dartpy/collision/collision_option.cpp
+++ b/python/dartpy/collision/collision_option.cpp
@@ -8,6 +8,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>
 
+#include <format>
+
 namespace nb = nanobind;
 
 namespace dart::python_nb {
@@ -58,7 +60,7 @@ void defCollisionOption(nb::module_& m)
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("enable_contact", repr_bool(self.enableContact));
         fields.emplace_back(
-            "max_contacts", std::to_string(self.maxNumContacts));
+            "max_contacts", std::format("{}", self.maxNumContacts));
         fields.emplace_back(
             "allow_negative_penetration_depth_contacts",
             repr_bool(self.allowNegativePenetrationDepthContacts));

--- a/python/dartpy/collision/collision_result.cpp
+++ b/python/dartpy/collision/collision_result.cpp
@@ -5,7 +5,7 @@
 
 #include <nanobind/nanobind.h>
 
-#include <format>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -23,8 +23,7 @@ void defCollisionResult(nb::module_& m)
       .def("__repr__", [](const CollisionResult& self) {
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("is_collision", repr_bool(self.isCollision()));
-        fields.emplace_back(
-            "contacts", std::format("{}", self.getNumContacts()));
+        fields.emplace_back("contacts", std::to_string(self.getNumContacts()));
         return format_repr("CollisionResult", fields);
       });
 }

--- a/python/dartpy/collision/collision_result.cpp
+++ b/python/dartpy/collision/collision_result.cpp
@@ -5,6 +5,8 @@
 
 #include <nanobind/nanobind.h>
 
+#include <format>
+
 namespace nb = nanobind;
 
 namespace dart::python_nb {
@@ -21,7 +23,8 @@ void defCollisionResult(nb::module_& m)
       .def("__repr__", [](const CollisionResult& self) {
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("is_collision", repr_bool(self.isCollision()));
-        fields.emplace_back("contacts", std::to_string(self.getNumContacts()));
+        fields.emplace_back(
+            "contacts", std::format("{}", self.getNumContacts()));
         return format_repr("CollisionResult", fields);
       });
 }

--- a/python/dartpy/dynamics/body_node.cpp
+++ b/python/dartpy/dynamics/body_node.cpp
@@ -16,6 +16,8 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <format>
+
 namespace nb = nanobind;
 
 namespace dart::python_nb {
@@ -116,9 +118,9 @@ void defBodyNode(nb::module_& m)
             fields.emplace_back(
                 "parent", parent ? repr_string(parent->getName()) : "None");
             fields.emplace_back(
-                "child_joints", std::to_string(self.getNumChildJoints()));
+                "child_joints", std::format("{}", self.getNumChildJoints()));
             fields.emplace_back(
-                "shape_nodes", std::to_string(self.getNumShapeNodes()));
+                "shape_nodes", std::format("{}", self.getNumShapeNodes()));
             return format_repr("BodyNode", fields);
           })
       .def(

--- a/python/dartpy/dynamics/body_node.cpp
+++ b/python/dartpy/dynamics/body_node.cpp
@@ -16,7 +16,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
-#include <format>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -118,9 +118,9 @@ void defBodyNode(nb::module_& m)
             fields.emplace_back(
                 "parent", parent ? repr_string(parent->getName()) : "None");
             fields.emplace_back(
-                "child_joints", std::format("{}", self.getNumChildJoints()));
+                "child_joints", std::to_string(self.getNumChildJoints()));
             fields.emplace_back(
-                "shape_nodes", std::format("{}", self.getNumShapeNodes()));
+                "shape_nodes", std::to_string(self.getNumShapeNodes()));
             return format_repr("BodyNode", fields);
           })
       .def(

--- a/python/dartpy/dynamics/chain.cpp
+++ b/python/dartpy/dynamics/chain.cpp
@@ -10,7 +10,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
-#include <format>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -159,9 +159,9 @@ void defChain(nb::module_& m)
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("name", repr_string(self.getName()));
         fields.emplace_back(
-            "body_nodes", std::format("{}", self.getNumBodyNodes()));
-        fields.emplace_back("joints", std::format("{}", self.getNumJoints()));
-        fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
+            "body_nodes", std::to_string(self.getNumBodyNodes()));
+        fields.emplace_back("joints", std::to_string(self.getNumJoints()));
+        fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
         fields.emplace_back("assembled", repr_bool(self.isAssembled()));
         fields.emplace_back("valid", repr_bool(self.isStillChain()));
         return format_repr("Chain", fields);

--- a/python/dartpy/dynamics/chain.cpp
+++ b/python/dartpy/dynamics/chain.cpp
@@ -10,6 +10,8 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <format>
+
 namespace nb = nanobind;
 
 namespace dart::python_nb {
@@ -157,9 +159,9 @@ void defChain(nb::module_& m)
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("name", repr_string(self.getName()));
         fields.emplace_back(
-            "body_nodes", std::to_string(self.getNumBodyNodes()));
-        fields.emplace_back("joints", std::to_string(self.getNumJoints()));
-        fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
+            "body_nodes", std::format("{}", self.getNumBodyNodes()));
+        fields.emplace_back("joints", std::format("{}", self.getNumJoints()));
+        fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
         fields.emplace_back("assembled", repr_bool(self.isAssembled()));
         fields.emplace_back("valid", repr_bool(self.isStillChain()));
         return format_repr("Chain", fields);

--- a/python/dartpy/dynamics/degree_of_freedom.cpp
+++ b/python/dartpy/dynamics/degree_of_freedom.cpp
@@ -9,7 +9,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
-#include <format>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -50,9 +50,9 @@ void defDegreeOfFreedom(nb::module_& m)
             std::vector<std::pair<std::string, std::string>> fields;
             fields.emplace_back("name", repr_string(self.getName()));
             fields.emplace_back(
-                "index", std::format("{}", self.getIndexInSkeleton()));
+                "index", std::to_string(self.getIndexInSkeleton()));
             fields.emplace_back(
-                "index_in_joint", std::format("{}", self.getIndexInJoint()));
+                "index_in_joint", std::to_string(self.getIndexInJoint()));
             fields.emplace_back(
                 "joint", joint ? repr_string(joint->getName()) : "None");
             fields.emplace_back(

--- a/python/dartpy/dynamics/degree_of_freedom.cpp
+++ b/python/dartpy/dynamics/degree_of_freedom.cpp
@@ -9,6 +9,8 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
+#include <format>
+
 namespace nb = nanobind;
 
 namespace dart::python_nb {
@@ -48,9 +50,9 @@ void defDegreeOfFreedom(nb::module_& m)
             std::vector<std::pair<std::string, std::string>> fields;
             fields.emplace_back("name", repr_string(self.getName()));
             fields.emplace_back(
-                "index", std::to_string(self.getIndexInSkeleton()));
+                "index", std::format("{}", self.getIndexInSkeleton()));
             fields.emplace_back(
-                "index_in_joint", std::to_string(self.getIndexInJoint()));
+                "index_in_joint", std::format("{}", self.getIndexInJoint()));
             fields.emplace_back(
                 "joint", joint ? repr_string(joint->getName()) : "None");
             fields.emplace_back(

--- a/python/dartpy/dynamics/inverse_kinematics.cpp
+++ b/python/dartpy/dynamics/inverse_kinematics.cpp
@@ -12,7 +12,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
-#include <format>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -120,7 +120,7 @@ void defInverseKinematics(nb::module_& m)
         fields.emplace_back(
             "target", target ? repr_string(target->getName()) : "None");
         fields.emplace_back("active", repr_bool(self.isActive()));
-        fields.emplace_back("dofs", std::format("{}", self.getDofs().size()));
+        fields.emplace_back("dofs", std::to_string(self.getDofs().size()));
         return format_repr("InverseKinematics", fields);
       });
 

--- a/python/dartpy/dynamics/inverse_kinematics.cpp
+++ b/python/dartpy/dynamics/inverse_kinematics.cpp
@@ -12,6 +12,8 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
+#include <format>
+
 namespace nb = nanobind;
 
 namespace dart::python_nb {
@@ -118,7 +120,7 @@ void defInverseKinematics(nb::module_& m)
         fields.emplace_back(
             "target", target ? repr_string(target->getName()) : "None");
         fields.emplace_back("active", repr_bool(self.isActive()));
-        fields.emplace_back("dofs", std::to_string(self.getDofs().size()));
+        fields.emplace_back("dofs", std::format("{}", self.getDofs().size()));
         return format_repr("InverseKinematics", fields);
       });
 

--- a/python/dartpy/dynamics/joint.cpp
+++ b/python/dartpy/dynamics/joint.cpp
@@ -14,8 +14,8 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
-#include <format>
 #include <span>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -80,7 +80,7 @@ void defJoint(nb::module_& m)
             std::vector<std::pair<std::string, std::string>> fields;
             fields.emplace_back("name", repr_string(self.getName()));
             fields.emplace_back("type", repr_string(self.getType()));
-            fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
+            fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
             fields.emplace_back(
                 "parent", parent ? repr_string(parent->getName()) : "None");
             fields.emplace_back(

--- a/python/dartpy/dynamics/joint.cpp
+++ b/python/dartpy/dynamics/joint.cpp
@@ -14,6 +14,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <format>
 #include <span>
 
 namespace nb = nanobind;
@@ -79,7 +80,7 @@ void defJoint(nb::module_& m)
             std::vector<std::pair<std::string, std::string>> fields;
             fields.emplace_back("name", repr_string(self.getName()));
             fields.emplace_back("type", repr_string(self.getType()));
-            fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
+            fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
             fields.emplace_back(
                 "parent", parent ? repr_string(parent->getName()) : "None");
             fields.emplace_back(

--- a/python/dartpy/dynamics/linkage.cpp
+++ b/python/dartpy/dynamics/linkage.cpp
@@ -10,6 +10,8 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <format>
+
 namespace nb = nanobind;
 
 namespace dart::python_nb {
@@ -73,9 +75,10 @@ void defLinkage(nb::module_& m)
             std::vector<std::pair<std::string, std::string>> fields;
             fields.emplace_back("name", repr_string(self.getName()));
             fields.emplace_back(
-                "body_nodes", std::to_string(self.getNumBodyNodes()));
-            fields.emplace_back("joints", std::to_string(self.getNumJoints()));
-            fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
+                "body_nodes", std::format("{}", self.getNumBodyNodes()));
+            fields.emplace_back(
+                "joints", std::format("{}", self.getNumJoints()));
+            fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
             fields.emplace_back("assembled", repr_bool(self.isAssembled()));
             return format_repr("Linkage", fields);
           })

--- a/python/dartpy/dynamics/linkage.cpp
+++ b/python/dartpy/dynamics/linkage.cpp
@@ -10,7 +10,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
-#include <format>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -75,10 +75,9 @@ void defLinkage(nb::module_& m)
             std::vector<std::pair<std::string, std::string>> fields;
             fields.emplace_back("name", repr_string(self.getName()));
             fields.emplace_back(
-                "body_nodes", std::format("{}", self.getNumBodyNodes()));
-            fields.emplace_back(
-                "joints", std::format("{}", self.getNumJoints()));
-            fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
+                "body_nodes", std::to_string(self.getNumBodyNodes()));
+            fields.emplace_back("joints", std::to_string(self.getNumJoints()));
+            fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
             fields.emplace_back("assembled", repr_bool(self.isAssembled()));
             return format_repr("Linkage", fields);
           })

--- a/python/dartpy/dynamics/skeleton.cpp
+++ b/python/dartpy/dynamics/skeleton.cpp
@@ -25,6 +25,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
+#include <format>
 #include <memory>
 #include <utility>
 
@@ -165,9 +166,10 @@ void defSkeleton(nb::module_& m)
   skeletonClass.def("__repr__", [](const Skeleton& self) {
     std::vector<std::pair<std::string, std::string>> fields;
     fields.emplace_back("name", repr_string(self.getName()));
-    fields.emplace_back("body_nodes", std::to_string(self.getNumBodyNodes()));
-    fields.emplace_back("joints", std::to_string(self.getNumJoints()));
-    fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
+    fields.emplace_back(
+        "body_nodes", std::format("{}", self.getNumBodyNodes()));
+    fields.emplace_back("joints", std::format("{}", self.getNumJoints()));
+    fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
     return format_repr("Skeleton", fields);
   });
 

--- a/python/dartpy/dynamics/skeleton.cpp
+++ b/python/dartpy/dynamics/skeleton.cpp
@@ -25,8 +25,8 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 
-#include <format>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace nb = nanobind;
@@ -166,10 +166,9 @@ void defSkeleton(nb::module_& m)
   skeletonClass.def("__repr__", [](const Skeleton& self) {
     std::vector<std::pair<std::string, std::string>> fields;
     fields.emplace_back("name", repr_string(self.getName()));
-    fields.emplace_back(
-        "body_nodes", std::format("{}", self.getNumBodyNodes()));
-    fields.emplace_back("joints", std::format("{}", self.getNumJoints()));
-    fields.emplace_back("dofs", std::format("{}", self.getNumDofs()));
+    fields.emplace_back("body_nodes", std::to_string(self.getNumBodyNodes()));
+    fields.emplace_back("joints", std::to_string(self.getNumJoints()));
+    fields.emplace_back("dofs", std::to_string(self.getNumDofs()));
     return format_repr("Skeleton", fields);
   });
 

--- a/python/dartpy/simulation/world.cpp
+++ b/python/dartpy/simulation/world.cpp
@@ -20,8 +20,8 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
-#include <format>
 #include <memory>
+#include <string>
 
 namespace nb = nanobind;
 
@@ -257,7 +257,7 @@ void defWorld(nb::module_& m)
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("name", repr_string(self.getName()));
         fields.emplace_back(
-            "skeletons", std::format("{}", self.getNumSkeletons()));
+            "skeletons", std::to_string(self.getNumSkeletons()));
         fields.emplace_back("time", repr_double(self.getTime()));
         fields.emplace_back("time_step", repr_double(self.getTimeStep()));
         return format_repr("World", fields);

--- a/python/dartpy/simulation/world.cpp
+++ b/python/dartpy/simulation/world.cpp
@@ -20,6 +20,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <format>
 #include <memory>
 
 namespace nb = nanobind;
@@ -256,7 +257,7 @@ void defWorld(nb::module_& m)
         std::vector<std::pair<std::string, std::string>> fields;
         fields.emplace_back("name", repr_string(self.getName()));
         fields.emplace_back(
-            "skeletons", std::to_string(self.getNumSkeletons()));
+            "skeletons", std::format("{}", self.getNumSkeletons()));
         fields.emplace_back("time", repr_double(self.getTime()));
         fields.emplace_back("time_step", repr_double(self.getTimeStep()));
         return format_repr("World", fields);


### PR DESCRIPTION
## Summary

- Adopt `std::format` for dartpy numeric repr field formatting.
- Remove the remaining `std::to_string` uses from `python/dartpy` binding sources.

## Motivation / Problem

- Continue the C++20 standard library adoption work on `main` with a focused Python binding cleanup.

## Changes / Key Changes

- Add `<format>` to the affected dartpy binding translation units.
- Format numeric repr fields in collision, dynamics, and simulation bindings with `std::format("{}", value)`.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
