### PR TITLE
Adopt ranges algorithms in linkage and MJCF tests

### DIFF
--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -346,7 +346,7 @@ void Linkage::Criteria::expandToTarget(
     trimBodyNodes(newBns, _target.mChain, true);
   } else if (target_bn->descendsFrom(start_bn)) {
     newBns = climbToTarget(target_bn, start_bn);
-    std::reverse(newBns.begin(), newBns.end());
+    std::ranges::reverse(newBns);
     trimBodyNodes(newBns, _target.mChain, false);
   } else {
     newBns = climbToCommonRoot(_start, _target, _target.mChain);
@@ -416,7 +416,7 @@ std::vector<BodyNode*> Linkage::Criteria::climbToCommonRoot(
   }
 
   std::vector<BodyNode*> bnTarget = climbToTarget(target_bn, root);
-  std::reverse(bnTarget.begin(), bnTarget.end());
+  std::ranges::reverse(bnTarget);
   trimBodyNodes(bnTarget, _chain, false);
 
   std::vector<BodyNode*> bnAll;

--- a/tests/integration/io/test_mjcf_parser.cpp
+++ b/tests/integration/io/test_mjcf_parser.cpp
@@ -1478,7 +1478,7 @@ TEST(MjcfParserTest, ComplexMjcfCoversDetails)
 
   const std::string meshFileName = meshPath.filename().string();
   std::string meshDirStr = tempDir.string();
-  std::replace(meshDirStr.begin(), meshDirStr.end(), '\\', '/');
+  std::ranges::replace(meshDirStr, '\\', '/');
   std::string xml = R"(
 <?xml version="1.0" ?>
 <mujoco model="complex_mjcf">
@@ -1617,7 +1617,7 @@ TEST(MjcfParserTest, CustomModelParsesBodiesGeomsAndActuators)
 
   const std::string meshFileName = meshPath.filename().string();
   std::string meshDirStr = tempDir.string();
-  std::replace(meshDirStr.begin(), meshDirStr.end(), '\\', '/');
+  std::ranges::replace(meshDirStr, '\\', '/');
   std::string xml = R"(
 <?xml version="1.0" ?>
 <mujoco model="custom_parser">


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges algorithms in linkage traversal and MJCF parser tests.

## Motivation / Problem

- Continue DART 7.0 C++20 modernization by replacing legacy iterator-pair algorithm calls with clearer range overloads.

## Changes / Key Changes

- Use `std::ranges::reverse` when reversing linkage body-node traversal vectors.
- Use `std::ranges::replace` for MJCF test path normalization.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: not required for internal refactor
- [x] Add unit tests for new functionality: not applicable, no behavior change
- [x] Document new methods and classes: not applicable
- [x] Add Python bindings (dartpy) if applicable: not applicable