### PR TITLE
Add a FEM twisting-bar py-demos showcase (toward IPC Fig 4 / Fig 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -924,6 +924,13 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     restores a perturbed node toward rest), a `BM_DeformableFemBarStep`
     benchmark, and a `Deformable FEM Bar (IPC)` py-demos scene (a tetrahedral
     cantilever sagging under gravity) in the `IPC Deformable (sx)` category.
+  - Added a `Deformable FEM Twist (IPC)` py-demos scene: a tetrahedral FEM beam
+    counter-rotated at both ends by opposing scripted Dirichlet boundary
+    conditions, then released so the stable neo-Hookean core untwists
+    elastically -- a DART-native step toward the IPC paper's Fig. 4 (rod twist)
+    / Fig. 14 (mat twist) volumetric-shear themes. Shares a reusable
+    hexahedral-to-tetrahedral bar mesh helper with the FEM cantilever scene; the
+    demos cycle smoke covers it.
   - Added internal experimental IPC projected-Newton search direction for the
     deformable solve: each iteration assembles the per-step Hessian (inertia +
     spring + self-contact barrier + static ground barrier) with per-element

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -45,22 +45,23 @@ lagged smoothed-Coulomb friction, and conservative CCD). They live in their own
 category so the IPC showcases stay together instead of mixing into the general
 `Experimental` (sx) scenes:
 
-| Scene id                            | Shows                                                 | IPC capability exercised                  |
-| ----------------------------------- | ----------------------------------------------------- | ----------------------------------------- |
-| `ipc_deformable_net`                | A pinned spring net sagging/swaying under gravity     | Projected-Newton elastodynamics           |
-| `ipc_deformable_drape`              | A mat draping over a step onto a ground barrier       | Ground + self-contact clamped-log barrier |
-| `ipc_deformable_trampoline`         | A corner-pinned membrane sagging and rebounding       | Taut-membrane projected-Newton dynamics   |
-| `ipc_deformable_friction_slide`     | A launched mat skidding to rest on a frictional floor | Lagged smoothed-Coulomb ground friction   |
-| `ipc_deformable_fem_bar`            | A tetrahedral cantilever sagging under gravity        | Stable neo-Hookean **FEM** elasticity     |
-| `ipc_deformable_scripted_dirichlet` | A banner billowing under a scripted Dirichlet BC      | Scripted Dirichlet boundary conditions    |
+| Scene id                            | Shows                                                 | IPC capability exercised                   |
+| ----------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| `ipc_deformable_net`                | A pinned spring net sagging/swaying under gravity     | Projected-Newton elastodynamics            |
+| `ipc_deformable_drape`              | A mat draping over a step onto a ground barrier       | Ground + self-contact clamped-log barrier  |
+| `ipc_deformable_trampoline`         | A corner-pinned membrane sagging and rebounding       | Taut-membrane projected-Newton dynamics    |
+| `ipc_deformable_friction_slide`     | A launched mat skidding to rest on a frictional floor | Lagged smoothed-Coulomb ground friction    |
+| `ipc_deformable_fem_bar`            | A tetrahedral cantilever sagging under gravity        | Stable neo-Hookean **FEM** elasticity      |
+| `ipc_deformable_fem_twist`          | A tetrahedral bar twisted at both ends, then released | **FEM** volumetric shear (toward Fig 4/14) |
+| `ipc_deformable_scripted_dirichlet` | A banner billowing under a scripted Dirichlet BC      | Scripted Dirichlet boundary conditions     |
 
 These are DART-native showcases, **not** faithful IPC paper-figure
 reproductions. The _contact, barrier, friction, and projected-Newton machinery_
 is genuine IPC; most scenes use a mass-spring elasticity model, while
