### PR TITLE
Add a capsule rod obstacle barrier for deformable bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1070,6 +1070,21 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     `FemCubeSettlesOnBoxObstacleWithoutPenetrating` regressions and a
     `Deformable FEM over Box (IPC)` py-demos scene (a FEM slab draping over a box
     obstacle).
+  - Added a capsule (rod/wire) collision shape and a static **capsule obstacle
+    barrier** for the experimental deformable solver (PLAN-081 M3 codimensional
+    collision objects). `CollisionShape::makeCapsule(radius, halfHeight)` adds a
+    `Capsule` shape type (a body-z-axis segment swept by a radius; exposed to
+    dartpy as `CollisionShape.capsule`). A static capsule opted in as a
+    deformable obstacle exerts the same clamped-log barrier (energy, gradient,
+    and rank-1 radial Hessian) as the sphere/box obstacles, with the surface
+    distance and outward normal taken from the analytic point-to-segment closest
+    point (`|node - closestOnAxis| - radius`). Unlike the sphere/box surface-CCD
+    obstacles the capsule is barrier-only, so a connected sheet drapes over it
+    freely. Adds a `CapsuleObstacleBarrierRepelsNodeRadially` solver regression,
+    a draped-cloth intersection-free regression, and a `Deformable Cloth over
+Capsule Rod (IPC)` py-demos scene (a cloth draping over a horizontal rod,
+    toward the paper's Fig. 18 codimensional-roller theme). The native collision
+    engine approximates a capsule by its bounding box for rigid-rigid queries.
   - Added `.seg` (segment) and `.pt` (point) codimensional-geometry importers
     (PLAN-081 M3 asset pipeline), completing the experimental importer set
     alongside `.msh` (tets) and `.obj` (triangles).

--- a/dart/simulation/experimental/body/collision_shape.hpp
+++ b/dart/simulation/experimental/body/collision_shape.hpp
@@ -47,6 +47,8 @@ enum class CollisionShapeType
   Sphere,
   Box,
   Mesh,
+  // Appended last so the serialized ordinals of the earlier types are stable.
+  Capsule,
 };
 
 /// Public value object describing a body's collision geometry.
@@ -66,7 +68,9 @@ struct CollisionShape
   double radius = 0.5;
 
   /// Box half extents along the body x/y/z axes (used when type == Box). Each
-  /// component must be positive.
+  /// component must be positive. For a Capsule, `halfExtents.z()` doubles as
+  /// the axial half-height (the segment runs +/- that distance along the body z
+  /// axis, swept by `radius`); this reuse keeps the serialized layout stable.
   Eigen::Vector3d halfExtents = Eigen::Vector3d::Constant(0.5);
 
   /// Mesh vertices in the body frame (used when type == Mesh).
@@ -103,6 +107,20 @@ struct CollisionShape
     shape.type = CollisionShapeType::Mesh;
     shape.vertices = std::move(vertices);
     shape.triangles = std::move(triangles);
+    return shape;
+  }
+
+  /// Create a capsule collision shape (a z-axis segment of half-length
+  /// `halfHeight` swept by `radius`). Both must be positive. The half-height is
+  /// stored in `halfExtents.z()` (x/y are set to `radius` so every component
+  /// stays positive for the shared shape validators).
+  [[nodiscard]] static CollisionShape makeCapsule(
+      double radius, double halfHeight)
+  {
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = radius;
+    shape.halfExtents = Eigen::Vector3d(radius, radius, halfHeight);
     return shape;
   }
 };

--- a/dart/simulation/experimental/body/rigid_body.cpp
+++ b/dart/simulation/experimental/body/rigid_body.cpp
@@ -105,6 +105,16 @@ void validateCollisionShape(
           "{} box collision shape half extents must be positive and finite",
           ownerName);
       break;
