### PR TITLE
Reuse a resident device buffer in the IPC deformable GPU PSD projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1030,6 +1030,18 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     1024, ~4x at 4096, and ~9x at 16384, so the backend adapter's minimum GPU
     batch size is raised from 64 to ~1024 blocks (small batches stay on the CPU
     backend where the host/device round trip would otherwise dominate).
+  - Gave the experimental IPC deformable GPU PSD projection a resident device
+    buffer (PLAN-081 Phase 3). The CUDA backend previously allocated and freed a
+    device buffer (and copied through a temporary host vector) on every
+    projected-Newton iteration; it now reuses one persistent device allocation
+    that grows on demand and is freed when the GPU backend is uninstalled, and
+    the backend adapter projects in place on the caller's packed buffer (no
+    per-call host copy). Results are bit-identical to before (same kernel and
+    transfers), so it is purely a performance change confined to the opt-in
+    `dart-simulation-experimental-cuda` sidecar; the default CPU runtime is
+    unaffected. A CUDA test asserts the resident buffer is reused across
+    same-or-smaller batches, grows once for a larger batch, and is released on
+    restore, with GPU/CPU parity preserved throughout.
   - Wired an optional GPU backend into the experimental IPC deformable solver's
     per-element PSD projection (PLAN-081 Phase 3). The projected-Newton assembly
     now collects its per-element spring (6x6) and self-contact barrier (12x12)

--- a/dart/simulation/experimental/compute/cuda/deformable_psd_projection_cuda.cpp
+++ b/dart/simulation/experimental/compute/cuda/deformable_psd_projection_cuda.cpp
@@ -68,50 +68,70 @@ void throwIfCudaError(cudaError_t status, std::string_view operation)
       cudaGetErrorString(status));
 }
 
