### PR TITLE
Use ranges projections in common helpers

### DIFF
--- a/dart/common/detail/cloneable.hpp
+++ b/dart/common/detail/cloneable.hpp
@@ -36,6 +36,9 @@
 #include <dart/common/cloneable.hpp>
 #include <dart/common/stl_helpers.hpp>
 
+#include <algorithm>
+#include <iterator>
+
 namespace dart {
 namespace common {
 
@@ -601,9 +604,10 @@ std::unique_ptr<CloneableVector<T>> CloneableVector<T>::clone() const
   std::vector<T> clonedVector;
   clonedVector.reserve(mVector.size());
 
-  for (const T& entry : mVector) {
-    clonedVector.push_back(entry->clone());
-  }
+  std::ranges::transform(
+      mVector, std::back_inserter(clonedVector), [](const T& entry) {
+        return entry->clone();
+      });
 
   return std::make_unique<CloneableVector<T>>(std::move(clonedVector));
 }

--- a/dart/common/detail/factory-impl.hpp
+++ b/dart/common/detail/factory-impl.hpp
@@ -37,6 +37,8 @@
 #include <dart/common/logging.hpp>
 #include <dart/common/memory.hpp>
 
+#include <algorithm>
+#include <iterator>
 #include <ranges>
 
 namespace dart {
@@ -155,9 +157,8 @@ template <typename KeyT, typename BaseT, typename HeldT, typename... Args>
 std::unordered_set<KeyT> Factory<KeyT, BaseT, HeldT, Args...>::getKeys() const
 {
   std::unordered_set<KeyT> keys;
-  for (const auto& key : std::views::keys(mCreatorMap)) {
-    keys.insert(key);
-  }
+  std::ranges::copy(
+      std::views::keys(mCreatorMap), std::inserter(keys, keys.end()));
 
   return keys;
 }

--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -372,9 +372,10 @@ void Profiler::printNode(
 {
   std::vector<const ProfileNode*> children;
   children.reserve(node.children.size());
-  for (const auto& [_, child] : node.children) {
-    children.push_back(child.get());
-  }
+  std::ranges::transform(
+      node.children | std::views::values,
+      std::back_inserter(children),
+      [](const auto& child) { return child.get(); });
 
   std::ranges::sort(
       children, [](const ProfileNode* lhs, const ProfileNode* rhs) {
@@ -479,7 +480,7 @@ void Profiler::printSummary(std::ostream& os)
   // Build hotspot list.
   std::vector<Flattened> hotspots;
   for (const auto& record : threads) {
-    for (const auto& [_, child] : record->root.children) {
+    for (const auto& child : record->root.children | std::views::values) {
       collectHotspots(*child, child->label, record->label, hotspots);
     }
   }


### PR DESCRIPTION
## Summary

- Use C++20 ranges algorithms and projections in common helper code that builds containers from existing containers.
- Keep behavior unchanged while removing projection loops in cloneable vectors, factory key collection, and profiler child traversal.

## Motivation / Problem

- These helpers were manually copying projected values into destination containers. Ranges algorithms express that projection directly and keep the container-building intent local.

## Changes / Key Changes

- Replaced `CloneableVector::clone()` manual clone loop with `std::ranges::transform`.
- Replaced `Factory::getKeys()` manual key insertion loop with `std::ranges::copy` over `std::views::keys`.
- Replaced profiler child collection/traversal loops with `std::views::values` and `std::ranges::transform`.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests` before local unit tests, because the local `test-unit` target did not prebuild those simulation-experimental executables
- `pixi run test-unit` (262/262 passed after the target prebuild above)

## Breaking Changes

- [x] None
- No API or behavior changes.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required; internal refactor only)
- [x] Add unit tests for new functionality (not required; no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)