### PR TITLE
Optimize IPC distance Hessians

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -765,6 +765,10 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     classification, derivative regression tests, edge-edge mollifier
     derivatives, and a microbenchmark surface for future deformable contact
     assembly.
+  - Replaced internal experimental IPC finite-difference distance Hessian
+    placeholders with feature-wise analytic point-triangle and edge-edge
+    Hessian paths, reducing local Hessian microbenchmark timings for future
+    deformable contact assembly.
   - Added internal experimental IPC contact candidate assembly for
     point-triangle and edge-edge primitive pairs with deterministic surface-edge
     extraction, incident/adjacent filtering, sweep-versus-brute-force

--- a/dart/simulation/experimental/detail/deformable_contact/primitive_distance.hpp
+++ b/dart/simulation/experimental/detail/deformable_contact/primitive_distance.hpp
@@ -39,6 +39,7 @@
 #include <limits>
 
 #include <cmath>
+#include <cstddef>
 
 namespace dart::simulation::experimental::detail::deformable_contact {
 
@@ -111,7 +112,6 @@ namespace detail {
 
 constexpr double kRelativeEpsilon
     = 64.0 * std::numeric_limits<double>::epsilon();
-constexpr double kFiniteDifferenceStep = 1e-6;
 constexpr double kMollifierThresholdScale = 1e-3;
 
 //==============================================================================
@@ -143,47 +143,102 @@ inline bool isParallelEdges(
 }
 
 //==============================================================================
-inline Matrix12d finiteDifferenceHessian(
-    const Vector12d& x, const auto& gradientFunction)
+inline Eigen::Matrix3d skew(const Eigen::Vector3d& value)
+{
+  Eigen::Matrix3d matrix;
+  matrix << 0.0, -value.z(), value.y(), value.z(), 0.0, -value.x(), -value.y(),
+      value.x(), 0.0;
+  return matrix;
+}
+
+//==============================================================================
+inline void scatterPointPointHessian(
+    Matrix12d& destination, const std::size_t blockA, const std::size_t blockB)
+{
+  const Eigen::Matrix3d identity = Eigen::Matrix3d::Identity();
+  destination.block<3, 3>(3 * blockA, 3 * blockA) += 2.0 * identity;
+  destination.block<3, 3>(3 * blockA, 3 * blockB) -= 2.0 * identity;
+  destination.block<3, 3>(3 * blockB, 3 * blockA) -= 2.0 * identity;
+  destination.block<3, 3>(3 * blockB, 3 * blockB) += 2.0 * identity;
+}
+
+//==============================================================================
+inline Matrix12d pointPointHessianMapped(
+    const std::size_t blockA, const std::size_t blockB)
 {
   Matrix12d hessian = Matrix12d::Zero();
+  scatterPointPointHessian(hessian, blockA, blockB);
+  return hessian;
+}
 
-  for (int axis = 0; axis < 12; ++axis) {
-    Vector12d forward = x;
-    Vector12d backward = x;
-    forward[axis] += kFiniteDifferenceStep;
-    backward[axis] -= kFiniteDifferenceStep;
-    hessian.col(axis) = (gradientFunction(forward) - gradientFunction(backward))
-                        / (2.0 * kFiniteDifferenceStep);
+//==============================================================================
+inline Matrix12d scatterThreeBlockHessian(
+    const Matrix9d& hessian,
+    const std::array<std::size_t, 3>& destinationBlocks)
+{
+  Matrix12d mapped = Matrix12d::Zero();
+  for (std::size_t row = 0; row < destinationBlocks.size(); ++row) {
+    for (std::size_t col = 0; col < destinationBlocks.size(); ++col) {
+      mapped.block<3, 3>(3 * destinationBlocks[row], 3 * destinationBlocks[col])
+          += hessian.block<3, 3>(3 * row, 3 * col);
+    }
   }
-
-  return 0.5 * (hessian + hessian.transpose());
+  return mapped;
 }
 
 //==============================================================================
-inline Vector12d stack4(
-    const Eigen::Vector3d& a,
-    const Eigen::Vector3d& b,
-    const Eigen::Vector3d& c,
-    const Eigen::Vector3d& d)
+inline Vector12d squaredNormGradientFromLinearVector(
+    const Eigen::Vector3d& value, const std::array<double, 4>& coefficients)
 {
-  Vector12d x;
-  x.segment<3>(0) = a;
-  x.segment<3>(3) = b;
-  x.segment<3>(6) = c;
-  x.segment<3>(9) = d;
-  return x;
+  Vector12d gradient = Vector12d::Zero();
+  for (int block = 0; block < 4; ++block) {
+    gradient.segment<3>(3 * block) = 2.0 * coefficients[block] * value;
+  }
+  return gradient;
 }
 
 //==============================================================================
-inline Eigen::Vector3d segment(const Vector12d& x, const int block)
+inline Matrix12d squaredNormHessianFromLinearVector(
+    const std::array<double, 4>& coefficients)
 {
-  return x.segment<3>(3 * block);
+  Matrix12d hessian = Matrix12d::Zero();
+  const Eigen::Matrix3d identity = Eigen::Matrix3d::Identity();
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col) {
+      hessian.block<3, 3>(3 * row, 3 * col)
+          = 2.0 * coefficients[row] * coefficients[col] * identity;
+    }
+  }
+  return hessian;
 }
 
 //==============================================================================
-inline Matrix12d crossSquaredNormHessianFromEdges(
-    const Eigen::Vector3d& u, const Eigen::Vector3d& v)
+inline Vector12d crossSquaredNormGradientFromLinearVectors(
+    const Eigen::Vector3d& u,
+    const Eigen::Vector3d& v,
+    const std::array<double, 4>& coefficientsU,
+    const std::array<double, 4>& coefficientsV)
+{
+  const double u2 = u.squaredNorm();
+  const double v2 = v.squaredNorm();
+  const double uv = u.dot(v);
+  const Eigen::Vector3d gradientU = 2.0 * (v2 * u - uv * v);
+  const Eigen::Vector3d gradientV = 2.0 * (u2 * v - uv * u);
+
+  Vector12d gradient = Vector12d::Zero();
+  for (int block = 0; block < 4; ++block) {
+    gradient.segment<3>(3 * block)
+        = coefficientsU[block] * gradientU + coefficientsV[block] * gradientV;
+  }
+  return gradient;
+}
+
+//==============================================================================
+inline Matrix12d crossSquaredNormHessianFromLinearVectors(
+    const Eigen::Vector3d& u,
+    const Eigen::Vector3d& v,
+    const std::array<double, 4>& coefficientsU,
+    const std::array<double, 4>& coefficientsV)
 {
   const double u2 = u.squaredNorm();
   const double v2 = v.squaredNorm();
@@ -197,21 +252,125 @@ inline Matrix12d crossSquaredNormHessianFromEdges(
   const Eigen::Matrix3d hVU = hUV.transpose();
 
   Matrix12d hessian = Matrix12d::Zero();
-  const std::array<double, 4> signU = {-1.0, 1.0, 0.0, 0.0};
-  const std::array<double, 4> signV = {0.0, 0.0, -1.0, 1.0};
-
   for (int row = 0; row < 4; ++row) {
     for (int col = 0; col < 4; ++col) {
       Eigen::Matrix3d block = Eigen::Matrix3d::Zero();
-      block += signU[row] * signU[col] * hUU;
-      block += signU[row] * signV[col] * hUV;
-      block += signV[row] * signU[col] * hVU;
-      block += signV[row] * signV[col] * hVV;
+      block += coefficientsU[row] * coefficientsU[col] * hUU;
+      block += coefficientsU[row] * coefficientsV[col] * hUV;
+      block += coefficientsV[row] * coefficientsU[col] * hVU;
+      block += coefficientsV[row] * coefficientsV[col] * hVV;
       hessian.block<3, 3>(3 * row, 3 * col) = block;
     }
   }
 
   return 0.5 * (hessian + hessian.transpose());
+}
+
+//==============================================================================
+inline Matrix12d crossSquaredNormHessianFromEdges(
+    const Eigen::Vector3d& u, const Eigen::Vector3d& v)
+{
+  return crossSquaredNormHessianFromLinearVectors(
+      u,
+      v,
+      std::array<double, 4>{-1.0, 1.0, 0.0, 0.0},
+      std::array<double, 4>{0.0, 0.0, -1.0, 1.0});
+}
+
+//==============================================================================
+inline Vector12d tripleProductGradientFromLinearVectors(
+    const Eigen::Vector3d& u,
+    const Eigen::Vector3d& v,
+    const Eigen::Vector3d& w,
+    const std::array<double, 4>& coefficientsU,
+    const std::array<double, 4>& coefficientsV,
+    const std::array<double, 4>& coefficientsW)
+{
+  const Eigen::Vector3d gradientU = v.cross(w);
+  const Eigen::Vector3d gradientV = w.cross(u);
+  const Eigen::Vector3d gradientW = u.cross(v);
+
+  Vector12d gradient = Vector12d::Zero();
+  for (int block = 0; block < 4; ++block) {
+    gradient.segment<3>(3 * block) = coefficientsU[block] * gradientU
+                                     + coefficientsV[block] * gradientV
+                                     + coefficientsW[block] * gradientW;
+  }
+  return gradient;
+}
+
+//==============================================================================
+inline Matrix12d tripleProductHessianFromLinearVectors(
+    const Eigen::Vector3d& u,
+    const Eigen::Vector3d& v,
+    const Eigen::Vector3d& w,
+    const std::array<double, 4>& coefficientsU,
+    const std::array<double, 4>& coefficientsV,
+    const std::array<double, 4>& coefficientsW)
+{
+  const Eigen::Matrix3d hUV = -skew(w);
+  const Eigen::Matrix3d hUW = skew(v);
+  const Eigen::Matrix3d hVU = hUV.transpose();
+  const Eigen::Matrix3d hVW = -skew(u);
+  const Eigen::Matrix3d hWU = hUW.transpose();
+  const Eigen::Matrix3d hWV = hVW.transpose();
+
+  Matrix12d hessian = Matrix12d::Zero();
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col) {
+      Eigen::Matrix3d block = Eigen::Matrix3d::Zero();
+      block += coefficientsU[row] * coefficientsV[col] * hUV;
+      block += coefficientsU[row] * coefficientsW[col] * hUW;
+      block += coefficientsV[row] * coefficientsU[col] * hVU;
+      block += coefficientsV[row] * coefficientsW[col] * hVW;
+      block += coefficientsW[row] * coefficientsU[col] * hWU;
+      block += coefficientsW[row] * coefficientsV[col] * hWV;
+      hessian.block<3, 3>(3 * row, 3 * col) = block;
+    }
+  }
+  return 0.5 * (hessian + hessian.transpose());
+}
+
+//==============================================================================
+inline Matrix12d ratioHessian(
+    const double numerator,
+    const Vector12d& numeratorGradient,
+    const Matrix12d& numeratorHessian,
+    const double denominator,
+    const Vector12d& denominatorGradient,
+    const Matrix12d& denominatorHessian)
+{
+  return numeratorHessian / denominator
+         - numerator * denominatorHessian / (denominator * denominator)
+         - (numeratorGradient * denominatorGradient.transpose()
+            + denominatorGradient * numeratorGradient.transpose())
+               / (denominator * denominator)
+         + 2.0 * numerator
+               * (denominatorGradient * denominatorGradient.transpose())
+               / (denominator * denominator * denominator);
+}
+
+//==============================================================================
+inline Matrix12d squaredRatioHessian(
+    const double numerator,
+    const Vector12d& numeratorGradient,
+    const Matrix12d& numeratorHessian,
+    const double denominator,
+    const Vector12d& denominatorGradient,
+    const Matrix12d& denominatorHessian)
+{
+  const double denominatorSquared = denominator * denominator;
+  const double denominatorCubed = denominatorSquared * denominator;
+
+  return (2.0 * numerator / denominator) * numeratorHessian
+         - (numerator * numerator / denominatorSquared) * denominatorHessian
+         + (2.0 / denominator)
+               * (numeratorGradient * numeratorGradient.transpose())
+         - (2.0 * numerator / denominatorSquared)
+               * (numeratorGradient * denominatorGradient.transpose()
+                  + denominatorGradient * numeratorGradient.transpose())
+         + (2.0 * numerator * numerator / denominatorCubed)
+               * (denominatorGradient * denominatorGradient.transpose());
 }
 
 } // namespace detail
