### PR TITLE
Track 4 deferred-migration dev tasks for retired prototype branches

### DIFF
--- a/docs/dev_tasks/benchmark_pr_comparison/README.md
+++ b/docs/dev_tasks/benchmark_pr_comparison/README.md
@@ -1,0 +1,95 @@
+# Per-PR Benchmark Comparison Comments — Dev Task
+
+## Current Status
+
+- [ ] Phase 0: Capture design intent and reconciliation with PLAN-080 (this PR)
+- [ ] Phase 1: Decide whether to extend the existing Performance Dashboard
+      runner with PR-comment hooks (preferred) or stand up a parallel
+      "committed JSON in `benchmarks/reports/`" pipeline as the prototype
+      proposed
+- [ ] Phase 2: Implement the chosen mechanism; comment template should
+      reference benchmark name, runner id, baseline ref, delta with
+      confidence interval, and link to the dashboard for history
+- [ ] Phase 3: Roll out gradually — start with a single benchmark suite on a
+      stable runner; expand once review-noise tradeoffs are visible
+
+## Goal
+
+Surface a PR-level "benchmark moved by N%" signal in the review thread so
+performance regressions are caught at review time rather than after merge,
+without contradicting the Performance Dashboard (PLAN-080, Complete) that
+already owns long-form benchmark history on GitHub Pages.
+
+## Non-Goals (for early phases)
+
+- Replacing the Performance Dashboard. PLAN-080 owns time-series history;
+  this work adds an orthogonal PR-time signal.
+- Comparing across runners. PR comparisons match a single runner id only;
+  cross-machine noise is out of scope.
+- Publishing the comparison from forks. Initial rollout uses the
+  protected-branch runner pattern already used by other DART CI workflows.
+
+## Key Decisions
+
+- **Reconcile with the Performance Dashboard before implementing**. PLAN-080
+  uses `benchmark-action/github-action-benchmark` and publishes per-benchmark
+  history to `dartsim.github.io/dart/performance/`. The prototype branch
+  built a parallel pipeline (committed JSON reports + custom site + custom
+  PR-comment workflow). Pick one source of truth; do not run both.
+- **PR comment is the deliverable**, not the dashboard. The comment cites
+  benchmark name, runner id, baseline ref / SHA, delta, and links back to
+  the dashboard for time-series context.
+- **Match runner ids, not hostnames**. The prototype's report-sanitization
+  step (strip hostnames and executable paths, record a non-sensitive runner
+  id under `context.dart_bench`) is the right shape and should be reused.
+- **Open question, blocks Phase 1**: whether the comparison data should be
+  produced by extending the existing dashboard's published JSON (read from
+  gh-pages) or by re-running on the PR and comparing against a cached
+  baseline. The first reuses existing infrastructure; the second matches the
+  prototype's design.
+
+## Prototype Reference
+
+The original prototype lived on the now-deleted `bm-report` branch. Commit
+SHAs (recoverable from reflog and `git fsck --unreachable` until natural
+expiry):
+
+- `3a36c6130a1 Add benchmark report workflows and dashboard` — full
+  prototype, including two workflows (`benchmark_publish.yml`,
+  `benchmark_reports.yml`), a site at `benchmarks/site/{index.html,site.js,
+styles.css}`, three scripts (`benchmark_report_compare.py`,
+  `benchmark_report_site.py`, `run_cpp_benchmark.py`), and the
+  `pixi run bm-report` task.
+- `f6fc8257e33` and `3d8ffde9037` — added and relocated the resume prompt.
+
+To inspect the prototype while reflog still holds it:
+
+```bash
+git show 3a36c6130a1 --stat
+git show 3a36c6130a1:scripts/benchmark_report_compare.py
+git show 3a36c6130a1:.github/workflows/benchmark_reports.yml
+git show 3a36c6130a1:docs/dev_tasks/bm_report/README.md
+```
+
+## Related Plans
+
+- PLAN-080 Performance Dashboard
+  (`docs/readthedocs/community/performance_dashboard.rst`,
+  `.github/workflows/performance_dashboard.yml`) — the existing time-series
+  surface this work must reconcile with.
+
+## Immediate Next Steps
+
+1. Land this dev-task folder.
+2. Before any Phase 1 implementation, write `01-reconciliation.md` here
+   recording the answer to the "extend the dashboard runner or stand up a
+   parallel pipeline" decision. Phase 1 is blocked until that lands.
+
+## Verification Gates
+
+- Phase 2: `pixi run lint`, `pixi run check-lint-yaml` for the workflow,
+  manual dry-run on a PR comparing the comment to the dashboard's history
+  for the same benchmark.
+- Phase 3: regression test — at least one stable benchmark must be wired
+  before broader rollout, and the comment must remain quiet on noise below
+  a documented threshold.

