### PR TITLE
Fix malformed contact constraint crash (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   * Fix SEGV in ImFontAtlas::AddFontFromMemoryCompressedTTF when null pointer is passed as compressed font data: [#2516](https://github.com/dartsim/dart/issues/2516)
 
+* Constraint
+
+  * Ignore malformed contacts with null collision objects instead of dereferencing them while creating `ContactConstraint`: [#2669](https://github.com/dartsim/dart/issues/2669)
+
 * Common
 
   * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -520,14 +520,32 @@ void ConstraintSolver::updateConstraints()
     }
 
     // Set colliding bodies
+    if (contact.collisionObject1 == nullptr
+        || contact.collisionObject2 == nullptr) {
+      dtwarn << "[ConstraintSolver] Ignoring contact with a null collision "
+             << "object.\n";
+      continue;
+    }
+
     auto shapeFrame1 = const_cast<dynamics::ShapeFrame*>(
         contact.collisionObject1->getShapeFrame());
     auto shapeFrame2 = const_cast<dynamics::ShapeFrame*>(
         contact.collisionObject2->getShapeFrame());
+    auto shapeNode1
+        = shapeFrame1 != nullptr ? shapeFrame1->asShapeNode() : nullptr;
+    auto shapeNode2
+        = shapeFrame2 != nullptr ? shapeFrame2->asShapeNode() : nullptr;
+    if (shapeNode1 == nullptr || shapeNode2 == nullptr
+        || shapeNode1->getBodyNodePtr() == nullptr
+        || shapeNode2->getBodyNodePtr() == nullptr) {
+      dtwarn << "[ConstraintSolver] Ignoring contact with a missing "
+             << "ShapeNode or BodyNode.\n";
+      continue;
+    }
 
     DART_SUPPRESS_DEPRECATED_BEGIN
-    shapeFrame1->asShapeNode()->getBodyNodePtr()->setColliding(true);
-    shapeFrame2->asShapeNode()->getBodyNodePtr()->setColliding(true);
+    shapeNode1->getBodyNodePtr()->setColliding(true);
+    shapeNode2->getBodyNodePtr()->setColliding(true);
     DART_SUPPRESS_DEPRECATED_END
 
     // If penetration depth is negative, then the collision isn't really
@@ -559,6 +577,9 @@ void ConstraintSolver::updateConstraints()
 
     auto contactConstraint = mContactSurfaceHandler->createConstraint(
         *contact, numContacts, mTimeStep);
+    if (contactConstraint == nullptr)
+      continue;
+
     mContactConstraints.push_back(contactConstraint);
 
     contactConstraint->update();

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -52,6 +52,29 @@
 namespace dart {
 namespace constraint {
 
+namespace {
+
+//==============================================================================
+dynamics::BodyNode* getContactBodyNode(
+    const collision::CollisionObject* collisionObject)
+{
+  if (collisionObject == nullptr)
+    return nullptr;
+
+  auto* shapeFrame
+      = const_cast<dynamics::ShapeFrame*>(collisionObject->getShapeFrame());
+  if (shapeFrame == nullptr)
+    return nullptr;
+
+  auto* shapeNode = shapeFrame->asShapeNode();
+  if (shapeNode == nullptr)
+    return nullptr;
+
+  return shapeNode->getBodyNodePtr().get();
+}
+
+} // namespace
+
 double ContactConstraint::mErrorAllowance = DART_ERROR_ALLOWANCE;
 double ContactConstraint::mErrorReductionParameter = DART_ERP;
 double ContactConstraint::mMaxErrorReductionVelocity = DART_MAX_ERV;
@@ -75,25 +98,28 @@ ContactConstraint::ContactConstraint(
     const ContactSurfaceParams& contactSurfaceParams)
   : ConstraintBase(),
     mTimeStep(timeStep),
-    mBodyNodeA(const_cast<dynamics::ShapeFrame*>(
-                   contact.collisionObject1->getShapeFrame())
-                   ->asShapeNode()
-                   ->getBodyNodePtr()
-                   .get()),
-    mBodyNodeB(const_cast<dynamics::ShapeFrame*>(
-                   contact.collisionObject2->getShapeFrame())
-                   ->asShapeNode()
-                   ->getBodyNodePtr()
-                   .get()),
+    mBodyNodeA(getContactBodyNode(contact.collisionObject1)),
+    mBodyNodeB(getContactBodyNode(contact.collisionObject2)),
     mContact(contact),
     mFirstFrictionalDirection(DART_DEFAULT_FRICTION_DIR),
+    mPrimaryFrictionCoeff(DART_DEFAULT_FRICTION_COEFF),
+    mSecondaryFrictionCoeff(DART_DEFAULT_FRICTION_COEFF),
     mPrimarySlipCompliance(DART_DEFAULT_SLIP_COMPLIANCE),
     mSecondarySlipCompliance(DART_DEFAULT_SLIP_COMPLIANCE),
+    mRestitutionCoeff(DART_DEFAULT_RESTITUTION_COEFF),
+    mContactSurfaceMotionVelocity(DART_DEFAULT_CONTACT_SURFACE_MOTION_VELOCITY),
+    mIsSelfCollision(false),
     mIsFrictionOn(true),
     mAppliedImpulseIndex(dynamics::INVALID_INDEX),
     mIsBounceOn(false),
     mActive(false)
 {
+  if (!hasValidBodyNodes()) {
+    dtwarn << "[ContactConstraint] Ignoring contact with a null collision "
+           << "object or missing ShapeNode.\n";
+    return;
+  }
+
   DART_ASSERT(
       contact.normal.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED);
 
@@ -343,6 +369,11 @@ const Eigen::Vector3d& ContactConstraint::getFrictionDirection1() const
 //==============================================================================
 void ContactConstraint::update()
 {
+  if (!hasValidBodyNodes()) {
+    mActive = false;
+    return;
+  }
+
   if (mBodyNodeA->isReactive() || mBodyNodeB->isReactive())
     mActive = true;
   else
@@ -352,6 +383,9 @@ void ContactConstraint::update()
 //==============================================================================
 void ContactConstraint::getInformation(ConstraintInfo* info)
 {
+  if (!hasValidBodyNodes())
+    return;
+
   // Fill w, where the LCP form is Ax = b + w (x >= 0, w >= 0, x^T w = 0)
   getRelVelocity(info->b);
 
@@ -471,6 +505,9 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
 //==============================================================================
 void ContactConstraint::applyUnitImpulse(std::size_t index)
 {
+  if (!hasValidBodyNodes())
+    return;
+
   DART_ASSERT(index < mDim && "Invalid Index.");
   // DART_ASSERT(isActive());
   DART_ASSERT(mBodyNodeA->isReactive() || mBodyNodeB->isReactive());
@@ -532,6 +569,9 @@ void ContactConstraint::getVelocityChange(double* vel, bool withCfm)
 {
   DART_ASSERT(vel != nullptr && "Null pointer is not allowed.");
 
+  if (!hasValidBodyNodes())
+    return;
+
   Eigen::Map<Eigen::VectorXd> velMap(vel, static_cast<int>(mDim));
   velMap.setZero();
 
@@ -562,6 +602,9 @@ void ContactConstraint::getVelocityChange(double* vel, bool withCfm)
 //==============================================================================
 void ContactConstraint::excite()
 {
+  if (!hasValidBodyNodes())
+    return;
+
   if (mBodyNodeA->isReactive())
     mBodyNodeA->getSkeleton()->setImpulseApplied(true);
 
@@ -572,6 +615,9 @@ void ContactConstraint::excite()
 //==============================================================================
 void ContactConstraint::unexcite()
 {
+  if (!hasValidBodyNodes())
+    return;
+
   if (mBodyNodeA->isReactive())
     mBodyNodeA->getSkeleton()->setImpulseApplied(false);
 
@@ -582,6 +628,9 @@ void ContactConstraint::unexcite()
 //==============================================================================
 void ContactConstraint::applyImpulse(double* lambda)
 {
+  if (!hasValidBodyNodes())
+    return;
+
   //----------------------------------------------------------------------------
   // Friction case
   //----------------------------------------------------------------------------
@@ -638,6 +687,9 @@ void ContactConstraint::applyImpulse(double* lambda)
 void ContactConstraint::getRelVelocity(double* relVel)
 {
   DART_ASSERT(relVel != nullptr && "Null pointer is not allowed.");
+
+  if (!hasValidBodyNodes())
+    return;
 
   Eigen::Map<Eigen::VectorXd> relVelMap(relVel, static_cast<int>(mDim));
   relVelMap.setZero();
@@ -707,6 +759,9 @@ double ContactConstraint::computeRestitutionCoefficient(
 dynamics::SkeletonPtr ContactConstraint::getRootSkeleton() const
 {
   DART_ASSERT(isActive());
+
+  if (!hasValidBodyNodes())
+    return nullptr;
 
   if (mBodyNodeA->isReactive())
     return ConstraintBase::getRootSkeleton(mBodyNodeA->getSkeleton());
@@ -786,6 +841,9 @@ ContactConstraint::getTangentBasisMatrixODE(const Eigen::Vector3d& n)
 //==============================================================================
 void ContactConstraint::uniteSkeletons()
 {
+  if (!hasValidBodyNodes())
+    return;
+
   if (!mBodyNodeA->isReactive() || !mBodyNodeB->isReactive())
     return;
 
@@ -839,6 +897,12 @@ void ContactConstraint::setSecondarySlipCompliance(double slip)
 const collision::Contact& ContactConstraint::getContact() const
 {
   return mContact;
+}
+
+//==============================================================================
+bool ContactConstraint::hasValidBodyNodes() const
+{
+  return mBodyNodeA != nullptr && mBodyNodeB != nullptr;
 }
 
 } // namespace constraint

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -180,6 +180,9 @@ private:
   void getRelVelocity(double* relVel);
 
   ///
+  bool hasValidBodyNodes() const;
+
+  ///
   void updateFirstFrictionalDirection();
 
   ///

--- a/dart/constraint/ContactSurface.cpp
+++ b/dart/constraint/ContactSurface.cpp
@@ -45,6 +45,25 @@
 namespace dart {
 namespace constraint {
 
+namespace {
+
+//==============================================================================
+dynamics::ShapeNode* getContactShapeNode(
+    const collision::CollisionObject* collisionObject)
+{
+  if (collisionObject == nullptr)
+    return nullptr;
+
+  auto* shapeFrame
+      = const_cast<dynamics::ShapeFrame*>(collisionObject->getShapeFrame());
+  if (shapeFrame == nullptr)
+    return nullptr;
+
+  return shapeFrame->asShapeNode();
+}
+
+} // namespace
+
 //==============================================================================
 ContactSurfaceHandler::ContactSurfaceHandler(ContactSurfaceHandlerPtr parent)
   : mParent(std::move(parent))
@@ -95,12 +114,13 @@ ContactSurfaceParams DefaultContactSurfaceHandler::createParams(
   ContactSurfaceParams params = ContactSurfaceHandler::createParams(
       contact, numContactsOnCollisionObject);
 
-  const auto* shapeNodeA = const_cast<dynamics::ShapeFrame*>(
-                               contact.collisionObject1->getShapeFrame())
-                               ->asShapeNode();
-  const auto* shapeNodeB = const_cast<dynamics::ShapeFrame*>(
-                               contact.collisionObject2->getShapeFrame())
-                               ->asShapeNode();
+  const auto* shapeNodeA = getContactShapeNode(contact.collisionObject1);
+  const auto* shapeNodeB = getContactShapeNode(contact.collisionObject2);
+  if (shapeNodeA == nullptr || shapeNodeB == nullptr) {
+    dtwarn << "[ContactConstraint] Ignoring contact surface parameters for "
+           << "a contact with a null collision object or missing ShapeNode.\n";
+    return params;
+  }
 
   const double restitutionCoeffA = computeRestitutionCoefficient(shapeNodeA);
   const double restitutionCoeffB = computeRestitutionCoefficient(shapeNodeB);
@@ -182,6 +202,9 @@ ContactConstraintPtr DefaultContactSurfaceHandler::createConstraint(
 {
   auto constraint = ContactSurfaceHandler::createConstraint(
       contact, numContactsOnCollisionObject, timeStep);
+
+  if (constraint == nullptr)
+    return nullptr;
 
   constraint->setPrimarySlipCompliance(
       constraint->getPrimarySlipCompliance()

--- a/tests/integration/test_ContactConstraint.cpp
+++ b/tests/integration/test_ContactConstraint.cpp
@@ -101,3 +101,26 @@ TEST(ContactConstraint, ContactWithKinematicJoint)
       std::make_shared<constraint::PgsBoxedLcpSolver>(), 1e-4);
 #endif
 }
+
+//==============================================================================
+TEST(ContactConstraint, MalformedContactWithNullCollisionObjectsIsInactive)
+{
+  collision::Contact contact;
+  contact.collisionObject1 = nullptr;
+  contact.collisionObject2 = nullptr;
+  contact.point = Eigen::Vector3d::Zero();
+  contact.normal = Eigen::Vector3d::UnitZ();
+  contact.force = Eigen::Vector3d::Zero();
+
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  constraint::ContactConstraint constraint(contact, 0.001);
+  DART_SUPPRESS_DEPRECATED_END
+
+  constraint::ConstraintBase& base = constraint;
+  EXPECT_EQ(0u, base.getDimension());
+  EXPECT_FALSE(base.isActive());
+
+  base.update();
+
+  EXPECT_FALSE(base.isActive());
+}

--- a/tests/unit/constraint/test_ContactSurface.cpp
+++ b/tests/unit/constraint/test_ContactSurface.cpp
@@ -119,6 +119,31 @@ CollisionSetup createCollidingBoxes(
 
 } // namespace
 
+TEST(ContactSurface, MalformedContactWithNullCollisionObjectsUsesDefaults)
+{
+  Contact contact;
+  contact.collisionObject1 = nullptr;
+  contact.collisionObject2 = nullptr;
+  contact.point = Eigen::Vector3d::Zero();
+  contact.normal = Eigen::Vector3d::UnitZ();
+  contact.force = Eigen::Vector3d::Zero();
+
+  DefaultContactSurfaceHandler handler;
+  auto params = handler.createParams(contact, 1);
+
+  EXPECT_DOUBLE_EQ(
+      params.mPrimaryFrictionCoeff, constraint::DART_DEFAULT_FRICTION_COEFF);
+  EXPECT_DOUBLE_EQ(
+      params.mSecondaryFrictionCoeff, constraint::DART_DEFAULT_FRICTION_COEFF);
+  EXPECT_DOUBLE_EQ(
+      params.mRestitutionCoeff, constraint::DART_DEFAULT_RESTITUTION_COEFF);
+  EXPECT_DOUBLE_EQ(
+      params.mPrimarySlipCompliance, constraint::DART_DEFAULT_SLIP_COMPLIANCE);
+  EXPECT_DOUBLE_EQ(
+      params.mSecondarySlipCompliance,
+      constraint::DART_DEFAULT_SLIP_COMPLIANCE);
+}
+
 //==============================================================================
 // Friction Coefficient Validation Tests
 //==============================================================================


### PR DESCRIPTION
## Summary

- Backport the malformed contact null-guard fix to `release-6.16`.
- Keep malformed `ContactConstraint`s inactive instead of dereferencing null collision objects.
- Add regression coverage for direct contact constraint construction and contact surface defaults.

## Motivation / Problem

- Fixes #2669 for DART 6.16.
- A user-provided malformed `collision::Contact` with null collision objects can crash constraint construction.

## Changes / Key Changes

- Skip malformed contacts in `ConstraintSolver` before creating contact constraints.
- Make `ContactConstraint` null-safe for missing collision objects, shape nodes, or body nodes.
- Make contact surface parameter creation fall back to default params when shape nodes are unavailable.

## Testing

- `pixi run lint`
- `pixi run sh -lc 'cmake -G Ninja -S . -B build/default/cpp/Release-issue2669-6.16 -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" -DDART_BUILD_DARTPY=OFF -DDART_BUILD_EXAMPLES=OFF -DDART_BUILD_TUTORIALS=OFF -DDART_BUILD_PROFILE=ON -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON -DDART_USE_SYSTEM_GOOGLETEST=ON -DDART_USE_SYSTEM_IMGUI=ON -DDART_USE_SYSTEM_TRACY=ON -DBUILD_TESTING=ON -DDART_VERBOSE=OFF'`
- `pixi run sh -lc 'cmake --build build/default/cpp/Release-issue2669-6.16 --target test_ContactConstraint test_ContactSurface --parallel "$JOBS" && ctest --test-dir build/default/cpp/Release-issue2669-6.16 --output-on-failure -R "^(test_ContactConstraint|test_ContactSurface)$" -j 1'`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2669
- DART 7 PR: #2673

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable: N/A