### PR TITLE
Showcase and test FEM volumetric bodies in IPC ground-barrier contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -931,6 +931,14 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     / Fig. 14 (mat twist) volumetric-shear themes. Shares a reusable
     hexahedral-to-tetrahedral bar mesh helper with the FEM cantilever scene; the
     demos cycle smoke covers it.
+  - Validated and showcased stable neo-Hookean FEM volumetric bodies in IPC
+    contact: a free tetrahedral FEM cube dropped onto a static ground barrier
+    falls, squashes, and settles on the barrier surface intersection-free (no
+    node crosses the ground top), exercising the FEM elasticity and the
+    clamped-log ground barrier together in one solve. Adds a
+    `FemCubeSettlesOnGroundBarrierWithoutPenetrating` regression and a
+    `Deformable FEM Drop (IPC)` py-demos scene -- a DART-native step toward the
+    paper's volumetric drop scenes (e.g. Fig. 12).
   - Added internal experimental IPC projected-Newton search direction for the
     deformable solve: each iteration assembles the per-step Hessian (inertia +
     spring + self-contact barrier + static ground barrier) with per-element

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -53,15 +53,17 @@ category so the IPC showcases stay together instead of mixing into the general
 | `ipc_deformable_friction_slide`     | A launched mat skidding to rest on a frictional floor | Lagged smoothed-Coulomb ground friction    |
 | `ipc_deformable_fem_bar`            | A tetrahedral cantilever sagging under gravity        | Stable neo-Hookean **FEM** elasticity      |
 | `ipc_deformable_fem_twist`          | A tetrahedral bar twisted at both ends, then released | **FEM** volumetric shear (toward Fig 4/14) |
+| `ipc_deformable_fem_drop`           | A FEM cube dropped onto a ground barrier, settling    | **FEM** volumetric body + IPC contact      |
 | `ipc_deformable_scripted_dirichlet` | A banner billowing under a scripted Dirichlet BC      | Scripted Dirichlet boundary conditions     |
 
 These are DART-native showcases, **not** faithful IPC paper-figure
 reproductions. The _contact, barrier, friction, and projected-Newton machinery_
