### PR TITLE
Surface benchmark enumerate failures in the CUDA smoke wrapper

### DIFF
--- a/scripts/run_benchmark_smoke.py
+++ b/scripts/run_benchmark_smoke.py
@@ -13,6 +13,13 @@ That keeps the CUDA (and any other) benchmark smoke honest: if the filter stops
 matching, the smoke step fails loudly instead of reporting a green pass over
 zero benchmarks.
 
+The enumeration step captures the binary's output to count matches. When the
+binary instead fails to enumerate at all (a missing executable, or a startup
+crash such as a CUDA-init failure during static benchmark registration), the
+wrapper re-emits the binary's own stdout/stderr and exits non-zero with an
+actionable message, so the real diagnostic still reaches the log rather than
+being swallowed behind a Python traceback.
+
 Usage:
     python scripts/run_benchmark_smoke.py <binary> [benchmark args...]
 
@@ -29,6 +36,10 @@ import sys
 from typing import List, Sequence
 
 
+class BenchmarkEnumerationError(RuntimeError):
+    """Raised when a benchmark binary cannot be enumerated for matches."""
+
+
 def count_matching_benchmarks(binary: str, run_args: Sequence[str]) -> int:
     """Return how many benchmarks ``run_args`` select in ``binary``.
 
@@ -36,13 +47,35 @@ def count_matching_benchmarks(binary: str, run_args: Sequence[str]) -> int:
     to stdout and ignores run-only flags such as ``--benchmark_min_time``. When
     nothing matches it writes a diagnostic to stderr and leaves stdout empty, so
     counting non-blank stdout lines yields the match count.
+
+    Raises ``BenchmarkEnumerationError`` when the binary is missing or exits
+    non-zero while enumerating, after re-emitting whatever the binary printed so
+    its own diagnostic is not lost.
     """
