### PR TITLE
Adopt C++20 concept for traversal callbacks

### DIFF
--- a/dart/common/detail/callback_traits.hpp
+++ b/dart/common/detail/callback_traits.hpp
@@ -30,49 +30,18 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_CONSTRAINT_DETAIL_CONSTRAINTSOVER_IMPL_HPP_
-#define DART_CONSTRAINT_DETAIL_CONSTRAINTSOVER_IMPL_HPP_
+#ifndef DART_COMMON_DETAIL_CALLBACK_TRAITS_HPP_
+#define DART_COMMON_DETAIL_CALLBACK_TRAITS_HPP_
 
-#include <dart/constraint/constraint_solver.hpp>
+#include <concepts>
 
-#include <dart/common/detail/callback_traits.hpp>
+namespace dart::common::detail {
 
-namespace dart::constraint {
+template <typename Func, typename... Args>
+concept ReturnsBool = requires(Func callable, Args... args) {
+  { callable(args...) } -> std::same_as<bool>;
+};
 
-//==============================================================================
-template <typename Func>
-void ConstraintSolver::eachConstraint(Func func) const
-{
-  if constexpr (common::detail::ReturnsBool<Func, const ConstraintBase*>) {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      if (!func(getConstraint(i))) {
-        return;
-      }
-    }
-  } else {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      func(getConstraint(i));
-    }
-  }
-}
+} // namespace dart::common::detail
 
-//==============================================================================
-template <typename Func>
-void ConstraintSolver::eachConstraint(Func func)
-{
-  if constexpr (common::detail::ReturnsBool<Func, ConstraintBase*>) {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      if (!func(getConstraint(i))) {
-        return;
-      }
-    }
-  } else {
-    for (auto i = 0u; i < getNumConstraints(); ++i) {
-      func(getConstraint(i));
-    }
-  }
-}
-
-} // namespace dart::constraint
-
-#endif // DART_CONSTRAINT_DETAIL_CONSTRAINTSOVER_IMPL_HPP_
+#endif // DART_COMMON_DETAIL_CALLBACK_TRAITS_HPP_

--- a/dart/dynamics/detail/basic_node_manager.hpp
+++ b/dart/dynamics/detail/basic_node_manager.hpp
@@ -38,6 +38,7 @@
 #include <dart/dynamics/node.hpp>
 
 #include <dart/common/class_with_virtual_base.hpp>
+#include <dart/common/detail/callback_traits.hpp>
 #include <dart/common/empty.hpp>
 #include <dart/common/name_manager.hpp>
 
