### PR TITLE
Add OGC and SPB contact planning

### DIFF
--- a/docs/plans/081-deformable-implicit-barrier-solver.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver.md
@@ -43,6 +43,10 @@
   reproduce as examples, tests, or benchmark reports, with per-row
   prerequisite kernels, performance targets, and `Status` tracking. Every
   paper-parity slice should advance at least one row toward `landed`.
+- SPB self-intersection recovery audit:
+  [`081-deformable-implicit-barrier-solver/spb-gap-audit.md`](081-deformable-implicit-barrier-solver/spb-gap-audit.md)
+  owns the Shortest Path to Boundary research and implementation sequence for
+  tetrahedral self-intersection recovery.
 - Implementation tracking: the first C++ slice is complete in this plan; future
   slices continue from the workstreams below. Because full IPC parity is now a
   multi-session implementation, start a new `docs/dev_tasks/` folder when that
@@ -90,6 +94,13 @@
    conservative queries; exact roots remain validation-only. PR #2709's public
    continuous-cast API is useful for reusable user-facing CCD exposure but is
    not a blocker for internal PLAN-081 solver work.
+   5a. **SPB self-intersection recovery** — Follow
+   [`spb-gap-audit.md`](081-deformable-implicit-barrier-solver/spb-gap-audit.md):
+   source/code audit, internal tetrahedral shortest-path-to-boundary query,
+   DCD vertex-tet and edge-tet candidates, recovery constraints or penalty
+   terms, hybrid CCD/DCD behavior, reduced paper-scene corpus, benchmark JSON,
+   and headless visual evidence. Keep SPB internal and tetrahedral-only until
+   those gates pass.
 6. **Coupling expansion** — Introduce pairwise rigid/deformable couplers behind
    the solver architecture once contact buffers expose the needed state views.
    Keep common `World::step()` free of coupler or solver vocabulary.
@@ -186,6 +197,9 @@ method family. In short, the remaining gap is:
   adaptation, and IPC accuracy diagnostics;
 - deformable self-contact, deformable-rigid/codimensional contact, and
   pair-culling broad phase;
+- recovery from already self-intersecting tetrahedral states via the SPB sidecar
+  if the corpus shows that CCD/barrier-only slices leave unresolved
+  penetrations in fast deformable solvers;
 - smoothed lagged friction with `epsilon_v`, tangent bases, contact-force
   lagging, and friction convergence diagnostics;
 - upstream tutorial, paper, stress, friction, scaling, SQP-comparison, and

--- a/docs/plans/081-deformable-implicit-barrier-solver.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver.md
@@ -47,6 +47,10 @@
   [`081-deformable-implicit-barrier-solver/spb-gap-audit.md`](081-deformable-implicit-barrier-solver/spb-gap-audit.md)
   owns the Shortest Path to Boundary research and implementation sequence for
   tetrahedral self-intersection recovery.
+- PD-IPC GPU audit:
+  [`081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md`](081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md)
+  owns the Penetration-free Projective Dynamics on the GPU research and
+  implementation sequence for GPU-accelerated IPC-class deformable contact.
 - Implementation tracking: the first C++ slice is complete in this plan; future
   slices continue from the workstreams below. Because full IPC parity is now a
   multi-session implementation, start a new `docs/dev_tasks/` folder when that
@@ -101,6 +105,13 @@
    terms, hybrid CCD/DCD behavior, reduced paper-scene corpus, benchmark JSON,
    and headless visual evidence. Keep SPB internal and tetrahedral-only until
    those gates pass.
+   5b. **PD-IPC GPU evaluation** - Follow
+   [`pd-ipc-gpu-gap-audit.md`](081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md):
+   source/code audit, CPU-verifiable two-level projective IPC slice, fast-CCD
+   validation against conservative DART CCD, A-Jacobi CPU/GPU prototype,
+   patch-based GPU culling, reduced paper-scene corpus, benchmark JSON,
+   same-host CPU/GPU packets, and headless visual evidence. Keep PD-IPC
+   internal and backend-neutral until those gates pass.
 6. **Coupling expansion** — Introduce pairwise rigid/deformable couplers behind
    the solver architecture once contact buffers expose the needed state views.
    Keep common `World::step()` free of coupler or solver vocabulary.
@@ -200,6 +211,9 @@ method family. In short, the remaining gap is:
 - recovery from already self-intersecting tetrahedral states via the SPB sidecar
   if the corpus shows that CCD/barrier-only slices leave unresolved
   penetrations in fast deformable solvers;
+- GPU-accelerated projective IPC via the PD-IPC sidecar if CPU IPC, VBD, and OGC
+  evidence shows a performance gap that can be closed without weakening DART's
+  conservative CCD contract or leaking backend concepts;
 - smoothed lagged friction with `epsilon_v`, tangent bases, contact-force
   lagging, and friction convergence diagnostics;
 - upstream tutorial, paper, stress, friction, scaling, SQP-comparison, and

