### PR TITLE
Establish AI-native workflow foundation

### DIFF
--- a/.claude/commands/dart-backport-pr.md
+++ b/.claude/commands/dart-backport-pr.md
@@ -29,7 +29,9 @@ Backport PR or commits: $ARGUMENTS
 4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
 5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.
 6. Run `pixi run lint` and the smallest relevant release-branch checks.
-7. Push and open a PR against the release branch with milestone `DART 6.16.x` or the current patch milestone.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, open the PR against the release branch with milestone
+   `DART 6.16.x` or the current patch milestone and use the PR template.
 
 ## Output
 

--- a/.claude/commands/dart-branch-cleanup.md
+++ b/.claude/commands/dart-branch-cleanup.md
@@ -14,31 +14,41 @@ Analyze or clean branches: $ARGUMENTS
 ## Modes
 
 - `analyze`: inspect only, no deletions
-- `action`: delete or prepare follow-up only when ownership and safety are clear
+- `action`: prepare follow-up, or delete only after ownership/safety are clear
+  and the maintainer/user gives explicit approval for each local or remote
+  branch deletion
 
 Default to `analyze` if the requested mode is ambiguous.
 
 ## Workflow
 
-1. `git fetch --all --prune`
-2. Determine target branch, usually `origin/main`.
-3. For each branch:
+1. `git fetch --all --no-prune`
+2. List stale remote-tracking refs without deleting them:
+   ```bash
+   git remote prune origin --dry-run
+   ```
+3. Determine target branch, usually `origin/main`.
+4. For each branch:
    ```bash
    git rev-list --left-right --count <TARGET>...<BRANCH>
    git log --oneline <TARGET>..<BRANCH>
    git diff --stat <TARGET>..<BRANCH>
    git cherry -v <TARGET> <BRANCH>
    ```
-4. Classify:
+5. Classify recommendations only; deleting a candidate requires explicit
+   maintainer/user approval:
    - `ahead=0`: safe deletion candidate
    - equivalent commits already landed: deletion candidate
    - small, current, useful diff: keep or rebase into PR
    - large or unclear diff: document follow-up before action
-5. Ask before deleting when ownership, branch purpose, or remote impact is unclear.
+6. Ask for explicit maintainer/user approval before pruning refs or deleting any
+   local or remote branch, even when ownership, branch purpose, and remote
+   impact look clear.
 
 ## Output
 
 - Branch summary with ahead/behind count and last commit date
 - Useful commits or risks
 - Recommendation: delete, keep, rebase, or needs follow-up
-- Actions taken, if action mode was explicitly requested
+- Actions taken after explicit maintainer/user approval, if action mode was
+  explicitly requested

--- a/.claude/commands/dart-close-issue.md
+++ b/.claude/commands/dart-close-issue.md
@@ -22,7 +22,8 @@ Close or prepare closing message for issue: $ARGUMENTS
    - thank the reporter
    - state the concrete resolution
    - link the fixing PR or relevant docs when available
-4. Only post and close if the user explicitly requested action:
+4. Only post and close if the user explicitly requested action and explicit
+   maintainer/user approval has been given:
    ```bash
    gh issue comment <ISSUE_NUMBER> --body "<message>"
    gh issue close <ISSUE_NUMBER>

--- a/.claude/commands/dart-docs-update.md
+++ b/.claude/commands/dart-docs-update.md
@@ -20,4 +20,7 @@ Update documentation: $ARGUMENTS
 3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
 4. Update indexes and cross-references that point to changed docs
 5. Run `pixi run lint` before committing
-6. Push and open a PR with the proper milestone
+6. Record the CHANGELOG decision for the docs/tooling change.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, use `.github/PULL_REQUEST_TEMPLATE.md` and the proper
+   milestone.

--- a/.claude/commands/dart-downstream-fix.md
+++ b/.claude/commands/dart-downstream-fix.md
@@ -21,16 +21,18 @@ Use for downstream issues in gz-physics, Gazebo, or gz-sim that trace back to DA
 2. Identify the DART API, component, and invalid usage pattern involved.
 3. Search for related validation and recovery patterns in DART.
 4. Plan the smallest fix and the regression test location.
-5. Implement on `main` first for DART 7:
-   - branch: `fix/<downstream-project>-<issue-number>-<brief-description>`
+5. Decide whether the bug applies to the active release line. For applicable
+   bug fixes, implement on `release-6.16` first, then cherry-pick or reapply to
+   `main` for DART 7:
+   - branch: `fix/<downstream-project>-<issue-number>-<brief-description>-6.16`
    - add a regression test that reproduces the downstream symptom
    - keep the fix minimal; no unrelated refactors
 6. Run `pixi run lint` and relevant tests; use `pixi run test-all` when feasible.
-7. Create a `main` PR with milestone `DART 7.0` and reference the downstream issue.
-8. If this is a bug fix applicable to the release line, create the release-branch PR too:
-   - branch from `release-6.16`
-   - adapt API differences if needed
-   - milestone `DART 6.16.x`
+7. Ask for explicit maintainer/user approval before pushing or creating PRs.
+   After approval, create the release-branch PR with milestone `DART 6.16.x`
+   and reference the downstream issue.
+8. Create the matching `main` PR with milestone `DART 7.0`; adapt API
+   differences if needed.
 
 ## Release-Line Differences
 

--- a/.claude/commands/dart-fix-ci.md
+++ b/.claude/commands/dart-fix-ci.md
@@ -21,14 +21,18 @@ Fix CI failure: $ARGUMENTS
 3. If a job is still in progress, wait for logs instead of guessing.
 4. Reproduce locally with the smallest relevant command:
    - formatting: `pixi run lint`
-   - tests: `pixi run test`, `pixi run test-unit`, or `ctest -R <TEST>`
+   - tests: `pixi run test`, `pixi run test-unit`, or another existing
+     focused `pixi run ...` test task
    - coverage: add targeted tests for uncovered changed lines
 5. Fix the root cause with minimal scope.
-6. If the failure is infrastructure-only, rerun the failed job or run:
+6. If the failure is infrastructure-only, ask for explicit maintainer/user
+   approval before rerunning the failed job or running:
    ```bash
    gh run rerun <RUN_ID> --failed
    ```
-7. Push and watch CI until the PR is green.
+7. Ask for explicit maintainer/user approval before pushing, CI re-triggers, or
+   other GitHub mutations; after approval, push and watch CI until the PR is
+   green.
 
 ## Output
 

--- a/.claude/commands/dart-fix-issue.md
+++ b/.claude/commands/dart-fix-issue.md
@@ -13,11 +13,16 @@ Fix GitHub issue: $ARGUMENTS
 ## Workflow
 
 1. `gh issue view $1` - Validate issue
-2. `git checkout -b fix/issue-$1 origin/main`
-3. Fix with minimal changes + add regression test
+2. Classify whether the issue is a bug fix that applies to `release-6.16`.
+   For applicable bug fixes, start from `origin/release-6.16`; otherwise start
+   from `origin/main`.
+3. Fix with minimal changes + add regression test. For dual-PR bug fixes, fix
+   `release-6.16` first, then cherry-pick or reapply to `main`.
 4. `pixi run lint`, then run the smallest relevant tests; use `pixi run test-all` before finalizing when feasible
-5. `git push -u origin HEAD && gh pr create`
-6. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
+5. Before PR creation, decide whether `CHANGELOG.md` needs an entry and fill
+   `.github/PULL_REQUEST_TEMPLATE.md`.
+6. After explicit maintainer/user approval, `git push -u origin HEAD && gh pr create --base <target-branch> --milestone "<milestone>"`
+7. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
 
 ## CRITICAL: Dual-PR for Bug Fixes
 

--- a/.claude/commands/dart-manage-pr.md
+++ b/.claude/commands/dart-manage-pr.md
@@ -3,7 +3,8 @@ description: manage an open DART pull request through CI, review, and cleanup
 agent: build
 ---
 
-Manage an open DART pull request: $ARGUMENTS
+Manage an open DART pull request after explicit maintainer/user approval for
+mutations: $ARGUMENTS
 
 ## Required Reading
 
@@ -51,13 +52,15 @@ gh pr checks <PR_NUMBER>
    - Reproduce locally with the relevant `pixi run ...` task or focused test.
    - Before committing fixes, run `pixi run lint`; also run build or tests when
      code or behavior changed.
-   - Commit only intended files, push, and continue monitoring the PR.
+   - Commit only intended files. Push only after explicit maintainer/user
+     approval, then continue monitoring the PR.
 4. Address reviews:
    - Use the `dart-review-pr` workflow for substantive review feedback.
    - Never reply to AI-generated review comments from bot users such as
      `chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
-   - Push AI-review fixes silently. Resolve threads when needed, then request a
-     fresh AI review only after the branch is ready:
+   - Apply AI-review fixes silently. After explicit maintainer/user approval
+     and after the branch is ready, push, resolve reviewed and addressed
+     threads, and request a fresh AI review:
      ```bash
      gh pr comment <PR_NUMBER> --body "@codex review"
      ```
@@ -67,6 +70,9 @@ gh pr checks <PR_NUMBER>
    - Confirm required checks are passing and review requirements are satisfied.
    - If the PR is draft and ready, mark it ready only when the user or task asks.
    - Do not merge unless explicitly asked or the workflow clearly includes merge.
+   - PR comments, review re-triggers, thread resolution, reviewer requests,
+     ready-for-review transitions, merges, and branch deletion are external
+     mutations and require explicit maintainer/user approval.
    - Confirm the merge method from repository settings or the user. Recent DART
      `main` PRs use single-parent PR-title commits, so prefer squash/rebase
      over merge commits unless the repository settings or user request differ.
@@ -74,20 +80,23 @@ gh pr checks <PR_NUMBER>
      accidentally.
 6. Clean up after merge:
    - Confirm the PR merged and identify the head branch before deleting.
-   - Prefer merge-time deletion with the requested merge method and head SHA:
+   - After explicit maintainer/user approval, prefer merge-time deletion with
+     the approved merge method and head SHA:
      ```bash
      gh pr merge <PR_NUMBER> --squash --match-head-commit <HEAD_SHA> --delete-branch
      ```
      Use `--rebase` or `--merge` instead of `--squash` when requested.
-   - Otherwise delete only the PR branch after confirming it has landed:
+   - After explicit maintainer/user approval, otherwise delete only the PR
+     branch after confirming it has landed:
      ```bash
      git push origin --delete <HEAD_BRANCH>
      git switch main
      git pull --ff-only
      git branch -D <HEAD_BRANCH>
      ```
-     Use force-delete locally only after confirming the PR branch has landed;
-     squash and rebase merges do not preserve the branch tip in `main` ancestry.
+     Use force-delete locally only after explicit maintainer/user approval and
+     after confirming the PR branch has landed; squash and rebase merges do not
+     preserve the branch tip in `main` ancestry.
 
 ## Output
 

--- a/.claude/commands/dart-mechanical-refactor.md
+++ b/.claude/commands/dart-mechanical-refactor.md
@@ -23,7 +23,9 @@ Perform mechanical refactor: $ARGUMENTS
    - `pixi run build`
    - `pixi run test-unit`
    - `pixi run test-all` when feasible
-7. Open a PR with a clear scope statement and no behavior-change claim unless tested.
+7. Ask for explicit maintainer/user approval before pushing or opening a PR.
+   After approval, open a PR with a clear scope statement and no
+   behavior-change claim unless tested.
 
 ## Output
 

--- a/.claude/commands/dart-merge-pr.md
+++ b/.claude/commands/dart-merge-pr.md
@@ -3,7 +3,7 @@ description: monitor CI and merge a ready PR
 agent: build
 ---
 
-Monitor and merge PR: $ARGUMENTS
+Monitor and merge PR after explicit maintainer/user approval: $ARGUMENTS
 
 ## Required Reading
 
@@ -22,15 +22,19 @@ Monitor and merge PR: $ARGUMENTS
 3. If any required check is pending, watch quietly until it passes or fails.
 4. If any check fails, use `/dart-fix-ci` or `$dart-fix-ci`; do not merge.
 5. Confirm merge method from repository settings. DART uses squash/rebase, not merge commits.
-6. Merge only when checks are green, the PR is not draft, and GitHub reports it mergeable.
-7. Use the current head SHA when merging so a moved branch cannot be merged accidentally.
-8. For squash merges, use the recent DART title convention:
+6. Ask for explicit maintainer/user approval before any merge action.
+7. Merge only after that approval, when checks are green, the PR is not draft,
+   and GitHub reports it mergeable.
+8. Use the current head SHA when merging so a moved branch cannot be merged accidentally.
+9. For squash merges, use the recent DART title convention:
    - commit title: `<PR title> (#<PR number>)`
    - no agent prefix
 
 ## Notes
 
-- If GitHub reports `BEHIND` but `mergeable=MERGEABLE` and required checks are green, do not update the branch just to make it current.
+- If GitHub reports `BEHIND` but `mergeable=MERGEABLE` and required checks are
+  green, do not update the branch without explicit maintainer/user approval
+  just to make it current.
 - Recent DART human-authored PRs use single-parent squash commits with the exact PR title plus `(#number)`.
 - Branch deletion is handled by repo settings unless the user explicitly asks for manual cleanup.
 

--- a/.claude/commands/dart-new-task.md
+++ b/.claude/commands/dart-new-task.md
@@ -17,10 +17,16 @@ Read these files first:
 
 1. **Understand the task** - Parse: goal, constraints, type (feature|bugfix|refactor|docs)
 2. **Assess scope** - Multi-phase or multi-session? Create `docs/dev_tasks/<task>/` (see `docs/dev_tasks/README.md` for criteria)
-3. **Setup** - Create branch from `origin/main`: `feature/<topic>`, `fix/<topic>`, etc.
+3. **Setup** - Choose the target branch before creating a topic branch:
+   - features/docs/non-bugfix refactors: branch from `origin/main`
+   - bug fixes that apply to the current release line: branch from
+     `origin/release-6.16` first, then cherry-pick or reapply to `main`
 4. **Implement** - Keep commits focused, follow code style
 5. **Verify** - Run `pixi run lint` before committing, then `pixi run test-all`
-6. **PR** - `git push -u origin HEAD` then `gh pr create --draft --milestone "DART 7.0"` (use `DART 6.16.x` for release-6.16); follow `.github/PULL_REQUEST_TEMPLATE.md`
+6. **PR** - After explicit maintainer/user approval, `git push -u origin HEAD`
+   then `gh pr create --draft --base <target-branch> --milestone "<milestone>"`
+   (`DART 7.0` for `main`, `DART 6.16.x` for `release-6.16`); follow
+   `.github/PULL_REQUEST_TEMPLATE.md`
 7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
 
 ## Type-Specific

--- a/.claude/commands/dart-pr.md
+++ b/.claude/commands/dart-pr.md
@@ -3,7 +3,8 @@ description: create a branch, commit, push, and open a DART pull request
 agent: build
 ---
 
-Prepare or open a DART pull request: $ARGUMENTS
+Prepare or open a DART pull request after explicit maintainer/user approval:
+$ARGUMENTS
 
 ## Required Reading
 
@@ -64,14 +65,16 @@ Use these practices:
    git checkout -b <type>/<topic> origin/<target-branch>
    ```
 7. Commit only intended files with a plain descriptive commit title.
-8. Push and open a draft PR:
+8. Ask for explicit maintainer/user approval before pushing or opening the draft
+   PR. If approved:
    ```bash
    git push -u origin HEAD
    gh pr create --draft --base <target-branch> --milestone "<milestone>" \
      --title "<plain title>" --body-file <filled-template-file>
    ```
-9. If `CHANGELOG.md` needs the PR number, add the changelog entry in a
-   follow-up commit after opening the draft PR.
+9. If `CHANGELOG.md` needs the PR number, keep the follow-up changelog commit
+   local until explicit maintainer/user approval is given for the additional
+   push or PR update.
 10. Monitor CI:
     ```bash
     gh pr checks <PR_NUMBER>
@@ -81,5 +84,5 @@ Use these practices:
 
 Never reply to AI-generated review comments from bot users such as
 `chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
-Push fixes silently and ask for a new AI review with `@codex review` only when
-needed.
+Make fixes silently. Push and ask for a new AI review with `@codex review` only
+after explicit maintainer/user approval.

--- a/.claude/commands/dart-release-ci-fix.md
+++ b/.claude/commands/dart-release-ci-fix.md
@@ -27,7 +27,9 @@ Fix release-branch CI: $ARGUMENTS
 4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
 5. Explain why the failure was not caught earlier and whether workflow coverage should change.
 6. Run `pixi run lint` and release-relevant build/tests.
-7. Push and create or update the release-branch PR with the current release milestone.
+7. Ask for explicit maintainer/user approval before pushing, creating, or
+   updating the release-branch PR; after approval, use the current release
+   milestone and PR template.
 8. Monitor CI until green.
 
 ## Output

--- a/.claude/commands/dart-release-merge-main.md
+++ b/.claude/commands/dart-release-merge-main.md
@@ -28,7 +28,9 @@ Merge release branch into main: $ARGUMENTS
    - files only on release: keep if still relevant to main
 6. Verify no unresolved conflicts remain.
 7. Run `pixi run lint` and relevant checks.
-8. Push and create a PR targeting `main` with milestone `DART 7.0`.
+8. Ask for explicit maintainer/user approval before pushing or creating the PR.
+   After approval, create a PR targeting `main` with milestone `DART 7.0` and
+   use the PR template.
 9. Monitor CI until green.
 
 ## Output

--- a/.claude/commands/dart-release-packaging.md
+++ b/.claude/commands/dart-release-packaging.md
@@ -3,7 +3,7 @@ description: create a release version bump and changelog PR
 agent: build
 ---
 
-Create release packaging PR: $ARGUMENTS
+Create release packaging PR after explicit maintainer/user approval: $ARGUMENTS
 
 ## Required Reading
 
@@ -25,8 +25,11 @@ Create release packaging PR: $ARGUMENTS
 6. Add the `CHANGELOG.md` release section with the release date and milestone link.
 7. Run `pixi run lint` and relevant packaging checks.
 8. Commit as `Packaging <NEW_VERSION>`.
-9. Push and create a PR against the release branch.
-10. Set the release milestone, for example `DART 6.16.x` or the specific version milestone if available.
+9. Ask for explicit maintainer/user approval before pushing, creating the PR,
+   or setting milestones.
+10. After approval, create the PR against the release branch with the release
+    milestone, for example `DART 6.16.x` or the specific version milestone if
+    available.
 
 ## Output
 

--- a/.claude/commands/dart-resume.md
+++ b/.claude/commands/dart-resume.md
@@ -33,7 +33,8 @@ and ask.
 - Continue with minimal scope and preserve existing user changes.
 - Run `pixi run lint` before committing.
 - Run relevant tests; use `pixi run test-all` before done when feasible.
-- Push with `git push -u origin HEAD` and create/update the PR.
+- Push with `git push -u origin HEAD` and create/update the PR only after
+  explicit maintainer/user approval.
 
 ## Safety
 

--- a/.claude/commands/dart-review-pr.md
+++ b/.claude/commands/dart-review-pr.md
@@ -25,14 +25,21 @@ Check: code style, tests, docs, focused commits
 gh pr view $1 --comments
 ```
 
