### PR TITLE
Guard XML attribute helpers against null elements (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
   * Ignore malformed contacts with null collision objects instead of dereferencing them while creating `ContactConstraint`: [#2669](https://github.com/dartsim/dart/issues/2669)
 
+* Parsers
+
+  * Return safe defaults from XML attribute helpers when callers pass a null element: [#2678](https://github.com/dartsim/dart/issues/2678)
+
 * Common
 
   * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds

--- a/dart/utils/XmlHelpers.cpp
+++ b/dart/utils/XmlHelpers.cpp
@@ -46,6 +46,25 @@
 namespace dart {
 namespace utils {
 
+namespace {
+
+bool warnIfNullAttributeElement(
+    const tinyxml2::XMLElement* element,
+    const std::string& attributeName,
+    const char* typeName,
+    const char* fallback)
+{
+  if (element != nullptr)
+    return false;
+
+  dtwarn << "[getAttribute] Error in parsing " << typeName
+         << " type attribute [" << attributeName
+         << "] of a null element. Returning " << fallback << ".\n";
+  return true;
+}
+
+} // namespace
+
 //==============================================================================
 std::string toString(bool v)
 {
@@ -695,6 +714,9 @@ bool readXmlFile(
 //==============================================================================
 bool hasAttribute(const tinyxml2::XMLElement* element, const char* const name)
 {
+  if (element == nullptr || name == nullptr)
+    return false;
+
   const char* const result = element->Attribute(name);
   return result != nullptr;
 }
@@ -716,6 +738,10 @@ void getAttribute(
 std::string getAttributeString(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "string", "empty string"))
+    return std::string();
+
   const char* const result = element->Attribute(attributeName.c_str());
 
   if (nullptr == result) {
@@ -732,6 +758,9 @@ std::string getAttributeString(
 bool getAttributeBool(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(element, attributeName, "bool", "false"))
+    return false;
+
   bool val = false;
   const int result = element->QueryBoolAttribute(attributeName.c_str(), &val);
 
@@ -749,6 +778,9 @@ bool getAttributeBool(
 int getAttributeInt(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(element, attributeName, "int", "zero"))
+    return 0;
+
   int val = 0;
   const int result = element->QueryIntAttribute(attributeName.c_str(), &val);
 
@@ -766,6 +798,10 @@ int getAttributeInt(
 unsigned int getAttributeUInt(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "unsigned int", "zero"))
+    return 0u;
+
   unsigned int val = 0u;
   const int result
       = element->QueryUnsignedAttribute(attributeName.c_str(), &val);
@@ -784,6 +820,9 @@ unsigned int getAttributeUInt(
 float getAttributeFloat(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(element, attributeName, "float", "zero"))
+    return 0.0f;
+
   float val = 0.0f;
   const int result = element->QueryFloatAttribute(attributeName.c_str(), &val);
 
@@ -801,6 +840,9 @@ float getAttributeFloat(
 double getAttributeDouble(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(element, attributeName, "double", "zero"))
+    return 0.0;
+
   double val = 0.0;
   const int result = element->QueryDoubleAttribute(attributeName.c_str(), &val);
 
@@ -827,6 +869,10 @@ char getAttributeChar(
 Eigen::Vector2i getAttributeVector2i(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "Eigen::Vector2i", "zero vector"))
+    return Eigen::Vector2i::Zero();
+
   const std::string val = getAttributeString(element, attributeName);
 
   return toVector2i(val);
@@ -836,6 +882,10 @@ Eigen::Vector2i getAttributeVector2i(
 Eigen::Vector2d getAttributeVector2d(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "Eigen::Vector2d", "zero vector"))
+    return Eigen::Vector2d::Zero();
+
   const std::string val = getAttributeString(element, attributeName);
 
   return toVector2d(val);
@@ -845,6 +895,10 @@ Eigen::Vector2d getAttributeVector2d(
 Eigen::Vector3d getAttributeVector3d(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "Eigen::Vector3d", "zero vector"))
+    return Eigen::Vector3d::Zero();
+
   const std::string val = getAttributeString(element, attributeName);
 
   return toVector3d(val);
@@ -854,6 +908,10 @@ Eigen::Vector3d getAttributeVector3d(
 Eigen::Vector4d getAttributeVector4d(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "Eigen::Vector4d", "zero vector"))
+    return Eigen::Vector4d::Zero();
+
   const std::string val = getAttributeString(element, attributeName);
 
   return toVector4d(val);
@@ -863,6 +921,10 @@ Eigen::Vector4d getAttributeVector4d(
 Eigen::Vector6d getAttributeVector6d(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "Eigen::Vector6d", "zero vector"))
+    return Eigen::Vector6d::Zero();
+
   const std::string val = getAttributeString(element, attributeName);
 
   return toVector6d(val);
@@ -872,6 +934,10 @@ Eigen::Vector6d getAttributeVector6d(
 Eigen::VectorXd getAttributeVectorXd(
     const tinyxml2::XMLElement* element, const std::string& attributeName)
 {
+  if (warnIfNullAttributeElement(
+          element, attributeName, "Eigen::VectorXd", "empty vector"))
+    return Eigen::VectorXd();
+
   const std::string val = getAttributeString(element, attributeName);
 
   return toVectorXd(val);

--- a/tests/unit/utils/test_XmlHelpers.cpp
+++ b/tests/unit/utils/test_XmlHelpers.cpp
@@ -235,6 +235,30 @@ TEST(XmlHelpers, GetValueStringWithMissingChildThrows)
   EXPECT_THROW(getValueString(root, "missing"), std::runtime_error);
 }
 
+TEST(XmlHelpers, GetAttributeHelpersWithNullElementReturnDefaults)
+{
+  const tinyxml2::XMLElement* element = nullptr;
+
+  EXPECT_FALSE(hasAttribute(element, "position"));
+  EXPECT_EQ(getAttributeString(element, "position"), "");
+  EXPECT_FALSE(getAttributeBool(element, "flag"));
+  EXPECT_EQ(getAttributeInt(element, "count"), 0);
+  EXPECT_EQ(getAttributeUInt(element, "count"), 0u);
+  EXPECT_FLOAT_EQ(getAttributeFloat(element, "value"), 0.0f);
+  EXPECT_DOUBLE_EQ(getAttributeDouble(element, "value"), 0.0);
+  EXPECT_EQ(getAttributeChar(element, "letter"), '\0');
+  EXPECT_EQ(getAttributeVector2i(element, "position"), Eigen::Vector2i::Zero());
+  EXPECT_TRUE(getAttributeVector2d(element, "position")
+                  .isApprox(Eigen::Vector2d::Zero()));
+  EXPECT_TRUE(getAttributeVector3d(element, "position")
+                  .isApprox(Eigen::Vector3d::Zero()));
+  EXPECT_TRUE(getAttributeVector4d(element, "position")
+                  .isApprox(Eigen::Vector4d::Zero()));
+  EXPECT_TRUE(getAttributeVector6d(element, "position")
+                  .isApprox(Eigen::Vector6d::Zero()));
+  EXPECT_EQ(getAttributeVectorXd(element, "position").size(), 0);
+}
+
 TEST(XmlHelpers, GetValueIntWithMissingChildThrows)
 {
   tinyxml2::XMLDocument doc;


### PR DESCRIPTION
## Summary

- Return safe defaults from XML attribute helpers when callers pass a null `tinyxml2::XMLElement`.
- Cover the reported `getAttributeVector2d(nullptr, ...)` path and related typed attribute helpers.
- Update the DART 6.16.8 changelog.

## Motivation / Problem

- Fixes #2678.
- `getAttributeVector2d()` calls through `getAttributeString()`, which dereferenced `element` before checking whether the caller supplied a valid XML element.
- A failed XML node lookup could therefore turn a malformed asset into a process crash instead of a managed default path.

## Changes / Key Changes

- Add null-element guards to `hasAttribute()` and typed XML attribute helpers.
- Return existing fallback values for null elements: empty string, false, zero scalar, zero fixed-size vector, or empty dynamic vector.
- Add unit coverage for null-element attribute helpers.

## Testing

- `DART_SAFE_JOBS=2 pixi run sh -lc 'cmake -G Ninja -S . -B build/default/cpp/Release-issue2678-6.16 -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" -DDART_BUILD_DARTPY=OFF -DDART_BUILD_GUI=OFF -DDART_BUILD_EXAMPLES=OFF -DDART_BUILD_TUTORIALS=OFF -DDART_BUILD_TESTS=ON -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON -DDART_USE_SYSTEM_GOOGLETEST=ON -DDART_USE_SYSTEM_TRACY=ON -DDART_VERBOSE=OFF'`
- `DART_SAFE_JOBS=2 pixi run sh -lc 'export CMAKE_BUILD_PARALLEL_LEVEL=${DART_SAFE_JOBS:-2}; cmake --build build/default/cpp/Release-issue2678-6.16 --target UNIT_utils_XmlHelpers --parallel "$CMAKE_BUILD_PARALLEL_LEVEL"'`
- `pixi run sh -lc 'ctest --test-dir build/default/cpp/Release-issue2678-6.16 --output-on-failure -R "^UNIT_utils_XmlHelpers$" -j 1'`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2678
- DART 7 PR: #2680

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)