### PR TITLE
Use fixed array helpers in loaders and geometry

### DIFF
--- a/dart/collision/ode/detail/ode_cylinder_mesh.cpp
+++ b/dart/collision/ode/detail/ode_cylinder_mesh.cpp
@@ -38,6 +38,7 @@
 #include <Eigen/Core>
 
 #include <algorithm>
+#include <array>
 
 #include <cmath>
 
@@ -61,7 +62,7 @@ void appendTriangle(
   }
 
   const auto baseIndex = static_cast<int>(vertices.size() / 3);
-  const Eigen::Vector3d points[] = {p1, p2, p3};
+  const auto points = std::to_array<Eigen::Vector3d>({p1, p2, p3});
   for (const auto& point : points) {
     vertices.push_back(point.x());
     vertices.push_back(point.y());

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -1557,7 +1557,10 @@ bool hasColladaExtension(std::string_view path)
   std::ranges::transform(extension, extension.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
   });
-  return extension == ".dae" || extension == ".zae";
+  constexpr auto colladaExtensions
+      = std::to_array<std::string_view>({".dae", ".zae"});
+  return std::ranges::find(colladaExtensions, std::string_view{extension})
+         != colladaExtensions.end();
 }
 
 bool isColladaResource(

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -1593,11 +1593,11 @@ bool isColladaResource(
   buffer.resize(read);
   resource->seek(0, common::Resource::SEEKTYPE_SET);
 
-  const auto upper = buffer.find("COLLADA");
-  const auto lower = buffer.find("collada");
-  const auto mixed = buffer.find("Collada");
-  return upper != std::string::npos || lower != std::string::npos
-         || mixed != std::string::npos;
+  constexpr auto colladaMarkers
+      = std::to_array<std::string_view>({"COLLADA", "Collada", "collada"});
+  return std::ranges::any_of(colladaMarkers, [&](std::string_view marker) {
+    return buffer.find(marker) != std::string::npos;
+  });
 }
 
 } // namespace

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -49,6 +49,7 @@
 #include <assimp/postprocess.h>
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <iomanip>
 #include <iterator>
