### PR TITLE
fix(test): use std::numbers::pi instead of M_PI (fixes Windows build)

### DIFF
--- a/tests/unit/simulation/experimental/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/experimental/world/test_deformable_body.cpp
@@ -43,6 +43,7 @@
 
 #include <array>
 #include <limits>
+#include <numbers>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -1194,7 +1195,7 @@ TEST(DeformableBody, CapsuleObstacleFrictionDeceleratesSlidingNode)
     sx::RigidBodyOptions rodOptions;
     rodOptions.isStatic = true;
     rodOptions.orientation = Eigen::Quaterniond(
-        Eigen::AngleAxisd(-M_PI / 2.0, Eigen::Vector3d::UnitX()));
+        Eigen::AngleAxisd(-std::numbers::pi / 2.0, Eigen::Vector3d::UnitX()));
     auto rod = world.addRigidBody("rod", rodOptions);
     constexpr double radius = 0.2;
     // The rod is long enough that the frictionless node stays on the


### PR DESCRIPTION
Fixes the Windows build break. **CI Windows has been red on `main` for hours** (since #2808) with no fix in flight.

## Cause

`tests/unit/simulation/experimental/world/test_deformable_body.cpp` (added in #2808, "Add Coulomb friction against the capsule rod obstacle") uses `M_PI`. MSVC does not declare `M_PI` unless `_USE_MATH_DEFINES` is defined before `<cmath>`, so the file compiles on glibc/libc++ (Linux/macOS) but fails on Windows:

```
test_deformable_body.cpp(1197,28): error C2065: 'M_PI': undeclared identifier
```

This breaks the `tests` target build → the **Tests (Release)** / CI Windows job (and blocks every PR's Windows check, including #2815 and #2803).

## Fix

Use the portable C++20 `std::numbers::pi` — the repo's prevailing convention (27 existing usages) — with an explicit `<numbers>` include. Verified the construct compiles at `-std=c++20`. Behavior is identical (`-std::numbers::pi / 2.0 == -M_PI / 2.0`).
