### PR TITLE
Constrain template contracts with concepts

### DIFF
--- a/dart/common/detail/castable-impl.hpp
+++ b/dart/common/detail/castable-impl.hpp
@@ -36,13 +36,27 @@
 #include "dart/common/macros.hpp"
 
 #include <dart/common/castable.hpp>
-#include <dart/common/metaprogramming.hpp>
+
+#include <concepts>
+#include <string_view>
 
 namespace dart::common {
 
+namespace detail {
+
 //==============================================================================
-DART_CREATE_MEMBER_CHECK(getType);
-DART_CREATE_MEMBER_CHECK(getStaticType);
+template <typename T>
+concept HasTypeString = requires(const T& value) {
+  { value.getType() } -> std::convertible_to<std::string_view>;
+};
+
+//==============================================================================
+template <typename T>
+concept HasStaticTypeString = requires {
+  { T::getStaticType() } -> std::convertible_to<std::string_view>;
+};
+
+} // namespace detail
 
 //==============================================================================
 template <typename Base>
@@ -50,8 +64,7 @@ template <typename Derived>
 bool Castable<Base>::is() const
 {
   if constexpr (
-      has_member_getType<Base>::value
-      && has_member_getStaticType<Derived>::value) {
+      detail::HasTypeString<Base> && detail::HasStaticTypeString<Derived>) {
     return (base().getType() == Derived::getStaticType());
   } else {
     return (dynamic_cast<const Derived*>(&base()) != nullptr);

--- a/dart/common/detail/connection_body.hpp
+++ b/dart/common/detail/connection_body.hpp
@@ -35,6 +35,7 @@
 
 #include <dart/export.hpp>
 
+#include <iterator>
 #include <memory>
 
 namespace dart {
@@ -138,7 +139,7 @@ struct DefaultCombiner
 {
   using result_type = T;
 
-  template <typename InputIterator>
+  template <std::bidirectional_iterator InputIterator>
   static T process(InputIterator first, InputIterator last)
   {
     // If there are no slots to call, just return the

--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -84,7 +84,8 @@ void SingleLockableReference<Lockable>::unlock() noexcept
 
 //==============================================================================
 template <detail::LockableObject Lockable>
-template <detail::LockablePointerInputIterator<Lockable> InputIterator>
+template <typename InputIterator>
+  requires detail::LockablePointerInputIterator<InputIterator, Lockable>
 MultiLockableReference<Lockable>::MultiLockableReference(
     std::weak_ptr<const void> lockableHolder,
     InputIterator first,

--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -35,16 +35,13 @@
 
 #include <dart/common/lockable_reference.hpp>
 
-#include <concepts>
-#include <iterator>
 #include <ranges>
-#include <type_traits>
 
 namespace dart {
 namespace common {
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 SingleLockableReference<Lockable>::SingleLockableReference(
     std::weak_ptr<const void> lockableHolder, Lockable& lockable) noexcept
   : mLockableHolder(std::move(lockableHolder)), mLockable(lockable)
@@ -53,7 +50,7 @@ SingleLockableReference<Lockable>::SingleLockableReference(
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void SingleLockableReference<Lockable>::lock()
 {
   if (mLockableHolder.expired()) {
@@ -64,7 +61,7 @@ void SingleLockableReference<Lockable>::lock()
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 bool SingleLockableReference<Lockable>::try_lock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -75,7 +72,7 @@ bool SingleLockableReference<Lockable>::try_lock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void SingleLockableReference<Lockable>::unlock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -86,27 +83,19 @@ void SingleLockableReference<Lockable>::unlock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
-template <typename InputIterator>
+template <detail::LockableObject Lockable>
+template <detail::LockablePointerInputIterator<Lockable> InputIterator>
 MultiLockableReference<Lockable>::MultiLockableReference(
     std::weak_ptr<const void> lockableHolder,
     InputIterator first,
     InputIterator last)
   : mLockableHolder(std::move(lockableHolder)), mLockables(first, last)
 {
-  using IteratorValueType =
-      typename std::iterator_traits<InputIterator>::value_type;
-  using IteratorLockable
-      = std::remove_pointer_t<std::remove_cvref_t<IteratorValueType>>;
-
-  static_assert(
-      std::same_as<Lockable, IteratorLockable>,
-      "Lockable of this class and the lockable of InputIterator are not the "
-      "same.");
+  // Do nothing
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void MultiLockableReference<Lockable>::lock()
 {
   if (mLockableHolder.expired()) {
@@ -119,7 +108,7 @@ void MultiLockableReference<Lockable>::lock()
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 bool MultiLockableReference<Lockable>::try_lock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -136,7 +125,7 @@ bool MultiLockableReference<Lockable>::try_lock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void MultiLockableReference<Lockable>::unlock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -149,7 +138,7 @@ void MultiLockableReference<Lockable>::unlock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 template <typename T>
 T* MultiLockableReference<Lockable>::ptr(T& obj)
 {
@@ -157,7 +146,7 @@ T* MultiLockableReference<Lockable>::ptr(T& obj)
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 template <typename T>
 T* MultiLockableReference<Lockable>::ptr(T* obj)
 {

--- a/dart/common/detail/stopwatch-impl.hpp
+++ b/dart/common/detail/stopwatch-impl.hpp
@@ -53,35 +53,28 @@ void print_duration_if_non_zero(
 } // namespace
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 Stopwatch<UnitType, ClockType>::Stopwatch(bool start)
   : mStart(ClockType::now()), mElapsed(0), mPaused(!start)
 {
-  // clang-format off
-  static_assert(std::same_as<UnitType, std::chrono::seconds>
-      || std::same_as<UnitType, std::chrono::milliseconds>
-      || std::same_as<UnitType, std::chrono::microseconds>
-      || std::same_as<UnitType, std::chrono::nanoseconds>,
-      "Invalid unit");
-  // clang-format on
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 Stopwatch<UnitType, ClockType>::~Stopwatch()
 {
   // Do nothing
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 bool Stopwatch<UnitType, ClockType>::isStarted() const
 {
   return !mPaused;
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::start()
 {
   if (!mPaused) {
@@ -93,7 +86,7 @@ void Stopwatch<UnitType, ClockType>::start()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::stop()
 {
   if (mPaused) {
@@ -105,7 +98,7 @@ void Stopwatch<UnitType, ClockType>::stop()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::reset()
 {
   mStart = ClockType::now();
@@ -113,7 +106,7 @@ void Stopwatch<UnitType, ClockType>::reset()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -128,7 +121,7 @@ double Stopwatch<UnitType, ClockType>::elapsedS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedMS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -144,7 +137,7 @@ double Stopwatch<UnitType, ClockType>::elapsedMS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedUS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -160,7 +153,7 @@ double Stopwatch<UnitType, ClockType>::elapsedUS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedNS() const
 {
   if constexpr (std::same_as<UnitType, std::chrono::nanoseconds>) {
@@ -175,7 +168,7 @@ double Stopwatch<UnitType, ClockType>::elapsedNS() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 UnitType Stopwatch<UnitType, ClockType>::duration() const
 {
   if (mPaused) {
@@ -188,7 +181,7 @@ UnitType Stopwatch<UnitType, ClockType>::duration() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
 {
   auto t = duration();
@@ -233,7 +226,7 @@ void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 std::ostream& operator<<(
     std::ostream& os, const Stopwatch<UnitType, ClockType>& sw)
 {

--- a/dart/common/lockable_reference.hpp
+++ b/dart/common/lockable_reference.hpp
@@ -33,11 +33,33 @@
 #ifndef DART_COMMON_LOCKABLEREFERENCE_HPP_
 #define DART_COMMON_LOCKABLEREFERENCE_HPP_
 
+#include <concepts>
+#include <iterator>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 namespace dart {
 namespace common {
+
+namespace detail {
+
+template <typename T>
+concept LockableObject = requires(T lockable) {
+  { lockable.lock() } -> std::same_as<void>;
+  { lockable.try_lock() } -> std::convertible_to<bool>;
+  { lockable.unlock() } -> std::same_as<void>;
+};
+
+template <typename Iterator, typename Lockable>
+concept LockablePointerInputIterator
+    = std::input_iterator<Iterator>
+      && std::same_as<
+          std::remove_pointer_t<std::remove_cvref_t<
+              typename std::iterator_traits<Iterator>::value_type>>,
+          Lockable>;
+
+} // namespace detail
 
 /// LockableReference is a wrapper class of single or multiple Lockable
 /// object(s) to provide unified interface that guarantees deadlock-free locking
@@ -75,7 +97,7 @@ protected:
 /// This class references a single lockable.
 ///
 /// @tparam LockableT The standard C++ Lockable concept object type.
-template <typename LockableT>
+template <detail::LockableObject LockableT>
 class SingleLockableReference final : public LockableReference
 {
 public:
@@ -114,7 +136,7 @@ private:
 /// deadlock.
 ///
 /// @tparam LockableT The standard C++ Lockable concept object type.
-template <typename LockableT>
+template <detail::LockableObject LockableT>
 class MultiLockableReference final : public LockableReference
 {
 public:
@@ -127,7 +149,7 @@ public:
   /// lockable holder is not destructed.
   /// @param[in] first First iterator of lockable to be added to this class.
   /// @param[in] last Last iterator of lockable to be added to this class.
-  template <typename InputIterator>
+  template <detail::LockablePointerInputIterator<Lockable> InputIterator>
   MultiLockableReference(
       std::weak_ptr<const void> lockableHolder,
       InputIterator first,

--- a/dart/common/lockable_reference.hpp
+++ b/dart/common/lockable_reference.hpp
@@ -149,7 +149,8 @@ public:
   /// lockable holder is not destructed.
   /// @param[in] first First iterator of lockable to be added to this class.
   /// @param[in] last Last iterator of lockable to be added to this class.
-  template <detail::LockablePointerInputIterator<Lockable> InputIterator>
+  template <typename InputIterator>
+    requires detail::LockablePointerInputIterator<InputIterator, Lockable>
   MultiLockableReference(
       std::weak_ptr<const void> lockableHolder,
       InputIterator first,

--- a/dart/common/stopwatch.hpp
+++ b/dart/common/stopwatch.hpp
@@ -36,13 +36,25 @@
 #include <dart/export.hpp>
 
 #include <chrono>
+#include <concepts>
 #include <iostream>
 
 namespace dart::common {
 
+namespace detail {
+
+/// Returns true for the supported Stopwatch duration units.
+template <typename UnitType>
+concept StopwatchUnit = std::same_as<UnitType, std::chrono::seconds>
+                        || std::same_as<UnitType, std::chrono::milliseconds>
+                        || std::same_as<UnitType, std::chrono::microseconds>
+                        || std::same_as<UnitType, std::chrono::nanoseconds>;
+
+} // namespace detail
+
 /// Simple stopwatch implementation
 template <
-    typename UnitType,
+    detail::StopwatchUnit UnitType,
     typename ClockType = std::chrono::high_resolution_clock>
 class Stopwatch final
 {
@@ -87,7 +99,7 @@ public:
   void print(std::ostream& os = std::cout) const;
 
   /// Prints state of the stopwatch
-  template <typename T, typename U>
+  template <detail::StopwatchUnit T, typename U>
   friend std::ostream& operator<<(std::ostream& os, const Stopwatch<T, U>& sw);
 
 private:

--- a/python/dartpy/common/polymorphic_caster.hpp
+++ b/python/dartpy/common/polymorphic_caster.hpp
@@ -2,6 +2,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include <concepts>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -123,7 +124,7 @@ private:
 
 } // namespace detail
 
-template <typename Base, typename Derived>
+template <typename Base, std::derived_from<Base> Derived>
 inline void registerPolymorphicCaster()
 {
   detail::PolymorphicCasterRegistry<Base>::registerType(


### PR DESCRIPTION
## Summary
- Add C++20 concepts for lockable reference template arguments.
- Constrain combiner iterator inputs and common template helper contracts to the operations they actually require.
- Replace older template detection machinery with direct `requires` concepts where it improves diagnostics.
- Require dartpy polymorphic caster registrations to use types derived from the registered base.
- Constrain `Stopwatch` duration units at the template boundary instead of inside the constructor body.
- Rebased onto current `main` so the branch satisfies GitHub's up-to-date merge requirement.

## Motivation / Problem
- These templates already relied on lock/try_lock/unlock, iterator traversal, type-string APIs, base-derived relationships, and a fixed set of stopwatch duration units, but violations surfaced later through less direct template errors.
- Making the contracts explicit gives clearer diagnostics while preserving runtime behavior.
- The earlier logging-trait change is intentionally omitted because current `main` already has the better concept-based form.

## Changes / Key Changes
- Introduce `detail::LockableObject` and `detail::LockablePointerInputIterator` for lockable references.
- Replace the multi-lockable constructor's body-level static assertion with a constructor constraint.
- Spell the multi-lockable constructor constraint with a trailing `requires` clause so MSVC matches the out-of-class definition.
- Use `requires` expressions for `Castable` type-string detection instead of macro-generated member checks.
- Constrain `DefaultCombiner::process` to bidirectional iterators because it decrements `last`.
- Apply `std::derived_from` to dartpy polymorphic caster registration.
- Add `detail::StopwatchUnit` so invalid `Stopwatch` unit types are rejected as template constraint violations.

## Testing
- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)
- `pixi run test-py` (152/152 passed)
- CI fix follow-up: `git diff --check`
- CI fix follow-up: `pixi run lint`
- CI fix follow-up: `cmake --build build/default/cpp/Release --target UNIT_common_lockable_reference`
- CI fix follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^UNIT_common_lockable_reference$'`
- CI fix follow-up: `pixi run build`
- Rebase follow-up: `cmake --build build/default/cpp/Release --target UNIT_common_lockable_reference UNIT_common_castable UNIT_common_stopwatch UNIT_common_signal UNIT_common_template_coverage py_test_stopwatch py_test_lifetime`
- Rebase follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_common_lockable_reference|UNIT_common_castable|UNIT_common_stopwatch|UNIT_common_signal|UNIT_common_template_coverage)$'` (5/5 passed)

## Breaking Changes
- [x] None

## Related Issues / PRs (backports)
- None

---
#### Checklist
- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: behavior-preserving refactor)
- [x] Add unit tests for new functionality (not applicable: no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (build/test coverage only; no binding API change)
