### PR TITLE
Align DART 7 release policy, publish DART 6.16 support packet, fix stale PLAN-110 dashboard note

### DIFF
--- a/docs/onboarding/release-roadmap.md
+++ b/docs/onboarding/release-roadmap.md
@@ -30,6 +30,70 @@ design.
 - Publish the Gazebo support window, branch/version matrix, and sunset date or
   sunset trigger before DART 7 removes legacy API surfaces from main.
 
+### DART 6.16 Support Packet
+
+This packet is the published support window for the DART 6.16 compatibility
+line. It exists so downstream users — primarily Gazebo via `gz-physics` — know
+which branch to track, what fixes to expect, and when the line will close. The
+companion CI lane split (keeping required gz-physics validation on
+`release-6.16` while main's gz-physics workflow stays a manual migration canary)
+is a separate maintainer-gated branch-protection change and is **not** in scope
+for this document update.
+
+**Gazebo support window**
+
+- Pinned gz-physics branch: `gz-physics9_9.0.0` (the branch cloned by the
+  `pixi.toml` Gazebo integration task; see `feature.gazebo.tasks` `download-gz`).
+- Validation command: `pixi run -e gazebo test-gz`, run on `release-6.16` or a
+  release branch when compatibility surfaces change. Main-branch runs are
+  migration canaries, not a DART 7 API design constraint.
+- DART version compatibility floor for the pinned gz-physics checkout: DART
+  6.10+ (`scripts/patch_gz_physics.py` `MIN_COMPATIBLE_VERSION = (6, 10)`,
+  `MAX_COMPATIBLE_VERSION = (7, 0)`), so DART 7's generated
+  `DARTConfigVersion.cmake` still satisfies pinned gz-physics `find_package`
+  requests during migration.
+
+**Branch / version matrix**
+
+| Branch         | DART line       | Public API target      | gz-physics pin                         | Backport policy                                              |
+| -------------- | --------------- | ---------------------- | -------------------------------------- | ------------------------------------------------------------ |
+| `release-6.16` | DART 6 (6.16.x) | Established DART 6 API | `gz-physics9_9.0.0`                    | Compatibility-critical fixes only (see scope below)          |
+| `main`         | DART 7 (7.0.0)  | DART 7 clean-break API | `gz-physics9_9.0.0` (migration canary) | DART 7 development; no DART 6 compatibility shims by default |
+
+**Backport scope (release-6.16)**
+
+Backport only:
+
+- critical bug fixes,
+- build fixes,
+- security fixes,
+- Gazebo/gz-physics compatibility fixes that released downstream users need.
+
+Do not backport normal DART 7 features. Each backport should record the
+gz-physics compatibility evidence (`pixi run -e gazebo test-gz`) when it touches
+a compatibility surface, or note why gz-physics is unaffected.
+
+**Sunset condition (trigger-based)**
+
+The DART 6.16 support line sunsets on a trigger, not a fixed calendar date:
+
+- **Trigger:** DART 7.0.0 is published to package managers **and** a maintainer
+  decision sets a support tail. After DART 7.0.0 is published, DART 6.16 enters
+  a maintenance-only tail of **N months** (security/critical-only), after which
+  the line is closed.
+- **N is a maintainer decision** and is intentionally left unset here. A typical
+  starting point for discussion is 6–12 months after DART 7.0.0 publication, but
+  the concrete value, and whether the tail is security-only or also build/compat,
+  **requires maintainer sign-off** before it is treated as policy.
+- Until DART 7.0.0 is published and N is decided, `release-6.16` remains the
+  active compatibility line and the sunset clock has not started.
+
+> Maintainer sign-off needed: (1) the value of **N** (support-tail length after
+> DART 7.0.0 publication) and the tail's fix scope; (2) the Gazebo CI lane split
+> (required gz-physics validation pinned to `release-6.16`; main's gz-physics
+> workflow demoted to a manual canary), which is a separate branch-protection
+> change outside this PR.
+
 ## DART 7: Clean-Break Release
 
 - `main` targets DART 7.0.0 as a clean break from the DART 6 public API, with a

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -583,15 +583,17 @@ its own line so status updates remain git-history friendly.
 - Dimension: Algorithm extensibility
 - Scope note: WS1–WS5 first slices plus the PLAN-080-WS4 boxed-LCP contact
   prerequisite are implemented and verified (FD-of-step validated; default build
-  untouched and bitwise-identical when off). The work is committed on
-  `feature/differentiable-simulation` and open as PR #2761 (milestone DART 7.0,
-  CHANGELOG included). Remaining for that path is hardening/examples/promotion,
-  not new workstreams. Dojo is now tracked as a separate planned evaluation
+  untouched and bitwise-identical when off). That path landed via PR #2761
+  (merged 2026-05-30, milestone DART 7.0, CHANGELOG included; the
+  `feature/differentiable-simulation` branch was deleted post-merge). Remaining
+  for that path is hardening/examples/promotion, not new workstreams. Dojo is
+  now tracked as a separate planned evaluation
   track under PLAN-110: maximal-coordinate variational hard-contact NCP/IPM with
   implicit gradients, using Dojo.jl as method evidence and a comparison baseline
   rather than a dependency.