--- a/docs/dev_tasks/benchmark_pr_comparison/RESUME.md
+++ b/docs/dev_tasks/benchmark_pr_comparison/RESUME.md
@@ -1,0 +1,50 @@
+# Resume: Per-PR Benchmark Comparison Comments
+
+## Last Session Summary
+
+Captured the per-PR benchmark-comparison comment design from the retired
+`bm-report` branch as a tracked dev task. The prototype built a parallel
+benchmark pipeline (committed JSON reports + custom site + workflows) that
+overlapped with the existing Performance Dashboard (PLAN-080, Complete).
+Phase 1 is blocked on a reconciliation decision: extend the dashboard
+runner with PR-comment hooks, or stand up the prototype's parallel
+pipeline.
+
+## Current Branch
+
+`main` — no implementation work after the prototype.
+
+## Immediate Next Step
+
+Write `docs/dev_tasks/benchmark_pr_comparison/01-reconciliation.md` choosing
+between (a) extending the existing
+`.github/workflows/performance_dashboard.yml` runner with a PR-comment
+hook that reads gh-pages history for the baseline, or (b) standing up the
+prototype's parallel `benchmark_reports.yml` workflow with committed JSON
+reports. Phase 1 is blocked until that decision is recorded.
+
+## Context That Would Be Lost
+
+- The Performance Dashboard already publishes per-benchmark history via
+  `benchmark-action/github-action-benchmark` to
+  `dartsim.github.io/dart/performance/`. Do not run two pipelines.
+- The prototype's report sanitization (strip hostnames and executable
+  paths, record a runner id under `context.dart_bench`) is the right shape;
+  reuse it.
+- PR comparisons match a single runner id; cross-machine comparison is out
+  of scope.
+
+## How to Resume
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b feature/bm-comparison-reconciliation
+
+# Inspect the prototype (while reflog still holds it):
+git show 3a36c6130a1 --stat
+git show 3a36c6130a1:scripts/benchmark_report_compare.py
+git show 3a36c6130a1:.github/workflows/benchmark_reports.yml
+```
+
+Then write `01-reconciliation.md` and unblock Phase 1.

--- a/docs/dev_tasks/skel_format_evolution/README.md
+++ b/docs/dev_tasks/skel_format_evolution/README.md
@@ -1,0 +1,96 @@
+# SKEL Format Evolution — Dev Task
+
+## Current Status
+
+- [ ] Phase 0: Capture strategic decision + prototype reference (this PR)
+- [ ] Phase 1: SKEL deprecation. Add a runtime deprecation warning to
+      `dart::utils::SkelParser`, update tutorials and onboarding to point at
+      URDF / SDF / MJCF, and remove SKEL examples that have a URDF/SDF twin
+- [ ] Phase 2: YAML front-ends for URDF and SDF (not for SKEL). Decide on a
+      YAML parser (rapidyaml is the prototype's pick) and add the front-ends
+      behind `dart::io::ModelFormat::UrdfYaml` and `SdfYaml`, mirroring the
+      existing format dispatch
+- [ ] Phase 3: USD support. Coordinate with
+      [`usd_scene_loader/`](../usd_scene_loader/) so SKEL evolution and USD
+      adoption share design pressure on the unified `dart::io` front door
+- [ ] Phase 4: Export writers for URDF, SDF, and YAML so DART can round-trip
+      a scene back to portable text
+
+## Goal
+
+Close out [issue #496](https://github.com/dartsim/dart/issues/496) (2015
+proposal to convert SKEL XML to YAML) with a decision _not_ to YAML-ify SKEL,
+and instead invest the same engineering budget into deprecating SKEL,
+enhancing URDF and SDF, adopting USD, and adding format-export so DART scenes
+can leave the engine in the same standards-track formats they came in.
+
+## Non-Goals
+
+- Re-implementing SKEL as YAML. Issue #496's literal proposal is rejected;
+  the rationale is in _Key Decisions_ below.
+- Forcing existing SKEL users off the format on a hard deadline. Read-only
+  SKEL parsing stays until DART 8 removes deprecated DART 6 / 7 APIs.
+- Building DART-specific YAML schemas that diverge from the URDF and SDF
+  semantics. YAML front-ends are alternate syntax over the same models.
+
+## Key Decisions
+
+- **SKEL is legacy, not evolving**. The format is verbose, string-based, and
+  has no installed-base outside DART. Industry has converged on URDF (ROS)
+  and SDF (Gazebo); MuJoCo and Drake have YAML alternatives over those same
+  models, not over a fork-specific schema.
+- **YAML belongs on URDF and SDF, not on SKEL**. A YAML front-end over
+  `urdfdom` and `libsdformat` reuses the canonical models and authoring
+  ecosystems. A SKEL-only YAML schema would create a third format DART has
+  to maintain.
+- **USD is the medium-term scene format**. Pixar / NVIDIA convergence makes
+  USD the most likely cross-engine scene format. Loader work is tracked
+  separately under [`usd_scene_loader/`](../usd_scene_loader/); SKEL
+  evolution should not duplicate that surface.
+- **Export is part of the work**. SDF / URDF / YAML writers turn DART into a
+  round-trip engine rather than read-only, which unblocks save / load in
+  the dartsim editor (PLAN-101) and downstream pipelines like gz-physics.
+
+## Prototype Reference
+
+The original prototype lived on the now-deleted `feature/skel_yaml` branch.
+Tip commit SHA (recoverable from reflog and `git fsck --unreachable` until
+natural expiry):
+
+- `1dd83e31586 wip` — adds 6 files (1,991 lines total) under
+  `docs/dev_tasks/skel_format/`: `README.md`, `migration-guide.md`,
+  `phase-01-deprecation.md`, `phase-02-yaml.md`, `phase-03-usd.md`, and
+  `phase-04-export.md`. The detailed phase planning, deprecation timing
+  table, YAML library tradeoff matrix, USD schema notes, and export round-
+  trip strategy live there.
+
+To inspect the verbose prototype during a phase pickup:
+
+```bash
+git show 1dd83e31586:docs/dev_tasks/skel_format/phase-01-deprecation.md
+git show 1dd83e31586:docs/dev_tasks/skel_format/phase-02-yaml.md
+git show 1dd83e31586:docs/dev_tasks/skel_format/phase-03-usd.md
+git show 1dd83e31586:docs/dev_tasks/skel_format/phase-04-export.md
+git show 1dd83e31586:docs/dev_tasks/skel_format/migration-guide.md
+```
+
+This compact dev task is the durable strategic frame; the prototype's
+verbose phase docs are reusable seed material for the agent that picks each
+phase up.
+
+## Immediate Next Steps
+
+1. Land this dev-task folder.
+2. When Phase 1 starts, fork a feature branch off `main`, run the
+   deprecation warning + tutorial update as a single small PR, and remove
+   the SKEL example files that have URDF / SDF twins.
+
+## Verification Gates
+
+- Phase 1: `pixi run lint`, `pixi run test-py` (parser warnings) and
+  `pixi run check-docs-policy` (tutorial references stay accurate).
+- Phase 2: focused tests under `tests/integration/io/` for the YAML
+  front-ends, parity with the XML originals.
+- Phase 3: see `usd_scene_loader/` gates.
+- Phase 4: round-trip tests that load a scene from each format and write it
+  back, comparing the re-parsed models.

--- a/docs/dev_tasks/skel_format_evolution/RESUME.md
+++ b/docs/dev_tasks/skel_format_evolution/RESUME.md
@@ -1,0 +1,45 @@
+# Resume: SKEL Format Evolution
+
+## Last Session Summary
+
+Captured the strategic decision to close out
+[issue #496](https://github.com/dartsim/dart/issues/496) by _not_ converting
+SKEL to YAML, and to invest instead in SKEL deprecation, URDF / SDF YAML
+front-ends, USD adoption (via [`usd_scene_loader/`](../usd_scene_loader/)),
+and export writers. The retired `feature/skel_yaml` branch carried a
+1,991-line draft plan; that draft is preserved by SHA so the verbose phase
+docs can seed each phase as it picks up.
+
+## Current Branch
+
+`main` — no implementation work after the prototype plan.
+
+## Immediate Next Step
+
+Pick Phase 1 (SKEL deprecation). Open a focused PR that adds a runtime
+deprecation warning to `dart::utils::SkelParser`, updates tutorials and
+onboarding to point at URDF / SDF / MJCF, and removes SKEL examples that
+have a URDF / SDF twin.
+
+## Context That Would Be Lost
+
+- The 2015 issue #496 proposed converting SKEL XML to YAML. That proposal is
+  rejected here; the rationale lives in `README.md` under _Key Decisions_.
+- YAML belongs on URDF and SDF (third-party canonical models), not on SKEL.
+- USD work is tracked separately under
+  [`usd_scene_loader/`](../usd_scene_loader/) — do not duplicate.
+- Export is part of the work, not a follow-up: round-trip enables save /
+  load in the dartsim editor (PLAN-101).
+
+## How to Resume
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b feature/skel-deprecation-phase1
+
+# Inspect the prototype plan (while reflog still holds it):
+git show 1dd83e31586:docs/dev_tasks/skel_format/phase-01-deprecation.md
+```
+
+Then translate the prototype's Phase 1 plan into a deprecation-warning PR.