@@ -298,18 +457,40 @@ inline Matrix9d pointEdgeSquaredDistanceHessian(
     const Eigen::Vector3d& a,
     const Eigen::Vector3d& b)
 {
-  const Vector12d x = detail::stack4(p, a, b, Eigen::Vector3d::Zero());
-  const auto hessian12
-      = detail::finiteDifferenceHessian(x, [](const Vector12d& value) {
-          Vector12d gradient = Vector12d::Zero();
-          gradient.head<9>() = pointEdgeSquaredDistanceGradient(
-              detail::segment(value, 0),
-              detail::segment(value, 1),
-              detail::segment(value, 2));
-          return gradient;
-        });
+  const auto distance = pointEdgeSquaredDistance(p, a, b);
+  if (distance.feature == PointEdgeFeature::PointEdgeStart) {
+    return detail::pointPointHessianMapped(0, 1).topLeftCorner<9, 9>();
+  }
+  if (distance.feature == PointEdgeFeature::PointEdgeEnd) {
+    return detail::pointPointHessianMapped(0, 2).topLeftCorner<9, 9>();
+  }
 
-  return hessian12.topLeftCorner<9, 9>();
+  const Eigen::Vector3d u = b - a;
+  const Eigen::Vector3d w = p - a;
+  constexpr std::array<double, 4> coefficientsU = {0.0, -1.0, 1.0, 0.0};
+  constexpr std::array<double, 4> coefficientsW = {1.0, -1.0, 0.0, 0.0};
+
+  const double numerator = u.cross(w).squaredNorm();
+  const double denominator = u.squaredNorm();
+  const Vector12d numeratorGradient
+      = detail::crossSquaredNormGradientFromLinearVectors(
+          u, w, coefficientsU, coefficientsW);
+  const Matrix12d numeratorHessian
+      = detail::crossSquaredNormHessianFromLinearVectors(
+          u, w, coefficientsU, coefficientsW);
+  const Vector12d denominatorGradient
+      = detail::squaredNormGradientFromLinearVector(u, coefficientsU);
+  const Matrix12d denominatorHessian
+      = detail::squaredNormHessianFromLinearVector(coefficientsU);
+
+  return detail::ratioHessian(
+             numerator,
+             numeratorGradient,
+             numeratorHessian,
+             denominator,
+             denominatorGradient,
+             denominatorHessian)
+      .topLeftCorner<9, 9>();
 }
 
 //==============================================================================