--- a/docs/plans/081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md
@@ -1,0 +1,138 @@
+# PLAN-081 PD-IPC GPU Gap Audit
+
+- Operating state: `PLAN-081` in [`../dashboard.md`](../dashboard.md)
+- Owner plan:
+  [`../081-deformable-implicit-barrier-solver.md`](../081-deformable-implicit-barrier-solver.md)
+- Purpose: plan the research and implementation path for Penetration-free
+  Projective Dynamics on the GPU (PD-IPC) as a DART-owned GPU-accelerated
+  deformable contact solver path.
+
+## Source Evidence
+
+- Paper: Lan, Ma, Yang, Zheng, Li, and Jiang, "Penetration-free Projective
+  Dynamics on the GPU," ACM Transactions on Graphics 41(4), Article 69, 2022.
+  The paper combines projective dynamics with IPC-style barriers, a two-level
+  projective IPC iteration, GPU patch-based collision culling, minimum-gradient
+  Newton CCD pruning, and an aggregated Jacobi (A-Jacobi) global solve.
+- The paper's guarantee is conditional: intersection-free trajectories are
+  claimed when deformable bodies start apart, and CCD pruning keeps each outer
+  loop feasible. DART must not use PD-IPC as recovery evidence for already
+  self-intersecting states; that remains the SPB sidecar's role.
+- Public talk/slides: the GAMES webinar deck records the same decomposition
+  into two-level projective IPC, A-Jacobi, patch-based GPU collision culling,
+  and comparisons against CPU IPC on rubber-helicopter and armadillo scenes.
+- Reference CCD implementation:
+  `Continuous-Collision-Detection/Fast-Approximate-Root-CCD` at HEAD
+  `ecf87abbbf6b7c5ebdb946a8f4883021455aab10`, MIT licensed. Its README says
+  the implementation is faithful to the paper description but can produce false
+  negatives for both point-triangle and edge-edge queries. Treat this as a
+  validation and risk source, not as an implementation to vendor or trust for
+  production CCD.
+- Robotics projective-dynamics reference:
+  `DragonZoom/projective-dynamics-for-robotics` at HEAD
+  `e0671d78253eea580f558a0e6ea5e08942f488c9`, Apache-2.0 licensed. Its README
+  describes an early ROS2 package for real-time projective dynamics of
+  deformable robot parts, with only simple visualization available. Treat it as
+  robotics use-case evidence, not as a DART runtime dependency.
+
+## DART Placement
+
+PD-IPC belongs under PLAN-081 first. It is an IPC-class deformable contact path
+whose acceleration story depends on GPU data layout and solver kernels. It
+should reuse the PLAN-081 mesh/material/contact foundation and the PLAN-030
+compute boundary rather than creating a public GPU solver family. PLAN-104/VBD
+and OGC are comparison baselines because they already carry GPU-shaped
+deformable/contact evidence, but PD-IPC should not be framed as VBD or OGC.
+
+The first DART implementation should be internal and CPU-verifiable before any
+GPU claim. Public `World` and dartpy APIs must stay algorithm- and
+backend-neutral. Build flags, benchmarks, diagnostics, and developer docs may
+say CUDA or GPU when needed, but no public type, namespace, solver selector, or
+resource handle should expose PD-IPC, A-Jacobi, CUDA streams, kernels, memory
+pools, ROS2, or reference-project names.
+
+## Method Responsibilities To Audit
+
+| Area                           | PD-IPC responsibility                                                                                                                                                       | DART starting point                                                                                           | Status  |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
+| Mesh/material state            | Fullspace deformable solids and shells with projective local constraints, inertia, boundary conditions, and surface topology for contact.                                   | PLAN-081 mesh/material state, scene loading, IPC gap audit, and VBD elasticity kernels.                       | Planned |
+| Projective IPC iteration       | Two-level outer/inner loop that rebuilds barrier landmarks at outer iterations, runs local/global PD inner iterations, and applies CCD pruning after the inner solve.       | PLAN-081 IPC solver loop, barrier stiffness adaptation, and diagnostics are not complete yet.                 | Planned |
+| Contact and barrier projection | IPC-style PT/EE barriers, target-position construction, finite clearance, and candidate filtering for self-contact and inter-body contact.                                  | PLAN-081 PT/EE derivative work, conservative CCD line search, and SPB recovery sidecar.                       | Planned |
+| Fast CCD pruning               | Minimum-gradient Newton approximate root for cubic vertex-triangle and edge-edge CCD, compared against conservative/exact DART CCD.                                         | PR #2700 native primitive CCD and validation-only exact/root-safe query paths.                                | Planned |
+| GPU collision culling          | Patch-based GPU culling over dynamic surface primitives with deterministic candidate ordering and CPU fallback.                                                             | Native collision BVH/query foundations and PLAN-030 compute executor metadata.                                | Planned |
+| A-Jacobi global solve          | Aggregated Jacobi products, weighted variants, Chebyshev acceleration, sparsity suppression, and shared-memory/blocking strategy.                                           | VBD GPU/CUDA benchmark harness, compute-backend boundary checks, and internal solver diagnostics.             | Planned |
+| Corpus and benchmarks          | Table/figure scenes such as rubber helicopters, flattened armadillo, dragon, tiered skirt, animal-crossing, and Halloween-party workloads, scaled into DART-owned fixtures. | PLAN-081 figure showcase, benchmark JSON conventions, headless Filament capture path, and CUDA packet checks. | Planned |
+
+## Implementation Sequence
+
+1. **Source and equation audit** - Pin the paper PDF, GAMES deck, video, CCD
+   repository commit, and robotics repository commit. Map Algorithm 1, barrier
+   projection, CCD pruning, A-Jacobi equations, GPU culling, parameters, and
+   paper Table/Figure workloads to DART-owned row IDs.
+2. **CPU-verifiable projective IPC slice** - Add an internal CPU reference for
+   the two-level projective IPC iteration on a tiny mesh. This slice should use
+   DART's conservative CCD and exact validation queries first, so correctness
+   evidence is independent of the paper's approximate root shortcut.
+3. **Fast-CCD validation slice** - Reproduce the paper's minimum-gradient
+   Newton CCD and test it against DART conservative CCD on generated and
+   adversarial PT/EE cases, including the public false-negative examples from
+   `Fast-Approximate-Root-CCD`. Promotion requires zero missed collisions in the
+   accepted domain or a documented fallback to conservative CCD.
+4. **A-Jacobi CPU/GPU prototype slice** - Implement A-Jacobi behind internal
+   solver names with a CPU fallback and optional CUDA sidecar. Tests compare
+   residual decrease, Chebyshev compatibility, deterministic output, and
+   convergence against Jacobi, colored Gauss-Seidel/VBD, and PCG baselines on
+   the same systems.
+5. **GPU culling and data-layout slice** - Add patch-based culling and
+   device-resident contact buffers only behind PLAN-030 private compute
+   boundaries. Evidence must include transfer/setup/kernel/readback timing and
+   no default-package GPU runtime dependency.
+6. **Corpus, benchmark, and visual slice** - Add reduced DART-owned versions of
+   the paper scenes with invariants, benchmark/profiling JSON, headless Filament
+   captures, and same-host CPU/GPU packets. At least one shell scene and one
+   volumetric solid scene must pass before any broad PD-IPC claim.
+7. **Promotion decision** - Promote PD-IPC from evaluation only if it beats the
+   CPU IPC and VBD/OGC baselines on the same corpus without weakening DART's
+   conservative CCD/no-intersection contract or leaking backend details.
+
+## Acceptance Before Promotion
+
+PD-IPC progress is not promotable from evaluation to an active implementation
+claim until DART has:
+
+- a completed paper/deck/video/code matrix with pinned source versions and row
+  IDs for every adopted equation, algorithm, parameter, and workload;
+- CPU reference tests for projective IPC outer/inner iteration, barrier
+  projection, local/global PD energy decrease, and CCD pruning semantics;
+- PT/EE distance, derivative, barrier, and candidate-filtering tests shared
+  with the broader PLAN-081 IPC path;
+- fast-CCD validation against DART conservative CCD, including adversarial
+  false-negative examples and a fallback policy whenever approximate roots are
+  unsafe;
+- A-Jacobi residual, convergence, Chebyshev, deterministic-reduction, and
+  same-system baseline tests against Jacobi, VBD/colored Gauss-Seidel, and PCG;
+- optional GPU culling and A-Jacobi benchmarks that include setup, transfers,
+  kernel time, and readback, plus CPU fallback parity on the same input;
+- benchmark/profiling JSON for table/figure workloads and same-host CPU/GPU
+  packets that satisfy PLAN-030 GPU packet conventions before any speedup claim;
+- headless Filament evidence for every paper-inspired scene used in the claim;
+  and
+- `pixi run lint`, `pixi run build`, focused C++/CUDA tests,
+  `pixi run check-api-boundaries`,
+  `pixi run check-compute-backend-boundaries`, and
+  `pixi run check-no-gpu-runtime-dependencies` green for every implementation
+  slice.
+
+## Non-Goals
+
+- Do not vendor the paper assets, `Fast-Approximate-Root-CCD`, ROS2,
+  `projective-dynamics-for-robotics`, OpenGL/GLFW/GLEW, or any reference
+  dependency as a DART runtime dependency.
+- Do not expose PD-IPC, A-Jacobi, reference repository names, solver registries,
+  ECS storage, CUDA streams, kernels, memory pools, or backend/device resource
+  types through public C++ or dartpy APIs.
+- Do not replace DART's conservative CCD/no-intersection contract with the
+  approximate CCD shortcut unless the accepted domain is proven against
+  adversarial PT/EE tests.
+- Do not claim support for already self-intersecting recovery, rigid impact, or
+  broad GPU contact parity from a solver, CCD, culling, or single-scene slice.

