### PR TITLE
Use ranges predicates for early-exit scans

### DIFF
--- a/dart/collision/ode/ode_collision_detector.cpp
+++ b/dart/collision/ode/ode_collision_detector.cpp
@@ -428,29 +428,22 @@ void reportContacts(
   const auto pair = MakeNewPair(b1, b2);
   auto& pastContacsVec = FindPairInHist(*history, pair);
   auto results_vec_copy = result.getContacts();
+  const auto isCurrentPairContact = [&](const Contact& contact) {
+    return MakeNewPair(contact.collisionObject1, contact.collisionObject2)
+           == pair;
+  };
+  auto pairContacts
+      = results_vec_copy | std::views::filter(isCurrentPairContact);
 
-  bool sliding = false;
   constexpr double slidingThreshold = 1e-3;
-  std::size_t pairContactCount = 0u;
-  for (const auto& curr_cont : results_vec_copy) {
-    const auto current_pair
-        = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
-    if (current_pair != pair) {
-      continue;
-    }
-
-    ++pairContactCount;
-
-    if (computeTangentialSpeed(curr_cont) > slidingThreshold) {
-      sliding = true;
-      break;
-    }
-  }
-
-  if (sliding) {
+  if (std::ranges::any_of(pairContacts, [](const Contact& contact) {
+        return computeTangentialSpeed(contact) > slidingThreshold;
+      })) {
     return;
   }
 
+  const auto pairContactCount
+      = static_cast<std::size_t>(std::ranges::distance(pairContacts));
   const std::size_t pairTarget
       = std::min<std::size_t>(3u, option.maxNumContacts);
   if (pairContactCount >= pairTarget) {
@@ -469,12 +462,7 @@ void reportContacts(
       break;
     }
 
-    for (const auto& curr_cont : results_vec_copy) {
-      const auto res_pair
-          = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
-      if (res_pair != pair) {
-        continue;
-      }
+    for (const auto& curr_cont : pairContacts) {
       auto dist_v = past_cont.point - curr_cont.point;
       const auto dist_m = (dist_v.transpose() * dist_v).coeff(0, 0);
       if (dist_m < 0.01) {
@@ -492,12 +480,8 @@ void reportContacts(
       break;
     }
   }
-  for (const auto& item : results_vec_copy) {
-    const auto res_pair
-        = MakeNewPair(item.collisionObject1, item.collisionObject2);
-    if (res_pair == pair) {
-      pastContacsVec.push_back(item);
-    }
+  for (const auto& item : pairContacts) {
+    pastContacsVec.push_back(item);
   }
 
   const auto size = pastContacsVec.size();
@@ -593,16 +577,13 @@ void OdeCollisionDetector::pruneContactHistory(const CollisionResult& result)
 
   const auto& contacts = result.getContacts();
   for (auto& pastContact : mContactHistory) {
-    bool clear = true;
-    for (const auto& current : contacts) {
-      auto currentPair
-          = MakeNewPair(current.collisionObject1, current.collisionObject2);
-      if (pastContact.pair == currentPair) {
-        clear = false;
-        break;
-      }
-    }
-    if (clear) {
+    const auto hasCurrentContact
+        = std::ranges::any_of(contacts, [&](const Contact& current) {
+            auto currentPair = MakeNewPair(
+                current.collisionObject1, current.collisionObject2);
+            return pastContact.pair == currentPair;
+          });
+    if (!hasCurrentContact) {
       pastContact.history.clear();
     }
   }

--- a/dart/collision/ode/ode_collision_detector.cpp
+++ b/dart/collision/ode/ode_collision_detector.cpp
@@ -428,22 +428,29 @@ void reportContacts(
   const auto pair = MakeNewPair(b1, b2);
   auto& pastContacsVec = FindPairInHist(*history, pair);
   auto results_vec_copy = result.getContacts();
-  const auto isCurrentPairContact = [&](const Contact& contact) {
-    return MakeNewPair(contact.collisionObject1, contact.collisionObject2)
-           == pair;
-  };
-  auto pairContacts
-      = results_vec_copy | std::views::filter(isCurrentPairContact);
 
+  bool sliding = false;
   constexpr double slidingThreshold = 1e-3;
-  if (std::ranges::any_of(pairContacts, [](const Contact& contact) {
-        return computeTangentialSpeed(contact) > slidingThreshold;
-      })) {
+  std::size_t pairContactCount = 0u;
+  for (const auto& curr_cont : results_vec_copy) {
+    const auto current_pair
+        = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
+    if (current_pair != pair) {
+      continue;
+    }
+
+    ++pairContactCount;
+
+    if (computeTangentialSpeed(curr_cont) > slidingThreshold) {
+      sliding = true;
+      break;
+    }
+  }
+
+  if (sliding) {
     return;
   }
 
-  const auto pairContactCount
-      = static_cast<std::size_t>(std::ranges::distance(pairContacts));
   const std::size_t pairTarget
       = std::min<std::size_t>(3u, option.maxNumContacts);
   if (pairContactCount >= pairTarget) {
@@ -462,7 +469,12 @@ void reportContacts(
       break;
     }
 
-    for (const auto& curr_cont : pairContacts) {
+    for (const auto& curr_cont : results_vec_copy) {
+      const auto res_pair
+          = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
+      if (res_pair != pair) {
+        continue;
+      }
       auto dist_v = past_cont.point - curr_cont.point;
       const auto dist_m = (dist_v.transpose() * dist_v).coeff(0, 0);
       if (dist_m < 0.01) {
@@ -480,8 +492,12 @@ void reportContacts(
       break;
     }
   }
-  for (const auto& item : pairContacts) {
-    pastContacsVec.push_back(item);
+  for (const auto& item : results_vec_copy) {
+    const auto res_pair
+        = MakeNewPair(item.collisionObject1, item.collisionObject2);
+    if (res_pair == pair) {
+      pastContacsVec.push_back(item);
+    }
   }
 
   const auto size = pastContacsVec.size();

--- a/dart/constraint/constraint_solver.cpp
+++ b/dart/constraint/constraint_solver.cpp
@@ -583,15 +583,15 @@ void ConstraintSolver::updateConstraints()
       }
 
       const std::size_t dof = joint->getNumDofs();
-      for (std::size_t j = 0; j < dof; ++j) {
-        if (joint->getCoulombFriction(j) != 0.0) {
-          mJointCoulombFrictionConstraints.push_back(
-              std::allocate_shared<JointCoulombFrictionConstraint>(
-                  common::FrameStlAllocator<JointCoulombFrictionConstraint>(
-                      *mFrameAllocator),
-                  joint));
-          break;
-        }
+      const bool hasCoulombFriction = std::ranges::any_of(
+          std::views::iota(std::size_t{0}, dof),
+          [&](std::size_t j) { return joint->getCoulombFriction(j) != 0.0; });
+      if (hasCoulombFriction) {
+        mJointCoulombFrictionConstraints.push_back(
+            std::allocate_shared<JointCoulombFrictionConstraint>(
+                common::FrameStlAllocator<JointCoulombFrictionConstraint>(
+                    *mFrameAllocator),
+                joint));
       }
 
       if (joint->areLimitsEnforced()

--- a/dart/constraint/constraint_solver.cpp
+++ b/dart/constraint/constraint_solver.cpp
@@ -712,15 +712,10 @@ void ConstraintSolver::buildConstrainedGroups()
   // Build constraint groups
   //----------------------------------------------------------------------------
   for (const auto& activeConstraint : mActiveConstraints) {
-    bool found = false;
     const auto& skel = activeConstraint->getRootSkeleton();
-
-    for (const auto& constrainedGroup : mConstrainedGroups) {
-      if (constrainedGroup.mRootSkeleton == skel) {
-        found = true;
-        break;
-      }
-    }
+    const bool found = std::ranges::any_of(
+        mConstrainedGroups,
+        [&](const auto& group) { return group.mRootSkeleton == skel; });
 
     if (found) {
       continue;

--- a/dart/dynamics/hierarchical_ik.cpp
+++ b/dart/dynamics/hierarchical_ik.cpp
@@ -39,6 +39,8 @@
 #include "dart/dynamics/skeleton.hpp"
 #include "dart/math/optimization/gradient_descent_solver.hpp"
 
+#include <algorithm>
+#include <ranges>
 #include <utility>
 
 namespace dart {
@@ -226,19 +228,14 @@ const IKHierarchy& HierarchicalIK::getIKHierarchy() const
 //==============================================================================
 std::span<const Eigen::MatrixXd> HierarchicalIK::computeNullSpaces() const
 {
-  bool recompute = false;
   const ConstSkeletonPtr& skel = getSkeleton();
   const std::size_t nDofs = skel->getNumDofs();
-  if (!std::cmp_equal(mLastPositions.size(), nDofs)) {
-    recompute = true;
-  } else {
-    for (std::size_t i = 0; i < nDofs; ++i) {
-      if (mLastPositions[i] != skel->getDof(i)->getPosition()) {
-        recompute = true;
-        break;
-      }
-    }
-  }
+  const bool recompute
+      = !std::cmp_equal(mLastPositions.size(), nDofs)
+        || std::ranges::any_of(
+            std::views::iota(std::size_t{0}, nDofs), [&](std::size_t i) {
+              return mLastPositions[i] != skel->getDof(i)->getPosition();
+            });
 
   // TODO(MXG): When deciding whether we need to recompute, we should also check
   // the "version" of the Skeleton, as soon as the Skeleton versioning features

--- a/dart/simd/detail/math/exp_impl.hpp
+++ b/dart/simd/detail/math/exp_impl.hpp
@@ -37,6 +37,8 @@
 #include <dart/simd/detail/math/polynomial.hpp>
 #include <dart/simd/fwd.hpp>
 
+#include <algorithm>
+
 #include <cmath>
 
 namespace dart::simd::detail::math {
@@ -98,13 +100,8 @@ template <std::size_t W>
   alignas(A) float inRangeArr[W];
   select(inSimdRange, VecT::broadcast(1.0f), VecT::broadcast(0.0f))
       .store(inRangeArr);
-  bool needScalar = false;
-  for (std::size_t i = 0; i < W; ++i) {
-    if (inRangeArr[i] == 0.0f) {
-      needScalar = true;
-      break;
-    }
-  }
+  const bool needScalar = std::ranges::any_of(
+      inRangeArr, [](float value) { return value == 0.0f; });
   if (needScalar) {
     alignas(A) float xArr[W];
     alignas(A) float scalarArr[W];
@@ -185,13 +182,8 @@ template <std::size_t W>
   alignas(A) double inRangeArr[W];
   select(inSimdRange, VecT::broadcast(1.0), VecT::broadcast(0.0))
       .store(inRangeArr);
-  bool needScalar = false;
-  for (std::size_t i = 0; i < W; ++i) {
-    if (inRangeArr[i] == 0.0) {
-      needScalar = true;
-      break;
-    }
-  }
+  const bool needScalar = std::ranges::any_of(
+      inRangeArr, [](double value) { return value == 0.0; });
   if (needScalar) {
     alignas(A) double xArr[W];
     alignas(A) double scalarArr[W];

--- a/dart/simd/detail/math/sincos_impl.hpp
+++ b/dart/simd/detail/math/sincos_impl.hpp
@@ -37,6 +37,7 @@
 #include <dart/simd/detail/math/polynomial.hpp>
 #include <dart/simd/fwd.hpp>
 
+#include <algorithm>
 #include <utility>
 
 #include <cmath>
@@ -140,18 +141,13 @@ DART_SIMD_INLINE void sincosImplSimd(
   alignas(A) float xArr[W];
   alignas(A) float scalarSin[W];
   alignas(A) float scalarCos[W];
-  bool needScalar = false;
-  {
+  const bool needScalar = [&] {
     alignas(A) float inRangeArr[W];
     select(inRange, VecT::broadcast(1.0f), VecT::broadcast(0.0f))
         .store(inRangeArr);
-    for (std::size_t i = 0; i < W; ++i) {
-      if (inRangeArr[i] == 0.0f) {
-        needScalar = true;
-        break;
-      }
-    }
-  }
+    return std::ranges::any_of(
+        inRangeArr, [](float value) { return value == 0.0f; });
+  }();
   if (needScalar) {
     x.store(xArr);
     for (std::size_t i = 0; i < W; ++i) {


### PR DESCRIPTION
## Summary

- Use C++20 ranges predicates for clear early-exit checks in contact-history pruning, constraint grouping, IK cache invalidation, and SIMD fallback detection.
- Keep the ODE contact-history lookup logic unchanged; this branch only modernizes the prune-time membership scan.
- Rebased onto current `main` after #2628 merged so CI validates the current integration state.

## Motivation / Problem

- These sites all compute a boolean by scanning a range and breaking at the first match.
- `std::ranges::any_of` makes the early-exit predicate explicit without changing runtime behavior.
- The earlier broader ODE contact-history rewrite was intentionally removed because that path is platform-sensitive and the lookup rewrite did not provide enough benefit.

## Changes / Key Changes

- Replace manual boolean/break loops with `std::ranges::any_of`.
- Use `std::views::iota` only where the predicate needs index-based access.
- Leave the ODE pair lookup/insertion path as it was on `main`.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target INTEGRATION_collision_CapsuleGroundContact INTEGRATION_constraint_LcpSolverStability UNIT_constraint_ConstraintSolver UNIT_dynamics_InverseKinematics UNIT_simd_simd_math UNIT_simd_simd_operations_scalar`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(INTEGRATION_collision_CapsuleGroundContact|INTEGRATION_constraint_LcpSolverStability|UNIT_constraint_ConstraintSolver|UNIT_dynamics_InverseKinematics|UNIT_simd_simd_math|UNIT_simd_simd_operations_scalar)$'`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---
#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: behavior-preserving refactor)
- [x] Add unit tests for new functionality (not applicable: no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
