### PR TITLE
Add Filament G1 example scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,8 @@
     CI validation.
     ([#2647](https://github.com/dartsim/dart/pull/2647))
   - Added a Filament-rendered Unitree G1 scene and routed the in-tree
-    `g1_puppet` example runner through that Filament path.
+    `g1_puppet` example runner through that Filament path with visible IK
+    targets for hand and foot manipulation.
   - Fix SEGV in `ImFontAtlas::AddFontFromMemoryCompressedTTF` when null pointer is passed as compressed font data. ([#2516](https://github.com/dartsim/dart/issues/2516))
   - Added headless rendering support via `ViewerConfig` and pbuffer graphics context for CI pipelines and batch frame capture. Includes `Viewer::captureBuffer()` for raw RGBA pixel readback and a new `headless-rendering` CI job. ([#2466](https://github.com/dartsim/dart/pull/2466))
   - Added `ImGuiViewer` construction from `ViewerConfig` to support headless ImGui rendering and example frame capture workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@
     a pinned explicit fetch fallback, and GCC/Clang smoke coverage for local and
     CI validation.
     ([#2647](https://github.com/dartsim/dart/pull/2647))
+  - Added a Filament-rendered Unitree G1 scene and routed the in-tree
+    `g1_puppet` example runner through that Filament path.
   - Fix SEGV in `ImFontAtlas::AddFontFromMemoryCompressedTTF` when null pointer is passed as compressed font data. ([#2516](https://github.com/dartsim/dart/issues/2516))
   - Added headless rendering support via `ViewerConfig` and pbuffer graphics context for CI pipelines and batch frame capture. Includes `Viewer::captureBuffer()` for raw RGBA pixel readback and a new `headless-rendering` CI job. ([#2466](https://github.com/dartsim/dart/pull/2466))
   - Added `ImGuiViewer` construction from `ViewerConfig` to support headless ImGui rendering and example frame capture workflows.

--- a/examples/README.md
+++ b/examples/README.md
@@ -98,9 +98,10 @@ pixi run ex <example-target>
 ```
 
 For example, `pixi run ex hello_world` builds and runs `hello_world`. Examples
-with extra CMake requirements, such as `raylib` and `filament_gui`, declare
-those requirements in `scripts/run_cpp_example.py` so the same command shape can
-remain stable as more examples are added.
+with extra CMake requirements or redirected experimental GUI runners, such as
+`raylib`, `filament_gui`, and `g1_puppet`, declare those requirements in
+`scripts/run_cpp_example.py` so the same command shape can remain stable as more
+examples are added.
 
 ## Build Examples as One Project
 

--- a/examples/filament_gui/README.md
+++ b/examples/filament_gui/README.md
@@ -14,8 +14,8 @@
 - Controls: left drag orbits, right/middle drag pans, wheel zooms, Space
   pauses/resumes, `n` steps once while paused, a left click without dragging
   selects a renderable, arrow/PageUp/PageDown keys nudge selected free-joint
-  bodies or `SimpleFrame` visuals, Ctrl-left drag moves selected frame
-  renderables in a camera-facing plane, Escape exits, and `--frames` limits
+  bodies, `SimpleFrame` visuals, and G1 IK targets, Ctrl-left drag moves the
+  selected item in a camera-facing plane, Escape exits, and `--frames` limits
   rendered frame count. Use
   `--screenshot <path>` to write a binary PPM capture, and `--headless` to use
   Filament's headless swap-chain path without creating a GLFW window. Use
@@ -79,9 +79,11 @@
   uses that path for a legacy-style `SimpleFrame` anchor, child frame, and axis
   marker layout.
 - The `--scene g1` fixture loads the remote Unitree G1 URDF through DART's
-  normal resource retriever and renders it with Filament. Override the package
-  or robot source with `--g1-package-uri`, `--g1-robot-uri`, and
-  `--g1-package-name` when testing local G1 assets.
+  normal resource retriever and renders it with Filament. Colored IK target
+  markers are attached to both hands and feet; press `1`-`4` or click a marker,
+  then Ctrl-left drag or use the arrow/PageUp/PageDown keys to move the target
+  and apply IK. Override the package or robot source with `--g1-package-uri`,
+  `--g1-robot-uri`, and `--g1-package-name` when testing local G1 assets.
 
 ## Quick Run
 

--- a/examples/filament_gui/README.md
+++ b/examples/filament_gui/README.md
@@ -25,7 +25,8 @@
   for shading diagnostics; toggle it with `--orbit-light`, `--no-orbit-light`,
   or the panel checkbox, and tune the default 80-second full orbit with
   `--orbit-light-period <seconds>`.
-  Use `--scene drag-and-drop` to run the interaction fixture.
+  Use `--scene drag-and-drop` to run the interaction fixture, or `--scene g1`
+  to load the Unitree G1 humanoid used in the project README animation.
 
 ## Notes
 
@@ -77,6 +78,10 @@
   same backend-hidden descriptor layer. The `--scene drag-and-drop` fixture
   uses that path for a legacy-style `SimpleFrame` anchor, child frame, and axis
   marker layout.
+- The `--scene g1` fixture loads the remote Unitree G1 URDF through DART's
+  normal resource retriever and renders it with Filament. Override the package
+  or robot source with `--g1-package-uri`, `--g1-robot-uri`, and
+  `--g1-package-name` when testing local G1 assets.
 
 ## Quick Run
 
@@ -103,6 +108,12 @@ To run the interaction fixture:
 pixi run ex filament_gui --scene drag-and-drop
 ```
 
+To run the Unitree G1 fixture:
+
+```bash
+pixi run ex filament_gui --scene g1 --gui-scale 2
+```
+
 To capture both built-in fixtures for PR screenshots:
 
 ```bash
@@ -112,6 +123,8 @@ pixi run ex filament_gui --headless --scene all
 The capture paths are `build/<pixi-env>/filament_gui_mvp.ppm` and
 `build/<pixi-env>/filament_gui_drag_and_drop.ppm` unless
 `DART_FILAMENT_GUI_SCREENSHOT` is set.
+The G1 fixture intentionally stays out of `--scene all` because it fetches a
+remote robot package by default.
 
 ## Build Instructions
 

--- a/examples/filament_gui/main.cpp
+++ b/examples/filament_gui/main.cpp
@@ -126,6 +126,8 @@ using dart::dynamics::BoxShape;
 using dart::dynamics::CollisionAspect;
 using dart::dynamics::DynamicsAspect;
 using dart::dynamics::FreeJoint;
+using dart::dynamics::InverseKinematics;
+using dart::dynamics::InverseKinematicsPtr;
 using dart::dynamics::MeshShape;
 using dart::dynamics::PlaneShape;
 using dart::dynamics::Shape;
@@ -133,6 +135,7 @@ using dart::dynamics::ShapePtr;
 using dart::dynamics::ShapeNode;
 using dart::dynamics::SimpleFrame;
 using dart::dynamics::Skeleton;
+using dart::dynamics::SphereShape;
 using dart::dynamics::VisualAspect;
 using dart::dynamics::WeldJoint;
 using dart::examples::filament_gui::DebugDrawOptions;
@@ -157,6 +160,7 @@ using dart::examples::filament_gui::markScreenshotRequested;
 using dart::examples::filament_gui::markSimulationAdvanced;
 using dart::examples::filament_gui::makeOrbitCameraBasis;
 using dart::examples::filament_gui::makePerspectivePickRay;
+using dart::examples::filament_gui::makeRenderableId;
 using dart::examples::filament_gui::makeSelectionDebugLines;
 using dart::examples::filament_gui::normalizeRunOptions;
 using dart::examples::filament_gui::pickNearestRenderable;
@@ -879,9 +883,19 @@ filament::Texture* createSolidTexture(
   return texture;
 }
 
+struct G1IkHandle
+{
+  RenderableId targetRenderableId = 0;
+  std::string label;
+  int hotkey = 0;
+  std::shared_ptr<SimpleFrame> target;
+  InverseKinematicsPtr ik;
+};
+
 struct DartScene
 {
   dart::simulation::WorldPtr world;
+  std::vector<G1IkHandle> ikHandles;
 };
 
 enum class ExampleScene
@@ -1020,13 +1034,13 @@ std::shared_ptr<MeshShape> loadRequiredExampleMeshShape(
   return meshShape;
 }
 
-void makeVisualOnlySkeleton(const dart::dynamics::SkeletonPtr& skeleton)
+void disableSkeletonCollisionAndGravity(
+    const dart::dynamics::SkeletonPtr& skeleton)
 {
   if (!skeleton) {
     return;
   }
 
-  skeleton->setMobile(false);
   skeleton->disableSelfCollisionCheck();
   skeleton->setAdjacentBodyCheck(false);
   for (std::size_t i = 0; i < skeleton->getNumBodyNodes(); ++i) {
@@ -1040,6 +1054,16 @@ void makeVisualOnlySkeleton(const dart::dynamics::SkeletonPtr& skeleton)
       shapeNode->getCollisionAspect()->setCollidable(false);
     });
   }
+}
+
+void makeVisualOnlySkeleton(const dart::dynamics::SkeletonPtr& skeleton)
+{
+  if (!skeleton) {
+    return;
+  }
+
+  skeleton->setMobile(false);
+  disableSkeletonCollisionAndGravity(skeleton);
 }
 
 dart::dynamics::SkeletonPtr loadRequiredWamRobotSkeleton()
@@ -1254,6 +1278,67 @@ dart::dynamics::SkeletonPtr createG1Ground()
   return ground;
 }
 
+std::optional<std::pair<Eigen::Vector3d, Eigen::Vector3d>>
+computeVisualWorldBounds(const dart::dynamics::SkeletonPtr& skeleton)
+{
+  if (!skeleton) {
+    return std::nullopt;
+  }
+
+  bool hasBounds = false;
+  Eigen::Vector3d min = Eigen::Vector3d::Zero();
+  Eigen::Vector3d max = Eigen::Vector3d::Zero();
+
+  const auto includePoint = [&](const Eigen::Vector3d& point) {
+    if (!hasBounds) {
+      min = point;
+      max = point;
+      hasBounds = true;
+      return;
+    }
+    min = min.cwiseMin(point);
+    max = max.cwiseMax(point);
+  };
+
+  for (std::size_t i = 0; i < skeleton->getNumBodyNodes(); ++i) {
+    auto* body = skeleton->getBodyNode(i);
+    if (body == nullptr) {
+      continue;
+    }
+    body->eachShapeNodeWith<VisualAspect>([&](const ShapeNode* shapeNode) {
+      if (shapeNode == nullptr || shapeNode->getShape() == nullptr
+          || shapeNode->getVisualAspect()->isHidden()) {
+        return;
+      }
+
+      const auto& bounds = shapeNode->getShape()->getBoundingBox();
+      const Eigen::Vector3d localMin = bounds.getMin();
+      const Eigen::Vector3d localMax = bounds.getMax();
+      if (!localMin.allFinite() || !localMax.allFinite()) {
+        return;
+      }
+
+      const Eigen::Isometry3d transform = shapeNode->getWorldTransform();
+      for (int x = 0; x < 2; ++x) {
+        for (int y = 0; y < 2; ++y) {
+          for (int z = 0; z < 2; ++z) {
+            includePoint(transform * Eigen::Vector3d(
+                                         x == 0 ? localMin.x() : localMax.x(),
+                                         y == 0 ? localMin.y() : localMax.y(),
+                                         z == 0 ? localMin.z() : localMax.z()));
+          }
+        }
+      }
+    });
+  }
+
+  if (!hasBounds) {
+    return std::nullopt;
+  }
+
+  return std::make_pair(min, max);
+}
+
 dart::dynamics::SkeletonPtr loadG1Skeleton(const AppOptions& options)
 {
   dart::io::ReadOptions readOptions;
@@ -1270,12 +1355,88 @@ dart::dynamics::SkeletonPtr loadG1Skeleton(const AppOptions& options)
     if (auto* freeJoint
         = dynamic_cast<FreeJoint*>(rootBody->getParentJoint())) {
       Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
-      transform.translation().z() = 0.75;
       FreeJoint::setTransformOf(freeJoint, transform);
+      if (const auto bounds = computeVisualWorldBounds(robot)) {
+        constexpr double g1GroundClearance = 0.015;
+        transform.translation().z() = g1GroundClearance - bounds->first.z();
+        FreeJoint::setTransformOf(freeJoint, transform);
+      }
     }
   }
-  makeVisualOnlySkeleton(robot);
+  disableSkeletonCollisionAndGravity(robot);
   return robot;
+}
+
+void addG1IkTargets(
+    DartScene& scene, const dart::dynamics::SkeletonPtr& robot)
+{
+  struct Config
+  {
+    const char* bodyNode;
+    const char* targetName;
+    const char* label;
+    int hotkey;
+    Eigen::Vector4d color;
+  };
+
+  const std::array<Config, 4> configs{{
+      {"left_rubber_hand",
+       "ik_target_left_hand",
+       "1 left hand",
+       GLFW_KEY_1,
+       {0.18, 0.55, 1.0, 0.92}},
+      {"right_rubber_hand",
+       "ik_target_right_hand",
+       "2 right hand",
+       GLFW_KEY_2,
+       {1.0, 0.40, 0.24, 0.92}},
+      {"left_ankle_roll_link",
+       "ik_target_left_foot",
+       "3 left foot",
+       GLFW_KEY_3,
+       {0.26, 0.86, 0.34, 0.92}},
+      {"right_ankle_roll_link",
+       "ik_target_right_foot",
+       "4 right foot",
+       GLFW_KEY_4,
+       {0.95, 0.72, 0.18, 0.92}},
+  }};
+
+  if (!scene.world || !robot) {
+    return;
+  }
+
+  for (const Config& config : configs) {
+    auto* bodyNode = robot->getBodyNode(config.bodyNode);
+    if (bodyNode == nullptr) {
+      std::cerr << "Unable to find G1 body node '" << config.bodyNode
+                << "' for IK target.\n";
+      continue;
+    }
+
+    auto* endEffector = bodyNode->createEndEffector(
+        std::string(config.targetName) + "_effector");
+    auto ik = endEffector->getIK(true);
+    ik->setGradientMethod<InverseKinematics::JacobianTranspose>();
+    ik->getSolver()->setNumMaxIterations(30);
+
+    auto target = SimpleFrame::createShared(
+        dart::dynamics::Frame::World(),
+        config.targetName,
+        endEffector->getWorldTransform());
+    target->setShape(std::make_shared<SphereShape>(0.055));
+    target->getVisualAspect(true)->setRGBA(config.color);
+    scene.world->addSimpleFrame(target);
+    ik->setTarget(target);
+
+    G1IkHandle handle;
+    handle.targetRenderableId = makeRenderableId(*target);
+    handle.label = config.label;
+    handle.hotkey = config.hotkey;
+    handle.target = std::move(target);
+    handle.ik = std::move(ik);
+    scene.ikHandles.push_back(std::move(handle));
+  }
 }
 
 AppOptions parseOptions(int argc, char* argv[])
@@ -1538,6 +1699,65 @@ Eigen::Vector3d selectedNudgeFromKeyboard(
   return nudge;
 }
 
+G1IkHandle* findG1IkHandle(DartScene& scene, RenderableId targetRenderableId)
+{
+  const auto handle = std::find_if(
+      scene.ikHandles.begin(),
+      scene.ikHandles.end(),
+      [&](const G1IkHandle& candidate) {
+        return candidate.targetRenderableId == targetRenderableId;
+      });
+  return handle == scene.ikHandles.end() ? nullptr : &*handle;
+}
+
+const G1IkHandle* findG1IkHandle(
+    const DartScene& scene, RenderableId targetRenderableId)
+{
+  const auto handle = std::find_if(
+      scene.ikHandles.begin(),
+      scene.ikHandles.end(),
+      [&](const G1IkHandle& candidate) {
+        return candidate.targetRenderableId == targetRenderableId;
+      });
+  return handle == scene.ikHandles.end() ? nullptr : &*handle;
+}
+
+std::string selectionLabelForRenderable(
+    const DartScene& scene, const RenderableDescriptor& descriptor)
+{
+  if (const auto* handle = findG1IkHandle(scene, descriptor.id)) {
+    return handle->label + " IK target";
+  }
+
+  std::string label = descriptor.skeletonName.empty()
+                          ? descriptor.shapeFrameName
+                          : descriptor.skeletonName + "/" + descriptor.bodyName;
+  if (!descriptor.shapeNodeName.empty()) {
+    label += "/" + descriptor.shapeNodeName;
+  }
+  label += " (" + descriptor.geometry.shapeType + ")";
+  return label;
+}
+
+bool translateRenderableAndApplyIk(
+    DartScene& scene,
+    const RenderableDescriptor& descriptor,
+    const Eigen::Vector3d& worldTranslation)
+{
+  if (!translateFrameRenderable(descriptor, worldTranslation)) {
+    return false;
+  }
+
+  if (auto* handle = findG1IkHandle(scene, descriptor.id)) {
+    if (handle->ik) {
+      handle->ik->getSolver()->setNumMaxIterations(30);
+      handle->ik->solveAndApply(true);
+    }
+  }
+
+  return true;
+}
+
 DartScene createMvpDartScene()
 {
   DartScene scene;
@@ -1759,7 +1979,8 @@ DartScene createG1DartScene(const AppOptions& options)
   std::cout << "Loaded G1 robot from '" << options.g1RobotUri << "'.\n"
             << "Package root for '" << options.g1PackageName << "' set to '"
             << options.g1PackageUri << "'.\n";
-  scene.world->addSkeleton(std::move(g1));
+  scene.world->addSkeleton(g1);
+  addG1IkTargets(scene, g1);
 
   return scene;
 }
@@ -1866,12 +2087,12 @@ float3 orbitingKeyLightDirection(double elapsedSeconds, double orbitPeriodSecond
 
 double perspectiveNearPlane(const OrbitCamera& camera)
 {
-  return std::clamp(camera.distance * 0.01, 0.005, 0.05);
+  return std::clamp(camera.distance * 0.004, 0.002, 0.025);
 }
 
 double perspectiveFarPlane(const OrbitCamera& camera)
 {
-  return std::max(100.0, camera.distance + 80.0);
+  return std::max(30.0, camera.distance + 35.0);
 }
 
 float4 toRgba(const Eigen::Vector4d& rgba)
@@ -3521,12 +3742,7 @@ int main(int argc, char* argv[])
   auto* colorGrading = createDebugColorGrading(*engine);
   view->setColorGrading(colorGrading);
   view->setShadowingEnabled(true);
-  view->setShadowType(
-      options.headless ? filament::ShadowType::PCF : filament::ShadowType::PCSS);
-  filament::SoftShadowOptions softShadowOptions;
-  softShadowOptions.penumbraScale = options.headless ? 1.6f : 1.15f;
-  softShadowOptions.penumbraRatioScale = options.headless ? 2.0f : 1.35f;
-  view->setSoftShadowOptions(softShadowOptions);
+  view->setShadowType(filament::ShadowType::PCF);
   auto* indirectLight = createNeutralIndirectLight(*engine);
   auto* skybox = createNeutralSkybox(*engine);
   scene->setIndirectLight(indirectLight);
@@ -3883,16 +4099,14 @@ int main(int argc, char* argv[])
 
   auto lightEntity = EntityManager::get().create();
   filament::LightManager::ShadowOptions shadowOptions;
-  shadowOptions.mapSize = options.headless ? 512 : 4096;
-  shadowOptions.shadowCascades = options.headless ? 1 : 4;
-  shadowOptions.cascadeSplitPositions[0] = 0.08f;
-  shadowOptions.cascadeSplitPositions[1] = 0.22f;
-  shadowOptions.cascadeSplitPositions[2] = 0.55f;
-  shadowOptions.shadowFar = options.headless ? 12.0f : 16.0f;
-  shadowOptions.shadowFarHint = options.headless ? 8.0f : 8.0f;
+  shadowOptions.mapSize = options.headless ? 2048 : 4096;
+  shadowOptions.shadowCascades = options.headless ? 3 : 4;
+  shadowOptions.cascadeSplitPositions[0] = 0.10f;
+  shadowOptions.cascadeSplitPositions[1] = 0.30f;
+  shadowOptions.cascadeSplitPositions[2] = 0.62f;
+  shadowOptions.shadowFar = options.headless ? 10.0f : 14.0f;
+  shadowOptions.shadowFarHint = options.headless ? 4.5f : 5.5f;
   shadowOptions.screenSpaceContactShadows = false;
-  shadowOptions.maxShadowDistance = options.headless ? 0.8f : 0.25f;
-  shadowOptions.shadowBulbRadius = options.headless ? 0.16f : 0.08f;
   bool orbitLight = appOptions.orbitLight;
   const float3 keyLightDirection
       = orbitLight ? orbitingKeyLightDirection(
@@ -3977,6 +4191,14 @@ int main(int argc, char* argv[])
         requestSingleStep(lifecycle, false);
       }
       wasStepPressed = isStepPressed;
+
+      for (const auto& handle : dartScene.ikHandles) {
+        if (glfwGetKey(window, handle.hotkey) == GLFW_PRESS) {
+          selectedRenderableId = handle.targetRenderableId;
+          selectedLabel = handle.label + " IK target";
+          lifecycle.paused = true;
+        }
+      }
     }
     profile.inputMs += elapsedMs(phaseStart);
 
@@ -4084,7 +4306,8 @@ int main(int argc, char* argv[])
               return candidate.id == selectedRenderableId;
             });
         if (selectedDescriptor != descriptors.end()
-            && translateFrameRenderable(*selectedDescriptor, nudge)) {
+            && translateRenderableAndApplyIk(
+                dartScene, *selectedDescriptor, nudge)) {
           lifecycle.paused = true;
           descriptors = extractRenderables(*dartScene.world);
         }
@@ -4191,7 +4414,8 @@ int main(int argc, char* argv[])
                 return candidate.id == selectedRenderableId;
               });
           if (selectedDescriptor != descriptors.end()
-              && translateFrameRenderable(*selectedDescriptor, *translation)) {
+              && translateRenderableAndApplyIk(
+                  dartScene, *selectedDescriptor, *translation)) {
             selectedDragLastRay = ray;
             lifecycle.paused = true;
             descriptors = extractRenderables(*dartScene.world);
@@ -4211,14 +4435,7 @@ int main(int argc, char* argv[])
             selectedRenderableId = hit->id;
             const RenderableDescriptor& descriptor
                 = descriptors[hit->renderableIndex];
-            selectedLabel = descriptor.skeletonName.empty()
-                                ? descriptor.shapeFrameName
-                                : descriptor.skeletonName + "/"
-                                      + descriptor.bodyName;
-            if (!descriptor.shapeNodeName.empty()) {
-              selectedLabel += "/" + descriptor.shapeNodeName;
-            }
-            selectedLabel += " (" + descriptor.geometry.shapeType + ")";
+            selectedLabel = selectionLabelForRenderable(dartScene, descriptor);
           } else {
             selectedRenderableId = 0;
             selectedLabel = "none";
@@ -4253,7 +4470,12 @@ int main(int argc, char* argv[])
       ImGui::TextWrapped(
           "Mouse: left orbit, right/middle pan, wheel zoom, click select.");
       ImGui::TextWrapped(
-          "Keys: Space pause, N step, arrows/Pg move selected, Esc exit.");
+          "Keys: Space pause, N step, arrows/Pg or Ctrl-left drag selected, "
+          "Esc exit.");
+      if (!dartScene.ikHandles.empty()) {
+        ImGui::TextWrapped(
+            "G1 IK: press 1-4 or click a colored target, then move it.");
+      }
       ImGui::PopTextWrapPos();
       ImGui::Separator();
       ImGui::Text("scene: %s", sceneName(appOptions.scene));

--- a/examples/filament_gui/main.cpp
+++ b/examples/filament_gui/main.cpp
@@ -39,10 +39,15 @@
 #include "transparent_textured_lit_material.hpp"
 
 #include <dart/all.hpp>
+#include <dart/common/local_resource_retriever.hpp>
 #include <dart/common/profile.hpp>
 #include <dart/config.hpp>
 #include <dart/io/read.hpp>
+#include <dart/utils/composite_resource_retriever.hpp>
+#include <dart/utils/dart_resource_retriever.hpp>
+#include <dart/utils/http_resource_retriever.hpp>
 #include <dart/utils/mesh_loader.hpp>
+#include <dart/utils/package_resource_retriever.hpp>
 #include <dart/utils/urdf/All.hpp>
 
 #include <GLFW/glfw3.h>
@@ -883,6 +888,7 @@ enum class ExampleScene
 {
   Mvp,
   DragAndDrop,
+  G1,
 };
 
 struct AppOptions
@@ -895,6 +901,11 @@ struct AppOptions
   bool orbitLight = true;
   double orbitLightPeriodSeconds = 80.0;
   float guiScale = 1.0f;
+  std::string g1PackageName = "g1_description";
+  std::string g1PackageUri
+      = "https://raw.githubusercontent.com/unitreerobotics/unitree_ros/"
+        "master/robots/g1_description";
+  std::string g1RobotUri = "package://g1_description/g1_29dof.urdf";
 };
 
 constexpr const char* kWamFixtureSkeletonName = "visual_wam_robot";
@@ -902,8 +913,10 @@ constexpr const char* kAtlasFixtureSkeletonName = "visual_atlas_torso_mesh";
 constexpr const char* kAtlasRobotFixtureSkeletonName = "visual_atlas_robot";
 constexpr const char* kPbrEnvironmentFixtureSkeletonName =
     "visual_pbr_environment";
+constexpr const char* kG1FixtureSkeletonName = "visual_g1_robot";
 constexpr std::size_t kMinPbrEnvironmentRenderableCount = 4;
 constexpr std::size_t kMinDragAndDropFrameRenderableCount = 5;
+constexpr std::size_t kMinG1RenderableCount = 20;
 
 const char* sceneName(ExampleScene scene)
 {
@@ -912,6 +925,8 @@ const char* sceneName(ExampleScene scene)
       return "mvp";
     case ExampleScene::DragAndDrop:
       return "drag-and-drop";
+    case ExampleScene::G1:
+      return "g1";
   }
   return "mvp";
 }
@@ -926,22 +941,35 @@ bool parseSceneName(std::string_view name, ExampleScene& scene)
     scene = ExampleScene::DragAndDrop;
     return true;
   }
+  if (name == "g1") {
+    scene = ExampleScene::G1;
+    return true;
+  }
   return false;
 }
 
 OrbitCamera initialCameraForScene(ExampleScene scene)
 {
   OrbitCamera camera;
-  if (scene == ExampleScene::DragAndDrop) {
-    camera.target = Eigen::Vector3d(0.35, 0.15, 0.9);
-    camera.yaw = -0.72;
-    camera.pitch = 0.58;
-    camera.distance = 9.5;
-  } else {
-    camera.target = Eigen::Vector3d(0.15, 0.55, 0.75);
-    camera.yaw = -0.95;
-    camera.pitch = 0.38;
-    camera.distance = 7.2;
+  switch (scene) {
+    case ExampleScene::DragAndDrop:
+      camera.target = Eigen::Vector3d(0.35, 0.15, 0.9);
+      camera.yaw = -0.72;
+      camera.pitch = 0.58;
+      camera.distance = 9.5;
+      break;
+    case ExampleScene::G1:
+      camera.target = Eigen::Vector3d(0.0, 0.0, 0.85);
+      camera.yaw = -0.78;
+      camera.pitch = 0.24;
+      camera.distance = 3.4;
+      break;
+    case ExampleScene::Mvp:
+      camera.target = Eigen::Vector3d(0.15, 0.55, 0.75);
+      camera.yaw = -0.95;
+      camera.pitch = 0.38;
+      camera.distance = 7.2;
+      break;
   }
   return camera;
 }
@@ -1111,9 +1139,152 @@ dart::dynamics::SkeletonPtr createRequiredPbrEnvironmentSkeleton()
   return environment;
 }
 
+std::optional<std::string> getLastPathSegment(std::string value)
+{
+  if (value.empty()) {
+    return std::nullopt;
+  }
+
+  const std::size_t terminator = value.find_first_of("?#");
+  if (terminator != std::string::npos) {
+    value.erase(terminator);
+  }
+
+  while (value.ends_with('/') || value.ends_with('\\')) {
+    value.pop_back();
+  }
+
+  if (value.empty()) {
+    return std::nullopt;
+  }
+
+  const std::size_t slash = value.find_last_of("/\\");
+  std::string segment
+      = value.substr(slash == std::string::npos ? 0 : slash + 1);
+
+  if (segment.empty()) {
+    return std::nullopt;
+  }
+
+  return segment;
+}
+
+std::optional<std::string> inferPackageNameFromRobotUri(
+    const std::string& robotUri)
+{
+  if (robotUri.empty()) {
+    return std::nullopt;
+  }
+
+  dart::common::Uri uri;
+  if (!uri.fromStringOrPath(robotUri)) {
+    return std::nullopt;
+  }
+
+  if (!uri.mScheme || *uri.mScheme != "package" || !uri.mAuthority) {
+    return std::nullopt;
+  }
+
+  return uri.mAuthority.get();
+}
+
+std::optional<std::string> inferPackageNameFromPackageUri(
+    const std::string& packageUri)
+{
+  if (packageUri.empty()) {
+    return std::nullopt;
+  }
+
+  dart::common::Uri uri;
+  if (uri.fromStringOrPath(packageUri)) {
+    if (uri.mScheme && *uri.mScheme == "package" && uri.mAuthority) {
+      return uri.mAuthority.get();
+    }
+
+    if (uri.mPath) {
+      if (auto segment = getLastPathSegment(uri.mPath.get())) {
+        return segment;
+      }
+    }
+  }
+
+  return getLastPathSegment(packageUri);
+}
+
+dart::common::ResourceRetrieverPtr createG1ResourceRetriever(
+    const AppOptions& options)
+{
+  auto local = std::make_shared<dart::common::LocalResourceRetriever>();
+  auto dartRetriever = std::make_shared<dart::utils::DartResourceRetriever>();
+  auto http = std::make_shared<dart::utils::HttpResourceRetriever>();
+
+  auto passthrough = std::make_shared<dart::utils::CompositeResourceRetriever>();
+  passthrough->addSchemaRetriever("file", local);
+  passthrough->addSchemaRetriever("dart", dartRetriever);
+  passthrough->addSchemaRetriever("http", http);
+  passthrough->addSchemaRetriever("https", http);
+  passthrough->addDefaultRetriever(local);
+
+  auto packageRetriever
+      = std::make_shared<dart::utils::PackageResourceRetriever>(passthrough);
+  packageRetriever->addPackageDirectory(
+      options.g1PackageName, options.g1PackageUri);
+
+  auto resolver = std::make_shared<dart::utils::CompositeResourceRetriever>();
+  resolver->addSchemaRetriever("package", packageRetriever);
+  resolver->addSchemaRetriever("file", local);
+  resolver->addSchemaRetriever("dart", dartRetriever);
+  resolver->addSchemaRetriever("http", http);
+  resolver->addSchemaRetriever("https", http);
+  resolver->addDefaultRetriever(local);
+
+  return resolver;
+}
+
+dart::dynamics::SkeletonPtr createG1Ground()
+{
+  auto ground = Skeleton::create("g1_ground");
+  auto* body = ground->createJointAndBodyNodePair<WeldJoint>().second;
+
+  constexpr double thickness = 0.04;
+  auto* shapeNode = body->createShapeNodeWith<VisualAspect>(
+      std::make_shared<BoxShape>(Eigen::Vector3d(4.0, 4.0, thickness)));
+  shapeNode->setRelativeTranslation(Eigen::Vector3d(0.0, 0.0, -thickness / 2.0));
+  shapeNode->getVisualAspect()->setRGBA(Eigen::Vector4d(0.86, 0.88, 0.9, 1.0));
+  return ground;
+}
+
+dart::dynamics::SkeletonPtr loadG1Skeleton(const AppOptions& options)
+{
+  dart::io::ReadOptions readOptions;
+  readOptions.resourceRetriever = createG1ResourceRetriever(options);
+  const dart::common::Uri robotUri(options.g1RobotUri);
+  auto robot = dart::io::readSkeleton(robotUri, readOptions);
+  if (!robot) {
+    throw std::runtime_error(
+        "Failed to load G1 robot fixture from " + options.g1RobotUri);
+  }
+
+  robot->setName(kG1FixtureSkeletonName);
+  if (auto* rootBody = robot->getRootBodyNode()) {
+    if (auto* freeJoint
+        = dynamic_cast<FreeJoint*>(rootBody->getParentJoint())) {
+      Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+      transform.translation().z() = 0.75;
+      FreeJoint::setTransformOf(freeJoint, transform);
+    }
+  }
+  makeVisualOnlySkeleton(robot);
+  return robot;
+}
+
 AppOptions parseOptions(int argc, char* argv[])
 {
   AppOptions options;
+  bool g1PackageNameExplicit = false;
+  bool g1PackageUriExplicit = false;
+  bool g1RobotUriExplicit = false;
+
   for (int i = 1; i < argc; ++i) {
     const std::string_view arg(argv[i]);
     if (arg == "--frames" && i + 1 < argc) {
@@ -1164,9 +1335,23 @@ AppOptions parseOptions(int argc, char* argv[])
       const std::string_view sceneArg(argv[++i]);
       if (!parseSceneName(sceneArg, options.scene)) {
         std::cerr << "Unknown scene '" << sceneArg
-                  << "'. Expected 'mvp' or 'drag-and-drop'.\n";
+                  << "'. Expected 'mvp', 'drag-and-drop', or 'g1'.\n";
         std::exit(2);
       }
+    } else if (
+        (arg == "--g1-package-uri" || arg == "--package-uri")
+        && i + 1 < argc) {
+      options.g1PackageUri = argv[++i];
+      g1PackageUriExplicit = true;
+    } else if (
+        (arg == "--g1-robot-uri" || arg == "--robot-uri") && i + 1 < argc) {
+      options.g1RobotUri = argv[++i];
+      g1RobotUriExplicit = true;
+    } else if (
+        (arg == "--g1-package-name" || arg == "--package-name")
+        && i + 1 < argc) {
+      options.g1PackageName = argv[++i];
+      g1PackageNameExplicit = true;
     } else if (arg == "--help" || arg == "-h") {
       std::cout << "Usage: " << argv[0]
                 << " [--frames N] [--width N] [--height N]"
@@ -1176,10 +1361,30 @@ AppOptions parseOptions(int argc, char* argv[])
                    " [--orbit-light-period SECONDS]"
                    " [--gui-scale N]"
                    " [--profile]"
-                   " [--scene mvp|drag-and-drop]\n";
+                   " [--scene mvp|drag-and-drop|g1]"
+                   " [--g1-package-uri URI] [--g1-robot-uri URI]"
+                   " [--g1-package-name NAME]\n";
       std::exit(0);
     }
   }
+
+  if (!g1PackageNameExplicit) {
+    if (g1RobotUriExplicit) {
+      if (auto packageName
+          = inferPackageNameFromRobotUri(options.g1RobotUri)) {
+        options.g1PackageName = *packageName;
+      }
+    } else if (g1PackageUriExplicit) {
+      if (auto packageName
+          = inferPackageNameFromPackageUri(options.g1PackageUri)) {
+        options.g1PackageName = *packageName;
+      }
+    } else if (auto packageName
+               = inferPackageNameFromRobotUri(options.g1RobotUri)) {
+      options.g1PackageName = *packageName;
+    }
+  }
+
   normalizeRunOptions(options.run);
   if (options.guiScale != 1.0f) {
     options.run.width = std::max(
@@ -1543,13 +1748,31 @@ DartScene createDragAndDropScene()
   return scene;
 }
 
-DartScene createDartScene(ExampleScene scene)
+DartScene createG1DartScene(const AppOptions& options)
 {
-  switch (scene) {
+  DartScene scene;
+  scene.world = World::create("filament_gui_g1");
+  scene.world->setGravity(Eigen::Vector3d::Zero());
+  scene.world->addSkeleton(createG1Ground());
+
+  auto g1 = loadG1Skeleton(options);
+  std::cout << "Loaded G1 robot from '" << options.g1RobotUri << "'.\n"
+            << "Package root for '" << options.g1PackageName << "' set to '"
+            << options.g1PackageUri << "'.\n";
+  scene.world->addSkeleton(std::move(g1));
+
+  return scene;
+}
+
+DartScene createDartScene(const AppOptions& options)
+{
+  switch (options.scene) {
     case ExampleScene::Mvp:
       return createMvpDartScene();
     case ExampleScene::DragAndDrop:
       return createDragAndDropScene();
+    case ExampleScene::G1:
+      return createG1DartScene(options);
   }
   return createMvpDartScene();
 }
@@ -3380,7 +3603,7 @@ int main(int argc, char* argv[])
       fallbackBinding};
   TextureCache textureCache;
 
-  DartScene dartScene = createDartScene(appOptions.scene);
+  DartScene dartScene = createDartScene(appOptions);
   const auto initialDescriptors = extractRenderables(*dartScene.world);
   const std::size_t wamDescriptorCount = static_cast<std::size_t>(
       std::count_if(
@@ -3418,6 +3641,15 @@ int main(int argc, char* argv[])
                    && descriptor.material.visible
                    && descriptor.geometry.kind == ShapeKind::Mesh;
           }));
+  const std::size_t g1DescriptorCount = static_cast<std::size_t>(
+      std::count_if(
+          initialDescriptors.begin(),
+          initialDescriptors.end(),
+          [](const RenderableDescriptor& descriptor) {
+            return descriptor.skeletonName == kG1FixtureSkeletonName
+                   && descriptor.material.visible
+                   && descriptor.geometry.kind == ShapeKind::Mesh;
+          }));
   const std::size_t dragAndDropFrameDescriptorCount = static_cast<std::size_t>(
       std::count_if(
           initialDescriptors.begin(),
@@ -3452,6 +3684,14 @@ int main(int argc, char* argv[])
                 << pbrEnvironmentDescriptorCount << "\n";
       return 1;
     }
+  } else if (appOptions.scene == ExampleScene::G1) {
+    if (g1DescriptorCount < kMinG1RenderableCount) {
+      std::cerr << "Expected the G1 robot fixture to provide at least "
+                << kMinG1RenderableCount
+                << " visible mesh renderables, but extracted "
+                << g1DescriptorCount << "\n";
+      return 1;
+    }
   } else if (appOptions.scene == ExampleScene::DragAndDrop
              && dragAndDropFrameDescriptorCount
                     < kMinDragAndDropFrameRenderableCount) {
@@ -3467,6 +3707,7 @@ int main(int argc, char* argv[])
   std::size_t createdAtlasRenderableCount = 0;
   std::size_t createdAtlasRobotRenderableCount = 0;
   std::size_t createdPbrEnvironmentRenderableCount = 0;
+  std::size_t createdG1RenderableCount = 0;
   std::size_t createdDragAndDropFrameRenderableCount = 0;
   for (const RenderableDescriptor& descriptor : initialDescriptors) {
     if (!descriptor.material.visible) {
@@ -3493,6 +3734,10 @@ int main(int argc, char* argv[])
     if (descriptor.skeletonName == kPbrEnvironmentFixtureSkeletonName
         && descriptor.geometry.kind == ShapeKind::Mesh) {
       ++createdPbrEnvironmentRenderableCount;
+    }
+    if (descriptor.skeletonName == kG1FixtureSkeletonName
+        && descriptor.geometry.kind == ShapeKind::Mesh) {
+      ++createdG1RenderableCount;
     }
     if (!descriptor.shapeFrameName.empty()) {
       ++createdDragAndDropFrameRenderableCount;
@@ -3535,6 +3780,13 @@ int main(int argc, char* argv[])
       std::cerr << "Only " << createdPbrEnvironmentRenderableCount << " of "
                 << pbrEnvironmentDescriptorCount
                 << " PBR environment mesh renderables were created\n";
+      return 1;
+    }
+  } else if (appOptions.scene == ExampleScene::G1) {
+    if (createdG1RenderableCount < g1DescriptorCount) {
+      std::cerr << "Only " << createdG1RenderableCount << " of "
+                << g1DescriptorCount
+                << " G1 robot mesh renderables were created\n";
       return 1;
     }
   } else if (appOptions.scene == ExampleScene::DragAndDrop

--- a/examples/g1_puppet/README.md
+++ b/examples/g1_puppet/README.md
@@ -2,18 +2,37 @@
 
 ## Summary
 
-- Goal: load a remote URDF package and inspect a G1 model with IK handles.
+- Goal: load a remote URDF package and inspect a G1 model with the experimental
+  Filament viewer.
 - Concepts/APIs: `dart::io::readSkeleton`, `HttpResourceRetriever`,
-  `PackageResourceRetriever`.
-- Expected output: a kinematic G1 in an OSG viewer; keys 1-4 toggle IK targets.
-- Controls: drag body nodes with the mouse; press 1-4 to toggle IK targets.
+  `PackageResourceRetriever`, and the experimental Filament GUI scene.
+- Expected output: a kinematic G1 in a Filament viewer.
+- Controls: left drag orbits, right/middle drag pans, wheel zooms, click
+  selects renderables, and Escape exits.
 
 ## Notes
 
 - Override the package/robot source with `--package-uri`, `--robot-uri`, and
   `--package-name`.
-- Requires CLI11 for argument parsing (installed via pixi).
+- Requires CLI11 for the legacy standalone source in this directory.
+- The recommended in-tree runner now uses the Filament scene in
+  `examples/filament_gui`. The standalone source in this directory still
+  carries the legacy OSG IK implementation until the promoted Filament GUI API
+  has equivalent tool abstractions.
 - This example runs in kinematic mode (no physics simulation).
+
+## Run In Tree
+
+From the repository root:
+
+```bash
+pixi run ex g1_puppet --gui-scale 2
+```
+
+This builds and runs `examples/filament_gui --scene g1`, so it uses the same
+Filament renderer path as the other experimental GUI fixtures. The legacy G1
+source accepts the shorter option names; the Filament runner accepts both those
+names and the explicit `--g1-*` names.
 
 ## Build
 

--- a/examples/g1_puppet/README.md
+++ b/examples/g1_puppet/README.md
@@ -8,7 +8,8 @@
   `PackageResourceRetriever`, and the experimental Filament GUI scene.
 - Expected output: a kinematic G1 in a Filament viewer.
 - Controls: left drag orbits, right/middle drag pans, wheel zooms, click
-  selects renderables, and Escape exits.
+  selects renderables, Ctrl-left drag or arrow/PageUp/PageDown nudges selected
+  items, and Escape exits.
 
 ## Notes
 
@@ -16,9 +17,10 @@
   `--package-name`.
 - Requires CLI11 for the legacy standalone source in this directory.
 - The recommended in-tree runner now uses the Filament scene in
-  `examples/filament_gui`. The standalone source in this directory still
-  carries the legacy OSG IK implementation until the promoted Filament GUI API
-  has equivalent tool abstractions.
+  `examples/filament_gui`. It exposes colored IK targets for the hands and
+  feet; press `1`-`4` or click a target marker, then Ctrl-left drag or use the
+  arrow/PageUp/PageDown keys to move the target and solve IK. The standalone
+  source in this directory remains as the legacy OSG version.
 - This example runs in kinematic mode (no physics simulation).
 
 ## Run In Tree

--- a/scripts/run_cpp_example.py
+++ b/scripts/run_cpp_example.py
@@ -24,12 +24,19 @@ class ExampleSpec:
     build_target: str
     binary_name: str
     requirements: tuple[str, ...] = ()
+    default_args: tuple[str, ...] = ()
 
 
 EXAMPLE_SPECS = {
     "raylib": ExampleSpec("dart_raylib", "raylib", ("raylib",)),
     "dart_raylib": ExampleSpec("dart_raylib", "raylib", ("raylib",)),
     "filament_gui": ExampleSpec("dart_filament_gui", "filament_gui", ("filament",)),
+    "g1_puppet": ExampleSpec(
+        "dart_filament_gui",
+        "filament_gui",
+        ("filament",),
+        ("--scene", "g1"),
+    ),
 }
 
 
@@ -459,6 +466,7 @@ def _run_example_binary(
     run_args: list[str],
     env: dict[str, str],
 ) -> None:
+    run_args = [*spec.default_args, *run_args]
     binary = _binary_path(build_dir, spec.binary_name)
     if not binary.exists():
         raise SystemExit(f"Binary not found: {binary}")


### PR DESCRIPTION
## Summary

- Add a Filament-backed Unitree G1 scene and route the in-tree `g1_puppet` runner to it.
- Add visible hand and foot IK target markers for G1 manipulation.
- Tighten Filament shadow and camera defaults for cleaner example rendering.

## Motivation / Problem

- The G1 README animation should exercise the promoted Filament renderer path instead of the legacy OSG viewer.
- The example needs the old user-facing puppet workflow: visible end-effector targets that can be selected and moved to apply IK.

## Changes / Key Changes

- Add `--scene g1` resource loading, ground placement, and IK target setup in `examples/filament_gui`.
- Route `pixi run ex g1_puppet` to the Filament G1 scene.
- Improve shadow-map defaults and near/far clip ranges used by the Filament viewer.
- Update the Filament and G1 example docs plus CHANGELOG.

## Testing

```bash
pixi run ex filament_gui --gui-scale 2
```

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Stacked on #2647.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [x] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