--- a/docs/plans/081-deformable-implicit-barrier-solver/spb-gap-audit.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/spb-gap-audit.md
@@ -1,0 +1,118 @@
+# PLAN-081 SPB Gap Audit
+
+- Operating state: `PLAN-081` in [`../dashboard.md`](../dashboard.md)
+- Owner plan:
+  [`../081-deformable-implicit-barrier-solver.md`](../081-deformable-implicit-barrier-solver.md)
+- Purpose: plan the research and implementation path for Shortest Path to
+  Boundary for Self-Intersecting Meshes (SPB) as a DART-owned recovery and
+  contact-direction method for volumetric deformable self-intersections.
+
+## Source Evidence
+
+- Paper/project: Chen, Diaz, and Yuksel, "Shortest Path to Boundary for
+  Self-Intersecting Meshes," ACM Transactions on Graphics 42(4), 2023. The paper
+  defines a shortest boundary path for self-intersecting meshes, then computes
+  the exact shortest path from an internal point to a valid boundary point using
+  candidate boundary points and robust tetrahedral traversal.
+- ArXiv/project pages describe the target use case as collision and
+  self-collision handling for deformable volumetric objects when the fast
+  simulator does not guarantee complete collision resolution.
+- Supplemental material provides pseudocode for tetrahedral traversal,
+  exit-face selection, shortest-path query, and infeasible-region culling.
+- Reference code:
+  `AnkaChan/Shortest-Path-to-Boundary-for-Self-Intersecting-Meshes` at HEAD
+  `a0a8440af4bda83340bcd102f7d3150245a86b36`. The code is Apache-2.0, tested
+  with Windows/Visual Studio, and depends on MeshFrame2, CuMatrix, OneTBB,
+  Eigen, and Embree. Treat it as method evidence; do not vendor its third-party
+  stack or expose its project names through DART's public surface.
+
+## DART Placement
+
+SPB belongs under PLAN-081 first. It is not a replacement for IPC barriers, OGC,
+or native rigid collision. It is a volumetric deformable recovery method for
+states that are already intersecting, especially when a fast solver leaves
+preexisting DCD contacts unresolved and CCD can no longer see the earlier
+crossing.
+
+The first DART implementation should be internal and tetrahedral-only. It should
+consume DART-owned deformable body topology, surface extraction, and collision
+candidate records, then produce closest-boundary points, path directions,
+diagnostics, and optional recovery constraints or penalty terms for deformable
+solvers. PLAN-104/VBD may later reuse this sidecar as a recovery path for
+tetrahedral VBD scenes, but SPB should stay owned by PLAN-081 until the shared
+mesh/contact contract is stable.
+
+## Method Responsibilities To Audit
+
+| Area                    | SPB responsibility                                                                                                                                                                  | DART starting point                                                                                  | Status  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------- |
+| Topology preconditions  | Tetrahedral volume mesh with boundary surface, face-to-tet adjacency, surface vertices/faces, and inverted-element diagnostics.                                                     | `DeformableBodyOptions` tetrahedra, deterministic boundary-surface extraction, binary serialization. | Planned |
+| DCD candidates          | Vertex-tetrahedron and edge-tetrahedron penetration candidates that identify internal query points.                                                                                 | PLAN-081 scene/corpus loading plus deformable contact candidate infrastructure.                      | Planned |
+| Boundary candidates     | Boundary-face closest-point candidates, feasible-region culling for vertex/edge/face cases, and ordered BVH traversal.                                                              | Native collision BVH/query foundations; no Embree runtime dependency.                                | Planned |
+| Tetrahedral traversal   | Robust path-validity test from candidate boundary point to internal point, including loop recovery, inverted-tet handling, and precise stop reasons.                                | Internal geometry utilities and diagnostics; no public solver/cache type.                            | Planned |
+| Recovery output         | Closest boundary point, normal/path direction, path length, source collision row, and failure diagnostics for constraints or penalty forces.                                        | Deformable stage diagnostics and VBD/IPC contact reporting.                                          | Planned |
+| Hybrid CCD/DCD behavior | DCD+SPB for preexisting penetrations plus existing CCD/barrier paths for new crossings; no claim of standalone guarantees under high velocity.                                      | PLAN-081 conservative CCD line-search and contact kernels.                                           | Planned |
+| Corpus                  | Squishy-ball compression/head-on collision, twisted beam/rods, nested knot, pre-intersected noodle/squishy ball, octopi pile, and long-noodle pile scaled into DART-owned fixtures. | Deformable scene loader, benchmarks, and headless Filament capture path.                             | Planned |
+
+## Implementation Sequence
+
+1. **Source and equation audit** - Pin the arXiv/PDF, supplemental, and reference
+   code commit. Map definitions, Theorems 1-2, tetrahedral traversal,
+   infeasible-region culling, DCD candidate types, tolerances, and test data to
+   DART-owned names and row IDs.
+2. **Standalone query slice** - Add internal `detail/deformable_spb` query
+   helpers for a static tetrahedral mesh snapshot. Tests cover surface
+   extraction, vertex/edge/face candidate classification, zero-length
+   boundary/internal coincidences, loop-recovery diagnostics, inverted tets, and
+   closest-boundary selection on hand-built meshes.
+3. **DCD candidate slice** - Add internal vertex-tet and edge-tet DCD candidate
+   generation for deformable volume meshes. Tests distinguish self-collision,
+   inter-body collision, adjacency exclusions, and malformed/nonmanifold input
+   rejection before SPB is connected to a solver.
+4. **Recovery-constraint slice** - Convert SPB query results into internal
+   recovery constraints or penalty terms for one deformable solver path. Evidence
+   must show decreasing penetration depth, no public API leak, deterministic
+   diagnostics, and a clean fallback when the query cannot prove a valid path.
+5. **Hybrid CCD/DCD slice** - Pair SPB DCD recovery with existing CCD/barrier
+   logic so SPB handles preexisting intersections while CCD handles new
+   crossings. Tests must include the failure modes called out by the paper:
+   CCD-only missed residual penetrations, DCD-only high-velocity misses, and the
+   hybrid path reducing both.
+6. **Corpus, benchmark, and visual slice** - Add DART-owned reduced paper scenes
+   with invariants, benchmark/profiling JSON, and headless Filament captures.
+   The corpus should include at least one pre-intersected recovery scene and one
+   large-contact-count scene before any broad robustness claim.
+
+## Acceptance Before Promotion
+
+SPB progress is not promotable from evaluation to an active implementation claim
+until DART has:
+
+- a completed paper/supplemental/code matrix with pinned source versions;
+- standalone query tests for tetrahedral traversal, feasible-region culling,
+  inverted elements, loop recovery, and closest-boundary correctness;
+- DCD candidate tests for vertex-tet and edge-tet rows, including self and
+  inter-body cases;
+- recovery behavior tests showing penetration decreases from pre-intersected
+  states without relying on rest-shape shortest paths;
+- explicit limitation coverage for codimensional cloth/strands, thin/no-interior
+  volumes, non-Euclidean surface geodesics, and high-velocity DCD-only misses;
+- benchmark/profiling JSON for query counts, traversed tets, DCD candidates,
+  recovery solve cost, and comparison against IPC/CCD-only and any VBD recovery
+  baseline used in the same corpus;
+- headless Filament evidence for every paper-inspired scene used in the claim;
+  and
+- `pixi run lint`, `pixi run build`, focused C++ tests, and
+  `pixi run check-api-boundaries` green for every implementation slice.
+
+## Non-Goals
+
+- Do not vendor MeshFrame2, CuMatrix, OneTBB, Embree, or the reference test data
+  as runtime dependencies.
+- Do not expose SPB, the reference repository, Embree, solver registries, ECS
+  storage, or backend/resource types through the public C++ or dartpy facade.
+- Do not claim SPB handles cloth, strands, shell-only meshes, or arbitrary
+  surface geodesics; those are outside the paper's volumetric/tetrahedral scope.
+- Do not claim full self-intersection robustness from a standalone query or DCD
+  slice before recovery constraints, hybrid CCD/DCD behavior, corpus evidence,
+  and visual evidence are in place.

--- a/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md
+++ b/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md
@@ -48,7 +48,9 @@ Additional current references for this intake:
 - `avbd-2025`: augmented-Lagrangian contact/constraint handling in the VBD
   family.
 - `ogc-2025`: offset geometric contact, a newer codimensional finite-time
-  contact alternative to survey before adding more IPC-specific machinery.
+  contact alternative now tracked for implementation planning under
+  [`PLAN-104 OGC gap audit`](../104-vertex-block-descent-solver/ogc-gap-audit.md)
+  before it is used as evidence against more IPC-specific machinery.
 
 Detailed citations live in [`../../readthedocs/papers.md`](../../readthedocs/papers.md).
 
