### PR TITLE
Add the projected-Newton Hessian for the sphere obstacle barrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -904,6 +904,19 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     surface CCD limiter remains the tunnelling guard for fast motion. Adds
     regressions that a node in the band is pushed radially outward and that an
     untagged sphere is inert.
+  - Added the projected-Newton Hessian for the static sphere obstacle barrier
+    (PLAN-081 M2 increment), making obstacle contact a first-class Newton term
+    rather than relying on the steepest-descent fallback. The full per-node
+    barrier Hessian's tangential eigenvalues are non-positive, so its PSD
+    projection is the rank-1 radial curvature `max(0, B''(d)) n n^T` along the
+    outward normal -- the sphere analogue of the vertical ground-barrier
+    curvature. Equilibrium-preserving (the Hessian changes only the search
+    direction), so the existing sphere obstacle regressions are unchanged. Adds
+    a `FemCubeSettlesOnSphereObstacleWithoutPenetrating` regression (a FEM cube
+    dropped onto a sphere obstacle settles intersection-free) and a
+    `Deformable FEM over Sphere (IPC)` py-demos scene (a FEM slab draping over a
+    sphere obstacle), exercising FEM elasticity with the sphere + ground
+    barriers together.
   - Added stable neo-Hookean tetrahedral FEM elasticity to the experimental
     deformable solver (PLAN-081 M1, the paper-parity keystone). A new
     header-only `deformable_elasticity/fem_tet_element.hpp` kernel produces, per

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -3473,6 +3473,7 @@ bool computeProjectedNewtonDirection(
     const std::vector<Eigen::Vector3d>& positions,
     const std::vector<std::uint8_t>& fixed,
     const std::vector<StaticGroundBarrier>& barriers,
+    const std::vector<SphereObstacleBarrier>& sphereObstacles,
     const SelfContactBarrierInputs* contactBarrier,
     const GroundFrictionInputs* groundFriction,
     const SelfContactFrictionInputs* selfContactFriction,
@@ -3745,6 +3746,42 @@ bool computeProjectedNewtonDirection(
           static_cast<Eigen::Index>(3 * i + 2),
           static_cast<Eigen::Index>(3 * i + 2),
           std::max(0.0, second));
+    }
+  }
+
+  // Static sphere obstacle barrier Hessian. The full per-node barrier Hessian
+  // is B''(d) n n^T + (B'(d)/|x-c|)(I - n n^T) with n the outward radial
+  // normal; its tangential eigenvalues B'(d)/|x-c| are non-positive (the
+  // barrier force pulls the node radially out), so the PSD projection keeps
+  // only the rank-1 radial term max(0, B''(d)) n n^T -- the sphere analogue of
+  // the vertical ground barrier curvature, now along the radial normal.
+  if (!sphereObstacles.empty()) {
+    const double activationDistance = staticGroundBarrierActivationDistance();
+    constexpr double barrierScale = 25.0;
+    for (std::size_t i = 0; i < nodeCount; ++i) {
+      if (!isFree(i)) {
+        continue;
+      }
+      for (const auto& obstacle : sphereObstacles) {
+        const Eigen::Vector3d offset = positions[i] - obstacle.center;
+        const double centerDistance = offset.norm();
+        const double d = centerDistance - obstacle.radius;
+        if (d <= 0.0 || d >= activationDistance || centerDistance <= 0.0
+            || !std::isfinite(d)) {
+          continue;
+        }
+        const double distanceOffset = d - activationDistance;
+        const double logRatio = std::log(d / activationDistance);
+        const double second = -barrierScale
+                              * (2.0 * logRatio + 4.0 * distanceOffset / d
+                                 - (distanceOffset * distanceOffset) / (d * d));
+        const double curvature = std::max(0.0, second);
+        if (curvature <= 0.0) {
+          continue;
+        }
+        const Eigen::Vector3d normal = offset / centerDistance;
+        addBlock3(i, i, curvature * (normal * normal.transpose()));
+      }
     }
   }
 