-`ipc_deformable_fem_bar` exercises the new opt-in stable neo-Hookean **FEM**
-volumetric elasticity (PLAN-081 M1, the keystone toward the paper's volumetric
-scenes). Codimensional collision and the upstream mesh corpus are still needed
-for true figure reproduction. The catalog of upstream paper scenes lives at
+`ipc_deformable_fem_bar` and `ipc_deformable_fem_twist` exercise the new opt-in
+stable neo-Hookean **FEM** volumetric elasticity (PLAN-081 M1, the keystone
+toward the paper's volumetric scenes). Codimensional collision and the upstream
+mesh corpus are still needed for true figure reproduction. The catalog of upstream paper scenes lives at
 `docs/plans/081-deformable-implicit-barrier-solver/ipc_scene_corpus_manifest.json`;
 faithful corpus reproduction stays `planned` (it needs vendored assets,
 codimensional collision, and broader FEM coverage), so these scenes evoke the

--- a/python/examples/demos/_ipc_deformable_bridge.py
+++ b/python/examples/demos/_ipc_deformable_bridge.py
@@ -168,22 +168,24 @@ _CUBE_TETRAHEDRA = (
 )
 
 
-def build_fem_bar(
-    *,
+def _fem_bar_mesh(
     cells_x: int,
     cells_y: int,
     cells_z: int,
     cell_size: float,
     origin: Sequence[float],
-    youngs_modulus: float,
-    poisson_ratio: float = 0.3,
-    density: float = 1.0e3,
-) -> tuple["sx.DeformableBodyOptions", list[tuple[int, int]]]:
-    """A tetrahedralized FEM beam pinned at its ``x == 0`` face.
+) -> tuple[
+    list[np.ndarray],
+    list["sx.DeformableTetrahedron"],
+    list[tuple[int, int]],
+    Callable[[int, int, int], int],
+    tuple[int, int, int],
+]:
+    """Shared hexahedral->tetrahedral mesh for the FEM bar scenes.
 
-    Returns the ``DeformableBodyOptions`` (opting in to stable neo-Hookean FEM
-    elasticity, with tetrahedra and no spring edges) plus the unique tet edge
-    list for the render wireframe.
+    Returns node positions, tetrahedra, the unique tet edge list (render
+    wireframe), the ``node_index(i, j, k)`` accessor, and the ``(nx, ny, nz)``
+    node-grid dimensions.
     """
 
     nx, ny, nz = cells_x + 1, cells_y + 1, cells_z + 1
@@ -191,15 +193,18 @@ def build_fem_bar(
     def node_index(i: int, j: int, k: int) -> int:
         return i + nx * (j + ny * k)
 
-    positions: list[Sequence[float]] = []
+    positions: list[np.ndarray] = []
     for k in range(nz):
         for j in range(ny):
             for i in range(nx):
                 positions.append(
-                    (
-                        origin[0] + i * cell_size,
-                        origin[1] + j * cell_size,
-                        origin[2] + k * cell_size,
+                    np.asarray(
+                        (
+                            origin[0] + i * cell_size,
+                            origin[1] + j * cell_size,
+                            origin[2] + k * cell_size,
+                        ),
+                        dtype=float,
                     )
                 )
 
@@ -227,17 +232,101 @@ def build_fem_bar(
                     ):
                         edges.add((u, v) if u < v else (v, u))
 
-    fixed = [node_index(0, j, k) for k in range(nz) for j in range(ny)]
+    return positions, tetrahedra, sorted(edges), node_index, (nx, ny, nz)
 
+
+def _fem_bar_options(
+    positions: list[np.ndarray],
+    tetrahedra: list["sx.DeformableTetrahedron"],
+    youngs_modulus: float,
+    poisson_ratio: float,
+    density: float,
+) -> "sx.DeformableBodyOptions":
     options = sx.DeformableBodyOptions()
-    options.positions = [np.asarray(p, dtype=float) for p in positions]
+    options.positions = positions
     options.tetrahedra = tetrahedra
-    options.fixed_nodes = fixed
     options.material.youngs_modulus = youngs_modulus
     options.material.poisson_ratio = poisson_ratio
     options.material.density = density
     options.material.use_finite_element_elasticity = True
-    return options, sorted(edges)
+    return options
+
+
+def build_fem_bar(
+    *,
+    cells_x: int,
+    cells_y: int,
+    cells_z: int,
+    cell_size: float,
+    origin: Sequence[float],
+    youngs_modulus: float,
+    poisson_ratio: float = 0.3,
+    density: float = 1.0e3,
+) -> tuple["sx.DeformableBodyOptions", list[tuple[int, int]]]:
+    """A tetrahedralized FEM beam pinned at its ``x == 0`` face.
+
+    Returns the ``DeformableBodyOptions`` (opting in to stable neo-Hookean FEM
+    elasticity, with tetrahedra and no spring edges) plus the unique tet edge
+    list for the render wireframe.
+    """
+
+    positions, tetrahedra, edges, node_index, (_, ny, nz) = _fem_bar_mesh(
+        cells_x, cells_y, cells_z, cell_size, origin
+    )
+    options = _fem_bar_options(
+        positions, tetrahedra, youngs_modulus, poisson_ratio, density
+    )
+    options.fixed_nodes = [node_index(0, j, k) for k in range(nz) for j in range(ny)]
+    return options, edges
+
+
+def build_fem_twist_bar(
+    *,
+    cells_x: int,
+    cells_y: int,
+    cells_z: int,
+    cell_size: float,
+    origin: Sequence[float],
+    youngs_modulus: float,
+    twist_rate: float,
+    twist_end_time: float,
+    poisson_ratio: float = 0.3,
+    density: float = 1.0e3,
+) -> tuple["sx.DeformableBodyOptions", list[tuple[int, int]]]:
+    """A FEM beam twisted at both ends by opposing scripted rotations.
+
+    The two end faces are driven by ``DeformableDirichletBoundaryCondition``s
+    that counter-rotate about the bar's long (x) axis until ``twist_end_time``,
+    then release; the elastic FEM core resists the shear and untwists. The
+    scripted drive uses a linear ``omega x r`` extrapolation, so ``twist_rate``
+    and ``twist_end_time`` are kept small to stay near a true rotation. Toward
+    the IPC paper's Fig. 4 (rod twist) / Fig. 14 (mat twist) themes.
+    """
+
+    positions, tetrahedra, edges, node_index, (nx, ny, nz) = _fem_bar_mesh(
+        cells_x, cells_y, cells_z, cell_size, origin
+    )
+    options = _fem_bar_options(
+        positions, tetrahedra, youngs_modulus, poisson_ratio, density
+    )
+
+    axis_y = origin[1] + 0.5 * cells_y * cell_size
+    axis_z = origin[2] + 0.5 * cells_z * cell_size
+
+    def end_face(i: int) -> list[int]:
+        return [node_index(i, j, k) for k in range(nz) for j in range(ny)]
+
+    conditions = []
+    for face_i, sign in ((0, 1.0), (nx - 1, -1.0)):
+        condition = sx.DeformableDirichletBoundaryCondition()
+        condition.nodes = end_face(face_i)
+        condition.angular_velocity = np.array([sign * twist_rate, 0.0, 0.0])
+        condition.center = np.array([origin[0] + face_i * cell_size, axis_y, axis_z])
+        condition.start_time = 0.0
+        condition.end_time = twist_end_time
+        conditions.append(condition)
+    options.dirichlet_boundary_conditions = conditions
+    return options, edges
 
 
 class IpcDeformableBridge:
@@ -350,6 +439,7 @@ class IpcDeformableBridge:
 __all__ = [
     "IpcDeformableBridge",
     "build_fem_bar",
+    "build_fem_twist_bar",
     "build_grid_options",
     "grid_index",
     "math",

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -21,6 +21,7 @@ from .scenes.hardcoded_design import SCENE as HARDCODED_DESIGN
 from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
 from .scenes.ipc_deformable_fem_bar import SCENE as IPC_DEFORMABLE_FEM_BAR
+from .scenes.ipc_deformable_fem_twist import SCENE as IPC_DEFORMABLE_FEM_TWIST
 from .scenes.ipc_deformable_friction_slide import SCENE as IPC_DEFORMABLE_FRICTION_SLIDE
 from .scenes.ipc_deformable_net import SCENE as IPC_DEFORMABLE_NET
 from .scenes.ipc_deformable_scripted_dirichlet import SCENE as IPC_DEFORMABLE_SCRIPTED
@@ -98,5 +99,6 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_TRAMPOLINE,
         IPC_DEFORMABLE_FRICTION_SLIDE,
         IPC_DEFORMABLE_FEM_BAR,
+        IPC_DEFORMABLE_FEM_TWIST,
         IPC_DEFORMABLE_SCRIPTED,
     ]

--- a/python/examples/demos/scenes/ipc_deformable_fem_twist.py
+++ b/python/examples/demos/scenes/ipc_deformable_fem_twist.py
@@ -1,0 +1,58 @@
+"""FEM twisting bar (experimental IPC deformable solver).
+
+A tetrahedralized beam is gripped at both ends and counter-rotated about its
+long axis, then released; the stable neo-Hookean FEM core stores the shear and
+untwists elastically. This is the volumetric-twist counterpart of the IPC
+paper's Fig. 4 (rod twist) and Fig. 14 (mat twist) stress tests, driven by the
+opt-in FEM elasticity (PLAN-081 M1) plus scripted Dirichlet boundary conditions.
+
+DART-native FEM showcase -- not a faithful paper-figure reproduction (no
+self-contact buckling, codimensional contact, or friction); it isolates
+large-shear volumetric elasticity.
+"""
+
+from __future__ import annotations
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_fem_twist_bar
+from ..runner import PythonDemoScene, SceneSetup
+
+
+def build() -> SceneSetup:
+    options, edges = build_fem_twist_bar(
+        cells_x=10,
+        cells_y=2,
+        cells_z=2,
+        cell_size=0.1,
+        origin=(-0.5, -0.1, 0.7),
+        youngs_modulus=8.0e5,
+        twist_rate=0.35,
+        twist_end_time=1.4,
+        poisson_ratio=0.3,
+        density=1.0e3,
+    )
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, 0.0]  # isolate the twist from gravity sag
+    world.time_step = 0.005
+    body = world.add_deformable_body("fem_twist", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_fem_twist")
+    bridge.add_deformable_visual(body, name="fem_twist", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_fem_twist",
+    title="Deformable FEM Twist (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A tetrahedral FEM bar is twisted at both ends and untwists elastically.",
+    build=build,
+)

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -110,6 +110,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_trampoline",
         "ipc_deformable_friction_slide",
         "ipc_deformable_fem_bar",
+        "ipc_deformable_fem_twist",
         "ipc_deformable_scripted_dirichlet",
     }
     assert expected_ipc <= set(by_id), "missing IPC deformable scenes"


### PR DESCRIPTION
## Summary

Adds a **`Deformable FEM Twist (IPC)`** scene to the `IPC Deformable (sx)`
py-demos category: a tetrahedral FEM beam whose two end faces are
**counter-rotated** about its long axis by opposing scripted Dirichlet boundary
conditions until a release time, after which the stable neo-Hookean FEM core
untwists elastically.

This is the volumetric-shear counterpart of the IPC paper's **Fig. 4 (rod
twist)** and **Fig. 14 (mat twist)** stress tests, exercising the opt-in FEM
elasticity landed in M1 (#2787) under large shear — a DART-native step toward
those figure themes (PLAN-081).

## Details

- Refactors the FEM cantilever's hexahedral→tetrahedral mesh generation into a
  shared `_fem_bar_mesh` helper used by both `build_fem_bar` (pinned cantilever)
  and the new `build_fem_twist_bar` (both ends driven by opposing rotations).
- The scripted drive uses a linear `omega x r` extrapolation, so the twist rate
  and window are kept small to stay near a true rotation, then released.

## Test plan

- Demos cycle smoke (`test_demos_cycle.py`) steps every scene headlessly,
  including the new twist scene; the registry test pins it to the dedicated
  category.
- Verified headlessly: the bar stays finite and bounded through the
  twist-and-release (99 nodes; cross-section radius preserved, no blow-up).
- `pixi run test-all`: **6/6 PASSED**.

## Honest scope

DART-native FEM showcase, **not** a faithful paper-figure reproduction (no
self-contact buckling, codimensional contact, or the upstream rod/mat meshes);
it isolates large-shear volumetric elasticity.
