### PR TITLE
Packaging 6.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 ## DART 6
 
+### [DART 6.17.0 (2026-06-01)](https://github.com/dartsim/dart/milestone/85?closed=1)
+
+DART 6.17.0 is a maintenance release on the DART 6 LTS compatibility line. It
+backports bug fixes and additive improvements to the classic DART 6 API that were
+made on `main` during DART 7 development, so that DART 6 and gz-physics users
+receive them before the DART 7 clean break removes the legacy API from `main`.
+
+* GUI
+
+  * Fix `RealTimeWorldNode` stalling when the viewer lags behind real time: [#2088](https://github.com/dartsim/dart/pull/2088)
+
+* Collision
+
+  * Preserve the minimum pair distance in FCL distance queries: [#2243](https://github.com/dartsim/dart/pull/2243), [#1539](https://github.com/dartsim/dart/issues/1539)
+  * Fix plane collision handling for the Bullet and FCL backends: [#2246](https://github.com/dartsim/dart/pull/2246)
+  * Fix an FCL mesh contact regression: [#2258](https://github.com/dartsim/dart/pull/2258)
+  * Fix Bullet ellipsoid rolling by using primitive sphere/ellipsoid shapes: [#2274](https://github.com/dartsim/dart/pull/2274)
+  * Handle non-`Skeleton` `MetaSkeleton` subscriptions in `CollisionGroup` without crashing: [#2277](https://github.com/dartsim/dart/pull/2277)
+  * Stabilize FCL contact normals and make collision ordering deterministic: [#2282](https://github.com/dartsim/dart/pull/2282)
+  * Guard the body-node collision filter against missing body nodes: [#2343](https://github.com/dartsim/dart/pull/2343)
+  * Add `Contact` accessors for the shape frame, shape node, and body node: [#2245](https://github.com/dartsim/dart/pull/2245)
+  * Fix memory leaks and a use-after-free in the Bullet collision backend: [#2101](https://github.com/dartsim/dart/pull/2101)
+  * Fix a Bullet collision-detection correctness issue: [#2091](https://github.com/dartsim/dart/pull/2091)
+  * Fix ODE `HeightmapShape` visual/collision mismatch and a dangling-pointer bug: [#2305](https://github.com/dartsim/dart/pull/2305)
+
+* Constraint
+
+  * Recover finite Dantzig LCP solutions instead of zeroing the result when only some entries are NaN: [#2253](https://github.com/dartsim/dart/pull/2253)
+
+* Dynamics
+
+  * Compute `BodyNode` potential energy from the center of mass: [#2224](https://github.com/dartsim/dart/pull/2224)
+  * Add `BodyNode` world-transform derivative APIs: [#2131](https://github.com/dartsim/dart/pull/2131)
+  * Preserve Collada unit scaling in `MeshShape`: [#2152](https://github.com/dartsim/dart/pull/2152)
+  * Add debug assertions for non-finite joint inputs: [#2273](https://github.com/dartsim/dart/pull/2273)
+  * Emit collision-shape added/removed signals on shape changes: [#2250](https://github.com/dartsim/dart/pull/2250)
+  * Deep-copy shapes when cloning skeletons: [#2239](https://github.com/dartsim/dart/pull/2239), [#896](https://github.com/dartsim/dart/issues/896)
+  * Add `PlanarJoint` SE(2) conversion helpers: [#2231](https://github.com/dartsim/dart/pull/2231)
+  * Fix joint impulse statefulness by moving impulse state into `GenericJointState`: [#2308](https://github.com/dartsim/dart/pull/2308)
+  * Add a state-independent `Joint::integratePositions` overload: [#2309](https://github.com/dartsim/dart/pull/2309)
+  * Validate negative physics parameters at runtime instead of asserting: [#2431](https://github.com/dartsim/dart/pull/2431)
+  * Clear stale joint commands when the actuator type changes: [#2098](https://github.com/dartsim/dart/pull/2098)
+  * Fix the `FreeJoint` world Jacobian translation: [#2298](https://github.com/dartsim/dart/pull/2298)
+
+* Parsers
+
+  * Enforce SDF joint position limits when finite: [#2232](https://github.com/dartsim/dart/pull/2232)
+  * Handle tiny/degenerate SDF inertial data and warn on missing `<inertial>`: [#2284](https://github.com/dartsim/dart/pull/2284)
+
+* Common
+
+  * Fix `Signal` thread-safety regressions: [#2181](https://github.com/dartsim/dart/pull/2181)
+  * Add `StlAllocator::max_size` and make `deallocate` `noexcept`: [#2287](https://github.com/dartsim/dart/pull/2287)
+  * Fix `Aspect` lifecycle when an aspect is replaced: [#2304](https://github.com/dartsim/dart/pull/2304)
+  * Make `CloneableMap` copy null-safe: [#2358](https://github.com/dartsim/dart/pull/2358)
+
+* Build
+
+  * Prefer the prefix-local Vulkan loader for the ImGui example: [#2085](https://github.com/dartsim/dart/pull/2085)
+  * Allow configuring (or disabling) the examples install destination: [#2100](https://github.com/dartsim/dart/pull/2100)
+  * Register `dart::utils` parser sources correctly in CMake: [#2314](https://github.com/dartsim/dart/pull/2314)
+
 ### [DART 6.16.8 (2026-05-31)](https://github.com/dartsim/dart/milestone/93?closed=1)
 
 * GUI

--- a/examples/atlas_puppet/CMakeLists.txt
+++ b/examples/atlas_puppet/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/atlas_simbicon/CMakeLists.txt
+++ b/examples/atlas_simbicon/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/biped_stand/CMakeLists.txt
+++ b/examples/biped_stand/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/box_stacking/CMakeLists.txt
+++ b/examples/box_stacking/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/boxes/CMakeLists.txt
+++ b/examples/boxes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_add_delete_skels/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_add_delete_skels/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_atlas_simbicon/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_atlas_simbicon/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_biped_stand/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_biped_stand/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_hardcoded_design/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_hardcoded_design/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
@@ -41,7 +41,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_hybrid_dynamics/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_hybrid_dynamics/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_joint_constraints/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_joint_constraints/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_mixed_chain/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_mixed_chain/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_operational_space_control/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_operational_space_control/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_chain/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_chain/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_cubes/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_cubes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_loop/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_loop/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_rigid_shapes/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_rigid_shapes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_simple_frames/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_simple_frames/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_soft_bodies/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_soft_bodies/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/deprecated_examples/glut_vehicle/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_vehicle/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/drag_and_drop/CMakeLists.txt
+++ b/examples/drag_and_drop/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/empty/CMakeLists.txt
+++ b/examples/empty/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/fetch/CMakeLists.txt
+++ b/examples/fetch/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/heightmap/CMakeLists.txt
+++ b/examples/heightmap/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/hubo_puppet/CMakeLists.txt
+++ b/examples/hubo_puppet/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/imgui/CMakeLists.txt
+++ b/examples/imgui/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/operational_space_control/CMakeLists.txt
+++ b/examples/operational_space_control/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/point_cloud/CMakeLists.txt
+++ b/examples/point_cloud/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/rerun/CMakeLists.txt
+++ b/examples/rerun/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/rigid_shapes/CMakeLists.txt
+++ b/examples/rigid_shapes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/soft_bodies/CMakeLists.txt
+++ b/examples/soft_bodies/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/speed_test/CMakeLists.txt
+++ b/examples/speed_test/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/tinkertoy/CMakeLists.txt
+++ b/examples/tinkertoy/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/examples/wam_ikfast/CMakeLists.txt
+++ b/examples/wam_ikfast/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.16.8</version>
+  <version>6.17.0</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.16.8"
+version = "6.17.0"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]

--- a/tutorials/tutorial_biped/CMakeLists.txt
+++ b/tutorials/tutorial_biped/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_biped_finished/CMakeLists.txt
+++ b/tutorials/tutorial_biped_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_collisions/CMakeLists.txt
+++ b/tutorials/tutorial_collisions/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_collisions_finished/CMakeLists.txt
+++ b/tutorials/tutorial_collisions_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_dominoes/CMakeLists.txt
+++ b/tutorials/tutorial_dominoes/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_dominoes_finished/CMakeLists.txt
+++ b/tutorials/tutorial_dominoes_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_multi_pendulum/CMakeLists.txt
+++ b/tutorials/tutorial_multi_pendulum/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})

--- a/tutorials/tutorial_multi_pendulum_finished/CMakeLists.txt
+++ b/tutorials/tutorial_multi_pendulum_finished/CMakeLists.txt
@@ -12,7 +12,7 @@ if(DART_IN_SOURCE_BUILD)
   return()
 endif()
 
-find_package(DART 6.16 REQUIRED COMPONENTS ${required_components} CONFIG)
+find_package(DART 6.17 REQUIRED COMPONENTS ${required_components} CONFIG)
 
 file(GLOB srcs "*.cpp" "*.hpp")
 add_executable(${example_name} ${srcs})


### PR DESCRIPTION
## Summary

Opens the **DART 6.17.0** release on the DART 6 LTS compatibility line: bumps version metadata `6.16.8 → 6.17.0` and adds the `CHANGELOG.md` 6.17.0 section. This is the packaging companion to the grouped backport PRs that port classic-DART-6 API fixes/improvements from `main` before the DART 7 clean break removes that surface.

## Motivation / Problem

DART 6 remains the maintained compatibility line for the established API and gz-physics users. Per `docs/onboarding/release-roadmap.md`, fixes and additive improvements made on `main` during DART 7 development need a DART 6 home. 6.17.0 is the new minor that collects them.

## Changes / Key Changes

- `package.xml`, `pixi.toml`: version `6.16.8 → 6.17.0`.
- 44 `find_package(DART 6.16 …)` pins in `examples/` and `tutorials/` → `6.17`.
- `CHANGELOG.md`: new `DART 6.17.0` section (milestone #85) listing all backported fixes, grouped by subsystem. This PR owns the 6.17.0 changelog section; the backport PRs carry code only.

## Testing

- `pixi run lint` / `pixi run check-lint` (formatting + version-metadata consistency).
- Package-config / `find_package` version agreement checked across examples and tutorials.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

Companion backport PRs (all target `release-6.17`): dynamics, collision, common, parsers, GUI, build. The changelog entries reference the original `main` PRs.

---

#### Checklist

- [x] Milestone set (DART 6.17.0)
- [x] CHANGELOG.md updated
- [x] Version metadata consistent (`package.xml`, `pixi.toml`, example `find_package` requirements)
