### PR TITLE
Plan experimental world IK roadmap

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # Exclude generated and third-party content to keep signal-to-noise low.
 skip = ./.git,./.pixi,./build,./build-*,./docs/readthedocs/_build,./docs/readthedocs/_generated,./external,./node_modules,*/_build/*,*/_generated/*,*/.venv/*,*/__pycache__/*
 # Ignore domain terms that are not typos.
-ignore-words-list = DOUBLECLICK,mKe,Reacher,reacher,abd,normalY,kInf,matc,inout,lod,toi
+ignore-words-list = DOUBLECLICK,mKe,Reacher,reacher,abd,Buss,normalY,kInf,matc,inout,lod,toi
 # Treat camelCase identifiers ending in an axis suffix (finalY, initialX, posZ,
 # velY, ...) as code rather than typos of "finally"/"initially": a word ending
 # in an uppercase X/Y/Z is an identifier. Genuine lowercase typos (finaly,

--- a/docs/plans/120-inverse-kinematics-and-motion.md
+++ b/docs/plans/120-inverse-kinematics-and-motion.md
@@ -1,0 +1,172 @@
+# PLAN-120: Inverse Kinematics And Motion Synthesis
+
+- Operating state: `PLAN-120` in [`dashboard.md`](dashboard.md)
+- Outcome: the experimental `World` gains a DART-owned inverse-kinematics
+  surface that covers the useful DART 6 IK behaviors, exposes a portfolio of
+  pose and motion-level IK methods, and lets users either choose a method
+  explicitly or ask for an `auto` policy that selects and explains a reasonable
+  method for the current robot, target set, constraints, seeds, and recent trial
+  evidence. The design must treat IK as more than independent per-frame pose
+  solving: motion-level solves need continuity, singularity avoidance,
+  local-minimum escape, collision/limit handling, and manifold-correct state
+  distances.
+- Current evidence:
+  - Classic DART already has the first parity target:
+    `dart/dynamics/inverse_kinematics.hpp` provides `InverseKinematics`,
+    task-space regions, objectives, null-space objectives, DOF selection,
+    Jacobian transpose, damped least squares, analytical methods, and
+    `IKFast`; `dart/dynamics/hierarchical_ik.hpp` provides `CompositeIK` and
+    `WholeBodyIK` with hierarchy-level/null-space behavior.
+  - Classic DART already protects some non-Euclidean IK math: Jacobian methods
+    call `convertJacobianMethodOutputToGradient(...)` because FreeJoint and
+    BallJoint cannot be integrated by plain vector addition.
+  - The experimental API design already reserves the right seams:
+    kinematics-only `World::sync(WorldSyncStage::Kinematics)`, future explicit
+    state spaces, functional rollouts, collision-query stages, and a solver
+    capability matrix in
+    [`../design/simulation_experimental_cpp_api.md`](../design/simulation_experimental_cpp_api.md)
+    and
+    [`../design/simulation_experimental_python_api.md`](../design/simulation_experimental_python_api.md).
+  - PLAN-100 records the DART 7 Lie-group surface in
+    `dart/math/lie_group/`; IK must use the same manifold/retraction
+    conventions for distance, interpolation, and update, not Euler-angle or
+    raw Euclidean shortcuts.
+
+## Owner Docs
+
+- Public facade rules:
+  [`../design/simulation_experimental_cpp_api.md`](../design/simulation_experimental_cpp_api.md),
+  [`../design/simulation_experimental_python_api.md`](../design/simulation_experimental_python_api.md)
+- Solver architecture:
+  [`../design/simulation_solver_architecture.md`](../design/simulation_solver_architecture.md)
+- Lie-group owner:
+  [`../onboarding/architecture.md#12-math-module-dartmath`](../onboarding/architecture.md#12-math-module-dartmath)
+  and PLAN-100 in [`dashboard.md`](dashboard.md)
+- Research references:
+  [`nakamura-1987-task-priority`](../readthedocs/papers.md#nakamura-1987-task-priority),
+  [`buss-kim-2005-sdls`](../readthedocs/papers.md#buss-kim-2005-sdls),
+  [`aristidou-lasenby-2011-fabrik`](../readthedocs/papers.md#aristidou-lasenby-2011-fabrik),
+  [`beeson-ames-2015-tracik`](../readthedocs/papers.md#beeson-ames-2015-tracik),
+  [`starke-2020-bioik`](../readthedocs/papers.md#starke-2020-bioik),
+  [`rakita-2018-relaxedik`](../readthedocs/papers.md#rakita-2018-relaxedik),
+  [`zucker-2013-chomp`](../readthedocs/papers.md#zucker-2013-chomp),
+  [`mukadam-2018-gpmp2`](../readthedocs/papers.md#mukadam-2018-gpmp2),
+  and [`ames-2022-ikflow`](../readthedocs/papers.md#ames-2022-ikflow)
+- Future durable design doc, before implementation starts:
+  `docs/design/inverse_kinematics_motion.md`
+
+## Scope
+
+This plan covers IK and kinematic motion synthesis for the experimental
+simulation stack. It is an algorithm-extensibility plan, not a near-term DART 7
+promotion promise.
+
+It includes:
+
+- pose IK for one or more task targets;
+- whole-body and hierarchical/task-priority IK parity with classic DART where
+  the experimental `World` owns matching topology and state;
+- analytical, Jacobian-based, optimization-based, heuristic/evolutionary,
+  statistical, and learned proposal methods behind DART-owned capability names;
+- motion-level IK over a horizon, including continuity and feasibility costs;
+- an `auto` selector with deterministic diagnostics and benchmark evidence;
+- C++ and dartpy surfaces that share the same capability model.
+
+It does not include:
+
+- replacing full dynamics control, inverse dynamics, or trajectory optimization
+  under actuation/contact constraints;
+- exposing solver registries, plugin loaders, backend task systems, learned
+  model internals, or ECS storage as public API;
+- making learned/AI solvers default before datasets, error bounds, fallback
+  behavior, and deterministic diagnostics are proven.
+
+## Method Families To Evaluate
+
+| Family                              | DART role                                                                                                                                                                                                               | First design question                                                                                                    |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Classic whole-body/task-priority IK | Parity foundation. Preserve DART 6 `WholeBodyIK`, `CompositeIK`, hierarchy levels, null-space objectives, and task-space regions where experimental topology supports them.                                             | What public task and constraint value objects replace the classic `Skeleton`/`JacobianNode` attachment model?            |
+| Jacobian methods                    | Required local baseline. Start from Jacobian transpose and damped least squares, then evaluate selectively damped or dynamically weighted variants for singularities and limits.                                        | Which manifold tangent, damping, weighting, and trust-region rules are stable enough to expose?                          |
+| Analytical methods                  | Fast exact branch when robot geometry supports it. Keep `IKFast`/generated-code parity as a bridge, but expose analytical capability rather than an engine-named public solver.                                         | How are multiple analytical branches scored against continuity, limits, collision, and user preference?                  |
+| Constrained optimization            | Generic constrained baseline. Evaluate SQP/QP/TRAC-IK-like approaches for joint limits, collision, manipulability, task priorities, and secondary objectives.                                                           | Which constraints must be common DART task objects rather than solver-specific callback functions?                       |
+| Heuristic and evolutionary methods  | Global/multi-objective fallback. Evaluate FABRIK/CCD-style fast heuristics and BioIK-style memetic optimization as seed generators or direct solvers.                                                                   | Which methods remain chain-only, and which can honestly support tree, whole-body, closed-chain, or multi-effector tasks? |
+| Statistical trajectory methods      | Motion-level prior. Evaluate GPMP2-style Gaussian-process priors for continuous-time smoothness, replanning, and uncertainty-aware waypoint interpolation.                                                              | What state-space metric and collision-query interface make the prior manifold-correct?                                   |
+| Learned proposal methods            | Deferred accelerator for diverse seeds, not a correctness source. Evaluate IKFlow-like generators only as proposal distributions refined by checked DART solvers.                                                       | What datasets, robot-family generalization tests, fallback rules, and model-version diagnostics are required?            |
+| Auto policy                         | User-facing selector, not hidden magic. Select, rank, or fall back among methods from robot dimensions, task count, joint manifold, limits, constraints, warm-start history, requested horizon, and pre-trial outcomes. | What diagnostics prove why `auto` chose a method and when it tried or rejected alternatives?                             |
+
+## Workstreams
+
+0. **Design inventory and benchmark packet** - map classic DART IK features to
+   experimental `World` concepts; define a small scene set covering open-chain
+   arms, whole-body/multi-effector targets, redundant arms, ball/free joints,
+   joint limits, near-singular poses, unreachable targets, and collision-query
+   tasks. Create `docs/design/inverse_kinematics_motion.md` before code starts.
+1. **State-space and task model** - define manifold-aware state, tangent,
+   distance, interpolation, and retraction contracts. IK distances live in
+   tangent spaces (`SO(3)`, `SE(3)`, and product groups), with explicit weights
+   and units; raw Euler-angle or simple Euclidean position differences are not
+   acceptable for orientation or free-joint motion.
+2. **Pose IK parity foundation** - implement the DART 6 parity slice for
+   task-space targets, DOF selection, joint limits, seeds, objective and
+   null-space objective handling, whole-body/hierarchical composition, and
+   analytical-solver branch scoring where supported.
+3. **Solver portfolio** - add method families only behind documented capability
+   values. Each method records supported topology, coordinate support,
+   constraints, determinism, differentiability, execution shape, failure modes,
+   and fallback behavior.
+4. **Motion-level IK** - add horizon-based solves that optimize a trajectory or
+   rollout rather than solving frames independently. Required costs include
+   target error, joint displacement, velocity/acceleration or smoothness,
+   singularity/manipulability margin, joint/closure/collision limits, and
+   branch-continuity penalties for analytical or multi-solution methods.
+5. **Auto selection and pre-trials** - implement `auto` as an evaluator-driven
+   policy that can run bounded pre-trials, score candidates, cache recent
+   outcomes, and return diagnostics. It must be deterministic under a supplied
+   seed and must expose when it falls back to a safer method.
+6. **C++/Python promotion** - align C++ and dartpy naming, examples, docs,
+   serialization, and error reporting. Python may expose ergonomic builders, but
+   it must not expose C++ solver registries, backend names, or learned-model
+   runtime internals.
+
+## Acceptance Criteria
+
+- The design inventory names every classic DART IK feature that is carried
+  forward, intentionally changed, deferred, or rejected, with a migration note
+  for users of `InverseKinematics`, `WholeBodyIK`, `CompositeIK`, and `IKFast`.
+- State-space tests prove manifold-correct integration, interpolation, and
+  distance for revolute/prismatic chains, spherical joints, free joints, and
+  mixed product spaces; pose and motion costs use those operations.
+- Pose IK parity tests cover task-space regions, Jacobian transpose, damped
+  least squares, whole-body hierarchy/null-space behavior, seeds, joint limits,
+  analytical multi-branch scoring, unreachable targets, and deterministic
+  failure diagnostics.
+- Motion-level IK is not complete until long-horizon tests show continuity
+  across equivalent analytical branches, warm-started and cold-started
+  trajectories, near-singular targets, local-minimum escape attempts,
+  collision/closure constraints when those owners exist, and no per-frame
+  discontinuity hidden by interpolation.
+- Each solver family has a benchmark row reporting solve time, success rate,
+  final task error, limit/collision violations, singularity margin, trajectory
+  smoothness, branch switches, and memory allocations on the shared scene set.
+- `auto` is complete only when it is explained by a checked scoring policy,
+  stable under a seed, benchmarked against explicit method choices, and able to
+  return a structured reason for each accepted, rejected, or fallback method.
+- Public APIs remain backend-neutral and method-family oriented. They do not
+  expose solver registry types, ECS components, generated-code internals,
+  learned-model tensor backends, or implementation-specific cache ownership;
+  `check-api-boundaries` stays green when code exists.
+- C++ and Python examples cover at least one pose IK solve, one whole-body
+  multi-target solve, one analytical or generated-code branch, and one
+  motion-level solve over a horizon.
+
+## Revision Triggers
+
+- Experimental `World` gains or changes public multibody topology, state-space,
+  collision-query, closure-projection, rollout, or model-loading APIs.
+- PLAN-080 changes articulated-body state ownership or Jacobian availability.
+- PLAN-100 changes Lie-group tangent/retraction semantics.
+- A benchmark shows a method family is not competitive enough to keep, or a
+  learned/statistical method becomes reliable enough to promote from deferred
+  proposal generation to a checked solver family.
+- A maintainer changes the DART 8 promotion scope for kinematics-only,
+  planning, rollout, or optimization APIs.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -72,6 +72,7 @@ they should not own priority, timeline, or active implementation state.
 | [`082-rigid-implicit-barrier-contact.md`](082-rigid-implicit-barrier-contact.md)           | PLAN-082 rigid IPC scope, manifest, and acceptance criteria     |
 | [`110-differentiable-simulation.md`](110-differentiable-simulation.md)                     | PLAN-110 differentiable simulation scope, audits, and gates     |
 | [`101-dartsim-gui-simulator.md`](101-dartsim-gui-simulator.md)                             | PLAN-101 dartsim GUI simulator scope, phases, and acceptance    |
+| [`120-inverse-kinematics-and-motion.md`](120-inverse-kinematics-and-motion.md)             | PLAN-120 IK solver portfolio, whole-body parity, and motion IK  |
 | Numbered initiative files, such as `010-*.md`                                              | Active plan scope, evidence, open gaps, and acceptance criteria |
 | [`AGENTS.md`](AGENTS.md)                                                                   | Local rules for agents editing plan docs                        |
 | [`../ai/north-star.md`](../ai/north-star.md)                                               | Mission, current state, missing capabilities, and readiness bar |

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -520,3 +520,26 @@ its own line so status updates remain git-history friendly.
   smoothness/accuracy contract, finite-difference gradient agreement, one
   reproduced Dojo example packet, benchmark/profiling JSON, and proof that no
   Dojo.jl dependency or solver/cache/backend type leaks into the public surface.
+
+### PLAN-120: Inverse Kinematics And Motion Synthesis
+
+- Owner doc:
+  [`120-inverse-kinematics-and-motion.md`](120-inverse-kinematics-and-motion.md)
+- Status: Proposed
+- Horizon: Later
+- Dimension: Algorithm extensibility
+- Next step: Run the Phase 0 design inventory before implementation: map
+  classic DART `InverseKinematics`/`WholeBodyIK`/`CompositeIK`/`IKFast` behavior
+  to experimental `World` concepts; define the shared IK benchmark scene set;
+  draft `docs/design/inverse_kinematics_motion.md`; and decide which pose,
+  motion-level, and `auto` selection APIs can wait on existing experimental
+  state-space, kinematics-only, rollout, collision-query, and model-loading
+  seams.
+- Gate: PLAN-120 is not implementation-ready until the design inventory proves
+  manifold-correct state-space operations for mixed joint spaces, carries
+  forward or intentionally retires each DART 6 whole-body IK feature, ranks
+  Jacobian/analytical/optimization/heuristic/statistical/learned proposal
+  families against shared scenes, defines long-horizon motion IK evidence that
+  prevents per-frame discontinuities, singularity stalls, and local-minimum
+  traps from being hidden, and specifies deterministic diagnostics for the
+  `auto` policy.

--- a/docs/readthedocs/papers.md
+++ b/docs/readthedocs/papers.md
@@ -183,27 +183,36 @@ Springer, 2006.
 
 ## Algorithms & Methods (Papers)
 
-| ID                             | Reference                                                                                                                  | Topic                              | Status      | Priority | Verdict   |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- | -------- | --------- |
-| `featherstone-1983`            | Featherstone, "Calculation of robot dynamics using articulated-body inertias" (1983)                                       | dynamics                           | planned     | high     | adopt     |
-| `liu-jain-mbs`                 | Liu & Jain, _A Quick Tutorial on Multibody Dynamics_                                                                       | dynamics                           | implemented | —        | adopt     |
-| `tan-lcp`                      | Tan, Siu & Liu, _Contact Handling for Articulated Rigid Bodies Using LCP_                                                  | contact                            | implemented | —        | adopt     |
-| `stewart-trinkle-1996`         | Stewart & Trinkle, "An implicit time-stepping scheme … Coulomb friction" (1996)                                            | contact                            | referenced  | medium   | baseline  |
-| `baraff-1996`                  | Baraff, "Linear-time dynamics using Lagrange multipliers" (1996)                                                           | dynamics                           | referenced  | low      | reference |
-| `macklin-xpbd-2016`            | Macklin et al., "XPBD: position-based simulation of compliant constrained dynamics" (2016)                                 | integration                        | referenced  | medium   | evaluate  |
-| `gjk-1988`                     | Gilbert, Johnson & Keerthi, GJK distance algorithm (1988)                                                                  | collision                          | implemented | —        | adopt     |
-| `ipc-2020`                     | Li et al., "Incremental Potential Contact" (2020)                                                                          | contact                            | in-progress | high     | adopt     |
-| `rigid-ipc-2021`               | Ferguson et al., "Intersection-free Rigid Body Dynamics" (2021)                                                            | contact                            | in-progress | high     | adopt     |
-| `werling-2021`                 | Werling et al., "Fast and Feature-Complete Differentiable Physics … Articulated Rigid Bodies" (2021)                       | differentiable                     | in-progress | high     | adopt     |
-| `howell-2022-dojo`             | Howell et al., "Dojo: A Differentiable Physics Engine for Robotics" (2022)                                                 | differentiable/contact/integration | planned     | high     | evaluate  |
-| `lee-vi-2016`                  | Lee, Liu, Park & Srinivasa, "A Linear-Time Variational Integrator for Multibody Systems" (2016)                            | integration                        | planned     | high     | adopt     |
-| `marsden-west-2001`            | Marsden & West, "Discrete mechanics and variational integrators" (2001)                                                    | integration                        | referenced  | medium   | reference |
-| `chen-2024-vbd`                | Chen et al., "Vertex Block Descent" (SIGGRAPH 2024)                                                                        | integration                        | in-progress | high     | adopt     |
-| `vbd-2024`                     | Chen et al., "Vertex Block Descent" (2024) — VI contact survey                                                             | contact                            | referenced  | medium   | evaluate  |
-| `avbd-2025`                    | Giles et al., "Augmented Vertex Block Descent" (2025)                                                                      | contact                            | referenced  | medium   | evaluate  |
-| `johnson-murphey-2009`         | Johnson & Murphey, "Scalable variational integrators for constrained mechanical systems in generalized coordinates" (2009) | integration                        | referenced  | high     | baseline  |
-| `leyendecker-2008`             | Leyendecker, Marsden & Ortiz, "Variational integrators for constrained dynamical systems" (2008)                           | integration                        | referenced  | high     | evaluate  |
-| `kobilarov-crane-desbrun-2009` | Kobilarov, Crane & Desbrun, "Lie group integrators for animation and control of vehicles" (2009)                           | integration                        | referenced  | medium   | reference |
+| ID                              | Reference                                                                                                                  | Topic                              | Status      | Priority | Verdict   |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- | -------- | --------- |
+| `featherstone-1983`             | Featherstone, "Calculation of robot dynamics using articulated-body inertias" (1983)                                       | dynamics                           | planned     | high     | adopt     |
+| `liu-jain-mbs`                  | Liu & Jain, _A Quick Tutorial on Multibody Dynamics_                                                                       | dynamics                           | implemented | —        | adopt     |
+| `tan-lcp`                       | Tan, Siu & Liu, _Contact Handling for Articulated Rigid Bodies Using LCP_                                                  | contact                            | implemented | —        | adopt     |
+| `stewart-trinkle-1996`          | Stewart & Trinkle, "An implicit time-stepping scheme … Coulomb friction" (1996)                                            | contact                            | referenced  | medium   | baseline  |
+| `baraff-1996`                   | Baraff, "Linear-time dynamics using Lagrange multipliers" (1996)                                                           | dynamics                           | referenced  | low      | reference |
+| `macklin-xpbd-2016`             | Macklin et al., "XPBD: position-based simulation of compliant constrained dynamics" (2016)                                 | integration                        | referenced  | medium   | evaluate  |
+| `gjk-1988`                      | Gilbert, Johnson & Keerthi, GJK distance algorithm (1988)                                                                  | collision                          | implemented | —        | adopt     |
+| `ipc-2020`                      | Li et al., "Incremental Potential Contact" (2020)                                                                          | contact                            | in-progress | high     | adopt     |
+| `rigid-ipc-2021`                | Ferguson et al., "Intersection-free Rigid Body Dynamics" (2021)                                                            | contact                            | in-progress | high     | adopt     |
+| `werling-2021`                  | Werling et al., "Fast and Feature-Complete Differentiable Physics … Articulated Rigid Bodies" (2021)                       | differentiable                     | in-progress | high     | adopt     |
+| `howell-2022-dojo`              | Howell et al., "Dojo: A Differentiable Physics Engine for Robotics" (2022)                                                 | differentiable/contact/integration | planned     | high     | evaluate  |
+| `lee-vi-2016`                   | Lee, Liu, Park & Srinivasa, "A Linear-Time Variational Integrator for Multibody Systems" (2016)                            | integration                        | planned     | high     | adopt     |
+| `marsden-west-2001`             | Marsden & West, "Discrete mechanics and variational integrators" (2001)                                                    | integration                        | referenced  | medium   | reference |
+| `chen-2024-vbd`                 | Chen et al., "Vertex Block Descent" (SIGGRAPH 2024)                                                                        | integration                        | in-progress | high     | adopt     |
+| `vbd-2024`                      | Chen et al., "Vertex Block Descent" (2024) — VI contact survey                                                             | contact                            | referenced  | medium   | evaluate  |
+| `avbd-2025`                     | Giles et al., "Augmented Vertex Block Descent" (2025)                                                                      | contact                            | referenced  | medium   | evaluate  |
+| `nakamura-1987-task-priority`   | Nakamura, Hanafusa & Yoshikawa, "Task-Priority Based Redundancy Control of Robot Manipulators" (1987)                      | kinematics                         | planned     | medium   | adopt     |
+| `buss-kim-2005-sdls`            | Buss & Kim, "Selectively Damped Least Squares for Inverse Kinematics" (2005)                                               | kinematics                         | planned     | medium   | evaluate  |
+| `aristidou-lasenby-2011-fabrik` | Aristidou & Lasenby, "FABRIK: A fast, iterative solver for the Inverse Kinematics problem" (2011)                          | kinematics                         | planned     | medium   | evaluate  |
+| `beeson-ames-2015-tracik`       | Beeson & Ames, "TRAC-IK: An open-source library for improved solving of generic inverse kinematics" (2015)                 | kinematics                         | planned     | medium   | baseline  |
+| `starke-2020-bioik`             | Starke, _Bio IK: A Memetic Evolutionary Algorithm for Generic Multi-Objective Inverse Kinematics_ (2020)                   | kinematics                         | planned     | medium   | evaluate  |
+| `rakita-2018-relaxedik`         | Rakita, Mutlu & Gleicher, "RelaxedIK: Real-time Synthesis of Accurate and Feasible Robot Arm Motion" (2018)                | kinematics                         | planned     | high     | baseline  |
+| `zucker-2013-chomp`             | Zucker et al., "CHOMP: Covariant Hamiltonian Optimization for Motion Planning" (2013)                                      | motion-planning                    | referenced  | medium   | baseline  |
+| `mukadam-2018-gpmp2`            | Mukadam et al., "Continuous-time Gaussian process motion planning via probabilistic inference" (2018)                      | motion-planning                    | referenced  | medium   | evaluate  |
+| `ames-2022-ikflow`              | Ames, Morgan & Konidaris, "IKFlow: Generating Diverse Inverse Kinematics Solutions" (2022)                                 | kinematics                         | deferred    | medium   | evaluate  |
+| `johnson-murphey-2009`          | Johnson & Murphey, "Scalable variational integrators for constrained mechanical systems in generalized coordinates" (2009) | integration                        | referenced  | high     | baseline  |
+| `leyendecker-2008`              | Leyendecker, Marsden & Ortiz, "Variational integrators for constrained dynamical systems" (2008)                           | integration                        | referenced  | high     | evaluate  |
+| `kobilarov-crane-desbrun-2009`  | Kobilarov, Crane & Desbrun, "Lie group integrators for animation and control of vehicles" (2009)                           | integration                        | referenced  | medium   | reference |
 
 ### `featherstone-1983`
 
@@ -593,6 +602,123 @@ Giles, et al. "Augmented Vertex Block Descent." _ACM Transactions on Graphics_
   normal-force clamp. Identified as the best structural fit for adding hard,
   drift-free non-penetration and a friction cone to the variational integrator
   without a global PSD solve (PLAN-082 contact rung C3). Not a commitment.
+
+### `nakamura-1987-task-priority`
+
+Nakamura, Y., Hanafusa, H., & Yoshikawa, T. "Task-Priority Based Redundancy
+Control of Robot Manipulators." _International Journal of Robotics Research_,
+6(2), 1987. DOI:
+[10.1177/027836498700600201](https://doi.org/10.1177/027836498700600201).
+
+- **Type:** paper · **Topic:** kinematics · **Status:** planned · **Priority:** medium · **Verdict:** adopt
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Grounds whole-body and task-priority IK: higher-priority task
+  residuals constrain lower-priority objectives through redundancy/null spaces.
+  Classic DART already has related `HierarchicalIK`, `CompositeIK`, and
+  `WholeBodyIK` APIs; the experimental world needs a DART-owned task model
+  before carrying them forward.
+
+### `buss-kim-2005-sdls`
+
+Buss, S. R., & Kim, J.-S. "Selectively Damped Least Squares for Inverse
+Kinematics." _Journal of Graphics Tools_, 10(3), 2005. DOI:
+[10.1080/2151237X.2005.10129202](https://doi.org/10.1080/2151237X.2005.10129202).
+
+- **Type:** paper · **Topic:** kinematics · **Status:** planned · **Priority:** medium · **Verdict:** evaluate
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Candidate singularity-robust extension to classic DART's Jacobian
+  DLS baseline. Evaluate against DART's manifold state-space contract and
+  near-singular benchmark scenes before adopting.
+
+### `aristidou-lasenby-2011-fabrik`
+
+Aristidou, A., & Lasenby, J. "FABRIK: A fast, iterative solver for the Inverse
+Kinematics problem." _Graphical Models_, 73(5), 2011. DOI:
+[10.1016/j.gmod.2011.05.003](https://doi.org/10.1016/j.gmod.2011.05.003).
+
+- **Type:** paper · **Topic:** kinematics · **Status:** planned · **Priority:** medium · **Verdict:** evaluate
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Candidate fast heuristic or seed generator for simple chains and
+  animation-style tasks. Must be benchmarked honestly for joint limits,
+  orientation objectives, trees, whole-body targets, and closed chains before
+  any broad support claim.
+
+### `beeson-ames-2015-tracik`
+
+Beeson, P., & Ames, B. "TRAC-IK: An open-source library for improved solving of
+generic inverse kinematics." _IEEE-RAS International Conference on Humanoid
+Robots_, 2015. DOI:
+[10.1109/HUMANOIDS.2015.7363472](https://doi.org/10.1109/HUMANOIDS.2015.7363472).
+
+- **Type:** paper · **Topic:** kinematics · **Status:** planned · **Priority:** medium · **Verdict:** baseline
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Baseline for generic constrained IK with joint limits and
+  optimization-based fallback behavior. DART should not expose a TRAC-IK-named
+  public solver; use method-family names and compare against the behavior.
+
+### `starke-2020-bioik`
+
+Starke, S. _Bio IK: A Memetic Evolutionary Algorithm for Generic Multi-Objective
+Inverse Kinematics._ Dissertation, University of Hamburg, 2020.
+<https://ediss.sub.uni-hamburg.de/handle/ediss/8703>
+
+- **Type:** paper · **Topic:** kinematics · **Status:** planned · **Priority:** medium · **Verdict:** evaluate
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Candidate evolutionary/local-search family for multi-objective,
+  multi-effector, whole-body IK and seed generation. Evaluate as a bounded
+  fallback or pre-trial method, not as a replacement for checked local solvers.
+
+### `rakita-2018-relaxedik`
+
+Rakita, D., Mutlu, B., & Gleicher, M. "RelaxedIK: Real-time Synthesis of
+Accurate and Feasible Robot Arm Motion." _Robotics: Science and Systems XIV_, 2018. DOI:
+[10.15607/RSS.2018.XIV.043](https://doi.org/10.15607/RSS.2018.XIV.043).
+
+- **Type:** paper · **Topic:** kinematics/motion-planning · **Status:** planned · **Priority:** high · **Verdict:** baseline
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Baseline for treating IK as real-time motion synthesis with
+  competing objectives such as pose accuracy, continuity, collision avoidance,
+  and singularity avoidance. This is the closest published fit for the
+  "not just per-frame IK" requirement.
+
+### `zucker-2013-chomp`
+
+Zucker, M., Ratliff, N., Dragan, A., Pivtoraiko, M., Klingensmith, M., Dellin,
+C., Bagnell, J. A., & Srinivasa, S. "CHOMP: Covariant Hamiltonian Optimization
+for Motion Planning." _International Journal of Robotics Research_, 32(9), 2013.
+<https://publications.ri.cmu.edu/chomp-covariant-hamiltonian-optimization-for-motion-planning>
+
+- **Type:** paper · **Topic:** motion-planning · **Status:** referenced · **Priority:** medium · **Verdict:** baseline
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Baseline trajectory-optimization framing for smoothness,
+  obstacle/collision cost, and local-minimum mitigation over a whole motion
+  rather than independent pose IK frames.
+
+### `mukadam-2018-gpmp2`
+
+Mukadam, M., Dong, J., Yan, X., Dellaert, F., & Boots, B. "Continuous-time
+Gaussian process motion planning via probabilistic inference." _International
+Journal of Robotics Research_, 37(11), 2018. arXiv:
+[1707.07383](https://arxiv.org/abs/1707.07383).
+
+- **Type:** paper · **Topic:** motion-planning/statistics · **Status:** referenced · **Priority:** medium · **Verdict:** evaluate
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Candidate statistical trajectory prior for smooth continuous-time
+  IK/motion solves. Evaluate after DART owns explicit state-space, collision
+  query, and rollout APIs.
+
+### `ames-2022-ikflow`
+
+Ames, B., Morgan, J., & Konidaris, G. "IKFlow: Generating Diverse Inverse
+Kinematics Solutions." _IEEE Robotics and Automation Letters_, 7(3), 2022.
+arXiv: [2111.08933](https://arxiv.org/abs/2111.08933).
+
+- **Type:** paper · **Topic:** kinematics/learning · **Status:** deferred · **Priority:** medium · **Verdict:** evaluate
+- **Where used:** [`PLAN-120`](https://github.com/dartsim/dart/blob/main/docs/plans/120-inverse-kinematics-and-motion.md).
+- **Notes:** Learned diverse-solution generator to evaluate as a proposal
+  distribution for classical refinement, not as an unchecked correctness source
+  or default solver. Requires datasets, model-version diagnostics, deterministic
+  fallback, and cross-robot generalization evidence.
 
 ### `johnson-murphey-2009`
 


### PR DESCRIPTION
## Summary

- Adds PLAN-120 for long-term experimental World inverse kinematics and motion synthesis.
- Records the IK method families to evaluate, including whole-body/task-priority parity, Jacobian, analytical, constrained optimization, heuristic/evolutionary, statistical, learned proposal, and `auto` selection paths.
- Adds research-catalog entries for the IK and motion-planning references cited by the new plan.

## Motivation / Problem

- Experimental World planning did not yet have an owner for IK beyond the existing dynamics, differentiability, rollout, and kinematics-only API seams.
- The requested IK direction is a long-term research/design problem: it needs DART 6 whole-body IK parity, multiple solver families, continuous motion-level IK, singularity/local-minimum handling, and manifold-correct joint-space metrics before implementation starts.

## Changes / Key Changes

- Adds `docs/plans/120-inverse-kinematics-and-motion.md` as the detailed owner for PLAN-120.
- Adds PLAN-120 to `docs/plans/dashboard.md` with Phase 0 design-inventory next step and implementation-readiness gate.
- Adds the PLAN-120 index row in `docs/plans/README.md`.
- Adds IK/motion references to `docs/readthedocs/papers.md` for task-priority IK, SDLS, FABRIK, TRAC-IK, BioIK, RelaxedIK, CHOMP, GPMP2, and IKFlow.
- Adds `Buss` to `.codespellrc` for the cited author surname.

## Testing

- `pixi run lint`
- `pixi run check-lint-md`
- `pixi run check-docs-policy`
- `pixi run check-lint-spell`
- `git diff --check`

## Breaking Changes

- [x] None
- Docs-only planning update; no API, ABI, behavior, or package changes.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: N/A, docs-only living-plan update with no release-note surface
- [x] Add unit tests for new functionality: N/A, no code or behavior changes
- [x] Document new methods and classes: N/A, no new API methods/classes; the new plan documents future design requirements
- [x] Add Python bindings (dartpy) if applicable: N/A, no bindings changes