--- a/docs/dev_tasks/skeleton_simulation_mode/README.md
+++ b/docs/dev_tasks/skeleton_simulation_mode/README.md
@@ -1,0 +1,90 @@
+# Skeleton Simulation-Mode Lifecycle — Dev Task
+
+## Current Status
+
+- [ ] Phase 0: Captured prototype reference and design intent (this PR)
+- [ ] Phase 1: Decide whether the lifecycle marker lives on the legacy
+      `dart::dynamics::Skeleton` / `BodyNode` or only on the experimental
+      World's frame storage (PLAN-050)
+- [ ] Phase 2: Implement the chosen surface with snake_case headers, parser
+      plumbing, and dartpy bindings
+- [ ] Phase 3: Wire dartsim editor (PLAN-101) so edit-time selection,
+      undo/redo, and project save/load operate on `Design` skeletons; promote
+      to `Simulation` only when the editor enters Run mode
+
+## Goal
+
+Give every Skeleton (and BodyNode) a first-class lifecycle marker that
+distinguishes an object being edited from one being actively simulated by a
+World, so the dartsim editor (PLAN-101) can author skeletons without paying
+the full simulation invariants and so World can reject ambiguous ownership
+transitions at the API boundary.
+
+## Non-Goals (for early phases)
+
+- Re-introducing `World::createSkeletonFromUri` — that helper was already
+  removed in `main` (see commits referenced below); caller-side
+  `dart::io::read*` + `World::addSkeleton` stays the only entry point.
+- Multi-World ownership or shared skeletons across Worlds.
+- Re-implementing edit-time picking or transforms on top of this enum;
+  that work belongs to the dartsim editor task
+  (`docs/dev_tasks/dartsim_workbench_completion/`).
+
+## Key Decisions
+
+- **Surface**: an `enum class SimulationMode { Design, Simulation }` reachable
+  from `Skeleton::getSimulationMode()` / `setSimulationMode()` /
+  `isSimulationMode()` is the prototype's proposed API. Default state is
+  `Design`; `World::addSkeleton` flips to `Simulation` and `removeSkeleton`
+  flips back. The transition is the API boundary that enforces ownership.
+- **Naming**: snake_case header `dart/dynamics/simulation_mode.hpp` (the
+  prototype's `dart/dynamics/SimulationMode.hpp` predates the snake_case
+  migration; `docs/onboarding/code-style.md` is the rule).
+- **Parser plumbing**: parsers (`SkelParser`, `VskParser`, `MjcfParser`,
+  `SdfParser`, `UrdfParser`) construct skeletons in `Design` mode so the
+  result can be inspected or edited before being added to a World. The
+  prototype already threaded the enum through all five parsers.
+- **Open question, blocks Phase 1**: the experimental World (PLAN-050,
+  complete on main) stores frames under
+  `dart/simulation/experimental/frame/`, not `dart::dynamics::Skeleton`. The
+  lifecycle marker may belong only on the experimental side, with the legacy
+  Skeleton API left untouched until DART 8 removes it. This decision must be
+  made before writing snake_case headers.
+
+## Prototype Reference
+
+The original prototype lived on the now-deleted `refactor/ownership` branch.
+Commit SHAs (recoverable from reflog and `git fsck --unreachable` until
+natural expiry):
+
+- `9cf76c0b44e Refine skeleton ownership and tooling` — first cut that
+  introduced the enum.
+- `581d1ee60e5 Add World::createSkeletonFromUri` and
+  `ce7feea4302 Keep World::addSkeleton available temporarily` — the
+  intermediate ownership tightening; the second is the rollback that aligned
+  with the eventual removal-only design.
+- `d1b6c14e060 Remove World::createSkeletonFromUri` — the surviving half;
+  this matches main's current state and is the _non-goal_ anchor.
+
+Files of interest in the prototype: `dart/dynamics/SimulationMode.hpp`
+(20-line enum), `dart/dynamics/{Skeleton,BodyNode}.{cpp,hpp}` and their
+`detail/` private layout, all five parser files under `dart/utils/`, the
+dartpy bindings in `python/dartpy/{dynamics/skeleton,simulation/world}.cpp`,
+and the `docs/onboarding/self-collision.md` note that paired with the
+removal.
+
+## Immediate Next Steps
+
+1. Land this dev-task folder so the design is discoverable.
+2. Before any Phase 1 implementation, resolve the legacy-vs-experimental
+   placement question with a short design note here under the
+   `01-placement.md` filename, or fold it into the experimental-World
+   onboarding doc if the answer is "experimental only".
+
+## Verification Gates
+
+- Phase 2: `pixi run lint`, `pixi run test-unit`, focused parser tests,
+  `pixi run check-api-boundaries`.
+- Phase 3: dartsim engine + headless smoke prove that opening a project file
+  produces `Design` skeletons and that pressing Run promotes them to
+  `Simulation` without leaking the enum publicly through the editor surface.

