### PR TITLE
Add a clamped-log barrier force for static box obstacles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -917,6 +917,20 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     `Deformable FEM over Sphere (IPC)` py-demos scene (a FEM slab draping over a
     sphere obstacle), exercising FEM elasticity with the sphere + ground
     barriers together.
+  - Added a clamped-log barrier force (energy + gradient + projected-Newton
+    Hessian) for static oriented BOX obstacles (PLAN-081 M2 increment), the box
+    analogue of the sphere obstacle barrier. The closest point on the box surface
+    -- and hence the surface distance and outward normal -- is found by clamping
+    the node into the box's local frame, which handles face, edge, and corner
+    contact uniformly; the barrier pushes nearby deformable nodes out along that
+    normal, and its PSD-projected Hessian is the rank-1 radial curvature along
+    it. Reuses the existing `setDeformableSurfaceCcdObstacle` opt-in (the box CCD
+    limiter stays the tunnelling guard; box obstacles previously had no smooth
+    contact force); purely additive (all existing box surface-CCD regressions
+    unchanged). Adds `BoxObstacleBarrierRepelsNodeAlongFaceNormal` and
+    `FemCubeSettlesOnBoxObstacleWithoutPenetrating` regressions and a
+    `Deformable FEM over Box (IPC)` py-demos scene (a FEM slab draping over a box
+    obstacle).
   - Added stable neo-Hookean tetrahedral FEM elasticity to the experimental
     deformable solver (PLAN-081 M1, the paper-parity keystone). A new
     header-only `deformable_elasticity/fem_tet_element.hpp` kernel produces, per

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -734,6 +734,19 @@ struct SphereObstacleBarrier
   double radius = 0.0;
 };
 
