### PR TITLE
Adopt C++20 concepts in core helpers

### DIFF
--- a/dart/common/detail/logging-impl.hpp
+++ b/dart/common/detail/logging-impl.hpp
@@ -58,30 +58,14 @@
 
 namespace detail_log_arg {
 
-template <typename Stream, typename T, typename = void>
-struct is_stream_insertable : std::false_type
-{
-};
-
 template <typename Stream, typename T>
-struct is_stream_insertable<
-    Stream,
-    T,
-    std::void_t<decltype(std::declval<Stream&>() << std::declval<const T&>())>>
-  : std::true_type
-{
-};
-
-template <typename T, typename = void>
-struct has_pointer_get : std::false_type
-{
-};
+concept StreamInsertable
+    = requires(Stream& stream, const T& value) { stream << value; };
 
 template <typename T>
-struct has_pointer_get<T, std::void_t<decltype(std::declval<T&>().get())>>
-  : std::bool_constant<std::is_pointer_v<
-        std::remove_reference_t<decltype(std::declval<T&>().get())>>>
-{
+concept PointerLikeGet = requires(T& value) {
+  value.get();
+  requires std::is_pointer_v<std::remove_reference_t<decltype(value.get())>>;
 };
 
 template <typename T>
@@ -97,7 +81,7 @@ auto normalize(T&& arg)
     } else {
       return std::forward<T>(arg);
     }
-  } else if constexpr (has_pointer_get<Decayed>::value) {
+  } else if constexpr (PointerLikeGet<Decayed>) {
     using RawPointer
         = std::remove_reference_t<decltype(std::declval<Decayed&>().get())>;
     using Pointee = std::remove_cv_t<std::remove_pointer_t<RawPointer>>;
@@ -115,7 +99,7 @@ auto normalize(T&& arg)
       return static_cast<std::underlying_type_t<Decayed>>(arg);
     } else if constexpr (kHasFormatter) {
       return std::forward<T>(arg);
-    } else if constexpr (is_stream_insertable<std::ostream, Decayed>::value) {
+    } else if constexpr (StreamInsertable<std::ostream, Decayed>) {
       return fmt::streamed(std::forward<T>(arg));
     } else {
       return std::forward<T>(arg);

--- a/dart/math/detail/icosphere-impl.hpp
+++ b/dart/math/detail/icosphere-impl.hpp
@@ -42,7 +42,7 @@ namespace dart {
 namespace math {
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 std::size_t Icosphere<S>::getNumVertices(std::size_t subdivisions)
 {
   std::size_t numVertices = 12;
@@ -53,21 +53,21 @@ std::size_t Icosphere<S>::getNumVertices(std::size_t subdivisions)
 }
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 std::size_t Icosphere<S>::getNumEdges(std::size_t subdivisions)
 {
   return getNumTriangles(subdivisions) / 2 * 3;
 }
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 std::size_t Icosphere<S>::getNumTriangles(std::size_t subdivisions)
 {
   return 20 * std::pow(4, subdivisions);
 }
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 std::pair<typename Icosphere<S>::Vertices, typename Icosphere<S>::Triangles>
 Icosphere<S>::computeIcosahedron(S radius)
 {
@@ -103,33 +103,31 @@ Icosphere<S>::computeIcosahedron(S radius)
 }
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 Icosphere<S>::Icosphere(S radius, std::size_t subdivisions)
   : mRadius(radius), mSubdivisions(subdivisions)
 {
-  static_assert(
-      std::floating_point<S>, "Scalar must be a floating point type.");
   DART_ASSERT(radius > 0);
 
   build();
 }
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 S Icosphere<S>::getRadius() const
 {
   return mRadius;
 }
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 std::size_t Icosphere<S>::getNumSubdivisions() const
 {
   return mSubdivisions;
 }
 
 //==============================================================================
-template <typename S>
+template <std::floating_point S>
 void Icosphere<S>::build()
 {
   // Reference: https://schneide.blog/2016/07/15/generating-an-icosphere-in-c/

--- a/dart/math/detail/random-impl.hpp
+++ b/dart/math/detail/random-impl.hpp
@@ -63,9 +63,9 @@ concept UniformIntCompatible
 
 /// Check whether T is derived from Eigen::MatrixBase
 template <typename T>
-concept EigenMatrix = std::is_base_of_v<
-    Eigen::MatrixBase<std::remove_cvref_t<T>>,
-    std::remove_cvref_t<T>>;
+concept EigenMatrix = std::derived_from<
+    std::remove_cvref_t<T>,
+    Eigen::MatrixBase<std::remove_cvref_t<T>>>;
 
 //==============================================================================
 // Kept for backward compatibility if needed elsewhere

--- a/dart/math/helpers.hpp
+++ b/dart/math/helpers.hpp
@@ -183,6 +183,9 @@ constexpr T defaultRelTolerance()
 
 namespace detail {
 
+template <typename T>
+concept ArithmeticScalar = std::integral<T> || std::floating_point<T>;
+
 template <typename Float>
 using FloatByteArray = std::array<std::byte, sizeof(Float)>;
 
@@ -301,8 +304,8 @@ inline bool isApprox(
 
 template <typename DerivedA, typename DerivedB>
   requires(
-      std::is_arithmetic_v<typename DerivedA::Scalar>
-      && std::is_arithmetic_v<typename DerivedB::Scalar>
+      detail::ArithmeticScalar<typename DerivedA::Scalar>
+      && detail::ArithmeticScalar<typename DerivedB::Scalar>
       && !(
           std::floating_point<typename DerivedA::Scalar>
           && std::floating_point<typename DerivedB::Scalar>))

--- a/dart/math/icosphere.hpp
+++ b/dart/math/icosphere.hpp
@@ -37,6 +37,7 @@
 
 #include <Eigen/Core>
 
+#include <concepts>
 #include <map>
 #include <vector>
 
@@ -45,7 +46,7 @@ namespace math {
 
 /// The class Icosphere represents an icosphere where the subdivision and radius
 /// are configurable.
-template <typename S_>
+template <std::floating_point S_>
 class Icosphere : public TriMesh<S_>
 {
 public:


### PR DESCRIPTION
## Summary

- Adopt C++20 concepts in core logging and math helpers where they replace local SFINAE/type-trait contracts.

## Motivation / Problem

- Continue C++20 modernization only where the newer language facility improves the template contract or removes older detection boilerplate.
- Keep behavior unchanged while making constraints easier to read at the declaration site.

## Changes / Key Changes

- Replace logging argument SFINAE traits with named `requires` concepts for stream insertion and pointer-like `.get()` support.
- Constrain `Icosphere` directly to floating-point scalar types and align the implementation definitions with that constraint.
- Use `std::derived_from` for Eigen matrix detection in random helpers.
- Introduce an arithmetic scalar concept for mixed scalar `isApprox` overload constraints.

## Testing

- `git diff --check`
- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: behavior-preserving refactor)
- [x] Add unit tests for new functionality (not applicable: no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