-Apply minimal fixes, verify, push.
+Apply minimal fixes locally and verify. Do not push, comment, resolve threads,
+or re-trigger review without explicit maintainer/user approval for that
+external mutation.
 
 ## AI-Generated Reviews (Codex, Copilot, etc.)
 
-1. Push fix silently (no reply)
-2. Resolve thread via GraphQL (see ai-tools.md)
-3. Re-trigger: `gh pr comment $1 --body "@codex review"`
-4. Monitor CI: `gh pr checks $1`
-5. Check for new review, repeat until no comments + CI green
+1. Make the local fix silently (no reply)
+2. Run the relevant local gates, including `pixi run lint` before any commit
+3. Ask for explicit maintainer/user approval before push, thread resolution,
+   PR comment, or review re-trigger
+4. If approved, push the fix silently
+5. If approved, resolve only reviewed and addressed thread IDs via GraphQL (see
+   ai-tools.md)
+6. If approved, re-trigger: `gh pr comment $1 --body "@codex review"`
+7. Monitor CI: `gh pr checks $1`
+8. Check for new review, repeat until no comments + CI green
 
 Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/.claude/skills/dart-ci/SKILL.md
+++ b/.claude/skills/dart-ci/SKILL.md
@@ -23,7 +23,7 @@ gh run view <RUN_ID> --json status,conclusion,url
 gh run view <RUN_ID> --job <JOB_ID> --log-failed
 gh run view <RUN_ID> --json jobs --jq '.jobs[] | {name, databaseId}'
 
-# Rerun failed jobs
+# Rerun failed jobs only after explicit maintainer/user approval
 gh run rerun <RUN_ID> --failed
 gh run rerun <RUN_ID> --job <DATABASE_ID>
 ```
@@ -36,7 +36,7 @@ For complete CI/CD guide: `docs/onboarding/ci-cd.md`
 
 | Failure Type         | Solution                                                 |
 | -------------------- | -------------------------------------------------------- |
-| Formatting fails     | `pixi run lint` then push                                |
+| Formatting fails     | `pixi run lint`; push only after approval                |
 | Codecov patch fails  | Add tests for uncovered lines                            |
 | FreeBSD RTTI fails   | Use type enums + `static_cast` instead of `dynamic_cast` |
 | macOS ARM64 SEGFAULT | Replace `alloca()`/VLAs with `std::vector<T>`            |
@@ -59,7 +59,8 @@ For complete CI/CD guide: `docs/onboarding/ci-cd.md`
 1. Identify failing step from job logs
 2. Reproduce locally with same build toggles
 3. Fix the smallest failing test
-4. Push and monitor: `gh run watch <RUN_ID>`
+4. Push only after explicit maintainer/user approval, then monitor:
+   `gh run watch <RUN_ID>`
 
 ## Caching
 

--- a/.claude/skills/dart-contribute/SKILL.md
+++ b/.claude/skills/dart-contribute/SKILL.md
@@ -23,17 +23,23 @@ For code style: `docs/onboarding/code-style.md`
 ## PR Workflow
 
 ```bash
-# Create branch
+# Features, docs, and non-bugfix refactors start from main
 git checkout -b <type>/<topic> origin/main
+
+# Bug fixes that apply to the current release line start from release-6.16
+git checkout -b fix/<topic>-6.16 origin/release-6.16
 
 # Make changes, then
 pixi run lint
 pixi run test-all
 
-# Push and create PR
+# After explicit maintainer/user approval, push and create PR
 git push -u origin HEAD
-gh pr create --draft --milestone "DART 7.0"
+gh pr create --draft --base <target-branch> --milestone "<milestone>"
 ```
+
+Use `--base main --milestone "DART 7.0"` for main PRs and
+`--base release-6.16 --milestone "DART 6.16.x"` for release-line PRs.
 
 Rule of thumb: run `pixi run lint` before committing so auto-fixes are included.
 
@@ -43,7 +49,8 @@ Use plain descriptive commit messages and PR titles. Do not prefix them with age
 
 ## Milestones (Required)
 
-Always set a milestone when creating PRs:
+Always set a milestone when creating PRs after explicit maintainer/user
+approval:
 
 | Target Branch  | Milestone                     |
 | -------------- | ----------------------------- |
@@ -51,7 +58,7 @@ Always set a milestone when creating PRs:
 | `release-6.16` | `DART 6.16.x` (current patch) |
 
 ```bash
-# Set milestone on existing PR
+# After explicit maintainer/user approval, set milestone on existing PR
 gh pr edit <PR#> --milestone "DART 7.0"
 
 # List available milestones
@@ -69,11 +76,11 @@ Steps:
 
 1. Fix on `release-6.16` first
 2. Cherry-pick to `main`
-3. Create separate PRs for each
+3. After explicit maintainer/user approval, create separate PRs for each
 
-## CHANGELOG (After PR Created)
+## CHANGELOG (After Approved PR Exists)
 
-After creating a PR, check if CHANGELOG.md needs updating:
+After the approved PR exists, check if CHANGELOG.md needs updating:
 
 | Change Type                      | Update CHANGELOG?                    |
 | -------------------------------- | ------------------------------------ |
@@ -98,7 +105,8 @@ Format: `- Description. ([#PR](https://github.com/dartsim/dart/pull/PR))`
 - Address all feedback
 - Keep changes minimal
 - Update tests if behavior changed
-- Run full validation before pushing fixes
+- Run full validation, then ask for explicit maintainer/user approval before
+  pushing fixes
 
 ## CI Loop
 

--- a/.claude/skills/dart-test/SKILL.md
+++ b/.claude/skills/dart-test/SKILL.md
@@ -12,8 +12,8 @@ Load this skill when writing or debugging tests.
 ```bash
 pixi run test         # Quick test run
 pixi run test-all     # Full validation
-ctest -R <pattern>    # Run specific tests
-ctest -V              # Verbose output
+pixi run test-unit    # Unit tests
+pixi run test-py      # Python tests
 ```
 
 ## Full Documentation
@@ -46,8 +46,8 @@ pixi run test-all     # Must pass
 ## Debugging Test Failures
 
 ```bash
-# Run single test with verbose output
-ctest -R TestName -V
+# Run the smallest existing Pixi test task that covers the failure
+pixi run test-unit
 
 # Get CI logs
 gh run view <RUN_ID> --log-failed

--- a/.codex/skills/dart-audit-agent-compliance/SKILL.md
+++ b/.codex/skills/dart-audit-agent-compliance/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Audit Agent Compliance: audit and fix gaps when agents miss d
 
 # dart-audit-agent-compliance
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-audit-agent-compliance`.
+Use this skill in Codex to run the DART `dart-audit-agent-compliance` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 

--- a/.codex/skills/dart-backport-pr/SKILL.md
+++ b/.codex/skills/dart-backport-pr/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Backport PR: backport a merged main PR to a release branch"
 
 # dart-backport-pr
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-backport-pr`.
+Use this skill in Codex to run the DART `dart-backport-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -49,7 +50,9 @@ Backport PR or commits: $ARGUMENTS
 4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
 5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.
 6. Run `pixi run lint` and the smallest relevant release-branch checks.
-7. Push and open a PR against the release branch with milestone `DART 6.16.x` or the current patch milestone.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, open the PR against the release branch with milestone
+   `DART 6.16.x` or the current patch milestone and use the PR template.
 
 ## Output
 

--- a/.codex/skills/dart-branch-cleanup/SKILL.md
+++ b/.codex/skills/dart-branch-cleanup/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Branch Cleanup: analyze or clean stale repository branches"
 
 # dart-branch-cleanup
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-branch-cleanup`.
+Use this skill in Codex to run the DART `dart-branch-cleanup` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -34,31 +35,41 @@ Analyze or clean branches: $ARGUMENTS
 ## Modes
 
 - `analyze`: inspect only, no deletions
-- `action`: delete or prepare follow-up only when ownership and safety are clear
+- `action`: prepare follow-up, or delete only after ownership/safety are clear
+  and the maintainer/user gives explicit approval for each local or remote
+  branch deletion
 
 Default to `analyze` if the requested mode is ambiguous.
 
 ## Workflow
 
-1. `git fetch --all --prune`
-2. Determine target branch, usually `origin/main`.
-3. For each branch:
+1. `git fetch --all --no-prune`
+2. List stale remote-tracking refs without deleting them:
+   ```bash
+   git remote prune origin --dry-run
+   ```
+3. Determine target branch, usually `origin/main`.
+4. For each branch:
    ```bash
    git rev-list --left-right --count <TARGET>...<BRANCH>
    git log --oneline <TARGET>..<BRANCH>
    git diff --stat <TARGET>..<BRANCH>
    git cherry -v <TARGET> <BRANCH>
    ```
-4. Classify:
+5. Classify recommendations only; deleting a candidate requires explicit
+   maintainer/user approval:
    - `ahead=0`: safe deletion candidate
    - equivalent commits already landed: deletion candidate
    - small, current, useful diff: keep or rebase into PR
    - large or unclear diff: document follow-up before action
-5. Ask before deleting when ownership, branch purpose, or remote impact is unclear.
+6. Ask for explicit maintainer/user approval before pruning refs or deleting any
+   local or remote branch, even when ownership, branch purpose, and remote
+   impact look clear.
 
 ## Output
 
 - Branch summary with ahead/behind count and last commit date
 - Useful commits or risks
 - Recommendation: delete, keep, rebase, or needs follow-up
-- Actions taken, if action mode was explicitly requested
+- Actions taken after explicit maintainer/user approval, if action mode was
+  explicitly requested

--- a/.codex/skills/dart-ci/SKILL.md
+++ b/.codex/skills/dart-ci/SKILL.md
@@ -27,7 +27,7 @@ gh run view <RUN_ID> --json status,conclusion,url
 gh run view <RUN_ID> --job <JOB_ID> --log-failed
 gh run view <RUN_ID> --json jobs --jq '.jobs[] | {name, databaseId}'
 
-# Rerun failed jobs
+# Rerun failed jobs only after explicit maintainer/user approval
 gh run rerun <RUN_ID> --failed
 gh run rerun <RUN_ID> --job <DATABASE_ID>
 ```
@@ -40,7 +40,7 @@ For complete CI/CD guide: `docs/onboarding/ci-cd.md`
 
 | Failure Type         | Solution                                                 |
 | -------------------- | -------------------------------------------------------- |
-| Formatting fails     | `pixi run lint` then push                                |
+| Formatting fails     | `pixi run lint`; push only after approval                |
 | Codecov patch fails  | Add tests for uncovered lines                            |
 | FreeBSD RTTI fails   | Use type enums + `static_cast` instead of `dynamic_cast` |
 | macOS ARM64 SEGFAULT | Replace `alloca()`/VLAs with `std::vector<T>`            |
@@ -63,7 +63,8 @@ For complete CI/CD guide: `docs/onboarding/ci-cd.md`
 1. Identify failing step from job logs
 2. Reproduce locally with same build toggles
 3. Fix the smallest failing test
-4. Push and monitor: `gh run watch <RUN_ID>`
+4. Push only after explicit maintainer/user approval, then monitor:
+   `gh run watch <RUN_ID>`
 
 ## Caching
 

--- a/.codex/skills/dart-close-issue/SKILL.md
+++ b/.codex/skills/dart-close-issue/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Close Issue: draft and optionally post a GitHub issue closing
 
 # dart-close-issue
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-close-issue`.
+Use this skill in Codex to run the DART `dart-close-issue` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -42,7 +43,8 @@ Close or prepare closing message for issue: $ARGUMENTS
    - thank the reporter
    - state the concrete resolution
    - link the fixing PR or relevant docs when available
-4. Only post and close if the user explicitly requested action:
+4. Only post and close if the user explicitly requested action and explicit
+   maintainer/user approval has been given:
    ```bash
    gh issue comment <ISSUE_NUMBER> --body "<message>"
    gh issue close <ISSUE_NUMBER>

--- a/.codex/skills/dart-contribute/SKILL.md
+++ b/.codex/skills/dart-contribute/SKILL.md
@@ -27,17 +27,23 @@ For code style: `docs/onboarding/code-style.md`
 ## PR Workflow
 
 ```bash
-# Create branch
+# Features, docs, and non-bugfix refactors start from main
 git checkout -b <type>/<topic> origin/main
+
+# Bug fixes that apply to the current release line start from release-6.16
+git checkout -b fix/<topic>-6.16 origin/release-6.16
 
 # Make changes, then
 pixi run lint
 pixi run test-all
 
-# Push and create PR
+# After explicit maintainer/user approval, push and create PR
 git push -u origin HEAD
-gh pr create --draft --milestone "DART 7.0"
+gh pr create --draft --base <target-branch> --milestone "<milestone>"
 ```
+
+Use `--base main --milestone "DART 7.0"` for main PRs and
+`--base release-6.16 --milestone "DART 6.16.x"` for release-line PRs.
 
 Rule of thumb: run `pixi run lint` before committing so auto-fixes are included.
 
@@ -47,7 +53,8 @@ Use plain descriptive commit messages and PR titles. Do not prefix them with age
 
 ## Milestones (Required)
 
-Always set a milestone when creating PRs:
+Always set a milestone when creating PRs after explicit maintainer/user
+approval:
 
 | Target Branch  | Milestone                     |
 | -------------- | ----------------------------- |
