### PR TITLE
Adopt C++20 ranges in GUI data setup

### DIFF
--- a/dart/gui/default_event_handler.cpp
+++ b/dart/gui/default_event_handler.cpp
@@ -42,7 +42,9 @@
 
 #include <osgGA/GUIEventAdapter>
 
+#include <algorithm>
 #include <iostream>
+#include <span>
 
 namespace dart {
 namespace gui {
@@ -55,10 +57,8 @@ DefaultEventHandler::DefaultEventHandler(Viewer* _viewer)
   mViewer->addInstructionText("Spacebar:     Turn simulation on/off\n");
   mViewer->addInstructionText("Ctrl+H:       Turn headlights on/off\n");
 
-  for (std::size_t i = 0; i < NUM_MOUSE_BUTTONS; ++i) {
-    for (std::size_t j = 0; j < BUTTON_NOTHING; ++j) {
-      mSuppressButtonPicks[i][j] = false;
-    }
+  for (auto& suppressedEvents : mSuppressButtonPicks) {
+    std::ranges::fill(suppressedEvents, false);
   }
   mSuppressMovePicks = false;
 
@@ -423,9 +423,8 @@ void DefaultEventHandler::eventPick(const ::osgGA::GUIEventAdapter& ea)
 //==============================================================================
 void DefaultEventHandler::clearButtonEvents()
 {
-  for (std::size_t i = 0; i < NUM_MOUSE_BUTTONS; ++i) {
-    mLastButtonEvent[i] = BUTTON_NOTHING;
-  }
+  std::ranges::fill(
+      std::span{mLastButtonEvent, NUM_MOUSE_BUTTONS}, BUTTON_NOTHING);
 }
 
 //==============================================================================
@@ -434,9 +433,7 @@ void DefaultEventHandler::handleDestructionNotification(
 {
   MouseEventHandler* meh = const_cast<MouseEventHandler*>(
       dynamic_cast<const MouseEventHandler*>(_subject));
-  if (mMouseEventHandlers.contains(meh)) {
-    mMouseEventHandlers.erase(meh);
-  }
+  mMouseEventHandlers.erase(meh);
 }
 
 } // namespace gui

--- a/dart/gui/drag_and_drop.cpp
+++ b/dart/gui/drag_and_drop.cpp
@@ -43,6 +43,7 @@
 #include "dart/gui/viewer.hpp"
 #include "dart/math/helpers.hpp"
 
+#include <algorithm>
 #include <span>
 
 namespace dart {
@@ -581,11 +582,10 @@ void InteractiveFrameDnD::update()
   }
 
   mAmMoving = false;
-  for (std::size_t i = 0; i < mDnDs.size(); ++i) {
-    DragAndDrop* dnd = mDnDs[i];
+  std::ranges::for_each(mDnDs, [this](DragAndDrop* dnd) {
     dnd->update();
-    mAmMoving |= dnd->isMoving();
-  }
+    mAmMoving = mAmMoving || dnd->isMoving();
+  });
 
   if (mAmMoving) {
     for (std::size_t i = 0; i < InteractiveTool::NUM_TYPES; ++i) {
@@ -595,9 +595,9 @@ void InteractiveFrameDnD::update()
             = mInteractiveFrame->getTool((InteractiveTool::Type)i, j);
         if (!dnd->isMoving() && tool->getEnabled()) {
           const auto shapeFrames = tool->getShapeFrames();
-          for (std::size_t s = 0; s < shapeFrames.size(); ++s) {
-            shapeFrames[s]->getVisualAspect(true)->setHidden(true);
-          }
+          std::ranges::for_each(shapeFrames, [](auto* shapeFrame) {
+            shapeFrame->getVisualAspect(true)->setHidden(true);
+          });
         }
       }
     }
@@ -608,9 +608,9 @@ void InteractiveFrameDnD::update()
             = mInteractiveFrame->getTool((InteractiveTool::Type)i, j);
         if (tool->getEnabled()) {
           const auto shapeFrames = tool->getShapeFrames();
-          for (std::size_t s = 0; s < shapeFrames.size(); ++s) {
-            shapeFrames[s]->getVisualAspect(true)->setHidden(false);
-          }
+          std::ranges::for_each(shapeFrames, [](auto* shapeFrame) {
+            shapeFrame->getVisualAspect(true)->setHidden(false);
+          });
         }
       }
     }

--- a/dart/gui/grid_visual.cpp
+++ b/dart/gui/grid_visual.cpp
@@ -42,6 +42,10 @@
 
 #include <osg/Depth>
 
+#include <algorithm>
+#include <iterator>
+#include <ranges>
+
 namespace dart {
 namespace gui {
 
@@ -442,15 +446,17 @@ void GridVisual::refresh()
 
     mMajorLineFaces->clear();
     mMajorLineFaces->reserve(mMajorLineVertices->size());
-    for (auto i = 0u; i < mMajorLineVertices->size(); ++i) {
-      mMajorLineFaces->push_back(i);
-    }
+    std::ranges::copy(
+        std::views::iota(
+            0u, static_cast<unsigned int>(mMajorLineVertices->size())),
+        std::back_inserter(*mMajorLineFaces));
 
     mMinorLineFaces->clear();
     mMinorLineFaces->reserve(mMinorLineVertices->size());
-    for (auto i = 0u; i < mMinorLineVertices->size(); ++i) {
-      mMinorLineFaces->push_back(i);
-    }
+    std::ranges::copy(
+        std::views::iota(
+            0u, static_cast<unsigned int>(mMinorLineVertices->size())),
+        std::back_inserter(*mMinorLineFaces));
 
     mMinorLineGeom->setVertexArray(mMinorLineVertices);
     mMinorLineGeom->getOrCreateStateSet()->setAttributeAndModes(

--- a/dart/gui/im_gui_handler.cpp
+++ b/dart/gui/im_gui_handler.cpp
@@ -670,9 +670,7 @@ void ImGuiHandler::newFrame(::osg::RenderInfo& renderInfo)
   mTime = currentTime;
   DART_ASSERT(mTime >= 0.0);
 
-  for (const auto i : std::views::iota(std::size_t{0}, mMousePressed.size())) {
-    io.MouseDown[i] = mMousePressed[i];
-  }
+  std::ranges::copy(mMousePressed, io.MouseDown);
 
   io.MouseWheel = mMouseWheel;
   mMouseWheel = 0.0f;

--- a/dart/gui/interactive_frame.cpp
+++ b/dart/gui/interactive_frame.cpp
@@ -281,7 +281,7 @@ void InteractiveFrame::createStandardVisualizationShapes(
 {
   const auto pi = math::pi;
 
-  thickness = std::clamp(thickness, 0.0, 10.0);
+  thickness = std::min(10.0, std::max(0.0, thickness));
   std::size_t resolution = 72;
   double ring_outer_scale = 0.7 * size;
   double ring_inner_scale = ring_outer_scale * (1 - 0.1 * thickness);

--- a/dart/gui/interactive_frame.cpp
+++ b/dart/gui/interactive_frame.cpp
@@ -132,9 +132,9 @@ InteractiveTool::getShapeFrames()
 {
   std::vector<dart::dynamics::SimpleFrame*> frames(mSimpleFrames.size());
 
-  for (auto i = 0u; i < frames.size(); ++i) {
-    frames[i] = mSimpleFrames[i].get();
-  }
+  std::ranges::transform(mSimpleFrames, frames.begin(), [](const auto& frame) {
+    return frame.get();
+  });
 
   return frames;
 }
@@ -145,9 +145,9 @@ InteractiveTool::getShapeFrames() const
 {
   std::vector<const dart::dynamics::SimpleFrame*> frames(mSimpleFrames.size());
 
-  for (auto i = 0u; i < frames.size(); ++i) {
-    frames[i] = mSimpleFrames[i].get();
-  }
+  std::ranges::transform(mSimpleFrames, frames.begin(), [](const auto& frame) {
+    return frame.get();
+  });
 
   return frames;
 }
@@ -249,9 +249,9 @@ InteractiveFrame::getShapeFrames()
 {
   std::vector<dart::dynamics::SimpleFrame*> frames(mSimpleFrames.size());
 
-  for (auto i = 0u; i < frames.size(); ++i) {
-    frames[i] = mSimpleFrames[i].get();
-  }
+  std::ranges::transform(mSimpleFrames, frames.begin(), [](const auto& frame) {
+    return frame.get();
+  });
 
   return frames;
 }
@@ -262,9 +262,9 @@ InteractiveFrame::getShapeFrames() const
 {
   std::vector<const dart::dynamics::SimpleFrame*> frames(mSimpleFrames.size());
 
-  for (auto i = 0u; i < frames.size(); ++i) {
-    frames[i] = mSimpleFrames[i].get();
-  }
+  std::ranges::transform(mSimpleFrames, frames.begin(), [](const auto& frame) {
+    return frame.get();
+  });
 
   return frames;
 }

--- a/dart/gui/interactive_frame.cpp
+++ b/dart/gui/interactive_frame.cpp
@@ -490,10 +490,10 @@ void InteractiveFrame::createStandardVisualizationShapes(
   for (std::size_t i = 0; i < InteractiveTool::NUM_TYPES; ++i) {
     for (std::size_t j = 0; j < 3; ++j) {
       const auto& shapesFrames = mTools[i][j]->getShapeFrames();
-      for (std::size_t s = 0; s < shapesFrames.size(); ++s) {
-        shapesFrames[s]->getShape()->setDataVariance(
+      std::ranges::for_each(shapesFrames, [](auto* shapeFrame) {
+        shapeFrame->getShape()->setDataVariance(
             dart::dynamics::Shape::DYNAMIC_COLOR);
-      }
+      });
     }
   }
 

--- a/dart/gui/interactive_frame.cpp
+++ b/dart/gui/interactive_frame.cpp
@@ -281,7 +281,7 @@ void InteractiveFrame::createStandardVisualizationShapes(
 {
   const auto pi = math::pi;
 
-  thickness = std::min(10.0, std::max(0.0, thickness));
+  thickness = std::clamp(thickness, 0.0, 10.0);
   std::size_t resolution = 72;
   double ring_outer_scale = 0.7 * size;
   double ring_inner_scale = ring_outer_scale * (1 - 0.1 * thickness);

--- a/dart/gui/polyhedron_visual.cpp
+++ b/dart/gui/polyhedron_visual.cpp
@@ -37,6 +37,7 @@
 
 #include <osg/StateSet>
 
+#include <algorithm>
 #include <limits>
 #include <set>
 #include <span>
@@ -332,10 +333,12 @@ void PolyhedronVisual::updateGeometry()
 
   mSurfaceVertices->resize(hullVertices.size());
   mSurfaceNormals->resize(hullVertices.size());
-  for (std::size_t i = 0; i < hullVertices.size(); ++i) {
-    const Eigen::Vector3d& v = hullVertices[i];
-    (*mSurfaceVertices)[i] = ::osg::Vec3(v[0], v[1], v[2]);
-  }
+  std::ranges::transform(
+      hullVertices,
+      mSurfaceVertices->begin(),
+      [](const Eigen::Vector3d& vertex) {
+        return ::osg::Vec3(vertex[0], vertex[1], vertex[2]);
+      });
 
   mSurfaceIndices->clear();
   mWireframeIndices->clear();
@@ -365,10 +368,13 @@ void PolyhedronVisual::updateGeometry()
     edges.insert(makeOrderedEdge(i2, i0));
   }
 
-  for (std::size_t i = 0; i < vertexNormals.size(); ++i) {
-    const Eigen::Vector3d normal = computeSafeNormal(vertexNormals[i]);
-    (*mSurfaceNormals)[i] = ::osg::Vec3(normal[0], normal[1], normal[2]);
-  }
+  std::ranges::transform(
+      vertexNormals,
+      mSurfaceNormals->begin(),
+      [](const Eigen::Vector3d& vertexNormal) {
+        const Eigen::Vector3d normal = computeSafeNormal(vertexNormal);
+        return ::osg::Vec3(normal[0], normal[1], normal[2]);
+      });
 
   for (const auto& edge : edges) {
     mWireframeIndices->push_back(static_cast<unsigned int>(edge.first));

--- a/dart/gui/polyhedron_visual.cpp
+++ b/dart/gui/polyhedron_visual.cpp
@@ -38,7 +38,9 @@
 #include <osg/StateSet>
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
+#include <ranges>
 #include <set>
 #include <span>
 #include <tuple>
@@ -108,14 +110,22 @@ void PolyhedronVisual::setVertices(
 
   if (vertices.rows() == 3) {
     converted.reserve(vertices.cols());
-    for (int i = 0; i < vertices.cols(); ++i) {
-      converted.emplace_back(vertices(0, i), vertices(1, i), vertices(2, i));
-    }
+    std::ranges::transform(
+        std::views::iota(Eigen::Index{0}, vertices.cols()),
+        std::back_inserter(converted),
+        [&vertices](const Eigen::Index i) {
+          return Eigen::Vector3d(
+              vertices(0, i), vertices(1, i), vertices(2, i));
+        });
   } else if (vertices.cols() == 3) {
     converted.reserve(vertices.rows());
-    for (int i = 0; i < vertices.rows(); ++i) {
-      converted.emplace_back(vertices(i, 0), vertices(i, 1), vertices(i, 2));
-    }
+    std::ranges::transform(
+        std::views::iota(Eigen::Index{0}, vertices.rows()),
+        std::back_inserter(converted),
+        [&vertices](const Eigen::Index i) {
+          return Eigen::Vector3d(
+              vertices(i, 0), vertices(i, 1), vertices(i, 2));
+        });
   } else {
     DART_WARN(
         "[PolyhedronVisual::setVertices] Expected either a 3xN or Nx3 matrix. "

--- a/dart/gui/render/convex_mesh_shape_node.cpp
+++ b/dart/gui/render/convex_mesh_shape_node.cpp
@@ -42,6 +42,8 @@
 #include <osg/Geode>
 #include <osg/Geometry>
 
+#include <algorithm>
+
 namespace dart {
 namespace gui {
 namespace render {
@@ -76,12 +78,12 @@ void computeVertexNormals(
     normals[triangle[2]] += n;
   }
 
-  for (auto& normal : normals) {
+  std::ranges::for_each(normals, [](auto& normal) {
     const double norm = normal.norm();
     if (norm > 1e-12) {
       normal /= norm;
     }
-  }
+  });
 }
 
 } // namespace
@@ -278,9 +280,10 @@ void ConvexMeshShapeDrawable::refresh(bool firstTime)
       mNormals->resize(vertexCount);
     }
 
-    for (std::size_t i = 0; i < vertexCount; ++i) {
-      (*mVertices)[i] = eigToOsgVec3((*vertices)[i]);
-    }
+    std::ranges::transform(
+        *vertices, mVertices->begin(), [](const Eigen::Vector3d& vertex) {
+          return eigToOsgVec3(vertex);
+        });
     setVertexArray(mVertices);
 
     const Normals* normals = nullptr;
@@ -293,9 +296,10 @@ void ConvexMeshShapeDrawable::refresh(bool firstTime)
     }
 
     if (normals) {
-      for (std::size_t i = 0; i < vertexCount; ++i) {
-        (*mNormals)[i] = eigToOsgVec3((*normals)[i]);
-      }
+      std::ranges::transform(
+          *normals, mNormals->begin(), [](const Eigen::Vector3d& normal) {
+            return eigToOsgVec3(normal);
+          });
       setNormalArray(mNormals, ::osg::Array::BIND_PER_VERTEX);
     }
   }

--- a/dart/gui/render/line_segment_shape_node.cpp
+++ b/dart/gui/render/line_segment_shape_node.cpp
@@ -44,6 +44,7 @@
 #include <osg/LineWidth>
 #include <osg/ShapeDrawable>
 
+#include <algorithm>
 #include <ranges>
 
 #include <cstddef>
@@ -236,9 +237,10 @@ void LineSegmentShapeDrawable::refresh(bool firstTime)
       mVertices->resize(vertices.size());
     }
 
-    for (const auto i : std::views::iota(std::size_t{0}, vertices.size())) {
-      (*mVertices)[i] = eigToOsgVec3(vertices[i]);
-    }
+    std::ranges::transform(
+        vertices, mVertices->begin(), [](const Eigen::Vector3d& vertex) {
+          return eigToOsgVec3(vertex);
+        });
 
     setVertexArray(mVertices);
   }

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -79,27 +79,14 @@ namespace {
 //==============================================================================
 bool isTransparent(const ::osg::Material* material)
 {
-  if (std::abs(material->getAmbient(::osg::Material::FRONT).a())
-      < 1 - getAlphaThreshold<float>()) {
-    return true;
-  }
-
-  if (std::abs(material->getDiffuse(::osg::Material::FRONT).a())
-      < 1 - getAlphaThreshold<float>()) {
-    return true;
-  }
-
-  if (std::abs(material->getSpecular(::osg::Material::FRONT).a())
-      < 1 - getAlphaThreshold<float>()) {
-    return true;
-  }
-
-  if (std::abs(material->getEmission(::osg::Material::FRONT).a())
-      < 1 - getAlphaThreshold<float>()) {
-    return true;
-  }
-
-  return false;
+  const std::array alphas{
+      material->getAmbient(::osg::Material::FRONT).a(),
+      material->getDiffuse(::osg::Material::FRONT).a(),
+      material->getSpecular(::osg::Material::FRONT).a(),
+      material->getEmission(::osg::Material::FRONT).a()};
+  return std::ranges::any_of(alphas, [](const auto alpha) {
+    return std::abs(alpha) < 1 - getAlphaThreshold<float>();
+  });
 }
 
 std::filesystem::path makeTemporaryTexturePath(std::string_view extension)

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -1083,43 +1083,64 @@ void MeshShapeGeometry::extractData(bool firstTime)
 
   // Load textures on the first pass through
   if (firstTime) {
-    unsigned int unit = 0;
-    const aiVector3D* aiTexCoords = mAiMesh->mTextureCoords[unit];
+    const std::span<aiVector3D* const> textureCoordSets{
+        mAiMesh->mTextureCoords, AI_MAX_NUMBER_OF_TEXTURECOORDS};
+    const std::span<const unsigned int> textureCoordComponents{
+        mAiMesh->mNumUVComponents, textureCoordSets.size()};
 
-    while (nullptr != aiTexCoords) {
-      switch (mAiMesh->mNumUVComponents[unit]) {
+    for (const auto unit :
+         std::views::iota(std::size_t{0}, textureCoordSets.size())) {
+      if (nullptr == textureCoordSets[unit]) {
+        break;
+      }
+
+      const std::span<const aiVector3D> texCoords{
+          textureCoordSets[unit], mAiMesh->mNumVertices};
+
+      switch (textureCoordComponents[unit]) {
         case 1: {
           ::osg::ref_ptr<::osg::FloatArray> texture
-              = new ::osg::FloatArray(mAiMesh->mNumVertices);
-          for (std::size_t i = 0; i < mAiMesh->mNumVertices; ++i) {
-            (*texture)[i] = aiTexCoords[i].x;
+              = new ::osg::FloatArray(texCoords.size());
+          for (const auto i :
+               std::views::iota(std::size_t{0}, texCoords.size())) {
+            (*texture)[i] = texCoords[i].x;
           }
-          setTexCoordArray(unit, texture, ::osg::Array::BIND_PER_VERTEX);
+          setTexCoordArray(
+              static_cast<unsigned int>(unit),
+              texture,
+              ::osg::Array::BIND_PER_VERTEX);
           break;
         }
         case 2: {
           ::osg::ref_ptr<::osg::Vec2Array> texture
-              = new ::osg::Vec2Array(mAiMesh->mNumVertices);
-          for (std::size_t i = 0; i < mAiMesh->mNumVertices; ++i) {
-            const aiVector3D& t = aiTexCoords[i];
+              = new ::osg::Vec2Array(texCoords.size());
+          for (const auto i :
+               std::views::iota(std::size_t{0}, texCoords.size())) {
+            const aiVector3D& t = texCoords[i];
             (*texture)[i] = ::osg::Vec2(t.x, t.y);
           }
-          setTexCoordArray(unit, texture, ::osg::Array::BIND_PER_VERTEX);
+          setTexCoordArray(
+              static_cast<unsigned int>(unit),
+              texture,
+              ::osg::Array::BIND_PER_VERTEX);
           break;
         }
         case 3: {
           ::osg::ref_ptr<::osg::Vec3Array> texture
-              = new ::osg::Vec3Array(mAiMesh->mNumVertices);
-          for (std::size_t i = 0; i < mAiMesh->mNumVertices; ++i) {
-            const aiVector3D& t = aiTexCoords[i];
+              = new ::osg::Vec3Array(texCoords.size());
+          for (const auto i :
+               std::views::iota(std::size_t{0}, texCoords.size())) {
+            const aiVector3D& t = texCoords[i];
             (*texture)[i] = ::osg::Vec3(t.x, t.y, t.z);
           }
-          setTexCoordArray(unit, texture, ::osg::Array::BIND_PER_VERTEX);
+          setTexCoordArray(
+              static_cast<unsigned int>(unit),
+              texture,
+              ::osg::Array::BIND_PER_VERTEX);
           break;
         }
-      } // switch(mAiMesh->mNumUVComponents[unit])
-      aiTexCoords = mAiMesh->mTextureCoords[++unit];
-    } // while(nullptr != aiTexCoords)
+      } // switch(textureCoordComponents[unit])
+    }
 
     const auto imagePaths
         = mMainNode->getTextureImagePaths(mAiMesh->mMaterialIndex);

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -575,8 +575,8 @@ void osgAiNode::extractData(bool firstTime)
     setMatrix(::osg::Matrixf((float*)(&M)));
   }
 
-  for (std::size_t i = 0; i < mAiNode->mNumChildren; ++i) {
-    aiNode* child = mAiNode->mChildren[i];
+  const std::span<aiNode*> children{mAiNode->mChildren, mAiNode->mNumChildren};
+  for (aiNode* child : children) {
     std::map<const aiNode*, osgAiNode*>::iterator it = mChildNodes.find(child);
 
     if (it == mChildNodes.end()) {
@@ -608,9 +608,9 @@ osgAiNode::~osgAiNode()
 //==============================================================================
 void osgAiNode::clearChildUtilizationFlags()
 {
-  for (auto& node_pair : mChildNodes) {
-    node_pair.second->clearUtilization();
-  }
+  std::ranges::for_each(mChildNodes | std::views::values, [](osgAiNode* node) {
+    node->clearUtilization();
+  });
 }
 
 //==============================================================================
@@ -663,8 +663,10 @@ void MeshShapeGeode::extractData(bool)
   DART_SUPPRESS_DEPRECATED_BEGIN
   const aiScene* scene = mMeshShape->getMesh();
   DART_SUPPRESS_DEPRECATED_END
-  for (std::size_t i = 0; i < mAiNode->mNumMeshes; ++i) {
-    aiMesh* mesh = scene->mMeshes[mAiNode->mMeshes[i]];
+  const std::span<const unsigned int> meshIndices{
+      mAiNode->mMeshes, mAiNode->mNumMeshes};
+  for (const unsigned int meshIndex : meshIndices) {
+    aiMesh* mesh = scene->mMeshes[meshIndex];
 
     std::map<const aiMesh*, MeshShapeGeometry*>::iterator it
         = mMeshes.find(mesh);
@@ -691,10 +693,9 @@ MeshShapeGeode::~MeshShapeGeode()
 //==============================================================================
 void MeshShapeGeode::clearChildUtilizationFlags()
 {
-  for (auto& node_pair : mMeshes) {
-    MeshShapeGeometry* geom = node_pair.second;
-    geom->clearUtilization();
-  }
+  std::ranges::for_each(
+      mMeshes | std::views::values,
+      [](MeshShapeGeometry* geom) { geom->clearUtilization(); });
 }
 
 //==============================================================================
@@ -851,22 +852,26 @@ void MeshShapeGeometry::extractData(bool firstTime)
   if (mShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_VERTICES)
       || mShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_ELEMENTS)
       || firstTime) {
-    if (mVertices->size() != mAiMesh->mNumVertices) {
-      mVertices->resize(mAiMesh->mNumVertices);
+    const std::span<const aiVector3D> aiVertices{
+        mAiMesh->mVertices, mAiMesh->mNumVertices};
+    if (mVertices->size() != aiVertices.size()) {
+      mVertices->resize(aiVertices.size());
     }
 
-    if (mNormals->size() != mAiMesh->mNumVertices) {
-      mNormals->resize(mAiMesh->mNumVertices);
+    if (mNormals->size() != aiVertices.size()) {
+      mNormals->resize(aiVertices.size());
     }
 
     const Eigen::Vector3f s = mMeshShape->getScale().cast<float>();
+    const std::span<const aiVector3D> aiNormals{
+        mAiMesh->mNormals, mAiMesh->mNormals ? aiVertices.size() : 0u};
 
-    for (std::size_t i = 0; i < mAiMesh->mNumVertices; ++i) {
-      const aiVector3D& v = mAiMesh->mVertices[i];
+    for (const auto i : std::views::iota(std::size_t{0}, aiVertices.size())) {
+      const aiVector3D& v = aiVertices[i];
       (*mVertices)[i] = ::osg::Vec3(v.x, v.y, v.z);
 
-      if (mAiMesh->mNormals) {
-        const aiVector3D& n = mAiMesh->mNormals[i];
+      if (!aiNormals.empty()) {
+        const aiVector3D& n = aiNormals[i];
         (*mNormals)[i] = ::osg::Vec3(n.x * s[0], n.y * s[1], n.z * s[2]);
       }
       // TODO(MXG): Consider computing normals for meshes that don't come with
@@ -904,8 +909,10 @@ void MeshShapeGeometry::extractData(bool firstTime)
           mColors->resize(mVertices->size());
         }
 
-        for (std::size_t i = 0; i < mAiMesh->mNumVertices; ++i) {
-          const aiColor4D& c = colors[i];
+        const std::span<const aiColor4D> aiColors{
+            colors, mAiMesh->mNumVertices};
+        for (const auto i : std::views::iota(std::size_t{0}, aiColors.size())) {
+          const aiColor4D& c = aiColors[i];
           if (mMeshShape->getAlphaMode() == dynamics::MeshShape::SHAPE_ALPHA) {
             (*mColors)[i] = ::osg::Vec4(
                 c.r, c.g, c.b, static_cast<float>(mVisualAspect->getAlpha()));

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -896,10 +896,19 @@ void MeshShapeGeometry::extractData(bool firstTime)
         index = AI_MAX_NUMBER_OF_COLOR_SETS - 1;
       }
 
-      aiColor4D* colors = nullptr;
-      while (nullptr == colors && index >= 0) {
-        colors = mAiMesh->mColors[index];
-        --index;
+      const aiColor4D* colors = nullptr;
+      if (index >= 0) {
+        const std::span<aiColor4D* const> colorSets{
+            mAiMesh->mColors, AI_MAX_NUMBER_OF_COLOR_SETS};
+        const auto candidateColorSets
+            = colorSets.first(static_cast<std::size_t>(index) + 1)
+              | std::views::reverse;
+        const auto colorSet = std::ranges::find_if(
+            candidateColorSets,
+            [](const auto* channel) { return channel != nullptr; });
+        if (colorSet != std::ranges::end(candidateColorSets)) {
+          colors = *colorSet;
+        }
       }
 
       if (colors) {

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -59,6 +59,7 @@
 #include <fstream>
 #include <iterator>
 #include <map>
+#include <ranges>
 #include <span>
 #include <sstream>
 #include <stdexcept>
@@ -1115,7 +1116,8 @@ void MeshShapeGeometry::extractData(bool firstTime)
 
     const auto imagePaths
         = mMainNode->getTextureImagePaths(mAiMesh->mMaterialIndex);
-    for (auto i = 0u; i < imagePaths.size(); ++i) {
+    for (const auto i :
+         std::views::iota(0u, static_cast<unsigned int>(imagePaths.size()))) {
       if (imagePaths[i].empty()) {
         continue;
       }

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -440,10 +440,13 @@ void MeshShapeNode::extractData(bool firstTime)
       std::vector<std::string> textureImageArray;
       textureImageArray.reserve(meshMat.textureImagePaths.size());
 
-      for (const auto& texturePath : meshMat.textureImagePaths) {
-        textureImageArray.emplace_back(materializeTextureImage(
-            texturePath, meshUriPtr, retriever, mTemporaryTextureFiles));
-      }
+      std::ranges::transform(
+          meshMat.textureImagePaths,
+          std::back_inserter(textureImageArray),
+          [&](const auto& texturePath) {
+            return materializeTextureImage(
+                texturePath, meshUriPtr, retriever, mTemporaryTextureFiles);
+          });
 
       mTextureImageArrays.emplace_back(std::move(textureImageArray));
     }
@@ -866,17 +869,20 @@ void MeshShapeGeometry::extractData(bool firstTime)
     const std::span<const aiVector3D> aiNormals{
         mAiMesh->mNormals, mAiMesh->mNormals ? aiVertices.size() : 0u};
 
-    for (const auto i : std::views::iota(std::size_t{0}, aiVertices.size())) {
-      const aiVector3D& v = aiVertices[i];
-      (*mVertices)[i] = ::osg::Vec3(v.x, v.y, v.z);
+    std::ranges::transform(
+        aiVertices, mVertices->begin(), [](const aiVector3D& vertex) {
+          return ::osg::Vec3(vertex.x, vertex.y, vertex.z);
+        });
 
-      if (!aiNormals.empty()) {
-        const aiVector3D& n = aiNormals[i];
-        (*mNormals)[i] = ::osg::Vec3(n.x * s[0], n.y * s[1], n.z * s[2]);
-      }
-      // TODO(MXG): Consider computing normals for meshes that don't come with
-      // normal data per vertex
+    if (!aiNormals.empty()) {
+      std::ranges::transform(
+          aiNormals, mNormals->begin(), [s](const aiVector3D& normal) {
+            return ::osg::Vec3(
+                normal.x * s[0], normal.y * s[1], normal.z * s[2]);
+          });
     }
+    // TODO(MXG): Consider computing normals for meshes that don't come with
+    // normal data per vertex
 
     setVertexArray(mVertices);
     if (mAiMesh->mNormals) {
@@ -920,21 +926,22 @@ void MeshShapeGeometry::extractData(bool firstTime)
 
         const std::span<const aiColor4D> aiColors{
             colors, mAiMesh->mNumVertices};
-        for (const auto i : std::views::iota(std::size_t{0}, aiColors.size())) {
-          const aiColor4D& c = aiColors[i];
-          if (mMeshShape->getAlphaMode() == dynamics::MeshShape::SHAPE_ALPHA) {
-            (*mColors)[i] = ::osg::Vec4(
-                c.r, c.g, c.b, static_cast<float>(mVisualAspect->getAlpha()));
-          } else if (mMeshShape->getAlphaMode() == dynamics::MeshShape::BLEND) {
-            (*mColors)[i] = ::osg::Vec4(
-                c.r,
-                c.g,
-                c.b,
-                c.a * static_cast<float>(mVisualAspect->getAlpha()));
-          } else {
-            (*mColors)[i] = ::osg::Vec4(c.r, c.g, c.b, c.a);
-          }
-        }
+        const auto alphaMode = mMeshShape->getAlphaMode();
+        const auto visualAlpha = static_cast<float>(mVisualAspect->getAlpha());
+        std::ranges::transform(
+            aiColors,
+            mColors->begin(),
+            [alphaMode, visualAlpha](const aiColor4D& color) {
+              if (alphaMode == dynamics::MeshShape::SHAPE_ALPHA) {
+                return ::osg::Vec4(color.r, color.g, color.b, visualAlpha);
+              }
+              if (alphaMode == dynamics::MeshShape::BLEND) {
+                return ::osg::Vec4(
+                    color.r, color.g, color.b, color.a * visualAlpha);
+              }
+
+              return ::osg::Vec4(color.r, color.g, color.b, color.a);
+            });
 
         setColorArray(mColors);
         setColorBinding(::osg::Geometry::BIND_PER_VERTEX);

--- a/dart/gui/render/multi_sphere_shape_node.cpp
+++ b/dart/gui/render/multi_sphere_shape_node.cpp
@@ -45,6 +45,7 @@
 #include <osg/Light>
 #include <osg/Material>
 
+#include <algorithm>
 #include <ranges>
 
 #include <cstddef>
@@ -237,12 +238,14 @@ void MultiSphereShapeDrawable::refresh(bool firstTime)
     // Convert the convex hull to OSG data types
     mVertices->resize(meshVertices.size());
     mNormals->resize(meshVertices.size());
-    for (const auto i : std::views::iota(std::size_t{0}, meshVertices.size())) {
-      const auto& v = meshVertices[i];
-      const auto& n = meshNormals[i];
-      (*mVertices)[i] = ::osg::Vec3(v[0], v[1], v[2]);
-      (*mNormals)[i] = ::osg::Vec3(n[0], n[1], n[2]);
-    }
+    std::ranges::transform(
+        meshVertices, mVertices->begin(), [](const Eigen::Vector3d& vertex) {
+          return ::osg::Vec3(vertex[0], vertex[1], vertex[2]);
+        });
+    std::ranges::transform(
+        meshNormals, mNormals->begin(), [](const Eigen::Vector3d& normal) {
+          return ::osg::Vec3(normal[0], normal[1], normal[2]);
+        });
     setVertexArray(mVertices);
     setNormalArray(mNormals, ::osg::Array::BIND_PER_VERTEX);
 

--- a/dart/gui/render/point_cloud_shape_node.cpp
+++ b/dart/gui/render/point_cloud_shape_node.cpp
@@ -47,6 +47,7 @@
 #include <osg/ShapeDrawable>
 #include <osg/Texture2D>
 
+#include <algorithm>
 #include <ranges>
 #include <span>
 
@@ -487,13 +488,13 @@ public:
         = shouldUseVisualAspectColor(points, colors, colorMode);
 
     mVertices->resize(points.size());
-    for (const auto i : std::views::iota(std::size_t{0}, points.size())) {
-      const auto& point = points[i];
-      mVertices->at(i).set(
-          static_cast<float>(point.x()),
-          static_cast<float>(point.y()),
-          static_cast<float>(point.z()));
-    }
+    std::ranges::transform(
+        points, mVertices->begin(), [](const Eigen::Vector3d& point) {
+          return ::osg::Vec3(
+              static_cast<float>(point.x()),
+              static_cast<float>(point.y()),
+              static_cast<float>(point.z()));
+        });
 
     if (useVisualAspectColor
         || colorMode == dynamics::PointCloudShape::USE_SHAPE_COLOR) {
@@ -516,14 +517,14 @@ public:
       mGeometry->setColorArray(mColors, ::osg::Array::BIND_OVERALL);
     } else if (colorMode == dynamics::PointCloudShape::BIND_PER_POINT) {
       mColors->resize(colors.size());
-      for (const auto i : std::views::iota(std::size_t{0}, colors.size())) {
-        const auto& color = colors[i];
-        mColors->at(i).set(
-            static_cast<float>(color[0]),
-            static_cast<float>(color[1]),
-            static_cast<float>(color[2]),
-            static_cast<float>(color[3]));
-      }
+      std::ranges::transform(
+          colors, mColors->begin(), [](const Eigen::Vector4d& color) {
+            return ::osg::Vec4(
+                static_cast<float>(color[0]),
+                static_cast<float>(color[1]),
+                static_cast<float>(color[2]),
+                static_cast<float>(color[3]));
+          });
       mGeometry->setColorArray(mColors, ::osg::Array::BIND_PER_VERTEX);
     }
 

--- a/dart/gui/render/point_cloud_shape_node.cpp
+++ b/dart/gui/render/point_cloud_shape_node.cpp
@@ -174,7 +174,7 @@ public:
     const auto ratio = 2.0f * pi / segmentCount;
 
     mVertices->resize(segmentCount);
-    for (auto i = 0u; i < segmentCount; ++i) {
+    for (const auto i : std::views::iota(0u, segmentCount)) {
       const auto angle = i * ratio;
       mVertices->at(i) = ::osg::Vec3(
           mRadius * ::std::cos(angle), 0, mRadius * ::std::sin(angle));
@@ -385,7 +385,7 @@ public:
     // Update position of cache boxes. The number of being updated boxes is
     // whichever the lower number of cache boxes and new points.
     const auto numUpdatingPoints = std::min(mPointNodes.size(), points.size());
-    for (auto i = 0u; i < numUpdatingPoints; ++i) {
+    for (const auto i : std::views::iota(std::size_t{0}, numUpdatingPoints)) {
       mPointNodes[i]->updateCenter(points[i]);
       mPointNodes[i]->updateSize(visualSize);
       if (useVisualAspectColor
@@ -400,7 +400,7 @@ public:
 
     // If the number of new points is greater than cache box, then create new
     // boxes that many.
-    for (auto i = mPointNodes.size(); i < points.size(); ++i) {
+    for (const auto i : std::views::iota(mPointNodes.size(), points.size())) {
       ::osg::ref_ptr<PointNode> pointNode;
       if (useVisualAspectColor
           || colorMode == dynamics::PointCloudShape::USE_SHAPE_COLOR) {

--- a/dart/gui/render/soft_mesh_shape_node.cpp
+++ b/dart/gui/render/soft_mesh_shape_node.cpp
@@ -216,9 +216,7 @@ static void computeNormals(
     std::vector<Eigen::Vector3d>& normals,
     const dart::dynamics::SoftBodyNode* bn)
 {
-  for (std::size_t i = 0; i < normals.size(); ++i) {
-    normals[i] = Eigen::Vector3d::Zero();
-  }
+  std::ranges::fill(normals, Eigen::Vector3d::Zero());
 
   for (std::size_t i = 0; i < bn->getNumFaces(); ++i) {
     const Eigen::Vector3i& face = bn->getFace(i);
@@ -227,9 +225,7 @@ static void computeNormals(
     }
   }
 
-  for (std::size_t i = 0; i < normals.size(); ++i) {
-    normals[i].normalize();
-  }
+  std::ranges::for_each(normals, [](auto& normal) { normal.normalize(); });
 }
 
 //==============================================================================

--- a/dart/gui/render/soft_mesh_shape_node.cpp
+++ b/dart/gui/render/soft_mesh_shape_node.cpp
@@ -207,7 +207,7 @@ static Eigen::Vector3d normalFromVertex(
   const Eigen::Vector3d n = dv1.cross(dv2);
 
   double weight = n.norm() / (dv1.norm() * dv2.norm());
-  weight = std::max(-1.0, std::min(1.0, weight));
+  weight = std::clamp(weight, -1.0, 1.0);
 
   return n.normalized() * asin(weight);
 }

--- a/dart/gui/render/soft_mesh_shape_node.cpp
+++ b/dart/gui/render/soft_mesh_shape_node.cpp
@@ -207,7 +207,7 @@ static Eigen::Vector3d normalFromVertex(
   const Eigen::Vector3d n = dv1.cross(dv2);
 
   double weight = n.norm() / (dv1.norm() * dv2.norm());
-  weight = std::clamp(weight, -1.0, 1.0);
+  weight = std::max(-1.0, std::min(1.0, weight));
 
   return n.normalized() * asin(weight);
 }

--- a/dart/gui/render/soft_mesh_shape_node.cpp
+++ b/dart/gui/render/soft_mesh_shape_node.cpp
@@ -44,6 +44,7 @@
 #include <osg/Geometry>
 
 #include <algorithm>
+#include <ranges>
 
 namespace dart {
 namespace gui {
@@ -272,10 +273,16 @@ void SoftMeshShapeDrawable::refresh(bool firstTime)
     }
 
     computeNormals(mEigNormals, bn);
-    for (std::size_t i = 0; i < bn->getNumPointMasses(); ++i) {
-      (*mVertices)[i] = eigToOsgVec3(bn->getPointMass(i)->getLocalPosition());
-      (*mNormals)[i] = eigToOsgVec3(mEigNormals[i]);
-    }
+    std::ranges::transform(
+        std::views::iota(std::size_t{0}, bn->getNumPointMasses()),
+        mVertices->begin(),
+        [bn](const std::size_t i) {
+          return eigToOsgVec3(bn->getPointMass(i)->getLocalPosition());
+        });
+    std::ranges::transform(
+        mEigNormals, mNormals->begin(), [](const Eigen::Vector3d& normal) {
+          return eigToOsgVec3(normal);
+        });
 
     setVertexArray(mVertices);
     setNormalArray(mNormals, ::osg::Array::BIND_PER_VERTEX);


### PR DESCRIPTION
## Summary

- Adopt C++20 ranges and spans in GUI data setup paths where they replace manual index, pointer-transfer, or raw Assimp array loops.

## Motivation / Problem

- Continue C++20 modernization only where the standard library makes intent clearer.
- Reduce manual loop bookkeeping in GUI frame collection, grid index generation, texture-unit traversal, point-cloud setup, mesh extraction, and side-effect-only shape/normal traversal.
- Treat Assimp fixed-size channel arrays as bounded views instead of open-ended or sentinel-only loops.
- Prefer standard algorithms for GUI event-state reset where the old code was spelling out bounded fills manually.
- Preserve existing floating-point clamping semantics instead of replacing nested `std::min` / `std::max` with `std::clamp`, because NaN handling differs.

## Changes / Key Changes

- Use `std::ranges::transform` to convert stored `SimpleFrame` owners into raw frame views.
- Use `std::views::iota` with `std::ranges::copy` to populate grid draw-index buffers.
- Use `std::views::iota` for texture-unit and point-cloud index traversal where the index is the domain value.
- Use `std::span` to view Assimp child-node, mesh-index, vertex, normal, color, and texture-coordinate buffers during mesh node extraction.
- Bound texture-coordinate channel traversal by Assimp's fixed channel arrays instead of open-ended sentinel iteration.
- Use a bounded color-channel span with reverse `std::ranges::find_if` to preserve backward search from the requested color index.
- Use `std::views::values` for map traversal when only cached mesh/node values are used.
- Use `std::ranges::for_each` for GUI shape-frame side-effect loops while preserving full traversal.
- Use `std::ranges::fill` / `std::ranges::for_each` for soft-mesh normal reset and normalization passes.
- Use `std::ranges::fill` with bounded button-event storage in `DefaultEventHandler` and avoid a redundant set lookup before erase.
- Use `std::ranges::transform` for polyhedron vertex and normal array conversion into OSG buffers.
- Use `std::ranges::copy` to sync ImGui mouse-button state into ImGui IO.
- Use `std::ranges::transform` for line-segment, point-cloud, convex-mesh, multi-sphere, soft-mesh, and Assimp mesh render-buffer conversion into OSG arrays.
- Use `std::ranges::transform` to materialize mesh texture image paths.
- Use `std::ranges::any_of` for mesh material alpha transparency checks.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: behavior-preserving refactor)
- [x] Add unit tests for new functionality (not applicable: no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)