-class DeviceDoubleBuffer
+// A device buffer that persists across projection calls. It reuses its
+// allocation whenever the requested element count fits the current capacity and
+// only reallocates (and frees the old storage) when a larger batch arrives, so
+// the per-call cudaMalloc/cudaFree round trip is removed from the solver's
+// projected-Newton hot path. Single-threaded use only (the PSD backend is a
+// process-global function pointer driven by the sequential deformable stage).
+class ResidentDeviceBuffer
 {
 public:
-  explicit DeviceDoubleBuffer(std::size_t count) : m_count(count)
-  {
-    if (m_count == 0) {
-      return;
-    }
+  ResidentDeviceBuffer() = default;
 
+  ~ResidentDeviceBuffer()
+  {
+    release();
+  }
+
+  ResidentDeviceBuffer(const ResidentDeviceBuffer&) = delete;
+  ResidentDeviceBuffer& operator=(const ResidentDeviceBuffer&) = delete;
+
+  // Returns device storage for at least `count` doubles, reusing the existing
+  // allocation when it is already large enough.
+  [[nodiscard]] double* ensure(std::size_t count)
+  {
+    if (count <= m_capacity) {
+      return m_data;
+    }
+    release();
     throwIfCudaError(
-        cudaMalloc(reinterpret_cast<void**>(&m_data), m_count * sizeof(double)),
+        cudaMalloc(reinterpret_cast<void**>(&m_data), count * sizeof(double)),
         "allocation");
-  }
-
-  ~DeviceDoubleBuffer()
-  {
-    if (m_data != nullptr) {
-      (void)cudaFree(m_data);
-    }
-  }
-
-  DeviceDoubleBuffer(const DeviceDoubleBuffer&) = delete;
-  DeviceDoubleBuffer& operator=(const DeviceDoubleBuffer&) = delete;
-
-  [[nodiscard]] double* data() noexcept
-  {
+    m_capacity = count;
+    ++m_allocationCount;
     return m_data;
   }
 
-  [[nodiscard]] std::size_t byteSize() const noexcept
+  void release() noexcept
   {
-    return m_count * sizeof(double);
+    if (m_data != nullptr) {
+      (void)cudaFree(m_data);
+      m_data = nullptr;
+    }
+    m_capacity = 0;
+  }
+
+  [[nodiscard]] std::size_t allocationCount() const noexcept
+  {
+    return m_allocationCount;
   }
 
 private:
   double* m_data = nullptr;
-  std::size_t m_count = 0;
+  std::size_t m_capacity = 0;
+  std::size_t m_allocationCount = 0;
 };
 
-std::size_t validateBlocks(
-    const std::vector<double>& blocks,
-    std::size_t dimension,
-    std::size_t blockCount,
-    std::string_view operation)
+// The resident device buffer reused across GPU projections (a function-local
+// static so it is constructed on first use and torn down at exit).
+ResidentDeviceBuffer& residentDeviceBuffer()
+{
+  static ResidentDeviceBuffer buffer;
+  return buffer;
+}
+
+void validateDimension(std::size_t dimension, std::string_view operation)
 {
   DART_EXPERIMENTAL_THROW_T_IF(
       dimension == 0 || dimension > kMaxPsdBlockDimension,
@@ -120,6 +140,15 @@ std::size_t validateBlocks(
       operation,
       dimension,
       kMaxPsdBlockDimension);
+}
+
+void validateBlocks(
+    const std::vector<double>& blocks,
+    std::size_t dimension,
+    std::size_t blockCount,
+    std::string_view operation)
+{
+  validateDimension(dimension, operation);
 
   const auto expected = dimension * dimension * blockCount;
   DART_EXPERIMENTAL_THROW_T_IF(
@@ -132,8 +161,40 @@ std::size_t validateBlocks(
       dimension,
       dimension,
       blocks.size());
+}
 
-  return expected;
+// In-place GPU PSD projection over a raw packed block buffer, reusing the
+// resident device buffer. Validates the dimension and device availability; the
+// caller owns the element-count bookkeeping (so this serves both the public
+// std::vector overload and the backend adapter without an extra host copy).
+void projectSymmetricBlocksToPsdCudaInPlace(
+    double* blocks, std::size_t dimension, std::size_t blockCount)
+{
+  validateDimension(dimension, "projectSymmetricBlocksToPsdCuda");
+  if (blocks == nullptr || blockCount == 0) {
+    return;
+  }
+
+  DART_EXPERIMENTAL_THROW_T_IF(
+      !isCudaRuntimeAvailable(),
+      sx::InvalidOperationException,
+      "CUDA runtime has no available device");
+
+  const std::size_t count = dimension * dimension * blockCount;
+  const std::size_t byteSize = count * sizeof(double);
+  double* device = residentDeviceBuffer().ensure(count);
+
+  throwIfCudaError(
+      cudaMemcpy(device, blocks, byteSize, cudaMemcpyHostToDevice),
+      "PSD block copy to device");
+  throwIfCudaError(
+      detail::launchProjectSymmetricBlocksToPsdKernel(
+          device, dimension, blockCount),
+      "PSD projection kernel");
+  throwIfCudaError(cudaDeviceSynchronize(), "PSD projection synchronize");
+  throwIfCudaError(
+      cudaMemcpy(blocks, device, byteSize, cudaMemcpyDeviceToHost),
+      "PSD block copy from device");
 }
 
 } // namespace
@@ -178,34 +239,7 @@ void projectSymmetricBlocksToPsdCuda(
   if (blockCount == 0) {
     return;
   }
-
-  DART_EXPERIMENTAL_THROW_T_IF(
-      !isCudaRuntimeAvailable(),
-      sx::InvalidOperationException,
-      "CUDA runtime has no available device");
-
-  DeviceDoubleBuffer deviceBlocks(blocks.size());
-  throwIfCudaError(
-      cudaMemcpy(
-          deviceBlocks.data(),
-          blocks.data(),
-          deviceBlocks.byteSize(),
-          cudaMemcpyHostToDevice),
-      "PSD block copy to device");
-
-  throwIfCudaError(
-      detail::launchProjectSymmetricBlocksToPsdKernel(
-          deviceBlocks.data(), dimension, blockCount),
-      "PSD projection kernel");
-  throwIfCudaError(cudaDeviceSynchronize(), "PSD projection synchronize");
-
-  throwIfCudaError(
-      cudaMemcpy(
-          blocks.data(),
-          deviceBlocks.data(),
-          deviceBlocks.byteSize(),
-          cudaMemcpyDeviceToHost),
-      "PSD block copy from device");
+  projectSymmetricBlocksToPsdCudaInPlace(blocks.data(), dimension, blockCount);
 }
 
 namespace {
@@ -231,10 +265,10 @@ void cudaPsdBackendAdapter(
     projectSymmetricBlocksToPsdCpu(blocks, dimension, blockCount);
     return;
   }
-  std::vector<double> buffer(
-      blocks, blocks + dimension * dimension * blockCount);
-  projectSymmetricBlocksToPsdCuda(buffer, dimension, blockCount);
-  std::copy(buffer.begin(), buffer.end(), blocks);
+  // Project in place on the caller's packed buffer through the resident device
+  // buffer, so the offload adds no per-call host allocation or device
+  // malloc/free -- only the host<->device copies the data movement requires.
+  projectSymmetricBlocksToPsdCudaInPlace(blocks, dimension, blockCount);
 }
 
 } // namespace
@@ -249,6 +283,14 @@ void installCudaDeformablePsdBackend()
 void restoreDefaultDeformablePsdBackend()
 {
   setDeformablePsdBlockProjector(nullptr);
+  // Free the device scratch when the GPU backend is uninstalled.
+  residentDeviceBuffer().release();
+}
+
+//==============================================================================
+std::size_t deformablePsdResidentBufferAllocationCount() noexcept
+{
+  return residentDeviceBuffer().allocationCount();
 }
 
 } // namespace dart::simulation::experimental::compute::cuda