@@ -438,14 +619,73 @@ inline Matrix12d pointTriangleSquaredDistanceHessian(
     const Eigen::Vector3d& b,
     const Eigen::Vector3d& c)
 {
-  const Vector12d x = detail::stack4(p, a, b, c);
-  return detail::finiteDifferenceHessian(x, [](const Vector12d& value) {
-    return pointTriangleSquaredDistanceGradient(
-        detail::segment(value, 0),
-        detail::segment(value, 1),
-        detail::segment(value, 2),
-        detail::segment(value, 3));
-  });
+  const auto distance = pointTriangleSquaredDistance(p, a, b, c);
+  switch (distance.feature) {
+    case PointTriangleFeature::VertexA:
+      return detail::pointPointHessianMapped(0, 1);
+    case PointTriangleFeature::VertexB:
+      return detail::pointPointHessianMapped(0, 2);
+    case PointTriangleFeature::VertexC:
+      return detail::pointPointHessianMapped(0, 3);
+    case PointTriangleFeature::EdgeAB:
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(p, a, b), {0, 1, 2});
+    case PointTriangleFeature::EdgeBC:
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(p, b, c), {0, 2, 3});
+    case PointTriangleFeature::EdgeCA:
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(p, c, a), {0, 3, 1});
+    case PointTriangleFeature::Degenerate: {
+      const auto abDistance = pointEdgeSquaredDistance(p, a, b);
+      const auto bcDistance = pointEdgeSquaredDistance(p, b, c);
+      const auto caDistance = pointEdgeSquaredDistance(p, c, a);
+      if (bcDistance.squaredDistance < abDistance.squaredDistance
+          && bcDistance.squaredDistance <= caDistance.squaredDistance) {
+        return detail::scatterThreeBlockHessian(
+            pointEdgeSquaredDistanceHessian(p, b, c), {0, 2, 3});
+      }
+      if (caDistance.squaredDistance < abDistance.squaredDistance
+          && caDistance.squaredDistance < bcDistance.squaredDistance) {
+        return detail::scatterThreeBlockHessian(
+            pointEdgeSquaredDistanceHessian(p, c, a), {0, 3, 1});
+      }
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(p, a, b), {0, 1, 2});
+    }
+    case PointTriangleFeature::Face:
+      break;
+  }
+
+  const Eigen::Vector3d u = b - a;
+  const Eigen::Vector3d v = c - a;
+  const Eigen::Vector3d w = p - a;
+  constexpr std::array<double, 4> coefficientsU = {0.0, -1.0, 1.0, 0.0};
+  constexpr std::array<double, 4> coefficientsV = {0.0, -1.0, 0.0, 1.0};
+  constexpr std::array<double, 4> coefficientsW = {1.0, -1.0, 0.0, 0.0};
+
+  const double numerator = u.cross(v).dot(w);
+  const double denominator = u.cross(v).squaredNorm();
+  const Vector12d numeratorGradient
+      = detail::tripleProductGradientFromLinearVectors(
+          u, v, w, coefficientsU, coefficientsV, coefficientsW);
+  const Matrix12d numeratorHessian
+      = detail::tripleProductHessianFromLinearVectors(
+          u, v, w, coefficientsU, coefficientsV, coefficientsW);
+  const Vector12d denominatorGradient
+      = detail::crossSquaredNormGradientFromLinearVectors(
+          u, v, coefficientsU, coefficientsV);
+  const Matrix12d denominatorHessian
+      = detail::crossSquaredNormHessianFromLinearVectors(
+          u, v, coefficientsU, coefficientsV);
+
+  return detail::squaredRatioHessian(
+      numerator,
+      numeratorGradient,
+      numeratorHessian,
+      denominator,
+      denominatorGradient,
+      denominatorHessian);
 }
 
 //==============================================================================