@@ -1386,18 +1387,18 @@ void MeshShape::extractMaterialsFromScene(
 
     // Extract texture paths for all texture types
     // Check common texture types and store them
-    const aiTextureType textureTypes[]
-        = {aiTextureType_DIFFUSE,
-           aiTextureType_SPECULAR,
-           aiTextureType_NORMALS,
-           aiTextureType_AMBIENT,
-           aiTextureType_EMISSIVE,
-           aiTextureType_HEIGHT,
-           aiTextureType_SHININESS,
-           aiTextureType_OPACITY,
-           aiTextureType_DISPLACEMENT,
-           aiTextureType_LIGHTMAP,
-           aiTextureType_REFLECTION};
+    constexpr auto textureTypes = std::to_array<aiTextureType>(
+        {aiTextureType_DIFFUSE,
+         aiTextureType_SPECULAR,
+         aiTextureType_NORMALS,
+         aiTextureType_AMBIENT,
+         aiTextureType_EMISSIVE,
+         aiTextureType_HEIGHT,
+         aiTextureType_SHININESS,
+         aiTextureType_OPACITY,
+         aiTextureType_DISPLACEMENT,
+         aiTextureType_LIGHTMAP,
+         aiTextureType_REFLECTION});
 
     for (const auto& type : textureTypes) {
       const auto count = aiMat->GetTextureCount(type);

--- a/dart/math/geometry.cpp
+++ b/dart/math/geometry.cpp
@@ -39,6 +39,7 @@
 #include <dart/simd/simd.hpp>
 
 #include <algorithm>
+#include <array>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -1237,8 +1238,8 @@ Eigen::Matrix3d eulerZYZToMatrix(const Eigen::Vector3d& _angle)
 Eigen::Isometry3d expMap(const Eigen::Vector6d& _S)
 {
   Eigen::Isometry3d ret = Eigen::Isometry3d::Identity();
-  double s2[] = {_S[0] * _S[0], _S[1] * _S[1], _S[2] * _S[2]};
-  double s3[] = {_S[0] * _S[1], _S[1] * _S[2], _S[2] * _S[0]};
+  const auto s2 = std::to_array({_S[0] * _S[0], _S[1] * _S[1], _S[2] * _S[2]});
+  const auto s3 = std::to_array({_S[0] * _S[1], _S[1] * _S[2], _S[2] * _S[0]});
   double theta = sqrt(s2[0] + s2[1] + s2[2]);
   double cos_t = cos(theta), alpha, beta, gamma;
 
@@ -1281,8 +1282,8 @@ Eigen::Isometry3d expMap(const Eigen::Vector6d& _S)
 Eigen::Isometry3d expAngular(const Eigen::Vector3d& _s)
 {
   Eigen::Isometry3d ret = Eigen::Isometry3d::Identity();
-  double s2[] = {_s[0] * _s[0], _s[1] * _s[1], _s[2] * _s[2]};
-  double s3[] = {_s[0] * _s[1], _s[1] * _s[2], _s[2] * _s[0]};
+  const auto s2 = std::to_array({_s[0] * _s[0], _s[1] * _s[1], _s[2] * _s[2]});
+  const auto s3 = std::to_array({_s[0] * _s[1], _s[1] * _s[2], _s[2] * _s[0]});
   double theta = sqrt(s2[0] + s2[1] + s2[2]);
   double cos_t = cos(theta);
   double alpha = 0.0;

--- a/dart/utils/mesh_loader.hpp
+++ b/dart/utils/mesh_loader.hpp
@@ -50,6 +50,7 @@
 #include <assimp/scene.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -264,7 +265,10 @@ typename MeshLoader<S>::aiScenePtr MeshLoader<S>::loadScene(
     std::ranges::transform(extension, extension.begin(), [](unsigned char c) {
       return static_cast<char>(std::tolower(c));
     });
-    return extension == ".dae" || extension == ".zae";
+    constexpr auto colladaExtensions
+        = std::to_array<std::string_view>({".dae", ".zae"});
+    return std::ranges::find(colladaExtensions, std::string_view{extension})
+           != colladaExtensions.end();
   };
 
   auto isColladaResource = [&](std::string_view uri) -> bool {

--- a/dart/utils/mesh_loader.hpp
+++ b/dart/utils/mesh_loader.hpp
@@ -300,11 +300,11 @@ typename MeshLoader<S>::aiScenePtr MeshLoader<S>::loadScene(
     buffer.resize(read);
     resource->seek(0, common::Resource::SEEKTYPE_SET);
 
-    const auto upper = buffer.find("COLLADA");
-    const auto lower = buffer.find("collada");
-    const auto mixed = buffer.find("Collada");
-    return upper != std::string::npos || lower != std::string::npos
-           || mixed != std::string::npos;
+    constexpr auto colladaMarkers
+        = std::to_array<std::string_view>({"COLLADA", "Collada", "collada"});
+    return std::ranges::any_of(colladaMarkers, [&](std::string_view marker) {
+      return buffer.find(marker) != std::string::npos;
+    });
   };
 
   const std::string filepathString(filepath);

--- a/dart/utils/skel_parser.cpp
+++ b/dart/utils/skel_parser.cpp
@@ -1068,8 +1068,7 @@ dynamics::SkeletonPtr readSkeleton(
     SkelBodyNode newBodyNode = readSoftBodyNode(
         xmlBodies.get(), skeletonFrame, _baseUri, _retriever);
 
-    BodyMap::const_iterator it = bodyNodes.find(newBodyNode.properties->mName);
-    if (it != bodyNodes.end()) {
+    if (bodyNodes.contains(newBodyNode.properties->mName)) {
       DART_ERROR(
           "[readSkeleton] Skeleton named [{}] has multiple BodyNodes with the "
           "name [{}], but BodyNode names must be unique! We will discard all "

--- a/dart/utils/urdf/urdf_parser.cpp
+++ b/dart/utils/urdf/urdf_parser.cpp
@@ -56,6 +56,7 @@
 #include <tinyxml2.h>
 
 #include <algorithm>
+#include <array>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -421,8 +422,17 @@ std::vector<UrdfParser::TransmissionInfo> UrdfParser::parseTransmissions(
     const std::string type
         = typeElement && typeElement->GetText() ? typeElement->GetText() : "";
 
-    if (!type.empty() && type.find("SimpleTransmission") == std::string::npos
-        && type.find("simple_transmission") == std::string::npos) {
+    constexpr auto supportedTransmissionTypeNames
+        = std::to_array<std::string_view>(
+            {"SimpleTransmission", "simple_transmission"});
+    const bool supportedTransmissionType
+        = type.empty()
+          || std::ranges::any_of(
+              supportedTransmissionTypeNames,
+              [&](std::string_view supportedName) {
+                return type.find(supportedName) != std::string::npos;
+              });
+    if (!supportedTransmissionType) {
       DART_WARN(
           "[UrdfParser] Transmission [{}] has unsupported type [{}]; skipping.",
           tx->Attribute("name") ? tx->Attribute("name") : "",

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -44,6 +44,7 @@
 
 #include <CLI/CLI.hpp>
 
+#include <array>
 #include <span>
 
 #include <cmath>
@@ -407,14 +408,14 @@ public:
         if (pcShow) {
           auto pointCloudShape = mNode->getPointCloudShape();
 
-          const char* colorModeItems[]
-              = {"Use shape color", "Bind overall", "Bind per point"};
+          const auto colorModeItems = std::to_array<const char*>(
+              {"Use shape color", "Bind overall", "Bind per point"});
           int colorMode = pointCloudShape->getColorMode();
           if (ImGui::Combo(
                   "Color Mode",
                   &colorMode,
-                  colorModeItems,
-                  IM_ARRAYSIZE(colorModeItems))) {
+                  colorModeItems.data(),
+                  static_cast<int>(colorModeItems.size()))) {
             if (colorMode == 0) {
               pointCloudShape->setColorMode(
                   dynamics::PointCloudShape::USE_SHAPE_COLOR);
@@ -443,14 +444,14 @@ public:
             }
           }
 
-          const char* pointShapeTypeItems[]
-              = {"Box", "Billboard Square", "Billboard Circle", "Point"};
+          const auto pointShapeTypeItems = std::to_array<const char*>(
+              {"Box", "Billboard Square", "Billboard Circle", "Point"});
           int pointShapeType = pointCloudShape->getPointShapeType();
           if (ImGui::Combo(
                   "Point Shape Type",
                   &pointShapeType,
-                  pointShapeTypeItems,
-                  IM_ARRAYSIZE(pointShapeTypeItems))) {
+                  pointShapeTypeItems.data(),
+                  static_cast<int>(pointShapeTypeItems.size()))) {
             if (pointShapeType == 0) {
               pointCloudShape->setPointShapeType(
                   dynamics::PointCloudShape::BOX);

--- a/tests/integration/collision/test_collision.cpp
+++ b/tests/integration/collision/test_collision.cpp
@@ -39,6 +39,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <iostream>
 #include <limits>
 #if DART_HAVE_ODE
@@ -1908,12 +1909,12 @@ TEST_F(Collision, CollisionOfPrescribedJointsRejectsInvalidTimeStep)
   const double originalTimeStep = world->getTimeStep();
   ASSERT_GT(originalTimeStep, 0.0);
 
-  const double invalidValues[]
-      = {std::numeric_limits<double>::quiet_NaN(),
-         std::numeric_limits<double>::infinity(),
-         -std::numeric_limits<double>::infinity(),
-         0.0,
-         -1.0};
+  const auto invalidValues = std::to_array(
+      {std::numeric_limits<double>::quiet_NaN(),
+       std::numeric_limits<double>::infinity(),
+       -std::numeric_limits<double>::infinity(),
+       0.0,
+       -1.0});
 
   for (double invalid : invalidValues) {
     world->setTimeStep(invalid);

--- a/tests/integration/collision/test_collision_accuracy.cpp
+++ b/tests/integration/collision/test_collision_accuracy.cpp
@@ -47,6 +47,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 using namespace dart::test;
 using dart::simulation::CollisionDetectorType;
 
@@ -86,17 +88,19 @@ TEST(Issue1184, Accuracy)
   };
 
 #if !defined(NDEBUG)
-  const auto groundInfoFunctions = {makePlaneGround};
-  const auto objectShapeFunctions = {makeSphereObject};
-  const auto halfsizes = {10.0};
-  const auto fallingModes = {true};
+  const auto groundInfoFunctions = std::to_array({makePlaneGround});
+  const auto objectShapeFunctions = std::to_array({makeSphereObject});
+  const auto halfsizes = std::to_array({10.0});
+  const auto fallingModes = std::to_array({true});
   const double dropHeight = 0.1;
   const double relativeTolerance = 1e-3; // 0.1% relative error
 #else
-  const auto groundInfoFunctions = {makePlaneGround, makeBoxGround};
-  const auto objectShapeFunctions = {makeBoxObject, makeSphereObject};
-  const auto halfsizes = {0.25, 1.0, 5.0, 10.0, 20.0};
-  const auto fallingModes = {true, false};
+  const auto groundInfoFunctions
+      = std::to_array({makePlaneGround, makeBoxGround});
+  const auto objectShapeFunctions
+      = std::to_array({makeBoxObject, makeSphereObject});
+  const auto halfsizes = std::to_array({0.25, 1.0, 5.0, 10.0, 20.0});
+  const auto fallingModes = std::to_array({true, false});
   const double dropHeight = 1.0;
   const double relativeTolerance = 1e-3; // 0.1% relative error
 #endif

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix.cpp
@@ -49,6 +49,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -149,8 +150,9 @@ bool isPlane(ShapeKind kind)
 
 bool isEdgeVertexKind(ShapeKind kind)
 {
-  return kind == ShapeKind::Box || kind == ShapeKind::Cylinder
-         || kind == ShapeKind::Cone;
+  constexpr auto kinds
+      = std::to_array({ShapeKind::Box, ShapeKind::Cylinder, ShapeKind::Cone});
+  return std::ranges::find(kinds, kind) != kinds.end();
 }
 
 dart::dynamics::ShapePtr makeShape(ShapeKind kind)

--- a/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
+++ b/tests/integration/collision/test_fcl_primitive_contact_matrix_fcl.cpp
@@ -38,6 +38,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -138,8 +139,9 @@ bool isPlane(ShapeKind kind)
 
 bool isEdgeVertexKind(ShapeKind kind)
 {
-  return kind == ShapeKind::Box || kind == ShapeKind::Cylinder
-         || kind == ShapeKind::Cone;
+  constexpr auto kinds
+      = std::to_array({ShapeKind::Box, ShapeKind::Cylinder, ShapeKind::Cone});
+  return std::ranges::find(kinds, kind) != kinds.end();
 }
 
 std::shared_ptr<fcl::CollisionGeometry<double>> makeGeometry(ShapeKind kind)

--- a/tests/integration/io/test_sdf_parser.cpp
+++ b/tests/integration/io/test_sdf_parser.cpp
@@ -57,6 +57,7 @@
 #include <sdf/sdf.hh>
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -64,6 +65,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include <cctype>
 #include <cstring>
@@ -906,9 +908,12 @@ TEST(SdfParser, WarnsOnTinyMassAndDefaultsInertia)
   const auto logs = capture.contents();
   const bool warningsCaptured = !logs.empty();
   if (warningsCaptured) {
-    const bool hasSmallMassWarning
-        = logs.find("very small mass") != std::string::npos
-          || logs.find("non-positive mass") != std::string::npos;
+    constexpr auto massWarningSnippets = std::to_array<std::string_view>(
+        {"very small mass", "non-positive mass"});
+    const bool hasSmallMassWarning = std::ranges::any_of(
+        massWarningSnippets, [&](std::string_view snippet) {
+          return logs.find(snippet) != std::string::npos;
+        });
     EXPECT_TRUE(hasSmallMassWarning)
         << "Expected warning about tiny mass clamping in logs: " << logs;
     std::string logsLower = logs;
@@ -2789,8 +2794,11 @@ f 1 2 3
 
   const auto logs = capture.contents();
   // Warning text for malformed <pose> varies by libsdformat version/platform
-  if (logs.find("must have 6 values") != std::string::npos
-      || logs.find("expected 3 values") != std::string::npos) {
+  constexpr auto poseWarningSnippets = std::to_array<std::string_view>(
+      {"must have 6 values", "expected 3 values"});
+  if (std::ranges::any_of(poseWarningSnippets, [&](std::string_view snippet) {
+        return logs.find(snippet) != std::string::npos;
+      })) {
     SUCCEED();
   }
 }

--- a/tests/unit/common/test_frame_allocator.cpp
+++ b/tests/unit/common/test_frame_allocator.cpp
@@ -38,6 +38,8 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
+#include <array>
+
 #include <cstdint>
 
 using namespace dart::common;
@@ -60,7 +62,7 @@ TEST_F(FrameAllocatorTest, BasicAllocate)
 {
   FrameAllocator allocator;
   size_t previousUsed = 0;
-  const size_t sizes[] = {8, 64, 256, 1024};
+  const auto sizes = std::to_array<size_t>({8, 64, 256, 1024});
   for (size_t size : sizes) {
     void* ptr = allocator.allocate(size);
     EXPECT_NE(ptr, nullptr);
@@ -73,7 +75,7 @@ TEST_F(FrameAllocatorTest, BasicAllocate)
 TEST_F(FrameAllocatorTest, Alignment)
 {
   FrameAllocator allocator;
-  const size_t alignments[] = {16, 32, 64};
+  const auto alignments = std::to_array<size_t>({16, 32, 64});
   for (size_t alignment : alignments) {
     void* ptr = allocator.allocateAligned(32, alignment);
     EXPECT_NE(ptr, nullptr);

--- a/tests/unit/dynamics/test_skeleton_accessors.cpp
+++ b/tests/unit/dynamics/test_skeleton_accessors.cpp
@@ -1484,8 +1484,7 @@ TEST(JointAccessors, CopyPropertiesAndWrenchQueries)
   (void)extendedProps;
   (void)movedProps;
 
-  std::array<Joint::ActuatorType, 3> types
-      = {Joint::FORCE, Joint::MIMIC, Joint::FORCE};
+  const auto types = std::to_array({Joint::FORCE, Joint::MIMIC, Joint::FORCE});
   auto skeletonC = Skeleton::create("joint_actuator_types");
   auto pairC = skeletonC->createJointAndBodyNodePair<BallJoint>();
   pairC.first->setActuatorTypes(types);

--- a/tests/unit/math/test_convhull.cpp
+++ b/tests/unit/math/test_convhull.cpp
@@ -34,6 +34,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <concepts>
 #include <iterator>
 #include <set>
@@ -48,18 +49,23 @@ using dart::math::detail::convexHull3dBuild;
 //==============================================================================
 TEST(ConvhullInternal, SortFloatAndInt)
 {
-  float values[] = {3.0f, 1.0f, 2.0f};
+  auto values = std::to_array<float>({3.0f, 1.0f, 2.0f});
   float* outValues = nullptr;
-  int indices[] = {0, 0, 0};
+  auto indices = std::to_array<int>({0, 0, 0});
   dart::math::detail::convhull_internal::sortFloat(
-      values, outValues, indices, 3, true);
+      values.data(),
+      outValues,
+      indices.data(),
+      static_cast<int>(values.size()),
+      true);
 
   EXPECT_FLOAT_EQ(values[0], 3.0f);
   EXPECT_FLOAT_EQ(values[1], 2.0f);
   EXPECT_FLOAT_EQ(values[2], 1.0f);
 
-  int ints[] = {3, 1, 2};
-  dart::math::detail::convhull_internal::sortInt(ints, 3);
+  auto ints = std::to_array<int>({3, 1, 2});
+  dart::math::detail::convhull_internal::sortInt(
+      ints.data(), static_cast<int>(ints.size()));
 
   EXPECT_EQ(ints[0], 1);
   EXPECT_EQ(ints[1], 2);

--- a/tests/unit/simd/test_eigen_interop.cpp
+++ b/tests/unit/simd/test_eigen_interop.cpp
@@ -37,6 +37,8 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
+#include <array>
+
 namespace ds = dart::simd;
 
 class EigenInteropTest : public ::testing::Test
@@ -180,11 +182,11 @@ TEST_F(EigenInteropTest, RoundTrip3Padded)
 
 TEST_F(EigenInteropTest, EigenSoA3Construction)
 {
-  std::array<Eigen::Vector3d, 4> aos
-      = {Eigen::Vector3d(1, 2, 3),
-         Eigen::Vector3d(4, 5, 6),
-         Eigen::Vector3d(7, 8, 9),
-         Eigen::Vector3d(10, 11, 12)};
+  const auto aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 2, 3),
+       Eigen::Vector3d(4, 5, 6),
+       Eigen::Vector3d(7, 8, 9),
+       Eigen::Vector3d(10, 11, 12)});
 
   ds::EigenSoA3d4 soa(aos);
 
@@ -206,11 +208,11 @@ TEST_F(EigenInteropTest, EigenSoA3Construction)
 
 TEST_F(EigenInteropTest, EigenSoA3ToAoS)
 {
-  std::array<Eigen::Vector3d, 4> original
-      = {Eigen::Vector3d(1, 2, 3),
-         Eigen::Vector3d(4, 5, 6),
-         Eigen::Vector3d(7, 8, 9),
-         Eigen::Vector3d(10, 11, 12)};
+  const auto original = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 2, 3),
+       Eigen::Vector3d(4, 5, 6),
+       Eigen::Vector3d(7, 8, 9),
+       Eigen::Vector3d(10, 11, 12)});
 
   ds::EigenSoA3d4 soa(original);
   auto result = soa.toAos();
@@ -239,17 +241,17 @@ TEST_F(EigenInteropTest, EigenSoA3GetSet)
 
 TEST_F(EigenInteropTest, Dot3)
 {
-  std::array<Eigen::Vector3d, 4> a_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto a_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
-  std::array<Eigen::Vector3d, 4> b_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto b_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
   ds::EigenSoA3d4 a(a_aos);
   ds::EigenSoA3d4 b(b_aos);
@@ -264,17 +266,17 @@ TEST_F(EigenInteropTest, Dot3)
 
 TEST_F(EigenInteropTest, Cross3)
 {
-  std::array<Eigen::Vector3d, 4> a_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 2, 3)};
+  const auto a_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 2, 3)});
 
-  std::array<Eigen::Vector3d, 4> b_aos
-      = {Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(4, 5, 6)};
+  const auto b_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(4, 5, 6)});
 
   ds::EigenSoA3d4 a(a_aos);
   ds::EigenSoA3d4 b(b_aos);
@@ -301,11 +303,11 @@ TEST_F(EigenInteropTest, Cross3)
 
 TEST_F(EigenInteropTest, TransposeAoSToSoA)
 {
-  std::array<Eigen::Vector3f, 4> aos
-      = {Eigen::Vector3f(1, 2, 3),
-         Eigen::Vector3f(4, 5, 6),
-         Eigen::Vector3f(7, 8, 9),
-         Eigen::Vector3f(10, 11, 12)};
+  const auto aos = std::to_array<Eigen::Vector3f>(
+      {Eigen::Vector3f(1, 2, 3),
+       Eigen::Vector3f(4, 5, 6),
+       Eigen::Vector3f(7, 8, 9),
+       Eigen::Vector3f(10, 11, 12)});
 
   auto soa = ds::transposeAosToSoa(aos);
 
@@ -334,11 +336,11 @@ TEST_F(EigenInteropTest, TransposeSoAToAoS)
 
 TEST_F(EigenInteropTest, EigenSoA4Construction)
 {
-  std::array<Eigen::Vector4d, 4> aos
-      = {Eigen::Vector4d(1, 2, 3, 4),
-         Eigen::Vector4d(5, 6, 7, 8),
-         Eigen::Vector4d(9, 10, 11, 12),
-         Eigen::Vector4d(13, 14, 15, 16)};
+  const auto aos = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 2, 3, 4),
+       Eigen::Vector4d(5, 6, 7, 8),
+       Eigen::Vector4d(9, 10, 11, 12),
+       Eigen::Vector4d(13, 14, 15, 16)});
 
   ds::EigenSoA4d4 soa(aos);
 
@@ -365,11 +367,11 @@ TEST_F(EigenInteropTest, EigenSoA4Construction)
 
 TEST_F(EigenInteropTest, EigenSoA4ToAoS)
 {
-  std::array<Eigen::Vector4d, 4> original
-      = {Eigen::Vector4d(1, 2, 3, 4),
-         Eigen::Vector4d(5, 6, 7, 8),
-         Eigen::Vector4d(9, 10, 11, 12),
-         Eigen::Vector4d(13, 14, 15, 16)};
+  const auto original = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 2, 3, 4),
+       Eigen::Vector4d(5, 6, 7, 8),
+       Eigen::Vector4d(9, 10, 11, 12),
+       Eigen::Vector4d(13, 14, 15, 16)});
 
   ds::EigenSoA4d4 soa(original);
   auto result = soa.toAos();
@@ -401,17 +403,17 @@ TEST_F(EigenInteropTest, EigenSoA4GetSet)
 
 TEST_F(EigenInteropTest, Dot4)
 {
-  std::array<Eigen::Vector4d, 4> a_aos
-      = {Eigen::Vector4d(1, 0, 0, 0),
-         Eigen::Vector4d(0, 1, 0, 0),
-         Eigen::Vector4d(0, 0, 1, 0),
-         Eigen::Vector4d(1, 1, 1, 1)};
+  const auto a_aos = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 0, 0, 0),
+       Eigen::Vector4d(0, 1, 0, 0),
+       Eigen::Vector4d(0, 0, 1, 0),
+       Eigen::Vector4d(1, 1, 1, 1)});
 
-  std::array<Eigen::Vector4d, 4> b_aos
-      = {Eigen::Vector4d(1, 0, 0, 0),
-         Eigen::Vector4d(0, 1, 0, 0),
-         Eigen::Vector4d(0, 0, 1, 0),
-         Eigen::Vector4d(1, 1, 1, 1)};
+  const auto b_aos = std::to_array<Eigen::Vector4d>(
+      {Eigen::Vector4d(1, 0, 0, 0),
+       Eigen::Vector4d(0, 1, 0, 0),
+       Eigen::Vector4d(0, 0, 1, 0),
+       Eigen::Vector4d(1, 1, 1, 1)});
 
   ds::EigenSoA4d4 a(a_aos);
   ds::EigenSoA4d4 b(b_aos);
@@ -426,11 +428,11 @@ TEST_F(EigenInteropTest, Dot4)
 
 TEST_F(EigenInteropTest, EigenSoA4TransposeAoSToSoA)
 {
-  std::array<Eigen::Vector4f, 4> aos
-      = {Eigen::Vector4f(1, 2, 3, 4),
-         Eigen::Vector4f(5, 6, 7, 8),
-         Eigen::Vector4f(9, 10, 11, 12),
-         Eigen::Vector4f(13, 14, 15, 16)};
+  const auto aos = std::to_array<Eigen::Vector4f>(
+      {Eigen::Vector4f(1, 2, 3, 4),
+       Eigen::Vector4f(5, 6, 7, 8),
+       Eigen::Vector4f(9, 10, 11, 12),
+       Eigen::Vector4f(13, 14, 15, 16)});
 
   auto soa = ds::transposeAosToSoa(aos);
 
@@ -463,11 +465,11 @@ TEST_F(EigenInteropTest, EigenSoA4TransposeSoAToAoS)
 
 TEST_F(EigenInteropTest, TransformPointsBatchIdentity)
 {
-  std::array<Eigen::Vector3d, 4> points_aos
-      = {Eigen::Vector3d(1, 2, 3),
-         Eigen::Vector3d(4, 5, 6),
-         Eigen::Vector3d(7, 8, 9),
-         Eigen::Vector3d(10, 11, 12)};
+  const auto points_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 2, 3),
+       Eigen::Vector3d(4, 5, 6),
+       Eigen::Vector3d(7, 8, 9),
+       Eigen::Vector3d(10, 11, 12)});
 
   ds::EigenSoA3d4 points(points_aos);
   auto identity = ds::Matrix4x4d::identity();
@@ -484,11 +486,11 @@ TEST_F(EigenInteropTest, TransformPointsBatchIdentity)
 
 TEST_F(EigenInteropTest, TransformPointsBatchTranslation)
 {
-  std::array<Eigen::Vector3d, 4> points_aos
-      = {Eigen::Vector3d(0, 0, 0),
-         Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1)};
+  const auto points_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(0, 0, 0),
+       Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1)});
 
   ds::EigenSoA3d4 points(points_aos);
 