@@ -55,7 +62,7 @@ Always set a milestone when creating PRs:
 | `release-6.16` | `DART 6.16.x` (current patch) |
 
 ```bash
-# Set milestone on existing PR
+# After explicit maintainer/user approval, set milestone on existing PR
 gh pr edit <PR#> --milestone "DART 7.0"
 
 # List available milestones
@@ -73,11 +80,11 @@ Steps:
 
 1. Fix on `release-6.16` first
 2. Cherry-pick to `main`
-3. Create separate PRs for each
+3. After explicit maintainer/user approval, create separate PRs for each
 
-## CHANGELOG (After PR Created)
+## CHANGELOG (After Approved PR Exists)
 
-After creating a PR, check if CHANGELOG.md needs updating:
+After the approved PR exists, check if CHANGELOG.md needs updating:
 
 | Change Type                      | Update CHANGELOG?                    |
 | -------------------------------- | ------------------------------------ |
@@ -102,7 +109,8 @@ Format: `- Description. ([#PR](https://github.com/dartsim/dart/pull/PR))`
 - Address all feedback
 - Keep changes minimal
 - Update tests if behavior changed
-- Run full validation before pushing fixes
+- Run full validation, then ask for explicit maintainer/user approval before
+  pushing fixes
 
 ## CI Loop
 

--- a/.codex/skills/dart-docs-update/SKILL.md
+++ b/.codex/skills/dart-docs-update/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Docs Update: update documentation without code changes"
 
 # dart-docs-update
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-docs-update`.
+Use this skill in Codex to run the DART `dart-docs-update` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -40,4 +41,7 @@ Update documentation: $ARGUMENTS
 3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
 4. Update indexes and cross-references that point to changed docs
 5. Run `pixi run lint` before committing
-6. Push and open a PR with the proper milestone
+6. Record the CHANGELOG decision for the docs/tooling change.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, use `.github/PULL_REQUEST_TEMPLATE.md` and the proper
+   milestone.

--- a/.codex/skills/dart-downstream-fix/SKILL.md
+++ b/.codex/skills/dart-downstream-fix/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Downstream Fix: fix a DART bug reported through gz-physics or
 
 # dart-downstream-fix
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-downstream-fix`.
+Use this skill in Codex to run the DART `dart-downstream-fix` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -41,16 +42,18 @@ Use for downstream issues in gz-physics, Gazebo, or gz-sim that trace back to DA
 2. Identify the DART API, component, and invalid usage pattern involved.
 3. Search for related validation and recovery patterns in DART.
 4. Plan the smallest fix and the regression test location.
-5. Implement on `main` first for DART 7:
-   - branch: `fix/<downstream-project>-<issue-number>-<brief-description>`
+5. Decide whether the bug applies to the active release line. For applicable
+   bug fixes, implement on `release-6.16` first, then cherry-pick or reapply to
+   `main` for DART 7:
+   - branch: `fix/<downstream-project>-<issue-number>-<brief-description>-6.16`
    - add a regression test that reproduces the downstream symptom
    - keep the fix minimal; no unrelated refactors
 6. Run `pixi run lint` and relevant tests; use `pixi run test-all` when feasible.
-7. Create a `main` PR with milestone `DART 7.0` and reference the downstream issue.
-8. If this is a bug fix applicable to the release line, create the release-branch PR too:
-   - branch from `release-6.16`
-   - adapt API differences if needed
-   - milestone `DART 6.16.x`
+7. Ask for explicit maintainer/user approval before pushing or creating PRs.
+   After approval, create the release-branch PR with milestone `DART 6.16.x`
+   and reference the downstream issue.
+8. Create the matching `main` PR with milestone `DART 7.0`; adapt API
+   differences if needed.
 
 ## Release-Line Differences
 

--- a/.codex/skills/dart-fix-ci/SKILL.md
+++ b/.codex/skills/dart-fix-ci/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Fix CI: debug and fix failing CI checks"
 
 # dart-fix-ci
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-fix-ci`.
+Use this skill in Codex to run the DART `dart-fix-ci` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -41,14 +42,18 @@ Fix CI failure: $ARGUMENTS
 3. If a job is still in progress, wait for logs instead of guessing.
 4. Reproduce locally with the smallest relevant command:
    - formatting: `pixi run lint`
-   - tests: `pixi run test`, `pixi run test-unit`, or `ctest -R <TEST>`
+   - tests: `pixi run test`, `pixi run test-unit`, or another existing
+     focused `pixi run ...` test task
    - coverage: add targeted tests for uncovered changed lines
 5. Fix the root cause with minimal scope.
-6. If the failure is infrastructure-only, rerun the failed job or run:
+6. If the failure is infrastructure-only, ask for explicit maintainer/user
+   approval before rerunning the failed job or running:
    ```bash
    gh run rerun <RUN_ID> --failed
    ```
-7. Push and watch CI until the PR is green.
+7. Ask for explicit maintainer/user approval before pushing, CI re-triggers, or
+   other GitHub mutations; after approval, push and watch CI until the PR is
+   green.
 
 ## Output
 

--- a/.codex/skills/dart-fix-issue/SKILL.md
+++ b/.codex/skills/dart-fix-issue/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Fix Issue: resolve a GitHub issue with a fix and regression t
 
 # dart-fix-issue
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-fix-issue`.
+Use this skill in Codex to run the DART `dart-fix-issue` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -33,11 +34,16 @@ Fix GitHub issue: $ARGUMENTS
 ## Workflow
 
 1. `gh issue view $1` - Validate issue
-2. `git checkout -b fix/issue-$1 origin/main`
-3. Fix with minimal changes + add regression test
+2. Classify whether the issue is a bug fix that applies to `release-6.16`.
+   For applicable bug fixes, start from `origin/release-6.16`; otherwise start
+   from `origin/main`.
+3. Fix with minimal changes + add regression test. For dual-PR bug fixes, fix
+   `release-6.16` first, then cherry-pick or reapply to `main`.
 4. `pixi run lint`, then run the smallest relevant tests; use `pixi run test-all` before finalizing when feasible
-5. `git push -u origin HEAD && gh pr create`
-6. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
+5. Before PR creation, decide whether `CHANGELOG.md` needs an entry and fill
+   `.github/PULL_REQUEST_TEMPLATE.md`.
+6. After explicit maintainer/user approval, `git push -u origin HEAD && gh pr create --base <target-branch> --milestone "<milestone>"`
+7. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
 
 ## CRITICAL: Dual-PR for Bug Fixes
 

--- a/.codex/skills/dart-improve-docs/SKILL.md
+++ b/.codex/skills/dart-improve-docs/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Improve Docs: capture completed-task learnings into durable d
 
 # dart-improve-docs
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-improve-docs`.
+Use this skill in Codex to run the DART `dart-improve-docs` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 

--- a/.codex/skills/dart-manage-pr/SKILL.md
+++ b/.codex/skills/dart-manage-pr/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Manage PR: manage an open DART pull request through CI, revie
 
 # dart-manage-pr
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-manage-pr`.
+Use this skill in Codex to run the DART `dart-manage-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -23,7 +24,8 @@ user.
 
 ## Command Body
 
-Manage an open DART pull request: $ARGUMENTS
+Manage an open DART pull request after explicit maintainer/user approval for
+mutations: $ARGUMENTS
 
 ## Required Reading
 
@@ -71,13 +73,15 @@ gh pr checks <PR_NUMBER>
    - Reproduce locally with the relevant `pixi run ...` task or focused test.
    - Before committing fixes, run `pixi run lint`; also run build or tests when
      code or behavior changed.
-   - Commit only intended files, push, and continue monitoring the PR.
+   - Commit only intended files. Push only after explicit maintainer/user
+     approval, then continue monitoring the PR.
 4. Address reviews:
    - Use the `dart-review-pr` workflow for substantive review feedback.
    - Never reply to AI-generated review comments from bot users such as
      `chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
-   - Push AI-review fixes silently. Resolve threads when needed, then request a
-     fresh AI review only after the branch is ready:
+   - Apply AI-review fixes silently. After explicit maintainer/user approval
+     and after the branch is ready, push, resolve reviewed and addressed
+     threads, and request a fresh AI review:
      ```bash
      gh pr comment <PR_NUMBER> --body "@codex review"
      ```
@@ -87,6 +91,9 @@ gh pr checks <PR_NUMBER>
    - Confirm required checks are passing and review requirements are satisfied.
    - If the PR is draft and ready, mark it ready only when the user or task asks.
    - Do not merge unless explicitly asked or the workflow clearly includes merge.
+   - PR comments, review re-triggers, thread resolution, reviewer requests,
+     ready-for-review transitions, merges, and branch deletion are external
+     mutations and require explicit maintainer/user approval.
    - Confirm the merge method from repository settings or the user. Recent DART
      `main` PRs use single-parent PR-title commits, so prefer squash/rebase
      over merge commits unless the repository settings or user request differ.
@@ -94,20 +101,23 @@ gh pr checks <PR_NUMBER>
      accidentally.
 6. Clean up after merge:
    - Confirm the PR merged and identify the head branch before deleting.
-   - Prefer merge-time deletion with the requested merge method and head SHA:
+   - After explicit maintainer/user approval, prefer merge-time deletion with
+     the approved merge method and head SHA:
      ```bash
      gh pr merge <PR_NUMBER> --squash --match-head-commit <HEAD_SHA> --delete-branch
      ```
      Use `--rebase` or `--merge` instead of `--squash` when requested.
-   - Otherwise delete only the PR branch after confirming it has landed:
+   - After explicit maintainer/user approval, otherwise delete only the PR
+     branch after confirming it has landed:
      ```bash
      git push origin --delete <HEAD_BRANCH>
      git switch main
      git pull --ff-only
      git branch -D <HEAD_BRANCH>
      ```
-     Use force-delete locally only after confirming the PR branch has landed;
-     squash and rebase merges do not preserve the branch tip in `main` ancestry.
+     Use force-delete locally only after explicit maintainer/user approval and
+     after confirming the PR branch has landed; squash and rebase merges do not
+     preserve the branch tip in `main` ancestry.
 
 ## Output
 

--- a/.codex/skills/dart-mechanical-refactor/SKILL.md
+++ b/.codex/skills/dart-mechanical-refactor/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Mechanical Refactor: perform a behavior-preserving mechanical
 
 # dart-mechanical-refactor
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-mechanical-refactor`.
+Use this skill in Codex to run the DART `dart-mechanical-refactor` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -43,7 +44,9 @@ Perform mechanical refactor: $ARGUMENTS
    - `pixi run build`
    - `pixi run test-unit`
    - `pixi run test-all` when feasible
-7. Open a PR with a clear scope statement and no behavior-change claim unless tested.
+7. Ask for explicit maintainer/user approval before pushing or opening a PR.
+   After approval, open a PR with a clear scope statement and no
+   behavior-change claim unless tested.
 
 ## Output
 

--- a/.codex/skills/dart-merge-pr/SKILL.md
+++ b/.codex/skills/dart-merge-pr/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Merge PR: monitor CI and merge a ready PR"
 
 # dart-merge-pr
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-merge-pr`.
+Use this skill in Codex to run the DART `dart-merge-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -23,7 +24,7 @@ user.
 
 ## Command Body
 
-Monitor and merge PR: $ARGUMENTS
+Monitor and merge PR after explicit maintainer/user approval: $ARGUMENTS
 
 ## Required Reading
 
@@ -42,15 +43,19 @@ Monitor and merge PR: $ARGUMENTS
 3. If any required check is pending, watch quietly until it passes or fails.
 4. If any check fails, use `/dart-fix-ci` or `$dart-fix-ci`; do not merge.
 5. Confirm merge method from repository settings. DART uses squash/rebase, not merge commits.
-6. Merge only when checks are green, the PR is not draft, and GitHub reports it mergeable.
-7. Use the current head SHA when merging so a moved branch cannot be merged accidentally.
-8. For squash merges, use the recent DART title convention:
+6. Ask for explicit maintainer/user approval before any merge action.
+7. Merge only after that approval, when checks are green, the PR is not draft,
+   and GitHub reports it mergeable.
+8. Use the current head SHA when merging so a moved branch cannot be merged accidentally.
+9. For squash merges, use the recent DART title convention:
    - commit title: `<PR title> (#<PR number>)`
    - no agent prefix
 
 ## Notes
 
-- If GitHub reports `BEHIND` but `mergeable=MERGEABLE` and required checks are green, do not update the branch just to make it current.
+- If GitHub reports `BEHIND` but `mergeable=MERGEABLE` and required checks are
+  green, do not update the branch without explicit maintainer/user approval
+  just to make it current.
 - Recent DART human-authored PRs use single-parent squash commits with the exact PR title plus `(#number)`.
 - Branch deletion is handled by repo settings unless the user explicitly asks for manual cleanup.
 

--- a/.codex/skills/dart-new-task/SKILL.md
+++ b/.codex/skills/dart-new-task/SKILL.md
@@ -9,8 +9,9 @@ description: "DART New Task: start a feature, bugfix, refactor, docs, build, or 
 
 # dart-new-task
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-new-task`.
+Use this skill in Codex to run the DART `dart-new-task` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -37,10 +38,16 @@ Read these files first:
 
 1. **Understand the task** - Parse: goal, constraints, type (feature|bugfix|refactor|docs)
 2. **Assess scope** - Multi-phase or multi-session? Create `docs/dev_tasks/<task>/` (see `docs/dev_tasks/README.md` for criteria)
-3. **Setup** - Create branch from `origin/main`: `feature/<topic>`, `fix/<topic>`, etc.
+3. **Setup** - Choose the target branch before creating a topic branch:
+   - features/docs/non-bugfix refactors: branch from `origin/main`
+   - bug fixes that apply to the current release line: branch from
+     `origin/release-6.16` first, then cherry-pick or reapply to `main`
 4. **Implement** - Keep commits focused, follow code style
 5. **Verify** - Run `pixi run lint` before committing, then `pixi run test-all`
-6. **PR** - `git push -u origin HEAD` then `gh pr create --draft --milestone "DART 7.0"` (use `DART 6.16.x` for release-6.16); follow `.github/PULL_REQUEST_TEMPLATE.md`
+6. **PR** - After explicit maintainer/user approval, `git push -u origin HEAD`
+   then `gh pr create --draft --base <target-branch> --milestone "<milestone>"`
+   (`DART 7.0` for `main`, `DART 6.16.x` for `release-6.16`); follow
+   `.github/PULL_REQUEST_TEMPLATE.md`
 7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
 
 ## Type-Specific

--- a/.codex/skills/dart-pr/SKILL.md
+++ b/.codex/skills/dart-pr/SKILL.md
@@ -9,8 +9,9 @@ description: "DART PR: create a branch, commit, push, and open a DART pull reque
 
 # dart-pr
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-pr`.
+Use this skill in Codex to run the DART `dart-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -23,7 +24,8 @@ user.
 
 ## Command Body
 
-Prepare or open a DART pull request: $ARGUMENTS
+Prepare or open a DART pull request after explicit maintainer/user approval:
+$ARGUMENTS
 
 ## Required Reading
 
@@ -84,14 +86,16 @@ Use these practices:
    git checkout -b <type>/<topic> origin/<target-branch>
    ```
 7. Commit only intended files with a plain descriptive commit title.
-8. Push and open a draft PR:
+8. Ask for explicit maintainer/user approval before pushing or opening the draft
+   PR. If approved:
    ```bash
    git push -u origin HEAD
    gh pr create --draft --base <target-branch> --milestone "<milestone>" \
      --title "<plain title>" --body-file <filled-template-file>
    ```
-9. If `CHANGELOG.md` needs the PR number, add the changelog entry in a
-   follow-up commit after opening the draft PR.
+9. If `CHANGELOG.md` needs the PR number, keep the follow-up changelog commit
+   local until explicit maintainer/user approval is given for the additional
+   push or PR update.
 10. Monitor CI:
     ```bash
     gh pr checks <PR_NUMBER>
@@ -101,5 +105,5 @@ Use these practices:
 
 Never reply to AI-generated review comments from bot users such as
 `chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
-Push fixes silently and ask for a new AI review with `@codex review` only when
-needed.
+Make fixes silently. Push and ask for a new AI review with `@codex review` only
+after explicit maintainer/user approval.

--- a/.codex/skills/dart-release-ci-fix/SKILL.md
+++ b/.codex/skills/dart-release-ci-fix/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Release CI Fix: debug and fix CI failures on a release branch
 
 # dart-release-ci-fix
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-release-ci-fix`.
+Use this skill in Codex to run the DART `dart-release-ci-fix` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -47,7 +48,9 @@ Fix release-branch CI: $ARGUMENTS
 4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
 5. Explain why the failure was not caught earlier and whether workflow coverage should change.
 6. Run `pixi run lint` and release-relevant build/tests.
-7. Push and create or update the release-branch PR with the current release milestone.
+7. Ask for explicit maintainer/user approval before pushing, creating, or
+   updating the release-branch PR; after approval, use the current release
+   milestone and PR template.
 8. Monitor CI until green.
 
 ## Output

--- a/.codex/skills/dart-release-merge-main/SKILL.md
+++ b/.codex/skills/dart-release-merge-main/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Release Merge Main: merge the active release branch back into
 
 # dart-release-merge-main
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-release-merge-main`.
+Use this skill in Codex to run the DART `dart-release-merge-main` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -48,7 +49,9 @@ Merge release branch into main: $ARGUMENTS
    - files only on release: keep if still relevant to main
 6. Verify no unresolved conflicts remain.
 7. Run `pixi run lint` and relevant checks.
-8. Push and create a PR targeting `main` with milestone `DART 7.0`.
+8. Ask for explicit maintainer/user approval before pushing or creating the PR.
+   After approval, create a PR targeting `main` with milestone `DART 7.0` and
+   use the PR template.
 9. Monitor CI until green.
 
 ## Output

--- a/.codex/skills/dart-release-packaging/SKILL.md
+++ b/.codex/skills/dart-release-packaging/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Release Packaging: create a release version bump and changelo
 
 # dart-release-packaging
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-release-packaging`.
+Use this skill in Codex to run the DART `dart-release-packaging` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -23,7 +24,7 @@ user.
 
 ## Command Body
 
-Create release packaging PR: $ARGUMENTS
+Create release packaging PR after explicit maintainer/user approval: $ARGUMENTS
 
 ## Required Reading
 
@@ -45,8 +46,11 @@ Create release packaging PR: $ARGUMENTS
 6. Add the `CHANGELOG.md` release section with the release date and milestone link.
 7. Run `pixi run lint` and relevant packaging checks.
 8. Commit as `Packaging <NEW_VERSION>`.
-9. Push and create a PR against the release branch.
-10. Set the release milestone, for example `DART 6.16.x` or the specific version milestone if available.
+9. Ask for explicit maintainer/user approval before pushing, creating the PR,
+   or setting milestones.
+10. After approval, create the PR against the release branch with the release
+    milestone, for example `DART 6.16.x` or the specific version milestone if
+    available.
 
 ## Output
 

--- a/.codex/skills/dart-resume/SKILL.md
+++ b/.codex/skills/dart-resume/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Resume: continue work from a previous session"
 
 # dart-resume
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-resume`.
+Use this skill in Codex to run the DART `dart-resume` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -53,7 +54,8 @@ and ask.
 - Continue with minimal scope and preserve existing user changes.
 - Run `pixi run lint` before committing.
 - Run relevant tests; use `pixi run test-all` before done when feasible.
-- Push with `git push -u origin HEAD` and create/update the PR.
+- Push with `git push -u origin HEAD` and create/update the PR only after
+  explicit maintainer/user approval.
 
 ## Safety
 

--- a/.codex/skills/dart-review-pr/SKILL.md
+++ b/.codex/skills/dart-review-pr/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Review PR: review a PR or address review feedback"
 
 # dart-review-pr
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-review-pr`.
+Use this skill in Codex to run the DART `dart-review-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -45,14 +46,21 @@ Check: code style, tests, docs, focused commits
 gh pr view $1 --comments
 ```
 
-Apply minimal fixes, verify, push.
+Apply minimal fixes locally and verify. Do not push, comment, resolve threads,
+or re-trigger review without explicit maintainer/user approval for that
+external mutation.
 
 ## AI-Generated Reviews (Codex, Copilot, etc.)
 
-1. Push fix silently (no reply)
-2. Resolve thread via GraphQL (see ai-tools.md)
-3. Re-trigger: `gh pr comment $1 --body "@codex review"`
-4. Monitor CI: `gh pr checks $1`
-5. Check for new review, repeat until no comments + CI green
+1. Make the local fix silently (no reply)
+2. Run the relevant local gates, including `pixi run lint` before any commit
+3. Ask for explicit maintainer/user approval before push, thread resolution,
+   PR comment, or review re-trigger
+4. If approved, push the fix silently
+5. If approved, resolve only reviewed and addressed thread IDs via GraphQL (see
+   ai-tools.md)
+6. If approved, re-trigger: `gh pr comment $1 --body "@codex review"`
+7. Monitor CI: `gh pr checks $1`
+8. Check for new review, repeat until no comments + CI green
 
 Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/.codex/skills/dart-test/SKILL.md
+++ b/.codex/skills/dart-test/SKILL.md
@@ -16,8 +16,8 @@ Load this skill when writing or debugging tests.
 ```bash
 pixi run test         # Quick test run
 pixi run test-all     # Full validation
-ctest -R <pattern>    # Run specific tests
-ctest -V              # Verbose output
+pixi run test-unit    # Unit tests
+pixi run test-py      # Python tests
 ```
 
 ## Full Documentation
@@ -50,8 +50,8 @@ pixi run test-all     # Must pass
 ## Debugging Test Failures
 
 ```bash
-# Run single test with verbose output
-ctest -R TestName -V
+# Run the smallest existing Pixi test task that covers the failure
+pixi run test-unit
 
 # Get CI logs
 gh run view <RUN_ID> --log-failed

--- a/.codex/skills/dart-triage-issue/SKILL.md
+++ b/.codex/skills/dart-triage-issue/SKILL.md
@@ -9,8 +9,9 @@ description: "DART Triage Issue: triage a GitHub issue and recommend next action
 
 # dart-triage-issue
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/dart-triage-issue`.
+Use this skill in Codex to run the DART `dart-triage-issue` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 

--- a/.opencode/command/dart-backport-pr.md
+++ b/.opencode/command/dart-backport-pr.md
@@ -33,7 +33,9 @@ Backport PR or commits: $ARGUMENTS
 4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
 5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.
 6. Run `pixi run lint` and the smallest relevant release-branch checks.
-7. Push and open a PR against the release branch with milestone `DART 6.16.x` or the current patch milestone.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, open the PR against the release branch with milestone
+   `DART 6.16.x` or the current patch milestone and use the PR template.
 
 ## Output
 

--- a/.opencode/command/dart-branch-cleanup.md
+++ b/.opencode/command/dart-branch-cleanup.md
@@ -18,31 +18,41 @@ Analyze or clean branches: $ARGUMENTS
 ## Modes
 
 - `analyze`: inspect only, no deletions
-- `action`: delete or prepare follow-up only when ownership and safety are clear
+- `action`: prepare follow-up, or delete only after ownership/safety are clear
+  and the maintainer/user gives explicit approval for each local or remote
+  branch deletion
 
 Default to `analyze` if the requested mode is ambiguous.
 
 ## Workflow
 
-1. `git fetch --all --prune`
-2. Determine target branch, usually `origin/main`.
-3. For each branch:
+1. `git fetch --all --no-prune`
+2. List stale remote-tracking refs without deleting them:
+   ```bash
+   git remote prune origin --dry-run
+   ```
+3. Determine target branch, usually `origin/main`.
+4. For each branch:
    ```bash
    git rev-list --left-right --count <TARGET>...<BRANCH>
    git log --oneline <TARGET>..<BRANCH>
    git diff --stat <TARGET>..<BRANCH>
    git cherry -v <TARGET> <BRANCH>
    ```
-4. Classify:
+5. Classify recommendations only; deleting a candidate requires explicit
+   maintainer/user approval:
    - `ahead=0`: safe deletion candidate
    - equivalent commits already landed: deletion candidate
    - small, current, useful diff: keep or rebase into PR
    - large or unclear diff: document follow-up before action
-5. Ask before deleting when ownership, branch purpose, or remote impact is unclear.
+6. Ask for explicit maintainer/user approval before pruning refs or deleting any
+   local or remote branch, even when ownership, branch purpose, and remote
+   impact look clear.
 
 ## Output
 
 - Branch summary with ahead/behind count and last commit date
 - Useful commits or risks
 - Recommendation: delete, keep, rebase, or needs follow-up
-- Actions taken, if action mode was explicitly requested
+- Actions taken after explicit maintainer/user approval, if action mode was
+  explicitly requested

--- a/.opencode/command/dart-close-issue.md
+++ b/.opencode/command/dart-close-issue.md
@@ -26,7 +26,8 @@ Close or prepare closing message for issue: $ARGUMENTS
    - thank the reporter
    - state the concrete resolution
    - link the fixing PR or relevant docs when available
-4. Only post and close if the user explicitly requested action:
+4. Only post and close if the user explicitly requested action and explicit
+   maintainer/user approval has been given:
    ```bash
    gh issue comment <ISSUE_NUMBER> --body "<message>"
    gh issue close <ISSUE_NUMBER>

--- a/.opencode/command/dart-docs-update.md
+++ b/.opencode/command/dart-docs-update.md
@@ -24,4 +24,7 @@ Update documentation: $ARGUMENTS
 3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
 4. Update indexes and cross-references that point to changed docs
 5. Run `pixi run lint` before committing
-6. Push and open a PR with the proper milestone
+6. Record the CHANGELOG decision for the docs/tooling change.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, use `.github/PULL_REQUEST_TEMPLATE.md` and the proper
+   milestone.

--- a/.opencode/command/dart-downstream-fix.md
+++ b/.opencode/command/dart-downstream-fix.md
@@ -25,16 +25,18 @@ Use for downstream issues in gz-physics, Gazebo, or gz-sim that trace back to DA
 2. Identify the DART API, component, and invalid usage pattern involved.
 3. Search for related validation and recovery patterns in DART.
 4. Plan the smallest fix and the regression test location.
-5. Implement on `main` first for DART 7:
-   - branch: `fix/<downstream-project>-<issue-number>-<brief-description>`
+5. Decide whether the bug applies to the active release line. For applicable
+   bug fixes, implement on `release-6.16` first, then cherry-pick or reapply to
+   `main` for DART 7:
+   - branch: `fix/<downstream-project>-<issue-number>-<brief-description>-6.16`
    - add a regression test that reproduces the downstream symptom
    - keep the fix minimal; no unrelated refactors
 6. Run `pixi run lint` and relevant tests; use `pixi run test-all` when feasible.
-7. Create a `main` PR with milestone `DART 7.0` and reference the downstream issue.
-8. If this is a bug fix applicable to the release line, create the release-branch PR too:
-   - branch from `release-6.16`
-   - adapt API differences if needed
-   - milestone `DART 6.16.x`
+7. Ask for explicit maintainer/user approval before pushing or creating PRs.
+   After approval, create the release-branch PR with milestone `DART 6.16.x`
+   and reference the downstream issue.
+8. Create the matching `main` PR with milestone `DART 7.0`; adapt API
+   differences if needed.
 
 ## Release-Line Differences
 

--- a/.opencode/command/dart-fix-ci.md
+++ b/.opencode/command/dart-fix-ci.md
@@ -25,14 +25,18 @@ Fix CI failure: $ARGUMENTS
 3. If a job is still in progress, wait for logs instead of guessing.
 4. Reproduce locally with the smallest relevant command:
    - formatting: `pixi run lint`
-   - tests: `pixi run test`, `pixi run test-unit`, or `ctest -R <TEST>`
+   - tests: `pixi run test`, `pixi run test-unit`, or another existing
+     focused `pixi run ...` test task
    - coverage: add targeted tests for uncovered changed lines
 5. Fix the root cause with minimal scope.
-6. If the failure is infrastructure-only, rerun the failed job or run:
+6. If the failure is infrastructure-only, ask for explicit maintainer/user
+   approval before rerunning the failed job or running:
    ```bash
    gh run rerun <RUN_ID> --failed
    ```
-7. Push and watch CI until the PR is green.
+7. Ask for explicit maintainer/user approval before pushing, CI re-triggers, or
+   other GitHub mutations; after approval, push and watch CI until the PR is
+   green.
 
 ## Output
 

--- a/.opencode/command/dart-fix-issue.md
+++ b/.opencode/command/dart-fix-issue.md
@@ -17,11 +17,16 @@ Fix GitHub issue: $ARGUMENTS
 ## Workflow
 
 1. `gh issue view $1` - Validate issue
-2. `git checkout -b fix/issue-$1 origin/main`
-3. Fix with minimal changes + add regression test
+2. Classify whether the issue is a bug fix that applies to `release-6.16`.
+   For applicable bug fixes, start from `origin/release-6.16`; otherwise start
+   from `origin/main`.
+3. Fix with minimal changes + add regression test. For dual-PR bug fixes, fix
+   `release-6.16` first, then cherry-pick or reapply to `main`.
 4. `pixi run lint`, then run the smallest relevant tests; use `pixi run test-all` before finalizing when feasible
-5. `git push -u origin HEAD && gh pr create`
-6. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
+5. Before PR creation, decide whether `CHANGELOG.md` needs an entry and fill
+   `.github/PULL_REQUEST_TEMPLATE.md`.
+6. After explicit maintainer/user approval, `git push -u origin HEAD && gh pr create --base <target-branch> --milestone "<milestone>"`
+7. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
 
 ## CRITICAL: Dual-PR for Bug Fixes
 

--- a/.opencode/command/dart-manage-pr.md
+++ b/.opencode/command/dart-manage-pr.md
@@ -7,7 +7,8 @@ agent: build
 <!-- Sync script: scripts/sync_ai_commands.py -->
 <!-- Run `pixi run sync-ai-commands` to update -->
 
-Manage an open DART pull request: $ARGUMENTS
+Manage an open DART pull request after explicit maintainer/user approval for
+mutations: $ARGUMENTS
 
 ## Required Reading
 
@@ -55,13 +56,15 @@ gh pr checks <PR_NUMBER>
    - Reproduce locally with the relevant `pixi run ...` task or focused test.
    - Before committing fixes, run `pixi run lint`; also run build or tests when
      code or behavior changed.
-   - Commit only intended files, push, and continue monitoring the PR.
+   - Commit only intended files. Push only after explicit maintainer/user
+     approval, then continue monitoring the PR.
 4. Address reviews:
    - Use the `dart-review-pr` workflow for substantive review feedback.
    - Never reply to AI-generated review comments from bot users such as
      `chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
-   - Push AI-review fixes silently. Resolve threads when needed, then request a
-     fresh AI review only after the branch is ready:
+   - Apply AI-review fixes silently. After explicit maintainer/user approval
+     and after the branch is ready, push, resolve reviewed and addressed
+     threads, and request a fresh AI review:
      ```bash
      gh pr comment <PR_NUMBER> --body "@codex review"
      ```
@@ -71,6 +74,9 @@ gh pr checks <PR_NUMBER>
    - Confirm required checks are passing and review requirements are satisfied.
    - If the PR is draft and ready, mark it ready only when the user or task asks.
    - Do not merge unless explicitly asked or the workflow clearly includes merge.
+   - PR comments, review re-triggers, thread resolution, reviewer requests,
+     ready-for-review transitions, merges, and branch deletion are external
+     mutations and require explicit maintainer/user approval.
    - Confirm the merge method from repository settings or the user. Recent DART
      `main` PRs use single-parent PR-title commits, so prefer squash/rebase
      over merge commits unless the repository settings or user request differ.
@@ -78,20 +84,23 @@ gh pr checks <PR_NUMBER>
      accidentally.
 6. Clean up after merge:
    - Confirm the PR merged and identify the head branch before deleting.
-   - Prefer merge-time deletion with the requested merge method and head SHA:
+   - After explicit maintainer/user approval, prefer merge-time deletion with
+     the approved merge method and head SHA:
      ```bash
      gh pr merge <PR_NUMBER> --squash --match-head-commit <HEAD_SHA> --delete-branch
      ```
      Use `--rebase` or `--merge` instead of `--squash` when requested.
-   - Otherwise delete only the PR branch after confirming it has landed:
+   - After explicit maintainer/user approval, otherwise delete only the PR
+     branch after confirming it has landed:
      ```bash
      git push origin --delete <HEAD_BRANCH>
      git switch main
      git pull --ff-only
      git branch -D <HEAD_BRANCH>
      ```
-     Use force-delete locally only after confirming the PR branch has landed;
-     squash and rebase merges do not preserve the branch tip in `main` ancestry.
+     Use force-delete locally only after explicit maintainer/user approval and
+     after confirming the PR branch has landed; squash and rebase merges do not
+     preserve the branch tip in `main` ancestry.
 
 ## Output
 

--- a/.opencode/command/dart-mechanical-refactor.md
+++ b/.opencode/command/dart-mechanical-refactor.md
@@ -27,7 +27,9 @@ Perform mechanical refactor: $ARGUMENTS
    - `pixi run build`
    - `pixi run test-unit`
    - `pixi run test-all` when feasible
-7. Open a PR with a clear scope statement and no behavior-change claim unless tested.
+7. Ask for explicit maintainer/user approval before pushing or opening a PR.
+   After approval, open a PR with a clear scope statement and no
+   behavior-change claim unless tested.
 
 ## Output
 

--- a/.opencode/command/dart-merge-pr.md
+++ b/.opencode/command/dart-merge-pr.md
@@ -7,7 +7,7 @@ agent: build
 <!-- Sync script: scripts/sync_ai_commands.py -->
 <!-- Run `pixi run sync-ai-commands` to update -->
 
-Monitor and merge PR: $ARGUMENTS
+Monitor and merge PR after explicit maintainer/user approval: $ARGUMENTS
 
 ## Required Reading
 
@@ -26,15 +26,19 @@ Monitor and merge PR: $ARGUMENTS
 3. If any required check is pending, watch quietly until it passes or fails.
 4. If any check fails, use `/dart-fix-ci` or `$dart-fix-ci`; do not merge.
 5. Confirm merge method from repository settings. DART uses squash/rebase, not merge commits.
-6. Merge only when checks are green, the PR is not draft, and GitHub reports it mergeable.
-7. Use the current head SHA when merging so a moved branch cannot be merged accidentally.
-8. For squash merges, use the recent DART title convention:
+6. Ask for explicit maintainer/user approval before any merge action.
+7. Merge only after that approval, when checks are green, the PR is not draft,
+   and GitHub reports it mergeable.
+8. Use the current head SHA when merging so a moved branch cannot be merged accidentally.
+9. For squash merges, use the recent DART title convention:
    - commit title: `<PR title> (#<PR number>)`
    - no agent prefix
 
 ## Notes
 
-- If GitHub reports `BEHIND` but `mergeable=MERGEABLE` and required checks are green, do not update the branch just to make it current.
+- If GitHub reports `BEHIND` but `mergeable=MERGEABLE` and required checks are
+  green, do not update the branch without explicit maintainer/user approval
+  just to make it current.
 - Recent DART human-authored PRs use single-parent squash commits with the exact PR title plus `(#number)`.
 - Branch deletion is handled by repo settings unless the user explicitly asks for manual cleanup.
 

--- a/.opencode/command/dart-new-task.md
+++ b/.opencode/command/dart-new-task.md
@@ -21,10 +21,16 @@ Read these files first:
 
 1. **Understand the task** - Parse: goal, constraints, type (feature|bugfix|refactor|docs)
 2. **Assess scope** - Multi-phase or multi-session? Create `docs/dev_tasks/<task>/` (see `docs/dev_tasks/README.md` for criteria)
-3. **Setup** - Create branch from `origin/main`: `feature/<topic>`, `fix/<topic>`, etc.
+3. **Setup** - Choose the target branch before creating a topic branch:
+   - features/docs/non-bugfix refactors: branch from `origin/main`
+   - bug fixes that apply to the current release line: branch from
+     `origin/release-6.16` first, then cherry-pick or reapply to `main`
 4. **Implement** - Keep commits focused, follow code style
 5. **Verify** - Run `pixi run lint` before committing, then `pixi run test-all`
-6. **PR** - `git push -u origin HEAD` then `gh pr create --draft --milestone "DART 7.0"` (use `DART 6.16.x` for release-6.16); follow `.github/PULL_REQUEST_TEMPLATE.md`
+6. **PR** - After explicit maintainer/user approval, `git push -u origin HEAD`
+   then `gh pr create --draft --base <target-branch> --milestone "<milestone>"`
+   (`DART 7.0` for `main`, `DART 6.16.x` for `release-6.16`); follow
+   `.github/PULL_REQUEST_TEMPLATE.md`
 7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
 
 ## Type-Specific

--- a/.opencode/command/dart-pr.md
+++ b/.opencode/command/dart-pr.md
@@ -7,7 +7,8 @@ agent: build
 <!-- Sync script: scripts/sync_ai_commands.py -->
 <!-- Run `pixi run sync-ai-commands` to update -->
 
-Prepare or open a DART pull request: $ARGUMENTS
+Prepare or open a DART pull request after explicit maintainer/user approval:
+$ARGUMENTS
 
 ## Required Reading
 
@@ -68,14 +69,16 @@ Use these practices:
    git checkout -b <type>/<topic> origin/<target-branch>
    ```
 7. Commit only intended files with a plain descriptive commit title.
-8. Push and open a draft PR:
+8. Ask for explicit maintainer/user approval before pushing or opening the draft
+   PR. If approved:
    ```bash
    git push -u origin HEAD
    gh pr create --draft --base <target-branch> --milestone "<milestone>" \
      --title "<plain title>" --body-file <filled-template-file>
    ```
-9. If `CHANGELOG.md` needs the PR number, add the changelog entry in a
-   follow-up commit after opening the draft PR.
+9. If `CHANGELOG.md` needs the PR number, keep the follow-up changelog commit
+   local until explicit maintainer/user approval is given for the additional
+   push or PR update.
 10. Monitor CI:
     ```bash
     gh pr checks <PR_NUMBER>
@@ -85,5 +88,5 @@ Use these practices:
 
 Never reply to AI-generated review comments from bot users such as
 `chatgpt-codex-connector[bot]`, `github-actions[bot]`, or `copilot[bot]`.
-Push fixes silently and ask for a new AI review with `@codex review` only when
-needed.
+Make fixes silently. Push and ask for a new AI review with `@codex review` only
+after explicit maintainer/user approval.

--- a/.opencode/command/dart-release-ci-fix.md
+++ b/.opencode/command/dart-release-ci-fix.md
@@ -31,7 +31,9 @@ Fix release-branch CI: $ARGUMENTS
 4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
 5. Explain why the failure was not caught earlier and whether workflow coverage should change.
 6. Run `pixi run lint` and release-relevant build/tests.
-7. Push and create or update the release-branch PR with the current release milestone.
+7. Ask for explicit maintainer/user approval before pushing, creating, or
+   updating the release-branch PR; after approval, use the current release
+   milestone and PR template.
 8. Monitor CI until green.
 
 ## Output

--- a/.opencode/command/dart-release-merge-main.md
+++ b/.opencode/command/dart-release-merge-main.md
@@ -32,7 +32,9 @@ Merge release branch into main: $ARGUMENTS
    - files only on release: keep if still relevant to main
 6. Verify no unresolved conflicts remain.
 7. Run `pixi run lint` and relevant checks.
-8. Push and create a PR targeting `main` with milestone `DART 7.0`.
+8. Ask for explicit maintainer/user approval before pushing or creating the PR.
+   After approval, create a PR targeting `main` with milestone `DART 7.0` and
+   use the PR template.
 9. Monitor CI until green.
 
 ## Output

--- a/.opencode/command/dart-release-packaging.md
+++ b/.opencode/command/dart-release-packaging.md
@@ -7,7 +7,7 @@ agent: build
 <!-- Sync script: scripts/sync_ai_commands.py -->
 <!-- Run `pixi run sync-ai-commands` to update -->
 
-Create release packaging PR: $ARGUMENTS
+Create release packaging PR after explicit maintainer/user approval: $ARGUMENTS
 
 ## Required Reading
 
@@ -29,8 +29,11 @@ Create release packaging PR: $ARGUMENTS
 6. Add the `CHANGELOG.md` release section with the release date and milestone link.
 7. Run `pixi run lint` and relevant packaging checks.
 8. Commit as `Packaging <NEW_VERSION>`.
-9. Push and create a PR against the release branch.
-10. Set the release milestone, for example `DART 6.16.x` or the specific version milestone if available.
+9. Ask for explicit maintainer/user approval before pushing, creating the PR,
+   or setting milestones.
+10. After approval, create the PR against the release branch with the release
+    milestone, for example `DART 6.16.x` or the specific version milestone if
+    available.
 
 ## Output
 

--- a/.opencode/command/dart-resume.md
+++ b/.opencode/command/dart-resume.md
@@ -37,7 +37,8 @@ and ask.
 - Continue with minimal scope and preserve existing user changes.
 - Run `pixi run lint` before committing.
 - Run relevant tests; use `pixi run test-all` before done when feasible.
-- Push with `git push -u origin HEAD` and create/update the PR.
+- Push with `git push -u origin HEAD` and create/update the PR only after
+  explicit maintainer/user approval.
 
 ## Safety
 

--- a/.opencode/command/dart-review-pr.md
+++ b/.opencode/command/dart-review-pr.md
@@ -29,14 +29,21 @@ Check: code style, tests, docs, focused commits
 gh pr view $1 --comments
 ```
 
-Apply minimal fixes, verify, push.
+Apply minimal fixes locally and verify. Do not push, comment, resolve threads,
+or re-trigger review without explicit maintainer/user approval for that
+external mutation.
 
 ## AI-Generated Reviews (Codex, Copilot, etc.)
 
-1. Push fix silently (no reply)
-2. Resolve thread via GraphQL (see ai-tools.md)
-3. Re-trigger: `gh pr comment $1 --body "@codex review"`
-4. Monitor CI: `gh pr checks $1`
-5. Check for new review, repeat until no comments + CI green
+1. Make the local fix silently (no reply)
+2. Run the relevant local gates, including `pixi run lint` before any commit
+3. Ask for explicit maintainer/user approval before push, thread resolution,
+   PR comment, or review re-trigger
+4. If approved, push the fix silently
+5. If approved, resolve only reviewed and addressed thread IDs via GraphQL (see
+   ai-tools.md)
+6. If approved, re-trigger: `gh pr comment $1 --body "@codex review"`
+7. Monitor CI: `gh pr checks $1`
+8. Check for new review, repeat until no comments + CI green
 
 Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ If this fails, see `docs/onboarding/ci-cd.md` for troubleshooting.
 | Python bindings | @docs/onboarding/python-bindings.md                         |
 | Model loading   | @docs/onboarding/io-parsing.md                              |
 | Build system    | @docs/onboarding/build-system.md                            |
-| AI tools        | @docs/onboarding/ai-tools.md                                |
+| AI tools        | @docs/ai/README.md @docs/onboarding/ai-tools.md             |
 | PR reviews      | @docs/onboarding/ai-tools.md (AI review handling rules)     |
 | Release work    | @docs/onboarding/release-management.md                      |
 | Dev tasks       | @docs/dev_tasks/README.md (when to create, cleanup rules)   |
@@ -97,7 +97,7 @@ Skills are in `.claude/skills/` (synced to `.codex/skills/` for Codex).
 
 - **Bug fixes**: Require PRs to BOTH `release-6.16` AND `main` branches. See `docs/onboarding/contributing.md`.
 - **Multi-phase tasks**: Create `docs/dev_tasks/<task>/` for tracking. See `docs/dev_tasks/README.md` for criteria.
-- **AI reviews**: NEVER reply to AI-generated review comments (usernames ending in `[bot]` like `chatgpt-codex-connector[bot]`, `github-actions[bot]`, `copilot[bot]`). No inline replies and no acknowledgment comments. Just push the fix silently, then re-trigger with a top-level `@codex review` comment when needed. See `docs/onboarding/ai-tools.md`.
+- **AI reviews**: NEVER reply to AI-generated review comments (usernames ending in `[bot]` like `chatgpt-codex-connector[bot]`, `github-actions[bot]`, `copilot[bot]`). No inline replies and no acknowledgment comments. Make local fixes silently. Pushes, PR comments, thread resolution, review re-triggers, and other GitHub mutations require explicit maintainer/user approval. See `docs/onboarding/ai-tools.md`.
 - **Commands**: Use `pixi run ...` tasks; don't invent new entry points.
 - **Formatting**: Run `pixi run lint` before committing (auto-fixes).
 - **Commit/PR titles**: Do not prefix commit messages or PR titles with agent tags like `[codex]`; use plain descriptive titles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 - Tooling and Docs
   - Added AI-native documentation architecture with AGENTS.md, module-specific guides, slash commands, and command sync automation. ([#2446](https://github.com/dartsim/dart/pull/2446), [#2447](https://github.com/dartsim/dart/pull/2447), [#2448](https://github.com/dartsim/dart/pull/2448), [#2449](https://github.com/dartsim/dart/pull/2449))
+  - Added the shared `docs/ai/` agent entrypoint and tightened AI workflow verification, approval-boundary checks, and dev-task cleanup guidance. ([#2649](https://github.com/dartsim/dart/pull/2649))
   - Extended AI command and skill synchronization so Claude Code, OpenCode, and Codex expose the same DART workflow capabilities with parity checks for generated command and skill files.
   - Promoted prompt-only AI workflows into synced workflow commands and removed the separate prompt-template folder.
   - Fixed generated Codex DART skill frontmatter so strict YAML parsers load AI workflow skills without warnings. ([#2546](https://github.com/dartsim/dart/pull/2546))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,22 @@ All source files should include a copyright header. We use the year of first pub
 ## Before Submitting a PR
 
 - [ ] Code follows the [DART style guide](docs/onboarding/code-style.md)
-- [ ] Build succeeds: `pixi run build` or `cmake --build build/`
-- [ ] Tests pass: `pixi run test` or `cmake --build build/ --target test`
-- [ ] Code is formatted: `make format` (in build directory)
+- [ ] Build succeeds: `pixi run build`
+- [ ] Tests pass: `pixi run test` or a more focused `pixi run ...` test task
+- [ ] Code is formatted: `pixi run lint`
 - [ ] Documentation is updated if needed
+- [ ] Bug fixes that apply to the release line have a `release-6.16` PR first,
+      then a `main` PR
+- [ ] PR uses `.github/PULL_REQUEST_TEMPLATE.md`
+- [ ] Target milestone is set (`DART 7.0` for `main`, `DART 6.16.x` for
+      `release-6.16`)
+- [ ] `CHANGELOG.md` is updated or the PR explains why no changelog entry is
+      needed
+- [ ] Any used `docs/dev_tasks/<task>/` folder is removed in this PR after
+      durable notes move into onboarding docs
+
+Advanced manual CMake details live in the [build guide](docs/onboarding/building.md),
+but the public contribution checklist uses `pixi run ...` tasks.
 
 ## Getting Help
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains documentation for DART users, developers, and contributo
 Located in `onboarding/` - **Architecture guides for developers:**
 
 - **[Onboarding Guide](onboarding/README.md)** - Complete internal architecture overview with diagrams
+- [AI Agent Entrypoint](ai/README.md) - AI-native workflow map, verification gates, sessions, and component ownership
 - [Core Architecture](onboarding/architecture.md) - Deep dive into simulation engine internals
 - [Aspect System](onboarding/aspect-system.md) - Aspect/State/Properties design and implementation
 - [Dynamics System](onboarding/dynamics.md) - Articulated body system and kinematics
@@ -41,5 +42,6 @@ _Format: ReStructuredText (RST) for Sphinx/ReadTheDocs publishing_
 - **Building from source?** → [onboarding/building.md](onboarding/building.md)
 - **Contributing code?** → [onboarding/contributing.md](onboarding/contributing.md) + [onboarding/code-style.md](onboarding/code-style.md)
 - **Understanding architecture?** → [onboarding/architecture.md](onboarding/architecture.md)
+- **Using AI agent workflows?** → [ai/README.md](ai/README.md) + [onboarding/ai-tools.md](onboarding/ai-tools.md)
 - **Using DART API?** → [dart.readthedocs.io](https://dart.readthedocs.io/)
 - **Looking for examples?** → [examples/](../examples/) and [tutorials/](../tutorials/)

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,74 @@
+# AI Agent Entrypoint
+
+This directory is the shared AI-native starting point for DART. It keeps
+durable agent workflow policy in tracked docs while tool-specific command and
+skill files stay thin, generated, or compatibility-focused.
+
+## Read Order
+
+For general DART agent work:
+
+1. `AGENTS.md`
+2. `docs/ai/README.md` (this file)
+3. `docs/ai/workflows.md`
+4. `docs/ai/verification.md`
+5. The task-specific onboarding doc listed in `AGENTS.md`
+
+For multi-session work, also read `docs/ai/sessions.md` and
+`docs/dev_tasks/README.md`.
+
+For AI component maintenance, read `docs/ai/components.md` and
+`docs/onboarding/ai-tools.md`.
+
+## Source Ownership
+
+| Surface                       | Role                                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `AGENTS.md`                   | Root pointer board and mandatory high-level rules                                    |
+| `docs/ai/`                    | Durable AI-native policy, workflow map, session rules, and verification expectations |
+| `docs/onboarding/ai-tools.md` | Tool compatibility and adapter maintenance details                                   |
+| `.claude/commands/`           | Temporary editable source for DART workflow command bodies                           |
+| `.claude/skills/`             | Editable source for DART domain skills                                               |
+| `.codex/skills/`              | Generated first-class Codex workflow and skill entrypoints                           |
+| `.opencode/command/`          | Generated OpenCode command entrypoints                                               |
+| `scripts/sync_ai_commands.py` | Adapter sync and AI docs consistency checker                                         |
+
+Do not hand-edit generated `.codex/` or `.opencode/` files. Update the source
+surface, then run `pixi run sync-ai-commands`.
+
+## Model Routing
+
+Codex is the primary implementation model for DART's first AI-native rollout.
+Claude Code and OpenCode remain supported compatibility surfaces, and Claude is
+still useful for fallback and independent review. This routing affects agent
+workflow design, not human contributor requirements: every AI workflow must map
+back to public docs and `pixi run ...` commands that a contributor can run
+without any AI tool.
+
+## Safety Boundary
+
+AI agents may inspect files, make local edits requested by the user, and run
+local verification. GitHub mutations require explicit maintainer or user
+approval, including pushes, PR comments, review-thread resolution, reviewer
+requests, merges, and review re-triggers such as `@codex review`.
+
+For automated review comments from bot accounts, make code fixes locally and do
+not reply inline. After explicit approval to update the PR, push the fix
+silently and use the approved top-level re-trigger path.
+
+## Required Gates
+
+Use the strongest gate that matches the work. At minimum, AI-surface changes
+must pass:
+
+```bash
+pixi run lint-md
+pixi run check-lint-md
+pixi run sync-ai-commands
+pixi run check-ai-commands
+pixi run check-docs-policy
+pixi run check-lint-spell
+```
+
+Before committing, DART still requires `pixi run lint`. Code changes require
+the build and test gates listed in `AGENTS.md` and the relevant onboarding docs.

--- a/docs/ai/components.md
+++ b/docs/ai/components.md
@@ -1,0 +1,45 @@
+# AI Components
+
+This document defines how DART maintains AI-facing components.
+
+## Ownership Model
+
+`AGENTS.md` is the root pointer board. `docs/ai/` owns durable AI-native policy.
+`docs/onboarding/ai-tools.md` owns compatibility details. The current editable
+workflow source is `.claude/commands/`, and the current editable domain-skill
+source is `.claude/skills/`.
+
+Generated surfaces are first-class entrypoints for their tools:
+
+- `.codex/skills/` for Codex;
+- `.opencode/command/` for OpenCode.
+
+Generated files include source metadata and must not be hand-edited.
+
+## Adding A Workflow
+
+1. Add the concise workflow source under `.claude/commands/dart-<name>.md`.
+2. Keep detailed policy in `docs/ai/` or `docs/onboarding/`.
+3. Add the workflow to `AGENTS.md` and `docs/ai/workflows.md`.
+4. Run `pixi run sync-ai-commands`.
+5. Run `pixi run check-ai-commands`.
+
+## Adding A Domain Skill
+
+1. Add `.claude/skills/dart-<name>/SKILL.md`.
+2. Keep the skill lightweight and point to full docs.
+3. Add the skill to `AGENTS.md` and `docs/ai/workflows.md`.
+4. Run `pixi run sync-ai-commands`.
+5. Run `pixi run check-ai-commands`.
+
+## Public Path Requirement
+
+Every AI workflow must map back to public docs and `pixi run ...` commands so a
+contributor can complete the same work manually. AI tooling can make the path
+faster; it must not be the only path.
+
+## Checks
+
+`scripts/sync_ai_commands.py` verifies adapter parity, metadata budgets, and the
+`docs/ai/workflows.md` capability index. `pixi run check-ai-commands` is the
+non-mutating CI check.

--- a/docs/ai/sessions.md
+++ b/docs/ai/sessions.md
@@ -1,0 +1,40 @@
+# AI Sessions
+
+Multi-session AI work uses the existing `docs/dev_tasks/` lifecycle. Do not add
+a separate permanent session system until repeated failures justify it.
+
+## When To Create A Dev Task
+
+Use `docs/dev_tasks/<task>/` when the work is multi-phase, crosses sessions,
+needs design decisions, or has dependencies between steps. Follow
+`docs/dev_tasks/README.md`.
+
+## Required Files
+
+| File        | Purpose                                                       |
+| ----------- | ------------------------------------------------------------- |
+| `README.md` | Current status, goal, key decisions, and immediate next steps |
+| `RESUME.md` | Handoff prompt for a fresh AI or human session                |
+
+A separate `TODO.md` is optional and should only be introduced with a checker or
+clear cleanup rule. Otherwise, status belongs in `README.md`.
+
+## Resume Discipline
+
+Update `RESUME.md` after significant progress and before ending a session. It
+must contain:
+
+- last session summary;
+- current branch and worktree state;
+- one immediate next step;
+- context that would otherwise be lost;
+- commands to verify the state.
+
+## Completion Discipline
+
+When a dev task completes:
+
+1. Move durable lessons to the relevant onboarding doc.
+2. Delete the task folder in the same PR.
+3. Run the verification gates listed in `docs/ai/verification.md`.
+4. Include the cleanup in the completion PR.

--- a/docs/ai/verification.md
+++ b/docs/ai/verification.md
@@ -1,0 +1,43 @@
+# AI Verification
+
+AI work is complete only when the requested outcome is mapped to concrete
+evidence. Passing a broad verifier is useful only when it covers the actual
+requirements.
+
+## Completion Audit
+
+Before finalizing substantial AI-assisted work:
+
+1. Restate the objective as concrete deliverables.
+2. Map each explicit request, file, command, gate, and deliverable to evidence.
+3. Inspect the actual files, command output, review state, or artifacts.
+4. Identify missing, weakly verified, or blocked requirements.
+5. Continue working until all required items are satisfied or a real blocker
+   remains.
+
+## Gate Selection
+
+| Change type         | Required gates                                                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| AI docs or adapters | `pixi run lint-md`, `pixi run check-lint-md`, `pixi run sync-ai-commands`, `pixi run check-ai-commands`, `pixi run check-docs-policy`, `pixi run check-lint-spell` |
+| Docs only           | `pixi run lint-md`, `pixi run check-lint-md`, `pixi run check-docs-policy`, `pixi run check-lint-spell`                                                            |
+| C++ code            | `pixi run lint`, `pixi run build`, focused tests or `pixi run test-unit`                                                                                           |
+| Python bindings     | `pixi run lint`, `pixi run build`, `pixi run test-py`                                                                                                              |
+| IO/model parsing    | `pixi run lint`, focused parser tests, relevant examples if affected                                                                                               |
+| CI workflow         | local reproduction when possible, `pixi run check-lint`, relevant build/test gate                                                                                  |
+| Release work        | release-management docs, changelog/version checks, target branch gates                                                                                             |
+
+Before any commit, run `pixi run lint` as required by `AGENTS.md`.
+
+## Review Safety Evidence
+
+When review feedback comes from an AI bot account:
+
+- Do not reply inline to the bot.
+- Verify the claim with code inspection or tests.
+- Add or update tests when a false positive should be permanently refuted.
+- Do not push, resolve threads, comment, or re-trigger review without explicit
+  maintainer/user approval.
+
+The final response should state which of those actions were local-only and which
+external mutations, if any, were explicitly approved.

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -1,0 +1,58 @@
+# AI Workflow Map
+
+DART exposes the same effective workflow set across supported AI tools:
+
+- Codex uses generated `$dart-*` skills from `.codex/skills/`.
+- Claude Code and OpenCode use `/dart-*` commands for workflows.
+- Domain skills such as `dart-build` and `dart-test` are lightweight pointers to
+  onboarding docs.
+
+Codex is the primary implementation path for the initial AI-native rollout, but
+all workflows must remain usable from public docs and `pixi run ...` commands.
+
+## User-Invoked Workflows
+
+| Capability                    | Codex                          | Claude/OpenCode                | Required docs and public path                                                                                                 | Minimum gate or exception                                                                                                                 |
+| ----------------------------- | ------------------------------ | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `dart-new-task`               | `$dart-new-task`               | `/dart-new-task`               | `docs/onboarding/building.md`, `docs/onboarding/contributing.md`, `docs/onboarding/code-style.md`, `docs/dev_tasks/README.md` | No local gate until edits begin; then use task-specific gates; explicit approval before push/PR creation                                  |
+| `dart-resume`                 | `$dart-resume`                 | `/dart-resume`                 | active `RESUME.md`, `docs/dev_tasks/README.md`, `docs/onboarding/ci-cd.md`, `docs/onboarding/contributing.md`                 | `git status --short --branch` before edits; explicit approval before push/PR update                                                       |
+| `dart-fix-issue`              | `$dart-fix-issue`              | `/dart-fix-issue`              | GitHub issue, `docs/onboarding/contributing.md` dual-PR bugfix rule                                                           | `pixi run lint`, focused build/test; explicit approval before push/PR creation                                                            |
+| `dart-fix-ci`                 | `$dart-fix-ci`                 | `/dart-fix-ci`                 | `docs/onboarding/ci-cd.md`, failing CI logs                                                                                   | local reproduction when possible; explicit approval before push, rerun, or CI re-trigger                                                  |
+| `dart-review-pr`              | `$dart-review-pr`              | `/dart-review-pr`              | PR diff, `docs/onboarding/code-style.md`, `docs/onboarding/ai-tools.md` review rules                                          | Read-only findings unless explicit approval allows mutations                                                                              |
+| `dart-pr`                     | `$dart-pr`                     | `/dart-pr`                     | `.github/PULL_REQUEST_TEMPLATE.md`, `docs/onboarding/contributing.md`, `docs/onboarding/ai-tools.md`                          | `pixi run lint`, target-specific gates, milestone and CHANGELOG decision; explicit approval before push/PR creation                       |
+| `dart-manage-pr`              | `$dart-manage-pr`              | `/dart-manage-pr`              | PR checks, `docs/onboarding/contributing.md`, `docs/onboarding/ci-cd.md`, `docs/onboarding/ai-tools.md`                       | Read-only inspection unless explicit approval allows mutations                                                                            |
+| `dart-merge-pr`               | `$dart-merge-pr`               | `/dart-merge-pr`               | `docs/onboarding/ci-cd.md`, `docs/onboarding/contributing.md`, PR checks                                                      | Maintainer-only; CI/review green and explicit merge approval                                                                              |
+| `dart-docs-update`            | `$dart-docs-update`            | `/dart-docs-update`            | `docs/README.md`, `docs/onboarding/ai-tools.md`, relevant docs                                                                | `pixi run lint-md`, `pixi run check-lint-md`, `pixi run check-docs-policy`, `pixi run check-lint-spell`; explicit approval before push/PR |
+| `dart-improve-docs`           | `$dart-improve-docs`           | `/dart-improve-docs`           | `docs/AGENTS.md`, `docs/onboarding/ai-tools.md`, relevant docs                                                                | `pixi run lint-md`, `pixi run check-lint-md`, `pixi run check-docs-policy`, `pixi run check-lint-spell`                                   |
+| `dart-audit-agent-compliance` | `$dart-audit-agent-compliance` | `/dart-audit-agent-compliance` | `docs/onboarding/ai-tools.md`, `docs/onboarding/contributing.md`                                                              | Relevant docs/AI checks for touched files                                                                                                 |
+| `dart-mechanical-refactor`    | `$dart-mechanical-refactor`    | `/dart-mechanical-refactor`    | `CONTRIBUTING.md`, `docs/onboarding/code-style.md`, affected module docs                                                      | `pixi run lint`, focused tests proving behavior preservation; explicit approval before push/PR creation                                   |
+| `dart-branch-cleanup`         | `$dart-branch-cleanup`         | `/dart-branch-cleanup`         | branch list, `docs/onboarding/ci-cd.md`, `docs/onboarding/contributing.md`                                                    | Read-only analysis unless explicit approval allows branch deletion                                                                        |
+| `dart-triage-issue`           | `$dart-triage-issue`           | `/dart-triage-issue`           | GitHub issue, `docs/onboarding/contributing.md`                                                                               | No local gate for read-only triage; explicit approval before labels/comments                                                              |
+| `dart-close-issue`            | `$dart-close-issue`            | `/dart-close-issue`            | issue context, `docs/onboarding/contributing.md`, closing evidence                                                            | No local gate for draft text; explicit approval before posting/closing                                                                    |
+| `dart-downstream-fix`         | `$dart-downstream-fix`         | `/dart-downstream-fix`         | downstream repro, `docs/onboarding/contributing.md` dual-PR bugfix rule, `docs/onboarding/ci-cd.md`                           | `pixi run lint`, regression test, focused build/test; explicit approval before push/PR creation                                           |
+| `dart-backport-pr`            | `$dart-backport-pr`            | `/dart-backport-pr`            | `docs/onboarding/contributing.md`, `docs/onboarding/release-management.md`                                                    | `pixi run lint`, release-target focused tests; explicit approval before push/PR creation                                                  |
+| `dart-release-ci-fix`         | `$dart-release-ci-fix`         | `/dart-release-ci-fix`         | `docs/onboarding/ci-cd.md`, `docs/onboarding/release-management.md`, release CI logs                                          | local reproduction when possible; explicit approval before push/PR update                                                                 |
+| `dart-release-merge-main`     | `$dart-release-merge-main`     | `/dart-release-merge-main`     | `docs/onboarding/release-management.md`, `docs/onboarding/ci-cd.md`                                                           | Maintainer-only; explicit approval before push/PR creation plus release gates                                                             |
+| `dart-release-packaging`      | `$dart-release-packaging`      | `/dart-release-packaging`      | `docs/onboarding/release-management.md`, `docs/onboarding/contributing.md`, changelog/version files                           | release verification gates and explicit maintainer/user approval before GitHub mutations                                                  |
+
+## Domain Skills
+
+| Capability        | Codex              | Manual public path                                                     |
+| ----------------- | ------------------ | ---------------------------------------------------------------------- |
+| `dart-build`      | `$dart-build`      | `docs/onboarding/building.md`, `pixi run build`                        |
+| `dart-ci`         | `$dart-ci`         | `docs/onboarding/ci-cd.md`                                             |
+| `dart-contribute` | `$dart-contribute` | `docs/onboarding/contributing.md`, `CONTRIBUTING.md`                   |
+| `dart-io`         | `$dart-io`         | `docs/onboarding/io-parsing.md`                                        |
+| `dart-python`     | `$dart-python`     | `docs/onboarding/python-bindings.md`                                   |
+| `dart-test`       | `$dart-test`       | `docs/onboarding/testing.md`, `pixi run test-unit`, `pixi run test-py` |
+
+## Expected Routing Scenarios
+
+| Prompt shape             | Expected workflow  | Required docs                                      | Minimum gates                                                                                                                             |
+| ------------------------ | ------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| "Fix issue #123"         | `dart-fix-issue`   | `contributing.md`, task-specific docs              | `pixi run lint`, focused build/test                                                                                                       |
+| "CI is failing on my PR" | `dart-fix-ci`      | `ci-cd.md`, failing logs                           | reproduction command plus fixed check                                                                                                     |
+| "Update docs for X"      | `dart-docs-update` | `docs/README.md`, `ai-tools.md`, relevant docs     | `pixi run lint-md`, `pixi run check-lint-md`, `pixi run check-docs-policy`, `pixi run check-lint-spell`; explicit approval before push/PR |
+| "Review PR #123"         | `dart-review-pr`   | `code-style.md`, `ai-tools.md`, PR diff            | read-only findings unless explicit approval allows mutations                                                                              |
+| "Create a PR"            | `dart-pr`          | PR template, `contributing.md`, `ai-tools.md`      | `pixi run lint`, target-specific gates, milestone/CHANGELOG decision, explicit approval before push/PR creation                           |
+| "Continue the task"      | `dart-resume`      | active `RESUME.md`, dev task, CI/contributing docs | `git status --short --branch`; explicit approval before push/PR update                                                                    |

--- a/docs/onboarding/ai-tools.md
+++ b/docs/onboarding/ai-tools.md
@@ -40,16 +40,18 @@ This document tracks AI coding assistant compatibility with DART's documentation
 
 ### Conventions
 
-| Convention                    | Rule                                                                       |
-| ----------------------------- | -------------------------------------------------------------------------- |
-| **Single source of truth**    | `AGENTS.md` contains all instructions; other files redirect                |
-| **Command naming**            | `dart-` prefix (e.g., `dart-new-task.md`)                                  |
-| **Skill naming**              | `dart-` prefix (e.g., `dart-build`)                                        |
-| **Skill descriptions**        | Start with display name and quote colon values (e.g., `"DART Build: ..."`) |
-| **No tool-specific language** | Use generic terms; avoid "Claude will..." or "Codex should..."             |
-| **Placeholders**              | Use `$ARGUMENTS`, `$1`, `$2` for command args                              |
-| **File references**           | Use `@file` syntax for auto-loading context                                |
-| **No separate fallbacks**     | Repeatable workflows live in `.claude/commands/`                           |
+| Convention                      | Rule                                                                                               |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Pointer board**               | `AGENTS.md` stays concise and points to durable docs                                               |
+| **AI-native policy**            | `docs/ai/` owns workflow maps, verification, sessions, and component ownership                     |
+| **Command naming**              | `dart-` prefix (e.g., `dart-new-task.md`)                                                          |
+| **Skill naming**                | `dart-` prefix (e.g., `dart-build`)                                                                |
+| **Skill descriptions**          | Start with display name and quote colon values (e.g., `"DART Build: ..."`)                         |
+| **Tool-specific language**      | Use generic terms except in compatibility or routing docs where tool behavior is the subject       |
+| **Placeholders**                | Use `$ARGUMENTS`, `$1`, `$2` for command args                                                      |
+| **Tracked file references**     | Use repo-relative `@file` syntax; home-directory references are only for untracked personal files  |
+| **Workflow source**             | Repeatable workflows currently live in `.claude/commands/` and are generated to Codex/OpenCode     |
+| **Manual public path required** | Every AI workflow must map back to public docs and `pixi run ...` commands for non-AI contributors |
 
 ### @file Import Syntax
 
@@ -79,19 +81,21 @@ The `@path/to/file` syntax tells agents to automatically load referenced files i
 - Paths are relative to repository root
 - Imports are NOT evaluated inside code blocks (use backticks to escape)
 - Recursive imports are supported (imported files can import other files)
-- Use `@~/.claude/file.md` for home directory references
+- Tracked project instructions must use repo-relative paths. Home-directory
+  references are only for untracked personal files.
 
 ### File Ownership
 
-| File/Directory                | Purpose              | When to Update                  |
-| ----------------------------- | -------------------- | ------------------------------- |
-| `AGENTS.md`                   | Primary instructions | When workflows change           |
-| `CLAUDE.md`, `GEMINI.md`      | Redirects only       | Rarely (keep minimal)           |
-| `.claude/commands/`           | Claude Code commands | When adding workflows           |
-| `.opencode/command/`          | OpenCode commands    | Auto-synced from `.claude/`     |
-| `.claude/skills/`             | Claude/OpenCode      | When adding domain knowledge    |
-| `.codex/skills/`              | Codex skills         | Auto-generated from `.claude/`  |
-| `docs/onboarding/ai-tools.md` | This file            | When tool compatibility changes |
+| File/Directory                | Purpose                      | When to Update                  |
+| ----------------------------- | ---------------------------- | ------------------------------- |
+| `AGENTS.md`                   | Root pointer board           | When workflows or gates change  |
+| `docs/ai/`                    | Durable AI-native policy     | When AI workflow policy changes |
+| `CLAUDE.md`, `GEMINI.md`      | Redirects only               | Rarely (keep minimal)           |
+| `.claude/commands/`           | Editable workflow source     | When adding workflows           |
+| `.opencode/command/`          | Generated OpenCode commands  | Auto-synced from `.claude/`     |
+| `.claude/skills/`             | Editable domain-skill source | When adding domain knowledge    |
+| `.codex/skills/`              | Generated Codex skills       | Auto-generated from `.claude/`  |
+| `docs/onboarding/ai-tools.md` | Tool compatibility details   | When tool compatibility changes |
 
 ### Adding a New Command
 
@@ -116,13 +120,13 @@ The `@path/to/file` syntax tells agents to automatically load referenced files i
 
 2. Sync to OpenCode and Codex: `pixi run lint` (includes `sync-ai-commands`)
 
-3. Update `AGENTS.md` or this document if the command should be discoverable in the root workflow table
+3. Update `AGENTS.md` and `docs/ai/workflows.md` if the command should be discoverable in the root workflow table
 
 4. Put long background material in `docs/onboarding/*.md`; keep command files concise and action-oriented
 
 Codex does not use project slash-command files directly. The sync script
-generates an equivalent Codex skill from each command, so `/dart-fix-ci` becomes
-`$dart-fix-ci`.
+generates a first-class Codex skill from each command, so `/dart-fix-ci`
+becomes `$dart-fix-ci`.
 
 ### Adding a New Skill
 
@@ -147,7 +151,7 @@ generates an equivalent Codex skill from each command, so `/dart-fix-ci` becomes
 
 2. Sync to Codex: `pixi run lint` (includes `sync-ai-commands`)
 
-3. Update `AGENTS.md` skills table
+3. Update `AGENTS.md` and `docs/ai/workflows.md` skills tables
 
 ### Skill Design Principles
 
@@ -247,7 +251,9 @@ DART skills are original content under BSD 2-Clause license.
 ### Keeping Commands and Skills in Sync
 
 Commands and skills exist in multiple directories because tools don't share paths.
-The `.claude/` directory is the **source of truth**.
+The `.claude/` directory is the current editable source for workflow commands
+and domain skills. Generated Codex/OpenCode files are first-class entrypoints
+for their tools, but they are overwritten by sync.
 
 **Automated sync** (included in `pixi run lint`):
 
@@ -264,6 +270,20 @@ pixi run check-ai-commands  # Check if in sync (CI mode, no changes)
 | `.claude/commands/` | `.opencode/command/`    | OpenCode commands             |
 | `.claude/commands/` | `.codex/skills/dart-*/` | Codex command workflow skills |
 | `.claude/skills/`   | `.codex/skills/`        | Codex domain skills           |
+
+Generated Codex skills are first-class Codex entrypoints even when their
+editable workflow source currently lives in `.claude/commands/`.
+
+**Durable AI-native decisions**:
+
+- Keep `AGENTS.md` as the concise pointer board, `docs/ai/` as shared agent
+  policy, and this document as the tool-compatibility reference.
+- Keep public contributor paths available through tracked docs and
+  `pixi run ...` tasks; AI workflows can route work, but must not be the only
+  way to complete it.
+- Treat `docs/dev_tasks/<task>/` folders as temporary working state. When the
+  task completes, move only durable decisions into onboarding docs and delete
+  the task folder in the same PR.
 
 **Effective capability parity**:
 
@@ -285,11 +305,12 @@ limits.
 - Target directories (`.codex/`, `.opencode/`) are excluded from prettier to prevent re-sync loops
 - Edit source files only; synced files are overwritten on each sync
 
-**Manual workflow** (if not using sync script):
+**Manual fallback**:
 
-1. Edit files in `.claude/` directory
-2. Copy changes to corresponding tool directories
-3. Verify all match
+If adapter sync is unavailable, fix or run the generator instead of manually
+maintaining generated files. `.codex/` and `.opencode/` outputs are overwritten
+by `pixi run sync-ai-commands`; edit `.claude/` source files, then regenerate
+and verify with `pixi run check-ai-commands`.
 
 Manual-only tools should read the `.claude/commands/dart-*.md` source files
 directly. There is no separate prompt-template folder.
@@ -378,17 +399,17 @@ directly. There is no separate prompt-template folder.
 ## Directory Structure
 
 ```
-.claude/                   # SOURCE OF TRUTH
+.claude/                   # Editable source for workflows and domain skills
 ├── commands/              # Claude Code commands
 │   └── dart-*.md
 └── skills/                # Claude + OpenCode skills
     └── dart-*/SKILL.md
 
-.opencode/                 # Auto-synced from .claude/
+.opencode/                 # Generated OpenCode commands
 └── command/               # OpenCode commands
     └── dart-*.md
 
-.codex/                    # Auto-synced from .claude/
+.codex/                    # Generated first-class Codex entrypoints
 └── skills/                # Codex domain + workflow skills
     └── dart-*/SKILL.md    # Includes command-derived $dart-* workflows
 ```
@@ -455,14 +476,15 @@ When AI agents (Claude Code, OpenCode, etc.) work on PRs, they may encounter rev
 - ❌ **NO** `gh pr comment` commands responding to bot feedback
 - ❌ **NO** PR comment replies acknowledging or addressing bot feedback
 - ❌ **NO** comments like "Addressed the Codex review feedback"
-- ✅ **YES** Push the code fix silently
-- ✅ **YES** Re-trigger review with `@codex review` after pushing
+- ✅ **YES** Make the local code fix silently
+- ✅ **YES** Ask for explicit maintainer/user approval before any push, PR
+  comment, thread resolution, reviewer request, merge, or review re-trigger
 
 **The code change IS the response. No acknowledgment needed.**
 
 **Guidance for AI agents addressing automated reviews**:
 
-- Address the feedback in code, then push the fix silently
+- Address the feedback in code locally, then ask before external mutations
 - If the feedback is valid, implement the fix without commenting
 - If the feedback appears incorrect (false positive):
   1. **Verify** the claim is false by running standalone tests or examining the code
@@ -472,7 +494,7 @@ When AI agents (Claude Code, OpenCode, etc.) work on PRs, they may encounter rev
      EXPECT_FLOAT_EQ(result, 210.0f);  // Verify correct behavior
      EXPECT_NE(result, 294.0f);        // Explicitly refute false claim
      ```
-  4. Push the test (no comment needed) - the test serves as permanent documentation
+  4. Add the test locally (no comment needed) - the test serves as permanent documentation
 - **Follow the review-fix loop** (see workflow below)
 
 This avoids noisy bot-to-bot conversations while still leveraging automated verification.
@@ -485,17 +507,20 @@ After identifying an AI-generated review comment to address:
 
 1. **Make the code fix**
 2. **Run `pixi run lint`** — MANDATORY before every commit (auto-fixes formatting)
-3. **Commit and push** silently (no reply to the comment)
-4. **Resolve the thread immediately** using GraphQL (see commands below)
-5. **Re-trigger the review**: `gh pr comment <PR> --body "@codex review"`
-6. **Monitor for results**:
+3. **Ask for explicit maintainer/user approval before external mutations**
+4. **If approved, commit and push** silently (no reply to the comment)
+5. **If approved, resolve the thread** using GraphQL (see commands below)
+6. **If approved, re-trigger the review**: `gh pr comment <PR> --body "@codex review"`
+7. **Monitor for results**:
    - New review comments → repeat from step 1
    - "No issues" or 👍 reaction → done, PR is ready for human review
 
 **Agents MUST:**
 
 - Run `pixi run lint` before EVERY commit (CI will fail otherwise)
-- Resolve threads automatically after pushing fixes (keeps PR clean)
+- Treat PR comments, pushes, thread resolution, reviewer requests, merges, and
+  review re-triggers as external mutations that require explicit approval
+- Keep local fixes read-only with respect to GitHub until that approval exists
 
 ### GraphQL Commands for Thread Resolution
 
@@ -513,7 +538,7 @@ gh api graphql -f query='
   }
 ' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
 
-# Resolve a thread by ID
+# Resolve a thread by ID only after explicit maintainer/user approval
 gh api graphql -f query='
   mutation {
     resolveReviewThread(input: {threadId: "PRRT_xxxx"}) {
@@ -522,11 +547,15 @@ gh api graphql -f query='
   }
 '
 
-# One-liner: resolve all unresolved threads for a PR
-PR=2458; gh api graphql -f query="query { repository(owner: \"dartsim\", name: \"dart\") { pullRequest(number: $PR) { reviewThreads(first: 50) { nodes { id isResolved } } } } }" --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id' | while read -r tid; do gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$tid\"}) { thread { isResolved } } }" > /dev/null && echo "Resolved: $tid"; done
+# Resolve only reviewed, addressed thread IDs after approval. Do not
+# bulk-resolve unresolved threads; that can hide human feedback or unresolved
+# bot findings.
 ```
 
-**Why resolve immediately**: Clicking "Resolve conversation" in the UI adds no comment noise. The code change is the response—the resolved thread shows the fix was acknowledged.
+**Why resolve after explicit maintainer/user approval**: Clicking "Resolve
+conversation" in the UI adds no comment noise. The code change is the response;
+the resolved thread shows the fix was acknowledged after the maintainer/user
+approved the PR mutation.
 
 ### Autonomous Review-Fix-Monitor Loop
 
@@ -538,13 +567,14 @@ For agents iterating on automated reviews, the complete loop is:
    a. Implement the fix (or add a test refuting a false positive)
    b. Run `pixi run lint` (MANDATORY)
    c. Build and run relevant tests
-   d. Commit and push silently (no reply to bot comment)
-3. Resolve addressed threads via GraphQL
-4. Re-trigger: `gh pr comment <PR> --body "@codex review"`
-5. Monitor CI: `gh pr checks <PR>`
-6. Wait for new review (poll with `gh api repos/dartsim/dart/pulls/<PR>/reviews`)
-7. If new review has comments → go to step 2
-8. If no new comments AND CI is green → done
+   d. Ask for explicit maintainer/user approval before push or PR mutation
+3. If approved, commit and push silently (no reply to bot comment)
+4. If approved, resolve addressed threads via GraphQL
+5. If approved, re-trigger: `gh pr comment <PR> --body "@codex review"`
+6. Monitor CI: `gh pr checks <PR>`
+7. Wait for new review (poll with `gh api repos/dartsim/dart/pulls/<PR>/reviews`)
+8. If new review has comments → go to step 2
+9. If no new comments AND CI is green → done
 ```
 
 **Checking for new reviews:**
@@ -579,9 +609,12 @@ gh pr checks <PR> --watch
 
 ## Known Limitations
 
-- **No cross-tool command sharing**: Claude Code and OpenCode read different directories
-- **Skill sharing works**: Both tools read `.claude/skills/`
-- **Command duplication required**: Must maintain both `.claude/commands/` and `.opencode/command/`
+- **Generated adapter copies**: Claude Code, OpenCode, and Codex read different
+  directories, so generated adapter copies exist for tool compatibility.
+- **Editable source of truth**: Maintain `.claude/` sources, then run
+  `pixi run sync-ai-commands` and `pixi run check-ai-commands`.
+- **Skill sharing works for manual tools**: Claude Code and OpenCode can read
+  `.claude/skills/` directly.
 
 ---
 

--- a/docs/onboarding/contributing.md
+++ b/docs/onboarding/contributing.md
@@ -91,23 +91,19 @@ git checkout -b feature/my-awesome-feature
 ### 4. Build and Test
 
 ```bash
-# Using pixi (recommended)
 pixi run build
 pixi run test
-
-# Or manually
-cmake --build build/
-cmake --build build/ --target test
 ```
+
+Use the more focused `pixi run ...` test tasks documented in
+`docs/onboarding/testing.md` when a full test run is not needed. Manual CMake
+commands are covered in `docs/onboarding/building.md` for advanced build-system
+debugging, but contributor workflow steps should use Pixi tasks.
 
 ### 5. Format Your Code
 
 ```bash
-# Using pixi
 pixi run lint
-
-# Or manually
-cmake --build build/$PIXI_ENVIRONMENT_NAME/cpp/Release --target format
 ```
 
 Rule of thumb: run `pixi run lint` before committing so auto-fixes are captured.
@@ -134,7 +130,8 @@ All contributions must include appropriate tests:
 
 - Located in `tests/unit/`
 - Use Google Test framework
-- Run with: `pixi run test` or `cmake --build build/ --target test`
+- Run with: `pixi run test`, `pixi run test-unit`, or a more focused
+  `pixi run ...` test task
 
 ### Integration Tests
 
@@ -147,11 +144,7 @@ All contributions must include appropriate tests:
 If modifying Python bindings:
 
 ```bash
-# Run Python tests
 pixi run test-py
-
-# Or manually
-python -m pytest python/tests/
 ```
 
 ### Coverage
@@ -159,11 +152,7 @@ python -m pytest python/tests/
 Check test coverage:
 
 ```bash
-# Generate coverage report
 pixi run coverage-view
-
-# Or manually
-cmake --build build/ --target coverage_view
 ```
 
 ## Code Review Process
@@ -302,6 +291,15 @@ Before submitting your pull request, verify:
 - [ ] Commit messages are clear and descriptive
 - [ ] No merge conflicts with main branch
 - [ ] PR description includes summary, motivation, and testing notes
+- [ ] PR description uses `.github/PULL_REQUEST_TEMPLATE.md`
+- [ ] Milestone is set for the target branch (`DART 7.0` for `main`,
+      `DART 6.16.x` for `release-6.16`)
+- [ ] `CHANGELOG.md` is updated when required, or the PR records why no entry is
+      needed
+- [ ] Bug fixes that apply to the release line have a `release-6.16` PR first,
+      then a `main` PR
+- [ ] Any `docs/dev_tasks/<task>/` folder used for tracking is removed after
+      durable notes move to onboarding docs
 
 ## Getting Help
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -213,6 +213,10 @@ check-lint-yaml = { cmd = """
     prettier --check '**/*.{yml,yaml}' '!**/.pixi/**' '!**/build/**' '!**/external/**' '!**/node_modules/**'
 """ }
 
+check-lint-md = { cmd = """
+    prettier --check '**/*.md' '!**/.pixi/**' '!**/build/**' '!**/external/**' '!**/node_modules/**' '!.codex/**' '!.opencode/**'
+""" }
+
 check-lint-rst = { cmd = ["python", "scripts/lint_rst.py"] }
 
 check-lint-spell = { cmd = "codespell --config .codespellrc" }
@@ -231,6 +235,7 @@ check-lint = { depends-on = [
   "check-lint-simulation-experimental",
   "check-lint-py",
   "check-lint-yaml",
+  "check-lint-md",
   "check-lint-rst",
   "check-lint-spell",
   "check-docs-policy",
@@ -1446,7 +1451,9 @@ lint = { depends-on = [
   "lint-cpp",
   "lint-py",
   "lint-yaml",
+  "lint-md",
   "lint-rst",
+  "sync-ai-commands",
 ] }
 
 check-lint-py = { cmd = """
@@ -1461,9 +1468,11 @@ check-lint = { depends-on = [
   "check-lint-cpp",
   "check-lint-py",
   "check-lint-yaml",
+  "check-lint-md",
   "check-lint-rst",
   "check-lint-spell",
   "check-docs-policy",
+  "check-ai-commands",
 ] }
 
 build = { cmd = """

--- a/scripts/sync_ai_commands.py
+++ b/scripts/sync_ai_commands.py
@@ -6,7 +6,8 @@ Different AI coding tools read from different directories:
 - OpenCode: .opencode/command/
 - Codex: .codex/skills/ (domain skills plus command-derived workflow skills)
 
-This script keeps them in sync using .claude/ as the source of truth.
+This script keeps them in sync using .claude/ as the current editable source
+for workflow commands and domain skills.
 It also verifies that every supported agent has the same effective DART
 capability set, even when tools expose workflows through different UI concepts
 (commands vs skills).
@@ -353,6 +354,653 @@ def validate_style_and_budget(repo_root: Path) -> bool:
     return True
 
 
+def parse_workflow_rows(workflow_content: str) -> dict[str, list[str]]:
+    """Extract user-invoked workflow table rows keyed by capability name."""
+    rows: dict[str, list[str]] = {}
+    in_user_table = False
+
+    for line in workflow_content.splitlines():
+        if line.startswith("## User-Invoked Workflows"):
+            in_user_table = True
+            continue
+        if in_user_table and line.startswith("## "):
+            break
+        if not in_user_table or not line.startswith("| `dart-"):
+            continue
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 5:
+            continue
+        match = re.fullmatch(r"`(dart-[a-z0-9-]+)`", cells[0])
+        if match:
+            rows[match.group(1)] = cells
+
+    return rows
+
+
+def parse_agents_workflow_rows(agents_content: str) -> dict[str, list[str]]:
+    """Extract AGENTS.md workflow command rows keyed by capability name."""
+    rows: dict[str, list[str]] = {}
+    in_workflow_table = False
+
+    for line in agents_content.splitlines():
+        if line.startswith("## Workflow Commands"):
+            in_workflow_table = True
+            continue
+        if in_workflow_table and line.startswith("## "):
+            break
+        if not in_workflow_table or not line.startswith("| `/dart-"):
+            continue
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        match = re.fullmatch(r"`/(dart-[a-z0-9-]+)(?: [^`]*)?`", cells[0])
+        if match:
+            rows[match.group(1)] = cells
+
+    return rows
+
+
+def parse_agents_skill_rows(agents_content: str) -> dict[str, list[str]]:
+    """Extract AGENTS.md domain skill rows keyed by skill name."""
+    rows: dict[str, list[str]] = {}
+    in_skill_table = False
+
+    for line in agents_content.splitlines():
+        if line.startswith("## Skills (On-Demand Knowledge)"):
+            in_skill_table = True
+            continue
+        if in_skill_table and line.startswith("## "):
+            break
+        if not in_skill_table or not line.startswith("| `dart-"):
+            continue
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        match = re.fullmatch(r"`(dart-[a-z0-9-]+)`", cells[0])
+        if match:
+            rows[match.group(1)] = cells
+
+    return rows
+
+
+def extract_required_reading_from_content(content: str) -> list[str]:
+    """Extract @file entries from a command Required Reading section."""
+    readings: list[str] = []
+    in_required_reading = False
+
+    for line in content.splitlines():
+        if line.startswith("## Required Reading"):
+            in_required_reading = True
+            continue
+        if in_required_reading and line.startswith("## "):
+            break
+        if not in_required_reading:
+            continue
+
+        match = re.match(r"@([^\s]+)", line.strip())
+        if match:
+            readings.append(match.group(1))
+
+    return readings
+
+
+def extract_required_reading(command_path: Path) -> list[str]:
+    """Extract @file entries from a command's Required Reading section."""
+    return extract_required_reading_from_content(command_path.read_text())
+
+
+def missing_required_reading_errors(
+    workflow_path_label: str,
+    name: str,
+    public_path: str,
+    required_reading: list[str],
+) -> list[str]:
+    """Return workflow row errors for required reading not in public path."""
+    return [
+        f"{workflow_path_label}: `{name}` missing required reading `{required}`"
+        for required in required_reading
+        if required != "AGENTS.md" and required not in public_path
+    ]
+
+
+def has_gate_evidence(gate_cell: str) -> bool:
+    """Return whether a workflow gate cell names a local gate or exception."""
+    accepted_markers = [
+        "pixi run",
+        "git status",
+        "local reproduction",
+        "focused build/test",
+        "focused tests",
+        "target-specific gates",
+        "release-target focused tests",
+        "regression test",
+        "CI/review green",
+        "CI is green",
+        "Read-only",
+        "read-only",
+        "No local gate",
+        "Maintainer-only",
+        "release verification",
+        "Relevant docs/AI checks",
+    ]
+    return any(marker in gate_cell for marker in accepted_markers)
+
+
+def validate_approval_boundary(repo_root: Path) -> list[str]:
+    """Check GitHub/remote mutation commands explicitly require approval."""
+    errors: list[str] = []
+    mutation_pattern_strings = [
+        r"\bgit push\b",
+        r"\bgh pr create\b",
+        r"\bgh pr comment\b",
+        r"\bgh pr edit\b",
+        r"\bgh pr merge\b",
+        r"\bgh pr ready\b",
+        r"\bgh pr review\b",
+        r"\bgh issue comment\b",
+        r"\bgh issue close\b",
+        r"\bgh issue edit\b",
+        r"\bgh run rerun\b",
+        r"\bgh pr update-branch\b",
+        r"\bgh api\b(?!\s+graphql\b)[^\n;|&]*(?:(?:--method(?:=|\s+)|-X\s*)"
+        + r"(?:POST|PATCH|PUT|DELETE)\b|(?:--field|-f)\s+\w+=)",
+        r"\bgh api graphql\b[^\n;|&]*\bmutation\b",
+        r"^\s*mutation(?:\s+\w+)?\s*\{",
+        r"\bgit fetch\b[^\n;|&]*(?:--prune\b|-[A-Za-z]*p[A-Za-z]*\b)",
+        r"\bgit remote update\b[^\n;|&]*(?:--prune\b|-[A-Za-z]*p[A-Za-z]*\b)",
+        r"\bgit remote prune\b",
+        r"\bgit branch\b[^\n;|&]*(?:-[A-Za-z]*[dD][A-Za-z]*\b|--delete\b)",
+        r"\bresolveReviewThread\b",
+        r"--delete-branch\b",
+        r"\borigin --delete\b",
+        r"^\s*(?:\d+\.\s*)?(?:[-*]\s*)?(?:if approved,\s*)?push\b",
+        r"\bpush(?:ing)? (?:the )?(?:fix(?:es)?|change|changes|commit|commits|branch)\b",
+        r"\bpush(?:ing)? and (?:ask|create|creating|monitor|open|opening|watch)\b",
+        r"\bpush(?:ing)?, (?:comment|resolve|re-trigger|retrigger)\b",
+        r"\bpush(?:es|ing)?\b.{0,120}\b(?:PRs?|pull requests?)\b",
+        r"\b(?:create|creating|open|opening)\b.{0,80}\b(?:PRs?|pull requests?)\b",
+        r"\bcreate or update (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\bcreate/update (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\bupdate (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\bupdating (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\b(?:PRs?|pull requests?) update\b",
+        r"\bset(?:ting)? (?:the )?.{0,120}milestones?\b",
+        r"\brerun(?:ning)? (?:the )?(?:failed )?(?:CI|check|job|jobs|workflow)\b",
+        r"\bmerg(?:e|ing) (?:the )?(?:PR|pull request)\b",
+        r"\bresolv(?:e|ing) (?:only )?(?:the )?(?:addressed |reviewed |reviewed and addressed |reviewed, addressed )?(?:review )?(?:thread IDs?|threads?|conversations?)\b",
+        r"\bdelet(?:e|ing)\b.{0,80}\bbranch(?:es)?\b",
+        r"\bbranch(?:es)? (?:is |are )?(?:a )?deletion candidate(?:s)?\b",
+        r"\bdeletion candidate(?:s)?\b",
+        r"\bprun(?:e|ing)\b.{0,80}\brefs?\b",
+        r"\bforce-delete locally\b",
+    ]
+    mutation_pattern = re.compile(
+        "|".join(f"(?:{pattern})" for pattern in mutation_pattern_strings), re.I
+    )
+    mutation_examples = {
+        "Open a PR with the release milestone": "uppercase PR opening prose",
+        "opening the release-branch PR": "gerund PR opening prose",
+        "After approval, push the fix": "non-line-initial push prose",
+        "pushing fixes to the PR": "gerund push prose",
+        "pushes to PRs": "plural push/PR prose",
+        "open a pull request": "pull request opening prose",
+        "update the pull request": "pull request update prose",
+        "open a DART pull request": "qualified pull request opening prose",
+        "Create release packaging PR": "qualified PR opening prose",
+        "gh pr update-branch": "PR update-branch command",
+        "gh api --method POST repos/dartsim/dart/issues/1/comments": "mutating gh api command",
+        "gh api --method=PATCH repos/dartsim/dart/issues/1": "mutating gh api equals method command",
+        "gh api -X DELETE repos/dartsim/dart/git/refs/heads/tmp": "mutating gh api short method command",
+        "gh api -XPOST repos/dartsim/dart/issues": "mutating gh api attached short method command",
+        "gh api repos/dartsim/dart/issues/1/comments -f body=x": "implicit mutating gh api field command",
+        'gh api graphql -f query="mutation { foo }"': "mutating gh api graphql command",
+        "mutation { resolveReviewThread": "GraphQL mutation block",
+        "git fetch --all --prune": "fetch prune command",
+        "git fetch origin --prune": "fetch remote prune command",
+        "git fetch origin -p": "fetch remote short prune command",
+        "git fetch -p": "fetch short prune command",
+        "git remote update --prune": "remote update prune command",
+        "git remote update origin --prune": "remote update remote prune command",
+        "git remote update -p": "remote update short prune command",
+        "git remote prune origin": "remote prune command",
+        "pruning refs": "pruning refs prose",
+        "Deleting stale branches": "branch deletion prose",
+        "delete any branch": "any branch deletion prose",
+        "deleting any local or remote branch": "local-or-remote branch deletion prose",
+        "git branch -D <HEAD_BRANCH>": "local branch deletion command",
+        "git branch -df <HEAD_BRANCH>": "combined branch force-delete command",
+        "git branch -rd origin/foo": "combined remote branch delete command",
+        "git branch --delete --force <HEAD_BRANCH>": "long-form branch deletion command",
+        "Branch is a deletion candidate": "branch deletion candidate prose",
+        "resolve the thread": "singular thread resolution prose",
+        "resolve only reviewed and addressed thread IDs": "reviewed thread ID resolution prose",
+        "update the PR after editing": "PR update prose",
+        "PR update after changelog edit": "noun PR update prose",
+        "After opening the PR, merge PR": "compound PR mutation prose",
+        "Rerunning failed jobs": "gerund CI rerun prose",
+        "Merging PR after checks pass": "gerund merge prose",
+        "Resolving addressed threads via GraphQL": "gerund thread-resolution prose",
+    }
+    for example, label in mutation_examples.items():
+        if not mutation_pattern.search(example):
+            errors.append(f"internal mutation pattern self-check failed: {label}")
+
+    approval_pattern = re.compile(r"explicit\s+(?:maintainer/user\s+)?approval", re.I)
+
+    def build_scan_text(lines: list[str], index: int, in_fence: bool) -> str:
+        """Join a Markdown paragraph or wrapped list item for prose scanning."""
+        current = lines[index]
+        current_stripped = current.strip()
+        if not current_stripped:
+            return ""
+
+        parts = [current_stripped]
+        current_indent = len(current) - len(current.lstrip())
+        current_is_list = bool(re.match(r"(?:[-*]|\d+\.)\s", current_stripped))
+        current_is_block = current_stripped.startswith(("#", "|", "```", "---"))
+
+        if current_is_block or in_fence:
+            return current_stripped
+
+        for next_line in lines[index + 1 : index + 5]:
+            next_stripped = next_line.strip()
+            if not next_stripped or next_stripped.startswith(("#", "|", "```", "---")):
+                break
+
+            next_indent = len(next_line) - len(next_line.lstrip())
+            next_is_list = bool(re.match(r"(?:[-*]|\d+\.)\s", next_stripped))
+            if current_is_list:
+                if next_indent <= current_indent:
+                    break
+            elif next_is_list:
+                break
+
+            parts.append(next_stripped)
+
+        return " ".join(parts)
+
+    def strip_safe_prune_commands(scan_text: str) -> str:
+        """Remove explicitly safe prune inspection commands before scanning."""
+        scan_text = re.sub(
+            r"\bgit fetch\b[^\n;|&]*--no-prune\b",
+            "",
+            scan_text,
+            flags=re.I,
+        )
+        scan_text = re.sub(
+            r"\bgit remote prune\b[^\n;|&]*--dry-run\b",
+            "",
+            scan_text,
+            flags=re.I,
+        )
+        return scan_text
+
+    def scan_lines(label: str, lines: list[str]) -> None:
+        frontmatter_end = 0
+        if lines and lines[0].strip() == "---":
+            for line_index, frontmatter_line in enumerate(lines[1:], start=1):
+                if frontmatter_line.strip() == "---":
+                    frontmatter_end = line_index + 1
+                    break
+
+        in_fence = False
+        for index, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_fence = not in_fence
+                continue
+            if index < frontmatter_end:
+                continue
+            if re.search(r"\bwhy resolve after\b", line, re.I):
+                continue
+            scan_text = strip_safe_prune_commands(
+                build_scan_text(lines, index, in_fence).replace("$ARGUMENTS", "")
+            )
+            if not mutation_pattern.search(scan_text):
+                continue
+
+            start = max(0, index - 6)
+            end = min(len(lines), index + 8)
+            context = "\n".join(lines[start:end])
+            if approval_pattern.search(context):
+                continue
+
+            errors.append(
+                f"{label}:{index + 1}: mutation command lacks "
+                "nearby explicit approval boundary"
+            )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["Push changes: $ARGUMENTS"],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: same-line "
+            "$ARGUMENTS hid mutation prose"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines("internal approval-boundary self-check", ["git fetch --all --prune"])
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: fetch prune command "
+            "was not detected"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines("internal approval-boundary self-check", ["git remote prune origin"])
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: remote prune command "
+            "was not detected"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines("internal approval-boundary self-check", ["git fetch --all --no-prune"])
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: --no-prune command "
+            "was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        [
+            "```bash",
+            "git fetch origin <RELEASE_BRANCH>",
+            "git checkout -B release/<NEW_VERSION>-version-bump origin/<RELEASE_BRANCH>",
+            "```",
+        ],
+    )
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: fenced safe fetch "
+            "was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["git fetch --all --no-prune && git push"],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: --no-prune hid "
+            "compound mutation"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["git remote prune origin --dry-run"],
+    )
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: prune dry-run command "
+            "was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["git remote prune origin --dry-run; gh pr merge"],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: prune dry-run hid "
+            "compound mutation"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["gh api graphql -f query='", "  query { repository { id } }"],
+    )
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: read-only GraphQL "
+            "query was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        [
+            "- `action`: delete only after ownership is clear",
+            "  and the branch deletion is requested",
+        ],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: wrapped branch "
+            "deletion prose was not detected"
+        )
+    else:
+        del errors[before_self_check:]
+
+    scan_paths = [
+        *sorted((repo_root / ".claude" / "commands").glob("*.md")),
+        *sorted((repo_root / ".claude" / "skills").glob("*/SKILL.md")),
+        *sorted((repo_root / "docs" / "ai").glob("*.md")),
+        repo_root / "docs" / "onboarding" / "ai-tools.md",
+    ]
+
+    for path in scan_paths:
+        scan_lines(display_path(path), path.read_text().splitlines())
+
+    for command_path in sorted((repo_root / ".claude" / "commands").glob("*.md")):
+        rendered_wrapper = render_codex_command_skill(command_path).split(
+            "\n## Command Body\n", 1
+        )[0]
+        scan_lines(
+            f"generated Codex wrapper for {command_path.stem}",
+            rendered_wrapper.splitlines(),
+        )
+
+    ai_tools = repo_root / "docs" / "onboarding" / "ai-tools.md"
+    if ai_tools.exists() and re.search(
+        r"resolve (?:all|every) unresolved thread", ai_tools.read_text(), re.I
+    ):
+        errors.append(
+            f"{display_path(ai_tools)}: bulk review-thread resolution is forbidden"
+        )
+
+    return errors
+
+
+def validate_ai_docs(repo_root: Path) -> bool:
+    """Validate the checked AI-native docs that index generated capabilities."""
+    errors: list[str] = []
+    docs_dir = repo_root / "docs" / "ai"
+    required_files = [
+        docs_dir / "README.md",
+        docs_dir / "workflows.md",
+        docs_dir / "verification.md",
+        docs_dir / "sessions.md",
+        docs_dir / "components.md",
+    ]
+
+    for path in required_files:
+        if not path.exists():
+            errors.append(f"{display_path(path)}: missing required AI doc")
+
+    agents_content = (repo_root / "AGENTS.md").read_text()
+    docs_readme_content = (repo_root / "docs" / "README.md").read_text()
+    if "docs/ai/README.md" not in agents_content:
+        errors.append("AGENTS.md: missing docs/ai/README.md pointer")
+    if "ai/README.md" not in docs_readme_content:
+        errors.append("docs/README.md: missing ai/README.md index link")
+
+    workflows_path = docs_dir / "workflows.md"
+    if workflows_path.exists():
+        workflow_content = workflows_path.read_text()
+        command_names = list_command_names(repo_root / ".claude" / "commands")
+        skill_names, skill_errors = list_skill_names(repo_root / ".claude" / "skills")
+        errors.extend(skill_errors)
+        expected = command_names | skill_names
+        workflow_rows = parse_workflow_rows(workflow_content)
+        agents_workflow_rows = parse_agents_workflow_rows(agents_content)
+        agents_skill_rows = parse_agents_skill_rows(agents_content)
+
+        if has_gate_evidence("explicit approval before push"):
+            errors.append(
+                "internal workflow gate self-check failed: approval-only gate accepted"
+            )
+
+        fake_required = extract_required_reading_from_content(
+            """
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/required.md (inline note)
+@docs/onboarding/extra.md
+
+## Workflow
+"""
+        )
+        fake_missing = missing_required_reading_errors(
+            "docs/ai/workflows.md",
+            "dart-fake",
+            "docs/onboarding/required.md",
+            fake_required,
+        )
+        if len(fake_missing) != 1 or "docs/onboarding/extra.md" not in fake_missing[0]:
+            errors.append(
+                "internal workflow docs self-check failed: missing required "
+                "reading was not detected"
+            )
+
+        for name in sorted(expected):
+            if f"`{name}`" not in workflow_content:
+                errors.append(
+                    f"{display_path(workflows_path)}: missing capability `{name}`"
+                )
+
+        for name in sorted(command_names):
+            cells = workflow_rows.get(name)
+            if not cells:
+                errors.append(
+                    f"{display_path(workflows_path)}: missing workflow row `{name}`"
+                )
+                continue
+            public_path = cells[3]
+            gate = cells[4]
+            if not public_path or public_path == "-":
+                errors.append(
+                    f"{display_path(workflows_path)}: `{name}` missing public path"
+                )
+            if not gate or not has_gate_evidence(gate):
+                errors.append(
+                    f"{display_path(workflows_path)}: `{name}` missing gate evidence"
+                )
+
+            errors.extend(
+                missing_required_reading_errors(
+                    display_path(workflows_path),
+                    name,
+                    public_path,
+                    extract_required_reading(
+                        repo_root / ".claude" / "commands" / f"{name}.md"
+                    ),
+                )
+            )
+
+        approval_workflows = {
+            "dart-backport-pr",
+            "dart-branch-cleanup",
+            "dart-close-issue",
+            "dart-docs-update",
+            "dart-downstream-fix",
+            "dart-fix-ci",
+            "dart-fix-issue",
+            "dart-manage-pr",
+            "dart-merge-pr",
+            "dart-mechanical-refactor",
+            "dart-new-task",
+            "dart-pr",
+            "dart-release-ci-fix",
+            "dart-release-merge-main",
+            "dart-release-packaging",
+            "dart-resume",
+            "dart-review-pr",
+            "dart-triage-issue",
+        }
+        for name in sorted(approval_workflows & command_names):
+            cells = workflow_rows.get(name)
+            row_text = " ".join(cells) if cells else ""
+            if cells and not ("explicit" in row_text and "approval" in row_text):
+                errors.append(
+                    f"{display_path(workflows_path)}: `{name}` missing approval gate"
+                )
+
+        documented = set(re.findall(r"`(dart-[a-z0-9-]+)`", workflow_content))
+        extra = documented - expected
+        for name in sorted(extra):
+            errors.append(
+                f"{display_path(workflows_path)}: unknown capability `{name}`"
+            )
+
+        for name in sorted(command_names):
+            cells = agents_workflow_rows.get(name)
+            if not cells:
+                errors.append(f"AGENTS.md: missing workflow command `{name}`")
+                continue
+            codex_cell = cells[1] if len(cells) > 1 else ""
+            codex_entry_pattern = rf"`\${re.escape(name)}(?: [^`]*)?`"
+            if not re.search(codex_entry_pattern, codex_cell):
+                errors.append(f"AGENTS.md: workflow `{name}` missing Codex skill")
+
+        extra_agent_workflows = set(agents_workflow_rows) - command_names
+        for name in sorted(extra_agent_workflows):
+            errors.append(f"AGENTS.md: unknown workflow command `{name}`")
+
+        for name in sorted(skill_names):
+            if name not in agents_skill_rows:
+                errors.append(f"AGENTS.md: missing domain skill `{name}`")
+
+        extra_agent_skills = set(agents_skill_rows) - skill_names
+        for name in sorted(extra_agent_skills):
+            errors.append(f"AGENTS.md: unknown domain skill `{name}`")
+
+    errors.extend(validate_approval_boundary(repo_root))
+
+    private_pattern = re.compile(r"(?:/home/|/Users/|~/|fbsource|arvr/libraries)")
+    for path in docs_dir.glob("*.md"):
+        for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+            if private_pattern.search(line):
+                errors.append(
+                    f"{display_path(path)}:{line_number}: private path reference"
+                )
+
+    if errors:
+        for error in errors:
+            print(f"  AI DOC ERROR: {error}")
+        return False
+
+    print("  OK: docs/ai entrypoint, workflow index, and public paths are valid")
+    return True
+
+
 def has_auto_gen_header(content: str) -> bool:
     """Check if content has the auto-generated header."""
     return "<!-- AUTO-GENERATED FILE" in content
@@ -482,8 +1130,9 @@ description: {json.dumps(skill_description)}
 
 # {command_name}
 
-Use this skill in Codex when you want the same workflow that Claude Code and
-OpenCode expose as `/{command_name}`.
+Use this skill in Codex to run the DART `{command_name}` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
 
 ## Invocation
 
@@ -649,6 +1298,11 @@ def sync_all(check_only: bool = False) -> bool:
 
     print("Skill and command style:")
     if not validate_style_and_budget(repo_root):
+        all_synced = False
+    print()
+
+    print("AI docs:")
+    if not validate_ai_docs(repo_root):
         all_synced = False
     print()
 


### PR DESCRIPTION
## Summary

- Add `docs/ai/` as the shared AI agent entrypoint for workflow routing, session discipline, verification, and component ownership.
- Tighten DART AI command and skill guidance so Codex, Claude Code, and OpenCode remain generated, checked, and mutation-safe.
- Harden `scripts/sync_ai_commands.py` to validate AI docs, generated adapter parity, required-reading coverage, approval-boundary wording, and unsafe GitHub mutation patterns.

## Motivation / Problem

- DART has multiple AI-facing surfaces, but agents need one tracked policy entrypoint and deterministic checks that keep those surfaces consistent.
- Generated Codex/OpenCode adapters should be treated as first-class workflow surfaces without becoming manually maintained sources of truth.
- AI review and PR-management workflows need explicit approval boundaries for pushes, PR comments, thread resolution, reruns, merges, and other GitHub mutations.

## Changes / Key Changes

- Adds `docs/ai/README.md`, `docs/ai/workflows.md`, `docs/ai/verification.md`, `docs/ai/sessions.md`, and `docs/ai/components.md`.
- Updates AGENTS, onboarding, contribution, and generated command/skill docs for AI workflow routing, dev-task cleanup, PR checklist, and approval policy.
- Extends `check-ai-commands` to validate `docs/ai` coverage, AGENTS table parity, command required-reading rows, public workflow paths, generated Codex wrappers, and approval-boundary scanner self-checks.
- Removes the completed `docs/dev_tasks/ai-native-transformation/` tracker after moving durable guidance into onboarding docs.

## Testing

- `pixi run lint`
- `pixi run check-lint`
- `pixi run check-ai-commands`
- `python -m py_compile scripts/sync_ai_commands.py`
- `git diff --check HEAD~1..HEAD`

## Breaking Changes

- [x] None
- Documentation and tooling checks only; no runtime API changes.

## Related Issues / PRs (backports)

- Related: #2446, #2447, #2448, #2449, #2546
- Backport: N/A, AI workflow documentation/tooling for `main`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality (N/A: no runtime functionality)
- [x] Document new methods and classes (N/A: no public API)
- [x] Add Python bindings (dartpy) if applicable (N/A)