### PR TITLE
Strengthen the deformable iterative CG preconditioner to incomplete-Cholesky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1099,6 +1099,24 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     a dartpy regression (a strip shoved along a rod slides far frictionless but is
     held back under friction, staying on the rod) and a `Deformable Friction on
 Capsule Rod (IPC)` py-demos scene.
+  - Strengthened the experimental deformable iterative solve's preconditioner
+    from diagonal (Jacobi) to **incomplete-Cholesky** (PLAN-081 M7). Stiff
+    barrier contact makes the projected-Newton Hessian ill-conditioned, where a
+    diagonal preconditioner leaves the conjugate gradient stalling against its
+    iteration cap and falling back to steepest descent; the incomplete-Cholesky
+    preconditioner (a sparse approximate factorization that drops fill, so the
+    solve still never fully factorizes and stays near O(nnz)) collapses the CG
+    iteration count so the iterative path carries stiff contact within the cap.
+    On a settling stiff FEM contact scene this cuts the iterative solver's
+    fallbacks below the direct solver's and reduces Newton iterations per step,
+    while remaining byte-compatible at the API level (still opt-in via
+    `useIterativeLinearSolver`). An incomplete-Cholesky breakdown that Eigen's
+    diagonal shifting cannot repair falls back to steepest descent, exactly as
+    the direct path does on an indefinite factorization. Adds a regression in
+    which a stiff FEM cube settles on a ground barrier through the iterative path
+    (never factorizing) with accepted CG steps dominating fallbacks and the same
+    equilibrium as the direct solver, plus a `cg_contact` py-demo of a stiff FEM
+    cube settling on a barrier via the incomplete-Cholesky CG solve.
   - Added an opt-in **iterative (conjugate-gradient) linear solve** for the
     experimental deformable projected-Newton step (PLAN-081 M7). When a body
     sets `DeformableMaterialProperties.useIterativeLinearSolver` (dartpy

--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -4643,17 +4643,27 @@ bool computeProjectedNewtonDirection(
 
   Eigen::VectorXd solution;
   if (solveIteratively) {
-    // Iterative path: a Jacobi (diagonal) preconditioned conjugate-gradient
+    // Iterative path: an incomplete-Cholesky preconditioned conjugate-gradient
     // solve. The inertia term (m/dt^2 on every free DOF) plus the PSD-projected
     // spring/barrier blocks make the Hessian symmetric positive definite, so CG
-    // is guaranteed to converge; it never factorizes, so time and memory stay
-    // near O(nnz) per iteration and the solve scales to meshes well past the
-    // direct cap. Reading only the lower triangle matches the direct solver's
-    // symmetric assumption. A non-converged or non-finite solve falls back to
-    // mass-scaled steepest descent below (conservative: a partial CG iterate is
-    // still a descent direction, but the exact-solve contract prefers the
-    // robust fallback).
-    Eigen::ConjugateGradient<Eigen::SparseMatrix<double>, Eigen::Lower> cg;
+    // is guaranteed to converge; it only ever factorizes *incompletely* (a
+    // sparse approximate Cholesky that drops fill), so time and memory stay
+    // near O(nnz) and the solve scales to meshes well past the direct cap. The
+    // incomplete-Cholesky preconditioner is far stronger than a diagonal
+    // (Jacobi) one on the ill-conditioned Hessians that stiff barrier contact
+    // produces -- it collapses the CG iteration count there, so the iterative
+    // path converges within the cap (and thus matches the direct solve) on
+    // contact scenes where plain Jacobi-CG would stall and fall back. Reading
+    // only the lower triangle matches the direct solver's symmetric assumption.
+    // A non-converged or non-finite solve (including an incomplete-Cholesky
+    // breakdown that Eigen's diagonal shifting cannot repair) falls back to
+    // mass-scaled steepest descent below, exactly as the direct path does on an
+    // indefinite factorization.
+    Eigen::ConjugateGradient<
+        Eigen::SparseMatrix<double>,
+        Eigen::Lower,
+        Eigen::IncompleteCholesky<double>>
+        cg;
     cg.setTolerance(1e-8);
     cg.setMaxIterations(static_cast<Eigen::Index>(2) * dim);
     cg.compute(hessian);

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -33,17 +33,21 @@ AI attribution). Net status by milestone:
   while tangential sliding + friction survive (the CCD limiter no longer scales the
   whole step). The "right" CCD fix (limit only the normal approach, keep fast-motion
   CCD safety) remains a documented higher-risk follow-up, cf. #2732.
-- **M7 scale + performance — first increment landing.** Opt-in **iterative
-  (Jacobi-preconditioned conjugate-gradient) projected-Newton linear solve**
-  (`DeformableMaterialProperties.useIterativeLinearSolver`): reuses the sparse SPD
-  Hessian assembly but solves with CG instead of `SimplicialLDLT`, so it never
-  factorizes (memory ~O(nnz), gentler scaling than direct fill-in). Meshes above
-  the direct node cap (20k) take CG automatically (ceiling raised to 1M nodes)
-  instead of degrading to gradient descent; non-convergence falls back to steepest
-  descent like the direct path. A CUDA backend exists for PSD projection + VBD
-  (another track, #2781); on-device GPU assembly/solve, a truly matrix-free
-  Hessian-vector CG, a stronger preconditioner (IC/AMG) for stiff barrier Hessians,
-  and the 688K-node Fig-22 run + Table-1 reference comparison remain.
+- **M7 scale + performance — two increments landed.** (1) Opt-in **iterative
+  conjugate-gradient projected-Newton linear solve**
+  (`DeformableMaterialProperties.useIterativeLinearSolver`, #2810): reuses the
+  sparse SPD Hessian assembly but solves with CG instead of `SimplicialLDLT`, so it
+  never factorizes (memory ~O(nnz), gentler scaling than direct fill-in). Meshes
+  above the direct node cap (20k) take CG automatically (ceiling raised to 1M
+  nodes) instead of degrading to gradient descent; non-convergence falls back to
+  steepest descent like the direct path. (2) **Incomplete-Cholesky preconditioner**
+  (this PR): upgraded from diagonal (Jacobi); on stiff barrier contact it collapses
+  the CG iteration count so the iterative path carries the solve within the cap
+  (fallbacks drop below the direct solver's, fewer Newton iters/step). A CUDA
+  backend exists for PSD projection + VBD (another track, #2781); on-device GPU
+  assembly/solve, a truly matrix-free Hessian-vector CG, an AMG preconditioner for
+  the largest systems, and the 688K-node Fig-22 run + Table-1 reference comparison
+  remain.
 
 Session PR train (all merged to `main`): #2787 FEM keystone, #2788 FEM twist,
 #2789 FEM+ground, #2790 sphere barrier Hessian, #2791 box barrier, #2792/#2793
@@ -51,27 +55,24 @@ GMSH 2.x/4.x, #2794 FCR material, #2795 FCR benchmark+SVD-dedup, #2796 exact FCR
 Hessian, #2797 solver diagnostics, #2798 FEM self-contact showcase, #2799
 benchmark Newton-iters, #2800 `.obj` importer, #2802 `.seg`/`.pt` importers, #2804
 capsule obstacle, #2805 adaptive stiffness, #2809 barrier-only obstacle (M5 done),
-and the iterative-CG solve (this PR, M7 increment). The IPC Deformable (sx)
-py-demos category now has ~20 scenes (latest: `ipc_deformable_cg_solver`).
+#2810 iterative-CG solve (M7 increment 1), and the incomplete-Cholesky
+preconditioner (this PR, M7 increment 2). The IPC Deformable (sx) py-demos category
+now has ~21 scenes (latest: `ipc_deformable_cg_solver`, `ipc_deformable_cg_contact`).
 
 ### M7 Next (resume here)
 
 M1–M6 + M5 are all complete; **M7 (scale + performance) is the only remaining
-milestone.** The opt-in iterative CG solve (this PR) is its first increment. The
-remaining M7 work, roughly in increasing-risk order:
+milestone.** Two increments landed (iterative CG solve #2810; incomplete-Cholesky
+preconditioner, this PR). The remaining M7 work, roughly in increasing-risk order:
 
-1. **Stronger preconditioner.** The current CG uses a Jacobi (diagonal)
-   preconditioner; stiff barrier-contact Hessians are ill-conditioned and can hit
-   the CG iteration cap → fall back to steepest descent (the direct solver falls
-   back at a similar rate on the same transients, so CG is not _worse_, but a
-   poorer convergence ceiling). An incomplete-Cholesky / AMG preconditioner would
-   let CG converge on stiff contact without falling back. CG params live in
-   `computeProjectedNewtonDirection` in `compute/world_step_stage.cpp`
-   (tolerance `1e-8`, `maxIterations = 2*dim`, `Eigen::Lower`).
-2. **Truly matrix-free CG.** The current path still assembles the sparse Hessian
+1. **Truly matrix-free CG.** The current path still assembles the sparse Hessian
    (triplets → `SparseMatrix`) before the CG solve; a matrix-free Hessian-vector
    product (per-element block × vector, scattered) would drop the assembly memory
-   for very large meshes (Fig 22, 688K nodes).
+   for very large meshes (Fig 22, 688K nodes). CG params live in
+   `computeProjectedNewtonDirection` in `compute/world_step_stage.cpp` (tolerance
+   `1e-8`, `maxIterations = 2*dim`, `Eigen::Lower`, `Eigen::IncompleteCholesky`).
+2. **AMG / multigrid preconditioner** for the largest systems (beyond what
+   incomplete-Cholesky handles).
 3. **GPU assembly + solve.** Extend the existing CUDA PSD-projection backend
    (#2781) to the full deformable assembly + a GPU CG, beyond the current PSD
    offload.

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -213,8 +213,8 @@ per scene. Acceptance: match or undercut IPC's per-step CPU time at equal
 accuracy on shared scenes (Table 1, Fig 23), then report GPU acceleration as
 net-new.
 
-**First increment landed:** an opt-in iterative (Jacobi-preconditioned
-conjugate-gradient) projected-Newton linear solve
+**First increment landed:** an opt-in iterative conjugate-gradient
+projected-Newton linear solve
 (`DeformableMaterialProperties.useIterativeLinearSolver` / dartpy
 `use_iterative_linear_solver`). It reuses the existing sparse SPD Hessian
 assembly but solves with CG instead of `SimplicialLDLT`, so it never factorizes
@@ -230,12 +230,24 @@ solve paths (CG run never factorizes), with a `cg_solver` py-demo and a
 `BM_DeformableCgBarStep` benchmark mirroring the direct FEM-bar benchmark for
 per-step scaling comparison.
 
+**Second increment landed:** the CG preconditioner was strengthened from
+diagonal (Jacobi) to **incomplete-Cholesky**. Stiff barrier contact makes the
+Hessian ill-conditioned, where Jacobi-CG stalls against its iteration cap and
+falls back to steepest descent; the incomplete-Cholesky preconditioner (a sparse
+approximate factorization that drops fill, so the solve still stays near O(nnz))
+collapses the CG iteration count so the iterative path carries stiff contact
+within the cap. On a settling stiff FEM contact scene this cuts the iterative
+solver's fallbacks below the direct solver's and reduces Newton iterations per
+step. Verified by a regression in which a stiff (E = 1e6) FEM cube settles on a
+ground barrier through the iterative path with accepted CG steps dominating
+fallbacks and the same equilibrium as the direct solve, plus a `cg_contact`
+py-demo.
+
 Remaining M7 work: a truly matrix-free Hessian-vector CG (skip the sparse
-assembly entirely), a stronger preconditioner (incomplete-Cholesky / AMG) so
-stiff barrier-contact Hessians converge without falling back, on-device GPU
-assembly + solve beyond the current PSD offload, the 688K-node Fig-22 scale
-run, and the profiling-grade per-scene Fig-23 statistics harness with the
-Table-1 CPU comparison against the reference.
+assembly entirely), an AMG / multigrid preconditioner for the largest systems,
+on-device GPU assembly + solve beyond the current PSD offload, the 688K-node
+Fig-22 scale run, and the profiling-grade per-scene Fig-23 statistics harness
+with the Table-1 CPU comparison against the reference.
 
 ## Honest status
 

--- a/python/examples/demos/registry.py
+++ b/python/examples/demos/registry.py
@@ -31,6 +31,7 @@ from .scenes.heightmap import SCENE as HEIGHTMAP
 from .scenes.hello_world import SCENE as HELLO_WORLD
 from .scenes.hybrid_dynamics import SCENE as HYBRID_DYNAMICS
 from .scenes.ipc_deformable_capsule_rod import SCENE as IPC_DEFORMABLE_CAPSULE_ROD
+from .scenes.ipc_deformable_cg_contact import SCENE as IPC_DEFORMABLE_CG_CONTACT
 from .scenes.ipc_deformable_cg_solver import SCENE as IPC_DEFORMABLE_CG_SOLVER
 from .scenes.ipc_deformable_drape import SCENE as IPC_DEFORMABLE_DRAPE
 from .scenes.ipc_deformable_fcr_twist import SCENE as IPC_DEFORMABLE_FCR_TWIST
@@ -185,6 +186,7 @@ def make_demo_scenes() -> list[PythonDemoScene]:
         IPC_DEFORMABLE_FEM_BUCKLE,
         IPC_DEFORMABLE_FEM_MSH,
         IPC_DEFORMABLE_CG_SOLVER,
+        IPC_DEFORMABLE_CG_CONTACT,
         IPC_DEFORMABLE_OBJ_CLOTH,
         IPC_DEFORMABLE_CAPSULE_ROD,
         IPC_DEFORMABLE_SEG_STRAND,

--- a/python/examples/demos/scenes/ipc_deformable_cg_contact.py
+++ b/python/examples/demos/scenes/ipc_deformable_cg_contact.py
@@ -1,0 +1,82 @@
+"""Stiff FEM cube settling on a ground barrier via the iterative CG solve (PLAN-081 M7).
+
+A dense, stiff tetrahedral FEM cube falls under gravity onto a static ground
+barrier, squashes on impact, and settles intersection-free -- driven by the
+**iterative** projected-Newton linear solve (``use_iterative_linear_solver``).
+Stiff barrier contact makes the Newton Hessian ill-conditioned, which is exactly
+where a diagonal (Jacobi) conjugate gradient stalls; the incomplete-Cholesky
+preconditioner collapses the CG iteration count so the matrix-light iterative
+solve carries the contact without falling back to steepest descent. CG never
+factorizes, so its memory stays near O(nnz) -- the scaling axis of the IPC
+paper's large-scale contact benchmarks (Fig. 23 / Table 1).
+
+DART-native FEM/scale showcase -- not a faithful IPC paper-figure reproduction
+(single analytic ground barrier; this isolates the volumetric elasticity, stiff
+contact, and the incomplete-Cholesky-preconditioned iterative linear solve).
+"""
+
+from __future__ import annotations
+
+import dartpy.simulation_experimental as sx
+
+from .._ipc_deformable_bridge import IpcDeformableBridge, build_fem_bar
+from ..runner import PythonDemoScene, SceneSetup
+
+_GROUND_CENTER = (0.0, 0.0, -0.06)
+_GROUND_HALF = (1.2, 1.2, 0.06)  # top face at z = 0.0
+
+
+def build() -> SceneSetup:
+    # A dense, stiff cube of FEM tetrahedra released above the barrier.
+    options, edges = build_fem_bar(
+        cells_x=5,
+        cells_y=5,
+        cells_z=5,
+        cell_size=0.05,
+        origin=(-0.125, -0.125, 0.34),
+        # A stiff modulus makes the contact Hessian ill-conditioned -- the regime
+        # where the incomplete-Cholesky preconditioner keeps CG converging.
+        youngs_modulus=1.0e6,
+        poisson_ratio=0.3,
+        density=1.0e3,
+    )
+    options.fixed_nodes = []
+    # Drive this body through the incomplete-Cholesky-preconditioned CG Newton
+    # solve instead of the sparse Cholesky factorization.
+    options.material.use_iterative_linear_solver = True
+
+    world = sx.World()
+    world.gravity = [0.0, 0.0, -9.81]
+    world.time_step = 0.004
+
+    ground = world.add_rigid_body("ground", position=_GROUND_CENTER)
+    ground.is_static = True
+    ground.set_collision_shape(sx.CollisionShape.box(_GROUND_HALF))
+    ground.is_deformable_ground_barrier = True
+
+    body = world.add_deformable_body("fem_cg_contact", options)
+    world.enter_simulation_mode()
+
+    bridge = IpcDeformableBridge(world, name="ipc_deformable_cg_contact")
+    bridge.add_rigid_box_visual(
+        _GROUND_CENTER,
+        tuple(2.0 * h for h in _GROUND_HALF),
+        (0.37, 0.40, 0.43),
+        name="ground_visual",
+    )
+    bridge.add_deformable_visual(body, name="fem_cg_contact", edges=edges)
+
+    return SceneSetup(
+        world=bridge.render_world,
+        pre_step=bridge.pre_step,
+        info={"sx_world": world, "nodes": body.node_count},
+    )
+
+
+SCENE = PythonDemoScene(
+    id="ipc_deformable_cg_contact",
+    title="Deformable FEM CG Contact (IPC)",
+    category="IPC Deformable (sx)",
+    summary="A stiff FEM cube settles on an IPC ground barrier via the incomplete-Cholesky CG Newton solve.",
+    build=build,
+)

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -400,6 +400,7 @@ def test_ipc_deformable_scenes_share_dedicated_category() -> None:
         "ipc_deformable_fem_buckle",
         "ipc_deformable_fem_msh",
         "ipc_deformable_cg_solver",
+        "ipc_deformable_cg_contact",
         "ipc_deformable_obj_cloth",
         "ipc_deformable_capsule_rod",
         "ipc_deformable_rod_friction",

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -3568,6 +3568,93 @@ TEST(DeformableBody, IterativeLinearSolverMatchesDirectSolve)
   }
 }
 
+//==============================================================================
+// Stiff barrier contact produces an ill-conditioned Hessian; a weak diagonal
+// (Jacobi) CG preconditioner stalls there and forces the iterative solver to
+// fall back to steepest descent. The incomplete-Cholesky preconditioner
+// collapses the CG iteration count so the iterative path carries the solve.
+// This drops a stiff FEM cube onto a ground barrier with the iterative solver
+// and checks it settles intersection-free through the CG path (never
+// factorizing), that accepted CG steps dominate the fallbacks (the
+// preconditioner is strong enough that CG -- not steepest descent -- does the
+// work), and that it reaches the same equilibrium as the direct solver on the
+// identical stiff scene.
+TEST(DeformableBody, IterativeSolverConvergesOnStiffGroundContact)
+{
+  struct StiffRun
+  {
+    std::vector<Eigen::Vector3d> positions;
+    std::size_t cgSolves = 0;
+    std::size_t numericFactorizations = 0;
+    std::size_t fallbacks = 0;
+    double minZ = std::numeric_limits<double>::infinity();
+  };
+
+  const auto runStiffCube = [](bool iterative) {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(0.004);
+
+    sx::RigidBodyOptions groundOptions;
+    groundOptions.isStatic = true;
+    groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+    auto ground = world.addRigidBody("ground", groundOptions);
+    ground.setCollisionShape(
+        sx::CollisionShape::makeBox(Eigen::Vector3d(5.0, 5.0, 0.5)));
+    ground.setDeformableGroundBarrier(true); // top face at z = 0
+
+    // A stiffer cube (E = 1e6) than the soft-contact equivalence test, so the
+    // contact Hessian is ill-conditioned enough to exercise the preconditioner.
+    auto options = makeFemCubeBody(0.2, Eigen::Vector3d(0.0, 0.0, 0.3), 1.0e6);
+    options.material.useIterativeLinearSolver = iterative;
+    auto body = world.addDeformableBody("stiff_cube", options);
+
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+
+    StiffRun run;
+    for (int i = 0; i < 250; ++i) {
+      world.step(executor, pipeline);
+      const auto& stats = stage.getLastStats();
+      run.cgSolves += stats.projectedNewtonIterativeSolves;
+      run.numericFactorizations += stats.projectedNewtonNumericFactorizations;
+      run.fallbacks += stats.projectedNewtonFallbacks;
+    }
+    for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+      run.positions.push_back(body.getPosition(i));
+      run.minZ = std::min(run.minZ, body.getPosition(i).z());
+    }
+    return run;
+  };
+
+  const StiffRun direct = runStiffCube(false);
+  const StiffRun iterative = runStiffCube(true);
+
+  // The iterative run took the CG path and never factorized.
+  EXPECT_GT(iterative.cgSolves, 0u);
+  EXPECT_EQ(iterative.numericFactorizations, 0u);
+
+  // Both settle intersection-free above the ground top (z = 0).
+  EXPECT_GE(direct.minZ, -1e-3);
+  EXPECT_GE(iterative.minZ, -1e-3);
+
+  // The incomplete-Cholesky CG carries the solve on this stiff contact:
+  // accepted CG steps strictly dominate the fallbacks. A diagonal
+  // preconditioner would stall on the ill-conditioned contact Hessian and let
+  // fallbacks pile up.
+  EXPECT_GT(iterative.cgSolves, iterative.fallbacks);
+
+  // Same physics: the iterative solver reaches the same stiff-contact
+  // equilibrium as the direct solver.
+  ASSERT_EQ(direct.positions.size(), iterative.positions.size());
+  for (std::size_t i = 0; i < direct.positions.size(); ++i) {
+    ASSERT_TRUE(iterative.positions[i].allFinite());
+    expectVectorNear(iterative.positions[i], direct.positions[i], 2e-3);
+  }
+}
+
 namespace {
 struct GroundSlideResult
 {


### PR DESCRIPTION
## Summary

Second increment of **PLAN-081 M7 (scale + performance)**: upgrade the
experimental deformable iterative (conjugate-gradient) projected-Newton solve
from a **diagonal (Jacobi)** preconditioner to an **incomplete-Cholesky** one
(`Eigen::IncompleteCholesky`).

Stiff barrier contact makes the projected-Newton Hessian ill-conditioned. A
diagonal preconditioner leaves CG crawling against its iteration cap there, so
the iterative path keeps falling back to mass-scaled steepest descent. The
incomplete-Cholesky preconditioner is a **sparse approximate factorization that
drops fill** — so the solve still never fully factorizes and stays near O(nnz) —
and it collapses the CG iteration count on the ill-conditioned contact Hessian,
so the iterative path **carries stiff contact within the cap** instead of falling
back.

Measured on a settling stiff FEM contact scene this cuts the iterative solver's
fallbacks **below the direct solver's** (was *above* with Jacobi) and reduces the
Newton iterations per step. The public surface is unchanged — still opt-in via
`useIterativeLinearSolver`. An incomplete-Cholesky breakdown that Eigen's
built-in diagonal shifting cannot repair reports non-success and falls back to
steepest descent, exactly as the direct path does on an indefinite factorization.

## Changes

- **Solver** (`compute/world_step_stage.cpp`): swap the CG preconditioner to
  `Eigen::IncompleteCholesky<double>`; updated rationale comment.
- **Test**: `IterativeSolverConvergesOnStiffGroundContact` — a stiff (E = 1e6)
  FEM cube settles on a ground barrier through the iterative path (never
  factorizing), with accepted CG steps dominating fallbacks and the same
  equilibrium as the direct solver.
- **Example**: `ipc_deformable_cg_contact` py-demo — a stiff FEM cube settling on
  a barrier via the incomplete-Cholesky CG solve (registered + pinned).
- **Docs**: CHANGELOG, PLAN-081 roadmap M7, dev-task RESUME handoff.

## Verification

`pixi run test-all` → **6/6 PASSED** (Linting, Build, Unit, Simulation-Experimental,
Python, Documentation).

## Deferred (later M7 increments)

An AMG / multigrid preconditioner for the largest systems, a truly matrix-free
Hessian-vector CG, on-device GPU assembly + solve, and the 688K-node Fig-22 scale
run with the Table-1 reference comparison.

Milestone: **DART 7.0**. Builds on #2810.