### PR TITLE
Add simultaneous-impact contact intake plan

### DIFF
--- a/docs/plans/082-rigid-implicit-barrier-contact.md
+++ b/docs/plans/082-rigid-implicit-barrier-contact.md
@@ -131,6 +131,8 @@
   [`../dev_tasks/rigid_body_dynamics_solver/`](../dev_tasks/rigid_body_dynamics_solver/)
 - Active rigid IPC implementation tracker:
   [`../dev_tasks/rigid_ipc_solver/`](../dev_tasks/rigid_ipc_solver/)
+- Simultaneous-impact intake and go/no-go sidecar:
+  [`082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md`](082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md)
 - Research catalog:
   [`../readthedocs/papers.md`](../readthedocs/papers.md)
 
@@ -173,6 +175,11 @@
    shared barrier, CCD, projected-Newton, friction, diagnostics, and corpus
    verification primitives so the next algorithm family can reuse them rather
    than adding another isolated solver stack.
+9. **Simultaneous-impact intake** - Keep the explicit event-level
+   simultaneous-impact papers as a benchmark/go-no-go sidecar rather than a new
+   solver commitment. Promote an impact operator only if solver-neutral DART
+   scenes show a gap not covered by sequential impulse, boxed LCP, rigid IPC, or
+   AVBD-style finite-time contact.
 
 ## Acceptance Criteria
 
@@ -196,6 +203,9 @@
   current DART rigid contact path, the audited reference implementation, and
   the paper-reported scene families; regressions or slower rows need an
   explicit accepted tradeoff rather than a parity claim.
+- Simultaneous-impact promotion requires the sidecar's literature matrix,
+  solver-neutral corpus, IPC/AVBD comparison, and public-boundary review before
+  any event-level operator becomes a PLAN-082 workstream.
 
 ## Revision Triggers
 
@@ -206,5 +216,8 @@
   CCD, Newton, friction, diagnostics, or benchmark infrastructure.
 - Hosted or local benchmark evidence shows the implicit-barrier path cannot be
   competitive without a different CPU/GPU data layout.
+- Solver-neutral simultaneous-impact scenes show restitution, ordering
+  uncertainty, energy, termination, or break-away gaps that rigid IPC and
+  AVBD-style finite-time contact do not cover.
 - A maintainer decides a manifest family should be manual, out of scope, or
   promoted earlier than this plan's sequencing.

