### PR TITLE
Support GMSH format 4.x in the .msh tetrahedral-mesh importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -934,11 +934,13 @@ qdot)` that reaches the target exactly even under inertial coupling. The
   - Added a GMSH `.msh` tetrahedral-mesh importer (PLAN-081 M4) so deformable
     FEM bodies can be built from external tet meshes rather than only procedural
     grids. `dart::simulation::experimental::io::loadGmshTetMesh` /
-    `loadGmshTetMeshFile` parse GMSH ASCII format 2.x: the `$Nodes` block and the
-    4-node tetrahedron (`$Elements` type 4) connectivity, remapping node ids to
+    `loadGmshTetMeshFile` parse GMSH ASCII format 2.x and 4.x (both the legacy
+    flat layout and the entity-block layout): the `$Nodes` and the 4-node
+    tetrahedron (`$Elements` type 4) connectivity, remapping node ids to
     0-based indices and ignoring non-tetra elements, raising
-    `InvalidArgumentException` on malformed or unsupported (binary / non-2.x)
-    input. Exposed to `dartpy` as `load_gmsh_tet_mesh(path)` returning a
+    `InvalidArgumentException` on malformed or unsupported (binary, or
+    version &lt; 2 / &ge; 5) input. Exposed to `dartpy` as
+    `load_gmsh_tet_mesh(path)` returning a
     `DeformableBodyOptions` (positions + tetrahedra). Adds parse / rejection /
     FEM-simulation regressions and a `Deformable FEM from .msh (IPC)` py-demos
     scene that loads a bundled tet-bar mesh and sags it as an FEM cantilever.

--- a/dart/simulation/experimental/io/gmsh_tet_mesh.cpp
+++ b/dart/simulation/experimental/io/gmsh_tet_mesh.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace dart::simulation::experimental::io {
 
@@ -44,6 +45,8 @@ namespace {
 
 // GMSH element type id for a 4-node (linear) tetrahedron.
 constexpr int kTetrahedronElementType = 4;
+
+using NodeIdMap = std::unordered_map<long long, std::size_t>;
 
 // Strip surrounding whitespace and a trailing CR (Windows line endings).
 std::string trimmed(const std::string& line)
@@ -56,13 +59,199 @@ std::string trimmed(const std::string& line)
   return line.substr(begin, end - begin + 1);
 }
 
+// Read the next line, stripped, throwing on truncation.
+std::string nextLine(std::istream& input, const char* context)
+{
+  std::string raw;
+  DART_EXPERIMENTAL_THROW_T_IF(
+      !std::getline(input, raw),
+      InvalidArgumentException,
+      "GMSH .msh: {}",
+      context);
+  return trimmed(raw);
+}
+
+// Read four 0-based remapped node indices from a tetrahedron element stream and
+// append the tetrahedron.
+void appendTetrahedron(
+    std::istream& element, TetMesh& mesh, const NodeIdMap& idToIndex)
+{
+  std::array<std::size_t, 4> tetrahedron{};
+  for (int k = 0; k < 4; ++k) {
+    long long nodeId = 0;
+    element >> nodeId;
+    DART_EXPERIMENTAL_THROW_T_IF(
+        !element,
+        InvalidArgumentException,
+        "GMSH .msh: malformed tetrahedron connectivity");
+    const auto found = idToIndex.find(nodeId);
+    DART_EXPERIMENTAL_THROW_T_IF(
+        found == idToIndex.end(),
+        InvalidArgumentException,
+        "GMSH .msh: tetrahedron references unknown node id {}",
+        nodeId);
+    tetrahedron[static_cast<std::size_t>(k)] = found->second;
+  }
+  mesh.tetrahedra.push_back(tetrahedron);
+}
+
+// --- Legacy format 2.x ------------------------------------------------------
+
+void parseNodesV2(std::istream& input, TetMesh& mesh, NodeIdMap& idToIndex)
+{
+  std::istringstream header(nextLine(input, "invalid $Nodes count"));
+  long long count = -1;
+  header >> count;
+  DART_EXPERIMENTAL_THROW_T_IF(
+      !header || count < 0,
+      InvalidArgumentException,
+      "GMSH .msh: invalid $Nodes count");
+  for (long long i = 0; i < count; ++i) {
+    std::istringstream node(nextLine(input, "truncated $Nodes block"));
+    long long id = 0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    node >> id >> x >> y >> z;
+    DART_EXPERIMENTAL_THROW_T_IF(
+        !node, InvalidArgumentException, "GMSH .msh: malformed node line");
+    idToIndex[id] = mesh.positions.size();
+    mesh.positions.emplace_back(x, y, z);
+  }
+}
+
+void parseElementsV2(
+    std::istream& input, TetMesh& mesh, const NodeIdMap& idToIndex)
+{
+  std::istringstream header(nextLine(input, "invalid $Elements count"));
+  long long count = -1;
+  header >> count;
+  DART_EXPERIMENTAL_THROW_T_IF(
+      !header || count < 0,
+      InvalidArgumentException,
+      "GMSH .msh: invalid $Elements count");
+  for (long long i = 0; i < count; ++i) {
+    std::istringstream element(nextLine(input, "truncated $Elements block"));
+    long long id = 0;
+    int type = 0;
+    int tagCount = 0;
+    element >> id >> type >> tagCount;
+    DART_EXPERIMENTAL_THROW_T_IF(
+        !element || tagCount < 0,
+        InvalidArgumentException,
+        "GMSH .msh: malformed element header");
+    for (int t = 0; t < tagCount; ++t) {
+      long long tag = 0;
+      element >> tag;
+    }
+    if (type == kTetrahedronElementType) {
+      appendTetrahedron(element, mesh, idToIndex);
+    }
+  }
+}
+
+// --- Format 4.x (entity blocks) ---------------------------------------------
+
+void parseNodesV4(std::istream& input, TetMesh& mesh, NodeIdMap& idToIndex)
+{
+  std::istringstream header(nextLine(input, "invalid $Nodes header"));
+  long long numBlocks = -1;
+  long long numNodes = 0;
+  long long minTag = 0;
+  long long maxTag = 0;
+  header >> numBlocks >> numNodes >> minTag >> maxTag;
+  DART_EXPERIMENTAL_THROW_T_IF(
+      !header || numBlocks < 0,
+      InvalidArgumentException,
+      "GMSH .msh: invalid $Nodes header");
+  for (long long b = 0; b < numBlocks; ++b) {
+    std::istringstream blockHeader(nextLine(input, "truncated $Nodes blocks"));
+    int dim = 0;
+    int tag = 0;
+    int parametric = 0;
+    long long blockNodes = -1;
+    blockHeader >> dim >> tag >> parametric >> blockNodes;
+    DART_EXPERIMENTAL_THROW_T_IF(
+        !blockHeader || blockNodes < 0,
+        InvalidArgumentException,
+        "GMSH .msh: malformed $Nodes block header");
+    // Format 4.1 lists all node tags in the block, then all coordinates.
+    std::vector<long long> tags(static_cast<std::size_t>(blockNodes));
+    for (long long k = 0; k < blockNodes; ++k) {
+      std::istringstream tagStream(nextLine(input, "truncated $Nodes tags"));
+      tagStream >> tags[static_cast<std::size_t>(k)];
+      DART_EXPERIMENTAL_THROW_T_IF(
+          !tagStream,
+          InvalidArgumentException,
+          "GMSH .msh: malformed node tag");
+    }
+    for (long long k = 0; k < blockNodes; ++k) {
+      std::istringstream coord(nextLine(input, "truncated $Nodes coordinates"));
+      double x = 0.0;
+      double y = 0.0;
+      double z = 0.0;
+      coord >> x >> y >> z;
+      DART_EXPERIMENTAL_THROW_T_IF(
+          !coord,
+          InvalidArgumentException,
+          "GMSH .msh: malformed node coordinate");
+      idToIndex[tags[static_cast<std::size_t>(k)]] = mesh.positions.size();
+      mesh.positions.emplace_back(x, y, z);
+    }
+  }
+}
+
+void parseElementsV4(
+    std::istream& input, TetMesh& mesh, const NodeIdMap& idToIndex)
+{
+  std::istringstream header(nextLine(input, "invalid $Elements header"));
+  long long numBlocks = -1;
+  long long numElements = 0;
+  long long minTag = 0;
+  long long maxTag = 0;
+  header >> numBlocks >> numElements >> minTag >> maxTag;
+  DART_EXPERIMENTAL_THROW_T_IF(
+      !header || numBlocks < 0,
+      InvalidArgumentException,
+      "GMSH .msh: invalid $Elements header");
+  for (long long b = 0; b < numBlocks; ++b) {
+    std::istringstream blockHeader(
+        nextLine(input, "truncated $Elements blocks"));
+    int dim = 0;
+    int tag = 0;
+    int type = 0;
+    long long blockElements = -1;
+    // In format 4.1 the element type is per block; every line is
+    // "<elementTag> <node ids...>".
+    blockHeader >> dim >> tag >> type >> blockElements;
+    DART_EXPERIMENTAL_THROW_T_IF(
+        !blockHeader || blockElements < 0,
+        InvalidArgumentException,
+        "GMSH .msh: malformed $Elements block header");
+    for (long long k = 0; k < blockElements; ++k) {
+      std::istringstream element(nextLine(input, "truncated $Elements block"));
+      if (type != kTetrahedronElementType) {
+        continue; // ignore points, lines, triangles, etc.
+      }
+      long long elementTag = 0;
+      element >> elementTag;
+      DART_EXPERIMENTAL_THROW_T_IF(
+          !element,
+          InvalidArgumentException,
+          "GMSH .msh: malformed element line");
+      appendTetrahedron(element, mesh, idToIndex);
+    }
+  }
+}
+
 } // namespace
 
 //==============================================================================
 TetMesh loadGmshTetMesh(std::istream& input)
 {
   TetMesh mesh;
-  std::unordered_map<long long, std::size_t> idToIndex;
+  NodeIdMap idToIndex;
+  int majorVersion = 0;
   bool sawFormat = false;
   bool sawNodes = false;
   bool sawElements = false;
@@ -72,94 +261,41 @@ TetMesh loadGmshTetMesh(std::istream& input)
     const std::string line = trimmed(raw);
 
     if (line == "$MeshFormat") {
-      std::getline(input, raw);
-      std::istringstream header(trimmed(raw));
+      std::istringstream header(nextLine(input, "missing $MeshFormat body"));
       double version = 0.0;
       int fileType = -1;
       header >> version >> fileType;
       DART_EXPERIMENTAL_THROW_T_IF(
-          !header || version < 2.0 || version >= 3.0,
+          !header || version < 2.0 || version >= 5.0,
           InvalidArgumentException,
-          "GMSH .msh: unsupported format version (only ASCII 2.x is "
+          "GMSH .msh: unsupported format version (only ASCII 2.x and 4.x are "
           "supported)");
       DART_EXPERIMENTAL_THROW_T_IF(
           fileType != 0,
           InvalidArgumentException,
           "GMSH .msh: binary format is not supported (expected ASCII)");
+      majorVersion = static_cast<int>(version);
       sawFormat = true;
     } else if (line == "$Nodes") {
-      std::getline(input, raw);
-      std::istringstream countStream(trimmed(raw));
-      long long count = -1;
-      countStream >> count;
       DART_EXPERIMENTAL_THROW_T_IF(
-          !countStream || count < 0,
+          !sawFormat,
           InvalidArgumentException,
-          "GMSH .msh: invalid $Nodes count");
-      for (long long i = 0; i < count; ++i) {
-        DART_EXPERIMENTAL_THROW_T_IF(
-            !std::getline(input, raw),
-            InvalidArgumentException,
-            "GMSH .msh: truncated $Nodes block");
-        std::istringstream node(trimmed(raw));
-        long long id = 0;
-        double x = 0.0;
-        double y = 0.0;
-        double z = 0.0;
-        node >> id >> x >> y >> z;
-        DART_EXPERIMENTAL_THROW_T_IF(
-            !node, InvalidArgumentException, "GMSH .msh: malformed node line");
-        idToIndex[id] = mesh.positions.size();
-        mesh.positions.emplace_back(x, y, z);
+          "GMSH .msh: $Nodes before $MeshFormat");
+      if (majorVersion >= 4) {
+        parseNodesV4(input, mesh, idToIndex);
+      } else {
+        parseNodesV2(input, mesh, idToIndex);
       }
       sawNodes = true;
     } else if (line == "$Elements") {
-      std::getline(input, raw);
-      std::istringstream countStream(trimmed(raw));
-      long long count = -1;
-      countStream >> count;
       DART_EXPERIMENTAL_THROW_T_IF(
-          !countStream || count < 0,
+          !sawFormat,
           InvalidArgumentException,
-          "GMSH .msh: invalid $Elements count");
-      for (long long i = 0; i < count; ++i) {
-        DART_EXPERIMENTAL_THROW_T_IF(
-            !std::getline(input, raw),
-            InvalidArgumentException,
-            "GMSH .msh: truncated $Elements block");
-        std::istringstream element(trimmed(raw));
-        long long id = 0;
-        int type = 0;
-        int tagCount = 0;
-        element >> id >> type >> tagCount;
-        DART_EXPERIMENTAL_THROW_T_IF(
-            !element || tagCount < 0,
-            InvalidArgumentException,
-            "GMSH .msh: malformed element header");
-        for (int t = 0; t < tagCount; ++t) {
-          long long tag = 0;
-          element >> tag;
-        }
-        if (type != kTetrahedronElementType) {
-          continue; // ignore points, lines, triangles, etc.
-        }
-        std::array<std::size_t, 4> tetrahedron{};
-        for (int k = 0; k < 4; ++k) {
-          long long nodeId = 0;
-          element >> nodeId;
-          DART_EXPERIMENTAL_THROW_T_IF(
-              !element,
-              InvalidArgumentException,
-              "GMSH .msh: malformed tetrahedron connectivity");
-          const auto found = idToIndex.find(nodeId);
-          DART_EXPERIMENTAL_THROW_T_IF(
-              found == idToIndex.end(),
-              InvalidArgumentException,
-              "GMSH .msh: tetrahedron references unknown node id {}",
-              nodeId);
-          tetrahedron[static_cast<std::size_t>(k)] = found->second;
-        }
-        mesh.tetrahedra.push_back(tetrahedron);
+          "GMSH .msh: $Elements before $MeshFormat");
+      if (majorVersion >= 4) {
+        parseElementsV4(input, mesh, idToIndex);
+      } else {
+        parseElementsV2(input, mesh, idToIndex);
       }
       sawElements = true;
     }

--- a/dart/simulation/experimental/io/gmsh_tet_mesh.hpp
+++ b/dart/simulation/experimental/io/gmsh_tet_mesh.hpp
@@ -51,12 +51,13 @@ struct TetMesh
   std::vector<std::array<std::size_t, 4>> tetrahedra;
 };
 
-/// Parse a GMSH ASCII ``.msh`` (format version 2.x) tetrahedral mesh from a
-/// stream. Reads the ``$Nodes`` block and the 4-node tetrahedron (``$Elements``
-/// element type 4) connectivity, remapping GMSH node ids to 0-based indices;
+/// Parse a GMSH ASCII ``.msh`` (format version 2.x or 4.x) tetrahedral mesh
+/// from a stream. Reads the ``$Nodes`` and the 4-node tetrahedron
+/// (``$Elements`` element type 4) connectivity for both the legacy (2.x) and
+/// entity-block (4.x) layouts, remapping GMSH node ids to 0-based indices;
 /// other element types (points, lines, triangles) are ignored. Throws
-/// ``InvalidArgumentException`` on malformed input or an unsupported (non-2.x
-/// or binary) format.
+/// ``InvalidArgumentException`` on malformed input or an unsupported (binary,
+/// or version &lt; 2 / &ge; 5) format.
 TetMesh loadGmshTetMesh(std::istream& input);
 
 /// Same as ``loadGmshTetMesh``, reading from a file path.

--- a/tests/unit/simulation/experimental/world/test_gmsh_tet_mesh.cpp
+++ b/tests/unit/simulation/experimental/world/test_gmsh_tet_mesh.cpp
@@ -95,6 +95,23 @@ TEST(GmshTetMesh, ParsesNodesAndTetrahedraIgnoringOtherElements)
 }
 
 //==============================================================================
+TEST(GmshTetMesh, ParsesFormat41EntityBlocks)
+{
+  // GMSH 4.1 entity-block layout: node tags then coordinates per block; a
+  // per-block element type. One tetrahedron over four nodes.
+  const io::TetMesh mesh = parse(
+      "$MeshFormat\n4.1 0 8\n$EndMeshFormat\n"
+      "$Nodes\n1 4 1 4\n2 1 0 4\n1\n2\n3\n4\n"
+      "0 0 0\n1 0 0\n0 1 0\n0 0 1\n$EndNodes\n"
+      "$Elements\n1 1 1 1\n3 1 4 1\n1 1 2 3 4\n$EndElements\n");
+
+  ASSERT_EQ(mesh.positions.size(), 4u);
+  ASSERT_EQ(mesh.tetrahedra.size(), 1u);
+  EXPECT_TRUE(mesh.positions[3].isApprox(Eigen::Vector3d(0.0, 0.0, 1.0)));
+  EXPECT_EQ(mesh.tetrahedra[0], (std::array<std::size_t, 4>{0, 1, 2, 3}));
+}
+
+//==============================================================================
 TEST(GmshTetMesh, RejectsMalformedAndUnsupportedMeshes)
 {
   // Unsupported (binary) format.
@@ -104,9 +121,9 @@ TEST(GmshTetMesh, RejectsMalformedAndUnsupportedMeshes)
           "$Elements\n0\n$EndElements\n"),
       sx::InvalidArgumentException);
 
-  // Unsupported version (4.x).
+  // Unsupported version (5.x is beyond the supported 2.x/4.x range).
   EXPECT_THROW(
-      parse("$MeshFormat\n4.1 0 8\n$EndMeshFormat\n"),
+      parse("$MeshFormat\n5.0 0 8\n$EndMeshFormat\n"),
       sx::InvalidArgumentException);
 
   // Tetra references an unknown node id.


### PR DESCRIPTION
## Summary

The GMSH `.msh` importer (#2792) parsed only the legacy **format 2.x** layout.
Modern GMSH (4.x) defaults to **format 4.1**, which stores `$Nodes` / `$Elements`
as **entity blocks** with a different structure. This extends the parser to
handle both, so the importer works with meshes produced by current GMSH.

## Details

`loadGmshTetMesh` now branches on the `$MeshFormat` major version:
- **2.x**: flat `<id> <x> <y> <z>` nodes and
  `<id> <type> <ntags> <tags…> <nodes…>` elements (unchanged).
- **4.x**: entity-block headers; `$Nodes` lists the block's node **tags** then
  its **coordinates**; `$Elements` carries a **per-block** element type (only
  type-4 tetrahedra are kept).

Shared node-id remapping + tetrahedron-append logic. Binary files and versions
`< 2` / `≥ 5` are still rejected.

## Tests

- `ParsesFormat41EntityBlocks`: parses a 4.1 entity-block mesh (tags-then-coords,
  per-block element type) into the same `TetMesh`.
- The version-rejection case is retargeted to 5.x (4.x is now supported); the
  2.x / malformed / FEM-simulation regressions are unchanged.
- `pixi run test-all`: **6/6 PASSED**.
