### PR TITLE
Skip rod/box friction deformable tests on reduced builds

### DIFF
--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -287,6 +287,8 @@ def test_ipc_deformable_rod_friction_decelerates_sliding_strip() -> None:
     slides measurably less with friction than without, while staying on the rod.
     """
 
+    _require_sx_attrs("DeformableBodyOptions")
+
     import numpy as np
 
     from examples.demos.scenes import ipc_deformable_rod_friction as scene
@@ -326,6 +328,8 @@ def test_ipc_deformable_barrier_only_box_friction_decelerates_strip() -> None:
     far frictionless but is held back under friction, staying above the top face --
     the CCD-free path to box/sphere obstacle friction.
     """
+
+    _require_sx_attrs("DeformableBodyOptions")
 
     import numpy as np
 


### PR DESCRIPTION
On reduced builds (experimental/deformable support off — e.g. the macOS arm64 CI
job and `Release Tests (arm64)`), `dartpy.simulation_experimental` omits the
deformable types. Two newer friction tests build an `sx.DeformableBodyOptions`
strip via `scene._build_strip()` but — unlike the sibling deformable tests —
lacked a `_require_sx_attrs(...)` guard, so they failed with
`AttributeError: module 'dartpy.simulation_experimental' has no attribute ...`
instead of skipping, reddening `CI macOS`.

Adds the same `_require_sx_attrs("DeformableBodyOptions")` guard the other
deformable tests already use to:
- `test_ipc_deformable_rod_friction_decelerates_sliding_strip`
- `test_ipc_deformable_barrier_only_box_friction_decelerates_strip`

### Test plan
- Full builds: unchanged (guard passes; tests run).
- Reduced builds (deformable off): both skip instead of erroring.