--- a/dart/simulation/experimental/compute/cuda/deformable_psd_projection_cuda.cuh
+++ b/dart/simulation/experimental/compute/cuda/deformable_psd_projection_cuda.cuh
@@ -93,6 +93,21 @@ void projectSymmetricBlocksToPsdReference(
 void installCudaDeformablePsdBackend();
 
 /// Restore the built-in CPU PSD projection backend installed by default.
+///
+/// Also releases the resident device buffer (see
+/// @ref deformablePsdResidentBufferAllocationCount), so uninstalling the GPU
+/// backend frees its device scratch.
 void restoreDefaultDeformablePsdBackend();
+
+/// Cumulative number of device-buffer allocations the resident PSD scratch has
+/// performed.
+///
+/// The GPU projection reuses one persistent device allocation across calls
+/// instead of allocating and freeing per call; it grows (and bumps this count)
+/// only when a batch needs more storage than the current capacity, and is
+/// freed by @ref restoreDefaultDeformablePsdBackend. This count therefore stays
+/// flat across same-or-smaller batches. Exposed (build-tree only) so tests can
+/// assert the per-call `cudaMalloc`/`cudaFree` round trip was removed.
+[[nodiscard]] std::size_t deformablePsdResidentBufferAllocationCount() noexcept;
 
 } // namespace dart::simulation::experimental::compute::cuda

--- a/docs/dev_tasks/ipc_deformable_solver/README.md
+++ b/docs/dev_tasks/ipc_deformable_solver/README.md
@@ -155,8 +155,15 @@
         256 blocks, ~1.4x at 1024, ~4x at 4096, ~9x at 16384) sets the backend
         adapter's minimum GPU batch size (~1024 blocks); smaller batches stay on
         the CPU backend.
-  - [ ] Remaining Phase 3 work: a resident GPU solve path (the current backend
-        round-trips host<->device per batch; persistent device buffers are a
+  - [x] Resident GPU device buffer: the CUDA PSD backend reuses one persistent
+        device allocation that grows on demand (freed when the backend is
+        uninstalled) and projects in place on the caller's packed buffer,
+        removing the per-iteration `cudaMalloc`/`cudaFree` and the temporary
+        host copy. Bit-identical results (only the device storage is reused);
+        a CUDA test asserts the buffer is reused across same-or-smaller batches,
+        grows once for a larger batch, and is released on restore.
+  - [ ] Remaining Phase 3 work: a fully resident GPU solve path (the per-batch
+        host<->device copies remain; keeping the assembly/solve on-device is a
         follow-up), matrix-free CG for very large meshes, adaptive barrier
         stiffness, barrier forces for rigid/codimensional obstacles, and
         complementarity/solver-stat diagnostics. Known approximation: the

--- a/tests/unit/simulation/experimental/cuda/test_deformable_psd_projection_cuda.cpp
+++ b/tests/unit/simulation/experimental/cuda/test_deformable_psd_projection_cuda.cpp
@@ -274,3 +274,62 @@ TEST(CudaDeformablePsdProjection, GpuVsCpuPerfGateAtSolverScale)
               << "ms speedup=" << (gpuMs > 0.0 ? cpuMs / gpuMs : 0.0) << "x\n";
   }
 }
