### PR TITLE
Add core CI for branch pushes

### DIFF
--- a/.github/actions/ci-scope/action.yml
+++ b/.github/actions/ci-scope/action.yml
@@ -1,0 +1,44 @@
+name: Determine CI scope
+description: Classify the current GitHub Actions event into DART CI tiers.
+
+outputs:
+  full_ci:
+    description: "true for PRs, protected branch/tag pushes, schedules, and manual runs"
+    value: ${{ steps.scope.outputs.full_ci }}
+  core_branch_push:
+    description: "true for ordinary branch pushes that should run only core CI"
+    value: ${{ steps.scope.outputs.core_branch_push }}
+
+runs:
+  using: composite
+  steps:
+    - id: scope
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        full_ci=false
+        core_branch_push=false
+
+        if [[ "$GITHUB_EVENT_NAME" == "pull_request" \
+          || "$GITHUB_EVENT_NAME" == "schedule" \
+          || "$GITHUB_EVENT_NAME" == "workflow_dispatch" \
+          || "$GITHUB_REF" == "refs/heads/main" \
+          || "$GITHUB_REF" == refs/heads/release-* \
+          || "$GITHUB_REF" == refs/tags/v* ]]; then
+          full_ci=true
+        elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+          core_branch_push=true
+        fi
+
+        {
+          echo "full_ci=$full_ci"
+          echo "core_branch_push=$core_branch_push"
+        } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### CI scope"
+          echo
+          echo "- full_ci: $full_ci"
+          echo "- core_branch_push: $core_branch_push"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci_gz_physics.yml
+++ b/.github/workflows/ci_gz_physics.yml
@@ -5,8 +5,7 @@ name: CI gz-physics
 on:
   push:
     branches:
-      - "main"
-      - "release-*"
+      - "**"
   pull_request:
     branches:
       - "**"
@@ -22,9 +21,13 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
+      core_branch_push: ${{ steps.scope.outputs.core_branch_push }}
       code: ${{ steps.filter.outputs.code }}