@@ -512,11 +514,11 @@ TEST_F(EigenInteropTest, TransformPointsBatchTranslation)
 
 TEST_F(EigenInteropTest, TransformVectorsBatchIdentity)
 {
-  std::array<Eigen::Vector3d, 4> vectors_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto vectors_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
   ds::EigenSoA3d4 vectors(vectors_aos);
   auto identity = ds::Matrix4x4d::identity();
@@ -533,11 +535,11 @@ TEST_F(EigenInteropTest, TransformVectorsBatchIdentity)
 
 TEST_F(EigenInteropTest, TransformVectorsIgnoresTranslation)
 {
-  std::array<Eigen::Vector3d, 4> vectors_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(0, 0, 1),
-         Eigen::Vector3d(1, 1, 1)};
+  const auto vectors_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(0, 0, 1),
+       Eigen::Vector3d(1, 1, 1)});
 
   ds::EigenSoA3d4 vectors(vectors_aos);
 
@@ -559,11 +561,11 @@ TEST_F(EigenInteropTest, TransformVectorsIgnoresTranslation)
 
 TEST_F(EigenInteropTest, TransformPointsBatchRotation90Z)
 {
-  std::array<Eigen::Vector3d, 4> points_aos
-      = {Eigen::Vector3d(1, 0, 0),
-         Eigen::Vector3d(0, 1, 0),
-         Eigen::Vector3d(1, 1, 0),
-         Eigen::Vector3d(2, 0, 0)};
+  const auto points_aos = std::to_array<Eigen::Vector3d>(
+      {Eigen::Vector3d(1, 0, 0),
+       Eigen::Vector3d(0, 1, 0),
+       Eigen::Vector3d(1, 1, 0),
+       Eigen::Vector3d(2, 0, 0)});
 
   ds::EigenSoA3d4 points(points_aos);
 

--- a/tests/unit/simulation/experimental/common/test_diagnostics_profiling.cpp
+++ b/tests/unit/simulation/experimental/common/test_diagnostics_profiling.cpp
@@ -35,7 +35,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
 #include <chrono>
+#include <string>
+#include <string_view>
 #include <thread>
 
 using namespace dart::simulation::experimental::common;
@@ -44,22 +48,23 @@ TEST(Diagnostics, GetCompilerInfo_ReturnsNonEmpty)
 {
   std::string info = getCompilerInfo();
   EXPECT_FALSE(info.empty());
+  constexpr auto compilerNames
+      = std::to_array<std::string_view>({"GCC", "Clang", "MSVC", "Unknown"});
   EXPECT_TRUE(
-      info.find("GCC") != std::string::npos
-      || info.find("Clang") != std::string::npos
-      || info.find("MSVC") != std::string::npos
-      || info.find("Unknown") != std::string::npos);
+      std::ranges::any_of(compilerNames, [&](std::string_view compilerName) {
+        return info.find(compilerName) != std::string::npos;
+      }));
 }
 
 TEST(Diagnostics, GetCxxABI_ReturnsNonEmpty)
 {
   std::string abi = getCxxABI();
   EXPECT_FALSE(abi.empty());
-  EXPECT_TRUE(
-      abi.find("libstdc++") != std::string::npos
-      || abi.find("libc++") != std::string::npos
-      || abi.find("MSVC") != std::string::npos
-      || abi.find("unknown") != std::string::npos);
+  constexpr auto abiNames = std::to_array<std::string_view>(
+      {"libstdc++", "libc++", "MSVC", "unknown"});
+  EXPECT_TRUE(std::ranges::any_of(abiNames, [&](std::string_view abiName) {
+    return abi.find(abiName) != std::string::npos;
+  }));
 }
 
 TEST(Diagnostics, GetCxxStandard_ReturnsValidValue)


