### PR TITLE
Share LCP bound projection helper

### DIFF
--- a/dart/math/lcp/lcp_validation.hpp
+++ b/dart/math/lcp/lcp_validation.hpp
@@ -38,12 +38,37 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
 #include <limits>
 #include <string>
 
 #include <cmath>
 
 namespace dart::math::detail {
+
+inline double projectToBounds(double value, double lo, double hi)
+{
+  const bool hasLo = std::isfinite(lo);
+  const bool hasUpper = std::isfinite(hi);
+
+  if (hasLo && hasUpper) {
+    if (lo <= hi) {
+      return std::clamp(value, lo, hi);
+    }
+
+    return std::min(std::max(value, lo), hi);
+  }
+
+  if (hasLo) {
+    return std::max(value, lo);
+  }
+
+  if (hasUpper) {
+    return std::min(value, hi);
+  }
+
+  return value;
+}
 
 inline bool validateProblem(
     const LcpProblem& problem, std::string* message = nullptr)
@@ -186,13 +211,7 @@ inline double naturalResidualInfinityNorm(
   double maxResidual = 0.0;
 
   for (Eigen::Index i = 0; i < n; ++i) {
-    double projected = x[i] - w[i];
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
+    const double projected = projectToBounds(x[i] - w[i], lo[i], hi[i]);
 
     const double residual = x[i] - projected;
     maxResidual = std::max(maxResidual, std::abs(residual));

--- a/dart/math/lcp/other/staggering_solver.cpp
+++ b/dart/math/lcp/other/staggering_solver.cpp
@@ -211,13 +211,7 @@ LcpResult StaggeringSolver::solve(
           for (int k = 0; k < std::ssize(indices); ++k) {
             const int idx = indices[k];
             double updated = std::lerp(x[idx], values[k], relaxation);
-            if (std::isfinite(lo[idx])) {
-              updated = std::max(updated, lo[idx]);
-            }
-            if (std::isfinite(hi[idx])) {
-              updated = std::min(updated, hi[idx]);
-            }
-            x[idx] = updated;
+            x[idx] = detail::projectToBounds(updated, lo[idx], hi[idx]);
           }
         };
 
@@ -228,13 +222,7 @@ LcpResult StaggeringSolver::solve(
     for (int k = 0; k < std::ssize(indices); ++k) {
       const int idx = indices[k];
       double updated = std::lerp(x[idx], values[k], relaxation);
-      if (std::isfinite(loEff[idx])) {
-        updated = std::max(updated, loEff[idx]);
-      }
-      if (std::isfinite(hiEff[idx])) {
-        updated = std::min(updated, hiEff[idx]);
-      }
-      x[idx] = updated;
+      x[idx] = detail::projectToBounds(updated, loEff[idx], hiEff[idx]);
     }
   };
 

--- a/dart/math/lcp/projection/jacobi_solver.cpp
+++ b/dart/math/lcp/projection/jacobi_solver.cpp
@@ -204,14 +204,7 @@ LcpResult JacobiSolver::solve(
         value = std::lerp(x[i], step, relaxation);
       }
 
-      if (std::isfinite(loEff[i])) {
-        value = std::max(value, loEff[i]);
-      }
-      if (std::isfinite(hiEff[i])) {
-        value = std::min(value, hiEff[i]);
-      }
-
-      xNew[i] = value;
+      xNew[i] = detail::projectToBounds(value, loEff[i], hiEff[i]);
     }
 
     x = xNew;

--- a/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
+++ b/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
@@ -218,14 +218,7 @@ LcpResult RedBlackGaussSeidelSolver::solve(
       return value;
     }
 
-    double projected = value;
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
-    return projected;
+    return detail::projectToBounds(value, lo[i], hi[i]);
   };
 
   auto updateIndex = [&](int i, const Eigen::VectorXd& xRead) {

--- a/dart/math/lcp/projection/subspace_minimization_solver.cpp
+++ b/dart/math/lcp/projection/subspace_minimization_solver.cpp
@@ -262,14 +262,7 @@ LcpResult SubspaceMinimizationSolver::solve(
 
       for (int r = 0; r < fSize; ++r) {
         const int i = freeIndices[r];
-        double value = xFree[r];
-        if (std::isfinite(loEff[i])) {
-          value = std::max(value, loEff[i]);
-        }
-        if (std::isfinite(hiEff[i])) {
-          value = std::min(value, hiEff[i]);
-        }
-        x[i] = value;
+        x[i] = detail::projectToBounds(xFree[r], loEff[i], hiEff[i]);
       }
     }
 

--- a/dart/math/lcp/projection/symmetric_psor_solver.cpp
+++ b/dart/math/lcp/projection/symmetric_psor_solver.cpp
@@ -205,14 +205,7 @@ LcpResult SymmetricPsorSolver::solve(
       return value;
     }
 
-    double projected = value;
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
-    return projected;
+    return detail::projectToBounds(value, lo[i], hi[i]);
   };
 
   auto updateIndex = [&](int i) {


### PR DESCRIPTION
## Summary

- Add a shared LCP helper for projecting values into finite bounds.
- Use `std::clamp` for ordered finite bounds while preserving the previous fallback behavior for inverted bounds.
- Replace duplicated solver-local projection snippets in Jacobi, red-black Gauss-Seidel, symmetric PSOR, subspace minimization, and staggering solvers.
- Rebase onto current `main` so the branch satisfies the up-to-date merge requirement.

## Motivation / Problem

- Several LCP solvers duplicated the same finite-bound projection logic.
- Centralizing the operation keeps projection semantics consistent and makes the common valid finite-bound case clearer with the STL helper.

## Changes / Key Changes

- Introduce `detail::projectToBounds(...)` in `lcp_validation.hpp`.
- Reuse it in LCP residual validation and projection solver update paths.
- Preserve previous max-then-min behavior if a caller supplies inverted finite bounds.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)
- Rebase follow-up: `git diff --check origin/main...HEAD`
- Rebase follow-up: `pixi run lint`
- Rebase follow-up: `pixi run build`
- Rebase follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^UNIT_math_lcp_math_lcp_(additional_solvers|all_solvers_smoke|dantzig_misc|dantzig_solver|dantzig_vs_ode|lcp_comparison_harness|lcp_edge_cases|lcp_newton_solvers|lcp_projection_solvers|lcp_solvers_stress|lcp_problems|lcp_types|lcp_validation_and_solvers|lemke|pgs|pivot_matrix)$'`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md not required (internal refactor, no behavior/API change)
- [x] Existing LCP unit/integration tests cover this refactor
- [x] Documentation not required (internal helper only)
- [x] Python bindings not applicable