### PR TITLE
Restore ArrowShape NaN head length handling

### DIFF
--- a/dart/dynamics/arrow_shape.cpp
+++ b/dart/dynamics/arrow_shape.cpp
@@ -152,7 +152,7 @@ void ArrowShape::configureArrow(
   mProperties = _properties;
 
   mProperties.mHeadLengthScale
-      = std::clamp(mProperties.mHeadLengthScale, 0.0, 1.0);
+      = std::max(0.0, std::min(1.0, mProperties.mHeadLengthScale));
   mProperties.mMinHeadLength = std::max(0.0, mProperties.mMinHeadLength);
   mProperties.mMaxHeadLength = std::max(0.0, mProperties.mMaxHeadLength);
   mProperties.mHeadRadiusScale = std::max(1.0, mProperties.mHeadRadiusScale);

--- a/tests/unit/dynamics/test_arrow_shape.cpp
+++ b/tests/unit/dynamics/test_arrow_shape.cpp
@@ -6,6 +6,9 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <limits>
+
+#include <cmath>
 
 namespace dart {
 namespace utils {
@@ -212,6 +215,19 @@ TEST(ArrowShapeTest, PropertiesClampedToValidRange)
   EXPECT_GE(clampedProps.mMinHeadLength, 0.0);
   EXPECT_GE(clampedProps.mMaxHeadLength, 0.0);
   EXPECT_GE(clampedProps.mHeadRadiusScale, 1.0);
+}
+
+//==============================================================================
+TEST(ArrowShapeTest, NaNHeadLengthScaleFallsBackToUpperBound)
+{
+  ArrowShape::Properties props;
+  props.mHeadLengthScale = std::numeric_limits<double>::quiet_NaN();
+
+  ArrowShape arrow(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitX(), props);
+
+  const auto& clamped = arrow.getProperties();
+  EXPECT_FALSE(std::isnan(clamped.mHeadLengthScale));
+  EXPECT_DOUBLE_EQ(clamped.mHeadLengthScale, 1.0);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Restores the pre-#2632 NaN behavior for ArrowShape head length scaling.

## Motivation / Problem

- Codex review on #2632 correctly noted that replacing the old min/max expression with std::clamp allowed NaN to propagate into arrow geometry.

## Changes / Key Changes

- Restores the min/max expression for mHeadLengthScale so NaN falls back to the upper bound.
- Adds a regression test for NaN head length scale handling.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --target UNIT_dynamics_ArrowShape`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R ^UNIT_dynamics_ArrowShape`
- `pixi run build`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #2632

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
