### PR TITLE
Link Filament's macOS system frameworks so the dartpy wheel builds

### DIFF
--- a/cmake/dart_find_filament.cmake
+++ b/cmake/dart_find_filament.cmake
@@ -147,15 +147,43 @@ if(Filament_zstd_LIBRARY)
 endif()
 
 if(APPLE)
-  find_library(Filament_Foundation_LIBRARY NAMES Foundation)
-  if(Filament_Foundation_LIBRARY)
-    list(APPEND Filament_LIBRARIES "${Filament_Foundation_LIBRARY}")
-  endif()
+  # Filament's macOS backends pull in several system frameworks: Metal +
+  # QuartzCore (CAMetalLayer) for the Metal backend, CoreVideo for the
+  # texture-cache interop, Cocoa for the NSView/NSWindow surface, plus
+  # IOKit/CoreGraphics/OpenGL. The conda-forge `Filament::filament` CONFIG
+  # target does not always carry these in its link interface, and the dartpy
+  # wheel is the only macOS build that links Filament with the GUI enabled
+  # (the arm64 test jobs build GUI-off), so a missing framework surfaces there
+  # as undefined Metal/CoreVideo/QuartzCore/AppKit symbols when linking
+  # `_dartpy.so`. Collect them so they reach every Filament consumer.
+  set(_dart_filament_apple_frameworks)
+  foreach(
+    _dart_fw
+    Foundation
+    Cocoa
+    Metal
+    CoreVideo
+    QuartzCore
+    IOKit
+    CoreGraphics
+    OpenGL
+  )
+    find_library(Filament_${_dart_fw}_FRAMEWORK NAMES ${_dart_fw})
+    mark_as_advanced(Filament_${_dart_fw}_FRAMEWORK)
+    if(Filament_${_dart_fw}_FRAMEWORK)
+      list(
+        APPEND _dart_filament_apple_frameworks
+        "${Filament_${_dart_fw}_FRAMEWORK}"
+      )
+    endif()
+  endforeach()
 
   find_library(Filament_objc_LIBRARY NAMES objc)
   if(Filament_objc_LIBRARY)
-    list(APPEND Filament_LIBRARIES "${Filament_objc_LIBRARY}")
+    list(APPEND _dart_filament_apple_frameworks "${Filament_objc_LIBRARY}")
   endif()
+
+  list(APPEND Filament_LIBRARIES ${_dart_filament_apple_frameworks})
 elseif(WIN32)
   list(APPEND Filament_LIBRARIES opengl32)
 endif()
@@ -248,6 +276,25 @@ if(Filament_FOUND AND NOT TARGET Filament::filament)
   )
 endif()
 
+# When `Filament::filament` comes from a CONFIG package (e.g. conda-forge), its
+# link interface may omit the macOS system frameworks discovered above. Append
+# them so every consumer of Filament — including the dartpy extension built for
+# the wheel — resolves Metal/CoreVideo/QuartzCore/AppKit and friends. The
+# manual-find path already folds them into the interface via Filament_LIBRARIES;
+# this also covers the CONFIG path, resolving the `Filament::filament` alias to
+# its real target since properties cannot be set on an ALIAS.
+if(APPLE AND TARGET Filament::filament AND _dart_filament_apple_frameworks)
+  get_target_property(_dart_filament_real Filament::filament ALIASED_TARGET)
+  if(NOT _dart_filament_real)
+    set(_dart_filament_real Filament::filament)
+  endif()
+  set_property(
+    TARGET ${_dart_filament_real}
+    APPEND
+    PROPERTY INTERFACE_LINK_LIBRARIES "${_dart_filament_apple_frameworks}"
+  )
+endif()
+
 if(Filament_FOUND AND NOT TARGET Filament::matc)
   add_executable(Filament::matc IMPORTED)
   set_target_properties(
@@ -270,7 +317,6 @@ mark_as_advanced(
   Filament_smol_v_LIBRARY
   Filament_shaders_LIBRARY
   Filament_zstd_LIBRARY
-  Filament_Foundation_LIBRARY
   Filament_objc_LIBRARY
   Filament_cxx_LIBRARY
   Filament_cxxabi_LIBRARY


### PR DESCRIPTION
## Summary

- Links the macOS system frameworks that Filament requires so the dartpy **wheel builds on macOS** (`Wheels | macos-latest Py312`, a required check, currently fails to link `_dartpy.so`).

## Motivation / Problem

The macOS wheel build fails at the link step for `_dartpy.so`:

```
Undefined symbols for architecture arm64:
  "_CVPixelBuffer*", "_CVMetalTextureCache*", "_CVOpenGLTextureCache*"   (CoreVideo)
  "_MTLCreateSystemDefaultDevice", "_OBJC_CLASS_$_MTL*"                  (Metal)
  "_OBJC_CLASS_$_CAMetalLayer"                                          (QuartzCore)
  "_NSView*", "_NSWindow*"                                              (AppKit / Cocoa)
ld: symbol(s) not found for architecture arm64
```

`cmake/dart_find_filament.cmake` only added **Foundation** and **objc** on `APPLE`, but Filament's Metal and GL backends also need **Metal, CoreVideo, QuartzCore, Cocoa, IOKit, CoreGraphics, and OpenGL**. The gap stayed hidden because the dartpy wheel is the **only** macOS CI build that links Filament with the GUI enabled — the `Release/Debug Tests (arm64)` jobs build with `DART_BUILD_SIMULATION_EXPERIMENTAL=OFF` (GUI off). The conda-forge `Filament::filament` CONFIG target does not carry these frameworks in its link interface, so consumers must supply them.

## Changes / Key Changes

- In `cmake/dart_find_filament.cmake`, discover the required macOS frameworks (`Foundation`, `Cocoa`, `Metal`, `CoreVideo`, `QuartzCore`, `IOKit`, `CoreGraphics`, `OpenGL`) plus `objc`, and:
  - fold them into `Filament_LIBRARIES` for the **manual-find** path (where we build the `Filament::filament` INTERFACE target ourselves), and
  - append them to the resolved `Filament::filament` target's `INTERFACE_LINK_LIBRARIES` for the **CONFIG** path (e.g. conda-forge), resolving the alias to its real target since `set_property` cannot target an `ALIAS`.
- Result: the frameworks propagate to every Filament consumer — `dart-gui`, the demos app, and the wheel's `_dartpy.so`.

## Testing

- CMake-only change; **inert off macOS** (the whole block is guarded by `if(APPLE)`), so Linux/Windows builds are unaffected.
- `pixi run check-lint-cmake` (gersemi) clean — which also confirms the file parses.
- The macOS link behavior cannot be exercised on the available Linux runner; **validated via this PR's `Wheels | macos-latest Py312` CI job**.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Restores the `Wheels | macos-latest Py312` required check, currently failing on `main`. Independent of the differentiable-simulation work (PR #2761) and the demos-cycle reduced-build fix (PR #2783). No backport (DART 7 `main` only).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [ ] CHANGELOG.md updated if required — build/CI fix for an unreleased (DART 7 TBD) wheel; no user-facing API change
- [ ] Add unit tests for new functionality — n/a (CMake link config; covered by the wheel CI job)
- [x] Document new methods and classes — inline CMake comment explains the macOS-frameworks rationale
- [ ] Add Python bindings (dartpy) if applicable — n/a
