### PR TITLE
Add stable neo-Hookean FEM tetrahedral elasticity to the deformable solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -904,6 +904,26 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     surface CCD limiter remains the tunnelling guard for fast motion. Adds
     regressions that a node in the band is pushed radially outward and that an
     untagged sphere is inert.
+  - Added stable neo-Hookean tetrahedral FEM elasticity to the experimental
+    deformable solver (PLAN-081 M1, the paper-parity keystone). A new
+    header-only `deformable_elasticity/fem_tet_element.hpp` kernel produces, per
+    tetrahedron, the stable neo-Hookean (Smith et al. 2018) strain energy, its
+    12x1 nodal gradient, and the true 12x12 Hessian, validated by
+    finite-difference gradient/Hessian tests (plus rest-state zero force,
+    inversion-robustness, and zero-Poisson stability). The solver wires it in as
+    an opt-in elasticity model via the new
+    `DeformableMaterialProperties.useFiniteElementElasticity` flag (also exposed
+    to `dartpy` as `use_finite_element_elasticity`): when set, each tetrahedron
+    contributes its energy/gradient to the objective and its PSD-projected 12x12
+    Hessian to the sparse projected-Newton assembly through the same batched
+    projection seam as the spring and barrier blocks. The model is inversion-safe
+    (finite for every deformation gradient, including det F <= 0). Default (flag
+    off) leaves the mass-spring path byte-identical -- all existing deformable
+    regressions are unchanged. Adds solver regressions (a pinned FEM tetrahedron
+    resists gravity where a springless body free-falls; stationary at rest;
+    restores a perturbed node toward rest), a `BM_DeformableFemBarStep`
+    benchmark, and a `Deformable FEM Bar (IPC)` py-demos scene (a tetrahedral
+    cantilever sagging under gravity) in the `IPC Deformable (sx)` category.
   - Added internal experimental IPC projected-Newton search direction for the
     deformable solve: each iteration assembles the per-step Hessian (inertia +
     spring + self-contact barrier + static ground barrier) with per-element

--- a/dart/simulation/experimental/body/deformable_body_options.hpp
+++ b/dart/simulation/experimental/body/deformable_body_options.hpp
@@ -90,6 +90,12 @@ struct DeformableMaterialProperties
   /// Must be finite and non-negative. Zero (the default) disables friction, so
   /// existing contact behavior is unchanged unless friction is opted in.
   double frictionCoefficient = 0.0;
+
+  /// Opt in to stable neo-Hookean tetrahedral FEM elasticity (using
+  /// ``youngsModulus`` / ``poissonRatio``) instead of the default mass-spring
+  /// edge model. Requires the body to carry tetrahedra. Off by default, so
+  /// existing spring bodies are unchanged.
+  bool useFiniteElementElasticity = false;
 };
 
 /// Scripted Dirichlet boundary condition over deformable nodes.

--- a/dart/simulation/experimental/comps/deformable_body.cpp
+++ b/dart/simulation/experimental/comps/deformable_body.cpp
@@ -243,6 +243,7 @@ private:
     io::writePOD(output, component.youngsModulus);
     io::writePOD(output, component.poissonRatio);
     io::writePOD(output, component.frictionCoefficient);
+    io::writePOD(output, component.useFiniteElementElasticity);
   }
 
   void loadComponent(
@@ -252,6 +253,7 @@ private:
     io::readPOD(input, component.youngsModulus);
     io::readPOD(input, component.poissonRatio);
     io::readPOD(input, component.frictionCoefficient);
+    io::readPOD(input, component.useFiniteElementElasticity);
   }
 };
 

--- a/dart/simulation/experimental/comps/deformable_body.hpp
+++ b/dart/simulation/experimental/comps/deformable_body.hpp
@@ -119,6 +119,7 @@ struct DeformableMaterial
   double youngsModulus = 1.0e5;
   double poissonRatio = 0.3;
   double frictionCoefficient = 0.0;
+  bool useFiniteElementElasticity = false;
 };
 
 /// Time-ranged scripted Dirichlet boundary region for deformable nodes.

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -50,6 +50,7 @@
 #include "dart/simulation/experimental/detail/deformable_contact/candidate_set.hpp"
 #include "dart/simulation/experimental/detail/deformable_contact/continuous_collision_step.hpp"
 #include "dart/simulation/experimental/detail/deformable_contact/tangent_stencil.hpp"
+#include "dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp"
 #include "dart/simulation/experimental/world.hpp"
 
 #include <Eigen/Cholesky>