+// A static (oriented) box opted in as a deformable obstacle exerts a
+// clamped-log barrier on nearby deformable nodes along the outward surface
+// normal -- the box analogue of the sphere obstacle barrier. The closest point
+// on the box surface (and hence the surface distance and outward normal) is
+// found by clamping the node into the box's local frame, which handles
+// face/edge/corner contact uniformly.
+struct BoxObstacleBarrier
+{
+  Eigen::Vector3d center = Eigen::Vector3d::Zero();
+  Eigen::Matrix3d rotation = Eigen::Matrix3d::Identity();
+  Eigen::Vector3d halfExtents = Eigen::Vector3d::Zero();
+};
+
 //==============================================================================
 struct DeformableContactSolverScratch
 {
@@ -1672,6 +1685,37 @@ std::vector<SphereObstacleBarrier> collectSphereObstacleBarriers(
 }
 
 //==============================================================================
+std::vector<BoxObstacleBarrier> collectBoxObstacleBarriers(const World& world)
+{
+  const auto& registry = world.getRegistry();
+  auto view = registry.view<
+      comps::RigidBodyTag,
+      comps::StaticBodyTag,
+      comps::DeformableSurfaceCcdObstacleTag,
+      comps::CollisionGeometry,
+      comps::Transform>();
+
+  std::vector<BoxObstacleBarrier> obstacles;
+  for (const auto entity : view) {
+    const auto& geometry = view.get<comps::CollisionGeometry>(entity);
+    const auto& transform = view.get<comps::Transform>(entity);
+    if (geometry.shape.type != CollisionShapeType::Box
+        || !geometry.shape.halfExtents.allFinite()
+        || (geometry.shape.halfExtents.array() <= 0.0).any()
+        || !transform.position.allFinite()
+        || !transform.orientation.coeffs().allFinite()) {
+      continue;
+    }
+    BoxObstacleBarrier obstacle;
+    obstacle.center = transform.position;
+    obstacle.rotation = transform.orientation.normalized().toRotationMatrix();
+    obstacle.halfExtents = geometry.shape.halfExtents;
+    obstacles.push_back(obstacle);
+  }
+  return obstacles;
+}
+
+//==============================================================================
 // The supporting static-ground contact under a node: the highest barrier
 // surface across all barriers at the node's (x, y), together with that
 // surface's geometric normal. Mirrors the max-top selection of the legacy
@@ -2256,6 +2300,82 @@ double addSphereObstacleBarrierEnergy(
 }
 
 //==============================================================================
+// Closest-surface distance from a node to an oriented box obstacle, with the
+// outward world-frame surface normal set when the distance is positive. The
+// node is clamped into the box's local frame; |local - clamp(local)| is the
+// distance to the surface (0 inside/on the box), uniform across face, edge, and
+// corner contact.
+double boxObstacleSurfaceDistance(
+    const Eigen::Vector3d& position,
+    const BoxObstacleBarrier& obstacle,
+    Eigen::Vector3d& outwardNormal)
+{
+  const Eigen::Vector3d local
+      = obstacle.rotation.transpose() * (position - obstacle.center);
+  const Eigen::Vector3d clamped
+      = local.cwiseMax(-obstacle.halfExtents).cwiseMin(obstacle.halfExtents);
+  const Eigen::Vector3d delta = local - clamped;
+  const double distance = delta.norm();
+  if (distance > 0.0 && std::isfinite(distance)) {
+    outwardNormal = obstacle.rotation * (delta / distance);
+  }
+  return distance;
+}
+
+//==============================================================================
+// Adds the clamped-log barrier energy/gradient pushing free deformable nodes
+// out of the activation band of an oriented box obstacle, along the outward
+// surface normal. The box analogue of addSphereObstacleBarrierEnergy.
+double addBoxObstacleBarrierEnergy(
+    const std::vector<Eigen::Vector3d>& positions,
+    const std::vector<std::uint8_t>& fixed,
+    const std::vector<BoxObstacleBarrier>& obstacles,
+    std::vector<Eigen::Vector3d>* gradient)
+{
+  if (obstacles.empty()) {
+    return 0.0;
+  }
+
+  const double activationDistance = staticGroundBarrierActivationDistance();
+  constexpr double barrierScale = 25.0;
+
+  double energy = 0.0;
+  for (std::size_t i = 0; i < positions.size(); ++i) {
+    if (fixed[i] != 0u) {
+      continue;
+    }
+
+    for (const auto& obstacle : obstacles) {
+      Eigen::Vector3d normal;
+      const double distance
+          = boxObstacleSurfaceDistance(positions[i], obstacle, normal);
+      if (distance <= 0.0 || !std::isfinite(distance)) {
+        // On or inside the box: a penetration the barrier forbids.
+        return std::numeric_limits<double>::infinity();
+      }
+      if (distance >= activationDistance) {
+        continue;
+      }
+
+      const double normalizedDistance = distance / activationDistance;
+      const double distanceOffset = distance - activationDistance;
+      energy += -barrierScale * distanceOffset * distanceOffset
+                * std::log(normalizedDistance);
+
+      if (gradient != nullptr) {
+        const double derivative
+            = -barrierScale
+              * (2.0 * distanceOffset * std::log(normalizedDistance)
+                 + distanceOffset * distanceOffset / distance);
+        (*gradient)[i] += derivative * normal;
+      }
+    }
+  }
+
+  return energy;
+}
+
+//==============================================================================
 // Tangential speed below which static-ground friction smoothly vanishes (the
 // IPC mollifier velocity threshold epsv). Scaled by the time step to a
 // displacement radius.
@@ -2817,6 +2937,7 @@ double evaluateDeformableObjective(
     const std::vector<std::uint8_t>& fixed,
     const std::vector<StaticGroundBarrier>& barriers,
     const std::vector<SphereObstacleBarrier>& sphereObstacles,
+    const std::vector<BoxObstacleBarrier>& boxObstacles,
     double timeStep,
     std::vector<Eigen::Vector3d>* gradient,
     const SelfContactBarrierInputs* contactBarrier = nullptr,
@@ -2876,6 +2997,8 @@ double evaluateDeformableObjective(
   energy += addStaticGroundBarrierEnergy(positions, fixed, barriers, gradient);
   energy += addSphereObstacleBarrierEnergy(
       positions, fixed, sphereObstacles, gradient);
+  energy
+      += addBoxObstacleBarrierEnergy(positions, fixed, boxObstacles, gradient);
   if (contactBarrier != nullptr) {
     energy += addSelfContactBarrierEnergy(
         positions, fixed, *contactBarrier, barrierActiveContacts, gradient);
@@ -3474,6 +3597,7 @@ bool computeProjectedNewtonDirection(
     const std::vector<std::uint8_t>& fixed,
     const std::vector<StaticGroundBarrier>& barriers,
     const std::vector<SphereObstacleBarrier>& sphereObstacles,
+    const std::vector<BoxObstacleBarrier>& boxObstacles,
     const SelfContactBarrierInputs* contactBarrier,
     const GroundFrictionInputs* groundFriction,
     const SelfContactFrictionInputs* selfContactFriction,
@@ -3785,6 +3909,38 @@ bool computeProjectedNewtonDirection(
     }
   }
 
+  // Static box obstacle barrier Hessian: the rank-1 radial curvature
+  // max(0, B''(d)) n n^T along the outward box-surface normal, the box analogue
+  // of the sphere obstacle barrier Hessian above (the tangential eigenvalues
+  // are again non-positive and drop out under PSD projection).
+  if (!boxObstacles.empty()) {
+    const double activationDistance = staticGroundBarrierActivationDistance();
+    constexpr double barrierScale = 25.0;
+    for (std::size_t i = 0; i < nodeCount; ++i) {
+      if (!isFree(i)) {
+        continue;
+      }
+      for (const auto& obstacle : boxObstacles) {
+        Eigen::Vector3d normal;
+        const double d
+            = boxObstacleSurfaceDistance(positions[i], obstacle, normal);
+        if (d <= 0.0 || d >= activationDistance || !std::isfinite(d)) {
+          continue;
+        }
+        const double distanceOffset = d - activationDistance;
+        const double logRatio = std::log(d / activationDistance);
+        const double second = -barrierScale
+                              * (2.0 * logRatio + 4.0 * distanceOffset / d
+                                 - (distanceOffset * distanceOffset) / (d * d));
+        const double curvature = std::max(0.0, second);
+        if (curvature <= 0.0) {
+          continue;
+        }
+        addBlock3(i, i, curvature * (normal * normal.transpose()));
+      }
+    }
+  }
+
   // Lagged ground-friction Hessian: a 3x3 tangent-plane block per node with an
   // active friction normal force. With P = I - n n^T the tangent projector onto
   // the plane orthogonal to the lagged ground normal n, T = u_T/||u_T|| the
@@ -3980,6 +4136,7 @@ void advanceDeformableBody(
     double timeStep,
     const std::vector<StaticGroundBarrier>& barriers,
     const std::vector<SphereObstacleBarrier>& sphereObstacles,
+    const std::vector<BoxObstacleBarrier>& boxObstacles,
     const comps::DeformableMaterial& material,
     DeformableSolverStats& stats)
 {
@@ -4058,7 +4215,8 @@ void advanceDeformableBody(
       scratch.next, scratch.activeFixed, barriers, &stats);
 
   if (model.edges.empty() && barriers.empty() && sphereObstacles.empty()
-      && rigidSurfaceSnapshots.empty() && movingRigidSurfaceSnapshots.empty()
+      && boxObstacles.empty() && rigidSurfaceSnapshots.empty()
+      && movingRigidSurfaceSnapshots.empty()
       && contactScratch.surfaceTriangles.empty()
       && femElasticityPtr == nullptr) {
     for (std::size_t i = 0; i < nodeCount; ++i) {
@@ -4158,6 +4316,7 @@ void advanceDeformableBody(
           scratch.activeFixed,
           barriers,
           sphereObstacles,
+          boxObstacles,
           timeStep,
           &scratch.gradient,
           &contactBarrier,
@@ -4273,6 +4432,7 @@ void advanceDeformableBody(
                 scratch.activeFixed,
                 barriers,
                 sphereObstacles,
+                boxObstacles,
                 timeStep,
                 nullptr,
                 &contactBarrier,
@@ -4325,6 +4485,7 @@ void advanceDeformableBody(
           scratch.activeFixed,
           barriers,
           sphereObstacles,
+          boxObstacles,
           &contactBarrier,
           &groundFriction,
           &selfContactFriction,
@@ -4422,6 +4583,7 @@ void advanceDeformableBody(
           scratch.activeFixed,
           barriers,
           sphereObstacles,
+          boxObstacles,
           timeStep,
           &scratch.gradient,
           &terminalBarrier,
@@ -4884,6 +5046,7 @@ void DeformableDynamicsStage::execute(
 
   const auto barriers = collectStaticGroundBarriers(world);
   const auto sphereObstacles = collectSphereObstacleBarriers(world);
+  const auto boxObstacles = collectBoxObstacleBarriers(world);
   const auto rigidSurfaceSnapshots
       = collectStaticRigidSurfaceCcdObstacles(world, m_lastStats);
   const auto timeStep = world.getTimeStep();
@@ -4953,6 +5116,7 @@ void DeformableDynamicsStage::execute(
         timeStep,
         barriers,
         sphereObstacles,
+        boxObstacles,
         material,
         m_lastStats);
   }

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -76,10 +76,11 @@ follow-up material variant. Rest data (`restPositions`,
 
 ### M2 — Obstacle barrier completeness (analytic + box) + codim wiring
 
-Progress: the **projected-Newton Hessian for the sphere obstacle barrier** has
-landed (rank-1 radial curvature `max(0, B''(d)) n n^T`), so sphere-obstacle
-contact is now a first-class Newton term; a FEM slab draping over a sphere
-obstacle is shown in py-demos. Remaining M2:
+Progress: the **sphere obstacle barrier Hessian** and a full **box obstacle
+barrier** (energy + gradient + projected-Newton Hessian, via local-frame clamp
+for face/edge/corner) have landed, so sphere- and box-obstacle contact are now
+first-class Newton terms; FEM slabs draping over a sphere and over a box are
+shown in py-demos. Remaining M2:
 
 Generalize obstacle contact into a real clamped-log **force** everywhere: an
 analytic half-space (plane) collision object, a box-obstacle barrier force

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -55,6 +55,7 @@ category so the IPC showcases stay together instead of mixing into the general
 | `ipc_deformable_fem_twist`          | A tetrahedral bar twisted at both ends, then released | **FEM** volumetric shear (toward Fig 4/14) |
 | `ipc_deformable_fem_drop`           | A FEM cube dropped onto a ground barrier, settling    | **FEM** volumetric body + IPC contact      |
 | `ipc_deformable_fem_sphere`         | A FEM slab draping over a sphere obstacle             | **FEM** + sphere obstacle barrier (Newton) |
+| `ipc_deformable_fem_box`            | A FEM slab draping over a box "table" obstacle        | **FEM** + box obstacle barrier (Newton)    |
 | `ipc_deformable_scripted_dirichlet` | A banner billowing under a scripted Dirichlet BC      | Scripted Dirichlet boundary conditions     |
 
 These are DART-native showcases, **not** faithful IPC paper-figure

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -21,6 +21,7 @@ from .scenes.hardcoded_design import SCENE as HARDCODED_DESIGN
 from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
 from .scenes.ipc_deformable_fem_bar import SCENE as IPC_DEFORMABLE_FEM_BAR
+from .scenes.ipc_deformable_fem_box import SCENE as IPC_DEFORMABLE_FEM_BOX
 from .scenes.ipc_deformable_fem_drop import SCENE as IPC_DEFORMABLE_FEM_DROP
 from .scenes.ipc_deformable_fem_sphere import SCENE as IPC_DEFORMABLE_FEM_SPHERE
 from .scenes.ipc_deformable_fem_twist import SCENE as IPC_DEFORMABLE_FEM_TWIST
@@ -104,5 +105,6 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_FEM_TWIST,
         IPC_DEFORMABLE_FEM_DROP,
         IPC_DEFORMABLE_FEM_SPHERE,
+        IPC_DEFORMABLE_FEM_BOX,
         IPC_DEFORMABLE_SCRIPTED,
     ]

--- a/python/examples/demos/scenes/ipc_deformable_fem_box.py
+++ b/python/examples/demos/scenes/ipc_deformable_fem_box.py
@@ -1,0 +1,85 @@
+"""FEM slab draping over a box obstacle (experimental IPC deformable solver).
+
+A free tetrahedral FEM slab is dropped onto a static box ("table") resting on
+the ground. The box is opted in as a deformable obstacle, so its clamped-log
+barrier (along the outward surface normal, a first-class projected-Newton term)
+keeps the slab outside the box while the ground barrier catches the overhanging
+edges: the slab drapes over the flat top and down the sides intersection-free.
+This exercises stable neo-Hookean FEM elasticity (PLAN-081 M1) with the box
+obstacle barrier and the ground barrier in one solve.
+
+DART-native FEM showcase -- not a faithful IPC paper-figure reproduction.
+"""
+
+from __future__ import annotations
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_fem_bar
+from ..runner import PythonDemoScene, SceneSetup
+
+_BOX_HALF = (0.16, 0.16, 0.1)
+_BOX_CENTER = (0.0, 0.0, _BOX_HALF[2])  # resting on the ground top (z = 0)
+_GROUND_CENTER = (0.0, 0.0, -0.06)
+_GROUND_HALF = (1.2, 1.2, 0.06)
+
+
+def build() -> SceneSetup:
+    options, edges = build_fem_bar(
+        cells_x=8,
+        cells_y=8,
+        cells_z=1,
+        cell_size=0.06,
+        origin=(-0.24, -0.24, 0.4),
+        youngs_modulus=4.0e4,
+        poisson_ratio=0.3,
+        density=1.0e3,
+    )
+    options.fixed_nodes = []
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -9.81]
+    world.time_step = 0.004
+
+    ground = world.add_rigid_body("ground", position=_GROUND_CENTER)
+    ground.is_static = True
+    ground.set_collision_shape(sx.CollisionShape.box(_GROUND_HALF))
+    ground.is_deformable_ground_barrier = True
+
+    box = world.add_rigid_body("box", position=_BOX_CENTER)
+    box.is_static = True
+    box.set_collision_shape(sx.CollisionShape.box(_BOX_HALF))
+    box.is_deformable_surface_ccd_obstacle = True
+
+    body = world.add_deformable_body("fem_box", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_fem_box")
+    bridge.add_rigid_box_visual(
+        _GROUND_CENTER,
+        tuple(2.0 * h for h in _GROUND_HALF),
+        (0.37, 0.40, 0.43),
+        name="ground_visual",
+    )
+    bridge.add_rigid_box_visual(
+        _BOX_CENTER,
+        tuple(2.0 * h for h in _BOX_HALF),
+        (0.52, 0.45, 0.34),
+        name="box_visual",
+    )
+    bridge.add_deformable_visual(body, name="fem_box", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_fem_box",
+    title="Deformable FEM over Box (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A FEM slab drapes over a box obstacle via the box barrier + ground barrier.",
+    build=build,
+)

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -113,6 +113,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_fem_twist",
         "ipc_deformable_fem_drop",
         "ipc_deformable_fem_sphere",
+        "ipc_deformable_fem_box",
         "ipc_deformable_scripted_dirichlet",
     }
     assert expected_ipc <= set(by_id), "missing IPC deformable scenes"

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -993,6 +993,86 @@ TEST(DeformableBody, FemCubeSettlesOnSphereObstacleWithoutPenetrating)
 }
 
 //==============================================================================
+// A static box opted in as a deformable obstacle exerts a clamped-log barrier
+// along the outward surface normal: a node resting just outside a box face (in
+// the activation band) is pushed straight out along that face normal.
+TEST(DeformableBody, BoxObstacleBarrierRepelsNodeAlongFaceNormal)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.1);
+
+  sx::RigidBodyOptions boxOptions;
+  boxOptions.isStatic = true;
+  auto box = world.addRigidBody("obstacle_box", boxOptions);
+  box.setCollisionShape(
+      sx::CollisionShape::makeBox(Eigen::Vector3d(0.5, 0.5, 0.5)));
+  box.setDeformableSurfaceCcdObstacle(true);
+
+  // 0.505 is inside the band off the +x face (surface 0.5, distance 0.005).
+  sx::DeformableBodyOptions options;
+  options.positions = {Eigen::Vector3d(0.505, 0.0, 0.0)};
+  options.velocities = {Eigen::Vector3d::Zero()};
+  auto body = world.addDeformableBody("node", options);
+
+  world.step(10);
+
+  const auto position = body.getPosition(0);
+  EXPECT_GT(position.x(), 0.52);        // repelled past the band edge along +x
+  EXPECT_LT(position.x(), 2.0);         // finite (no blow-up)
+  EXPECT_NEAR(position.y(), 0.0, 1e-9); // purely along the face normal
+  EXPECT_NEAR(position.z(), 0.0, 1e-9);
+}
+
+//==============================================================================
+// A FEM cube dropped onto a static box obstacle settles on the surface
+// intersection-free: the box obstacle barrier (energy, gradient, and Hessian)
+// keeps every node outside the box while the FEM elasticity conforms the cube
+// to the obstacle, all finite.
+TEST(DeformableBody, FemCubeSettlesOnBoxObstacleWithoutPenetrating)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world.setTimeStep(0.004);
+
+  const Eigen::Vector3d boxCenter(0.0, 0.0, 0.0);
+  const Eigen::Vector3d boxHalf(0.3, 0.3, 0.3); // top face at z = 0.3
+  sx::RigidBodyOptions boxOptions;
+  boxOptions.isStatic = true;
+  boxOptions.position = boxCenter;
+  auto box = world.addRigidBody("obstacle_box", boxOptions);
+  box.setCollisionShape(sx::CollisionShape::makeBox(boxHalf));
+  box.setDeformableSurfaceCcdObstacle(true);
+
+  auto body = world.addDeformableBody(
+      "fem_cube",
+      makeFemCubeBody(
+          0.16, Eigen::Vector3d(-0.06, -0.06, 0.5), /*youngsModulus=*/2.0e5));
+
+  const auto minBoxSurfaceDistance = [&]() {
+    double minimum = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+      const Eigen::Vector3d local = body.getPosition(i) - boxCenter;
+      const Eigen::Vector3d clamped
+          = local.cwiseMax(-boxHalf).cwiseMin(boxHalf);
+      minimum = std::min(minimum, (local - clamped).norm());
+    }
+    return minimum;
+  };
+
+  ASSERT_GT(minBoxSurfaceDistance(), 0.05);
+  world.step(250);
+
+  double minZ = std::numeric_limits<double>::infinity();
+  for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+    minZ = std::min(minZ, body.getPosition(i).z());
+    EXPECT_TRUE(body.getPosition(i).allFinite());
+  }
+  EXPECT_LT(minZ, 0.45);                     // fell onto the box
+  EXPECT_GE(minBoxSurfaceDistance(), -1e-3); // no node inside the box
+}
+
+//==============================================================================
 TEST(DeformableBody, StepCountWithExecutorRunsDefaultDeformableStage)
 {
   sx::World world;


### PR DESCRIPTION
## Summary

Gives static **oriented box obstacles** a full clamped-log barrier force
(energy + gradient + **projected-Newton Hessian**) — the box analogue of the
sphere obstacle barrier (PLAN-081 M2 increment). Box obstacles previously had
only the surface-CCD tunnelling guard and **no smooth contact force**.

## Details

The closest point on the box surface (and hence the surface distance and
outward normal) is found by **clamping the node into the box's local frame**;
`|local − clamp(local)|` handles **face, edge, and corner** contact uniformly.
The barrier pushes nearby free nodes out along that normal, and its
PSD-projected Hessian is the rank-1 radial curvature `max(0, B''(d))·nnᵀ` (the
tangential eigenvalues are non-positive, as for the sphere).

Reuses the existing `setDeformableSurfaceCcdObstacle` opt-in (consistent with
the sphere obstacle barrier; the box CCD limiter remains the tunnelling guard).
**Purely additive** — all existing box surface-CCD regressions are unchanged,
and ground-barrier boxes (a different tag) are unaffected.

## Tests + example

- `BoxObstacleBarrierRepelsNodeAlongFaceNormal`: a node in the band off a box
  face is pushed straight out along the face normal.
- `FemCubeSettlesOnBoxObstacleWithoutPenetrating`: a FEM cube dropped onto a box
  obstacle settles intersection-free.
- `Deformable FEM over Box (IPC)` py-demos scene: a FEM slab draping over a box
  "table".
- `test_deformable_body`: 79/79; demos cycle covers the new scene.
- `pixi run test-all`: **6/6 PASSED**.