-is genuine IPC; most scenes use a mass-spring elasticity model, while
-`ipc_deformable_fem_bar` and `ipc_deformable_fem_twist` exercise the new opt-in
-stable neo-Hookean **FEM** volumetric elasticity (PLAN-081 M1, the keystone
-toward the paper's volumetric scenes). Codimensional collision and the upstream
-mesh corpus are still needed for true figure reproduction. The catalog of upstream paper scenes lives at
+is genuine IPC; most scenes use a mass-spring elasticity model, while the
+`ipc_deformable_fem_*` scenes (cantilever, twist, ground-barrier drop) exercise
+the new opt-in stable neo-Hookean **FEM** volumetric elasticity (PLAN-081 M1,
+the keystone toward the paper's volumetric scenes), including a volumetric body
+in IPC contact. Codimensional collision and the upstream mesh corpus are still
+needed for true figure reproduction. The catalog of upstream paper scenes lives at
 `docs/plans/081-deformable-implicit-barrier-solver/ipc_scene_corpus_manifest.json`;
 faithful corpus reproduction stays `planned` (it needs vendored assets,
 codimensional collision, and broader FEM coverage), so these scenes evoke the

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -21,6 +21,7 @@ from .scenes.hardcoded_design import SCENE as HARDCODED_DESIGN
 from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
 from .scenes.ipc_deformable_fem_bar import SCENE as IPC_DEFORMABLE_FEM_BAR
+from .scenes.ipc_deformable_fem_drop import SCENE as IPC_DEFORMABLE_FEM_DROP
 from .scenes.ipc_deformable_fem_twist import SCENE as IPC_DEFORMABLE_FEM_TWIST
 from .scenes.ipc_deformable_friction_slide import SCENE as IPC_DEFORMABLE_FRICTION_SLIDE
 from .scenes.ipc_deformable_net import SCENE as IPC_DEFORMABLE_NET
@@ -100,5 +101,6 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_FRICTION_SLIDE,
         IPC_DEFORMABLE_FEM_BAR,
         IPC_DEFORMABLE_FEM_TWIST,
+        IPC_DEFORMABLE_FEM_DROP,
         IPC_DEFORMABLE_SCRIPTED,
     ]

--- a/python/examples/demos/scenes/ipc_deformable_fem_drop.py
+++ b/python/examples/demos/scenes/ipc_deformable_fem_drop.py
@@ -1,0 +1,73 @@
+"""FEM cube dropped onto a ground barrier (experimental IPC deformable solver).
+
+A free tetrahedral FEM cube falls under gravity onto a static ground barrier,
+squashes on impact, and settles intersection-free on the barrier surface. This
+is the first DART showcase combining stable neo-Hookean *volumetric* FEM
+elasticity (PLAN-081 M1) with the landed IPC clamped-log ground barrier contact
+-- a step toward the paper's volumetric drop scenes (e.g. Fig. 12 mass/stiffness
+drops).
+
+DART-native FEM showcase -- not a faithful paper-figure reproduction (single
+analytic ground barrier; no codimensional obstacles or friction).
+"""
+
+from __future__ import annotations
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_fem_bar
+from ..runner import PythonDemoScene, SceneSetup
+
+_GROUND_CENTER = (0.0, 0.0, -0.06)
+_GROUND_HALF = (1.2, 1.2, 0.06)  # top face at z = 0.0
+
+
+def build() -> SceneSetup:
+    # A cube of FEM tetrahedra, released above the barrier (no pinned nodes).
+    options, edges = build_fem_bar(
+        cells_x=3,
+        cells_y=3,
+        cells_z=3,
+        cell_size=0.08,
+        origin=(-0.12, -0.12, 0.34),
+        youngs_modulus=1.5e5,
+        poisson_ratio=0.3,
+        density=1.0e3,
+    )
+    options.fixed_nodes = []
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -9.81]
+    world.time_step = 0.004
+
+    ground = world.add_rigid_body("ground", position=_GROUND_CENTER)
+    ground.is_static = True
+    ground.set_collision_shape(sx.CollisionShape.box(_GROUND_HALF))
+    ground.is_deformable_ground_barrier = True
+
+    body = world.add_deformable_body("fem_drop", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_fem_drop")
+    bridge.add_rigid_box_visual(
+        _GROUND_CENTER,
+        tuple(2.0 * h for h in _GROUND_HALF),
+        (0.37, 0.40, 0.43),
+        name="ground_visual",
+    )
+    bridge.add_deformable_visual(body, name="fem_drop", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_fem_drop",
+    title="Deformable FEM Drop (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A FEM cube falls and settles on an IPC ground barrier without penetrating.",
+    build=build,
+)

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -111,6 +111,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_friction_slide",
         "ipc_deformable_fem_bar",
         "ipc_deformable_fem_twist",
+        "ipc_deformable_fem_drop",
         "ipc_deformable_scripted_dirichlet",
     }
     assert expected_ipc <= set(by_id), "missing IPC deformable scenes"

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -41,6 +41,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -860,6 +861,82 @@ TEST(DeformableBody, FemTetrahedronRestoresStretchedNodeTowardRest)
   world.step(400);
   EXPECT_TRUE(body.getPosition(3).allFinite());
   expectVectorNear(body.getPosition(3), Eigen::Vector3d(0.0, 0.0, 1.0), 5e-2);
