### PR TITLE
Adopt C++20 concepts in experimental serialization

### DIFF
--- a/dart/simulation/experimental/io/auto_serialization.hpp
+++ b/dart/simulation/experimental/io/auto_serialization.hpp
@@ -110,7 +110,7 @@ void autoSerialize(
           writePOD(out, field(i, j));
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       // POD types (int, double, bool, enums, etc.)
       writePOD(out, field);
     } else {
@@ -153,7 +153,7 @@ void autoDeserialize(std::istream& in, T& component)
           }
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       // POD types
       readPOD(in, field);
     } else {
@@ -215,7 +215,7 @@ void autoSerialize(
       writePOD(out, field.x());
       writePOD(out, field.y());
       writePOD(out, field.z());
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       writePOD(out, field);
     } else {
       // Complex nested type
@@ -263,7 +263,7 @@ void autoDeserialize(std::istream& in, T& component)
           }
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       readPOD(in, field);
     } else {
       // Complex nested type
@@ -298,7 +298,7 @@ void autoSerialize(
           writePOD(out, field(i, j));
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       writePOD(out, field);
     } else {
       // Recursively serialize nested structs
@@ -330,7 +330,7 @@ void autoDeserialize(std::istream& in, T& value)
           }
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       readPOD(in, field);
     } else {
       // Recursively deserialize nested structs

--- a/dart/simulation/experimental/io/binary_io.hpp
+++ b/dart/simulation/experimental/io/binary_io.hpp
@@ -71,6 +71,10 @@ constexpr std::uint32_t kBinaryFormatVersion = 1;
 
 namespace detail {
 
+template <typename T>
+concept TriviallyCopyable
+    = std::is_trivially_copyable_v<std::remove_cvref_t<T>>;
+
 inline void writeBytes(std::ostream& out, std::span<const std::byte> bytes)
 {
   out.write(
@@ -100,22 +104,16 @@ std::span<std::byte> asWritableBytes(T& value)
 } // namespace detail
 
 // Write a POD (Plain Old Data) type to binary stream
-template <typename T>
+template <detail::TriviallyCopyable T>
 void writePOD(std::ostream& out, const T& value)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "writePOD requires trivially copyable type");
   detail::writeBytes(out, detail::asBytes(value));
 }
 
 // Read a POD (Plain Old Data) type from binary stream
-template <typename T>
+template <detail::TriviallyCopyable T>
 void readPOD(std::istream& in, T& value)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "readPOD requires trivially copyable type");
   detail::readBytes(in, detail::asWritableBytes(value));
 }
 
@@ -168,12 +166,9 @@ void DART_EXPERIMENTAL_API readMatrixXd(std::istream& in, Eigen::MatrixXd& mat);
 //==============================================================================
 
 // Write a POD span to binary stream (size-prefixed)
-template <typename T>
+template <detail::TriviallyCopyable T>
 void writeVector(std::ostream& out, std::span<const T> vec)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "writeVector requires trivially copyable type");
   std::size_t size = vec.size();
   writePOD(out, size);
   if (size > 0) {
@@ -182,12 +177,9 @@ void writeVector(std::ostream& out, std::span<const T> vec)
 }
 
 // Read std::vector of POD types from binary stream
-template <typename T>
+template <detail::TriviallyCopyable T>
 void readVector(std::istream& in, std::vector<T>& vec)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "readVector requires trivially copyable type");
   std::size_t size;
   readPOD(in, size);
   vec.resize(size);