@@ -4287,6 +4324,7 @@ void advanceDeformableBody(
           scratch.next,
           scratch.activeFixed,
           barriers,
+          sphereObstacles,
           &contactBarrier,
           &groundFriction,
           &selfContactFriction,

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -76,6 +76,11 @@ follow-up material variant. Rest data (`restPositions`,
 
 ### M2 — Obstacle barrier completeness (analytic + box) + codim wiring
 
+Progress: the **projected-Newton Hessian for the sphere obstacle barrier** has
+landed (rank-1 radial curvature `max(0, B''(d)) n n^T`), so sphere-obstacle
+contact is now a first-class Newton term; a FEM slab draping over a sphere
+obstacle is shown in py-demos. Remaining M2:
+
 Generalize obstacle contact into a real clamped-log **force** everywhere: an
 analytic half-space (plane) collision object, a box-obstacle barrier force
 (reuse PT distance kernels against the box's triangulated faces), the

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -54,6 +54,7 @@ category so the IPC showcases stay together instead of mixing into the general
 | `ipc_deformable_fem_bar`            | A tetrahedral cantilever sagging under gravity        | Stable neo-Hookean **FEM** elasticity      |
 | `ipc_deformable_fem_twist`          | A tetrahedral bar twisted at both ends, then released | **FEM** volumetric shear (toward Fig 4/14) |
 | `ipc_deformable_fem_drop`           | A FEM cube dropped onto a ground barrier, settling    | **FEM** volumetric body + IPC contact      |
+| `ipc_deformable_fem_sphere`         | A FEM slab draping over a sphere obstacle             | **FEM** + sphere obstacle barrier (Newton) |
 | `ipc_deformable_scripted_dirichlet` | A banner billowing under a scripted Dirichlet BC      | Scripted Dirichlet boundary conditions     |
 
 These are DART-native showcases, **not** faithful IPC paper-figure

--- a/python/examples/demos/_ipc_deformable_bridge.py
+++ b/python/examples/demos/_ipc_deformable_bridge.py
@@ -405,6 +405,20 @@ class IpcDeformableBridge:
         frame.create_visual_aspect().set_color(list(color))
         self.render_world.add_simple_frame(frame)
 
+    def add_rigid_sphere_visual(
+        self,
+        center: Sequence[float],
+        radius: float,
+        color: tuple[float, float, float],
+        name: str = "sphere_obstacle",
+    ) -> None:
+        """A static sphere SimpleFrame (e.g. a deformable obstacle barrier)."""
+
+        frame = dart.SimpleFrame(dart.Frame.world(), name, _translation(center))
+        frame.set_shape(dart.SphereShape(float(radius)))
+        frame.create_visual_aspect().set_color(list(color))
+        self.render_world.add_simple_frame(frame)
+
     def sync(self) -> None:
         """Copy every deformable node position onto its sphere + wireframe."""
 

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -22,6 +22,7 @@ from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
 from .scenes.ipc_deformable_fem_bar import SCENE as IPC_DEFORMABLE_FEM_BAR
 from .scenes.ipc_deformable_fem_drop import SCENE as IPC_DEFORMABLE_FEM_DROP
+from .scenes.ipc_deformable_fem_sphere import SCENE as IPC_DEFORMABLE_FEM_SPHERE
 from .scenes.ipc_deformable_fem_twist import SCENE as IPC_DEFORMABLE_FEM_TWIST
 from .scenes.ipc_deformable_friction_slide import SCENE as IPC_DEFORMABLE_FRICTION_SLIDE
 from .scenes.ipc_deformable_net import SCENE as IPC_DEFORMABLE_NET
@@ -102,5 +103,6 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_FEM_BAR,
         IPC_DEFORMABLE_FEM_TWIST,
         IPC_DEFORMABLE_FEM_DROP,
+        IPC_DEFORMABLE_FEM_SPHERE,
         IPC_DEFORMABLE_SCRIPTED,
     ]

--- a/python/examples/demos/scenes/ipc_deformable_fem_sphere.py
+++ b/python/examples/demos/scenes/ipc_deformable_fem_sphere.py
@@ -1,0 +1,82 @@
+"""FEM slab draping over a sphere obstacle (experimental IPC deformable solver).
+
+A free tetrahedral FEM slab is dropped onto a static sphere resting on the
+ground. The sphere is opted in as a deformable obstacle, so its radial
+clamped-log barrier (now a first-class projected-Newton term) pushes the slab's
+nodes out along the surface normal while the ground barrier catches the
+overhanging edges: the slab drapes over the curved obstacle intersection-free.
+This combines stable neo-Hookean FEM elasticity (PLAN-081 M1) with the sphere
+obstacle barrier and the ground barrier in one solve.
+
+DART-native FEM showcase -- not a faithful IPC paper-figure reproduction.
+"""
+
+from __future__ import annotations
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_fem_bar
+from ..runner import PythonDemoScene, SceneSetup
+
+_SPHERE_RADIUS = 0.12
+_SPHERE_CENTER = (0.0, 0.0, _SPHERE_RADIUS)  # resting on the ground top (z = 0)
+_GROUND_CENTER = (0.0, 0.0, -0.06)
+_GROUND_HALF = (1.2, 1.2, 0.06)
+
+
+def build() -> SceneSetup:
+    options, edges = build_fem_bar(
+        cells_x=8,
+        cells_y=8,
+        cells_z=1,
+        cell_size=0.06,
+        origin=(-0.24, -0.24, 0.42),
+        youngs_modulus=3.0e4,
+        poisson_ratio=0.3,
+        density=1.0e3,
+    )
+    options.fixed_nodes = []
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -9.81]
+    world.time_step = 0.004
+
+    ground = world.add_rigid_body("ground", position=_GROUND_CENTER)
+    ground.is_static = True
+    ground.set_collision_shape(sx.CollisionShape.box(_GROUND_HALF))
+    ground.is_deformable_ground_barrier = True
+
+    sphere = world.add_rigid_body("sphere", position=_SPHERE_CENTER)
+    sphere.is_static = True
+    sphere.set_collision_shape(sx.CollisionShape.sphere(_SPHERE_RADIUS))
+    sphere.is_deformable_surface_ccd_obstacle = True
+
+    body = world.add_deformable_body("fem_sphere", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_fem_sphere")
+    bridge.add_rigid_box_visual(
+        _GROUND_CENTER,
+        tuple(2.0 * h for h in _GROUND_HALF),
+        (0.37, 0.40, 0.43),
+        name="ground_visual",
+    )
+    bridge.add_rigid_sphere_visual(
+        _SPHERE_CENTER, _SPHERE_RADIUS, (0.52, 0.45, 0.34), name="sphere_visual"
+    )
+    bridge.add_deformable_visual(body, name="fem_sphere", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_fem_sphere",
+    title="Deformable FEM over Sphere (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A FEM slab drapes over a sphere obstacle via the radial barrier + ground barrier.",
+    build=build,
+)

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -112,6 +112,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_fem_bar",
         "ipc_deformable_fem_twist",
         "ipc_deformable_fem_drop",
+        "ipc_deformable_fem_sphere",
         "ipc_deformable_scripted_dirichlet",
     }
     assert expected_ipc <= set(by_id), "missing IPC deformable scenes"

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -940,6 +940,59 @@ TEST(DeformableBody, FemCubeSettlesOnGroundBarrierWithoutPenetrating)
 }
 
 //==============================================================================
