### PR TITLE
Fix ImGui color picker crash without context (DART 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,7 @@
     CI validation.
     ([#2647](https://github.com/dartsim/dart/pull/2647))
   - Fix SEGV in `ImFontAtlas::AddFontFromMemoryCompressedTTF` when null pointer is passed as compressed font data. ([#2516](https://github.com/dartsim/dart/issues/2516))
+  - Fix `ImGui::ColorPicker3`/`ColorPicker4` crashes when called without an active ImGui context or window. ([#2668](https://github.com/dartsim/dart/issues/2668))
   - Added headless rendering support via `ViewerConfig` and pbuffer graphics context for CI pipelines and batch frame capture. Includes `Viewer::captureBuffer()` for raw RGBA pixel readback and a new `headless-rendering` CI job. ([#2466](https://github.com/dartsim/dart/pull/2466))
   - Added headless and screenshot capture support to `dart::gui::vsg::SimpleViewer`, including buffer readback for offscreen validation.
   - Added `ImGuiViewer` construction from `ViewerConfig` to support headless ImGui rendering and example frame capture workflows.

--- a/cmake/patches/imgui_null_font_guard.cmake
+++ b/cmake/patches/imgui_null_font_guard.cmake
@@ -1,9 +1,11 @@
-# Patch: Add null pointer validation to ImGui font loading functions
+# Patch: Add null pointer validation to ImGui functions
 # Fixes: https://github.com/dartsim/dart/issues/2516
+# Fixes: https://github.com/dartsim/dart/issues/2668
 #
 # ImGui v1.84.2 does not validate input pointers in AddFontFromMemory*
 # functions, causing SEGV when nullptr is passed (e.g., from a failed
-# resource load). This patch adds early-return guards.
+# resource load). It also assumes ColorPicker4 has a current context and window.
+# This patch adds early-return guards.
 #
 # Usage: cmake -DIMGUI_SOURCE_DIR=<path> -P imgui_null_font_guard.cmake
 
@@ -19,59 +21,108 @@ endif()
 
 file(READ "${file}" content)
 
-# Guard: only patch once (idempotent)
-string(FIND "${content}" "DART patch" already_patched)
-if(NOT already_patched EQUAL -1)
-  message(STATUS "imgui_draw.cpp already patched, skipping")
-  return()
-endif()
+set(patches_applied FALSE)
 
-# Patch AddFontFromMemoryTTF
-string(REPLACE
-  "IM_ASSERT(!Locked && \"Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!\");
+# Guard: only patch each issue once (idempotent)
+string(FIND "${content}" "issue #2516" issue2516_patched)
+if(issue2516_patched EQUAL -1)
+  set(before_issue2516 "${content}")
+
+  # Patch AddFontFromMemoryTTF
+  string(REPLACE
+    "IM_ASSERT(!Locked && \"Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!\");
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
     IM_ASSERT(font_cfg.FontData == NULL);
     font_cfg.FontData = ttf_data;"
-  "IM_ASSERT(!Locked && \"Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!\");
+    "IM_ASSERT(!Locked && \"Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!\");
     // [DART patch] Guard against null/empty input (issue #2516)
     if (ttf_data == NULL || ttf_size <= 0)
         return NULL;
     ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
     IM_ASSERT(font_cfg.FontData == NULL);
     font_cfg.FontData = ttf_data;"
-  content "${content}"
-)
+    content "${content}"
+  )
 
-# Patch AddFontFromMemoryCompressedTTF
-string(REPLACE
-  "const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);"
-  "// [DART patch] Guard against null/empty input to prevent SEGV in stb_decompress (issue #2516)
+  # Patch AddFontFromMemoryCompressedTTF
+  string(REPLACE
+    "const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);"
+    "// [DART patch] Guard against null/empty input to prevent SEGV in stb_decompress (issue #2516)
     if (compressed_ttf_data == NULL || compressed_ttf_size <= 0)
         return NULL;
 
     const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);"
-  content "${content}"
-)
+    content "${content}"
+  )
 
-# Patch AddFontFromMemoryCompressedBase85TTF
-string(REPLACE
-  "int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;"
-  "// [DART patch] Guard against null input (issue #2516)
+  # Patch AddFontFromMemoryCompressedBase85TTF
+  string(REPLACE
+    "int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;"
+    "// [DART patch] Guard against null input (issue #2516)
     if (compressed_ttf_data_base85 == NULL)
         return NULL;
     int compressed_ttf_size = (((int)strlen(compressed_ttf_data_base85) + 4) / 5) * 4;"
-  content "${content}"
-)
-
-# Verify all three patches were applied (detect source drift from ImGui updates)
-string(FIND "${content}" "DART patch" _patch_found)
-if(_patch_found EQUAL -1)
-  message(FATAL_ERROR
-    "ImGui null-pointer patch failed: none of the expected patterns were found "
-    "in ${file}. The ImGui source may have changed. Update the patch patterns "
-    "to match the current ImGui version."
+    content "${content}"
   )
+
+  if(content STREQUAL before_issue2516)
+    message(FATAL_ERROR
+      "ImGui null-font patch failed: none of the expected patterns were found "
+      "in ${file}. The ImGui source may have changed. Update the patch patterns "
+      "to match the current ImGui version."
+    )
+  endif()
+
+  set(patches_applied TRUE)
 endif()
 
-file(WRITE "${file}" "${content}")
-message(STATUS "Patched imgui_draw.cpp with null pointer guards (issue #2516)")
+set(widgets_file "${IMGUI_SOURCE_DIR}/imgui_widgets.cpp")
+
+if(NOT EXISTS "${widgets_file}")
+  message(FATAL_ERROR "imgui_widgets.cpp not found at ${widgets_file}")
+endif()
+
+file(READ "${widgets_file}" widgets_content)
+
+string(FIND "${widgets_content}" "issue #2668" issue2668_patched)
+if(issue2668_patched EQUAL -1)
+  set(before_issue2668 "${widgets_content}")
+
+  string(REPLACE
+    "bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col)
+{
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;"
+    "bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col)
+{
+    // [DART patch] Guard against missing context/window before GetCurrentWindow() (issue #2668)
+    if (GImGui == NULL || GImGui->CurrentWindow == NULL)
+        return false;
+
+    ImGuiContext& g = *GImGui;
+    ImGuiWindow* window = GetCurrentWindow();
+    if (window->SkipItems)
+        return false;"
+    widgets_content "${widgets_content}"
+  )
+
+  if(widgets_content STREQUAL before_issue2668)
+    message(FATAL_ERROR
+      "ImGui ColorPicker patch failed: expected pattern not found in "
+      "${widgets_file}. The ImGui source may have changed. Update the patch "
+      "pattern to match the current ImGui version."
+    )
+  endif()
+
+  file(WRITE "${widgets_file}" "${widgets_content}")
+  set(patches_applied TRUE)
+endif()
+
+if(patches_applied)
+  file(WRITE "${file}" "${content}")
+  message(STATUS "Patched ImGui with DART null pointer guards")
+else()
+  message(STATUS "ImGui DART null pointer guards already patched, skipping")
+endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -347,11 +347,16 @@ if(TARGET dart-gui)
   dart_add_test("unit" UNIT_gui_HeightmapShapeNode gui/test_heightmap_shape_node.cpp)
   dart_add_test(
     "unit" UNIT_gui_ImGuiWindowScaling gui/test_im_gui_window_scaling.cpp)
-  # Null font guard test only works with fetched (patched) ImGui, not system ImGui
+  # DART-patched ImGui guard tests only work with fetched ImGui, not system ImGui.
   if(NOT DART_USE_SYSTEM_IMGUI)
     dart_add_test(
       "unit" UNIT_gui_ImGuiNullFontGuard gui/test_imgui_null_font_guard.cpp)
     target_link_libraries(UNIT_gui_ImGuiNullFontGuard dart-gui)
+    dart_add_test(
+      "unit"
+      UNIT_gui_ImGuiColorPickerGuard
+      gui/test_imgui_color_picker_guard.cpp)
+    target_link_libraries(UNIT_gui_ImGuiColorPickerGuard dart-gui)
   endif()
   dart_add_test(
     "unit" UNIT_gui_HeadlessViewer gui/test_headless_viewer.cpp)

--- a/tests/unit/gui/test_imgui_color_picker_guard.cpp
+++ b/tests/unit/gui/test_imgui_color_picker_guard.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/gui/include_im_gui.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+class ScopedImGuiContextRestore
+{
+public:
+  ScopedImGuiContextRestore() : mPreviousContext(ImGui::GetCurrentContext())
+  {
+    // Do nothing
+  }
+
+  ~ScopedImGuiContextRestore()
+  {
+    ImGui::SetCurrentContext(mPreviousContext);
+  }
+
+private:
+  ImGuiContext* mPreviousContext;
+};
+
+} // namespace
+
+TEST(Issue2668, ColorPicker3ReturnsFalseWithoutCurrentContext)
+{
+  ScopedImGuiContextRestore restore;
+  ImGui::SetCurrentContext(nullptr);
+
+  float color[3] = {1.0f, 0.0f, 0.0f};
+
+  EXPECT_FALSE(ImGui::ColorPicker3("Fuzz Color Picker", color, 0));
+  EXPECT_FLOAT_EQ(color[0], 1.0f);
+  EXPECT_FLOAT_EQ(color[1], 0.0f);
+  EXPECT_FLOAT_EQ(color[2], 0.0f);
+}
+
+TEST(Issue2668, ColorPicker3ReturnsFalseWithoutCurrentWindow)
+{
+  ScopedImGuiContextRestore restore;
+  ImGuiContext* context = ImGui::CreateContext();
+  ImGui::SetCurrentContext(context);
+
+  float color[3] = {1.0f, 0.0f, 0.0f};
+
+  EXPECT_FALSE(ImGui::ColorPicker3("Fuzz Color Picker", color, 0));
+  EXPECT_FLOAT_EQ(color[0], 1.0f);
+  EXPECT_FLOAT_EQ(color[1], 0.0f);
+  EXPECT_FLOAT_EQ(color[2], 0.0f);
+
+  ImGui::DestroyContext(context);
+}


### PR DESCRIPTION
## Summary

- Adds a DART patch for fetched ImGui so `ColorPicker3` / `ColorPicker4` return `false` when called without a current ImGui context or window.
- Adds a fetched-ImGui regression test covering the no-current-context and no-current-window cases.
- Updates the changelog for the GUI crash fix.

## Motivation / Problem

- Fixes a null pointer dereference reported in #2668 where `ImGui::ColorPicker3()` can reach `ColorPicker4()` and dereference `GImGui` / `GetCurrentWindow()` before validating UI context state.
- Upstream ImGui `v1.92.8` and upstream `main` still have the same dereference sequence, so upgrading the fetched ImGui version does not remove the need for the DART guard.

## Changes / Key Changes

- Extends `cmake/patches/imgui_null_font_guard.cmake` to patch `imgui_widgets.cpp` in addition to the existing null-font guards.
- Makes the patch idempotent per issue marker so existing #2516 guards and the new #2668 guard can be applied independently.
- Adds `UNIT_gui_ImGuiColorPickerGuard` for fetched-ImGui builds.

## Testing

- `cmake --build build/default/cpp/Release-vendored-imgui-main --target UNIT_gui_ImGuiColorPickerGuard UNIT_gui_ImGuiNullFontGuard --parallel "$JOBS"`
- `ctest --test-dir build/default/cpp/Release-vendored-imgui-main --output-on-failure -R "^UNIT_gui_ImGui(ColorPickerGuard|NullFontGuard)$" -j 1`
- `pixi run lint`

## Breaking Changes

- [x] None
- N/A: this only adds an early-return guard for invalid ImGui context/window state in DART-patched fetched ImGui.

## Related Issues / PRs (backports)

- Fixes #2668
- DART 6.16 backport PR: #2672

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no public API added
- [x] Add Python bindings (dartpy) if applicable: N/A, no Python API changed