@@ -567,14 +807,61 @@ inline Matrix12d edgeEdgeSquaredDistanceHessian(
     const Eigen::Vector3d& c,
     const Eigen::Vector3d& d)
 {
-  const Vector12d x = detail::stack4(a, b, c, d);
-  return detail::finiteDifferenceHessian(x, [](const Vector12d& value) {
-    return edgeEdgeSquaredDistanceGradient(
-        detail::segment(value, 0),
-        detail::segment(value, 1),
-        detail::segment(value, 2),
-        detail::segment(value, 3));
-  });
+  const auto distance = edgeEdgeSquaredDistance(a, b, c, d);
+  switch (distance.feature) {
+    case EdgeEdgeFeature::EdgeAStartEdgeBStart:
+      return detail::pointPointHessianMapped(0, 2);
+    case EdgeEdgeFeature::EdgeAStartEdgeBEnd:
+      return detail::pointPointHessianMapped(0, 3);
+    case EdgeEdgeFeature::EdgeAEndEdgeBStart:
+      return detail::pointPointHessianMapped(1, 2);
+    case EdgeEdgeFeature::EdgeAEndEdgeBEnd:
+      return detail::pointPointHessianMapped(1, 3);
+    case EdgeEdgeFeature::EdgeAInteriorEdgeBStart:
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(c, a, b), {2, 0, 1});
+    case EdgeEdgeFeature::EdgeAInteriorEdgeBEnd:
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(d, a, b), {3, 0, 1});
+    case EdgeEdgeFeature::EdgeAStartEdgeBInterior:
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(a, c, d), {0, 2, 3});
+    case EdgeEdgeFeature::EdgeAEndEdgeBInterior:
+      return detail::scatterThreeBlockHessian(
+          pointEdgeSquaredDistanceHessian(b, c, d), {1, 2, 3});
+    case EdgeEdgeFeature::EdgeAInteriorEdgeBInterior:
+      break;
+  }
+
+  const Eigen::Vector3d u = b - a;
+  const Eigen::Vector3d v = d - c;
+  const Eigen::Vector3d w = a - c;
+  constexpr std::array<double, 4> coefficientsU = {-1.0, 1.0, 0.0, 0.0};
+  constexpr std::array<double, 4> coefficientsV = {0.0, 0.0, -1.0, 1.0};
+  constexpr std::array<double, 4> coefficientsW = {1.0, 0.0, -1.0, 0.0};
+
+  const double numerator = u.cross(v).dot(w);
+  const double denominator = u.cross(v).squaredNorm();
+  const Vector12d numeratorGradient
+      = detail::tripleProductGradientFromLinearVectors(
+          u, v, w, coefficientsU, coefficientsV, coefficientsW);
+  const Matrix12d numeratorHessian
+      = detail::tripleProductHessianFromLinearVectors(
+          u, v, w, coefficientsU, coefficientsV, coefficientsW);
+  const Vector12d denominatorGradient
+      = detail::crossSquaredNormGradientFromLinearVectors(
+          u, v, coefficientsU, coefficientsV);
+  const Matrix12d denominatorHessian
+      = detail::crossSquaredNormHessianFromLinearVectors(
+          u, v, coefficientsU, coefficientsV);
+
+  return detail::squaredRatioHessian(
+      numerator,
+      numeratorGradient,
+      numeratorHessian,
+      denominator,
+      denominatorGradient,
+      denominatorHessian);
 }
 
 //==============================================================================

--- a/docs/dev_tasks/ipc_deformable_solver/README.md
+++ b/docs/dev_tasks/ipc_deformable_solver/README.md
@@ -21,10 +21,13 @@
       CCD line-search bounds.
   - [x] Internal primitive-distance kernel sub-slice: point-triangle and
         edge-edge squared-distance values, closest-feature classification,
-        gradients, finite-difference Hessians for the first solver-facing
-        contract, IPC-style edge-edge mollifier threshold/value/gradient/
-        Hessian, finite-difference regression tests, and
-        `bm_ipc_distance_kernels`.
+        gradients, the first solver-facing Hessian contract, IPC-style
+        edge-edge mollifier threshold/value/gradient/Hessian,
+        finite-difference regression tests, and `bm_ipc_distance_kernels`.
+  - [x] Internal analytic-Hessian optimization sub-slice: feature-wise exact
+        point-triangle and edge-edge distance Hessians for vertex, edge, face,
+        and interior closest features, degenerate triangle edge fallback, and
+        benchmark evidence replacing the finite-difference Hessian placeholder.
   - [x] Internal candidate-set sub-slice: deterministic unique surface-edge
         extraction, point-triangle and edge-edge primitive candidate assembly,
         incident/adjacent exclusion filters, exact activation-distance filtering
@@ -35,9 +38,9 @@
         separation-band handling, deterministic candidate aggregation, exact CCD
         regression tests, sampled safety checks, and
         `bm_ipc_continuous_collision_step`.