### PR DESCRIPTION
## Summary
- Use `std::to_array` for fixed local arrays in mesh/loading and geometry paths.
- Use `std::to_array` for small ImGui option lists, test value sets, SIMD interop datasets, and test parameter ranges.
- Use fixed membership arrays for Collada extension/content checks, edge/vertex shape-kind checks, URDF transmission aliases, and diagnostic/log warning snippets.
- Use `BodyMap::contains` for the SKEL duplicate-name check.
- Rebase onto current `main` so the branch satisfies the up-to-date merge requirement.

## Motivation / Problem
- Several fixed-size local arrays relied on C array decay, initializer-list type deduction, or macro/manual size calculations.
- C++20 fixed arrays make bounds and data access explicit while preserving existing order and values.
- Named membership arrays avoid duplicating short `||` chains when the code checks fixed allowed-value sets.
- `std::to_array` removes duplicated element counts from fixed test datasets whose initializer already defines the size.

## Changes / Key Changes
- Convert ODE cylinder mesh, mesh texture type, and geometry helper arrays to fixed arrays.
- Convert point-cloud ImGui option arrays and collision/frame-allocator test arrays to fixed arrays.
- Convert convex-hull test buffers and collision accuracy parameter ranges to fixed arrays.
- Use fixed extension and content-marker arrays in Collada loader checks.
- Use fixed shape-kind arrays in FCL primitive contact matrix edge/vertex checks.
- Use fixed string-view sets for URDF transmission alias checks and diagnostic/log-warning tests.
- Convert SIMD interop and joint actuator-type fixed test data to `std::to_array`.
- Replace the SKEL parser duplicate body-name lookup with `contains`.