@@ -75,6 +76,7 @@
 namespace dart::simulation::experimental::compute {
 
 namespace dc = dart::simulation::experimental::detail::deformable_contact;
+namespace fem = dart::simulation::experimental::detail::deformable_elasticity;
 
 namespace {
 
@@ -2747,6 +2749,60 @@ std::size_t accumulateContactDistanceDiagnostics(
 }
 
 //==============================================================================
+// Stable neo-Hookean FEM elasticity inputs. When non-null (opt-in via
+// DeformableMaterial.useFiniteElementElasticity), each tetrahedron contributes
+// a volumetric strain energy/gradient/Hessian instead of the mass-spring edge
+// model. Null preserves the spring objective exactly.
+struct FemElasticityInputs
+{
+  const std::vector<comps::DeformableTetrahedron>* tetrahedra = nullptr;
+  const std::vector<fem::TetRestShape>* restShapes = nullptr;
+  fem::LameParameters lame;
+};
+
+// Adds the stable neo-Hookean strain energy/gradient over every valid
+// tetrahedron, scattering each element's 12-vector force gradient into its four
+// nodes (fixed nodes receive no gradient, like the spring term).
+double addFemElasticityEnergy(
+    const std::vector<Eigen::Vector3d>& positions,
+    const std::vector<std::uint8_t>& fixed,
+    const FemElasticityInputs& inputs,
+    std::vector<Eigen::Vector3d>* gradient)
+{
+  if (inputs.tetrahedra == nullptr || inputs.restShapes == nullptr) {
+    return 0.0;
+  }
+  const auto& tets = *inputs.tetrahedra;
+  const auto& rests = *inputs.restShapes;
+  const std::size_t count = std::min(tets.size(), rests.size());
+  double energy = 0.0;
+  for (std::size_t t = 0; t < count; ++t) {
+    const auto& tet = tets[t];
+    const fem::TetElementResult element = fem::evaluateStableNeoHookeanTet(
+        positions[tet.nodeA],
+        positions[tet.nodeB],
+        positions[tet.nodeC],
+        positions[tet.nodeD],
+        rests[t],
+        inputs.lame,
+        /*computeHessian=*/false);
+    if (!element.valid) {
+      continue;
+    }
+    energy += element.energy;
+    if (gradient != nullptr) {
+      const std::array<std::size_t, 4> nodes
+          = {tet.nodeA, tet.nodeB, tet.nodeC, tet.nodeD};
+      for (int i = 0; i < 4; ++i) {
+        if (fixed[nodes[i]] == 0u) {
+          (*gradient)[nodes[i]] += element.gradient.segment<3>(3 * i);
+        }
+      }
+    }
+  }
+  return energy;
+}
+
 double evaluateDeformableObjective(
     const comps::DeformableNodeState& state,
     const comps::DeformableSpringModel& model,
@@ -2760,7 +2816,8 @@ double evaluateDeformableObjective(
     const SelfContactBarrierInputs* contactBarrier = nullptr,
     std::size_t* barrierActiveContacts = nullptr,
     const GroundFrictionInputs* groundFriction = nullptr,
-    const SelfContactFrictionInputs* selfContactFriction = nullptr)
+    const SelfContactFrictionInputs* selfContactFriction = nullptr,
+    const FemElasticityInputs* femElasticity = nullptr)
 {
   if (gradient != nullptr) {
     if (gradient->size() != positions.size()) {
@@ -2806,6 +2863,10 @@ double evaluateDeformableObjective(
     }
   }
 
+  if (femElasticity != nullptr) {
+    energy
+        += addFemElasticityEnergy(positions, fixed, *femElasticity, gradient);
+  }
   energy += addStaticGroundBarrierEnergy(positions, fixed, barriers, gradient);
   energy += addSphereObstacleBarrierEnergy(
       positions, fixed, sphereObstacles, gradient);
@@ -3409,6 +3470,7 @@ bool computeProjectedNewtonDirection(
     const SelfContactBarrierInputs* contactBarrier,
     const GroundFrictionInputs* groundFriction,
     const SelfContactFrictionInputs* selfContactFriction,
+    const FemElasticityInputs* femElasticity,
     const double timeStep,
     const std::vector<Eigen::Vector3d>& gradient,
     std::vector<Eigen::Vector3d>& direction,
@@ -3530,6 +3592,53 @@ bool computeProjectedNewtonDirection(
       for (int bj = 0; bj < 2; ++bj) {
         addBlock3(
             nodes[bi], nodes[bj], edgeHessian.block<3, 3>(3 * bi, 3 * bj));
+      }
+    }
+  }
+
+  // Stable neo-Hookean FEM elasticity Hessian per tetrahedron, PSD-projected
+  // over its 12x12 block through the same batched seam as the spring and
+  // barrier blocks. Null femElasticity (the default mass-spring path) skips
+  // this entirely, so spring bodies assemble exactly as before.
+  if (femElasticity != nullptr && femElasticity->tetrahedra != nullptr
+      && femElasticity->restShapes != nullptr) {
+    const auto& tets = *femElasticity->tetrahedra;
+    const auto& rests = *femElasticity->restShapes;
+    const std::size_t tetCount = std::min(tets.size(), rests.size());
+    constexpr std::size_t kTetBlockEntries = 144; // 12x12
+    std::vector<double> tetBlocks;
+    std::vector<std::array<std::size_t, 4>> tetBlockNodes;
+    tetBlocks.reserve(kTetBlockEntries * tetCount);
+    tetBlockNodes.reserve(tetCount);
+    for (std::size_t t = 0; t < tetCount; ++t) {
+      const auto& tet = tets[t];
+      const fem::TetElementResult element = fem::evaluateStableNeoHookeanTet(
+          positions[tet.nodeA],
+          positions[tet.nodeB],
+          positions[tet.nodeC],
+          positions[tet.nodeD],
+          rests[t],
+          femElasticity->lame,
+          /*computeHessian=*/true);
+      if (!element.valid) {
+        continue;
+      }
+      const std::size_t offset = tetBlocks.size();
+      tetBlocks.resize(offset + kTetBlockEntries);
+      Eigen::Map<Eigen::Matrix<double, 12, 12, Eigen::RowMajor>>(
+          tetBlocks.data() + offset) = element.hessian;
+      tetBlockNodes.push_back({tet.nodeA, tet.nodeB, tet.nodeC, tet.nodeD});
+    }
+    projectSymmetricBlocksToPsd(tetBlocks.data(), 12, tetBlockNodes.size());
+    for (std::size_t b = 0; b < tetBlockNodes.size(); ++b) {
+      const Eigen::Map<const Eigen::Matrix<double, 12, 12, Eigen::RowMajor>>
+          projected(tetBlocks.data() + b * kTetBlockEntries);
+      const auto& nodes = tetBlockNodes[b];
+      for (int bi = 0; bi < 4; ++bi) {
+        for (int bj = 0; bj < 4; ++bj) {
+          addBlock3(
+              nodes[bi], nodes[bj], projected.block<3, 3>(3 * bi, 3 * bj));
+        }
       }
     }
   }
@@ -3828,12 +3937,40 @@ void advanceDeformableBody(
     double timeStep,
     const std::vector<StaticGroundBarrier>& barriers,
     const std::vector<SphereObstacleBarrier>& sphereObstacles,
-    double frictionCoefficient,
+    const comps::DeformableMaterial& material,
     DeformableSolverStats& stats)
 {
   const auto nodeCount = state.positions.size();
   if (nodeCount == 0) {
     return;
+  }
+
+  const double frictionCoefficient = material.frictionCoefficient;
+
+  // Opt-in stable neo-Hookean FEM elasticity. Precompute each tetrahedron's
+  // rest shape from the rest positions once per step; the inputs are passed by
+  // pointer into the objective and projected-Newton assembly, replacing the
+  // mass-spring edge model for this body. Null (the default) leaves the spring
+  // path byte-identical.
+  std::vector<fem::TetRestShape> femRestShapes;
+  FemElasticityInputs femElasticity;
+  const FemElasticityInputs* femElasticityPtr = nullptr;
+  if (material.useFiniteElementElasticity && !topology.tetrahedra.empty()
+      && topology.restPositions.size() == nodeCount) {
+    femRestShapes.reserve(topology.tetrahedra.size());
+    for (const auto& tet : topology.tetrahedra) {
+      femRestShapes.push_back(
+          fem::makeTetRestShape(
+              topology.restPositions[tet.nodeA],
+              topology.restPositions[tet.nodeB],
+              topology.restPositions[tet.nodeC],
+              topology.restPositions[tet.nodeD]));
+    }
+    femElasticity.tetrahedra = &topology.tetrahedra;
+    femElasticity.restShapes = &femRestShapes;
+    femElasticity.lame
+        = fem::lameParameters(material.youngsModulus, material.poissonRatio);
+    femElasticityPtr = &femElasticity;
   }
 
   stats.nodeCount += nodeCount;
@@ -3876,7 +4013,8 @@ void advanceDeformableBody(
 
   if (model.edges.empty() && barriers.empty() && sphereObstacles.empty()
       && rigidSurfaceSnapshots.empty() && movingRigidSurfaceSnapshots.empty()
-      && contactScratch.surfaceTriangles.empty()) {
+      && contactScratch.surfaceTriangles.empty()
+      && femElasticityPtr == nullptr) {
     for (std::size_t i = 0; i < nodeCount; ++i) {
       if (scratch.activeFixed[i] == 0u) {
         scratch.next[i] = scratch.inertialTargets[i];
@@ -3979,7 +4117,8 @@ void advanceDeformableBody(
           &contactBarrier,
           &stats.selfContactBarrierActiveContacts,
           &groundFriction,
-          &selfContactFriction);
+          &selfContactFriction,
+          femElasticityPtr);
       if (!std::isfinite(energy)) {
         brokeEarly = true;
         break;
@@ -4093,7 +4232,8 @@ void advanceDeformableBody(
                 &contactBarrier,
                 nullptr,
                 &groundFriction,
-                &selfContactFriction);
+                &selfContactFriction,
+                femElasticityPtr);
             if (std::isfinite(candidateEnergy)
                 && candidateEnergy <= energy + armijo * directionalDerivative) {
               // Record the accepted step's infinity norm (the actual per-node
@@ -4141,6 +4281,7 @@ void advanceDeformableBody(
           &contactBarrier,
           &groundFriction,
           &selfContactFriction,
+          femElasticityPtr,
           timeStep,
           scratch.gradient,
           scratch.direction,
@@ -4239,7 +4380,8 @@ void advanceDeformableBody(
           &terminalBarrier,
           nullptr,
           &terminalGroundFriction,
-          &terminalSelfContactFriction);
+          &terminalSelfContactFriction,
+          femElasticityPtr);
       if (std::isfinite(terminalEnergy)) {
         lastGradSquared
             = gradientNormSquared(scratch.gradient, scratch.activeFixed);
@@ -4764,7 +4906,7 @@ void DeformableDynamicsStage::execute(
         timeStep,
         barriers,
         sphereObstacles,
-        material.frictionCoefficient,
+        material,
         m_lastStats);
   }
 }

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -761,6 +761,12 @@ struct DeformableContactSolverScratch
   std::vector<int> newtonPatternOuter;
   std::vector<int> newtonPatternInner;
   bool newtonPatternValid = false;
+
+  // Cached per-tetrahedron FEM rest shapes (inverse rest edge matrix + rest
+  // volume). The rest configuration never changes, so these are computed once
+  // (when the cached count first matches the body's tetrahedron count) and
+  // reused every step instead of re-inverting each tet's rest edges per step.
+  std::vector<fem::TetRestShape> femRestShapes;
 };
 
 //==============================================================================
@@ -3947,27 +3953,30 @@ void advanceDeformableBody(
 
   const double frictionCoefficient = material.frictionCoefficient;
 
-  // Opt-in stable neo-Hookean FEM elasticity. Precompute each tetrahedron's
-  // rest shape from the rest positions once per step; the inputs are passed by
-  // pointer into the objective and projected-Newton assembly, replacing the
-  // mass-spring edge model for this body. Null (the default) leaves the spring
-  // path byte-identical.
-  std::vector<fem::TetRestShape> femRestShapes;
+  // Opt-in stable neo-Hookean FEM elasticity. Each tetrahedron's rest shape is
+  // computed once and cached in the per-entity scratch (the rest configuration
+  // never changes), then reused every step; the inputs are passed by pointer
+  // into the objective and projected-Newton assembly, replacing the mass-spring
+  // edge model for this body. Null (the default) leaves the spring path
+  // byte-identical.
   FemElasticityInputs femElasticity;
   const FemElasticityInputs* femElasticityPtr = nullptr;
   if (material.useFiniteElementElasticity && !topology.tetrahedra.empty()
       && topology.restPositions.size() == nodeCount) {
-    femRestShapes.reserve(topology.tetrahedra.size());
-    for (const auto& tet : topology.tetrahedra) {
-      femRestShapes.push_back(
-          fem::makeTetRestShape(
-              topology.restPositions[tet.nodeA],
-              topology.restPositions[tet.nodeB],
-              topology.restPositions[tet.nodeC],
-              topology.restPositions[tet.nodeD]));
+    if (contactScratch.femRestShapes.size() != topology.tetrahedra.size()) {
+      contactScratch.femRestShapes.clear();
+      contactScratch.femRestShapes.reserve(topology.tetrahedra.size());
+      for (const auto& tet : topology.tetrahedra) {
+        contactScratch.femRestShapes.push_back(
+            fem::makeTetRestShape(
+                topology.restPositions[tet.nodeA],
+                topology.restPositions[tet.nodeB],
+                topology.restPositions[tet.nodeC],
+                topology.restPositions[tet.nodeD]));
+      }
     }
     femElasticity.tetrahedra = &topology.tetrahedra;
-    femElasticity.restShapes = &femRestShapes;
+    femElasticity.restShapes = &contactScratch.femRestShapes;
     femElasticity.lame
         = fem::lameParameters(material.youngsModulus, material.poissonRatio);
     femElasticityPtr = &femElasticity;

--- a/dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp
+++ b/dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary form, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice and this list of conditions in the documentation
+ *     and/or other materials provided with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// Stable neo-Hookean tetrahedral finite-element strain energy.
+//
+// This is the IPC-class volumetric elasticity kernel: it produces, for one
+// linear tetrahedron, the elastic strain energy, its 12x1 nodal force gradient,
+// and the (true, not yet PSD-projected) 12x12 nodal Hessian. The solver feeds
+// the 12x12 block through the existing batched PSD-projection seam before the
+// projected-Newton assembly, exactly like the spring and barrier blocks.
+//
+// Material: the *stable* neo-Hookean model of Smith, Goes, and Kim,
+// "Stable Neo-Hookean Flesh Simulation" (ACM TOG 2018). It is C-infinity and
+// finite for *every* deformation gradient F, including degenerate/inverted
+// elements (det F <= 0), so it cannot blow up during the Newton line search.
+// The original IPC paper (Li et al. 2020) uses neo-Hookean / fixed-corotational
+// elasticity; this inversion-robust variant is the documented DART material for
+// the FEM elasticity slice (PLAN-081), with fixed-corotational as a follow-up.
+//
+// Energy density (rest-state-zeroed so a tet at its rest shape stores no
+// energy; the constant is dropped in a lambda-stable form):
+//
+//   psi(F) = (mu/2)(Ic - 3) - (mu/2) ln((Ic + 1)/4)
+//          + (lambda/2)(J^2 - 1) - (lambda + 3*mu/4)(J - 1)
+//
+// with Ic = ||F||_F^2 = tr(F^T F) and J = det F. The rest-stability constant
+// alpha = 1 + 3*mu/(4*lambda) only ever appears as lambda*alpha = lambda +
+// 3*mu/4, so the kernel stays finite as lambda -> 0 (Poisson ratio -> 0).
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include <cmath>
+
+namespace dart::simulation::experimental::detail::deformable_elasticity {
+
+using Vector9d = Eigen::Matrix<double, 9, 1>;
+using Vector12d = Eigen::Matrix<double, 12, 1>;
+using Matrix9d = Eigen::Matrix<double, 9, 9>;
+using Matrix12d = Eigen::Matrix<double, 12, 12>;
+using Matrix9x12d = Eigen::Matrix<double, 9, 12>;
+
+/// Lame parameters (shear modulus mu, first Lame parameter lambda).
+struct LameParameters
+{
+  double mu = 0.0;
+  double lambda = 0.0;
+};
+
+/// Convert engineering (Young's modulus, Poisson ratio) to Lame parameters.
+/// Valid for poissonRatio in [0, 0.5); the near-incompressible limit
+/// (poissonRatio -> 0.5) sends lambda -> +infinity, which the caller should
+/// clamp at the material level.
+inline LameParameters lameParameters(
+    const double youngsModulus, const double poissonRatio)
+{
+  LameParameters lame;
+  const double e = std::max(0.0, youngsModulus);
+  const double nu = poissonRatio;
+  lame.mu = e / (2.0 * (1.0 + nu));
+  const double denom = (1.0 + nu) * (1.0 - 2.0 * nu);
+  lame.lambda = (std::abs(denom) > 0.0) ? (e * nu / denom) : 0.0;
+  return lame;
+}
+
+/// Rest configuration of a linear tetrahedron: the inverse of the rest edge
+/// matrix Dm = [X1-X0 | X2-X0 | X3-X0] and the rest volume |det Dm| / 6.
+struct TetRestShape
+{
+  Eigen::Matrix3d inverseRestEdges = Eigen::Matrix3d::Identity();
+  double restVolume = 0.0;
+  bool valid = false;
+};
+
+/// Build the rest shape from the four rest-position corners. A degenerate
+/// (near-zero-volume) tetrahedron yields ``valid == false`` and is skipped by
+/// the element evaluator.
+inline TetRestShape makeTetRestShape(
+    const Eigen::Vector3d& restX0,
+    const Eigen::Vector3d& restX1,
+    const Eigen::Vector3d& restX2,
+    const Eigen::Vector3d& restX3)
+{
+  TetRestShape rest;
+  Eigen::Matrix3d dm;
+  dm.col(0) = restX1 - restX0;
+  dm.col(1) = restX2 - restX0;
+  dm.col(2) = restX3 - restX0;
+  const double det = dm.determinant();
+  constexpr double kMinRestVolume = 1e-14;
+  if (!std::isfinite(det) || std::abs(det) <= 6.0 * kMinRestVolume) {
+    return rest;
+  }
+  rest.inverseRestEdges = dm.inverse();
+  rest.restVolume = std::abs(det) / 6.0;
+  rest.valid = true;
+  return rest;
+}
+
+/// Deformation gradient F = Ds * Bm, with Ds = [x1-x0 | x2-x0 | x3-x0].
+inline Eigen::Matrix3d deformationGradient(
+    const Eigen::Vector3d& x0,
+    const Eigen::Vector3d& x1,
+    const Eigen::Vector3d& x2,
+    const Eigen::Vector3d& x3,
+    const Eigen::Matrix3d& inverseRestEdges)
+{
+  Eigen::Matrix3d ds;
+  ds.col(0) = x1 - x0;
+  ds.col(1) = x2 - x0;
+  ds.col(2) = x3 - x0;
+  return ds * inverseRestEdges;
+}
+
+namespace detail {
+
+/// Skew-symmetric cross-product matrix [v]x with [v]x a = v x a.
+inline Eigen::Matrix3d skew(const Eigen::Vector3d& v)
+{
+  Eigen::Matrix3d m;
+  m << 0.0, -v.z(), v.y(), v.z(), 0.0, -v.x(), -v.y(), v.x(), 0.0;
+  return m;
+}
+
+/// dJ/dF as a 3x3 matrix (the cofactor matrix), columns f1xf2, f2xf0, f0xf1.
+/// Robust for every F (no inverse), so it is well defined at det F = 0.
+inline Eigen::Matrix3d determinantGradient(const Eigen::Matrix3d& f)
+{
+  Eigen::Matrix3d g;
+  g.col(0) = f.col(1).cross(f.col(2));
+  g.col(1) = f.col(2).cross(f.col(0));
+  g.col(2) = f.col(0).cross(f.col(1));
+  return g;
+}
+
+/// d^2 J / dF^2 as a 9x9 matrix in column-stacked vec(F) ordering
+/// [f0; f1; f2]. Block (i,j) is the 3x3 second derivative w.r.t. columns i, j.
+inline Matrix9d determinantHessian(const Eigen::Matrix3d& f)
+{
+  const Eigen::Matrix3d s0 = skew(f.col(0));
+  const Eigen::Matrix3d s1 = skew(f.col(1));
+  const Eigen::Matrix3d s2 = skew(f.col(2));
+  Matrix9d h = Matrix9d::Zero();
+  h.block<3, 3>(0, 3) = -s2;
+  h.block<3, 3>(0, 6) = s1;
+  h.block<3, 3>(3, 0) = s2;
+  h.block<3, 3>(3, 6) = -s0;
+  h.block<3, 3>(6, 0) = -s1;
+  h.block<3, 3>(6, 3) = s0;
+  return h;
+}
+
+} // namespace detail
+
+/// Stable neo-Hookean strain-energy density (rest-state-zeroed).
+inline double stableNeoHookeanEnergyDensity(
+    const Eigen::Matrix3d& f, const LameParameters& lame)
+{
+  const double ic = f.squaredNorm();
+  const double j = f.determinant();
+  const double lambdaAlpha = lame.lambda + 0.75 * lame.mu;
+  return 0.5 * lame.mu * (ic - 3.0)
+      - 0.5 * lame.mu * std::log((ic + 1.0) / 4.0)
+      + 0.5 * lame.lambda * (j * j - 1.0) - lambdaAlpha * (j - 1.0);
+}
+
+/// First Piola-Kirchhoff stress P = dpsi/dF (a 3x3 matrix).
+inline Eigen::Matrix3d stableNeoHookeanFirstPiola(
+    const Eigen::Matrix3d& f, const LameParameters& lame)
+{
+  const double ic = f.squaredNorm();
+  const double j = f.determinant();
+  const double lambdaAlpha = lame.lambda + 0.75 * lame.mu;
+  Eigen::Matrix3d p = lame.mu * (ic / (ic + 1.0)) * f;
+  p.noalias()
+      += (lame.lambda * j - lambdaAlpha) * detail::determinantGradient(f);
+  return p;
+}
+
+/// Material Hessian d^2 psi / dF^2 (9x9, column-stacked vec(F) ordering).
+/// This is the *true* energy Hessian; it may be indefinite for large
+/// deformations and is meant to be PSD-projected by the caller before the
+/// projected-Newton solve.
+inline Matrix9d stableNeoHookeanEnergyHessian(
+    const Eigen::Matrix3d& f, const LameParameters& lame)
+{
+  const double ic = f.squaredNorm();
+  const double j = f.determinant();
+  const double lambdaAlpha = lame.lambda + 0.75 * lame.mu;
+  const double denom = ic + 1.0;
+
+  const Eigen::Map<const Vector9d> vecF(f.data());
+  const Eigen::Matrix3d g = detail::determinantGradient(f);
+  const Eigen::Map<const Vector9d> vecG(g.data());
+
+  Matrix9d h = Matrix9d::Zero();
+  h.diagonal().array() += lame.mu * (ic / denom);
+  h.noalias() += (2.0 * lame.mu / (denom * denom)) * (vecF * vecF.transpose());
+  h.noalias() += lame.lambda * (vecG * vecG.transpose());
+  h.noalias() += (lame.lambda * j - lambdaAlpha) * detail::determinantHessian(f);
+  return h;
+}
+
+/// Constant Jacobian dvec(F)/dq (9x12), mapping nodal coordinates
+/// q = [x0; x1; x2; x3] to the column-stacked deformation gradient.
+inline Matrix9x12d deformationGradientJacobian(
+    const Eigen::Matrix3d& inverseRestEdges)
+{
+  Matrix9x12d dFdq = Matrix9x12d::Zero();
+  for (int k = 0; k < 3; ++k) {
+    const double b0 = inverseRestEdges(0, k);
+    const double b1 = inverseRestEdges(1, k);
+    const double b2 = inverseRestEdges(2, k);
+    const double c0 = -(b0 + b1 + b2);
+    for (int d = 0; d < 3; ++d) {
+      const int row = 3 * k + d;
+      dFdq(row, 0 + d) = c0; // node 0
+      dFdq(row, 3 + d) = b0; // node 1
+      dFdq(row, 6 + d) = b1; // node 2
+      dFdq(row, 9 + d) = b2; // node 3
+    }
+  }
+  return dFdq;
+}
+
+/// Per-element energy, 12x1 gradient, and 12x12 Hessian for one tetrahedron.
+struct TetElementResult
+{
+  double energy = 0.0;
+  Vector12d gradient = Vector12d::Zero();
+  Matrix12d hessian = Matrix12d::Zero();
+  bool valid = false;
+};
+
+/// Evaluate the stable neo-Hookean element. The gradient and Hessian are scaled
+/// by the rest volume so they integrate the energy over the element. Set
+/// ``computeHessian`` to false to skip the (more expensive) Hessian assembly,
+/// e.g. inside a gradient-only line-search probe.
+inline TetElementResult evaluateStableNeoHookeanTet(
+    const Eigen::Vector3d& x0,
+    const Eigen::Vector3d& x1,
+    const Eigen::Vector3d& x2,
+    const Eigen::Vector3d& x3,
+    const TetRestShape& rest,
+    const LameParameters& lame,
+    const bool computeHessian = true)
+{
+  TetElementResult result;
+  if (!rest.valid) {
+    return result;
+  }
+
+  const Eigen::Matrix3d f
+      = deformationGradient(x0, x1, x2, x3, rest.inverseRestEdges);
+  const double w = rest.restVolume;
+
+  result.energy = w * stableNeoHookeanEnergyDensity(f, lame);
+
+  const Eigen::Matrix3d p = stableNeoHookeanFirstPiola(f, lame);
+  const Matrix9x12d dFdq = deformationGradientJacobian(rest.inverseRestEdges);
+  const Eigen::Map<const Vector9d> vecP(p.data());
+  result.gradient.noalias() = w * (dFdq.transpose() * vecP);
+
+  if (computeHessian) {
+    const Matrix9d hMaterial = stableNeoHookeanEnergyHessian(f, lame);
+    result.hessian.noalias() = w * (dFdq.transpose() * hMaterial * dFdq);
+  }
+
+  result.valid = true;
+  return result;
+}
+
+} // namespace dart::simulation::experimental::detail::deformable_elasticity

--- a/dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp
+++ b/dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp
@@ -189,9 +189,8 @@ inline double stableNeoHookeanEnergyDensity(
   const double ic = f.squaredNorm();
   const double j = f.determinant();
   const double lambdaAlpha = lame.lambda + 0.75 * lame.mu;
-  return 0.5 * lame.mu * (ic - 3.0)
-      - 0.5 * lame.mu * std::log((ic + 1.0) / 4.0)
-      + 0.5 * lame.lambda * (j * j - 1.0) - lambdaAlpha * (j - 1.0);
+  return 0.5 * lame.mu * (ic - 3.0) - 0.5 * lame.mu * std::log((ic + 1.0) / 4.0)
+         + 0.5 * lame.lambda * (j * j - 1.0) - lambdaAlpha * (j - 1.0);
 }
 
 /// First Piola-Kirchhoff stress P = dpsi/dF (a 3x3 matrix).
@@ -227,7 +226,8 @@ inline Matrix9d stableNeoHookeanEnergyHessian(
   h.diagonal().array() += lame.mu * (ic / denom);
   h.noalias() += (2.0 * lame.mu / (denom * denom)) * (vecF * vecF.transpose());
   h.noalias() += lame.lambda * (vecG * vecG.transpose());
-  h.noalias() += (lame.lambda * j - lambdaAlpha) * detail::determinantHessian(f);
+  h.noalias()
+      += (lame.lambda * j - lambdaAlpha) * detail::determinantHessian(f);
   return h;
 }
 

--- a/dart/simulation/experimental/world.cpp
+++ b/dart/simulation/experimental/world.cpp
@@ -680,6 +680,8 @@ PreparedDeformableBodyData prepareDeformableBodyOptions(
   data.material.youngsModulus = options.material.youngsModulus;
   data.material.poissonRatio = options.material.poissonRatio;
   data.material.frictionCoefficient = options.material.frictionCoefficient;
+  data.material.useFiniteElementElasticity
+      = options.material.useFiniteElementElasticity;
 
   for (std::size_t i = 0; i < nodeCount; ++i) {
     validateDeformableFiniteVector(options.positions[i], "positions", i);

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -32,7 +32,7 @@ scenes).
   projected Newton with batched PSD projection (+ optional CUDA backend),
   lagged smoothed Coulomb friction (ground + self-contact), conservative
   PT/EE CCD limiters, and active-set sweep-and-prune broad phase.
-- **153/154 corpus scenes need FEM** *and* upstream meshes; 0 meshes are
+- **153/154 corpus scenes need FEM** _and_ upstream meshes; 0 meshes are
   vendored and there is no `.msh`/`.obj`/`.seg`/`.pt` importer. So essentially
   no paper scene is reproducible today, and **every showcase figure row is
   still `planned`.**
@@ -43,7 +43,19 @@ The milestones are ordered by dependency. Each ships as one PR off `main`
 (milestone DART 7.0) with **kernel + correctness tests + a runnable example +
 a benchmark**, per the standing slice contract.
 
-### M1 — FEM tetrahedral elasticity (the keystone) — IN PROGRESS
+### M1 — FEM tetrahedral elasticity (the keystone) — LANDED
+
+Status: the stable neo-Hookean kernel
+(`detail/deformable_elasticity/fem_tet_element.hpp`) is implemented and
+finite-difference-validated; the solver wires it in as an opt-in elasticity
+model (`DeformableMaterialProperties.useFiniteElementElasticity`, also exposed to
+`dartpy`), assembling each tet's PSD-projected 12x12 Hessian through the existing
+batched seam. Ships with solver regressions, a `BM_DeformableFemBarStep`
+benchmark, and a `Deformable FEM Bar (IPC)` py-demos cantilever. The mass-spring
+path is byte-identical when the flag is off. Follow-ups within M1: fixed-corotational
+(FCR) material variant; per-body rest-shape caching (currently recomputed per
+step); twist/large-deformation showcase toward Fig. 4 / Fig. 14.
+
 Add a per-tetrahedron strain-energy term producing per-element energy,
 12-vector gradient, and 12×12 Hessian, reusing the existing PSD-projection
 batch seam and sparse projected-Newton assembly. Material from the existing
@@ -52,15 +64,17 @@ neo-Hookean** (Smith et al. 2018) — inversion-safe (finite energy for all F,
 including J ≤ 0), C∞, and the standard in modern IPC toolkits; FCR is a
 follow-up material variant. Rest data (`restPositions`,
 `tetrahedronRestVolumes`) already exists.
+
 - Tests: finite-difference gradient/Hessian consistency; rest-state zero
   energy + zero force; monotone energy under stretch; inversion-robustness
   (finite energy + force for an inverted element); determinism.
 - Example: a twisting / squashing FEM bar in py-demos (toward Fig 4 / Fig 14).
 - Benchmark: per-step FEM assembly + solve cost at a few mesh sizes.
-- Unblocks: every volumetric figure becomes *physically* possible (Figs 4, 12,
+- Unblocks: every volumetric figure becomes _physically_ possible (Figs 4, 12,
   13, 14, 15, 22, Table 1), pending obstacles/friction/assets per below.
 
 ### M2 — Obstacle barrier completeness (analytic + box) + codim wiring
+
 Generalize obstacle contact into a real clamped-log **force** everywhere: an
 analytic half-space (plane) collision object, a box-obstacle barrier force
 (reuse PT distance kernels against the box's triangulated faces), the
@@ -70,28 +84,33 @@ set so codimensional contact has barrier coverage. Unblocks the plane-drop
 unit families and is a prerequisite for codim objects.
 
 ### M3 — Codimensional collision objects (triangle / edge / vertex)
+
 Static (then moving) codimensional obstacles with barrier + CCD, plus the
 `.obj` / `.seg` / `.pt` importers. Unblocks Fig 2 (knives, points), Fig 17
 (pin-cushions), Fig 18 (codim rollers), and the 9-scene codim-unit family.
 
 ### M4 — Upstream asset pipeline + `.msh` (GMSH) importer
+
 A fetch-into-fixtures workflow for the upstream meshes pinned at
 `573d2c7e0…` (no vendoring, no runtime dependency), plus a GMSH `.msh`
 tet-mesh importer in `dart/io`. Port the contact-free tutorial scenes
 (`2cubesFall` DBC/NBC) first as regression fixtures, then the contact scenes.
 
 ### M5 — Mesh-vs-obstacle friction completeness
+
 Extend lagged smoothed Coulomb friction beyond the static-ground coefficient to
 mesh-vs-obstacle and codim contacts. Unblocks the friction figures: Fig 5 (card
 house), Fig 7 (cement arch), Fig 8 (ball-on-roller), Fig 16 (Armadillo roller),
 Fig 20 (stick-slip rod).
 
 ### M6 — Adaptive barrier stiffness (κ homotopy)
+
 IPC stiffness adaptation with a minimum-stiffness scale and force-balance
 update; additive (defaults to today's fixed κ). Unblocks Fig 12 (large
 mass/stiffness ratios) robustness.
 
 ### M7 — Scale + performance (CPU then GPU) until beating the reference
+
 Matrix-free / AMGCL-class iterative linear solve for very large systems (Fig
 22, 688K nodes), on-device GPU assembly + solve beyond the current PSD offload,
 and a profiling-grade benchmark harness that emits Fig-23-shaped statistics
@@ -105,7 +124,7 @@ net-new.
 This is a multi-PR program. No paper figure is reproducible until at least M1
 (FEM) lands, and the contact-heavy figures additionally need M2/M3/M5 plus the
 M4 assets. The mass-spring showcases already in py-demos (`IPC Deformable (sx)`)
-evoke the paper's *themes* but are explicitly **not** figure reproductions and
+evoke the paper's _themes_ but are explicitly **not** figure reproductions and
 do not count toward parity. Progress is tracked by promoting figure rows in
 [`ipc-paper-figure-showcase.md`](ipc-paper-figure-showcase.md) from `planned`
 → `in-progress` → `landed` → `reference-beaten`.

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -1,0 +1,111 @@
+# IPC Paper-Parity Roadmap
+
+Authoritative execution roadmap for taking DART's experimental deformable
+solver from its current mass-spring contact scaffold to faithful reproduction
+of the IPC paper (Li et al. 2020) experiments, with correctness tests and
+performance benchmarks that match or beat the reference, on **both CPU and
+GPU**. Companion to [`ipc-paper-figure-showcase.md`](ipc-paper-figure-showcase.md)
+(figure-by-figure targets), [`ipc-paper-gap-audit.md`](ipc-paper-gap-audit.md)
+(Algorithm 1 / kernel matrix), and
+[`ipc_scene_corpus_manifest.json`](ipc_scene_corpus_manifest.json) (154 upstream
+scenes).
+
+## Ground truth (audited from the paper + current code, 2026-05-30)
+
+- **Every IPC simulation scene is FEM-tetrahedral.** Figs 1, 2, 4, 5, 7, 8,
+  13–22 and the Fig 10/11/12 unit tests are all volumetric tetrahedral FE
+  bodies with a **neo-Hookean** (default) or **fixed-corotational (FCR)**
+  material, stepped with implicit Euler (implicit Newmark only for the
+  high-speed Fig 19 / golf-ball). Figs 3/6/9 are method diagrams, not scenes.
+- **The original IPC is CPU-only — the paper reports no GPU numbers anywhere.**
+  Timings come from multi-threaded CPU machines (TBB assembly, CHOLMOD direct
+  solve, AMGCL only for the 688K-node Fig 22). The CPU baselines to beat are
+  **Fig 23** (16-scene per-step statistics) and **Table 1** (h-sweep on the
+  twisted-rods scene). Consequently the GPU story is **net-new acceleration**:
+  there is no published GPU baseline to match — the win is (a) match/undercut
+  IPC's per-step CPU time at equal accuracy, then (b) add GPU as a bonus.
+- **DART today is mass-spring, not FEM.** Elastic energy is per-edge
+  `0.5·k·(L−L0)²`; tets are inert scaffolding (lumped mass + surface
+  extraction only). `DeformableMaterial.youngsModulus/poissonRatio` exist but
+  are unused. On top of the spring net, real IPC machinery is landed: C2
+  clamped-log barrier (self-contact PT+EE, ground, sphere obstacle), sparse
+  projected Newton with batched PSD projection (+ optional CUDA backend),
+  lagged smoothed Coulomb friction (ground + self-contact), conservative
+  PT/EE CCD limiters, and active-set sweep-and-prune broad phase.
+- **153/154 corpus scenes need FEM** *and* upstream meshes; 0 meshes are
+  vendored and there is no `.msh`/`.obj`/`.seg`/`.pt` importer. So essentially
+  no paper scene is reproducible today, and **every showcase figure row is
+  still `planned`.**
+
+## Critical path (capability-ordered)
+
+The milestones are ordered by dependency. Each ships as one PR off `main`
+(milestone DART 7.0) with **kernel + correctness tests + a runnable example +
+a benchmark**, per the standing slice contract.
+
+### M1 — FEM tetrahedral elasticity (the keystone) — IN PROGRESS
+Add a per-tetrahedron strain-energy term producing per-element energy,
+12-vector gradient, and 12×12 Hessian, reusing the existing PSD-projection
+batch seam and sparse projected-Newton assembly. Material from the existing
+`youngsModulus`/`poissonRatio` (→ Lamé μ, λ). First model: **stable
+neo-Hookean** (Smith et al. 2018) — inversion-safe (finite energy for all F,
+including J ≤ 0), C∞, and the standard in modern IPC toolkits; FCR is a
+follow-up material variant. Rest data (`restPositions`,
+`tetrahedronRestVolumes`) already exists.
+- Tests: finite-difference gradient/Hessian consistency; rest-state zero
+  energy + zero force; monotone energy under stretch; inversion-robustness
+  (finite energy + force for an inverted element); determinism.
+- Example: a twisting / squashing FEM bar in py-demos (toward Fig 4 / Fig 14).
+- Benchmark: per-step FEM assembly + solve cost at a few mesh sizes.
+- Unblocks: every volumetric figure becomes *physically* possible (Figs 4, 12,
+  13, 14, 15, 22, Table 1), pending obstacles/friction/assets per below.
+
+### M2 — Obstacle barrier completeness (analytic + box) + codim wiring
+Generalize obstacle contact into a real clamped-log **force** everywhere: an
+analytic half-space (plane) collision object, a box-obstacle barrier force
+(reuse PT distance kernels against the box's triangulated faces), the
+projected-Newton Hessian for the sphere/box obstacle barriers, and wire the
+already-implemented point-edge / point-point distance kernels into the active
+set so codimensional contact has barrier coverage. Unblocks the plane-drop
+unit families and is a prerequisite for codim objects.
+
+### M3 — Codimensional collision objects (triangle / edge / vertex)
+Static (then moving) codimensional obstacles with barrier + CCD, plus the
+`.obj` / `.seg` / `.pt` importers. Unblocks Fig 2 (knives, points), Fig 17
+(pin-cushions), Fig 18 (codim rollers), and the 9-scene codim-unit family.
+
+### M4 — Upstream asset pipeline + `.msh` (GMSH) importer
+A fetch-into-fixtures workflow for the upstream meshes pinned at
+`573d2c7e0…` (no vendoring, no runtime dependency), plus a GMSH `.msh`
+tet-mesh importer in `dart/io`. Port the contact-free tutorial scenes
+(`2cubesFall` DBC/NBC) first as regression fixtures, then the contact scenes.
+
+### M5 — Mesh-vs-obstacle friction completeness
+Extend lagged smoothed Coulomb friction beyond the static-ground coefficient to
+mesh-vs-obstacle and codim contacts. Unblocks the friction figures: Fig 5 (card
+house), Fig 7 (cement arch), Fig 8 (ball-on-roller), Fig 16 (Armadillo roller),
+Fig 20 (stick-slip rod).
+
+### M6 — Adaptive barrier stiffness (κ homotopy)
+IPC stiffness adaptation with a minimum-stiffness scale and force-balance
+update; additive (defaults to today's fixed κ). Unblocks Fig 12 (large
+mass/stiffness ratios) robustness.
+
+### M7 — Scale + performance (CPU then GPU) until beating the reference
+Matrix-free / AMGCL-class iterative linear solve for very large systems (Fig
+22, 688K nodes), on-device GPU assembly + solve beyond the current PSD offload,
+and a profiling-grade benchmark harness that emits Fig-23-shaped statistics
+(avg/max contacts per step, Newton iterations per step, peak memory, s/step)
+per scene. Acceptance: match or undercut IPC's per-step CPU time at equal
+accuracy on shared scenes (Table 1, Fig 23), then report GPU acceleration as
+net-new.
+
+## Honest status
+
+This is a multi-PR program. No paper figure is reproducible until at least M1
+(FEM) lands, and the contact-heavy figures additionally need M2/M3/M5 plus the
+M4 assets. The mass-spring showcases already in py-demos (`IPC Deformable (sx)`)
+evoke the paper's *themes* but are explicitly **not** figure reproductions and
+do not count toward parity. Progress is tracked by promoting figure rows in
+[`ipc-paper-figure-showcase.md`](ipc-paper-figure-showcase.md) from `planned`
+→ `in-progress` → `landed` → `reference-beaten`.

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -52,9 +52,10 @@ model (`DeformableMaterialProperties.useFiniteElementElasticity`, also exposed t
 `dartpy`), assembling each tet's PSD-projected 12x12 Hessian through the existing
 batched seam. Ships with solver regressions, a `BM_DeformableFemBarStep`
 benchmark, and a `Deformable FEM Bar (IPC)` py-demos cantilever. The mass-spring
-path is byte-identical when the flag is off. Follow-ups within M1: fixed-corotational
-(FCR) material variant; per-body rest-shape caching (currently recomputed per
-step); twist/large-deformation showcase toward Fig. 4 / Fig. 14.
+path is byte-identical when the flag is off. Each tet's rest shape is cached in
+the per-entity scratch (computed once, reused every step). Follow-ups within M1:
+fixed-corotational (FCR) material variant; twist/large-deformation showcase
+toward Fig. 4 / Fig. 14.
 
 Add a per-tetrahedron strain-energy term producing per-element energy,
 12-vector gradient, and 12×12 Hessian, reusing the existing PSD-projection

--- a/python/dartpy/simulation_experimental/module.cpp
+++ b/python/dartpy/simulation_experimental/module.cpp
@@ -1464,7 +1464,10 @@ void defSimulationExperimentalModule(nb::module_& m)
       .def_rw("poisson_ratio", &sim::DeformableMaterialProperties::poissonRatio)
       .def_rw(
           "friction_coefficient",
-          &sim::DeformableMaterialProperties::frictionCoefficient);
+          &sim::DeformableMaterialProperties::frictionCoefficient)
+      .def_rw(
+          "use_finite_element_elasticity",
+          &sim::DeformableMaterialProperties::useFiniteElementElasticity);
 
   nb::class_<sim::DeformableEdge>(m, "DeformableEdge")
       .def(

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -51,16 +51,21 @@ category so the IPC showcases stay together instead of mixing into the general
 | `ipc_deformable_drape`              | A mat draping over a step onto a ground barrier       | Ground + self-contact clamped-log barrier |
 | `ipc_deformable_trampoline`         | A corner-pinned membrane sagging and rebounding       | Taut-membrane projected-Newton dynamics   |
 | `ipc_deformable_friction_slide`     | A launched mat skidding to rest on a frictional floor | Lagged smoothed-Coulomb ground friction   |
+| `ipc_deformable_fem_bar`            | A tetrahedral cantilever sagging under gravity        | Stable neo-Hookean **FEM** elasticity     |
 | `ipc_deformable_scripted_dirichlet` | A banner billowing under a scripted Dirichlet BC      | Scripted Dirichlet boundary conditions    |
 
-These are DART-native point-mass/spring showcases, **not** faithful IPC
-paper-figure reproductions: the solver is mass-spring, so the _contact, barrier,
-friction, and projected-Newton machinery_ is genuine IPC, but the _elasticity_
-is not FEM/codimensional. The catalog of upstream paper scenes lives at
+These are DART-native showcases, **not** faithful IPC paper-figure
+reproductions. The _contact, barrier, friction, and projected-Newton machinery_
+is genuine IPC; most scenes use a mass-spring elasticity model, while
+`ipc_deformable_fem_bar` exercises the new opt-in stable neo-Hookean **FEM**
+volumetric elasticity (PLAN-081 M1, the keystone toward the paper's volumetric
+scenes). Codimensional collision and the upstream mesh corpus are still needed
+for true figure reproduction. The catalog of upstream paper scenes lives at
 `docs/plans/081-deformable-implicit-barrier-solver/ipc_scene_corpus_manifest.json`;
-faithful corpus reproduction stays `planned` (it needs vendored assets and an
-FEM/codimensional material model), so these scenes evoke the paper's _themes_
-(draping, self-contact, friction, scripted boundaries) rather than reproducing
+faithful corpus reproduction stays `planned` (it needs vendored assets,
+codimensional collision, and broader FEM coverage), so these scenes evoke the
+paper's _themes_ (volumetric elasticity, draping, self-contact, friction,
+scripted boundaries) rather than reproducing
 its figures.
 
 The scenes share `_ipc_deformable_bridge.py`, which builds the grid topology and

--- a/python/examples/demos/_ipc_deformable_bridge.py
+++ b/python/examples/demos/_ipc_deformable_bridge.py
@@ -29,11 +29,9 @@ import math
 import sys
 from typing import Any, Callable, Iterable, Sequence
 
-import numpy as np
-
 import dartpy as dart
 import dartpy.simulation_experimental as sx
-
+import numpy as np
 
 # Node-sphere radii and colors mirror the C++ deformable demo.
 _FIXED_NODE_RADIUS = 0.045
@@ -157,6 +155,91 @@ def build_grid_options(
     return options
 
 
+# The 6-tetrahedron (Kuhn) decomposition of a hexahedral cell, indexed by the
+# cell's eight corners along the main diagonal corner0 -> corner7. |det| rest
+# volumes make per-tet orientation irrelevant to the FEM energy.
+_CUBE_TETRAHEDRA = (
+    (0, 1, 3, 7),
+    (0, 3, 2, 7),
+    (0, 2, 6, 7),
+    (0, 6, 4, 7),
+    (0, 4, 5, 7),
+    (0, 5, 1, 7),
+)
+
+
+def build_fem_bar(
+    *,
+    cells_x: int,
+    cells_y: int,
+    cells_z: int,
+    cell_size: float,
+    origin: Sequence[float],
+    youngs_modulus: float,
+    poisson_ratio: float = 0.3,
+    density: float = 1.0e3,
+) -> tuple["sx.DeformableBodyOptions", list[tuple[int, int]]]:
+    """A tetrahedralized FEM beam pinned at its ``x == 0`` face.
+
+    Returns the ``DeformableBodyOptions`` (opting in to stable neo-Hookean FEM
+    elasticity, with tetrahedra and no spring edges) plus the unique tet edge
+    list for the render wireframe.
+    """
+
+    nx, ny, nz = cells_x + 1, cells_y + 1, cells_z + 1
+
+    def node_index(i: int, j: int, k: int) -> int:
+        return i + nx * (j + ny * k)
+
+    positions: list[Sequence[float]] = []
+    for k in range(nz):
+        for j in range(ny):
+            for i in range(nx):
+                positions.append(
+                    (
+                        origin[0] + i * cell_size,
+                        origin[1] + j * cell_size,
+                        origin[2] + k * cell_size,
+                    )
+                )
+
+    tetrahedra: list[sx.DeformableTetrahedron] = []
+    edges: set[tuple[int, int]] = set()
+    for k in range(cells_z):
+        for j in range(cells_y):
+            for i in range(cells_x):
+                # Cube corners in bit order (x, y, z): corner b has
+                # x = b&1, y = (b>>1)&1, z = (b>>2)&1.
+                corner = [
+                    node_index(i + (b & 1), j + ((b >> 1) & 1), k + ((b >> 2) & 1))
+                    for b in range(8)
+                ]
+                for a, b, c, d in _CUBE_TETRAHEDRA:
+                    n0, n1, n2, n3 = corner[a], corner[b], corner[c], corner[d]
+                    tetrahedra.append(sx.DeformableTetrahedron(n0, n1, n2, n3))
+                    for u, v in (
+                        (n0, n1),
+                        (n0, n2),
+                        (n0, n3),
+                        (n1, n2),
+                        (n1, n3),
+                        (n2, n3),
+                    ):
+                        edges.add((u, v) if u < v else (v, u))
+
+    fixed = [node_index(0, j, k) for k in range(nz) for j in range(ny)]
+
+    options = sx.DeformableBodyOptions()
+    options.positions = [np.asarray(p, dtype=float) for p in positions]
+    options.tetrahedra = tetrahedra
+    options.fixed_nodes = fixed
+    options.material.youngs_modulus = youngs_modulus
+    options.material.poisson_ratio = poisson_ratio
+    options.material.density = density
+    options.material.use_finite_element_elasticity = True
+    return options, sorted(edges)
+
+
 class IpcDeformableBridge:
     """Mirrors sx deformable bodies onto a render `dart.simulation.World`."""
 
@@ -170,19 +253,32 @@ class IpcDeformableBridge:
         self._deformables: list[tuple[Any, list[Any], Any]] = []
         self._step_failed = False
 
-    def add_deformable_visual(self, body: Any, name: str = "deformable") -> None:
-        """Create per-node spheres + an edge wireframe for ``body``."""
+    def add_deformable_visual(
+        self,
+        body: Any,
+        name: str = "deformable",
+        edges: Iterable[tuple[int, int]] | None = None,
+    ) -> None:
+        """Create per-node spheres + an edge wireframe for ``body``.
+
+        ``edges`` overrides the wireframe connectivity; when ``None`` the body's
+        own spring edges are used. FEM bodies carry tetrahedra rather than spring
+        edges, so they pass an explicit tet-derived wireframe.
+        """
 
         node_count = body.node_count
 
         edge_shape = dart.LineSegmentShape(_EDGE_THICKNESS)
         for i in range(node_count):
             edge_shape.addVertex(np.asarray(body.node_position(i), dtype=float))
-        for i in range(body.edge_count):
-            edge = body.edge(i)
-            edge_shape.addConnection(edge.node_a, edge.node_b)
-        edge_frame = dart.SimpleFrame(
-            dart.Frame.world(), f"{name}_edges", np.eye(4))
+        if edges is None:
+            edges = [
+                (body.edge(i).node_a, body.edge(i).node_b)
+                for i in range(body.edge_count)
+            ]
+        for node_a, node_b in edges:
+            edge_shape.addConnection(int(node_a), int(node_b))
+        edge_frame = dart.SimpleFrame(dart.Frame.world(), f"{name}_edges", np.eye(4))
         edge_frame.set_shape(edge_shape)
         edge_frame.create_visual_aspect().set_color(list(_EDGE_COLOR))
         self.render_world.add_simple_frame(edge_frame)
@@ -196,10 +292,11 @@ class IpcDeformableBridge:
                 _translation(body.node_position(i)),
             )
             frame.set_shape(
-                dart.SphereShape(
-                    _FIXED_NODE_RADIUS if fixed else _FREE_NODE_RADIUS))
+                dart.SphereShape(_FIXED_NODE_RADIUS if fixed else _FREE_NODE_RADIUS)
+            )
             frame.create_visual_aspect().set_color(
-                list(_FIXED_NODE_COLOR if fixed else _FREE_NODE_COLOR))
+                list(_FIXED_NODE_COLOR if fixed else _FREE_NODE_COLOR)
+            )
             self.render_world.add_simple_frame(frame)
             node_frames.append(frame)
 
@@ -252,6 +349,7 @@ class IpcDeformableBridge:
 # Re-export math for scene modules that shape their grids with trig.
 __all__ = [
     "IpcDeformableBridge",
+    "build_fem_bar",
     "build_grid_options",
     "grid_index",
     "math",

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -20,6 +20,7 @@ from .scenes.free_joint_cases import SCENE as FREE_JOINT_CASES
 from .scenes.hardcoded_design import SCENE as HARDCODED_DESIGN
 from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
+from .scenes.ipc_deformable_fem_bar import SCENE as IPC_DEFORMABLE_FEM_BAR
 from .scenes.ipc_deformable_friction_slide import SCENE as IPC_DEFORMABLE_FRICTION_SLIDE
 from .scenes.ipc_deformable_net import SCENE as IPC_DEFORMABLE_NET
 from .scenes.ipc_deformable_scripted_dirichlet import SCENE as IPC_DEFORMABLE_SCRIPTED
@@ -96,5 +97,6 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_DRAPE,
         IPC_DEFORMABLE_TRAMPOLINE,
         IPC_DEFORMABLE_FRICTION_SLIDE,
+        IPC_DEFORMABLE_FEM_BAR,
         IPC_DEFORMABLE_SCRIPTED,
     ]

--- a/python/examples/demos/scenes/ipc_deformable_fem_bar.py
+++ b/python/examples/demos/scenes/ipc_deformable_fem_bar.py
@@ -1,0 +1,55 @@
+"""FEM cantilever bar (experimental IPC deformable solver).
+
+A tetrahedralized beam is pinned at one end and sags under gravity, held by
+stable neo-Hookean *finite-element* volumetric elasticity (PLAN-081 M1) rather
+than the mass-spring edge model the other scenes use. This is the first DART
+deformable showcase driven by true FEM elasticity -- the keystone capability for
+the IPC paper's volumetric scenes (e.g. Fig. 4 rod twist / Fig. 14 mat twist).
+
+DART-native FEM showcase -- not a faithful IPC paper-figure reproduction (no
+codimensional contact or friction here; this isolates the volumetric elasticity).
+"""
+
+from __future__ import annotations
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_fem_bar
+from ..runner import PythonDemoScene, SceneSetup
+
+
+def build() -> SceneSetup:
+    options, edges = build_fem_bar(
+        cells_x=10,
+        cells_y=1,
+        cells_z=1,
+        cell_size=0.12,
+        origin=(-0.6, -0.06, 0.75),
+        youngs_modulus=5.0e6,
+        poisson_ratio=0.3,
+        density=1.0e3,
+    )
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -9.81]
+    world.time_step = 0.005
+    body = world.add_deformable_body("fem_bar", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_fem_bar")
+    bridge.add_deformable_visual(body, name="fem_bar", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_fem_bar",
+    title="Deformable FEM Bar (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A tetrahedral FEM cantilever sags under gravity via stable neo-Hookean elasticity.",
+    build=build,
+)

--- a/python/stubs/dartpy/simulation_experimental.pyi
+++ b/python/stubs/dartpy/simulation_experimental.pyi
@@ -34,6 +34,7 @@ __all__: list[str] = [
     "LoopClosureRuntimePolicy",
     "LoopClosureSpec",
     "Multibody",
+    "MultibodyOptions",
     "RigidBody",
     "RigidBodyOptions",
     "StateSpace",
@@ -435,7 +436,7 @@ class Link(Frame):
     @center_of_mass.setter
     def center_of_mass(self, arg: object, /) -> None: ...
 
-    def apply_force(self, force: object, point: object = ..., force_in_world_frame: bool = True, point_in_world_frame: bool = False) -> None: ...
+    def apply_force(self, force: object, point: object = ..., force_in_world_frame: bool = ..., point_in_world_frame: bool = ...) -> None: ...
 
     @property
     def translation(self) -> Annotated[NDArray[numpy.float64], dict(shape=(3), order='C')]: ...
@@ -895,6 +896,12 @@ class DeformableMaterialProperties:
 
     @friction_coefficient.setter
     def friction_coefficient(self, arg: float, /) -> None: ...
+
+    @property
+    def use_finite_element_elasticity(self) -> bool: ...
+
+    @use_finite_element_elasticity.setter
+    def use_finite_element_elasticity(self, arg: bool, /) -> None: ...
 
 class DeformableEdge:
     def __init__(self, node_a: int = ..., node_b: int = ..., rest_length: float = ...) -> None: ...

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -109,6 +109,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_drape",
         "ipc_deformable_trampoline",
         "ipc_deformable_friction_slide",
+        "ipc_deformable_fem_bar",
         "ipc_deformable_scripted_dirichlet",
     }
     assert expected_ipc <= set(by_id), "missing IPC deformable scenes"

--- a/tests/benchmark/simulation/experimental/bm_deformable_body.cpp
+++ b/tests/benchmark/simulation/experimental/bm_deformable_body.cpp
@@ -42,6 +42,7 @@
 #include <benchmark/benchmark.h>
 
 #include <algorithm>
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -170,6 +171,66 @@ sx::DeformableBodyOptions makeTetraMeshOptions(int tetrahedronCount)
     options.edges.push_back({base + 2u, base + 3u, -1.0});
   }
 
+  return options;
+}
+
+//==============================================================================
+// A connected FEM beam of ``cellsX`` hexahedral cells (each split into six
+// tetrahedra), pinned at its x == 0 face and opting in to stable neo-Hookean
+// FEM elasticity (no spring edges). Used to benchmark the FEM assembly + sparse
+// projected-Newton solve cost as the element count grows.
+sx::DeformableBodyOptions makeFemBarOptions(int cellsX)
+{
+  cellsX = std::max(cellsX, 1);
+  const int nx = cellsX + 1;
+  const int ny = 2;
+  const int nz = 2;
+  constexpr double h = 0.1;
+  const auto nodeIndex = [&](int i, int j, int k) {
+    return static_cast<std::size_t>(i + nx * (j + ny * k));
+  };
+
+  sx::DeformableBodyOptions options;
+  options.material.density = 1.0e3;
+  options.material.youngsModulus = 5.0e5;
+  options.material.poissonRatio = 0.3;
+  options.material.useFiniteElementElasticity = true;
+
+  for (int k = 0; k < nz; ++k) {
+    for (int j = 0; j < ny; ++j) {
+      for (int i = 0; i < nx; ++i) {
+        options.positions.push_back(Eigen::Vector3d(i * h, j * h, 1.0 + k * h));
+      }
+    }
+  }
+
+  static constexpr int kCubeTets[6][4]
+      = {{0, 1, 3, 7},
+         {0, 3, 2, 7},
+         {0, 2, 6, 7},
+         {0, 6, 4, 7},
+         {0, 4, 5, 7},
+         {0, 5, 1, 7}};
+  for (int ci = 0; ci < cellsX; ++ci) {
+    std::array<std::size_t, 8> corner{};
+    for (int b = 0; b < 8; ++b) {
+      corner[static_cast<std::size_t>(b)]
+          = nodeIndex(ci + (b & 1), (b >> 1) & 1, (b >> 2) & 1);
+    }
+    for (const auto& tet : kCubeTets) {
+      options.tetrahedra.push_back(
+          {corner[static_cast<std::size_t>(tet[0])],
+           corner[static_cast<std::size_t>(tet[1])],
+           corner[static_cast<std::size_t>(tet[2])],
+           corner[static_cast<std::size_t>(tet[3])]});
+    }
+  }
+
+  for (int k = 0; k < nz; ++k) {
+    for (int j = 0; j < ny; ++j) {
+      options.fixedNodes.push_back(nodeIndex(0, j, k));
+    }
+  }
   return options;
 }
 
@@ -862,6 +923,52 @@ void BM_DeformableTetraMeshStep(benchmark::State& state)
 }
 
 //==============================================================================
+struct DeformableFemBarWorld
+{
+  explicit DeformableFemBarWorld(int cellsX)
+  {
+    body = world.addDeformableBody("fem_bar", makeFemBarOptions(cellsX));
+    nodeCount = body.getNodeCount();
+    tetrahedronCount = body.getTetrahedronCount();
+    for (std::size_t i = 0; i < nodeCount; ++i) {
+      totalMass += body.getMass(i);
+    }
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(1.0 / 240.0);
+    world.enterSimulationMode();
+  }
+
+  sx::World world;
+  sx::DeformableBody body;
+  std::size_t nodeCount = 0;
+  std::size_t tetrahedronCount = 0;
+  double totalMass = 0.0;
+};
+
+//==============================================================================
+// Steps a connected FEM beam (stable neo-Hookean elasticity) under gravity:
+// measures the per-step cost of the FEM energy/gradient/Hessian assembly plus
+// the sparse projected-Newton solve as the tetrahedron count grows.
+void BM_DeformableFemBarStep(benchmark::State& state)
+{
+  const auto cellsX = static_cast<int>(state.range(0));
+  DeformableFemBarWorld fixture(cellsX);
+
+  for (auto _ : state) {
+    fixture.world.step();
+    benchmark::DoNotOptimize(
+        fixture.body.getPosition(fixture.nodeCount - 1u).z());
+  }
+
+  state.counters["nodes"] = static_cast<double>(fixture.nodeCount);
+  state.counters["tetrahedra"] = static_cast<double>(fixture.tetrahedronCount);
+  state.counters["total_mass"] = fixture.totalMass;
+  state.counters["contact_constraints"] = 0.0;
+  state.SetItemsProcessed(
+      static_cast<int64_t>(state.iterations() * fixture.nodeCount));
+}
+
+//==============================================================================
 void BM_DeformableGridStage(benchmark::State& state)
 {
   const auto columns = static_cast<int>(state.range(0));
@@ -1327,6 +1434,8 @@ BENCHMARK(BM_DeformableGridStep)
 BENCHMARK(BM_DeformableTetraMeshSetup)->Arg(1)->Arg(8)->Arg(32);
 
 BENCHMARK(BM_DeformableTetraMeshStep)->Arg(1)->Arg(8)->Arg(32);
+
+BENCHMARK(BM_DeformableFemBarStep)->Arg(2)->Arg(8)->Arg(24);
 
 // The 32x16 (512-node) and 48x24 (1152-node) grids exceed the former 256-node
 // dense-solve cap, so they exercise the sparse projected-Newton path; compare

--- a/tests/unit/simulation/experimental/CMakeLists.txt
+++ b/tests/unit/simulation/experimental/CMakeLists.txt
@@ -45,6 +45,8 @@ if(DART_EXPERIMENTAL_BUILD_TESTS)
   dart_experimental_add_unit_test_dir(common ${CMAKE_CURRENT_SOURCE_DIR}/common)
   dart_experimental_add_unit_test_dir(compute ${CMAKE_CURRENT_SOURCE_DIR}/compute)
   dart_experimental_add_unit_test_dir(contact ${CMAKE_CURRENT_SOURCE_DIR}/contact)
+  dart_experimental_add_unit_test_dir(
+    elasticity ${CMAKE_CURRENT_SOURCE_DIR}/elasticity)
   if(TARGET test_continuous_collision_step)
     target_link_libraries(
       test_continuous_collision_step

--- a/tests/unit/simulation/experimental/CMakeLists.txt
+++ b/tests/unit/simulation/experimental/CMakeLists.txt
@@ -46,7 +46,8 @@ if(DART_EXPERIMENTAL_BUILD_TESTS)
   dart_experimental_add_unit_test_dir(compute ${CMAKE_CURRENT_SOURCE_DIR}/compute)
   dart_experimental_add_unit_test_dir(contact ${CMAKE_CURRENT_SOURCE_DIR}/contact)
   dart_experimental_add_unit_test_dir(
-    elasticity ${CMAKE_CURRENT_SOURCE_DIR}/elasticity)
+    elasticity ${CMAKE_CURRENT_SOURCE_DIR}/elasticity
+  )
   if(TARGET test_continuous_collision_step)
     target_link_libraries(
       test_continuous_collision_step

--- a/tests/unit/simulation/experimental/elasticity/test_fem_tet_element.cpp
+++ b/tests/unit/simulation/experimental/elasticity/test_fem_tet_element.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary form, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice and this list of conditions in the documentation
+ *     and/or other materials provided with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <functional>
+
+#include <cmath>
+
+namespace fem = dart::simulation::experimental::detail::deformable_elasticity;
+
+namespace {
+
+using Nodes = std::array<Eigen::Vector3d, 4>;
+
+//==============================================================================
+// The canonical rest tetrahedron (det Dm = 1, rest volume 1/6).
+Nodes restTetrahedron()
+{
+  return {
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(0.0, 1.0, 0.0),
+      Eigen::Vector3d(0.0, 0.0, 1.0)};
+}
+
+//==============================================================================
+double energyAt(
+    const Nodes& x, const fem::TetRestShape& rest, const fem::LameParameters& lame)
+{
+  return fem::evaluateStableNeoHookeanTet(
+             x[0], x[1], x[2], x[3], rest, lame, /*computeHessian=*/false)
+      .energy;
+}
+
+//==============================================================================
+// Central-difference gradient of the energy w.r.t. the 12 nodal coordinates.
+fem::Vector12d finiteGradient(
+    const Nodes& x, const fem::TetRestShape& rest, const fem::LameParameters& lame)
+{
+  constexpr double h = 1e-6;
+  fem::Vector12d grad = fem::Vector12d::Zero();
+  for (int node = 0; node < 4; ++node) {
+    for (int axis = 0; axis < 3; ++axis) {
+      Nodes plus = x;
+      Nodes minus = x;
+      plus[node][axis] += h;
+      minus[node][axis] -= h;
+      grad[3 * node + axis]
+          = (energyAt(plus, rest, lame) - energyAt(minus, rest, lame)) / (2.0 * h);
+    }
+  }
+  return grad;
+}
+
+//==============================================================================
+// Central-difference Hessian via differencing the analytic gradient.
+fem::Matrix12d finiteHessian(
+    const Nodes& x, const fem::TetRestShape& rest, const fem::LameParameters& lame)
+{
+  constexpr double h = 1e-6;
+  fem::Matrix12d hess = fem::Matrix12d::Zero();
+  for (int node = 0; node < 4; ++node) {
+    for (int axis = 0; axis < 3; ++axis) {
+      Nodes plus = x;
+      Nodes minus = x;
+      plus[node][axis] += h;
+      minus[node][axis] -= h;
+      const fem::Vector12d gradPlus
+          = fem::evaluateStableNeoHookeanTet(
+                plus[0], plus[1], plus[2], plus[3], rest, lame)
+                .gradient;
+      const fem::Vector12d gradMinus
+          = fem::evaluateStableNeoHookeanTet(
+                minus[0], minus[1], minus[2], minus[3], rest, lame)
+                .gradient;
+      hess.col(3 * node + axis) = (gradPlus - gradMinus) / (2.0 * h);
+    }
+  }
+  return hess;
+}
+
+//==============================================================================
+// A representative, non-inverted deformed configuration for the FD checks.
+Nodes deformedTetrahedron()
+{
+  return {
+      Eigen::Vector3d(0.02, -0.01, 0.03),
+      Eigen::Vector3d(1.21, 0.10, -0.04),
+      Eigen::Vector3d(-0.05, 0.92, 0.08),
+      Eigen::Vector3d(0.11, 0.18, 1.13)};
+}
+
+} // namespace
+
+//==============================================================================
+TEST(FemTetElement, LameParametersMatchClosedForm)
+{
+  const fem::LameParameters lame = fem::lameParameters(1.0e5, 0.3);
+  EXPECT_NEAR(lame.mu, 1.0e5 / (2.0 * 1.3), 1e-6);
+  EXPECT_NEAR(lame.lambda, 1.0e5 * 0.3 / (1.3 * 0.4), 1e-6);
+}
+
+//==============================================================================
+TEST(FemTetElement, RestShapeVolumeMatchesAnalytic)
+{
+  const Nodes rest = restTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  ASSERT_TRUE(shape.valid);
+  EXPECT_NEAR(shape.restVolume, 1.0 / 6.0, 1e-12);
+  // Bm = Dm^-1 = I for the canonical rest tet.
+  EXPECT_TRUE(shape.inverseRestEdges.isApprox(Eigen::Matrix3d::Identity(), 1e-12));
+}
+
+//==============================================================================
+TEST(FemTetElement, DegenerateRestShapeIsInvalid)
+{
+  // Four coplanar points have zero rest volume.
+  const fem::TetRestShape shape = fem::makeTetRestShape(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(0.0, 1.0, 0.0),
+      Eigen::Vector3d(1.0, 1.0, 0.0));
+  EXPECT_FALSE(shape.valid);
+  const fem::TetElementResult result = fem::evaluateStableNeoHookeanTet(
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(0.0, 1.0, 0.0),
+      Eigen::Vector3d(1.0, 1.0, 0.0),
+      shape,
+      fem::lameParameters(1.0e3, 0.3));
+  EXPECT_FALSE(result.valid);
+  EXPECT_EQ(result.energy, 0.0);
+}
+
+//==============================================================================
+TEST(FemTetElement, RestStateHasZeroEnergyAndForce)
+{
+  const Nodes rest = restTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  const fem::LameParameters lame = fem::lameParameters(1.0e4, 0.3);
+  const fem::TetElementResult result = fem::evaluateStableNeoHookeanTet(
+      rest[0], rest[1], rest[2], rest[3], shape, lame);
+  ASSERT_TRUE(result.valid);
+  EXPECT_NEAR(result.energy, 0.0, 1e-9);
+  EXPECT_LT(result.gradient.cwiseAbs().maxCoeff(), 1e-7);
+}
+
+//==============================================================================
+TEST(FemTetElement, GradientMatchesFiniteDifference)
+{
+  const Nodes rest = restTetrahedron();
+  const Nodes x = deformedTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  const fem::LameParameters lame = fem::lameParameters(1.0e3, 0.3);
+
+  const fem::TetElementResult result
+      = fem::evaluateStableNeoHookeanTet(x[0], x[1], x[2], x[3], shape, lame);
+  const fem::Vector12d numeric = finiteGradient(x, shape, lame);
+
+  const double tol = 1e-5 * (1.0 + numeric.cwiseAbs().maxCoeff());
+  EXPECT_LT((result.gradient - numeric).cwiseAbs().maxCoeff(), tol);
+}
+
+//==============================================================================
+TEST(FemTetElement, HessianMatchesFiniteDifference)
+{
+  const Nodes rest = restTetrahedron();
+  const Nodes x = deformedTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  const fem::LameParameters lame = fem::lameParameters(1.0e3, 0.3);
+
+  const fem::TetElementResult result
+      = fem::evaluateStableNeoHookeanTet(x[0], x[1], x[2], x[3], shape, lame);
+  const fem::Matrix12d numeric = finiteHessian(x, shape, lame);
+
+  const double tol = 1e-4 * (1.0 + numeric.cwiseAbs().maxCoeff());
+  EXPECT_LT((result.hessian - numeric).cwiseAbs().maxCoeff(), tol);
+  // The Hessian must be symmetric.
+  EXPECT_LT(
+      (result.hessian - result.hessian.transpose()).cwiseAbs().maxCoeff(),
+      1e-9 * (1.0 + result.hessian.cwiseAbs().maxCoeff()));
+}
+
+//==============================================================================
+TEST(FemTetElement, EnergyIncreasesUnderStretch)
+{
+  const Nodes rest = restTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  const fem::LameParameters lame = fem::lameParameters(1.0e4, 0.3);
+
+  double previous = -1.0;
+  for (const double scale : {1.0, 1.1, 1.5, 2.0}) {
+    Nodes x = rest;
+    for (auto& node : x) {
+      node *= scale;
+    }
+    const double energy = energyAt(x, shape, lame);
+    EXPECT_GE(energy, previous);
+    if (scale > 1.0) {
+      EXPECT_GT(energy, 0.0);
+    }
+    previous = energy;
+  }
+}
+
+//==============================================================================
+TEST(FemTetElement, InvertedElementStaysFinite)
+{
+  const Nodes rest = restTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  const fem::LameParameters lame = fem::lameParameters(1.0e4, 0.3);
+
+  // Reflect the fourth node below the base plane so det F < 0 (inverted).
+  Nodes inverted = rest;
+  inverted[3].z() = -1.0;
+  const Eigen::Matrix3d f = fem::deformationGradient(
+      inverted[0], inverted[1], inverted[2], inverted[3], shape.inverseRestEdges);
+  ASSERT_LT(f.determinant(), 0.0);
+
+  const fem::TetElementResult result = fem::evaluateStableNeoHookeanTet(
+      inverted[0], inverted[1], inverted[2], inverted[3], shape, lame);
+  ASSERT_TRUE(result.valid);
+  EXPECT_TRUE(std::isfinite(result.energy));
+  EXPECT_GT(result.energy, 0.0);
+  EXPECT_TRUE(result.gradient.allFinite());
+  EXPECT_TRUE(result.hessian.allFinite());
+}
+
+//==============================================================================
+TEST(FemTetElement, ZeroPoissonRatioStaysFinite)
+{
+  // lambda -> 0; the kernel must not divide by lambda (alpha would diverge).
+  const Nodes rest = restTetrahedron();
+  const Nodes x = deformedTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  const fem::LameParameters lame = fem::lameParameters(1.0e3, 0.0);
+  EXPECT_NEAR(lame.lambda, 0.0, 1e-12);
+
+  const fem::TetElementResult result
+      = fem::evaluateStableNeoHookeanTet(x[0], x[1], x[2], x[3], shape, lame);
+  ASSERT_TRUE(result.valid);
+  EXPECT_TRUE(std::isfinite(result.energy));
+  const fem::Vector12d numeric = finiteGradient(x, shape, lame);
+  const double tol = 1e-5 * (1.0 + numeric.cwiseAbs().maxCoeff());
+  EXPECT_LT((result.gradient - numeric).cwiseAbs().maxCoeff(), tol);
+}

--- a/tests/unit/simulation/experimental/elasticity/test_fem_tet_element.cpp
+++ b/tests/unit/simulation/experimental/elasticity/test_fem_tet_element.cpp
@@ -57,7 +57,9 @@ Nodes restTetrahedron()
 
 //==============================================================================
 double energyAt(
-    const Nodes& x, const fem::TetRestShape& rest, const fem::LameParameters& lame)
+    const Nodes& x,
+    const fem::TetRestShape& rest,
+    const fem::LameParameters& lame)
 {
   return fem::evaluateStableNeoHookeanTet(
              x[0], x[1], x[2], x[3], rest, lame, /*computeHessian=*/false)
@@ -67,7 +69,9 @@ double energyAt(
 //==============================================================================
 // Central-difference gradient of the energy w.r.t. the 12 nodal coordinates.
 fem::Vector12d finiteGradient(
-    const Nodes& x, const fem::TetRestShape& rest, const fem::LameParameters& lame)
+    const Nodes& x,
+    const fem::TetRestShape& rest,
+    const fem::LameParameters& lame)
 {
   constexpr double h = 1e-6;
   fem::Vector12d grad = fem::Vector12d::Zero();
@@ -78,7 +82,8 @@ fem::Vector12d finiteGradient(
       plus[node][axis] += h;
       minus[node][axis] -= h;
       grad[3 * node + axis]
-          = (energyAt(plus, rest, lame) - energyAt(minus, rest, lame)) / (2.0 * h);
+          = (energyAt(plus, rest, lame) - energyAt(minus, rest, lame))
+            / (2.0 * h);
     }
   }
   return grad;
@@ -87,7 +92,9 @@ fem::Vector12d finiteGradient(
 //==============================================================================
 // Central-difference Hessian via differencing the analytic gradient.
 fem::Matrix12d finiteHessian(
-    const Nodes& x, const fem::TetRestShape& rest, const fem::LameParameters& lame)
+    const Nodes& x,
+    const fem::TetRestShape& rest,
+    const fem::LameParameters& lame)
 {
   constexpr double h = 1e-6;
   fem::Matrix12d hess = fem::Matrix12d::Zero();
@@ -141,7 +148,8 @@ TEST(FemTetElement, RestShapeVolumeMatchesAnalytic)
   ASSERT_TRUE(shape.valid);
   EXPECT_NEAR(shape.restVolume, 1.0 / 6.0, 1e-12);
   // Bm = Dm^-1 = I for the canonical rest tet.
-  EXPECT_TRUE(shape.inverseRestEdges.isApprox(Eigen::Matrix3d::Identity(), 1e-12));
+  EXPECT_TRUE(
+      shape.inverseRestEdges.isApprox(Eigen::Matrix3d::Identity(), 1e-12));
 }
 
 //==============================================================================
@@ -252,7 +260,11 @@ TEST(FemTetElement, InvertedElementStaysFinite)
   Nodes inverted = rest;
   inverted[3].z() = -1.0;
   const Eigen::Matrix3d f = fem::deformationGradient(
-      inverted[0], inverted[1], inverted[2], inverted[3], shape.inverseRestEdges);
+      inverted[0],
+      inverted[1],
+      inverted[2],
+      inverted[3],
+      shape.inverseRestEdges);
   ASSERT_LT(f.determinant(), 0.0);
 
   const fem::TetElementResult result = fem::evaluateStableNeoHookeanTet(

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -756,6 +756,113 @@ TEST(DeformableBody, FreeParticleMatchesImplicitEulerTargetForDifferentMasses)
 }
 
 //==============================================================================
+// A single-tetrahedron body that opts in to stable neo-Hookean FEM elasticity
+// (no spring edges, so elasticity comes entirely from the FEM term).
+sx::DeformableBodyOptions makeFemTetrahedronBody(double youngsModulus = 1.0e5)
+{
+  sx::DeformableBodyOptions options = makeSingleTetrahedronBody();
+  options.material.youngsModulus = youngsModulus;
+  options.material.poissonRatio = 0.3;
+  options.material.useFiniteElementElasticity = true;
+  options.fixedNodes = {0};
+  return options;
+}
+
+//==============================================================================
+// With FEM elasticity opted in, a tetrahedron pinned at one node hangs from
+// that node and settles at a bounded deflection under gravity: the stiff
+// material resists deformation, so the free nodes do not run away. The same
+// body WITHOUT FEM (and without spring edges) has no elastic force, so its free
+// nodes free-fall far below. The large gap between the two is the FEM term
+// doing work, and confirms it is strictly opt-in.
+TEST(DeformableBody, FemTetrahedronResistsGravityWhereSpringlessBodyFreeFalls)
+{
+  const auto runFreeNodeDrop = [](bool useFem) {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(0.01);
+    sx::DeformableBodyOptions options = makeSingleTetrahedronBody();
+    options.fixedNodes = {0};
+    options.material.useFiniteElementElasticity = useFem;
+    auto body = world.addDeformableBody("tet", options);
+    world.step(200);
+    // Node 0 is pinned in both cases.
+    EXPECT_LT((body.getPosition(0) - Eigen::Vector3d::Zero()).norm(), 1e-9);
+    double minZ = 0.0;
+    for (int i = 1; i < 4; ++i) {
+      minZ = std::min(minZ, body.getPosition(i).z());
+      EXPECT_TRUE(body.getPosition(i).allFinite());
+    }
+    return minZ;
+  };
+
+  const double femMinZ = runFreeNodeDrop(/*useFem=*/true);
+  const double springlessMinZ = runFreeNodeDrop(/*useFem=*/false);
+
+  // FEM holds the hanging tetrahedron near its rest extent ...
+  EXPECT_GT(femMinZ, -3.0);
+  // ... while without any elastic force the free nodes have fallen far.
+  EXPECT_LT(springlessMinZ, -15.0);
+  EXPECT_LT(springlessMinZ, femMinZ - 10.0);
+}
+
+//==============================================================================
+// At its rest shape with no external load, a FEM tetrahedron stores zero strain
+// energy and exerts zero force, so it stays put across many steps.
+TEST(DeformableBody, FemTetrahedronIsStationaryAtRest)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.02);
+  auto body = world.addDeformableBody("fem_rest", makeFemTetrahedronBody());
+
+  world.step(25);
+
+  expectVectorNear(body.getPosition(0), Eigen::Vector3d::Zero());
+  expectVectorNear(body.getPosition(1), Eigen::Vector3d::UnitX());
+  expectVectorNear(body.getPosition(2), Eigen::Vector3d::UnitY());
+  expectVectorNear(body.getPosition(3), Eigen::Vector3d::UnitZ());
+}
+
+//==============================================================================
+// A FEM tetrahedron given an initial outward velocity on a free node is pulled
+// back toward its rest shape by the elastic restoring force, and the implicit
+// solve dissipates the motion so it settles near rest rather than diverging.
+// A softer material keeps the transient displacement clearly visible.
+TEST(DeformableBody, FemTetrahedronRestoresStretchedNodeTowardRest)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.01);
+  auto options = makeFemTetrahedronBody(/*youngsModulus=*/1.0e3);
+  options.fixedNodes = {0, 1, 2};
+  options.velocities
+      = {Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d(0.0, 0.0, 10.0)};
+  auto body = world.addDeformableBody("fem_stretch", options);
+
+  // The driven node is clearly displaced from its rest position (z = 1) by the
+  // initial velocity before the elastic force arrests it.
+  double peakDisplacement = 0.0;
+  for (int step = 0; step < 60; ++step) {
+    world.step();
+    peakDisplacement
+        = std::max(peakDisplacement, std::abs(body.getPosition(3).z() - 1.0));
+    EXPECT_TRUE(body.getPosition(3).allFinite());
+  }
+  EXPECT_GT(peakDisplacement, 0.02);
+
+  // After many steps the elastic restoring force + implicit dissipation settle
+  // the free node back near its rest position (0, 0, 1); a body with no elastic
+  // force would never return.
+  world.step(400);
+  EXPECT_TRUE(body.getPosition(3).allFinite());
+  expectVectorNear(body.getPosition(3), Eigen::Vector3d(0.0, 0.0, 1.0), 5e-2);
+}
+
+//==============================================================================
 TEST(DeformableBody, StepCountWithExecutorRunsDefaultDeformableStage)
 {
   sx::World world;


### PR DESCRIPTION
## Summary

Adds **stable neo-Hookean tetrahedral FEM elasticity** to the experimental
deformable solver — the keystone capability (PLAN-081 **M1**) for reproducing
the IPC paper's volumetric scenes, every one of which is FEM-tetrahedral. Until
now DART's deformable solver was mass-spring only; the IPC barrier / friction /
projected-Newton machinery was real, but the *elasticity* was not.

See the new [`ipc-parity-roadmap.md`](docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md)
for the full capability-ordered path to paper parity (M1 FEM → M2 obstacle/codim
barrier force → M3 codim collision → M4 asset pipeline → M5 friction → M6
adaptive stiffness → M7 scale + GPU). Note the original IPC is **CPU-only**, so
the published baselines (Fig 23 / Table 1) are CPU and GPU is net-new.

## What's here

- **Kernel** (`detail/deformable_elasticity/fem_tet_element.hpp`, header-only):
  stable neo-Hookean (Smith et al. 2018) per-tet strain energy, 12×1 gradient,
  and the true 12×12 Hessian. Inversion-safe (finite for every F, incl. det F ≤
  0), C∞, and λ-stable down to Poisson ratio 0. Determinant gradient/Hessian use
  the cofactor / skew structure (no matrix inverse).
- **Solver wiring**: `evaluateDeformableObjective` /
  `computeProjectedNewtonDirection` take a nullable `FemElasticityInputs*`
  (mirroring the contact/friction inputs). Each tet adds its energy/gradient to
  the objective and its PSD-projected 12×12 Hessian to the sparse projected-
  Newton assembly through the **same batched projection seam** as the spring and
  barrier blocks. Null inputs (every existing spring body) leave the assembly
  byte-identical.
- **Opt-in**: `DeformableMaterialProperties.useFiniteElementElasticity` (default
  off; serialized; exposed to dartpy as `material.use_finite_element_elasticity`
  with regenerated stubs).
- **Example**: a `Deformable FEM Bar (IPC)` py-demos scene — a tetrahedral
  cantilever sagging under gravity, in the `IPC Deformable (sx)` category.
- **Benchmark**: `BM_DeformableFemBarStep` over growing element counts.

## Tests

- **Kernel** (`test_fem_tet_element`): finite-difference gradient + Hessian
  consistency, rest-state zero energy/force, monotone-under-stretch, inverted-
  element finiteness, zero-Poisson stability, degenerate-rest skip (10 cases).
- **Solver** (`test_deformable_body`): a pinned FEM tetrahedron resists gravity
  where a springless body free-falls; rest-shape stationary; a perturbed node is
  restored toward rest. All 68 existing deformable regressions unchanged (75/75).
- `pixi run test-all`: **6/6 PASSED** (Linting / Build / Unit / Sim-Experimental
  / Python / Documentation).

## Honest scope

This isolates volumetric FEM elasticity; it is not yet a paper-figure
reproduction (codimensional collision, mesh-vs-obstacle friction, and the
upstream mesh corpus are M2–M5). FCR material and per-body rest-shape caching
are M1 follow-ups.
