### PR TITLE
Remove duplicated block from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,25 +83,5 @@ dist/
 # ImGui configuration
 imgui.ini
 
-# Temporary directory for dependencies
-.deps/
-
-# Language server and editor cache
-.cache/
-
 # Gazebo physics plugins
 /libgz-physics-*.so
-
-# Python distribution artifacts
-dist/
-*.egg-info
-
-# Python wheel files
-*.whl
-
-# pixi environments
-.pixi
-
-# ImGui configuration
-imgui.ini
-.cache/


### PR DESCRIPTION
## Summary

- Collapse a duplicated block in `.gitignore` on `release-6.16` to a single copy of each rule.

## Motivation / Problem

- A merge accident left `release-6.16`'s `.gitignore` with a second copy of several sections (`.deps/`, `.cache/`, `dist/`/`*.egg-info`, `*.whl`, `.pixi`, `imgui.ini`) plus a stray third `.cache/` entry at end of file. `.cache/` appeared 3×; `.deps/`, `.pixi`, `imgui.ini` appeared 2×.

## Changes / Key Changes

- Remove the duplicated block (20 lines), keeping a single copy of each ignore rule.
- Preserve the unique `# Gazebo physics plugins` (`/libgz-physics-*.so`) entry, which lived inside the duplicated region and is **not** redundant.

## Testing

- `.gitignore`-only change; no build/test gate covers it. Verified post-edit that each entry (`.cache/`, `.deps/`, `.pixi`, `imgui.ini`) appears exactly once and `libgz-physics` is retained.
- No behavior change: duplicate `.gitignore` entries are no-ops.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- `main`'s `.gitignore` already has each entry once (no duplication), so no `main`-side companion PR is needed. This is a `release-6.16`-only artifact.
- Supersedes the stale `6.16/freebsd_patches` branch, whose single-line `.cache/` removal addressed only part of the duplication. That branch will be deleted once this lands.

---

#### Checklist

- [x] Milestone set (DART 6.16.8)
- [ ] CHANGELOG.md updated if required — N/A (no functional/behavioral change)
- [ ] Add unit tests for new functionality — N/A
- [ ] Document new methods and classes — N/A
- [ ] Add Python bindings (dartpy) if applicable — N/A