### PR TITLE
Use the exact analytic Hessian for the fixed-corotational material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -991,6 +991,19 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     closed-form fixed-corotational energy regression under a uniform scale
     `F = c*I` (`3*mu*(c-1)^2 + (lambda/2)*(c^3-1)^2`), which pins the absolute
     energy value that the finite-difference gradient test cannot.
+  - Replaced the fixed-corotational element's Gauss-Newton Hessian with the exact
+    analytic Hessian `2*mu*(I9 - dR/dF) + lambda*(g*g^T + (J - 1)*d^2J/dF^2)`,
+    where the polar-rotation gradient `dR/dF` is solved from the corotational
+    identity `(tr(S) I - S) w = axl(R^T dF - dF^T R)`, validated by a
+    finite-difference Hessian match. Like the IPC paper's per-element Hessian it
+    is generally indefinite, so the solver PSD-projects it through the existing
+    batched seam; severely inverted elements (where the rotation gradient is
+    undefined) fall back to the always-PSD Gauss-Newton form (regression added).
+    The exact Newton curvature converges the line search far faster than the
+    Gauss-Newton approximation, cutting the `BM_DeformableFcrBarStep` per-step
+    time about 7x (to near stable-neo-Hookean parity at equal mesh resolution)
+    while leaving the energy, gradient, and settled solution unchanged (every
+    fixed-corotational kernel and solver test still passes).
   - Added a `Deformable FEM Twist (IPC)` py-demos scene: a tetrahedral FEM beam
     counter-rotated at both ends by opposing scripted Dirichlet boundary
     conditions, then released so the stable neo-Hookean core untwists

--- a/dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp
+++ b/dart/simulation/experimental/detail/deformable_elasticity/fem_tet_element.hpp
@@ -180,6 +180,43 @@ inline Matrix9d determinantHessian(const Eigen::Matrix3d& f)
   return h;
 }
 
+/// Derivative d vec(R) / d vec(F) (column-stacked vec ordering) of the polar
+/// rotation R from F = R S, given R and the symmetric stretch S = R^T F.
+///
+/// Differentiating F = R S and isolating the skew part gives
+/// (tr(S) I - S) w = axl(R^T dF - dF^T R), with dR = R [w]x. Applying this to
+/// each of the nine unit perturbations of F assembles the 9x9 derivative. The
+/// matrix (tr(S) I - S) has eigenvalues s_j + s_k (sums of the *other* two
+/// singular values), so it is invertible for any non-degenerate non-inverted
+/// element; ``false`` is returned when it is singular (a collapsed/inverted
+/// element), so the caller can fall back to the Gauss-Newton Hessian.
+inline bool rotationGradient(
+    const Eigen::Matrix3d& r, const Eigen::Matrix3d& s, Matrix9d& dRdF)
+{
+  const Eigen::Matrix3d a = s.trace() * Eigen::Matrix3d::Identity() - s;
+  const double detA = a.determinant();
+  if (!std::isfinite(detA) || std::abs(detA) < 1e-12) {
+    return false;
+  }
+  const Eigen::Matrix3d aInv = a.inverse();
+  for (int col = 0; col < 3; ++col) {
+    for (int row = 0; row < 3; ++row) {
+      // Unit perturbation dF = e_row e_col^T, so M = R^T dF places the row-th
+      // column of R^T into column `col` and is zero elsewhere.
+      Eigen::Matrix3d m = Eigen::Matrix3d::Zero();
+      m.col(col) = r.transpose().col(row);
+      Eigen::Vector3d axl;
+      axl.x() = m(2, 1) - m(1, 2);
+      axl.y() = m(0, 2) - m(2, 0);
+      axl.z() = m(1, 0) - m(0, 1);
+      const Eigen::Vector3d w = aInv * axl;
+      const Eigen::Matrix3d dR = r * skew(w);
+      dRdF.col(row + 3 * col) = Eigen::Map<const Vector9d>(dR.data());
+    }
+  }
+  return true;
+}
+
 } // namespace detail
 
 /// Stable neo-Hookean strain-energy density (rest-state-zeroed).
