### PR TITLE
Embed live performance dashboard in the RTD page

### DIFF
--- a/docs/readthedocs/community/performance_dashboard.rst
+++ b/docs/readthedocs/community/performance_dashboard.rst
@@ -7,6 +7,16 @@ results over time:
 * Dashboard:
   `https://dartsim.github.io/dart/performance/ <https://dartsim.github.io/dart/performance/>`_
 
+The live dashboard is embedded below. If it does not load (for example before
+the first publication), open it directly with the link above.
+
+.. raw:: html
+
+   <iframe src="https://dartsim.github.io/dart/performance/"
+           title="DART performance dashboard"
+           width="100%" height="720" loading="lazy"
+           style="border: 1px solid #d0d7de; border-radius: 6px;"></iframe>
+
 It leads with end-to-end world-step cases — stepping the experimental World
 (sequential vs the parallel compute executor) and real robot models such as
 Atlas — alongside focused lower-level kernels, so the headline numbers reflect


### PR DESCRIPTION
## Summary

The Read the Docs *Performance Dashboard* page
(`docs/readthedocs/community/performance_dashboard.rst`) previously only linked
to the hosted dashboard. Embed the live dashboard inline via an `iframe` so the
charts render directly within the docs page, with the direct link kept as a
fallback.

The hosted dashboard is now live at https://dartsim.github.io/dart/performance/
and serves with no `X-Frame-Options`/CSP restriction, so it can be framed.

## Testing

- `pixi run lint-rst` and `pixi run lint-spell` pass.
- Verified the live page renders the real benchmark data and that github.io
  serves it without frame-blocking headers.
- The RTD docs build in CI exercises the page render.

## Test plan

- [ ] After merge, confirm the dashboard renders inline on
      `dart.readthedocs.io/en/latest/community/performance_dashboard.html`.