### PR TITLE
Fix performance dashboard: configure build before benchmarks

### DIFF
--- a/.github/workflows/performance_dashboard.yml
+++ b/.github/workflows/performance_dashboard.yml
@@ -60,10 +60,24 @@ jobs:
       - name: Configure environment for compiler cache
         uses: ./.github/actions/configure-compiler-cache
 
+      # Configure the CMake build (no GUI/examples/tutorials/dartpy) so the
+      # benchmark targets can be built. run_cpp_benchmark.py builds each target
+      # but requires the build directory to already be configured.
+      - name: Configure build
+        env:
+          DART_BUILD_GUI_OVERRIDE: "OFF"
+          DART_BUILD_EXAMPLES_OVERRIDE: "OFF"
+          DART_BUILD_TUTORIALS_OVERRIDE: "OFF"
+          DART_BUILD_DARTPY_OVERRIDE: "OFF"
+        run: |
+          pixi run --locked -e collision-reference config
+
       - name: Run benchmark surfaces
+        # Tolerate a flaky surface: publish whatever produced results. The merge
+        # step below fails only if no benchmark rows were produced at all.
         run: |
           pixi run --locked -e collision-reference \
-            python scripts/run_performance_dashboard_benchmarks.py --continue-on-error
+            python scripts/run_performance_dashboard_benchmarks.py --continue-on-error || true
 
       - name: Merge benchmark results
         run: |


### PR DESCRIPTION
## Summary

The first `main` run of the **Performance Dashboard** workflow
([run 26335979540](https://github.com/dartsim/dart/actions/runs/26335979540))
failed at the *Run benchmark surfaces* step: every surface errored with
`Build directory build/collision-reference/cpp/Release does not exist`.

The workflow invoked `run_performance_dashboard_benchmarks.py` directly, which
builds each benchmark target but requires the CMake build directory to already
be **configured**. Nothing configured it first, so no targets could build.

## Fix

- Add a **Configure build** step before the benchmarks
  (`DART_BUILD_GUI/EXAMPLES/TUTORIALS/DARTPY_OVERRIDE=OFF`) so the build tree
  exists without pulling in Filament/GUI deps the benchmarks don't need.
- Let a single flaky surface not fail the whole publish (`|| true`); the merge
  step still fails if *no* benchmark rows are produced.

## Testing

- Verified locally that the experimental-World (`bm_compute_graph`) and robot
  (`dynamics_cache_io`) targets build and run from a configured tree with GUI
  off, producing valid Google Benchmark JSON.
- The dashboard workflow only runs on `main`/dispatch, so it can't run on this
  PR; after merge I'll trigger it via `workflow_dispatch` to confirm the publish.

## Test plan

- [ ] After merge, dispatch the workflow and confirm it publishes to
      `gh-pages/performance/`.
- [ ] Confirm `dartsim.github.io/dart/performance/` renders.