### PR TITLE
Adopt C++20 ranges in benchmark setup

### DIFF
--- a/tests/benchmark/common/bm_allocators.cpp
+++ b/tests/benchmark/common/bm_allocators.cpp
@@ -54,6 +54,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <array>
 #include <vector>
 
 #include <cstddef>
@@ -671,8 +672,8 @@ BENCHMARK(BM_StlContainer_Frame)
 // Section 8: Multi-Size Realistic Workload
 // =============================================================================
 
-static constexpr size_t kRealisticSizes[] = {16, 32, 64, 128, 256, 512, 1024};
-static constexpr size_t kRealisticSizeCount = 7;
+static constexpr auto kRealisticSizes
+    = std::to_array<size_t>({16, 32, 64, 128, 256, 512, 1024});
 static constexpr size_t kRealisticOps = 1000;
 
 static void BM_RealisticWorkload_Std(benchmark::State& state)
@@ -685,7 +686,7 @@ static void BM_RealisticWorkload_Std(benchmark::State& state)
   for (auto _ : state) {
     size_t totalBytes = 0;
     for (size_t i = 0; i < kRealisticOps; ++i) {
-      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizeCount];
+      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizes.size()];
       ptrs[i] = {alloc.allocate(sz), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
       totalBytes += sz;
@@ -716,7 +717,7 @@ static void BM_RealisticWorkload_FreeList(benchmark::State& state)
   for (auto _ : state) {
     size_t totalBytes = 0;
     for (size_t i = 0; i < kRealisticOps; ++i) {
-      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizeCount];
+      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizes.size()];
       ptrs[i] = {alloc.allocate(sz), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
       totalBytes += sz;
@@ -746,7 +747,7 @@ static void BM_RealisticWorkload_Pool(benchmark::State& state)
   for (auto _ : state) {
     size_t totalBytes = 0;
     for (size_t i = 0; i < kRealisticOps; ++i) {
-      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizeCount];
+      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizes.size()];
       ptrs[i] = {alloc.allocate(sz), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
       totalBytes += sz;

--- a/tests/benchmark/common/bm_allocators_comparative.cpp
+++ b/tests/benchmark/common/bm_allocators_comparative.cpp
@@ -65,6 +65,7 @@
 #include <foonathan/memory/namespace_alias.hpp>
 #include <foonathan/memory/std_allocator.hpp>
 
+#include <array>
 #include <memory_resource>
 #include <vector>
 
@@ -261,8 +262,8 @@ BENCHMARK(BM_Stack_StdPmr)
 // Tests how well each allocator handles heterogeneous allocation patterns.
 // =============================================================================
 
-static constexpr size_t kMultiSizes[] = {16, 32, 64, 128, 256, 512};
-static constexpr size_t kMultiSizeCount = 6;
+static constexpr auto kMultiSizes
+    = std::to_array<size_t>({16, 32, 64, 128, 256, 512});
 static constexpr size_t kMultiOps = 4096;
 
 static void BM_MultiPool_DART(benchmark::State& state)
@@ -273,7 +274,7 @@ static void BM_MultiPool_DART(benchmark::State& state)
   lcgState = 77u;
   for (auto _ : state) {
     for (size_t i = 0; i < kMultiOps; ++i) {
-      const size_t sz = kMultiSizes[lcgNext() % kMultiSizeCount];
+      const size_t sz = kMultiSizes[lcgNext() % kMultiSizes.size()];
       ptrs[i] = {alloc.allocate(sz), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
     }
@@ -294,7 +295,7 @@ static void BM_MultiPool_Foonathan(benchmark::State& state)
   lcgState = 77u;
   for (auto _ : state) {
     for (size_t i = 0; i < kMultiOps; ++i) {
-      const size_t sz = kMultiSizes[lcgNext() % kMultiSizeCount];
+      const size_t sz = kMultiSizes[lcgNext() % kMultiSizes.size()];
       ptrs[i] = {pool.allocate_node(sz), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
     }
@@ -316,7 +317,7 @@ static void BM_MultiPool_StdPmr(benchmark::State& state)
   lcgState = 77u;
   for (auto _ : state) {
     for (size_t i = 0; i < kMultiOps; ++i) {
-      const size_t sz = kMultiSizes[lcgNext() % kMultiSizeCount];
+      const size_t sz = kMultiSizes[lcgNext() % kMultiSizes.size()];
       ptrs[i] = {pool.allocate(sz, alignof(std::max_align_t)), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
     }
@@ -336,8 +337,8 @@ BENCHMARK(BM_MultiPool_StdPmr)->Repetitions(5)->ReportAggregatesOnly(true);
 // Simulates a full physics step allocation pattern.
 // =============================================================================
 
-static constexpr size_t kRealisticSizes[] = {16, 32, 64, 128, 256, 512, 1024};
-static constexpr size_t kRealisticSizeCount = 7;
+static constexpr auto kRealisticSizes
+    = std::to_array<size_t>({16, 32, 64, 128, 256, 512, 1024});
 static constexpr size_t kRealisticOps = 1000;
 
 static void BM_Realistic_DART(benchmark::State& state)
@@ -348,7 +349,7 @@ static void BM_Realistic_DART(benchmark::State& state)
   lcgState = 99u;
   for (auto _ : state) {
     for (size_t i = 0; i < kRealisticOps; ++i) {
-      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizeCount];
+      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizes.size()];
       ptrs[i] = {alloc.allocate(sz), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
     }
@@ -376,7 +377,7 @@ static void BM_Realistic_Foonathan(benchmark::State& state)
   lcgState = 99u;
   for (auto _ : state) {
     for (size_t i = 0; i < kRealisticOps; ++i) {
-      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizeCount];
+      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizes.size()];
       ptrs[i] = {pool.allocate_node(sz), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
     }
@@ -405,7 +406,7 @@ static void BM_Realistic_StdPmr(benchmark::State& state)
   lcgState = 99u;
   for (auto _ : state) {
     for (size_t i = 0; i < kRealisticOps; ++i) {
-      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizeCount];
+      const size_t sz = kRealisticSizes[lcgNext() % kRealisticSizes.size()];
       ptrs[i] = {pool.allocate(sz, alignof(std::max_align_t)), sz};
       benchmark::DoNotOptimize(ptrs[i].first);
     }
@@ -542,8 +543,8 @@ BENCHMARK(BM_SteadyState_StdPmr)
 // reset. Tests the exact usage pattern in DART's ConstraintSolver.
 // =============================================================================
 
-static constexpr size_t kFrameSizes[] = {24, 48, 96, 192, 384};
-static constexpr size_t kFrameSizeCount = 5;
+static constexpr auto kFrameSizes
+    = std::to_array<size_t>({24, 48, 96, 192, 384});
 
 static void BM_FrameBulk_DART(benchmark::State& state)
 {
@@ -554,7 +555,7 @@ static void BM_FrameBulk_DART(benchmark::State& state)
   lcgState = 55u;
   for (auto _ : state) {
     for (size_t i = 0; i < count; ++i) {
-      const size_t sz = kFrameSizes[lcgNext() % kFrameSizeCount];
+      const size_t sz = kFrameSizes[lcgNext() % kFrameSizes.size()];
       void* p = alloc.allocateAligned(sz, 32);
       benchmark::DoNotOptimize(p);
     }
@@ -579,7 +580,7 @@ static void BM_FrameBulk_Foonathan(benchmark::State& state)
   for (auto _ : state) {
     auto marker = stack.top();
     for (size_t i = 0; i < count; ++i) {
-      const size_t sz = kFrameSizes[lcgNext() % kFrameSizeCount];
+      const size_t sz = kFrameSizes[lcgNext() % kFrameSizes.size()];
       void* p = stack.allocate(sz, 32);
       benchmark::DoNotOptimize(p);
     }
@@ -605,7 +606,7 @@ static void BM_FrameBulk_StdPmr(benchmark::State& state)
     std::pmr::monotonic_buffer_resource mono(
         backing.get(), arenaSize, std::pmr::null_memory_resource());
     for (size_t i = 0; i < count; ++i) {
-      const size_t sz = kFrameSizes[lcgNext() % kFrameSizeCount];
+      const size_t sz = kFrameSizes[lcgNext() % kFrameSizes.size()];
       void* p = mono.allocate(sz, 32);
       benchmark::DoNotOptimize(p);
     }

--- a/tests/benchmark/lcpsolver/CMakeLists.txt
+++ b/tests/benchmark/lcpsolver/CMakeLists.txt
@@ -32,6 +32,17 @@ add_executable(BM_MATRIX_MULTIPLY bm_matrix_multiply.cpp)
 target_link_libraries(BM_MATRIX_MULTIPLY dart benchmark::benchmark)
 set_target_properties(BM_MATRIX_MULTIPLY PROPERTIES FOLDER "Benchmarks")
 
+foreach(benchmark_target IN ITEMS
+  BM_LCPSOLVER
+  BM_LCPSOLVER_SOLVERS
+  BM_LCP_COMPARE
+  BM_ROW_SWAPPING
+  BM_DOT_PRODUCT
+  BM_MATRIX_MULTIPLY
+)
+  target_compile_features(${benchmark_target} PRIVATE cxx_std_20)
+endforeach()
+
 # Add to formatting
 dart_format_add(
   bm_lcpsolver.cpp

--- a/tests/benchmark/lcpsolver/bm_dot_product.cpp
+++ b/tests/benchmark/lcpsolver/bm_dot_product.cpp
@@ -9,6 +9,7 @@
 #include <benchmark/benchmark.h>
 
 #include <random>
+#include <ranges>
 #include <vector>
 
 using dReal = double;
@@ -63,7 +64,7 @@ public:
 
     a.resize(N);
     b.resize(N);
-    for (int i = 0; i < N; ++i) {
+    for (const int i : std::views::iota(0, N)) {
       a[i] = dis(gen);
       b[i] = dis(gen);
     }

--- a/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcp_compare.cpp
@@ -41,6 +41,7 @@
 #include <iterator>
 #include <limits>
 #include <random>
+#include <ranges>
 #include <sstream>
 #include <string>
 
@@ -71,8 +72,8 @@ LcpProblem MakeStandardSpdProblem(int n, unsigned seed)
   std::uniform_real_distribution<double> dist(-1.0, 1.0);
 
   Eigen::MatrixXd M(n, n);
-  for (int r = 0; r < n; ++r) {
-    for (int c = 0; c < n; ++c) {
+  for (const int r : std::views::iota(0, n)) {
+    for (const int c : std::views::iota(0, n)) {
       M(r, c) = dist(rng);
     }
   }
@@ -82,7 +83,7 @@ LcpProblem MakeStandardSpdProblem(int n, unsigned seed)
         + static_cast<double>(n) * Eigen::MatrixXd::Identity(n, n);
 
   Eigen::VectorXd xStar(n);
-  for (int i = 0; i < n; ++i) {
+  for (const int i : std::views::iota(0, n)) {
     xStar[i] = std::abs(dist(rng)) + 0.1;
   }
 
@@ -106,8 +107,8 @@ LcpProblem MakeBoxedActiveBoundsProblem(int n, unsigned seed)
   std::uniform_real_distribution<double> slackDist(0.1, 1.0);
 
   Eigen::MatrixXd M(n, n);
-  for (int r = 0; r < n; ++r) {
-    for (int c = 0; c < n; ++c) {
+  for (const int r : std::views::iota(0, n)) {
+    for (const int c : std::views::iota(0, n)) {
       M(r, c) = dist(rng);
     }
   }
@@ -122,7 +123,7 @@ LcpProblem MakeBoxedActiveBoundsProblem(int n, unsigned seed)
 
   Eigen::VectorXd xStar(n);
   Eigen::VectorXd w = Eigen::VectorXd::Zero(n);
-  for (int i = 0; i < n; ++i) {
+  for (const int i : std::views::iota(0, n)) {
     const int mode = i % 3;
     if (mode == 0) {
       xStar[i] = lo[i];
@@ -154,8 +155,8 @@ LcpProblem MakeFrictionIndexProblem(int numContacts, unsigned seed)
   std::uniform_real_distribution<double> muDist(0.2, 1.0);
 
   Eigen::MatrixXd M(n, n);
-  for (int r = 0; r < n; ++r) {
-    for (int c = 0; c < n; ++c) {
+  for (const int r : std::views::iota(0, n)) {
+    for (const int c : std::views::iota(0, n)) {
       M(r, c) = dist(rng);
     }
   }
@@ -169,7 +170,7 @@ LcpProblem MakeFrictionIndexProblem(int numContacts, unsigned seed)
   Eigen::VectorXd hi = Eigen::VectorXd::Zero(n);
   Eigen::VectorXi findex = Eigen::VectorXi::Constant(n, -1);
 
-  for (int c = 0; c < numContacts; ++c) {
+  for (const int c : std::views::iota(0, numContacts)) {
     const int base = 3 * c;
     const double normal = std::abs(dist(rng)) + 0.5;
     const double mu = muDist(rng);
@@ -339,7 +340,8 @@ static void BM_LcpCompare_ShockPropagation_Standard(benchmark::State& state)
 
   params.layers.clear();
   params.layers.reserve(params.blockSizes.size());
-  for (auto i = 0; i < std::ssize(params.blockSizes); ++i) {
+  for (const auto i :
+       std::views::iota(std::ptrdiff_t{0}, std::ssize(params.blockSizes))) {
     params.layers.push_back({static_cast<int>(i)});
   }
 
@@ -832,7 +834,7 @@ static void BM_LcpCompare_ShockPropagation_FrictionIndex(
   params.blockSizes.assign(numContacts, 3);
   params.layers.clear();
   params.layers.reserve(numContacts);
-  for (int i = 0; i < numContacts; ++i) {
+  for (const int i : std::views::iota(0, numContacts)) {
     params.layers.push_back({i});
   }
 

--- a/tests/benchmark/lcpsolver/bm_lcpsolver_solvers.cpp
+++ b/tests/benchmark/lcpsolver/bm_lcpsolver_solvers.cpp
@@ -17,6 +17,7 @@
 
 #include <limits>
 #include <random>
+#include <ranges>
 
 namespace {
 
@@ -29,8 +30,8 @@ LcpProblem makeStandardSpdProblem(int n, unsigned seed)
   std::uniform_real_distribution<double> dist(-1.0, 1.0);
 
   Eigen::MatrixXd M(n, n);
-  for (int r = 0; r < n; ++r) {
-    for (int c = 0; c < n; ++c) {
+  for (const int r : std::views::iota(0, n)) {
+    for (const int c : std::views::iota(0, n)) {
       M(r, c) = dist(rng);
     }
   }
@@ -40,7 +41,7 @@ LcpProblem makeStandardSpdProblem(int n, unsigned seed)
         + static_cast<double>(n) * Eigen::MatrixXd::Identity(n, n);
 
   Eigen::VectorXd xStar(n);
-  for (int i = 0; i < n; ++i) {
+  for (const int i : std::views::iota(0, n)) {
     xStar[i] = std::abs(dist(rng)) + 0.1;
   }
 
@@ -64,8 +65,8 @@ LcpProblem makeBoxedActiveBoundsSpdProblem(int n, unsigned seed)
   std::uniform_real_distribution<double> slackDist(0.1, 1.0);
 
   Eigen::MatrixXd M(n, n);
-  for (int r = 0; r < n; ++r) {
-    for (int c = 0; c < n; ++c) {
+  for (const int r : std::views::iota(0, n)) {
+    for (const int c : std::views::iota(0, n)) {
       M(r, c) = dist(rng);
     }
   }
@@ -80,7 +81,7 @@ LcpProblem makeBoxedActiveBoundsSpdProblem(int n, unsigned seed)
 
   Eigen::VectorXd xStar(n);
   Eigen::VectorXd w = Eigen::VectorXd::Zero(n);
-  for (int i = 0; i < n; ++i) {
+  for (const int i : std::views::iota(0, n)) {
     const int mode = i % 3;
     if (mode == 0) {
       xStar[i] = lo[i];
@@ -112,8 +113,8 @@ LcpProblem makeFrictionIndexSpdProblem(int numContacts, unsigned seed)
   std::uniform_real_distribution<double> muDist(0.2, 1.0);
 
   Eigen::MatrixXd M(n, n);
-  for (int r = 0; r < n; ++r) {
-    for (int c = 0; c < n; ++c) {
+  for (const int r : std::views::iota(0, n)) {
+    for (const int c : std::views::iota(0, n)) {
       M(r, c) = dist(rng);
     }
   }
@@ -127,7 +128,7 @@ LcpProblem makeFrictionIndexSpdProblem(int numContacts, unsigned seed)
   Eigen::VectorXd hi = Eigen::VectorXd::Zero(n);
   Eigen::VectorXi findex = Eigen::VectorXi::Constant(n, -1);
 
-  for (int c = 0; c < numContacts; ++c) {
+  for (const int c : std::views::iota(0, numContacts)) {
     const int base = 3 * c;
     const double normal = std::abs(dist(rng)) + 0.5;
     const double mu = muDist(rng);

--- a/tests/benchmark/lcpsolver/bm_matrix_multiply.cpp
+++ b/tests/benchmark/lcpsolver/bm_matrix_multiply.cpp
@@ -35,6 +35,7 @@
 #include <Eigen/Dense>
 #include <benchmark/benchmark.h>
 
+#include <algorithm>
 #include <random>
 #include <vector>
 
@@ -55,12 +56,8 @@ public:
     B.resize(size * size);
     C.resize(size * size);
 
-    for (auto& val : A) {
-      val = dist(rng);
-    }
-    for (auto& val : B) {
-      val = dist(rng);
-    }
+    std::ranges::generate(A, [&] { return dist(rng); });
+    std::ranges::generate(B, [&] { return dist(rng); });
   }
 
   void TearDown(const ::benchmark::State&) override

--- a/tests/benchmark/lcpsolver/bm_row_swapping.cpp
+++ b/tests/benchmark/lcpsolver/bm_row_swapping.cpp
@@ -36,6 +36,7 @@
 
 #include <algorithm>
 #include <random>
+#include <ranges>
 #include <vector>
 
 #include <cstring>
@@ -64,7 +65,7 @@ public:
 
     // Create row pointers
     rows_.resize(n);
-    for (int i = 0; i < n; ++i) {
+    for (const int i : std::views::iota(0, n)) {
       rows_[i] = data_.data() + i * nskip_;
     }
   }
@@ -132,7 +133,7 @@ public:
   {
     // Initialize row pointers to point into Eigen matrix
     rows_.resize(n);
-    for (int i = 0; i < n; ++i) {
+    for (const int i : std::views::iota(0, n)) {
       rows_[i] = matrix_.data() + i * n; // Eigen is column-major, need stride
     }
   }
@@ -171,7 +172,7 @@ std::vector<std::pair<int, int>> generateSwapPairs(int n, int num_swaps)
   std::vector<std::pair<int, int>> swaps;
   swaps.reserve(num_swaps);
 
-  for (int i = 0; i < num_swaps; ++i) {
+  for ([[maybe_unused]] const int ignored : std::views::iota(0, num_swaps)) {
     int i1 = dist(rng);
     int i2 = dist(rng);
     if (i1 > i2) {


### PR DESCRIPTION
## Summary

- Adopt `std::views::iota` and `std::ranges::generate` in benchmark setup/data generation code.
- Replace fixed benchmark workload arrays with `std::to_array` and derive counts from `.size()`.
- Ensure LCP benchmark executables request C++20 so benchmark-only targets can use C++20 library features directly.

## Motivation / Problem

- Continue the C++20 modernization pass with a benchmark-focused batch that avoids conflicts with the current C++20 PR queue.

## Changes / Key Changes

- Updated LCP benchmark problem generators and fixtures to use C++20 range/view utilities where they clarify setup loops.
- Updated allocator benchmark fixed-size tables to use `std::to_array`.
- Added `cxx_std_20` compile features to LCP benchmark targets.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run cmake --build build/default/cpp/Release --target BM_LCPSOLVER_SOLVERS BM_LCP_COMPARE BM_ROW_SWAPPING BM_DOT_PRODUCT BM_MATRIX_MULTIPLY bm_allocators bm_allocators_comparative`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
