### PR TITLE
Add a FEM self-contact showcase: a beam buckling onto itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1017,6 +1017,17 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     stage/pipeline API. The user-supplied-pipeline `step` overloads leave it
     unchanged (read the stage's own `getLastStats` there). Adds C++ and Python
     regressions.
+  - Added a `Deformable FEM Self-Contact (IPC)` py-demos scene: a slender
+    tetrahedral FEM beam whose pinned ends are driven toward each other by
+    opposing scripted Dirichlet boundaries, so the soft FEM core buckles and
+    folds onto itself; the always-on clamped-log self-contact barrier holds the
+    folding surface apart at a positive separation. This is the first DART-native
+    showcase of self-collision (the heart of the IPC method) on a volumetric FEM
+    body, toward the paper's self-collision stress tests, with a reusable
+    `build_fem_compression_bar` bridge helper. A regression drives the beam
+    through the buckle and asserts -- via the new solver diagnostics -- that the
+    self-contact barrier activates, holds every active contact at a strictly
+    positive distance (no interpenetration), and keeps the solve finite.
   - Added a `Deformable FEM Twist (IPC)` py-demos scene: a tetrahedral FEM beam
     counter-rotated at both ends by opposing scripted Dirichlet boundary
     conditions, then released so the stable neo-Hookean core untwists

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -75,6 +75,14 @@ curvature cut the `BM_DeformableFcrBarStep` per-step time ~7x, to near
 stable-neo-Hookean parity at equal mesh resolution. M1 FEM (both materials, exact
 Newton curvature, benchmarked) is now fully realized.
 
+FEM **self-contact** is also now demonstrated end-to-end: a `Deformable FEM
+Self-Contact (IPC)` showcase compresses a slender FEM beam end-to-end until it
+buckles and folds onto itself, and the always-on clamped-log self-contact barrier
+holds the folding surface at a strictly positive separation (verified via the new
+`World` solver diagnostics: the barrier activates, every active contact stays at
+a positive distance, and the solve stays finite). This couples the FEM keystone
+with the IPC self-collision machinery on a volumetric body.
+
 Add a per-tetrahedron strain-energy term producing per-element energy,
 12-vector gradient, and 12×12 Hessian, reusing the existing PSD-projection
 batch seam and sparse projected-Newton assembly. Material from the existing

--- a/python/examples/demos/_ipc_deformable_bridge.py
+++ b/python/examples/demos/_ipc_deformable_bridge.py
@@ -339,6 +339,55 @@ def build_fem_twist_bar(
     return options, edges
 
 
+def build_fem_compression_bar(
+    *,
+    cells_x: int,
+    cells_y: int,
+    cells_z: int,
+    cell_size: float,
+    origin: Sequence[float],
+    youngs_modulus: float,
+    compression_rate: float,
+    compression_end_time: float,
+    poisson_ratio: float = 0.3,
+    density: float = 1.0e3,
+) -> tuple["sx.DeformableBodyOptions", list[tuple[int, int]]]:
+    """A slender FEM beam whose two pinned end faces are driven toward each other.
+
+    Opposing scripted ``DeformableDirichletBoundaryCondition``s translate the end
+    faces inward (along the bar's long x axis) at ``compression_rate`` until
+    ``compression_end_time``; the soft FEM core buckles and folds onto itself, so
+    its surface comes into contact with itself. This exercises the self-contact
+    barrier on a volumetric FEM body -- a DART-native step toward the IPC paper's
+    self-collision stress tests.
+    """
+
+    positions, tetrahedra, edges, node_index, (nx, ny, nz) = _fem_bar_mesh(
+        cells_x, cells_y, cells_z, cell_size, origin
+    )
+    options = _fem_bar_options(
+        positions, tetrahedra, youngs_modulus, poisson_ratio, density
+    )
+
+    axis_y = origin[1] + 0.5 * cells_y * cell_size
+    axis_z = origin[2] + 0.5 * cells_z * cell_size
+
+    def end_face(i: int) -> list[int]:
+        return [node_index(i, j, k) for k in range(nz) for j in range(ny)]
+
+    conditions = []
+    for face_i, sign in ((0, 1.0), (nx - 1, -1.0)):
+        condition = sx.DeformableDirichletBoundaryCondition()
+        condition.nodes = end_face(face_i)
+        condition.linear_velocity = np.array([sign * compression_rate, 0.0, 0.0])
+        condition.center = np.array([origin[0] + face_i * cell_size, axis_y, axis_z])
+        condition.start_time = 0.0
+        condition.end_time = compression_end_time
+        conditions.append(condition)
+    options.dirichlet_boundary_conditions = conditions
+    return options, edges
+
+
 class IpcDeformableBridge:
     """Mirrors sx deformable bodies onto a render `dart.simulation.World`."""
 

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -22,13 +22,14 @@ from .scenes.empty import SCENE as EMPTY
 from .scenes.experimental_rigid_body_gui import SCENE as EXPERIMENTAL_RIGID_BODY_GUI
 from .scenes.free_joint_cases import SCENE as FREE_JOINT_CASES
 from .scenes.hardcoded_design import SCENE as HARDCODED_DESIGN
-from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.heightmap import SCENE as HEIGHTMAP
+from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.hybrid_dynamics import SCENE as HYBRID_DYNAMICS
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
 from .scenes.ipc_deformable_fcr_twist import SCENE as IPC_DEFORMABLE_FCR_TWIST
 from .scenes.ipc_deformable_fem_bar import SCENE as IPC_DEFORMABLE_FEM_BAR
 from .scenes.ipc_deformable_fem_box import SCENE as IPC_DEFORMABLE_FEM_BOX
+from .scenes.ipc_deformable_fem_buckle import SCENE as IPC_DEFORMABLE_FEM_BUCKLE
 from .scenes.ipc_deformable_fem_drop import SCENE as IPC_DEFORMABLE_FEM_DROP
 from .scenes.ipc_deformable_fem_msh import SCENE as IPC_DEFORMABLE_FEM_MSH
 from .scenes.ipc_deformable_fem_sphere import SCENE as IPC_DEFORMABLE_FEM_SPHERE
@@ -140,6 +141,7 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_FEM_DROP,
         IPC_DEFORMABLE_FEM_SPHERE,
         IPC_DEFORMABLE_FEM_BOX,
+        IPC_DEFORMABLE_FEM_BUCKLE,
         IPC_DEFORMABLE_FEM_MSH,
         IPC_DEFORMABLE_SCRIPTED,
     ]

--- a/python/examples/demos/scenes/ipc_deformable_fem_buckle.py
+++ b/python/examples/demos/scenes/ipc_deformable_fem_buckle.py
@@ -1,0 +1,65 @@
+"""FEM self-contact under compression (experimental IPC deformable solver).
+
+A slender tetrahedralized beam is gripped at both ends and the grips are driven
+toward each other, so the soft FEM core buckles and folds onto itself. Where the
+folding surface would pass through itself, the IPC clamped-log self-contact
+barrier holds it apart at a positive separation -- self-collision is the heart of
+the IPC method, here on a volumetric FEM body. This is a DART-native step toward
+the paper's self-collision stress tests (e.g. the mat/rod buckling figures),
+driven by the opt-in FEM elasticity (PLAN-081) plus scripted Dirichlet boundary
+conditions and the always-on surface self-contact barrier.
+
+DART-native FEM showcase -- not a faithful paper-figure reproduction; it isolates
+volumetric FEM elasticity colliding with itself under a prescribed compression.
+"""
+
+from __future__ import annotations
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_fem_compression_bar
+from ..runner import PythonDemoScene, SceneSetup
+
+
+def build() -> SceneSetup:
+    options, edges = build_fem_compression_bar(
+        cells_x=24,
+        cells_y=2,
+        cells_z=2,
+        cell_size=0.05,
+        origin=(-0.6, -0.05, 0.5),
+        youngs_modulus=2.0e4,
+        compression_rate=0.12,
+        compression_end_time=3.0,
+        poisson_ratio=0.3,
+        density=1.0e3,
+    )
+
+    world = sx.World()
+    world.gravity = [
+        0.0,
+        0.0,
+        -3.0,
+    ]  # gentle downward bias breaks the buckling symmetry
+    world.time_step = 0.004
+    body = world.add_deformable_body("fem_buckle", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_fem_buckle")
+    bridge.add_deformable_visual(body, name="fem_buckle", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_fem_buckle",
+    title="Deformable FEM Self-Contact (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A tetrahedral FEM beam is compressed end-to-end until it buckles "
+    "and folds onto itself, held apart by the self-contact barrier.",
+    build=build,
+)

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -94,6 +94,56 @@ def test_ipc_deformable_grid_builder_topology() -> None:
     assert (second.node_a, second.node_b, second.node_c) == (1, columns + 1, columns)
 
 
+def test_ipc_deformable_fem_self_contact_activates_under_compression() -> None:
+    """The FEM buckling showcase actually self-collides, intersection-free.
+
+    Driving a slender FEM beam's pinned ends together makes it buckle and fold
+    onto itself; the self-contact barrier must (a) activate and (b) hold the
+    folding surface at a positive separation (no interpenetration), with the
+    solve staying finite. Verified through the solver-diagnostics snapshot.
+    """
+
+    import dartpy.simulation_experimental as sx
+    import numpy as np
+    from examples.demos._ipc_deformable_bridge import build_fem_compression_bar
+
+    options, _edges = build_fem_compression_bar(
+        cells_x=24,
+        cells_y=2,
+        cells_z=2,
+        cell_size=0.05,
+        origin=(-0.6, -0.05, 0.5),
+        youngs_modulus=2.0e4,
+        compression_rate=0.12,
+        compression_end_time=3.0,
+    )
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -3.0]
+    world.time_step = 0.004
+    body = world.add_deformable_body("fem_buckle", options)
+    world.enter_simulation_mode()
+
+    max_active = 0
+    positive_separation_samples = 0
+    for _ in range(260):
+        world.step()
+        diag = world.last_deformable_solver_diagnostics
+        max_active = max(max_active, diag.self_contact_barrier_active_contacts)
+        if diag.converged_active_contact_count > 0:
+            # The barrier must hold the active contacts strictly apart.
+            assert diag.min_active_contact_distance > 0.0
+            positive_separation_samples += 1
+
+    # The beam self-collided (the barrier activated) over the compression.
+    assert max_active > 0
+    assert positive_separation_samples > 0
+
+    # The solve stayed finite throughout (the barrier never let it blow up).
+    final = np.array([body.node_position(i) for i in range(body.node_count)])
+    assert np.isfinite(final).all()
+
+
 def test_ipc_deformable_scenes_share_dedicated_category() -> None:
     """The IPC deformable scenes live in their own dedicated menu category.
 
@@ -115,6 +165,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_fem_drop",
         "ipc_deformable_fem_sphere",
         "ipc_deformable_fem_box",
+        "ipc_deformable_fem_buckle",
         "ipc_deformable_fem_msh",
         "ipc_deformable_scripted_dirichlet",
     }


### PR DESCRIPTION
## Summary

Adds the first DART-native showcase of **self-collision** — the heart of the IPC
method — on a volumetric FEM body. A `Deformable FEM Self-Contact (IPC)` py-demos
scene drives a slender tetrahedral FEM beam's two pinned end faces toward each
other (opposing scripted Dirichlet boundaries), so the soft FEM core buckles and
folds onto itself; the always-on clamped-log self-contact barrier holds the
folding surface apart at a positive separation.

This couples the FEM elasticity keystone (PLAN-081) with the surface self-contact
barrier, toward the paper's self-collision stress tests.

## What's added

- `build_fem_compression_bar` — a reusable bridge helper (sibling of the
  twist-bar builder) that drives the end faces inward via linear-velocity
  Dirichlet boundaries.
- `ipc_deformable_fem_buckle.py` — the scene, in the `IPC Deformable (sx)`
  category.

## Verification

A regression (`test_ipc_deformable_fem_self_contact_activates_under_compression`)
steps the beam through the buckle and asserts — via the `World` solver
diagnostics (#2797) — that:

- the self-contact barrier **activates** (`self_contact_barrier_active_contacts > 0`),
- every converged active contact stays at a **strictly positive distance**
  (`min_active_contact_distance > 0` → no interpenetration),
- the solve stays **finite** throughout.

Empirically the barrier holds the folding surface at ~0.014–0.020 separation
(within the `d_hat = 0.02` band) while self-contacts grow into the hundreds. The
demos-cycle smoke also builds and steps the scene.

`pixi run test-all` — **6/6 PASSED**.