+    case CollisionShapeType::Capsule:
+      DART_EXPERIMENTAL_THROW_T_IF(
+          !std::isfinite(shape.radius) || shape.radius <= 0.0
+              || !std::isfinite(shape.halfExtents.z())
+              || shape.halfExtents.z() <= 0.0,
+          InvalidArgumentException,
+          "{} capsule collision shape radius and half-height must be positive "
+          "and finite",
+          ownerName);
+      break;
     case CollisionShapeType::Mesh: {
       DART_EXPERIMENTAL_THROW_T_IF(
           shape.vertices.empty(),

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -802,6 +802,19 @@ struct BoxObstacleBarrier
   Eigen::Vector3d halfExtents = Eigen::Vector3d::Zero();
 };
 
+// A static capsule (a segment swept by a radius -- a rod/wire) opted in as a
+// deformable obstacle exerts a clamped-log barrier on nearby deformable nodes
+// along the outward radial normal. The closest point on the capsule surface is
+// found from the point-to-segment closest point, so the distance is
+// |node - closestOnSegment| - radius. This is the codimensional (1D) obstacle
+// analogue of the sphere (0D point) and box obstacles.
+struct CapsuleObstacleBarrier
+{
+  Eigen::Vector3d pointA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d pointB = Eigen::Vector3d::Zero();
+  double radius = 0.0;
+};
+
 //==============================================================================
 struct DeformableContactSolverScratch
 {
@@ -1699,6 +1712,7 @@ std::vector<StaticGroundBarrier> collectStaticGroundBarriers(const World& world)
         barriers.push_back(barrier);
         break;
       }
+      case CollisionShapeType::Capsule:
       case CollisionShapeType::Mesh:
         break;
     }
@@ -1767,6 +1781,43 @@ std::vector<BoxObstacleBarrier> collectBoxObstacleBarriers(const World& world)
     obstacle.center = transform.position;
     obstacle.rotation = transform.orientation.normalized().toRotationMatrix();
     obstacle.halfExtents = geometry.shape.halfExtents;
+    obstacles.push_back(obstacle);
+  }
+  return obstacles;
+}
+
+//==============================================================================
+std::vector<CapsuleObstacleBarrier> collectCapsuleObstacleBarriers(
+    const World& world)
+{
+  const auto& registry = world.getRegistry();
+  auto view = registry.view<
+      comps::RigidBodyTag,
+      comps::StaticBodyTag,
+      comps::DeformableSurfaceCcdObstacleTag,
+      comps::CollisionGeometry,
+      comps::Transform>();
+
+  std::vector<CapsuleObstacleBarrier> obstacles;
+  for (const auto entity : view) {
+    const auto& geometry = view.get<comps::CollisionGeometry>(entity);
+    const auto& transform = view.get<comps::Transform>(entity);
+    const double radius = geometry.shape.radius;
+    const double halfHeight = geometry.shape.halfExtents.z();
+    if (geometry.shape.type != CollisionShapeType::Capsule || !(radius > 0.0)
+        || !std::isfinite(radius) || !(halfHeight > 0.0)
+        || !std::isfinite(halfHeight) || !transform.position.allFinite()
+        || !transform.orientation.coeffs().allFinite()) {
+      continue;
+    }
+    // The capsule axis is the body z axis; map its two segment endpoints into
+    // the world frame.
+    const Eigen::Vector3d axis
+        = transform.orientation.normalized().toRotationMatrix().col(2);
+    CapsuleObstacleBarrier obstacle;
+    obstacle.pointA = transform.position - halfHeight * axis;
+    obstacle.pointB = transform.position + halfHeight * axis;
+    obstacle.radius = radius;
     obstacles.push_back(obstacle);
   }
   return obstacles;
@@ -2377,6 +2428,85 @@ double boxObstacleSurfaceDistance(
     outwardNormal = obstacle.rotation * (delta / distance);
   }
   return distance;
+}
+
+//==============================================================================
+// Closest-surface distance from a node to a capsule obstacle, with the outward
+// radial surface normal set when positive. The distance is the point-to-segment
+// axis distance minus the radius; the normal points from the closest axis point
+// to the node.
+double capsuleObstacleSurfaceDistance(
+    const Eigen::Vector3d& position,
+    const CapsuleObstacleBarrier& obstacle,
+    Eigen::Vector3d& outwardNormal)
+{
+  const Eigen::Vector3d axis = obstacle.pointB - obstacle.pointA;
+  const double axisLengthSq = axis.squaredNorm();
+  double t = 0.0;
+  if (axisLengthSq > 0.0) {
+    t = (position - obstacle.pointA).dot(axis) / axisLengthSq;
+    t = std::clamp(t, 0.0, 1.0);
+  }
+  const Eigen::Vector3d closest = obstacle.pointA + t * axis;
+  const Eigen::Vector3d delta = position - closest;
+  const double axisDistance = delta.norm();
+  if (axisDistance > 0.0 && std::isfinite(axisDistance)) {
+    outwardNormal = delta / axisDistance;
+  }
+  return axisDistance - obstacle.radius;
+}
+
+//==============================================================================
+// Adds the clamped-log barrier energy/gradient pushing free deformable nodes
+// out of the activation band of a capsule obstacle, along the outward radial
+// normal. The capsule analogue of addBoxObstacleBarrierEnergy.
+double addCapsuleObstacleBarrierEnergy(
+    const std::vector<Eigen::Vector3d>& positions,
+    const std::vector<std::uint8_t>& fixed,
+    const std::vector<CapsuleObstacleBarrier>& obstacles,
+    std::vector<Eigen::Vector3d>* gradient)
+{
+  if (obstacles.empty()) {
+    return 0.0;
+  }
+
+  const double activationDistance = staticGroundBarrierActivationDistance();
+  constexpr double barrierScale = 25.0;
+
+  double energy = 0.0;
+  for (std::size_t i = 0; i < positions.size(); ++i) {
+    if (fixed[i] != 0u) {
+      continue;
+    }
+
+    for (const auto& obstacle : obstacles) {
+      Eigen::Vector3d normal;
+      const double distance
+          = capsuleObstacleSurfaceDistance(positions[i], obstacle, normal);
+      if (distance <= 0.0 || !std::isfinite(distance)) {
+        // On or inside the capsule: a penetration the barrier forbids.
+        return std::numeric_limits<double>::infinity();
+      }
+      if (distance >= activationDistance) {
+        continue;
+      }
+
+      const double normalizedDistance = distance / activationDistance;
+      const double distanceOffset = distance - activationDistance;
+      energy += -barrierScale * distanceOffset * distanceOffset
+                * std::log(normalizedDistance);
+
+      if (gradient != nullptr) {
+        const double derivative
+            = -barrierScale
+              * (2.0 * distanceOffset * std::log(normalizedDistance)
+                 + distanceOffset * distanceOffset / distance);
+        (*gradient)[i] += derivative * normal;
+      }
+    }
+  }
+
+  return energy;
 }
 
 //==============================================================================
