### PR TITLE
Use empty checks in core containers

### DIFF
--- a/dart/dynamics/hierarchical_ik.cpp
+++ b/dart/dynamics/hierarchical_ik.cpp
@@ -423,7 +423,7 @@ void HierarchicalIK::Objective::evalGradient(
     hik->setPositions(_x);
 
     const auto nullspaces = hik->computeNullSpaces();
-    if (nullspaces.size() > 0) {
+    if (!nullspaces.empty()) {
       // Project through the deepest null space
       mGradCache = nullspaces.back() * mGradCache;
     }
@@ -685,7 +685,7 @@ CompositeIK::ConstModuleSet CompositeIK::getModuleSet() const
 //==============================================================================
 void CompositeIK::refreshIKHierarchy()
 {
-  if (mModuleSet.size() == 0) {
+  if (mModuleSet.empty()) {
     mHierarchy.clear();
     return;
   }

--- a/dart/dynamics/line_segment_shape.cpp
+++ b/dart/dynamics/line_segment_shape.cpp
@@ -127,7 +127,7 @@ std::size_t LineSegmentShape::addVertex(
   mVertices.push_back(_v);
 
   if (_parent > mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempting to add a vertex to be a child of vertex #{}, but no "
           "vertices exist yet. No connection will be created for the new "
@@ -152,7 +152,7 @@ std::size_t LineSegmentShape::addVertex(
 void LineSegmentShape::removeVertex(std::size_t _idx)
 {
   if (_idx >= mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempting to remove vertex #{}, but this LineSegmentShape contains "
           "no vertices. No vertex will be removed.",
@@ -175,7 +175,7 @@ void LineSegmentShape::removeVertex(std::size_t _idx)
 void LineSegmentShape::setVertex(std::size_t _idx, const Eigen::Vector3d& _v)
 {
   if (_idx >= mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempting to set vertex #{}, but no vertices exist in this "
           "LineSegmentShape yet.",
@@ -225,7 +225,7 @@ std::span<const Eigen::Vector3d> LineSegmentShape::getVertices() const
 void LineSegmentShape::addConnection(std::size_t _idx1, std::size_t _idx2)
 {
   if (_idx1 >= mVertices.size() || _idx2 >= mVertices.size()) {
-    if (mVertices.size() == 0) {
+    if (mVertices.empty()) {
       DART_WARN(
           "Attempted to create a connection between vertex #{} and vertex #{}, "
           "but no vertices exist for this LineSegmentShape yet. No connection "
@@ -265,7 +265,7 @@ void LineSegmentShape::removeConnection(
 void LineSegmentShape::removeConnection(std::size_t _connectionIdx)
 {
   if (_connectionIdx >= mConnections.size()) {
-    if (mConnections.size() == 0) {
+    if (mConnections.empty()) {
       DART_WARN(
           "Attempting to remove connection #{}, but no connections exist yet. "
           "No connection will be removed.",

--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -47,7 +47,7 @@ std::vector<BodyNode*> Linkage::Criteria::satisfy() const
   std::vector<BodyNode*> bns;
 
   if (nullptr == mStart.mNode.lock()) {
-    if (mTargets.size() == 0) {
+    if (mTargets.empty()) {
       return bns;
     }
 
@@ -258,13 +258,13 @@ void Linkage::Criteria::expandDownstream(
   }
   recorder.push_back(Recording(_start, 0));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
     if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
       stepToNextChild(recorder, _bns, r, mMapOfTerminals, 0);
     } else {
       recorder.pop_back();
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }
@@ -283,7 +283,7 @@ void Linkage::Criteria::expandUpstream(
   }
   recorder.push_back(Recording(_start, -1));
 
-  while (recorder.size() > 0) {
+  while (!recorder.empty()) {
     Recording& r = recorder.back();
 
     if (r.mCount == -1) {
@@ -323,7 +323,7 @@ void Linkage::Criteria::expandUpstream(
       // If we've iterated through all the children of this node, pop it
       recorder.pop_back();
       // Move on to the next child
-      if (recorder.size() > 0) {
+      if (!recorder.empty()) {
         ++recorder.back().mCount;
       }
     }
@@ -353,13 +353,13 @@ void Linkage::Criteria::expandToTarget(
   }
 
   // Remove the start BodyNode if it's supposed to be excluded
-  if (EXCLUDE == _start.mPolicy && newBns.size() > 0
+  if (EXCLUDE == _start.mPolicy && !newBns.empty()
       && newBns.front() == start_bn) {
     newBns.erase(newBns.begin());
   }
 
   // Remove the target BodyNode if it's supposed to be excluded
-  if (EXCLUDE == _target.mPolicy && newBns.size() > 0
+  if (EXCLUDE == _target.mPolicy && !newBns.empty()
       && newBns.back() == target_bn) {
     newBns.pop_back();
   }

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -911,7 +911,7 @@ BodyNode* Skeleton::getRootBodyNode(std::size_t _treeIdx)
     return mTreeCache[_treeIdx].mBodyNodes[0];
   }
 
-  if (mTreeCache.size() == 0) {
+  if (mTreeCache.empty()) {
     DART_THROW_T(
         common::OutOfRangeException,
         "Requested a root BodyNode from Skeleton '{}' with no BodyNodes",
@@ -3668,7 +3668,7 @@ static void computeSupportPolygon(
     ee_indices[i] = originalEE_map[vertex_indices[i]];
   }
 
-  if (polygon.size() > 0) {
+  if (!polygon.empty()) {
     centroid = math::computeCentroidOfHull(polygon);
   } else {
     centroid = Eigen::Vector2d::Constant(std::nan(""));

--- a/dart/dynamics/soft_body_node.cpp
+++ b/dart/dynamics/soft_body_node.cpp
@@ -84,7 +84,7 @@ bool SoftBodyNodeUniqueProperties::connectPointMasses(
     std::size_t i1, std::size_t i2)
 {
   if (i1 >= mPointProps.size() || i2 >= mPointProps.size()) {
-    if (mPointProps.size() == 0) {
+    if (mPointProps.empty()) {
       DART_WARN(
           "Attempting to add a connection between indices {} and {}, but there "
           "are currently no entries in mPointProps!",

--- a/dart/gui/drag_and_drop.cpp
+++ b/dart/gui/drag_and_drop.cpp
@@ -391,7 +391,7 @@ public:
 
       if (BUTTON_RELEASE == event || BUTTON_NOTHING == event) {
         const auto picks = mEventHandler->getMovePicks();
-        if (picks.size() > 0) {
+        if (!picks.empty()) {
           const PickInfo& pick = picks[0];
           if (pick.frame->getParentFrame()
               != mFrame->getTool((InteractiveTool::Type)mTool, mCoordinate)) {
@@ -418,7 +418,7 @@ public:
       }
 
       const auto picks = mEventHandler->getMovePicks();
-      if (picks.size() == 0) {
+      if (picks.empty()) {
         return;
       }
 

--- a/dart/gui/support_polygon_visual.cpp
+++ b/dart/gui/support_polygon_visual.cpp
@@ -277,7 +277,7 @@ void SupportPolygonVisual::refresh()
   if (mDisplayCentroid) {
     Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
 
-    if (poly.size() > 0) {
+    if (!poly.empty()) {
       const Eigen::Vector2d& Cp = (dart::dynamics::INVALID_INDEX == mTreeIndex)
                                       ? skel->getSupportCentroid()
                                       : skel->getSupportCentroid(mTreeIndex);

--- a/dart/math/geometry.cpp
+++ b/dart/math/geometry.cpp
@@ -1631,7 +1631,7 @@ SupportPolygon computeConvexHull(std::span<const Eigen::Vector2d> points)
 //==============================================================================
 Eigen::Vector2d computeCentroidOfHull(const SupportPolygon& _convexHull)
 {
-  if (_convexHull.size() == 0) {
+  if (_convexHull.empty()) {
     Eigen::Vector2d invalid = Eigen::Vector2d::Constant(std::nan(""));
     std::ostringstream invalidStream;
     invalidStream << invalid.transpose();
@@ -1906,7 +1906,7 @@ bool isInsideSupportPolygon(
     const SupportPolygon& _support,
     bool _includeEdge)
 {
-  if (_support.size() == 0) {
+  if (_support.empty()) {
     return false;
   }
 
@@ -2021,7 +2021,7 @@ Eigen::Vector2d computeClosestPointOnSupportPolygon(
     const Eigen::Vector2d& _p,
     const SupportPolygon& _support)
 {
-  if (_support.size() == 0) {
+  if (_support.empty()) {
     _index1 = static_cast<std::size_t>(-1);
     _index2 = _index1;
     return _p;

--- a/dart/math/optimization/problem.cpp
+++ b/dart/math/optimization/problem.cpp
@@ -142,7 +142,7 @@ Eigen::VectorXd& Problem::getSeed(std::size_t _index)
     return mSeeds[_index];
   }
 
-  if (mSeeds.size() == 0) {
+  if (mSeeds.empty()) {
     DART_WARN(
         "Requested seed at index [{}], but there are currently no seeds. "
         "Returning the problem's initial guess instead.",

--- a/dart/utils/xml_helpers.cpp
+++ b/dart/utils/xml_helpers.cpp
@@ -220,7 +220,7 @@ Eigen::Vector6d toVector6d(std::string_view str)
 Eigen::VectorXd toVectorXd(std::string_view str)
 {
   const std::vector<std::string> pieces = common::split(common::trim(str));
-  DART_ASSERT(pieces.size() > 0);
+  DART_ASSERT(!pieces.empty());
 
   Eigen::VectorXd ret(pieces.size());
   assignDoublePieces(ret, pieces, "double", "Eigen::VectorXd");

--- a/tests/integration/simulation/test_world.cpp
+++ b/tests/integration/simulation/test_world.cpp
@@ -770,7 +770,7 @@ TEST(World, SetNewConstraintSolver)
 
   auto solver1 = std::make_unique<constraint::ConstraintSolver>(
       std::make_shared<math::DantzigSolver>());
-  EXPECT_TRUE(solver1->getSkeletons().size() == 0);
+  EXPECT_TRUE(solver1->getSkeletons().empty());
   EXPECT_TRUE(solver1->getNumConstraints() == 0);
 
   world->setConstraintSolver(std::move(solver1));
@@ -779,7 +779,7 @@ TEST(World, SetNewConstraintSolver)
 
   auto solver2 = std::make_unique<constraint::ConstraintSolver>(
       std::make_shared<math::PgsSolver>());
-  EXPECT_TRUE(solver2->getSkeletons().size() == 0);
+  EXPECT_TRUE(solver2->getSkeletons().empty());
   EXPECT_TRUE(solver2->getNumConstraints() == 0);
 
   world->setConstraintSolver(std::move(solver2));

--- a/tutorials/tutorial_dominoes_finished/main.cpp
+++ b/tutorials/tutorial_dominoes_finished/main.cpp
@@ -374,7 +374,7 @@ public:
 
     // snippet:cpp-dominoes-lesson1a-last-start
     const SkeletonPtr& lastDomino
-        = mDominoes.size() > 0 ? mDominoes.back() : mFirstDomino;
+        = !mDominoes.empty() ? mDominoes.back() : mFirstDomino;
     // snippet:cpp-dominoes-lesson1a-last-end
 
     // Compute the position for the new domino
@@ -443,7 +443,7 @@ public:
   void deleteLastDomino()
   {
     // snippet:cpp-dominoes-lesson1c-delete-start
-    if (mDominoes.size() > 0) {
+    if (!mDominoes.empty()) {
       SkeletonPtr lastDomino = mDominoes.back();
       mDominoes.pop_back();
       mWorld->removeSkeleton(lastDomino);


### PR DESCRIPTION
## Summary

- Replace `size() == 0` and `size() > 0` with `empty()` / `!empty()` for STL-style containers in dynamics, GUI, optimizer, XML helper, simulation tests, and tutorial code.
- Keep Eigen vector/matrix checks on `size()` because those types do not expose `empty()`.

## Motivation / Problem

- These sites only care whether a container has elements, so `empty()` expresses intent directly and avoids asking for a count.
- This is a targeted C++20-era cleanup, not a blanket conversion; API-specific cases such as Eigen remain unchanged.

## Changes / Key Changes

- Update hierarchical IK, line segment, soft body, drag-and-drop, support polygon, optimization seed, and XML vector parsing emptiness checks.
- Update skeleton tree/support-polygon emptiness checks, constraint-solver test expectations, and domino tutorial container checks.
- Leave behavior and warning paths unchanged.

## Testing

- `git diff --check`
- `pixi run lint`
- `pixi run build`
- `cmake --build build/default/cpp/Release --target UNIT_dynamics_LineSegmentShape UNIT_dynamics_SoftBodyNode UNIT_dynamics_SkeletonProperties UNIT_dynamics_InverseKinematics INTEGRATION_dynamics_AtlasIK UNIT_math_optimization_Problem INTEGRATION_optimization_Optimizer UNIT_simulation_World INTEGRATION_simulation_World test_xml_helpersNone drag_and_drop polyhedron_visual py_test_optimizer py_test_world py_test_skeleton`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_dynamics_LineSegmentShape|UNIT_dynamics_SoftBodyNode|UNIT_dynamics_SkeletonProperties|UNIT_dynamics_InverseKinematics|INTEGRATION_dynamics_AtlasIK|UNIT_math_optimization_Problem|INTEGRATION_optimization_Optimizer|UNIT_simulation_World|INTEGRATION_simulation_World|test_xml_helpersNone)$'`
- Skeleton/tutorial follow-up: `git diff --check`
- Skeleton/tutorial follow-up: `pixi run lint`
- Skeleton/tutorial follow-up: `pixi run build`
- Skeleton/tutorial follow-up: `cmake --build build/default/cpp/Release --target UNIT_dynamics_SkeletonAccessors INTEGRATION_simulation_World tutorial_dominoes_finished`
- Skeleton/tutorial follow-up: `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_dynamics_SkeletonAccessors|INTEGRATION_simulation_World)$'`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: not required for behavior-preserving cleanup
- [x] Add unit tests for new functionality: not applicable
- [x] Document new methods and classes: not applicable
- [x] Add Python bindings (dartpy) if applicable: not applicable