-  - [ ] Remaining Phase 2 work: analytic distance Hessians, tangent bases,
-        motion-aware candidate culling, barrier/candidate integration,
-        solver-owned contact buffers, and solver-wired CCD line search.
+  - [ ] Remaining Phase 2 work: tangent bases, motion-aware candidate culling,
+        barrier/candidate integration, solver-owned contact buffers, and
+        solver-wired CCD line search.
 - [ ] Phase 3: clamped barriers, projected Newton, sparse assembly, and solver
       statistics.
 - [ ] Phase 4: lagged smoothed friction and friction diagnostics.
@@ -78,11 +81,11 @@ DART-owned implementation.
 
 ## Immediate Next Steps
 
-1. Continue Phase 2 with analytic distance Hessian optimization, tangent bases,
-   motion-aware candidate culling, barrier/candidate integration,
-   solver-owned contact buffers, and solver-wired CCD line search. The current
-   primitive kernels, candidate sets, and CCD step-bound helpers are internal
-   scaffolding only and are not yet wired into `World::step()`.
+1. Continue Phase 2 with tangent bases, motion-aware candidate culling,
+   barrier/candidate integration, solver-owned contact buffers, and
+   solver-wired CCD line search. The current primitive kernels, candidate sets,
+   analytic Hessians, and CCD step-bound helpers are internal scaffolding only
+   and are not yet wired into `World::step()`.
 2. Finish the rest of Slice 1 from PLAN-081 in parallel when needed for corpus
    scenes: broader scene asset loading, BE/NM state, output diagnostics
    compatibility decisions, and more contact-free mesh replays. The
@@ -126,11 +129,11 @@ CCD line search, projected Newton, or full scene-corpus parity.
 
 For the primitive-distance kernel sub-slice, keep the verification language
 precise: it covers internal squared-distance values, closest-feature
-classification, gradients, finite-difference Hessians, the edge-edge mollifier,
-finite-difference derivative tests, and microbenchmark timings. It does not yet
-cover analytic distance Hessians, tangent bases, broad-phase candidate assembly,
-CCD line search, barrier assembly, projected Newton, friction, or scene-level
-IPC contact behavior.
+classification, gradients, feature-wise analytic Hessians, the edge-edge
+mollifier, finite-difference derivative tests, and microbenchmark timings. It
+does not yet cover tangent bases, broad-phase candidate assembly, CCD line
+search, barrier assembly, projected Newton, friction, or scene-level IPC
+contact behavior.
 
 For the candidate-set sub-slice, keep the verification language precise: it
 covers deterministic surface-edge extraction, internal point-triangle and
@@ -163,11 +166,15 @@ pixi run check-api-boundaries
 
 The first local gate pass on 2026-05-27 passed `pixi run lint`, the focused
 target build, 13 `test_primitive_distance` cases, the CTest registration path,
-`pixi run check-api-boundaries`, and `pixi run check-lint`. The latest benchmark
-smoke reported roughly 8-19 ns for value/gradient distance paths, 213 ns for the
-analytic edge-edge mollifier Hessian path, and about 0.61-0.69 us for the
-finite-difference distance Hessian placeholders. Treat those Hessian numbers as
-a temporary optimization target, not as final IPC performance evidence.
+`pixi run check-api-boundaries`, and `pixi run check-lint`. The latest analytic
+Hessian optimization gate passed the same 13-case test binary and reported
+roughly 8-16 ns for value/gradient distance paths, 487 ns for the
+point-triangle face distance Hessian, 486 ns for the point-triangle edge
+Hessian, 26 ns for the point-triangle vertex Hessian, 515 ns for the edge-edge
+interior distance Hessian, 490 ns for the edge-edge point-edge Hessian, 22 ns
+for the edge-edge point-point Hessian, and 203 ns for the analytic edge-edge
+mollifier Hessian path. CPU scaling was enabled, so treat these as local smoke
+numbers rather than a final performance claim.
 
 Current candidate-set local gates:
 

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -23,11 +23,15 @@ friction directives and must not be described as IPC scene parity.
 
 The primitive-distance kernel sub-slice starts PLAN-081 Phase 2 with internal
 point-triangle and edge-edge squared-distance kernels, closest-feature
-classification, gradients, finite-difference Hessians for the first
-solver-facing validation contract, IPC-style edge-edge mollifier derivatives,
-feature-region regression tests, and `bm_ipc_distance_kernels`. It is still
-scaffolding: analytic distance Hessians, tangent bases, CCD line-search bounds,
-barrier assembly, projected Newton, and friction are not implemented yet.
+classification, gradients, the first solver-facing Hessian contract, IPC-style
+edge-edge mollifier derivatives, feature-region regression tests, and
+`bm_ipc_distance_kernels`.
+
+The analytic-Hessian optimization sub-slice replaces the finite-difference
+distance Hessian placeholder with feature-wise exact point-triangle and
+edge-edge Hessian paths for vertex, edge, face, and interior closest features.
+It is still scaffolding: tangent bases, solver-wired CCD line search, barrier
+assembly, projected Newton, and friction are not implemented yet.
 
 The candidate-set sub-slice adds deterministic unique surface-edge extraction,
 internal point-triangle and edge-edge primitive candidate assembly,
@@ -47,17 +51,15 @@ candidate culling, barrier assembly, projected Newton, or friction.
 
 ## Current Branch
 
-`feature/ipc-deformable-contact-kernels` - stacked on
-`feature/ipc-scene-boundary-diagnostics`, adding internal primitive distance
-kernels, candidate assembly, and CCD step-bound helpers for the next deformable
-contact slices.
+`feature/ipc-distance-hessian-optimization` - stacked on
+`feature/ipc-deformable-contact-kernels`, adding feature-wise analytic
+distance Hessians for the next deformable contact slices.
 
 ## Immediate Next Step
 
