### PR TITLE
Add IPC moving rigid surface CCD limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -818,6 +818,15 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     line-search limiter, with point-triangle and physical box-edge CCD
     regressions and benchmark counters. This is a CCD limiter only, not rigid
     contact response or IPC parity.
+  - Added internal experimental moving rigid box surface CCD limiting for free
+    (non-static) deformable-surface CCD obstacles: the deformable stage predicts
+    each obstacle's end-of-step transform from its velocity (mirroring the rigid
+    position integrator that runs after the deformable stage) and tiles the
+    swept motion with overlapping static pose samples so the deformable cannot
+    settle in or tunnel through the obstacle's swept corridor, with focused
+    regressions and benchmark counters. This is a one-way conservative CCD
+    limiter only (timing-agnostic, no rigid contact response or two-way
+    coupling) and is not IPC parity.
   - Added internal experimental IPC conservative continuous-collision step
     bounds for point-triangle and edge-edge primitive candidate pairs by
     wrapping native primitive CCD, with exact-CCD regression tests, sampled

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -1186,6 +1186,175 @@ std::vector<SurfaceContactSnapshot> collectStaticRigidSurfaceCcdObstacles(
 }
 
 //==============================================================================
+// Predict a free rigid body's end-of-step transform from its current pose and
+// velocity WITHOUT mutating any component. Mirrors integrateRigidBodyPosition
+// exactly so the deformable stage limits against the SAME motion that
+// RigidBodyPositionStage will later apply at stage 5.
+comps::Transform predictRigidBodyEndTransform(
+    const comps::Transform& transform,
+    const comps::Velocity& velocity,
+    const double timeStep)
+{
+  comps::Transform end = transform;
+  end.position = transform.position + velocity.linear * timeStep;
+
+  auto orientation = normalizeOrIdentity(transform.orientation);
+  const double angularSpeed = velocity.angular.norm();
+  if (angularSpeed > 0.0 && std::isfinite(angularSpeed)) {
+    const auto rotation = Eigen::AngleAxisd(
+        angularSpeed * timeStep, velocity.angular.normalized());
+    orientation = rotation * orientation;
+    orientation.normalize();
+  }
+  end.orientation = normalizeOrIdentity(orientation);
+  return end;
+}
+
+//==============================================================================
+// Number of intermediate static box poses that tile a moving obstacle's swept
+// motion. Below the cap, consecutive sample centers are one box min-half-extent
+// apart so the sampled boxes overlap with margin. The count is capped so a
+// pathologically fast obstacle cannot explode the work; past the cap the
+// residual spacing grows, and the caller restores overlap by inflating the
+// sampled boxes (see collectMovingRigidSurfaceCcdObstacles), so the swept
+// corridor stays covered rather than developing tunnelable gaps.
+std::size_t movingRigidSurfaceCcdSampleCount(
+    const Eigen::Vector3d& halfExtents,
+    const comps::Transform& startTransform,
+    const comps::Transform& endTransform,
+    const Eigen::Vector3d& angularVelocity,
+    const double timeStep)
+{
+  constexpr std::size_t kMaxSamples = 64;
+  const double minHalfExtent = halfExtents.minCoeff();
+  if (!(minHalfExtent > 0.0)) {
+    return 2;
+  }
+
+  const double linearMotion
+      = (endTransform.position - startTransform.position).norm();
+  const double radius = halfExtents.norm();
+  const double angularMotion = radius * angularVelocity.norm() * timeStep;
+  const double motion = linearMotion + angularMotion;
+  if (!std::isfinite(motion) || motion <= 0.0) {
+    return 2;
+  }
+
+  const auto segments
+      = static_cast<std::size_t>(std::ceil(motion / minHalfExtent));
+  const std::size_t samples = std::min(kMaxSamples, segments + 1);
+  return std::max<std::size_t>(samples, 2);
+}
+
+//==============================================================================
+// Collect conservative static box snapshots that tile each MOVING rigid box
+// obstacle's swept motion over the step. Each snapshot is an ordinary static
+// pose, so the existing static-style limiter and
+// interBodySurfaceContactStepBound handle them unchanged. The obstacle end pose
+// is predicted from velocity, so the deformable is limited against where the
+// obstacle will be even though the deformable stage runs before
+// RigidBodyPositionStage.
+//
+// This treats the swept volume as a static blocker for the step (timing-
+// agnostic): it is more conservative than a timing-aware sweep for fast
+// obstacles. At IPC-scale time steps the per-step motion is small, so few
+// samples closely approximate the true contact surface. Consecutive sample
+// boxes are kept overlapping so the deformable cannot tunnel between them: when
+// the sample count hits its cap and the natural spacing would open gaps, the
+// sampled boxes are isotropically inflated by half the residual spacing, which
+// keeps the real obstacle inside each sample and the corridor covered (at the
+// cost of extra over-conservatism). Coverage of the swept hull is exact along
+// the box min axis for axis-aligned motion; for diagonal motion a bounded,
+// half-extent-scale thin-corner under-coverage remains, inherent to all box
+// supersampling.
+std::vector<SurfaceContactSnapshot> collectMovingRigidSurfaceCcdObstacles(
+    const World& world, const double timeStep, DeformableSolverStats& stats)
+{
+  ++stats.movingRigidSurfaceCcdSnapshotBuilds;
+
+  const auto& registry = world.getRegistry();
+  // Moving obstacles are free (non-static) rigid bodies integrated by
+  // RigidBodyPositionStage. entt::exclude<StaticBodyTag> keeps this set
+  // disjoint from collectStaticRigidSurfaceCcdObstacles so no body is limited
+  // or counted twice. comps::Velocity is required to predict the end pose.
+  auto view = registry.view<
+      comps::RigidBodyTag,
+      comps::DeformableSurfaceCcdObstacleTag,
+      comps::CollisionGeometry,
+      comps::Transform,
+      comps::Velocity>(entt::exclude<comps::StaticBodyTag>);
+
+  std::vector<SurfaceContactSnapshot> snapshots;
+  for (const auto entity : view) {
+    const auto& geometry = view.get<comps::CollisionGeometry>(entity);
+    const auto& transform = view.get<comps::Transform>(entity);
+    const auto& velocity = view.get<comps::Velocity>(entity);
+    if (geometry.shape.type != CollisionShapeType::Box
+        || !geometry.shape.halfExtents.allFinite()
+        || (geometry.shape.halfExtents.array() <= 0.0).any()
+        || !transform.position.allFinite() || !velocity.linear.allFinite()
+        || !velocity.angular.allFinite()) {
+      continue;
+    }
+
+    const auto endTransform
+        = predictRigidBodyEndTransform(transform, velocity, timeStep);
+    const auto& halfExtents = geometry.shape.halfExtents;
+    const std::size_t samples = movingRigidSurfaceCcdSampleCount(
+        halfExtents, transform, endTransform, velocity.angular, timeStep);
+
+    // Keep consecutive sample boxes overlapping. The natural (uncapped) spacing
+    // is one box min-half-extent, so the boxes overlap with margin; once the
+    // sample count is capped the residual spacing can exceed the box min
+    // dimension, so inflate each sampled box isotropically by half the residual
+    // spacing to bridge the gap. inflation is 0 in the common (uncapped) case.
+    const double minHalfExtent = halfExtents.minCoeff();
+    const double linearMotion
+        = (endTransform.position - transform.position).norm();
+    const double angularMotion
+        = halfExtents.norm() * velocity.angular.norm() * timeStep;
+    const double motion = linearMotion + angularMotion;
+    const double spacing = (samples > 1 && std::isfinite(motion))
+                               ? motion / static_cast<double>(samples - 1)
+                               : 0.0;
+    const double inflation = std::max(0.0, 0.5 * spacing - minHalfExtent);
+    const Eigen::Vector3d sampleHalfExtents
+        = halfExtents + Eigen::Vector3d::Constant(inflation);
+    if (inflation > 0.0) {
+      ++stats.movingRigidSurfaceCcdInflatedBoxCount;
+    }
+
+    const Eigen::Quaterniond startOrientation
+        = normalizeOrIdentity(transform.orientation);
+    const Eigen::Quaterniond endOrientation
+        = normalizeOrIdentity(endTransform.orientation);
+
+    for (std::size_t k = 0; k < samples; ++k) {
+      // samples is always >= 2, so the denominator is never zero.
+      const double fraction
+          = static_cast<double>(k) / static_cast<double>(samples - 1);
+      comps::Transform sampleTransform;
+      sampleTransform.position
+          = transform.position
+            + fraction * (endTransform.position - transform.position);
+      sampleTransform.orientation
+          = startOrientation.slerp(fraction, endOrientation);
+
+      auto snapshot = makeStaticBoxSurfaceCcdSnapshot(
+          entity, sampleHalfExtents, sampleTransform);
+      stats.movingRigidSurfaceCcdTriangleCount
+          += snapshot.surfaceTriangles.size();
+      stats.movingRigidSurfaceCcdEdgeCount += snapshot.surfaceEdges.size();
+      ++stats.movingRigidSurfaceCcdSampleCount;
+      snapshots.push_back(std::move(snapshot));
+    }
+    ++stats.movingRigidSurfaceCcdBoxCount;
+  }
+
+  return snapshots;
+}
+
+//==============================================================================
 std::optional<double> boxTopAt(
     const StaticGroundBarrier& barrier, const Eigen::Vector3d& position)
 {
@@ -2139,6 +2308,105 @@ bool applyStaticRigidSurfaceCcdLimit(
 }
 
 //==============================================================================
+// Conservative CCD limiter against MOVING rigid box obstacles. The snapshots
+// are static poses sampled along the obstacle's predicted swept motion, so this
+// reuses exactly the static-obstacle step-bound path; only the stat family
+// differs. Limiting against every sampled pose keeps the deformable out of the
+// obstacle's swept corridor.
+bool applyMovingRigidSurfaceCcdLimit(
+    std::span<const SurfaceContactSnapshot> movingRigidSurfaceSnapshots,
+    const std::vector<Eigen::Vector3d>& current,
+    const std::vector<Eigen::Vector3d>& direction,
+    const std::vector<Eigen::Vector3d>& gradient,
+    const std::vector<std::uint8_t>& fixed,
+    DeformableContactSolverScratch& contactScratch,
+    DeformableSolverStats& stats,
+    double& step,
+    std::vector<Eigen::Vector3d>& candidate,
+    double& directionalDerivative)
+{
+  if (movingRigidSurfaceSnapshots.empty()) {
+    return true;
+  }
+
+  if (contactScratch.surfaceTriangles.empty()) {
+    contactScratch.interBodyCurrentEdges.clear();
+  } else {
+    dc::buildUniqueSurfaceEdges(
+        contactScratch.surfaceTriangles, contactScratch.interBodyCurrentEdges);
+  }
+
+  ++stats.movingRigidSurfaceCcdCandidateBuilds;
+  bool hit = false;
+  bool indeterminate = false;
+  double stepBound = 1.0;
+
+  for (const auto& snapshot : movingRigidSurfaceSnapshots) {
+    if (snapshot.surfaceTriangles.empty()) {
+      continue;
+    }
+
+    const auto result = interBodySurfaceContactStepBound(
+        current,
+        candidate,
+        contactScratch.surfaceTriangles,
+        contactScratch.surfaceContactPointMask,
+        contactScratch.interBodyCurrentEdges,
+        snapshot,
+        makeSurfaceContactCandidateOptions(),
+        makeSurfaceContactCcdOptions(),
+        contactScratch);
+
+    stats.movingRigidSurfaceCcdPointTriangleCandidates
+        += result.pointTriangleCandidateCount;
+    stats.movingRigidSurfaceCcdEdgeEdgeCandidates
+        += result.edgeEdgeCandidateCount;
+    stats.movingRigidSurfaceCcdPointTriangleChecks
+        += result.stats.pointTriangleChecks;
+    stats.movingRigidSurfaceCcdEdgeEdgeChecks += result.stats.edgeEdgeChecks;
+    stats.movingRigidSurfaceCcdHits += result.stats.hits;
+    stats.movingRigidSurfaceCcdMisses += result.stats.misses;
+    stats.movingRigidSurfaceCcdIndeterminateCount += result.stats.indeterminate;
+    stats.movingRigidSurfaceCcdZeroStepCount += result.stats.zeroStepCount;
+
+    indeterminate = indeterminate || result.indeterminate;
+    if (result.indeterminate) {
+      stepBound = 0.0;
+    }
+    if (result.hit && (!hit || result.stepBound < stepBound)) {
+      hit = true;
+      stepBound = result.stepBound;
+    }
+  }
+
+  if (indeterminate) {
+    return false;
+  }
+
+  if (!hit) {
+    return true;
+  }
+
+  stepBound = std::clamp(stepBound, 0.0, 1.0);
+  if (stepBound <= 0.0) {
+    ++stats.movingRigidSurfaceCcdZeroStepCount;
+    return false;
+  }
+
+  const double safeFraction = std::nextafter(stepBound, 0.0);
+  if (safeFraction <= 0.0 || !std::isfinite(safeFraction)) {
+    ++stats.movingRigidSurfaceCcdZeroStepCount;
+    return false;
+  }
+
+  step *= safeFraction;
+  ++stats.movingRigidSurfaceCcdLimitedSteps;
+  directionalDerivative = buildLineSearchCandidate(
+      current, direction, gradient, fixed, step, candidate);
+  return true;
+}
+
+//==============================================================================
 bool applyStaticGroundBarrierCcdLimit(
     const std::vector<Eigen::Vector3d>& current,
     const std::vector<Eigen::Vector3d>& direction,
@@ -2316,6 +2584,7 @@ void advanceDeformableBody(
     DeformableContactSolverScratch& contactScratch,
     std::span<const SurfaceContactSnapshot> surfaceSnapshots,
     std::span<const SurfaceContactSnapshot> rigidSurfaceSnapshots,
+    std::span<const SurfaceContactSnapshot> movingRigidSurfaceSnapshots,
     const Eigen::Vector3d& gravity,
     double timeStep,
     const std::vector<StaticGroundBarrier>& barriers,
@@ -2365,6 +2634,7 @@ void advanceDeformableBody(
       scratch.next, scratch.activeFixed, barriers, &stats);
 
   if (model.edges.empty() && barriers.empty() && rigidSurfaceSnapshots.empty()
+      && movingRigidSurfaceSnapshots.empty()
       && contactScratch.surfaceTriangles.empty()) {
     for (std::size_t i = 0; i < nodeCount; ++i) {
       if (scratch.activeFixed[i] == 0u) {
@@ -2445,6 +2715,17 @@ void advanceDeformableBody(
                 directionalDerivative)
             && applyStaticRigidSurfaceCcdLimit(
                 rigidSurfaceSnapshots,
+                scratch.next,
+                scratch.direction,
+                scratch.gradient,
+                scratch.activeFixed,
+                contactScratch,
+                stats,
+                step,
+                scratch.candidate,
+                directionalDerivative)
+            && applyMovingRigidSurfaceCcdLimit(
+                movingRigidSurfaceSnapshots,
                 scratch.next,
                 scratch.direction,
                 scratch.gradient,
@@ -2890,6 +3171,8 @@ void DeformableDynamicsStage::execute(
   const auto rigidSurfaceSnapshots
       = collectStaticRigidSurfaceCcdObstacles(world, m_lastStats);
   const auto timeStep = world.getTimeStep();
+  const auto movingRigidSurfaceSnapshots
+      = collectMovingRigidSurfaceCcdObstacles(world, timeStep, m_lastStats);
   const auto gravity = world.getGravity();
   m_lastStats.staticGroundBarrierCount = barriers.size();
 
@@ -2948,6 +3231,7 @@ void DeformableDynamicsStage::execute(
         contactScratch,
         surfaceSnapshots,
         rigidSurfaceSnapshots,
+        movingRigidSurfaceSnapshots,
         gravity,
         timeStep,
         barriers,

--- a/dart/simulation/experimental/compute/world_step_stage.hpp
+++ b/dart/simulation/experimental/compute/world_step_stage.hpp
@@ -98,6 +98,22 @@ struct DeformableSolverStats
   std::size_t staticRigidSurfaceCcdIndeterminateCount = 0;
   std::size_t staticRigidSurfaceCcdLimitedSteps = 0;
   std::size_t staticRigidSurfaceCcdZeroStepCount = 0;
+  std::size_t movingRigidSurfaceCcdSnapshotBuilds = 0;
+  std::size_t movingRigidSurfaceCcdBoxCount = 0;
+  std::size_t movingRigidSurfaceCcdSampleCount = 0;
+  std::size_t movingRigidSurfaceCcdInflatedBoxCount = 0;
+  std::size_t movingRigidSurfaceCcdTriangleCount = 0;
+  std::size_t movingRigidSurfaceCcdEdgeCount = 0;
+  std::size_t movingRigidSurfaceCcdCandidateBuilds = 0;
+  std::size_t movingRigidSurfaceCcdPointTriangleCandidates = 0;
+  std::size_t movingRigidSurfaceCcdEdgeEdgeCandidates = 0;
+  std::size_t movingRigidSurfaceCcdPointTriangleChecks = 0;
+  std::size_t movingRigidSurfaceCcdEdgeEdgeChecks = 0;
+  std::size_t movingRigidSurfaceCcdHits = 0;
+  std::size_t movingRigidSurfaceCcdMisses = 0;
+  std::size_t movingRigidSurfaceCcdIndeterminateCount = 0;
+  std::size_t movingRigidSurfaceCcdLimitedSteps = 0;
+  std::size_t movingRigidSurfaceCcdZeroStepCount = 0;
 
   void reset() noexcept
   {

--- a/docs/dev_tasks/ipc_deformable_solver/README.md
+++ b/docs/dev_tasks/ipc_deformable_solver/README.md
@@ -78,9 +78,17 @@
         opted-in static box collision shapes triangulated into stationary
         surface snapshots with physical box edges for deformable line-search
         CCD limiting.
-  - [ ] Remaining Phase 2 work: non-box/deforming/moving rigid surface
-        coverage, broader solver-wired CCD line-search coverage, and stronger
-        spatial acceleration for larger meshes.
+  - [x] Internal moving rigid box surface CCD line-search sub-slice: free
+        (non-static) opted-in box obstacles whose end-of-step transform is
+        predicted from velocity (mirroring the rigid position integrator that
+        runs after the deformable stage) and whose swept motion is tiled by
+        overlapping static pose samples, so the deformable cannot settle in or
+        tunnel through the obstacle's swept corridor. One-way, timing-agnostic
+        conservative limiter with focused regressions and benchmark counters.
+  - [ ] Remaining Phase 2 work: non-box/deforming rigid surface coverage,
+        timing-aware (non-over-conservative) moving-obstacle CCD, broader
+        solver-wired CCD line-search coverage, and stronger spatial
+        acceleration for larger meshes.
 - [ ] Phase 3: clamped barriers, projected Newton, sparse assembly, and solver
       statistics.
 - [ ] Phase 4: lagged smoothed friction and friction diagnostics.
@@ -302,6 +310,29 @@ implement rigid collision response, moving obstacle contact, arbitrary mesh
 obstacles, barrier/contact forces, friction, projected Newton, adaptive
 barrier stiffness, no-intersection/no-inversion guarantees, solver selection,
 or full IPC paper parity.
+
+For the moving rigid box surface CCD line-search sub-slice, keep the
+verification language precise: it covers free (non-static) opted-in box
+obstacles collected at `DeformableDynamicsStage` start, whose end-of-step
+transform is predicted from `comps::Velocity` using the exact
+`integrateRigidBodyPosition` formula (so the prediction matches the pose
+`RigidBodyPositionStage` applies after the deformable stage), and whose swept
+motion is tiled by overlapping static pose samples spaced at most one box
+min-half-extent apart (capped at 64 samples). The deformable line-search
+limiter reuses the static-pose point-triangle and edge-edge CCD reducers over
+those samples. The moving collector is disjoint from the static one
+(`entt::exclude<StaticBodyTag>`), so a body is never limited or counted twice.
+It is a one-way, timing-agnostic conservative limiter: it never misses a
+penetration but is more conservative than a timing-aware sweep for fast
+obstacles, and it does not implement rigid collision response, two-way
+coupling, contact forces, friction, projected Newton, arbitrary mesh
+obstacles, kinematically scripted (velocity-free `setTransform`) obstacles,
+or full IPC paper parity. The sample count is capped (64); past the cap the
+sampled boxes are isotropically inflated to keep consecutive samples
+overlapping, so the swept corridor stays covered (more over-conservative)
+rather than opening tunnelable gaps. Coverage is exact along the box min axis
+for axis-aligned motion; diagonal motion leaves a bounded, half-extent-scale
+thin-corner under-coverage inherent to box supersampling.
 
 Current primitive-distance local gates:
 

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -142,15 +142,19 @@ candidate culling, barrier assembly, projected Newton, or friction.
 
 ## Current Branch
 
-`feature/ipc-rigid-surface-ccd` - stacked on
-`feature/ipc-sweep-pair-traversal`, adding an explicitly opted-in static box
-surface CCD limiter for deformable line searches.
+`feature/ipc-moving-rigid-surface-ccd` - based on `main` (the IPC stack
+#2723-#2732 has landed), adding a moving rigid box surface CCD limiter: free
+(non-static) opted-in box obstacles whose end-of-step transform is predicted
+from velocity and whose swept motion is tiled by overlapping static pose
+samples for the deformable line-search limiter.
 
 ## Immediate Next Step
 
-After this sub-slice lands, continue Phase 2 with non-box/deforming/moving
-rigid surface contact candidates, broader solver-wired CCD coverage, and
-stronger spatial acceleration for larger meshes.
+After this sub-slice lands, continue Phase 2 with non-box/deforming rigid
+surface coverage, a timing-aware (non-over-conservative) moving-obstacle CCD,
+broader solver-wired CCD coverage, and stronger spatial acceleration. The
+moving-obstacle limiter is one-way and timing-agnostic; two-way contact forces
+and coupled rigid/deformable solves remain Phase 3.
 
 ## Context That Would Be Lost
 
@@ -166,7 +170,7 @@ stronger spatial acceleration for larger meshes.
 ## How To Resume
 
 ```bash
-git checkout feature/ipc-ccd-line-search
+git checkout feature/ipc-moving-rigid-surface-ccd
 git status && git log -3 --oneline
 cmake --build build/default/cpp/Release --target test_primitive_distance bm_ipc_distance_kernels
 ctest --test-dir build/default/cpp/Release -R '^test_primitive_distance$' --output-on-failure
@@ -214,6 +218,9 @@ cmake --build build/default/cpp/Release --target test_deformable_body test_seria
 ./build/default/cpp/Release/bin/test_serialization --gtest_filter='Serialization.PreservesRigidBodyCollisionComponents'
 PYTHONPATH=build/default/cpp/Release/python ./.pixi/envs/default/bin/python -m pytest python/tests/unit/simulation/test_experimental_world.py -k 'collision_query'
 ./build/default/cpp/Release/bin/bm_deformable_body --benchmark_min_time=0.03s --benchmark_filter='BM_DeformableStaticRigidSurfaceCcdStage'
+cmake --build build/default/cpp/Release --target test_deformable_body bm_deformable_body
+./build/default/cpp/Release/bin/test_deformable_body --gtest_filter='DeformableBody.MovingRigidSurfaceCcd*:DeformableBody.MovingAndStaticRigidSurfaceCcdCollectorsAreDisjoint'
+./build/default/cpp/Release/bin/bm_deformable_body --benchmark_min_time=0.03s --benchmark_filter='BM_DeformableMovingRigidSurfaceCcdStage'
 ```
 
 Switch to `feature/ipc-scene-boundary-diagnostics` when reviewing the stacked

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-paper-figure-showcase.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-paper-figure-showcase.md
@@ -47,6 +47,14 @@ Internal kernels with only unit tests and microbenchmarks (PRs #2719→#2732 to
 date) do not satisfy these goals; they enable them. Every kernel must
 eventually back at least one figure entry in the table.
 
+Infrastructure progress note: a one-way conservative moving rigid box surface
+CCD limiter has landed as Phase-2 scaffolding (the deformable line search now
+predicts a free obstacle's swept motion and stays out of its corridor). It is
+enabling infrastructure for the moving-obstacle figures (Fig. 8, 13, 15, 16,
+18), which remain `planned`: those figures need two-way contact forces /
+friction and timing-aware coupling that this one-way, timing-agnostic limiter
+does not provide.
+
 ## Showcase Catalog
 
 Status column: `planned` (not yet implemented), `in-progress` (PR open),

--- a/tests/benchmark/simulation/experimental/bm_deformable_body.cpp
+++ b/tests/benchmark/simulation/experimental/bm_deformable_body.cpp
@@ -539,6 +539,71 @@ struct DeformableStaticRigidSurfaceCcdWorld
 };
 
 //==============================================================================
+struct DeformableMovingRigidSurfaceCcdWorld
+{
+  DeformableMovingRigidSurfaceCcdWorld(int boxCount, bool crossing)
+  {
+    boxCount = std::max(boxCount, 0);
+
+    sx::DeformableBodyOptions movingOptions;
+    movingOptions.edgeStiffness = 0.0;
+    movingOptions.damping = 0.0;
+
+    constexpr double spacing = 3.0;
+    const int nodeCount = std::max(boxCount, 1);
+    for (int i = 0; i < nodeCount; ++i) {
+      const double offset = spacing * static_cast<double>(i);
+      movingOptions.positions.push_back(
+          Eigen::Vector3d(offset - 1.0, 0.0, 0.0));
+      movingOptions.velocities.push_back(
+          Eigen::Vector3d(crossing ? 20.0 : -1.0, 0.0, 0.0));
+      movingOptions.masses.push_back(1.0);
+
+      if (i < boxCount) {
+        // Free (non-static) obstacle moving toward the node when crossing, so
+        // the deformable stage predicts its swept motion and limits against it.
+        sx::RigidBodyOptions boxOptions;
+        boxOptions.isStatic = false;
+        boxOptions.position = Eigen::Vector3d(offset, 0.0, 0.0);
+        auto box = world.addRigidBody(
+            "moving_surface_ccd_box_" + std::to_string(i), boxOptions);
+        box.setCollisionShape(
+            sx::CollisionShape::makeBox(Eigen::Vector3d(0.05, 1.0, 1.0)));
+        box.setDeformableSurfaceCcdObstacle(true);
+        box.setLinearVelocity(Eigen::Vector3d(crossing ? -2.0 : 2.0, 0.0, 0.0));
+        boxes.push_back(box);
+      }
+    }
+
+    initialPositions = movingOptions.positions;
+    initialVelocities = movingOptions.velocities;
+    movingBody = world.addDeformableBody("surface_ccd_points", movingOptions);
+    this->nodeCount = movingBody.getNodeCount();
+    this->boxCount = static_cast<std::size_t>(boxCount);
+
+    world.setGravity(Eigen::Vector3d::Zero());
+    world.setTimeStep(0.1);
+    world.enterSimulationMode();
+  }
+
+  void reset()
+  {
+    for (std::size_t i = 0; i < initialPositions.size(); ++i) {
+      movingBody.setPosition(i, initialPositions[i]);
+      movingBody.setVelocity(i, initialVelocities[i]);
+    }
+  }
+
+  sx::World world;
+  sx::DeformableBody movingBody;
+  std::vector<sx::RigidBody> boxes;
+  std::vector<Eigen::Vector3d> initialPositions;
+  std::vector<Eigen::Vector3d> initialVelocities;
+  std::size_t nodeCount = 0;
+  std::size_t boxCount = 0;
+};
+
+//==============================================================================
 struct RigidOnlyWorld
 {
   explicit RigidOnlyWorld(int staticBodyCount)
@@ -888,6 +953,65 @@ void BM_DeformableStaticRigidSurfaceCcdStage(benchmark::State& state)
 }
 
 //==============================================================================
+void BM_DeformableMovingRigidSurfaceCcdStage(benchmark::State& state)
+{
+  const auto boxCount = static_cast<int>(state.range(0));
+  const bool crossing = state.range(1) != 0;
+  DeformableMovingRigidSurfaceCcdWorld fixture(boxCount, crossing);
+  sx::compute::SequentialExecutor executor;
+  sx::compute::DeformableDynamicsStage deformableStage;
+  sx::compute::WorldStepPipeline pipeline;
+  pipeline.addStage(deformableStage);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    fixture.reset();
+    state.ResumeTiming();
+    fixture.world.step(executor, pipeline);
+    benchmark::DoNotOptimize(
+        fixture.movingBody.getPosition(fixture.nodeCount - 1u).x());
+  }
+
+  const auto& stats = deformableStage.getLastStats();
+  state.counters["nodes"] = static_cast<double>(fixture.nodeCount);
+  state.counters["moving_surface_boxes"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdBoxCount);
+  state.counters["moving_surface_samples"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdSampleCount);
+  state.counters["moving_surface_triangles"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdTriangleCount);
+  state.counters["moving_surface_edges"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdEdgeCount);
+  state.counters["crossing"] = crossing ? 1.0 : 0.0;
+  state.counters["candidate_builds"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdCandidateBuilds);
+  state.counters["pt_candidates"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdPointTriangleCandidates);
+  state.counters["ee_candidates"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdEdgeEdgeCandidates);
+  state.counters["ccd_pt_checks"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdPointTriangleChecks);
+  state.counters["ccd_ee_checks"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdEdgeEdgeChecks);
+  state.counters["ccd_hits"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdHits);
+  state.counters["ccd_indeterminate"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdIndeterminateCount);
+  state.counters["ccd_limited_steps"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdLimitedSteps);
+  state.counters["ccd_zero_steps"]
+      = static_cast<double>(stats.movingRigidSurfaceCcdZeroStepCount);
+  state.counters["line_search_trials"]
+      = static_cast<double>(stats.lineSearchTrials);
+  state.counters["line_search_rejects"]
+      = static_cast<double>(stats.rejectedLineSearchCandidates);
+  state.counters["accepted_steps"]
+      = static_cast<double>(stats.acceptedLineSearchSteps);
+  state.SetItemsProcessed(
+      static_cast<int64_t>(state.iterations() * fixture.nodeCount));
+}
+
+//==============================================================================
 void BM_DeformableSceneLoad(benchmark::State& state)
 {
   const auto scenePath = benchmarkScenePath();
@@ -985,6 +1109,13 @@ BENCHMARK(BM_DeformableStaticGroundBarrierCcdStage)
     ->Args({32, 1});
 
 BENCHMARK(BM_DeformableStaticRigidSurfaceCcdStage)
+    ->Args({0, 1})
+    ->Args({1, 0})
+    ->Args({1, 1})
+    ->Args({8, 1})
+    ->Args({32, 1});
+
+BENCHMARK(BM_DeformableMovingRigidSurfaceCcdStage)
     ->Args({0, 1})
     ->Args({1, 0})
     ->Args({1, 1})

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -322,6 +322,46 @@ private:
   Eigen::Isometry3d m_transform;
 };
 
+//==============================================================================
+// Adds a non-static (free) rigid box tagged as a deformable-surface CCD
+// obstacle with a prescribed world-frame velocity. The deformable stage
+// predicts this body's end-of-step pose from its velocity, so the moving CCD
+// limiter constrains the deformable against where the box will be.
+sx::RigidBody addMovingSurfaceCcdBox(
+    sx::World& world,
+    const std::string& name,
+    const Eigen::Vector3d& position,
+    const Eigen::Vector3d& halfExtents,
+    const Eigen::Vector3d& linearVelocity,
+    const Eigen::Vector3d& angularVelocity = Eigen::Vector3d::Zero(),
+    const Eigen::Quaterniond& orientation = Eigen::Quaterniond::Identity())
+{
+  sx::RigidBodyOptions options;
+  options.isStatic = false;
+  options.position = position;
+  options.orientation = orientation;
+  auto body = world.addRigidBody(name, options);
+  body.setCollisionShape(sx::CollisionShape::makeBox(halfExtents));
+  body.setDeformableSurfaceCcdObstacle(true);
+  body.setLinearVelocity(linearVelocity);
+  body.setAngularVelocity(angularVelocity);
+  return body;
+}
+
+//==============================================================================
+// True when `point` lies strictly outside the axis-or-oriented box centered at
+// `center` with the given orientation and half extents (i.e. positive
+// separation on at least one axis in the box's local frame).
+bool isOutsideBox(
+    const Eigen::Vector3d& point,
+    const Eigen::Vector3d& center,
+    const Eigen::Quaterniond& orientation,
+    const Eigen::Vector3d& halfExtents)
+{
+  const Eigen::Vector3d local = orientation.conjugate() * (point - center);
+  return (local.array().abs() > halfExtents.array()).any();
+}
+
 } // namespace
 
 //==============================================================================
@@ -1722,4 +1762,379 @@ TEST(DeformableBody, SerializationPreservesMeshTopologyAndMaterial)
   world2.setTimeStep(0.05);
   world2.step();
   EXPECT_LT(body2->getPosition(3).z(), 1.0 + 0.05 * 0.5);
+}
+
+//==============================================================================
+// A deformable node advancing toward a box that is itself moving toward the
+// node is conservatively limited so it does not enter the box's predicted
+// end-of-step pose. The custom pipeline runs only the deformable stage; the
+// limiter still predicts the box end pose from its velocity.
+TEST(DeformableBody, MovingRigidSurfaceCcdLimitsAgainstPredictedPose)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.1);
+  const Eigen::Vector3d halfExtents(0.05, 1.0, 1.0);
+  addMovingSurfaceCcdBox(
+      world,
+      "moving_box",
+      Eigen::Vector3d(2.0, 0.0, 0.0),
+      halfExtents,
+      Eigen::Vector3d(-20.0, 0.0, 0.0));
+
+  auto body = world.addDeformableBody(
+      "approaching_point",
+      makeSingleNodeBodyOptions(
+          Eigen::Vector3d(-1.0, 0.0, 0.0), Eigen::Vector3d(20.0, 0.0, 0.0)));
+
+  compute::SequentialExecutor executor;
+  compute::DeformableDynamicsStage stage;
+  compute::WorldStepPipeline pipeline;
+  pipeline.addStage(stage);
+  world.step(executor, pipeline);
+
+  const auto& stats = stage.getLastStats();
+  EXPECT_EQ(stats.movingRigidSurfaceCcdBoxCount, 1u);
+  // The swept motion is tiled by overlapping static pose samples (>= 2), each
+  // contributing the box's 12 triangles / 12 edges.
+  EXPECT_GE(stats.movingRigidSurfaceCcdSampleCount, 2u);
+  EXPECT_EQ(
+      stats.movingRigidSurfaceCcdTriangleCount,
+      12u * stats.movingRigidSurfaceCcdSampleCount);
+  EXPECT_EQ(
+      stats.movingRigidSurfaceCcdEdgeCount,
+      12u * stats.movingRigidSurfaceCcdSampleCount);
+  EXPECT_GT(stats.movingRigidSurfaceCcdCandidateBuilds, 0u);
+  EXPECT_GT(stats.movingRigidSurfaceCcdPointTriangleCandidates, 0u);
+  EXPECT_GT(stats.movingRigidSurfaceCcdPointTriangleChecks, 0u);
+  EXPECT_GT(stats.movingRigidSurfaceCcdHits, 0u);
+  EXPECT_GT(stats.movingRigidSurfaceCcdLimitedSteps, 0u);
+  // The moving obstacle path must not be confused with the static one.
+  EXPECT_EQ(stats.staticRigidSurfaceCcdBoxCount, 0u);
+
+  // The node moved toward its free target but was limited short of it.
+  const Eigen::Vector3d finalPosition = body.getPosition(0);
+  EXPECT_GT(finalPosition.x(), -1.0);
+  EXPECT_LT(finalPosition.x(), 1.0);
+
+  // Conservative guarantee: the node stays outside the box's predicted end pose
+  // (center moves by velocity * dt = -20 * 0.1 = -2.0 to the origin).
+  const Eigen::Vector3d predictedEndCenter(0.0, 0.0, 0.0);
+  EXPECT_TRUE(isOutsideBox(
+      finalPosition,
+      predictedEndCenter,
+      Eigen::Quaterniond::Identity(),
+      halfExtents));
+}
+
+//==============================================================================
+// Isolates the ordering fix: with the box STATIC at its start pose, the node's
+// own trajectory never reaches it, so the static limiter does not engage and
+// the node reaches its free target. With the SAME geometry but the box moving
+// onto the node's path, the moving limiter predicts the end pose and limits the
+// node. Same node motion, opposite outcome -> the prediction is what matters.
+TEST(DeformableBody, MovingRigidSurfaceCcdConstrainsWhereStaticSnapshotWouldNot)
+{
+  const Eigen::Vector3d boxStart(2.0, 0.0, 0.0);
+  const Eigen::Vector3d halfExtents(0.05, 1.0, 1.0);
+  const Eigen::Vector3d nodeStart(-1.0, 0.0, 0.0);
+  const Eigen::Vector3d nodeVelocity(20.0, 0.0, 0.0);
+
+  // Baseline: a static box at the start pose is too far from the node's
+  // trajectory to limit it.
+  double staticFinalX = 0.0;
+  {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d::Zero());
+    world.setTimeStep(0.1);
+    addStaticSurfaceCcdBox(world, "static_box", boxStart, halfExtents);
+    auto body = world.addDeformableBody(
+        "approaching_point",
+        makeSingleNodeBodyOptions(nodeStart, nodeVelocity));
+
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+    world.step(executor, pipeline);
+
+    const auto& stats = stage.getLastStats();
+    EXPECT_EQ(stats.movingRigidSurfaceCcdBoxCount, 0u);
+    EXPECT_EQ(stats.staticRigidSurfaceCcdLimitedSteps, 0u);
+    staticFinalX = body.getPosition(0).x();
+    EXPECT_GT(staticFinalX, 0.9); // reached free target ~ +1.0
+  }
+
+  // Moving: the same box sweeps onto the node's path and is predicted, so the
+  // node is limited well short of its free target.
+  double movingFinalX = 0.0;
+  {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d::Zero());
+    world.setTimeStep(0.1);
+    addMovingSurfaceCcdBox(
+        world,
+        "moving_box",
+        boxStart,
+        halfExtents,
+        Eigen::Vector3d(-20.0, 0.0, 0.0));
+    auto body = world.addDeformableBody(
+        "approaching_point",
+        makeSingleNodeBodyOptions(nodeStart, nodeVelocity));
+
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+    world.step(executor, pipeline);
+
+    const auto& stats = stage.getLastStats();
+    EXPECT_EQ(stats.staticRigidSurfaceCcdBoxCount, 0u);
+    EXPECT_GT(stats.movingRigidSurfaceCcdLimitedSteps, 0u);
+    movingFinalX = body.getPosition(0).x();
+  }
+
+  // The moving prediction constrains the node where the static snapshot did
+  // not.
+  EXPECT_LT(movingFinalX, staticFinalX);
+  EXPECT_LT(movingFinalX, 0.9);
+}
+
+//==============================================================================
+// An obstacle receding from the deformable must not spuriously limit it.
+TEST(DeformableBody, MovingRigidSurfaceCcdDoesNotLimitRecedingObstacle)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.1);
+  addMovingSurfaceCcdBox(
+      world,
+      "receding_box",
+      Eigen::Vector3d(2.0, 0.0, 0.0),
+      Eigen::Vector3d(0.05, 1.0, 1.0),
+      Eigen::Vector3d(20.0, 0.0, 0.0)); // moves away in +x
+
+  auto body = world.addDeformableBody(
+      "approaching_point",
+      makeSingleNodeBodyOptions(
+          Eigen::Vector3d(-1.0, 0.0, 0.0), Eigen::Vector3d(20.0, 0.0, 0.0)));
+
+  compute::SequentialExecutor executor;
+  compute::DeformableDynamicsStage stage;
+  compute::WorldStepPipeline pipeline;
+  pipeline.addStage(stage);
+  world.step(executor, pipeline);
+
+  const auto& stats = stage.getLastStats();
+  EXPECT_EQ(stats.movingRigidSurfaceCcdBoxCount, 1u);
+  EXPECT_EQ(stats.movingRigidSurfaceCcdHits, 0u);
+  EXPECT_EQ(stats.movingRigidSurfaceCcdLimitedSteps, 0u);
+  // The node reaches its free target unimpeded.
+  EXPECT_GT(body.getPosition(0).x(), 0.9);
+}
+
+//==============================================================================
+// A fast-rotating obstacle is handled conservatively: its swept motion is tiled
+// by sampled rotated poses, so a node advancing toward the spinning slab is
+// limited and stays outside the slab's rotated end pose, deterministically.
+TEST(DeformableBody, MovingRigidSurfaceCcdHandlesRotatingObstacle)
+{
+  const Eigen::Vector3d boxCenter(0.0, 0.0, 0.0);
+  const Eigen::Vector3d halfExtents(1.0, 0.1, 1.0);
+  const Eigen::Vector3d angularVelocity(0.0, 0.0, 10.0); // 10 rad/s about z
+  const double timeStep = 0.1;                           // theta = 1.0 rad
+
+  std::size_t limitedSteps = 0;
+  std::size_t boxCount = 0;
+  const auto run = [&]() {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d::Zero());
+    world.setTimeStep(timeStep);
+    addMovingSurfaceCcdBox(
+        world,
+        "spinning_slab",
+        boxCenter,
+        halfExtents,
+        Eigen::Vector3d::Zero(),
+        angularVelocity);
+    // Node starts outside the slab's swept disc on the +x side and drives in
+    // toward the center, so it must be limited by the rotating obstacle.
+    auto body = world.addDeformableBody(
+        "approaching_point",
+        makeSingleNodeBodyOptions(
+            Eigen::Vector3d(1.5, 0.0, 0.0), Eigen::Vector3d(-10.0, 0.0, 0.0)));
+
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+    world.step(executor, pipeline);
+    limitedSteps = stage.getLastStats().movingRigidSurfaceCcdLimitedSteps;
+    boxCount = stage.getLastStats().movingRigidSurfaceCcdBoxCount;
+    return body.getPosition(0);
+  };
+
+  const Eigen::Vector3d finalPosition = run();
+
+  EXPECT_EQ(boxCount, 1u);
+  EXPECT_GT(limitedSteps, 0u);
+
+  // Predicted end orientation: rotation by theta = |angular| * dt = 1.0 rad
+  // about z. The node must remain outside the obstacle's rotated end pose.
+  const Eigen::Quaterniond endOrientation(
+      Eigen::AngleAxisd(10.0 * timeStep, Eigen::Vector3d::UnitZ()));
+  EXPECT_TRUE(
+      isOutsideBox(finalPosition, boxCenter, endOrientation, halfExtents));
+
+  // Determinism: identical inputs produce identical output.
+  const Eigen::Vector3d repeat = run();
+  EXPECT_DOUBLE_EQ(finalPosition.x(), repeat.x());
+  EXPECT_DOUBLE_EQ(finalPosition.y(), repeat.y());
+  EXPECT_DOUBLE_EQ(finalPosition.z(), repeat.z());
+}
+
+//==============================================================================
+// The moving and static rigid obstacle collectors are disjoint: a static CCD
+// box increments only static counters and a moving CCD box increments only
+// moving counters.
+TEST(DeformableBody, MovingAndStaticRigidSurfaceCcdCollectorsAreDisjoint)
+{
+  const Eigen::Vector3d halfExtents(0.05, 1.0, 1.0);
+
+  {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d::Zero());
+    world.setTimeStep(0.1);
+    addStaticSurfaceCcdBox(
+        world, "static_box", Eigen::Vector3d::Zero(), halfExtents);
+    auto body = world.addDeformableBody(
+        "fast_point",
+        makeSingleNodeBodyOptions(
+            Eigen::Vector3d(-1.0, 0.0, 0.0), Eigen::Vector3d(20.0, 0.0, 0.0)));
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+    world.step(executor, pipeline);
+    EXPECT_TRUE(body.isValid());
+    const auto& stats = stage.getLastStats();
+    EXPECT_EQ(stats.staticRigidSurfaceCcdBoxCount, 1u);
+    EXPECT_EQ(stats.movingRigidSurfaceCcdBoxCount, 0u);
+    EXPECT_EQ(stats.movingRigidSurfaceCcdCandidateBuilds, 0u);
+    EXPECT_EQ(stats.movingRigidSurfaceCcdHits, 0u);
+  }
+
+  {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d::Zero());
+    world.setTimeStep(0.1);
+    addMovingSurfaceCcdBox(
+        world,
+        "moving_box",
+        Eigen::Vector3d(2.0, 0.0, 0.0),
+        halfExtents,
+        Eigen::Vector3d(-20.0, 0.0, 0.0));
+    auto body = world.addDeformableBody(
+        "fast_point",
+        makeSingleNodeBodyOptions(
+            Eigen::Vector3d(-1.0, 0.0, 0.0), Eigen::Vector3d(20.0, 0.0, 0.0)));
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+    world.step(executor, pipeline);
+    EXPECT_TRUE(body.isValid());
+    const auto& stats = stage.getLastStats();
+    EXPECT_EQ(stats.movingRigidSurfaceCcdBoxCount, 1u);
+    EXPECT_EQ(stats.staticRigidSurfaceCcdBoxCount, 0u);
+    EXPECT_EQ(stats.staticRigidSurfaceCcdCandidateBuilds, 0u);
+    EXPECT_EQ(stats.staticRigidSurfaceCcdHits, 0u);
+  }
+}
+
+//==============================================================================
+// A very fast obstacle exceeds the sample cap; the sampled boxes are then
+// inflated to keep overlapping, so the deformable still cannot tunnel into the
+// swept corridor (the conservative invariant holds past the cap).
+TEST(
+    DeformableBody, MovingRigidSurfaceCcdInflatesSamplesPastCapWithoutTunneling)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.1);
+  // minHalfExtent = 0.05; motion = 200 * 0.1 = 20 >> 64 * 0.05, so the sample
+  // count is capped and the boxes must be inflated to bridge the residual gaps.
+  const Eigen::Vector3d halfExtents(0.05, 1.0, 1.0);
+  addMovingSurfaceCcdBox(
+      world,
+      "very_fast_box",
+      Eigen::Vector3d(2.0, 0.0, 0.0),
+      halfExtents,
+      Eigen::Vector3d(-200.0, 0.0, 0.0));
+
+  // Node approaches the corridor from the +x side (outside the swept region).
+  auto body = world.addDeformableBody(
+      "approaching_point",
+      makeSingleNodeBodyOptions(
+          Eigen::Vector3d(3.0, 0.0, 0.0), Eigen::Vector3d(-10.0, 0.0, 0.0)));
+
+  compute::SequentialExecutor executor;
+  compute::DeformableDynamicsStage stage;
+  compute::WorldStepPipeline pipeline;
+  pipeline.addStage(stage);
+  world.step(executor, pipeline);
+
+  const auto& stats = stage.getLastStats();
+  EXPECT_EQ(stats.movingRigidSurfaceCcdBoxCount, 1u);
+  EXPECT_GT(stats.movingRigidSurfaceCcdInflatedBoxCount, 0u);
+  EXPECT_GT(stats.movingRigidSurfaceCcdLimitedSteps, 0u);
+
+  // The node is stopped before entering the swept corridor (start box right
+  // face is at x = 2.05); it must not tunnel into or across the corridor.
+  const Eigen::Vector3d finalPosition = body.getPosition(0);
+  EXPECT_GT(finalPosition.x(), 2.0);
+  EXPECT_LT(finalPosition.x(), 3.0);
+}
+
+//==============================================================================
+// End-to-end through the FULL default pipeline: the obstacle is actually
+// integrated by RigidBodyPositionStage (stage 5) after the deformable solve
+// (stage 4). With gravity off and no rigid contacts the obstacle velocity is
+// constant across stages, so the velocity-based prediction the deformable stage
+// limits against equals the pose the obstacle really reaches, and the node ends
+// outside the obstacle's realized end pose.
+TEST(DeformableBody, MovingRigidSurfaceCcdMatchesRealizedMotionInFullPipeline)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.1);
+
+  const Eigen::Vector3d boxStart(1.0, 0.0, 0.0);
+  const Eigen::Vector3d halfExtents(0.2, 1.0, 1.0);
+  const Eigen::Vector3d boxVelocity(-1.0, 0.0, 0.0);
+  auto box = addMovingSurfaceCcdBox(
+      world, "moving_box", boxStart, halfExtents, boxVelocity);
+
+  // Free target (+1.0) lies inside the obstacle's end pose, so the node must be
+  // limited by the full-pipeline solve.
+  auto body = world.addDeformableBody(
+      "approaching_point",
+      makeSingleNodeBodyOptions(
+          Eigen::Vector3d(-0.5, 0.0, 0.0), Eigen::Vector3d(15.0, 0.0, 0.0)));
+
+  world.step(); // default pipeline: integrates the obstacle at stage 5
+
+  // Obstacle velocity is unchanged (no gravity, no rigid contacts), so the
+  // predicted end pose equals the realized one: center = 1.0 + (-1.0) * 0.1.
+  expectVectorNear(box.getLinearVelocity(), boxVelocity, 1e-12);
+  const Eigen::Vector3d realizedEndCenter
+      = boxStart + boxVelocity * world.getTimeStep();
+
+  const Eigen::Vector3d finalPosition = body.getPosition(0);
+  EXPECT_GT(finalPosition.x(), -0.5); // advanced toward its target
+  EXPECT_TRUE(isOutsideBox(
+      finalPosition,
+      realizedEndCenter,
+      Eigen::Quaterniond::Identity(),
+      halfExtents));
 }