@@ -59,7 +61,7 @@ Detailed citations live in [`../../readthedocs/papers.md`](../../readthedocs/pap
 | Instantaneous impact operators | `smith-2012-rosi`, `zhang-2015-qce`, `vouga-2017-all-well`, `halm-posa-2024-set-valued-impact` | Post-impact velocity/impulse selection when several rigid contacts occur at the same instant.     | Evaluate as a rigid-impact benchmark and possible restitution backstop; do not start with public API or broad implementation.   |
 | Finite-time hard contact       | `ipc-2020`, `rigid-ipc-2021`                                                                   | Persistent non-penetrating contact, friction, CCD line search, barriers, and optimization solves. | Active path for robust geometry and stacking; likely supersedes many "simultaneous contact" stability goals without impact map. |
 | Block/augmented contact        | `chen-2024-vbd`, `avbd-2025`                                                                   | Fast implicit-Euler minimization with local blocks, augmented forces, constraints, stacking.      | Existing PLAN-104/VI-contact-roadmap evidence; compare before adding a separate instantaneous-impact solver.                    |
-| Geometry-contact alternatives  | `ogc-2025`                                                                                     | Penetration-free codimensional contact using offset geometry and local displacement bounds.       | Survey for deformable/codimensional performance tradeoffs; not a rigid-impact replacement.                                      |
+| Geometry-contact alternatives  | `ogc-2025`                                                                                     | Penetration-free codimensional contact using offset geometry and local displacement bounds.       | Implement/evaluate under PLAN-104 first; not a rigid-impact replacement.                                                        |
 
 ## Initial Verdict
 

--- a/docs/plans/104-vertex-block-descent-solver.md
+++ b/docs/plans/104-vertex-block-descent-solver.md
@@ -30,11 +30,15 @@
   [`../design/simulation_experimental_cpp_api.md`](../design/simulation_experimental_cpp_api.md),
   [`../design/simulation_experimental_python_api.md`](../design/simulation_experimental_python_api.md)
 - Research references: [`../readthedocs/papers.md`](../readthedocs/papers.md)
-  (`chen-2024-vbd`, `tinyvbd`, `gaia`).
+  (`chen-2024-vbd`, `tinyvbd`, `gaia`, `ogc-2025`).
 - VBD paper/reference gap audit:
   [`104-vertex-block-descent-solver/vbd-paper-gap-audit.md`](104-vertex-block-descent-solver/vbd-paper-gap-audit.md)
   owns the method scope, the component-by-component gap, the elastic-energy
   targets, and the reference performance numbers to beat.
+- OGC paper/source gap audit:
+  [`104-vertex-block-descent-solver/ogc-gap-audit.md`](104-vertex-block-descent-solver/ogc-gap-audit.md)
+  owns the Offset Geometric Contact research and implementation sequence for
+  codimensional VBD contact.
 
 ## Current Implementation Evidence
 
@@ -52,8 +56,9 @@ tilted-strand plus contact showcase py-demos.
 
 Remaining durable work is deliberately narrower than the retired task tracker:
 self-contact tangential friction, committed benchmark/profiling JSON, paper
-tetrahedral scene reproduction, Phase 8 SoA plus Gaia CPU comparison, and
-same-GPU RTX-4090 Table 1 reproduction.
+tetrahedral scene reproduction, OGC source/code audit plus CPU proof-of-contact,
+Phase 8 SoA plus Gaia CPU comparison, and same-GPU RTX-4090 Table 1
+reproduction.
 
 ## Relationship To PLAN-081
 
@@ -62,9 +67,12 @@ same experimental deformable ECS components and the same variational
 implicit-Euler objective. They differ in the inner solver: PLAN-081 pursues an
 implicit-barrier projected-Newton-style method; PLAN-104 pursues per-vertex
 block coordinate descent. VBD reuses the PLAN-081 `deformable_contact` kernels
-for contact/friction rather than duplicating them. The public deformable stage
-stays algorithm-neutral; which inner solver runs is an internal/explicit-opt-in
-decision, not a leaked solver registry.
+for contact/friction rather than duplicating them. OGC starts as a PLAN-104
+codimensional-contact sidecar because the paper's fast path is VBD plus local
+displacement bounds, but it must compare against PLAN-081 IPC-style barriers
+before any supersession claim. The public deformable stage stays
+algorithm-neutral; which inner solver or contact model runs is an
+internal/explicit-opt-in decision, not a leaked solver registry.
 
 ## Workstreams
 
@@ -95,6 +103,12 @@ decision, not a leaked solver registry.
    boundary; benchmarks versus the reference/paper GPU numbers.
 10. **Corpus + visual evidence** — DART-native examples, tests, benchmarks,
     profiling JSON, and headless Filament captures reproducing the paper scenes.
+11. **Offset Geometric Contact evaluation** — Follow
+    [`ogc-gap-audit.md`](104-vertex-block-descent-solver/ogc-gap-audit.md):
+    source/code audit, internal vertex-facet and edge-edge OGC contact
+    construction, conservative per-vertex bounds and truncation, VBD
+    force/Hessian integration, reduced paper-scene corpus, CPU benchmark packets,
+    then private GPU evidence. Keep OGC names internal until those gates pass.
 
 ## Acceptance Criteria
 
@@ -109,6 +123,10 @@ VBD-parity progress is not complete until the implementation:
   reference implementations on matched scenes;
 - adds FEM hyperelasticity, acceleration, damping, contact, and friction with
   focused tests;
+- promotes OGC only after the sidecar proves contact construction,
+  conservative bounds, VBD force/Hessian agreement, penetration-free repeated
+  steps, documented limitations, benchmark/profiling JSON, and headless visual
+  evidence against the same corpus used for IPC/VBD comparison;
 - records benchmark/profiling JSON for kernels, the solver, and scenes on both
   CPU and GPU, and demonstrates beating the reference and/or paper numbers
   before any performance-parity claim;

--- a/docs/plans/104-vertex-block-descent-solver/ogc-gap-audit.md
+++ b/docs/plans/104-vertex-block-descent-solver/ogc-gap-audit.md
@@ -1,0 +1,118 @@
+# PLAN-104 OGC Gap Audit
+
+- Operating state: `PLAN-104` in [`../dashboard.md`](../dashboard.md)
+- Owner plan:
+  [`../104-vertex-block-descent-solver.md`](../104-vertex-block-descent-solver.md)
+- Purpose: plan the research and implementation path for Offset Geometric
+  Contact (OGC) as a DART-owned codimensional contact model for the experimental
+  deformable/VBD stack.
+
+## Source Evidence
+
+- Paper/project: Chen et al., "Offset Geometric Contact," ACM Transactions on
+  Graphics 44(4), Article 160, 2025. The project page and PDF describe OGC as a
+  penetration-free codimensional contact method that offsets each face along its
+  normal direction, computes local per-vertex displacement bounds, and avoids
+  continuous collision detection in the solver loop.
+- Author project page: records the same SIGGRAPH 2025 publication, the paper
+  video, and public links to Gaia and Newton code.
+- Gaia reference code: `AnkaChan/Gaia` at HEAD
+  `c229692045465a76233f9fba9197fb22bbfb3694` contains the C++ VBD/contact code
+  family to audit. Treat it as method evidence only; do not vendor Gaia or expose
+  Gaia names through DART's public surface.
+- Newton reference code: `newton-physics/newton` at HEAD
+  `df43cef24ca61d39f0c7cf0ed542ec1ed8a07580` links OGC to the Warp/Newton VBD
+  solver path. Treat it as a comparison and GPU-shape reference, not as a DART
+  dependency.
+
+## DART Placement
+
+OGC belongs under PLAN-104 first. It is a contact model for codimensional
+deformable primitives and is presented with VBD as the fast solver path. It
+should reuse the PLAN-081 shared deformable contact kernels and broad-phase
+foundations where possible, then compare against IPC-class barriers before any
+claim that it supersedes part of PLAN-081. It is not a PLAN-082 event-level
+simultaneous-impact operator and should not be framed as a rigid-impact
+replacement.
+
+The public deformable facade remains algorithm-neutral. Until the audit and
+implementation gates below pass, OGC is an internal method family: no public
+`OgcSolver`, no solver registry, no Gaia/Newton/Warp dependency, and no device or
+backend type in public C++ or dartpy signatures.
+
+## Method Responsibilities To Audit
+
+| Area                | OGC responsibility                                                                                                                                                      | DART starting point                                                                        | Status  |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------- |
+| Offset geometry     | Intersection-aware offset geometry for triangle faces and edge/vertex subfaces, with normals that keep contact forces orthogonal to the contacted face.                 | PLAN-081 distance/derivative kernels and PLAN-104 surface self-contact penalties.          | Planned |
+| Contact detection   | Vertex-facet and edge-edge queries over non-offset primitives, duplicate suppression, adjacent primitive filtering, and contact set construction.                       | Native collision BVH/query utilities plus deformable surface topology.                     | Planned |
+| Conservative bounds | Per-vertex displacement bounds from local distance evidence so penetration-free steps do not require CCD every solver iteration.                                        | Existing VBD iteration/update loop and runtime diagnostics.                                | Planned |
+| Contact energy      | Normal contact energy plus lagged friction terms, with force/Hessian accumulation usable by per-vertex VBD blocks.                                                      | VBD force/Hessian block kernels and current lagged surface contact terms.                  | Planned |
+| Bound truncation    | Initial guess and per-iteration displacement truncation, with contact refresh controlled by an exceeded-bound threshold.                                                | VBD solver loop and stage stats.                                                           | Planned |
+| CPU/GPU shape       | Local operations, deterministic reductions, and fixed-budget iteration evidence before any GPU claim.                                                                   | PLAN-030 compute boundary and PLAN-104 CPU/CUDA benchmark harnesses.                       | Planned |
+| Corpus              | Cloth twisting, knot tightening, yarn/rod stress, cloth-on-body, T-shirt manipulation, and large layered cloth, scaled into DART-owned tests, examples, and benchmarks. | Existing deformable/VBD demos, headless Filament capture path, benchmark JSON conventions. | Planned |
+
+## Implementation Sequence
+
+1. **Source and equation audit** - Pin the exact paper PDF, Gaia commit, and
+   Newton commit. Map OGC equations, algorithms, and code paths to DART-owned
+   names, data structures, and tests. Record which rows are paper-only,
+   Gaia-backed, Newton-backed, or missing.
+2. **CPU detector slice** - Add internal `detail/deformable_ogc` geometry and
+   contact-set construction for vertex-facet and edge-edge rows on static mesh
+   snapshots. This slice does not affect `World::step()`. Tests prove adjacency
+   filtering, duplicate suppression, closest-subface classification, and
+   deterministic contact sets on small hand-built meshes.
+3. **Conservative-bound slice** - Compute per-vertex bounds from the detected
+   contacts and nearest distances, then add standalone truncation tests. Evidence
+   must show that a penetration-free state remains penetration-free under bounded
+   displacements and that high-velocity sparse-contact cases are reported as an
+   OGC weakness rather than hidden by broad claims.
+4. **VBD integration slice** - Wire OGC contact energy and lagged friction into
+   the internal VBD contact accumulation path behind DART-owned policy names.
+   Tests compare force/Hessian finite differences, block energy decrease,
+   penetration-free repeated steps, and behavior against the existing IPC-style
+   contact kernels on matched scenes.
+5. **Corpus and visual slice** - Add DART-owned reduced versions of the paper
+   scenes: twisted cloth, knot pull, layered cloth, yarn/rod pull-through, and
+   cloth-on-body. Each scene needs invariants, a focused test or benchmark row,
+   profiling JSON, and long-horizon headless Filament captures before being used
+   as acceptance evidence.
+6. **GPU/private compute slice** - Only after CPU correctness and corpus gates
+   pass, map the local operations to DART's private compute boundary. Claims
+   require CPU and GPU benchmark packets on the same corpus, deterministic
+   reduction policy, and proof that no runtime GPU dependency leaks into the
+   default build.
+
+## Acceptance Before Promotion
+
+OGC progress is not promotable from evaluation to an active implementation claim
+until DART has:
+
+- a completed source/code matrix for the paper PDF, Gaia, and Newton paths;
+- internal tests for vertex-facet and edge-edge OGC contact construction,
+  adjacent/duplicate filtering, conservative bounds, truncation, and refresh
+  thresholds;
+- force and Hessian finite-difference coverage for the normal and friction terms
+  used by VBD;
+- penetration-free repeated-step evidence from initially valid codimensional
+  scenes, including at least one scene where IPC's small contact radius or CCD
+  line-search cost is the comparison target;
+- explicit tests or documentation for OGC limitations: contact-force
+  discontinuities and high-velocity sparse-contact cases where CCD-aware IPC can
+  take a larger step;
+- benchmark/profiling JSON comparing current VBD contact, IPC-style barriers,
+  OGC CPU, and any private GPU path on the same DART-owned corpus;
+- headless Filament evidence for the paper-inspired scenes used in the claim;
+  and
+- `pixi run lint`, `pixi run build`, focused C++ tests, and
+  `pixi run check-api-boundaries` green for every implementation slice.
+
+## Non-Goals
+
+- Do not vendor Gaia, Newton, Warp, or paper assets as runtime dependencies.
+- Do not expose OGC, Gaia, Newton, Warp, solver registries, ECS storage, or
+  compute backend types through the public facade.
+- Do not use OGC to replace rigid IPC, simultaneous-impact evaluation, or
+  general rigid contact before a DART-owned comparison corpus proves that scope.
+- Do not claim full paper parity from a detector, bound, or single-scene slice.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -69,8 +69,14 @@ they should not own priority, timeline, or active implementation state.
 | [`035-native-collision-dashboard.md`](035-native-collision-dashboard.md)                                                               | Durable native-collision feature/performance dashboard          |
 | [`035-native-collision/coverage-matrix.md`](035-native-collision/coverage-matrix.md)                                                   | Durable row-level native-collision coverage matrix sidecar      |
 | [`035-native-collision/benchmark-manifest.md`](035-native-collision/benchmark-manifest.md)                                             | Generated native-collision benchmark evidence manifest          |
+| [`081-deformable-implicit-barrier-solver.md`](081-deformable-implicit-barrier-solver.md)                                               | PLAN-081 deformable IPC scope, slices, and acceptance evidence  |
+| [`081-deformable-implicit-barrier-solver/ipc-paper-gap-audit.md`](081-deformable-implicit-barrier-solver/ipc-paper-gap-audit.md)       | PLAN-081 IPC paper/repository parity checklist                  |
+| [`081-deformable-implicit-barrier-solver/spb-gap-audit.md`](081-deformable-implicit-barrier-solver/spb-gap-audit.md)                   | PLAN-081 SPB source audit and self-intersection recovery plan   |
 | [`082-rigid-implicit-barrier-contact.md`](082-rigid-implicit-barrier-contact.md)                                                       | PLAN-082 rigid IPC scope, manifest, and acceptance criteria     |
 | [`082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md`](082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md) | PLAN-082 simultaneous-impact intake and go/no-go sidecar        |
+| [`104-vertex-block-descent-solver.md`](104-vertex-block-descent-solver.md)                                                             | PLAN-104 VBD solver scope, remaining corpus/performance work    |
+| [`104-vertex-block-descent-solver/vbd-paper-gap-audit.md`](104-vertex-block-descent-solver/vbd-paper-gap-audit.md)                     | PLAN-104 VBD paper/reference gap audit                          |
+| [`104-vertex-block-descent-solver/ogc-gap-audit.md`](104-vertex-block-descent-solver/ogc-gap-audit.md)                                 | PLAN-104 OGC source audit and implementation sequence           |
 | [`110-differentiable-simulation.md`](110-differentiable-simulation.md)                                                                 | PLAN-110 differentiable simulation scope, audits, and gates     |
 | [`101-dartsim-gui-simulator.md`](101-dartsim-gui-simulator.md)                                                                         | PLAN-101 dartsim GUI simulator scope, phases, and acceptance    |
 | [`120-inverse-kinematics-and-motion.md`](120-inverse-kinematics-and-motion.md)                                                         | PLAN-120 IK solver portfolio, whole-body parity, and motion IK  |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -71,6 +71,7 @@ they should not own priority, timeline, or active implementation state.
 | [`035-native-collision/benchmark-manifest.md`](035-native-collision/benchmark-manifest.md)                                             | Generated native-collision benchmark evidence manifest          |
 | [`081-deformable-implicit-barrier-solver.md`](081-deformable-implicit-barrier-solver.md)                                               | PLAN-081 deformable IPC scope, slices, and acceptance evidence  |
 | [`081-deformable-implicit-barrier-solver/ipc-paper-gap-audit.md`](081-deformable-implicit-barrier-solver/ipc-paper-gap-audit.md)       | PLAN-081 IPC paper/repository parity checklist                  |
+| [`081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md`](081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md)     | PLAN-081 PD-IPC GPU source audit and implementation sequence    |
 | [`081-deformable-implicit-barrier-solver/spb-gap-audit.md`](081-deformable-implicit-barrier-solver/spb-gap-audit.md)                   | PLAN-081 SPB source audit and self-intersection recovery plan   |
 | [`082-rigid-implicit-barrier-contact.md`](082-rigid-implicit-barrier-contact.md)                                                       | PLAN-082 rigid IPC scope, manifest, and acceptance criteria     |
 | [`082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md`](082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md) | PLAN-082 simultaneous-impact intake and go/no-go sidecar        |

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -149,6 +149,11 @@ its own line so status updates remain git-history friendly.
   mesh/material state, scene loading, BE/Newmark integration, PT/EE distance
   derivatives, conservative CCD line search, projected Newton, friction,
   diagnostics, and the complete upstream example/test/benchmark/visual corpus.
+  Track Shortest Path to Boundary as a separate self-intersection recovery
+  sidecar in
+  [`081-deformable-implicit-barrier-solver/spb-gap-audit.md`](081-deformable-implicit-barrier-solver/spb-gap-audit.md):
+  first source/code audit, then a standalone tetrahedral query and DCD recovery
+  spike before any solver or public API claim.
 - Gate: Full IPC-parity progress is not complete until the implementation
   distinguishes the first point-mass/static-ground slice from full IPC, keeps
   IPC naming backend-neutral, proves mesh contact, barrier, distance, CCD,
@@ -157,7 +162,11 @@ its own line so status updates remain git-history friendly.
   records benchmark/profiling JSON for kernels/solver/scenes/scaling, verifies
   long-horizon headless Filament captures for GUI examples, and keeps
   `pixi run lint`, `pixi run build`, focused C++ tests, and
-  `check-api-boundaries` green.
+  `check-api-boundaries` green. SPB additionally needs the sidecar source/code
+  matrix, tetrahedral traversal and feasible-region tests, vertex-tet and
+  edge-tet DCD candidate tests, pre-intersected recovery evidence, limitation
+  coverage, CCD/DCD comparison packets, and no public SPB/reference-project,
+  Embree, MeshFrame2, CuMatrix, solver, ECS, or backend-type leak.
 
 ### PLAN-082: Rigid Implicit-Barrier Contact Solver
 
@@ -217,9 +226,12 @@ its own line so status updates remain git-history friendly.
   adding the TinyVBD tilted-strand plus contact showcase py-demos; it also
   retires the temporary `docs/dev_tasks/vbd_deformable_solver/` tracker by
   promoting the gap audit into this plan. Remaining work, in order:
-  self-contact tangential friction, committed benchmark/profiling JSON for the
-  new scenes, paper tetrahedral scene reproduction, Phase 8b SoA + Gaia-CPU
-  comparison, and Phase 9 RTX-4090 same-GPU Table 1 reproduction.
+  self-contact tangential friction, OGC source/code audit and CPU
+  proof-of-contact from
+  [`104-vertex-block-descent-solver/ogc-gap-audit.md`](104-vertex-block-descent-solver/ogc-gap-audit.md),
+  committed benchmark/profiling JSON for the new scenes, paper tetrahedral scene
+  reproduction, Phase 8b SoA + Gaia-CPU comparison, and Phase 9 RTX-4090
+  same-GPU Table 1 reproduction.
 - Gate: VBD progress is not complete until the implementation distinguishes
   each internal kernel slice from a wired solver, keeps VBD naming
   backend-neutral, proves per-vertex force/Hessian correctness, PD Hessian
@@ -229,7 +241,11 @@ its own line so status updates remain git-history friendly.
   JSON that beats the reference and/or paper numbers before any parity claim,
   verifies headless Filament captures for GUI examples, and keeps
   `pixi run lint`, `pixi run build`, focused C++ tests, and
-  `check-api-boundaries` green.
+  `check-api-boundaries` green. OGC additionally needs the sidecar source/code
+  matrix, vertex-facet and edge-edge contact tests, conservative-bound and
+  truncation tests, force/Hessian finite-difference evidence, limitation
+  coverage, IPC/VBD comparison packets, and no public OGC/Gaia/Newton/Warp or
+  backend-type leak.
 
 ### PLAN-082: Linear-Time Variational Integrator
 

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -104,9 +104,11 @@ its own line so status updates remain git-history friendly.
   resource-access metadata behind a verified scheduler contract (honest
   declarations, deferred structural changes, deterministic reductions, cost
   gate); heterogeneous batches and single-scene contact/constraint GPU work
-  (Pattern B, only after Pattern A evidence justifies it); and differentiable
-  state types if differentiability is promoted from a deferred to a committed
-  capability. Rationale for each lives in
+  (Pattern B, only after Pattern A evidence justifies it), including any PD-IPC
+  GPU contact path tracked under
+  [`081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md`](081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md);
+  and differentiable state types if differentiability is promoted from a
+  deferred to a committed capability. Rationale for each lives in
   [`../design/compute_backend_research.md`](../design/compute_backend_research.md).
 - Gate: `pixi run test-simulation-experimental` covers graph/world parity for
   the current CPU foundation; `pixi run bm-compute-check` keeps the full
@@ -154,6 +156,11 @@ its own line so status updates remain git-history friendly.
   [`081-deformable-implicit-barrier-solver/spb-gap-audit.md`](081-deformable-implicit-barrier-solver/spb-gap-audit.md):
   first source/code audit, then a standalone tetrahedral query and DCD recovery
   spike before any solver or public API claim.
+  Track Penetration-free Projective Dynamics on the GPU as a separate
+  GPU-accelerated IPC sidecar in
+  [`081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md`](081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md):
+  first source/code audit, then a CPU-verifiable projective IPC slice and
+  fast-CCD validation before any A-Jacobi, GPU-culling, or speedup claim.
 - Gate: Full IPC-parity progress is not complete until the implementation
   distinguishes the first point-mass/static-ground slice from full IPC, keeps
   IPC naming backend-neutral, proves mesh contact, barrier, distance, CCD,
@@ -166,7 +173,13 @@ its own line so status updates remain git-history friendly.
   matrix, tetrahedral traversal and feasible-region tests, vertex-tet and
   edge-tet DCD candidate tests, pre-intersected recovery evidence, limitation
   coverage, CCD/DCD comparison packets, and no public SPB/reference-project,
-  Embree, MeshFrame2, CuMatrix, solver, ECS, or backend-type leak.
+  Embree, MeshFrame2, CuMatrix, solver, ECS, or backend-type leak. PD-IPC
+  additionally needs the sidecar source/code matrix, CPU reference tests for the
+  two-level projective IPC loop, fast-CCD validation against conservative DART
+  CCD including public false-negative examples, A-Jacobi residual/convergence
+  tests, optional GPU culling and solver packets with setup/transfer/readback
+  timing, and no public PD-IPC/A-Jacobi/reference-project/CUDA or backend-type
+  leak.
 
 ### PLAN-082: Rigid Implicit-Barrier Contact Solver
 

--- a/docs/readthedocs/papers.md
+++ b/docs/readthedocs/papers.md
@@ -194,6 +194,7 @@ Springer, 2006.
 | `gjk-1988`                         | Gilbert, Johnson & Keerthi, GJK distance algorithm (1988)                                                                  | collision                          | implemented | —        | adopt     |
 | `ipc-2020`                         | Li et al., "Incremental Potential Contact" (2020)                                                                          | contact                            | in-progress | high     | adopt     |
 | `rigid-ipc-2021`                   | Ferguson et al., "Intersection-free Rigid Body Dynamics" (2021)                                                            | contact                            | in-progress | high     | adopt     |
+| `chen-2023-spb`                    | Chen, Diaz & Yuksel, "Shortest Path to Boundary for Self-Intersecting Meshes" (2023)                                       | contact/collision                  | planned     | high     | evaluate  |
 | `werling-2021`                     | Werling et al., "Fast and Feature-Complete Differentiable Physics … Articulated Rigid Bodies" (2021)                       | differentiable                     | in-progress | high     | adopt     |
 | `howell-2022-dojo`                 | Howell et al., "Dojo: A Differentiable Physics Engine for Robotics" (2022)                                                 | differentiable/contact/integration | planned     | high     | evaluate  |
 | `lee-vi-2016`                      | Lee, Liu, Park & Srinivasa, "A Linear-Time Variational Integrator for Multibody Systems" (2016)                            | integration                        | planned     | high     | adopt     |
@@ -206,7 +207,7 @@ Springer, 2006.
 | `vouga-2017-all-well`              | Vouga et al., "All's Well That Ends Well: Guaranteed Resolution of Simultaneous Rigid Body Impact" (2017)                  | contact/impact                     | referenced  | medium   | evaluate  |
 | `halm-posa-2024-set-valued-impact` | Halm & Posa, "Set-valued rigid-body dynamics for simultaneous, inelastic, frictional impacts" (2024)                       | contact/impact                     | referenced  | medium   | evaluate  |
 | `lelidec-2024-contact-models`      | Le Lidec et al., "Contact Models in Robotics: a Comparative Analysis" (2024)                                               | contact/survey                     | referenced  | medium   | reference |
-| `ogc-2025`                         | Chen et al., "Offset Geometric Contact" (2025)                                                                             | contact/collision                  | referenced  | medium   | evaluate  |
+| `ogc-2025`                         | Chen et al., "Offset Geometric Contact" (2025)                                                                             | contact/collision                  | planned     | high     | evaluate  |
 | `nakamura-1987-task-priority`      | Nakamura, Hanafusa & Yoshikawa, "Task-Priority Based Redundancy Control of Robot Manipulators" (1987)                      | kinematics                         | planned     | medium   | adopt     |
 | `buss-kim-2005-sdls`               | Buss & Kim, "Selectively Damped Least Squares for Inverse Kinematics" (2005)                                               | kinematics                         | planned     | medium   | evaluate  |
 | `aristidou-lasenby-2011-fabrik`    | Aristidou & Lasenby, "FABRIK: A fast, iterative solver for the Inverse Kinematics problem" (2011)                          | kinematics                         | planned     | medium   | evaluate  |
@@ -729,6 +730,34 @@ Related public resources:
   physical/computational criteria. Use it to keep the PLAN-082 comparison matrix
   honest, not as a direct implementation target.
 
+### `chen-2023-spb`
+
+He Chen, Elie Diaz, and Cem Yuksel. "Shortest Path to Boundary for
+Self-Intersecting Meshes." _ACM Transactions on Graphics_, 42(4), 2023. DOI:
+[10.1145/3592136](https://doi.org/10.1145/3592136).
+
+Related public resources:
+
+- Project page:
+  [graphics.cs.utah.edu/research/projects/shortest-path-to-boundary](https://graphics.cs.utah.edu/research/projects/shortest-path-to-boundary/)
+- arXiv: [2305.09778](https://arxiv.org/abs/2305.09778)
+- Supplemental:
+  [sig23_shortest_path-supplemental.pdf](https://graphics.cs.utah.edu/research/projects/shortest-path-to-boundary/sig23_shortest_path-supplemental.pdf)
+- Code:
+  [AnkaChan/Shortest-Path-to-Boundary-for-Self-Intersecting-Meshes](https://github.com/AnkaChan/Shortest-Path-to-Boundary-for-Self-Intersecting-Meshes)
+- Paper video:
+  [youtube.com/watch?v=qRBHY9ntwbU](https://www.youtube.com/watch?v=qRBHY9ntwbU)
+
+- **Type:** paper · **Topic:** contact/collision · **Status:** planned · **Priority:** high · **Verdict:** evaluate
+- **Where used:**
+  [`PLAN-081 SPB gap audit`](https://github.com/dartsim/dart/blob/main/docs/plans/081-deformable-implicit-barrier-solver/spb-gap-audit.md).
+- **Notes:** Volumetric self-intersection recovery method for tetrahedral
+  deformables: DCD finds preexisting intersections, SPB finds a valid shortest
+  path from an internal point to the boundary, and CCD remains necessary for new
+  crossings. It is not a codimensional cloth/strand method and should remain an
+  internal recovery sidecar until DART has query tests, recovery constraints,
+  hybrid CCD/DCD evidence, benchmark packets, and visual captures.
+
 ### `ogc-2025`
 
 Anka He Chen, Jerry Hsu, Ziheng Liu, Miles Macklin, Yin Yang, and Cem Yuksel.
@@ -740,16 +769,23 @@ Related public resources:
   [graphics.cs.utah.edu/research/projects/ogc](https://graphics.cs.utah.edu/research/projects/ogc/)
 - Paper PDF:
   [Offset_Geometric_Contact-SIGGRAPH2025.pdf](https://graphics.cs.utah.edu/research/projects/ogc/Offset_Geometric_Contact-SIGGRAPH2025.pdf)
+- Code (Gaia):
+  [github.com/AnkaChan/Gaia](https://github.com/AnkaChan/Gaia)
+- Code (Newton):
+  [newton/\_src/solvers/vbd](https://github.com/newton-physics/newton/tree/main/newton/_src/solvers/vbd)
+- Paper video:
+  [youtube.com/watch?v=xxyniqSLJik](https://www.youtube.com/watch?v=xxyniqSLJik)
 
-- **Type:** paper · **Topic:** contact/collision · **Status:** referenced · **Priority:** medium · **Verdict:** evaluate
+- **Type:** paper · **Topic:** contact/collision · **Status:** planned · **Priority:** high · **Verdict:** evaluate
 - **Where used:**
+  [`PLAN-104 OGC gap audit`](https://github.com/dartsim/dart/blob/main/docs/plans/104-vertex-block-descent-solver/ogc-gap-audit.md),
   [`PLAN-082 simultaneous-impact intake`](https://github.com/dartsim/dart/blob/main/docs/plans/082-rigid-implicit-barrier-contact/simultaneous-impact-intake.md).
 - **Notes:** Newer finite-time contact alternative for codimensional objects:
   offset geometry, local displacement bounds, and GPU-friendly local operations
   that avoid expensive CCD in its target setting. It is not a rigid-impact
-  operator, but it is relevant when deciding whether IPC-style barriers or AVBD
-  already supersede older simultaneous-contact goals for deformable and
-  codimensional scenes.
+  operator. Its implementation path is now tracked under PLAN-104 as a VBD
+  contact sidecar with required source/code audit, CPU proof-of-contact,
+  IPC/VBD comparison packets, and public-boundary review before promotion.
 
 ### `nakamura-1987-task-priority`
 

--- a/docs/readthedocs/papers.md
+++ b/docs/readthedocs/papers.md
@@ -194,6 +194,7 @@ Springer, 2006.
 | `gjk-1988`                         | Gilbert, Johnson & Keerthi, GJK distance algorithm (1988)                                                                  | collision                          | implemented | —        | adopt     |
 | `ipc-2020`                         | Li et al., "Incremental Potential Contact" (2020)                                                                          | contact                            | in-progress | high     | adopt     |
 | `rigid-ipc-2021`                   | Ferguson et al., "Intersection-free Rigid Body Dynamics" (2021)                                                            | contact                            | in-progress | high     | adopt     |
+| `lan-2022-pdipc`                   | Lan et al., "Penetration-free Projective Dynamics on the GPU" (2022)                                                       | contact/integration/GPU            | planned     | high     | evaluate  |
 | `chen-2023-spb`                    | Chen, Diaz & Yuksel, "Shortest Path to Boundary for Self-Intersecting Meshes" (2023)                                       | contact/collision                  | planned     | high     | evaluate  |
 | `werling-2021`                     | Werling et al., "Fast and Feature-Complete Differentiable Physics … Articulated Rigid Bodies" (2021)                       | differentiable                     | in-progress | high     | adopt     |
 | `howell-2022-dojo`                 | Howell et al., "Dojo: A Differentiable Physics Engine for Robotics" (2022)                                                 | differentiable/contact/integration | planned     | high     | evaluate  |
@@ -409,6 +410,42 @@ Related public resources:
   smoothed friction, same-domain rigid method selection, CPU/GPU benchmark
   packets, comparison baselines, and headless Filament evidence for promoted
   scenes.
+
+### `lan-2022-pdipc`
+
+Lei Lan, Guanqun Ma, Yin Yang, Changxi Zheng, Minchen Li, and Chenfanfu Jiang.
+"Penetration-free Projective Dynamics on the GPU." _ACM Transactions on
+Graphics_, 41(4), Article 69, 2022. DOI:
+[10.1145/3528223.3530069](https://doi.org/10.1145/3528223.3530069).
+
+Related public resources:
+
+- Paper PDF:
+  [lan2022pdipc.pdf](https://www.math.ucla.edu/multiples/publication/lan2022pdipc.pdf)
+- GAMES webinar deck:
+  [Games2022240](https://games-1312234642.cos.ap-guangzhou.myqcloud.com/pdf/Games2022240%E8%93%9D%E7%A3%8A.pdf)
+- Summary page:
+  [Physics-Based Animation](https://www.physicsbasedanimation.com/2022/05/27/penetration-free-projective-dynamics-on-the-gpu/)
+- Paper video:
+  [youtube.com/watch?v=acEplzIIOEs](https://www.youtube.com/watch?v=acEplzIIOEs)
+- CCD reference implementation:
+  [Continuous-Collision-Detection/Fast-Approximate-Root-CCD](https://github.com/Continuous-Collision-Detection/Fast-Approximate-Root-CCD)
+- Robotics projective-dynamics reference:
+  [DragonZoom/projective-dynamics-for-robotics](https://github.com/DragonZoom/projective-dynamics-for-robotics)
+
+- **Type:** paper · **Topic:** contact/integration/GPU · **Status:** planned · **Priority:** high · **Verdict:** evaluate
+- **Where used:**
+  [`PLAN-081 PD-IPC GPU gap audit`](https://github.com/dartsim/dart/blob/main/docs/plans/081-deformable-implicit-barrier-solver/pd-ipc-gpu-gap-audit.md).
+- **Notes:** Candidate GPU acceleration path for IPC-class deformable contact:
+  it combines projective dynamics, IPC barriers, two-level local/global
+  iteration, A-Jacobi, patch-based GPU collision culling, and
+  minimum-gradient-Newton CCD pruning for solids and shells. DART should treat
+  the fast CCD shortcut as an optimization to validate against conservative
+  native CCD, because the public non-author CCD implementation reports missed
+  point-triangle and edge-edge collisions. Keep the method internal and
+  backend-neutral until CPU reference tests, A-Jacobi convergence evidence,
+  conservative-CCD fallback policy, GPU packet benchmarks, and headless visual
+  evidence pass.
 
 ### `werling-2021`
 


### PR DESCRIPTION
## Summary

- Add PLAN-104 planning for Offset Geometric Contact as a VBD/codimensional contact sidecar.
- Add PLAN-081 planning for Shortest Path to Boundary as tetrahedral deformable self-intersection recovery.
- Update the plan dashboard, plan index, paper catalog, and simultaneous-impact intake pointers so the new work has one owner surface each.

## Motivation / Problem

- OGC and SPB are relevant to DART's deformable/contact roadmap, but they need bounded evaluation plans before any solver, API, or backend claim.
- Keeping OGC under PLAN-104 and SPB under PLAN-081 avoids duplicate initiatives and makes the promotion gates explicit.

## Changes / Key Changes

- Adds `docs/plans/104-vertex-block-descent-solver/ogc-gap-audit.md` with source evidence, DART placement, implementation sequence, acceptance gates, and non-goals.
- Adds `docs/plans/081-deformable-implicit-barrier-solver/spb-gap-audit.md` with source evidence, DART placement, implementation sequence, acceptance gates, and non-goals.
- Updates PLAN-104, PLAN-081, and `docs/plans/dashboard.md` with next steps and gates for OGC/SPB.
- Updates `docs/readthedocs/papers.md` and `docs/plans/README.md` with the new/updated reference and owner-doc links.
- Narrows the OGC pointer in the simultaneous-impact intake to PLAN-104 instead of treating it as a PLAN-082 rigid-impact implementation path.

## Testing

- `curl -L --fail --silent --show-error --head https://arxiv.org/pdf/2305.09778`
- `curl -L --fail --silent --show-error --head https://graphics.cs.utah.edu/research/projects/shortest-path-to-boundary/`
- `curl -L --fail --silent --show-error --head https://graphics.cs.utah.edu/research/projects/shortest-path-to-boundary/sig23_shortest_path-supplemental.pdf`
- `curl -L --fail --silent --show-error --head https://graphics.cs.utah.edu/research/projects/ogc/Offset_Geometric_Contact-SIGGRAPH2025.pdf`
- `git ls-remote https://github.com/AnkaChan/Shortest-Path-to-Boundary-for-Self-Intersecting-Meshes.git HEAD`
- `git ls-remote https://github.com/AnkaChan/Gaia.git HEAD`
- `git ls-remote https://github.com/newton-physics/newton.git HEAD`
- `pixi run lint-md`
- `pixi run check-lint-md`
- `pixi run check-docs-policy`
- `pixi run check-lint-spell`
- `git diff --check`
- `pixi run lint`

## Breaking Changes

- [x] None
- Documentation/planning only; no runtime, API, ABI, or behavior changes.

## Related Issues / PRs (backports)

- Related: #2824
- Backports: N/A, planning docs target `main` only.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required - N/A, planning docs only
- [x] Add unit tests for new functionality - N/A, planning docs only
- [x] Document new methods and classes - N/A, no new API
- [x] Add Python bindings (dartpy) if applicable - N/A, no code changes