### PR TITLE
Fail CUDA benchmark smoke when the filter matches nothing

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -932,13 +932,16 @@ set -euo pipefail
 BUILD_TYPE={{ build_type }}
 BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/${BUILD_TYPE}
 ctest --test-dir "${BUILD_DIR}" --output-on-failure -L simulation-experimental-cuda
-"${BUILD_DIR}/bin/bm_cuda_rigid_body_state_batch" \
+# Benchmark smoke runs go through run_benchmark_smoke.py because Google Benchmark
+# exits 0 even when a --benchmark_filter matches nothing; the wrapper fails loudly
+# so a renamed or dropped benchmark cannot silently stop being exercised.
+python scripts/run_benchmark_smoke.py "${BUILD_DIR}/bin/bm_cuda_rigid_body_state_batch" \
   --benchmark_filter='BM_Phase5RigidBodyBatch(CpuBaseline|Gpu)/1024/128/10$' \
   --benchmark_min_time=1ms
-"${BUILD_DIR}/bin/bm_cuda_rigid_body_state_batch" \
+python scripts/run_benchmark_smoke.py "${BUILD_DIR}/bin/bm_cuda_rigid_body_state_batch" \
   --benchmark_filter='BM_(CpuSingleThread|CpuMulticore|CudaResident)RigidBodyStateBatchLinearRollout/4/256/1$' \
   --benchmark_min_time=0.001s