### PR DESCRIPTION
## Summary

- Adds a moving (free, non-static) rigid box surface CCD limiter to the experimental IPC deformable solver, so a deformable body is conservatively kept out of an obstacle that *moves* during the step — not just static obstacles.
- The deformable stage runs before `RigidBodyPositionStage`, so an obstacle's new pose is applied *after* the deformable solve. This slice predicts each obstacle's end-of-step transform from its velocity (mirroring `integrateRigidBodyPosition` exactly) and limits the deformable against where the obstacle *will be*.
- Purely additive and opt-in: existing static/inter-body/ground-barrier CCD paths are unchanged; the obstacle is a free rigid body tagged with the existing `RigidBody::setDeformableSurfaceCcdObstacle(true)`.

## Motivation / Problem

The just-landed static rigid surface CCD limiter (#2732) snapshots obstacles at the start of the step only. A *moving* obstacle's pose is integrated by `RigidBodyPositionStage` (stage 5) **after** the deformable solve (stage 4), so a deformable body solved against the start-of-step snapshot could be penetrated by the obstacle's realized motion. Moving rigid obstacles are the prescribed next Phase-2 step in PLAN-081 and underpin the roller / funnel / trash-compactor paper figures (Fig. 8, 13, 15, 16, 18).

## Changes / Key Changes

- `predictRigidBodyEndTransform()` — predicts a free rigid body's end-of-step pose from `comps::Velocity` without mutating state, using the exact `integrateRigidBodyPosition` formula, so the limited motion matches the pose stage 5 applies.
- `collectMovingRigidSurfaceCcdObstacles()` — views free rigid CCD-obstacle boxes (`entt::exclude<StaticBodyTag>`, disjoint from the static collector) and tiles each obstacle's predicted swept motion with overlapping **static** box pose samples (linear position lerp + orientation slerp). Consecutive sample centers are one box min-half-extent apart; when the sample count hits its cap (64) the sampled boxes are isotropically inflated by half the residual spacing so they keep overlapping (no tunnelable gaps). Each sample is an ordinary static snapshot, so `interBodySurfaceContactStepBound` and the limiter path are reused unchanged.
- `applyMovingRigidSurfaceCcdLimit()` — mirrors `applyStaticRigidSurfaceCcdLimit` over the moving samples with its own `movingRigidSurfaceCcd*` stat family; wired into the `advanceDeformableBody` line-search chain and `DeformableDynamicsStage::execute`.
- Benchmark fixture/case `BM_DeformableMovingRigidSurfaceCcdStage` with per-stage counters.
- Dev-task README/RESUME, CHANGELOG, and figure-showcase notes updated; honest about the one-way / timing-agnostic scope.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Rigid CCD obstacles for deformables | Static boxes only (start-of-step snapshot). A moving obstacle could penetrate the deformable because its pose is applied after the deformable solve. | Free moving boxes are predicted from velocity and their swept motion is tiled with overlapping static samples; the deformable is conservatively kept out of the realized end pose. |
| Opt-in surface | `setDeformableSurfaceCcdObstacle` on a static box | Same flag on a free (non-static) box with a velocity; static and moving collectors are disjoint. |
| Conservativeness under fast motion | n/a | Sample count capped; boxes inflated past the cap so coverage holds (more over-conservative, never under). |

## Testing

- `pixi run test-all` (lint + build + unit + simulation-experimental + python + docs): all passed.
- New focused regressions in `test_deformable_body` (50 tests total pass): limit-vs-predicted-end-pose, static-snapshot-would-not-limit contrast (isolates the ordering fix), receding obstacle no-op, rotating obstacle stays outside rotated end pose, cap/inflation no-tunneling, full-pipeline predicted-equals-realized motion, disjoint static/moving collectors.
- `BM_DeformableMovingRigidSurfaceCcdStage` builds and runs; counters confirm the limiter engages on crossing and is a no-op when receding, with sample counts scaling with motion.

## Breaking Changes

- [x] None — internal experimental scaffolding only; no public API, ABI, Python binding, file-format, example command, or existing solver behavior changes. The static/inter-body/ground-barrier paths, `SurfaceContactSnapshot`, and `interBodySurfaceContactStepBound` are byte-unchanged.

## Scope / Limitations (honest)

- One-way, timing-agnostic conservative CCD limiter: it never misses a penetration but is more conservative than a timing-aware sweep for fast obstacles. It does **not** provide rigid contact response, two-way coupling, contact forces, friction, projected Newton, arbitrary mesh obstacles, or kinematically scripted (velocity-free `setTransform`) obstacles. It is not IPC parity. The roller/funnel/trash-compactor figures remain `planned` until contact forces land.

## Related Issues / PRs

- Continues the PLAN-081 IPC deformable-solver stack (#2719→#2732, all merged to `main`). Stacked directly on `main`.
- Backport: none. Experimental DART 7.0 IPC roadmap work.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated
- [x] Add unit tests for new functionality
- [x] Document new methods and classes — N/A public; internal experimental helpers, dev-task docs updated
- [x] Add Python bindings (dartpy) if applicable — N/A, no public API or bindings
