### PR TITLE
Renderer docs: software-render gotcha and interpolation caveat

### DIFF
--- a/docs/design/renderer_realtime_and_scalability.md
+++ b/docs/design/renderer_realtime_and_scalability.md
@@ -46,9 +46,15 @@ for smoothness; robotics stacks also surface a real-time factor.
 ### Recommendation (follow-up)
 
 1. **State interpolation** — keep previous/current poses and render the blend by
-   `alpha = accumulator/dt`. This is the single biggest fix for perceived
-   lag/stutter at a fixed sim rate. Requires exposing the leftover accumulator
-   and a prev-pose snapshot to the extraction/render path.
+   `alpha = accumulator/dt`. This is the canonical fix for perceived lag/stutter
+   at a fixed sim rate. Caveat for DART: the gain is large only when few sim
+   steps run per rendered frame (large sim `dt` relative to frame time). At
+   DART's typical small timestep (e.g. 1000 Hz → ~16 steps per 60 FPS frame) the
+   leftover-accumulator blend is sub-millisecond, so the visual benefit is
+   minimal; and interpolation does **not** help a GPU-bound viewer (where the
+   limit is render throughput, not sim/render mismatch). Prioritize this only
+   when profiling shows few sim steps per rendered frame. Requires exposing the
+   leftover accumulator and a prev-pose snapshot to the extraction/render path.
 2. **Render/sim decoupling** — optionally move `world->step()` to a background
    thread with a double-buffered state the render thread interpolates, so a slow
    render never blocks physics (MuJoCo/Bullet/Unreal model).

--- a/docs/onboarding/gui-rendering.md
+++ b/docs/onboarding/gui-rendering.md
@@ -86,7 +86,11 @@ higher-fidelity offline rendering later. Three pieces support that:
   with smoothed CPU per-phase timings, GPU frame time from Filament frame-info,
   FPS, a real-time-factor (sim-vs-wall) readout that shows whether playback is
   keeping up, and fixed-scale history plots against the 60 FPS budget — see
-  `dart/gui/detail/perf_hud.cpp`.
+  `dart/gui/detail/perf_hud.cpp`. Interpreting the readout: a very high GPU
+  frame time (far over the 60 FPS budget) while CPU time is low usually means
+  the GPU driver is not active and OpenGL/Vulkan fell back to Mesa software
+  rendering (llvmpipe/lavapipe), not that the GPU is slow. Confirm the active
+  device (e.g. `nvidia-smi`, `glxinfo`) before optimizing the renderer.
 - **Scene-sync cost.** Per-frame scene extraction is the dominant CPU cost, not
   GPU rendering. `dart::gui::RenderableExtractor` caches each shape's geometry by
   shape version so `describeShape` is not rebuilt every frame for static


### PR DESCRIPTION
## Summary

- Small docs-only follow-up to the merged renderer performance work (#2694).

## Changes / Key Changes

- `docs/onboarding/gui-rendering.md`: note that an unexpectedly high GPU frame
  time in the perf HUD usually means the GPU driver is inactive and the graphics
  API fell back to Mesa software rendering (llvmpipe/lavapipe), not a slow GPU —
  check the active device (`nvidia-smi`, `glxinfo`) before optimizing.
- `docs/design/renderer_realtime_and_scalability.md`: clarify that state
  interpolation mainly helps when few sim steps run per rendered frame (large
  sim dt); at DART's typical small timestep it adds little, and it does not help
  a GPU-bound viewer. Prevents future work from treating interpolation as the
  fix for throughput-limited rendering.

## Testing

- Docs-only. `pixi run lint-md`, `check-lint-md`, `check-docs-policy`,
  `check-lint-spell` all pass.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows up #2694 (renderer profiling, backend selection, scene-sync cache).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [ ] CHANGELOG.md updated if required (docs-only; no entry needed)
- [ ] Add unit tests for new functionality (docs-only)
- [x] Document new methods and classes (docs change itself)
- [ ] Add Python bindings (dartpy) if applicable (N/A)