+      full_ci: ${{ steps.scope.outputs.full_ci }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/ci-scope
+        id: scope
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -32,7 +35,12 @@ jobs:
 
   test_gazebo:
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
+    if: >-
+      (needs.changes.outputs.full_ci == 'true' ||
+      needs.changes.outputs.core_branch_push == 'true') &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
     name: GZ Physics Tests
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci_gz_physics.yml
+++ b/.github/workflows/ci_gz_physics.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   changes:
+    if: github.event.deleted != true
     runs-on: ubuntu-latest
     outputs:
       core_branch_push: ${{ steps.scope.outputs.core_branch_push }}

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -3,8 +3,7 @@ name: CI Lint
 on:
   push:
     branches:
-      - "main"
-      - "release-*"
+      - "**"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
   pull_request:
@@ -36,6 +35,7 @@ jobs:
 
   docs:
     name: Documentation
+    if: github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
+    if: github.event.deleted != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,7 +36,11 @@ jobs:
 
   docs:
     name: Documentation
-    if: github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')
+    if: >-
+      github.event.deleted != true &&
+      (github.event_name != 'push' ||
+      github.ref == 'refs/heads/main' ||
+      startsWith(github.ref, 'refs/heads/release-'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci_simd.yml
+++ b/.github/workflows/ci_simd.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   simd-x86-levels:
+    if: github.event.deleted != true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -92,6 +93,7 @@ jobs:
           cd build && ctest -R "UNIT_simd" --output-on-failure
 
   simd-arm64-neon:
+    if: github.event.deleted != true
     runs-on: macos-latest
     name: ARM64 NEON (macOS)
     env:

--- a/.github/workflows/ci_simd.yml
+++ b/.github/workflows/ci_simd.yml
@@ -3,8 +3,7 @@ name: CI SIMD Multi-Arch
 on:
   push:
     branches:
-      - "main"
-      - "release-*"
+      - "**"
     paths:
       - "dart/simd/**"
       - "tests/unit/simd/**"

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -5,8 +5,7 @@ name: CI Linux
 on:
   push:
     branches:
-      - "main"
-      - "release-*"
+      - "**"
   pull_request:
     branches:
       - "**"
@@ -22,9 +21,13 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
+      core_branch_push: ${{ steps.scope.outputs.core_branch_push }}
       code: ${{ steps.filter.outputs.code }}
+      full_ci: ${{ steps.scope.outputs.full_ci }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/ci-scope
+        id: scope
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -33,7 +36,10 @@ jobs:
   coverage:
     needs: changes
     # Skip for workflow_dispatch; bypass changes gate for schedule (no file-change payload)
-    if: github.event_name != 'workflow_dispatch' && (github.event_name == 'schedule' || needs.changes.outputs.code == 'true')
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      github.event_name != 'workflow_dispatch' &&
+      (github.event_name == 'schedule' || needs.changes.outputs.code == 'true')
     name: Coverage (Debug)
     runs-on: ubuntu-latest
     env:
@@ -73,9 +79,65 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
+  build-core:
+    needs: changes
+    if: needs.changes.outputs.core_branch_push == 'true' && needs.changes.outputs.code == 'true'
+    name: Core Tests (Linux)
+    runs-on: ubuntu-latest
+    env:
+      DART_PARALLEL_JOBS: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pixi (CI)
+        uses: ./.github/actions/setup-pixi-ci
+        with:
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: libgl1-mesa-dev libglu1-mesa-dev
+          version: 2
+
+      - name: Configure environment for compiler cache
+        uses: ./.github/actions/configure-compiler-cache
+
+      - name: Run Release C++ tests
+        run: |
+          DART_VERBOSE=ON \
+          BUILD_TYPE=Release \
+          DART_BUILD_SIMULATION_EXPERIMENTAL_OVERRIDE=OFF \
+          pixi run test ON Release
+
+      - name: Run Release Python tests
+        run: |
+          DART_VERBOSE=ON \
+          BUILD_TYPE=Release \
+          DART_BUILD_SIMULATION_EXPERIMENTAL_OVERRIDE=OFF \
+          pixi run test-py ON Release
+
+      - name: Build Release examples
+        run: |
+          DART_VERBOSE=ON \
+          BUILD_TYPE=Release \
+          DART_BUILD_SIMULATION_EXPERIMENTAL_OVERRIDE=OFF \
+          pixi run build-examples ON Release
+
+      - name: Install
+        run: |
+          DART_VERBOSE=ON \
+          BUILD_TYPE=Release \
+          pixi run install
+
   build-release:
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
     name: Release Tests
     runs-on: ubuntu-latest
     env:
@@ -132,7 +194,11 @@ jobs:
 
   build-debug:
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
     name: Debug Tests
     runs-on: ubuntu-latest
     env:
@@ -171,7 +237,11 @@ jobs:
 
   build-asserts:
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
     name: Asserts enabled (no -DNDEBUG)
     runs-on: ubuntu-latest
     env:
@@ -222,7 +292,11 @@ jobs:
 
   eigen-overalignment:
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
     name: Eigen 64-byte alignment
     runs-on: ubuntu-latest
     env:
@@ -246,7 +320,11 @@ jobs:
 
   headless-rendering:
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
     name: Headless Rendering Tests
     runs-on: ubuntu-latest
     env:
@@ -290,7 +368,11 @@ jobs:
 
   filament-gui-smoke:
     needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
     name: Filament GUI Smoke (${{ matrix.compiler.name }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   changes:
+    if: github.event.deleted != true
     runs-on: ubuntu-latest
     outputs:
       core_branch_push: ${{ steps.scope.outputs.core_branch_push }}

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -19,7 +19,9 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
   - Suggested (Unverified): `gh pr checks <PR_NUMBER> --watch --interval 30 --fail-fast`
   - Suggested (Unverified): `gh run view --job <JOB_ID> --log-failed`
 - Gotchas:
-  - PR branch CI should run from `pull_request`; push-triggered CI is reserved for `main`, `release-*`, tags, schedules, and manual runs.
+  - Feature branch pushes run a core pre-PR tier only; full required coverage
+    still runs from `pull_request`, protected branch pushes, release tags,
+    schedules, and manual runs.
   - `gh run watch` is blocking and can run for a long time; use a persistent shell and re-run it if your terminal session times out.
   - `gh run view --job <JOB_ID> --log-failed` only works after the job completes; use the REST logs endpoint (or wait) when a run is still in progress.
   - If a PR is not mergeable due to conflicts, CI checks may be blocked or fail early (including AppVeyor); resolve conflicts locally and push before re-running CI.
@@ -188,13 +190,14 @@ DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run test-eigen-overalignment
 
 | Workflow             | Purpose               | Platforms      | Trigger                             | Doc-only skip |
 | -------------------- | --------------------- | -------------- | ----------------------------------- | ------------- |
-| `ci_lint.yml`        | Lint + docs build     | Ubuntu         | PR, main/release push               | No            |
-| `ci_ubuntu.yml`      | Build, test, coverage | Ubuntu         | PR, main/release push, schedule     | Yes           |
+| `ci_lint.yml`        | Lint + docs build     | Ubuntu         | Any branch push, PR, manual         | No            |
+| `ci_ubuntu.yml`      | Build, test, coverage | Ubuntu         | Branch push core; PR/main full      | Yes           |
 | `ci_macos.yml`       | Build, test           | macOS          | PR, main/release push, schedule     | Yes           |
 | `ci_windows.yml`     | Build, test           | Windows        | PR, main/release push, schedule     | Yes           |
 | `ci_freebsd.yml`     | Build, test (VM)      | FreeBSD        | Schedule, manual                    | N/A           |
 | `ci_altlinux.yml`    | Build, test (Docker)  | Alt Linux      | PR, schedule, manual                | N/A           |
-| `ci_gz_physics.yml`  | Gazebo integration    | Ubuntu         | PR, main/release push, schedule     | Yes           |
+| `ci_gz_physics.yml`  | Gazebo integration    | Ubuntu         | Branch push core; PR/main full      | Yes           |
+| `ci_simd.yml`        | SIMD multi-arch       | Ubuntu         | Branch/PR path-scoped, manual       | N/A           |
 | `publish_dartpy.yml` | Python wheels         | Multi-platform | PR, main/release/tag push, schedule | Yes           |
 
 ### CI Tiering Policy
@@ -204,6 +207,7 @@ project's continuous validation surface.
 
 | Tier                      | Required before merge | Examples                                                                                |
 | ------------------------- | --------------------- | --------------------------------------------------------------------------------------- |
+| Core branch push          | No                    | Lint, Ubuntu core release tests, gz-physics compatibility, path-scoped SIMD             |
 | Required PR               | Yes                   | Lint/docs, core Linux, macOS, Windows, gz-physics compatibility, baseline dartpy wheels |
 | Conditional PR            | When affected         | SIMD-only CI, path-filtered platform jobs for code changes                              |
 | Main/release continuous   | After merge           | Full platform coverage on protected branches; full wheels on `main` and release tags    |
@@ -213,6 +217,8 @@ Guardrails:
 
 - Keep gz-physics compatibility in the required PR tier. The Gazebo downstream
   build/test catches integration breakages that core unit tests can miss.
+- Treat core branch-push CI as early feedback only. It should be useful enough
+  before a PR exists, but it is not a substitute for the required PR tier.
 - Do not move a job from required PR coverage to continuous-only coverage
   without evidence that it is expensive, redundant for most PRs, or better
   suited to scheduled validation.
@@ -226,8 +232,10 @@ Guardrails:
 
 ### Design Principles
 
-**Optimize for fast feedback on PRs:**
+**Optimize for fast feedback on branches and PRs:**
 
+- Feature branch pushes run a small core tier so contributors can get useful CI
+  signal before opening a PR.
 - Essential validations run on every PR
 - Full matrix testing runs on main branch and releases
 - Debug builds run on schedule (2x per week)
@@ -376,16 +384,19 @@ runners. Windows keeps Release-only tests to keep runtime acceptable.
 **Behavior:**
 
 - **PRs**: Release and Debug jobs run on Ubuntu/macOS when code paths change
-- **Windows**: Release-only tests run on PRs, pushes, schedules, and manual dispatch
+- **Windows**: Release-only tests run on PRs, protected branch pushes,
+  schedules, and manual dispatch
 - **Doc-only changes**: Platform jobs are skipped by path filters; lint/docs still run
 
 ### Python Wheel Builds
 
-Full wheel matrix is expensive, so PRs and branch pushes outside `main` run only
-the baseline Python version on each OS. `main`, tags, schedules, and manual runs
-keep the full matrix. In a May 2026 PR run, the six non-baseline Py313/Py314
-wheel jobs consumed 146.6 job-minutes, while the three baseline Py312 wheel jobs
-kept Ubuntu, macOS, and Windows packaging coverage in the PR tier.
+Full wheel matrix is expensive, so PRs outside `main` run only the baseline
+Python version on each OS. Feature branch pushes skip wheel builds in the core
+pre-PR tier; open a PR for baseline wheel coverage or use manual dispatch for
+the full matrix. `main`, tags, schedules, and manual runs keep the full matrix.
+In a May 2026 PR run, the six non-baseline Py313/Py314 wheel jobs consumed
+146.6 job-minutes, while the three baseline Py312 wheel jobs kept Ubuntu,
+macOS, and Windows packaging coverage in the PR tier.
 
 **Pattern** (see `publish_dartpy.yml`):
 
@@ -404,7 +415,7 @@ build_wheels:
 
 - **PRs**: Baseline Python wheel builds on Ubuntu, macOS, and Windows
 - **PR workflow changes**: Full Python-version matrix builds
-- **Non-main branch pushes**: Baseline Python wheel builds on Ubuntu, macOS, and Windows
+- **Feature branch pushes**: Wheel builds are skipped by the core branch-push tier
 - **Main branch**: Full Python-version matrix builds
 - **Release tags**: Full Python-version matrix builds
 - **Scheduled/manual runs**: Full Python-version matrix builds
@@ -430,7 +441,10 @@ so platform test jobs do not each rebuild docs.
 
 **Key design:**
 
-- `ci_lint.yml` runs on ALL changes (including doc-only changes) to catch formatting and documentation issues early
+- `ci_lint.yml` runs lint on all branch pushes and PRs, including doc-only
+  changes. The documentation build runs on PRs, protected branch pushes, and
+  manual dispatch, but is skipped for ordinary feature branch pushes to keep
+  the pre-PR tier small.
 - FreeBSD CI (`ci_freebsd.yml`) runs on schedule/manual only to reduce maintenance burden; Alt Linux also runs on PRs for distro repro coverage
 - Lint is removed from platform-specific workflows since it's covered by the dedicated job
 
@@ -480,6 +494,14 @@ maintenance-workflow-only changes
 - Gazebo integration: Integration tests
 - dartpy wheels: Baseline Python version on Ubuntu, macOS, and Windows
 
+**Feature branch pushes:**
+
+- Lint
+- Ubuntu core release path: Release C++ tests, Release Python tests, examples,
+  and install
+- Gazebo integration: gz-physics compatibility tests when code paths change
+- SIMD multi-arch tests when SIMD paths change
+
 **Scheduled runs:**
 
 - Repeat the PR validation on a fixed cadence
@@ -492,7 +514,8 @@ GitHub Actions uses granular pixi tasks instead of `pixi run test-all` so CI
 does not repeat local-only validation in every platform job:
 
 - `pixi run check-lint` runs once in `ci_lint.yml`
-- `pixi run docs-build` runs once in `ci_lint.yml`
+- `pixi run docs-build` runs once in `ci_lint.yml` for PRs, protected branch
+  pushes, and manual runs
 - Platform jobs run explicit C++ and dartpy test tasks for their selected
   coverage slice
 - Release jobs build examples and install where that platform covers the path


### PR DESCRIPTION
## Summary

- Add a core branch-push CI tier so feature branch commits get useful GitHub Actions feedback before a PR exists.
- Keep full PR/main coverage intact by gating heavier jobs behind a shared CI-scope helper.
- Document the branch-push, PR, protected-branch, and scheduled/manual CI tiers.

<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

## Motivation / Problem

- Feature branch pushes were triggering zero CI after the path/trigger optimization work.
- Opening a PR only to get any CI signal is not a good contributor workflow.
- Naively enabling all workflows on all branch pushes would duplicate expensive PR/main CI.

<!-- Why is this change needed? What problem does it solve? -->

## Changes / Key Changes

- Add `.github/actions/ci-scope` to classify events as full CI or core branch-push CI.
- Run feature branch pushes through:
  - `CI Lint` lint job only; docs stay on PR/protected/manual.
  - `CI Linux` `Core Tests (Linux)` only; full Linux jobs stay on PR/main/release/schedule/manual.
  - `CI gz-physics` when code paths change.
  - `CI SIMD Multi-Arch` only when SIMD paths or the SIMD workflow change.
- Leave macOS, Windows, Alt Linux, FreeBSD, CodeQL, docs, full Linux variants, and dartpy wheel coverage in their existing PR/main/scheduled/manual tiers.

<!-- High-level list of key changes. -->

## Testing

- `pixi run check-lint-yaml`
- `git diff --check`
- `pixi run lint`
- Parsed all workflow/action YAML with `pixi run python` and `yaml.safe_load`.
- Manually checked the CI-scope truth table for feature branch push, doc-only branch push, PR, `main`, `release-*`, schedule, and manual cases.
- Pushed `ed7334a65b1b5a34561a8fa8afe41734e01b8961` before opening this PR and confirmed push-event CI triggered:
  - `CI Lint`: https://github.com/dartsim/dart/actions/runs/26004654710
  - `CI Linux`: https://github.com/dartsim/dart/actions/runs/26004654664
  - `CI gz-physics`: https://github.com/dartsim/dart/actions/runs/26004654671
  - `CI SIMD Multi-Arch`: https://github.com/dartsim/dart/actions/runs/26004654659
- Observed branch-push behavior before PR creation:
  - `CI Linux` ran `Core Tests (Linux)` and skipped coverage, debug, asserts, Eigen, headless, filament, and full `Release Tests`.
  - `CI Lint` ran `Lint` and skipped `Documentation`.
  - `CI gz-physics` ran `GZ Physics Tests`.
  - `CI SIMD Multi-Arch` ran because this PR changes `ci_simd.yml`; ordinary non-SIMD branches remain path-scoped.

Evidence from recent `main` push CI on `f308030e7b8d53cca8150c856c9400ccc1cd4950`:

- Existing Linux `Release Tests` job took about 154.8 runner-minutes; ASAN alone took about 101.1 minutes.
- The proposed branch-push Linux core path keeps Release C++ tests, Release Python tests, examples, and install, which measured about 53.3 runner-minutes in that run.
- `CI gz-physics` measured about 31.6 runner-minutes; lint measured about 1.3 runner-minutes.
- This keeps the ordinary code branch-push tier around 86 runner-minutes plus path-scoped SIMD when relevant, while avoiding macOS, Windows, wheels, coverage, debug, ASAN, asserts, Eigen, headless, filament, docs, Alt Linux, FreeBSD, and CodeQL until PR/main/scheduled/manual coverage.

## Breaking Changes

- [x] None
- No user-facing API or build-interface changes.

<!-- If breaking changes exist, describe impact and migration steps. -->

## Related Issues / PRs (backports)

- Follows up on CI trigger/path optimization work in #2655 and dartpy wheel tiering in #2657.
- Backport: N/A, CI policy change for `main`.

<!-- List issue links and any related/backport PRs. -->

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (N/A: CI-only workflow policy change)
- [x] Add unit tests for new functionality (N/A: GitHub Actions workflow change)
- [x] Document new methods and classes (N/A: no API changes)
- [x] Add Python bindings (dartpy) if applicable (N/A)
