### PR TITLE
Hide ImGui internal format symbols (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
   * Ignore malformed contacts with null collision objects instead of dereferencing them while creating `ContactConstraint`: [#2669](https://github.com/dartsim/dart/issues/2669)
 
+  * Hide bundled ImGui internal formatting helpers from shared library exports: [#2671](https://github.com/dartsim/dart/issues/2671)
+
 * Common
 
   * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds

--- a/dart/external/imgui/imgui_internal.h
+++ b/dart/external/imgui/imgui_internal.h
@@ -309,6 +309,14 @@ static inline bool      ImIsPowerOfTwo(ImU64 v)         { return v != 0 && (v & 
 static inline int       ImUpperPowerOfTwo(int v)        { v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16; v++; return v; }
 
 // Helpers: String, Formatting
+#ifndef IMGUI_INTERNAL_FORMAT_API
+#if defined(__GNUC__) || defined(__clang__)
+#define IMGUI_INTERNAL_FORMAT_API __attribute__((visibility("hidden")))
+#else
+#define IMGUI_INTERNAL_FORMAT_API IMGUI_API
+#endif
+#endif
+
 IMGUI_API int           ImStricmp(const char* str1, const char* str2);
 IMGUI_API int           ImStrnicmp(const char* str1, const char* str2, size_t count);
 IMGUI_API void          ImStrncpy(char* dst, const char* src, size_t count);
@@ -321,8 +329,8 @@ IMGUI_API const ImWchar*ImStrbolW(const ImWchar* buf_mid_line, const ImWchar* bu
 IMGUI_API const char*   ImStristr(const char* haystack, const char* haystack_end, const char* needle, const char* needle_end);
 IMGUI_API void          ImStrTrimBlanks(char* str);
 IMGUI_API const char*   ImStrSkipBlank(const char* str);
-IMGUI_API int           ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3);
-IMGUI_API int           ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3);
+IMGUI_INTERNAL_FORMAT_API int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3);
+IMGUI_INTERNAL_FORMAT_API int ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3);
 IMGUI_API const char*   ImParseFormatFindStart(const char* format);
 IMGUI_API const char*   ImParseFormatFindEnd(const char* format);
 IMGUI_API const char*   ImParseFormatTrimDecorations(const char* format, char* buf, size_t buf_size);

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -61,4 +61,9 @@ if(TARGET dart-external-imgui)
 
   dart_add_test("regression" test_Issue2668)
   target_link_libraries(test_Issue2668 dart-external-imgui)
+
+  dart_add_test("regression" test_Issue2671)
+  target_link_libraries(test_Issue2671
+    dart-external-imgui
+    ${CMAKE_DL_LIBS})
 endif()

--- a/tests/regression/test_Issue2671.cpp
+++ b/tests/regression/test_Issue2671.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/external/imgui/imgui.h>
+
+#include <gtest/gtest.h>
+
+#if defined(__linux__)
+  #include <dlfcn.h>
+#endif
+
+//==============================================================================
+TEST(Issue2671, BundledImguiPublicApiRemainsAvailable)
+{
+  ASSERT_NE(nullptr, ImGui::GetVersion());
+}
+
+#if defined(__linux__)
+//==============================================================================
+TEST(Issue2671, InternalFormattingHelpersAreNotExported)
+{
+  Dl_info info;
+  ASSERT_NE(0, dladdr(reinterpret_cast<const void*>(&ImGui::GetVersion), &info));
+  ASSERT_NE(nullptr, info.dli_fname);
+
+  void* handle = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+  if (handle == nullptr) {
+    handle = dlopen(info.dli_fname, RTLD_LAZY);
+  }
+
+  ASSERT_NE(nullptr, handle) << dlerror();
+
+  dlerror();
+  EXPECT_EQ(nullptr, dlsym(handle, "_Z14ImFormatStringPcmPKcz"));
+}
+#endif


### PR DESCRIPTION
## Summary

- Hide the bundled ImGui `ImFormatString` and `ImFormatStringV` helpers from the shared-library dynamic symbol table on GCC/Clang builds.
- Add a regression test that verifies public ImGui APIs remain loadable while the internal formatting helper is not exported.
- Update the DART 6.16.8 changelog.

## Motivation / Problem

- Fixes #2671.
- DART's bundled ImGui library currently exposes an internal varargs formatting helper as a dynamic symbol. External callers can bind to that internal helper and trigger undefined behavior with malformed format arguments.
- Checked upstream ImGui `v1.92.8` and current `master`; both still declare `ImFormatString` / `ImFormatStringV` with `IMGUI_API`, so an ImGui version bump alone does not fix this exported-symbol surface.

## Changes / Key Changes

- Add an `IMGUI_INTERNAL_FORMAT_API` visibility macro for the two internal formatting helper declarations in vendored ImGui.
- Keep the change scoped to DART's bundled ImGui source; system ImGui builds are not modified by DART.
- Cover the exported-symbol behavior with a Linux regression test using `dladdr`, `dlopen`, and `dlsym`.

## Testing

- `pixi run sh -lc 'cmake -G Ninja -S . -B build/default/cpp/Release-issue2671-6.16 -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" -DDART_BUILD_DARTPY=OFF -DDART_BUILD_EXAMPLES=OFF -DDART_BUILD_TUTORIALS=OFF -DDART_BUILD_PROFILE=ON -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON -DDART_USE_SYSTEM_GOOGLETEST=ON -DDART_USE_SYSTEM_IMGUI=OFF -DDART_USE_SYSTEM_TRACY=ON -DBUILD_TESTING=ON -DDART_VERBOSE=OFF'`
- `DART_SAFE_JOBS=2 pixi run sh -lc 'cmake --build build/default/cpp/Release-issue2671-6.16 --target test_Issue2671 --parallel "$CMAKE_BUILD_PARALLEL_LEVEL"'`
- `pixi run sh -lc 'ctest --test-dir build/default/cpp/Release-issue2671-6.16 --output-on-failure -R "^test_Issue2671$" -j 1'`
- `nm -D --defined-only build/default/cpp/Release-issue2671-6.16/dart/external/imgui/libdart-external-imgui.so | c++filt | rg 'ImFormatString|GetVersion|AddFontFromMemory'`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2671
- DART 7 PR: #2676

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)