### PR TITLE
Dashboard follow-up docs: CI gotchas + mark PLAN-080 complete

### DIFF
--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -63,6 +63,16 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
     SARIF filtering before upload; CodeQL config `paths-ignore` is not enough.
     Confirm Code Scanning has processed the relevant C++ analysis for the target
     commit before treating the open-alert count as final.
+  - Benchmark runners (`scripts/run_cpp_benchmark.py`,
+    `scripts/run_performance_dashboard_benchmarks.py`) build a target but do not
+    configure the tree. Run `pixi run config` (or a pixi task with
+    `depends-on = ["config"]`) first; on a fresh checkout or CI runner they
+    otherwise fail with `Build directory build/<env>/cpp/<type> does not exist`.
+  - Publishing to `gh-pages` triggers a full legacy Jekyll rebuild over the
+    versioned Doxygen docs, so newly pushed content (such as the performance
+    dashboard at `/performance/`) can take several minutes to appear and 404s
+    during the build. A root `.nojekyll` file makes Pages serve statically
+    (faster, and avoids Jekyll dropping underscore-prefixed Doxygen files).
 
 ## Common CI Failure Modes
 

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -131,17 +131,16 @@ its own line so status updates remain git-history friendly.
 
 - Owner doc:
   [`../readthedocs/community/performance_dashboard.rst`](../readthedocs/community/performance_dashboard.rst)
-- Status: Active
-- Horizon: Now
+- Status: Complete
+- Horizon: Later
 - Dimension: Scalable compute
-- Next step: Merge the `Performance Dashboard` workflow
-  (`benchmark-action/github-action-benchmark`), enable GitHub Pages from the
-  `gh-pages` branch, and let the first `main` run publish to
-  `dartsim.github.io/dart/performance/`.
+- Next step: Live at `dartsim.github.io/dart/performance/` via
+  `benchmark-action/github-action-benchmark` and embedded in the Read the Docs
+  page. Optional future work: per-PR regression comments and a secondary backend
+  (Bencher/CodSpeed).
 - Gate: `pixi run bm-dashboard-preview` renders the dashboard locally from real
-  Google Benchmark JSON; after publication the hosted page shows per-benchmark
-  history. Per-PR regression comments and an optional secondary backend
-  (Bencher/CodSpeed) are deferred future work, not launch blockers.
+  Google Benchmark JSON; each `main` publish updates the hosted per-benchmark
+  history.
 
 ### PLAN-040: DART 7 Release Hardening
 


### PR DESCRIPTION
## Summary

Documentation follow-ups after the performance dashboard shipped (#2693, #2696,
#2703) and went live at https://dartsim.github.io/dart/performance/.

- **`docs/onboarding/ci-cd.md`** — capture two durable CI gotchas surfaced while
  shipping the dashboard:
  - Benchmark runners (`run_cpp_benchmark.py`,
    `run_performance_dashboard_benchmarks.py`) require a configured build first
    (`pixi run config` / a task with `depends-on = ["config"]`); otherwise they
    fail with `Build directory … does not exist` (root cause of #2696).
  - Pushing to `gh-pages` triggers a slow full Jekyll rebuild over the versioned
    Doxygen docs, so new content takes minutes to appear; `.nojekyll` would serve
    statically (see caveat below).
- **`docs/plans/dashboard.md`** — mark PLAN-080 **Complete**, pointing at the
  Read the Docs owner doc.

## Testing

- `pixi run check-docs-policy`, `pixi run lint-md`, `pixi run lint-spell` pass.

## Note

`.nojekyll` is documented as a *possible* mitigation, not applied here: the
`gh-pages` root landing page is Jekyll-rendered from `index.md` (no static
`index.html`), so a bare `.nojekyll` would 404 the root. Applying it safely needs
a static root page too — left as a separate decision.

## Test plan

- [ ] Docs render on Read the Docs after merge.