### PR TITLE
Fix dartpy autodoc stub imports and clang-format cache staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -571,6 +571,19 @@ py-demos` now builds a CUDA-enabled dartpy + Filament GUI and offloads the
   - Documentation and onboarding improvements (developer guides, CI/testing workflows, IK and servo docs, RTD updates, and translations). ([#2059](https://github.com/dartsim/dart/pull/2059), [#2062](https://github.com/dartsim/dart/pull/2062), [#2089](https://github.com/dartsim/dart/pull/2089), [#2095](https://github.com/dartsim/dart/pull/2095), [#2112](https://github.com/dartsim/dart/pull/2112), [#2156](https://github.com/dartsim/dart/pull/2156), [#2171](https://github.com/dartsim/dart/pull/2171), [#2173](https://github.com/dartsim/dart/pull/2173), [#2174](https://github.com/dartsim/dart/pull/2174), [#2183](https://github.com/dartsim/dart/pull/2183), [#2191](https://github.com/dartsim/dart/pull/2191), [#2196](https://github.com/dartsim/dart/pull/2196), [#2199](https://github.com/dartsim/dart/pull/2199), [#2203](https://github.com/dartsim/dart/pull/2203), [#2213](https://github.com/dartsim/dart/pull/2213), [#2215](https://github.com/dartsim/dart/pull/2215), [#2302](https://github.com/dartsim/dart/pull/2302), [#2303](https://github.com/dartsim/dart/pull/2303), [#2312](https://github.com/dartsim/dart/pull/2312), [#2087](https://github.com/dartsim/dart/pull/2087))
   - Maintenance merges and stability fixes for release branches and simulation-experimental builds. ([#2145](https://github.com/dartsim/dart/pull/2145), [#2188](https://github.com/dartsim/dart/pull/2188), [#2301](https://github.com/dartsim/dart/pull/2301), [#2341](https://github.com/dartsim/dart/pull/2341), [#2357](https://github.com/dartsim/dart/pull/2357), [#2223](https://github.com/dartsim/dart/pull/2223), [#2228](https://github.com/dartsim/dart/pull/2228), [#2236](https://github.com/dartsim/dart/pull/2236))
   - Miscellaneous repo hygiene: Docker build script fixes, Dependabot path cleanup, template updates, and badge/documentation cleanup. ([#2058](https://github.com/dartsim/dart/pull/2058), [#2291](https://github.com/dartsim/dart/pull/2291))
+  - Fixed the Read the Docs dartpy autodoc stub fallback so the generated stubs
+    import cleanly. Class-body forward references emitted by `nanobind`
+    (snake_case method aliases placed before the method, enclosing-class-qualified
+    nested enum members, and aliases to module classes defined later) are now
+    reordered or rewritten, and runtime-only submodules such as
+    `dartpy.simulation_experimental.diff` are bound to placeholder modules. The
+    `dartpy`, `gui`, `simulation_experimental`, and `io` API reference pages no
+    longer fail to import with `NameError`.
+  - Made `clang-format` discovery resilient to toolchain upgrades by dropping a
+    stale `CLANG_FORMAT_EXECUTABLE` cache entry when the cached binary no longer
+    exists, so the `format`/`check-format` targets re-resolve against the current
+    toolchain instead of failing with a dangling dependency when the pinned
+    `clang-format` version changes under an existing build tree.
 
 - Simulation
   - Added opt-in analytic differentiable simulation to the experimental `World`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1163,6 +1163,16 @@ if(DART_VERBOSE)
   message(STATUS "[ Code Formatting ]")
 endif()
 
+# find_program caches its result and will not re-search once
+# CLANG_FORMAT_EXECUTABLE is set, even if the cached path no longer exists. When
+# the pinned clang-format is upgraded under an existing build tree (e.g. the
+# pixi env moves clang-format-21 -> clang-format-22), the stale cache leaves a
+# dangling DEPENDS and breaks the `format`/`check-format` targets with
+# "needed by 'CMakeFiles/format', missing". Drop a vanished cache entry so the
+# search re-runs against the currently installed toolchain.
+if(CLANG_FORMAT_EXECUTABLE AND NOT EXISTS "${CLANG_FORMAT_EXECUTABLE}")
+  unset(CLANG_FORMAT_EXECUTABLE CACHE)
+endif()
 find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format-22 clang-format)
 
 get_property(formatting_files GLOBAL PROPERTY DART_FORMAT_FILES)

--- a/docs/readthedocs/conf.py
+++ b/docs/readthedocs/conf.py
@@ -3,6 +3,8 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import ast
+import builtins
 import importlib
 import keyword
 import os
@@ -70,6 +72,166 @@ def _rename_placeholder(text: str, name: str) -> str:
     return pattern.sub(repl, text)
 
 
+_BUILTIN_NAMES = frozenset(dir(builtins))
+
+
+def _stmt_defined_names(stmt: ast.stmt) -> list[str]:
+    """Return the names a statement binds in its enclosing namespace."""
+
+    if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return [stmt.name]
+    if isinstance(stmt, ast.Assign):
+        return [t.id for t in stmt.targets if isinstance(t, ast.Name)]
+    if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+        return [stmt.target.id]
+    if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+        return [alias.asname or alias.name.split(".")[0] for alias in stmt.names]
+    return []
+
+
+def _strip_enclosing_qualifier(value: ast.expr, class_names: frozenset[str]) -> ast.expr:
+    """Drop redundant ``EnclosingClass.`` qualifiers from an expression.
+
+    ``nanobind`` fully qualifies nested references (e.g.
+    ``LinkageCriteria.ExpansionPolicy.INCLUDE``). Inside the class body the
+    enclosing class name is not yet bound, so the simple name
+    (``ExpansionPolicy.INCLUDE``) is what is actually in scope.
+    """
+
+    class _Stripper(ast.NodeTransformer):
+        def visit_Attribute(self, node: ast.Attribute) -> ast.expr:
+            self.generic_visit(node)
+            if isinstance(node.value, ast.Name) and node.value.id in class_names:
+                return ast.copy_location(ast.Name(id=node.attr, ctx=ast.Load()), node)
+            return node
+
+    return _Stripper().visit(value)
+
+
+def _loaded_root_names(value: ast.expr) -> set[str]:
+    """Return the identifiers an expression reads (roots of attribute chains)."""
+
+    return {
+        node.id
+        for node in ast.walk(value)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+
+
+def _fix_forward_references(text: str) -> str:
+    """Make stub class bodies importable despite forward references.
+
+    ``nanobind``'s stub generator emits class-level statements that reference
+    names defined later. That is harmless for type checkers (which never execute
+    the stub) but raises ``NameError`` when Sphinx autodoc imports the generated
+    module, silently dropping the whole module from the API reference. Several
+    shapes occur and are handled below:
+
+    * ``get_size = getSize`` placed before the overriding ``def getSize`` in a
+      derived class -> moved after the definition it points at.
+    * ``INCLUDE: ... = LinkageCriteria.ExpansionPolicy.INCLUDE`` -> the redundant
+      enclosing-class qualifier is dropped so the in-scope name resolves.
+    * ``Tangent: TypeAlias = SO3Tangent`` where ``SO3Tangent`` is defined later
+      at module scope -> rewritten as a string forward reference.
+    * any remaining value referencing a not-yet-bound name -> neutralised
+      (annotation kept, value dropped or replaced with ``...``) so the class
+      body still imports.
+    """
+
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return text
+
+    module_defs: dict[str, int] = {}
+    for index, stmt in enumerate(tree.body):
+        for name in _stmt_defined_names(stmt):
+            module_defs.setdefault(name, index)
+
+    changed = False
+
+    def _process_class(node: ast.ClassDef, enclosing: frozenset[str], threshold: int):
+        nonlocal changed
+        class_names = enclosing | {node.name}
+
+        for stmt in node.body:
+            if isinstance(stmt, ast.ClassDef):
+                _process_class(stmt, class_names, threshold)
+
+        local_first: dict[str, int] = {}
+        for index, stmt in enumerate(node.body):
+            for name in _stmt_defined_names(stmt):
+                local_first.setdefault(name, index)
+
+        def _available(name: str, index: int) -> bool:
+            return (
+                0 <= local_first.get(name, -1) < index
+                or 0 <= module_defs.get(name, -1) < threshold
+                or name in _BUILTIN_NAMES
+            )
+
+        kept: list[ast.stmt] = []
+        deferred: list[ast.stmt] = []
+        for index, stmt in enumerate(node.body):
+            value = getattr(stmt, "value", None)
+            if isinstance(stmt, (ast.Assign, ast.AnnAssign)) and value is not None:
+                stripped = _strip_enclosing_qualifier(value, class_names)
+                if ast.dump(stripped) != ast.dump(value):
+                    stmt.value = value = stripped
+                    changed = True
+
+                if isinstance(value, ast.Name) and local_first.get(value.id, -1) > index:
+                    # Alias to a name defined later in this class; move it past.
+                    deferred.append(stmt)
+                    changed = True
+                    continue
+
+                unresolved = [r for r in _loaded_root_names(value) if not _available(r, index)]
+                if unresolved:
+                    if isinstance(value, ast.Name):
+                        stmt.value = ast.copy_location(ast.Constant(value=value.id), value)
+                    elif isinstance(stmt, ast.AnnAssign):
+                        stmt.value = None
+                    else:
+                        stmt.value = ast.copy_location(ast.Constant(value=...), value)
+                    changed = True
+            kept.append(stmt)
+
+        if deferred:
+            node.body = kept + deferred
+
+    for module_index, node in enumerate(tree.body):
+        if isinstance(node, ast.ClassDef):
+            _process_class(node, frozenset(), module_index)
+
+    if not changed:
+        return text
+
+    return ast.unparse(tree) + "\n"
+
+
+def _neutralize_dynamic_submodule_imports(text: str) -> str:
+    """Replace imports of runtime-only ``dartpy`` submodules with placeholders.
+
+    Some submodules have no stub of their own -- e.g.
+    ``dartpy.simulation_experimental.diff``, a pure-Python PyTorch bridge that
+    ``dartpy/__init__.py`` attaches at runtime. The flat stub modules cannot host
+    real submodules, so ``import dartpy.<parent>.<child> as <alias>`` raises
+    ImportError when autodoc imports the stub. Bind the alias to an empty
+    placeholder module instead so the import resolves and the attribute exists.
+    """
+
+    pattern = re.compile(
+        r"(?m)^(?P<indent>[ \t]*)import dartpy\.(?P<path>\w+(?:\.\w+)+) as (?P<alias>\w+)[ \t]*$"
+    )
+
+    def repl(match: re.Match[str]) -> str:
+        indent, path, alias = match.group("indent", "path", "alias")
+        return f'{indent}{alias} = __import__("types").ModuleType("dartpy.{path}")'
+
+    return pattern.sub(repl, text)
+
+
 def _sanitize_stub_source(text: str) -> str:
     """Rename invalid identifiers originating from the stub generator."""
 
@@ -93,7 +255,8 @@ def _sanitize_stub_source(text: str) -> str:
     for placeholder in ("std", "dart"):
         text = _rename_placeholder(text, placeholder)
 
-    return _strip_class_bases(text)
+    text = _neutralize_dynamic_submodule_imports(text)
+    return _fix_forward_references(_strip_class_bases(text))
 
 
 def _prepare_stub_modules(package: str) -> bool:


### PR DESCRIPTION
## Summary

- Fix the dartpy autodoc stub fallback so the Read the Docs / `docs-build` API
  reference imports every generated stub module instead of silently failing.
- Make `clang-format` discovery resilient to toolchain upgrades so the
  `format`/`check-format` targets do not break under an existing build tree.

## Motivation / Problem

Two issues surfaced while running `pixi run test-all && pixi run -e cuda test-all`:

1. **Docs autodoc import failures.** The autodoc dartpy fallback (always used on
   Read the Docs, and locally whenever the compiled `dartpy` is unavailable)
   copies the generated `nanobind` stubs and renames `.pyi -> .py` so Sphinx can
   import them. Several class-body forward references that are valid for type
   checkers (which never execute the stub) raise `NameError` when the module is
   actually imported, so autodoc dropped the `dartpy`, `gui`,
   `simulation_experimental`, and `io` API pages with
   `WARNING: autodoc: failed to import module ...`. Shapes observed:
   - snake_case method aliases emitted before the overriding method in derived
     classes (`get_size = getSize`);
   - enclosing-class-qualified nested enum members
     (`INCLUDE = LinkageCriteria.ExpansionPolicy.INCLUDE`);
   - aliases to module-level classes defined later (`Tangent = SO3Tangent`);
   - imports of runtime-only submodules with no stub of their own
     (`dartpy.simulation_experimental.diff`, attached at runtime by
     `dartpy/__init__.py`).
2. **CUDA lint failure.** `pixi run -e cuda test-all` failed at the lint stage:
   `ninja: error: '.../clang-format-21', needed by 'CMakeFiles/format', missing`.
   `find_program` caches `CLANG_FORMAT_EXECUTABLE` and never re-searches once it
   is set, so after the pixi env upgraded `clang-format-21 -> clang-format-22`
   under an existing build tree the cache kept a dangling path and the format
   target could never build.

## Changes / Key Changes

- `docs/readthedocs/conf.py`: `_sanitize_stub_source` now reorders aliases after
  the methods they reference, drops redundant enclosing-class qualifiers,
  rewrites later-defined module aliases as string forward references, neutralizes
  any remaining value that reads a not-yet-bound name, and binds runtime-only
  submodule imports to placeholder modules. All twelve generated stub modules
  import cleanly.
- `CMakeLists.txt`: unset `CLANG_FORMAT_EXECUTABLE` before `find_program` when the
  cached path no longer exists, so the search re-resolves against the installed
  toolchain.
- `CHANGELOG.md`: documented both fixes under *Tooling and Docs*.

## Testing

- `pixi run test-all` -> 6/6 PASSED (Documentation build now reports zero autodoc
  import failures).
- `pixi run -e cuda test-all` -> 7/7 PASSED (lint no longer fails; CUDA C++ tests
  and benchmark smoke run on the GPU).
- Focused check: prepared the stub package exactly as `conf.py` does and imported
  `dartpy` and all eleven submodules -> 12/12 import, with `LocalResource.get_size`
  resolving to the real method and `SO3.Tangent` rendering as a forward reference.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None. Both fixes target documentation/build tooling on `main` only.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated if required
- [ ] Add unit tests for new functionality (docs/build tooling; validated via `test-all` and a focused stub-import check)
- [x] Document new methods and classes (docstrings on the new `conf.py` helpers)
- [ ] Add Python bindings (dartpy) if applicable (N/A)