--- a/docs/dev_tasks/skeleton_simulation_mode/RESUME.md
+++ b/docs/dev_tasks/skeleton_simulation_mode/RESUME.md
@@ -1,0 +1,49 @@
+# Resume: Skeleton Simulation-Mode Lifecycle
+
+## Last Session Summary
+
+Captured the `SimulationMode { Design, Simulation }` lifecycle marker design
+from the retired `refactor/ownership` branch as a tracked dev task. The
+prototype branch was retired because the simple half of its scope (removing
+`World::createSkeletonFromUri`) already landed on main, and the surviving
+design half (the enum + parser plumbing) needs a placement decision before it
+can land cleanly under the snake_case + experimental-World layout.
+
+## Current Branch
+
+`main` — no implementation work on the lifecycle marker has started after the
+prototype.
+
+## Immediate Next Step
+
+Decide whether the lifecycle marker belongs on the legacy
+`dart::dynamics::Skeleton` (and propagate through five parsers) or only on
+the experimental World's frame storage (PLAN-050). Record the decision as
+`01-placement.md` here. Phase 1 implementation is blocked on this.
+
+## Context That Would Be Lost
+
+- The prototype attached `mSimulationMode = SimulationMode::Design` directly
+  to `Skeleton` and threaded the enum through `SkelParser`, `VskParser`,
+  `MjcfParser`, `SdfParser`, and `UrdfParser` — a wide surface change.
+- The dartsim editor (PLAN-101) is the immediate consumer; it needs
+  edit-time skeletons that do not yet satisfy simulation invariants.
+- `World::createSkeletonFromUri` is _gone_ on main; do not re-introduce it.
+  Caller-side `dart::io::read*` + `World::addSkeleton` is the only entry
+  point.
+
+## How to Resume
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b feature/simulation-mode-placement
+
+# Inspect prototype (while reflog still holds it):
+git show 9cf76c0b44e --stat
+git show 9cf76c0b44e:dart/dynamics/SimulationMode.hpp
+git show 9cf76c0b44e:dart/dynamics/Skeleton.hpp | grep -nE "SimulationMode"
+```
+
+Then write `docs/dev_tasks/skeleton_simulation_mode/01-placement.md`
+recording the legacy-vs-experimental decision and unblock Phase 1.

--- a/docs/dev_tasks/usd_scene_loader/README.md
+++ b/docs/dev_tasks/usd_scene_loader/README.md
@@ -1,0 +1,100 @@
+# OpenUSD Scene Loader — Dev Task
+
+## Current Status
+
+- [ ] Phase 0: Captured prototype reference and migration requirements (this PR)
+- [ ] Phase 1: Add `dart::io::ModelFormat::Usd` and a snake_case `dart/io/usd/`
+      implementation behind the unified `dart::io::readWorld` / `readSkeleton`
+      front door
+- [ ] Phase 2: Map USD prims to experimental World shapes/joints (PLAN-050);
+      keep the loader behind the API-boundary policy
+- [ ] Phase 3: Filament-backed viewer example (replace the OSG prototype) plus
+      headless smoke coverage under the dartsim engine
+- [ ] Phase 4: dartpy bindings against the snake_case API and Linux/macOS
+      pytest stability (the prototype's macOS pytest aborts must be resolved
+      before the loader is enabled by default)
+
+## Goal
+
+Make `.usda` / `.usd` scenes loadable through DART's unified IO front door so a
+researcher can drop a USD asset into an experimental World and visualize it
+through the maintained Filament renderer, with parity to the existing URDF /
+SDF / MJCF / SKEL paths.
+
+## Non-Goals (for early phases)
+
+- Writing USD back out — read-only loader first.
+- Authoring USD physics schema (USDPhysics) features beyond the minimum needed
+  to land a working rigid-body chain plus the Unitree H1 minimal sample.
+- Re-introducing the OSG viewer that the prototype example used; the project
+  has standardized on Filament (see PLAN-060 / PLAN-090).
+
+## Key Decisions
+
+- **Front door**: extend `dart::io::ModelFormat` with `Usd` and route reads
+  through `dart::io::readWorld` / `readSkeleton`, mirroring SDF / URDF / MJCF.
+  Do not create a parallel `dart::utils::UsdParser` namespace as the prototype
+  did.
+- **Naming**: snake_case headers under `dart/io/usd/` (e.g.
+  `usd_parser.{cpp,hpp}`), per `docs/onboarding/code-style.md` and the
+  completed snake_case migration. The prototype's PascalCase paths
+  (`dart/utils/usd/UsdParser.{cpp,hpp}`) predate the migration.
+- **World target**: bind first against the experimental World
+  (`dart/simulation/experimental/`, PLAN-050) so the loader co-evolves with
+  the new shape/loader APIs. The legacy `dart::simulation::World` does not
+  need a USD path.
+- **Viewer example**: build the example against the dartsim engine + Filament
+  (see PLAN-101 and `docs/onboarding/gui-rendering.md`). The prototype's
+  OSG-based `examples/usd_viewer/main.cpp` is incompatible with the
+  retired-OSG policy.
+- **Dependency**: pxr (OpenUSD). Discovery lives in
+  `cmake/dart_find_pxr.cmake` (snake_case) and is opt-in via a CMake toggle
+  similar to `DART_BUILD_GUI_FILAMENT`. The prototype's
+  `cmake/DARTFindpxr.cmake` is the starting point but must be renamed.
+- **macOS stability**: the prototype's six diagnostic commits chased a pytest
+  abort on macOS without resolving it. Phase 4 must address the root cause
+  (likely an OpenUSD plugin-path or fork-safety issue) before the loader is
+  enabled in default Linux + macOS Pixi environments.
+
+## Prototype Reference
+
+The original prototype lived on the now-deleted `feature/usd-viewer` branch.
+Commit SHAs (recoverable from reflog and `git fsck --unreachable` until natural
+expiry):
+
+- Feature commit: `28bad2773d18ce47bbaef98508d385abe1a8aead`
+  ("Add OpenUSD loader and viewer support") — the substantive prototype.
+- macOS diagnostics tail: `82f9a261361..b7a7ac09823` — five commits chasing
+  pytest aborts; useful as a clue trail when Phase 4 picks up macOS stability.
+
+To inspect the prototype contents during Phase 1:
+
+```bash
+git fetch origin
+# If still in reflog window
+git show 28bad2773d1 --stat
+git show 28bad2773d1:dart/utils/usd/UsdParser.hpp
+git show 28bad2773d1:examples/usd_viewer/main.cpp
+```
+
+Files of interest in the prototype: `dart/utils/usd/UsdParser.{cpp,hpp}`,
+`cmake/DARTFindpxr.cmake`, `data/usd/{simple_chain,unitree_h1_minimal}.usda`,
+`python/dartpy/utils/UsdParser.cpp`,
+`tests/integration/io/test_UsdParser.cpp`,
+`python/tests/unit/test_usd_parser.py`.
+
+## Immediate Next Steps
+
+1. Land this dev-task folder so the work is discoverable.
+2. When a contributor or agent picks Phase 1 up, fork a fresh branch off
+   `main`, port the parser surface into `dart/io/usd/` under the unified
+   `readWorld` / `readSkeleton` API, and adapt the sample data and tests to
+   the snake_case + experimental-World layout.
+
+## Verification Gates
+
+- Phase 1: `pixi run lint`, `pixi run test-unit`, focused USD integration
+  test, `pixi run check-api-boundaries`.
+- Phase 3: GUI smoke runs the USD sample headlessly under the dartsim engine.
+- Phase 4: dartpy unit tests pass on Linux + macOS Pixi environments without
+  pytest aborts.

--- a/docs/dev_tasks/usd_scene_loader/RESUME.md
+++ b/docs/dev_tasks/usd_scene_loader/RESUME.md
@@ -1,0 +1,45 @@
+# Resume: OpenUSD Scene Loader
+
+## Last Session Summary
+
+Captured the OpenUSD scene-loader prototype (formerly on
+`origin/feature/usd-viewer`) as a tracked dev task. The prototype branch was
+retired because it predated the snake_case migration, used the retired OSG
+viewer, exposed a parallel `dart::utils::UsdParser` namespace instead of the
+unified `dart::io` front door, and left macOS pytest aborts unresolved.
+
+## Current Branch
+
+`main` — no implementation work on the loader has started after the prototype.
+
+## Immediate Next Step
+
+Pick a feature branch off `main`, then port the prototype's parser core (see
+`README.md` Prototype Reference for SHAs) into `dart/io/usd/usd_parser.{cpp,hpp}`
+behind `dart::io::ModelFormat::Usd`. Keep dependencies behind a CMake toggle
+parallel to `DART_BUILD_GUI_FILAMENT`.
+
+## Context That Would Be Lost
+
+- The prototype's macOS pytest aborts (see tail commit
+  `b7a7ac09823 Collect lldb backtrace on mac pytest aborts`) were never root-
+  caused; likely an OpenUSD plugin path / fork-safety issue. Treat as a
+  Phase 4 blocker, not a parser bug.
+- The viewer example must target Filament + dartsim engine, not OSG
+  (PLAN-060 / PLAN-090 retired OSG).
+- `dart::simulation::experimental` (PLAN-050) is the World target; the
+  legacy `dart::simulation::World` does not need a USD path.
+
+## How to Resume
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b feature/usd-loader-phase1
+
+# Inspect prototype (while reflog still holds it):
+git show 28bad2773d1 --stat
+git show 28bad2773d1:dart/utils/usd/UsdParser.hpp
+```
+
+Then start Phase 1 from `docs/dev_tasks/usd_scene_loader/README.md`.