-- Next step: Drive PR #2761 to merge (experimental surface, single-branch to
-  `main`). Then: run the torch-autograd test (`pip install torch`); add the
+- Next step: The WS1–WS5 experimental surface is merged to `main` (PR #2761);
+  the remaining work is the hardening/examples/Dojo-spike follow-ups. Run the
+  torch-autograd test (`pip install torch`); add the
   standalone worked trajectory-optimization / system-identification example
   programs (the GUI demo and the convergence tests already ship); harden the
   static-friction Dantzig degenerate-pivot warning (shared `dart/math/lcp`, its


### PR DESCRIPTION
Documentation-only release-policy housekeeping for the DART 7 line. Three
work items (D1, A1, A3), no code changes.

## D1 — Dashboard staleness fix (PLAN-110)

PR #2761 (experimental opt-in differentiable simulation, WS1–WS5) merged to
`main` on 2026-05-30 and its `feature/differentiable-simulation` branch was
deleted. The dashboard still framed PLAN-110 as "open as PR #2761" with a next
step of "Drive PR #2761 to merge." Rewrote the scope note and next step to
reflect that the WS1–WS5 experimental surface is merged to `main`, with the
remaining work being the hardening/examples/Dojo-spike follow-ups (kept
verbatim). Status stays **Active** — the follow-up path is still part of the
intended path, so the doc's status rules do not require a change.

Verified merge state: `gh pr view 2761 --json state,mergedAt` →
`MERGED`, `2026-05-30T18:17:40Z`.

## A1 — Policy alignment audit (no edits invented)

Audited `docs/onboarding/release-roadmap.md`, `docs/plans/dashboard.md`,
`docs/ai/north-star.md`, `README.md`, and the top of `CHANGELOG.md` for the
three-part policy:

- `main` = DART 7 clean break (Python-first, C++20),
- `release-6.16` = DART 6 compatibility line,
- DART 8 = post-DART-7 cleanup (NOT the DART 6 removal point).

**Finding: already consistent.** No genuine inconsistencies were found, so no
edits were invented to manufacture changes. (README is silent on DART 8, which
is not an inconsistency; the roadmap and north-star both state the DART 8
framing explicitly and correctly.)

## A3 — DART 6.16 support packet

Added a concrete **DART 6.16 Support Packet** subsection under the roadmap's
"DART 6.16: Compatibility Line" section, satisfying that section's own action
item to publish the support window, branch/version matrix, and sunset trigger
before DART 7 removes legacy API surfaces. Captures:

- Pinned gz-physics branch `gz-physics9_9.0.0` (verified against `pixi.toml`
  `feature.gazebo` `download-gz`).
- Branch/version matrix (`release-6.16` = DART 6.16.x, `main` = DART 7.0.0) with
  the DART 6.10+ compatibility floor from `scripts/patch_gz_physics.py`.
- Backport scope: critical bug/build/security/Gazebo-compat fixes only.
- A **trigger-based** sunset condition (DART 7.0.0 published + N-month tail), no
  invented calendar date.

## Maintainer decisions flagged (not decided here)

1. **Sunset tail N** — the support-tail length (and fix scope) after DART 7.0.0
   publication is intentionally left unset and flagged for maintainer sign-off;
   6–12 months is offered only as a discussion starting point.
2. **Gazebo CI lane split (A2)** — pinning required gz-physics validation to
   `release-6.16` and demoting main's gz-physics workflow to a manual canary is
   a separate maintainer-gated branch-protection change and is explicitly out of
   scope for this PR.

## Gates

- `pixi run lint-md` — PASS (all files Prettier-clean, no reformatting needed).
- `pixi run check-lint-md` — PASS.
- `pixi run check-docs-policy` — pre-existing failure unrelated to this PR
  (`docs/dev_tasks/py_demos_ux` missing `README.md`/`RESUME.md`); confirmed it
  also fails on the clean base via `git stash`. Not introduced by these changes
  and out of scope.