### PR TITLE
Fix experimental build regression: AVBD rigid contact vs compound CollisionGeometry

### DIFF
--- a/dart/simulation/experimental/detail/deformable_vbd/rigid_world_contact.hpp
+++ b/dart/simulation/experimental/detail/deformable_vbd/rigid_world_contact.hpp
@@ -282,31 +282,36 @@ inline AvbdContactEndpointId avbdRigidWorldContactEndpointId(
     return endpoint;
   }
 
-  if (geometry->shape.type == CollisionShapeType::Box
-      && geometry->shape.halfExtents.allFinite()
-      && (geometry->shape.halfExtents.array() > 0.0).all()) {
+  // CollisionGeometry now holds a vector of shapes (compound-shape support,
+  // PLAN-080 #2838); the AVBD feature keying uses the primary (first) shape,
+  // matching the previous single-shape behavior.
+  const auto* shape = geometry->getPrimaryShape();
+  if (shape == nullptr) {
+    return endpoint;
+  }
+
+  if (shape->type == CollisionShapeType::Box && shape->halfExtents.allFinite()
+      && (shape->halfExtents.array() > 0.0).all()) {
     const std::uint64_t featureCode
-        = avbdBoxContactFeatureCode(localPoint, geometry->shape.halfExtents);
+        = avbdBoxContactFeatureCode(localPoint, shape->halfExtents);
     endpoint.feature = packAvbdContactFeatureId(
         avbdBoxContactFeatureKind(featureCode),
         packAvbdBoxContactFeatureId(/*boxIndex=*/0, featureCode));
   } else if (
-      geometry->shape.type == CollisionShapeType::Cylinder
-      && std::isfinite(geometry->shape.radius) && geometry->shape.radius > 0.0
-      && geometry->shape.halfExtents.allFinite()
-      && geometry->shape.halfExtents.z() > 0.0) {
+      shape->type == CollisionShapeType::Cylinder
+      && std::isfinite(shape->radius) && shape->radius > 0.0
+      && shape->halfExtents.allFinite() && shape->halfExtents.z() > 0.0) {
     const std::uint64_t featureCode = avbdCylinderContactFeatureCode(
-        localPoint, geometry->shape.radius, geometry->shape.halfExtents.z());
+        localPoint, shape->radius, shape->halfExtents.z());
     endpoint.feature = packAvbdContactFeatureId(
         avbdCylinderContactFeatureKind(featureCode),
         packAvbdCylinderContactFeatureId(/*cylinderIndex=*/0, featureCode));
   } else if (
-      geometry->shape.type == CollisionShapeType::Capsule
-      && std::isfinite(geometry->shape.radius) && geometry->shape.radius > 0.0
-      && geometry->shape.halfExtents.allFinite()
-      && geometry->shape.halfExtents.z() > 0.0) {
-    const std::uint64_t featureCode = avbdCapsuleContactFeatureCode(
-        localPoint, geometry->shape.halfExtents.z());
+      shape->type == CollisionShapeType::Capsule && std::isfinite(shape->radius)
+      && shape->radius > 0.0 && shape->halfExtents.allFinite()
+      && shape->halfExtents.z() > 0.0) {
+    const std::uint64_t featureCode
+        = avbdCapsuleContactFeatureCode(localPoint, shape->halfExtents.z());
     endpoint.feature = packAvbdContactFeatureId(
         avbdCapsuleContactFeatureKind(featureCode),
         packAvbdCapsuleContactFeatureId(/*capsuleIndex=*/0, featureCode));


### PR DESCRIPTION
## Urgent: main does not currently compile

`main` fails to build the experimental simulation tests (`dart_experimental_tests`) due to a **semantic conflict between two separately-merged PRs**:

- **#2838** (PLAN-080 model loader) changed `comps::CollisionGeometry` from a single `shape` member to a `std::vector<CollisionShape> shapes` (compound-shape support), exposing `hasShapes()` / `getPrimaryShape()`.
- **#2837** (AVBD rigid contact feature keys) still reads `geometry->shape.{type,halfExtents,radius}` in `detail/deformable_vbd/rigid_world_contact.hpp`.

Both merged cleanly in git (no textual conflict) but are mutually inconsistent, so the tree no longer compiles:

```
rigid_world_contact.hpp:285: error: 'const struct ...comps::CollisionGeometry'
  has no member named 'shape'; did you mean 'shapes'?
```

This is a classic parallel-development *semantic* merge collision that the per-file git merge can't catch.

## Fix

Use `CollisionGeometry::getPrimaryShape()` (the first shape, matching the prior single-shape behavior) in the AVBD rigid-world contact feature-keying function, and skip endpoints whose geometry has no shape. Behavior-preserving for the existing single-shape bodies; for compound geometry it keys on the primary shape (box/cylinder/capsule indices remain 0, as before).

## Verification

- `pixi run build-simulation-experimental-tests` ✅ (was failing on `main`)
- `ctest -L simulation-experimental` → **58/58 pass**
- `pixi run lint` ✅

## Note

Recommend fast-tracking: until this lands, every PR's experimental build/CI is red. Found while rebasing other DART 7 work onto latest `main`.