-    result = subprocess.run(
-        [binary, "--benchmark_list_tests=true", *run_args],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [binary, "--benchmark_list_tests=true", *run_args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise BenchmarkEnumerationError(
+            f"benchmark binary not found: {binary}"
+        ) from exc
+
+    if result.returncode != 0:
+        # Surface the binary's own output (e.g. a CUDA startup error) instead of
+        # letting capture_output swallow it behind a bare traceback.
+        if result.stdout:
+            sys.stdout.write(result.stdout)
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+        raise BenchmarkEnumerationError(
+            f"benchmark binary '{binary}' exited {result.returncode} while "
+            "enumerating benchmarks with --benchmark_list_tests=true"
+        )
+
     return sum(1 for line in result.stdout.splitlines() if line.strip())
 
 
@@ -55,7 +88,12 @@ def _describe_filter(run_args: Sequence[str]) -> str:
 
 def run_smoke(binary: str, run_args: Sequence[str]) -> int:
     """List-then-run ``binary``; fail when the filter selects no benchmarks."""
-    matched = count_matching_benchmarks(binary, run_args)
+    try:
+        matched = count_matching_benchmarks(binary, run_args)
+    except BenchmarkEnumerationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
     if matched == 0:
         print(
             f"ERROR: benchmark filter '{_describe_filter(run_args)}' matched no "
@@ -65,7 +103,11 @@ def run_smoke(binary: str, run_args: Sequence[str]) -> int:
         )
         return 1
 
-    completed = subprocess.run([binary, *run_args], check=False)
+    try:
+        completed = subprocess.run([binary, *run_args], check=False)
+    except FileNotFoundError:
+        print(f"ERROR: benchmark binary not found: {binary}", file=sys.stderr)
+        return 1
     return completed.returncode
 
 

--- a/tests/test_run_benchmark_smoke.py
+++ b/tests/test_run_benchmark_smoke.py
@@ -18,8 +18,9 @@ def load_smoke_module():
 
 
 class _CompletedStub:
-    def __init__(self, stdout="", returncode=0):
+    def __init__(self, stdout="", stderr="", returncode=0):
         self.stdout = stdout
+        self.stderr = stderr
         self.returncode = returncode
 
 
@@ -46,6 +47,50 @@ def test_count_matching_benchmarks_counts_nonblank_stdout_lines(monkeypatch):
     assert captured["kwargs"]["capture_output"] is True
 
 
+def test_count_matching_benchmarks_raises_and_reemits_on_nonzero(monkeypatch, capsys):
+    module = load_smoke_module()
+
+    def fake_run(cmd, **kwargs):
+        return _CompletedStub(
+            stdout="partial stdout\n",
+            stderr="CUDA driver init failed\n",
+            returncode=134,
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    try:
+        module.count_matching_benchmarks("bin/bm", ["--benchmark_filter=BM_X$"])
+        raised = False
+    except module.BenchmarkEnumerationError as exc:
+        raised = True
+        assert "exited 134" in str(exc)
+
+    assert raised
+    # The binary's own diagnostic must reach the log, not be swallowed.
+    out = capsys.readouterr()
+    assert "partial stdout" in out.out
+    assert "CUDA driver init failed" in out.err
+
+
+def test_count_matching_benchmarks_raises_on_missing_binary(monkeypatch):
+    module = load_smoke_module()
+
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    try:
+        module.count_matching_benchmarks("bin/missing", ["--benchmark_filter=BM_X$"])
+        raised = False
+    except module.BenchmarkEnumerationError as exc:
+        raised = True
+        assert "not found" in str(exc)
+
+    assert raised
+
+
 def test_run_smoke_fails_and_skips_run_when_no_match(monkeypatch):
     module = load_smoke_module()
     calls = []
@@ -61,6 +106,24 @@ def test_run_smoke_fails_and_skips_run_when_no_match(monkeypatch):
 
     assert rc == 1
     # Only the list invocation runs; the benchmark itself must not be executed.
+    assert len(calls) == 1
+    assert "--benchmark_list_tests=true" in calls[0]
+
+
+def test_run_smoke_fails_and_skips_run_when_enumerate_errors(monkeypatch):
+    module = load_smoke_module()
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _CompletedStub(stderr="boom\n", returncode=1)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    rc = module.run_smoke("bin/bm", ["--benchmark_filter=BM_X$"])
+
+    assert rc == 1
+    # The enumerate failure must abort before the real benchmark run.
     assert len(calls) == 1
     assert "--benchmark_list_tests=true" in calls[0]
 


### PR DESCRIPTION
## Summary

- Make the CUDA benchmark smoke wrapper surface a benchmark binary's own error when it fails to enumerate, instead of swallowing it behind a bare Python traceback.

## Motivation / Problem

Follow-up to #2828. `scripts/run_benchmark_smoke.py` lists matching benchmarks with `subprocess.run(..., check=True, capture_output=True)` before running them. If the binary fails to enumerate at all — a missing executable, or a startup crash such as a CUDA-init failure during static benchmark registration — `check=True` raised an uncaught `CalledProcessError`. Because `capture_output=True` had captured the child's stdout/stderr, the binary's own diagnostic (the real CUDA/runtime error) was lost and the CI log showed only a Python traceback. That is a regression in diagnosability versus the previous direct invocation, which streamed the binary's stderr straight to the log.

(No correctness impact: under `set -euo pipefail` the smoke still aborted loudly, so there was never a silent pass. This is purely about making a real failure debuggable.)

Surfaced by an adversarial self-review of #2828 (two independent review lenses flagged it; verification confirmed it as a real, minor diagnosability defect).

## Changes / Key Changes

- `count_matching_benchmarks` lists with `check=False`; on a non-zero exit it re-emits the binary's captured stdout/stderr and raises `BenchmarkEnumerationError`. A missing binary (`FileNotFoundError`) is handled the same way.
- `run_smoke` catches `BenchmarkEnumerationError`, prints an actionable `ERROR:` line, and returns `1` — so every failure mode (zero match, enumerate crash, missing binary) fails loudly without a raw traceback. The real benchmark run is unchanged (still streamed, exit code propagated).
- Tests cover the non-zero-enumerate path (asserting the binary's output is re-emitted) and the missing-binary path.

## Testing

- `pixi run -e cuda python -m pytest tests/test_run_benchmark_smoke.py` — 9 passed.
- Reproduced an enumerate failure on a real CUDA binary (`--totally_bogus_flag_xyz`): the binary's `error: unrecognized command-line flag` now prints, followed by the actionable `ERROR:` line, exit `1`, no traceback.
- `pixi run -e cuda test-cuda` on a CUDA host (RTX 5000 Ada): 3/3 CUDA unit tests pass; all three benchmark smokes run through the wrapper and pass — no regression.
- `black --check` and `isort --check-only` clean.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #2828 (Fail CUDA benchmark smoke when the filter matches nothing).