-After this sub-slice lands, continue Phase 2 with analytic distance Hessian
-optimization, tangent bases, motion-aware candidate culling,
-barrier/candidate integration, solver-owned contact buffers, and solver-wired
-CCD line search.
+After this sub-slice lands, continue Phase 2 with tangent bases,
+motion-aware candidate culling, barrier/candidate integration,
+solver-owned contact buffers, and solver-wired CCD line search.
 
 ## Context That Would Be Lost
 

--- a/tests/benchmark/simulation/experimental/bm_ipc_distance_kernels.cpp
+++ b/tests/benchmark/simulation/experimental/bm_ipc_distance_kernels.cpp
@@ -45,6 +45,26 @@ std::array<Eigen::Vector3d, 4> pointTriangleCase()
 }
 
 //==============================================================================
+std::array<Eigen::Vector3d, 4> pointTriangleEdgeCase()
+{
+  return {
+      Eigen::Vector3d(0.5, -1.0, 1.5),
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(0.0, 1.0, 0.0)};
+}
+
+//==============================================================================
+std::array<Eigen::Vector3d, 4> pointTriangleVertexCase()
+{
+  return {
+      Eigen::Vector3d(-1.0, -1.0, 1.5),
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(0.0, 1.0, 0.0)};
+}
+
+//==============================================================================
 std::array<Eigen::Vector3d, 4> edgeEdgeCase()
 {
   return {
@@ -52,6 +72,26 @@ std::array<Eigen::Vector3d, 4> edgeEdgeCase()
       Eigen::Vector3d(1.1, 0.2, 0.3),
       Eigen::Vector3d(0.2, -1.2, 1.4),
       Eigen::Vector3d(-0.1, 1.3, 1.8)};
+}
+
+//==============================================================================
+std::array<Eigen::Vector3d, 4> edgeEdgePointPointCase()
+{
+  return {
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(-1.0, 1.0, 0.4),
+      Eigen::Vector3d(-1.0, 2.0, 0.4)};
+}
+
+//==============================================================================
+std::array<Eigen::Vector3d, 4> edgeEdgePointEdgeCase()
+{
+  return {
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(0.5, 1.0, 0.4),
+      Eigen::Vector3d(0.5, 2.0, 0.4)};
 }
 
 //==============================================================================
@@ -100,6 +140,28 @@ static void BM_IpcPointTriangleDistanceHessian(benchmark::State& state)
 BENCHMARK(BM_IpcPointTriangleDistanceHessian);
 
 //==============================================================================
+static void BM_IpcPointTriangleDistanceHessianEdge(benchmark::State& state)
+{
+  const auto [p, a, b, c] = pointTriangleEdgeCase();
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+        dc::pointTriangleSquaredDistanceHessian(p, a, b, c));
+  }
+}
+BENCHMARK(BM_IpcPointTriangleDistanceHessianEdge);
+
+//==============================================================================
+static void BM_IpcPointTriangleDistanceHessianVertex(benchmark::State& state)
+{
+  const auto [p, a, b, c] = pointTriangleVertexCase();
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+        dc::pointTriangleSquaredDistanceHessian(p, a, b, c));
+  }
+}
+BENCHMARK(BM_IpcPointTriangleDistanceHessianVertex);
+
+//==============================================================================
 static void BM_IpcEdgeEdgeDistanceValue(benchmark::State& state)
 {
   const auto [a, b, c, d] = edgeEdgeCase();
@@ -129,6 +191,26 @@ static void BM_IpcEdgeEdgeDistanceHessian(benchmark::State& state)
   }
 }
 BENCHMARK(BM_IpcEdgeEdgeDistanceHessian);
+
+//==============================================================================
+static void BM_IpcEdgeEdgeDistanceHessianPointPoint(benchmark::State& state)
+{
+  const auto [a, b, c, d] = edgeEdgePointPointCase();
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(dc::edgeEdgeSquaredDistanceHessian(a, b, c, d));
+  }
+}
+BENCHMARK(BM_IpcEdgeEdgeDistanceHessianPointPoint);
+
+//==============================================================================
+static void BM_IpcEdgeEdgeDistanceHessianPointEdge(benchmark::State& state)
+{
+  const auto [a, b, c, d] = edgeEdgePointEdgeCase();
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(dc::edgeEdgeSquaredDistanceHessian(a, b, c, d));
+  }
+}
+BENCHMARK(BM_IpcEdgeEdgeDistanceHessianPointEdge);
 
 //==============================================================================
 static void BM_IpcEdgeEdgeMollifier(benchmark::State& state)

--- a/tests/unit/simulation/experimental/contact/test_primitive_distance.cpp
+++ b/tests/unit/simulation/experimental/contact/test_primitive_distance.cpp
@@ -147,6 +147,38 @@ void expectMatrixNear(
 }
 
 //==============================================================================
