### PR TITLE
Expose the deformable iterative-solve count in the public solver diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1099,6 +1099,16 @@ qdot)` that reaches the target exactly even under inertial coupling. The
     a dartpy regression (a strip shoved along a rod slides far frictionless but is
     held back under friction, staying on the rod) and a `Deformable Friction on
 Capsule Rod (IPC)` py-demos scene.
+  - Exposed the iterative-solve count through the public deformable solver
+    diagnostics (PLAN-081 M7). `DeformableSolverDiagnostics` (dartpy
+    `last_deformable_solver_diagnostics`) now carries
+    `projectedNewtonIterativeSolves` / `projected_newton_iterative_solves`, the
+    public mirror of the internal stat: it counts the Newton iterations whose
+    linear solve took the iterative (incomplete-Cholesky-preconditioned CG) path
+    instead of the sparse Cholesky factorization, so callers can observe and tune
+    which solve path a body uses (zero means every solve was direct). Adds C++
+    and Python regressions that the default direct solve reports zero while an
+    opt-in iterative body reports a nonzero count.
   - Added a chunky 3D FEM-cube **direct-vs-iterative scaling benchmark** for the
     experimental deformable solver (PLAN-081 M7). `BM_DeformableCube3dDirectStep`
     and `BM_DeformableCube3dCgStep` step a solid N^3 cube of FEM tetrahedra

--- a/dart/simulation/experimental/world.cpp
+++ b/dart/simulation/experimental/world.cpp
@@ -135,6 +135,8 @@ DeformableSolverDiagnostics makeDeformableSolverDiagnostics(
   diagnostics.lineSearchTrials = stats.lineSearchTrials;
   diagnostics.projectedNewtonSteps = stats.projectedNewtonSteps;
   diagnostics.projectedNewtonFallbacks = stats.projectedNewtonFallbacks;
+  diagnostics.projectedNewtonIterativeSolves
+      = stats.projectedNewtonIterativeSolves;
   diagnostics.selfContactBarrierActiveContacts
       = stats.selfContactBarrierActiveContacts;
   diagnostics.frictionDissipation = stats.frictionDissipation;

--- a/dart/simulation/experimental/world.hpp
+++ b/dart/simulation/experimental/world.hpp
@@ -90,6 +90,13 @@ struct DeformableSolverDiagnostics
   /// used when the Newton direction was not a descent direction.
   std::size_t projectedNewtonSteps = 0;
   std::size_t projectedNewtonFallbacks = 0;
+  /// Newton iterations whose linear solve took the iterative
+  /// (incomplete-Cholesky preconditioned conjugate-gradient) path instead of
+  /// the sparse Cholesky factorization -- either because the mesh exceeds the
+  /// direct-solve node cap or because the body opted in via
+  /// ``DeformableMaterialProperties.useIterativeLinearSolver``. Zero means
+  /// every solve used the direct factorization.
+  std::size_t projectedNewtonIterativeSolves = 0;
   /// Self-contact barrier active contacts summed over every solver iteration.
   std::size_t selfContactBarrierActiveContacts = 0;
   /// Coulomb friction energy dissipated at the converged iterate.

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -33,7 +33,8 @@ AI attribution). Net status by milestone:
   while tangential sliding + friction survive (the CCD limiter no longer scales the
   whole step). The "right" CCD fix (limit only the normal approach, keep fast-motion
   CCD safety) remains a documented higher-risk follow-up, cf. #2732.
-- **M7 scale + performance — three increments landed.** (1) Opt-in **iterative
+- **M7 scale + performance — four increments landed** (#2810/#2811/#2812 + the
+  public iterative-solve diagnostic). (1) Opt-in **iterative
   conjugate-gradient projected-Newton linear solve**
   (`DeformableMaterialProperties.useIterativeLinearSolver`, #2810): reuses the
   sparse SPD Hessian assembly but solves with CG instead of `SimplicialLDLT`, so it
@@ -59,8 +60,9 @@ Hessian, #2797 solver diagnostics, #2798 FEM self-contact showcase, #2799
 benchmark Newton-iters, #2800 `.obj` importer, #2802 `.seg`/`.pt` importers, #2804
 capsule obstacle, #2805 adaptive stiffness, #2809 barrier-only obstacle (M5 done),
 #2810 iterative-CG solve (M7 increment 1), #2811 incomplete-Cholesky
-preconditioner (M7 increment 2), and the chunky-3D scaling benchmark (this PR, M7
-increment 3). The IPC Deformable (sx) py-demos category
+preconditioner (M7 increment 2), #2812 chunky-3D scaling benchmark (M7 increment
+3), and the public iterative-solve diagnostic (this PR, M7 increment 4). The IPC
+Deformable (sx) py-demos category
 now has ~21 scenes (latest: `ipc_deformable_cg_solver`, `ipc_deformable_cg_contact`).
 
 ### M7 Next (resume here)

--- a/python/dartpy/simulation_experimental/module.cpp
+++ b/python/dartpy/simulation_experimental/module.cpp
@@ -1622,6 +1622,9 @@ void defSimulationExperimentalModule(nb::module_& m)
           "projected_newton_fallbacks",
           &sim::DeformableSolverDiagnostics::projectedNewtonFallbacks)
       .def_ro(
+          "projected_newton_iterative_solves",
+          &sim::DeformableSolverDiagnostics::projectedNewtonIterativeSolves)
+      .def_ro(
           "self_contact_barrier_active_contacts",
           &sim::DeformableSolverDiagnostics::selfContactBarrierActiveContacts)
       .def_ro(

--- a/python/stubs/dartpy/simulation_experimental.pyi
+++ b/python/stubs/dartpy/simulation_experimental.pyi
@@ -968,6 +968,9 @@ class DeformableSolverDiagnostics:
     def projected_newton_fallbacks(self) -> int: ...
 
     @property
+    def projected_newton_iterative_solves(self) -> int: ...
+
+    @property
     def self_contact_barrier_active_contacts(self) -> int: ...
 
     @property

--- a/python/tests/unit/simulation/test_experimental_world.py
+++ b/python/tests/unit/simulation/test_experimental_world.py
@@ -2592,6 +2592,9 @@ def test_experimental_world_exposes_deformable_solver_diagnostics():
     assert after.solver_iterations >= 1
     assert after.objective_evaluations >= 1
     assert after.projected_newton_steps + after.projected_newton_fallbacks >= 1
+    # This body uses the default direct (sparse Cholesky) solve, so the iterative
+    # (conjugate-gradient) path is never taken.
+    assert after.projected_newton_iterative_solves == 0
     # No contacts in this free-hanging single tet.
     assert after.self_contact_barrier_active_contacts == 0
     assert after.converged_active_contact_count == 0
@@ -2599,6 +2602,38 @@ def test_experimental_world_exposes_deformable_solver_diagnostics():
     # The snapshot is read-only.
     with pytest.raises((AttributeError, TypeError)):
         after.node_count = 99
+
+
+def test_experimental_world_iterative_solver_diagnostic():
+    sx = _simulation_experimental()
+    world = sx.World(time_step=0.01)
+    world.gravity = [0.0, 0.0, -9.81]
+
+    options = sx.DeformableBodyOptions()
+    options.positions = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([1.0, 0.0, 0.0]),
+        np.array([0.0, 1.0, 0.0]),
+        np.array([0.0, 0.0, 1.0]),
+    ]
+    options.tetrahedra = [sx.DeformableTetrahedron(0, 1, 2, 3)]
+    options.material.youngs_modulus = 1.0e4
+    options.material.use_finite_element_elasticity = True
+    # Opt in to the iterative (incomplete-Cholesky-preconditioned CG) linear
+    # solve instead of the sparse Cholesky factorization.
+    options.material.use_iterative_linear_solver = True
+    options.fixed_nodes = [0]
+    world.add_deformable_body("tet", options)
+
+    # The iterative-solve count surfaces through the public diagnostics, so a
+    # caller can observe which linear-solve path the projected-Newton step took.
+    total_iterative_solves = 0
+    for _ in range(8):
+        world.step()
+        total_iterative_solves += (
+            world.last_deformable_solver_diagnostics.projected_newton_iterative_solves
+        )
+    assert total_iterative_solves > 0
 
 
 def test_experimental_deformable_body_boundary_conditions_python_api():

--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -855,6 +855,39 @@ TEST(DeformableBody, ExposesDeformableSolverDiagnostics)
 }
 
 //==============================================================================
+// The public solver diagnostics expose which linear-solve path each Newton
+// iteration took: the default direct (sparse Cholesky) solve never reports an
+// iterative solve, while a body opting in to the iterative
+// (incomplete-Cholesky-preconditioned CG) solve surfaces a nonzero count. This
+// is the public-API mirror of the internal projectedNewtonIterativeSolves stat,
+// so Python callers can observe and tune the solver path.
+TEST(DeformableBody, DiagnosticsExposeIterativeSolveCount)
+{
+  const auto totalIterativeSolves = [](bool iterative) {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(0.01);
+    auto options = makeFemTetrahedronBody();
+    options.material.useIterativeLinearSolver = iterative;
+    world.addDeformableBody("fem", options);
+
+    std::size_t total = 0;
+    for (int i = 0; i < 8; ++i) {
+      world.step(1);
+      total += world.getLastDeformableSolverDiagnostics()
+                   .projectedNewtonIterativeSolves;
+    }
+    return total;
+  };
+
+  // The default direct solve never takes the iterative path...
+  EXPECT_EQ(totalIterativeSolves(false), 0u);
+  // ...while the opt-in iterative solve surfaces through the public
+  // diagnostics.
+  EXPECT_GT(totalIterativeSolves(true), 0u);
+}
+
+//==============================================================================
 // A FEM tetrahedron given an initial outward velocity on a free node is pulled
 // back toward its rest shape by the elastic restoring force, and the implicit
 // solve dissipates the motion so it settles near rest rather than diverging.


### PR DESCRIPTION
## Summary

Fourth increment of **PLAN-081 M7 (scale + performance)** — observability. Surface
the projected-Newton iterative-solve count through the public
`DeformableSolverDiagnostics` (dartpy `last_deformable_solver_diagnostics`):
`projectedNewtonIterativeSolves` / `projected_newton_iterative_solves`, the
curated mirror of the internal stat added with the iterative solve (#2810).

It counts the Newton iterations whose linear solve took the iterative
(incomplete-Cholesky-preconditioned CG) path instead of the sparse Cholesky
factorization — either because the mesh exceeds the direct-solve node cap or
because the body opted in via `useIterativeLinearSolver`. Zero means every solve
used the direct factorization.

This closes a public-API observability gap: callers could already read the
projected-Newton step/fallback counters but not which linear-solve path a body
actually used, so they could not confirm or tune the iterative opt-in from
outside the solver.

## Changes

- `DeformableSolverDiagnostics` gains the field (`world.hpp`), mapped from the
  internal stat (`world.cpp`), bound as `projected_newton_iterative_solves`
  (`module.cpp` + stub).
- **Tests**: C++ (`DiagnosticsExposeIterativeSolveCount`) and Python
  (`test_experimental_world_iterative_solver_diagnostic`) regressions — the
  default direct solve reports zero, an opt-in iterative body reports nonzero.
- **Docs**: CHANGELOG, dev-task RESUME handoff.

## Verification

`pixi run test-all` → **6/6 PASSED**.

Milestone: **DART 7.0**. Builds on #2810, #2811, #2812.