### PR TITLE
Adopt targeted STL helpers across core code

### DIFF
--- a/dart/collision/collision_group.cpp
+++ b/dart/collision/collision_group.cpp
@@ -317,8 +317,8 @@ void CollisionGroup::removeDeletedShapeFrames()
           static_cast<const dynamics::MetaSkeleton*>(source));
       if (skelSearch != mSkeletonSources.end()) {
         skelSearch->second.mObjects.erase(shapeFrame);
-        for (auto& child : skelSearch->second.mChildren) {
-          child.second.mFrames.erase(shapeFrame);
+        for (auto& child : skelSearch->second.mChildren | std::views::values) {
+          child.mFrames.erase(shapeFrame);
         }
       }
 

--- a/dart/collision/collision_group.cpp
+++ b/dart/collision/collision_group.cpp
@@ -647,10 +647,10 @@ bool CollisionGroup::updateBodyNodeSource(BodyNodeSources::value_type& entry)
 
   // Remove from this group and ShapeFrames that no longer belong to the
   // BodyNode
-  for (const auto& unusedFrame : unusedFrames) {
+  for (const auto* unusedFrame : unusedFrames | std::views::keys) {
     updateNeeded = true;
-    removeShapeFrameInternal(unusedFrame.first, bn.get());
-    source.mObjects.erase(unusedFrame.first);
+    removeShapeFrameInternal(unusedFrame, bn.get());
+    source.mObjects.erase(unusedFrame);
   }
 
   return updateNeeded;

--- a/dart/collision/collision_group.cpp
+++ b/dart/collision/collision_group.cpp
@@ -39,6 +39,7 @@
 #include "dart/dynamics/skeleton.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 #include <cassert>
 #include <cstdint>
@@ -490,8 +491,8 @@ bool CollisionGroup::updateSkeletonSource(SkeletonSources::value_type& entry)
   if (!meta) {
     // This skeleton no longer exists, so we should remove all its contents from
     // the CollisionGroup.
-    for (const auto& object : source.mObjects) {
-      removeShapeFrameInternal(object.second->mFrame, entry.first);
+    for (const auto& object : source.mObjects | std::views::values) {
+      removeShapeFrameInternal(object->mFrame, entry.first);
     }
 
     return true;

--- a/dart/collision/detail/collision_group.hpp
+++ b/dart/collision/detail/collision_group.hpp
@@ -40,6 +40,8 @@
 #include <dart/dynamics/body_node.hpp>
 #include <dart/dynamics/skeleton.hpp>
 
+#include <ranges>
+
 namespace dart {
 namespace collision {
 
@@ -248,8 +250,8 @@ void CollisionGroup::unsubscribeFrom(
 {
   auto it = mBodyNodeSources.find(bodyNode);
   if (it != mBodyNodeSources.end()) {
-    for (const auto& entry : it->second.mObjects) {
-      removeShapeFrameInternal(entry.first, bodyNode);
+    for (const auto* shapeFrame : it->second.mObjects | std::views::keys) {
+      removeShapeFrameInternal(shapeFrame, bodyNode);
     }
 
     mBodyNodeSources.erase(it);
@@ -265,8 +267,8 @@ void CollisionGroup::unsubscribeFrom(
 {
   auto it = mSkeletonSources.find(skeleton);
   if (it != mSkeletonSources.end()) {
-    for (const auto& entry : it->second.mObjects) {
-      removeShapeFrameInternal(entry.first, skeleton);
+    for (const auto* shapeFrame : it->second.mObjects | std::views::keys) {
+      removeShapeFrameInternal(shapeFrame, skeleton);
     }
 
     mSkeletonSources.erase(it);

--- a/dart/collision/ode/detail/ode_cylinder_mesh.cpp
+++ b/dart/collision/ode/detail/ode_cylinder_mesh.cpp
@@ -38,6 +38,7 @@
 #include <Eigen/Core>
 
 #include <algorithm>
+#include <array>
 
 #include <cmath>
 
@@ -61,7 +62,7 @@ void appendTriangle(
   }
 
   const auto baseIndex = static_cast<int>(vertices.size() / 3);
-  const Eigen::Vector3d points[] = {p1, p2, p3};
+  const auto points = std::to_array<Eigen::Vector3d>({p1, p2, p3});
   for (const auto& point : points) {
     vertices.push_back(point.x());
     vertices.push_back(point.y());

--- a/dart/collision/ode/ode_collision_detector.cpp
+++ b/dart/collision/ode/ode_collision_detector.cpp
@@ -428,29 +428,22 @@ void reportContacts(
   const auto pair = MakeNewPair(b1, b2);
   auto& pastContacsVec = FindPairInHist(*history, pair);
   auto results_vec_copy = result.getContacts();
+  const auto isCurrentPairContact = [&](const Contact& contact) {
+    return MakeNewPair(contact.collisionObject1, contact.collisionObject2)
+           == pair;
+  };
+  auto pairContacts
+      = results_vec_copy | std::views::filter(isCurrentPairContact);
 
-  bool sliding = false;
   constexpr double slidingThreshold = 1e-3;
-  std::size_t pairContactCount = 0u;
-  for (const auto& curr_cont : results_vec_copy) {
-    const auto current_pair
-        = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
-    if (current_pair != pair) {
-      continue;
-    }
-
-    ++pairContactCount;
-
-    if (computeTangentialSpeed(curr_cont) > slidingThreshold) {
-      sliding = true;
-      break;
-    }
-  }
-
-  if (sliding) {
+  if (std::ranges::any_of(pairContacts, [](const Contact& contact) {
+        return computeTangentialSpeed(contact) > slidingThreshold;
+      })) {
     return;
   }
 
+  const auto pairContactCount
+      = static_cast<std::size_t>(std::ranges::distance(pairContacts));
   const std::size_t pairTarget
       = std::min<std::size_t>(3u, option.maxNumContacts);
   if (pairContactCount >= pairTarget) {
@@ -469,12 +462,7 @@ void reportContacts(
       break;
     }
 
-    for (const auto& curr_cont : results_vec_copy) {
-      const auto res_pair
-          = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
-      if (res_pair != pair) {
-        continue;
-      }
+    for (const auto& curr_cont : pairContacts) {
       auto dist_v = past_cont.point - curr_cont.point;
       const auto dist_m = (dist_v.transpose() * dist_v).coeff(0, 0);
       if (dist_m < 0.01) {
@@ -492,12 +480,8 @@ void reportContacts(
       break;
     }
   }
-  for (const auto& item : results_vec_copy) {
-    const auto res_pair
-        = MakeNewPair(item.collisionObject1, item.collisionObject2);
-    if (res_pair == pair) {
-      pastContacsVec.push_back(item);
-    }
+  for (const auto& item : pairContacts) {
+    pastContacsVec.push_back(item);
   }
 
   const auto size = pastContacsVec.size();
@@ -593,16 +577,13 @@ void OdeCollisionDetector::pruneContactHistory(const CollisionResult& result)
 
   const auto& contacts = result.getContacts();
   for (auto& pastContact : mContactHistory) {
-    bool clear = true;
-    for (const auto& current : contacts) {
-      auto currentPair
-          = MakeNewPair(current.collisionObject1, current.collisionObject2);
-      if (pastContact.pair == currentPair) {
-        clear = false;
-        break;
-      }
-    }
-    if (clear) {
+    const auto hasCurrentContact
+        = std::ranges::any_of(contacts, [&](const Contact& current) {
+            auto currentPair = MakeNewPair(
+                current.collisionObject1, current.collisionObject2);
+            return pastContact.pair == currentPair;
+          });
+    if (!hasCurrentContact) {
       pastContact.history.clear();
     }
   }

--- a/dart/collision/ode/ode_collision_detector.cpp
+++ b/dart/collision/ode/ode_collision_detector.cpp
@@ -428,22 +428,29 @@ void reportContacts(
   const auto pair = MakeNewPair(b1, b2);
   auto& pastContacsVec = FindPairInHist(*history, pair);
   auto results_vec_copy = result.getContacts();
-  const auto isCurrentPairContact = [&](const Contact& contact) {
-    return MakeNewPair(contact.collisionObject1, contact.collisionObject2)
-           == pair;
-  };
-  auto pairContacts
-      = results_vec_copy | std::views::filter(isCurrentPairContact);
 
+  bool sliding = false;
   constexpr double slidingThreshold = 1e-3;
-  if (std::ranges::any_of(pairContacts, [](const Contact& contact) {
-        return computeTangentialSpeed(contact) > slidingThreshold;
-      })) {
+  std::size_t pairContactCount = 0u;
+  for (const auto& curr_cont : results_vec_copy) {
+    const auto current_pair
+        = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
+    if (current_pair != pair) {
+      continue;
+    }
+
+    ++pairContactCount;
+
+    if (computeTangentialSpeed(curr_cont) > slidingThreshold) {
+      sliding = true;
+      break;
+    }
+  }
+
+  if (sliding) {
     return;
   }
 
-  const auto pairContactCount
-      = static_cast<std::size_t>(std::ranges::distance(pairContacts));
   const std::size_t pairTarget
       = std::min<std::size_t>(3u, option.maxNumContacts);
   if (pairContactCount >= pairTarget) {
@@ -462,7 +469,12 @@ void reportContacts(
       break;
     }
 
-    for (const auto& curr_cont : pairContacts) {
+    for (const auto& curr_cont : results_vec_copy) {
+      const auto res_pair
+          = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
+      if (res_pair != pair) {
+        continue;
+      }
       auto dist_v = past_cont.point - curr_cont.point;
       const auto dist_m = (dist_v.transpose() * dist_v).coeff(0, 0);
       if (dist_m < 0.01) {
@@ -480,8 +492,12 @@ void reportContacts(
       break;
     }
   }
-  for (const auto& item : pairContacts) {
-    pastContacsVec.push_back(item);
+  for (const auto& item : results_vec_copy) {
+    const auto res_pair
+        = MakeNewPair(item.collisionObject1, item.collisionObject2);
+    if (res_pair == pair) {
+      pastContacsVec.push_back(item);
+    }
   }
 
   const auto size = pastContacsVec.size();

--- a/dart/common/composite.cpp
+++ b/dart/common/composite.cpp
@@ -36,6 +36,7 @@
 #include "dart/common/macros.hpp"
 
 #include <iostream>
+#include <ranges>
 
 #include <cassert>
 
@@ -246,8 +247,8 @@ void Composite::matchAspects(const Composite* otherComposite)
     return;
   }
 
-  for (auto& aspect : mAspectMap) {
-    _replaceAspect(aspect.second, nullptr);
+  for (auto& aspect : mAspectMap | std::views::values) {
+    _replaceAspect(aspect, nullptr);
   }
 
   duplicateAspects(otherComposite);

--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -178,7 +178,7 @@ void Profiler::popScope(Profiler::ThreadRecord& record)
 std::uint64_t Profiler::sumInclusiveChildren(const ProfileNode& node)
 {
   std::uint64_t total = 0;
-  for (const auto& [_, child] : node.children) {
+  for (const auto& child : node.children | std::views::values) {
     total += child->inclusiveNs;
   }
   return total;
@@ -274,7 +274,7 @@ std::size_t Profiler::maxLabelWidth(
     const ProfileNode& node, std::size_t minWidth, std::size_t maxWidth)
 {
   std::size_t width = node.label.size();
-  for (const auto& [_, child] : node.children) {
+  for (const auto& child : node.children | std::views::values) {
     width = std::max(width, maxLabelWidth(*child, minWidth, maxWidth));
   }
   return std::clamp<std::size_t>(width, minWidth, maxWidth);
@@ -355,7 +355,7 @@ void Profiler::collectHotspots(
        node.inclusiveNs,
        node.selfNs,
        node.callCount});
-  for (const auto& [_, child] : node.children) {
+  for (const auto& child : node.children | std::views::values) {
     const auto childPath
         = path.empty() ? child->label : (path + " > " + child->label);
     collectHotspots(*child, childPath, threadLabel, out);
@@ -565,7 +565,7 @@ void Profiler::clearNode(ProfileNode& node)
   node.selfNs = 0;
   node.minNs = Profiler::kUnsetDuration;
   node.maxNs = 0;
-  for (auto& [_, child] : node.children) {
+  for (auto& child : node.children | std::views::values) {
     clearNode(*child);
   }
   node.children.clear();

--- a/dart/common/detail/stopwatch-impl.hpp
+++ b/dart/common/detail/stopwatch-impl.hpp
@@ -116,62 +116,28 @@ void Stopwatch<UnitType, ClockType>::reset()
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedS() const
 {
-  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
-    return duration().count() * 1e-9;
-  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
-    return duration().count() * 1e-6;
-  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
-    return duration().count() * 1e-3;
-  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
-    return duration().count();
-  }
+  return std::chrono::duration<double>(duration()).count();
 }
 
 //==============================================================================
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedMS() const
 {
-  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
-    return duration().count() * 1e-6;
-  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
-    return duration().count() * 1e-3;
-  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
-    return duration().count();
-  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
-    return duration().count() * 1e+3;
-    ;
-  }
+  return std::chrono::duration<double, std::milli>(duration()).count();
 }
 
 //==============================================================================
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedUS() const
 {
-  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
-    return duration().count() * 1e-3;
-  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
-    return duration().count();
-  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
-    return duration().count() * 1e+3;
-  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
-    return duration().count() * 1e+6;
-    ;
-  }
+  return std::chrono::duration<double, std::micro>(duration()).count();
 }
 
 //==============================================================================
 template <typename UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedNS() const
 {
-  if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
-    return duration().count();
-  } else if constexpr (std::same_as<UnitType, std::chrono::microseconds>) {
-    return duration().count() * 1e+3;
-  } else if constexpr (std::same_as<UnitType, std::chrono::milliseconds>) {
-    return duration().count() * 1e+6;
-  } else if constexpr (std::same_as<UnitType, std::chrono::seconds>) {
-    return duration().count() * 1e+9;
-  }
+  return std::chrono::duration<double, std::nano>(duration()).count();
 }
 
 //==============================================================================

--- a/dart/common/uri.cpp
+++ b/dart/common/uri.cpp
@@ -42,11 +42,6 @@
 
 #include <cassert>
 
-static bool startsWith(std::string_view target, std::string_view prefix)
-{
-  return target.starts_with(prefix);
-}
-
 namespace dart {
 namespace common {
 
@@ -374,7 +369,7 @@ bool Uri::fromRelativeUri(const Uri& base, const Uri& relative, bool /*strict*/)
           mQuery = base.mQuery;
         }
       } else {
-        if (relative.mPath->front() == '/') {
+        if (relative.mPath->starts_with('/')) {
           mPath = removeDotSegments(*relative.mPath);
         } else {
           mPath = removeDotSegments(mergePaths(base, relative));
@@ -568,7 +563,7 @@ std::string Uri::getFilesystemPath() const
   if (mScheme.get_value_or("") == "file") {
     const std::string& filesystemPath = getPath();
 
-    if (!filesystemPath.empty() && filesystemPath[0] == '/') {
+    if (filesystemPath.starts_with('/')) {
       return filesystemPath.substr(1);
     }
   }
@@ -602,25 +597,26 @@ std::string Uri::removeDotSegments(const std::string& path)
   // 1.  The input buffer is initialized with the now-appended path
   //     components and the output buffer is initialized to the empty
   //     string.
-  std::string input = path;
+  std::string_view input = path;
   std::string output;
+  output.reserve(path.size());
 
   // 2.  While the input buffer is not empty, loop as follows:
   while (!input.empty()) {
     // A.  If the input buffer begins with a prefix of "../" or "./",
     //     then remove that prefix from the input buffer; otherwise,
-    if (startsWith(input, "../")) {
-      input = input.substr(3);
-    } else if (startsWith(input, "./")) {
-      input = input.substr(2);
+    if (input.starts_with("../")) {
+      input.remove_prefix(3);
+    } else if (input.starts_with("./")) {
+      input.remove_prefix(2);
     }
     // B.  if the input buffer begins with a prefix of "/./" or "/.",
     //     where "." is a complete path segment, then replace that
     //     prefix with "/" in the input buffer; otherwise,
     else if (input == "/.") {
       input = "/";
-    } else if (startsWith(input, "/./")) {
-      input = "/" + input.substr(3);
+    } else if (input.starts_with("/./")) {
+      input.remove_prefix(2);
     }
     // C.  if the input buffer begins with a prefix of "/../" or "/..",
     //     where ".." is a complete path segment, then replace that
@@ -636,8 +632,8 @@ std::string Uri::removeDotSegments(const std::string& path)
       } else {
         output = "";
       }
-    } else if (startsWith(input, "/../")) {
-      input = "/" + input.substr(4);
+    } else if (input.starts_with("/../")) {
+      input.remove_prefix(3);
 
       std::size_t index = output.find_last_of('/');
       if (index != std::string::npos) {
@@ -649,7 +645,7 @@ std::string Uri::removeDotSegments(const std::string& path)
     // D.  if the input buffer consists only of "." or "..", then remove
     //     that from the input buffer; otherwise,
     else if (input == "." || input == "..") {
-      input = "";
+      input = {};
     }
     // E.  move the first path segment in the input buffer to the end of
     //     the output buffer, including the initial "/" character (if
@@ -658,12 +654,13 @@ std::string Uri::removeDotSegments(const std::string& path)
     else {
       // Start at index one so we keep the leading '/'.
       std::size_t index = input.find_first_of('/', 1);
-      output += input.substr(0, index);
+      const auto segment = input.substr(0, index);
+      output.append(segment);
 
       if (index != std::string::npos) {
-        input = input.substr(index);
+        input.remove_prefix(index);
       } else {
-        input = "";
+        input = {};
       }
     }
   }

--- a/dart/constraint/constraint_solver.cpp
+++ b/dart/constraint/constraint_solver.cpp
@@ -583,15 +583,15 @@ void ConstraintSolver::updateConstraints()
       }
 
       const std::size_t dof = joint->getNumDofs();
-      for (std::size_t j = 0; j < dof; ++j) {
-        if (joint->getCoulombFriction(j) != 0.0) {
-          mJointCoulombFrictionConstraints.push_back(
-              std::allocate_shared<JointCoulombFrictionConstraint>(
-                  common::FrameStlAllocator<JointCoulombFrictionConstraint>(
-                      *mFrameAllocator),
-                  joint));
-          break;
-        }
+      const bool hasCoulombFriction = std::ranges::any_of(
+          std::views::iota(std::size_t{0}, dof),
+          [&](std::size_t j) { return joint->getCoulombFriction(j) != 0.0; });
+      if (hasCoulombFriction) {
+        mJointCoulombFrictionConstraints.push_back(
+            std::allocate_shared<JointCoulombFrictionConstraint>(
+                common::FrameStlAllocator<JointCoulombFrictionConstraint>(
+                    *mFrameAllocator),
+                joint));
       }
 
       if (joint->areLimitsEnforced()

--- a/dart/constraint/constraint_solver.cpp
+++ b/dart/constraint/constraint_solver.cpp
@@ -712,15 +712,10 @@ void ConstraintSolver::buildConstrainedGroups()
   // Build constraint groups
   //----------------------------------------------------------------------------
   for (const auto& activeConstraint : mActiveConstraints) {
-    bool found = false;
     const auto& skel = activeConstraint->getRootSkeleton();
-
-    for (const auto& constrainedGroup : mConstrainedGroups) {
-      if (constrainedGroup.mRootSkeleton == skel) {
-        found = true;
-        break;
-      }
-    }
+    const bool found = std::ranges::any_of(
+        mConstrainedGroups,
+        [&](const auto& group) { return group.mRootSkeleton == skel; });
 
     if (found) {
       continue;

--- a/dart/constraint/contact_constraint.cpp
+++ b/dart/constraint/contact_constraint.cpp
@@ -40,6 +40,7 @@
 #include "dart/math/constants.hpp"
 #include "dart/math/helpers.hpp"
 
+#include <algorithm>
 #include <iostream>
 
 namespace dart {
@@ -248,10 +249,9 @@ void ContactConstraint::setErrorAllowance(double allowance)
     DART_WARN(
         "Error reduction parameter[{}] is lower than 0.0. It is set to 0.0.",
         allowance);
-    allowance = 0.0;
   }
 
-  mErrorAllowance = allowance;
+  mErrorAllowance = std::max(allowance, 0.0);
 }
 
 //==============================================================================
@@ -268,16 +268,14 @@ void ContactConstraint::setErrorReductionParameter(double erp)
     DART_WARN(
         "Error reduction parameter[{}] is lower than 0.0. It is set to 0.0.",
         erp);
-    erp = 0.0;
   }
   if (erp > 1.0) {
     DART_WARN(
         "Error reduction parameter[{}] is greater than 1.0. It is set to 1.0.",
         erp);
-    erp = 1.0;
   }
 
-  mErrorReductionParameter = erp;
+  mErrorReductionParameter = std::clamp(erp, 0.0, 1.0);
 }
 
 //==============================================================================
@@ -295,10 +293,9 @@ void ContactConstraint::setMaxErrorReductionVelocity(double erv)
         "Maximum error reduction velocity[{}] is lower than 0.0. It is set to "
         "0.0.",
         erv);
-    erv = 0.0;
   }
 
-  mMaxErrorReductionVelocity = erv;
+  mMaxErrorReductionVelocity = std::max(erv, 0.0);
 }
 
 //==============================================================================
@@ -316,10 +313,9 @@ void ContactConstraint::setConstraintForceMixing(double cfm)
         "Constraint force mixing parameter[{}] is lower than 1e-9. It is set "
         "to 1e-9.",
         cfm);
-    cfm = 1e-9;
   }
 
-  mConstraintForceMixing = cfm;
+  mConstraintForceMixing = std::max(cfm, 1e-9);
 }
 
 //==============================================================================

--- a/dart/constraint/coupler_constraint.cpp
+++ b/dart/constraint/coupler_constraint.cpp
@@ -96,16 +96,14 @@ std::string_view CouplerConstraint::getStaticType()
 //==============================================================================
 void CouplerConstraint::setConstraintForceMixing(double cfm)
 {
-  double clamped = cfm;
-  if (clamped < 1e-9) {
+  if (cfm < 1e-9) {
     DART_WARN(
         "[CouplerConstraint::setConstraintForceMixing] Constraint force "
         "mixing parameter[{}] is lower than 1e-9. It is set to 1e-9.",
         cfm);
-    clamped = 1e-9;
   }
 
-  mConstraintForceMixing = clamped;
+  mConstraintForceMixing = std::max(cfm, 1e-9);
 }
 
 //==============================================================================

--- a/dart/constraint/mimic_motor_constraint.cpp
+++ b/dart/constraint/mimic_motor_constraint.cpp
@@ -38,6 +38,7 @@
 #include "dart/dynamics/joint.hpp"
 #include "dart/dynamics/skeleton.hpp"
 
+#include <algorithm>
 #include <iostream>
 
 #include <cmath>
@@ -108,16 +109,14 @@ std::string_view MimicMotorConstraint::getStaticType()
 //==============================================================================
 void MimicMotorConstraint::setConstraintForceMixing(double cfm)
 {
-  double clamped = cfm;
-  if (clamped < 1e-9) {
+  if (cfm < 1e-9) {
     DART_WARN(
         "Constraint force mixing parameter[{}] is lower than 1e-9. It is set "
         "to 1e-9.",
         cfm);
-    clamped = 1e-9;
   }
 
-  mConstraintForceMixing = clamped;
+  mConstraintForceMixing = std::max(cfm, 1e-9);
 }
 
 //==============================================================================
@@ -129,20 +128,17 @@ double MimicMotorConstraint::getConstraintForceMixing()
 //==============================================================================
 void MimicMotorConstraint::setErrorReductionParameter(double erp)
 {
-  double clamped = erp;
-  if (clamped < 0.0) {
+  if (erp < 0.0) {
     DART_WARN(
         "Error reduction parameter [{}] is lower than 0.0. It is set to 0.0.",
         erp);
-    clamped = 0.0;
-  } else if (clamped > 1.0) {
+  } else if (erp > 1.0) {
     DART_WARN(
         "Error reduction parameter [{}] is greater than 1.0. It is set to 1.0.",
         erp);
-    clamped = 1.0;
   }
 
-  mErrorReductionParameter = clamped;
+  mErrorReductionParameter = std::clamp(erp, 0.0, 1.0);
 }
 
 //==============================================================================

--- a/dart/dynamics/arrow_shape.cpp
+++ b/dart/dynamics/arrow_shape.cpp
@@ -152,7 +152,7 @@ void ArrowShape::configureArrow(
   mProperties = _properties;
 
   mProperties.mHeadLengthScale
-      = std::max(0.0, std::min(1.0, mProperties.mHeadLengthScale));
+      = std::clamp(mProperties.mHeadLengthScale, 0.0, 1.0);
   mProperties.mMinHeadLength = std::max(0.0, mProperties.mMinHeadLength);
   mProperties.mMaxHeadLength = std::max(0.0, mProperties.mMaxHeadLength);
   mProperties.mHeadRadiusScale = std::max(1.0, mProperties.mHeadRadiusScale);

--- a/dart/dynamics/body_node.cpp
+++ b/dart/dynamics/body_node.cpp
@@ -386,8 +386,8 @@ void BodyNode::duplicateNodes(const BodyNode* otherBodyNode)
   }
 
   const NodeMap& otherMap = otherBodyNode->mNodeMap;
-  for (const auto& vec : otherMap) {
-    for (const auto& node : vec.second) {
+  for (const auto& nodes : otherMap | std::views::values) {
+    for (const auto& node : nodes) {
       node->cloneNode(this)->attach();
     }
   }
@@ -415,8 +415,8 @@ void BodyNode::matchNodes(const BodyNode* otherBodyNode)
 std::vector<Node*> BodyNode::getNodes()
 {
   std::vector<Node*> nodes;
-  for (auto& nodeType : mNodeMap) {
-    nodes.insert(nodes.end(), nodeType.second.begin(), nodeType.second.end());
+  for (auto& nodeGroup : mNodeMap | std::views::values) {
+    nodes.insert(nodes.end(), nodeGroup.begin(), nodeGroup.end());
   }
 
   return nodes;
@@ -426,8 +426,8 @@ std::vector<Node*> BodyNode::getNodes()
 std::vector<const Node*> BodyNode::getNodes() const
 {
   std::vector<const Node*> nodes;
-  for (const auto& nodeType : mNodeMap) {
-    nodes.insert(nodes.end(), nodeType.second.begin(), nodeType.second.end());
+  for (const auto& nodeGroup : mNodeMap | std::views::values) {
+    nodes.insert(nodes.end(), nodeGroup.begin(), nodeGroup.end());
   }
 
   return nodes;

--- a/dart/dynamics/hierarchical_ik.cpp
+++ b/dart/dynamics/hierarchical_ik.cpp
@@ -39,6 +39,8 @@
 #include "dart/dynamics/skeleton.hpp"
 #include "dart/math/optimization/gradient_descent_solver.hpp"
 
+#include <algorithm>
+#include <ranges>
 #include <utility>
 
 namespace dart {
@@ -226,19 +228,14 @@ const IKHierarchy& HierarchicalIK::getIKHierarchy() const
 //==============================================================================
 std::span<const Eigen::MatrixXd> HierarchicalIK::computeNullSpaces() const
 {
-  bool recompute = false;
   const ConstSkeletonPtr& skel = getSkeleton();
   const std::size_t nDofs = skel->getNumDofs();
-  if (!std::cmp_equal(mLastPositions.size(), nDofs)) {
-    recompute = true;
-  } else {
-    for (std::size_t i = 0; i < nDofs; ++i) {
-      if (mLastPositions[i] != skel->getDof(i)->getPosition()) {
-        recompute = true;
-        break;
-      }
-    }
-  }
+  const bool recompute
+      = !std::cmp_equal(mLastPositions.size(), nDofs)
+        || std::ranges::any_of(
+            std::views::iota(std::size_t{0}, nDofs), [&](std::size_t i) {
+              return mLastPositions[i] != skel->getDof(i)->getPosition();
+            });
 
   // TODO(MXG): When deciding whether we need to recompute, we should also check
   // the "version" of the Skeleton, as soon as the Skeleton versioning features

--- a/dart/dynamics/hierarchical_ik.cpp
+++ b/dart/dynamics/hierarchical_ik.cpp
@@ -423,7 +423,7 @@ void HierarchicalIK::Objective::evalGradient(
     hik->setPositions(_x);
 
     const auto nullspaces = hik->computeNullSpaces();
-    if (nullspaces.size() > 0) {
+    if (!nullspaces.empty()) {
       // Project through the deepest null space
       mGradCache = nullspaces.back() * mGradCache;
     }
@@ -685,7 +685,7 @@ CompositeIK::ConstModuleSet CompositeIK::getModuleSet() const
 //==============================================================================
 void CompositeIK::refreshIKHierarchy()
 {
-  if (mModuleSet.size() == 0) {
+  if (mModuleSet.empty()) {
     mHierarchy.clear();
     return;
   }

--- a/dart/dynamics/line_segment_shape.cpp
+++ b/dart/dynamics/line_segment_shape.cpp
@@ -127,7 +127,7 @@ std::size_t LineSegmentShape::addVertex(
   mVertices.push_back(_v);
 
   if (_parent > mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempting to add a vertex to be a child of vertex #{}, but no "
           "vertices exist yet. No connection will be created for the new "
@@ -152,7 +152,7 @@ std::size_t LineSegmentShape::addVertex(
 void LineSegmentShape::removeVertex(std::size_t _idx)
 {
   if (_idx >= mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempting to remove vertex #{}, but this LineSegmentShape contains "
           "no vertices. No vertex will be removed.",
@@ -175,7 +175,7 @@ void LineSegmentShape::removeVertex(std::size_t _idx)
 void LineSegmentShape::setVertex(std::size_t _idx, const Eigen::Vector3d& _v)
 {
   if (_idx >= mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempting to set vertex #{}, but no vertices exist in this "
           "LineSegmentShape yet.",
@@ -225,7 +225,7 @@ std::span<const Eigen::Vector3d> LineSegmentShape::getVertices() const
 void LineSegmentShape::addConnection(std::size_t _idx1, std::size_t _idx2)
 {
   if (_idx1 >= mVertices.size() || _idx2 >= mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempted to create a connection between vertex #{} and vertex #{}, "
           "but no vertices exist for this LineSegmentShape yet. No connection "
@@ -265,7 +265,7 @@ void LineSegmentShape::removeConnection(
 void LineSegmentShape::removeConnection(std::size_t _connectionIdx)
 {
   if (_connectionIdx >= mConnections.size()) {
-    if (mConnections.size() == 0) {
+    if (mConnections.empty()) {
       DART_WARN(
           "Attempting to remove connection #{}, but no connections exist yet. "
           "No connection will be removed.",

--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -47,7 +47,7 @@ std::vector<BodyNode*> Linkage::Criteria::satisfy() const
   std::vector<BodyNode*> bns;
 
   if (nullptr == mStart.mNode.lock()) {
-    if (mTargets.size() == 0) {
+    if (mTargets.empty()) {
       return bns;
     }
 
@@ -258,13 +258,13 @@ void Linkage::Criteria::expandDownstream(
   }
   recorder.push_back(Recording(_start, 0));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
     if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
       stepToNextChild(recorder, _bns, r, mMapOfTerminals, 0);
     } else {
       recorder.pop_back();
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }
@@ -283,7 +283,7 @@ void Linkage::Criteria::expandUpstream(
   }
   recorder.push_back(Recording(_start, -1));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
 
     if (r.mCount == -1) {
@@ -323,7 +323,7 @@ void Linkage::Criteria::expandUpstream(
       // If we've iterated through all the children of this node, pop it
       recorder.pop_back();
       // Move on to the next child
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }
@@ -353,13 +353,13 @@ void Linkage::Criteria::expandToTarget(
   }
 
   // Remove the start BodyNode if it's supposed to be excluded
-  if (EXCLUDE == _start.mPolicy && newBns.size() > 0
+  if (EXCLUDE == _start.mPolicy && !newBns.empty()
       && newBns.front() == start_bn) {
     newBns.erase(newBns.begin());
   }
 
   // Remove the target BodyNode if it's supposed to be excluded
-  if (EXCLUDE == _target.mPolicy && newBns.size() > 0
+  if (EXCLUDE == _target.mPolicy && !newBns.empty()
       && newBns.back() == target_bn) {
     newBns.pop_back();
   }

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -1557,7 +1557,10 @@ bool hasColladaExtension(std::string_view path)
   std::ranges::transform(extension, extension.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
   });
-  return extension == ".dae" || extension == ".zae";
+  constexpr auto colladaExtensions
+      = std::to_array<std::string_view>({".dae", ".zae"});
+  return std::ranges::find(colladaExtensions, std::string_view{extension})
+         != colladaExtensions.end();
 }
 
 bool isColladaResource(

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -184,7 +184,7 @@ private:
         return &byPath->second;
       }
 
-      if (!path.empty() && path.front() == '/') {
+      if (path.starts_with('/')) {
         const auto byTrim = mData.find(path.substr(1));
         if (byTrim != mData.end()) {
           return &byTrim->second;

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -1593,11 +1593,11 @@ bool isColladaResource(
   buffer.resize(read);
   resource->seek(0, common::Resource::SEEKTYPE_SET);
 
-  const auto upper = buffer.find("COLLADA");
-  const auto lower = buffer.find("collada");
-  const auto mixed = buffer.find("Collada");
-  return upper != std::string::npos || lower != std::string::npos
-         || mixed != std::string::npos;
+  constexpr auto colladaMarkers
+      = std::to_array<std::string_view>({"COLLADA", "Collada", "collada"});
+  return std::ranges::any_of(colladaMarkers, [&](std::string_view marker) {
+    return buffer.find(marker) != std::string::npos;
+  });
 }
 
 } // namespace

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -49,6 +49,7 @@
 #include <assimp/postprocess.h>
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <iomanip>
 #include <iterator>
@@ -1386,18 +1387,18 @@ void MeshShape::extractMaterialsFromScene(
 
     // Extract texture paths for all texture types
     // Check common texture types and store them
-    const aiTextureType textureTypes[]
-        = {aiTextureType_DIFFUSE,
-           aiTextureType_SPECULAR,
-           aiTextureType_NORMALS,
-           aiTextureType_AMBIENT,
-           aiTextureType_EMISSIVE,
-           aiTextureType_HEIGHT,
-           aiTextureType_SHININESS,
-           aiTextureType_OPACITY,
-           aiTextureType_DISPLACEMENT,
-           aiTextureType_LIGHTMAP,
-           aiTextureType_REFLECTION};
+    constexpr auto textureTypes = std::to_array<aiTextureType>(
+        {aiTextureType_DIFFUSE,
+         aiTextureType_SPECULAR,
+         aiTextureType_NORMALS,
+         aiTextureType_AMBIENT,
+         aiTextureType_EMISSIVE,
+         aiTextureType_HEIGHT,
+         aiTextureType_SHININESS,
+         aiTextureType_OPACITY,
+         aiTextureType_DISPLACEMENT,
+         aiTextureType_LIGHTMAP,
+         aiTextureType_REFLECTION});
 
     for (const auto& type : textureTypes) {
       const auto count = aiMat->GetTextureCount(type);

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -539,8 +539,8 @@ SkeletonPtr Skeleton::cloneSkeleton(const std::string& cloneName) const
 
   // Clone over the nodes in such a way that their indexing will match up with
   // the original
-  for (const auto& nodeType : mNodeMap) {
-    for (const auto& node : nodeType.second) {
+  for (const auto& nodes : mNodeMap | std::views::values) {
+    for (const auto& node : nodes) {
       const BodyNode* originalBn = node->getBodyNodePtr();
       BodyNode* newBn = skelClone->getBodyNode(originalBn->getName());
       node->cloneNode(newBn)->attach();
@@ -1351,8 +1351,7 @@ bool Skeleton::checkIndexingConsistency() const
     }
 
     const BodyNode::NodeMap& nodeMap = bn->mNodeMap;
-    for (const auto& nodeType : nodeMap) {
-      const std::vector<Node*>& nodes = nodeType.second;
+    for (const auto& nodes : nodeMap | std::views::values) {
       for (std::size_t k = 0; k < nodes.size(); ++k) {
         const Node* node = nodes[k];
         if (node->getBodyNodePtr() != bn) {
@@ -1426,8 +1425,7 @@ bool Skeleton::checkIndexingConsistency() const
   // Check each Node in the Skeleton-scope NodeMap
   {
     const Skeleton::NodeMap& nodeMap = mNodeMap;
-    for (const auto& nodeType : nodeMap) {
-      const std::vector<Node*>& nodes = nodeType.second;
+    for (const auto& nodes : nodeMap | std::views::values) {
       for (std::size_t k = 0; k < nodes.size(); ++k) {
         const Node* node = nodes[k];
         if (node->getSkeleton().get() != this) {
@@ -1528,8 +1526,7 @@ bool Skeleton::checkIndexingConsistency() const
   for (std::size_t i = 0; i < mTreeNodeMaps.size(); ++i) {
     const NodeMap& nodeMap = mTreeNodeMaps[i];
 
-    for (const auto& nodeType : nodeMap) {
-      const std::vector<Node*>& nodes = nodeType.second;
+    for (const auto& nodes : nodeMap | std::views::values) {
       for (std::size_t k = 0; k < nodes.size(); ++k) {
         const Node* node = nodes[k];
         if (node->getBodyNodePtr()->mTreeIndex != i) {
@@ -2353,8 +2350,8 @@ void Skeleton::registerBodyNode(BodyNode* _newBodyNode)
   _newBodyNode->init(getPtr());
 
   BodyNode::NodeMap& nodeMap = _newBodyNode->mNodeMap;
-  for (auto& nodeType : nodeMap) {
-    for (auto& node : nodeType.second) {
+  for (auto& nodes : nodeMap | std::views::values) {
+    for (auto& node : nodes) {
       registerNode(node);
     }
   }
@@ -2523,8 +2520,8 @@ void Skeleton::unregisterBodyNode(BodyNode* _oldBodyNode)
   unregisterJoint(_oldBodyNode->getParentJoint());
 
   BodyNode::NodeMap& nodeMap = _oldBodyNode->mNodeMap;
-  for (auto& nodeType : nodeMap) {
-    for (auto& node : nodeType.second) {
+  for (auto& nodes : nodeMap | std::views::values) {
+    for (auto& node : nodes) {
       unregisterNode(node);
     }
   }

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -911,7 +911,7 @@ BodyNode* Skeleton::getRootBodyNode(std::size_t _treeIdx)
     return mTreeCache[_treeIdx].mBodyNodes[0];
   }
 
-  if (mTreeCache.size() == 0) {
+  if (mTreeCache.empty()) {
     DART_THROW_T(
         common::OutOfRangeException,
         "Requested a root BodyNode from Skeleton '{}' with no BodyNodes",
@@ -3664,7 +3664,7 @@ static void computeSupportPolygon(
     ee_indices[i] = originalEE_map[vertex_indices[i]];
   }
 
-  if (polygon.size() > 0) {
+  if (!polygon.empty()) {
     centroid = math::computeCentroidOfHull(polygon);
   } else {
     centroid = Eigen::Vector2d::Constant(std::nan(""));

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -2508,8 +2508,7 @@ void Skeleton::destructOldTree(std::size_t tree)
     }
   }
 
-  for (auto& nodeType : mSpecializedTreeNodes) {
-    std::vector<NodeMap::iterator>* nodeRepo = nodeType.second;
+  for (auto* nodeRepo : mSpecializedTreeNodes | std::views::values) {
     nodeRepo->erase(nodeRepo->begin() + tree);
   }
 }

--- a/dart/dynamics/soft_body_node.cpp
+++ b/dart/dynamics/soft_body_node.cpp
@@ -84,7 +84,7 @@ bool SoftBodyNodeUniqueProperties::connectPointMasses(
     std::size_t i1, std::size_t i2)
 {
   if (i1 >= mPointProps.size() || i2 >= mPointProps.size()) {
-    if (mPointProps.size() == 0) {
+    if (mPointProps.empty()) {
       DART_WARN(
           "Attempting to add a connection between indices {} and {}, but there "
           "are currently no entries in mPointProps!",

--- a/dart/gui/drag_and_drop.cpp
+++ b/dart/gui/drag_and_drop.cpp
@@ -391,7 +391,7 @@ public:
 
       if (BUTTON_RELEASE == event || BUTTON_NOTHING == event) {
         const auto picks = mEventHandler->getMovePicks();
-        if (picks.size() > 0) {
+        if (!picks.empty()) {
           const PickInfo& pick = picks[0];
           if (pick.frame->getParentFrame()
               != mFrame->getTool((InteractiveTool::Type)mTool, mCoordinate)) {
@@ -418,7 +418,7 @@ public:
       }
 
       const auto picks = mEventHandler->getMovePicks();
-      if (picks.size() == 0) {
+      if (picks.empty()) {
         return;
       }
 

--- a/dart/gui/interactive_frame.cpp
+++ b/dart/gui/interactive_frame.cpp
@@ -281,7 +281,7 @@ void InteractiveFrame::createStandardVisualizationShapes(
 {
   const auto pi = math::pi;
 
-  thickness = std::min(10.0, std::max(0.0, thickness));
+  thickness = std::clamp(thickness, 0.0, 10.0);
   std::size_t resolution = 72;
   double ring_outer_scale = 0.7 * size;
   double ring_inner_scale = ring_outer_scale * (1 - 0.1 * thickness);

--- a/dart/gui/render/mesh_shape_node.cpp
+++ b/dart/gui/render/mesh_shape_node.cpp
@@ -105,7 +105,7 @@ std::filesystem::path makeTemporaryTexturePath(std::string_view extension)
     }
 
     if (!extension.empty()) {
-      if (extension.front() == '.') {
+      if (extension.starts_with('.')) {
         name << extension;
       } else {
         name << "." << extension;

--- a/dart/gui/render/soft_mesh_shape_node.cpp
+++ b/dart/gui/render/soft_mesh_shape_node.cpp
@@ -208,7 +208,7 @@ static Eigen::Vector3d normalFromVertex(
   const Eigen::Vector3d n = dv1.cross(dv2);
 
   double weight = n.norm() / (dv1.norm() * dv2.norm());
-  weight = std::max(-1.0, std::min(1.0, weight));
+  weight = std::clamp(weight, -1.0, 1.0);
 
   return n.normalized() * asin(weight);
 }

--- a/dart/gui/support_polygon_visual.cpp
+++ b/dart/gui/support_polygon_visual.cpp
@@ -277,7 +277,7 @@ void SupportPolygonVisual::refresh()
   if (mDisplayCentroid) {
     Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
 
-    if (poly.size() > 0) {
+    if (!poly.empty()) {
       const Eigen::Vector2d& Cp = (dart::dynamics::INVALID_INDEX == mTreeIndex)
                                       ? skel->getSupportCentroid()
                                       : skel->getSupportCentroid(mTreeIndex);

--- a/dart/math/geometry.cpp
+++ b/dart/math/geometry.cpp
@@ -1632,7 +1632,7 @@ SupportPolygon computeConvexHull(std::span<const Eigen::Vector2d> points)
 //==============================================================================
 Eigen::Vector2d computeCentroidOfHull(const SupportPolygon& _convexHull)
 {
-  if (_convexHull.size() == 0) {
+  if (_convexHull.empty()) {
     Eigen::Vector2d invalid = Eigen::Vector2d::Constant(std::nan(""));
     std::ostringstream invalidStream;
     invalidStream << invalid.transpose();
@@ -1907,7 +1907,7 @@ bool isInsideSupportPolygon(
     const SupportPolygon& _support,
     bool _includeEdge)
 {
-  if (_support.size() == 0) {
+  if (_support.empty()) {
     return false;
   }
 
@@ -2022,7 +2022,7 @@ Eigen::Vector2d computeClosestPointOnSupportPolygon(
     const Eigen::Vector2d& _p,
     const SupportPolygon& _support)
 {
-  if (_support.size() == 0) {
+  if (_support.empty()) {
     _index1 = static_cast<std::size_t>(-1);
     _index2 = _index1;
     return _p;

--- a/dart/math/geometry.cpp
+++ b/dart/math/geometry.cpp
@@ -39,6 +39,7 @@
 #include <dart/simd/simd.hpp>
 
 #include <algorithm>
+#include <array>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -1237,8 +1238,8 @@ Eigen::Matrix3d eulerZYZToMatrix(const Eigen::Vector3d& _angle)
 Eigen::Isometry3d expMap(const Eigen::Vector6d& _S)
 {
   Eigen::Isometry3d ret = Eigen::Isometry3d::Identity();
-  double s2[] = {_S[0] * _S[0], _S[1] * _S[1], _S[2] * _S[2]};
-  double s3[] = {_S[0] * _S[1], _S[1] * _S[2], _S[2] * _S[0]};
+  const auto s2 = std::to_array({_S[0] * _S[0], _S[1] * _S[1], _S[2] * _S[2]});
+  const auto s3 = std::to_array({_S[0] * _S[1], _S[1] * _S[2], _S[2] * _S[0]});
   double theta = sqrt(s2[0] + s2[1] + s2[2]);
   double cos_t = cos(theta), alpha, beta, gamma;
 
@@ -1281,8 +1282,8 @@ Eigen::Isometry3d expMap(const Eigen::Vector6d& _S)
 Eigen::Isometry3d expAngular(const Eigen::Vector3d& _s)
 {
   Eigen::Isometry3d ret = Eigen::Isometry3d::Identity();
-  double s2[] = {_s[0] * _s[0], _s[1] * _s[1], _s[2] * _s[2]};
-  double s3[] = {_s[0] * _s[1], _s[1] * _s[2], _s[2] * _s[0]};
+  const auto s2 = std::to_array({_s[0] * _s[0], _s[1] * _s[1], _s[2] * _s[2]});
+  const auto s3 = std::to_array({_s[0] * _s[1], _s[1] * _s[2], _s[2] * _s[0]});
   double theta = sqrt(s2[0] + s2[1] + s2[2]);
   double cos_t = cos(theta);
   double alpha = 0.0;

--- a/dart/math/optimization/problem.cpp
+++ b/dart/math/optimization/problem.cpp
@@ -142,7 +142,7 @@ Eigen::VectorXd& Problem::getSeed(std::size_t _index)
     return mSeeds[_index];
   }
 
-  if (mSeeds.size() == 0) {
+  if (mSeeds.empty()) {
     DART_WARN(
         "Requested seed at index [{}], but there are currently no seeds. "
         "Returning the problem's initial guess instead.",

--- a/dart/simd/detail/math/exp_impl.hpp
+++ b/dart/simd/detail/math/exp_impl.hpp
@@ -37,6 +37,8 @@
 #include <dart/simd/detail/math/polynomial.hpp>
 #include <dart/simd/fwd.hpp>
 
+#include <algorithm>
+
 #include <cmath>
 
 namespace dart::simd::detail::math {
@@ -98,13 +100,8 @@ template <std::size_t W>
   alignas(A) float inRangeArr[W];
   select(inSimdRange, VecT::broadcast(1.0f), VecT::broadcast(0.0f))
       .store(inRangeArr);
-  bool needScalar = false;
-  for (std::size_t i = 0; i < W; ++i) {
-    if (inRangeArr[i] == 0.0f) {
-      needScalar = true;
-      break;
-    }
-  }
+  const bool needScalar = std::ranges::any_of(
+      inRangeArr, [](float value) { return value == 0.0f; });
   if (needScalar) {
     alignas(A) float xArr[W];
     alignas(A) float scalarArr[W];
@@ -185,13 +182,8 @@ template <std::size_t W>
   alignas(A) double inRangeArr[W];
   select(inSimdRange, VecT::broadcast(1.0), VecT::broadcast(0.0))
       .store(inRangeArr);
-  bool needScalar = false;
-  for (std::size_t i = 0; i < W; ++i) {
-    if (inRangeArr[i] == 0.0) {
-      needScalar = true;
-      break;
-    }
-  }
+  const bool needScalar = std::ranges::any_of(
+      inRangeArr, [](double value) { return value == 0.0; });
   if (needScalar) {
     alignas(A) double xArr[W];
     alignas(A) double scalarArr[W];

--- a/dart/simd/detail/math/sincos_impl.hpp
+++ b/dart/simd/detail/math/sincos_impl.hpp
@@ -37,6 +37,7 @@
 #include <dart/simd/detail/math/polynomial.hpp>
 #include <dart/simd/fwd.hpp>
 
+#include <algorithm>
 #include <utility>
 
 #include <cmath>
@@ -140,18 +141,13 @@ DART_SIMD_INLINE void sincosImplSimd(
   alignas(A) float xArr[W];
   alignas(A) float scalarSin[W];
   alignas(A) float scalarCos[W];
-  bool needScalar = false;
-  {
+  const bool needScalar = [&] {
     alignas(A) float inRangeArr[W];
     select(inRange, VecT::broadcast(1.0f), VecT::broadcast(0.0f))
         .store(inRangeArr);
-    for (std::size_t i = 0; i < W; ++i) {
-      if (inRangeArr[i] == 0.0f) {
-        needScalar = true;
-        break;
-      }
-    }
-  }
+    return std::ranges::any_of(
+        inRangeArr, [](float value) { return value == 0.0f; });
+  }();
   if (needScalar) {
     x.store(xArr);
     for (std::size_t i = 0; i < W; ++i) {

--- a/dart/simd/detail/scalar/operations.hpp
+++ b/dart/simd/detail/scalar/operations.hpp
@@ -41,7 +41,6 @@
 
 #include <cmath>
 #include <cstddef>
-#include <cstring>
 
 namespace dart::simd {
 
@@ -431,7 +430,9 @@ template <std::size_t W>
   alignas(64) float srcArr[W];
   alignas(64) std::int32_t dstArr[W];
   v.store(srcArr);
-  std::memcpy(dstArr, srcArr, sizeof(float) * W);
+  for (std::size_t i = 0; i < W; ++i) {
+    dstArr[i] = detail::toBits(srcArr[i]);
+  }
   return Vec<std::int32_t, W>::load(dstArr);
 }
 
@@ -442,7 +443,9 @@ template <std::size_t W>
   alignas(64) std::int32_t srcArr[W];
   alignas(64) float dstArr[W];
   v.store(srcArr);
-  std::memcpy(dstArr, srcArr, sizeof(float) * W);
+  for (std::size_t i = 0; i < W; ++i) {
+    dstArr[i] = detail::fromBits<float>(srcArr[i]);
+  }
   return Vec<float, W>::load(dstArr);
 }
 
@@ -453,7 +456,9 @@ template <std::size_t W>
   alignas(64) double srcArr[W];
   alignas(64) std::int64_t dstArr[W];
   v.store(srcArr);
-  std::memcpy(dstArr, srcArr, sizeof(double) * W);
+  for (std::size_t i = 0; i < W; ++i) {
+    dstArr[i] = detail::toBits(srcArr[i]);
+  }
   return Vec<std::int64_t, W>::load(dstArr);
 }
 
@@ -464,7 +469,9 @@ template <std::size_t W>
   alignas(64) std::int64_t srcArr[W];
   alignas(64) double dstArr[W];
   v.store(srcArr);
-  std::memcpy(dstArr, srcArr, sizeof(double) * W);
+  for (std::size_t i = 0; i < W; ++i) {
+    dstArr[i] = detail::fromBits<double>(srcArr[i]);
+  }
   return Vec<double, W>::load(dstArr);
 }
 

--- a/dart/simulation/experimental/common/profiling.cpp
+++ b/dart/simulation/experimental/common/profiling.cpp
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <ranges>
 #include <unordered_map>
 #include <vector>
 
@@ -84,7 +85,7 @@ void ProfileStats::printSummary()
   // Convert to vector for sorting
   std::vector<Entry> sortedEntries;
   sortedEntries.reserve(entries.size());
-  for (const auto& [_, entry] : entries) {
+  for (const auto& entry : entries | std::views::values) {
     sortedEntries.push_back(entry);
   }
 

--- a/dart/utils/dart_resource_retriever.cpp
+++ b/dart/utils/dart_resource_retriever.cpp
@@ -174,7 +174,7 @@ void DartResourceRetriever::addDataDirectory(std::string_view dataDirectory)
 {
   // Strip a trailing slash.
   std::string normalizedDataDirectory;
-  if (!dataDirectory.empty() && dataDirectory.back() == '/') {
+  if (dataDirectory.ends_with('/')) {
     normalizedDataDirectory
         = std::string(dataDirectory.substr(0, dataDirectory.size() - 1));
   } else {

--- a/dart/utils/mesh_loader.hpp
+++ b/dart/utils/mesh_loader.hpp
@@ -50,6 +50,7 @@
 #include <assimp/scene.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -264,7 +265,10 @@ typename MeshLoader<S>::aiScenePtr MeshLoader<S>::loadScene(
     std::ranges::transform(extension, extension.begin(), [](unsigned char c) {
       return static_cast<char>(std::tolower(c));
     });
-    return extension == ".dae" || extension == ".zae";
+    constexpr auto colladaExtensions
+        = std::to_array<std::string_view>({".dae", ".zae"});
+    return std::ranges::find(colladaExtensions, std::string_view{extension})
+           != colladaExtensions.end();
   };
 
   auto isColladaResource = [&](std::string_view uri) -> bool {

--- a/dart/utils/mesh_loader.hpp
+++ b/dart/utils/mesh_loader.hpp
@@ -300,11 +300,11 @@ typename MeshLoader<S>::aiScenePtr MeshLoader<S>::loadScene(
     buffer.resize(read);
     resource->seek(0, common::Resource::SEEKTYPE_SET);
 
-    const auto upper = buffer.find("COLLADA");
-    const auto lower = buffer.find("collada");
-    const auto mixed = buffer.find("Collada");
-    return upper != std::string::npos || lower != std::string::npos
-           || mixed != std::string::npos;
+    constexpr auto colladaMarkers
+        = std::to_array<std::string_view>({"COLLADA", "Collada", "collada"});
+    return std::ranges::any_of(colladaMarkers, [&](std::string_view marker) {
+      return buffer.find(marker) != std::string::npos;
+    });
   };
 
   const std::string filepathString(filepath);

--- a/dart/utils/package_resource_retriever.cpp
+++ b/dart/utils/package_resource_retriever.cpp
@@ -63,8 +63,7 @@ void PackageResourceRetriever::addPackageDirectory(
 {
   // Strip a trailing slash.
   std::string_view normalizedPackageDirectory = packageDirectory;
-  if (!normalizedPackageDirectory.empty()
-      && normalizedPackageDirectory.back() == '/') {
+  if (normalizedPackageDirectory.ends_with('/')) {
     normalizedPackageDirectory = normalizedPackageDirectory.substr(
         0, normalizedPackageDirectory.size() - 1);
   }

--- a/dart/utils/sdf/sdf_parser.cpp
+++ b/dart/utils/sdf/sdf_parser.cpp
@@ -594,7 +594,7 @@ bool requiresBaseUriResolution(std::string_view requested)
     return false;
   }
 
-  if (requested.front() == '/') {
+  if (requested.starts_with('/')) {
     return false;
   }
 

--- a/dart/utils/skel_parser.cpp
+++ b/dart/utils/skel_parser.cpp
@@ -1068,8 +1068,7 @@ dynamics::SkeletonPtr readSkeleton(
     SkelBodyNode newBodyNode = readSoftBodyNode(
         xmlBodies.get(), skeletonFrame, _baseUri, _retriever);
 
-    BodyMap::const_iterator it = bodyNodes.find(newBodyNode.properties->mName);
-    if (it != bodyNodes.end()) {
+    if (bodyNodes.contains(newBodyNode.properties->mName)) {
       DART_ERROR(
           "[readSkeleton] Skeleton named [{}] has multiple BodyNodes with the "
           "name [{}], but BodyNode names must be unique! We will discard all "

--- a/dart/utils/urdf/urdf_parser.cpp
+++ b/dart/utils/urdf/urdf_parser.cpp
@@ -56,6 +56,7 @@
 #include <tinyxml2.h>
 
 #include <algorithm>
+#include <array>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -421,8 +422,17 @@ std::vector<UrdfParser::TransmissionInfo> UrdfParser::parseTransmissions(
     const std::string type
         = typeElement && typeElement->GetText() ? typeElement->GetText() : "";
 
-    if (!type.empty() && type.find("SimpleTransmission") == std::string::npos
-        && type.find("simple_transmission") == std::string::npos) {
+    constexpr auto supportedTransmissionTypeNames
+        = std::to_array<std::string_view>(
+            {"SimpleTransmission", "simple_transmission"});
+    const bool supportedTransmissionType
+        = type.empty()
+          || std::ranges::any_of(
+              supportedTransmissionTypeNames,
+              [&](std::string_view supportedName) {
+                return type.find(supportedName) != std::string::npos;
+              });
+    if (!supportedTransmissionType) {
       DART_WARN(
           "[UrdfParser] Transmission [{}] has unsupported type [{}]; skipping.",
           tx->Attribute("name") ? tx->Attribute("name") : "",

--- a/dart/utils/xml_helpers.cpp
+++ b/dart/utils/xml_helpers.cpp
@@ -220,7 +220,7 @@ Eigen::Vector6d toVector6d(std::string_view str)
 Eigen::VectorXd toVectorXd(std::string_view str)
 {
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  DART_ASSERT(pieces.size() > 0);
+  DART_ASSERT(!pieces.empty());
 
   Eigen::VectorXd ret(pieces.size());
   assignDoublePieces(ret, pieces, "double", "Eigen::VectorXd");

--- a/examples/csv_logger/main.cpp
+++ b/examples/csv_logger/main.cpp
@@ -79,7 +79,7 @@ void printUsage(const char* argv0)
 
 bool parseSizeT(std::string_view value, std::size_t& output)
 {
-  if (value.empty() || value.front() == '-') {
+  if (value.empty() || value.starts_with('-')) {
     return false;
   }
 

--- a/examples/g1_puppet/main.cpp
+++ b/examples/g1_puppet/main.cpp
@@ -149,7 +149,7 @@ std::optional<std::string> getLastPathSegment(std::string value)
     value.erase(terminator);
   }
 
-  while (!value.empty() && (value.back() == '/' || value.back() == '\\')) {
+  while (value.ends_with('/') || value.ends_with('\\')) {
     value.pop_back();
   }
 

--- a/examples/headless_simulation/main.cpp
+++ b/examples/headless_simulation/main.cpp
@@ -72,7 +72,7 @@ void printUsage(const char* argv0)
 
 bool parseSizeT(std::string_view value, std::size_t& output)
 {
-  if (value.empty() || value.front() == '-') {
+  if (value.empty() || value.starts_with('-')) {
     return false;
   }
 
@@ -93,7 +93,7 @@ bool parseSizeT(std::string_view value, std::size_t& output)
 
 bool parseUnsignedInt(std::string_view value, unsigned int& output)
 {
-  if (value.empty() || value.front() == '-') {
+  if (value.empty() || value.starts_with('-')) {
     return false;
   }
 

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -44,6 +44,7 @@
 
 #include <CLI/CLI.hpp>
 
+#include <array>
 #include <span>
 
 #include <cmath>
@@ -407,14 +408,14 @@ public:
         if (pcShow) {
           auto pointCloudShape = mNode->getPointCloudShape();
 
-          const char* colorModeItems[]
-              = {"Use shape color", "Bind overall", "Bind per point"};
+          const auto colorModeItems = std::to_array<const char*>(
+              {"Use shape color", "Bind overall", "Bind per point"});
           int colorMode = pointCloudShape->getColorMode();
           if (ImGui::Combo(
                   "Color Mode",
                   &colorMode,
-                  colorModeItems,
-                  IM_ARRAYSIZE(colorModeItems))) {
+                  colorModeItems.data(),
+                  static_cast<int>(colorModeItems.size()))) {
             if (colorMode == 0) {
               pointCloudShape->setColorMode(
                   dynamics::PointCloudShape::USE_SHAPE_COLOR);
@@ -443,14 +444,14 @@ public:
             }
           }
 
-          const char* pointShapeTypeItems[]
-              = {"Box", "Billboard Square", "Billboard Circle", "Point"};
+          const auto pointShapeTypeItems = std::to_array<const char*>(
+              {"Box", "Billboard Square", "Billboard Circle", "Point"});
           int pointShapeType = pointCloudShape->getPointShapeType();
           if (ImGui::Combo(
                   "Point Shape Type",
                   &pointShapeType,
-                  pointShapeTypeItems,
-                  IM_ARRAYSIZE(pointShapeTypeItems))) {
+                  pointShapeTypeItems.data(),
+                  static_cast<int>(pointShapeTypeItems.size()))) {
             if (pointShapeType == 0) {
               pointCloudShape->setPointShapeType(
                   dynamics::PointCloudShape::BOX);

--- a/tests/integration/collision/test_collision.cpp
+++ b/tests/integration/collision/test_collision.cpp
@@ -39,6 +39,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <iostream>
 #include <limits>
 #if DART_HAVE_ODE
@@ -1908,12 +1909,12 @@ TEST_F(Collision, CollisionOfPrescribedJointsRejectsInvalidTimeStep)
   const double originalTimeStep = world->getTimeStep();
   ASSERT_GT(originalTimeStep, 0.0);
 
-  const double invalidValues[]
-      = {std::numeric_limits<double>::quiet_NaN(),
-         std::numeric_limits<double>::infinity(),
-         -std::numeric_limits<double>::infinity(),
-         0.0,
-         -1.0};
+  const auto invalidValues = std::to_array(
+      {std::numeric_limits<double>::quiet_NaN(),
+       std::numeric_limits<double>::infinity(),
+       -std::numeric_limits<double>::infinity(),
+       0.0,
+       -1.0});
 
   for (double invalid : invalidValues) {
     world->setTimeStep(invalid);

--- a/tests/integration/collision/test_collision_accuracy.cpp
+++ b/tests/integration/collision/test_collision_accuracy.cpp
@@ -47,6 +47,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 using namespace dart::test;
 using dart::simulation::CollisionDetectorType;
 
@@ -86,17 +88,19 @@ TEST(Issue1184, Accuracy)
   };
 
 #if !defined(NDEBUG)
-  const auto groundInfoFunctions = {makePlaneGround};
-  const auto objectShapeFunctions = {makeSphereObject};
-  const auto halfsizes = {10.0};
-  const auto fallingModes = {true};
+  const auto groundInfoFunctions = std::to_array({makePlaneGround});
+  const auto objectShapeFunctions = std::to_array({makeSphereObject});
+  const auto halfsizes = std::to_array({10.0});
+  const auto fallingModes = std::to_array({true});
   const double dropHeight = 0.1;
   const double relativeTolerance = 1e-3; // 0.1% relative error
 #else
-  const auto groundInfoFunctions = {makePlaneGround, makeBoxGround};
-  const auto objectShapeFunctions = {makeBoxObject, makeSphereObject};
-  const auto halfsizes = {0.25, 1.0, 5.0, 10.0, 20.0};
-  const auto fallingModes = {true, false};
+  const auto groundInfoFunctions
+      = std::to_array({makePlaneGround, makeBoxGround});
+  const auto objectShapeFunctions
+      = std::to_array({makeBoxObject, makeSphereObject});
+  const auto halfsizes = std::to_array({0.25, 1.0, 5.0, 10.0, 20.0});
+  const auto fallingModes = std::to_array({true, false});
   const double dropHeight = 1.0;
   const double relativeTolerance = 1e-3; // 0.1% relative error
 #endif

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
@@ -49,6 +49,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -149,8 +150,9 @@ bool isPlane(ShapeKind kind)
 
 bool isEdgeVertexKind(ShapeKind kind)
 {
-  return kind == ShapeKind::Box || kind == ShapeKind::Cylinder
-         || kind == ShapeKind::Cone;
+  constexpr auto kinds
+      = std::to_array({ShapeKind::Box, ShapeKind::Cylinder, ShapeKind::Cone});
+  return std::ranges::find(kinds, kind) != kinds.end();
 }
 
 dart::dynamics::ShapePtr makeShape(ShapeKind kind)

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
@@ -38,6 +38,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -138,8 +139,9 @@ bool isPlane(ShapeKind kind)
 
 bool isEdgeVertexKind(ShapeKind kind)
 {
-  return kind == ShapeKind::Box || kind == ShapeKind::Cylinder
-         || kind == ShapeKind::Cone;
+  constexpr auto kinds
+      = std::to_array({ShapeKind::Box, ShapeKind::Cylinder, ShapeKind::Cone});
+  return std::ranges::find(kinds, kind) != kinds.end();
 }
 
 std::shared_ptr<fcl::CollisionGeometry<double>> makeGeometry(ShapeKind kind)

--- a/tests/integration/io/test_sdf_parser.cpp
+++ b/tests/integration/io/test_sdf_parser.cpp
@@ -57,6 +57,7 @@
 #include <sdf/sdf.hh>
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -64,6 +65,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include <cctype>
 #include <cstring>
@@ -906,9 +908,12 @@ TEST(SdfParser, WarnsOnTinyMassAndDefaultsInertia)
   const auto logs = capture.contents();
   const bool warningsCaptured = !logs.empty();
   if (warningsCaptured) {
-    const bool hasSmallMassWarning
-        = logs.find("very small mass") != std::string::npos
-          || logs.find("non-positive mass") != std::string::npos;
+    constexpr auto massWarningSnippets = std::to_array<std::string_view>(
+        {"very small mass", "non-positive mass"});
+    const bool hasSmallMassWarning = std::ranges::any_of(
+        massWarningSnippets, [&](std::string_view snippet) {
+          return logs.find(snippet) != std::string::npos;
+        });
     EXPECT_TRUE(hasSmallMassWarning)
         << "Expected warning about tiny mass clamping in logs: " << logs;
     std::string logsLower = logs;
@@ -2789,8 +2794,11 @@ f 1 2 3
 
   const auto logs = capture.contents();
   // Warning text for malformed <pose> varies by libsdformat version/platform
-  if (logs.find("must have 6 values") != std::string::npos
-      || logs.find("expected 3 values") != std::string::npos) {
+  constexpr auto poseWarningSnippets = std::to_array<std::string_view>(
+      {"must have 6 values", "expected 3 values"});
+  if (std::ranges::any_of(poseWarningSnippets, [&](std::string_view snippet) {
+        return logs.find(snippet) != std::string::npos;
+      })) {
     SUCCEED();
   }
 }

--- a/tests/integration/simulation/test_world.cpp
+++ b/tests/integration/simulation/test_world.cpp
@@ -770,7 +770,7 @@ TEST(World, SetNewConstraintSolver)
 
   auto solver1 = std::make_unique<constraint::ConstraintSolver>(
       std::make_shared<math::DantzigSolver>());
-  EXPECT_TRUE(solver1->getSkeletons().size() == 0);
+  EXPECT_TRUE(solver1->getSkeletons().empty());
   EXPECT_TRUE(solver1->getNumConstraints() == 0);
 
   world->setConstraintSolver(std::move(solver1));
@@ -779,7 +779,7 @@ TEST(World, SetNewConstraintSolver)
 
   auto solver2 = std::make_unique<constraint::ConstraintSolver>(
       std::make_shared<math::PgsSolver>());
-  EXPECT_TRUE(solver2->getSkeletons().size() == 0);
+  EXPECT_TRUE(solver2->getSkeletons().empty());
   EXPECT_TRUE(solver2->getNumConstraints() == 0);
 
   world->setConstraintSolver(std::move(solver2));

--- a/tests/unit/common/test_frame_allocator.cpp
+++ b/tests/unit/common/test_frame_allocator.cpp
@@ -38,6 +38,8 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
+#include <array>
+
 #include <cstdint>
 
 using namespace dart::common;
@@ -60,7 +62,7 @@ TEST_F(FrameAllocatorTest, BasicAllocate)
 {
   FrameAllocator allocator;
   size_t previousUsed = 0;
-  const size_t sizes[] = {8, 64, 256, 1024};
+  const auto sizes = std::to_array<size_t>({8, 64, 256, 1024});
   for (size_t size : sizes) {
     void* ptr = allocator.allocate(size);
     EXPECT_NE(ptr, nullptr);
@@ -73,7 +75,7 @@ TEST_F(FrameAllocatorTest, BasicAllocate)
 TEST_F(FrameAllocatorTest, Alignment)
 {
   FrameAllocator allocator;
-  const size_t alignments[] = {16, 32, 64};
+  const auto alignments = std::to_array<size_t>({16, 32, 64});
   for (size_t alignment : alignments) {
     void* ptr = allocator.allocateAligned(32, alignment);
     EXPECT_NE(ptr, nullptr);

--- a/tests/unit/common/test_uri.cpp
+++ b/tests/unit/common/test_uri.cpp
@@ -408,6 +408,10 @@ TEST(UriHelpers, removeDotSegments_RemovesDotAndDotDotSegments)
 {
   EXPECT_EQ(Uri::removeDotSegments("/.."), "/");
   EXPECT_EQ(Uri::removeDotSegments(".."), "");
+  EXPECT_EQ(Uri::removeDotSegments("/./g"), "/g");
+  EXPECT_EQ(Uri::removeDotSegments("a/b/./c"), "a/b/c");
+  EXPECT_EQ(Uri::removeDotSegments("/a/b/../c"), "/a/c");
+  EXPECT_EQ(Uri::removeDotSegments("mid/content=5/../6"), "mid/6");
 }
 
 TEST(UriHelpers, fromRelativeUri_StringViewOverload)

--- a/tests/unit/dynamics/test_arrow_shape.cpp
+++ b/tests/unit/dynamics/test_arrow_shape.cpp
@@ -48,7 +48,7 @@ private:
     if (isSampleUri(uri)) {
       std::filesystem::path path = mDataRoot;
       std::string relative = uri.getPath();
-      if (!relative.empty() && relative.front() == '/') {
+      if (relative.starts_with('/')) {
         relative.erase(0, 1);
       }
       path /= relative;

--- a/tests/unit/dynamics/test_mesh_shape.cpp
+++ b/tests/unit/dynamics/test_mesh_shape.cpp
@@ -213,7 +213,7 @@ private:
       if (byPath != mData.end()) {
         return &byPath->second;
       }
-      if (!path.empty() && path.front() == '/') {
+      if (path.starts_with('/')) {
         const auto byTrim = mData.find(path.substr(1));
         if (byTrim != mData.end()) {
           return &byTrim->second;

--- a/tests/unit/dynamics/test_skeleton_accessors.cpp
+++ b/tests/unit/dynamics/test_skeleton_accessors.cpp
@@ -1484,8 +1484,7 @@ TEST(JointAccessors, CopyPropertiesAndWrenchQueries)
   (void)extendedProps;
   (void)movedProps;
 
-  std::array<Joint::ActuatorType, 3> types
-      = {Joint::FORCE, Joint::MIMIC, Joint::FORCE};
+  const auto types = std::to_array({Joint::FORCE, Joint::MIMIC, Joint::FORCE});
   auto skeletonC = Skeleton::create("joint_actuator_types");
   auto pairC = skeletonC->createJointAndBodyNodePair<BallJoint>();
   pairC.first->setActuatorTypes(types);

--- a/tests/unit/math/test_convhull.cpp
+++ b/tests/unit/math/test_convhull.cpp
@@ -34,6 +34,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <concepts>
 #include <iterator>
 #include <set>
@@ -48,18 +49,23 @@ using dart::math::detail::convexHull3dBuild;
 //==============================================================================
 TEST(ConvhullInternal, SortFloatAndInt)
 {
-  float values[] = {3.0f, 1.0f, 2.0f};
+  auto values = std::to_array<float>({3.0f, 1.0f, 2.0f});
   float* outValues = nullptr;
-  int indices[] = {0, 0, 0};
+  auto indices = std::to_array<int>({0, 0, 0});
   dart::math::detail::convhull_internal::sortFloat(
-      values, outValues, indices, 3, true);
+      values.data(),
+      outValues,
+      indices.data(),
+      static_cast<int>(values.size()),
+      true);
 
   EXPECT_FLOAT_EQ(values[0], 3.0f);
   EXPECT_FLOAT_EQ(values[1], 2.0f);
   EXPECT_FLOAT_EQ(values[2], 1.0f);
 
-  int ints[] = {3, 1, 2};
-  dart::math::detail::convhull_internal::sortInt(ints, 3);
+  auto ints = std::to_array<int>({3, 1, 2});
+  dart::math::detail::convhull_internal::sortInt(
+      ints.data(), static_cast<int>(ints.size()));
 
   EXPECT_EQ(ints[0], 1);
   EXPECT_EQ(ints[1], 2);

--- a/tests/unit/simd/test_eigen_interop.cpp
+++ b/tests/unit/simd/test_eigen_interop.cpp
@@ -37,6 +37,8 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
+#include <array>
+
 namespace ds = dart::simd;
 
 class EigenInteropTest : public ::testing::Test
@@ -180,11 +182,11 @@ TEST_F(EigenInteropTest, RoundTrip3Padded)
 
 TEST_F(EigenInteropTest, EigenSoA3Construction)
 {
-  std::array<Eigen::Vector3d, 4> aos
-      = {Eigen::Vector3d(1, 2, 3),
-         Eigen::Vector3d(4, 5, 6),
-         Eigen::Vector3d(7, 8, 9),
-         Eigen::Vector3d(10, 11, 12)};
+  const auto aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 2, 3),
+       Eigen::Vector3d(4, 5, 6),
+       Eigen::Vector3d(7, 8, 9),
+       Eigen::Vector3d(10, 11, 12)});
 
   ds::EigenSoA3d4 soa(aos);
 
@@ -206,11 +208,11 @@ TEST_F(EigenInteropTest, EigenSoA3Construction)
 
 TEST_F(EigenInteropTest, EigenSoA3ToAoS)
 {
-  std::array<Eigen::Vector3d, 4> original
-      = {Eigen::Vector3d(1, 2, 3),
-         Eigen::Vector3d(4, 5, 6),
-         Eigen::Vector3d(7, 8, 9),
-         Eigen::Vector3d(10, 11, 12)};
+  const auto original = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 2, 3),
+       Eigen::Vector3d(4, 5, 6),
+       Eigen::Vector3d(7, 8, 9),
+       Eigen::Vector3d(10, 11, 12)});
 
   ds::EigenSoA3d4 soa(original);
   auto result = soa.toAos();
@@ -239,17 +241,17 @@ TEST_F(EigenInteropTest, EigenSoA3GetSet)
 
 TEST_F(EigenInteropTest, Dot3)
 {
-  std::array<Eigen::Vector3d, 4> a_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto a_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
-  std::array<Eigen::Vector3d, 4> b_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto b_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
   ds::EigenSoA3d4 a(a_aos);
   ds::EigenSoA3d4 b(b_aos);
@@ -264,17 +266,17 @@ TEST_F(EigenInteropTest, Dot3)
 
 TEST_F(EigenInteropTest, Cross3)
 {
-  std::array<Eigen::Vector3d, 4> a_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 2, 3)};
+  const auto a_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 2, 3)});
 
-  std::array<Eigen::Vector3d, 4> b_aos
-      = {Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(4, 5, 6)};
+  const auto b_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(4, 5, 6)});
 
   ds::EigenSoA3d4 a(a_aos);
   ds::EigenSoA3d4 b(b_aos);
@@ -301,11 +303,11 @@ TEST_F(EigenInteropTest, Cross3)
 
 TEST_F(EigenInteropTest, TransposeAoSToSoA)
 {
-  std::array<Eigen::Vector3f, 4> aos
-      = {Eigen::Vector3f(1, 2, 3),
-         Eigen::Vector3f(4, 5, 6),
-         Eigen::Vector3f(7, 8, 9),
-         Eigen::Vector3f(10, 11, 12)};
+  const auto aos = std::to_array<Eigen::Vector3f>(
+      {Eigen::Vector3f(1, 2, 3),
+       Eigen::Vector3f(4, 5, 6),
+       Eigen::Vector3f(7, 8, 9),
+       Eigen::Vector3f(10, 11, 12)});
 
   auto soa = ds::transposeAosToSoa(aos);
 
@@ -334,11 +336,11 @@ TEST_F(EigenInteropTest, TransposeSoAToAoS)
 
 TEST_F(EigenInteropTest, EigenSoA4Construction)
 {
-  std::array<Eigen::Vector4d, 4> aos
-      = {Eigen::Vector4d(1, 2, 3, 4),
-         Eigen::Vector4d(5, 6, 7, 8),
-         Eigen::Vector4d(9, 10, 11, 12),
-         Eigen::Vector4d(13, 14, 15, 16)};
+  const auto aos = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 2, 3, 4),
+       Eigen::Vector4d(5, 6, 7, 8),
+       Eigen::Vector4d(9, 10, 11, 12),
+       Eigen::Vector4d(13, 14, 15, 16)});
 
   ds::EigenSoA4d4 soa(aos);
 
@@ -365,11 +367,11 @@ TEST_F(EigenInteropTest, EigenSoA4Construction)
 
 TEST_F(EigenInteropTest, EigenSoA4ToAoS)
 {
-  std::array<Eigen::Vector4d, 4> original
-      = {Eigen::Vector4d(1, 2, 3, 4),
-         Eigen::Vector4d(5, 6, 7, 8),
-         Eigen::Vector4d(9, 10, 11, 12),
-         Eigen::Vector4d(13, 14, 15, 16)};
+  const auto original = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 2, 3, 4),
+       Eigen::Vector4d(5, 6, 7, 8),
+       Eigen::Vector4d(9, 10, 11, 12),
+       Eigen::Vector4d(13, 14, 15, 16)});
 
   ds::EigenSoA4d4 soa(original);
   auto result = soa.toAos();
@@ -401,17 +403,17 @@ TEST_F(EigenInteropTest, EigenSoA4GetSet)
 
 TEST_F(EigenInteropTest, Dot4)
 {
-  std::array<Eigen::Vector4d, 4> a_aos
-      = {Eigen::Vector4d(1, 0, 0, 0),
-         Eigen::Vector4d(0, 1, 0, 0),
-         Eigen::Vector4d(0, 0, 1, 0),
-         Eigen::Vector4d(1, 1, 1, 1)};
+  const auto a_aos = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 0, 0, 0),
+       Eigen::Vector4d(0, 1, 0, 0),
+       Eigen::Vector4d(0, 0, 1, 0),
+       Eigen::Vector4d(1, 1, 1, 1)});
 
-  std::array<Eigen::Vector4d, 4> b_aos
-      = {Eigen::Vector4d(1, 0, 0, 0),
-         Eigen::Vector4d(0, 1, 0, 0),
-         Eigen::Vector4d(0, 0, 1, 0),
-         Eigen::Vector4d(1, 1, 1, 1)};
+  const auto b_aos = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 0, 0, 0),
+       Eigen::Vector4d(0, 1, 0, 0),
+       Eigen::Vector4d(0, 0, 1, 0),
+       Eigen::Vector4d(1, 1, 1, 1)});
 
   ds::EigenSoA4d4 a(a_aos);
   ds::EigenSoA4d4 b(b_aos);
@@ -426,11 +428,11 @@ TEST_F(EigenInteropTest, Dot4)
 
 TEST_F(EigenInteropTest, EigenSoA4TransposeAoSToSoA)
 {
-  std::array<Eigen::Vector4f, 4> aos
-      = {Eigen::Vector4f(1, 2, 3, 4),
-         Eigen::Vector4f(5, 6, 7, 8),
-         Eigen::Vector4f(9, 10, 11, 12),
-         Eigen::Vector4f(13, 14, 15, 16)};
+  const auto aos = std::to_array<Eigen::Vector4f>(
+      {Eigen::Vector4f(1, 2, 3, 4),
+       Eigen::Vector4f(5, 6, 7, 8),
+       Eigen::Vector4f(9, 10, 11, 12),
+       Eigen::Vector4f(13, 14, 15, 16)});
 
   auto soa = ds::transposeAosToSoa(aos);
 
@@ -463,11 +465,11 @@ TEST_F(EigenInteropTest, EigenSoA4TransposeSoAToAoS)
 
 TEST_F(EigenInteropTest, TransformPointsBatchIdentity)
 {
-  std::array<Eigen::Vector3d, 4> points_aos
-      = {Eigen::Vector3d(1, 2, 3),
-         Eigen::Vector3d(4, 5, 6),
-         Eigen::Vector3d(7, 8, 9),
-         Eigen::Vector3d(10, 11, 12)};
+  const auto points_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 2, 3),
+       Eigen::Vector3d(4, 5, 6),
+       Eigen::Vector3d(7, 8, 9),
+       Eigen::Vector3d(10, 11, 12)});
 
   ds::EigenSoA3d4 points(points_aos);
   auto identity = ds::Matrix4x4d::identity();
@@ -484,11 +486,11 @@ TEST_F(EigenInteropTest, TransformPointsBatchIdentity)
 
 TEST_F(EigenInteropTest, TransformPointsBatchTranslation)
 {
-  std::array<Eigen::Vector3d, 4> points_aos
-      = {Eigen::Vector3d(0, 0, 0),
-         Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1)};
+  const auto points_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(0, 0, 0),
+       Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1)});
 
   ds::EigenSoA3d4 points(points_aos);
 
@@ -512,11 +514,11 @@ TEST_F(EigenInteropTest, TransformPointsBatchTranslation)
 
 TEST_F(EigenInteropTest, TransformVectorsBatchIdentity)
 {
-  std::array<Eigen::Vector3d, 4> vectors_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto vectors_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
   ds::EigenSoA3d4 vectors(vectors_aos);
   auto identity = ds::Matrix4x4d::identity();
@@ -533,11 +535,11 @@ TEST_F(EigenInteropTest, TransformVectorsBatchIdentity)
 
 TEST_F(EigenInteropTest, TransformVectorsIgnoresTranslation)
 {
-  std::array<Eigen::Vector3d, 4> vectors_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto vectors_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
   ds::EigenSoA3d4 vectors(vectors_aos);
 
@@ -559,11 +561,11 @@ TEST_F(EigenInteropTest, TransformVectorsIgnoresTranslation)
 
 TEST_F(EigenInteropTest, TransformPointsBatchRotation90Z)
 {
-  std::array<Eigen::Vector3d, 4> points_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(1, 1, 0),
-         Eigen::Vector3d(2, 0, 0)};
+  const auto points_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(1, 1, 0),
+       Eigen::Vector3d(2, 0, 0)});
 
   ds::EigenSoA3d4 points(points_aos);
 

--- a/tests/unit/simulation/experimental/common/test_diagnostics_profiling.cpp
+++ b/tests/unit/simulation/experimental/common/test_diagnostics_profiling.cpp
@@ -35,7 +35,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
 #include <chrono>
+#include <string>
+#include <string_view>
 #include <thread>
 
 using namespace dart::simulation::experimental::common;
@@ -44,22 +48,23 @@ TEST(Diagnostics, GetCompilerInfo_ReturnsNonEmpty)
 {
   std::string info = getCompilerInfo();
   EXPECT_FALSE(info.empty());
+  constexpr auto compilerNames
+      = std::to_array<std::string_view>({"GCC", "Clang", "MSVC", "Unknown"});
   EXPECT_TRUE(
-      info.find("GCC") != std::string::npos
-      || info.find("Clang") != std::string::npos
-      || info.find("MSVC") != std::string::npos
-      || info.find("Unknown") != std::string::npos);
+      std::ranges::any_of(compilerNames, [&](std::string_view compilerName) {
+        return info.find(compilerName) != std::string::npos;
+      }));
 }
 
 TEST(Diagnostics, GetCxxABI_ReturnsNonEmpty)
 {
   std::string abi = getCxxABI();
   EXPECT_FALSE(abi.empty());
-  EXPECT_TRUE(
-      abi.find("libstdc++") != std::string::npos
-      || abi.find("libc++") != std::string::npos
-      || abi.find("MSVC") != std::string::npos
-      || abi.find("unknown") != std::string::npos);
+  constexpr auto abiNames = std::to_array<std::string_view>(
+      {"libstdc++", "libc++", "MSVC", "unknown"});
+  EXPECT_TRUE(std::ranges::any_of(abiNames, [&](std::string_view abiName) {
+    return abi.find(abiName) != std::string::npos;
+  }));
 }
 
 TEST(Diagnostics, GetCxxStandard_ReturnsValidValue)

--- a/tutorials/tutorial_dominoes_finished/main.cpp
+++ b/tutorials/tutorial_dominoes_finished/main.cpp
@@ -374,7 +374,7 @@ public:
 
     // snippet:cpp-dominoes-lesson1a-last-start
     const SkeletonPtr& lastDomino
-        = mDominoes.size() > 0 ? mDominoes.back() : mFirstDomino;
+        = !mDominoes.empty() ? mDominoes.back() : mFirstDomino;
     // snippet:cpp-dominoes-lesson1a-last-end
 
     // Compute the position for the new domino
@@ -443,7 +443,7 @@ public:
   void deleteLastDomino()
   {
     // snippet:cpp-dominoes-lesson1c-delete-start
-    if (mDominoes.size() > 0) {
+    if (!mDominoes.empty()) {
       SkeletonPtr lastDomino = mDominoes.back();
       mDominoes.pop_back();
       mWorld->removeSkeleton(lastDomino);


### PR DESCRIPTION
## Summary

- Consolidate the smaller C++20/STL cleanup PRs into one larger batch to reduce CI queue pressure.
- Adopt targeted standard helpers where they directly improve intent: chrono duration casts, bit casts, `starts_with` / `ends_with`, fixed arrays, map key/value views, `empty()`, `std::clamp`, and ranges predicates.
- Keep the scope behavior-preserving and avoid conversions where the type contract is not a clear match, such as Eigen size checks or ordered-bound-sensitive clamp expressions.

## Motivation / Problem

- The prior one-topic-per-small-change approach created too many CI matrices and slowed actual merge velocity.
- This PR carries the same reviewed local changes in a single CI lane, superseding several draft PRs without broadening into unrelated behavior changes.

## Changes / Key Changes

- Common/utilities: simplify stopwatch duration conversions, URI/resource path prefix and suffix checks, XML helper emptiness checks, and scalar bit conversions.
- Dynamics/GUI/math: use fixed arrays, map views, emptiness helpers, and fixed-bound clamp calls in targeted container and geometry paths.
- Constraints/collision/SIMD: use standard clamp/max helpers and ranges predicates in early-exit scans and small helper loops.
- Tests/examples/tutorials: update matching helper idioms in touched tests and examples so the production/test code stays consistent.

## Consolidation

Supersedes draft PRs: #2627, #2630, #2637, #2638, #2640, #2641.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target UNIT_common_stopwatch UNIT_common_uri UNIT_common_frame_allocator UNIT_dynamics_Linkage UNIT_dynamics_LineSegmentShape UNIT_dynamics_SoftBodyNode UNIT_dynamics_SkeletonAccessors UNIT_dynamics_SkeletonProperties UNIT_dynamics_MeshShape UNIT_math_geometry UNIT_math_Convhull UNIT_constraint_CouplerConstraint UNIT_constraint_MotorConstraints INTEGRATION_constraint_ContactConstraint INTEGRATION_simulation_MimicConstraint INTEGRATION_simulation_World INTEGRATION_dynamics_AtlasIK INTEGRATION_collision_Collision INTEGRATION_collision_CollisionAccuracy INTEGRATION_collision_FclPrimitiveContactMatrix INTEGRATION_collision_FclPrimitiveContactMatrixFcl UNIT_simd_simd_math UNIT_simd_simd_geometry UNIT_simd_simd_eigen_interop test_xml_helpersNone py_test_constraint py_test_optimizer py_test_world py_test_skeleton py_test_stopwatch py_test_uri`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_common_stopwatch|UNIT_common_uri|UNIT_common_frame_allocator|UNIT_dynamics_Linkage|UNIT_dynamics_LineSegmentShape|UNIT_dynamics_SoftBodyNode|UNIT_dynamics_SkeletonAccessors|UNIT_dynamics_SkeletonProperties|UNIT_dynamics_MeshShape|UNIT_math_geometry|UNIT_math_Convhull|UNIT_constraint_CouplerConstraint|UNIT_constraint_MotorConstraints|INTEGRATION_constraint_ContactConstraint|INTEGRATION_simulation_MimicConstraint|INTEGRATION_simulation_World|INTEGRATION_dynamics_AtlasIK|INTEGRATION_collision_Collision|INTEGRATION_collision_CollisionAccuracy|INTEGRATION_collision_FclPrimitiveContactMatrix|INTEGRATION_collision_FclPrimitiveContactMatrixFcl|UNIT_simd_simd_math|UNIT_simd_simd_geometry|UNIT_simd_simd_eigen_interop|test_xml_helpersNone)$'`
- Python test targets above each completed with `152 passed`.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Supersedes #2627, #2630, #2637, #2638, #2640, #2641.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: not required for behavior-preserving cleanup
- [x] Add unit tests for new functionality: not applicable
- [x] Document new methods and classes: not applicable
- [x] Add Python bindings (dartpy) if applicable: not applicable
