### PR TITLE
Adopt C++20 helpers in core utilities

### DIFF
--- a/dart/common/detail/castable-impl.hpp
+++ b/dart/common/detail/castable-impl.hpp
@@ -36,13 +36,27 @@
 #include "dart/common/macros.hpp"
 
 #include <dart/common/castable.hpp>
-#include <dart/common/metaprogramming.hpp>
+
+#include <concepts>
+#include <string_view>
 
 namespace dart::common {
 
+namespace detail {
+
 //==============================================================================
-DART_CREATE_MEMBER_CHECK(getType);
-DART_CREATE_MEMBER_CHECK(getStaticType);
+template <typename T>
+concept HasTypeString = requires(const T& value) {
+  { value.getType() } -> std::convertible_to<std::string_view>;
+};
+
+//==============================================================================
+template <typename T>
+concept HasStaticTypeString = requires {
+  { T::getStaticType() } -> std::convertible_to<std::string_view>;
+};
+
+} // namespace detail
 
 //==============================================================================
 template <typename Base>
@@ -50,8 +64,7 @@ template <typename Derived>
 bool Castable<Base>::is() const
 {
   if constexpr (
-      has_member_getType<Base>::value
-      && has_member_getStaticType<Derived>::value) {
+      detail::HasTypeString<Base> && detail::HasStaticTypeString<Derived>) {
     return (base().getType() == Derived::getStaticType());
   } else {
     return (dynamic_cast<const Derived*>(&base()) != nullptr);

--- a/dart/common/detail/connection_body.hpp
+++ b/dart/common/detail/connection_body.hpp
@@ -35,6 +35,7 @@
 
 #include <dart/export.hpp>
 
+#include <iterator>
 #include <memory>
 
 namespace dart {
@@ -138,7 +139,7 @@ struct DefaultCombiner
 {
   using result_type = T;
 
-  template <typename InputIterator>
+  template <std::bidirectional_iterator InputIterator>
   static T process(InputIterator first, InputIterator last)
   {
     // If there are no slots to call, just return the

--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -84,7 +84,8 @@ void SingleLockableReference<Lockable>::unlock() noexcept
 
 //==============================================================================
 template <detail::LockableObject Lockable>
-template <detail::LockablePointerInputIterator<Lockable> InputIterator>
+template <typename InputIterator>
+  requires detail::LockablePointerInputIterator<InputIterator, Lockable>
 MultiLockableReference<Lockable>::MultiLockableReference(
     std::weak_ptr<const void> lockableHolder,
     InputIterator first,

--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -35,16 +35,13 @@
 
 #include <dart/common/lockable_reference.hpp>
 
-#include <concepts>
-#include <iterator>
 #include <ranges>
-#include <type_traits>
 
 namespace dart {
 namespace common {
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 SingleLockableReference<Lockable>::SingleLockableReference(
     std::weak_ptr<const void> lockableHolder, Lockable& lockable) noexcept
   : mLockableHolder(std::move(lockableHolder)), mLockable(lockable)
@@ -53,7 +50,7 @@ SingleLockableReference<Lockable>::SingleLockableReference(
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void SingleLockableReference<Lockable>::lock()
 {
   if (mLockableHolder.expired()) {
@@ -64,7 +61,7 @@ void SingleLockableReference<Lockable>::lock()
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 bool SingleLockableReference<Lockable>::try_lock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -75,7 +72,7 @@ bool SingleLockableReference<Lockable>::try_lock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void SingleLockableReference<Lockable>::unlock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -86,27 +83,19 @@ void SingleLockableReference<Lockable>::unlock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
-template <typename InputIterator>
+template <detail::LockableObject Lockable>
+template <detail::LockablePointerInputIterator<Lockable> InputIterator>
 MultiLockableReference<Lockable>::MultiLockableReference(
     std::weak_ptr<const void> lockableHolder,
     InputIterator first,
     InputIterator last)
   : mLockableHolder(std::move(lockableHolder)), mLockables(first, last)
 {
-  using IteratorValueType =
-      typename std::iterator_traits<InputIterator>::value_type;
-  using IteratorLockable
-      = std::remove_pointer_t<std::remove_cvref_t<IteratorValueType>>;
-
-  static_assert(
-      std::same_as<Lockable, IteratorLockable>,
-      "Lockable of this class and the lockable of InputIterator are not the "
-      "same.");
+  // Do nothing
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void MultiLockableReference<Lockable>::lock()
 {
   if (mLockableHolder.expired()) {
@@ -119,7 +108,7 @@ void MultiLockableReference<Lockable>::lock()
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 bool MultiLockableReference<Lockable>::try_lock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -136,7 +125,7 @@ bool MultiLockableReference<Lockable>::try_lock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void MultiLockableReference<Lockable>::unlock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -149,7 +138,7 @@ void MultiLockableReference<Lockable>::unlock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 template <typename T>
 T* MultiLockableReference<Lockable>::ptr(T& obj)
 {
@@ -157,7 +146,7 @@ T* MultiLockableReference<Lockable>::ptr(T& obj)
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 template <typename T>
 T* MultiLockableReference<Lockable>::ptr(T* obj)
 {

--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -83,10 +83,10 @@ void SingleLockableReference<Lockable>::unlock() noexcept
 }
 
 //==============================================================================
-template <detail::LockableObject Lockable>
+template <detail::LockableObject LockableT>
 template <typename InputIterator>
-  requires detail::LockablePointerInputIterator<InputIterator, Lockable>
-MultiLockableReference<Lockable>::MultiLockableReference(
+  requires detail::LockablePointerInputIterator<InputIterator, LockableT>
+MultiLockableReference<LockableT>::MultiLockableReference(
     std::weak_ptr<const void> lockableHolder,
     InputIterator first,
     InputIterator last)

--- a/dart/common/detail/memory_allocator-impl.hpp
+++ b/dart/common/detail/memory_allocator-impl.hpp
@@ -35,6 +35,9 @@
 
 #include <dart/common/memory_allocator.hpp>
 
+#include <memory>
+#include <utility>
+
 namespace dart::common {
 
 //==============================================================================
@@ -55,9 +58,9 @@ T* MemoryAllocator::construct(Args&&... args) noexcept
   }
 
   // Call constructor. Return nullptr if failed.
+  T* typedObject = static_cast<T*>(object);
   try {
-    return std::construct_at(
-        static_cast<T*>(object), std::forward<Args>(args)...);
+    return std::construct_at(typedObject, std::forward<Args>(args)...);
   } catch (...) {
     deallocate(object, sizeof(T));
     return nullptr;

--- a/dart/common/detail/memory_manager-impl.hpp
+++ b/dart/common/detail/memory_manager-impl.hpp
@@ -35,6 +35,9 @@
 
 #include <dart/common/memory_manager.hpp>
 
+#include <memory>
+#include <utility>
+
 namespace dart::common {
 
 //==============================================================================
@@ -48,9 +51,9 @@ T* MemoryManager::construct(Type type, Args&&... args) noexcept
   }
 
   // Call constructor. Return nullptr if failed.
+  T* typedObject = static_cast<T*>(object);
   try {
-    return std::construct_at(
-        static_cast<T*>(object), std::forward<Args>(args)...);
+    return std::construct_at(typedObject, std::forward<Args>(args)...);
   } catch (...) {
     deallocate(type, object, sizeof(T));
     return nullptr;

--- a/dart/common/detail/stopwatch-impl.hpp
+++ b/dart/common/detail/stopwatch-impl.hpp
@@ -53,35 +53,28 @@ void print_duration_if_non_zero(
 } // namespace
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 Stopwatch<UnitType, ClockType>::Stopwatch(bool start)
   : mStart(ClockType::now()), mElapsed(0), mPaused(!start)
 {
-  // clang-format off
-  static_assert(std::same_as<UnitType, std::chrono::seconds>
-      || std::same_as<UnitType, std::chrono::milliseconds>
-      || std::same_as<UnitType, std::chrono::microseconds>
-      || std::same_as<UnitType, std::chrono::nanoseconds>,
-      "Invalid unit");
-  // clang-format on
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 Stopwatch<UnitType, ClockType>::~Stopwatch()
 {
   // Do nothing
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 bool Stopwatch<UnitType, ClockType>::isStarted() const
 {
   return !mPaused;
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::start()
 {
   if (!mPaused) {
@@ -93,7 +86,7 @@ void Stopwatch<UnitType, ClockType>::start()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::stop()
 {
   if (mPaused) {
@@ -105,7 +98,7 @@ void Stopwatch<UnitType, ClockType>::stop()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::reset()
 {
   mStart = ClockType::now();
@@ -113,7 +106,7 @@ void Stopwatch<UnitType, ClockType>::reset()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -128,7 +121,7 @@ double Stopwatch<UnitType, ClockType>::elapsedS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedMS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -144,7 +137,7 @@ double Stopwatch<UnitType, ClockType>::elapsedMS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedUS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -160,7 +153,7 @@ double Stopwatch<UnitType, ClockType>::elapsedUS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedNS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -175,7 +168,7 @@ double Stopwatch<UnitType, ClockType>::elapsedNS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 UnitType Stopwatch<UnitType, ClockType>::duration() const
 {
   if (mPaused) {
@@ -188,7 +181,7 @@ UnitType Stopwatch<UnitType, ClockType>::duration() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
 {
   auto t = duration();
@@ -233,7 +226,7 @@ void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 std::ostream& operator<<(
     std::ostream& os, const Stopwatch<UnitType, ClockType>& sw)
 {

--- a/dart/common/lockable_reference.hpp
+++ b/dart/common/lockable_reference.hpp
@@ -150,7 +150,7 @@ public:
   /// @param[in] first First iterator of lockable to be added to this class.
   /// @param[in] last Last iterator of lockable to be added to this class.
   template <typename InputIterator>
-    requires detail::LockablePointerInputIterator<InputIterator, Lockable>
+    requires detail::LockablePointerInputIterator<InputIterator, LockableT>
   MultiLockableReference(
       std::weak_ptr<const void> lockableHolder,
       InputIterator first,

--- a/dart/common/lockable_reference.hpp
+++ b/dart/common/lockable_reference.hpp
@@ -33,11 +33,33 @@
 #ifndef DART_COMMON_LOCKABLEREFERENCE_HPP_
 #define DART_COMMON_LOCKABLEREFERENCE_HPP_
 
+#include <concepts>
+#include <iterator>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 namespace dart {
 namespace common {
+
+namespace detail {
+
+template <typename T>
+concept LockableObject = requires(T lockable) {
+  { lockable.lock() } -> std::same_as<void>;
+  { lockable.try_lock() } -> std::convertible_to<bool>;
+  { lockable.unlock() } -> std::same_as<void>;
+};
+
+template <typename Iterator, typename Lockable>
+concept LockablePointerInputIterator
+    = std::input_iterator<Iterator>
+      && std::same_as<
+          std::remove_pointer_t<std::remove_cvref_t<
+              typename std::iterator_traits<Iterator>::value_type>>,
+          Lockable>;
+
+} // namespace detail
 
 /// LockableReference is a wrapper class of single or multiple Lockable
 /// object(s) to provide unified interface that guarantees deadlock-free locking
@@ -75,7 +97,7 @@ protected:
 /// This class references a single lockable.
 ///
 /// @tparam LockableT The standard C++ Lockable concept object type.
-template <typename LockableT>
+template <detail::LockableObject LockableT>
 class SingleLockableReference final : public LockableReference
 {
 public:
@@ -114,7 +136,7 @@ private:
 /// deadlock.
 ///
 /// @tparam LockableT The standard C++ Lockable concept object type.
-template <typename LockableT>
+template <detail::LockableObject LockableT>
 class MultiLockableReference final : public LockableReference
 {
 public:
@@ -127,7 +149,7 @@ public:
   /// lockable holder is not destructed.
   /// @param[in] first First iterator of lockable to be added to this class.
   /// @param[in] last Last iterator of lockable to be added to this class.
-  template <typename InputIterator>
+  template <detail::LockablePointerInputIterator<Lockable> InputIterator>
   MultiLockableReference(
       std::weak_ptr<const void> lockableHolder,
       InputIterator first,

--- a/dart/common/lockable_reference.hpp
+++ b/dart/common/lockable_reference.hpp
@@ -149,7 +149,8 @@ public:
   /// lockable holder is not destructed.
   /// @param[in] first First iterator of lockable to be added to this class.
   /// @param[in] last Last iterator of lockable to be added to this class.
-  template <detail::LockablePointerInputIterator<Lockable> InputIterator>
+  template <typename InputIterator>
+    requires detail::LockablePointerInputIterator<InputIterator, Lockable>
   MultiLockableReference(
       std::weak_ptr<const void> lockableHolder,
       InputIterator first,

--- a/dart/common/stopwatch.hpp
+++ b/dart/common/stopwatch.hpp
@@ -36,13 +36,25 @@
 #include <dart/export.hpp>
 
 #include <chrono>
+#include <concepts>
 #include <iostream>
 
 namespace dart::common {
 
+namespace detail {
+
+/// Returns true for the supported Stopwatch duration units.
+template <typename UnitType>
+concept StopwatchUnit = std::same_as<UnitType, std::chrono::seconds>
+                        || std::same_as<UnitType, std::chrono::milliseconds>
+                        || std::same_as<UnitType, std::chrono::microseconds>
+                        || std::same_as<UnitType, std::chrono::nanoseconds>;
+
+} // namespace detail
+
 /// Simple stopwatch implementation
 template <
-    typename UnitType,
+    detail::StopwatchUnit UnitType,
     typename ClockType = std::chrono::high_resolution_clock>
 class Stopwatch final
 {
@@ -87,7 +99,7 @@ public:
   void print(std::ostream& os = std::cout) const;
 
   /// Prints state of the stopwatch
-  template <typename T, typename U>
+  template <detail::StopwatchUnit T, typename U>
   friend std::ostream& operator<<(std::ostream& os, const Stopwatch<T, U>& sw);
 
 private:

--- a/dart/dynamics/detail/body_node_pool.hpp
+++ b/dart/dynamics/detail/body_node_pool.hpp
@@ -56,7 +56,7 @@ public:
       "BodyNodePool requires sizeof(T) >= sizeof(void*).");
 
   static constexpr std::size_t kSlotAlignment
-      = alignof(T) > 32 ? alignof(T) : 32;
+      = std::max<std::size_t>(alignof(T), 32);
   static_assert(
       std::has_single_bit(kSlotAlignment),
       "BodyNodePool requires a power-of-two slot alignment.");

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -51,6 +51,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <queue>
 #include <ranges>
 #include <span>
@@ -452,10 +453,10 @@ Skeleton::~Skeleton()
 {
   for (BodyNode* bn : mSkelCache.mBodyNodes) {
     if (mBodyNodePool->owns(bn)) {
-      bn->~BodyNode();
+      std::destroy_at(bn);
       mBodyNodePool->deallocate(bn);
     } else if (mSoftBodyNodePool->owns(bn)) {
-      bn->~BodyNode();
+      std::destroy_at(bn);
       mSoftBodyNodePool->deallocate(bn);
     } else {
       // Either heap-allocated or from a borrowed chunk (cross-skeleton move).
@@ -467,7 +468,7 @@ Skeleton::~Skeleton()
       } else {
         // Memory lives in a borrowed chunk — just destruct, chunk ref handles
         // memory lifetime
-        bn->~BodyNode();
+        std::destroy_at(bn);
       }
     }
   }

--- a/dart/simd/memory.hpp
+++ b/dart/simd/memory.hpp
@@ -55,6 +55,16 @@ inline constexpr std::size_t default_vector_alignment = 32;
 inline constexpr std::size_t default_vector_alignment = 16;
 #endif
 
+namespace detail {
+
+[[nodiscard]] constexpr std::size_t alignUpToPowerOfTwo(
+    std::size_t value, std::size_t alignment) noexcept
+{
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+} // namespace detail
+
 template <typename T, std::size_t Alignment = default_vector_alignment>
 class AlignedAllocator
 {
@@ -66,7 +76,6 @@ public:
   using is_always_equal = std::true_type;
 
   static constexpr std::size_t alignment = Alignment;
-
   static_assert(
       std::has_single_bit(Alignment), "Alignment must be a power of two.");
 
@@ -97,7 +106,7 @@ public:
       ptr = nullptr;
     }
 #else
-    std::size_t aligned_bytes = (bytes + Alignment - 1) & ~(Alignment - 1);
+    std::size_t aligned_bytes = detail::alignUpToPowerOfTwo(bytes, Alignment);
     ptr = std::aligned_alloc(Alignment, aligned_bytes);
 #endif
 

--- a/python/dartpy/common/polymorphic_caster.hpp
+++ b/python/dartpy/common/polymorphic_caster.hpp
@@ -2,6 +2,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include <concepts>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -123,7 +124,7 @@ private:
 
 } // namespace detail
 
-template <typename Base, typename Derived>
+template <typename Base, std::derived_from<Base> Derived>
 inline void registerPolymorphicCaster()
 {
   detail::PolymorphicCasterRegistry<Base>::registerType(

--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -69,6 +69,7 @@
 #include <queue>
 #include <thread>
 #include <vector>
+#include <version>
 
 #include <cassert>
 #include <cmath>
@@ -914,7 +915,11 @@ static void BM_ParallelWorlds(benchmark::State& state)
   }
 
   for (auto _ : state) {
+#if defined(__cpp_lib_jthread)
     std::vector<std::jthread> threads;
+#else
+    std::vector<std::thread> threads;
+#endif
     threads.reserve(numThreads);
     for (int t = 0; t < numThreads; ++t) {
       threads.emplace_back([&worlds, t, stepsPerThread]() {
@@ -923,6 +928,11 @@ static void BM_ParallelWorlds(benchmark::State& state)
         }
       });
     }
+#if !defined(__cpp_lib_jthread)
+    for (auto& thread : threads) {
+      thread.join();
+    }
+#endif
   }
   state.SetItemsProcessed(
       static_cast<int64_t>(state.iterations()) * numThreads * stepsPerThread);

--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -914,7 +914,7 @@ static void BM_ParallelWorlds(benchmark::State& state)
   }
 
   for (auto _ : state) {
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     threads.reserve(numThreads);
     for (int t = 0; t < numThreads; ++t) {
       threads.emplace_back([&worlds, t, stepsPerThread]() {
@@ -922,9 +922,6 @@ static void BM_ParallelWorlds(benchmark::State& state)
           worlds[t]->step();
         }
       });
-    }
-    for (auto& thread : threads) {
-      thread.join();
     }
   }
   state.SetItemsProcessed(

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <atomic>
 #include <numeric>
+#include <stop_token>
 #include <thread>
 #include <vector>
 
@@ -411,9 +412,8 @@ TEST(Signal, ConcurrentUsage)
   std::atomic<int> callbackCount{0};
 
   {
-    std::atomic<bool> stopRequested{false};
-    std::thread raiser([&]() {
-      while (!stopRequested.load(std::memory_order_relaxed)) {
+    std::jthread raiser([&](std::stop_token stopToken) {
+      while (!stopToken.stop_requested()) {
         signal.raise();
         raiseCount.fetch_add(1, std::memory_order_relaxed);
       }
@@ -424,7 +424,7 @@ TEST(Signal, ConcurrentUsage)
     }
 
     {
-      std::vector<std::thread> workers;
+      std::vector<std::jthread> workers;
       workers.reserve(kNumThreads);
       for (int t = 0; t < kNumThreads; ++t) {
         workers.emplace_back([&]() {
@@ -437,14 +437,9 @@ TEST(Signal, ConcurrentUsage)
           }
         });
       }
-
-      for (std::thread& worker : workers) {
-        worker.join();
-      }
     }
 
-    stopRequested.store(true, std::memory_order_relaxed);
-    raiser.join();
+    raiser.request_stop();
   }
 
   EXPECT_EQ(signal.getNumConnections(), 0u);

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -39,9 +39,13 @@
 #include <algorithm>
 #include <atomic>
 #include <numeric>
-#include <stop_token>
 #include <thread>
 #include <vector>
+#include <version>
+
+#if defined(__cpp_lib_jthread)
+  #include <stop_token>
+#endif
 
 using namespace std;
 using namespace Eigen;
@@ -412,19 +416,33 @@ TEST(Signal, ConcurrentUsage)
   std::atomic<int> callbackCount{0};
 
   {
+#if defined(__cpp_lib_jthread)
     std::jthread raiser([&](std::stop_token stopToken) {
       while (!stopToken.stop_requested()) {
         signal.raise();
         raiseCount.fetch_add(1, std::memory_order_relaxed);
       }
     });
+#else
+    std::atomic<bool> stopRequested{false};
+    std::thread raiser([&]() {
+      while (!stopRequested.load(std::memory_order_relaxed)) {
+        signal.raise();
+        raiseCount.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+#endif
 
     while (raiseCount.load(std::memory_order_relaxed) == 0) {
       std::this_thread::yield();
     }
 
     {
+#if defined(__cpp_lib_jthread)
       std::vector<std::jthread> workers;
+#else
+      std::vector<std::thread> workers;
+#endif
       workers.reserve(kNumThreads);
       for (int t = 0; t < kNumThreads; ++t) {
         workers.emplace_back([&]() {
@@ -437,9 +455,19 @@ TEST(Signal, ConcurrentUsage)
           }
         });
       }
+#if !defined(__cpp_lib_jthread)
+      for (std::thread& worker : workers) {
+        worker.join();
+      }
+#endif
     }
 
+#if defined(__cpp_lib_jthread)
     raiser.request_stop();
+#else
+    stopRequested.store(true, std::memory_order_relaxed);
+    raiser.join();
+#endif
   }
 
   EXPECT_EQ(signal.getNumConnections(), 0u);

--- a/tests/unit/common/test_profile.cpp
+++ b/tests/unit/common/test_profile.cpp
@@ -41,6 +41,7 @@
   #include <sstream>
   #include <string>
   #include <thread>
+  #include <version>
 
 using dart::common::profile::Profiler;
 using dart::common::profile::ProfileScope;
@@ -86,10 +87,17 @@ TEST_F(ProfileTest, CapturesMultipleThreads)
   }
 
   {
+  #if defined(__cpp_lib_jthread)
     std::jthread worker([] {
+  #else
+    std::thread worker([] {
+  #endif
       ProfileScope workerScope("worker-work", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(3));
     });
+  #if !defined(__cpp_lib_jthread)
+    worker.join();
+  #endif
   }
 
   std::stringstream ss;

--- a/tests/unit/common/test_profile.cpp
+++ b/tests/unit/common/test_profile.cpp
@@ -86,11 +86,10 @@ TEST_F(ProfileTest, CapturesMultipleThreads)
   }
 
   {
-    std::thread worker([] {
+    std::jthread worker([] {
       ProfileScope workerScope("worker-work", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(3));
     });
-    worker.join();
   }
 
   std::stringstream ss;

--- a/tests/unit/common/test_profiler.cpp
+++ b/tests/unit/common/test_profiler.cpp
@@ -285,7 +285,7 @@ TEST(Profiler, SummaryMultipleThreads)
   ScopedEnvVar env("DART_PROFILE_COLOR", "0");
 
   {
-    std::thread worker([]() {
+    std::jthread worker([]() {
       common::profile::ProfileScope scope("WorkerScope", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     });
@@ -298,8 +298,6 @@ TEST(Profiler, SummaryMultipleThreads)
     profiler.markFrame();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     profiler.markFrame();
-
-    worker.join();
   }
 
   std::ostringstream oss;

--- a/tests/unit/common/test_profiler.cpp
+++ b/tests/unit/common/test_profiler.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <version>
 
 #include <cstdlib>
 
@@ -285,7 +286,11 @@ TEST(Profiler, SummaryMultipleThreads)
   ScopedEnvVar env("DART_PROFILE_COLOR", "0");
 
   {
+#if defined(__cpp_lib_jthread)
     std::jthread worker([]() {
+#else
+    std::thread worker([]() {
+#endif
       common::profile::ProfileScope scope("WorkerScope", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     });
@@ -298,6 +303,9 @@ TEST(Profiler, SummaryMultipleThreads)
     profiler.markFrame();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     profiler.markFrame();
+#if !defined(__cpp_lib_jthread)
+    worker.join();
+#endif
   }
 
   std::ostringstream oss;


### PR DESCRIPTION
## Summary

- Consolidate core utility lifetime helpers, concept constraints, and threaded-test cleanup into one PR to reduce CI queue pressure.
- Use standard lifetime helpers and C++20 constraints in common/dynamics/SIMD utility templates.
- Use `std::jthread` where available in threaded tests and benchmarks, with feature-test fallbacks for libc++ environments.

## Motivation / Problem

- These utility-level cleanups touch shared headers and therefore trigger broad CI work. Keeping them split across several small PRs was wasting CI capacity.
- The combined PR validates the template and test-thread changes together while preserving behavior.

## Changes / Key Changes

- Replace manual object lifetime operations in allocator, memory-manager, body-node pool, skeleton, and SIMD memory helpers with standard utilities.
- Add concepts/constraints to common template helpers, lockable references, stopwatch duration units, and dartpy polymorphic caster support.
- Modernize threaded tests and dynamics benchmark helpers with `std::jthread` when available, keeping portable fallbacks.

## Consolidation

Supersedes draft PRs: #2635, #2639.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target UNIT_common_lockable_reference UNIT_common_memory_allocator UNIT_common_memory_manager UNIT_common_profile UNIT_common_profiler UNIT_common_signal UNIT_common_stopwatch UNIT_dynamics_SkeletonAccessors INTEGRATION_utils_signal bm_dynamics_cache py_test_stopwatch py_test_skeleton`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_common_lockable_reference|UNIT_common_memory_allocator|UNIT_common_memory_manager|UNIT_common_profile|UNIT_common_profiler|UNIT_common_signal|UNIT_common_stopwatch|UNIT_dynamics_SkeletonAccessors|INTEGRATION_utils_signal)$'`
- Python test targets above each completed with `152 passed`.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Supersedes #2635 and #2639.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: not required for behavior-preserving cleanup
- [x] Add unit tests for new functionality: not applicable
- [x] Document new methods and classes: not applicable
- [x] Add Python bindings (dartpy) if applicable: not applicable