@@ -3024,6 +3154,7 @@ double evaluateDeformableObjective(
     const std::vector<StaticGroundBarrier>& barriers,
     const std::vector<SphereObstacleBarrier>& sphereObstacles,
     const std::vector<BoxObstacleBarrier>& boxObstacles,
+    const std::vector<CapsuleObstacleBarrier>& capsuleObstacles,
     double timeStep,
     std::vector<Eigen::Vector3d>* gradient,
     const SelfContactBarrierInputs* contactBarrier = nullptr,
@@ -3085,6 +3216,8 @@ double evaluateDeformableObjective(
       positions, fixed, sphereObstacles, gradient);
   energy
       += addBoxObstacleBarrierEnergy(positions, fixed, boxObstacles, gradient);
+  energy += addCapsuleObstacleBarrierEnergy(
+      positions, fixed, capsuleObstacles, gradient);
   if (contactBarrier != nullptr) {
     energy += addSelfContactBarrierEnergy(
         positions, fixed, *contactBarrier, barrierActiveContacts, gradient);
@@ -3847,6 +3980,7 @@ bool computeProjectedNewtonDirection(
     const std::vector<StaticGroundBarrier>& barriers,
     const std::vector<SphereObstacleBarrier>& sphereObstacles,
     const std::vector<BoxObstacleBarrier>& boxObstacles,
+    const std::vector<CapsuleObstacleBarrier>& capsuleObstacles,
     const SelfContactBarrierInputs* contactBarrier,
     const GroundFrictionInputs* groundFriction,
     const SelfContactFrictionInputs* selfContactFriction,
@@ -4184,6 +4318,38 @@ bool computeProjectedNewtonDirection(
     }
   }
 
+  // Capsule obstacle barrier Hessian: the same rank-1 radial block as the
+  // sphere/box obstacle barriers (curvature * n n^T along the outward radial
+  // normal; the tangential eigenvalues are non-positive and drop out under PSD
+  // projection).
+  if (!capsuleObstacles.empty()) {
+    const double activationDistance = staticGroundBarrierActivationDistance();
+    constexpr double barrierScale = 25.0;
+    for (std::size_t i = 0; i < nodeCount; ++i) {
+      if (!isFree(i)) {
+        continue;
+      }
+      for (const auto& obstacle : capsuleObstacles) {
+        Eigen::Vector3d normal;
+        const double d
+            = capsuleObstacleSurfaceDistance(positions[i], obstacle, normal);
+        if (d <= 0.0 || d >= activationDistance || !std::isfinite(d)) {
+          continue;
+        }
+        const double distanceOffset = d - activationDistance;
+        const double logRatio = std::log(d / activationDistance);
+        const double second = -barrierScale
+                              * (2.0 * logRatio + 4.0 * distanceOffset / d
+                                 - (distanceOffset * distanceOffset) / (d * d));
+        const double curvature = std::max(0.0, second);
+        if (curvature <= 0.0) {
+          continue;
+        }
+        addBlock3(i, i, curvature * (normal * normal.transpose()));
+      }
+    }
+  }
+
   // Lagged ground-friction Hessian: a 3x3 tangent-plane block per node with an
   // active friction normal force. With P = I - n n^T the tangent projector onto
   // the plane orthogonal to the lagged ground normal n, T = u_T/||u_T|| the
@@ -4382,6 +4548,7 @@ void advanceDeformableBody(
     const std::vector<StaticGroundBarrier>& barriers,
     const std::vector<SphereObstacleBarrier>& sphereObstacles,
     const std::vector<BoxObstacleBarrier>& boxObstacles,
+    const std::vector<CapsuleObstacleBarrier>& capsuleObstacles,
     const comps::DeformableMaterial& material,
     DeformableSolverStats& stats)
 {
@@ -4477,10 +4644,11 @@ void advanceDeformableBody(
         || (vbdConfig != nullptr && vbdConfig->contactStiffness > 0.0);
   const bool contactFree = rigidSurfaceFree && barriers.empty()
                            && sphereObstacles.empty() && boxObstacles.empty()
+                           && capsuleObstacles.empty()
                            && contactScratch.surfaceTriangles.empty();
   if (vbdConfig != nullptr && vbdConfig->enabled && rigidSurfaceFree
       && sphereObstacles.empty() && boxObstacles.empty()
-      && vbdHandlesBarriers) {
+      && capsuleObstacles.empty() && vbdHandlesBarriers) {
     runVbdDeformableSolve(
         state,
         model,
@@ -4594,6 +4762,7 @@ void advanceDeformableBody(
           barriers,
           sphereObstacles,
           boxObstacles,
+          capsuleObstacles,
           timeStep,
           &scratch.gradient,
           &contactBarrier,
@@ -4710,6 +4879,7 @@ void advanceDeformableBody(
                 barriers,
                 sphereObstacles,
                 boxObstacles,
+                capsuleObstacles,
                 timeStep,
                 nullptr,
                 &contactBarrier,
@@ -4763,6 +4933,7 @@ void advanceDeformableBody(
           barriers,
           sphereObstacles,
           boxObstacles,
+          capsuleObstacles,
           &contactBarrier,
           &groundFriction,
           &selfContactFriction,
@@ -4861,6 +5032,7 @@ void advanceDeformableBody(
           barriers,
           sphereObstacles,
           boxObstacles,
+          capsuleObstacles,
           timeStep,
           &scratch.gradient,
           &terminalBarrier,
@@ -5149,6 +5321,10 @@ bool copyCollisionShapeToRigidIpcSurface(
       }
       copySphereToRigidIpcSurface(shape.radius, surface);
       return true;
+    case CollisionShapeType::Capsule:
+      // Capsule rigid-IPC surfaces are not supported yet; deformable-vs-capsule
+      // contact uses the analytic capsule obstacle barrier.
+      return false;
   }
 
   return false;
@@ -5902,6 +6078,7 @@ void DeformableDynamicsStage::execute(
   const auto barriers = collectStaticGroundBarriers(world);
   const auto sphereObstacles = collectSphereObstacleBarriers(world);
   const auto boxObstacles = collectBoxObstacleBarriers(world);
+  const auto capsuleObstacles = collectCapsuleObstacleBarriers(world);
   const auto rigidSurfaceSnapshots
       = collectStaticRigidSurfaceCcdObstacles(world, m_lastStats);
   const auto timeStep = world.getTimeStep();
@@ -5977,6 +6154,7 @@ void DeformableDynamicsStage::execute(
         barriers,
         sphereObstacles,
         boxObstacles,
+        capsuleObstacles,
         material,
         m_lastStats);
   }

--- a/dart/simulation/experimental/multibody/link.cpp
+++ b/dart/simulation/experimental/multibody/link.cpp
@@ -78,6 +78,16 @@ void validateCollisionShape(const CollisionShape& shape, const char* ownerName)
           "{} box collision shape half extents must be positive and finite",
           ownerName);
       break;
+    case CollisionShapeType::Capsule:
+      DART_EXPERIMENTAL_THROW_T_IF(
+          !std::isfinite(shape.radius) || shape.radius <= 0.0
+              || !std::isfinite(shape.halfExtents.z())
+              || shape.halfExtents.z() <= 0.0,
+          InvalidArgumentException,
+          "{} capsule collision shape radius and half-height must be positive "
+          "and finite",
+          ownerName);
+      break;
     case CollisionShapeType::Mesh: {
       DART_EXPERIMENTAL_THROW_T_IF(
           shape.vertices.empty(),

--- a/dart/simulation/experimental/world.cpp
+++ b/dart/simulation/experimental/world.cpp
@@ -2242,6 +2242,15 @@ std::vector<Contact> World::collide()
       case CollisionShapeType::Box:
         shape = std::make_unique<ncol::BoxShape>(collisionShape.halfExtents);
         break;
+      case CollisionShapeType::Capsule:
+        // The native engine has no capsule primitive; approximate it with its
+        // axis-aligned bounding box for rigid-rigid queries. Deformable-vs-
+        // capsule contact uses the analytic capsule obstacle barrier instead.
+        shape = std::make_unique<ncol::BoxShape>(Eigen::Vector3d(
+            collisionShape.radius,
+            collisionShape.radius,
+            collisionShape.halfExtents.z() + collisionShape.radius));
+        break;
       case CollisionShapeType::Mesh:
         shape = std::make_unique<ncol::MeshShape>(
             collisionShape.vertices, collisionShape.triangles);

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -128,10 +128,20 @@ cloth, `io::loadObjTriangleMesh*`), `.seg` (segments → strand,
 exposed to dartpy (`load_obj_triangle_mesh` / `load_seg_line_mesh` /
 `load_point_set`) with `build_cloth_from_obj` / `build_strand_from_seg` /
 `build_particles_from_pt` helpers and draped-cloth / hanging-strand /
-falling-particles showcases. Remaining M3: the codimensional triangle/edge/vertex
-collision **objects** themselves (barrier + CCD against the deformable surface,
-extending the sphere/box obstacle machinery to non-volumetric geometry — a new
-`Capsule` collision shape for the rod/wire obstacle is the natural first step).
+falling-particles showcases.
+
+The first codimensional collision **object** has also LANDED: a `Capsule`
+(rod/wire) collision shape + a static **capsule obstacle barrier**
+(`CollisionShape::makeCapsule`, dartpy `CollisionShape.capsule`). A static capsule
+opted in as a deformable obstacle exerts the same clamped-log barrier (energy +
+gradient + rank-1 radial Hessian) as the sphere/box obstacles, with distance +
+normal from the analytic point-to-segment closest point; it is barrier-only (no
+surface CCD), so a connected sheet drapes over it freely. Ships a radial-repulsion
+regression, an intersection-free draped-cloth regression, and a `Deformable Cloth
+over Capsule Rod (IPC)` showcase (toward Fig. 18 codimensional rollers). Remaining
+M3: the point-cloud / single-triangle codim obstacles (the point obstacle is the
+sphere with radius -> 0; a thin box approximates a single triangle today), and a
+true codim-vs-codim CCD if needed for fast codim rollers.
 
 ### M4 — Upstream asset pipeline + `.msh` (GMSH) importer
 

--- a/examples/demos/scenes/experimental_rigid_body_gui.cpp
+++ b/examples/demos/scenes/experimental_rigid_body_gui.cpp
@@ -20,6 +20,7 @@
 #include <dart/simulation/world.hpp>
 
 #include <dart/dynamics/box_shape.hpp>
+#include <dart/dynamics/capsule_shape.hpp>
 #include <dart/dynamics/frame.hpp>
 #include <dart/dynamics/mesh_shape.hpp>
 #include <dart/dynamics/simple_frame.hpp>
@@ -58,6 +59,11 @@ std::shared_ptr<dynamics::Shape> makeVisualShape(
       return std::make_shared<dynamics::SphereShape>(shape.radius);
     case sx::CollisionShapeType::Box:
       return std::make_shared<dynamics::BoxShape>(2.0 * shape.halfExtents);
+    case sx::CollisionShapeType::Capsule:
+      // halfExtents.z() is the axial half-height; the cylinder length is twice
+      // that (the spherical caps add `radius` at each end).
+      return std::make_shared<dynamics::CapsuleShape>(
+          shape.radius, 2.0 * shape.halfExtents.z());
     case sx::CollisionShapeType::Mesh: {
       auto mesh = std::make_shared<math::TriMesh<double>>();
       const math::TriMesh<double>::Vertices vertices(

--- a/python/dartpy/simulation_experimental/module.cpp
+++ b/python/dartpy/simulation_experimental/module.cpp
@@ -479,7 +479,8 @@ void defSimulationExperimentalModule(nb::module_& m)
 
   nb::enum_<sim::CollisionShapeType>(m, "CollisionShapeType")
       .value("SPHERE", sim::CollisionShapeType::Sphere)
-      .value("BOX", sim::CollisionShapeType::Box);
+      .value("BOX", sim::CollisionShapeType::Box)
+      .value("CAPSULE", sim::CollisionShapeType::Capsule);
 
   nb::class_<sim::CollisionShape>(m, "CollisionShape")
       .def_static("sphere", &sim::CollisionShape::makeSphere, nb::arg("radius"))
@@ -489,6 +490,11 @@ void defSimulationExperimentalModule(nb::module_& m)
             return sim::CollisionShape::makeBox(toVector3(halfExtents));
           },
           nb::arg("half_extents"))
+      .def_static(
+          "capsule",
+          &sim::CollisionShape::makeCapsule,
+          nb::arg("radius"),
+          nb::arg("half_height"))
       .def_prop_ro(
           "type", [](const sim::CollisionShape& self) { return self.type; })
       .def_prop_ro(

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -28,6 +28,7 @@ from .scenes.hardcoded_design import SCENE as HARDCODED_DESIGN
 from .scenes.heightmap import SCENE as HEIGHTMAP
 from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.hybrid_dynamics import SCENE as HYBRID_DYNAMICS
+from .scenes.ipc_deformable_capsule_rod import SCENE as IPC_DEFORMABLE_CAPSULE_ROD
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
 from .scenes.ipc_deformable_fcr_twist import SCENE as IPC_DEFORMABLE_FCR_TWIST
 from .scenes.ipc_deformable_fem_bar import SCENE as IPC_DEFORMABLE_FEM_BAR
@@ -175,6 +176,7 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_FEM_BUCKLE,
         IPC_DEFORMABLE_FEM_MSH,
         IPC_DEFORMABLE_OBJ_CLOTH,
+        IPC_DEFORMABLE_CAPSULE_ROD,
         IPC_DEFORMABLE_SEG_STRAND,
         IPC_DEFORMABLE_PT_PARTICLES,
         IPC_DEFORMABLE_SCRIPTED,

--- a/python/examples/demos/scenes/ipc_deformable_capsule_rod.py
+++ b/python/examples/demos/scenes/ipc_deformable_capsule_rod.py
@@ -1,0 +1,80 @@
+"""Cloth draping over a capsule rod obstacle (experimental IPC deformable solver).
+
+A mass-spring cloth (loaded from the bundled ``.obj`` mesh) is dropped over a
+static horizontal capsule -- a rod/wire -- opted in as a deformable obstacle. The
+capsule's clamped-log barrier (PLAN-081 M3 codimensional collision objects) pushes
+the cloth nodes out along the radial normal from the rod axis, so the sheet drapes
+over the curved rod and its two halves hang down on either side, intersection-free.
+Unlike the sphere/box surface-CCD obstacles, the capsule obstacle is barrier-only,
+so the connected sheet drapes freely rather than being limited as a rigid body.
+A DART-native step toward the IPC paper's Fig. 18 codimensional-roller theme.
+
+DART-native showcase -- not a faithful IPC paper-figure reproduction.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_cloth_from_obj
+from ..runner import PythonDemoScene, SceneSetup
+
+_CLOTH_PATH = Path(__file__).resolve().parent.parent / "assets" / "cloth_grid.obj"
+_ROD_RADIUS = 0.1
+_ROD_HALF_HEIGHT = 0.45
+_ROD_CENTER = (0.0, 0.0, 0.25)
+# Lay the capsule axis (body z) along world y, via a -90 deg rotation about x.
+_ROD_ORIENTATION = (math.cos(-math.pi / 4), math.sin(-math.pi / 4), 0.0, 0.0)
+
+
+def build() -> SceneSetup:
+    options, edges = build_cloth_from_obj(
+        _CLOTH_PATH,
+        mass=0.02,
+        edge_stiffness=200.0,
+        damping=1.0,
+        translate=(0.0, 0.0, 0.5),
+    )
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -9.81]
+    world.time_step = 0.004
+
+    rod = world.add_rigid_body(
+        "rod", position=_ROD_CENTER, orientation=_ROD_ORIENTATION
+    )
+    rod.is_static = True
+    rod.set_collision_shape(sx.CollisionShape.capsule(_ROD_RADIUS, _ROD_HALF_HEIGHT))
+    rod.is_deformable_surface_ccd_obstacle = True
+
+    body = world.add_deformable_body("capsule_cloth", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_capsule_rod")
+    # Approximate the horizontal rod with an axis-aligned box visual along y.
+    bridge.add_rigid_box_visual(
+        _ROD_CENTER,
+        (2.0 * _ROD_RADIUS, 2.0 * (_ROD_HALF_HEIGHT + _ROD_RADIUS), 2.0 * _ROD_RADIUS),
+        (0.52, 0.45, 0.34),
+        name="rod_visual",
+    )
+    bridge.add_deformable_visual(body, name="capsule_cloth", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_capsule_rod",
+    title="Deformable Cloth over Capsule Rod (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A cloth drapes over a static capsule rod obstacle via its "
+    "codimensional radial barrier.",
+    build=build,
+)

--- a/python/stubs/dartpy/simulation_experimental.pyi
+++ b/python/stubs/dartpy/simulation_experimental.pyi
@@ -121,6 +121,7 @@ class RigidBodySolver(enum.Enum):
     SEQUENTIAL_IMPULSE = 0
 
     IPC = 1
+
 class ContactSolverMethod(enum.Enum):
     SEQUENTIAL_IMPULSE = 0
 
@@ -147,12 +148,17 @@ class CollisionShapeType(enum.Enum):
 
     BOX = 1
 
+    CAPSULE = 3
+
 class CollisionShape:
     @staticmethod
     def sphere(radius: float) -> CollisionShape: ...
 
     @staticmethod
     def box(half_extents: object) -> CollisionShape: ...
+
+    @staticmethod
+    def capsule(radius: float, half_height: float) -> CollisionShape: ...
 
     @property
     def type(self) -> CollisionShapeType: ...

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -216,6 +216,49 @@ def test_ipc_deformable_obj_cloth_loads_and_drapes() -> None:
     assert float(z.min()) > -0.21
 
 
+def test_ipc_deformable_cloth_drapes_over_capsule_rod_without_penetrating() -> None:
+    """The capsule (rod) obstacle barrier holds a draping cloth off its surface.
+
+    A cloth dropped over a static horizontal capsule rod must drape over it (its
+    halves hang down on either side), stay finite, and keep every node strictly
+    outside the rod surface -- the codimensional-obstacle analogue of the
+    sphere/box settle tests, verified by the analytic point-to-segment distance.
+    """
+
+    import numpy as np
+
+    from examples.demos.scenes import ipc_deformable_capsule_rod as scene
+
+    setup = scene.build()
+    world = setup.info["sx_world"]
+    body = world.get_deformable_body("capsule_cloth")
+    n = body.node_count
+
+    for _ in range(260):
+        world.step()
+
+    points = np.array([body.node_position(i) for i in range(n)])
+    assert np.isfinite(points).all()
+    # The sheet draped over the rod (clear vertical spread).
+    assert float(points[:, 2].max() - points[:, 2].min()) > 0.2
+
+    # Every node stays strictly outside the capsule surface (no interpenetration).
+    center = np.asarray(scene._ROD_CENTER, dtype=float)
+    axis = np.array([0.0, 1.0, 0.0])  # body z -> world y (the scene's rotation)
+    point_a = center + scene._ROD_HALF_HEIGHT * axis
+    point_b = center - scene._ROD_HALF_HEIGHT * axis
+    seg = point_b - point_a
+    seg_len_sq = float(seg @ seg)
+    min_surface = float("inf")
+    for p in points:
+        t = np.clip((p - point_a) @ seg / seg_len_sq, 0.0, 1.0)
+        closest = point_a + t * seg
+        min_surface = min(
+            min_surface, float(np.linalg.norm(p - closest)) - scene._ROD_RADIUS
+        )
+    assert min_surface > 0.0
+
+
 def test_ipc_deformable_seg_and_pt_importers_feed_solves() -> None:
     """The .seg and .pt importers feed real deformable solves.
 
@@ -278,6 +321,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_fem_buckle",
         "ipc_deformable_fem_msh",
         "ipc_deformable_obj_cloth",
+        "ipc_deformable_capsule_rod",
         "ipc_deformable_seg_strand",
         "ipc_deformable_pt_particles",
         "ipc_deformable_scripted_dirichlet",

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -1110,6 +1110,41 @@ TEST(DeformableBody, BoxObstacleBarrierRepelsNodeAlongFaceNormal)
 }
 
 //==============================================================================
+// A static capsule (z-axis rod) opted in as a deformable obstacle radially
+// repels a nearby node along the outward normal from the capsule axis -- the
+// codimensional (rod) analogue of the sphere/box obstacle barriers.
+TEST(DeformableBody, CapsuleObstacleBarrierRepelsNodeRadially)
+{
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.1);
+
+  sx::RigidBodyOptions capsuleOptions;
+  capsuleOptions.isStatic = true;
+  auto capsule = world.addRigidBody("obstacle_capsule", capsuleOptions);
+  // A z-axis capsule: radius 0.3, half-height 0.4 (so the cylindrical side
+  // spans z in [-0.4, 0.4]).
+  capsule.setCollisionShape(
+      sx::CollisionShape::makeCapsule(/*radius=*/0.3, /*halfHeight=*/0.4));
+  capsule.setDeformableSurfaceCcdObstacle(true);
+
+  // 0.305 is inside the band off the cylindrical side (surface 0.3, distance
+  // 0.005), at z = 0 (mid-segment).
+  sx::DeformableBodyOptions options;
+  options.positions = {Eigen::Vector3d(0.305, 0.0, 0.0)};
+  options.velocities = {Eigen::Vector3d::Zero()};
+  auto body = world.addDeformableBody("node", options);
+
+  world.step(10);
+
+  const auto position = body.getPosition(0);
+  EXPECT_GT(position.x(), 0.32);        // repelled past the band edge along +x
+  EXPECT_LT(position.x(), 2.0);         // finite (no blow-up)
+  EXPECT_NEAR(position.y(), 0.0, 1e-9); // purely along the radial normal
+  EXPECT_NEAR(position.z(), 0.0, 1e-9); // mid-segment: no axial push
+}
+
+//==============================================================================
 // A FEM cube dropped onto a static box obstacle settles on the surface
 // intersection-free: the box obstacle barrier (energy, gradient, and Hessian)
 // keeps every node outside the box while the FEM elasticity conforms the cube


### PR DESCRIPTION
## Summary

Adds a **capsule (rod/wire) collision shape** and a static **capsule obstacle
barrier** — the first codimensional collision object (PLAN-081 **M3**), which
deformable bodies drape over.

## What's added

- `CollisionShape::makeCapsule(radius, halfHeight)` → a `Capsule` shape type (a
  body-z-axis segment swept by `radius`), exposed to dartpy as
  `CollisionShape.capsule`. The half-height reuses `halfExtents.z()` so the
  serialized layout is unchanged.
- A static capsule opted in as a deformable obstacle exerts the **same
  clamped-log barrier** (energy + gradient + rank-1 radial Hessian) as the
  sphere/box obstacles, threaded through the objective and projected-Newton
  assembly. Distance + normal come from the analytic point-to-segment closest
  point: `|node − closestOnAxis| − radius`.
- Unlike the sphere/box surface-CCD obstacles, the capsule is **barrier-only**,
  so a connected sheet drapes over it freely (no rigid-body CCD limiting).

The new `Capsule` enum value is handled in every collision-shape switch:
validators, native-shape conversion (bounding-box approximation for rigid-rigid
queries), ground-barrier / rigid-IPC-surface collection, and the GUI visual
factory (rendered as a `dynamics::CapsuleShape`).

## Tests

- `CapsuleObstacleBarrierRepelsNodeRadially` — a node in the band is repelled
  radially outward from the rod axis, finite.
- A draped-cloth regression: a cloth dropped over a horizontal capsule rod drapes
  over it and every node stays **strictly outside** the rod surface (verified by
  the analytic point-to-segment distance).

## Example

`Deformable Cloth over Capsule Rod (IPC)` py-demos scene — a cloth draping over a
horizontal rod (toward the paper's Fig. 18 codimensional rollers).

## Verification

`pixi run test-all` — **6/6 PASSED**.