### PR TITLE
Adopt targeted C++20 helpers across core paths

### DIFF
--- a/dart/common/detail/castable-impl.hpp
+++ b/dart/common/detail/castable-impl.hpp
@@ -36,13 +36,27 @@
 #include "dart/common/macros.hpp"
 
 #include <dart/common/castable.hpp>
-#include <dart/common/metaprogramming.hpp>
+
+#include <concepts>
+#include <string_view>
 
 namespace dart::common {
 
+namespace detail {
+
 //==============================================================================
-DART_CREATE_MEMBER_CHECK(getType);
-DART_CREATE_MEMBER_CHECK(getStaticType);
+template <typename T>
+concept HasTypeString = requires(const T& value) {
+  { value.getType() } -> std::convertible_to<std::string_view>;
+};
+
+//==============================================================================
+template <typename T>
+concept HasStaticTypeString = requires {
+  { T::getStaticType() } -> std::convertible_to<std::string_view>;
+};
+
+} // namespace detail
 
 //==============================================================================
 template <typename Base>
@@ -50,8 +64,7 @@ template <typename Derived>
 bool Castable<Base>::is() const
 {
   if constexpr (
-      has_member_getType<Base>::value
-      && has_member_getStaticType<Derived>::value) {
+      detail::HasTypeString<Base> && detail::HasStaticTypeString<Derived>) {
     return (base().getType() == Derived::getStaticType());
   } else {
     return (dynamic_cast<const Derived*>(&base()) != nullptr);

--- a/dart/common/detail/connection_body.hpp
+++ b/dart/common/detail/connection_body.hpp
@@ -35,6 +35,7 @@
 
 #include <dart/export.hpp>
 
+#include <iterator>
 #include <memory>
 
 namespace dart {
@@ -138,7 +139,7 @@ struct DefaultCombiner
 {
   using result_type = T;
 
-  template <typename InputIterator>
+  template <std::bidirectional_iterator InputIterator>
   static T process(InputIterator first, InputIterator last)
   {
     // If there are no slots to call, just return the

--- a/dart/common/detail/lockable_reference-impl.hpp
+++ b/dart/common/detail/lockable_reference-impl.hpp
@@ -35,16 +35,13 @@
 
 #include <dart/common/lockable_reference.hpp>
 
-#include <concepts>
-#include <iterator>
 #include <ranges>
-#include <type_traits>
 
 namespace dart {
 namespace common {
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 SingleLockableReference<Lockable>::SingleLockableReference(
     std::weak_ptr<const void> lockableHolder, Lockable& lockable) noexcept
   : mLockableHolder(std::move(lockableHolder)), mLockable(lockable)
@@ -53,7 +50,7 @@ SingleLockableReference<Lockable>::SingleLockableReference(
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void SingleLockableReference<Lockable>::lock()
 {
   if (mLockableHolder.expired()) {
@@ -64,7 +61,7 @@ void SingleLockableReference<Lockable>::lock()
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 bool SingleLockableReference<Lockable>::try_lock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -75,7 +72,7 @@ bool SingleLockableReference<Lockable>::try_lock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void SingleLockableReference<Lockable>::unlock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -86,27 +83,20 @@ void SingleLockableReference<Lockable>::unlock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject LockableT>
 template <typename InputIterator>
-MultiLockableReference<Lockable>::MultiLockableReference(
+  requires detail::LockablePointerInputIterator<InputIterator, LockableT>
+MultiLockableReference<LockableT>::MultiLockableReference(
     std::weak_ptr<const void> lockableHolder,
     InputIterator first,
     InputIterator last)
   : mLockableHolder(std::move(lockableHolder)), mLockables(first, last)
 {
-  using IteratorValueType =
-      typename std::iterator_traits<InputIterator>::value_type;
-  using IteratorLockable
-      = std::remove_pointer_t<std::remove_cvref_t<IteratorValueType>>;
-
-  static_assert(
-      std::same_as<Lockable, IteratorLockable>,
-      "Lockable of this class and the lockable of InputIterator are not the "
-      "same.");
+  // Do nothing
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void MultiLockableReference<Lockable>::lock()
 {
   if (mLockableHolder.expired()) {
@@ -119,7 +109,7 @@ void MultiLockableReference<Lockable>::lock()
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 bool MultiLockableReference<Lockable>::try_lock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -136,7 +126,7 @@ bool MultiLockableReference<Lockable>::try_lock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 void MultiLockableReference<Lockable>::unlock() noexcept
 {
   if (mLockableHolder.expired()) {
@@ -149,7 +139,7 @@ void MultiLockableReference<Lockable>::unlock() noexcept
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 template <typename T>
 T* MultiLockableReference<Lockable>::ptr(T& obj)
 {
@@ -157,7 +147,7 @@ T* MultiLockableReference<Lockable>::ptr(T& obj)
 }
 
 //==============================================================================
-template <typename Lockable>
+template <detail::LockableObject Lockable>
 template <typename T>
 T* MultiLockableReference<Lockable>::ptr(T* obj)
 {

--- a/dart/common/detail/memory_allocator-impl.hpp
+++ b/dart/common/detail/memory_allocator-impl.hpp
@@ -35,6 +35,9 @@
 
 #include <dart/common/memory_allocator.hpp>
 
+#include <memory>
+#include <utility>
+
 namespace dart::common {
 
 //==============================================================================
@@ -55,9 +58,9 @@ T* MemoryAllocator::construct(Args&&... args) noexcept
   }
 
   // Call constructor. Return nullptr if failed.
+  T* typedObject = static_cast<T*>(object);
   try {
-    return std::construct_at(
-        static_cast<T*>(object), std::forward<Args>(args)...);
+    return std::construct_at(typedObject, std::forward<Args>(args)...);
   } catch (...) {
     deallocate(object, sizeof(T));
     return nullptr;

--- a/dart/common/detail/memory_manager-impl.hpp
+++ b/dart/common/detail/memory_manager-impl.hpp
@@ -35,6 +35,9 @@
 
 #include <dart/common/memory_manager.hpp>
 
+#include <memory>
+#include <utility>
+
 namespace dart::common {
 
 //==============================================================================
@@ -48,9 +51,9 @@ T* MemoryManager::construct(Type type, Args&&... args) noexcept
   }
 
   // Call constructor. Return nullptr if failed.
+  T* typedObject = static_cast<T*>(object);
   try {
-    return std::construct_at(
-        static_cast<T*>(object), std::forward<Args>(args)...);
+    return std::construct_at(typedObject, std::forward<Args>(args)...);
   } catch (...) {
     deallocate(type, object, sizeof(T));
     return nullptr;

--- a/dart/common/detail/stopwatch-impl.hpp
+++ b/dart/common/detail/stopwatch-impl.hpp
@@ -53,35 +53,28 @@ void print_duration_if_non_zero(
 } // namespace
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 Stopwatch<UnitType, ClockType>::Stopwatch(bool start)
   : mStart(ClockType::now()), mElapsed(0), mPaused(!start)
 {
-  // clang-format off
-  static_assert(std::same_as<UnitType, std::chrono::seconds>
-      || std::same_as<UnitType, std::chrono::milliseconds>
-      || std::same_as<UnitType, std::chrono::microseconds>
-      || std::same_as<UnitType, std::chrono::nanoseconds>,
-      "Invalid unit");
-  // clang-format on
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 Stopwatch<UnitType, ClockType>::~Stopwatch()
 {
   // Do nothing
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 bool Stopwatch<UnitType, ClockType>::isStarted() const
 {
   return !mPaused;
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::start()
 {
   if (!mPaused) {
@@ -93,7 +86,7 @@ void Stopwatch<UnitType, ClockType>::start()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::stop()
 {
   if (mPaused) {
@@ -105,7 +98,7 @@ void Stopwatch<UnitType, ClockType>::stop()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::reset()
 {
   mStart = ClockType::now();
@@ -113,35 +106,35 @@ void Stopwatch<UnitType, ClockType>::reset()
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedS() const
 {
   return std::chrono::duration<double>(duration()).count();
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedMS() const
 {
   return std::chrono::duration<double, std::milli>(duration()).count();
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedUS() const
 {
   return std::chrono::duration<double, std::micro>(duration()).count();
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 double Stopwatch<UnitType, ClockType>::elapsedNS() const
 {
   return std::chrono::duration<double, std::nano>(duration()).count();
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 UnitType Stopwatch<UnitType, ClockType>::duration() const
 {
   if (mPaused) {
@@ -154,7 +147,7 @@ UnitType Stopwatch<UnitType, ClockType>::duration() const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
 {
   auto t = duration();
@@ -199,7 +192,7 @@ void Stopwatch<UnitType, ClockType>::print(std::ostream& os) const
 }
 
 //==============================================================================
-template <typename UnitType, typename ClockType>
+template <detail::StopwatchUnit UnitType, typename ClockType>
 std::ostream& operator<<(
     std::ostream& os, const Stopwatch<UnitType, ClockType>& sw)
 {

--- a/dart/common/lockable_reference.hpp
+++ b/dart/common/lockable_reference.hpp
@@ -33,11 +33,33 @@
 #ifndef DART_COMMON_LOCKABLEREFERENCE_HPP_
 #define DART_COMMON_LOCKABLEREFERENCE_HPP_
 
+#include <concepts>
+#include <iterator>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 namespace dart {
 namespace common {
+
+namespace detail {
+
+template <typename T>
+concept LockableObject = requires(T lockable) {
+  { lockable.lock() } -> std::same_as<void>;
+  { lockable.try_lock() } -> std::convertible_to<bool>;
+  { lockable.unlock() } -> std::same_as<void>;
+};
+
+template <typename Iterator, typename Lockable>
+concept LockablePointerInputIterator
+    = std::input_iterator<Iterator>
+      && std::same_as<
+          std::remove_pointer_t<std::remove_cvref_t<
+              typename std::iterator_traits<Iterator>::value_type>>,
+          Lockable>;
+
+} // namespace detail
 
 /// LockableReference is a wrapper class of single or multiple Lockable
 /// object(s) to provide unified interface that guarantees deadlock-free locking
@@ -75,7 +97,7 @@ protected:
 /// This class references a single lockable.
 ///
 /// @tparam LockableT The standard C++ Lockable concept object type.
-template <typename LockableT>
+template <detail::LockableObject LockableT>
 class SingleLockableReference final : public LockableReference
 {
 public:
@@ -114,7 +136,7 @@ private:
 /// deadlock.
 ///
 /// @tparam LockableT The standard C++ Lockable concept object type.
-template <typename LockableT>
+template <detail::LockableObject LockableT>
 class MultiLockableReference final : public LockableReference
 {
 public:
@@ -128,6 +150,7 @@ public:
   /// @param[in] first First iterator of lockable to be added to this class.
   /// @param[in] last Last iterator of lockable to be added to this class.
   template <typename InputIterator>
+    requires detail::LockablePointerInputIterator<InputIterator, LockableT>
   MultiLockableReference(
       std::weak_ptr<const void> lockableHolder,
       InputIterator first,

--- a/dart/common/stopwatch.hpp
+++ b/dart/common/stopwatch.hpp
@@ -36,13 +36,25 @@
 #include <dart/export.hpp>
 
 #include <chrono>
+#include <concepts>
 #include <iostream>
 
 namespace dart::common {
 
+namespace detail {
+
+/// Returns true for the supported Stopwatch duration units.
+template <typename UnitType>
+concept StopwatchUnit = std::same_as<UnitType, std::chrono::seconds>
+                        || std::same_as<UnitType, std::chrono::milliseconds>
+                        || std::same_as<UnitType, std::chrono::microseconds>
+                        || std::same_as<UnitType, std::chrono::nanoseconds>;
+
+} // namespace detail
+
 /// Simple stopwatch implementation
 template <
-    typename UnitType,
+    detail::StopwatchUnit UnitType,
     typename ClockType = std::chrono::high_resolution_clock>
 class Stopwatch final
 {
@@ -87,7 +99,7 @@ public:
   void print(std::ostream& os = std::cout) const;
 
   /// Prints state of the stopwatch
-  template <typename T, typename U>
+  template <detail::StopwatchUnit T, typename U>
   friend std::ostream& operator<<(std::ostream& os, const Stopwatch<T, U>& sw);
 
 private:

--- a/dart/dynamics/arrow_shape.cpp
+++ b/dart/dynamics/arrow_shape.cpp
@@ -152,7 +152,7 @@ void ArrowShape::configureArrow(
   mProperties = _properties;
 
   mProperties.mHeadLengthScale
-      = std::clamp(mProperties.mHeadLengthScale, 0.0, 1.0);
+      = std::max(0.0, std::min(1.0, mProperties.mHeadLengthScale));
   mProperties.mMinHeadLength = std::max(0.0, mProperties.mMinHeadLength);
   mProperties.mMaxHeadLength = std::max(0.0, mProperties.mMaxHeadLength);
   mProperties.mHeadRadiusScale = std::max(1.0, mProperties.mHeadRadiusScale);

--- a/dart/dynamics/detail/body_node_pool.hpp
+++ b/dart/dynamics/detail/body_node_pool.hpp
@@ -56,7 +56,7 @@ public:
       "BodyNodePool requires sizeof(T) >= sizeof(void*).");
 
   static constexpr std::size_t kSlotAlignment
-      = alignof(T) > 32 ? alignof(T) : 32;
+      = std::max<std::size_t>(alignof(T), 32);
   static_assert(
       std::has_single_bit(kSlotAlignment),
       "BodyNodePool requires a power-of-two slot alignment.");

--- a/dart/dynamics/inverse_kinematics.cpp
+++ b/dart/dynamics/inverse_kinematics.cpp
@@ -42,6 +42,7 @@
 #include <iterator>
 #include <numeric>
 #include <unordered_map>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -1077,7 +1078,7 @@ void InverseKinematics::Analytical::addExtraDofGradient(
   for (std::size_t i = 0; i < mExtraDofs.size(); ++i) {
     std::size_t depIndex = mExtraDofs[i];
     int gradIndex = gradMap[depIndex];
-    if (gradIndex == -1) {
+    if (gradIndex < 0) {
       continue;
     }
 
@@ -1089,13 +1090,14 @@ void InverseKinematics::Analytical::addExtraDofGradient(
   for (std::size_t i = 0; i < mExtraDofs.size(); ++i) {
     std::size_t depIndex = mExtraDofs[i];
     int gradIndex = gradMap[depIndex];
-    if (gradIndex == -1) {
+    if (gradIndex < 0) {
       continue;
     }
 
-    double weight = mGradientP.mComponentWeights.size() > gradIndex
-                        ? mGradientP.mComponentWeights[gradIndex]
-                        : 1.0;
+    double weight
+        = std::cmp_less(gradIndex, mGradientP.mComponentWeights.size())
+              ? mGradientP.mComponentWeights[gradIndex]
+              : 1.0;
 
     double dq = weight * mExtraDofGradCache[i];
 

--- a/dart/dynamics/linkage.cpp
+++ b/dart/dynamics/linkage.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <unordered_set>
+#include <utility>
 
 namespace dart {
 namespace dynamics {
@@ -260,7 +261,7 @@ void Linkage::Criteria::expandDownstream(
 
   while (!recorder.empty()) {
     Recording& r = recorder.back();
-    if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
+    if (std::cmp_less(r.mCount, r.mNode->getNumChildBodyNodes())) {
       stepToNextChild(recorder, _bns, r, mMapOfTerminals, 0);
     } else {
       recorder.pop_back();
@@ -303,7 +304,7 @@ void Linkage::Criteria::expandUpstream(
         // If we originally came from this node, then just continue to the next
         ++r.mCount;
       }
-    } else if (r.mCount < static_cast<int>(r.mNode->getNumChildBodyNodes())) {
+    } else if (std::cmp_less(r.mCount, r.mNode->getNumChildBodyNodes())) {
       // Greater than -1 means we need to add the children
 
       if (recorder.size() == 1) {

--- a/dart/dynamics/skeleton.cpp
+++ b/dart/dynamics/skeleton.cpp
@@ -51,6 +51,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <queue>
 #include <ranges>
 #include <span>
@@ -452,10 +453,10 @@ Skeleton::~Skeleton()
 {
   for (BodyNode* bn : mSkelCache.mBodyNodes) {
     if (mBodyNodePool->owns(bn)) {
-      bn->~BodyNode();
+      std::destroy_at(bn);
       mBodyNodePool->deallocate(bn);
     } else if (mSoftBodyNodePool->owns(bn)) {
-      bn->~BodyNode();
+      std::destroy_at(bn);
       mSoftBodyNodePool->deallocate(bn);
     } else {
       // Either heap-allocated or from a borrowed chunk (cross-skeleton move).
@@ -467,7 +468,7 @@ Skeleton::~Skeleton()
       } else {
         // Memory lives in a borrowed chunk — just destruct, chunk ref handles
         // memory lifetime
-        bn->~BodyNode();
+        std::destroy_at(bn);
       }
     }
   }

--- a/dart/math/lcp/lcp_validation.hpp
+++ b/dart/math/lcp/lcp_validation.hpp
@@ -38,12 +38,37 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
 #include <limits>
 #include <string>
 
 #include <cmath>
 
 namespace dart::math::detail {
+
+inline double projectToBounds(double value, double lo, double hi)
+{
+  const bool hasLo = std::isfinite(lo);
+  const bool hasUpper = std::isfinite(hi);
+
+  if (hasLo && hasUpper) {
+    if (lo <= hi) {
+      return std::clamp(value, lo, hi);
+    }
+
+    return std::min(std::max(value, lo), hi);
+  }
+
+  if (hasLo) {
+    return std::max(value, lo);
+  }
+
+  if (hasUpper) {
+    return std::min(value, hi);
+  }
+
+  return value;
+}
 
 inline bool validateProblem(
     const LcpProblem& problem, std::string* message = nullptr)
@@ -186,13 +211,7 @@ inline double naturalResidualInfinityNorm(
   double maxResidual = 0.0;
 
   for (Eigen::Index i = 0; i < n; ++i) {
-    double projected = x[i] - w[i];
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
+    const double projected = projectToBounds(x[i] - w[i], lo[i], hi[i]);
 
     const double residual = x[i] - projected;
     maxResidual = std::max(maxResidual, std::abs(residual));

--- a/dart/math/lcp/other/staggering_solver.cpp
+++ b/dart/math/lcp/other/staggering_solver.cpp
@@ -211,13 +211,7 @@ LcpResult StaggeringSolver::solve(
           for (int k = 0; k < std::ssize(indices); ++k) {
             const int idx = indices[k];
             double updated = std::lerp(x[idx], values[k], relaxation);
-            if (std::isfinite(lo[idx])) {
-              updated = std::max(updated, lo[idx]);
-            }
-            if (std::isfinite(hi[idx])) {
-              updated = std::min(updated, hi[idx]);
-            }
-            x[idx] = updated;
+            x[idx] = detail::projectToBounds(updated, lo[idx], hi[idx]);
           }
         };
 
@@ -228,13 +222,7 @@ LcpResult StaggeringSolver::solve(
     for (int k = 0; k < std::ssize(indices); ++k) {
       const int idx = indices[k];
       double updated = std::lerp(x[idx], values[k], relaxation);
-      if (std::isfinite(loEff[idx])) {
-        updated = std::max(updated, loEff[idx]);
-      }
-      if (std::isfinite(hiEff[idx])) {
-        updated = std::min(updated, hiEff[idx]);
-      }
-      x[idx] = updated;
+      x[idx] = detail::projectToBounds(updated, loEff[idx], hiEff[idx]);
     }
   };
 

--- a/dart/math/lcp/projection/apgd_solver.cpp
+++ b/dart/math/lcp/projection/apgd_solver.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <span>
 #include <vector>
 
 #include <cmath>
@@ -121,27 +122,57 @@ LcpResult ApgdSolver::solve(
     return result;
   }
 
-  std::vector<double> Adata(static_cast<std::size_t>(n * nSkip), 0.0);
-  std::vector<double> xdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> xPrevData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> ydata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> bdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> loData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> hiData(static_cast<std::size_t>(n), 0.0);
-  std::vector<int> findexData(static_cast<std::size_t>(n), -1);
+  const auto problemSize = static_cast<std::size_t>(n);
+  const auto paddedSize = static_cast<std::size_t>(nSkip);
+
+  std::vector<double> Adata(problemSize * paddedSize, 0.0);
+  std::vector<double> xdata(problemSize, 0.0);
+  std::vector<double> xPrevData(problemSize, 0.0);
+  std::vector<double> ydata(problemSize, 0.0);
+  std::vector<double> bdata(problemSize, 0.0);
+  std::vector<double> loData(problemSize, 0.0);
+  std::vector<double> hiData(problemSize, 0.0);
+  std::vector<int> findexData(problemSize, -1);
+
+  std::span<double> aValues{Adata};
+  std::span<double> xValues{xdata};
+  std::span<double> xPrevValues{xPrevData};
+  std::span<double> yValues{ydata};
+  std::span<double> bValues{bdata};
+  std::span<double> loValues{loData};
+  std::span<double> hiValues{hiData};
+  std::span<int> findexValues{findexData};
+
+  auto aRow = [&](int row) -> std::span<double> {
+    return aValues.subspan(
+        static_cast<std::size_t>(row) * paddedSize, problemSize);
+  };
+
+  auto projectIntoBounds = [&](double value, std::size_t idx) {
+    if (findexValues[idx] >= 0) {
+      const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
+      const double frictionLimit
+          = std::abs(hiValues[idx] * xValues[frictionIndex]);
+      return std::clamp(value, -frictionLimit, frictionLimit);
+    }
+
+    return std::clamp(value, loValues[idx], hiValues[idx]);
+  };
 
   for (int r = 0; r < n; ++r) {
-    bdata[static_cast<std::size_t>(r)] = b[r];
+    const auto idx = static_cast<std::size_t>(r);
+    std::span<double> row = aRow(r);
+    bValues[idx] = b[r];
     const double initVal
         = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
-    xdata[static_cast<std::size_t>(r)] = initVal;
-    xPrevData[static_cast<std::size_t>(r)] = initVal;
-    ydata[static_cast<std::size_t>(r)] = initVal;
-    loData[static_cast<std::size_t>(r)] = lo[r];
-    hiData[static_cast<std::size_t>(r)] = hi[r];
-    findexData[static_cast<std::size_t>(r)] = findex[r];
+    xValues[idx] = initVal;
+    xPrevValues[idx] = initVal;
+    yValues[idx] = initVal;
+    loValues[idx] = lo[r];
+    hiValues[idx] = hi[r];
+    findexValues[idx] = findex[r];
     for (int c = 0; c < n; ++c) {
-      Adata[static_cast<std::size_t>(r * nSkip + c)] = A(r, c);
+      row[static_cast<std::size_t>(c)] = A(r, c);
     }
   }
 
@@ -149,21 +180,23 @@ LcpResult ApgdSolver::solve(
   order.reserve(static_cast<std::size_t>(n));
 
   for (int i = 0; i < n; ++i) {
-    if (Adata[static_cast<std::size_t>(nSkip * i + i)]
-        >= params->epsilonForDivision) {
+    const auto idx = static_cast<std::size_t>(i);
+    std::span<double> row = aRow(i);
+    if (row[idx] >= params->epsilonForDivision) {
       order.push_back(i);
     } else {
-      xdata[static_cast<std::size_t>(i)] = 0.0;
-      ydata[static_cast<std::size_t>(i)] = 0.0;
+      xValues[idx] = 0.0;
+      yValues[idx] = 0.0;
     }
   }
 
   for (const auto& index : order) {
-    const double invDiag
-        = 1.0 / Adata[static_cast<std::size_t>(nSkip * index + index)];
-    bdata[static_cast<std::size_t>(index)] *= invDiag;
+    const auto idx = static_cast<std::size_t>(index);
+    std::span<double> row = aRow(index);
+    const double invDiag = 1.0 / row[idx];
+    bValues[idx] *= invDiag;
     for (int j = 0; j < n; ++j) {
-      Adata[static_cast<std::size_t>(nSkip * index + j)] *= invDiag;
+      row[static_cast<std::size_t>(j)] *= invDiag;
     }
   }
 
@@ -178,58 +211,39 @@ LcpResult ApgdSolver::solve(
                         / static_cast<double>(restartIter + 3);
     for (const auto& index : order) {
       const std::size_t idx = static_cast<std::size_t>(index);
-      ydata[idx] = xdata[idx] + beta * (xdata[idx] - xPrevData[idx]);
+      yValues[idx] = xValues[idx] + beta * (xValues[idx] - xPrevValues[idx]);
     }
 
     for (const auto& index : order) {
-      xPrevData[static_cast<std::size_t>(index)]
-          = xdata[static_cast<std::size_t>(index)];
+      const auto idx = static_cast<std::size_t>(index);
+      xPrevValues[idx] = xValues[idx];
     }
 
     bool possibleToTerminate = true;
 
     for (const auto& index : order) {
       const std::size_t idx = static_cast<std::size_t>(index);
-      const double* APtr = Adata.data() + nSkip * index;
-      double newX = bdata[idx];
+      const std::span<double> row = aRow(index);
+      double newX = bValues[idx];
 
       for (int j = 0; j < index; j++) {
-        newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * xValues[static_cast<std::size_t>(j)];
       }
 
       for (int j = index + 1; j < n; j++) {
-        newX -= APtr[j] * ydata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * yValues[static_cast<std::size_t>(j)];
       }
 
-      const double oldX = xdata[idx];
+      const double oldX = xValues[idx];
       newX = std::lerp(oldX, newX, relaxation);
-
-      if (findexData[idx] >= 0) {
-        const double hiTmp = std::abs(
-            hiData[idx] * xdata[static_cast<std::size_t>(findexData[idx])]);
-        const double loTmp = -hiTmp;
-
-        if (newX > hiTmp) {
-          xdata[idx] = hiTmp;
-        } else if (newX < loTmp) {
-          xdata[idx] = loTmp;
-        } else {
-          xdata[idx] = newX;
-        }
-      } else {
-        if (newX > hiData[idx]) {
-          xdata[idx] = hiData[idx];
-        } else if (newX < loData[idx]) {
-          xdata[idx] = loData[idx];
-        } else {
-          xdata[idx] = newX;
-        }
-      }
+      xValues[idx] = projectIntoBounds(newX, idx);
 
       if (possibleToTerminate
-          && std::abs(xdata[idx]) > params->epsilonForDivision) {
+          && std::abs(xValues[idx]) > params->epsilonForDivision) {
         const double relativeDeltaX
-            = std::abs((xdata[idx] - oldX) / xdata[idx]);
+            = std::abs((xValues[idx] - oldX) / xValues[idx]);
         if (relativeDeltaX > relativeTolerance) {
           possibleToTerminate = false;
         }
@@ -243,12 +257,14 @@ LcpResult ApgdSolver::solve(
       double residualPrev = 0.0;
       for (const auto& index : order) {
         const std::size_t idx = static_cast<std::size_t>(index);
-        const double* APtr = Adata.data() + nSkip * index;
-        double wNow = -bdata[idx];
-        double wPrev = -bdata[idx];
+        const std::span<double> row = aRow(index);
+        double wNow = -bValues[idx];
+        double wPrev = -bValues[idx];
         for (int j = 0; j < n; ++j) {
-          wNow += APtr[j] * xdata[static_cast<std::size_t>(j)];
-          wPrev += APtr[j] * xPrevData[static_cast<std::size_t>(j)];
+          wNow += row[static_cast<std::size_t>(j)]
+                  * xValues[static_cast<std::size_t>(j)];
+          wPrev += row[static_cast<std::size_t>(j)]
+                   * xPrevValues[static_cast<std::size_t>(j)];
         }
         residualNow += wNow * wNow;
         residualPrev += wPrev * wPrev;

--- a/dart/math/lcp/projection/apgd_solver.cpp
+++ b/dart/math/lcp/projection/apgd_solver.cpp
@@ -153,10 +153,10 @@ LcpResult ApgdSolver::solve(
       const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
       const double frictionLimit
           = std::abs(hiValues[idx] * xValues[frictionIndex]);
-      return std::clamp(value, -frictionLimit, frictionLimit);
+      return detail::projectToBounds(value, -frictionLimit, frictionLimit);
     }
 
-    return std::clamp(value, loValues[idx], hiValues[idx]);
+    return detail::projectToBounds(value, loValues[idx], hiValues[idx]);
   };
 
   for (int r = 0; r < n; ++r) {

--- a/dart/math/lcp/projection/jacobi_solver.cpp
+++ b/dart/math/lcp/projection/jacobi_solver.cpp
@@ -204,14 +204,7 @@ LcpResult JacobiSolver::solve(
         value = std::lerp(x[i], step, relaxation);
       }
 
-      if (std::isfinite(loEff[i])) {
-        value = std::max(value, loEff[i]);
-      }
-      if (std::isfinite(hiEff[i])) {
-        value = std::min(value, hiEff[i]);
-      }
-
-      xNew[i] = value;
+      xNew[i] = detail::projectToBounds(value, loEff[i], hiEff[i]);
     }
 
     x = xNew;

--- a/dart/math/lcp/projection/pgs_solver.cpp
+++ b/dart/math/lcp/projection/pgs_solver.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+#include <span>
 #include <vector>
 
 #include <cmath>
@@ -125,22 +126,49 @@ LcpResult PgsSolver::solve(
     return result;
   }
 
-  std::vector<double> Adata(static_cast<std::size_t>(n * nSkip), 0.0);
-  std::vector<double> xdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> bdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> loData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> hiData(static_cast<std::size_t>(n), 0.0);
-  std::vector<int> findexData(static_cast<std::size_t>(n), -1);
+  const auto problemSize = static_cast<std::size_t>(n);
+  const auto paddedSize = static_cast<std::size_t>(nSkip);
+
+  std::vector<double> Adata(problemSize * paddedSize, 0.0);
+  std::vector<double> xdata(problemSize, 0.0);
+  std::vector<double> bdata(problemSize, 0.0);
+  std::vector<double> loData(problemSize, 0.0);
+  std::vector<double> hiData(problemSize, 0.0);
+  std::vector<int> findexData(problemSize, -1);
+
+  std::span<double> aValues{Adata};
+  std::span<double> xValues{xdata};
+  std::span<double> bValues{bdata};
+  std::span<double> loValues{loData};
+  std::span<double> hiValues{hiData};
+  std::span<int> findexValues{findexData};
+
+  auto aRow = [&](int row) -> std::span<double> {
+    return aValues.subspan(
+        static_cast<std::size_t>(row) * paddedSize, problemSize);
+  };
+
+  auto projectIntoBounds = [&](double value, std::size_t idx) {
+    if (findexValues[idx] >= 0) {
+      const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
+      const double frictionLimit
+          = std::abs(hiValues[idx] * xValues[frictionIndex]);
+      return std::clamp(value, -frictionLimit, frictionLimit);
+    }
+
+    return std::clamp(value, loValues[idx], hiValues[idx]);
+  };
 
   for (int r = 0; r < n; ++r) {
-    bdata[static_cast<std::size_t>(r)] = b[r];
-    xdata[static_cast<std::size_t>(r)]
-        = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
-    loData[static_cast<std::size_t>(r)] = lo[r];
-    hiData[static_cast<std::size_t>(r)] = hi[r];
-    findexData[static_cast<std::size_t>(r)] = findex[r];
+    const auto idx = static_cast<std::size_t>(r);
+    std::span<double> row = aRow(r);
+    bValues[idx] = b[r];
+    xValues[idx] = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
+    loValues[idx] = lo[r];
+    hiValues[idx] = hi[r];
+    findexValues[idx] = findex[r];
     for (int c = 0; c < n; ++c) {
-      Adata[static_cast<std::size_t>(r * nSkip + c)] = A(r, c);
+      row[static_cast<std::size_t>(c)] = A(r, c);
     }
   }
 
@@ -149,57 +177,34 @@ LcpResult PgsSolver::solve(
 
   bool possibleToTerminate = true;
   for (int i = 0; i < n; ++i) {
-    if (Adata[static_cast<std::size_t>(nSkip * i + i)]
-        < params->epsilonForDivision) {
-      xdata[static_cast<std::size_t>(i)] = 0.0;
+    const auto idx = static_cast<std::size_t>(i);
+    std::span<double> row = aRow(i);
+    if (row[idx] < params->epsilonForDivision) {
+      xValues[idx] = 0.0;
       continue;
     }
 
     order.push_back(i);
 
-    const double* APtr = Adata.data() + nSkip * i;
-    const double oldX = xdata[static_cast<std::size_t>(i)];
+    const double oldX = xValues[idx];
 
-    double newX = bdata[static_cast<std::size_t>(i)];
+    double newX = bValues[idx];
     for (int j = 0; j < i; ++j) {
-      newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+      newX -= row[static_cast<std::size_t>(j)]
+              * xValues[static_cast<std::size_t>(j)];
     }
     for (int j = i + 1; j < n; ++j) {
-      newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+      newX -= row[static_cast<std::size_t>(j)]
+              * xValues[static_cast<std::size_t>(j)];
     }
 
-    newX /= Adata[static_cast<std::size_t>(nSkip * i + i)];
+    newX /= row[idx];
 
     newX = std::lerp(oldX, newX, relaxation);
-
-    if (findexData[static_cast<std::size_t>(i)] >= 0) {
-      const double hiTmp = std::abs(
-          hiData[static_cast<std::size_t>(i)]
-          * xdata[static_cast<std::size_t>(
-              findexData[static_cast<std::size_t>(i)])]);
-      const double loTmp = -hiTmp;
-
-      if (newX > hiTmp) {
-        xdata[static_cast<std::size_t>(i)] = hiTmp;
-      } else if (newX < loTmp) {
-        xdata[static_cast<std::size_t>(i)] = loTmp;
-      } else {
-        xdata[static_cast<std::size_t>(i)] = newX;
-      }
-    } else {
-      if (newX > hiData[static_cast<std::size_t>(i)]) {
-        xdata[static_cast<std::size_t>(i)]
-            = hiData[static_cast<std::size_t>(i)];
-      } else if (newX < loData[static_cast<std::size_t>(i)]) {
-        xdata[static_cast<std::size_t>(i)]
-            = loData[static_cast<std::size_t>(i)];
-      } else {
-        xdata[static_cast<std::size_t>(i)] = newX;
-      }
-    }
+    xValues[idx] = projectIntoBounds(newX, idx);
 
     if (possibleToTerminate) {
-      const double deltaX = std::abs(xdata[static_cast<std::size_t>(i)] - oldX);
+      const double deltaX = std::abs(xValues[idx] - oldX);
       if (deltaX > absTolerance) {
         possibleToTerminate = false;
       }
@@ -211,11 +216,12 @@ LcpResult PgsSolver::solve(
   if (!possibleToTerminate && maxIterations > 1) {
     // Normalize to avoid repeated division in the main iteration loop.
     for (const auto& index : order) {
-      const double invDiag
-          = 1.0 / Adata[static_cast<std::size_t>(nSkip * index + index)];
-      bdata[static_cast<std::size_t>(index)] *= invDiag;
+      const auto idx = static_cast<std::size_t>(index);
+      std::span<double> row = aRow(index);
+      const double invDiag = 1.0 / row[idx];
+      bValues[idx] *= invDiag;
       for (int j = 0; j < n; ++j) {
-        Adata[static_cast<std::size_t>(nSkip * index + j)] *= invDiag;
+        row[static_cast<std::size_t>(j)] *= invDiag;
       }
     }
 
@@ -230,52 +236,28 @@ LcpResult PgsSolver::solve(
       possibleToTerminate = true;
 
       for (const auto& index : order) {
-        const double* APtr = Adata.data() + nSkip * index;
-        double newX = bdata[static_cast<std::size_t>(index)];
-        const double oldX = xdata[static_cast<std::size_t>(index)];
+        const auto idx = static_cast<std::size_t>(index);
+        const std::span<double> row = aRow(index);
+        double newX = bValues[idx];
+        const double oldX = xValues[idx];
 
         for (int j = 0; j < index; j++) {
-          newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+          newX -= row[static_cast<std::size_t>(j)]
+                  * xValues[static_cast<std::size_t>(j)];
         }
 
         for (int j = index + 1; j < n; j++) {
-          newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+          newX -= row[static_cast<std::size_t>(j)]
+                  * xValues[static_cast<std::size_t>(j)];
         }
 
         newX = std::lerp(oldX, newX, relaxation);
-
-        if (findexData[static_cast<std::size_t>(index)] >= 0) {
-          const double hiTmp = std::abs(
-              hiData[static_cast<std::size_t>(index)]
-              * xdata[static_cast<std::size_t>(
-                  findexData[static_cast<std::size_t>(index)])]);
-          const double loTmp = -hiTmp;
-
-          if (newX > hiTmp) {
-            xdata[static_cast<std::size_t>(index)] = hiTmp;
-          } else if (newX < loTmp) {
-            xdata[static_cast<std::size_t>(index)] = loTmp;
-          } else {
-            xdata[static_cast<std::size_t>(index)] = newX;
-          }
-        } else {
-          if (newX > hiData[static_cast<std::size_t>(index)]) {
-            xdata[static_cast<std::size_t>(index)]
-                = hiData[static_cast<std::size_t>(index)];
-          } else if (newX < loData[static_cast<std::size_t>(index)]) {
-            xdata[static_cast<std::size_t>(index)]
-                = loData[static_cast<std::size_t>(index)];
-          } else {
-            xdata[static_cast<std::size_t>(index)] = newX;
-          }
-        }
+        xValues[idx] = projectIntoBounds(newX, idx);
 
         if (possibleToTerminate
-            && std::abs(xdata[static_cast<std::size_t>(index)])
-                   > params->epsilonForDivision) {
-          const double relativeDeltaX = std::abs(
-              (xdata[static_cast<std::size_t>(index)] - oldX)
-              / xdata[static_cast<std::size_t>(index)]);
+            && std::abs(xValues[idx]) > params->epsilonForDivision) {
+          const double relativeDeltaX
+              = std::abs((xValues[idx] - oldX) / xValues[idx]);
           if (relativeDeltaX > relativeTolerance) {
             possibleToTerminate = false;
           }

--- a/dart/math/lcp/projection/pgs_solver.cpp
+++ b/dart/math/lcp/projection/pgs_solver.cpp
@@ -153,10 +153,10 @@ LcpResult PgsSolver::solve(
       const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
       const double frictionLimit
           = std::abs(hiValues[idx] * xValues[frictionIndex]);
-      return std::clamp(value, -frictionLimit, frictionLimit);
+      return detail::projectToBounds(value, -frictionLimit, frictionLimit);
     }
 
-    return std::clamp(value, loValues[idx], hiValues[idx]);
+    return detail::projectToBounds(value, loValues[idx], hiValues[idx]);
   };
 
   for (int r = 0; r < n; ++r) {

--- a/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
+++ b/dart/math/lcp/projection/red_black_gauss_seidel_solver.cpp
@@ -218,14 +218,7 @@ LcpResult RedBlackGaussSeidelSolver::solve(
       return value;
     }
 
-    double projected = value;
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
-    return projected;
+    return detail::projectToBounds(value, lo[i], hi[i]);
   };
 
   auto updateIndex = [&](int i, const Eigen::VectorXd& xRead) {

--- a/dart/math/lcp/projection/subspace_minimization_solver.cpp
+++ b/dart/math/lcp/projection/subspace_minimization_solver.cpp
@@ -262,14 +262,7 @@ LcpResult SubspaceMinimizationSolver::solve(
 
       for (int r = 0; r < fSize; ++r) {
         const int i = freeIndices[r];
-        double value = xFree[r];
-        if (std::isfinite(loEff[i])) {
-          value = std::max(value, loEff[i]);
-        }
-        if (std::isfinite(hiEff[i])) {
-          value = std::min(value, hiEff[i]);
-        }
-        x[i] = value;
+        x[i] = detail::projectToBounds(xFree[r], loEff[i], hiEff[i]);
       }
     }
 

--- a/dart/math/lcp/projection/symmetric_psor_solver.cpp
+++ b/dart/math/lcp/projection/symmetric_psor_solver.cpp
@@ -205,14 +205,7 @@ LcpResult SymmetricPsorSolver::solve(
       return value;
     }
 
-    double projected = value;
-    if (std::isfinite(lo[i])) {
-      projected = std::max(projected, lo[i]);
-    }
-    if (std::isfinite(hi[i])) {
-      projected = std::min(projected, hi[i]);
-    }
-    return projected;
+    return detail::projectToBounds(value, lo[i], hi[i]);
   };
 
   auto updateIndex = [&](int i) {

--- a/dart/math/lcp/projection/tgs_solver.cpp
+++ b/dart/math/lcp/projection/tgs_solver.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <span>
 #include <vector>
 
 #include <cmath>
@@ -112,23 +113,51 @@ LcpResult TgsSolver::solve(
                                        ? options.relativeTolerance
                                        : mDefaultOptions.relativeTolerance;
 
-  std::vector<double> Adata(static_cast<std::size_t>(n * nSkip), 0.0);
-  std::vector<double> xdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> bdata(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> loData(static_cast<std::size_t>(n), 0.0);
-  std::vector<double> hiData(static_cast<std::size_t>(n), 0.0);
-  std::vector<int> findexData(static_cast<std::size_t>(n), -1);
+  const auto problemSize = static_cast<std::size_t>(n);
+  const auto paddedSize = static_cast<std::size_t>(nSkip);
+
+  std::vector<double> Adata(problemSize * paddedSize, 0.0);
+  std::vector<double> xdata(problemSize, 0.0);
+  std::vector<double> bdata(problemSize, 0.0);
+  std::vector<double> loData(problemSize, 0.0);
+  std::vector<double> hiData(problemSize, 0.0);
+  std::vector<int> findexData(problemSize, -1);
+
+  std::span<double> aValues{Adata};
+  std::span<double> xValues{xdata};
+  std::span<double> bValues{bdata};
+  std::span<double> loValues{loData};
+  std::span<double> hiValues{hiData};
+  std::span<int> findexValues{findexData};
+
+  auto aRow = [&](int row) -> std::span<double> {
+    return aValues.subspan(
+        static_cast<std::size_t>(row) * paddedSize, problemSize);
+  };
+
+  auto projectIntoBounds = [&](double value, std::size_t idx) {
+    if (findexValues[idx] >= 0) {
+      const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
+      const double frictionLimit
+          = std::abs(hiValues[idx] * xValues[frictionIndex]);
+      return std::clamp(value, -frictionLimit, frictionLimit);
+    }
+
+    return std::clamp(value, loValues[idx], hiValues[idx]);
+  };
 
   for (int r = 0; r < n; ++r) {
-    bdata[static_cast<std::size_t>(r)] = b[r];
+    const auto idx = static_cast<std::size_t>(r);
+    std::span<double> row = aRow(r);
+    bValues[idx] = b[r];
     const double initVal
         = (options.warmStart && std::isfinite(x[r])) ? x[r] : 0.0;
-    xdata[static_cast<std::size_t>(r)] = initVal;
-    loData[static_cast<std::size_t>(r)] = lo[r];
-    hiData[static_cast<std::size_t>(r)] = hi[r];
-    findexData[static_cast<std::size_t>(r)] = findex[r];
+    xValues[idx] = initVal;
+    loValues[idx] = lo[r];
+    hiValues[idx] = hi[r];
+    findexValues[idx] = findex[r];
     for (int c = 0; c < n; ++c) {
-      Adata[static_cast<std::size_t>(r * nSkip + c)] = A(r, c);
+      row[static_cast<std::size_t>(c)] = A(r, c);
     }
   }
 
@@ -136,18 +165,21 @@ LcpResult TgsSolver::solve(
   order.reserve(static_cast<std::size_t>(n));
 
   for (int i = 0; i < n; ++i) {
-    if (Adata[static_cast<std::size_t>(nSkip * i + i)]
-        >= params->epsilonForDivision) {
+    const auto idx = static_cast<std::size_t>(i);
+    const std::span<double> row = aRow(i);
+    if (row[idx] >= params->epsilonForDivision) {
       order.push_back(i);
     } else {
-      xdata[static_cast<std::size_t>(i)] = 0.0;
+      xValues[idx] = 0.0;
     }
   }
 
-  std::vector<double> invDiag(static_cast<std::size_t>(n), 0.0);
+  std::vector<double> invDiag(problemSize, 0.0);
+  std::span<double> invDiagValues{invDiag};
   for (const auto& index : order) {
-    invDiag[static_cast<std::size_t>(index)]
-        = 1.0 / Adata[static_cast<std::size_t>(nSkip * index + index)];
+    const auto idx = static_cast<std::size_t>(index);
+    const std::span<double> row = aRow(index);
+    invDiagValues[idx] = 1.0 / row[idx];
   }
 
   int iterationsUsed = 0;
@@ -163,31 +195,23 @@ LcpResult TgsSolver::solve(
 
     for (const auto& index : order) {
       const std::size_t idx = static_cast<std::size_t>(index);
-      const double* APtr = Adata.data() + nSkip * index;
+      const std::span<double> row = aRow(index);
 
-      double newX = bdata[idx];
+      double newX = bValues[idx];
       for (int j = 0; j < index; ++j) {
-        newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * xValues[static_cast<std::size_t>(j)];
       }
       for (int j = index + 1; j < n; ++j) {
-        newX -= APtr[j] * xdata[static_cast<std::size_t>(j)];
+        newX -= row[static_cast<std::size_t>(j)]
+                * xValues[static_cast<std::size_t>(j)];
       }
-      newX *= invDiag[idx];
+      newX *= invDiagValues[idx];
 
-      const double oldX = xdata[idx];
+      const double oldX = xValues[idx];
       newX = std::lerp(oldX, newX, relaxation);
-
-      double loVal = loData[idx];
-      double hiVal = hiData[idx];
-      if (findexData[idx] >= 0) {
-        const double fricLimit = std::abs(
-            hiData[idx] * xdata[static_cast<std::size_t>(findexData[idx])]);
-        loVal = -fricLimit;
-        hiVal = fricLimit;
-      }
-
-      newX = std::clamp(newX, loVal, hiVal);
-      xdata[idx] = newX;
+      newX = projectIntoBounds(newX, idx);
+      xValues[idx] = newX;
 
       if (possibleToTerminate && std::abs(newX) > params->epsilonForDivision) {
         const double relativeDelta = std::abs((newX - oldX) / newX);

--- a/dart/math/lcp/projection/tgs_solver.cpp
+++ b/dart/math/lcp/projection/tgs_solver.cpp
@@ -140,10 +140,10 @@ LcpResult TgsSolver::solve(
       const auto frictionIndex = static_cast<std::size_t>(findexValues[idx]);
       const double frictionLimit
           = std::abs(hiValues[idx] * xValues[frictionIndex]);
-      return std::clamp(value, -frictionLimit, frictionLimit);
+      return detail::projectToBounds(value, -frictionLimit, frictionLimit);
     }
 
-    return std::clamp(value, loValues[idx], hiValues[idx]);
+    return detail::projectToBounds(value, loValues[idx], hiValues[idx]);
   };
 
   for (int r = 0; r < n; ++r) {

--- a/dart/math/optimization/gradient_descent_solver.cpp
+++ b/dart/math/optimization/gradient_descent_solver.cpp
@@ -127,7 +127,7 @@ bool GradientDescentSolver::solve()
   }
 
   Eigen::VectorXd x = problem->getInitialGuess();
-  DART_ASSERT(x.size() == static_cast<int>(dim));
+  DART_ASSERT(std::cmp_equal(x.size(), dim));
 
   Eigen::VectorXd lastx = x;
   Eigen::VectorXd dx(x.size());
@@ -183,8 +183,7 @@ bool GradientDescentSolver::solve()
       if (objective) {
         objective->evalGradient(x, dxMap);
       }
-      for (int i = 0; i < static_cast<int>(problem->getNumEqConstraints());
-           ++i) {
+      for (std::size_t i = 0; i < problem->getNumEqConstraints(); ++i) {
         if (std::abs(mEqConstraintCostCache[i]) < tol) {
           continue;
         }
@@ -193,7 +192,7 @@ bool GradientDescentSolver::solve()
 
         // Get the user-specified weight if available, otherwise use the default
         // weight value
-        double weight = mGradientP.mEqConstraintWeights.size() > i
+        double weight = std::cmp_less(i, mGradientP.mEqConstraintWeights.size())
                             ? mGradientP.mEqConstraintWeights[i]
                             : mGradientP.mDefaultConstraintWeight;
 
@@ -204,8 +203,7 @@ bool GradientDescentSolver::solve()
         dx += weight * grad * math::sign(mEqConstraintCostCache[i]);
       }
 
-      for (int i = 0; i < static_cast<int>(problem->getNumIneqConstraints());
-           ++i) {
+      for (std::size_t i = 0; i < problem->getNumIneqConstraints(); ++i) {
         if (mIneqConstraintCostCache[i] < tol) {
           continue;
         }
@@ -214,9 +212,10 @@ bool GradientDescentSolver::solve()
 
         // Get the user-specified weight if available, otherwise use the
         // default weight value
-        double weight = mGradientP.mIneqConstraintWeights.size() > i
-                            ? mGradientP.mIneqConstraintWeights[i]
-                            : mGradientP.mDefaultConstraintWeight;
+        double weight
+            = std::cmp_less(i, mGradientP.mIneqConstraintWeights.size())
+                  ? mGradientP.mIneqConstraintWeights[i]
+                  : mGradientP.mDefaultConstraintWeight;
 
         dx += weight * grad;
       }

--- a/dart/simd/memory.hpp
+++ b/dart/simd/memory.hpp
@@ -55,6 +55,16 @@ inline constexpr std::size_t default_vector_alignment = 32;
 inline constexpr std::size_t default_vector_alignment = 16;
 #endif
 
+namespace detail {
+
+[[nodiscard]] constexpr std::size_t alignUpToPowerOfTwo(
+    std::size_t value, std::size_t alignment) noexcept
+{
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+} // namespace detail
+
 template <typename T, std::size_t Alignment = default_vector_alignment>
 class AlignedAllocator
 {
@@ -66,7 +76,6 @@ public:
   using is_always_equal = std::true_type;
 
   static constexpr std::size_t alignment = Alignment;
-
   static_assert(
       std::has_single_bit(Alignment), "Alignment must be a power of two.");
 
@@ -97,7 +106,7 @@ public:
       ptr = nullptr;
     }
 #else
-    std::size_t aligned_bytes = (bytes + Alignment - 1) & ~(Alignment - 1);
+    std::size_t aligned_bytes = detail::alignUpToPowerOfTwo(bytes, Alignment);
     ptr = std::aligned_alloc(Alignment, aligned_bytes);
 #endif
 

--- a/dart/simulation/experimental/io/auto_serialization.hpp
+++ b/dart/simulation/experimental/io/auto_serialization.hpp
@@ -110,7 +110,7 @@ void autoSerialize(
           writePOD(out, field(i, j));
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       // POD types (int, double, bool, enums, etc.)
       writePOD(out, field);
     } else {
@@ -153,7 +153,7 @@ void autoDeserialize(std::istream& in, T& component)
           }
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       // POD types
       readPOD(in, field);
     } else {
@@ -215,7 +215,7 @@ void autoSerialize(
       writePOD(out, field.x());
       writePOD(out, field.y());
       writePOD(out, field.z());
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       writePOD(out, field);
     } else {
       // Complex nested type
@@ -263,7 +263,7 @@ void autoDeserialize(std::istream& in, T& component)
           }
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       readPOD(in, field);
     } else {
       // Complex nested type
@@ -298,7 +298,7 @@ void autoSerialize(
           writePOD(out, field(i, j));
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       writePOD(out, field);
     } else {
       // Recursively serialize nested structs
@@ -330,7 +330,7 @@ void autoDeserialize(std::istream& in, T& value)
           }
         }
       }
-    } else if constexpr (std::is_trivially_copyable_v<FieldType>) {
+    } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       readPOD(in, field);
     } else {
       // Recursively deserialize nested structs

--- a/dart/simulation/experimental/io/binary_io.cpp
+++ b/dart/simulation/experimental/io/binary_io.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/simulation/experimental/io/binary_io.hpp"
 
+#include <span>
 #include <stdexcept>
 
 namespace dart::simulation::experimental::io {
@@ -120,8 +121,9 @@ void writeVectorXd(std::ostream& out, const Eigen::VectorXd& vec)
 {
   std::size_t size = vec.size();
   writePOD(out, size);
-  for (Eigen::Index i = 0; i < vec.size(); ++i) {
-    writePOD(out, vec(i));
+  if (size > 0) {
+    detail::writeBytes(
+        out, std::as_bytes(std::span<const double>(vec.data(), size)));
   }
 }
 
@@ -131,8 +133,9 @@ void readVectorXd(std::istream& in, Eigen::VectorXd& vec)
   std::size_t size;
   readPOD(in, size);
   vec.resize(size);
-  for (Eigen::Index i = 0; i < static_cast<Eigen::Index>(size); ++i) {
-    readPOD(in, vec(i));
+  if (size > 0) {
+    detail::readBytes(
+        in, std::as_writable_bytes(std::span<double>(vec.data(), size)));
   }
 }
 

--- a/dart/simulation/experimental/io/binary_io.hpp
+++ b/dart/simulation/experimental/io/binary_io.hpp
@@ -71,6 +71,10 @@ constexpr std::uint32_t kBinaryFormatVersion = 1;
 
 namespace detail {
 
+template <typename T>
+concept TriviallyCopyable
+    = std::is_trivially_copyable_v<std::remove_cvref_t<T>>;
+
 inline void writeBytes(std::ostream& out, std::span<const std::byte> bytes)
 {
   out.write(
@@ -100,22 +104,16 @@ std::span<std::byte> asWritableBytes(T& value)
 } // namespace detail
 
 // Write a POD (Plain Old Data) type to binary stream
-template <typename T>
+template <detail::TriviallyCopyable T>
 void writePOD(std::ostream& out, const T& value)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "writePOD requires trivially copyable type");
   detail::writeBytes(out, detail::asBytes(value));
 }
 
 // Read a POD (Plain Old Data) type from binary stream
-template <typename T>
+template <detail::TriviallyCopyable T>
 void readPOD(std::istream& in, T& value)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "readPOD requires trivially copyable type");
   detail::readBytes(in, detail::asWritableBytes(value));
 }
 
@@ -168,12 +166,9 @@ void DART_EXPERIMENTAL_API readMatrixXd(std::istream& in, Eigen::MatrixXd& mat);
 //==============================================================================
 
 // Write a POD span to binary stream (size-prefixed)
-template <typename T>
+template <detail::TriviallyCopyable T>
 void writeVector(std::ostream& out, std::span<const T> vec)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "writeVector requires trivially copyable type");
   std::size_t size = vec.size();
   writePOD(out, size);
   if (size > 0) {
@@ -182,12 +177,9 @@ void writeVector(std::ostream& out, std::span<const T> vec)
 }
 
 // Read std::vector of POD types from binary stream
-template <typename T>
+template <detail::TriviallyCopyable T>
 void readVector(std::istream& in, std::vector<T>& vec)
 {
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "readVector requires trivially copyable type");
   std::size_t size;
   readPOD(in, size);
   vec.resize(size);

--- a/dart/simulation/experimental/space/auto_mapper.hpp
+++ b/dart/simulation/experimental/space/auto_mapper.hpp
@@ -50,10 +50,24 @@ namespace dart::simulation::experimental::space {
 
 namespace detail {
 
+template <typename Field>
+concept ArithmeticField = std::integral<std::remove_cvref_t<Field>>
+                          || std::floating_point<std::remove_cvref_t<Field>>;
+
+template <typename Field>
+concept EnumField = std::is_enum_v<std::remove_cvref_t<Field>>;
+
+template <typename Field>
+concept ScalarField = ArithmeticField<Field> || EnumField<Field>;
+
+template <typename Field>
+concept AggregateField = std::is_aggregate_v<std::remove_cvref_t<Field>>;
+
 template <typename T>
-concept IsometryField
-    = std::same_as<T, Eigen::Isometry3d>
-      || std::derived_from<T, Eigen::Transform<double, 3, Eigen::Isometry>>;
+concept IsometryField = std::same_as<std::remove_cvref_t<T>, Eigen::Isometry3d>
+                        || std::derived_from<
+                            std::remove_cvref_t<T>,
+                            Eigen::Transform<double, 3, Eigen::Isometry>>;
 
 } // namespace detail
 
@@ -66,7 +80,7 @@ size_t extractFieldToVector(
   using FieldType = std::remove_cvref_t<Field>;
   size_t count = 0;
 
-  if constexpr (std::is_arithmetic_v<FieldType>) {
+  if constexpr (detail::ArithmeticField<FieldType>) {
     // Scalar types (double, float, int, etc.)
     vec[offset] = static_cast<double>(field);
     count = 1;
@@ -103,7 +117,7 @@ size_t extractFieldToVector(
     vec[offset + 2] = field.y();
     vec[offset + 3] = field.z();
     count = 4;
-  } else if constexpr (std::is_enum_v<FieldType>) {
+  } else if constexpr (detail::EnumField<FieldType>) {
     // Enums as integers
     vec[offset] = static_cast<double>(static_cast<int>(field));
     count = 1;
@@ -125,7 +139,7 @@ size_t injectVectorToField(
   using FieldType = std::remove_cvref_t<Field>;
   size_t count = 0;
 
-  if constexpr (std::is_arithmetic_v<FieldType>) {
+  if constexpr (detail::ArithmeticField<FieldType>) {
     field = static_cast<FieldType>(vec[offset]);
     count = 1;
   } else if constexpr (detail::IsometryField<FieldType>) {
@@ -157,7 +171,7 @@ size_t injectVectorToField(
     field.y() = vec[offset + 2];
     field.z() = vec[offset + 3];
     count = 4;
-  } else if constexpr (std::is_enum_v<FieldType>) {
+  } else if constexpr (detail::EnumField<FieldType>) {
     field = static_cast<FieldType>(static_cast<int>(vec[offset]));
     count = 1;
   } else {
@@ -176,7 +190,7 @@ constexpr size_t getFieldDimension()
 {
   using FieldType = std::remove_cvref_t<Field>;
 
-  if constexpr (std::is_arithmetic_v<FieldType> || std::is_enum_v<FieldType>) {
+  if constexpr (detail::ScalarField<FieldType>) {
     return 1;
   } else if constexpr (std::same_as<FieldType, Eigen::Vector2d>) {
     return 2;
@@ -184,11 +198,11 @@ constexpr size_t getFieldDimension()
     return 3;
   } else if constexpr (std::same_as<FieldType, Eigen::Quaterniond>) {
     return 4;
-  } else if constexpr (std::same_as<FieldType, Eigen::Isometry3d>) {
+  } else if constexpr (detail::IsometryField<FieldType>) {
     return 7; // Translation (3) + Quaternion (4)
   } else if constexpr (std::same_as<FieldType, Eigen::VectorXd>) {
     return 0; // Dynamic size - must be computed at runtime
-  } else if constexpr (std::is_aggregate_v<FieldType>) {
+  } else if constexpr (detail::AggregateField<FieldType>) {
     // Nested aggregate struct - sum dimensions of all fields
     size_t total = 0;
     boost::pfr::for_each_field(FieldType{}, [&](const auto& field) {

--- a/dart/simulation/experimental/space/component_mapper.hpp
+++ b/dart/simulation/experimental/space/component_mapper.hpp
@@ -46,7 +46,8 @@ namespace dart::simulation::experimental {
 namespace detail {
 
 template <typename Field>
-concept ArithmeticField = std::is_arithmetic_v<std::remove_cvref_t<Field>>;
+concept ArithmeticField = std::integral<std::remove_cvref_t<Field>>
+                          || std::floating_point<std::remove_cvref_t<Field>>;
 
 template <typename Field>
 concept EigenVectorField = requires(Field field, Eigen::Index i) {

--- a/dart/simulation/experimental/space/state_space.cpp
+++ b/dart/simulation/experimental/space/state_space.cpp
@@ -34,8 +34,12 @@
 
 #include "dart/simulation/experimental/common/exceptions.hpp"
 
+#include <algorithm>
 #include <format>
+#include <iterator>
 #include <stdexcept>
+
+#include <cstddef>
 
 namespace dart::simulation::experimental {
 
@@ -134,9 +138,10 @@ std::vector<double> StateSpace::getLowerBounds() const
   bounds.reserve(m_totalDimension);
 
   for (const auto& var : m_variables) {
-    for (size_t i = 0; i < var.dimension; ++i) {
-      bounds.push_back(var.lowerBound);
-    }
+    std::ranges::fill_n(
+        std::back_inserter(bounds),
+        static_cast<std::ptrdiff_t>(var.dimension),
+        var.lowerBound);
   }
 
   return bounds;
@@ -148,9 +153,10 @@ std::vector<double> StateSpace::getUpperBounds() const
   bounds.reserve(m_totalDimension);
 
   for (const auto& var : m_variables) {
-    for (size_t i = 0; i < var.dimension; ++i) {
-      bounds.push_back(var.upperBound);
-    }
+    std::ranges::fill_n(
+        std::back_inserter(bounds),
+        static_cast<std::ptrdiff_t>(var.dimension),
+        var.upperBound);
   }
 
   return bounds;

--- a/dart/simulation/experimental/space/vector_mapper.cpp
+++ b/dart/simulation/experimental/space/vector_mapper.cpp
@@ -34,9 +34,13 @@
 
 #include "dart/simulation/experimental/common/exceptions.hpp"
 
+#include <algorithm>
 #include <format>
+#include <iterator>
 #include <stdexcept>
 #include <utility>
+
+#include <cstddef>
 
 namespace dart::simulation::experimental {
 
@@ -82,9 +86,11 @@ void VectorMapper::toVector(
       offset += written;
     } else {
       // No mapper for this variable, fill with zeros
-      for (size_t j = 0; j < variables[i].dimension; ++j) {
-        output[offset++] = 0.0;
-      }
+      std::ranges::fill_n(
+          std::next(output.begin(), static_cast<std::ptrdiff_t>(offset)),
+          static_cast<std::ptrdiff_t>(variables[i].dimension),
+          0.0);
+      offset += variables[i].dimension;
     }
   }
 }
@@ -105,9 +111,7 @@ void VectorMapper::toEigen(
   toVector(registry, temp);
 
   // Copy to Eigen vector
-  for (size_t i = 0; i < temp.size(); ++i) {
-    output[i] = temp[i];
-  }
+  std::ranges::copy(temp, output.data());
 }
 
 void VectorMapper::fromVector(

--- a/python/dartpy/common/polymorphic_caster.hpp
+++ b/python/dartpy/common/polymorphic_caster.hpp
@@ -2,6 +2,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include <concepts>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -123,7 +124,7 @@ private:
 
 } // namespace detail
 
-template <typename Base, typename Derived>
+template <typename Base, std::derived_from<Base> Derived>
 inline void registerPolymorphicCaster()
 {
   detail::PolymorphicCasterRegistry<Base>::registerType(

--- a/tests/benchmark/dynamics/bm_dynamics_cache.cpp
+++ b/tests/benchmark/dynamics/bm_dynamics_cache.cpp
@@ -69,6 +69,7 @@
 #include <queue>
 #include <thread>
 #include <vector>
+#include <version>
 
 #include <cassert>
 #include <cmath>
@@ -914,7 +915,11 @@ static void BM_ParallelWorlds(benchmark::State& state)
   }
 
   for (auto _ : state) {
+#if defined(__cpp_lib_jthread)
+    std::vector<std::jthread> threads;
+#else
     std::vector<std::thread> threads;
+#endif
     threads.reserve(numThreads);
     for (int t = 0; t < numThreads; ++t) {
       threads.emplace_back([&worlds, t, stepsPerThread]() {
@@ -923,9 +928,11 @@ static void BM_ParallelWorlds(benchmark::State& state)
         }
       });
     }
+#if !defined(__cpp_lib_jthread)
     for (auto& thread : threads) {
       thread.join();
     }
+#endif
   }
   state.SetItemsProcessed(
       static_cast<int64_t>(state.iterations()) * numThreads * stepsPerThread);

--- a/tests/integration/utils/test_signal.cpp
+++ b/tests/integration/utils/test_signal.cpp
@@ -41,6 +41,11 @@
 #include <numeric>
 #include <thread>
 #include <vector>
+#include <version>
+
+#if defined(__cpp_lib_jthread)
+  #include <stop_token>
+#endif
 
 using namespace std;
 using namespace Eigen;
@@ -411,6 +416,14 @@ TEST(Signal, ConcurrentUsage)
   std::atomic<int> callbackCount{0};
 
   {
+#if defined(__cpp_lib_jthread)
+    std::jthread raiser([&](std::stop_token stopToken) {
+      while (!stopToken.stop_requested()) {
+        signal.raise();
+        raiseCount.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+#else
     std::atomic<bool> stopRequested{false};
     std::thread raiser([&]() {
       while (!stopRequested.load(std::memory_order_relaxed)) {
@@ -418,13 +431,18 @@ TEST(Signal, ConcurrentUsage)
         raiseCount.fetch_add(1, std::memory_order_relaxed);
       }
     });
+#endif
 
     while (raiseCount.load(std::memory_order_relaxed) == 0) {
       std::this_thread::yield();
     }
 
     {
+#if defined(__cpp_lib_jthread)
+      std::vector<std::jthread> workers;
+#else
       std::vector<std::thread> workers;
+#endif
       workers.reserve(kNumThreads);
       for (int t = 0; t < kNumThreads; ++t) {
         workers.emplace_back([&]() {
@@ -437,14 +455,19 @@ TEST(Signal, ConcurrentUsage)
           }
         });
       }
-
+#if !defined(__cpp_lib_jthread)
       for (std::thread& worker : workers) {
         worker.join();
       }
+#endif
     }
 
+#if defined(__cpp_lib_jthread)
+    raiser.request_stop();
+#else
     stopRequested.store(true, std::memory_order_relaxed);
     raiser.join();
+#endif
   }
 
   EXPECT_EQ(signal.getNumConnections(), 0u);

--- a/tests/unit/common/test_profile.cpp
+++ b/tests/unit/common/test_profile.cpp
@@ -41,6 +41,7 @@
   #include <sstream>
   #include <string>
   #include <thread>
+  #include <version>
 
 using dart::common::profile::Profiler;
 using dart::common::profile::ProfileScope;
@@ -86,11 +87,17 @@ TEST_F(ProfileTest, CapturesMultipleThreads)
   }
 
   {
+  #if defined(__cpp_lib_jthread)
+    std::jthread worker([] {
+  #else
     std::thread worker([] {
+  #endif
       ProfileScope workerScope("worker-work", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(3));
     });
+  #if !defined(__cpp_lib_jthread)
     worker.join();
+  #endif
   }
 
   std::stringstream ss;

--- a/tests/unit/common/test_profiler.cpp
+++ b/tests/unit/common/test_profiler.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <version>
 
 #include <cstdlib>
 
@@ -285,7 +286,11 @@ TEST(Profiler, SummaryMultipleThreads)
   ScopedEnvVar env("DART_PROFILE_COLOR", "0");
 
   {
+#if defined(__cpp_lib_jthread)
+    std::jthread worker([]() {
+#else
     std::thread worker([]() {
+#endif
       common::profile::ProfileScope scope("WorkerScope", __FILE__, __LINE__);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     });
@@ -298,8 +303,9 @@ TEST(Profiler, SummaryMultipleThreads)
     profiler.markFrame();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     profiler.markFrame();
-
+#if !defined(__cpp_lib_jthread)
     worker.join();
+#endif
   }
 
   std::ostringstream oss;

--- a/tests/unit/dynamics/test_arrow_shape.cpp
+++ b/tests/unit/dynamics/test_arrow_shape.cpp
@@ -6,6 +6,9 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <limits>
+
+#include <cmath>
 
 namespace dart {
 namespace utils {
@@ -212,6 +215,19 @@ TEST(ArrowShapeTest, PropertiesClampedToValidRange)
   EXPECT_GE(clampedProps.mMinHeadLength, 0.0);
   EXPECT_GE(clampedProps.mMaxHeadLength, 0.0);
   EXPECT_GE(clampedProps.mHeadRadiusScale, 1.0);
+}
+
+//==============================================================================
+TEST(ArrowShapeTest, NaNHeadLengthScaleFallsBackToUpperBound)
+{
+  ArrowShape::Properties props;
+  props.mHeadLengthScale = std::numeric_limits<double>::quiet_NaN();
+
+  ArrowShape arrow(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitX(), props);
+
+  const auto& clamped = arrow.getProperties();
+  EXPECT_FALSE(std::isnan(clamped.mHeadLengthScale));
+  EXPECT_DOUBLE_EQ(clamped.mHeadLengthScale, 1.0);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Consolidates the remaining targeted C++20/STL modernization work from #2624, #2629, and #2631.
- Includes the follow-up ArrowShape NaN regression fix from #2642.

## Motivation / Problem

- Keeping the remaining work split across several PRs forces each PR behind `main` after every merge and causes repeated CI reruns.
- This batch keeps the changes reviewable while reducing CI churn to a single merge gate.

## Changes / Key Changes

- Uses targeted C++20 helpers where they remove manual loops or strengthen API contracts in common, dynamics, LCP, SIMD, simulation-experimental, and dartpy code paths.
- Preserves legacy ArrowShape NaN head-length handling and adds a regression test.
- Keeps the changes behavior-preserving except for tests that document expected behavior.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `cmake --build build/default/cpp/Release --target dart_experimental_tests` (required before rerunning `pixi run test-unit` because the first run exposed missing simulation-experimental test executables)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Supersedes #2624
- Supersedes #2629
- Supersedes #2631
- Supersedes #2642
- Follow-up to #2632

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
