### PR TITLE
Packaging 6.16.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## DART 6
 
-### [DART 6.16.8 (TBD)](https://github.com/dartsim/dart/milestone/93?closed=1)
+### [DART 6.16.8 (2026-05-31)](https://github.com/dartsim/dart/milestone/93?closed=1)
 
 * GUI
 
   * Fix SEGV in ImFontAtlas::AddFontFromMemoryCompressedTTF when null pointer is passed as compressed font data: [#2516](https://github.com/dartsim/dart/issues/2516)
   * Fix `ImGui::ColorPicker3`/`ColorPicker4` crashes when called without an active ImGui context or window: [#2668](https://github.com/dartsim/dart/issues/2668)
+  * Use modern ImGui modifier key names in the OSG ImGui handler for newer ImGui builds. ([#2526](https://github.com/dartsim/dart/pull/2526))
 
 * Constraint
 
@@ -38,6 +39,8 @@
 * Tooling and Docs
 
   * Improve FreeBSD VM CI startup resilience with a release image URL, fallback image downloads, a longer SSH readiness window, fresh VM container startup, KVM group propagation, retry handling, and startup diagnostics. ([#2532](https://github.com/dartsim/dart/pull/2532))
+  * Remove duplicate `.gitignore` entries. ([#2735](https://github.com/dartsim/dart/pull/2735))
+  * Update Pixi lockfiles for current conda-forge package builds. ([#2766](https://github.com/dartsim/dart/pull/2766), [#2780](https://github.com/dartsim/dart/pull/2780))
 
 ### [DART 6.16.7 (2026-02-10)](https://github.com/dartsim/dart/milestone/92?closed=1)
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.16.7</version>
+  <version>6.16.8</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.16.7"
+version = "6.16.8"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
## Summary

- Package DART 6.16.8 for the release-6.16 maintenance line.

## Motivation / Problem

- Milestone DART 6.16.8 is complete and release-6.16 needs version metadata and changelog finalization before tagging.

## Changes / Key Changes

- Bump `package.xml` and `pixi.toml` from 6.16.7 to 6.16.8.
- Date the DART 6.16.8 changelog section.
- Add release notes for the ImGui modifier-key backport, .gitignore cleanup, and release-branch Pixi lockfile updates included after v6.16.7.

## Testing

- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- DART 6.16.8 milestone: https://github.com/dartsim/dart/milestone/93

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable