### PR TITLE
Adopt C++20 library helpers in numeric code

### DIFF
--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -346,7 +346,7 @@ void Linkage::Criteria::expandToTarget(
     trimBodyNodes(newBns, _target.mChain, true);
   } else if (target_bn->descendsFrom(start_bn)) {
     newBns = climbToTarget(target_bn, start_bn);
-    std::reverse(newBns.begin(), newBns.end());
+    std::ranges::reverse(newBns);
     trimBodyNodes(newBns, _target.mChain, false);
   } else {
     newBns = climbToCommonRoot(_start, _target, _target.mChain);
@@ -416,7 +416,7 @@ std::vector<BodyNode*> Linkage::Criteria::climbToCommonRoot(
   }
 
   std::vector<BodyNode*> bnTarget = climbToTarget(target_bn, root);
-  std::reverse(bnTarget.begin(), bnTarget.end());
+  std::ranges::reverse(bnTarget);
   trimBodyNodes(bnTarget, _chain, false);
 
   std::vector<BodyNode*> bnAll;

--- a/dart/math/lcp/pivoting/dantzig/lcp.cpp
+++ b/dart/math/lcp/pivoting/dantzig/lcp.cpp
@@ -246,21 +246,21 @@ bool SolveLCP(
   // Create PivotMatrix from work array
   PivotMatrix<Scalar> A_pivot(n, n, A_work, nskip);
 
-  auto L = std::make_unique<Scalar[]>(nSize * nskipSize);
-  auto d = std::make_unique<Scalar[]>(n);
+  auto L = std::make_unique_for_overwrite<Scalar[]>(nSize * nskipSize);
+  auto d = std::make_unique_for_overwrite<Scalar[]>(nSize);
   std::unique_ptr<Scalar[]> wStorage;
   Scalar* w = outer_w;
   if (!w) {
     wStorage = std::make_unique_for_overwrite<Scalar[]>(n);
     w = wStorage.get();
   }
-  auto delta_w = std::make_unique<Scalar[]>(n);
-  auto delta_x = std::make_unique<Scalar[]>(n);
-  auto Dell = std::make_unique<Scalar[]>(n);
-  auto ell = std::make_unique<Scalar[]>(n);
-  auto p = std::make_unique<int[]>(n);
-  auto C = std::make_unique<int[]>(n);
-  auto state = std::make_unique<bool[]>(n);
+  auto delta_w = std::make_unique_for_overwrite<Scalar[]>(nSize);
+  auto delta_x = std::make_unique_for_overwrite<Scalar[]>(nSize);
+  auto Dell = std::make_unique_for_overwrite<Scalar[]>(nSize);
+  auto ell = std::make_unique_for_overwrite<Scalar[]>(nSize);
+  auto p = std::make_unique_for_overwrite<int[]>(nSize);
+  auto C = std::make_unique_for_overwrite<int[]>(nSize);
+  auto state = std::make_unique<bool[]>(nSize);
 
   // create LCP object. note that tmp is set to delta_w to save space, this
   // optimization relies on knowledge of how tmp is used, so be careful!

--- a/dart/math/lcp/pivoting/dantzig/matrix.hpp
+++ b/dart/math/lcp/pivoting/dantzig/matrix.hpp
@@ -327,7 +327,7 @@ template <typename Scalar>
 inline void SetValue(Scalar* a, size_t n, Scalar value)
 {
   DART_ASSERT(a);
-  std::fill(a, a + n, value);
+  std::ranges::fill_n(a, n, value);
 }
 
 /// Set an Eigen vector/matrix to a specific value (Eigen version)

--- a/dart/simd/dynamic/matrix.hpp
+++ b/dart/simd/dynamic/matrix.hpp
@@ -39,6 +39,8 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
+
 namespace dart::simd {
 
 template <typename T>
@@ -110,7 +112,7 @@ public:
 
   void setZero()
   {
-    std::fill(data_.begin(), data_.end(), T(0));
+    std::ranges::fill(data_, T(0));
   }
 
   void setIdentity()
@@ -291,7 +293,7 @@ public:
   {
     DynamicMatrix result(
         static_cast<std::size_t>(m.rows()), static_cast<std::size_t>(m.cols()));
-    std::copy(m.data(), m.data() + m.size(), result.data_.data());
+    std::ranges::copy_n(m.data(), m.size(), result.data_.data());
     return result;
   }
 };

--- a/dart/simd/dynamic/vector.hpp
+++ b/dart/simd/dynamic/vector.hpp
@@ -38,6 +38,7 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
 #include <initializer_list>
 #include <numeric>
 
@@ -269,7 +270,7 @@ public:
   [[nodiscard]] static DynamicVector fromEigen(const Eigen::VectorX<T>& v)
   {
     DynamicVector result(static_cast<std::size_t>(v.size()));
-    std::copy(v.data(), v.data() + v.size(), result.data_.data());
+    std::ranges::copy_n(v.data(), v.size(), result.data_.data());
     return result;
   }
 };

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <numeric>
 #include <thread>
@@ -296,7 +297,7 @@ TEST(Signal, ReturnValues)
   signal1.connect(&quotient);
   signal1.connect(&sum);
   signal1.connect(&difference);
-  EXPECT_EQ(signal1(5, 3), *std::max_element(res.begin(), res.end()));
+  EXPECT_EQ(signal1(5, 3), *std::ranges::max_element(res));
 
   // signal_sum
   Signal<float(float, float), signal_sum> signal2;

--- a/tests/unit/math/lcp/test_lcp_validation_and_solvers.cpp
+++ b/tests/unit/math/lcp/test_lcp_validation_and_solvers.cpp
@@ -35,6 +35,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <limits>
 #include <string>
 #include <vector>
@@ -1103,8 +1104,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, p, q, Eigen::RowMajor> Be;
   Eigen::Matrix<double, q, r, Eigen::RowMajor> Ce;
-  std::copy(B.begin(), B.end(), Be.data());
-  std::copy(C.begin(), C.end(), Ce.data());
+  std::ranges::copy(B, Be.data());
+  std::ranges::copy(C, Ce.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected0 = Be * Ce;
   for (int i = 0; i < p * r; ++i) {
     EXPECT_NEAR(A0[static_cast<std::size_t>(i)], expected0.data()[i], 1e-12);
@@ -1117,8 +1118,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, q, p, Eigen::RowMajor> Be1;
   Eigen::Matrix<double, q, r, Eigen::RowMajor> Ce1;
-  std::copy(B1.begin(), B1.end(), Be1.data());
-  std::copy(C1.begin(), C1.end(), Ce1.data());
+  std::ranges::copy(B1, Be1.data());
+  std::ranges::copy(C1, Ce1.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected1
       = Be1.transpose() * Ce1;
   for (int i = 0; i < p * r; ++i) {
@@ -1132,8 +1133,8 @@ TEST(DantzigMatrixCoverage, MultiplyVariantsMatchEigen)
 
   Eigen::Matrix<double, p, q, Eigen::RowMajor> Be2;
   Eigen::Matrix<double, r, q, Eigen::RowMajor> Ce2;
-  std::copy(B2.begin(), B2.end(), Be2.data());
-  std::copy(C2.begin(), C2.end(), Ce2.data());
+  std::ranges::copy(B2, Be2.data());
+  std::ranges::copy(C2, Ce2.data());
   Eigen::Matrix<double, p, r, Eigen::RowMajor> expected2
       = Be2 * Ce2.transpose();
   for (int i = 0; i < p * r; ++i) {

--- a/tests/unit/simd/test_operations_scalar.cpp
+++ b/tests/unit/simd/test_operations_scalar.cpp
@@ -34,6 +34,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include <cmath>
 
 namespace dart::simd {
@@ -334,7 +336,7 @@ TYPED_TEST(OperationsScalarTest, Hmin)
   }
 
   auto v = vec_type::loadu(data.data());
-  scalar_type expected = *std::min_element(data.begin(), data.end());
+  scalar_type expected = *std::ranges::min_element(data);
   this->expect_near(hmin(v), expected);
 }
 
@@ -350,7 +352,7 @@ TYPED_TEST(OperationsScalarTest, Hmax)
   }
 
   auto v = vec_type::loadu(data.data());
-  scalar_type expected = *std::max_element(data.begin(), data.end());
+  scalar_type expected = *std::ranges::max_element(data);
   this->expect_near(hmax(v), expected);
 }
 


### PR DESCRIPTION
## Summary

- Replace iterator-pair algorithm calls with C++20 `std::ranges` forms where a range is already available.
- Use `std::make_unique_for_overwrite` for Dantzig LCP workspace buffers that are filled before use.
- Keep Dantzig state storage value-initialized where initial permutation can touch state bits before they are semantically assigned.

## Motivation / Problem

- Continue the C++20 modernization pass with a larger, behavior-preserving library-helper batch across core numeric, SIMD, and test code.

## Changes / Key Changes

- Updated linkage and SIMD helpers to use `std::ranges` algorithms for whole-range operations.
- Updated Dantzig LCP workspace allocation to skip unnecessary value-initialization for buffers that are subsequently initialized by the solver.
- Updated LCP and SIMD tests to use range-based algorithms when copying or computing extrema.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-all`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
