### PR TITLE
Hide ImGui internal format symbols (DART 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   - Developer workflow updates: refactored pixi tasks, tuned pixi parallelism, simplified the devcontainer, and bumped the DART version to 7.0.0. ([#2083](https://github.com/dartsim/dart/pull/2083), [#2208](https://github.com/dartsim/dart/pull/2208), [#2255](https://github.com/dartsim/dart/pull/2255), [#2046](https://github.com/dartsim/dart/pull/2046))
   - Added ASan build mode and example install destination controls. ([#2101](https://github.com/dartsim/dart/pull/2101), [#2100](https://github.com/dartsim/dart/pull/2100))
   - GUI dependency handling updates: switched ImGui to FetchContent, prefer local Vulkan loader, and removed bundled lodepng. ([#2056](https://github.com/dartsim/dart/pull/2056), [#2085](https://github.com/dartsim/dart/pull/2085), [#2051](https://github.com/dartsim/dart/pull/2051))
+  - Hide fetched ImGui internal formatting helpers from shared library exports. ([#2671](https://github.com/dartsim/dart/issues/2671))
   - Pixi tasks and helper scripts now guard optional targets (dartpy, GUI examples) automatically, detect missing generator targets before invoking `cmake --build`, and expose `DART_BUILD_*_OVERRIDE` environment hooks so CI and local workflows can toggle bindings/apps without editing `pixi.toml`.
   - Exported `DynamicJointConstraint` and `JointConstraint` on Windows so constraint unit tests link successfully.
   - Exported soft contact constraints, DART collision helpers, `computeIntersection`, and IK property types on Windows to fix shared-library unit test linking. ([#2462](https://github.com/dartsim/dart/pull/2462))

--- a/cmake/patches/imgui_null_font_guard.cmake
+++ b/cmake/patches/imgui_null_font_guard.cmake
@@ -1,11 +1,16 @@
-# Patch: Add null pointer validation to ImGui functions
+# Patch: Apply DART fixes to fetched ImGui sources
 # Fixes: https://github.com/dartsim/dart/issues/2516
 # Fixes: https://github.com/dartsim/dart/issues/2668
+# Fixes: https://github.com/dartsim/dart/issues/2671
 #
 # ImGui v1.84.2 does not validate input pointers in AddFontFromMemory*
 # functions, causing SEGV when nullptr is passed (e.g., from a failed
 # resource load). It also assumes ColorPicker4 has a current context and window.
 # This patch adds early-return guards.
+#
+# ImGui also declares internal formatting helpers with IMGUI_API, which exports
+# them from DART's fetched shared library. Keep those helpers hidden from the
+# dynamic ABI while preserving ImGui's internal uses.
 #
 # Usage: cmake -DIMGUI_SOURCE_DIR=<path> -P imgui_null_font_guard.cmake
 
@@ -14,9 +19,52 @@ if(NOT DEFINED IMGUI_SOURCE_DIR)
 endif()
 
 set(file "${IMGUI_SOURCE_DIR}/imgui_draw.cpp")
+set(internal_file "${IMGUI_SOURCE_DIR}/imgui_internal.h")
 
 if(NOT EXISTS "${file}")
   message(FATAL_ERROR "imgui_draw.cpp not found at ${file}")
+endif()
+
+if(NOT EXISTS "${internal_file}")
+  message(FATAL_ERROR "imgui_internal.h not found at ${internal_file}")
+endif()
+
+file(READ "${internal_file}" internal_content)
+
+string(FIND "${internal_content}" "IMGUI_INTERNAL_FORMAT_API" internal_already_patched)
+if(internal_already_patched EQUAL -1)
+  string(REPLACE
+    "IMGUI_API int           ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3);"
+    "#ifndef IMGUI_INTERNAL_FORMAT_API
+#if defined(__GNUC__) || defined(__clang__)
+#define IMGUI_INTERNAL_FORMAT_API __attribute__((visibility(\"hidden\")))
+#else
+#define IMGUI_INTERNAL_FORMAT_API IMGUI_API
+#endif
+#endif
+IMGUI_INTERNAL_FORMAT_API int ImFormatString(char* buf, size_t buf_size, const char* fmt, ...) IM_FMTARGS(3);"
+    internal_content "${internal_content}"
+  )
+
+  string(REPLACE
+    "IMGUI_API int           ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3);"
+    "IMGUI_INTERNAL_FORMAT_API int ImFormatStringV(char* buf, size_t buf_size, const char* fmt, va_list args) IM_FMTLIST(3);"
+    internal_content "${internal_content}"
+  )
+
+  string(FIND "${internal_content}" "IMGUI_INTERNAL_FORMAT_API int ImFormatString(" _format_patch_found)
+  if(_format_patch_found EQUAL -1)
+    message(FATAL_ERROR
+      "ImGui internal format symbol patch failed: expected declarations were "
+      "not found in ${internal_file}. The ImGui source may have changed. "
+      "Update the patch patterns to match the current ImGui version."
+    )
+  endif()
+
+  file(WRITE "${internal_file}" "${internal_content}")
+  message(STATUS "Patched imgui_internal.h to hide internal format helpers (issue #2671)")
+else()
+  message(STATUS "imgui_internal.h already patched, skipping")
 endif()
 
 file(READ "${file}" content)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -357,6 +357,11 @@ if(TARGET dart-gui)
       UNIT_gui_ImGuiColorPickerGuard
       gui/test_imgui_color_picker_guard.cpp)
     target_link_libraries(UNIT_gui_ImGuiColorPickerGuard dart-gui)
+    dart_add_test(
+      "unit" UNIT_gui_ImGuiInternalFormatSymbols
+      gui/test_imgui_internal_format_symbols.cpp)
+    target_link_libraries(
+      UNIT_gui_ImGuiInternalFormatSymbols dart-imgui-lib ${CMAKE_DL_LIBS})
   endif()
   dart_add_test(
     "unit" UNIT_gui_HeadlessViewer gui/test_headless_viewer.cpp)

--- a/tests/unit/gui/test_imgui_internal_format_symbols.cpp
+++ b/tests/unit/gui/test_imgui_internal_format_symbols.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/gui/include_im_gui.hpp>
+
+#include <gtest/gtest.h>
+
+#if defined(__linux__)
+  #include <dlfcn.h>
+#endif
+
+//==============================================================================
+TEST(Issue2671, FetchedImguiPublicApiRemainsAvailable)
+{
+  ASSERT_NE(nullptr, ImGui::GetVersion());
+}
+
+#if defined(__linux__)
+//==============================================================================
+TEST(Issue2671, InternalFormattingHelpersAreNotExported)
+{
+  Dl_info info;
+  ASSERT_NE(0, dladdr(reinterpret_cast<const void*>(&ImGui::GetVersion), &info));
+  ASSERT_NE(nullptr, info.dli_fname);
+
+  void* handle = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+  if (handle == nullptr) {
+    handle = dlopen(info.dli_fname, RTLD_LAZY);
+  }
+
+  ASSERT_NE(nullptr, handle) << dlerror();
+
+  dlerror();
+  EXPECT_EQ(nullptr, dlsym(handle, "_Z14ImFormatStringPcmPKcz"));
+}
+#endif


### PR DESCRIPTION
## Summary

- Hide fetched ImGui internal formatting helpers from the shared-library dynamic symbol table.
- Add a Linux regression test that keeps public ImGui APIs available while verifying `ImFormatString` is not exported.
- Update the DART 7 changelog.

## Motivation / Problem

- Fixes #2671.
- The reported reproducer manually binds ImGui's internal C variadic helper `ImFormatString` and passes a type-mismatched `%s` argument. C variadic calls cannot be made runtime type-safe from the callee side, but DART can stop exposing this internal helper from its fetched ImGui shared library.
- Checked upstream ImGui `v1.92.8` and current `master`; both still declare `ImFormatString` / `ImFormatStringV` with `IMGUI_API`, so an ImGui version bump alone does not fix this exported-symbol surface.

## Changes / Key Changes

- Extends the fetched-ImGui CMake patch to mark `ImFormatString` and `ImFormatStringV` hidden on GCC/Clang builds.
- Keeps the existing issue #2516 null-font patch independent and idempotent.
- Adds `UNIT_gui_ImGuiInternalFormatSymbols` for fetched-ImGui builds.

## Testing

- `cmake -G Ninja -S . -B build/default/cpp/Release-issue2671-main ... -DDART_USE_SYSTEM_IMGUI=OFF`
- `cmake --build build/default/cpp/Release-issue2671-main --target UNIT_gui_ImGuiInternalFormatSymbols --parallel 2`
- `ctest --test-dir build/default/cpp/Release-issue2671-main --output-on-failure -R "^UNIT_gui_ImGuiInternalFormatSymbols$" -j 1`
- `nm -D --defined-only build/default/cpp/Release-issue2671-main/lib/libdart-imgui-lib.so | c++filt | rg 'ImFormatString|GetVersion|AddFontFromMemory'`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2671
- DART 6.16 backport: #2675

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)