### PR TITLE
Add stable dartpy wheel CI gate

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -135,9 +135,42 @@ jobs:
           path: ./dist/*.whl
           name: ${{ matrix.os }}-py${{ matrix.python-version }}
 
+  wheels:
+    name: Wheels
+    needs: [changes, build_wheels]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wheel matrix result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          WHEEL_RESULT: ${{ needs.build_wheels.result }}
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "::error::changes job result was '$CHANGES_RESULT'"
+            exit 1
+          fi
+
+          if [[ "$WHEEL_RESULT" == "success" ]]; then
+            exit 0
+          fi
+
+          if [[ "$WHEEL_RESULT" == "skipped" && "$CODE_CHANGED" != "true" ]]; then
+            if [[ "$EVENT_NAME" == "pull_request" || "$REF_NAME" == refs/heads/* ]]; then
+              echo "Wheel build skipped because this update does not affect wheel-relevant code."
+              exit 0
+            fi
+          fi
+
+          echo "::error::build_wheels job result was '$WHEEL_RESULT'"
+          exit 1
+
   upload_pypi:
     name: Wheels | Publish to PyPI
-    needs: [build_wheels]
+    needs: [build_wheels, wheels]
     runs-on: ubuntu-latest
     # Publish all tagged versions (stable and dev) to production PyPI
     # Examples: v7.0.0, v7.0.0.dev0, v7.0.0.alpha1, v7.0.0.beta1, v7.0.0.rc1

--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -137,13 +137,14 @@ jobs:
 
   wheels:
     name: Wheels
-    needs: [changes, build_wheels]
+    needs: [changes, wheel_matrix, build_wheels]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check wheel matrix result
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
+          MATRIX_RESULT: ${{ needs.wheel_matrix.result }}
           WHEEL_RESULT: ${{ needs.build_wheels.result }}
           CODE_CHANGED: ${{ needs.changes.outputs.code }}
           EVENT_NAME: ${{ github.event_name }}
@@ -151,6 +152,11 @@ jobs:
         run: |
           if [[ "$CHANGES_RESULT" != "success" ]]; then
             echo "::error::changes job result was '$CHANGES_RESULT'"
+            exit 1
+          fi
+
+          if [[ "$MATRIX_RESULT" != "success" ]]; then
+            echo "::error::wheel_matrix job result was '$MATRIX_RESULT'"
             exit 1
           fi
 

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -227,6 +227,9 @@ Guardrails:
   dispatch.
 - Run the full dartpy wheel matrix when `publish_dartpy.yml` itself changes so
   workflow edits validate both PR and continuous wheel tiers before merge.
+- Require stable aggregate check names for variable CI matrices. For dartpy
+  wheels, branch protection should require `Wheels`; individual wheel legs may
+  change by tier and should not be required directly.
 - `main`, release, release-tag, scheduled, and manual workflows must preserve
   the full coverage that PR tiering skips.
 


### PR DESCRIPTION
## Summary

- Add a stable `Wheels` check to the dartpy publishing workflow.
- Document that variable CI matrices should be protected through aggregate gate checks, not individual matrix legs.

## Motivation / Problem

- Branch protection can wait forever when it requires matrix jobs that a tiered workflow intentionally does not emit.
- The dartpy wheel matrix varies by tier: ordinary PRs run baseline Py312 wheels, while workflow edits, protected branches, releases, schedules, and manual dispatches run the expanded Python matrix.

## Changes / Key Changes

- Add a `Wheels` gate job that succeeds only when the emitted wheel matrix succeeds.
- Allow the gate to pass when wheel builds are intentionally skipped for updates that do not affect wheel-relevant code.
- Make PyPI publishing wait for the wheel gate on tag builds.
- Update CI docs with the branch-protection rule for variable matrices.

## Testing

- `pixi run check-lint-yaml`
- `pixi run lint` with `docs/readthedocs/_generated` temporarily moved out of the lint scan, then restored
- `git diff --check`
- YAML parse check for `.github/workflows/publish_dartpy.yml`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #2660 and #2657.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: N/A, CI-only change
- [x] Add unit tests for new functionality: N/A, workflow policy change
- [x] Document new methods and classes: N/A, no API changes
- [x] Add Python bindings (dartpy) if applicable: N/A, no binding changes
