### PR TITLE
Adopt ranges algorithms in remaining helpers

### DIFF
--- a/dart/common/string.cpp
+++ b/dart/common/string.cpp
@@ -34,6 +34,22 @@
 
 #include <algorithm>
 
+#include <cctype>
+
+namespace {
+
+char toUpperChar(unsigned char c)
+{
+  return static_cast<char>(std::toupper(c));
+}
+
+char toLowerChar(unsigned char c)
+{
+  return static_cast<char>(std::tolower(c));
+}
+
+} // namespace
+
 namespace dart::common {
 
 //==============================================================================
@@ -46,7 +62,7 @@ std::string toUpper(std::string str)
 //==============================================================================
 void toUpperInPlace(std::string& str)
 {
-  std::ranges::transform(str, str.begin(), ::toupper);
+  std::ranges::transform(str, str.begin(), toUpperChar);
 }
 
 //==============================================================================
@@ -59,7 +75,7 @@ std::string toLower(std::string str)
 //==============================================================================
 void toLowerInPlace(std::string& str)
 {
-  std::ranges::transform(str, str.begin(), ::tolower);
+  std::ranges::transform(str, str.begin(), toLowerChar);
 }
 
 //==============================================================================

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -62,6 +62,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include <cctype>
 #include <cstring>
 
 namespace dart {
@@ -1552,7 +1553,9 @@ bool hasColladaExtension(std::string_view path)
   }
 
   std::string extension(path.substr(extensionIndex));
-  std::ranges::transform(extension, extension.begin(), ::tolower);
+  std::ranges::transform(extension, extension.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
   return extension == ".dae" || extension == ".zae";
 }
 

--- a/dart/utils/mesh_loader.hpp
+++ b/dart/utils/mesh_loader.hpp
@@ -261,8 +261,9 @@ typename MeshLoader<S>::aiScenePtr MeshLoader<S>::loadScene(
     }
 
     std::string extension(path.substr(extensionIndex));
-    std::transform(
-        extension.begin(), extension.end(), extension.begin(), ::tolower);
+    std::ranges::transform(extension, extension.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
     return extension == ".dae" || extension == ".zae";
   };
 

--- a/tests/integration/io/test_sdf_parser.cpp
+++ b/tests/integration/io/test_sdf_parser.cpp
@@ -65,6 +65,7 @@
 #include <sstream>
 #include <string>
 
+#include <cctype>
 #include <cstring>
 
 #if DART_HAVE_spdlog
@@ -911,8 +912,9 @@ TEST(SdfParser, WarnsOnTinyMassAndDefaultsInertia)
     EXPECT_TRUE(hasSmallMassWarning)
         << "Expected warning about tiny mass clamping in logs: " << logs;
     std::string logsLower = logs;
-    std::transform(
-        logsLower.begin(), logsLower.end(), logsLower.begin(), ::tolower);
+    std::ranges::transform(logsLower, logsLower.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
     EXPECT_NE(logsLower.find("clamping to"), std::string::npos)
         << "Expected warning about tiny mass clamping in logs: " << logs;
     EXPECT_NE(logs.find("defines <mass> but no <inertia>"), std::string::npos)

--- a/tests/unit/math/lcp/test_lcp_validation_and_solvers.cpp
+++ b/tests/unit/math/lcp/test_lcp_validation_and_solvers.cpp
@@ -35,6 +35,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <limits>
 #include <string>
 #include <vector>
@@ -1103,8 +1104,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, p, q, Eigen::RowMajor> Be;
   Eigen::Matrix<double, q, r, Eigen::RowMajor> Ce;
-  std::copy(B.begin(), B.end(), Be.data());
-  std::copy(C.begin(), C.end(), Ce.data());
+  std::ranges::copy(B, Be.data());
+  std::ranges::copy(C, Ce.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected0 = Be * Ce;
   for (int i = 0; i < p * r; ++i) {
     EXPECT_NEAR(A0[static_cast<std::size_t>(i)], expected0.data()[i], 1e-12);
@@ -1117,8 +1118,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, q, p, Eigen::RowMajor> Be1;
   Eigen::Matrix<double, q, r, Eigen::RowMajor> Ce1;
-  std::copy(B1.begin(), B1.end(), Be1.data());
-  std::copy(C1.begin(), C1.end(), Ce1.data());
+  std::ranges::copy(B1, Be1.data());
+  std::ranges::copy(C1, Ce1.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected1
       = Be1.transpose() * Ce1;
   for (int i = 0; i < p * r; ++i) {
@@ -1132,8 +1133,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, p, q, Eigen::RowMajor> Be2;
   Eigen::Matrix<double, r, q, Eigen::RowMajor> Ce2;
-  std::copy(B2.begin(), B2.end(), Be2.data());
-  std::copy(C2.begin(), C2.end(), Ce2.data());
+  std::ranges::copy(B2, Be2.data());
+  std::ranges::copy(C2, Ce2.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected2
       = Be2 * Ce2.transpose();
   for (int i = 0; i < p * r; ++i) {


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges algorithm overloads for remaining transform/copy helper sites.
- Route string case conversion through unsigned-char safe `std::tolower`/`std::toupper` adapters.

## Motivation / Problem

- Continue C++20 standard library adoption on `main` while reducing iterator boilerplate and avoiding signed-char pitfalls in case conversion.

## Changes / Key Changes

- Use `std::ranges::transform` in remaining mesh/SDF lowercase helpers.
- Use `std::ranges::copy` in LCP matrix validation setup.
- Add direct `<cctype>`/`<algorithm>` includes where needed.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
