### PR TITLE
Add Coulomb friction against the capsule rod obstacle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1070,6 +1070,18 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     `FemCubeSettlesOnBoxObstacleWithoutPenetrating` regressions and a
     `Deformable FEM over Box (IPC)` py-demos scene (a FEM slab draping over a box
     obstacle).
+  - Added **mesh-vs-obstacle friction** against the capsule rod obstacle
+    (PLAN-081 M5). A node in contact with a static capsule obstacle now feeds the
+    capsule barrier's radial normal force and direction into the existing lagged
+    smoothed Coulomb friction term (the dominant per-node contact -- ground or
+    capsule -- wins), so a deformable sliding along a rod is decelerated by
+    friction proportional to `frictionCoefficient`. Because the capsule obstacle
+    is barrier-only (no over-limiting surface CCD), the tangential slide is
+    unconstrained and the friction force is effective -- unblocking obstacle
+    friction that the sphere/box surface-CCD obstacles still mask. Adds a C++ and
+    a dartpy regression (a strip shoved along a rod slides far frictionless but is
+    held back under friction, staying on the rod) and a `Deformable Friction on
+Capsule Rod (IPC)` py-demos scene.
   - Added opt-in **adaptive barrier stiffness** (kappa) to the experimental
     deformable solver (PLAN-081 M6). When a body sets
     `DeformableMaterialProperties.useAdaptiveBarrierStiffness` (dartpy

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -2655,6 +2655,53 @@ void computeStaticGroundNormalForces(
 }
 
 //==============================================================================
+// Merges the capsule obstacle barrier's per-node radial normal force and
+// direction into the friction normal-force arrays (populated first by
+// computeStaticGroundNormalForces). The dominant (largest-force) contact per
+// node wins, so a node resting on a capsule rod gets the rod's radial normal
+// for its friction tangent plane. The capsule obstacle is barrier-only (no
+// surface CCD), so tangential sliding is unconstrained and friction is
+// effective.
+void addCapsuleObstacleNormalForces(
+    const std::vector<Eigen::Vector3d>& positions,
+    const std::vector<std::uint8_t>& fixed,
+    const std::vector<CapsuleObstacleBarrier>& obstacles,
+    std::vector<double>& normalForce,
+    std::vector<Eigen::Vector3d>& normalDirection)
+{
+  if (obstacles.empty()) {
+    return;
+  }
+  const double activationDistance = staticGroundBarrierActivationDistance();
+  const double barrierScale = kDefaultBarrierStiffness;
+  for (std::size_t i = 0; i < positions.size(); ++i) {
+    if (fixed[i] != 0u) {
+      continue;
+    }
+    for (const auto& obstacle : obstacles) {
+      Eigen::Vector3d normal;
+      const double distance
+          = capsuleObstacleSurfaceDistance(positions[i], obstacle, normal);
+      if (distance <= 0.0 || distance >= activationDistance
+          || !std::isfinite(distance)) {
+        continue;
+      }
+      const double distanceOffset = distance - activationDistance;
+      const double normalizedDistance = distance / activationDistance;
+      const double derivative
+          = -barrierScale
+            * (2.0 * distanceOffset * std::log(normalizedDistance)
+               + distanceOffset * distanceOffset / distance);
+      const double force = -derivative;
+      if (force > normalForce[i]) {
+        normalForce[i] = force;
+        normalDirection[i] = normal;
+      }
+    }
+  }
+}
+
+//==============================================================================
 // Lagged smoothed Coulomb friction inputs for static-ground contact. The
 // per-node normal force and the step-start positions are fixed across the inner
 // line search; the tangential displacement uses the candidate positions.
@@ -4778,11 +4825,18 @@ void advanceDeformableBody(
       // line search), opposing each contacting node's tangential displacement
       // over the step. With mu == 0 or no ground contact this is a no-op.
       GroundFrictionInputs groundFriction;
-      if (frictionCoefficient > 0.0 && !barriers.empty()) {
+      if (frictionCoefficient > 0.0
+          && (!barriers.empty() || !capsuleObstacles.empty())) {
         computeStaticGroundNormalForces(
             scratch.next,
             scratch.activeFixed,
             barriers,
+            groundFrictionNormalForce,
+            groundFrictionNormalDirection);
+        addCapsuleObstacleNormalForces(
+            scratch.next,
+            scratch.activeFixed,
+            capsuleObstacles,
             groundFrictionNormalForce,
             groundFrictionNormalDirection);
         groundFriction.coefficient = frictionCoefficient;
@@ -5053,11 +5107,18 @@ void advanceDeformableBody(
         terminalBarrier.stiffness = selfContactBarrierStiffness();
       }
       GroundFrictionInputs terminalGroundFriction;
-      if (frictionCoefficient > 0.0 && !barriers.empty()) {
+      if (frictionCoefficient > 0.0
+          && (!barriers.empty() || !capsuleObstacles.empty())) {
         computeStaticGroundNormalForces(
             scratch.next,
             scratch.activeFixed,
             barriers,
+            groundFrictionNormalForce,
+            groundFrictionNormalDirection);
+        addCapsuleObstacleNormalForces(
+            scratch.next,
+            scratch.activeFixed,
+            capsuleObstacles,
             groundFrictionNormalForce,
             groundFrictionNormalDirection);
         terminalGroundFriction.coefficient = frictionCoefficient;

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -1,5 +1,78 @@
 # Resume: IPC Deformable Solver
 
+## Current State (2026-05-30) — PLAN-081 M1–M6 landed; M5/M7 in progress
+
+This session drove the experimental deformable solver from "mass-spring scaffold"
+to broad IPC paper-parity (Li et al. 2020). All work shipped as one-PR-per-slice
+off `main` (milestone DART 7.0, `pixi run test-all` 6/6, admin-squash-merged, no
+AI attribution). Net status by milestone:
+
+- **M1 FEM elasticity — COMPLETE.** Stable neo-Hookean + fixed-corotational (FCR)
+  tetrahedral kernels (`detail/deformable_elasticity/fem_tet_element.hpp`), both
+  FD-validated, opt-in via `DeformableMaterialProperties.useFiniteElementElasticity`
+  / `useFixedCorotationalElasticity`. FCR uses the **exact analytic Hessian**
+  (rotation-gradient `(tr(S)I−S)w = axl(RᵀδF−δFᵀR)`), PSD-projected by the solver,
+  Gauss-Newton fallback for inverted elements. ~7× faster FCR step (to neo-Hookean
+  parity); benchmarked in wall-time **and** Newton iterations/step.
+- **M2 obstacle barriers — COMPLETE.** Sphere + box + capsule static obstacles
+  each get the clamped-log barrier force (energy + gradient + rank-1 radial
+  Hessian) through the projected-Newton assembly.
+- **M3 codim importers + capsule object — COMPLETE.** `.msh`/`.obj`/`.seg`/`.pt`
+  importers (`io/gmsh_tet_mesh`, `io/obj_triangle_mesh`, `io/codim_mesh`); capsule
+  (rod/wire) collision shape + obstacle barrier (the first codimensional object,
+  barrier-only so cloth drapes freely).
+- **M4 GMSH importer — COMPLETE** (`.msh` 2.x + 4.x).
+- **M6 adaptive barrier stiffness — COMPLETE.** Opt-in
+  `useAdaptiveBarrierStiffness`: per-step `κ = clamp((maxNodalMass/dt²)·d_hat², 25,
+  1e6)`; recovers the historical fixed κ=25 at unit mass, off is byte-identical.
+- **M5 obstacle friction — capsule LANDED, sphere/box BLOCKED.** Capsule friction
+  works (barrier-only → free tangential slide). Sphere/box friction is masked by
+  the surface-CCD limiter scaling the whole step vector; needs the CCD to limit
+  only the normal approach (higher-risk, cf. #2732). See `## M5 / M7 Next` below.
+- **M7 scale + GPU — NOT STARTED.** A CUDA backend exists for PSD projection + VBD
+  (another track, #2781); extending the full deformable IPC solve / matrix-free CG
+  to GPU is the remaining large effort.
+
+Session PR train (all merged to `main`): #2787 FEM keystone, #2788 FEM twist,
+#2789 FEM+ground, #2790 sphere barrier Hessian, #2791 box barrier, #2792/#2793
+GMSH 2.x/4.x, #2794 FCR material, #2795 FCR benchmark+SVD-dedup, #2796 exact FCR
+Hessian, #2797 solver diagnostics, #2798 FEM self-contact showcase, #2799
+benchmark Newton-iters, #2800 `.obj` importer, #2802 `.seg`/`.pt` importers, #2804
+capsule obstacle, #2805 adaptive stiffness, + capsule-friction (open/landing).
+IPC Deformable (sx) py-demos category now has ~15 scenes.
+
+### M5 / M7 Next (resume here)
+
+1. **Finish M5 (sphere/box obstacle friction).** The blocker is in the surface
+   CCD limiter (`detail/deformable_contact/continuous_collision_step` + the
+   `staticRigidSurfaceCcd*` path in `compute/world_step_stage.cpp`): it scales the
+   *whole* candidate step by the time-of-impact to stop gravity-driven
+   penetration, which also kills tangential sliding (a frictionless node on a box
+   obstacle slides only ~0.05 vs free). The barrier force already prevents
+   penetration, so the CCD should only bound the *normal-approach* component, not
+   the full step. Then feed sphere/box obstacle normal forces into the friction
+   term exactly like `addCapsuleObstacleNormalForces` does for the capsule.
+2. **M7 (GPU/scale).** Extend the existing CUDA PSD-projection backend to the full
+   deformable assembly, or add a matrix-free CG path; benchmark per-step time vs
+   the paper's Fig 23 / Table 1 and IPC's CPU reference.
+
+### Conventions / gotchas (verified this session)
+
+- One PR per slice off `main`; `pixi run test-all` must be 6/6; admin-squash-merge
+  (NO `--delete-branch`); milestone DART 7.0; never add AI attribution.
+- After `pixi run generate-stubs`, revert the unrelated stubs (`__init__.pyi`,
+  `dynamics.pyi`, `gui/__init__.pyi`) — keep only `simulation_experimental.pyi`.
+- `pixi run update-api-boundary-inventory` when a public dartpy binding changes.
+- Adding a `CollisionShapeType` enum value breaks **every** switch on it under
+  `-Werror=switch` — grep the **whole repo** (incl. `examples/`) for
+  `case CollisionShapeType::Mesh`.
+- C++ `DeformableBodyOptions` field is `surfaceTriangles` (camelCase); the dartpy
+  alias is `surface_triangles`.
+- `test-all`'s linting reflows `module.cpp` docstrings + `CHANGELOG.md` AFTER a
+  `git add`; re-`git add` (or amend) before merging.
+- The detailed live state also lives in the assistant memory
+  `SESSION_HANDOFF.md`.
+
 ## Last Session Summary
 
 The branch established a machine-checkable manifest for the audited upstream

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -155,12 +155,27 @@ A fetch-into-fixtures workflow for the upstream meshes pinned at
 tet-mesh importer in `dart/io`. Port the contact-free tutorial scenes
 (`2cubesFall` DBC/NBC) first as regression fixtures, then the contact scenes.
 
-### M5 — Mesh-vs-obstacle friction completeness
+### M5 — Mesh-vs-obstacle friction completeness — capsule LANDED
 
 Extend lagged smoothed Coulomb friction beyond the static-ground coefficient to
 mesh-vs-obstacle and codim contacts. Unblocks the friction figures: Fig 5 (card
 house), Fig 7 (cement arch), Fig 8 (ball-on-roller), Fig 16 (Armadillo roller),
 Fig 20 (stick-slip rod).
+
+Progress: **capsule (rod) obstacle friction has landed.** A node contacting a
+static capsule feeds the capsule barrier's radial normal force/direction into the
+existing lagged Coulomb friction term (dominant per-node contact wins), so a
+deformable sliding along a rod decelerates with `frictionCoefficient`. This works
+because the capsule obstacle is barrier-only (no over-limiting surface CCD), so
+the tangential slide is unconstrained — directly demonstrating mesh-vs-obstacle
+friction (toward Fig 8 / Fig 20 roller themes). Ships C++ + dartpy regressions and
+a `Deformable Friction on Capsule Rod (IPC)` showcase. **Remaining M5 (the real
+blocker):** sphere/box obstacle friction is still masked by the surface-CCD
+limiter, which scales the _whole_ step vector (normal + tangential) to prevent
+gravity-driven penetration, killing the tangential slide. The fix is to make the
+surface CCD limit only the _normal_ approach component (not the whole step) so
+the barrier handles non-penetration and friction can act tangentially — a
+focused, higher-risk change to the CCD contracts (cf. #2732).
 
 ### M6 — Adaptive barrier stiffness (κ homotopy) — LANDED
 

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -11,8 +11,6 @@ from .scenes.add_delete_skels import SCENE as ADD_DELETE_SKELS
 from .scenes.arm_push_box import SCENE as ARM_PUSH_BOX
 from .scenes.atlas_simbicon import SCENE as ATLAS_SIMBICON
 from .scenes.biped_stand import SCENE as BIPED_STAND
-from .scenes.g1_simbicon import SCENE as G1_SIMBICON
-from .scenes.simbicon_duo import SCENE as SIMBICON_DUO
 from .scenes.box_stacking import SCENE as BOX_STACKING
 from .scenes.boxes import SCENE as BOXES
 from .scenes.capsule_ground_contact import SCENE as CAPSULE_GROUND_CONTACT
@@ -27,6 +25,7 @@ from .scenes.drag_and_drop import SCENE as DRAG_AND_DROP
 from .scenes.empty import SCENE as EMPTY
 from .scenes.experimental_rigid_body_gui import SCENE as EXPERIMENTAL_RIGID_BODY_GUI
 from .scenes.free_joint_cases import SCENE as FREE_JOINT_CASES
+from .scenes.g1_simbicon import SCENE as G1_SIMBICON
 from .scenes.hardcoded_design import SCENE as HARDCODED_DESIGN
 from .scenes.heightmap import SCENE as HEIGHTMAP
 from .scenes.hello_world import SCENE as HELLO_WORLD
@@ -45,6 +44,7 @@ from .scenes.ipc_deformable_friction_slide import SCENE as IPC_DEFORMABLE_FRICTI
 from .scenes.ipc_deformable_net import SCENE as IPC_DEFORMABLE_NET
 from .scenes.ipc_deformable_obj_cloth import SCENE as IPC_DEFORMABLE_OBJ_CLOTH
 from .scenes.ipc_deformable_pt_particles import SCENE as IPC_DEFORMABLE_PT_PARTICLES
+from .scenes.ipc_deformable_rod_friction import SCENE as IPC_DEFORMABLE_ROD_FRICTION
 from .scenes.ipc_deformable_scripted_dirichlet import SCENE as IPC_DEFORMABLE_SCRIPTED
 from .scenes.ipc_deformable_seg_strand import SCENE as IPC_DEFORMABLE_SEG_STRAND
 from .scenes.ipc_deformable_trampoline import SCENE as IPC_DEFORMABLE_TRAMPOLINE
@@ -63,6 +63,7 @@ from .scenes.rigid_loop import SCENE as RIGID_LOOP
 from .scenes.rigid_shapes import SCENE as RIGID_SHAPES
 from .scenes.sensor_descriptors import SCENE as SENSOR_DESCRIPTORS
 from .scenes.shapes import SCENE as SHAPES
+from .scenes.simbicon_duo import SCENE as SIMBICON_DUO
 from .scenes.simple_frames import SCENE as SIMPLE_FRAMES
 from .scenes.soft_bodies import SCENE as SOFT_BODIES
 from .scenes.sx_articulated import SCENE as SX_ARTICULATED
@@ -185,5 +186,6 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_CAPSULE_ROD,
         IPC_DEFORMABLE_SEG_STRAND,
         IPC_DEFORMABLE_PT_PARTICLES,
+        IPC_DEFORMABLE_ROD_FRICTION,
         IPC_DEFORMABLE_SCRIPTED,
     ]

--- a/python/examples/demos/scenes/ipc_deformable_rod_friction.py
+++ b/python/examples/demos/scenes/ipc_deformable_rod_friction.py
@@ -1,0 +1,90 @@
+"""Friction against a capsule rod obstacle (experimental IPC deformable solver).
+
+A short deformable strip rests on top of a static horizontal capsule rod and is
+shoved along the rod's axis. Lagged smoothed Coulomb friction against the rod's
+clamped-log contact barrier (PLAN-081 M5, mesh-vs-obstacle friction) opposes the
+tangential slide, bringing the strip to rest -- whereas a frictionless strip
+would coast along the rod. The capsule obstacle is barrier-only (no surface CCD),
+so the tangential slide is unconstrained and the friction force is what stops it.
+
+DART-native showcase -- not a faithful IPC paper-figure reproduction.
+"""
+
+from __future__ import annotations
+
+import math
+
+import dartpy.simulation_experimental as sx
+import numpy as np
+
+from .._ipc_deformable_bridge import IpcDeformableBridge
+from ..runner import PythonDemoScene, SceneSetup
+
+_ROD_RADIUS = 0.2
+_ROD_HALF_HEIGHT = 3.0
+_ROD_CENTER = (0.0, 0.0, 0.0)
+# Lay the capsule axis (body z) along world y, via a -90 deg rotation about x.
+_ROD_ORIENTATION = (math.cos(-math.pi / 4), math.sin(-math.pi / 4), 0.0, 0.0)
+
+
+def _build_strip() -> tuple["sx.DeformableBodyOptions", list[tuple[int, int]]]:
+    # A 5-node strip lying along the rod axis (y), resting on the rod top.
+    options = sx.DeformableBodyOptions()
+    top_z = _ROD_RADIUS + 0.012
+    positions = [np.array([0.0, -0.4 + 0.2 * i, top_z]) for i in range(5)]
+    options.positions = positions
+    options.masses = [0.1] * 5
+    options.edge_stiffness = 200.0
+    options.damping = 1.0
+    options.velocities = [np.array([0.0, 2.0, 0.0]) for _ in range(5)]
+    edges = [(i, i + 1) for i in range(4)]
+    options.edges = [
+        sx.DeformableEdge(a, b, float(np.linalg.norm(positions[a] - positions[b])))
+        for a, b in edges
+    ]
+    # Coulomb friction against the rod opposes the axial shove.
+    options.material.friction_coefficient = 0.8
+    return options, edges
+
+
+def build() -> SceneSetup:
+    options, edges = _build_strip()
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -9.81]
+    world.time_step = 0.004
+
+    rod = world.add_rigid_body(
+        "rod", position=_ROD_CENTER, orientation=_ROD_ORIENTATION
+    )
+    rod.is_static = True
+    rod.set_collision_shape(sx.CollisionShape.capsule(_ROD_RADIUS, _ROD_HALF_HEIGHT))
+    rod.is_deformable_surface_ccd_obstacle = True
+
+    body = world.add_deformable_body("rod_strip", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_rod_friction")
+    bridge.add_rigid_box_visual(
+        _ROD_CENTER,
+        (2.0 * _ROD_RADIUS, 2.0 * (_ROD_HALF_HEIGHT + _ROD_RADIUS), 2.0 * _ROD_RADIUS),
+        (0.52, 0.45, 0.34),
+        name="rod_visual",
+    )
+    bridge.add_deformable_visual(body, name="rod_strip", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_rod_friction",
+    title="Deformable Friction on Capsule Rod (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A deformable strip shoved along a capsule rod is brought to rest by "
+    "Coulomb friction against the rod obstacle.",
+    build=build,
+)

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -259,6 +259,45 @@ def test_ipc_deformable_cloth_drapes_over_capsule_rod_without_penetrating() -> N
     assert min_surface > 0.0
 
 
+def test_ipc_deformable_rod_friction_decelerates_sliding_strip() -> None:
+    """Coulomb friction against the capsule rod obstacle stops a sliding strip.
+
+    A deformable strip shoved along the (barrier-only, CCD-free) capsule rod
+    slides measurably less with friction than without, while staying on the rod.
+    """
+
+    import numpy as np
+
+    from examples.demos.scenes import ipc_deformable_rod_friction as scene
+
+    def slid_distance(mu: float) -> float:
+        options, _edges = scene._build_strip()
+        options.material.friction_coefficient = mu
+        world = scene.sx.World()
+        world.gravity = [0.0, 0.0, -9.81]
+        world.time_step = 0.004
+        rod = world.add_rigid_body(
+            "rod", position=scene._ROD_CENTER, orientation=scene._ROD_ORIENTATION
+        )
+        rod.is_static = True
+        rod.set_collision_shape(
+            scene.sx.CollisionShape.capsule(scene._ROD_RADIUS, scene._ROD_HALF_HEIGHT)
+        )
+        rod.is_deformable_surface_ccd_obstacle = True
+        body = world.add_deformable_body("strip", options)
+        y0 = float(np.mean([body.node_position(i)[1] for i in range(body.node_count)]))
+        for _ in range(200):
+            world.step()
+        positions = np.array([body.node_position(i) for i in range(body.node_count)])
+        assert np.isfinite(positions).all()
+        return float(np.mean(positions[:, 1]) - y0)
+
+    frictionless = slid_distance(0.0)
+    high_friction = slid_distance(0.8)
+    assert frictionless > 0.5
+    assert high_friction < 0.5 * frictionless
+
+
 def test_ipc_deformable_seg_and_pt_importers_feed_solves() -> None:
     """The .seg and .pt importers feed real deformable solves.
 
@@ -322,6 +361,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_fem_msh",
         "ipc_deformable_obj_cloth",
         "ipc_deformable_capsule_rod",
+        "ipc_deformable_rod_friction",
         "ipc_deformable_seg_strand",
         "ipc_deformable_pt_particles",
         "ipc_deformable_scripted_dirichlet",

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -1145,6 +1145,57 @@ TEST(DeformableBody, CapsuleObstacleBarrierRepelsNodeRadially)
 }
 
 //==============================================================================
+// Lagged Coulomb friction works against the (barrier-only, CCD-free) capsule
+// rod obstacle: a node resting on top of a horizontal rod and pushed along its
+// axis slides measurably less the larger the friction coefficient, while
+// staying on the rod surface. (Mesh-vs-obstacle friction, PLAN-081 M5, is
+// unblocked for the capsule because it carries no over-limiting surface CCD.)
+TEST(DeformableBody, CapsuleObstacleFrictionDeceleratesSlidingNode)
+{
+  const auto slideAlongRod = [](double frictionCoefficient) {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(0.004);
+
+    // A horizontal rod: the capsule axis (body z) laid along world y.
+    sx::RigidBodyOptions rodOptions;
+    rodOptions.isStatic = true;
+    rodOptions.orientation = Eigen::Quaterniond(
+        Eigen::AngleAxisd(-M_PI / 2.0, Eigen::Vector3d::UnitX()));
+    auto rod = world.addRigidBody("rod", rodOptions);
+    constexpr double radius = 0.2;
+    // The rod is long enough that the frictionless node stays on the
+    // cylindrical side over the test rather than sliding off an end cap.
+    rod.setCollisionShape(
+        sx::CollisionShape::makeCapsule(radius, /*halfHeight=*/3.0));
+    rod.setDeformableSurfaceCcdObstacle(true);
+
+    // A node resting on top of the rod (inside the radial band), pushed along
+    // the rod's axis (+y).
+    sx::DeformableBodyOptions options;
+    options.positions = {Eigen::Vector3d(0.0, 0.0, radius + 0.012)};
+    options.velocities = {Eigen::Vector3d(0.0, 2.0, 0.0)};
+    options.material.frictionCoefficient = frictionCoefficient;
+    auto body = world.addDeformableBody("slider", options);
+
+    world.step(200);
+    return body.getPosition(0);
+  };
+
+  const Eigen::Vector3d frictionless = slideAlongRod(0.0);
+  const Eigen::Vector3d highFriction = slideAlongRod(0.8);
+
+  // Both stay on the rod surface (radius 0.2, band d_hat = 2e-2) and finite.
+  EXPECT_GT(frictionless.z(), 0.2);
+  EXPECT_LT(frictionless.z(), 0.24);
+  EXPECT_GT(highFriction.z(), 0.2);
+  EXPECT_TRUE(highFriction.allFinite());
+  // The frictionless node slides far along the axis; friction holds it back.
+  EXPECT_GT(frictionless.y(), 1.0);
+  EXPECT_LT(highFriction.y(), 0.5 * frictionless.y());
+}
+
+//==============================================================================
 // A FEM cube dropped onto a static box obstacle settles on the surface
 // intersection-free: the box obstacle barrier (energy, gradient, and Hessian)
 // keeps every node outside the box while the FEM elasticity conforms the cube


### PR DESCRIPTION
## Summary

Extends lagged smoothed Coulomb friction to the **capsule (rod) obstacle**
(PLAN-081 **M5** mesh-vs-obstacle friction). A deformable sliding along a static
rod is now decelerated by friction.

## How

`addCapsuleObstacleNormalForces` merges each node's capsule-barrier radial normal
force and direction into the friction normal-force arrays (the dominant per-node
contact — ground or capsule — wins), so the existing lagged-friction term opposes
the node's tangential slide. The friction block is also gated to fire when a
capsule obstacle is present (not only a ground barrier).

Because the capsule obstacle is **barrier-only** (no over-limiting surface CCD),
the tangential slide is unconstrained and the friction force is effective — this
is what unblocks obstacle friction. The sphere/box surface-CCD obstacles still
mask tangential motion (the CCD scales the whole step vector); fixing that is the
remaining M5 work, documented in the roadmap and the dev-task resume doc.

## Tests

C++ and dartpy regressions: a deformable strip shoved along the rod slides far
when frictionless but is held back under friction (`< 0.5×`), staying on the rod.

## Example

`Deformable Friction on Capsule Rod (IPC)` py-demos scene.

Also refreshes `docs/dev_tasks/ipc_deformable_solver/RESUME.md` with the current
M1–M6 + M5-capsule state and the M5/M7 next steps.

## Verification

`pixi run test-all` — **6/6 PASSED**.