### PR TITLE
Use key and value views for map loops

### DIFF
--- a/dart/collision/collision_group.cpp
+++ b/dart/collision/collision_group.cpp
@@ -317,8 +317,8 @@ void CollisionGroup::removeDeletedShapeFrames()
           static_cast<const dynamics::MetaSkeleton*>(source));
       if (skelSearch != mSkeletonSources.end()) {
         skelSearch->second.mObjects.erase(shapeFrame);
-        for (auto& child : skelSearch->second.mChildren) {
-          child.second.mFrames.erase(shapeFrame);
+        for (auto& child : skelSearch->second.mChildren | std::views::values) {
+          child.mFrames.erase(shapeFrame);
         }
       }
 

--- a/dart/collision/collision_group.cpp
+++ b/dart/collision/collision_group.cpp
@@ -647,10 +647,10 @@ bool CollisionGroup::updateBodyNodeSource(BodyNodeSources::value_type& entry)
 
   // Remove from this group and ShapeFrames that no longer belong to the
   // BodyNode
-  for (const auto& unusedFrame : unusedFrames) {
+  for (const auto* unusedFrame : unusedFrames | std::views::keys) {
     updateNeeded = true;
-    removeShapeFrameInternal(unusedFrame.first, bn.get());
-    source.mObjects.erase(unusedFrame.first);
+    removeShapeFrameInternal(unusedFrame, bn.get());
+    source.mObjects.erase(unusedFrame);
   }
 
   return updateNeeded;

--- a/dart/collision/collision_group.cpp
+++ b/dart/collision/collision_group.cpp
@@ -39,6 +39,7 @@
 #include "dart/dynamics/skeleton.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 #include <cassert>
 #include <cstdint>
@@ -490,8 +491,8 @@ bool CollisionGroup::updateSkeletonSource(SkeletonSources::value_type& entry)
   if (!meta) {
     // This skeleton no longer exists, so we should remove all its contents from
     // the CollisionGroup.
-    for (const auto& object : source.mObjects) {
-      removeShapeFrameInternal(object.second->mFrame, entry.first);
+    for (const auto& object : source.mObjects | std::views::values) {
+      removeShapeFrameInternal(object->mFrame, entry.first);
     }
 
     return true;

--- a/dart/collision/detail/collision_group.hpp
+++ b/dart/collision/detail/collision_group.hpp
@@ -40,6 +40,8 @@
 #include <dart/dynamics/body_node.hpp>
 #include <dart/dynamics/skeleton.hpp>
 
+#include <ranges>
+
 namespace dart {
 namespace collision {
 
@@ -248,8 +250,8 @@ void CollisionGroup::unsubscribeFrom(
 {
   auto it = mBodyNodeSources.find(bodyNode);
   if (it != mBodyNodeSources.end()) {
-    for (const auto& entry : it->second.mObjects) {
-      removeShapeFrameInternal(entry.first, bodyNode);
+    for (const auto* shapeFrame : it->second.mObjects | std::views::keys) {
+      removeShapeFrameInternal(shapeFrame, bodyNode);
     }
 
     mBodyNodeSources.erase(it);
@@ -265,8 +267,8 @@ void CollisionGroup::unsubscribeFrom(
 {
   auto it = mSkeletonSources.find(skeleton);
   if (it != mSkeletonSources.end()) {
-    for (const auto& entry : it->second.mObjects) {
-      removeShapeFrameInternal(entry.first, skeleton);
+    for (const auto* shapeFrame : it->second.mObjects | std::views::keys) {
+      removeShapeFrameInternal(shapeFrame, skeleton);
     }
 
     mSkeletonSources.erase(it);

--- a/dart/common/composite.cpp
+++ b/dart/common/composite.cpp
@@ -36,6 +36,7 @@
 #include "dart/common/macros.hpp"
 
 #include <iostream>
+#include <ranges>
 
 #include <cassert>
 
@@ -246,8 +247,8 @@ void Composite::matchAspects(const Composite* otherComposite)
     return;
   }
 
-  for (auto& aspect : mAspectMap) {
-    _replaceAspect(aspect.second, nullptr);
+  for (auto& aspect : mAspectMap | std::views::values) {
+    _replaceAspect(aspect, nullptr);
   }
 
   duplicateAspects(otherComposite);

--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -178,7 +178,7 @@ void Profiler::popScope(Profiler::ThreadRecord& record)
 std::uint64_t Profiler::sumInclusiveChildren(const ProfileNode& node)
 {
   std::uint64_t total = 0;
-  for (const auto& [_, child] : node.children) {
+  for (const auto& child : node.children | std::views::values) {
     total += child->inclusiveNs;
   }
   return total;
@@ -274,7 +274,7 @@ std::size_t Profiler::maxLabelWidth(
     const ProfileNode& node, std::size_t minWidth, std::size_t maxWidth)
 {
   std::size_t width = node.label.size();
-  for (const auto& [_, child] : node.children) {
+  for (const auto& child : node.children | std::views::values) {
     width = std::max(width, maxLabelWidth(*child, minWidth, maxWidth));
   }
   return std::clamp<std::size_t>(width, minWidth, maxWidth);
@@ -355,7 +355,7 @@ void Profiler::collectHotspots(
        node.inclusiveNs,
        node.selfNs,
        node.callCount});
-  for (const auto& [_, child] : node.children) {
+  for (const auto& child : node.children | std::views::values) {
     const auto childPath
         = path.empty() ? child->label : (path + " > " + child->label);
     collectHotspots(*child, childPath, threadLabel, out);
@@ -565,7 +565,7 @@ void Profiler::clearNode(ProfileNode& node)
   node.selfNs = 0;
   node.minNs = Profiler::kUnsetDuration;
   node.maxNs = 0;
-  for (auto& [_, child] : node.children) {
+  for (auto& child : node.children | std::views::values) {
     clearNode(*child);
   }
   node.children.clear();

--- a/dart/dynamics/body_node.cpp
+++ b/dart/dynamics/body_node.cpp
@@ -386,8 +386,8 @@ void BodyNode::duplicateNodes(const BodyNode* otherBodyNode)
   }
 
   const NodeMap& otherMap = otherBodyNode->mNodeMap;
-  for (const auto& vec : otherMap) {
-    for (const auto& node : vec.second) {
+  for (const auto& nodes : otherMap | std::views::values) {
+    for (const auto& node : nodes) {
       node->cloneNode(this)->attach();
     }
   }
@@ -415,8 +415,8 @@ void BodyNode::matchNodes(const BodyNode* otherBodyNode)
 std::vector<Node*> BodyNode::getNodes()
 {
   std::vector<Node*> nodes;
-  for (auto& nodeType : mNodeMap) {
-    nodes.insert(nodes.end(), nodeType.second.begin(), nodeType.second.end());
+  for (auto& nodeGroup : mNodeMap | std::views::values) {
+    nodes.insert(nodes.end(), nodeGroup.begin(), nodeGroup.end());
   }
 
   return nodes;
@@ -426,8 +426,8 @@ std::vector<Node*> BodyNode::getNodes()
 std::vector<const Node*> BodyNode::getNodes() const
 {
   std::vector<const Node*> nodes;
-  for (const auto& nodeType : mNodeMap) {
-    nodes.insert(nodes.end(), nodeType.second.begin(), nodeType.second.end());
+  for (const auto& nodeGroup : mNodeMap | std::views::values) {
+    nodes.insert(nodes.end(), nodeGroup.begin(), nodeGroup.end());
   }
 
   return nodes;

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -539,8 +539,8 @@ SkeletonPtr Skeleton::cloneSkeleton(const std::string& cloneName) const
 
   // Clone over the nodes in such a way that their indexing will match up with
   // the original
-  for (const auto& nodeType : mNodeMap) {
-    for (const auto& node : nodeType.second) {
+  for (const auto& nodes : mNodeMap | std::views::values) {
+    for (const auto& node : nodes) {
       const BodyNode* originalBn = node->getBodyNodePtr();
       BodyNode* newBn = skelClone->getBodyNode(originalBn->getName());
       node->cloneNode(newBn)->attach();
@@ -1351,8 +1351,7 @@ bool Skeleton::checkIndexingConsistency() const
     }
 
     const BodyNode::NodeMap& nodeMap = bn->mNodeMap;
-    for (const auto& nodeType : nodeMap) {
-      const std::vector<Node*>& nodes = nodeType.second;
+    for (const auto& nodes : nodeMap | std::views::values) {
       for (std::size_t k = 0; k < nodes.size(); ++k) {
         const Node* node = nodes[k];
         if (node->getBodyNodePtr() != bn) {
@@ -1426,8 +1425,7 @@ bool Skeleton::checkIndexingConsistency() const
   // Check each Node in the Skeleton-scope NodeMap
   {
     const Skeleton::NodeMap& nodeMap = mNodeMap;
-    for (const auto& nodeType : nodeMap) {
-      const std::vector<Node*>& nodes = nodeType.second;
+    for (const auto& nodes : nodeMap | std::views::values) {
       for (std::size_t k = 0; k < nodes.size(); ++k) {
         const Node* node = nodes[k];
         if (node->getSkeleton().get() != this) {
@@ -1528,8 +1526,7 @@ bool Skeleton::checkIndexingConsistency() const
   for (std::size_t i = 0; i < mTreeNodeMaps.size(); ++i) {
     const NodeMap& nodeMap = mTreeNodeMaps[i];
 
-    for (const auto& nodeType : nodeMap) {
-      const std::vector<Node*>& nodes = nodeType.second;
+    for (const auto& nodes : nodeMap | std::views::values) {
       for (std::size_t k = 0; k < nodes.size(); ++k) {
         const Node* node = nodes[k];
         if (node->getBodyNodePtr()->mTreeIndex != i) {
@@ -2353,8 +2350,8 @@ void Skeleton::registerBodyNode(BodyNode* _newBodyNode)
   _newBodyNode->init(getPtr());
 
   BodyNode::NodeMap& nodeMap = _newBodyNode->mNodeMap;
-  for (auto& nodeType : nodeMap) {
-    for (auto& node : nodeType.second) {
+  for (auto& nodes : nodeMap | std::views::values) {
+    for (auto& node : nodes) {
       registerNode(node);
     }
   }
@@ -2523,8 +2520,8 @@ void Skeleton::unregisterBodyNode(BodyNode* _oldBodyNode)
   unregisterJoint(_oldBodyNode->getParentJoint());
 
   BodyNode::NodeMap& nodeMap = _oldBodyNode->mNodeMap;
-  for (auto& nodeType : nodeMap) {
-    for (auto& node : nodeType.second) {
+  for (auto& nodes : nodeMap | std::views::values) {
+    for (auto& node : nodes) {
       unregisterNode(node);
     }
   }

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -2508,8 +2508,7 @@ void Skeleton::destructOldTree(std::size_t tree)
     }
   }
 
-  for (auto& nodeType : mSpecializedTreeNodes) {
-    std::vector<NodeMap::iterator>* nodeRepo = nodeType.second;
+  for (auto* nodeRepo : mSpecializedTreeNodes | std::views::values) {
     nodeRepo->erase(nodeRepo->begin() + tree);
   }
 }

--- a/dart/simulation/experimental/common/profiling.cpp
+++ b/dart/simulation/experimental/common/profiling.cpp
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <ranges>
 #include <unordered_map>
 #include <vector>
 
@@ -84,7 +85,7 @@ void ProfileStats::printSummary()
   // Convert to vector for sorting
   std::vector<Entry> sortedEntries;
   sortedEntries.reserve(entries.size());
-  for (const auto& [_, entry] : entries) {
+  for (const auto& entry : entries | std::views::values) {
     sortedEntries.push_back(entry);
   }
 


### PR DESCRIPTION
## Summary

- Use `std::views::keys` and `std::views::values` where map loops only consume keys or values.
- Cover collision group cleanup, node-map traversal, profiler tree traversal, and experimental profiling summaries.
- Rebased onto current `main` after #2628 merged and resolved the profiler conflict by keeping the already-merged `std::ranges::transform` collection form.

## Motivation / Problem

- Several loops destructured map entries only to ignore either the key or the value.
- Key/value views make the used data explicit and remove placeholder bindings without changing behavior.
- The change stays limited to map traversal sites where the view directly clarifies intent.

## Changes / Key Changes

- Replace unused map-entry destructuring with `std::views::keys` or `std::views::values`.
- Add `<ranges>` includes where the translation unit did not already include it.
- Keep existing ordering, mutation, and erase behavior unchanged.

## Testing

- `git diff --check origin/main...HEAD`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target UNIT_collision_CollisionGroup UNIT_common_profile UNIT_common_profiler UNIT_dynamics_BodyNodePtr UNIT_dynamics_NodePtr UNIT_dynamics_SkeletonClone UNIT_dynamics_SkeletonAccessors UNIT_dynamics_BasicNodeManager test_diagnostics_profiling`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_collision_CollisionGroup|UNIT_common_profile|UNIT_common_profiler|UNIT_dynamics_SkeletonClone|UNIT_dynamics_SkeletonAccessors|UNIT_dynamics_BasicNodeManager|UNIT_dynamics_BodyNodePtr|UNIT_dynamics_NodePtr|test_diagnostics_profiling)$'`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---
#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: behavior-preserving refactor)
- [x] Add unit tests for new functionality (not applicable: no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