@@ -299,9 +300,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func) const                                       \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -315,9 +314,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func)                                             \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -363,9 +360,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func) const                \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \
@@ -379,9 +374,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func)                      \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \
@@ -407,9 +400,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func) const                                       \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -423,9 +414,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(Func func)                                             \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(); ++i) {                 \
         if (!func(get##AspectName(i)))                                         \
           return;                                                              \
@@ -458,9 +447,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func) const                \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, const AspectName*>,           \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, const AspectName*>) {      \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \
@@ -474,9 +461,7 @@ const NodeType* BasicNodeManagerForSkeleton::getNode(
   template <typename Func>                                                     \
   void each##AspectName(std::size_t treeIndex, Func func)                      \
   {                                                                            \
-    if constexpr (std::is_same_v<                                              \
-                      std::invoke_result_t<Func, AspectName*>,                 \
-                      bool>) {                                                 \
+    if constexpr (common::detail::ReturnsBool<Func, AspectName*>) {            \
       for (auto i = 0u; i < getNum##PluralAspectName(treeIndex); ++i) {        \
         if (!func(get##AspectName(treeIndex, i)))                              \
           return;                                                              \

--- a/dart/dynamics/detail/body_node.hpp
+++ b/dart/dynamics/detail/body_node.hpp
@@ -37,6 +37,8 @@
 #include <dart/dynamics/shape_node.hpp>
 #include <dart/dynamics/skeleton.hpp>
 
+#include <dart/common/detail/callback_traits.hpp>
+
 #include <utility>
 
 namespace dart {
@@ -298,9 +300,7 @@ void BodyNode::removeAllShapeNodesWith()
 template <typename AspectT, typename Func>
 void BodyNode::eachShapeNodeWith(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const ShapeNode*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const ShapeNode*>) {
     for (auto i = 0u; i < getNumShapeNodes(); ++i) {
       const ShapeNode* shapeNode = getShapeNode(i);
       if (shapeNode->has<AspectT>()) {
@@ -323,7 +323,7 @@ void BodyNode::eachShapeNodeWith(Func func) const
 template <typename AspectT, typename Func>
 void BodyNode::eachShapeNodeWith(Func func)
 {
-  if constexpr (std::is_same_v<std::invoke_result_t<Func, ShapeNode*>, bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, ShapeNode*>) {
     for (auto i = 0u; i < getNumShapeNodes(); ++i) {
       ShapeNode* shapeNode = getShapeNode(i);
       if (shapeNode->has<AspectT>()) {

--- a/dart/dynamics/detail/meta_skeleton-impl.hpp
+++ b/dart/dynamics/detail/meta_skeleton-impl.hpp
@@ -35,15 +35,15 @@
 
 #include <dart/dynamics/meta_skeleton.hpp>
 
+#include <dart/common/detail/callback_traits.hpp>
+
 namespace dart::dynamics {
 
 //==============================================================================
 template <typename Func>
 void MetaSkeleton::eachBodyNode(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::BodyNode*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const dynamics::BodyNode*>) {
     for (auto i = 0u; i < getNumBodyNodes(); ++i) {
       if (!func(getBodyNode(i))) {
         return;
@@ -60,9 +60,7 @@ void MetaSkeleton::eachBodyNode(Func func) const
 template <typename Func>
 void MetaSkeleton::eachBodyNode(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::BodyNode*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::BodyNode*>) {
     for (auto i = 0u; i < getNumBodyNodes(); ++i) {
       if (!func(getBodyNode(i))) {
         return;
@@ -79,9 +77,7 @@ void MetaSkeleton::eachBodyNode(Func func)
 template <typename Func>
 void MetaSkeleton::eachJoint(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::Joint*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const dynamics::Joint*>) {
     for (auto i = 0u; i < getNumJoints(); ++i) {
       if (!func(getJoint(i))) {
         return;
@@ -98,9 +94,7 @@ void MetaSkeleton::eachJoint(Func func) const
 template <typename Func>
 void MetaSkeleton::eachJoint(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::Joint*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::Joint*>) {
     for (auto i = 0u; i < getNumJoints(); ++i) {
       if (!func(getJoint(i))) {
         return;
@@ -117,10 +111,8 @@ void MetaSkeleton::eachJoint(Func func)
 template <typename Func>
 void MetaSkeleton::eachDof(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::
-                        invoke_result_t<Func, const dynamics::DegreeOfFreedom*>,
-                    bool>) {
+  if constexpr (common::detail::
+                    ReturnsBool<Func, const dynamics::DegreeOfFreedom*>) {
     for (auto i = 0u; i < getNumDofs(); ++i) {
       if (!func(getDof(i))) {
         return;
@@ -137,9 +129,7 @@ void MetaSkeleton::eachDof(Func func) const
 template <typename Func>
 void MetaSkeleton::eachDof(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::DegreeOfFreedom*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::DegreeOfFreedom*>) {
     for (auto i = 0u; i < getNumDofs(); ++i) {
       if (!func(getDof(i))) {
         return;

--- a/dart/simulation/detail/world-impl.hpp
+++ b/dart/simulation/detail/world-impl.hpp
@@ -41,6 +41,8 @@
 
 #include <dart/simulation/world.hpp>
 
+#include <dart/common/detail/callback_traits.hpp>
+
 #include <algorithm>
 
 namespace dart {
@@ -57,9 +59,7 @@ WorldPtr World::create(Args&&... args)
 template <typename Func>
 void World::eachSkeleton(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::Skeleton*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, const dynamics::Skeleton*>) {
     (void)std::ranges::all_of(
         mSkeletons, [&func](auto skel) { return func(skel.get()); });
   } else {
@@ -73,9 +73,7 @@ void World::eachSkeleton(Func func) const
 template <typename Func>
 void World::eachSkeleton(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::Skeleton*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::Skeleton*>) {
     (void)std::ranges::all_of(
         mSkeletons, [&func](auto skel) { return func(skel.get()); });
   } else {
@@ -89,9 +87,8 @@ void World::eachSkeleton(Func func)
 template <typename Func>
 void World::eachSimpleFrame(Func func) const
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, const dynamics::SimpleFrame*>,
-                    bool>) {
+  if constexpr (common::detail::
+                    ReturnsBool<Func, const dynamics::SimpleFrame*>) {
     (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {
       return func(simpleFrame.get());
     });
@@ -106,9 +103,7 @@ void World::eachSimpleFrame(Func func) const
 template <typename Func>
 void World::eachSimpleFrame(Func func)
 {
-  if constexpr (std::is_same_v<
-                    std::invoke_result_t<Func, dynamics::SimpleFrame*>,
-                    bool>) {
+  if constexpr (common::detail::ReturnsBool<Func, dynamics::SimpleFrame*>) {
     (void)std::ranges::all_of(mSimpleFrames, [&func](auto simpleFrame) {
       return func(simpleFrame.get());
     });


### PR DESCRIPTION
## Summary

- Add an internal `common::detail::ReturnsBool` concept for traversal callback return checks.
- Replace repeated `std::invoke_result_t` / `std::is_same_v<..., bool>` checks in traversal helpers.
- Keep the existing exact-bool early-stop behavior for callbacks.

## Motivation / Problem

- Continue the C++20 modernization pass with a focused traversal-helper batch that reduces repeated type-trait plumbing without changing traversal semantics.

## Changes / Key Changes

- Added `dart/common/detail/callback_traits.hpp` with a C++20 concept for exact bool-return callbacks.
- Updated body node, meta-skeleton, node-manager, world, and constraint traversal helpers to use the shared concept.
- Preserved the existing behavior where callbacks returning exactly `bool` can stop iteration and other callbacks visit all items.

## Testing

- `pixi run lint`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
