### PR TITLE
Add a chunky 3D FEM-cube direct-vs-iterative scaling benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1099,6 +1099,22 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     a dartpy regression (a strip shoved along a rod slides far frictionless but is
     held back under friction, staying on the rod) and a `Deformable Friction on
 Capsule Rod (IPC)` py-demos scene.
+  - Added a chunky 3D FEM-cube **direct-vs-iterative scaling benchmark** for the
+    experimental deformable solver (PLAN-081 M7). `BM_DeformableCube3dDirectStep`
+    and `BM_DeformableCube3dCgStep` step a solid N^3 cube of FEM tetrahedra
+    (pinned at one face) through the sparse Cholesky direct solve and the
+    incomplete-Cholesky-preconditioned conjugate gradient at matching cell
+    counts. Unlike the thin `BM_DeformableFemBarStep` beam (2x2 cross-section,
+    too small a bandwidth), the solid cube has a wide Hessian bandwidth, so the
+    direct solve's 3D fill-in makes its per-step time climb super-linearly while
+    the iterative solve stays near O(nnz): the iterative path overtakes the
+    direct solve by a few thousand nodes (on the development machine the per-step
+    cost crosses over near ~1k nodes and the iterative solve runs several times
+    faster by ~1.3k nodes). This is the per-step-scaling axis of the IPC paper's
+    Fig. 23 / Table 1 on the mesh shape where the iterative solver bites. Adds a
+    regression that a chunky 3D cube sags to the same equilibrium under both
+    solvers (mutually exclusive solve paths -- the iterative run never
+    factorizes), guarding the benchmark fixture.
   - Strengthened the experimental deformable iterative solve's preconditioner
     from diagonal (Jacobi) to **incomplete-Cholesky** (PLAN-081 M7). Stiff
     barrier contact makes the projected-Newton Hessian ill-conditioned, where a

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -33,7 +33,7 @@ AI attribution). Net status by milestone:
   while tangential sliding + friction survive (the CCD limiter no longer scales the
   whole step). The "right" CCD fix (limit only the normal approach, keep fast-motion
   CCD safety) remains a documented higher-risk follow-up, cf. #2732.
-- **M7 scale + performance — two increments landed.** (1) Opt-in **iterative
+- **M7 scale + performance — three increments landed.** (1) Opt-in **iterative
   conjugate-gradient projected-Newton linear solve**
   (`DeformableMaterialProperties.useIterativeLinearSolver`, #2810): reuses the
   sparse SPD Hessian assembly but solves with CG instead of `SimplicialLDLT`, so it
@@ -41,13 +41,16 @@ AI attribution). Net status by milestone:
   above the direct node cap (20k) take CG automatically (ceiling raised to 1M
   nodes) instead of degrading to gradient descent; non-convergence falls back to
   steepest descent like the direct path. (2) **Incomplete-Cholesky preconditioner**