## Testing
- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)
- Rebase follow-up: `git diff --check origin/main...HEAD`
- Rebase follow-up: `pixi run lint`
- Rebase follow-up: `pixi run build`
- Rebase follow-up: `cmake --build build/default/cpp/Release --target INTEGRATION_collision_Collision INTEGRATION_collision_CollisionAccuracy INTEGRATION_collision_FclPrimitiveContactMatrix INTEGRATION_collision_FclPrimitiveContactMatrixFcl INTEGRATION_io_SdfParser INTEGRATION_io_UrdfParser INTEGRATION_io_SkelParser UNIT_collision_OdeCylinderMesh UNIT_dynamics_MeshShape UNIT_common_frame_allocator UNIT_math_geometry UNIT_math_Convhull test_sdf_helpersNone test_diagnostics_profiling`
- Rebase follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(INTEGRATION_collision_Collision|INTEGRATION_collision_CollisionAccuracy|INTEGRATION_collision_FclPrimitiveContactMatrix|INTEGRATION_collision_FclPrimitiveContactMatrixFcl|INTEGRATION_io_SdfParser|INTEGRATION_io_UrdfParser|INTEGRATION_io_SkelParser|UNIT_collision_OdeCylinderMesh|UNIT_dynamics_MeshShape|UNIT_common_frame_allocator|UNIT_math_geometry|UNIT_math_Convhull|test_sdf_helpersNone|test_diagnostics_profiling)$'`
- SIMD follow-up: `git diff --check`
- SIMD follow-up: `pixi run lint`
- SIMD follow-up: `pixi run build`
- SIMD follow-up: `cmake --build build/default/cpp/Release --target UNIT_simd_simd_eigen_interop UNIT_dynamics_SkeletonAccessors`
- SIMD follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_simd_simd_eigen_interop|UNIT_dynamics_SkeletonAccessors)$'`

## Breaking Changes
- [x] None

## Related Issues / PRs (backports)
- None

---
#### Checklist
- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md not required (behavior-preserving refactor)
- [x] Existing unit/integration tests cover this refactor
- [x] Documentation not required (no user-facing API change)
- [x] Python bindings not applicable
