### PR TITLE
Use checked comparisons in solver helpers

### DIFF
--- a/dart/dynamics/inverse_kinematics.cpp
+++ b/dart/dynamics/inverse_kinematics.cpp
@@ -42,6 +42,7 @@
 #include <iterator>
 #include <numeric>
 #include <unordered_map>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -1077,7 +1078,7 @@ void InverseKinematics::Analytical::addExtraDofGradient(
   for (std::size_t i = 0; i < mExtraDofs.size(); ++i) {
     std::size_t depIndex = mExtraDofs[i];
     int gradIndex = gradMap[depIndex];
-    if (gradIndex == -1) {
+    if (gradIndex < 0) {
       continue;
     }
 
@@ -1089,13 +1090,14 @@ void InverseKinematics::Analytical::addExtraDofGradient(
   for (std::size_t i = 0; i < mExtraDofs.size(); ++i) {
     std::size_t depIndex = mExtraDofs[i];
     int gradIndex = gradMap[depIndex];
-    if (gradIndex == -1) {
+    if (gradIndex < 0) {
       continue;
     }
 
-    double weight = mGradientP.mComponentWeights.size() > gradIndex
-                        ? mGradientP.mComponentWeights[gradIndex]
-                        : 1.0;
+    double weight
+        = std::cmp_less(gradIndex, mGradientP.mComponentWeights.size())
+              ? mGradientP.mComponentWeights[gradIndex]
+              : 1.0;
 
     double dq = weight * mExtraDofGradCache[i];
 

--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <unordered_set>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -258,13 +259,13 @@ void Linkage::Criteria::expandDownstream(
   }
   recorder.push_back(Recording(_start, 0));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
-    if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
+    if (std::cmp_less(r.mCount, r.mNode->getNumChildBodyNodes())) {
       stepToNextChild(recorder, _bns, r, mMapOfTerminals, 0);
     } else {
       recorder.pop_back();
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }
@@ -283,7 +284,7 @@ void Linkage::Criteria::expandUpstream(
   }
   recorder.push_back(Recording(_start, -1));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
 
     if (r.mCount == -1) {
@@ -303,7 +304,7 @@ void Linkage::Criteria::expandUpstream(
         // If we originally came from this node, then just continue to the next
         ++r.mCount;
       }
-    } else if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
+    } else if (std::cmp_less(r.mCount, r.mNode->getNumChildBodyNodes())) {
       // Greater than -1 means we need to add the children
 
       if (recorder.size() == 1) {
@@ -323,7 +324,7 @@ void Linkage::Criteria::expandUpstream(
       // If we've iterated through all the children of this node, pop it
       recorder.pop_back();
       // Move on to the next child
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }

--- a/dart/math/optimization/gradient_descent_solver.cpp
+++ b/dart/math/optimization/gradient_descent_solver.cpp
@@ -127,7 +127,7 @@ bool GradientDescentSolver::solve()
   }
 
   Eigen::VectorXd x = problem->getInitialGuess();
-  DART_ASSERT(x.size() == static_cast<int>(dim));
+  DART_ASSERT(std::cmp_equal(x.size(), dim));
 
   Eigen::VectorXd lastx = x;
   Eigen::VectorXd dx(x.size());
@@ -183,8 +183,7 @@ bool GradientDescentSolver::solve()
       if (objective) {
         objective->evalGradient(x, dxMap);
       }
-      for (int i = 0; i < static_cast<int>(problem->getNumEqConstraints());
-           ++i) {
+      for (std::size_t i = 0; i < problem->getNumEqConstraints(); ++i) {
         if (std::abs(mEqConstraintCostCache[i]) < tol) {
           continue;
         }
@@ -193,7 +192,7 @@ bool GradientDescentSolver::solve()
 
         // Get the user-specified weight if available, otherwise use the default
         // weight value
-        double weight = mGradientP.mEqConstraintWeights.size() > i
+        double weight = std::cmp_less(i, mGradientP.mEqConstraintWeights.size())
                             ? mGradientP.mEqConstraintWeights[i]
                             : mGradientP.mDefaultConstraintWeight;
 
@@ -204,8 +203,7 @@ bool GradientDescentSolver::solve()
         dx += weight * grad * math::sign(mEqConstraintCostCache[i]);
       }
 
-      for (int i = 0; i < static_cast<int>(problem->getNumIneqConstraints());
-           ++i) {
+      for (std::size_t i = 0; i < problem->getNumIneqConstraints(); ++i) {
         if (mIneqConstraintCostCache[i] < tol) {
           continue;
         }
@@ -214,9 +212,10 @@ bool GradientDescentSolver::solve()
 
         // Get the user-specified weight if available, otherwise use the
         // default weight value
-        double weight = mGradientP.mIneqConstraintWeights.size() > i
-                            ? mGradientP.mIneqConstraintWeights[i]
-                            : mGradientP.mDefaultConstraintWeight;
+        double weight
+            = std::cmp_less(i, mGradientP.mIneqConstraintWeights.size())
+                  ? mGradientP.mIneqConstraintWeights[i]
+                  : mGradientP.mDefaultConstraintWeight;
 
         dx += weight * grad;
       }


### PR DESCRIPTION
## Summary

- Use C++20 checked integer comparison helpers in linkage traversal and solver-size checks.
- Replace signed/unsigned casts with explicit `std::cmp_less` / `std::cmp_equal` predicates where the comparison intent matters.
- Keep the branch focused on comparison clarity; no thread-lifetime changes are included.
- Rebased onto current `main` so the branch satisfies GitHub's up-to-date merge requirement.

## Motivation / Problem

- Several traversal and optimizer checks mixed signed counters with `std::size_t` or Eigen index values.
- The old code relied on casts at comparison sites, which made the signedness contract less visible.

## Changes / Key Changes

- Use `std::cmp_less` in Linkage and InverseKinematics path/limit comparisons.
- Use `std::cmp_equal` in GradientDescentSolver size checks.
- Use `empty()` for linkage recorder-stack checks where only emptiness matters.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)
- Rebase follow-up: `cmake --build build/default/cpp/Release --target UNIT_dynamics_InverseKinematics UNIT_dynamics_Linkage UNIT_math_optimization_GradientDescentSolver INTEGRATION_optimization_inverse_kinematics INTEGRATION_optimization_Optimizer INTEGRATION_dynamics_AtlasIK py_test_inverse_kinematics py_test_atlas_ik py_test_optimizer`
- Rebase follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_dynamics_InverseKinematics|UNIT_dynamics_Linkage|UNIT_math_optimization_GradientDescentSolver|INTEGRATION_optimization_inverse_kinematics|INTEGRATION_optimization_Optimizer|INTEGRATION_dynamics_AtlasIK)$'` (6/6 passed)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md not required (internal refactor, no behavior/API change)
- [x] Existing unit/integration tests cover this refactor
- [x] Documentation not required (no user-facing API change)
- [x] Python bindings not applicable
