### PR TITLE
Fix PoolAllocator table growth leak (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
   * Fix spdlog/fmt 12 builds by treating DART logging format parameters as runtime format strings. ([#2540](https://github.com/dartsim/dart/pull/2540), [#2538](https://github.com/dartsim/dart/issues/2538))
 
-  * Fix PoolAllocator leaking old memory block tables when the table grows.
+  * Fix PoolAllocator leaking old memory block tables when the table grows. ([#2646](https://github.com/dartsim/dart/pull/2646))
 
 * Simulation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
   * Fix spdlog/fmt 12 builds by treating DART logging format parameters as runtime format strings. ([#2540](https://github.com/dartsim/dart/pull/2540), [#2538](https://github.com/dartsim/dart/issues/2538))
 
+  * Fix PoolAllocator leaking old memory block tables when the table grows.
+
 * Simulation
 
   * Reject NaN, infinite, zero, and negative `World::setTimeStep()` values to prevent invalid timesteps from reaching the ODE LCP solver. ([#2532](https://github.com/dartsim/dart/pull/2532), [#2531](https://github.com/dartsim/dart/issues/2531))

--- a/dart/common/PoolAllocator.cpp
+++ b/dart/common/PoolAllocator.cpp
@@ -138,6 +138,7 @@ void* PoolAllocator::allocate(size_t bytes) noexcept
 
   if (mCurrentMemoryBlockIndex == mMemoryBlocksSize) {
     MemoryBlock* currentMemoryBlocks = mMemoryBlocks;
+    const int currentMemoryBlocksSize = mMemoryBlocksSize;
     mMemoryBlocksSize += 64;
     mMemoryBlocks = mBaseAllocator.allocateAs<MemoryBlock>(mMemoryBlocksSize);
     std::memcpy(
@@ -146,6 +147,8 @@ void* PoolAllocator::allocate(size_t bytes) noexcept
         mCurrentMemoryBlockIndex * sizeof(MemoryBlock));
     std::memset(
         mMemoryBlocks + mCurrentMemoryBlockIndex, 0, 64 * sizeof(MemoryBlock));
+    mBaseAllocator.deallocate(
+        currentMemoryBlocks, currentMemoryBlocksSize * sizeof(MemoryBlock));
   }
 
   MemoryBlock* newBlock = mMemoryBlocks + mCurrentMemoryBlockIndex;

--- a/tests/unit/common/test_PoolAllocator.cpp
+++ b/tests/unit/common/test_PoolAllocator.cpp
@@ -36,6 +36,11 @@
 
 #include <gtest/gtest.h>
 
+#include <utility>
+#include <vector>
+
+#include <cstddef>
+
 using namespace dart;
 using namespace common;
 
@@ -110,4 +115,26 @@ TEST(PoolAllocatorTest, Allocate)
   a.deallocate(ptr5, 2048);
 
   EXPECT_TRUE(a.isEmpty());
+}
+
+//==============================================================================
+TEST(PoolAllocatorTest, RawAllocatorGrowsMemoryBlockTable)
+{
+  PoolAllocator allocator;
+
+  const PoolAllocator& constAllocator = allocator;
+  EXPECT_EQ(&constAllocator.getBaseAllocator(), &MemoryAllocator::GetDefault());
+
+  std::vector<std::pair<void*, std::size_t>> allocations;
+  for (std::size_t size = 8; size <= 8 * 65; size += 8) {
+    auto* ptr = allocator.allocate(size);
+    ASSERT_NE(ptr, nullptr);
+    allocations.emplace_back(ptr, size);
+  }
+
+  EXPECT_EQ(allocator.getNumAllocatedMemoryBlocks(), 65);
+
+  for (const auto& allocation : allocations) {
+    allocator.deallocate(allocation.first, allocation.second);
+  }
 }


### PR DESCRIPTION
## Summary

- Fix `PoolAllocator` table growth so the old `mMemoryBlocks` table is released after copying existing entries.
- Add regression coverage that grows a raw `PoolAllocator` beyond the initial 64-block table.
- Add the release changelog entry.

## Motivation / Problem

- When `PoolAllocator` needed to grow `mMemoryBlocks`, it copied the old table into the new allocation but never deallocated the old table.
- This is the `release-6.16` backport for the leak fixed on `main` in #2643.

## Changes / Key Changes

- Preserve the previous memory block table size before growth and deallocate the old table after `memcpy`/`memset`.
- Add `PoolAllocatorTest.RawAllocatorGrowsMemoryBlockTable` to exercise the growth path.
- Update `CHANGELOG.md` under DART 6.16.8 Common.

## Testing

- `pixi run lint`
- `pixi run cmake --build build/default/cpp/Release -j --target UNIT_common_PoolAllocator`
- `pixi run ctest --test-dir build/default/cpp/Release -R '^UNIT_common_PoolAllocator$' --output-on-failure`\n- `pixi run cmake --build build/default/cpp/asan -j --target UNIT_common_PoolAllocator`\n- `pixi run env ASAN_OPTIONS=detect_leaks=1 ctest --test-dir build/default/cpp/asan -R '^UNIT_common_PoolAllocator$' --output-on-failure`\n- `git diff --check`\n\n## Breaking Changes\n\n- [x] None\n\n## Related Issues / PRs (backports)\n\n- Main PR: #2643\n\n---\n\n#### Checklist\n\n- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)\n- [x] CHANGELOG.md updated if required\n- [x] Add unit tests for new functionality\n- [x] Document new methods and classes (N/A: no API changes)\n- [x] Add Python bindings (dartpy) if applicable (N/A: no Python API changes)