### PR TITLE
Fix ImGui color picker crash without context (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * GUI
 
   * Fix SEGV in ImFontAtlas::AddFontFromMemoryCompressedTTF when null pointer is passed as compressed font data: [#2516](https://github.com/dartsim/dart/issues/2516)
+  * Fix `ImGui::ColorPicker3`/`ColorPicker4` crashes when called without an active ImGui context or window: [#2668](https://github.com/dartsim/dart/issues/2668)
 
 * Common
 

--- a/dart/external/imgui/imgui_widgets.cpp
+++ b/dart/external/imgui/imgui_widgets.cpp
@@ -5026,6 +5026,10 @@ static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2
 // FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)
 bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col)
 {
+    // [DART patch] Guard against missing context/window before GetCurrentWindow() (issue #2668)
+    if (GImGui == NULL || GImGui->CurrentWindow == NULL)
+        return false;
+
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -58,4 +58,7 @@ endif()
 if(TARGET dart-external-imgui)
   dart_add_test("regression" test_Issue2516)
   target_link_libraries(test_Issue2516 dart-external-imgui)
+
+  dart_add_test("regression" test_Issue2668)
+  target_link_libraries(test_Issue2668 dart-external-imgui)
 endif()

--- a/tests/regression/test_Issue2668.cpp
+++ b/tests/regression/test_Issue2668.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/external/imgui/imgui.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+class ScopedImGuiContextRestore
+{
+public:
+  ScopedImGuiContextRestore() : mPreviousContext(ImGui::GetCurrentContext())
+  {
+    // Do nothing
+  }
+
+  ~ScopedImGuiContextRestore()
+  {
+    ImGui::SetCurrentContext(mPreviousContext);
+  }
+
+private:
+  ImGuiContext* mPreviousContext;
+};
+
+} // namespace
+
+TEST(Issue2668, ColorPicker3ReturnsFalseWithoutCurrentContext)
+{
+  ScopedImGuiContextRestore restore;
+  ImGui::SetCurrentContext(nullptr);
+
+  float color[3] = {1.0f, 0.0f, 0.0f};
+
+  EXPECT_FALSE(ImGui::ColorPicker3("Fuzz Color Picker", color, 0));
+  EXPECT_FLOAT_EQ(color[0], 1.0f);
+  EXPECT_FLOAT_EQ(color[1], 0.0f);
+  EXPECT_FLOAT_EQ(color[2], 0.0f);
+}
+
+TEST(Issue2668, ColorPicker3ReturnsFalseWithoutCurrentWindow)
+{
+  ScopedImGuiContextRestore restore;
+  ImGuiContext* context = ImGui::CreateContext();
+  ImGui::SetCurrentContext(context);
+
+  float color[3] = {1.0f, 0.0f, 0.0f};
+
+  EXPECT_FALSE(ImGui::ColorPicker3("Fuzz Color Picker", color, 0));
+  EXPECT_FLOAT_EQ(color[0], 1.0f);
+  EXPECT_FLOAT_EQ(color[1], 0.0f);
+  EXPECT_FLOAT_EQ(color[2], 0.0f);
+
+  ImGui::DestroyContext(context);
+}


### PR DESCRIPTION
## Summary

- Adds a vendored ImGui guard so `ColorPicker3` / `ColorPicker4` return `false` when called without a current ImGui context or window.
- Adds a regression test for the no-current-context and no-current-window cases.
- Updates the DART 6.16 changelog for the GUI crash fix.

## Motivation / Problem

- Fixes a null pointer dereference reported in #2668 where `ImGui::ColorPicker3()` can reach `ColorPicker4()` and dereference `GImGui` / `GetCurrentWindow()` before validating UI context state.
- Upstream ImGui `v1.92.8` and upstream `main` still have the same dereference sequence, so upgrading ImGui does not remove the need for the guard.

## Changes / Key Changes

- Adds an early-return guard in vendored `imgui_widgets.cpp` before `ColorPicker4()` uses the ImGui context/window.
- Adds `test_Issue2668` under regression tests, gated on `dart-external-imgui`.

## Testing

- `cmake --build build/default/cpp/Release-vendored-imgui --target test_Issue2668 --parallel "$JOBS"`
- `ctest --test-dir build/default/cpp/Release-vendored-imgui --output-on-failure -R "^test_Issue2668$" -j 1`
- `cmake --build build/default/cpp/Release-vendored-imgui --target test_Issue2516 --parallel "$JOBS"`
- `ctest --test-dir build/default/cpp/Release-vendored-imgui --output-on-failure -R "^test_Issue2516$|^test_Issue2668$" -j 1`
- `pixi run lint`

## Breaking Changes

- [x] None
- N/A: this only adds an early-return guard for invalid ImGui context/window state.

## Related Issues / PRs (backports)

- Fixes #2668
- Main/DART 7 PR: #2670

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no public API added
- [x] Add Python bindings (dartpy) if applicable: N/A, no Python API changed