+
+//==============================================================================
+// The GPU projection reuses one resident device buffer across calls rather than
+// allocating and freeing per call: a first batch allocates, repeated
+// same-or-smaller batches reuse it (no new allocation), a larger batch grows it
+// once, and restoring the backend frees it (so a subsequent batch
+// re-allocates). Results stay equal to the CPU reference throughout, proving
+// the resident buffer is purely a performance change.
+TEST(
+    CudaDeformablePsdProjection,
+    ResidentDeviceBufferReusesAllocationAcrossCalls)
+{
+  if (!cuda::isCudaRuntimeAvailable()) {
+    GTEST_SKIP() << "CUDA runtime has no available device";
+  }
+
+  constexpr std::size_t dim = 12;
+  constexpr std::size_t smallCount = 1024;
+  constexpr std::size_t largeCount = 4096;
+
+  // Release any resident buffer left by earlier tests so the first projection
+  // below is guaranteed to allocate; assertions then track allocation deltas.
+  cuda::restoreDefaultDeformablePsdBackend();
+
+  const auto project = [&](std::size_t count) {
+    const auto reference = makeSymmetricBlocks(dim, count);
+    std::vector<double> cpu = reference;
+    cuda::projectSymmetricBlocksToPsdReference(cpu, dim, count);
+    std::vector<double> gpu = reference;
+    cuda::projectSymmetricBlocksToPsdCuda(gpu, dim, count);
+    EXPECT_LT(maxAbsDifference(cpu, gpu), 1e-9) << "count=" << count;
+  };
+
+  const std::size_t base = cuda::deformablePsdResidentBufferAllocationCount();
+
+  project(smallCount); // first use after release -> exactly one allocation
+  const std::size_t afterFirst
+      = cuda::deformablePsdResidentBufferAllocationCount();
+  EXPECT_EQ(afterFirst, base + 1);
+
+  project(smallCount); // same size -> reuse, no new allocation
+  EXPECT_EQ(cuda::deformablePsdResidentBufferAllocationCount(), afterFirst);
+
+  project(largeCount); // larger than capacity -> one growth allocation
+  const std::size_t afterGrow
+      = cuda::deformablePsdResidentBufferAllocationCount();
+  EXPECT_EQ(afterGrow, afterFirst + 1);
+
+  project(smallCount); // smaller than capacity -> reuse, no new allocation
+  EXPECT_EQ(cuda::deformablePsdResidentBufferAllocationCount(), afterGrow);
+
+  // Restoring the backend releases the device scratch, so the next projection
+  // allocates afresh.
+  cuda::restoreDefaultDeformablePsdBackend();
+  project(smallCount);
+  EXPECT_EQ(cuda::deformablePsdResidentBufferAllocationCount(), afterGrow + 1);
+
+  cuda::restoreDefaultDeformablePsdBackend();
+}


### PR DESCRIPTION
## Summary

Removes the per-iteration device allocation from the experimental IPC deformable GPU PSD-projection backend (PLAN-081 Phase 3 follow-up).

The CUDA backend previously allocated and freed a device buffer on **every** projected-Newton iteration, and the backend adapter additionally copied the packed Hessian blocks through a temporary host `std::vector` on each call. Under the solver that is a `cudaMalloc`/`cudaFree` plus a host allocation per outer iteration.

This PR:
- Replaces the per-call `DeviceDoubleBuffer` with a **resident, grow-on-demand** device buffer reused across calls (reallocates only when a batch exceeds the current capacity) and freed when the GPU backend is uninstalled.
- Adds a raw-pointer **in-place** projection that runs on the caller's packed buffer through the resident device buffer; the backend adapter routes through it, so the offload no longer makes a per-call host copy.
- The public `std::vector<double>&` overload validates the buffer size and delegates to the same in-place path (unchanged API).

## Behavior

**Bit-identical** results — same kernel, same host↔device transfers; only the device storage is reused. This is purely a performance change confined to the opt-in `dart-simulation-experimental-cuda` sidecar. The default CPU runtime is untouched, so the no-GPU-runtime-dependency guarantee and `pixi run test-all` (which doesn't build the sidecar) are unaffected.

The remaining per-batch host↔device copies are inherent to the current design; keeping the assembly/solve fully on-device is a documented follow-up.

## Tests & evidence

- New `ResidentDeviceBufferReusesAllocationAcrossCalls` CUDA test (via an exposed allocation counter): a first batch allocates, repeated same-or-smaller batches reuse without allocating, a larger batch grows it exactly once, and restoring the backend releases it — with GPU/CPU-reference parity (`< 1e-9`) preserved at every step.
- All 6 cuda tests pass on an RTX 5000 Ada (`pixi run -e cuda ctest -R deformable_psd`); `BackendInjectionRoutesThroughCoreSeam` still passes through the new in-place adapter.
- `pixi run test-all`: all 6 categories PASS (default build unaffected).

Milestone: DART 7.0.