+}
+
+//==============================================================================
+// A free FEM cube (one hexahedral cell split into six tetrahedra) opting in to
+// stable neo-Hookean elasticity, released above the ground top.
+sx::DeformableBodyOptions makeFemCubeBody(
+    double size, const Eigen::Vector3d& origin, double youngsModulus)
+{
+  sx::DeformableBodyOptions options;
+  for (int corner = 0; corner < 8; ++corner) {
+    options.positions.push_back(
+        origin
+        + size
+              * Eigen::Vector3d(
+                  corner & 1, (corner >> 1) & 1, (corner >> 2) & 1));
+  }
+  // Kuhn six-tetrahedron decomposition of the cell along the 0->7 diagonal.
+  const std::array<std::array<std::size_t, 4>, 6> tets = {{
+      {0, 1, 3, 7},
+      {0, 3, 2, 7},
+      {0, 2, 6, 7},
+      {0, 6, 4, 7},
+      {0, 4, 5, 7},
+      {0, 5, 1, 7},
+  }};
+  for (const auto& tet : tets) {
+    options.tetrahedra.push_back(
+        sx::DeformableTetrahedron{tet[0], tet[1], tet[2], tet[3]});
+  }
+  options.material.youngsModulus = youngsModulus;
+  options.material.poissonRatio = 0.3;
+  options.material.useFiniteElementElasticity = true;
+  return options;
+}
+
+//==============================================================================
+// A volumetric FEM cube dropped onto a static ground barrier settles on the
+// barrier surface intersection-free: gravity pulls it down, the IPC clamped-log
+// ground barrier catches it (no node crosses the ground top), and the stable
+// neo-Hookean elasticity keeps the cube finite as it squashes and rests. This
+// exercises FEM elasticity and barrier contact together in one solve.
+TEST(DeformableBody, FemCubeSettlesOnGroundBarrierWithoutPenetrating)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world.setTimeStep(0.004);
+
+  sx::RigidBodyOptions groundOptions;
+  groundOptions.isStatic = true;
+  groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+  auto ground = world.addRigidBody("ground", groundOptions);
+  ground.setCollisionShape(
+      sx::CollisionShape::makeBox(Eigen::Vector3d(5.0, 5.0, 0.5)));
+  ground.setDeformableGroundBarrier(true); // top face at z = 0
+
+  auto body = world.addDeformableBody(
+      "fem_cube", makeFemCubeBody(0.2, Eigen::Vector3d(0.0, 0.0, 0.3), 1.5e5));
+
+  const auto minNodeZ = [&]() {
+    double minimum = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+      minimum = std::min(minimum, body.getPosition(i).z());
+    }
+    return minimum;
+  };
+
+  ASSERT_GT(minNodeZ(), 0.25);
+  world.step(250);
+
+  // The cube has fallen onto the barrier (well below its release height) ...
+  EXPECT_LT(minNodeZ(), 0.1);
+  // ... but no node has crossed the ground top, and everything stays finite.
+  for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+    EXPECT_TRUE(body.getPosition(i).allFinite());
+    EXPECT_GE(body.getPosition(i).z(), -1e-3);
+  }
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

Validates and showcases the M1 stable neo-Hookean **FEM elasticity** working
together with the landed IPC **ground barrier** contact in a single solve: a
free tetrahedral FEM cube dropped onto a static ground barrier falls, squashes
on impact, and **settles on the barrier surface intersection-free** (no node
crosses the ground top), staying finite throughout.

This is the first DART showcase of a **volumetric FEM body in IPC contact** — a
step toward the paper's volumetric drop scenes (e.g. Fig. 12).

## What's here

- **Solver regression** `FemCubeSettlesOnGroundBarrierWithoutPenetrating`: a
  Kuhn-decomposed FEM cube + ground barrier; asserts the cube falls (min node z
  drops well below release), no node penetrates the ground top, and all nodes
  stay finite.
- **Example** `Deformable FEM Drop (IPC)`: the same drop in py-demos
  (`IPC Deformable (sx)` category), rendered over the barrier box.

## Test plan

- `test_deformable_body`: 76/76 (new FEM cube test + all existing).
- Demos cycle smoke covers the new scene; registry test pins it to the category.
- `pixi run test-all`: **6/6 PASSED**.

## Honest scope

DART-native FEM showcase, **not** a faithful paper-figure reproduction (single
analytic ground barrier; no codimensional obstacles or friction).