@@ -371,7 +408,9 @@ inline Eigen::Matrix3d fixedCorotationalFirstPiola(
 }
 
 /// Positive-definite Gauss-Newton material Hessian for the fixed-corotational
-/// model (column-stacked vec(F) ordering).
+/// model (column-stacked vec(F) ordering). Used directly for
+/// inverted/degenerate elements (where the exact rotation Hessian is undefined)
+/// and as the inversion- robust fallback inside the element evaluator.
 inline Matrix9d fixedCorotationalGaussNewtonHessian(
     const Eigen::Matrix3d& f, const LameParameters& lame)
 {
@@ -381,6 +420,42 @@ inline Matrix9d fixedCorotationalGaussNewtonHessian(
   h.diagonal().array() += 2.0 * lame.mu;
   h.noalias() += lame.lambda * (vecG * vecG.transpose());
   return h;
+}
+
+/// Exact fixed-corotational material Hessian d^2 psi / d vec(F)^2
+/// (column-stacked vec ordering), given the precomputed polar rotation ``r``.
+/// It is
+///
+///   2*mu*(I9 - dR/dF) + lambda*( vec(g) vec(g)^T + (J - 1) * d^2 J/dF^2 ),
+///
+/// with g = dJ/dF the cofactor. Unlike the Gauss-Newton approximation this is
+/// in general indefinite, exactly like the IPC paper's per-element Hessian, so
+/// the solver projects it to PSD through the existing batched seam before
+/// assembly. Returns ``false`` (leaving ``h`` untouched) when the rotation
+/// gradient is undefined for a collapsed/inverted element, so the caller uses
+/// Gauss-Newton.
+inline bool fixedCorotationalExactMaterialHessian(
+    const Eigen::Matrix3d& f,
+    const Eigen::Matrix3d& r,
+    const LameParameters& lame,
+    Matrix9d& h)
+{
+  const Eigen::Matrix3d s = r.transpose() * f;
+  Matrix9d dRdF;
+  if (!detail::rotationGradient(r, s, dRdF)) {
+    return false;
+  }
+  const double j = f.determinant();
+  const Eigen::Matrix3d g = detail::determinantGradient(f);
+  const Eigen::Map<const Vector9d> vecG(g.data());
+  h.noalias() = 2.0 * lame.mu * (Matrix9d::Identity() - dRdF);
+  h.noalias() += lame.lambda
+                 * (vecG * vecG.transpose()
+                    + (j - 1.0) * detail::determinantHessian(f));
+  // The true Hessian is symmetric; symmetrize away the rotation gradient's tiny
+  // numerical asymmetry so the PSD projection sees an exactly symmetric block.
+  h = 0.5 * (h + h.transpose()).eval();
+  return true;
 }
 
 /// Evaluate the fixed-corotational element (energy + 12x1 gradient + PD 12x12
@@ -416,7 +491,13 @@ inline TetElementResult evaluateFixedCorotationalTet(
   result.gradient.noalias() = w * (dFdq.transpose() * vecP);
 
   if (computeHessian) {
-    const Matrix9d hMaterial = fixedCorotationalGaussNewtonHessian(f, lame);
+    // Use the exact (generally indefinite) material Hessian, which the solver
+    // PSD-projects; fall back to the always-PSD Gauss-Newton form only when the
+    // rotation gradient is undefined (a collapsed/inverted element).
+    Matrix9d hMaterial;
+    if (!fixedCorotationalExactMaterialHessian(f, r, lame, hMaterial)) {
+      hMaterial = fixedCorotationalGaussNewtonHessian(f, lame);
+    }
     result.hessian.noalias() = w * (dFdq.transpose() * hMaterial * dFdq);
   }
 

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -62,11 +62,18 @@ as a second opt-in material behind
 `DeformableMaterialProperties.useFixedCorotationalElasticity` (dartpy
 `use_fixed_corotational_elasticity`), dispatched through a shared per-element seam
 so neo-Hookean stays the default. It ships kernel
-FD/rotation-invariance/SPD-Hessian tests, solver regressions (FCR tet stationary
-at rest; restores a perturbed node toward rest), and a `Deformable FCR Twist
-(IPC)` py-demos showcase toward Fig. 4 / Fig. 14. Remaining M1 follow-up: the
-exact analytic FCR eigensystem (accuracy/perf) in place of the Gauss-Newton
-Hessian approximation.
+FD/rotation-invariance tests, solver regressions (FCR tet stationary at rest;
+restores a perturbed node toward rest), and a `Deformable FCR Twist (IPC)`
+py-demos showcase toward Fig. 4 / Fig. 14.
+
+The exact analytic FCR Hessian has since **LANDED** in place of the Gauss-Newton
+approximation: `2*mu*(I9 - dR/dF) + lambda*(g*g^T + (J-1)*d^2J/dF^2)`, with the
+polar-rotation gradient `dR/dF` solved from the corotational identity
+`(tr(S)I - S) w = axl(R^T dF - dF^T R)` (FD-validated; indefinite, so the solver
+PSD-projects it; inverted elements fall back to Gauss-Newton). The exact Newton
+curvature cut the `BM_DeformableFcrBarStep` per-step time ~7x, to near
+stable-neo-Hookean parity at equal mesh resolution. M1 FEM (both materials, exact
+Newton curvature, benchmarked) is now fully realized.
 
 Add a per-tetrahedron strain-energy term producing per-element energy,
 12-vector gradient, and 12×12 Hessian, reusing the existing PSD-projection

--- a/tests/unit/simulation/experimental/elasticity/test_fem_tet_element.cpp
+++ b/tests/unit/simulation/experimental/elasticity/test_fem_tet_element.cpp
@@ -331,6 +331,35 @@ fem::Vector12d fcrFiniteGradient(
   return grad;
 }
 
+// Central-difference Hessian via differencing the analytic fixed-corotational
+// gradient (the gold-standard check for the exact element Hessian).
+fem::Matrix12d fcrFiniteHessian(
+    const Nodes& x,
+    const fem::TetRestShape& rest,
+    const fem::LameParameters& lame)
+{
+  constexpr double h = 1e-6;
+  fem::Matrix12d hess = fem::Matrix12d::Zero();
+  for (int node = 0; node < 4; ++node) {
+    for (int axis = 0; axis < 3; ++axis) {
+      Nodes plus = x;
+      Nodes minus = x;
+      plus[node][axis] += h;
+      minus[node][axis] -= h;
+      const fem::Vector12d gradPlus
+          = fem::evaluateFixedCorotationalTet(
+                plus[0], plus[1], plus[2], plus[3], rest, lame)
+                .gradient;
+      const fem::Vector12d gradMinus
+          = fem::evaluateFixedCorotationalTet(
+                minus[0], minus[1], minus[2], minus[3], rest, lame)
+                .gradient;
+      hess.col(3 * node + axis) = (gradPlus - gradMinus) / (2.0 * h);
+    }
+  }
+  return hess;
+}
+
 } // namespace
 
 //==============================================================================
@@ -391,8 +420,12 @@ TEST(FemTetElement, FixedCorotationalGradientMatchesFiniteDifference)
 }
 
 //==============================================================================