-"${BUILD_DIR}/bin/bm_vbd_cuda" \
+python scripts/run_benchmark_smoke.py "${BUILD_DIR}/bin/bm_vbd_cuda" \
   --benchmark_filter='BM_Vbd(Cpu|Cuda)Step/32$' \
   --benchmark_min_time=0.001s
 """,

--- a/scripts/run_benchmark_smoke.py
+++ b/scripts/run_benchmark_smoke.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Run a Google Benchmark binary as a smoke check that fails on an empty filter.
+
+Google Benchmark exits with status 0 even when ``--benchmark_filter`` matches no
+benchmarks; it only prints ``Failed to match any benchmarks against regex`` to
+stderr. A smoke invocation therefore passes silently once a benchmark is
+renamed, removed, or reparametrized, hiding the fact that the targeted component
+is no longer exercised.
+
+This wrapper first lists the benchmarks the filter selects and fails when that
+set is empty, then runs the benchmark for real and propagates its exit code.
+That keeps the CUDA (and any other) benchmark smoke honest: if the filter stops
+matching, the smoke step fails loudly instead of reporting a green pass over
+zero benchmarks.
+
+Usage:
+    python scripts/run_benchmark_smoke.py <binary> [benchmark args...]
+
+Example:
+    python scripts/run_benchmark_smoke.py build/.../bin/bm_vbd_cuda \\
+        --benchmark_filter='BM_Vbd(Cpu|Cuda)Step/32$' --benchmark_min_time=0.001s
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from typing import List, Sequence
+
+
+def count_matching_benchmarks(binary: str, run_args: Sequence[str]) -> int:
+    """Return how many benchmarks ``run_args`` select in ``binary``.
+
+    ``--benchmark_list_tests=true`` prints one matching benchmark name per line
+    to stdout and ignores run-only flags such as ``--benchmark_min_time``. When
+    nothing matches it writes a diagnostic to stderr and leaves stdout empty, so
+    counting non-blank stdout lines yields the match count.
+    """
+    result = subprocess.run(
+        [binary, "--benchmark_list_tests=true", *run_args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return sum(1 for line in result.stdout.splitlines() if line.strip())
+
+
+def _describe_filter(run_args: Sequence[str]) -> str:
+    for arg in run_args:
+        if arg.startswith("--benchmark_filter="):
+            return arg[len("--benchmark_filter=") :]
+    return "<no --benchmark_filter given>"
+
+
+def run_smoke(binary: str, run_args: Sequence[str]) -> int:
+    """List-then-run ``binary``; fail when the filter selects no benchmarks."""
+    matched = count_matching_benchmarks(binary, run_args)
+    if matched == 0:
+        print(
+            f"ERROR: benchmark filter '{_describe_filter(run_args)}' matched no "
+            f"benchmarks in {binary}. The smoke target no longer exercises any "
+            "benchmark; update the filter or the benchmark registration.",
+            file=sys.stderr,
+        )
+        return 1
+
+    completed = subprocess.run([binary, *run_args], check=False)
+    return completed.returncode
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a Google Benchmark smoke check that fails on an empty filter.",
+    )
+    parser.add_argument("binary", help="Path to the Google Benchmark executable.")
+    parser.add_argument(
+        "benchmark_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments forwarded to the benchmark (e.g. --benchmark_filter=...).",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    run_args: List[str] = [arg for arg in args.benchmark_args if arg != "--"]
+    return run_smoke(args.binary, run_args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_run_benchmark_smoke.py
+++ b/tests/test_run_benchmark_smoke.py
@@ -1,0 +1,127 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_smoke_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    scripts_dir = repo_root / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "dart_run_benchmark_smoke", scripts_dir / "run_benchmark_smoke.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _CompletedStub:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def test_count_matching_benchmarks_counts_nonblank_stdout_lines(monkeypatch):
+    module = load_smoke_module()
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _CompletedStub(stdout="BM_A/1\nBM_B/2\n\n")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    count = module.count_matching_benchmarks("bin/bm", ["--benchmark_filter=BM_"])
+
+    assert count == 2
+    # The list invocation must ask Google Benchmark to enumerate, not run.
+    assert captured["cmd"] == [
+        "bin/bm",
+        "--benchmark_list_tests=true",
+        "--benchmark_filter=BM_",
+    ]
+    assert captured["kwargs"]["capture_output"] is True
+
+
+def test_run_smoke_fails_and_skips_run_when_no_match(monkeypatch):
+    module = load_smoke_module()
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        # First call is the list invocation; report zero matches.
+        return _CompletedStub(stdout="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    rc = module.run_smoke("bin/bm", ["--benchmark_filter=BM_Missing$"])
+
+    assert rc == 1
+    # Only the list invocation runs; the benchmark itself must not be executed.
+    assert len(calls) == 1
+    assert "--benchmark_list_tests=true" in calls[0]
+
+
+def test_run_smoke_runs_and_propagates_exit_code_when_matched(monkeypatch):
+    module = load_smoke_module()
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "--benchmark_list_tests=true" in cmd:
+            return _CompletedStub(stdout="BM_Real/32\n")
+        return _CompletedStub(returncode=7)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    rc = module.run_smoke(
+        "bin/bm", ["--benchmark_filter=BM_Real/32$", "--benchmark_min_time=0.001s"]
+    )
+
+    assert rc == 7
+    assert len(calls) == 2
+    # The real run forwards the smoke args verbatim and excludes the list flag.
+    assert calls[1] == [
+        "bin/bm",
+        "--benchmark_filter=BM_Real/32$",
+        "--benchmark_min_time=0.001s",
+    ]
+
+
+def test_describe_filter_reports_filter_or_placeholder():
+    module = load_smoke_module()
+
+    assert module._describe_filter(["--benchmark_filter=BM_X$"]) == "BM_X$"
+    assert module._describe_filter(["--benchmark_min_time=1ms"]).startswith("<no")
+
+
+def test_main_forwards_remainder_args(monkeypatch):
+    module = load_smoke_module()
+    seen = {}
+
+    def fake_run_smoke(binary, run_args):
+        seen["binary"] = binary
+        seen["run_args"] = list(run_args)
+        return 0
+
+    monkeypatch.setattr(module, "run_smoke", fake_run_smoke)
+
+    rc = module.main(
+        ["bin/bm", "--benchmark_filter=BM_X$", "--", "--benchmark_min_time=1ms"]
+    )
+
+    assert rc == 0
+    assert seen["binary"] == "bin/bm"
+    # The bare "--" separator is stripped; benchmark flags pass through.
+    assert seen["run_args"] == [
+        "--benchmark_filter=BM_X$",
+        "--benchmark_min_time=1ms",
+    ]
+
+
+def test_real_subprocess_run_signature_is_available():
+    # Guard against importing a stubbed subprocess module.
+    assert subprocess.run is not None


### PR DESCRIPTION
## Summary

- Make the CUDA benchmark smoke in `test-cuda` (run by `pixi run -e cuda test-all`) fail when a `--benchmark_filter` matches zero benchmarks, instead of silently passing.

## Motivation / Problem

Google Benchmark exits with status `0` even when `--benchmark_filter` matches no benchmarks — it only prints `Failed to match any benchmarks against regex` to stderr. The three benchmark smoke invocations in the `test-cuda` task called the benchmark binaries directly, so `set -euo pipefail` could not catch a zero-match. If a CUDA benchmark were renamed, removed, or reparametrized, the smoke step would report a green pass over **zero** benchmarks, hiding the loss of coverage for a CUDA component. This undercuts the guarantee that `pixi run -e cuda test-all` exercises all CUDA components.

## Changes / Key Changes

- Add `scripts/run_benchmark_smoke.py`: lists the benchmarks a filter selects (`--benchmark_list_tests=true`), fails loudly when none match, then runs the benchmark for real and propagates its exit code.
- Route the three `test-cuda` benchmark smoke runs through the wrapper.
- Add `tests/test_run_benchmark_smoke.py` covering empty-match failure, run-skipping on no match, exit-code propagation, list-vs-run invocation, and argument forwarding.

## Testing

- `pixi run -e cuda python -m pytest tests/test_run_benchmark_smoke.py tests/test_test_all.py` — 15 passed.
- `pixi run -e cuda test-cuda` on a CUDA host (RTX 5000 Ada): 3/3 CUDA unit tests pass; all three benchmark smokes now run through the wrapper and pass.
- Manually verified the wrapper exits `1` on a deliberately non-matching filter and `0` (running the benchmark) on a real filter.
- `pixi run -e cuda lint-toml`, `check-phase5-cuda-workflow`, `check-phase5-cuda-benchmark-contract`; `black --check` and `isort --check-only` clean.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #2827 (Enable CUDA-aware test-all validation).
