### PR TITLE
Fix Update Lock Files workflow failing with exit code 127

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -36,8 +36,8 @@ jobs:
           pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
       - name: Update lockfiles
         run: |
-          pixi global install pixi-diff-to-markdown
-          pixi update --json --no-install | pixi-diff-to-markdown >> diff.md
+          set -o pipefail
+          pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:


### PR DESCRIPTION
## Summary

- Fix the weekly **Update Lock Files** workflow, which has failed on every scheduled run since 2026-01-17 and stopped producing `Update pixi lockfile` PRs.

## Motivation / Problem

The last successful run was 2026-01-10 (PRs #2416 / #2417). Every scheduled run since has failed with **exit code 127** in the `Update lockfiles` step:

```
pixi-diff-to-markdown: 0.3.9 (installed)
    └─ exposes: pixi-diff-to-markdown
/home/runner/work/_temp/....sh: line 2: pixi-diff-to-markdown: command not found
##[error]Process completed with exit code 127.
```

`pixi global install` exposes the binary under `~/.pixi/bin`, but that directory is **not on `PATH`** — `setup-pixi` installs pixi itself to `${{ runner.temp }}/pixi/bin`. So `pixi global install` succeeded, yet the next line could not find `pixi-diff-to-markdown`, and the job exited before reaching `create-pull-request`.

(For history: the earlier 2026-01-17 failures were a separate self-hosted-runner `EACCES` on `/usr/local/bin/pixi`, addressed by #2654 switching to `prefix-dev/setup-pixi`; this PR fixes the remaining `command not found` failure.)

## Changes / Key Changes

- Replace `pixi global install pixi-diff-to-markdown` + bare invocation with the pattern from the [official pixi docs](https://pixi.sh/latest/integration/ci/updates_github_actions/): `pixi exec pixi-diff-to-markdown`, which runs the tool in a temporary environment and needs no `PATH` manipulation.
- Add `set -o pipefail` so a failing `pixi update` is not masked by the downstream pipe.

```diff
       - name: Update lockfiles
         run: |
-          pixi global install pixi-diff-to-markdown
-          pixi update --json --no-install | pixi-diff-to-markdown >> diff.md
+          set -o pipefail
+          pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
```

## Testing

- Verified locally with pixi 0.69.0: `pixi update --dry-run --json --no-install | pixi exec pixi-diff-to-markdown` runs with **exit 0** and produces a valid 136-line markdown dependency diff; `pixi.lock` left untouched (dry-run).
- `pixi exec pixi-diff-to-markdown --help` resolves and runs (the command that previously failed with 127).

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #2654. The workflow definition runs from the default branch for scheduled events, so this single change fixes lockfile updates for both `main` and `release-6.16` matrix entries.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable