### PR TITLE
Filter generated dependency CodeQL alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -115,15 +115,22 @@ jobs:
           for sarif in "${sarif_files[@]}"; do
             tmp="${sarif}.tmp"
             jq '
-              (.runs[]?.results) |= map(
+              def primary_uri:
+                .locations[0].physicalLocation.artifactLocation.uri // "";
+
+              def generated_or_dependency_path:
+                gsub("\\\\"; "/")
+                | (
+                  test("(^|/)(\\.pixi|build|dist|\\.cache)(/|$)")
+                  or test("(^|/)(third-party|external)(/|$)")
+                );
+
+              (.runs[]?.results) |= ((. // []) | map(
                 select(
-                  (
-                    .locations[0].physicalLocation.artifactLocation.uri // ""
-                    | startswith(".pixi/")
-                  )
+                  (primary_uri | generated_or_dependency_path)
                   | not
                 )
-              )
+              ))
             ' "$sarif" > "$tmp"
             mv "$tmp" "$sarif"
           done
@@ -132,3 +139,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: sarif-results
+          wait-for-processing: "true"


### PR DESCRIPTION
## Summary

- Filter generated and dependency CodeQL SARIF results before uploading them to code scanning.

## Motivation / Problem

- The current open code-scanning alerts are generated dependency findings under `build/default/cpp/Release/_deps/vsgimgui-src`, not first-party DART source.
- The existing CodeQL config ignores generated and dependency paths, but C++ manual-build SARIF can still include dependency findings discovered through the build.

## Changes / Key Changes

- Keep CodeQL analyze's existing `failure-only` upload behavior for failed-run diagnostics.
- Normalize SARIF artifact paths to `/` separators before filtering.
- Drop SARIF results from generated output directory segments: `.pixi`, `build`, `dist`, `.cache`.
- Drop SARIF results from vendored dependency directories named `third-party` or `external`.
- Upload only filtered SARIF results and wait for GitHub processing.

## Testing

- `pixi run lint`
- `pixi run check-lint-yaml`
- `git diff --check origin/main..HEAD`
- Parsed workflow with PyYAML and asserted CodeQL analyze/upload/filter inputs.
- Extracted filter step and passed `bash -n`.
- Executed filter loop under `bash` against temporary `cpp.sarif` and `python.sarif`.
- Synthetic SARIF tests: removed live generated paths plus relative/absolute/Windows generated paths, `.cache`, `third-party`, handled empty/null/missing `results`, preserved first-party/no-location findings, and preserved SARIF metadata/automation identity.
- Live coverage check: current open alerts are 8, all 8 match the local filter.
- Instance-level coverage check: alerts 133-140 have 16 open instances across `main` and stale PR #2652; all 16 match the local filter.
- Release-branch check: `refs/heads/release-6.16` has 0 open code-scanning alerts.

## Breaking Changes

- [x] None
- Workflow-only change; no runtime/API/ABI/source compatibility impact.

## Related Issues / PRs (backports)

- Code-scanning alerts 133-140.
- Backport: None. Open alerts are on `refs/heads/main`; no open release-branch code-scanning alerts were found.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: N/A, workflow-only security tooling change.
- [x] Add unit tests for new functionality: N/A, workflow-only change validated with SARIF filter checks.
- [x] Document new methods and classes: N/A, no public API changes.
- [x] Add Python bindings (dartpy) if applicable: N/A, no Python API changes.
