### PR TITLE
Clarify primary documentation site

### DIFF
--- a/docs/onboarding/api-documentation.md
+++ b/docs/onboarding/api-documentation.md
@@ -140,9 +140,13 @@ pixi run api-docs-build    # Convenience task that runs both builders
 
 ### GitHub Pages
 
-The GitHub Pages workflow and the `gh-pages` branch are no longer part of the
-documentation pipeline. Historical builds remain available at their existing
-URLs, but new changes are exclusively published via Read the Docs.
+GitHub Pages is no longer part of the primary documentation pipeline.
+Historical C++ API builds remain available at their existing
+`https://dartsim.github.io/dart/v6.*` URLs, and the performance dashboard is
+published from the `gh-pages` branch at
+`https://dartsim.github.io/dart/performance/`. User-facing documentation
+changes should still go to Read the Docs unless they specifically maintain one
+of those GitHub Pages surfaces.
 
 ## Troubleshooting
 

--- a/docs/readthedocs/community/performance_dashboard.rst
+++ b/docs/readthedocs/community/performance_dashboard.rst
@@ -19,9 +19,9 @@ workflow runs DART's benchmark suites and hands the Google Benchmark JSON to
 the history on the ``gh-pages`` branch and renders an interactive Chart.js page.
 There is no external account, API token, or third-party service to maintain.
 
-The dashboard URL returns ``404`` until the first ``main`` push, scheduled, or
-manually dispatched run of the **Performance Dashboard** workflow has published
-to ``gh-pages``.
+The dashboard URL returns ``404`` until a ``main`` push, scheduled, or manually
+dispatched run of the **Performance Dashboard** workflow has published to
+``gh-pages`` and GitHub Pages has finished building the branch.
 
 How it works
 ------------

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
     structures and algorithms for kinematic and dynamic applications in robotics
     and computer animation.
   </description>
-  <url type="website">http://dartsim.github.io/</url>
+  <url type="website">https://dart.readthedocs.io/</url>
   <url type="repository">https://github.com/dartsim/dart</url>
   <url type="bugtracker">https://github.com/dartsim/dart/issues</url>
   <maintainer email="grey@openrobotics.org">Michael X. Grey</maintainer>


### PR DESCRIPTION
## Summary

- Point DART package metadata at the maintained Read the Docs site.
- Clarify that GitHub Pages is no longer the primary docs pipeline, but still hosts historical C++ API docs and the performance dashboard.
- Clarify the performance dashboard can return `404` until the GitHub Pages build finishes.

<!-- Describe this pull request. Link to relevant GitHub issues, if any. -->

## Motivation / Problem

- Discussion #1927 identified user confusion between the legacy `dartsim.github.io` site and the maintained Read the Docs site.
- PR #2696 also made `dartsim.github.io/dart/performance/` an active GitHub Pages surface, so the docs should not imply GitHub Pages can simply be removed.

<!-- Why is this change needed? What problem does it solve? -->

## Changes / Key Changes

- Update `package.xml` website URL to `https://dart.readthedocs.io/`.
- Update `docs/onboarding/api-documentation.md` to distinguish primary RTD docs from the retained GitHub Pages surfaces.
- Update `docs/readthedocs/community/performance_dashboard.rst` to mention the GitHub Pages build delay.

<!-- High-level list of key changes. -->

## Testing

- `pixi run lint`
- `git diff --check`
- `python - <<'PY' ... ET.parse('package.xml') ... PY`

## Breaking Changes

- [x] None
- Documentation/metadata-only change; no API or behavior changes.

<!-- If breaking changes exist, describe impact and migration steps. -->

## Related Issues / PRs (backports)

- Relates to https://github.com/dartsim/dart/discussions/1927
- Relates to https://github.com/dartsim/dart/pull/2696
- Companion website PR: https://github.com/dartsim/dartsim.github.io/pull/29
- Backports: N/A, targets `main` docs/metadata only.

<!-- List issue links and any related/backport PRs. -->

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: N/A, docs/metadata-only change
- [x] Add unit tests for new functionality: N/A, no code behavior change
- [x] Document new methods and classes: N/A, no new API
- [x] Add Python bindings (dartpy) if applicable: N/A