+// A FEM cube dropped onto a static sphere obstacle settles against the curved
+// surface intersection-free: the radial clamped-log obstacle barrier (now a
+// projected-Newton term) keeps every node outside the sphere while the stable
+// neo-Hookean elasticity conforms the cube to the obstacle, all finite. This
+// exercises FEM elasticity and the sphere obstacle barrier (energy, gradient,
+// and Hessian) together.
+TEST(DeformableBody, FemCubeSettlesOnSphereObstacleWithoutPenetrating)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world.setTimeStep(0.004);
+
+  const Eigen::Vector3d sphereCenter(0.1, 0.1, 0.0);
+  const double sphereRadius = 0.5;
+  sx::RigidBodyOptions sphereOptions;
+  sphereOptions.isStatic = true;
+  sphereOptions.position = sphereCenter;
+  auto sphere = world.addRigidBody("obstacle_sphere", sphereOptions);
+  sphere.setCollisionShape(sx::CollisionShape::makeSphere(sphereRadius));
+  sphere.setDeformableSurfaceCcdObstacle(true);
+
+  // A small FEM cube released just above the sphere's top.
+  auto body = world.addDeformableBody(
+      "fem_cube",
+      makeFemCubeBody(
+          0.16, Eigen::Vector3d(0.02, 0.02, 0.62), /*youngsModulus=*/2.0e5));
+
+  const auto minSurfaceDistance = [&]() {
+    double minimum = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+      minimum = std::min(
+          minimum, (body.getPosition(i) - sphereCenter).norm() - sphereRadius);
+    }
+    return minimum;
+  };
+
+  ASSERT_GT(minSurfaceDistance(), 0.05);
+  world.step(250);
+
+  // The cube has fallen onto the sphere (well below its release height) ...
+  double minZ = std::numeric_limits<double>::infinity();
+  for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+    minZ = std::min(minZ, body.getPosition(i).z());
+  }
+  EXPECT_LT(minZ, 0.55);
+  // ... but no node penetrates the sphere surface, and all stay finite.
+  EXPECT_GT(minSurfaceDistance(), -1e-3);
+  for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+    EXPECT_TRUE(body.getPosition(i).allFinite());
+  }
+}
+
+//==============================================================================
 TEST(DeformableBody, StepCountWithExecutorRunsDefaultDeformableStage)
 {
   sx::World world;


### PR DESCRIPTION
## Summary

The static sphere obstacle barrier (#2776) was **energy + gradient only**, so
obstacle contact fell back to steepest descent in the projected-Newton solve.
This adds its **projected-Newton Hessian** so obstacle contact is a first-class
Newton term (PLAN-081 M2 increment).

## Details

The full per-node barrier Hessian is `B''(d)·nnᵀ + (B'(d)/|x−c|)(I − nnᵀ)` with
`n` the outward radial normal. Its tangential eigenvalues `B'(d)/|x−c|` are
**non-positive** (the barrier force pulls the node radially out), so the PSD
projection keeps only the rank-1 radial curvature `max(0, B''(d))·nnᵀ` — the
sphere analogue of the vertical ground-barrier curvature.

**Equilibrium-preserving**: the Hessian changes only the Newton search
direction, not the energy minimum, so the existing sphere obstacle regressions
are unchanged.

## Tests + example

- `FemCubeSettlesOnSphereObstacleWithoutPenetrating`: a FEM cube dropped onto a
  sphere obstacle settles intersection-free (no node inside the sphere).
- `Deformable FEM over Sphere (IPC)` py-demos scene: a FEM slab draping over a
  sphere obstacle (FEM + sphere obstacle barrier + ground barrier together), with
  a new sphere-obstacle visual on the render bridge.
- `test_deformable_body`: 77/77; demos cycle covers the new scene.
- `pixi run test-all`: **6/6 PASSED**.
