### PR TITLE
Adopt C++20 helpers in LCP and solver code

### DIFF
--- a/dart/dynamics/inverse_kinematics.cpp
+++ b/dart/dynamics/inverse_kinematics.cpp
@@ -42,6 +42,7 @@
 #include <iterator>
 #include <numeric>
 #include <unordered_map>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -1077,7 +1078,7 @@ void InverseKinematics::Analytical::addExtraDofGradient(
   for (std::size_t i = 0; i < mExtraDofs.size(); ++i) {
     std::size_t depIndex = mExtraDofs[i];
     int gradIndex = gradMap[depIndex];
-    if (gradIndex == -1) {
+    if (gradIndex < 0) {
       continue;
     }
 
@@ -1089,13 +1090,14 @@ void InverseKinematics::Analytical::addExtraDofGradient(
   for (std::size_t i = 0; i < mExtraDofs.size(); ++i) {
     std::size_t depIndex = mExtraDofs[i];
     int gradIndex = gradMap[depIndex];
-    if (gradIndex == -1) {
+    if (gradIndex < 0) {
       continue;
     }
 
-    double weight = mGradientP.mComponentWeights.size() > gradIndex
-                        ? mGradientP.mComponentWeights[gradIndex]
-                        : 1.0;
+    double weight
+        = std::cmp_less(gradIndex, mGradientP.mComponentWeights.size())
+              ? mGradientP.mComponentWeights[gradIndex]
+              : 1.0;
 
     double dq = weight * mExtraDofGradCache[i];
 

--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <unordered_set>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -258,13 +259,13 @@ void Linkage::Criteria::expandDownstream(
   }
   recorder.push_back(Recording(_start, 0));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
-    if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
+    if (std::cmp_less(r.mCount, r.mNode->getNumChildBodyNodes())) {
       stepToNextChild(recorder, _bns, r, mMapOfTerminals, 0);
     } else {
       recorder.pop_back();
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }
@@ -283,7 +284,7 @@ void Linkage::Criteria::expandUpstream(
   }
   recorder.push_back(Recording(_start, -1));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
 
     if (r.mCount == -1) {
@@ -303,7 +304,7 @@ void Linkage::Criteria::expandUpstream(
         // If we originally came from this node, then just continue to the next
         ++r.mCount;
       }
-    } else if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
+    } else if (std::cmp_less(r.mCount, r.mNode->getNumChildBodyNodes())) {
       // Greater than -1 means we need to add the children
 
       if (recorder.size() == 1) {
@@ -323,7 +324,7 @@ void Linkage::Criteria::expandUpstream(
       // If we've iterated through all the children of this node, pop it
       recorder.pop_back();
       // Move on to the next child
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }

--- a/dart/math/lcp/lcp_validation.hpp
+++ b/dart/math/lcp/lcp_validation.hpp
@@ -38,12 +38,37 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
 #include <limits>
 #include <string>
 
 #include <cmath>
 
 namespace dart::math::detail {
+
+inline double projectToBounds(double value, double lo, double hi)
+{
+  const bool hasLo = std::isfinite(lo);
+  const bool hasUpper = std::isfinite(hi);
+
+  if (hasLo && hasUpper) {
+    if (lo <= hi) {
+      return std::clamp(value, lo, hi);
+    }
+
+    return std::min(std::max(value, lo), hi);
+  }
+
+  if (hasLo) {
+    return std::max(value, lo);
+  }
+
+  if (hasUpper) {
+    return std::min(value, hi);
+  }
+
+  return value;
+}
 
 inline bool validateProblem(
     const LcpProblem& problem, std::string* message = nullptr)
@@ -186,13 +211,7 @@ inline double naturalResidualInfinityNorm(
   double maxResidual = 0.0;
 
   for (Eigen::Index i = 0; i < n; ++i) {
-    double projected = x[i] - w[i];
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
+    const double projected = projectToBounds(x[i] - w[i], lo[i], hi[i]);
 
     const double residual = x[i] - projected;
     maxResidual = std::max(maxResidual, std::abs(residual));

--- a/dart/math/lcp/other/staggering_solver.cpp
+++ b/dart/math/lcp/other/staggering_solver.cpp
@@ -211,13 +211,7 @@ LcpResult StaggeringSolver::solve(
           for (int k = 0; k < std::ssize(indices); ++k) {
             const int idx = indices[k];
             double updated = std::lerp(x[idx], values[k], relaxation);
-            if (std::isfinite(lo[idx])) {
-              updated = std::max(updated, lo[idx]);
-            }
-            if (std::isfinite(hi[idx])) {
-              updated = std::min(updated, hi[idx]);
-            }
-            x[idx] = updated;
+            x[idx] = detail::projectToBounds(updated, lo[idx], hi[idx]);
           }
         };
 
@@ -228,13 +222,7 @@ LcpResult StaggeringSolver::solve(
     for (int k = 0; k < std::ssize(indices); ++k) {
       const int idx = indices[k];
       double updated = std::lerp(x[idx], values[k], relaxation);
-      if (std::isfinite(loEff[idx])) {
-        updated = std::max(updated, loEff[idx]);
-      }
-      if (std::isfinite(hiEff[idx])) {
-        updated = std::min(updated, hiEff[idx]);
-      }
-      x[idx] = updated;
+      x[idx] = detail::projectToBounds(updated, loEff[idx], hiEff[idx]);
     }
   };
 

--- a/dart/math/lcp/projection/apgd_solver.cpp
+++ b/dart/math/lcp/projection/apgd_solver.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <span>
 #include <vector>
 
 #include <cmath>
@@ -121,27 +122,57 @@ LcpResult ApgdSolver::solve(
     return result;
   }
 
-  std::vector<double> Adata(static_cast<std::size_t>(n * nSkip), 0.0);
-  std::vector<double> xdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> xPrevData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> ydata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> bdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> loData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> hiData(static_cast<std::size_t>(n), 0.0);
-  std::vector<int> findexData(static_cast<std::size_t>(n), -1);
+  const auto problemSize = static_cast<std::size_t>(n);
+  const auto paddedSize = static_cast<std::size_t>(nSkip);
+
+  std::vector<double> Adata(problemSize * paddedSize, 0.0);
+  std::vector<double> xdata(problemSize, 0.0);
+  std::vector<double> xPrevData(problemSize, 0.0);
+  std::vector<double> ydata(problemSize, 0.0);
+  std::vector<double> bdata(problemSize, 0.0);
+  std::vector<double> loData(problemSize, 0.0);
+  std::vector<double> hiData(problemSize, 0.0);
+  std::vector<int> findexData(problemSize, -1);
+
+  std::span<double> aValues{Adata};
+  std::span<double> xValues{xdata};
+  std::span<double> xPrevValues{xPrevData};
+  std::span<double> yValues{ydata};
+  std::span<double> bValues{bdata};
+  std::span<double> loValues{loData};
+  std::span<double> hiValues{hiData};
+  std::span<int> findexValues{findexData};
+
+  auto aRow = [&](int row) -> std::span<double> {
+    return aValues.subspan(
+        static_cast<std::size_t>(row) * paddedSize, problemSize);
+  };
+
+  auto projectIntoBounds = [&](double value, std::size_t idx) {
+    if (findexValues[idx] >= 0) {
+      const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
+      const double frictionLimit
+          = std::abs(hiValues[idx] * xValues[frictionIndex]);
+      return std::clamp(value, -frictionLimit, frictionLimit);
+    }
+
+    return std::clamp(value, loValues[idx], hiValues[idx]);
+  };
 
   for (int r = 0; r < n; ++r) {
-    bdata[static_cast<std::size_t>(r)] = b[r];
+    const auto idx = static_cast<std::size_t>(r);
+    std::span<double> row = aRow(r);
+    bValues[idx] = b[r];
     const double initVal
         = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
-    xdata[static_cast<std::size_t>(r)] = initVal;
-    xPrevData[static_cast<std::size_t>(r)] = initVal;
-    ydata[static_cast<std::size_t>(r)] = initVal;
-    loData[static_cast<std::size_t>(r)] = lo[r];
-    hiData[static_cast<std::size_t>(r)] = hi[r];
-    findexData[static_cast<std::size_t>(r)] = findex[r];
+    xValues[idx] = initVal;
+    xPrevValues[idx] = initVal;
+    yValues[idx] = initVal;
+    loValues[idx] = lo[r];
+    hiValues[idx] = hi[r];
+    findexValues[idx] = findex[r];
     for (int c = 0; c < n; ++c) {
-      Adata[static_cast<std::size_t>(r * nSkip + c)] = A(r, c);
+      row[static_cast<std::size_t>(c)] = A(r, c);
     }
   }
 
@@ -149,21 +180,23 @@ LcpResult ApgdSolver::solve(
   order.reserve(static_cast<std::size_t>(n));
 
   for (int i = 0; i < n; ++i) {
-    if (Adata[static_cast<std::size_t>(nSkip * i + i)]
-        >= params->epsilonForDivision) {
+    const auto idx = static_cast<std::size_t>(i);
+    std::span<double> row = aRow(i);
+    if (row[idx] >= params->epsilonForDivision) {
       order.push_back(i);
     } else {
-      xdata[static_cast<std::size_t>(i)] = 0.0;
-      ydata[static_cast<std::size_t>(i)] = 0.0;
+      xValues[idx] = 0.0;
+      yValues[idx] = 0.0;
     }
   }
 
   for (const auto& index : order) {
-    const double invDiag
-        = 1.0 / Adata[static_cast<std::size_t>(nSkip * index + index)];
-    bdata[static_cast<std::size_t>(index)] *= invDiag;
+    const auto idx = static_cast<std::size_t>(index);
+    std::span<double> row = aRow(index);
+    const double invDiag = 1.0 / row[idx];
+    bValues[idx] *= invDiag;
     for (int j = 0; j < n; ++j) {
-      Adata[static_cast<std::size_t>(nSkip * index + j)] *= invDiag;
+      row[static_cast<std::size_t>(j)] *= invDiag;
     }
   }
 
@@ -178,58 +211,39 @@ LcpResult ApgdSolver::solve(
                         / static_cast<double>(restartIter + 3);
     for (const auto& index : order) {
       const std::size_t idx = static_cast<std::size_t>(index);
-      ydata[idx] = xdata[idx] + beta * (xdata[idx] - xPrevData[idx]);
+      yValues[idx] = xValues[idx] + beta * (xValues[idx] - xPrevValues[idx]);
     }
 
     for (const auto& index : order) {
-      xPrevData[static_cast<std::size_t>(index)]
-          = xdata[static_cast<std::size_t>(index)];
+      const auto idx = static_cast<std::size_t>(index);
+      xPrevValues[idx] = xValues[idx];
     }
 
     bool possibleToTerminate = true;
 
     for (const auto& index : order) {
       const std::size_t idx = static_cast<std::size_t>(index);
-      const double* APtr = Adata.data() + nSkip * index;
-      double newX = bdata[idx];
+      const std::span<double> row = aRow(index);
+      double newX = bValues[idx];
 
       for (int j = 0; j < index; j++) {
-        newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * xValues[static_cast<std::size_t>(j)];
       }
 
       for (int j = index + 1; j < n; j++) {
-        newX -= APtr[j] * ydata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * yValues[static_cast<std::size_t>(j)];
       }
 
-      const double oldX = xdata[idx];
+      const double oldX = xValues[idx];
       newX = std::lerp(oldX, newX, relaxation);
-
-      if (findexData[idx] >= 0) {
-        const double hiTmp = std::abs(
-            hiData[idx] * xdata[static_cast<std::size_t>(findexData[idx])]);
-        const double loTmp = -hiTmp;
-
-        if (newX > hiTmp) {
-          xdata[idx] = hiTmp;
-        } else if (newX < loTmp) {
-          xdata[idx] = loTmp;
-        } else {
-          xdata[idx] = newX;
-        }
-      } else {
-        if (newX > hiData[idx]) {
-          xdata[idx] = hiData[idx];
-        } else if (newX < loData[idx]) {
-          xdata[idx] = loData[idx];
-        } else {
-          xdata[idx] = newX;
-        }
-      }
+      xValues[idx] = projectIntoBounds(newX, idx);
 
       if (possibleToTerminate
-          && std::abs(xdata[idx]) > params->epsilonForDivision) {
+          && std::abs(xValues[idx]) > params->epsilonForDivision) {
         const double relativeDeltaX
-            = std::abs((xdata[idx] - oldX) / xdata[idx]);
+            = std::abs((xValues[idx] - oldX) / xValues[idx]);
         if (relativeDeltaX > relativeTolerance) {
           possibleToTerminate = false;
         }
@@ -243,12 +257,14 @@ LcpResult ApgdSolver::solve(
       double residualPrev = 0.0;
       for (const auto& index : order) {
         const std::size_t idx = static_cast<std::size_t>(index);
-        const double* APtr = Adata.data() + nSkip * index;
-        double wNow = -bdata[idx];
-        double wPrev = -bdata[idx];
+        const std::span<double> row = aRow(index);
+        double wNow = -bValues[idx];
+        double wPrev = -bValues[idx];
         for (int j = 0; j < n; ++j) {
-          wNow += APtr[j] * xdata[static_cast<std::size_t>(j)];
-          wPrev += APtr[j] * xPrevData[static_cast<std::size_t>(j)];
+          wNow += row[static_cast<std::size_t>(j)]
+                  * xValues[static_cast<std::size_t>(j)];
+          wPrev += row[static_cast<std::size_t>(j)]
+                   * xPrevValues[static_cast<std::size_t>(j)];
         }
         residualNow += wNow * wNow;
         residualPrev += wPrev * wPrev;

--- a/dart/math/lcp/projection/jacobi_solver.cpp
+++ b/dart/math/lcp/projection/jacobi_solver.cpp
@@ -204,14 +204,7 @@ LcpResult JacobiSolver::solve(
         value = std::lerp(x[i], step, relaxation);
       }
 
-      if (std::isfinite(loEff[i])) {
-        value = std::max(value, loEff[i]);
-      }
-      if (std::isfinite(hiEff[i])) {
-        value = std::min(value, hiEff[i]);
-      }
-
-      xNew[i] = value;
+      xNew[i] = detail::projectToBounds(value, loEff[i], hiEff[i]);
     }
 
     x = xNew;

--- a/dart/math/lcp/projection/pgs_solver.cpp
+++ b/dart/math/lcp/projection/pgs_solver.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+#include <span>
 #include <vector>
 
 #include <cmath>
@@ -125,22 +126,49 @@ LcpResult PgsSolver::solve(
     return result;
   }
 
-  std::vector<double> Adata(static_cast<std::size_t>(n * nSkip), 0.0);
-  std::vector<double> xdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> bdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> loData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> hiData(static_cast<std::size_t>(n), 0.0);
-  std::vector<int> findexData(static_cast<std::size_t>(n), -1);
+  const auto problemSize = static_cast<std::size_t>(n);
+  const auto paddedSize = static_cast<std::size_t>(nSkip);
+
+  std::vector<double> Adata(problemSize * paddedSize, 0.0);
+  std::vector<double> xdata(problemSize, 0.0);
+  std::vector<double> bdata(problemSize, 0.0);
+  std::vector<double> loData(problemSize, 0.0);
+  std::vector<double> hiData(problemSize, 0.0);
+  std::vector<int> findexData(problemSize, -1);
+
+  std::span<double> aValues{Adata};
+  std::span<double> xValues{xdata};
+  std::span<double> bValues{bdata};
+  std::span<double> loValues{loData};
+  std::span<double> hiValues{hiData};
+  std::span<int> findexValues{findexData};
+
+  auto aRow = [&](int row) -> std::span<double> {
+    return aValues.subspan(
+        static_cast<std::size_t>(row) * paddedSize, problemSize);
+  };
+
+  auto projectIntoBounds = [&](double value, std::size_t idx) {
+    if (findexValues[idx] >= 0) {
+      const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
+      const double frictionLimit
+          = std::abs(hiValues[idx] * xValues[frictionIndex]);
+      return std::clamp(value, -frictionLimit, frictionLimit);
+    }
+
+    return std::clamp(value, loValues[idx], hiValues[idx]);
+  };
 
   for (int r = 0; r < n; ++r) {
-    bdata[static_cast<std::size_t>(r)] = b[r];
-    xdata[static_cast<std::size_t>(r)]
-        = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
-    loData[static_cast<std::size_t>(r)] = lo[r];
-    hiData[static_cast<std::size_t>(r)] = hi[r];
-    findexData[static_cast<std::size_t>(r)] = findex[r];
+    const auto idx = static_cast<std::size_t>(r);
+    std::span<double> row = aRow(r);
+    bValues[idx] = b[r];
+    xValues[idx] = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
+    loValues[idx] = lo[r];
+    hiValues[idx] = hi[r];
+    findexValues[idx] = findex[r];
     for (int c = 0; c < n; ++c) {
-      Adata[static_cast<std::size_t>(r * nSkip + c)] = A(r, c);
+      row[static_cast<std::size_t>(c)] = A(r, c);
     }
   }
 
@@ -149,57 +177,34 @@ LcpResult PgsSolver::solve(
 
   bool possibleToTerminate = true;
   for (int i = 0; i < n; ++i) {
-    if (Adata[static_cast<std::size_t>(nSkip * i + i)]
-        < params->epsilonForDivision) {
-      xdata[static_cast<std::size_t>(i)] = 0.0;
+    const auto idx = static_cast<std::size_t>(i);
+    std::span<double> row = aRow(i);
+    if (row[idx] < params->epsilonForDivision) {
+      xValues[idx] = 0.0;
       continue;
     }
 
     order.push_back(i);
 
-    const double* APtr = Adata.data() + nSkip * i;
-    const double oldX = xdata[static_cast<std::size_t>(i)];
+    const double oldX = xValues[idx];
 
-    double newX = bdata[static_cast<std::size_t>(i)];
+    double newX = bValues[idx];
     for (int j = 0; j < i; ++j) {
-      newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+      newX -= row[static_cast<std::size_t>(j)]
+              * xValues[static_cast<std::size_t>(j)];
     }
     for (int j = i + 1; j < n; ++j) {
-      newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+      newX -= row[static_cast<std::size_t>(j)]
+              * xValues[static_cast<std::size_t>(j)];
     }
 
-    newX /= Adata[static_cast<std::size_t>(nSkip * i + i)];
+    newX /= row[idx];
 
     newX = std::lerp(oldX, newX, relaxation);
-
-    if (findexData[static_cast<std::size_t>(i)] >= 0) {
-      const double hiTmp = std::abs(
-          hiData[static_cast<std::size_t>(i)]
-          * xdata[static_cast<std::size_t>(
-              findexData[static_cast<std::size_t>(i)])]);
-      const double loTmp = -hiTmp;
-
-      if (newX > hiTmp) {
-        xdata[static_cast<std::size_t>(i)] = hiTmp;
-      } else if (newX < loTmp) {
-        xdata[static_cast<std::size_t>(i)] = loTmp;
-      } else {
-        xdata[static_cast<std::size_t>(i)] = newX;
-      }
-    } else {
-      if (newX > hiData[static_cast<std::size_t>(i)]) {
-        xdata[static_cast<std::size_t>(i)]
-            = hiData[static_cast<std::size_t>(i)];
-      } else if (newX < loData[static_cast<std::size_t>(i)]) {
-        xdata[static_cast<std::size_t>(i)]
-            = loData[static_cast<std::size_t>(i)];
-      } else {
-        xdata[static_cast<std::size_t>(i)] = newX;
-      }
-    }
+    xValues[idx] = projectIntoBounds(newX, idx);
 
     if (possibleToTerminate) {
-      const double deltaX = std::abs(xdata[static_cast<std::size_t>(i)] - oldX);
+      const double deltaX = std::abs(xValues[idx] - oldX);
       if (deltaX > absTolerance) {
         possibleToTerminate = false;
       }
@@ -211,11 +216,12 @@ LcpResult PgsSolver::solve(
   if (!possibleToTerminate && maxIterations > 1) {
     // Normalize to avoid repeated division in the main iteration loop.
     for (const auto& index : order) {
-      const double invDiag
-          = 1.0 / Adata[static_cast<std::size_t>(nSkip * index + index)];
-      bdata[static_cast<std::size_t>(index)] *= invDiag;
+      const auto idx = static_cast<std::size_t>(index);
+      std::span<double> row = aRow(index);
+      const double invDiag = 1.0 / row[idx];
+      bValues[idx] *= invDiag;
       for (int j = 0; j < n; ++j) {
-        Adata[static_cast<std::size_t>(nSkip * index + j)] *= invDiag;
+        row[static_cast<std::size_t>(j)] *= invDiag;
       }
     }
 
@@ -230,52 +236,28 @@ LcpResult PgsSolver::solve(
       possibleToTerminate = true;
 
       for (const auto& index : order) {
-        const double* APtr = Adata.data() + nSkip * index;
-        double newX = bdata[static_cast<std::size_t>(index)];
-        const double oldX = xdata[static_cast<std::size_t>(index)];
+        const auto idx = static_cast<std::size_t>(index);
+        const std::span<double> row = aRow(index);
+        double newX = bValues[idx];
+        const double oldX = xValues[idx];
 
         for (int j = 0; j < index; j++) {
-          newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+          newX -= row[static_cast<std::size_t>(j)]
+                  * xValues[static_cast<std::size_t>(j)];
         }
 
         for (int j = index + 1; j < n; j++) {
-          newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+          newX -= row[static_cast<std::size_t>(j)]
+                  * xValues[static_cast<std::size_t>(j)];
         }
 
         newX = std::lerp(oldX, newX, relaxation);
-
-        if (findexData[static_cast<std::size_t>(index)] >= 0) {
-          const double hiTmp = std::abs(
-              hiData[static_cast<std::size_t>(index)]
-              * xdata[static_cast<std::size_t>(
-                  findexData[static_cast<std::size_t>(index)])]);
-          const double loTmp = -hiTmp;
-
-          if (newX > hiTmp) {
-            xdata[static_cast<std::size_t>(index)] = hiTmp;
-          } else if (newX < loTmp) {
-            xdata[static_cast<std::size_t>(index)] = loTmp;
-          } else {
-            xdata[static_cast<std::size_t>(index)] = newX;
-          }
-        } else {
-          if (newX > hiData[static_cast<std::size_t>(index)]) {
-            xdata[static_cast<std::size_t>(index)]
-                = hiData[static_cast<std::size_t>(index)];
-          } else if (newX < loData[static_cast<std::size_t>(index)]) {
-            xdata[static_cast<std::size_t>(index)]
-                = loData[static_cast<std::size_t>(index)];
-          } else {
-            xdata[static_cast<std::size_t>(index)] = newX;
-          }
-        }
+        xValues[idx] = projectIntoBounds(newX, idx);
 
         if (possibleToTerminate
-            && std::abs(xdata[static_cast<std::size_t>(index)])
-                   > params->epsilonForDivision) {
-          const double relativeDeltaX = std::abs(
-              (xdata[static_cast<std::size_t>(index)] - oldX)
-              / xdata[static_cast<std::size_t>(index)]);
+            && std::abs(xValues[idx]) > params->epsilonForDivision) {
+          const double relativeDeltaX
+              = std::abs((xValues[idx] - oldX) / xValues[idx]);
           if (relativeDeltaX > relativeTolerance) {
             possibleToTerminate = false;
           }

--- a/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
+++ b/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
@@ -218,14 +218,7 @@ LcpResult RedBlackGaussSeidelSolver::solve(
       return value;
     }
 
-    double projected = value;
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
-    return projected;
+    return detail::projectToBounds(value, lo[i], hi[i]);
   };
 
   auto updateIndex = [&](int i, const Eigen::VectorXd& xRead) {

--- a/dart/math/lcp/projection/subspace_minimization_solver.cpp
+++ b/dart/math/lcp/projection/subspace_minimization_solver.cpp
@@ -262,14 +262,7 @@ LcpResult SubspaceMinimizationSolver::solve(
 
       for (int r = 0; r < fSize; ++r) {
         const int i = freeIndices[r];
-        double value = xFree[r];
-        if (std::isfinite(loEff[i])) {
-          value = std::max(value, loEff[i]);
-        }
-        if (std::isfinite(hiEff[i])) {
-          value = std::min(value, hiEff[i]);
-        }
-        x[i] = value;
+        x[i] = detail::projectToBounds(xFree[r], loEff[i], hiEff[i]);
       }
     }
 

--- a/dart/math/lcp/projection/symmetric_psor_solver.cpp
+++ b/dart/math/lcp/projection/symmetric_psor_solver.cpp
@@ -205,14 +205,7 @@ LcpResult SymmetricPsorSolver::solve(
       return value;
     }
 
-    double projected = value;
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
-    return projected;
+    return detail::projectToBounds(value, lo[i], hi[i]);
   };
 
   auto updateIndex = [&](int i) {

--- a/dart/math/lcp/projection/tgs_solver.cpp
+++ b/dart/math/lcp/projection/tgs_solver.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <span>
 #include <vector>
 
 #include <cmath>
@@ -112,23 +113,51 @@ LcpResult TgsSolver::solve(
                                        ? options.relativeTolerance
                                        : mDefaultOptions.relativeTolerance;
 
-  std::vector<double> Adata(static_cast<std::size_t>(n * nSkip), 0.0);
-  std::vector<double> xdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> bdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> loData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> hiData(static_cast<std::size_t>(n), 0.0);
-  std::vector<int> findexData(static_cast<std::size_t>(n), -1);
+  const auto problemSize = static_cast<std::size_t>(n);
+  const auto paddedSize = static_cast<std::size_t>(nSkip);
+
+  std::vector<double> Adata(problemSize * paddedSize, 0.0);
+  std::vector<double> xdata(problemSize, 0.0);
+  std::vector<double> bdata(problemSize, 0.0);
+  std::vector<double> loData(problemSize, 0.0);
+  std::vector<double> hiData(problemSize, 0.0);
+  std::vector<int> findexData(problemSize, -1);
+
+  std::span<double> aValues{Adata};
+  std::span<double> xValues{xdata};
+  std::span<double> bValues{bdata};
+  std::span<double> loValues{loData};
+  std::span<double> hiValues{hiData};
+  std::span<int> findexValues{findexData};
+
+  auto aRow = [&](int row) -> std::span<double> {
+    return aValues.subspan(
+        static_cast<std::size_t>(row) * paddedSize, problemSize);
+  };
+
+  auto projectIntoBounds = [&](double value, std::size_t idx) {
+    if (findexValues[idx] >= 0) {
+      const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
+      const double frictionLimit
+          = std::abs(hiValues[idx] * xValues[frictionIndex]);
+      return std::clamp(value, -frictionLimit, frictionLimit);
+    }
+
+    return std::clamp(value, loValues[idx], hiValues[idx]);
+  };
 
   for (int r = 0; r < n; ++r) {
-    bdata[static_cast<std::size_t>(r)] = b[r];
+    const auto idx = static_cast<std::size_t>(r);
+    std::span<double> row = aRow(r);
+    bValues[idx] = b[r];
     const double initVal
         = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
-    xdata[static_cast<std::size_t>(r)] = initVal;
-    loData[static_cast<std::size_t>(r)] = lo[r];
-    hiData[static_cast<std::size_t>(r)] = hi[r];
-    findexData[static_cast<std::size_t>(r)] = findex[r];
+    xValues[idx] = initVal;
+    loValues[idx] = lo[r];
+    hiValues[idx] = hi[r];
+    findexValues[idx] = findex[r];
     for (int c = 0; c < n; ++c) {
-      Adata[static_cast<std::size_t>(r * nSkip + c)] = A(r, c);
+      row[static_cast<std::size_t>(c)] = A(r, c);
     }
   }
 
@@ -136,18 +165,21 @@ LcpResult TgsSolver::solve(
   order.reserve(static_cast<std::size_t>(n));
 
   for (int i = 0; i < n; ++i) {
-    if (Adata[static_cast<std::size_t>(nSkip * i + i)]
-        >= params->epsilonForDivision) {
+    const auto idx = static_cast<std::size_t>(i);
+    const std::span<double> row = aRow(i);
+    if (row[idx] >= params->epsilonForDivision) {
       order.push_back(i);
     } else {
-      xdata[static_cast<std::size_t>(i)] = 0.0;
+      xValues[idx] = 0.0;
     }
   }
 
-  std::vector<double> invDiag(static_cast<std::size_t>(n), 0.0);
+  std::vector<double> invDiag(problemSize, 0.0);
+  std::span<double> invDiagValues{invDiag};
   for (const auto& index : order) {
-    invDiag[static_cast<std::size_t>(index)]
-        = 1.0 / Adata[static_cast<std::size_t>(nSkip * index + index)];
+    const auto idx = static_cast<std::size_t>(index);
+    const std::span<double> row = aRow(index);
+    invDiagValues[idx] = 1.0 / row[idx];
   }
 
   int iterationsUsed = 0;
@@ -163,31 +195,23 @@ LcpResult TgsSolver::solve(
 
     for (const auto& index : order) {
       const std::size_t idx = static_cast<std::size_t>(index);
-      const double* APtr = Adata.data() + nSkip * index;
+      const std::span<double> row = aRow(index);
 
-      double newX = bdata[idx];
+      double newX = bValues[idx];
       for (int j = 0; j < index; ++j) {
-        newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * xValues[static_cast<std::size_t>(j)];
       }
       for (int j = index + 1; j < n; ++j) {
-        newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * xValues[static_cast<std::size_t>(j)];
       }
-      newX *= invDiag[idx];
+      newX *= invDiagValues[idx];
 
-      const double oldX = xdata[idx];
+      const double oldX = xValues[idx];
       newX = std::lerp(oldX, newX, relaxation);
-
-      double loVal = loData[idx];
-      double hiVal = hiData[idx];
-      if (findexData[idx] >= 0) {
-        const double fricLimit = std::abs(
-            hiData[idx] * xdata[static_cast<std::size_t>(findexData[idx])]);
-        loVal = -fricLimit;
-        hiVal = fricLimit;
-      }
-
-      newX = std::clamp(newX, loVal, hiVal);
-      xdata[idx] = newX;
+      newX = projectIntoBounds(newX, idx);
+      xValues[idx] = newX;
 
       if (possibleToTerminate && std::abs(newX) > params->epsilonForDivision) {
         const double relativeDelta = std::abs((newX - oldX) / newX);

--- a/dart/math/optimization/gradient_descent_solver.cpp
+++ b/dart/math/optimization/gradient_descent_solver.cpp
@@ -127,7 +127,7 @@ bool GradientDescentSolver::solve()
   }
 
   Eigen::VectorXd x = problem->getInitialGuess();
-  DART_ASSERT(x.size() == static_cast<int>(dim));
+  DART_ASSERT(std::cmp_equal(x.size(), dim));
 
   Eigen::VectorXd lastx = x;
   Eigen::VectorXd dx(x.size());
@@ -183,8 +183,7 @@ bool GradientDescentSolver::solve()
       if (objective) {
         objective->evalGradient(x, dxMap);
       }
-      for (int i = 0; i < static_cast<int>(problem->getNumEqConstraints());
-           ++i) {
+      for (std::size_t i = 0; i < problem->getNumEqConstraints(); ++i) {
         if (std::abs(mEqConstraintCostCache[i]) < tol) {
           continue;
         }
@@ -193,7 +192,7 @@ bool GradientDescentSolver::solve()
 
         // Get the user-specified weight if available, otherwise use the default
         // weight value
-        double weight = mGradientP.mEqConstraintWeights.size() > i
+        double weight = std::cmp_less(i, mGradientP.mEqConstraintWeights.size())
                             ? mGradientP.mEqConstraintWeights[i]
                             : mGradientP.mDefaultConstraintWeight;
 
@@ -204,8 +203,7 @@ bool GradientDescentSolver::solve()
         dx += weight * grad * math::sign(mEqConstraintCostCache[i]);
       }
 
-      for (int i = 0; i < static_cast<int>(problem->getNumIneqConstraints());
-           ++i) {
+      for (std::size_t i = 0; i < problem->getNumIneqConstraints(); ++i) {
         if (mIneqConstraintCostCache[i] < tol) {
           continue;
         }
@@ -214,9 +212,10 @@ bool GradientDescentSolver::solve()
 
         // Get the user-specified weight if available, otherwise use the
         // default weight value
-        double weight = mGradientP.mIneqConstraintWeights.size() > i
-                            ? mGradientP.mIneqConstraintWeights[i]
-                            : mGradientP.mDefaultConstraintWeight;
+        double weight
+            = std::cmp_less(i, mGradientP.mIneqConstraintWeights.size())
+                  ? mGradientP.mIneqConstraintWeights[i]
+                  : mGradientP.mDefaultConstraintWeight;
 
         dx += weight * grad;
       }


### PR DESCRIPTION
## Summary

- Consolidate the LCP/span, bound-projection, and checked-comparison solver cleanups into one PR to reduce CI queue pressure.
- Use `std::span` views in projection solvers where helper functions only need contiguous bounds/forces views.
- Share LCP bound projection logic through a validation helper and use checked integer comparisons in solver-adjacent loops.

## Motivation / Problem

- The previous split across multiple small draft PRs created separate full CI matrices for related solver cleanups.
- These changes are behavior-preserving and benefit from being validated together because they touch the same math/solver area.

## Changes / Key Changes

- Update APGD, PGS, and TGS projection solvers to pass span views for lower/upper bounds and force vectors.
- Add and reuse a shared LCP bound-projection helper in projection and other LCP solvers.
- Use checked comparisons in inverse kinematics, linkage traversal, and gradient-descent iteration helpers.

## Consolidation

Supersedes draft PRs: #2634, #2636.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target UNIT_math_lcp_math_lcp_lcp_projection_solvers UNIT_math_lcp_math_lcp_lcp_validation_and_solvers UNIT_math_lcp_math_lcp_all_solvers_smoke UNIT_math_optimization_GradientDescentSolver UNIT_dynamics_InverseKinematics UNIT_dynamics_Linkage INTEGRATION_dynamics_AtlasIK`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_math_lcp_math_lcp_lcp_projection_solvers|UNIT_math_lcp_math_lcp_lcp_validation_and_solvers|UNIT_math_lcp_math_lcp_all_solvers_smoke|UNIT_math_optimization_GradientDescentSolver|UNIT_dynamics_InverseKinematics|UNIT_dynamics_Linkage|INTEGRATION_dynamics_AtlasIK)$'`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Supersedes #2634 and #2636.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: not required for behavior-preserving cleanup
- [x] Add unit tests for new functionality: not applicable
- [x] Document new methods and classes: not applicable
- [x] Add Python bindings (dartpy) if applicable: not applicable
