### PR TITLE
Include simulation coverage in Codecov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,8 @@
   - Linked `dart-gui` to Foundation on Apple platforms so OpenSceneGraph's macOS resource-path initialization has the Objective-C Foundation runtime it requires.
   - Removed the Filament GUI smoke CI job's distro libc++ package dependency and made its example runner use Pixi-provided libc++/libc++abi libraries when available.
   - Limited Codecov CI uploads to the generated `coverage.info` report so the uploader does not rescan gcov files after the coverage task has already produced lcov output.
+  - Included simulation-experimental and simulation detail implementation files
+    in Codecov reports by removing stale Codecov path exclusions. ([#2835](https://github.com/dartsim/dart/pull/2835))
   - Added support for assimp 6.x while maintaining backward compatibility with assimp 5.x
   - Added opt-in CUDA smoke support for experimental simulation builds, including
     a gated CMake option, Pixi CUDA environment, private SoA integration test and

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,9 +26,6 @@ coverage:
     # Test code (shouldn't count toward coverage)
     - "tests/**"
 
-    # Template implementation headers (coverage tracked via explicit instantiation in .cpp files)
-    - "**/*-impl.hpp"
-
     # GUI - requires display for testing
     # BACKLOG: Revisit when headless CI is feasible
     - "dart/gui/**"
@@ -36,10 +33,6 @@ coverage:
     # Generated/config files
     - "dart/config.hpp"
     - "**/*.in" # CMake template files
-
-    # Experimental APIs under heavy development
-    # BACKLOG: Test when APIs stabilize
-    - "dart/simulation/experimental/**"
 
     # Deprecated code scheduled for removal
     - "**/SmartPointer.hpp"
@@ -110,7 +103,6 @@ component_management:
       name: "Simulation"
       paths:
         - dart/simulation/**
-        - "!dart/simulation/experimental/**"
 
     - component_id: dart_io
       name: "I/O"


### PR DESCRIPTION
## Summary

- Include `dart/simulation/experimental/**` in the Codecov report.
- Include simulation implementation headers such as `dart/simulation/detail/world-impl.hpp` in the Codecov report.

## Motivation / Problem

- Codecov was hiding the simulation-experimental tree because `codecov.yml` explicitly ignored `dart/simulation/experimental/**` and excluded it from the Simulation component.
- The broad `**/*-impl.hpp` ignore also hid `dart/simulation/detail/world-impl.hpp`, which made the simulation code tree incomplete in Codecov.

## Changes / Key Changes

- Removed the Codecov ignore for `dart/simulation/experimental/**`.
- Removed the broad `**/*-impl.hpp` Codecov ignore.
- Removed the Simulation component negation for `dart/simulation/experimental/**`.

## Testing

- `pixi run lint`
- `curl -fsS --connect-timeout 10 -X POST --data-binary @codecov.yml https://codecov.io/validate`
- `DART_BUILD_GUI_OVERRIDE=OFF DART_FETCH_FILAMENT_OVERRIDE=OFF DART_DISABLE_COMPILER_CACHE=ON pixi run config-coverage`
- `pixi run bash -lc 'set -euo pipefail; PARALLEL_JOBS=${DART_PARALLEL_JOBS:-4}; CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/Debug python scripts/cmake_build.py --parallel ${PARALLEL_JOBS} --target UNIT_simulation_World --target test_world'`
- `pixi run bash -lc 'set -euo pipefail; ./build/default/cpp/Debug/bin/UNIT_simulation_World --gtest_filter="WorldTests.EachSkeleton:WorldTests.EachSimpleFrame:WorldTests.EachSkeletonEmpty"; ./build/default/cpp/Debug/bin/test_world --gtest_filter="World.Construction:World.StepIntegratesRigidBodyStateAndAdvancesClock"'`
- Focused `lcov --capture` plus the same removal filters as `pixi run coverage-report`; verified `SF:` entries for `dart/simulation/detail/world-impl.hpp` and `dart/simulation/experimental/**`.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable