### PR TITLE
Guard C3D save dimensions (DART 6.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
   * Hide bundled ImGui internal formatting helpers from shared library exports: [#2671](https://github.com/dartsim/dart/issues/2671)
 
+* Utils
+
+  * Reject mismatched C3D frame or marker counts in `saveC3DFile()` instead of indexing past point data: [#2681](https://github.com/dartsim/dart/issues/2681)
+
 * Common
 
   * Fix iterator invalidation in Subject/Observer notification loops that caused non-deterministic SEGFAULT on macOS arm64 Debug builds

--- a/dart/utils/C3D.cpp
+++ b/dart/utils/C3D.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/C3D.hpp"
 
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 
@@ -193,6 +194,17 @@ bool saveC3DFile(
   c3d_head hdr;
   c3d_param parm;
   c3d_frame frame;
+
+  if (_nFrame < 0 || _nMarker < 0)
+    return false;
+
+  if (static_cast<std::size_t>(_nFrame) > _pointData.size())
+    return false;
+
+  for (int i = 0; i < _nFrame; ++i) {
+    if (static_cast<std::size_t>(_nMarker) > _pointData[i].size())
+      return false;
+  }
 
   if ((file = fopen(_fileName, "wb")) == nullptr)
     return false;

--- a/tests/unit/utils/test_C3D.cpp
+++ b/tests/unit/utils/test_C3D.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/utils/C3D.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace dart::utils;
+
+TEST(C3D, SaveRejectsFrameCountLargerThanData)
+{
+  std::vector<std::vector<Eigen::Vector3d>> data{
+      {Eigen::Vector3d(1.0, 2.0, 3.0)}};
+
+  EXPECT_FALSE(saveC3DFile("invalid_frame_count.c3d", data, 10000, 1, 120.0));
+}
+
+TEST(C3D, SaveRejectsMarkerCountLargerThanData)
+{
+  std::vector<std::vector<Eigen::Vector3d>> data{
+      {Eigen::Vector3d(1.0, 2.0, 3.0)}};
+
+  EXPECT_FALSE(saveC3DFile("invalid_marker_count.c3d", data, 1, 2, 120.0));
+}
+
+TEST(C3D, SaveRejectsNegativeDimensions)
+{
+  std::vector<std::vector<Eigen::Vector3d>> data{
+      {Eigen::Vector3d(1.0, 2.0, 3.0)}};
+
+  EXPECT_FALSE(saveC3DFile("negative_frame_count.c3d", data, -1, 1, 120.0));
+  EXPECT_FALSE(saveC3DFile("negative_marker_count.c3d", data, 1, -1, 120.0));
+}


### PR DESCRIPTION
## Summary

- Reject invalid C3D save frame or marker counts before writing output.
- Add unit coverage for oversized frame counts, oversized marker counts, and negative dimensions.
- Update the DART 6.16.8 changelog.

## Motivation / Problem

- Fixes #2681.
- `saveC3DFile()` used `_nFrame` and `_nMarker` as loop bounds without checking them against `_pointData`, so mismatched caller-provided dimensions could index beyond the available point data and crash.

## Changes / Key Changes

- Return `false` from `saveC3DFile()` when frame or marker counts are negative or exceed the supplied data dimensions.
- Add `UNIT_utils_C3D` regression tests for malformed dimensions.
- Add a changelog entry under Utils.

## Testing

- `DART_SAFE_JOBS=2 pixi run sh -lc 'cmake -G Ninja -S . -B build/default/cpp/Release-issue2681-6.16 -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" -DDART_BUILD_DARTPY=OFF -DDART_BUILD_GUI=OFF -DDART_BUILD_EXAMPLES=OFF -DDART_BUILD_TUTORIALS=OFF -DDART_BUILD_TESTS=ON -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON -DDART_USE_SYSTEM_GOOGLETEST=ON -DDART_USE_SYSTEM_TRACY=ON -DDART_VERBOSE=OFF'`
- `DART_SAFE_JOBS=2 pixi run sh -lc 'export CMAKE_BUILD_PARALLEL_LEVEL=${DART_SAFE_JOBS:-2}; cmake --build build/default/cpp/Release-issue2681-6.16 --target UNIT_utils_C3D --parallel "$CMAKE_BUILD_PARALLEL_LEVEL"'`
- `pixi run sh -lc 'ctest --test-dir build/default/cpp/Release-issue2681-6.16 --output-on-failure -R "^UNIT_utils_C3D$" -j 1'`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #2681
- DART 7 PR: N/A (`dart/utils/C3D.*` is not present on `main`)

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)