--- a/dart/simulation/experimental/space/auto_mapper.hpp
+++ b/dart/simulation/experimental/space/auto_mapper.hpp
@@ -50,10 +50,24 @@ namespace dart::simulation::experimental::space {
 
 namespace detail {
 
+template <typename Field>
+concept ArithmeticField = std::integral<std::remove_cvref_t<Field>>
+                          || std::floating_point<std::remove_cvref_t<Field>>;
+
+template <typename Field>
+concept EnumField = std::is_enum_v<std::remove_cvref_t<Field>>;
+
+template <typename Field>
+concept ScalarField = ArithmeticField<Field> || EnumField<Field>;
+
+template <typename Field>
+concept AggregateField = std::is_aggregate_v<std::remove_cvref_t<Field>>;
+
 template <typename T>
-concept IsometryField
-    = std::same_as<T, Eigen::Isometry3d>
-      || std::derived_from<T, Eigen::Transform<double, 3, Eigen::Isometry>>;
+concept IsometryField = std::same_as<std::remove_cvref_t<T>, Eigen::Isometry3d>
+                        || std::derived_from<
+                            std::remove_cvref_t<T>,
+                            Eigen::Transform<double, 3, Eigen::Isometry>>;
 
 } // namespace detail
 
@@ -66,7 +80,7 @@ size_t extractFieldToVector(
   using FieldType = std::remove_cvref_t<Field>;
   size_t count = 0;
 
-  if constexpr (std::is_arithmetic_v<FieldType>) {
+  if constexpr (detail::ArithmeticField<FieldType>) {
     // Scalar types (double, float, int, etc.)
     vec[offset] = static_cast<double>(field);
     count = 1;
@@ -103,7 +117,7 @@ size_t extractFieldToVector(
     vec[offset + 2] = field.y();
     vec[offset + 3] = field.z();
     count = 4;
-  } else if constexpr (std::is_enum_v<FieldType>) {
+  } else if constexpr (detail::EnumField<FieldType>) {
     // Enums as integers
     vec[offset] = static_cast<double>(static_cast<int>(field));
     count = 1;
@@ -125,7 +139,7 @@ size_t injectVectorToField(
   using FieldType = std::remove_cvref_t<Field>;
   size_t count = 0;
 
-  if constexpr (std::is_arithmetic_v<FieldType>) {
+  if constexpr (detail::ArithmeticField<FieldType>) {
     field = static_cast<FieldType>(vec[offset]);
     count = 1;
   } else if constexpr (detail::IsometryField<FieldType>) {
@@ -157,7 +171,7 @@ size_t injectVectorToField(
     field.y() = vec[offset + 2];
     field.z() = vec[offset + 3];
     count = 4;
-  } else if constexpr (std::is_enum_v<FieldType>) {
+  } else if constexpr (detail::EnumField<FieldType>) {
     field = static_cast<FieldType>(static_cast<int>(vec[offset]));
     count = 1;
   } else {
@@ -176,7 +190,7 @@ constexpr size_t getFieldDimension()
 {
   using FieldType = std::remove_cvref_t<Field>;
 
-  if constexpr (std::is_arithmetic_v<FieldType> || std::is_enum_v<FieldType>) {
+  if constexpr (detail::ScalarField<FieldType>) {
     return 1;
   } else if constexpr (std::same_as<FieldType, Eigen::Vector2d>) {
     return 2;
@@ -184,11 +198,11 @@ constexpr size_t getFieldDimension()
     return 3;
   } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
     return 4;
-  } else if constexpr (std::same_as<FieldType, Eigen::Isometry3d>) {
+  } else if constexpr (detail::IsometryField<FieldType>) {
     return 7; // Translation (3) + Quaternion (4)
   } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
     return 0; // Dynamic size - must be computed at runtime
-  } else if constexpr (std::is_aggregate_v<FieldType>) {
+  } else if constexpr (detail::AggregateField<FieldType>) {
     // Nested aggregate struct - sum dimensions of all fields
     size_t total = 0;
     boost::pfr::for_each_field(FieldType{}, [&](const auto& field) {

--- a/dart/simulation/experimental/space/component_mapper.hpp
+++ b/dart/simulation/experimental/space/component_mapper.hpp
@@ -46,7 +46,8 @@ namespace dart::simulation::experimental {
 namespace detail {
 
 template <typename Field>
-concept ArithmeticField = std::is_arithmetic_v<std::remove_cvref_t<Field>>;
+concept ArithmeticField = std::integral<std::remove_cvref_t<Field>>
+                          || std::floating_point<std::remove_cvref_t<Field>>;
 
 template <typename Field>
 concept EigenVectorField = requires(Field field, Eigen::Index i) {


### PR DESCRIPTION
## Summary

- Add a named C++20 concept for trivially copyable experimental binary I/O helpers.
- Reuse that concept in automatic serialization field dispatch.
- Add named scalar, enum, aggregate, and isometry field concepts in experimental state-space mapping.
- Rebased onto current `main` so the branch satisfies GitHub's up-to-date merge requirement.

## Motivation / Problem

- Experimental serialization and vector mapping repeated the same type-trait predicates across related templates.
- The binary I/O helpers accepted unconstrained templates and checked the trivially-copyable contract inside the function body.

## Changes / Key Changes

- Constrain writePOD, readPOD, writeVector, and readVector with detail::TriviallyCopyable.
- Replace repeated std::is_trivially_copyable_v dispatch with the shared binary I/O concept.
- Express arithmetic fields with std::integral/std::floating_point and reuse named concepts for mapper field classification.
- Align isometry dimension detection with the existing isometry field concept.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)
- Rebase follow-up: `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- Rebase follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_assert|test_diagnostics_profiling|test_logging|test_frames|test_serialization|test_world|test_frame|test_joint|test_link|test_multi_body|test_auto_mapper|test_state_space|test_vector_mapper)$'` (13/13 passed)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md not required (internal refactor, no behavior/API change)
- [x] Existing unit/integration tests cover this refactor
- [x] Documentation not required (no user-facing API change)
- [x] Python bindings not applicable
