### PR TITLE
Use C++20 string prefix checks in resource paths

### DIFF
--- a/dart/common/uri.cpp
+++ b/dart/common/uri.cpp
@@ -42,11 +42,6 @@
 
 #include <cassert>
 
-static bool startsWith(std::string_view target, std::string_view prefix)
-{
-  return target.starts_with(prefix);
-}
-
 namespace dart {
 namespace common {
 
@@ -374,7 +369,7 @@ bool Uri::fromRelativeUri(const Uri& base, const Uri& relative, bool /*strict*/)
           mQuery = base.mQuery;
         }
       } else {
-        if (relative.mPath->front() == '/') {
+        if (relative.mPath->starts_with('/')) {
           mPath = removeDotSegments(*relative.mPath);
         } else {
           mPath = removeDotSegments(mergePaths(base, relative));
@@ -568,7 +563,7 @@ std::string Uri::getFilesystemPath() const
   if (mScheme.get_value_or("") == "file") {
     const std::string& filesystemPath = getPath();
 
-    if (!filesystemPath.empty() && filesystemPath[0] == '/') {
+    if (filesystemPath.starts_with('/')) {
       return filesystemPath.substr(1);
     }
   }
@@ -602,25 +597,26 @@ std::string Uri::removeDotSegments(const std::string& path)
   // 1.  The input buffer is initialized with the now-appended path
   //     components and the output buffer is initialized to the empty
   //     string.
-  std::string input = path;
+  std::string_view input = path;
   std::string output;
+  output.reserve(path.size());
 
   // 2.  While the input buffer is not empty, loop as follows:
   while (!input.empty()) {
     // A.  If the input buffer begins with a prefix of "../" or "./",
     //     then remove that prefix from the input buffer; otherwise,
-    if (startsWith(input, "../")) {
-      input = input.substr(3);
-    } else if (startsWith(input, "./")) {
-      input = input.substr(2);
+    if (input.starts_with("../")) {
+      input.remove_prefix(3);
+    } else if (input.starts_with("./")) {
+      input.remove_prefix(2);
     }
     // B.  if the input buffer begins with a prefix of "/./" or "/.",
     //     where "." is a complete path segment, then replace that
     //     prefix with "/" in the input buffer; otherwise,
     else if (input == "/.") {
       input = "/";
-    } else if (startsWith(input, "/./")) {
-      input = "/" + input.substr(3);
+    } else if (input.starts_with("/./")) {
+      input.remove_prefix(2);
     }
     // C.  if the input buffer begins with a prefix of "/../" or "/..",
     //     where ".." is a complete path segment, then replace that
@@ -636,8 +632,8 @@ std::string Uri::removeDotSegments(const std::string& path)
       } else {
         output = "";
       }
-    } else if (startsWith(input, "/../")) {
-      input = "/" + input.substr(4);
+    } else if (input.starts_with("/../")) {
+      input.remove_prefix(3);
 
       std::size_t index = output.find_last_of('/');
       if (index != std::string::npos) {
@@ -649,7 +645,7 @@ std::string Uri::removeDotSegments(const std::string& path)
     // D.  if the input buffer consists only of "." or "..", then remove
     //     that from the input buffer; otherwise,
     else if (input == "." || input == "..") {
-      input = "";
+      input = {};
     }
     // E.  move the first path segment in the input buffer to the end of
     //     the output buffer, including the initial "/" character (if
@@ -658,12 +654,13 @@ std::string Uri::removeDotSegments(const std::string& path)
     else {
       // Start at index one so we keep the leading '/'.
       std::size_t index = input.find_first_of('/', 1);
-      output += input.substr(0, index);
+      const auto segment = input.substr(0, index);
+      output.append(segment);
 
       if (index != std::string::npos) {
-        input = input.substr(index);
+        input.remove_prefix(index);
       } else {
-        input = "";
+        input = {};
       }
     }
   }

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -184,7 +184,7 @@ private:
         return &byPath->second;
       }
 
-      if (!path.empty() && path.front() == '/') {
+      if (path.starts_with('/')) {
         const auto byTrim = mData.find(path.substr(1));
         if (byTrim != mData.end()) {
           return &byTrim->second;

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -105,7 +105,7 @@ std::filesystem::path makeTemporaryTexturePath(std::string_view extension)
     }
 
     if (!extension.empty()) {
-      if (extension.front() == '.') {
+      if (extension.starts_with('.')) {
         name << extension;
       } else {
         name << "." << extension;

--- a/dart/utils/dart_resource_retriever.cpp
+++ b/dart/utils/dart_resource_retriever.cpp
@@ -174,7 +174,7 @@ void DartResourceRetriever::addDataDirectory(std::string_view dataDirectory)
 {
   // Strip a trailing slash.
   std::string normalizedDataDirectory;
-  if (!dataDirectory.empty() && dataDirectory.back() == '/') {
+  if (dataDirectory.ends_with('/')) {
     normalizedDataDirectory
         = std::string(dataDirectory.substr(0, dataDirectory.size() - 1));
   } else {

--- a/dart/utils/package_resource_retriever.cpp
+++ b/dart/utils/package_resource_retriever.cpp
@@ -63,8 +63,7 @@ void PackageResourceRetriever::addPackageDirectory(
 {
   // Strip a trailing slash.
   std::string_view normalizedPackageDirectory = packageDirectory;
-  if (!normalizedPackageDirectory.empty()
-      && normalizedPackageDirectory.back() == '/') {
+  if (normalizedPackageDirectory.ends_with('/')) {
     normalizedPackageDirectory = normalizedPackageDirectory.substr(
         0, normalizedPackageDirectory.size() - 1);
   }

--- a/dart/utils/sdf/sdf_parser.cpp
+++ b/dart/utils/sdf/sdf_parser.cpp
@@ -594,7 +594,7 @@ bool requiresBaseUriResolution(std::string_view requested)
     return false;
   }
 
-  if (requested.front() == '/') {
+  if (requested.starts_with('/')) {
     return false;
   }
 

--- a/examples/csv_logger/main.cpp
+++ b/examples/csv_logger/main.cpp
@@ -79,7 +79,7 @@ void printUsage(const char* argv0)
 
 bool parseSizeT(std::string_view value, std::size_t& output)
 {
-  if (value.empty() || value.front() == '-') {
+  if (value.empty() || value.starts_with('-')) {
     return false;
   }
 

--- a/examples/g1_puppet/main.cpp
+++ b/examples/g1_puppet/main.cpp
@@ -149,7 +149,7 @@ std::optional<std::string> getLastPathSegment(std::string value)
     value.erase(terminator);
   }
 
-  while (!value.empty() && (value.back() == '/' || value.back() == '\\')) {
+  while (value.ends_with('/') || value.ends_with('\\')) {
     value.pop_back();
   }
 

--- a/examples/headless_simulation/main.cpp
+++ b/examples/headless_simulation/main.cpp
@@ -72,7 +72,7 @@ void printUsage(const char* argv0)
 
 bool parseSizeT(std::string_view value, std::size_t& output)
 {
-  if (value.empty() || value.front() == '-') {
+  if (value.empty() || value.starts_with('-')) {
     return false;
   }
 
@@ -93,7 +93,7 @@ bool parseSizeT(std::string_view value, std::size_t& output)
 
 bool parseUnsignedInt(std::string_view value, unsigned int& output)
 {
-  if (value.empty() || value.front() == '-') {
+  if (value.empty() || value.starts_with('-')) {
     return false;
   }
 

--- a/tests/unit/common/test_uri.cpp
+++ b/tests/unit/common/test_uri.cpp
@@ -408,6 +408,10 @@ TEST(UriHelpers, removeDotSegments_RemovesDotAndDotDotSegments)
 {
   EXPECT_EQ(Uri::removeDotSegments("/.."), "/");
   EXPECT_EQ(Uri::removeDotSegments(".."), "");
+  EXPECT_EQ(Uri::removeDotSegments("/./g"), "/g");
+  EXPECT_EQ(Uri::removeDotSegments("a/b/./c"), "a/b/c");
+  EXPECT_EQ(Uri::removeDotSegments("/a/b/../c"), "/a/c");
+  EXPECT_EQ(Uri::removeDotSegments("mid/content=5/../6"), "mid/6");
 }
 
 TEST(UriHelpers, fromRelativeUri_StringViewOverload)

--- a/tests/unit/dynamics/test_arrow_shape.cpp
+++ b/tests/unit/dynamics/test_arrow_shape.cpp
@@ -48,7 +48,7 @@ private:
     if (isSampleUri(uri)) {
       std::filesystem::path path = mDataRoot;
       std::string relative = uri.getPath();
-      if (!relative.empty() && relative.front() == '/') {
+      if (relative.starts_with('/')) {
         relative.erase(0, 1);
       }
       path /= relative;

--- a/tests/unit/dynamics/test_mesh_shape.cpp
+++ b/tests/unit/dynamics/test_mesh_shape.cpp
@@ -213,7 +213,7 @@ private:
       if (byPath != mData.end()) {
         return &byPath->second;
       }
-      if (!path.empty() && path.front() == '/') {
+      if (path.starts_with('/')) {
         const auto byTrim = mData.find(path.substr(1));
         if (byTrim != mData.end()) {
           return &byTrim->second;


### PR DESCRIPTION
## Summary

- Uses C++20 `starts_with` and `ends_with` for URI, resource path, texture-extension, and example argument prefix/suffix checks.
- Removes a local `startsWith()` wrapper in `Uri` now that the standard API is available.
- Simplifies trailing-slash normalization for DART/package resource directories and example path parsing.
- Keeps URI dot-segment removal on a `std::string_view` input buffer to avoid repeated input-string copies while walking the path.
- Rebased onto current `main` so the branch satisfies GitHub's up-to-date merge requirement.

## Motivation / Problem

- The touched code was manually guarding empty strings before indexing the first or last character.
- URI dot-segment removal repeatedly reassigned substring copies while implementing an input-buffer walk.
- C++20 string prefix/suffix APIs express the path intent directly and handle empty strings safely.

## Changes / Key Changes

- Replaced manual leading-slash checks in `Uri`, SDF base-URI resolution, mesh resource lookup, and mesh/arrow shape tests with `starts_with('/')`.
- Replaced manual trailing-slash checks in DART/package resource retrievers and the G1 puppet path parser with `ends_with('/')` / `ends_with('\\')`.
- Replaced remaining guarded `front()` prefix checks in temporary texture extension handling and example numeric argument parsing with `starts_with()`.
- Replaced internal `startsWith()` helper calls in URI dot-segment removal with standard `starts_with()` calls.
- Changed URI dot-segment removal to advance a `std::string_view` input with `remove_prefix()` and reserve the output buffer.
- Added focused URI dot-segment test cases for dot, dot-dot, and relative path segments.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests` before rerunning local unit tests, because the local `test-unit` target did not prebuild those simulation-experimental executables on the first attempt
- `pixi run test-unit` (262/262 passed after the target prebuild above)
- Rebase follow-up: `cmake --build build/default/cpp/Release --target INTEGRATION_io_SdfParser INTEGRATION_utils_LocalResourceRetriever INTEGRATION_utils_CompositeResourceRetriever INTEGRATION_utils_DartResourceRetriever INTEGRATION_utils_PackageResourceRetriever UNIT_common_uri UNIT_dynamics_MeshShape UNIT_dynamics_ArrowShape UNIT_gui_MeshShapeNodeMaterialUpdates test_sdf_helpersNone test_HttpResourceRetriever UNIT_io_SdfParser_Errors`
- Rebase follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(INTEGRATION_io_SdfParser|INTEGRATION_utils_LocalResourceRetriever|INTEGRATION_utils_CompositeResourceRetriever|INTEGRATION_utils_DartResourceRetriever|INTEGRATION_utils_PackageResourceRetriever|UNIT_common_uri|UNIT_dynamics_MeshShape|UNIT_dynamics_ArrowShape|UNIT_gui_MeshShapeNodeMaterialUpdates|test_sdf_helpersNone|test_HttpResourceRetriever|UNIT_io_SdfParser_Errors)$'` (12/12 passed)

## Breaking Changes

- [x] None
- No API or behavior changes.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required; behavior-preserving internal cleanup)
- [x] Add unit tests for new functionality (covered URI normalization paths)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
