### PR TITLE
Adopt ranges algorithms in benchmark utilities

### DIFF
--- a/examples/speed_test/main.cpp
+++ b/examples/speed_test/main.cpp
@@ -35,6 +35,7 @@
 #include <dart/all.hpp>
 #include <dart/io/read.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <numeric>
 
@@ -162,11 +163,8 @@ void print_results(const std::vector<double>& result)
   double mean = sum / result.size();
   std::cout << "Average: " << mean << "\n";
   std::vector<double> diff(result.size());
-  std::transform(
-      result.begin(),
-      result.end(),
-      diff.begin(),
-      std::bind(std::minus<double>(), mean, std::placeholders::_1));
+  std::ranges::transform(
+      result, diff.begin(), [mean](double value) { return mean - value; });
   double stddev = std::sqrt(
       std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0)
       / result.size());

--- a/tests/benchmark/lcpsolver/bm_lcpsolver.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcpsolver.cpp
@@ -14,6 +14,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <algorithm>
 #include <vector>
 
 using dReal = double;
@@ -129,8 +130,8 @@ static void BM_Dantzig_F32_Solver(
 
   for (auto _ : state) {
     // Reset solution vectors
-    std::fill(x_f.begin(), x_f.end(), 0.0f);
-    std::fill(w_f.begin(), w_f.end(), 0.0f);
+    std::ranges::fill(x_f, 0.0f);
+    std::ranges::fill(w_f, 0.0f);
 
     // Solve LCP using template version with float
     bool success = dart::math::SolveLCP<float>(


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges algorithms in benchmark-oriented utility code.
- Replace `std::bind` usage in the speed-test statistics helper with a direct lambda.

## Motivation / Problem

- Continue the DART 7.0 C++20 modernization by simplifying legacy iterator-pair algorithm calls where range overloads are clearer.

## Changes / Key Changes

- Use `std::ranges::fill` when resetting LCP benchmark solution vectors.
- Use `std::ranges::transform` in the speed-test standard-deviation helper.
- Add direct `<algorithm>` includes for the adopted ranges algorithms.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: not required for internal refactor
- [x] Add unit tests for new functionality: not applicable, no behavior change
- [x] Document new methods and classes: not applicable
- [x] Add Python bindings (dartpy) if applicable: not applicable