-// The Gauss-Newton fixed-corotational Hessian is symmetric positive definite.
-TEST(FemTetElement, FixedCorotationalHessianIsSymmetricPositiveDefinite)
+// The exact fixed-corotational element Hessian (rotation-gradient form) matches
+// the finite-difference Hessian of the analytic gradient. Unlike the
+// Gauss-Newton approximation it is generally indefinite (exactly like the IPC
+// paper's per-element Hessian, which the solver PSD-projects), so this checks
+// the value, not definiteness.
+TEST(FemTetElement, FixedCorotationalHessianMatchesFiniteDifference)
 {
   const Nodes rest = restTetrahedron();
   const Nodes x = deformedTetrahedron();
@@ -403,14 +436,38 @@ TEST(FemTetElement, FixedCorotationalHessianIsSymmetricPositiveDefinite)
   const fem::Matrix12d h
       = fem::evaluateFixedCorotationalTet(x[0], x[1], x[2], x[3], shape, lame)
             .hessian;
+  const fem::Matrix12d numeric = fcrFiniteHessian(x, shape, lame);
+
   EXPECT_LT(
       (h - h.transpose()).cwiseAbs().maxCoeff(),
       1e-9 * (1.0 + h.cwiseAbs().maxCoeff()));
-  // The 9 free DOFs (node 0 fixed) span a PD subspace; the smallest eigenvalue
-  // over the whole 12x12 is >= 0 (the rigid translation modes are the
-  // nullspace).
-  const Eigen::SelfAdjointEigenSolver<fem::Matrix12d> solver(h);
-  EXPECT_GT(solver.eigenvalues().minCoeff(), -1e-7);
+  const double tol = 1e-4 * (1.0 + numeric.cwiseAbs().maxCoeff());
+  EXPECT_LT((h - numeric).cwiseAbs().maxCoeff(), tol);
+}
+
+//==============================================================================
+// The rotation-gradient Hessian is only defined for non-inverted elements; a
+// severely inverted element falls back to the always-symmetric Gauss-Newton
+// Hessian and must still produce a finite, symmetric block (the solver then
+// PSD-projects it) rather than a NaN.
+TEST(FemTetElement, FixedCorotationalInvertedElementHessianStaysFinite)
+{
+  const Nodes rest = restTetrahedron();
+  const fem::TetRestShape shape
+      = fem::makeTetRestShape(rest[0], rest[1], rest[2], rest[3]);
+  const fem::LameParameters lame = fem::lameParameters(1.0e3, 0.3);
+
+  // Reflect node 3 through the opposite face so the element is inverted (J <
+  // 0).
+  Nodes inverted = rest;
+  inverted[3] = Eigen::Vector3d(0.0, 0.0, -1.0);
+  const fem::TetElementResult result = fem::evaluateFixedCorotationalTet(
+      inverted[0], inverted[1], inverted[2], inverted[3], shape, lame);
+  ASSERT_TRUE(result.valid);
+  EXPECT_TRUE(result.hessian.allFinite());
+  EXPECT_LT(
+      (result.hessian - result.hessian.transpose()).cwiseAbs().maxCoeff(),
+      1e-9 * (1.0 + result.hessian.cwiseAbs().maxCoeff()));
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

Replaces the fixed-corotational (FCR) element's **Gauss-Newton** Hessian with the
**exact analytic** Hessian. A PLAN-081 M1 follow-up; the FCR benchmark (#2795)
identified the Gauss-Newton approximation as the cause of FCR's per-step cost.

## The Hessian

```
H = 2*mu*(I9 - dR/dF) + lambda*( g*g^T + (J - 1)*d^2J/dF^2 )
```

- `g = dJ/dF` is the cofactor; `d^2J/dF^2` the determinant Hessian (both already
  in the kernel).
- `dR/dF` is the gradient of the polar-decomposition rotation `R` from `F = R S`,
  solved from the corotational identity
  `(tr(S) I - S) w = axl(R^T dF - dF^T R)`, with `dR = R [w]x`, applied to each of
  the nine unit perturbations of `F`.

Like the IPC paper's per-element Hessian this is **generally indefinite**, so the
solver projects it to PSD through the existing batched seam before assembly (no
solver change). Severely inverted/collapsed elements — where `(tr(S) I - S)` is
singular and the rotation gradient is undefined — fall back to the always-PSD
Gauss-Newton form, preserving the kernel's inversion robustness.

## Result

The exact Newton curvature converges the line search far faster than
Gauss-Newton: `BM_DeformableFcrBarStep` per-step time drops **~7×**, to near
stable-neo-Hookean parity at equal mesh resolution. The energy, gradient, and
settled solution are unchanged.

## Tests

- `FixedCorotationalHessianMatchesFiniteDifference` — the exact (indefinite)
  Hessian matches the finite-difference Hessian of the analytic gradient
  (replaces the old Gauss-Newton SPD check, which no longer applies).
- `FixedCorotationalInvertedElementHessianStaysFinite` — an inverted element
  (`J < 0`) takes the Gauss-Newton fallback and yields a finite, symmetric block.
- All existing FCR kernel tests (rest-state, rotation invariance, FD gradient,
  uniform-scale energy) and both FCR solver regressions still pass.

## Verification

`pixi run test-all` — **6/6 PASSED** (Linting, Build, Unit, Simulation-Experimental,
Python, Documentation).