### PR DESCRIPTION
## Summary

- Add four new tracked dev tasks under `docs/dev_tasks/` that capture design intent and prototype references from retired wip branches.
- Each task has the required `README.md` + `RESUME.md` (per `docs/dev_tasks/README.md`) and points at the prototype commit SHA so the original code stays recoverable from reflog.

## Motivation / Problem

- A recent branch-cleanup pass (see `docs/dev_tasks/branch_cleanup/01_progress.md`) verdicted several old prototype branches as MIGRATE-CONCEPT — useful idea, but the implementation needs rework against current snake_case / experimental World / Filament / dart::io conventions, not a rebase of the stale branch.
- Without a tracked home, those concepts get lost when the prototype branches are deleted. GitHub issues add noise; a `docs/dev_tasks/<task>/` folder is the in-repo convention DART already uses for multi-phase work.

## Changes / Key Changes

- `docs/dev_tasks/usd_scene_loader/` — OpenUSD scene loader aligned with `dart::io::ModelFormat::Usd`, experimental World (PLAN-050), and Filament viewer (PLAN-101). Replaces the OSG + `dart::utils::UsdParser` prototype on the retired `feature/usd-viewer` branch.
- `docs/dev_tasks/skeleton_simulation_mode/` — `SimulationMode { Design, Simulation }` skeleton lifecycle marker design from the retired `refactor/ownership` branch. The simple half (removing `World::createSkeletonFromUri`) already landed on main; the lifecycle marker needs a legacy-vs-experimental placement decision.
- `docs/dev_tasks/skel_format_evolution/` — strategic decision to close `#496` by *not* converting SKEL to YAML, and instead invest in SKEL deprecation, URDF/SDF YAML front-ends, USD adoption (coordinated with `usd_scene_loader/`), and export writers. Compresses 1991 lines of plan from the retired `feature/skel_yaml` branch into a tracked frame.
- `docs/dev_tasks/benchmark_pr_comparison/` — per-PR benchmark comparison comments design from the retired `bm-report` branch. Phase 1 is blocked on reconciliation with the existing Performance Dashboard (PLAN-080, Complete).

## Testing

- `pixi run lint-md` — clean.
- `pixi run check-docs-policy` — clean.
- `pixi run lint-spell` — clean.
- Each dev_task folder has both required files (`README.md` + `RESUME.md`) per `docs/dev_tasks/README.md`.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Source prototype branches (will be deleted after this PR merges): `feature/usd-viewer`, `refactor/ownership`, `feature/skel_yaml`, `bm-report`.
- Source prototype SHAs are recorded in each `README.md` Prototype Reference section so the code stays inspectable while reflog holds them.
- Branch cleanup context: `docs/dev_tasks/branch_cleanup/01_progress.md`.
- SKEL evolution closes the design space around issue [#496](https://github.com/dartsim/dart/issues/496) (decision: do not pursue the 2015 proposal).

---

#### Checklist

- [x] Milestone set (DART 7.0)
- [ ] CHANGELOG.md updated — N/A (tracking docs only; no library/feature change)
- [ ] Add unit tests for new functionality — N/A
- [x] Document new methods and classes — dev_task docs are the deliverable
- [ ] Add Python bindings (dartpy) if applicable — N/A