### PR TITLE
Fix update lockfile pixi setup

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -21,6 +21,7 @@ jobs:
       cancel-in-progress: false
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         base: [main, release-6.16]
     steps:
@@ -28,11 +29,10 @@ jobs:
         with:
           ref: ${{ matrix.base }}
       - name: Setup pixi (CI)
-        uses: ./.github/actions/setup-pixi-ci
+        uses: prefix-dev/setup-pixi@v0.9.4
         with:
           cache: false
           run-install: false
-          self-hosted-install: false
           pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
       - name: Update lockfiles
         run: |


### PR DESCRIPTION
## Summary

- Fix the scheduled update-lockfiles workflow when its matrix checks out `release-6.16`.

## Motivation / Problem

- The scheduled run https://github.com/dartsim/dart/actions/runs/25955857332 fails in `Maintenance | Update pixi.lock (release-6.16)` because the workflow checks out `release-6.16` and then tries to run the local action `./.github/actions/setup-pixi-ci`. That helper exists on `main`, but not on `release-6.16`.

## Changes / Key Changes

- Use `prefix-dev/setup-pixi@v0.9.4` directly in `update_lockfiles.yml` so pixi setup is available after checking out either matrix branch.
- Set the update-lockfiles matrix `fail-fast: false` so one branch failure does not cancel the other branch's lockfile update job.

## Testing

- `pixi run lint-yaml`
- `pixi run check-lint-yaml`
- `git diff --check`
- `actionlint .github/workflows/update_lockfiles.yml`
- `pixi run lint`
- `git push --dry-run -u origin HEAD`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- https://github.com/dartsim/dart/actions/runs/25955857332
- Related CI trigger-path cleanup: https://github.com/dartsim/dart/pull/2655
- Backport PRs: None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (N/A: CI workflow-only fix; no release-facing behavior change.)
- [x] Add unit tests for new functionality (N/A: workflow-only change.)
- [x] Document new methods and classes (N/A: no API changes.)
- [x] Add Python bindings (dartpy) if applicable (N/A: no Python API changes.)