### PR TITLE
Adopt STL helpers in support utilities

### DIFF
--- a/dart/collision/ode/ode_collision_detector.cpp
+++ b/dart/collision/ode/ode_collision_detector.cpp
@@ -100,16 +100,15 @@ std::deque<Contact>& FindPairInHist(
     std::vector<OdeCollisionDetector::ContactHistoryItem>& cache,
     const OdeCollisionDetector::CollObjPair& pair)
 {
-  for (auto& item : cache) {
-    if (pair.first == item.pair.first && pair.second == item.pair.second) {
-      return item.history;
-    }
+  auto item = std::ranges::find_if(cache, [&pair](const auto& candidate) {
+    return pair.first == candidate.pair.first
+           && pair.second == candidate.pair.second;
+  });
+  if (item != cache.end()) {
+    return item->history;
   }
-  auto newItem
-      = OdeCollisionDetector::ContactHistoryItem{pair, std::deque<Contact>()};
-  cache.push_back(newItem);
 
-  return cache.back().history;
+  return cache.emplace_back(pair, std::deque<Contact>{}).history;
 }
 
 void eraseHistoryForObject(

--- a/dart/common/detail/name_manager.hpp
+++ b/dart/common/detail/name_manager.hpp
@@ -145,8 +145,8 @@ bool NameManager<T>::addName(std::string_view name, const T& obj)
   }
 
   const std::string nameString(name);
-  mMap.insert(std::pair<std::string, T>(nameString, obj));
-  mReverseMap.insert(std::pair<T, std::string>(obj, nameString));
+  mMap.emplace(nameString, obj);
+  mReverseMap.emplace(obj, nameString);
 
   DART_ASSERT(mReverseMap.size() == mMap.size());
 
@@ -182,7 +182,7 @@ bool NameManager<T>::removeObject(const T& obj)
 {
   DART_ASSERT(mReverseMap.size() == mMap.size());
 
-  typename std::map<T, std::string>::iterator rit = mReverseMap.find(obj);
+  auto rit = mReverseMap.find(obj);
 
   if (rit == mReverseMap.end()) {
     return false;
@@ -254,8 +254,7 @@ std::string NameManager<T>::getName(const T& obj) const
 {
   DART_ASSERT(mReverseMap.size() == mMap.size());
 
-  typename std::map<T, std::string>::const_iterator result
-      = mReverseMap.find(obj);
+  const auto result = mReverseMap.find(obj);
 
   if (result != mReverseMap.end()) {
     return result->second;
@@ -271,7 +270,7 @@ std::string NameManager<T>::changeObjectName(
 {
   DART_ASSERT(mReverseMap.size() == mMap.size());
 
-  typename std::map<T, std::string>::iterator rit = mReverseMap.find(obj);
+  auto rit = mReverseMap.find(obj);
   if (rit == mReverseMap.end()) {
     return std::string(newName);
   }

--- a/dart/dynamics/mesh_shape.cpp
+++ b/dart/dynamics/mesh_shape.cpp
@@ -55,6 +55,7 @@
 #include <iterator>
 #include <limits>
 #include <locale>
+#include <numeric>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -650,21 +651,31 @@ const aiScene* MeshShape::convertToAssimpMesh() const
   const bool hasSubMeshes = !mSubMeshRanges.empty() && mMaterials.size() > 1;
   bool useSubMeshes = hasSubMeshes;
   if (useSubMeshes) {
-    std::size_t totalVertices = 0;
-    std::size_t totalTriangles = 0;
-    for (const auto& range : mSubMeshRanges) {
-      if (range.vertexOffset + range.vertexCount > vertices.size()
-          || range.triangleOffset + range.triangleCount > triangles.size()) {
-        useSubMeshes = false;
-        break;
-      }
-      totalVertices += range.vertexCount;
-      totalTriangles += range.triangleCount;
-    }
-    if (useSubMeshes
-        && (totalVertices != vertices.size()
-            || totalTriangles != triangles.size())) {
+    const bool rangesWithinMesh
+        = std::ranges::all_of(mSubMeshRanges, [&](const auto& range) {
+            return range.vertexOffset + range.vertexCount <= vertices.size()
+                   && range.triangleOffset + range.triangleCount
+                          <= triangles.size();
+          });
+    if (!rangesWithinMesh) {
       useSubMeshes = false;
+    } else {
+      const std::size_t totalVertices = std::accumulate(
+          mSubMeshRanges.begin(),
+          mSubMeshRanges.end(),
+          std::size_t{0},
+          [](std::size_t total, const auto& range) {
+            return total + range.vertexCount;
+          });
+      const std::size_t totalTriangles = std::accumulate(
+          mSubMeshRanges.begin(),
+          mSubMeshRanges.end(),
+          std::size_t{0},
+          [](std::size_t total, const auto& range) {
+            return total + range.triangleCount;
+          });
+      useSubMeshes = totalVertices == vertices.size()
+                     && totalTriangles == triangles.size();
     }
   }
 
@@ -893,16 +904,20 @@ std::shared_ptr<math::PolygonMesh<double>> MeshShape::convertAssimpPolygonMesh(
 
   auto polygonMesh = std::make_shared<math::PolygonMesh<double>>();
 
-  std::size_t totalVertices = 0;
-  std::size_t totalFaces = 0;
-  for (std::size_t i = 0; i < scene->mNumMeshes; ++i) {
-    const aiMesh* assimpMesh = scene->mMeshes[i];
-    if (!assimpMesh) {
-      continue;
-    }
-    totalVertices += assimpMesh->mNumVertices;
-    totalFaces += assimpMesh->mNumFaces;
-  }
+  const std::size_t totalVertices = std::accumulate(
+      scene->mMeshes,
+      scene->mMeshes + scene->mNumMeshes,
+      std::size_t{0},
+      [](std::size_t total, const aiMesh* assimpMesh) {
+        return assimpMesh ? total + assimpMesh->mNumVertices : total;
+      });
+  const std::size_t totalFaces = std::accumulate(
+      scene->mMeshes,
+      scene->mMeshes + scene->mNumMeshes,
+      std::size_t{0},
+      [](std::size_t total, const aiMesh* assimpMesh) {
+        return assimpMesh ? total + assimpMesh->mNumFaces : total;
+      });
 
   polygonMesh->reserveVertices(totalVertices);
   polygonMesh->reserveFaces(totalFaces);

--- a/dart/simulation/recording.cpp
+++ b/dart/simulation/recording.cpp
@@ -43,6 +43,22 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
+#include <numeric>
+
+namespace {
+
+int totalDofs(std::span<const int> skeletonDofs)
+{
+  return std::accumulate(skeletonDofs.begin(), skeletonDofs.end(), 0);
+}
+
+int dofOffset(std::span<const int> skeletonDofs, int skeletonIndex)
+{
+  return std::accumulate(
+      skeletonDofs.begin(), std::next(skeletonDofs.begin(), skeletonIndex), 0);
+}
+
+} // namespace
 
 namespace dart {
 namespace simulation {
@@ -90,51 +106,42 @@ int Recording::getNumDofs(int _skelIdx) const
 //==============================================================================
 int Recording::getNumContacts(int _frameIdx) const
 {
-  int totalDofs = 0;
-  for (std::size_t i = 0; i < mNumGenCoordsForSkeletons.size(); i++) {
-    totalDofs += mNumGenCoordsForSkeletons[i];
-  }
-  return (mBakedStates[_frameIdx].size() - totalDofs) / 6;
+  return (mBakedStates[_frameIdx].size()
+          - totalDofs(std::span<const int>{mNumGenCoordsForSkeletons}))
+         / 6;
 }
 
 //==============================================================================
 Eigen::VectorXd Recording::getConfig(int _frameIdx, int _skelIdx) const
 {
-  int index = 0;
-  for (int i = 0; i < _skelIdx; i++) {
-    index += mNumGenCoordsForSkeletons[i];
-  }
+  const int index
+      = dofOffset(std::span<const int>{mNumGenCoordsForSkeletons}, _skelIdx);
   return mBakedStates[_frameIdx].segment(index, getNumDofs(_skelIdx));
 }
 
 //==============================================================================
 double Recording::getGenCoord(int _frameIdx, int _skelIdx, int _dofIdx) const
 {
-  int index = 0;
-  for (int i = 0; i < _skelIdx; i++) {
-    index += mNumGenCoordsForSkeletons[i];
-  }
+  const int index
+      = dofOffset(std::span<const int>{mNumGenCoordsForSkeletons}, _skelIdx);
   return mBakedStates[_frameIdx][index + _dofIdx];
 }
 
 //==============================================================================
 Eigen::Vector3d Recording::getContactPoint(int _frameIdx, int _contactIdx) const
 {
-  int totalDofs = 0;
-  for (std::size_t i = 0; i < mNumGenCoordsForSkeletons.size(); i++) {
-    totalDofs += mNumGenCoordsForSkeletons[i];
-  }
-  return mBakedStates[_frameIdx].segment(totalDofs + _contactIdx * 6, 3);
+  const int contactOffset
+      = totalDofs(std::span<const int>{mNumGenCoordsForSkeletons});
+  return mBakedStates[_frameIdx].segment(contactOffset + _contactIdx * 6, 3);
 }
 
 //==============================================================================
 Eigen::Vector3d Recording::getContactForce(int _frameIdx, int _contactIdx) const
 {
-  int totalDofs = 0;
-  for (std::size_t i = 0; i < mNumGenCoordsForSkeletons.size(); i++) {
-    totalDofs += mNumGenCoordsForSkeletons[i];
-  }
-  return mBakedStates[_frameIdx].segment(totalDofs + _contactIdx * 6 + 3, 3);
+  const int contactOffset
+      = totalDofs(std::span<const int>{mNumGenCoordsForSkeletons});
+  return mBakedStates[_frameIdx].segment(
+      contactOffset + _contactIdx * 6 + 3, 3);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Adopt targeted STL helpers in support utility code where they reduce repeated manual loops or clarify intent.
- Keep the changes local to implementation details with no public API or behavior changes.

## Motivation / Problem

- Several support paths repeated small accumulation/search patterns that are easier to read with standard library helpers.
- This keeps the C++20 adoption work focused on clear simplification rather than broad mechanical conversion.

## Changes / Key Changes

- Use local span-based helpers and `std::accumulate` for recording DOF totals and offsets.
- Use standard range algorithms for ODE contact-history lookup and mesh/submesh validation.
- Simplify mesh export/import reservation calculations and name-manager insertions.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (N/A: implementation-only refactor)
- [x] Add unit tests for new functionality (N/A: no new functionality)
- [x] Document new methods and classes (N/A: no new APIs)
- [x] Add Python bindings (dartpy) if applicable (N/A: no new bindings)