### PR TITLE
Use jthread in threaded tests and benchmarks

### DIFF
--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -69,6 +69,7 @@
 #include <queue>
 #include <thread>
 #include <vector>
+#include <version>
 
 #include <cassert>
 #include <cmath>
@@ -914,7 +915,11 @@ static void BM_ParallelWorlds(benchmark::State& state)
   }
 
   for (auto _ : state) {
+#if defined(__cpp_lib_jthread)
     std::vector<std::jthread> threads;
+#else
+    std::vector<std::thread> threads;
+#endif
     threads.reserve(numThreads);
     for (int t = 0; t < numThreads; ++t) {
       threads.emplace_back([&worlds, t, stepsPerThread]() {
@@ -923,6 +928,11 @@ static void BM_ParallelWorlds(benchmark::State& state)
         }
       });
     }
+#if !defined(__cpp_lib_jthread)
+    for (auto& thread : threads) {
+      thread.join();
+    }
+#endif
   }
   state.SetItemsProcessed(
       static_cast<int64_t>(state.iterations()) * numThreads * stepsPerThread);

--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -914,7 +914,7 @@ static void BM_ParallelWorlds(benchmark::State& state)
   }
 
   for (auto _ : state) {
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     threads.reserve(numThreads);
     for (int t = 0; t < numThreads; ++t) {
       threads.emplace_back([&worlds, t, stepsPerThread]() {
@@ -922,9 +922,6 @@ static void BM_ParallelWorlds(benchmark::State& state)
           worlds[t]->step();
         }
       });
-    }
-    for (auto& thread : threads) {
-      thread.join();
     }
   }
   state.SetItemsProcessed(

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <atomic>
 #include <numeric>
+#include <stop_token>
 #include <thread>
 #include <vector>
 
@@ -411,9 +412,8 @@ TEST(Signal, ConcurrentUsage)
   std::atomic<int> callbackCount{0};
 
   {
-    std::atomic<bool> stopRequested{false};
-    std::thread raiser([&]() {
-      while (!stopRequested.load(std::memory_order_relaxed)) {
+    std::jthread raiser([&](std::stop_token stopToken) {
+      while (!stopToken.stop_requested()) {
         signal.raise();
         raiseCount.fetch_add(1, std::memory_order_relaxed);
       }
@@ -424,7 +424,7 @@ TEST(Signal, ConcurrentUsage)
     }
 
     {
-      std::vector<std::thread> workers;
+      std::vector<std::jthread> workers;
       workers.reserve(kNumThreads);
       for (int t = 0; t < kNumThreads; ++t) {
         workers.emplace_back([&]() {
@@ -437,14 +437,9 @@ TEST(Signal, ConcurrentUsage)
           }
         });
       }
-
-      for (std::thread& worker : workers) {
-        worker.join();
-      }
     }
 
-    stopRequested.store(true, std::memory_order_relaxed);
-    raiser.join();
+    raiser.request_stop();
   }
 
   EXPECT_EQ(signal.getNumConnections(), 0u);

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -39,9 +39,13 @@
 #include <algorithm>
 #include <atomic>
 #include <numeric>
-#include <stop_token>
 #include <thread>
 #include <vector>
+#include <version>
+
+#if defined(__cpp_lib_jthread)
+  #include <stop_token>
+#endif
 
 using namespace std;
 using namespace Eigen;
@@ -412,19 +416,33 @@ TEST(Signal, ConcurrentUsage)
   std::atomic<int> callbackCount{0};
 
   {
+#if defined(__cpp_lib_jthread)
     std::jthread raiser([&](std::stop_token stopToken) {
       while (!stopToken.stop_requested()) {
         signal.raise();
         raiseCount.fetch_add(1, std::memory_order_relaxed);
       }
     });
+#else
+    std::atomic<bool> stopRequested{false};
+    std::thread raiser([&]() {
+      while (!stopRequested.load(std::memory_order_relaxed)) {
+        signal.raise();
+        raiseCount.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+#endif
 
     while (raiseCount.load(std::memory_order_relaxed) == 0) {
       std::this_thread::yield();
     }
 
     {
+#if defined(__cpp_lib_jthread)
       std::vector<std::jthread> workers;
+#else
+      std::vector<std::thread> workers;
+#endif
       workers.reserve(kNumThreads);
       for (int t = 0; t < kNumThreads; ++t) {
         workers.emplace_back([&]() {
@@ -437,9 +455,19 @@ TEST(Signal, ConcurrentUsage)
           }
         });
       }
+#if !defined(__cpp_lib_jthread)
+      for (std::thread& worker : workers) {
+        worker.join();
+      }
+#endif
     }
 
+#if defined(__cpp_lib_jthread)
     raiser.request_stop();
+#else
+    stopRequested.store(true, std::memory_order_relaxed);
+    raiser.join();
+#endif
   }
 
   EXPECT_EQ(signal.getNumConnections(), 0u);

--- a/tests/unit/common/test_profile.cpp
+++ b/tests/unit/common/test_profile.cpp
@@ -41,6 +41,7 @@
   #include <sstream>
   #include <string>
   #include <thread>
+  #include <version>
 
 using dart::common::profile::Profiler;
 using dart::common::profile::ProfileScope;
@@ -86,10 +87,17 @@ TEST_F(ProfileTest, CapturesMultipleThreads)
   }
 
   {
+  #if defined(__cpp_lib_jthread)
     std::jthread worker([] {
+  #else
+    std::thread worker([] {
+  #endif
       ProfileScope workerScope("worker-work", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(3));
     });
+  #if !defined(__cpp_lib_jthread)
+    worker.join();
+  #endif
   }
 
   std::stringstream ss;

--- a/tests/unit/common/test_profile.cpp
+++ b/tests/unit/common/test_profile.cpp
@@ -86,11 +86,10 @@ TEST_F(ProfileTest, CapturesMultipleThreads)
   }
 
   {
-    std::thread worker([] {
+    std::jthread worker([] {
       ProfileScope workerScope("worker-work", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(3));
     });
-    worker.join();
   }
 
   std::stringstream ss;

--- a/tests/unit/common/test_profiler.cpp
+++ b/tests/unit/common/test_profiler.cpp
@@ -285,7 +285,7 @@ TEST(Profiler, SummaryMultipleThreads)
   ScopedEnvVar env("DART_PROFILE_COLOR", "0");
 
   {
-    std::thread worker([]() {
+    std::jthread worker([]() {
       common::profile::ProfileScope scope("WorkerScope", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     });
@@ -298,8 +298,6 @@ TEST(Profiler, SummaryMultipleThreads)
     profiler.markFrame();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     profiler.markFrame();
-
-    worker.join();
   }
 
   std::ostringstream oss;

--- a/tests/unit/common/test_profiler.cpp
+++ b/tests/unit/common/test_profiler.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <version>
 
 #include <cstdlib>
 
@@ -285,7 +286,11 @@ TEST(Profiler, SummaryMultipleThreads)
   ScopedEnvVar env("DART_PROFILE_COLOR", "0");
 
   {
+#if defined(__cpp_lib_jthread)
     std::jthread worker([]() {
+#else
+    std::thread worker([]() {
+#endif
       common::profile::ProfileScope scope("WorkerScope", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     });
@@ -298,6 +303,9 @@ TEST(Profiler, SummaryMultipleThreads)
     profiler.markFrame();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     profiler.markFrame();
+#if !defined(__cpp_lib_jthread)
+    worker.join();
+#endif
   }
 
   std::ostringstream oss;


### PR DESCRIPTION
## Summary

- Replace manual `std::thread` ownership with `std::jthread` in threaded tests and the parallel-worlds benchmark.
- Use `std::stop_token` for the long-running signal raiser thread instead of a separate atomic stop flag.
- Keep thread work and test assertions unchanged while making joins scoped and exception-safe.

## Motivation / Problem

- These tests and benchmarks start finite worker threads and immediately join them manually.
- `std::jthread` is a C++20 fit here because it joins on scope exit, reducing cleanup boilerplate and avoiding leaked joinable threads if a test assertion or exception exits the scope early.
- The signal stress test had a separate stop flag only to terminate the raiser thread; `std::stop_token` expresses that ownership directly.

## Changes / Key Changes

- Convert worker thread containers from `std::vector<std::thread>` to `std::vector<std::jthread>`.
- Convert single worker threads in profiler tests to scoped `std::jthread`.
- Convert the signal test raiser to a `std::jthread` with `std::stop_token`.

## Testing

- `git diff --check`
- `pixi run lint`
- `cmake --build build/default/cpp/Release --target INTEGRATION_utils_signal UNIT_common_profile UNIT_common_profiler bm_dynamics_cache`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(INTEGRATION_utils_signal|UNIT_common_profile|UNIT_common_profiler)$'`
- `./build/default/cpp/Release/bin/bm_dynamics_cache --benchmark_filter='BM_ParallelWorlds/1' --benchmark_min_time=0.01s --benchmark_repetitions=1`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests`
- `pixi run test-unit` (262/262 passed)
- `pixi run build`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: behavior-preserving test/benchmark refactor)
- [x] Add unit tests for new functionality (not applicable: no new functionality)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)