+template <typename Derived>
+void expectFiniteSymmetric(
+    const Eigen::MatrixBase<Derived>& matrix, const double tolerance = 1e-12)
+{
+  for (int row = 0; row < matrix.rows(); ++row) {
+    for (int col = 0; col < matrix.cols(); ++col) {
+      ASSERT_TRUE(std::isfinite(matrix(row, col)))
+          << "row=" << row << " col=" << col;
+      ASSERT_NEAR(matrix(row, col), matrix(col, row), tolerance)
+          << "row=" << row << " col=" << col;
+    }
+  }
+}
+
+//==============================================================================
+template <typename Derived>
+void expectTranslationNullspace(
+    const Eigen::MatrixBase<Derived>& hessian,
+    const int blockCount,
+    const double tolerance = 1e-10)
+{
+  for (int axis = 0; axis < 3; ++axis) {
+    Eigen::VectorXd translation = Eigen::VectorXd::Zero(3 * blockCount);
+    for (int block = 0; block < blockCount; ++block) {
+      translation[3 * block + axis] = 1.0;
+    }
+    EXPECT_NEAR((hessian * translation).norm(), 0.0, tolerance);
+    EXPECT_NEAR((translation.transpose() * hessian).norm(), 0.0, tolerance);
+  }
+}
+
+//==============================================================================
 void expectPointEdgeDerivativesMatch(
     const Eigen::Vector3d& p,
     const Eigen::Vector3d& a,
@@ -174,6 +206,8 @@ void expectPointEdgeDerivativesMatch(
       = dc::pointEdgeSquaredDistanceHessian(p, a, b);
   const dc::Matrix9d numericHessian
       = finiteHessian(x, value).topLeftCorner<9, 9>();
+  expectFiniteSymmetric(analyticHessian);
+  expectTranslationNullspace(analyticHessian, 3);
   expectMatrixNear(analyticHessian, numericHessian, 2e-4);
 }
 
@@ -205,6 +239,8 @@ void expectPointTriangleDerivativesMatch(
   const dc::Matrix12d analyticHessian
       = dc::pointTriangleSquaredDistanceHessian(p, a, b, c);
   const dc::Matrix12d numericHessian = finiteHessian(x, value);
+  expectFiniteSymmetric(analyticHessian);
+  expectTranslationNullspace(analyticHessian, 4);
   expectMatrixNear(analyticHessian, numericHessian, 2e-4);
 }
 
@@ -236,6 +272,8 @@ void expectEdgeEdgeDerivativesMatch(
   const dc::Matrix12d analyticHessian
       = dc::edgeEdgeSquaredDistanceHessian(a, b, c, d);
   const dc::Matrix12d numericHessian = finiteHessian(x, value);
+  expectFiniteSymmetric(analyticHessian);
+  expectTranslationNullspace(analyticHessian, 4);
   expectMatrixNear(analyticHessian, numericHessian, 2e-4);
 }
 
@@ -361,23 +399,47 @@ TEST(IpcPrimitiveDistance, PointEdgeFeatureDerivativesMatchFiniteDifferences)
 TEST(IpcPrimitiveDistance, PointTriangleDerivativesMatchFiniteDifferences)
 {
   const Eigen::Vector3d a(0.0, 0.0, 0.0);
-  const Eigen::Vector3d b(1.2, 0.1, 0.0);
-  const Eigen::Vector3d c(-0.1, 1.1, 0.2);
+  const Eigen::Vector3d b(1.0, 0.0, 0.0);
+  const Eigen::Vector3d c(0.0, 1.0, 0.0);
 
   expectPointTriangleDerivativesMatch(
-      Eigen::Vector3d(-1.0, -1.0, 1.7),
+      Eigen::Vector3d(-1.0, -1.0, 1.5),
       a,
       b,
       c,
       dc::PointTriangleFeature::VertexA);
   expectPointTriangleDerivativesMatch(
-      Eigen::Vector3d(0.5, -1.0, 1.7),
+      Eigen::Vector3d(2.0, -0.5, 1.5),
+      a,
+      b,
+      c,
+      dc::PointTriangleFeature::VertexB);
+  expectPointTriangleDerivativesMatch(
+      Eigen::Vector3d(-0.5, 2.0, 1.5),
+      a,
+      b,
+      c,
+      dc::PointTriangleFeature::VertexC);
+  expectPointTriangleDerivativesMatch(
+      Eigen::Vector3d(0.5, -1.0, 1.5),
       a,
       b,
       c,
       dc::PointTriangleFeature::EdgeAB);
   expectPointTriangleDerivativesMatch(
-      Eigen::Vector3d(0.23, 0.31, 1.7),
+      Eigen::Vector3d(0.8, 0.8, 1.5),
+      a,
+      b,
+      c,
+      dc::PointTriangleFeature::EdgeBC);
+  expectPointTriangleDerivativesMatch(
+      Eigen::Vector3d(-1.0, 0.5, 1.5),
+      a,
+      b,
+      c,
+      dc::PointTriangleFeature::EdgeCA);
+  expectPointTriangleDerivativesMatch(
+      Eigen::Vector3d(0.25, 0.25, 1.5),
       a,
       b,
       c,
@@ -414,15 +476,51 @@ TEST(IpcPrimitiveDistance, EdgeEdgeDerivativesMatchFiniteDifferences)
   expectEdgeEdgeDerivativesMatch(
       Eigen::Vector3d(0.0, 0.0, 0.0),
       Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(-1.0, 1.0, 0.4),
+      Eigen::Vector3d(-1.0, 2.0, 0.4),
+      dc::EdgeEdgeFeature::EdgeAStartEdgeBStart);
+  expectEdgeEdgeDerivativesMatch(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(-1.0, -2.0, 0.4),
+      Eigen::Vector3d(-1.0, -1.0, 0.4),
+      dc::EdgeEdgeFeature::EdgeAStartEdgeBEnd);
+  expectEdgeEdgeDerivativesMatch(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
       Eigen::Vector3d(2.0, 1.0, 0.4),
       Eigen::Vector3d(2.0, 2.0, 0.4),
       dc::EdgeEdgeFeature::EdgeAEndEdgeBStart);
   expectEdgeEdgeDerivativesMatch(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(2.0, -2.0, 0.4),
+      Eigen::Vector3d(2.0, -1.0, 0.4),
+      dc::EdgeEdgeFeature::EdgeAEndEdgeBEnd);
+  expectEdgeEdgeDerivativesMatch(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(0.5, 1.0, 0.4),
+      Eigen::Vector3d(0.5, 2.0, 0.4),
+      dc::EdgeEdgeFeature::EdgeAInteriorEdgeBStart);
+  expectEdgeEdgeDerivativesMatch(
       Eigen::Vector3d(-1.0, 0.0, 0.0),
       Eigen::Vector3d(1.0, 0.0, 0.0),
-      Eigen::Vector3d(0.0, 2.0, 0.4),
-      Eigen::Vector3d(0.0, 3.0, 0.4),
-      dc::EdgeEdgeFeature::EdgeAInteriorEdgeBStart);
+      Eigen::Vector3d(0.0, -3.0, 0.4),
+      Eigen::Vector3d(0.0, -2.0, 0.4),
+      dc::EdgeEdgeFeature::EdgeAInteriorEdgeBEnd);
+  expectEdgeEdgeDerivativesMatch(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(-1.0, -1.0, 0.4),
+      Eigen::Vector3d(-1.0, 1.0, 0.4),
+      dc::EdgeEdgeFeature::EdgeAStartEdgeBInterior);
+  expectEdgeEdgeDerivativesMatch(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(2.0, -1.0, 0.4),
+      Eigen::Vector3d(2.0, 1.0, 0.4),
+      dc::EdgeEdgeFeature::EdgeAEndEdgeBInterior);
   expectEdgeEdgeDerivativesMatch(
       Eigen::Vector3d(-0.8, -0.1, 0.0),
       Eigen::Vector3d(1.1, 0.2, 0.3),
@@ -457,6 +555,12 @@ TEST(IpcPrimitiveDistance, HandlesParallelAndNearParallelEdgeEdgeDistances)
   EXPECT_TRUE(std::isfinite(nearParallelSkew.squaredDistance));
   EXPECT_GE(nearParallelSkew.squaredDistance, 0.0);
   EXPECT_LT(std::abs(nearParallelSkew.squaredDistance - 1e-8), 1e-12);
+  expectFiniteSymmetric(
+      dc::edgeEdgeSquaredDistanceHessian(
+          Eigen::Vector3d(-1.0, 0.0, 0.0),
+          Eigen::Vector3d(1.0, 0.0, 0.0),
+          Eigen::Vector3d(-1.0, 1e-8, 1e-4),
+          Eigen::Vector3d(1.0, 2e-8, 1e-4)));
 
   const auto smallParallel = dc::edgeEdgeSquaredDistance(
       Eigen::Vector3d(0.0, 0.0, 0.0),
@@ -466,6 +570,12 @@ TEST(IpcPrimitiveDistance, HandlesParallelAndNearParallelEdgeEdgeDistances)
   EXPECT_NEAR(smallParallel.squaredDistance, 1e-16, 1e-28);
   EXPECT_EQ(
       smallParallel.feature, dc::EdgeEdgeFeature::EdgeAInteriorEdgeBStart);
+  expectFiniteSymmetric(
+      dc::edgeEdgeSquaredDistanceHessian(
+          Eigen::Vector3d(0.0, 0.0, 0.0),
+          Eigen::Vector3d(1e-4, 0.0, 0.0),
+          Eigen::Vector3d(2e-5, 1e-8, 0.0),
+          Eigen::Vector3d(8e-5, 1e-8, 0.0)));
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Replaces the internal experimental IPC distance-Hessian finite-difference placeholder with feature-wise analytic Hessian paths for point-triangle and edge-edge distances.
- Keeps the change internal to the deformable-contact kernel scaffolding; no public API or runtime IPC solver behavior changes yet.
- Expands derivative tests and microbenchmarks so future barrier/contact assembly has a faster and better-covered Hessian contract to build on.

## Motivation / Problem

- The current IPC roadmap is moving from replay/corpus scaffolding toward solver-owned contact assembly and projected Newton steps.
- Distance Hessians sit directly on that path, so leaving the internal contract backed by a finite-difference placeholder would make the next barrier and solver slices slower and harder to validate.
- This PR moves that contract to closed-form, feature-dispatched kernels while preserving finite-difference tests as independent correctness checks.

## Changes / Key Changes

- Adds analytic point-edge, point-triangle, and edge-edge squared-distance Hessian helpers for the active closest-feature region.
- Dispatches point-triangle Hessians across vertex, edge, face, and degenerate-edge fallback cases.
- Dispatches edge-edge Hessians across endpoint-endpoint, endpoint-edge, and interior-interior cases, including near-parallel finite/symmetry coverage.
- Extends unit tests to cover all point-triangle closest-feature labels, all nine edge-edge closest-feature labels, finite/symmetric Hessian invariants, and translation nullspace invariants.
- Extends `bm_ipc_distance_kernels` with feature-specific Hessian benchmark cases.
- Updates the IPC dev-task notes and changelog to mark the finite-difference Hessian placeholder as replaced.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Internal Hessian implementation | Finite-difference placeholder for distance Hessians. | Feature-wise analytic Hessian paths for point-triangle and edge-edge distances. |
| Correctness coverage | Finite-difference comparison on narrower representative cases. | Finite-difference comparison plus finite/symmetric and translation-nullspace invariants across vertex, edge, face, endpoint, endpoint-edge, and interior feature regions. |
| Local Hessian smoke timings | Dev-task note recorded about 0.61-0.69 us for finite-difference distance-Hessian placeholders. | Latest local smoke: PT face 487 ns, PT edge 486 ns, PT vertex 26 ns, EE interior 515 ns, EE point-edge 490 ns, EE point-point 22 ns. CPU scaling was enabled, so these are local smoke numbers rather than final cross-machine performance claims. |

## Testing

- `cmake --build build/default/cpp/Release --target test_primitive_distance bm_ipc_distance_kernels`
- `./build/default/cpp/Release/bin/test_primitive_distance`
- `ctest --test-dir build/default/cpp/Release -R '^test_primitive_distance$' --output-on-failure`
- `./build/default/cpp/Release/bin/bm_ipc_distance_kernels --benchmark_min_time=0.05s --benchmark_filter='BM_Ipc'`
- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run check-api-boundaries`
- `git diff --check`

## Breaking Changes

- [x] None
- Internal experimental deformable-contact helpers only; no public API, ABI, Python binding, file-format, or example command changes.

## Related Issues / PRs (backports)

- Stacked on `feature/ipc-deformable-contact-kernels`, after the IPC scene/corpus stack in #2718 and #2719.
- Backport: none. This is experimental DART 7.0 IPC roadmap work.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes - N/A, internal experimental helpers only; dev-task documentation updated
- [x] Add Python bindings (dartpy) if applicable - N/A, no public API or bindings