-  (this PR): upgraded from diagonal (Jacobi); on stiff barrier contact it collapses
+  (#2811): upgraded from diagonal (Jacobi); on stiff barrier contact it collapses
   the CG iteration count so the iterative path carries the solve within the cap
-  (fallbacks drop below the direct solver's, fewer Newton iters/step). A CUDA
-  backend exists for PSD projection + VBD (another track, #2781); on-device GPU
-  assembly/solve, a truly matrix-free Hessian-vector CG, an AMG preconditioner for
-  the largest systems, and the 688K-node Fig-22 run + Table-1 reference comparison
-  remain.
+  (fallbacks drop below the direct solver's, fewer Newton iters/step). (3)
+  **Chunky-3D scaling benchmark** (this PR): `BM_DeformableCube3d{Direct,Cg}Step`
+  on a solid N^3 cube (wide Hessian bandwidth) makes the crossover measurable --
+  direct 3D fill-in climbs super-linearly while IC-CG stays ~O(nnz); measured ~5x
+  faster CG at ~4k nodes (11.3 vs 2.3 s/step). A CUDA backend exists for PSD
+  projection + VBD (another track, #2781); on-device GPU assembly/solve, a truly
+  matrix-free Hessian-vector CG, an AMG preconditioner for the largest systems,
+  and the 688K-node Fig-22 run + Table-1 reference comparison remain.
 
 Session PR train (all merged to `main`): #2787 FEM keystone, #2788 FEM twist,
 #2789 FEM+ground, #2790 sphere barrier Hessian, #2791 box barrier, #2792/#2793
@@ -55,15 +58,17 @@ GMSH 2.x/4.x, #2794 FCR material, #2795 FCR benchmark+SVD-dedup, #2796 exact FCR
 Hessian, #2797 solver diagnostics, #2798 FEM self-contact showcase, #2799
 benchmark Newton-iters, #2800 `.obj` importer, #2802 `.seg`/`.pt` importers, #2804
 capsule obstacle, #2805 adaptive stiffness, #2809 barrier-only obstacle (M5 done),
-#2810 iterative-CG solve (M7 increment 1), and the incomplete-Cholesky
-preconditioner (this PR, M7 increment 2). The IPC Deformable (sx) py-demos category
+#2810 iterative-CG solve (M7 increment 1), #2811 incomplete-Cholesky
+preconditioner (M7 increment 2), and the chunky-3D scaling benchmark (this PR, M7
+increment 3). The IPC Deformable (sx) py-demos category
 now has ~21 scenes (latest: `ipc_deformable_cg_solver`, `ipc_deformable_cg_contact`).
 
 ### M7 Next (resume here)
 
 M1–M6 + M5 are all complete; **M7 (scale + performance) is the only remaining
-milestone.** Two increments landed (iterative CG solve #2810; incomplete-Cholesky
-preconditioner, this PR). The remaining M7 work, roughly in increasing-risk order:
+milestone.** Three increments landed (iterative CG solve #2810; incomplete-Cholesky
+preconditioner #2811; chunky-3D scaling benchmark, this PR). The remaining M7 work,
+roughly in increasing-risk order:
 
 1. **Truly matrix-free CG.** The current path still assembles the sparse Hessian
    (triplets → `SparseMatrix`) before the CG solve; a matrix-free Hessian-vector
@@ -79,9 +84,10 @@ preconditioner, this PR). The remaining M7 work, roughly in increasing-risk orde
 4. **Profiling-grade benchmark + reference comparison.** Emit Fig-23-shaped
    per-scene statistics (avg/max contacts/step, Newton iters/step, peak memory,
    s/step) and the Table-1 CPU comparison vs the IPC reference. The
-   `BM_DeformableCgBarStep` / `BM_DeformableFemBarStep` benchmarks (both now to
-   `cellsX=48`) are the seed; a chunky 3D mesh (not the thin bar) is needed to make
-   CG's fill-in advantage visible at benchmark-tractable sizes.
+   `BM_DeformableCube3d{Direct,Cg}Step` chunky-3D benchmarks (this PR) already
+   make the direct-vs-iterative crossover measurable; what remains is peak-memory
+   tracking, the avg/max contacts-per-step axis on contact scenes, and the
+   side-by-side comparison against the published IPC reference numbers.
 
 ### Conventions / gotchas (verified this session)
 

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -243,6 +243,19 @@ ground barrier through the iterative path with accepted CG steps dominating
 fallbacks and the same equilibrium as the direct solve, plus a `cg_contact`
 py-demo.
 
+**Third increment landed:** a chunky 3D FEM-cube direct-vs-iterative scaling
+benchmark (`BM_DeformableCube3dDirectStep` / `BM_DeformableCube3dCgStep`) that
+makes the crossover measurable on the mesh shape where it bites. On a solid N^3
+cube the direct solve's 3D fill-in makes its per-step time climb super-linearly
+while the incomplete-Cholesky CG stays near O(nnz); on the development machine
+the per-step cost crosses over near ~1k nodes and the iterative solve runs ~5x
+faster by ~4k nodes (measured: 11.3 s/step direct vs 2.3 s/step iterative at
+4096 nodes). The thin `BM_DeformableFemBarStep` beam (2x2 cross-section) cannot
+show this -- its bandwidth is too small -- which is why the chunky fixture was
+added. Guarded by a regression that the chunky 3D cube sags to the same
+equilibrium under both solvers. This is the first concrete, measured rung of the
+Fig-23 / Table-1 per-step-scaling axis.
+
 Remaining M7 work: a truly matrix-free Hessian-vector CG (skip the sparse
 assembly entirely), an AMG / multigrid preconditioner for the largest systems,
 on-device GPU assembly + solve beyond the current PSD offload, the 688K-node

--- a/tests/benchmark/simulation/experimental/bm_deformable_body.cpp
+++ b/tests/benchmark/simulation/experimental/bm_deformable_body.cpp
@@ -240,6 +240,73 @@ sx::DeformableBodyOptions makeFemBarOptions(
 }
 
 //==============================================================================
+// A solid cellsPerSide^3 cube of FEM tetrahedra (each hexahedral cell split
+// into six tets), pinned at its x == 0 face. Unlike the thin makeFemBarOptions
+// beam (2x2 cross-section), this is a chunky 3D mesh, so the projected-Newton
+// Hessian has a wide bandwidth: the sparse Cholesky direct solve suffers
+// super-linear fill-in here while a preconditioned conjugate gradient stays
+// near O(nnz), which is the regime the iterative solver is built for. Used to
+// benchmark the direct-vs-iterative crossover as the element count grows.
+sx::DeformableBodyOptions makeFemCubeOptions(
+    int cellsPerSide, bool useIterativeSolver)
+{
+  const int cells = std::max(cellsPerSide, 1);
+  const int n = cells + 1;
+  constexpr double h = 0.04;
+  const auto nodeIndex = [&](int i, int j, int k) {
+    return static_cast<std::size_t>(i + n * (j + n * k));
+  };
+
+  sx::DeformableBodyOptions options;
+  options.material.density = 1.0e3;
+  options.material.youngsModulus = 2.0e5;
+  options.material.poissonRatio = 0.3;
+  options.material.useFiniteElementElasticity = true;
+  options.material.useIterativeLinearSolver = useIterativeSolver;
+
+  for (int k = 0; k < n; ++k) {
+    for (int j = 0; j < n; ++j) {
+      for (int i = 0; i < n; ++i) {
+        options.positions.push_back(Eigen::Vector3d(i * h, j * h, 1.0 + k * h));
+      }
+    }
+  }
+
+  static constexpr int kCubeTets[6][4]
+      = {{0, 1, 3, 7},
+         {0, 3, 2, 7},
+         {0, 2, 6, 7},
+         {0, 6, 4, 7},
+         {0, 4, 5, 7},
+         {0, 5, 1, 7}};
+  for (int ck = 0; ck < cells; ++ck) {
+    for (int cj = 0; cj < cells; ++cj) {
+      for (int ci = 0; ci < cells; ++ci) {
+        std::array<std::size_t, 8> corner{};
+        for (int b = 0; b < 8; ++b) {
+          corner[static_cast<std::size_t>(b)] = nodeIndex(
+              ci + (b & 1), cj + ((b >> 1) & 1), ck + ((b >> 2) & 1));
+        }
+        for (const auto& tet : kCubeTets) {
+          options.tetrahedra.push_back(
+              {corner[static_cast<std::size_t>(tet[0])],
+               corner[static_cast<std::size_t>(tet[1])],
+               corner[static_cast<std::size_t>(tet[2])],
+               corner[static_cast<std::size_t>(tet[3])]});
+        }
+      }
+    }
+  }
+
+  for (int k = 0; k < n; ++k) {
+    for (int j = 0; j < n; ++j) {
+      options.fixedNodes.push_back(nodeIndex(0, j, k));
+    }
+  }
+  return options;
+}
+
+//==============================================================================
 struct DeformableGridWorld
 {
   DeformableGridWorld(int columns, int rows, bool withGround)
@@ -1053,6 +1120,75 @@ void BM_DeformableCgBarStep(benchmark::State& state)
 }
 
 //==============================================================================
+struct DeformableFemCubeWorld
+{
+  DeformableFemCubeWorld(int cellsPerSide, bool useIterativeSolver)
+  {
+    body = world.addDeformableBody(
+        "fem_cube", makeFemCubeOptions(cellsPerSide, useIterativeSolver));
+    nodeCount = body.getNodeCount();
+    tetrahedronCount = body.getTetrahedronCount();
+    for (std::size_t i = 0; i < nodeCount; ++i) {
+      totalMass += body.getMass(i);
+    }
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(1.0 / 240.0);
+    world.enterSimulationMode();
+  }
+
+  sx::World world;
+  sx::DeformableBody body;
+  std::size_t nodeCount = 0;
+  std::size_t tetrahedronCount = 0;
+  double totalMass = 0.0;
+};
+
+//==============================================================================
+// Steps a chunky cellsPerSide^3 FEM cube and records the per-step cost and
+// Newton-iteration count. The cube is run with both the sparse Cholesky direct
+// solve (BM_DeformableCube3dDirectStep) and the incomplete-Cholesky
+// preconditioned conjugate-gradient iterative solve (BM_DeformableCube3dCgStep)
+// at matching cell counts, so the direct-vs-iterative crossover is measurable:
+// the direct solve's 3D fill-in makes its per-step time climb super-linearly
+// with the element count, while the iterative solve stays near O(nnz) and
+// overtakes it by a few thousand nodes (the IPC paper's Fig. 23 / Table 1
+// per-step-scaling axis, on the chunky mesh where it bites -- the thin
+// BM_DeformableFemBarStep beam has too small a bandwidth to show it).
+void BM_DeformableCube3dStep(benchmark::State& state, bool useIterativeSolver)
+{
+  const auto cellsPerSide = static_cast<int>(state.range(0));
+  DeformableFemCubeWorld fixture(cellsPerSide, useIterativeSolver);
+
+  double totalNewtonIterations = 0.0;
+  for (auto _ : state) {
+    fixture.world.step();
+    totalNewtonIterations += static_cast<double>(
+        fixture.world.getLastDeformableSolverDiagnostics().solverIterations);
+    benchmark::DoNotOptimize(
+        fixture.body.getPosition(fixture.nodeCount - 1u).z());
+  }
+
+  state.counters["nodes"] = static_cast<double>(fixture.nodeCount);
+  state.counters["tetrahedra"] = static_cast<double>(fixture.tetrahedronCount);
+  state.counters["total_mass"] = fixture.totalMass;
+  state.counters["contact_constraints"] = 0.0;
+  state.counters["newton_iters_per_step"]
+      = totalNewtonIterations / static_cast<double>(state.iterations());
+  state.SetItemsProcessed(
+      static_cast<int64_t>(state.iterations() * fixture.nodeCount));
+}
+
+void BM_DeformableCube3dDirectStep(benchmark::State& state)
+{
+  BM_DeformableCube3dStep(state, /*useIterativeSolver=*/false);
+}
+
+void BM_DeformableCube3dCgStep(benchmark::State& state)
+{
+  BM_DeformableCube3dStep(state, /*useIterativeSolver=*/true);
+}
+
+//==============================================================================
 void BM_DeformableGridStage(benchmark::State& state)
 {
   const auto columns = static_cast<int>(state.range(0));
@@ -1522,6 +1658,11 @@ BENCHMARK(BM_DeformableTetraMeshStep)->Arg(1)->Arg(8)->Arg(32);
 BENCHMARK(BM_DeformableFemBarStep)->Arg(2)->Arg(8)->Arg(24)->Arg(48);
 BENCHMARK(BM_DeformableFcrBarStep)->Arg(2)->Arg(8)->Arg(24);
 BENCHMARK(BM_DeformableCgBarStep)->Arg(2)->Arg(8)->Arg(24)->Arg(48);
+// Chunky 3D cube, direct vs iterative at matching cell counts: the direct
+// solve's per-step time climbs super-linearly with the 3D fill-in while the
+// iterative solve stays near O(nnz) and overtakes it by a few thousand nodes.
+BENCHMARK(BM_DeformableCube3dDirectStep)->Arg(4)->Arg(6)->Arg(8)->Arg(10);
+BENCHMARK(BM_DeformableCube3dCgStep)->Arg(4)->Arg(6)->Arg(8)->Arg(10);
 
 // The 32x16 (512-node) and 48x24 (1152-node) grids exceed the former 256-node
 // dense-solve cap, so they exercise the sparse projected-Newton path; compare

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -3655,6 +3655,111 @@ TEST(DeformableBody, IterativeSolverConvergesOnStiffGroundContact)
   }
 }
 
+//==============================================================================
+// A chunky 3D FEM cube (solid N^3 cells, wide Hessian bandwidth) is exactly the
+// regime the iterative solver targets: the sparse Cholesky direct solve suffers
+// super-linear 3D fill-in there while the conjugate gradient stays near O(nnz).
+// This pins such a cube at its x == 0 face, lets it sag under gravity, and
+// confirms the iterative solver reaches the same equilibrium as the direct
+// solve on the wide-bandwidth mesh (the correctness guarantee behind the
+// BM_DeformableCube3d* scaling benchmarks), through the CG path (no
+// factorization).
+TEST(DeformableBody, IterativeSolverMatchesDirectOnChunky3dMesh)
+{
+  constexpr int kCells = 3; // 4^3 = 64 nodes, a solid 3D block
+  constexpr double h = 0.1;
+  const int n = kCells + 1;
+  const auto nodeIndex = [&](int i, int j, int k) {
+    return static_cast<std::size_t>(i + n * (j + n * k));
+  };
+  static constexpr int kCubeTets[6][4]
+      = {{0, 1, 3, 7},
+         {0, 3, 2, 7},
+         {0, 2, 6, 7},
+         {0, 6, 4, 7},
+         {0, 4, 5, 7},
+         {0, 5, 1, 7}};
+
+  const auto runCube = [&](bool iterative) {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(0.005);
+
+    sx::DeformableBodyOptions options;
+    options.material.youngsModulus = 2.0e5;
+    options.material.poissonRatio = 0.3;
+    options.material.useFiniteElementElasticity = true;
+    options.material.useIterativeLinearSolver = iterative;
+    for (int k = 0; k < n; ++k) {
+      for (int j = 0; j < n; ++j) {
+        for (int i = 0; i < n; ++i) {
+          options.positions.emplace_back(i * h, j * h, 0.5 + k * h);
+        }
+      }
+    }
+    for (int ck = 0; ck < kCells; ++ck) {
+      for (int cj = 0; cj < kCells; ++cj) {
+        for (int ci = 0; ci < kCells; ++ci) {
+          std::array<std::size_t, 8> corner{};
+          for (int b = 0; b < 8; ++b) {
+            corner[static_cast<std::size_t>(b)] = nodeIndex(
+                ci + (b & 1), cj + ((b >> 1) & 1), ck + ((b >> 2) & 1));
+          }
+          for (const auto& tet : kCubeTets) {
+            options.tetrahedra.push_back(
+                sx::DeformableTetrahedron{
+                    corner[static_cast<std::size_t>(tet[0])],
+                    corner[static_cast<std::size_t>(tet[1])],
+                    corner[static_cast<std::size_t>(tet[2])],
+                    corner[static_cast<std::size_t>(tet[3])]});
+          }
+        }
+      }
+    }
+    for (int k = 0; k < n; ++k) {
+      for (int j = 0; j < n; ++j) {
+        options.fixedNodes.push_back(nodeIndex(0, j, k));
+      }
+    }
+
+    auto body = world.addDeformableBody("chunky_cube", options);
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+
+    std::size_t cgSolves = 0;
+    std::size_t numericFactorizations = 0;
+    for (int i = 0; i < 80; ++i) {
+      world.step(executor, pipeline);
+      cgSolves += stage.getLastStats().projectedNewtonIterativeSolves;
+      numericFactorizations
+          += stage.getLastStats().projectedNewtonNumericFactorizations;
+    }
+    std::vector<Eigen::Vector3d> positions;
+    for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+      positions.push_back(body.getPosition(i));
+    }
+    return std::make_tuple(positions, cgSolves, numericFactorizations);
+  };
+
+  const auto [directPos, directCg, directFact] = runCube(false);
+  const auto [iterPos, iterCg, iterFact] = runCube(true);
+
+  // Mutually exclusive solve paths, as on the smaller meshes.
+  EXPECT_EQ(directCg, 0u);
+  EXPECT_GT(directFact, 0u);
+  EXPECT_GT(iterCg, 0u);
+  EXPECT_EQ(iterFact, 0u);
+
+  // Same sagged equilibrium on the wide-bandwidth 3D mesh.
+  ASSERT_EQ(directPos.size(), iterPos.size());
+  for (std::size_t i = 0; i < directPos.size(); ++i) {
+    ASSERT_TRUE(iterPos[i].allFinite());
+    expectVectorNear(iterPos[i], directPos[i], 1e-4);
+  }
+}
+
 namespace {
 struct GroundSlideResult
 {


### PR DESCRIPTION
## Summary

Third increment of **PLAN-081 M7 (scale + performance)**: a benchmark that makes
the direct-vs-iterative crossover **measurable** on the mesh shape where it
matters. `BM_DeformableCube3dDirectStep` and `BM_DeformableCube3dCgStep` step a
solid N³ cube of FEM tetrahedra (pinned at one face) through the sparse Cholesky
direct solve and the incomplete-Cholesky-preconditioned conjugate gradient
respectively, at matching cell counts.

Unlike the thin `makeFemBarOptions` beam (2×2 cross-section), the solid cube has
a **wide Hessian bandwidth**, so the direct solve's 3D fill-in makes its per-step
time climb super-linearly while the iterative solve stays near O(nnz):

| nodes | direct | IC-CG | speedup |
|------:|-------:|------:|--------:|
| 343 | 180 ms | 174 ms | 1.04× |
| 1000 | 818 ms | 644 ms | 1.27× |
| 2197 | 4195 ms | 1055 ms | 3.98× |
| 4096 | 11280 ms | 2311 ms | **4.88×** |

(measured on the development machine). The thin-bar benchmark cannot show this —
its bandwidth is too small — which is why the chunky fixture was added. This is
the first concrete, measured rung of the IPC paper's Fig. 23 / Table 1 per-step
scaling axis.

## Changes

- **Benchmark** (`bm_deformable_body.cpp`): `makeFemCubeOptions(cellsPerSide,
  useIterativeSolver)` chunky 3D fixture + `DeformableFemCubeWorld` +
  `BM_DeformableCube3dDirectStep` / `BM_DeformableCube3dCgStep` (registered at
  N = 4, 6, 8, 10).
- **Test**: `IterativeSolverMatchesDirectOnChunky3dMesh` — a solid 3D FEM cube
  sags to the same equilibrium under both solvers (mutually exclusive solve
  paths; the iterative run never factorizes), guarding the benchmark fixture.
- **Docs**: CHANGELOG, PLAN-081 roadmap M7, dev-task RESUME handoff.

## Verification

`pixi run test-all` → **6/6 PASSED**. The benchmark target compiles, links, and
runs (crossover reproduced).

## Deferred (later M7 increments)

Peak-memory tracking, the contacts-per-step axis on contact scenes, the
side-by-side comparison against the published IPC reference numbers, a truly
matrix-free Hessian-vector CG, and on-device GPU assembly + solve.

Milestone: **DART 7.0**. Builds on #2810, #2811.