### PR TITLE
Adopt C++20 numeric constants in math helpers

### DIFF
--- a/dart/dynamics/ikfast.h
+++ b/dart/dynamics/ikfast.h
@@ -30,10 +30,11 @@
    - IKFAST_NAMESPACE - Enclose all functions and classes in this namespace, the ``main`` function is excluded.
 
  */
-#include <vector>
-#include <list>
-#include <stdexcept>
 #include <cmath>
+#include <list>
+#include <numbers>
+#include <stdexcept>
+#include <vector>
 
 #ifndef IKFAST_HEADER_COMMON
 #define IKFAST_HEADER_COMMON
@@ -169,11 +170,14 @@ public:
                 solution[i] = _vbasesol[i].foffset;
             else {
                 solution[i] = freevalues[_vbasesol[i].freeind]*_vbasesol[i].fmul + _vbasesol[i].foffset;
-                if( solution[i] > T(3.14159265358979) ) {
-                    solution[i] -= T(6.28318530717959);
+                const T pi = T(std::numbers::pi_v<long double>);
+                const T negativePi = T(-std::numbers::pi_v<long double>);
+                const T twoPi = T(2 * std::numbers::pi_v<long double>);
+                if( solution[i] > pi ) {
+                    solution[i] -= twoPi;
                 }
-                else if( solution[i] < T(-3.14159265358979) ) {
-                    solution[i] += T(6.28318530717959);
+                else if( solution[i] < negativePi ) {
+                    solution[i] += twoPi;
                 }
             }
         }

--- a/dart/simd/detail/math/constants.hpp
+++ b/dart/simd/detail/math/constants.hpp
@@ -86,9 +86,10 @@ struct MathConstants
   // Square roots
   static constexpr T sqrt2 = std::numbers::sqrt2_v<T>;
   static constexpr T invSqrt2 = T(1) / std::numbers::sqrt2_v<T>;
-  static constexpr T sqrtPi = T(1.77245385090551602729816748334114518);
+  static constexpr T sqrtPi = T(1) / std::numbers::inv_sqrtpi_v<T>;
   static constexpr T invSqrtPi = std::numbers::inv_sqrtpi_v<T>;
-  static constexpr T sqrt2Pi = T(2.50662827463100050241576528481104525);
+  static constexpr T sqrt2Pi
+      = std::numbers::sqrt2_v<T> / std::numbers::inv_sqrtpi_v<T>;
 
   // Special values
   static constexpr T infinity = std::numeric_limits<T>::infinity();

--- a/dart/simd/detail/math/exp_impl.hpp
+++ b/dart/simd/detail/math/exp_impl.hpp
@@ -65,7 +65,7 @@ template <std::size_t W>
   using MaskT = VecMask<float, W>;
 
   constexpr float range = 88.3762588501f;
-  constexpr float invLog2 = 1.44269504088896341f;
+  constexpr float invLog2 = MathConstants<float>::log2E;
   constexpr float nlog2Hi = -0.693359375f;
   constexpr float nlog2Lo = 2.12194440e-4f;
 
@@ -135,7 +135,7 @@ template <std::size_t W>
   using MaskT = VecMask<double, W>;
 
   constexpr double range = 709.43613930310391424428;
-  constexpr double invLog2 = 1.44269504088896340736;
+  constexpr double invLog2 = MathConstants<double>::log2E;
   constexpr double nlog2Hi = -0.693145751953125;
   constexpr double nlog2Lo = -1.42860682030941723212e-6;
 

--- a/dart/simd/detail/math/log_impl.hpp
+++ b/dart/simd/detail/math/log_impl.hpp
@@ -63,7 +63,7 @@ template <std::size_t W>
   using VecT = Vec<float, W>;
   using MaskT = VecMask<float, W>;
 
-  constexpr float invSqrt2 = 0.70710678118654752440f;
+  constexpr float invSqrt2 = MathConstants<float>::invSqrt2;
   constexpr float log2Hi = 0.693359375f;
   constexpr float log2Lo = -2.121944400546905827679e-4f;
 


### PR DESCRIPTION
## Summary

- Adopt C++20 `<numbers>` constants in SIMD math helpers and the shared IKFast header.

## Motivation / Problem

- Several math helpers still spelled standard constants as raw literals even though DART now builds as C++20.

## Changes / Key Changes

- Use `std::numbers`-backed `MathConstants` values for SIMD log/exp constants.
- Derive SIMD sqrt-pi constants from `std::numbers::inv_sqrtpi_v`.
- Use `std::numbers::pi_v<long double>` for IKFast solution normalization while preserving construction through the configured real type.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