--- a/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md
+++ b/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md
@@ -1,0 +1,168 @@
+# Simultaneous-Impact Intake For PLAN-082
+
+This sidecar intakes the `awesome-robotics-simulation` simultaneous-contact
+papers and newer adjacent contact research into the rigid contact roadmap. It
+does **not** create a new solver commitment. PLAN-082 remains the owner because
+the question is whether DART needs an explicit instantaneous rigid-impact
+operator in addition to the active rigid IPC finite-time contact path, and how
+that decision compares against IPC, VBD, and AVBD work already tracked by the
+living plans.
+
+## Scope
+
+In scope:
+
+- simultaneous rigid-body impact and restitution models;
+- high-speed, nearly simultaneous contact cases where event ordering matters;
+- benchmarks that reveal break-away, symmetry, finite termination, energy
+  conservation or non-injection, and drift behavior;
+- comparison against DART's current sequential impulse path, boxed-LCP contact,
+  rigid IPC, and the AVBD/VI contact-roadmap alternatives.
+
+Out of scope for this intake:
+
+- a public solver registry, a named upstream solver selector, or a dependency on
+  any reference implementation;
+- replacing PLAN-082 rigid IPC, PLAN-081 deformable IPC, or PLAN-104 VBD/AVBD;
+- claiming differentiable impact support. If derivatives become the reason to
+  adopt one of these models, route that decision through PLAN-110 after the
+  forward impact operator exists.
+
+## Source Set
+
+The seed list is the
+[`awesome-robotics-simulation` simultaneous-contact section](https://github.com/jslee02/awesome-robotics-simulation#simultaneous-contact),
+which names:
+
+- `smith-2012-rosi`: Reflections on Simultaneous Impact.
+- `zhang-2015-qce`: Quadratic Contact Energy Model for Multi-impact Simulation.
+- `vouga-2017-all-well`: All's Well That Ends Well: Guaranteed Resolution of
+  Simultaneous Rigid Body Impact.
+
+Additional current references for this intake:
+
+- `halm-posa-2024-set-valued-impact`: set-valued simultaneous, inelastic,
+  frictional impacts for robotics.
+- `lelidec-2024-contact-models`: robotics contact-model survey and benchmark
+  criteria.
+- `avbd-2025`: augmented-Lagrangian contact/constraint handling in the VBD
+  family.
+- `ogc-2025`: offset geometric contact, a newer codimensional finite-time
+  contact alternative to survey before adding more IPC-specific machinery.
+
+Detailed citations live in [`../../readthedocs/papers.md`](../../readthedocs/papers.md).
+
+## Taxonomy
+
+| Family                         | References                                                                                     | What it solves                                                                                    | DART stance                                                                                                                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Instantaneous impact operators | `smith-2012-rosi`, `zhang-2015-qce`, `vouga-2017-all-well`, `halm-posa-2024-set-valued-impact` | Post-impact velocity/impulse selection when several rigid contacts occur at the same instant.     | Evaluate as a rigid-impact benchmark and possible restitution backstop; do not start with public API or broad implementation.   |
+| Finite-time hard contact       | `ipc-2020`, `rigid-ipc-2021`                                                                   | Persistent non-penetrating contact, friction, CCD line search, barriers, and optimization solves. | Active path for robust geometry and stacking; likely supersedes many "simultaneous contact" stability goals without impact map. |
+| Block/augmented contact        | `chen-2024-vbd`, `avbd-2025`                                                                   | Fast implicit-Euler minimization with local blocks, augmented forces, constraints, stacking.      | Existing PLAN-104/VI-contact-roadmap evidence; compare before adding a separate instantaneous-impact solver.                    |
+| Geometry-contact alternatives  | `ogc-2025`                                                                                     | Penetration-free codimensional contact using offset geometry and local displacement bounds.       | Survey for deformable/codimensional performance tradeoffs; not a rigid-impact replacement.                                      |
+
+## Initial Verdict
+
+Do **not** open a standalone simultaneous-impact implementation now.
+
+The active rigid IPC path already owns rigid contact robustness, conservative
+CCD, barrier/contact objectives, projected Newton, friction, runtime fixture
+behavior, and comparison evidence. AVBD is the best currently recorded
+augmented-Lagrangian alternative for hard, drift-free constraints without a
+global PSD solve in the variational-integrator contact roadmap. Those finite-time
+paths should stay higher priority than an event-level impact map unless DART
+needs a capability they do not provide:
+
+- restitution or bounce behavior that the implicit barrier/contact paths cannot
+  represent honestly;
+- high-speed nearly simultaneous rigid impacts where contact ordering uncertainty
+  dominates the result;
+- a robotics-control use case that needs set-valued or uncertainty-aware impact
+  outcomes rather than a single post-impact velocity;
+- a regression corpus where the current sequential impulse / boxed-LCP / rigid
+  IPC paths inject energy, fail to terminate, lose symmetry, or miss break-away.
+
+Until one of those triggers is demonstrated, simultaneous-impact work should
+remain a benchmark/intake sidecar under PLAN-082.
+
+## Research Checklist
+
+Before any implementation slice, build a row-level comparison matrix over the
+seed papers and DART's current solvers:
+
+| Axis                         | Evidence to record                                                                                                      |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Contact scope                | frictionless/frictional, elastic/inelastic, rigid-only, articulated, granular, persistent contact, restitution support. |
+| Physical desiderata          | feasibility, symmetry, break-away, kinetic-energy conservation/non-injection, finite termination, no drift.             |
+| Solver shape                 | LCP, generalized reflections, pairwise propagation, quadratic energy, set-valued differential inclusion, optimization.  |
+| Outputs                      | unique post-impact velocity, bounded set of outcomes, per-contact impulses, diagnostics, uncertainty information.       |
+| DART fit                     | reuse of `dart/math/lcp`, current contact Jacobians, rigid IPC CCD/barriers, boxed-LCP snapshots, benchmark harnesses.  |
+| Differentiability            | whether a fixed-mode Jacobian is possible and whether mode/order switches make the gradient a subgradient only.         |
+| Supersession by IPC/AVBD/OGC | which required scenes are already better handled by finite-time contact, augmented-Lagrangian constraints, or OGC.      |
+
+## Candidate Corpus
+
+Start with tests and benchmarks that are solver-independent and can be run
+against current DART paths before a new operator exists:
+
+- Newton's cradle and chained balls for wave propagation and break-away;
+- two-corner rocking block or heel-toe foot strike for impact-order ambiguity;
+- billiards break or dense granular pattern for simultaneous impact sensitivity;
+- symmetric stacked rigid bodies for symmetry preservation and energy behavior;
+- high-speed block/peg examples that distinguish restitution from persistent
+  contact;
+- a no-restitution stacking scene already covered by rigid IPC/AVBD to prove
+  whether the finite-time path makes an impact operator unnecessary.
+
+Each scene needs expected invariants before it becomes acceptance evidence:
+post-impact feasibility, kinetic-energy bound, drift bound over repeated impacts,
+termination/iteration budget, and whether break-away or sticking is expected.
+
+## Sequencing
+
+1. **Literature matrix and catalog** — Keep this sidecar and the research catalog
+   current. Record which simultaneous-impact desiderata matter to DART and which
+   are already covered by rigid IPC, AVBD, or OGC-style finite-time contact.
+2. **Solver-neutral corpus** — Add DART-owned fixture descriptions and focused
+   checks for the candidate corpus. Run them against sequential impulse, boxed
+   LCP, and rigid IPC first; file gaps as evidence rather than adding a solver.
+3. **Minimal internal baseline** — If the corpus exposes a real gap, prototype one
+   internal impact operator on the smallest frictionless rigid scenes:
+   LCP-inelastic baseline plus either generalized-reflection termination wrapping
+   or QCE-style quadratic energy. Expose no public API.
+4. **Decision gate** — Compare the baseline with rigid IPC and AVBD on the same
+   corpus. If finite-time contact meets the required invariants, park the impact
+   operator. If restitution/order uncertainty remains uniquely valuable, promote a
+   narrow PLAN-082 workstream.
+5. **Promotion slice** — Only after the gate, add an opt-in internal rigid-impact
+   mode with DART-owned names, diagnostics, serialization behavior, focused tests,
+   benchmark JSON, and no solver-registry leak.
+
+## Acceptance Before Promotion
+
+An explicit simultaneous-impact operator is not promotable until DART has:
+
+- a completed literature matrix covering all seed and current references above;
+- solver-neutral DART tests/benchmarks for the candidate corpus;
+- evidence showing the active rigid IPC/AVBD paths do not already satisfy the
+  required invariants for the target scenes;
+- an internal prototype with finite termination, feasibility, energy, break-away,
+  and symmetry evidence on named scenes;
+- a public-boundary review proving no upstream project name, solver registry,
+  reverse-pass cache, or ECS storage leaks into the facade;
+- a dashboard update that either promotes the workstream under PLAN-082 or parks
+  this sidecar with the reason.
+
+## Open Questions
+
+- Is DART's near-term need accurate restitution/bounce, or only robust
+  non-penetrating contact and stacking?
+- Should set-valued impact outcomes be exposed to control/learning users, or are
+  they only benchmark evidence for uncertainty-aware simulation?
+- Can rigid IPC's finite-time barrier solve and AVBD-style augmented forces cover
+  the candidate corpus without an event-level operator?
+- If an event-level operator lands, how does it compose with rigid IPC inside one
+  timestep without double-counting impulses or violating the CCD line-search
+  contract?
+- Does PLAN-110 need derivatives through impact outcomes, or is finite-difference
+  / subgradient documentation enough for impact scenes?

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -60,24 +60,25 @@ they should not own priority, timeline, or active implementation state.
 
 ## Files
 
-| File                                                                                       | Purpose                                                         |
-| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
-| [`README.md`](README.md)                                                                   | Planning rules, structure, and revision workflow                |
-| [`dashboard.md`](dashboard.md)                                                             | Single source of truth for plan operating state                 |
-| [`north-star-roadmap.md`](north-star-roadmap.md)                                           | Strategic framing and sequencing principles                     |
-| [`030-compute-resource-access/`](030-compute-resource-access/)                             | PLAN-030 resource-access mission and evaluator contract         |
-| [`035-native-collision-dashboard.md`](035-native-collision-dashboard.md)                   | Durable native-collision feature/performance dashboard          |
-| [`035-native-collision/coverage-matrix.md`](035-native-collision/coverage-matrix.md)       | Durable row-level native-collision coverage matrix sidecar      |
-| [`035-native-collision/benchmark-manifest.md`](035-native-collision/benchmark-manifest.md) | Generated native-collision benchmark evidence manifest          |
-| [`082-rigid-implicit-barrier-contact.md`](082-rigid-implicit-barrier-contact.md)           | PLAN-082 rigid IPC scope, manifest, and acceptance criteria     |
-| [`110-differentiable-simulation.md`](110-differentiable-simulation.md)                     | PLAN-110 differentiable simulation scope, audits, and gates     |
-| [`101-dartsim-gui-simulator.md`](101-dartsim-gui-simulator.md)                             | PLAN-101 dartsim GUI simulator scope, phases, and acceptance    |
-| [`120-inverse-kinematics-and-motion.md`](120-inverse-kinematics-and-motion.md)             | PLAN-120 IK solver portfolio, whole-body parity, and motion IK  |
-| Numbered initiative files, such as `010-*.md`                                              | Active plan scope, evidence, open gaps, and acceptance criteria |
-| [`AGENTS.md`](AGENTS.md)                                                                   | Local rules for agents editing plan docs                        |
-| [`../ai/north-star.md`](../ai/north-star.md)                                               | Mission, current state, missing capabilities, and readiness bar |
-| [`../ai/verification.md`](../ai/verification.md)                                           | Completion audit and gate-selection rules                       |
-| External owner docs linked from `dashboard.md`                                             | Source docs for initiatives that do not need a plan file yet    |
+| File                                                                                                                                   | Purpose                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [`README.md`](README.md)                                                                                                               | Planning rules, structure, and revision workflow                |
+| [`dashboard.md`](dashboard.md)                                                                                                         | Single source of truth for plan operating state                 |
+| [`north-star-roadmap.md`](north-star-roadmap.md)                                                                                       | Strategic framing and sequencing principles                     |
+| [`030-compute-resource-access/`](030-compute-resource-access/)                                                                         | PLAN-030 resource-access mission and evaluator contract         |
+| [`035-native-collision-dashboard.md`](035-native-collision-dashboard.md)                                                               | Durable native-collision feature/performance dashboard          |
+| [`035-native-collision/coverage-matrix.md`](035-native-collision/coverage-matrix.md)                                                   | Durable row-level native-collision coverage matrix sidecar      |
+| [`035-native-collision/benchmark-manifest.md`](035-native-collision/benchmark-manifest.md)                                             | Generated native-collision benchmark evidence manifest          |
+| [`082-rigid-implicit-barrier-contact.md`](082-rigid-implicit-barrier-contact.md)                                                       | PLAN-082 rigid IPC scope, manifest, and acceptance criteria     |
+| [`082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md`](082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md) | PLAN-082 simultaneous-impact intake and go/no-go sidecar        |
+| [`110-differentiable-simulation.md`](110-differentiable-simulation.md)                                                                 | PLAN-110 differentiable simulation scope, audits, and gates     |
+| [`101-dartsim-gui-simulator.md`](101-dartsim-gui-simulator.md)                                                                         | PLAN-101 dartsim GUI simulator scope, phases, and acceptance    |
+| [`120-inverse-kinematics-and-motion.md`](120-inverse-kinematics-and-motion.md)                                                         | PLAN-120 IK solver portfolio, whole-body parity, and motion IK  |
+| Numbered initiative files, such as `010-*.md`                                                                                          | Active plan scope, evidence, open gaps, and acceptance criteria |
+| [`AGENTS.md`](AGENTS.md)                                                                                                               | Local rules for agents editing plan docs                        |
+| [`../ai/north-star.md`](../ai/north-star.md)                                                                                           | Mission, current state, missing capabilities, and readiness bar |
+| [`../ai/verification.md`](../ai/verification.md)                                                                                       | Completion audit and gate-selection rules                       |
+| External owner docs linked from `dashboard.md`                                                                                         | Source docs for initiatives that do not need a plan file yet    |
 
 ## Directory Structure
 

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -180,7 +180,10 @@ its own line so status updates remain git-history friendly.
   runtime fixture behavior, production convergence criteria, production-ready
   default activation criteria, mixed-domain coupling, rigorous interval
   arithmetic, direct CCD evaluator parity, remaining comparison script
-  commands, and full fixture/test/benchmark/visual parity.
+  commands, and full fixture/test/benchmark/visual parity. Keep the
+  simultaneous-impact intake as a PLAN-082 sidecar until solver-neutral scenes
+  prove a restitution/order-uncertainty gap not already covered by rigid IPC or
+  AVBD-style finite-time contact.
 - Gate: Full rigid IPC progress is not complete until the implementation covers
   every manifest row with DART-owned tests, examples, benchmarks, comparison
   packets, CPU/GPU evidence where applicable, and headless Filament visual
@@ -188,7 +191,9 @@ its own line so status updates remain git-history friendly.
   audited upstream checkout, public APIs remain backend-neutral and free of
   solver registries/ECS storage, and every promoted runtime slice passes
   `pixi run lint`, `pixi run build`, focused C++ tests, and
-  `check-api-boundaries`.
+  `check-api-boundaries`. A simultaneous-impact operator additionally requires
+  the sidecar literature matrix, corpus evidence, IPC/AVBD comparison, and
+  public-boundary review before promotion.
 
 ### PLAN-104: Vertex Block Descent Solver
 

--- a/docs/readthedocs/papers.md
+++ b/docs/readthedocs/papers.md
@@ -710,7 +710,8 @@ Related public resources:
 
 Quentin Le Lidec, Wilson Jallet, Louis Montaut, Ivan Laptev, Cordelia Schmid,
 and Justin Carpentier. "Contact Models in Robotics: a Comparative Analysis."
-arXiv:2304.06372v3, 2024.
+_IEEE Transactions on Robotics_, 40, 3716-3733, 2024. DOI:
+[10.1109/TRO.2024.3434208](https://doi.org/10.1109/TRO.2024.3434208).
 
 Related public resources:
 
@@ -718,6 +719,7 @@ Related public resources:
   [di.ens.fr/willow/projects/contact_models_in_robotics](https://www.di.ens.fr/willow/projects/contact_models_in_robotics/)
 - Paper PDF:
   [lelidec2024contacts.pdf](https://simple-robotics.github.io/publications/contact-models/static/paper/lelidec2024contacts.pdf)
+- arXiv: [2304.06372](https://arxiv.org/abs/2304.06372)
 
 - **Type:** paper · **Topic:** contact/survey · **Status:** referenced · **Priority:** medium · **Verdict:** reference
 - **Where used:**

--- a/docs/readthedocs/papers.md
+++ b/docs/readthedocs/papers.md
@@ -183,36 +183,42 @@ Springer, 2006.
 
 ## Algorithms & Methods (Papers)
 
-| ID                              | Reference                                                                                                                  | Topic                              | Status      | Priority | Verdict   |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- | -------- | --------- |
-| `featherstone-1983`             | Featherstone, "Calculation of robot dynamics using articulated-body inertias" (1983)                                       | dynamics                           | planned     | high     | adopt     |
-| `liu-jain-mbs`                  | Liu & Jain, _A Quick Tutorial on Multibody Dynamics_                                                                       | dynamics                           | implemented | —        | adopt     |
-| `tan-lcp`                       | Tan, Siu & Liu, _Contact Handling for Articulated Rigid Bodies Using LCP_                                                  | contact                            | implemented | —        | adopt     |
-| `stewart-trinkle-1996`          | Stewart & Trinkle, "An implicit time-stepping scheme … Coulomb friction" (1996)                                            | contact                            | referenced  | medium   | baseline  |
-| `baraff-1996`                   | Baraff, "Linear-time dynamics using Lagrange multipliers" (1996)                                                           | dynamics                           | referenced  | low      | reference |
-| `macklin-xpbd-2016`             | Macklin et al., "XPBD: position-based simulation of compliant constrained dynamics" (2016)                                 | integration                        | referenced  | medium   | evaluate  |
-| `gjk-1988`                      | Gilbert, Johnson & Keerthi, GJK distance algorithm (1988)                                                                  | collision                          | implemented | —        | adopt     |
-| `ipc-2020`                      | Li et al., "Incremental Potential Contact" (2020)                                                                          | contact                            | in-progress | high     | adopt     |
-| `rigid-ipc-2021`                | Ferguson et al., "Intersection-free Rigid Body Dynamics" (2021)                                                            | contact                            | in-progress | high     | adopt     |
-| `werling-2021`                  | Werling et al., "Fast and Feature-Complete Differentiable Physics … Articulated Rigid Bodies" (2021)                       | differentiable                     | in-progress | high     | adopt     |
-| `howell-2022-dojo`              | Howell et al., "Dojo: A Differentiable Physics Engine for Robotics" (2022)                                                 | differentiable/contact/integration | planned     | high     | evaluate  |
-| `lee-vi-2016`                   | Lee, Liu, Park & Srinivasa, "A Linear-Time Variational Integrator for Multibody Systems" (2016)                            | integration                        | planned     | high     | adopt     |
-| `marsden-west-2001`             | Marsden & West, "Discrete mechanics and variational integrators" (2001)                                                    | integration                        | referenced  | medium   | reference |
-| `chen-2024-vbd`                 | Chen et al., "Vertex Block Descent" (SIGGRAPH 2024)                                                                        | integration                        | in-progress | high     | adopt     |
-| `vbd-2024`                      | Chen et al., "Vertex Block Descent" (2024) — VI contact survey                                                             | contact                            | referenced  | medium   | evaluate  |
-| `avbd-2025`                     | Giles et al., "Augmented Vertex Block Descent" (2025)                                                                      | contact                            | referenced  | medium   | evaluate  |
-| `nakamura-1987-task-priority`   | Nakamura, Hanafusa & Yoshikawa, "Task-Priority Based Redundancy Control of Robot Manipulators" (1987)                      | kinematics                         | planned     | medium   | adopt     |
-| `buss-kim-2005-sdls`            | Buss & Kim, "Selectively Damped Least Squares for Inverse Kinematics" (2005)                                               | kinematics                         | planned     | medium   | evaluate  |
-| `aristidou-lasenby-2011-fabrik` | Aristidou & Lasenby, "FABRIK: A fast, iterative solver for the Inverse Kinematics problem" (2011)                          | kinematics                         | planned     | medium   | evaluate  |
-| `beeson-ames-2015-tracik`       | Beeson & Ames, "TRAC-IK: An open-source library for improved solving of generic inverse kinematics" (2015)                 | kinematics                         | planned     | medium   | baseline  |
-| `starke-2020-bioik`             | Starke, _Bio IK: A Memetic Evolutionary Algorithm for Generic Multi-Objective Inverse Kinematics_ (2020)                   | kinematics                         | planned     | medium   | evaluate  |
-| `rakita-2018-relaxedik`         | Rakita, Mutlu & Gleicher, "RelaxedIK: Real-time Synthesis of Accurate and Feasible Robot Arm Motion" (2018)                | kinematics                         | planned     | high     | baseline  |
-| `zucker-2013-chomp`             | Zucker et al., "CHOMP: Covariant Hamiltonian Optimization for Motion Planning" (2013)                                      | motion-planning                    | referenced  | medium   | baseline  |
-| `mukadam-2018-gpmp2`            | Mukadam et al., "Continuous-time Gaussian process motion planning via probabilistic inference" (2018)                      | motion-planning                    | referenced  | medium   | evaluate  |
-| `ames-2022-ikflow`              | Ames, Morgan & Konidaris, "IKFlow: Generating Diverse Inverse Kinematics Solutions" (2022)                                 | kinematics                         | deferred    | medium   | evaluate  |
-| `johnson-murphey-2009`          | Johnson & Murphey, "Scalable variational integrators for constrained mechanical systems in generalized coordinates" (2009) | integration                        | referenced  | high     | baseline  |
-| `leyendecker-2008`              | Leyendecker, Marsden & Ortiz, "Variational integrators for constrained dynamical systems" (2008)                           | integration                        | referenced  | high     | evaluate  |
-| `kobilarov-crane-desbrun-2009`  | Kobilarov, Crane & Desbrun, "Lie group integrators for animation and control of vehicles" (2009)                           | integration                        | referenced  | medium   | reference |
+| ID                                 | Reference                                                                                                                  | Topic                              | Status      | Priority | Verdict   |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------- | -------- | --------- |
+| `featherstone-1983`                | Featherstone, "Calculation of robot dynamics using articulated-body inertias" (1983)                                       | dynamics                           | planned     | high     | adopt     |
+| `liu-jain-mbs`                     | Liu & Jain, _A Quick Tutorial on Multibody Dynamics_                                                                       | dynamics                           | implemented | —        | adopt     |
+| `tan-lcp`                          | Tan, Siu & Liu, _Contact Handling for Articulated Rigid Bodies Using LCP_                                                  | contact                            | implemented | —        | adopt     |
+| `stewart-trinkle-1996`             | Stewart & Trinkle, "An implicit time-stepping scheme … Coulomb friction" (1996)                                            | contact                            | referenced  | medium   | baseline  |
+| `baraff-1996`                      | Baraff, "Linear-time dynamics using Lagrange multipliers" (1996)                                                           | dynamics                           | referenced  | low      | reference |
+| `macklin-xpbd-2016`                | Macklin et al., "XPBD: position-based simulation of compliant constrained dynamics" (2016)                                 | integration                        | referenced  | medium   | evaluate  |
+| `gjk-1988`                         | Gilbert, Johnson & Keerthi, GJK distance algorithm (1988)                                                                  | collision                          | implemented | —        | adopt     |
+| `ipc-2020`                         | Li et al., "Incremental Potential Contact" (2020)                                                                          | contact                            | in-progress | high     | adopt     |
+| `rigid-ipc-2021`                   | Ferguson et al., "Intersection-free Rigid Body Dynamics" (2021)                                                            | contact                            | in-progress | high     | adopt     |
+| `werling-2021`                     | Werling et al., "Fast and Feature-Complete Differentiable Physics … Articulated Rigid Bodies" (2021)                       | differentiable                     | in-progress | high     | adopt     |
+| `howell-2022-dojo`                 | Howell et al., "Dojo: A Differentiable Physics Engine for Robotics" (2022)                                                 | differentiable/contact/integration | planned     | high     | evaluate  |
+| `lee-vi-2016`                      | Lee, Liu, Park & Srinivasa, "A Linear-Time Variational Integrator for Multibody Systems" (2016)                            | integration                        | planned     | high     | adopt     |
+| `marsden-west-2001`                | Marsden & West, "Discrete mechanics and variational integrators" (2001)                                                    | integration                        | referenced  | medium   | reference |
+| `chen-2024-vbd`                    | Chen et al., "Vertex Block Descent" (SIGGRAPH 2024)                                                                        | integration                        | in-progress | high     | adopt     |
+| `vbd-2024`                         | Chen et al., "Vertex Block Descent" (2024) — VI contact survey                                                             | contact                            | referenced  | medium   | evaluate  |
+| `avbd-2025`                        | Giles et al., "Augmented Vertex Block Descent" (2025)                                                                      | contact                            | referenced  | medium   | evaluate  |
+| `smith-2012-rosi`                  | Smith et al., "Reflections on Simultaneous Impact" (2012)                                                                  | contact/impact                     | referenced  | medium   | baseline  |
+| `zhang-2015-qce`                   | Zhang et al., "Quadratic Contact Energy Model for Multi-impact Simulation" (2015)                                          | contact/impact                     | referenced  | medium   | evaluate  |
+| `vouga-2017-all-well`              | Vouga et al., "All's Well That Ends Well: Guaranteed Resolution of Simultaneous Rigid Body Impact" (2017)                  | contact/impact                     | referenced  | medium   | evaluate  |
+| `halm-posa-2024-set-valued-impact` | Halm & Posa, "Set-valued rigid-body dynamics for simultaneous, inelastic, frictional impacts" (2024)                       | contact/impact                     | referenced  | medium   | evaluate  |
+| `lelidec-2024-contact-models`      | Le Lidec et al., "Contact Models in Robotics: a Comparative Analysis" (2024)                                               | contact/survey                     | referenced  | medium   | reference |
+| `ogc-2025`                         | Chen et al., "Offset Geometric Contact" (2025)                                                                             | contact/collision                  | referenced  | medium   | evaluate  |
+| `nakamura-1987-task-priority`      | Nakamura, Hanafusa & Yoshikawa, "Task-Priority Based Redundancy Control of Robot Manipulators" (1987)                      | kinematics                         | planned     | medium   | adopt     |
+| `buss-kim-2005-sdls`               | Buss & Kim, "Selectively Damped Least Squares for Inverse Kinematics" (2005)                                               | kinematics                         | planned     | medium   | evaluate  |
+| `aristidou-lasenby-2011-fabrik`    | Aristidou & Lasenby, "FABRIK: A fast, iterative solver for the Inverse Kinematics problem" (2011)                          | kinematics                         | planned     | medium   | evaluate  |
+| `beeson-ames-2015-tracik`          | Beeson & Ames, "TRAC-IK: An open-source library for improved solving of generic inverse kinematics" (2015)                 | kinematics                         | planned     | medium   | baseline  |
+| `starke-2020-bioik`                | Starke, _Bio IK: A Memetic Evolutionary Algorithm for Generic Multi-Objective Inverse Kinematics_ (2020)                   | kinematics                         | planned     | medium   | evaluate  |
+| `rakita-2018-relaxedik`            | Rakita, Mutlu & Gleicher, "RelaxedIK: Real-time Synthesis of Accurate and Feasible Robot Arm Motion" (2018)                | kinematics                         | planned     | high     | baseline  |
+| `zucker-2013-chomp`                | Zucker et al., "CHOMP: Covariant Hamiltonian Optimization for Motion Planning" (2013)                                      | motion-planning                    | referenced  | medium   | baseline  |
+| `mukadam-2018-gpmp2`               | Mukadam et al., "Continuous-time Gaussian process motion planning via probabilistic inference" (2018)                      | motion-planning                    | referenced  | medium   | evaluate  |
+| `ames-2022-ikflow`                 | Ames, Morgan & Konidaris, "IKFlow: Generating Diverse Inverse Kinematics Solutions" (2022)                                 | kinematics                         | deferred    | medium   | evaluate  |
+| `johnson-murphey-2009`             | Johnson & Murphey, "Scalable variational integrators for constrained mechanical systems in generalized coordinates" (2009) | integration                        | referenced  | high     | baseline  |
+| `leyendecker-2008`                 | Leyendecker, Marsden & Ortiz, "Variational integrators for constrained dynamical systems" (2008)                           | integration                        | referenced  | high     | evaluate  |
+| `kobilarov-crane-desbrun-2009`     | Kobilarov, Crane & Desbrun, "Lie group integrators for animation and control of vehicles" (2009)                           | integration                        | referenced  | medium   | reference |
 
 ### `featherstone-1983`
 
@@ -591,17 +597,157 @@ Graphics_ (SIGGRAPH 2024). arXiv:2403.06321.
 
 ### `avbd-2025`
 
-Giles, et al. "Augmented Vertex Block Descent." _ACM Transactions on Graphics_
-(SIGGRAPH 2025).
+Chris Giles, Elie Diaz, and Cem Yuksel. "Augmented Vertex Block Descent."
+_ACM Transactions on Graphics_, 44(4), Article 90, 2025. DOI:
+[10.1145/3731195](https://doi.org/10.1145/3731195).
+
+Related public resources:
+
+- Project page:
+  [graphics.cs.utah.edu/research/projects/avbd](https://graphics.cs.utah.edu/research/projects/avbd/)
+- Paper PDF:
+  [Augmented_VBD-SIGGRAPH25.pdf](https://graphics.cs.utah.edu/research/projects/avbd/Augmented_VBD-SIGGRAPH25.pdf)
 
 - **Type:** paper · **Topic:** contact/integration · **Status:** referenced · **Priority:** medium · **Verdict:** evaluate
 - **Where used:** contact-extension survey in
-  [`PLAN-082 contact-roadmap`](https://github.com/dartsim/dart/blob/main/docs/plans/082-variational-integrator-solver/contact-roadmap.md).
+  [`PLAN-082 contact-roadmap`](https://github.com/dartsim/dart/blob/main/docs/plans/082-variational-integrator-solver/contact-roadmap.md)
+  and the
+  [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
 - **Notes:** Augmented-Lagrangian extension of VBD with bounded constraint
   forces (`f = clamp(k·C+λ, fmin, fmax)`) and Coulomb friction via a lagged
   normal-force clamp. Identified as the best structural fit for adding hard,
   drift-free non-penetration and a friction cone to the variational integrator
   without a global PSD solve (PLAN-082 contact rung C3). Not a commitment.
+
+### `smith-2012-rosi`
+
+Breannan Smith, Danny M. Kaufman, Etienne Vouga, Rasmus Tamstorf, and Eitan
+Grinspun. "Reflections on Simultaneous Impact." _ACM Transactions on Graphics_,
+31(4), Article 106, 2012. DOI:
+[10.1145/2185520.2185602](https://doi.org/10.1145/2185520.2185602).
+
+Related public resources:
+
+- Project page: [cs.columbia.edu/cg/rosi](https://www.cs.columbia.edu/cg/rosi/)
+- Paper PDF: [rosi.pdf](https://www.cs.columbia.edu/cg/rosi/rosi.pdf)
+- Supplement:
+  [rosi_supp.pdf](https://www.cs.columbia.edu/cg/rosi/rosi_supp.pdf)
+
+- **Type:** paper · **Topic:** contact/impact · **Status:** referenced · **Priority:** medium · **Verdict:** baseline
+- **Where used:**
+  [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
+- **Notes:** Baseline for event-level simultaneous impact: generalized
+  reflections, physical desiderata such as feasibility, symmetry, break-away,
+  kinetic-energy behavior, and a restitution model aimed at avoiding inelastic
+  collapse. DART should use it first as a benchmark/specification source, not as
+  a public solver identity.
+
+### `zhang-2015-qce`
+
+Tianxiang Zhang, Sheng Li, Dinesh Manocha, Guoping Wang, and Hanqiu Sun.
+"Quadratic Contact Energy Model for Multi-impact Simulation." _Computer Graphics
+Forum_, 34(7), 133-144, 2015. DOI:
+[10.1111/cgf.12752](https://doi.org/10.1111/cgf.12752).
+
+Related public resource:
+
+- Paper PDF:
+  [graphics.pku.edu.cn/docs/20220703165309179406.pdf](https://www.graphics.pku.edu.cn/docs/20220703165309179406.pdf)
+
+- **Type:** paper · **Topic:** contact/impact · **Status:** referenced · **Priority:** medium · **Verdict:** evaluate
+- **Where used:**
+  [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
+- **Notes:** Candidate multi-impact model that frames contact-point potential
+  energy with a closed-form quadratic contact energy, then combines it with LCP
+  handling for restitution and friction. Useful for a minimal internal baseline
+  if PLAN-082 proves that finite-time rigid IPC or AVBD-style contact leaves a
+  true restitution / wave-propagation gap.
+
+### `vouga-2017-all-well`
+
+Etienne Vouga, Breannan Smith, Danny M. Kaufman, Rasmus Tamstorf, and Eitan
+Grinspun. "All's Well That Ends Well: Guaranteed Resolution of Simultaneous
+Rigid Body Impact." _ACM Transactions on Graphics_, 36(4), Article 151, 2017.
+DOI: [10.1145/3072959.3073689](https://doi.org/10.1145/3072959.3073689).
+
+Related public resources:
+
+- Paper PDF:
+  [term-revised.pdf](https://www.cs.utexas.edu/~evouga/uploads/4/5/6/8/45689883/term-revised.pdf)
+- Project page:
+  [evouga/all's-well-that-ends-well](https://www.cs.utexas.edu/~evouga/allrsquos-well-that-ends-well-guaranteed-resolution-of-simultaneous-rigid-body-impact.html)
+
+- **Type:** paper · **Topic:** contact/impact · **Status:** referenced · **Priority:** medium · **Verdict:** evaluate
+- **Where used:**
+  [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
+- **Notes:** The strongest termination-focused follow-up to generalized
+  reflections and pairwise impact schemes. It belongs in DART as a go/no-go
+  benchmark for finite termination, approximate energy behavior, drift, and
+  break-away before any event-level impact operator is promoted.
+
+### `halm-posa-2024-set-valued-impact`
+
+Mathew Halm and Michael Posa. "Set-valued rigid-body dynamics for simultaneous,
+inelastic, frictional impacts." _International Journal of Robotics Research_,
+43(10), 2024. DOI:
+[10.1177/02783649241236860](https://doi.org/10.1177/02783649241236860).
+
+Related public resources:
+
+- Journal page:
+  [journals.sagepub.com/doi/10.1177/02783649241236860](https://journals.sagepub.com/doi/10.1177/02783649241236860)
+- arXiv: [2103.15714](https://arxiv.org/abs/2103.15714)
+
+- **Type:** paper · **Topic:** contact/impact · **Status:** referenced · **Priority:** medium · **Verdict:** evaluate
+- **Where used:**
+  [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
+- **Notes:** Robotics-specific newer reference that argues simultaneous
+  frictional impacts should sometimes be represented as a set of plausible
+  outcomes instead of a single heuristic ordering. Evaluate as an uncertainty /
+  benchmark direction before exposing any set-valued public API.
+
+### `lelidec-2024-contact-models`
+
+Quentin Le Lidec, Wilson Jallet, Louis Montaut, Ivan Laptev, Cordelia Schmid,
+and Justin Carpentier. "Contact Models in Robotics: a Comparative Analysis."
+arXiv:2304.06372v3, 2024.
+
+Related public resources:
+
+- Project page:
+  [di.ens.fr/willow/projects/contact_models_in_robotics](https://www.di.ens.fr/willow/projects/contact_models_in_robotics/)
+- Paper PDF:
+  [lelidec2024contacts.pdf](https://simple-robotics.github.io/publications/contact-models/static/paper/lelidec2024contacts.pdf)
+
+- **Type:** paper · **Topic:** contact/survey · **Status:** referenced · **Priority:** medium · **Verdict:** reference
+- **Where used:**
+  [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
+- **Notes:** Survey and benchmark framing for robotics contact models, including
+  Signorini/Coulomb/maximum-dissipation laws, simulator approximations, and
+  physical/computational criteria. Use it to keep the PLAN-082 comparison matrix
+  honest, not as a direct implementation target.
+
+### `ogc-2025`
+
+Anka He Chen, Jerry Hsu, Ziheng Liu, Miles Macklin, Yin Yang, and Cem Yuksel.
+"Offset Geometric Contact." _ACM Transactions on Graphics_, 44(4), Article 160, 2025. DOI: [10.1145/3731205](https://doi.org/10.1145/3731205).
+
+Related public resources:
+
+- Project page:
+  [graphics.cs.utah.edu/research/projects/ogc](https://graphics.cs.utah.edu/research/projects/ogc/)
+- Paper PDF:
+  [Offset_Geometric_Contact-SIGGRAPH2025.pdf](https://graphics.cs.utah.edu/research/projects/ogc/Offset_Geometric_Contact-SIGGRAPH2025.pdf)
+
+- **Type:** paper · **Topic:** contact/collision · **Status:** referenced · **Priority:** medium · **Verdict:** evaluate
+- **Where used:**
+  [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
+- **Notes:** Newer finite-time contact alternative for codimensional objects:
+  offset geometry, local displacement bounds, and GPU-friendly local operations
+  that avoid expensive CCD in its target setting. It is not a rigid-impact
+  operator, but it is relevant when deciding whether IPC-style barriers or AVBD
+  already supersede older simultaneous-contact goals for deformable and
+  codimensional scenes.
 
 ### `nakamura-1987-task-priority`
 


### PR DESCRIPTION
## Summary

- Add a PLAN-082 simultaneous-impact intake sidecar for the `awesome-robotics-simulation` simultaneous-contact papers and newer adjacent contact research.
- Record the current planning verdict: keep simultaneous impact as a benchmark/go-no-go track unless solver-neutral scenes prove rigid IPC or AVBD-style finite-time contact does not cover the required restitution/order-uncertainty behavior.
- Add stable research catalog entries for ROSI, QCE, All's Well, set-valued impact, Contact Models in Robotics, OGC, and refresh AVBD citation details.

## Motivation / Problem

- The simultaneous-contact literature needs a DART-owned intake path that compares event-level impact operators against the active rigid IPC, VBD/AVBD, and finite-time contact plans before any implementation commitment.
- Without a sidecar, the papers could either be lost as loose references or turn into a duplicate solver initiative before DART has evidence that IPC/AVBD are insufficient.

## Changes / Key Changes

- Add `docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md` with scope, source set, taxonomy, initial verdict, research checklist, candidate corpus, sequencing, promotion criteria, and open questions.
- Link the sidecar from PLAN-082 and the plan README, and add dashboard gate wording for any future simultaneous-impact promotion.
- Extend `docs/readthedocs/papers.md` with the requested and adjacent research references.

## Testing

- `pixi run lint`
- `pixi run check-lint-md`
- `pixi run check-docs-policy`
- `pixi run check-lint-spell`
- `git diff --check`

## Breaking Changes

- [x] None
- Docs-only planning/catalog update; no public API or behavior changes.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: N/A, docs-only planning/catalog update
- [x] Add unit tests for new functionality: N/A, no runtime behavior
- [x] Document new methods and classes: N/A, no new API
- [x] Add Python bindings (dartpy) if applicable: N/A, docs-only