### PR TITLE
De-ECS Frame/FreeFrame/FixedFrame public handle base (PLAN-041 U-WS5-BASE)

### DIFF
--- a/dart/simulation/experimental/body/rigid_body.cpp
+++ b/dart/simulation/experimental/body/rigid_body.cpp
@@ -189,8 +189,7 @@ void validateInertia(const Eigen::Matrix3d& inertia)
 namespace dart::simulation::experimental {
 
 //==============================================================================
-RigidBody::RigidBody(Entity entity, World* world)
-  : Frame(detail::toRegistryEntity(entity), world)
+RigidBody::RigidBody(Entity entity, World* world) : Frame(entity, world)
 {
   // Frame base constructor handles entity and world
 }
@@ -199,7 +198,8 @@ RigidBody::RigidBody(Entity entity, World* world)
 std::string RigidBody::getName() const
 {
   const auto& registry = getWorld()->getRegistry();
-  if (const auto* name = registry.try_get<comps::Name>(getEntity())) {
+  if (const auto* name
+      = registry.try_get<comps::Name>(detail::toRegistryEntity(getEntity()))) {
     return name->name;
   }
   return "";
@@ -229,8 +229,10 @@ void RigidBody::setTransform(const Eigen::Isometry3d& transform)
       "RigidBody transform rotation must be orthonormal");
 
   auto& registry = getWorld()->getRegistry();
-  auto& freeFrame = registry.get<comps::FreeFrameProperties>(getEntity());
-  auto& rigidTransform = registry.get<comps::Transform>(getEntity());
+  auto& freeFrame = registry.get<comps::FreeFrameProperties>(
+      detail::toRegistryEntity(getEntity()));
+  auto& rigidTransform
+      = registry.get<comps::Transform>(detail::toRegistryEntity(getEntity()));
 
   const Eigen::Isometry3d parentTransform = getParentFrame().getTransform();
   freeFrame.localTransform = parentTransform.inverse() * transform;
@@ -248,7 +250,10 @@ Eigen::Vector3d RigidBody::getLinearVelocity() const
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  return getWorld()->getRegistry().get<comps::Velocity>(getEntity()).linear;
+  return getWorld()
+      ->getRegistry()
+      .get<comps::Velocity>(detail::toRegistryEntity(getEntity()))
+      .linear;
 }
 
 //==============================================================================
@@ -259,7 +264,10 @@ void RigidBody::setLinearVelocity(const Eigen::Vector3d& velocity)
 
   validateFiniteVector(velocity, "linear velocity");
 
-  getWorld()->getRegistry().get<comps::Velocity>(getEntity()).linear = velocity;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Velocity>(detail::toRegistryEntity(getEntity()))
+      .linear = velocity;
 }
 
 //==============================================================================
@@ -268,7 +276,10 @@ Eigen::Vector3d RigidBody::getAngularVelocity() const
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  return getWorld()->getRegistry().get<comps::Velocity>(getEntity()).angular;
+  return getWorld()
+      ->getRegistry()
+      .get<comps::Velocity>(detail::toRegistryEntity(getEntity()))
+      .angular;
 }
 
 //==============================================================================
@@ -279,8 +290,10 @@ void RigidBody::setAngularVelocity(const Eigen::Vector3d& velocity)
 
   validateFiniteVector(velocity, "angular velocity");
 
-  getWorld()->getRegistry().get<comps::Velocity>(getEntity()).angular
-      = velocity;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Velocity>(detail::toRegistryEntity(getEntity()))
+      .angular = velocity;
 }
 
 //==============================================================================
@@ -289,7 +302,10 @@ double RigidBody::getMass() const
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  return getWorld()->getRegistry().get<comps::MassProperties>(getEntity()).mass;
+  return getWorld()
+      ->getRegistry()
+      .get<comps::MassProperties>(detail::toRegistryEntity(getEntity()))
+      .mass;
 }
 
 //==============================================================================
@@ -300,7 +316,10 @@ void RigidBody::setMass(double mass)
 
   validateMass(mass);
 
-  getWorld()->getRegistry().get<comps::MassProperties>(getEntity()).mass = mass;
+  getWorld()
+      ->getRegistry()
+      .get<comps::MassProperties>(detail::toRegistryEntity(getEntity()))
+      .mass = mass;
 }
 
 //==============================================================================
@@ -311,7 +330,7 @@ Eigen::Matrix3d RigidBody::getInertia() const
 
   return getWorld()
       ->getRegistry()
-      .get<comps::MassProperties>(getEntity())
+      .get<comps::MassProperties>(detail::toRegistryEntity(getEntity()))
       .inertia;
 }
 
@@ -323,8 +342,10 @@ void RigidBody::setInertia(const Eigen::Matrix3d& inertia)
 
   validateInertia(inertia);
 
-  getWorld()->getRegistry().get<comps::MassProperties>(getEntity()).inertia
-      = inertia;
+  getWorld()
+      ->getRegistry()
+      .get<comps::MassProperties>(detail::toRegistryEntity(getEntity()))
+      .inertia = inertia;
 }
 
 //==============================================================================
@@ -333,7 +354,10 @@ Eigen::Vector3d RigidBody::getForce() const
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  return getWorld()->getRegistry().get<comps::Force>(getEntity()).force;
+  return getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .force;
 }
 
 //==============================================================================
@@ -344,7 +368,10 @@ void RigidBody::setForce(const Eigen::Vector3d& force)
 
   validateFiniteVector(force, "force");
 
-  getWorld()->getRegistry().get<comps::Force>(getEntity()).force = force;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .force = force;
 }
 
 //==============================================================================
@@ -355,7 +382,10 @@ void RigidBody::applyForce(const Eigen::Vector3d& force)
 
   validateFiniteVector(force, "force");
 
-  getWorld()->getRegistry().get<comps::Force>(getEntity()).force += force;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .force += force;
 }
 
 //==============================================================================
@@ -364,7 +394,10 @@ void RigidBody::clearForce()
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  getWorld()->getRegistry().get<comps::Force>(getEntity()).force.setZero();
+  getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .force.setZero();
 }
 
 //==============================================================================
@@ -373,7 +406,10 @@ Eigen::Vector3d RigidBody::getTorque() const
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  return getWorld()->getRegistry().get<comps::Force>(getEntity()).torque;
+  return getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .torque;
 }
 
 //==============================================================================
@@ -384,7 +420,10 @@ void RigidBody::setTorque(const Eigen::Vector3d& torque)
 
   validateFiniteVector(torque, "torque");
 
-  getWorld()->getRegistry().get<comps::Force>(getEntity()).torque = torque;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .torque = torque;
 }
 
 //==============================================================================
@@ -395,7 +434,10 @@ void RigidBody::applyTorque(const Eigen::Vector3d& torque)
 
   validateFiniteVector(torque, "torque");
 
-  getWorld()->getRegistry().get<comps::Force>(getEntity()).torque += torque;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .torque += torque;
 }
 
 //==============================================================================
@@ -404,7 +446,10 @@ void RigidBody::clearTorque()
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  getWorld()->getRegistry().get<comps::Force>(getEntity()).torque.setZero();
+  getWorld()
+      ->getRegistry()
+      .get<comps::Force>(detail::toRegistryEntity(getEntity()))
+      .torque.setZero();
 }
 
 //==============================================================================
@@ -414,8 +459,10 @@ Eigen::Vector3d RigidBody::getLinearMomentum() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  const auto& mass = registry.get<comps::MassProperties>(getEntity());
-  const auto& velocity = registry.get<comps::Velocity>(getEntity());
+  const auto& mass = registry.get<comps::MassProperties>(
+      detail::toRegistryEntity(getEntity()));
+  const auto& velocity
+      = registry.get<comps::Velocity>(detail::toRegistryEntity(getEntity()));
   return mass.mass * velocity.linear;
 }
 
@@ -426,9 +473,12 @@ Eigen::Vector3d RigidBody::getAngularMomentum() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  const auto& mass = registry.get<comps::MassProperties>(getEntity());
-  const auto& velocity = registry.get<comps::Velocity>(getEntity());
-  const auto& transform = registry.get<comps::Transform>(getEntity());
+  const auto& mass = registry.get<comps::MassProperties>(
+      detail::toRegistryEntity(getEntity()));
+  const auto& velocity
+      = registry.get<comps::Velocity>(detail::toRegistryEntity(getEntity()));
+  const auto& transform
+      = registry.get<comps::Transform>(detail::toRegistryEntity(getEntity()));
 
   const Eigen::Matrix3d rotation
       = transform.orientation.normalized().toRotationMatrix();
@@ -444,9 +494,12 @@ double RigidBody::getKineticEnergy() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  const auto& mass = registry.get<comps::MassProperties>(getEntity());
-  const auto& velocity = registry.get<comps::Velocity>(getEntity());
-  const auto& transform = registry.get<comps::Transform>(getEntity());
+  const auto& mass = registry.get<comps::MassProperties>(
+      detail::toRegistryEntity(getEntity()));
+  const auto& velocity
+      = registry.get<comps::Velocity>(detail::toRegistryEntity(getEntity()));
+  const auto& transform
+      = registry.get<comps::Transform>(detail::toRegistryEntity(getEntity()));
 
   const Eigen::Matrix3d rotation
       = transform.orientation.normalized().toRotationMatrix();
@@ -466,8 +519,10 @@ double RigidBody::getPotentialEnergy() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  const auto& mass = registry.get<comps::MassProperties>(getEntity());
-  const auto& transform = registry.get<comps::Transform>(getEntity());
+  const auto& mass = registry.get<comps::MassProperties>(
+      detail::toRegistryEntity(getEntity()));
+  const auto& transform
+      = registry.get<comps::Transform>(detail::toRegistryEntity(getEntity()));
   return -mass.mass * getWorld()->getGravity().dot(transform.position);
 }
 
@@ -479,9 +534,11 @@ void RigidBody::setStatic(bool isStatic)
 
   auto& registry = getWorld()->getRegistry();
   if (isStatic) {
-    registry.emplace_or_replace<comps::StaticBodyTag>(getEntity());
+    registry.emplace_or_replace<comps::StaticBodyTag>(
+        detail::toRegistryEntity(getEntity()));
   } else {
-    registry.remove<comps::StaticBodyTag>(getEntity());
+    registry.remove<comps::StaticBodyTag>(
+        detail::toRegistryEntity(getEntity()));
   }
 }
 
@@ -491,7 +548,8 @@ bool RigidBody::isStatic() const
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
-  return getWorld()->getRegistry().all_of<comps::StaticBodyTag>(getEntity());
+  return getWorld()->getRegistry().all_of<comps::StaticBodyTag>(
+      detail::toRegistryEntity(getEntity()));
 }
 
 //==============================================================================
@@ -505,7 +563,8 @@ void RigidBody::setRestitution(double restitution)
       "RigidBody restitution must be in [0, 1]");
 
   auto& registry = getWorld()->getRegistry();
-  auto& material = registry.get_or_emplace<comps::ContactMaterial>(getEntity());
+  auto& material = registry.get_or_emplace<comps::ContactMaterial>(
+      detail::toRegistryEntity(getEntity()));
   material.restitution = restitution;
 }
 
@@ -516,8 +575,8 @@ double RigidBody::getRestitution() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  if (const auto* material
-      = registry.try_get<comps::ContactMaterial>(getEntity())) {
+  if (const auto* material = registry.try_get<comps::ContactMaterial>(
+          detail::toRegistryEntity(getEntity()))) {
     return material->restitution;
   }
   return 0.0;
@@ -534,7 +593,8 @@ void RigidBody::setFriction(double friction)
       "RigidBody friction must be non-negative and finite");
 
   auto& registry = getWorld()->getRegistry();
-  auto& material = registry.get_or_emplace<comps::ContactMaterial>(getEntity());
+  auto& material = registry.get_or_emplace<comps::ContactMaterial>(
+      detail::toRegistryEntity(getEntity()));
   material.friction = friction;
 }
 
@@ -545,8 +605,8 @@ double RigidBody::getFriction() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  if (const auto* material
-      = registry.try_get<comps::ContactMaterial>(getEntity())) {
+  if (const auto* material = registry.try_get<comps::ContactMaterial>(
+          detail::toRegistryEntity(getEntity()))) {
     return material->friction;
   }
   return 1.0;
@@ -561,11 +621,12 @@ void RigidBody::setCollisionShape(const CollisionShape& shape)
   validateCollisionShape(shape, "RigidBody");
 
   auto& registry = getWorld()->getRegistry();
-  const auto* existing
-      = registry.try_get<comps::CollisionGeometry>(getEntity());
+  const auto* existing = registry.try_get<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()));
   comps::CollisionGeometry geometry{{shape}};
   geometry.revision = existing ? existing->revision + 1 : 1;
-  registry.emplace_or_replace<comps::CollisionGeometry>(getEntity(), geometry);
+  registry.emplace_or_replace<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()), geometry);
 }
 
 //==============================================================================
@@ -577,8 +638,8 @@ void RigidBody::addCollisionShape(const CollisionShape& shape)
   validateCollisionShape(shape, "RigidBody");
 
   auto& registry = getWorld()->getRegistry();
-  auto& geometry
-      = registry.get_or_emplace<comps::CollisionGeometry>(getEntity());
+  auto& geometry = registry.get_or_emplace<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()));
   geometry.shapes.push_back(shape);
   ++geometry.revision;
 }
@@ -591,9 +652,11 @@ void RigidBody::setDeformableGroundBarrier(bool enabled)
 
   auto& registry = getWorld()->getRegistry();
   if (enabled) {
-    registry.get_or_emplace<comps::DeformableGroundBarrierTag>(getEntity());
+    registry.get_or_emplace<comps::DeformableGroundBarrierTag>(
+        detail::toRegistryEntity(getEntity()));
   } else {
-    registry.remove<comps::DeformableGroundBarrierTag>(getEntity());
+    registry.remove<comps::DeformableGroundBarrierTag>(
+        detail::toRegistryEntity(getEntity()));
   }
 }
 
@@ -604,7 +667,7 @@ bool RigidBody::isDeformableGroundBarrier() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   return getWorld()->getRegistry().all_of<comps::DeformableGroundBarrierTag>(
-      getEntity());
+      detail::toRegistryEntity(getEntity()));
 }
 
 //==============================================================================
@@ -616,9 +679,10 @@ void RigidBody::setDeformableSurfaceCcdObstacle(bool enabled)
   auto& registry = getWorld()->getRegistry();
   if (enabled) {
     registry.get_or_emplace<comps::DeformableSurfaceCcdObstacleTag>(
-        getEntity());
+        detail::toRegistryEntity(getEntity()));
   } else {
-    registry.remove<comps::DeformableSurfaceCcdObstacleTag>(getEntity());
+    registry.remove<comps::DeformableSurfaceCcdObstacleTag>(
+        detail::toRegistryEntity(getEntity()));
   }
 }
 
@@ -630,7 +694,8 @@ bool RigidBody::isDeformableSurfaceCcdObstacle() const
 
   return getWorld()
       ->getRegistry()
-      .all_of<comps::DeformableSurfaceCcdObstacleTag>(getEntity());
+      .all_of<comps::DeformableSurfaceCcdObstacleTag>(
+          detail::toRegistryEntity(getEntity()));
 }
 
 //==============================================================================
@@ -641,9 +706,11 @@ void RigidBody::setDeformableObstacleBarrierOnly(bool enabled)
 
   auto& registry = getWorld()->getRegistry();
   if (enabled) {
-    registry.get_or_emplace<comps::DeformableObstacleNoCcdTag>(getEntity());
+    registry.get_or_emplace<comps::DeformableObstacleNoCcdTag>(
+        detail::toRegistryEntity(getEntity()));
   } else {
-    registry.remove<comps::DeformableObstacleNoCcdTag>(getEntity());
+    registry.remove<comps::DeformableObstacleNoCcdTag>(
+        detail::toRegistryEntity(getEntity()));
   }
 }
 
@@ -654,7 +721,7 @@ bool RigidBody::isDeformableObstacleBarrierOnly() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   return getWorld()->getRegistry().all_of<comps::DeformableObstacleNoCcdTag>(
-      getEntity());
+      detail::toRegistryEntity(getEntity()));
 }
 
 //==============================================================================
@@ -664,8 +731,8 @@ std::optional<CollisionShape> RigidBody::getCollisionShape() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  if (const auto* geometry
-      = registry.try_get<comps::CollisionGeometry>(getEntity())) {
+  if (const auto* geometry = registry.try_get<comps::CollisionGeometry>(
+          detail::toRegistryEntity(getEntity()))) {
     if (const auto* shape = geometry->getPrimaryShape()) {
       return *shape;
     }
@@ -680,8 +747,8 @@ std::vector<CollisionShape> RigidBody::getCollisionShapes() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  if (const auto* geometry
-      = registry.try_get<comps::CollisionGeometry>(getEntity())) {
+  if (const auto* geometry = registry.try_get<comps::CollisionGeometry>(
+          detail::toRegistryEntity(getEntity()))) {
     return geometry->shapes;
   }
   return {};
@@ -694,11 +761,11 @@ bool RigidBody::hasCollisionShape() const
       !isValid(), InvalidArgumentException, "Invalid rigid body handle");
 
   const auto& registry = getWorld()->getRegistry();
-  const auto* geometry
-      = registry.try_get<comps::CollisionGeometry>(getEntity());
+  const auto* geometry = registry.try_get<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()));
   return geometry != nullptr && geometry->hasShapes();
 }
 
-// getEntity() and isValid() inherited from Frame
+// detail::toRegistryEntity(getEntity()) and isValid() inherited from Frame
 
 } // namespace dart::simulation::experimental

--- a/dart/simulation/experimental/constraint/loop_closure.cpp
+++ b/dart/simulation/experimental/constraint/loop_closure.cpp
@@ -137,13 +137,17 @@ LoopClosureFamily LoopClosure::getFamily() const
 //==============================================================================
 Frame LoopClosure::getFrameA() const
 {
-  return Frame(getLoopClosureComponent(*this).frameA, m_world);
+  return Frame(
+      detail::fromRegistryEntity(getLoopClosureComponent(*this).frameA),
+      m_world);
 }
 
 //==============================================================================
 Frame LoopClosure::getFrameB() const
 {
-  return Frame(getLoopClosureComponent(*this).frameB, m_world);
+  return Frame(
+      detail::fromRegistryEntity(getLoopClosureComponent(*this).frameB),
+      m_world);
 }
 
 //==============================================================================

--- a/dart/simulation/experimental/frame/fixed_frame.cpp
+++ b/dart/simulation/experimental/frame/fixed_frame.cpp
@@ -40,20 +40,14 @@
 namespace dart::simulation::experimental {
 
 //==============================================================================
-FixedFrame::FixedFrame(Entity entity, World* world)
-  : Frame(detail::toRegistryEntity(entity), world),
-    EntityObjectWith<
-        TagComps<comps::FixedFrameTag>,
-        ReadOnlyComps<>,
-        WriteOnlyComps<>,
-        ReadWriteComps<comps::FixedFrameProperties>>()
+FixedFrame::FixedFrame(Entity entity, World* world) : Frame(entity, world)
 {
   // Validate entity has FixedFrameProperties
 #ifndef NDEBUG
   auto& registry = world->getRegistry();
+  const auto enttEntity = detail::toRegistryEntity(entity);
   DART_EXPERIMENTAL_THROW_T_IF(
-      !registry.all_of<comps::FixedFrameProperties>(
-          detail::toRegistryEntity(entity)),
+      !registry.all_of<comps::FixedFrameProperties>(enttEntity),
       InvalidArgumentException,
       "Entity does not have FixedFrameProperties component");
 #endif
@@ -63,7 +57,8 @@ FixedFrame::FixedFrame(Entity entity, World* world)
 void FixedFrame::setLocalTransform(const Eigen::Isometry3d& transform)
 {
   auto& registry = m_world->getRegistry();
-  auto& props = registry.get<comps::FixedFrameProperties>(m_entity);
+  auto& props = registry.get<comps::FixedFrameProperties>(
+      detail::toRegistryEntity(m_entity));
   props.localTransform = transform;
 
   markSubtreeTransformCacheDirty();

--- a/dart/simulation/experimental/frame/fixed_frame.hpp
+++ b/dart/simulation/experimental/frame/fixed_frame.hpp
@@ -53,13 +53,7 @@ namespace dart::simulation::experimental {
 /// - End-effector frames
 ///
 /// DART6 equivalent: FixedFrame
-class DART_EXPERIMENTAL_API FixedFrame
-  : public Frame,
-    public EntityObjectWith<
-        TagComps<comps::FixedFrameTag>,
-        ReadOnlyComps<>,
-        WriteOnlyComps<>,
-        ReadWriteComps<comps::FixedFrameProperties>>
+class DART_EXPERIMENTAL_API FixedFrame : public Frame
 {
 public:
   /// Constructor (package-private, use World::addFixedFrame)

--- a/dart/simulation/experimental/frame/frame.cpp
+++ b/dart/simulation/experimental/frame/frame.cpp
@@ -33,14 +33,17 @@
 #include "dart/simulation/experimental/frame/frame.hpp"
 
 #include "dart/simulation/experimental/common/exceptions.hpp"
+#include "dart/simulation/experimental/detail/entity_conversion.hpp"
 #include "dart/simulation/experimental/frame/free_frame.hpp"
 #include "dart/simulation/experimental/world.hpp"
 
+#include <dart/simulation/experimental/comps/frame_types.hpp>
 #include <dart/simulation/experimental/comps/joint.hpp>
 #include <dart/simulation/experimental/comps/link.hpp>
 #include <dart/simulation/experimental/comps/name.hpp>
 
 #include <Eigen/Geometry>
+#include <entt/entt.hpp>
 
 #include <vector>
 
@@ -193,17 +196,13 @@ Eigen::Isometry3d getFrameLocalTransform(
 } // namespace
 
 //==============================================================================
-Frame::Frame(entt::entity entity, World* world)
-  : EntityObjectWith<
-        TagComps<comps::FrameTag>,
-        ReadOnlyComps<>,
-        WriteOnlyComps<>,
-        ReadWriteComps<comps::FrameState, comps::FrameCache>>()
+Frame::Frame(Entity entity, World* world) : m_entity(entity), m_world(world) {}
+
+//==============================================================================
+bool Frame::isWorld() const
 {
-  // Initialize base EntityObject with entity/world
-  // Virtual inheritance requires explicit initialization
-  m_entity = entity;
-  m_world = world;
+  // The default-constructed Entity sentinel (value == 0xFFFFFFFF) marks world.
+  return m_entity == Entity{};
 }
 
 //==============================================================================
@@ -216,7 +215,8 @@ Eigen::Isometry3d Frame::getLocalTransform() const
   DART_EXPERIMENTAL_THROW_T_IF(
       !isValid(), InvalidArgumentException, "Invalid frame handle");
 
-  return getFrameLocalTransform(m_world->getRegistry(), m_entity);
+  return getFrameLocalTransform(
+      m_world->getRegistry(), detail::toRegistryEntity(m_entity));
 }
 
 //==============================================================================
@@ -226,18 +226,21 @@ Frame Frame::getParentFrame() const
       !isValid(), InvalidArgumentException, "Invalid frame handle");
 
   // World frame: parent is itself
-  if (m_entity == entt::null) {
+  if (isWorld()) {
     return Frame::world();
   }
 
+  const auto enttEntity = detail::toRegistryEntity(m_entity);
+
   // Get parent from FrameState component (common to all frame types)
-  auto* frameState = tryGetReadOnly<comps::FrameState>();
+  const auto* frameState
+      = m_world->getRegistry().try_get<comps::FrameState>(enttEntity);
   DART_EXPERIMENTAL_THROW_T_IF(
       !frameState,
       InvalidOperationException,
       "Entity does not have FrameState component");
 
-  return Frame(frameState->parentFrame, m_world);
+  return Frame(detail::fromRegistryEntity(frameState->parentFrame), m_world);
 }
 
 //==============================================================================
@@ -250,8 +253,9 @@ std::string_view Frame::getName() const
     return "world";
   }
 
+  const auto enttEntity = detail::toRegistryEntity(m_entity);
   if (const auto* name
-      = m_world->getRegistry().try_get<comps::Name>(m_entity)) {
+      = m_world->getRegistry().try_get<comps::Name>(enttEntity)) {
     return name->name;
   }
 
@@ -268,13 +272,16 @@ void Frame::setParentFrame(const Frame& parent)
       !parent.isValid(), InvalidArgumentException, "Invalid parent frame");
 
   // World frame cannot change parent
-  if (m_entity == entt::null) {
+  if (isWorld()) {
     DART_EXPERIMENTAL_THROW_T(
         InvalidOperationException, "Cannot set parent of world frame");
   }
 
+  const auto enttEntity = detail::toRegistryEntity(m_entity);
+  auto& registry = m_world->getRegistry();
+
   // Get FrameState component (common to FreeFrame and FixedFrame)
-  auto* frameState = tryGetMutable<comps::FrameState>();
+  auto* frameState = registry.try_get<comps::FrameState>(enttEntity);
 
   DART_EXPERIMENTAL_THROW_T_IF(
       !frameState,
@@ -282,19 +289,16 @@ void Frame::setParentFrame(const Frame& parent)
       "Cannot change parent frame of Link. Links are connected through "
       "joints in a fixed tree structure.");
 
-  if (m_world && m_entity != entt::null) {
-    auto& registry = m_world->getRegistry();
-    if (registry.valid(m_entity) && registry.all_of<comps::Link>(m_entity)) {
-      DART_EXPERIMENTAL_THROW_T(
-          InvalidOperationException,
-          "Cannot change parent frame of Link. Links are connected through "
-          "joints in a fixed tree structure.");
-    }
+  if (registry.valid(enttEntity) && registry.all_of<comps::Link>(enttEntity)) {
+    DART_EXPERIMENTAL_THROW_T(
+        InvalidOperationException,
+        "Cannot change parent frame of Link. Links are connected through "
+        "joints in a fixed tree structure.");
   }
 
   const auto parentEntity = parent.getEntity();
 
-  if (parentEntity != entt::null) {
+  if (!parent.isWorld()) {
     DART_EXPERIMENTAL_THROW_T_IF(
         m_world != parent.m_world,
         InvalidArgumentException,
@@ -309,7 +313,7 @@ void Frame::setParentFrame(const Frame& parent)
   // Prevent cycles by walking up the prospective parent's ancestry.
   Frame ancestor = parent;
   std::size_t depth = 0;
-  while (ancestor.getEntity() != entt::null) {
+  while (!ancestor.isWorld()) {
     if (ancestor.getEntity() == m_entity) {
       DART_EXPERIMENTAL_THROW_T(
           InvalidOperationException, "Cannot create cyclic frame hierarchy");
@@ -330,8 +334,13 @@ void Frame::setParentFrame(const Frame& parent)
     }
   }
 
-  // Update parent in FrameState component
-  frameState->parentFrame = parentEntity;
+  // Update parent in FrameState component (parentFrame is entt::entity
+  // internally; world frame is represented as entt::null)
+  if (parent.isWorld()) {
+    frameState->parentFrame = entt::null;
+  } else {
+    frameState->parentFrame = detail::toRegistryEntity(parentEntity);
+  }
 
   markSubtreeTransformCacheDirty();
 }
@@ -343,14 +352,18 @@ const Eigen::Isometry3d& Frame::getTransform() const
       !isValid(), InvalidArgumentException, "Invalid frame handle");
 
   // World frame: return identity
-  if (m_entity == entt::null) {
+  if (isWorld()) {
     static const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
     return identity;
   }
 
+  const auto enttEntity = detail::toRegistryEntity(m_entity);
+
   // Frames with lazy evaluation (FreeFrame, FixedFrame) use FrameCache
-  // Use getCacheMutable() for cache updates in const method
-  auto* cache = getCacheMutable<comps::FrameCache>();
+  // const_cast is safe: cache mutation does not change observable state
+  auto* cache = const_cast<Frame*>(this)
+                    ->m_world->getRegistry()
+                    .try_get<comps::FrameCache>(enttEntity);
   DART_EXPERIMENTAL_THROW_T_IF(
       !cache,
       InvalidOperationException,
@@ -361,7 +374,7 @@ const Eigen::Isometry3d& Frame::getTransform() const
     auto parent = getParentFrame();
     cache->worldTransform
         = parent.getTransform()
-          * getFrameLocalTransform(m_world->getRegistry(), m_entity);
+          * getFrameLocalTransform(m_world->getRegistry(), enttEntity);
     cache->needTransformUpdate = false;
   }
 
@@ -423,7 +436,8 @@ Eigen::Isometry3d Frame::getTransform(const Frame& relativeTo) const
   // Optimization: transform to parent is just the local transform
   auto parent = getParentFrame();
   if (!parent.isWorld() && relativeTo.m_entity == parent.m_entity) {
-    return getFrameLocalTransform(m_world->getRegistry(), m_entity);
+    return getFrameLocalTransform(
+        m_world->getRegistry(), detail::toRegistryEntity(m_entity));
   }
 
   // General case: compute via world transforms
@@ -480,16 +494,17 @@ Eigen::Isometry3d Frame::getTransform(
 //==============================================================================
 Frame Frame::world()
 {
-  // Return a special frame representing the world
-  // Uses entt::null entity and nullptr world as markers
-  return Frame(entt::null, nullptr);
+  // Return a special frame representing the world.
+  // The default-constructed Entity sentinel (0xFFFFFFFF) marks the world frame;
+  // nullptr world is also a marker.
+  return Frame(Entity{}, nullptr);
 }
 
 //==============================================================================
 bool Frame::isValid() const
 {
-  // World frame is valid (entity is null, world can be null or non-null)
-  if (m_entity == entt::null) {
+  // World frame is valid (entity sentinel, world can be null or non-null)
+  if (isWorld()) {
     return true;
   }
 
@@ -498,14 +513,16 @@ bool Frame::isValid() const
     return false;
   }
 
+  const auto enttEntity = detail::toRegistryEntity(m_entity);
+
   // Check if entity exists in registry
   auto& registry = m_world->getRegistry();
-  if (!registry.valid(m_entity)) {
+  if (!registry.valid(enttEntity)) {
     return false;
   }
 
   // Check if entity has FrameTag
-  if (!registry.all_of<comps::FrameTag>(m_entity)) {
+  if (!registry.all_of<comps::FrameTag>(enttEntity)) {
     return false;
   }
 
@@ -519,7 +536,8 @@ void Frame::markSubtreeTransformCacheDirty()
     return;
   }
 
-  markSubtreeCacheDirty(m_world->getRegistry(), m_entity);
+  markSubtreeCacheDirty(
+      m_world->getRegistry(), detail::toRegistryEntity(m_entity));
 }
 
 } // namespace dart::simulation::experimental

--- a/dart/simulation/experimental/frame/frame.hpp
+++ b/dart/simulation/experimental/frame/frame.hpp
@@ -34,11 +34,10 @@
 
 #include <dart/simulation/experimental/fwd.hpp>
 
-#include <dart/simulation/experimental/comps/frame_types.hpp>
-#include <dart/simulation/experimental/ecs/entity_object.hpp>
+#include <dart/simulation/experimental/entity.hpp>
+#include <dart/simulation/experimental/export.hpp>
 
 #include <Eigen/Geometry>
-#include <entt/entt.hpp>
 
 #include <string_view>
 
@@ -50,17 +49,17 @@ namespace dart::simulation::experimental {
 /// participate in kinematic queries such as transform, velocity, and
 /// acceleration computations. Frames form a hierarchical tree structure.
 ///
-/// This is a lightweight handle class that wraps an entt::entity with
-/// convenient methods for frame-related operations. It's inspired by DART 6's
-/// Frame class but adapted for the ECS architecture.
+/// This is a lightweight handle class that stores an opaque `Entity` token
+/// and a `World*`. The promoted DART 7 public surface does not depend on
+/// the ECS storage backend; all registry access is performed in the `.cpp`
+/// through the internal `detail/entity_conversion.hpp` seam.
 ///
 /// ## What is a Frame?
 ///
 /// A Frame can be:
 /// - **Link**: Most common - rigid bodies in articulated systems
 /// - **Joint Frame**: Origin/axis of a joint (future)
-/// - **SimpleFrame**: User-defined frame with fixed offset from parent
-/// (future)
+/// - **SimpleFrame**: User-defined frame with fixed offset from parent (future)
 /// - **ShapeFrame**: Frame attached to collision/visual shapes (future)
 /// - **World Frame**: Root of all frame hierarchies
 ///
@@ -90,26 +89,13 @@ namespace dart::simulation::experimental {
 ///
 /// @see LinkComponent, FrameTag
 class DART_EXPERIMENTAL_API Frame
-  : public EntityObjectWith<
-        TagComps<comps::FrameTag>,
-        ReadOnlyComps<>,
-        WriteOnlyComps<>,
-        ReadWriteComps<comps::FrameState, comps::FrameCache>>
 {
 public:
-  // Allow internal classes to access getEntity() for ECS operations
-  friend class World;
-  friend class FreeFrame;
-  friend class FixedFrame;
-  friend class Multibody;
-
-  /// Construct a Frame handle from an entity and world
+  /// Construct a Frame handle from an opaque entity token and world.
   ///
-  /// @param entity Entity ID in the ECS registry
-  /// @param world Pointer to the owning World instance
-  ///
-  /// @note The entity must have FrameTag and LinkComponent (for Phase 1)
-  Frame(entt::entity entity, World* world);
+  /// @param entity Opaque entity token obtained from the World API.
+  /// @param world  Pointer to the owning World instance.
+  Frame(Entity entity, World* world);
 
   /// Virtual destructor
   virtual ~Frame() = default;
@@ -278,7 +264,7 @@ public:
   [[nodiscard]] static Frame world();
 
   //--------------------------------------------------------------------------
-  // Validity and Internal Access
+  // Validity and Identity
   //--------------------------------------------------------------------------
 
   /// Check if this Frame handle is valid
@@ -295,10 +281,7 @@ public:
   /// Check if this is the world frame
   ///
   /// @return true if this is the world frame, false otherwise
-  [[nodiscard]] bool isWorld() const
-  {
-    return m_entity == entt::null;
-  }
+  [[nodiscard]] bool isWorld() const;
 
   /// Check if two frames refer to the same entity
   ///
@@ -341,22 +324,24 @@ public:
     return !(*this == other);
   }
 
-  /// Get the underlying entity ID
+  /// Get the backend-neutral `Entity` token for this frame.
   ///
-  /// This is primarily for testing and internal use. External users should
-  /// generally use Frame methods rather than accessing the entity directly.
+  /// This is primarily for identity comparisons and for passing a frame
+  /// back to World APIs. Internal code that requires the registry entity
+  /// should convert via `detail::toRegistryEntity(frame.getEntity())`.
   ///
-  /// @return Entity ID in the ECS registry
-  [[nodiscard]] entt::entity getEntity() const
+  /// @return Opaque entity token
+  [[nodiscard]] Entity getEntity() const
   {
     return m_entity;
   }
 
-  // Note: m_entity and m_world are inherited from EntityObject<Frame>
-
 protected:
   /// Mark this frame and all descendant frame transform caches dirty.
   void markSubtreeTransformCacheDirty();
+
+  Entity m_entity; ///< Opaque entity token (null sentinel = world frame)
+  World* m_world;  ///< Owning World instance (nullptr = world frame)
 };
 
 } // namespace dart::simulation::experimental

--- a/dart/simulation/experimental/frame/free_frame.cpp
+++ b/dart/simulation/experimental/frame/free_frame.cpp
@@ -40,20 +40,14 @@
 namespace dart::simulation::experimental {
 
 //==============================================================================
-FreeFrame::FreeFrame(Entity entity, World* world)
-  : Frame(detail::toRegistryEntity(entity), world),
-    EntityObjectWith<
-        TagComps<comps::FreeFrameTag>,
-        ReadOnlyComps<>,
-        WriteOnlyComps<>,
-        ReadWriteComps<comps::FreeFrameProperties>>()
+FreeFrame::FreeFrame(Entity entity, World* world) : Frame(entity, world)
 {
   // Validate entity has FreeFrameProperties
 #ifndef NDEBUG
   auto& registry = world->getRegistry();
+  const auto enttEntity = detail::toRegistryEntity(entity);
   DART_EXPERIMENTAL_THROW_T_IF(
-      !registry.all_of<comps::FreeFrameProperties>(
-          detail::toRegistryEntity(entity)),
+      !registry.all_of<comps::FreeFrameProperties>(enttEntity),
       InvalidArgumentException,
       "Entity does not have FreeFrameProperties component");
 #endif
@@ -63,7 +57,8 @@ FreeFrame::FreeFrame(Entity entity, World* world)
 void FreeFrame::setLocalTransform(const Eigen::Isometry3d& transform)
 {
   auto& registry = m_world->getRegistry();
-  auto& props = registry.get<comps::FreeFrameProperties>(m_entity);
+  auto& props = registry.get<comps::FreeFrameProperties>(
+      detail::toRegistryEntity(m_entity));
   props.localTransform = transform;
 
   markSubtreeTransformCacheDirty();

--- a/dart/simulation/experimental/frame/free_frame.hpp
+++ b/dart/simulation/experimental/frame/free_frame.hpp
@@ -52,13 +52,7 @@ namespace dart::simulation::experimental {
 /// - Target frames for IK
 ///
 /// DART6 equivalent: SimpleFrame (with modifiable transform)
-class DART_EXPERIMENTAL_API FreeFrame
-  : public Frame,
-    public EntityObjectWith<
-        TagComps<comps::FreeFrameTag>,
-        ReadOnlyComps<>,
-        WriteOnlyComps<>,
-        ReadWriteComps<comps::FreeFrameProperties>>
+class DART_EXPERIMENTAL_API FreeFrame : public Frame
 {
 public:
   /// Constructor (package-private, use World::addFreeFrame)

--- a/dart/simulation/experimental/io/skeleton_loader.cpp
+++ b/dart/simulation/experimental/io/skeleton_loader.cpp
@@ -33,6 +33,7 @@
 
 #include "dart/simulation/experimental/common/exceptions.hpp"
 #include "dart/simulation/experimental/comps/link.hpp"
+#include "dart/simulation/experimental/detail/entity_conversion.hpp"
 #include "dart/simulation/experimental/multibody/joint.hpp"
 #include "dart/simulation/experimental/multibody/link.hpp"
 #include "dart/simulation/experimental/world.hpp"
@@ -541,7 +542,9 @@ void setParentToJointTransform(Link& link, const Eigen::Isometry3d& transform)
       "Cannot set parent-to-joint transform on an invalid loaded Link");
 
   auto& registry = world->getRegistry();
-  auto& linkComp = registry.get<comps::Link>(link.getEntity());
+  auto& linkComp = registry.get<comps::Link>(
+      dart::simulation::experimental::detail::toRegistryEntity(
+          link.getEntity()));
   linkComp.transformFromParentToJoint = transform;
 }
 

--- a/dart/simulation/experimental/multibody/link.cpp
+++ b/dart/simulation/experimental/multibody/link.cpp
@@ -161,31 +161,31 @@ void validateCollisionShape(const CollisionShape& shape, const char* ownerName)
 } // namespace
 
 //==============================================================================
-Link::Link(Entity entity, World* world)
-  : Frame(detail::toRegistryEntity(entity), world)
-{
-}
+Link::Link(Entity entity, World* world) : Frame(entity, world) {}
 
 //==============================================================================
 std::string_view Link::getName() const
 {
-  const auto& linkComp
-      = getWorld()->getRegistry().get<comps::Link>(getEntity());
+  const auto& linkComp = getWorld()->getRegistry().get<comps::Link>(
+      detail::toRegistryEntity(getEntity()));
   return linkComp.name;
 }
 
 //==============================================================================
 Joint Link::getParentJoint() const
 {
-  const auto& linkComp
-      = getWorld()->getRegistry().get<comps::Link>(getEntity());
+  const auto& linkComp = getWorld()->getRegistry().get<comps::Link>(
+      detail::toRegistryEntity(getEntity()));
   return Joint(detail::fromRegistryEntity(linkComp.parentJoint), getWorld());
 }
 
 //==============================================================================
 double Link::getMass() const
 {
-  return getWorld()->getRegistry().get<comps::Link>(getEntity()).mass.mass;
+  return getWorld()
+      ->getRegistry()
+      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .mass.mass;
 }
 
 //==============================================================================
@@ -196,13 +196,19 @@ void Link::setMass(double mass)
       InvalidArgumentException,
       "Link mass must be positive and finite");
 
-  getWorld()->getRegistry().get<comps::Link>(getEntity()).mass.mass = mass;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .mass.mass = mass;
 }
 
 //==============================================================================
 Eigen::Matrix3d Link::getInertia() const
 {
-  return getWorld()->getRegistry().get<comps::Link>(getEntity()).mass.inertia;
+  return getWorld()
+      ->getRegistry()
+      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .mass.inertia;
 }
 
 //==============================================================================
@@ -213,8 +219,10 @@ void Link::setInertia(const Eigen::Matrix3d& inertia)
       InvalidArgumentException,
       "Link inertia must be symmetric positive definite");
 
-  getWorld()->getRegistry().get<comps::Link>(getEntity()).mass.inertia
-      = inertia;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .mass.inertia = inertia;
 }
 
 //==============================================================================
@@ -222,7 +230,7 @@ Eigen::Vector3d Link::getCenterOfMass() const
 {
   return getWorld()
       ->getRegistry()
-      .get<comps::Link>(getEntity())
+      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
       .mass.localCenterOfMass;
 }
 
@@ -234,8 +242,10 @@ void Link::setCenterOfMass(const Eigen::Vector3d& centerOfMass)
       InvalidArgumentException,
       "Link center of mass must contain only finite values");
 
-  getWorld()->getRegistry().get<comps::Link>(getEntity()).mass.localCenterOfMass
-      = centerOfMass;
+  getWorld()
+      ->getRegistry()
+      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .mass.localCenterOfMass = centerOfMass;
 }
 
 //==============================================================================
@@ -258,7 +268,8 @@ void Link::applyForce(
   // point into the link frame, build the wrench [torque; force] at the point,
   // then transport it to the link origin and accumulate in the link frame.
   const Eigen::Isometry3d& worldTransform = getWorldTransform();
-  auto& linkComp = getWorld()->getRegistry().get<comps::Link>(getEntity());
+  auto& linkComp = getWorld()->getRegistry().get<comps::Link>(
+      detail::toRegistryEntity(getEntity()));
 
   Eigen::Isometry3d pointTransform = Eigen::Isometry3d::Identity();
   pointTransform.translation()
@@ -275,8 +286,8 @@ void Link::applyForce(
 std::optional<CollisionShape> Link::getCollisionShape() const
 {
   const auto& registry = getWorld()->getRegistry();
-  if (const auto* geometry
-      = registry.try_get<comps::CollisionGeometry>(getEntity())) {
+  if (const auto* geometry = registry.try_get<comps::CollisionGeometry>(
+          detail::toRegistryEntity(getEntity()))) {
     if (const auto* shape = geometry->getPrimaryShape()) {
       return *shape;
     }
@@ -288,8 +299,8 @@ std::optional<CollisionShape> Link::getCollisionShape() const
 std::vector<CollisionShape> Link::getCollisionShapes() const
 {
   const auto& registry = getWorld()->getRegistry();
-  if (const auto* geometry
-      = registry.try_get<comps::CollisionGeometry>(getEntity())) {
+  if (const auto* geometry = registry.try_get<comps::CollisionGeometry>(
+          detail::toRegistryEntity(getEntity()))) {
     return geometry->shapes;
   }
   return {};
@@ -301,11 +312,12 @@ void Link::setCollisionShape(const CollisionShape& shape)
   validateCollisionShape(shape, "Link");
 
   auto& registry = getWorld()->getRegistry();
-  const auto* existing
-      = registry.try_get<comps::CollisionGeometry>(getEntity());
+  const auto* existing = registry.try_get<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()));
   comps::CollisionGeometry geometry{{shape}};
   geometry.revision = existing ? existing->revision + 1 : 1;
-  registry.emplace_or_replace<comps::CollisionGeometry>(getEntity(), geometry);
+  registry.emplace_or_replace<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()), geometry);
 }
 
 //==============================================================================
@@ -314,8 +326,8 @@ void Link::addCollisionShape(const CollisionShape& shape)
   validateCollisionShape(shape, "Link");
 
   auto& registry = getWorld()->getRegistry();
-  auto& geometry
-      = registry.get_or_emplace<comps::CollisionGeometry>(getEntity());
+  auto& geometry = registry.get_or_emplace<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()));
   geometry.shapes.push_back(shape);
   ++geometry.revision;
 }
@@ -324,8 +336,8 @@ void Link::addCollisionShape(const CollisionShape& shape)
 bool Link::hasCollisionShape() const
 {
   const auto& registry = getWorld()->getRegistry();
-  const auto* geometry
-      = registry.try_get<comps::CollisionGeometry>(getEntity());
+  const auto* geometry = registry.try_get<comps::CollisionGeometry>(
+      detail::toRegistryEntity(getEntity()));
   return geometry != nullptr && geometry->hasShapes();
 }
 

--- a/dart/simulation/experimental/multibody/multibody.cpp
+++ b/dart/simulation/experimental/multibody/multibody.cpp
@@ -367,7 +367,7 @@ Link Multibody::addLink(std::string_view name, const LinkOptions& options)
 
   // Validate parent link exists
   auto& registry = m_world->getRegistry();
-  auto parentEntity = options.parentLink.getEntity();
+  auto parentEntity = detail::toRegistryEntity(options.parentLink.getEntity());
 
   DART_EXPERIMENTAL_THROW_T_IF(
       options.parentLink.getWorld() != m_world,
@@ -649,7 +649,7 @@ Eigen::MatrixXd Multibody::getJacobian(const Link& link) const
   const auto& structure = safeGet<comps::MultibodyStructure>(
       registry, detail::toRegistryEntity(m_entity));
   return compute::computeMultibodyLinkJacobian(
-      registry, structure, link.getEntity());
+      registry, structure, detail::toRegistryEntity(link.getEntity()));
 }
 
 //==============================================================================
@@ -664,7 +664,7 @@ Eigen::MatrixXd Multibody::getWorldJacobian(const Link& link) const
   const auto& structure = safeGet<comps::MultibodyStructure>(
       registry, detail::toRegistryEntity(m_entity));
   return compute::computeMultibodyLinkWorldJacobian(
-      registry, structure, link.getEntity());
+      registry, structure, detail::toRegistryEntity(link.getEntity()));
 }
 
 //==============================================================================
@@ -715,7 +715,9 @@ void Multibody::addGroundContactPoint(
   const auto& structure = safeGet<comps::MultibodyStructure>(
       registry, detail::toRegistryEntity(m_entity));
   const auto it = std::find(
-      structure.links.begin(), structure.links.end(), link.getEntity());
+      structure.links.begin(),
+      structure.links.end(),
+      detail::toRegistryEntity(link.getEntity()));
   DART_EXPERIMENTAL_THROW_T_IF(
       it == structure.links.end(),
       InvalidArgumentException,

--- a/dart/simulation/experimental/world.cpp
+++ b/dart/simulation/experimental/world.cpp
@@ -497,7 +497,7 @@ entt::entity resolveLoopClosureFrame(
       "LoopClosureSpec.{} belongs to a different world",
       fieldName);
 
-  return frame.getEntity();
+  return detail::toRegistryEntity(frame.getEntity());
 }
 
 //==============================================================================
@@ -1343,7 +1343,9 @@ entt::entity World::createFrameEntity(
   }
 
   auto& state = m_registry.emplace<comps::FrameState>(entity);
-  state.parentFrame = parentFrame.getEntity();
+  state.parentFrame = parentFrame.isWorld()
+                          ? entt::null
+                          : detail::toRegistryEntity(parentFrame.getEntity());
 
   auto& cache = m_registry.emplace<comps::FrameCache>(entity);
   cache.worldTransform = Eigen::Isometry3d::Identity();
@@ -1365,7 +1367,7 @@ entt::entity World::createFrameEntity(
 Frame World::resolveParentFrame(const Frame& parent) const
 {
   if (parent.isWorld()) {
-    return Frame(entt::null, const_cast<World*>(this));
+    return Frame(Entity{}, const_cast<World*>(this));
   }
 
   DART_EXPERIMENTAL_THROW_T_IF(
@@ -1516,7 +1518,7 @@ RigidBody World::addRigidBody(
 
   validateRigidBodyOptions(options);
 
-  Frame parent = Frame(entt::null, this);
+  Frame parent = Frame(Entity{}, this);
   const auto orientation = normalizeOrIdentity(options.orientation);
   const auto initialTransform = toIsometry(options.position, orientation);
 

--- a/docs/onboarding/api-boundary-inventory.md
+++ b/docs/onboarding/api-boundary-inventory.md
@@ -15,7 +15,7 @@ documented downstream migration or removal condition is satisfied.
 ## Summary
 
 - C++ public headers scanned: 478
-- C++ headers with exposed implementation debt: 115
+- C++ headers with exposed implementation debt: 116
 - C++ headers with compatibility signals: 51
 - dartpy binding sources scanned: 164
 - dartpy binding sources with allowlisted compatibility debt: 8
@@ -36,7 +36,7 @@ documented downstream migration or removal condition is satisfied.
 | sensor                  | 3       | 3         | 0             | 0            | 0            |
 | simd                    | 16      | 11        | 0             | 0            | 5            |
 | simulation              | 4       | 2         | 1             | 0            | 1            |
-| simulation/experimental | 77      | 0         | 1             | 65           | 11           |
+| simulation/experimental | 77      | 0         | 1             | 64           | 12           |
 | top-level               | 3       | 2         | 1             | 0            | 0            |
 | utils                   | 19      | 10        | 7             | 0            | 2            |
 
@@ -148,6 +148,7 @@ documented downstream migration or removal condition is satisfied.
 | dart/simulation/experimental/body/collision_body.hpp       | simulation/experimental | 0                | 1                  | `/// \`detail::toRegistryEntity(body.getEntity())\`.`                                                                                               |
 | dart/simulation/experimental/common/logging.hpp            | simulation/experimental | 0                | 7                  | `detail::log(`<br>`::dart::simulation::experimental::common::detail::log( \`                                                                        |
 | dart/simulation/experimental/constraint/loop_closure.hpp   | simulation/experimental | 0                | 1                  | `/// \`detail::toRegistryEntity(closure.getEntity())\`.`                                                                                            |
+| dart/simulation/experimental/frame/frame.hpp               | simulation/experimental | 0                | 1                  | `/// should convert via \`detail::toRegistryEntity(frame.getEntity())\`.`                                                                           |
 | dart/simulation/experimental/io/auto_serialization.hpp     | simulation/experimental | 0                | 38                 | `} else if constexpr (detail::IsVector3dList<FieldType>) {`<br>`detail::writeVector3dList(out, field);`                                             |
 | dart/simulation/experimental/io/binary_io.hpp              | simulation/experimental | 0                | 8                  | `template <detail::TriviallyCopyable T>`<br>`detail::writeBytes(out, detail::asBytes(value));`                                                      |
 | dart/simulation/experimental/io/serializer.hpp             | simulation/experimental | 0                | 1                  | `requires detail::HasSerializableFlag<ComponentT>`                                                                                                  |

--- a/tests/unit/simulation/experimental/compute/test_multibody_link_contact.cpp
+++ b/tests/unit/simulation/experimental/compute/test_multibody_link_contact.cpp
@@ -104,7 +104,8 @@ struct PrismaticLegWorld
 
     multibody = dart::simulation::experimental::detail::toRegistryEntity(
         robot.getEntity());
-    link = leg.getEntity();
+    link = dart::simulation::experimental::detail::toRegistryEntity(
+        leg.getEntity());
   }
 
   const sx::comps::MultibodyStructure& structure()
@@ -145,8 +146,10 @@ struct TwoPrismaticLinksWorld
 
     multibody = dart::simulation::experimental::detail::toRegistryEntity(
         robot.getEntity());
-    lower = lowerLink.getEntity();
-    upper = upperLink.getEntity();
+    lower = dart::simulation::experimental::detail::toRegistryEntity(
+        lowerLink.getEntity());
+    upper = dart::simulation::experimental::detail::toRegistryEntity(
+        upperLink.getEntity());
   }
 
   const sx::comps::MultibodyStructure& structure()
@@ -326,7 +329,8 @@ TEST(MultibodyLinkContact, CouplesDynamicRigidObstacleRow)
   contact.depth = 0.0; // no penetration: isolate the two-sided coupling
   contact.friction = 0.75;
   contact.restitution = 0.0;
-  contact.otherBody = obstacle.getEntity();
+  contact.otherBody = dart::simulation::experimental::detail::toRegistryEntity(
+      obstacle.getEntity());
 
   Eigen::VectorXd nextVelocity(1);
   nextVelocity << -0.4;
@@ -353,7 +357,10 @@ TEST(MultibodyLinkContact, CouplesDynamicRigidObstacleRow)
 
   // The dynamic obstacle is coupled in: unit mass and identity inertia, with
   // the arm measured from the obstacle's body origin to the contact point.
-  EXPECT_EQ(row.otherBody, obstacle.getEntity());
+  EXPECT_EQ(
+      row.otherBody,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          obstacle.getEntity()));
   EXPECT_DOUBLE_EQ(row.otherInvMass, 1.0);
   EXPECT_TRUE(row.otherInvInertia.isApprox(Eigen::Matrix3d::Identity(), 1e-12));
   EXPECT_TRUE(

--- a/tests/unit/simulation/experimental/compute/test_rigid_body_constraint.cpp
+++ b/tests/unit/simulation/experimental/compute/test_rigid_body_constraint.cpp
@@ -86,28 +86,16 @@ TEST(RigidBodyConstraint, AssemblesRigidOnlyStackRowsDeterministically)
 
   std::vector<sx::Contact> contacts;
   sx::Contact groundLower;
-  groundLower.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          ground.getEntity()),
-      &world);
-  groundLower.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          lower.getEntity()),
-      &world);
+  groundLower.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+  groundLower.bodyB = sx::CollisionBody(lower.getEntity(), &world);
   groundLower.point = Eigen::Vector3d(0.0, 0.0, 0.0);
   groundLower.normal = Eigen::Vector3d::UnitZ();
   groundLower.depth = 0.02;
   contacts.push_back(groundLower);
 
   sx::Contact lowerUpper;
-  lowerUpper.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          lower.getEntity()),
-      &world);
-  lowerUpper.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          upper.getEntity()),
-      &world);
+  lowerUpper.bodyA = sx::CollisionBody(lower.getEntity(), &world);
+  lowerUpper.bodyB = sx::CollisionBody(upper.getEntity(), &world);
   lowerUpper.point = Eigen::Vector3d(0.0, 0.0, 1.0);
   lowerUpper.normal = Eigen::Vector3d::UnitZ();
   lowerUpper.depth = 0.03;
@@ -132,12 +120,13 @@ TEST(RigidBodyConstraint, AssemblesRigidOnlyStackRowsDeterministically)
   expectVectorExactlyEqual(problem.hi, repeated.hi);
   expectVectorExactlyEqual(problem.findex, repeated.findex);
 
-  EXPECT_EQ(problem.constraints[0].bodyA, ground.getEntity());
-  EXPECT_EQ(problem.constraints[0].bodyB, lower.getEntity());
+  using sx::detail::toRegistryEntity;
+  EXPECT_EQ(problem.constraints[0].bodyA, toRegistryEntity(ground.getEntity()));
+  EXPECT_EQ(problem.constraints[0].bodyB, toRegistryEntity(lower.getEntity()));
   EXPECT_TRUE(problem.constraints[0].staticA);
   EXPECT_FALSE(problem.constraints[0].staticB);
-  EXPECT_EQ(problem.constraints[1].bodyA, lower.getEntity());
-  EXPECT_EQ(problem.constraints[1].bodyB, upper.getEntity());
+  EXPECT_EQ(problem.constraints[1].bodyA, toRegistryEntity(lower.getEntity()));
+  EXPECT_EQ(problem.constraints[1].bodyB, toRegistryEntity(upper.getEntity()));
   EXPECT_FALSE(problem.constraints[1].staticA);
   EXPECT_FALSE(problem.constraints[1].staticB);
 

--- a/tests/unit/simulation/experimental/compute/test_unified_constraint.cpp
+++ b/tests/unit/simulation/experimental/compute/test_unified_constraint.cpp
@@ -84,28 +84,16 @@ sx::compute::RigidBodyContactProblem buildRigidStackProblem(sx::World& world)
 
   std::vector<sx::Contact> contacts;
   sx::Contact groundLower;
-  groundLower.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          ground.getEntity()),
-      &world);
-  groundLower.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          lower.getEntity()),
-      &world);
+  groundLower.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+  groundLower.bodyB = sx::CollisionBody(lower.getEntity(), &world);
   groundLower.point = Eigen::Vector3d(0.0, 0.0, 0.0);
   groundLower.normal = Eigen::Vector3d::UnitZ();
   groundLower.depth = 0.02;
   contacts.push_back(groundLower);
 
   sx::Contact lowerUpper;
-  lowerUpper.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          lower.getEntity()),
-      &world);
-  lowerUpper.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          upper.getEntity()),
-      &world);
+  lowerUpper.bodyA = sx::CollisionBody(lower.getEntity(), &world);
+  lowerUpper.bodyB = sx::CollisionBody(upper.getEntity(), &world);
   lowerUpper.point = Eigen::Vector3d(0.0, 0.0, 1.0);
   lowerUpper.normal = Eigen::Vector3d::UnitZ();
   lowerUpper.depth = 0.03;
@@ -170,14 +158,16 @@ TEST(UnifiedConstraint, RigidFreeLinkBlockMatchesWithinMultibodyCoupling)
   arm.setInertia(Eigen::Matrix3d::Identity());
 
   sx::compute::LinkContact near;
-  near.link = arm.getEntity();
+  near.link = dart::simulation::experimental::detail::toRegistryEntity(
+      arm.getEntity());
   near.normal = Eigen::Vector3d::UnitY();
   near.point = Eigen::Vector3d(1.0, 0.0, 0.0);
   near.depth = 0.01;
   near.friction = 0.5;
 
   sx::compute::LinkContact far;
-  far.link = arm.getEntity();
+  far.link = dart::simulation::experimental::detail::toRegistryEntity(
+      arm.getEntity());
   far.normal = Eigen::Vector3d::UnitY();
   far.point = Eigen::Vector3d(2.0, 0.0, 0.0);
   far.depth = 0.0;
@@ -299,7 +289,8 @@ TEST(UnifiedConstraint, CrossMultibodyLinkRowAddsSecondArticulatedEnd)
     return std::pair{
         dart::simulation::experimental::detail::toRegistryEntity(
             robot.getEntity()),
-        link.getEntity()};
+        dart::simulation::experimental::detail::toRegistryEntity(
+            link.getEntity())};
   };
 
   const auto [robotA, linkA] = addPrismaticRobot("a");
@@ -399,7 +390,8 @@ TEST(UnifiedConstraint, FallbackFrictionUpdatesCrossMultibodyOtherEnd)
     return std::pair{
         dart::simulation::experimental::detail::toRegistryEntity(
             robot.getEntity()),
-        tip.getEntity()};
+        dart::simulation::experimental::detail::toRegistryEntity(
+            tip.getEntity())};
   };
 
   const auto [robotA, linkA] = addTwoAxisRobot("a");
@@ -509,7 +501,8 @@ TEST(UnifiedConstraint, FindexReferencesValidNormalRows)
   leg.setMass(1.0);
 
   sx::compute::LinkContact contact;
-  contact.link = leg.getEntity();
+  contact.link = dart::simulation::experimental::detail::toRegistryEntity(
+      leg.getEntity());
   contact.normal = Eigen::Vector3d::UnitZ();
   contact.point = Eigen::Vector3d::Zero();
   contact.depth = 0.01;
@@ -576,14 +569,16 @@ TEST(UnifiedConstraint, CompactsInactiveLinkRows)
   leg.setMass(1.0);
 
   sx::compute::LinkContact active;
-  active.link = leg.getEntity();
+  active.link = dart::simulation::experimental::detail::toRegistryEntity(
+      leg.getEntity());
   active.normal = Eigen::Vector3d::UnitZ(); // along the slide axis -> active
   active.point = Eigen::Vector3d::Zero();
   active.depth = 0.01;
   active.friction = 0.5;
 
   sx::compute::LinkContact inactive;
-  inactive.link = leg.getEntity();
+  inactive.link = dart::simulation::experimental::detail::toRegistryEntity(
+      leg.getEntity());
   inactive.normal = Eigen::Vector3d::UnitX(); // orthogonal to slide -> inactive
   inactive.point = Eigen::Vector3d::Zero();
   inactive.depth = 0.01;
@@ -655,14 +650,8 @@ TEST(UnifiedConstraint, CouplesSharedDynamicObstacleAcrossDomains)
   // Rigid contact: ground (A, static) vs obstacle (B, dynamic) -> R = bodyB.
   std::vector<sx::Contact> rigidContacts;
   sx::Contact groundObstacle;
-  groundObstacle.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          ground.getEntity()),
-      &world);
-  groundObstacle.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          obstacle.getEntity()),
-      &world);
+  groundObstacle.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+  groundObstacle.bodyB = sx::CollisionBody(obstacle.getEntity(), &world);
   groundObstacle.point = Eigen::Vector3d(0.05, -0.1, -0.5);
   groundObstacle.normal = Eigen::Vector3d::UnitZ();
   groundObstacle.depth = 0.01;
@@ -670,16 +659,22 @@ TEST(UnifiedConstraint, CouplesSharedDynamicObstacleAcrossDomains)
   const auto rigid = sx::compute::assembleRigidBodyContactProblem(
       world.getRegistry(), rigidContacts);
   ASSERT_EQ(rigid.constraints.size(), 1u);
-  ASSERT_EQ(rigid.constraints[0].bodyB, obstacle.getEntity());
+  ASSERT_EQ(
+      rigid.constraints[0].bodyB,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          obstacle.getEntity()));
 
   // Link contact: the prismatic leg pushes on the dynamic obstacle R.
   sx::compute::LinkContact legObstacle;
-  legObstacle.link = leg.getEntity();
+  legObstacle.link = dart::simulation::experimental::detail::toRegistryEntity(
+      leg.getEntity());
   legObstacle.normal = Eigen::Vector3d::UnitZ();
   legObstacle.point = Eigen::Vector3d(0.05, -0.1, 0.5);
   legObstacle.depth = 0.0;
   legObstacle.friction = 0.5;
-  legObstacle.otherBody = obstacle.getEntity();
+  legObstacle.otherBody
+      = dart::simulation::experimental::detail::toRegistryEntity(
+          obstacle.getEntity());
 
   Eigen::VectorXd nextVelocity(1);
   nextVelocity << -0.4;
@@ -777,14 +772,8 @@ TEST(UnifiedConstraint, SolvedSolutionSatisfiesBoxedLcpConditions)
 
   std::vector<sx::Contact> contacts;
   sx::Contact groundBox;
-  groundBox.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          ground.getEntity()),
-      &world);
-  groundBox.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          box.getEntity()),
-      &world);
+  groundBox.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+  groundBox.bodyB = sx::CollisionBody(box.getEntity(), &world);
   groundBox.point = Eigen::Vector3d(0.0, 0.0, 0.0);
   groundBox.normal = Eigen::Vector3d::UnitZ();
   groundBox.depth = 0.01;
@@ -855,14 +844,8 @@ TEST(UnifiedConstraint, SolveAndApplyStopsHeadOnRigidContact)
 
   std::vector<sx::Contact> contacts;
   sx::Contact contact;
-  contact.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          left.getEntity()),
-      &world);
-  contact.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          right.getEntity()),
-      &world);
+  contact.bodyA = sx::CollisionBody(left.getEntity(), &world);
+  contact.bodyB = sx::CollisionBody(right.getEntity(), &world);
   contact.point = Eigen::Vector3d::Zero();
   contact.normal = Eigen::Vector3d::UnitX(); // points left -> right
   contact.depth = 0.0;
@@ -885,9 +868,17 @@ TEST(UnifiedConstraint, SolveAndApplyStopsHeadOnRigidContact)
 
   auto& registry = world.getRegistry();
   const Eigen::Vector3d velocityLeft
-      = registry.get<sx::comps::Velocity>(left.getEntity()).linear;
+      = registry
+            .get<sx::comps::Velocity>(
+                dart::simulation::experimental::detail::toRegistryEntity(
+                    left.getEntity()))
+            .linear;
   const Eigen::Vector3d velocityRight
-      = registry.get<sx::comps::Velocity>(right.getEntity()).linear;
+      = registry
+            .get<sx::comps::Velocity>(
+                dart::simulation::experimental::detail::toRegistryEntity(
+                    right.getEntity()))
+            .linear;
   // No restitution: the approaching normal velocity is driven to zero.
   const double relativeNormal
       = (velocityRight - velocityLeft).dot(Eigen::Vector3d::UnitX());
@@ -909,7 +900,8 @@ TEST(UnifiedConstraint, SolveAndApplyDrivesLinkContactToTarget)
   leg.setMass(1.0);
 
   sx::compute::LinkContact contact;
-  contact.link = leg.getEntity();
+  contact.link = dart::simulation::experimental::detail::toRegistryEntity(
+      leg.getEntity());
   contact.normal = Eigen::Vector3d::UnitZ();
   contact.point = Eigen::Vector3d::Zero();
   contact.depth = 0.02; // penetration -> Baumgarte push-out target
@@ -973,12 +965,14 @@ TEST(UnifiedConstraint, SolveAndApplyDeliversNewtonImpulseToObstacle)
   auto obstacle = world.addRigidBody("obstacle", obstacleOptions);
 
   sx::compute::LinkContact contact;
-  contact.link = leg.getEntity();
+  contact.link = dart::simulation::experimental::detail::toRegistryEntity(
+      leg.getEntity());
   contact.normal = Eigen::Vector3d::UnitZ();
   contact.point = Eigen::Vector3d(0.1, 0.0, 0.5); // offset -> nonzero arm
   contact.depth = 0.0;
   contact.friction = 0.5;
-  contact.otherBody = obstacle.getEntity();
+  contact.otherBody = dart::simulation::experimental::detail::toRegistryEntity(
+      obstacle.getEntity());
 
   // The normal points into the link, so a negative normal velocity is the leg
   // approaching the obstacle -> an active contact with a positive impulse.
@@ -1026,8 +1020,9 @@ TEST(UnifiedConstraint, SolveAndApplyDeliversNewtonImpulseToObstacle)
       + tangentImpulse1 * row.otherInvInertia * row.otherArm.cross(row.tangent1)
       + tangentImpulse2 * row.otherInvInertia
             * row.otherArm.cross(row.tangent2));
-  const auto& obstacleVelocity
-      = registry.get<sx::comps::Velocity>(obstacle.getEntity());
+  const auto& obstacleVelocity = registry.get<sx::comps::Velocity>(
+      dart::simulation::experimental::detail::toRegistryEntity(
+          obstacle.getEntity()));
   EXPECT_TRUE(obstacleVelocity.linear.isApprox(expectedLinear, 1e-12));
   EXPECT_TRUE(obstacleVelocity.angular.isApprox(expectedAngular, 1e-12));
 }
@@ -1052,14 +1047,8 @@ TEST(UnifiedConstraint, FallbackStopsHeadOnRigidContact)
 
   std::vector<sx::Contact> contacts;
   sx::Contact contact;
-  contact.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          left.getEntity()),
-      &world);
-  contact.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          right.getEntity()),
-      &world);
+  contact.bodyA = sx::CollisionBody(left.getEntity(), &world);
+  contact.bodyB = sx::CollisionBody(right.getEntity(), &world);
   contact.point = Eigen::Vector3d::Zero();
   contact.normal = Eigen::Vector3d::UnitX();
   contact.depth = 0.0;
@@ -1080,8 +1069,16 @@ TEST(UnifiedConstraint, FallbackStopsHeadOnRigidContact)
 
   auto& registry = world.getRegistry();
   const double relativeNormal
-      = (registry.get<sx::comps::Velocity>(right.getEntity()).linear
-         - registry.get<sx::comps::Velocity>(left.getEntity()).linear)
+      = (registry
+             .get<sx::comps::Velocity>(
+                 dart::simulation::experimental::detail::toRegistryEntity(
+                     right.getEntity()))
+             .linear
+         - registry
+               .get<sx::comps::Velocity>(
+                   dart::simulation::experimental::detail::toRegistryEntity(
+                       left.getEntity()))
+               .linear)
             .dot(Eigen::Vector3d::UnitX());
   EXPECT_NEAR(relativeNormal, 0.0, 1e-9);
 }
@@ -1106,14 +1103,8 @@ TEST(UnifiedConstraint, FallbackFrictionOpposesSlidingWithoutReversing)
 
   std::vector<sx::Contact> contacts;
   sx::Contact contact;
-  contact.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          ground.getEntity()),
-      &world);
-  contact.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          box.getEntity()),
-      &world);
+  contact.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+  contact.bodyB = sx::CollisionBody(box.getEntity(), &world);
   contact.point = Eigen::Vector3d::Zero();
   contact.normal = Eigen::Vector3d::UnitZ();
   contact.depth = 0.01;
@@ -1133,7 +1124,11 @@ TEST(UnifiedConstraint, FallbackFrictionOpposesSlidingWithoutReversing)
       16);
 
   const Eigen::Vector3d boxVelocity
-      = world.getRegistry().get<sx::comps::Velocity>(box.getEntity()).linear;
+      = world.getRegistry()
+            .get<sx::comps::Velocity>(
+                dart::simulation::experimental::detail::toRegistryEntity(
+                    box.getEntity()))
+            .linear;
   // The normal contact arrests the descent and friction opposes (but does not
   // reverse) the tangential slide.
   EXPECT_GE(boxVelocity.z(), -1e-9);
@@ -1158,14 +1153,8 @@ TEST(UnifiedConstraint, ResolveUsesJointSolveWhenWellPosed)
 
   std::vector<sx::Contact> contacts;
   sx::Contact contact;
-  contact.bodyA = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          left.getEntity()),
-      &world);
-  contact.bodyB = sx::CollisionBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          right.getEntity()),
-      &world);
+  contact.bodyA = sx::CollisionBody(left.getEntity(), &world);
+  contact.bodyB = sx::CollisionBody(right.getEntity(), &world);
   contact.point = Eigen::Vector3d::Zero();
   contact.normal = Eigen::Vector3d::UnitX();
   contact.depth = 0.0;
@@ -1187,8 +1176,16 @@ TEST(UnifiedConstraint, ResolveUsesJointSolveWhenWellPosed)
 
   auto& registry = world.getRegistry();
   const double relativeNormal
-      = (registry.get<sx::comps::Velocity>(right.getEntity()).linear
-         - registry.get<sx::comps::Velocity>(left.getEntity()).linear)
+      = (registry
+             .get<sx::comps::Velocity>(
+                 dart::simulation::experimental::detail::toRegistryEntity(
+                     right.getEntity()))
+             .linear
+         - registry
+               .get<sx::comps::Velocity>(
+                   dart::simulation::experimental::detail::toRegistryEntity(
+                       left.getEntity()))
+               .linear)
             .dot(Eigen::Vector3d::UnitX());
   EXPECT_NEAR(relativeNormal, 0.0, 1e-9);
 }
@@ -1218,14 +1215,8 @@ TEST(UnifiedConstraint, FallbackResolvesCoplanarBoxOnPlane)
       = {{0.5, 0.5}, {0.5, -0.5}, {-0.5, 0.5}, {-0.5, -0.5}};
   for (const auto& corner : corners) {
     sx::Contact contact;
-    contact.bodyA = sx::CollisionBody(
-        dart::simulation::experimental::detail::fromRegistryEntity(
-            ground.getEntity()),
-        &world);
-    contact.bodyB = sx::CollisionBody(
-        dart::simulation::experimental::detail::fromRegistryEntity(
-            box.getEntity()),
-        &world);
+    contact.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+    contact.bodyB = sx::CollisionBody(box.getEntity(), &world);
     contact.point = Eigen::Vector3d(corner[0], corner[1], 0.0);
     contact.normal = Eigen::Vector3d::UnitZ();
     contact.depth = 0.01;
@@ -1249,7 +1240,9 @@ TEST(UnifiedConstraint, FallbackResolvesCoplanarBoxOnPlane)
   // The fallback arrests the box's descent and never injects upward velocity.
   const double boxVerticalVelocity
       = world.getRegistry()
-            .get<sx::comps::Velocity>(box.getEntity())
+            .get<sx::comps::Velocity>(
+                dart::simulation::experimental::detail::toRegistryEntity(
+                    box.getEntity()))
             .linear.z();
   EXPECT_NEAR(boxVerticalVelocity, 0.0, 1e-6);
 }

--- a/tests/unit/simulation/experimental/contact/test_boxed_lcp_contact.cpp
+++ b/tests/unit/simulation/experimental/contact/test_boxed_lcp_contact.cpp
@@ -140,11 +140,11 @@ TEST(AvbdContact, CompoundShapeFeatureKeysUseContactedShapeIndex)
   const sx::Contact& contact = contacts.front();
   const bool compoundIsA
       = sx::detail::toRegistryEntity(contact.bodyA.getEntity())
-        == compound.getEntity();
+        == sx::detail::toRegistryEntity(compound.getEntity());
   ASSERT_TRUE(
       compoundIsA
       || sx::detail::toRegistryEntity(contact.bodyB.getEntity())
-             == compound.getEntity());
+             == sx::detail::toRegistryEntity(compound.getEntity()));
   const std::size_t compoundShapeIndex
       = compoundIsA ? contact.shapeIndexA : contact.shapeIndexB;
   const Eigen::Vector3d compoundLocalPoint
@@ -179,7 +179,8 @@ TEST(AvbdContact, PenetratingRigidBodyProjectsVelocity)
   auto sphere = avbd->getRigidBody("sphere");
   ASSERT_TRUE(sphere.has_value());
   avbd->getRegistry().emplace_or_replace<sx::comps::RigidAvbdContactConfig>(
-      sphere->getEntity());
+      dart::simulation::experimental::detail::toRegistryEntity(
+          sphere->getEntity()));
   avbd->enterSimulationMode();
 
   avbd->step();
@@ -208,14 +209,15 @@ TEST(AvbdContact, FixedJointRowsParticipateInProjection)
   sphere->setTransform(spherePose);
 
   auto& registry = avbd->getRegistry();
+  const auto& toReg = dart::simulation::experimental::detail::toRegistryEntity;
   registry.emplace_or_replace<sx::comps::RigidAvbdContactConfig>(
-      sphere->getEntity());
+      toReg(sphere->getEntity()));
 
   const entt::entity jointEntity = registry.create();
   auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
-  joint.parentLink = ground->getEntity();
-  joint.childLink = sphere->getEntity();
+  joint.parentLink = toReg(ground->getEntity());
+  joint.childLink = toReg(sphere->getEntity());
 
   auto& config
       = registry.emplace<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);
@@ -254,8 +256,10 @@ TEST(AvbdContact, FixedJointRowsProjectWithoutContacts)
   const entt::entity jointEntity = registry.create();
   auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
-  joint.parentLink = base.getEntity();
-  joint.childLink = link.getEntity();
+  joint.parentLink = dart::simulation::experimental::detail::toRegistryEntity(
+      base.getEntity());
+  joint.childLink = dart::simulation::experimental::detail::toRegistryEntity(
+      link.getEntity());
 
   auto& config
       = registry.emplace<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);
@@ -292,8 +296,10 @@ TEST(AvbdContact, FixedJointAngularRowsProjectWithoutContacts)
   const entt::entity jointEntity = registry.create();
   auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
-  joint.parentLink = base.getEntity();
-  joint.childLink = link.getEntity();
+  joint.parentLink = dart::simulation::experimental::detail::toRegistryEntity(
+      base.getEntity());
+  joint.childLink = dart::simulation::experimental::detail::toRegistryEntity(
+      link.getEntity());
 
   auto& config
       = registry.emplace<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);
@@ -334,8 +340,10 @@ TEST(AvbdContact, FixedJointRowsProjectWithFallbackContacts)
   const entt::entity jointEntity = registry.create();
   auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
-  joint.parentLink = base.getEntity();
-  joint.childLink = link.getEntity();
+  joint.parentLink = dart::simulation::experimental::detail::toRegistryEntity(
+      base.getEntity());
+  joint.childLink = dart::simulation::experimental::detail::toRegistryEntity(
+      link.getEntity());
 
   auto& config
       = registry.emplace<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);

--- a/tests/unit/simulation/experimental/deformable_vbd/test_avbd_rigid_block.cpp
+++ b/tests/unit/simulation/experimental/deformable_vbd/test_avbd_rigid_block.cpp
@@ -1166,10 +1166,14 @@ TEST(AvbdRigidBlock, RigidWorldContactSnapshotBuildsManifoldRows)
   ASSERT_EQ(snapshot.fixed.size(), snapshot.entities.size());
   ASSERT_EQ(snapshot.contacts.size(), contacts.size());
 
-  const std::size_t groundIndex
-      = findEntityIndex(snapshot.entities, ground.getEntity());
-  const std::size_t sphereIndex
-      = findEntityIndex(snapshot.entities, sphere.getEntity());
+  const std::size_t groundIndex = findEntityIndex(
+      snapshot.entities,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          ground.getEntity()));
+  const std::size_t sphereIndex = findEntityIndex(
+      snapshot.entities,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          sphere.getEntity()));
   EXPECT_EQ(snapshot.fixed[groundIndex], 1u);
   EXPECT_EQ(snapshot.fixed[sphereIndex], 0u);
   EXPECT_DOUBLE_EQ(snapshot.masses[sphereIndex], 2.0);
@@ -1205,7 +1209,9 @@ TEST(AvbdRigidBlock, RigidWorldContactSnapshotBuildsManifoldRows)
                 sourceContact.bodyB.getEntity())));
     const auto expectEndpointFeature
         = [&](const vbd::AvbdContactEndpointId& endpoint, entt::entity entity) {
-            if (entity == ground.getEntity()) {
+            if (entity
+                == dart::simulation::experimental::detail::toRegistryEntity(
+                    ground.getEntity())) {
               const std::uint64_t groundFeatureCode
                   = vbd::avbdBoxContactFeatureCode(
                       sourceContact.point - ground.getTranslation(),
@@ -1286,18 +1292,9 @@ TEST(AvbdRigidBlock, RigidWorldContactSnapshotPersistsFeatureScopedRows)
   auto sphereB = world.addRigidBody("sphere_b", sphereOptions);
   sphereB.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
 
-  const sx::CollisionBody boxBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          box.getEntity()),
-      &world);
-  const sx::CollisionBody sphereBodyA(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          sphereA.getEntity()),
-      &world);
-  const sx::CollisionBody sphereBodyB(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          sphereB.getEntity()),
-      &world);
+  const sx::CollisionBody boxBody(box.getEntity(), &world);
+  const sx::CollisionBody sphereBodyA(sphereA.getEntity(), &world);
+  const sx::CollisionBody sphereBodyB(sphereB.getEntity(), &world);
   const std::vector<sx::Contact> contacts{
       {boxBody, sphereBodyA, Vec3(1.0, 0.1, 0.0), Vec3::UnitX(), 0.1},
       {boxBody, sphereBodyB, Vec3(0.0, 1.0, 0.1), Vec3::UnitY(), 0.2},
@@ -1344,18 +1341,9 @@ TEST(AvbdRigidBlock, RigidWorldContactSnapshotUsesCylinderFeatureIds)
   auto sphereB = world.addRigidBody("sphere_b", sphereOptions);
   sphereB.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
 
-  const sx::CollisionBody cylinderBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          cylinder.getEntity()),
-      &world);
-  const sx::CollisionBody sphereBodyA(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          sphereA.getEntity()),
-      &world);
-  const sx::CollisionBody sphereBodyB(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          sphereB.getEntity()),
-      &world);
+  const sx::CollisionBody cylinderBody(cylinder.getEntity(), &world);
+  const sx::CollisionBody sphereBodyA(sphereA.getEntity(), &world);
+  const sx::CollisionBody sphereBodyB(sphereB.getEntity(), &world);
   const std::vector<sx::Contact> contacts{
       {cylinderBody, sphereBodyA, Vec3(1.1, 0.0, 0.0), Vec3::UnitX(), 0.1},
       {cylinderBody, sphereBodyB, Vec3(0.0, 0.0, 2.1), Vec3::UnitZ(), 0.2},
@@ -1417,22 +1405,10 @@ TEST(AvbdRigidBlock, RigidWorldContactSnapshotUsesCapsuleFeatureIds)
   auto sphereC = world.addRigidBody("sphere_c", sphereOptions);
   sphereC.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
 
-  const sx::CollisionBody capsuleBody(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          capsule.getEntity()),
-      &world);
-  const sx::CollisionBody sphereBodyA(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          sphereA.getEntity()),
-      &world);
-  const sx::CollisionBody sphereBodyB(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          sphereB.getEntity()),
-      &world);
-  const sx::CollisionBody sphereBodyC(
-      dart::simulation::experimental::detail::fromRegistryEntity(
-          sphereC.getEntity()),
-      &world);
+  const sx::CollisionBody capsuleBody(capsule.getEntity(), &world);
+  const sx::CollisionBody sphereBodyA(sphereA.getEntity(), &world);
+  const sx::CollisionBody sphereBodyB(sphereB.getEntity(), &world);
+  const sx::CollisionBody sphereBodyC(sphereC.getEntity(), &world);
   const std::vector<sx::Contact> contacts{
       {capsuleBody, sphereBodyA, Vec3(1.1, 0.0, 0.0), Vec3::UnitX(), 0.1},
       {capsuleBody, sphereBodyB, Vec3(0.0, 0.0, 2.1), Vec3::UnitZ(), 0.2},
@@ -1484,8 +1460,10 @@ TEST(AvbdRigidBlock, RigidWorldSnapshotSolvesPointJointRows)
           world.getRegistry(), std::span<const sx::Contact>());
 
   std::vector<vbd::AvbdRigidWorldPointJointInput> joints(1);
-  joints[0].bodyA = base.getEntity();
-  joints[0].bodyB = link.getEntity();
+  joints[0].bodyA = dart::simulation::experimental::detail::toRegistryEntity(
+      base.getEntity());
+  joints[0].bodyB = dart::simulation::experimental::detail::toRegistryEntity(
+      link.getEntity());
   joints[0].anchorA = Vec3::Zero();
   joints[0].anchorB = Vec3::UnitX();
   joints[0].targetRelativeOrientation = Eigen::Quaterniond::Identity();
@@ -1497,8 +1475,10 @@ TEST(AvbdRigidBlock, RigidWorldSnapshotSolvesPointJointRows)
       1u);
   ASSERT_EQ(snapshot.joints.size(), 1u);
 
-  const std::size_t linkIndex
-      = findEntityIndex(snapshot.entities, link.getEntity());
+  const std::size_t linkIndex = findEntityIndex(
+      snapshot.entities,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          link.getEntity()));
   const double initialLinkX = snapshot.states[linkIndex].position.x();
 
   vbd::AvbdRigidWorldContactSolveOptions solveOptions;
@@ -1557,8 +1537,10 @@ TEST(AvbdRigidBlock, RigidWorldContactStepSolvesPointJointRows)
   auto link = world.addRigidBody("link", linkOptions);
 
   std::vector<vbd::AvbdRigidWorldPointJointInput> joints(1);
-  joints[0].bodyA = base.getEntity();
-  joints[0].bodyB = link.getEntity();
+  joints[0].bodyA = dart::simulation::experimental::detail::toRegistryEntity(
+      base.getEntity());
+  joints[0].bodyB = dart::simulation::experimental::detail::toRegistryEntity(
+      link.getEntity());
   joints[0].anchorA = Vec3::Zero();
   joints[0].anchorB = Vec3::UnitX();
   joints[0].targetRelativeOrientation = Eigen::Quaterniond::Identity();
@@ -1619,8 +1601,10 @@ TEST(AvbdRigidBlock, RigidWorldExtractsFixedJointInputs)
   const entt::entity jointEntity = registry.create();
   auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
-  joint.parentLink = base.getEntity();
-  joint.childLink = link.getEntity();
+  joint.parentLink = dart::simulation::experimental::detail::toRegistryEntity(
+      base.getEntity());
+  joint.childLink = dart::simulation::experimental::detail::toRegistryEntity(
+      link.getEntity());
   auto& config
       = registry.emplace<vbd::AvbdRigidWorldPointJointConfig>(jointEntity);
   config.localAnchorA = Vec3::Zero();
@@ -1632,8 +1616,14 @@ TEST(AvbdRigidBlock, RigidWorldExtractsFixedJointInputs)
   const std::vector<vbd::AvbdRigidWorldPointJointInput> joints
       = vbd::extractAvbdRigidWorldPointJointInputs(registry);
   ASSERT_EQ(joints.size(), 1u);
-  EXPECT_EQ(joints[0].bodyA, base.getEntity());
-  EXPECT_EQ(joints[0].bodyB, link.getEntity());
+  EXPECT_EQ(
+      joints[0].bodyA,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          base.getEntity()));
+  EXPECT_EQ(
+      joints[0].bodyB,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          link.getEntity()));
   EXPECT_NEAR(joints[0].anchorA.x(), 0.0, 1e-12);
   EXPECT_NEAR(joints[0].anchorB.x(), 1.0, 1e-12);
   EXPECT_DOUBLE_EQ(joints[0].startStiffness, 100.0);
@@ -1696,8 +1686,10 @@ TEST(AvbdRigidBlock, RigidWorldContactSnapshotSolveMovesDynamicBody)
           world.getRegistry(), world.collide(), contactOptions);
   ASSERT_FALSE(snapshot.contacts.empty());
 
-  const std::size_t sphereIndex
-      = findEntityIndex(snapshot.entities, sphere.getEntity());
+  const std::size_t sphereIndex = findEntityIndex(
+      snapshot.entities,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          sphere.getEntity()));
   const double initialSphereZ = snapshot.states[sphereIndex].position.z();
 
   vbd::AvbdRigidWorldContactSolveOptions solveOptions;
@@ -1751,8 +1743,10 @@ TEST(AvbdRigidBlock, RigidWorldContactSnapshotApplyWritesDynamicBodyState)
           world.getRegistry(), world.collide(), contactOptions);
   ASSERT_FALSE(snapshot.contacts.empty());
 
-  const std::size_t sphereIndex
-      = findEntityIndex(snapshot.entities, sphere.getEntity());
+  const std::size_t sphereIndex = findEntityIndex(
+      snapshot.entities,
+      dart::simulation::experimental::detail::toRegistryEntity(
+          sphere.getEntity()));
   const double initialSphereZ = sphere.getTransform().translation().z();
 
   vbd::AvbdRigidWorldContactSolveOptions solveOptions;

--- a/tests/unit/simulation/experimental/diff/test_diff_smooth_jacobian.cpp
+++ b/tests/unit/simulation/experimental/diff/test_diff_smooth_jacobian.cpp
@@ -35,6 +35,7 @@
 // code path and is registered only when DART_BUILD_DIFF is ON.
 
 #include <dart/simulation/experimental/comps/multibody.hpp>
+#include <dart/simulation/experimental/detail/entity_conversion.hpp>
 #include <dart/simulation/experimental/detail/smooth_jacobians.hpp>
 #include <dart/simulation/experimental/diff/step_derivatives.hpp>
 #include <dart/simulation/experimental/multibody/multibody.hpp>
@@ -311,7 +312,8 @@ sim::StepDerivatives analyticDerivatives(
       world.getRegistry(),
       world.getRegistry()
           .get<dart::simulation::experimental::comps::MultibodyStructure>(
-              mb->getEntity()),
+              dart::simulation::experimental::detail::toRegistryEntity(
+                  mb->getEntity())),
       world.getGravity(),
       world.getTimeStep(),
       tau);

--- a/tests/unit/simulation/experimental/frame/test_frame.cpp
+++ b/tests/unit/simulation/experimental/frame/test_frame.cpp
@@ -32,6 +32,7 @@
 
 #include <dart/simulation/experimental/common/exceptions.hpp>
 #include <dart/simulation/experimental/comps/frame_types.hpp>
+#include <dart/simulation/experimental/detail/entity_conversion.hpp>
 #include <dart/simulation/experimental/frame/fixed_frame.hpp>
 #include <dart/simulation/experimental/frame/frame.hpp>
 #include <dart/simulation/experimental/frame/free_frame.hpp>
@@ -53,7 +54,8 @@ TEST(Frame, LazyEvaluation)
   auto freeFrame = world.addFreeFrame("test");
 
   auto& registry = world.getRegistry();
-  auto entity = freeFrame.getEntity();
+  auto entity = dart::simulation::experimental::detail::toRegistryEntity(
+      freeFrame.getEntity());
 
   // Set transform but don't query world transform yet
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
@@ -88,7 +90,8 @@ TEST(Frame, CacheInvalidation)
   auto freeFrame = world.addFreeFrame("test");
 
   auto& registry = world.getRegistry();
-  auto entity = freeFrame.getEntity();
+  auto entity = dart::simulation::experimental::detail::toRegistryEntity(
+      freeFrame.getEntity());
 
   // Trigger cache computation
   [[maybe_unused]] auto T1 = freeFrame.getTransform();
@@ -220,8 +223,10 @@ TEST(Frame, ReparentInvalidatesSubtreeCaches)
   grandchild.setLocalTransform(T_grand);
 
   auto& registry = world.getRegistry();
-  auto childEntity = child.getEntity();
-  auto grandEntity = grandchild.getEntity();
+  auto childEntity = dart::simulation::experimental::detail::toRegistryEntity(
+      child.getEntity());
+  auto grandEntity = dart::simulation::experimental::detail::toRegistryEntity(
+      grandchild.getEntity());
 
   // Prime caches
   [[maybe_unused]] auto grandWorld = grandchild.getTransform();
@@ -259,7 +264,8 @@ TEST(Frame, FixedFrameCaching)
 
   // Check that cache is clean after query
   auto& registry = world.getRegistry();
-  auto entity = fixedFrame.getEntity();
+  auto entity = dart::simulation::experimental::detail::toRegistryEntity(
+      fixedFrame.getEntity());
   {
     const auto& cache = registry.get<comps::FrameCache>(entity);
     EXPECT_FALSE(cache.needTransformUpdate)
@@ -284,7 +290,8 @@ TEST(Frame, FixedFrameCacheInvalidation)
   [[maybe_unused]] auto T_cached = fixedFrame.getTransform();
 
   auto& registry = world.getRegistry();
-  auto entity = fixedFrame.getEntity();
+  auto entity = dart::simulation::experimental::detail::toRegistryEntity(
+      fixedFrame.getEntity());
   {
     const auto& cache = registry.get<comps::FrameCache>(entity);
     EXPECT_FALSE(cache.needTransformUpdate) << "Cache should be clean";

--- a/tests/unit/simulation/experimental/world/test_serialization.cpp
+++ b/tests/unit/simulation/experimental/world/test_serialization.cpp
@@ -502,7 +502,9 @@ TEST(Serialization, LoadsLegacyV8LinkRecord)
   Eigen::Matrix<double, 6, 1> externalForce;
   externalForce << 1.0, -2.0, 3.0, -4.0, 5.0, -6.0;
 
-  auto& linkComp = world1.getRegistry().get<comps::Link>(link.getEntity());
+  auto& linkComp = world1.getRegistry().get<comps::Link>(
+      dart::simulation::experimental::detail::toRegistryEntity(
+          link.getEntity()));
   linkComp.transformFromParentToJoint = unsavedParentToJoint;
   linkComp.transformFromParentJoint = legacyJointToLink;
   linkComp.worldTransform = worldTransform;
@@ -519,8 +521,9 @@ TEST(Serialization, LoadsLegacyV8LinkRecord)
   auto linkRestored = mbRestored->getLink("link");
   ASSERT_TRUE(linkRestored.has_value());
 
-  const auto& restoredLinkComp
-      = world2.getRegistry().get<comps::Link>(linkRestored->getEntity());
+  const auto& restoredLinkComp = world2.getRegistry().get<comps::Link>(
+      dart::simulation::experimental::detail::toRegistryEntity(
+          linkRestored->getEntity()));
   EXPECT_TRUE(restoredLinkComp.transformFromParentToJoint.isApprox(
       Eigen::Isometry3d::Identity()));
   EXPECT_TRUE(
@@ -537,8 +540,9 @@ TEST(Serialization, LoadsLegacyV8LinkRecord)
 
   auto baseRestored = mbRestored->getLink("base");
   ASSERT_TRUE(baseRestored.has_value());
-  const auto& restoredBaseComp
-      = world2.getRegistry().get<comps::Link>(baseRestored->getEntity());
+  const auto& restoredBaseComp = world2.getRegistry().get<comps::Link>(
+      dart::simulation::experimental::detail::toRegistryEntity(
+          baseRestored->getEntity()));
   ASSERT_EQ(restoredBaseComp.childJoints.size(), 1u);
   EXPECT_EQ(
       restoredBaseComp.childJoints.front(),
@@ -1232,7 +1236,8 @@ TEST(Serialization, CacheNotSerialized)
   // Verify cache is clean
   {
     auto& registry = world.getRegistry();
-    auto entity = frame.getEntity();
+    auto entity = dart::simulation::experimental::detail::toRegistryEntity(
+        frame.getEntity());
     ASSERT_TRUE(registry.valid(entity)) << "Entity should be valid";
     ASSERT_TRUE(
         registry.all_of<dart::simulation::experimental::comps::FrameCache>(
@@ -1557,7 +1562,8 @@ TEST(Serialization, CloneResetCounters)
   const auto& nextFrameName
       = cloneReg
             .get<dart::simulation::experimental::comps::Name>(
-                nextFrame.getEntity())
+                dart::simulation::experimental::detail::toRegistryEntity(
+                    nextFrame.getEntity()))
             .name;
   EXPECT_EQ(nextFrameName, "free_frame_003");
 

--- a/tests/unit/simulation/experimental/world/test_unified_constraint_stage.cpp
+++ b/tests/unit/simulation/experimental/world/test_unified_constraint_stage.cpp
@@ -14,6 +14,7 @@
 #include <dart/simulation/experimental/comps/dynamics.hpp>
 #include <dart/simulation/experimental/compute/multibody_dynamics.hpp>
 #include <dart/simulation/experimental/compute/sequential_executor.hpp>
+#include <dart/simulation/experimental/detail/entity_conversion.hpp>
 #include <dart/simulation/experimental/world.hpp>
 
 #include <gtest/gtest.h>
@@ -52,7 +53,11 @@ TEST(UnifiedConstraintStage, ArrestsAndSeparatesOverlappingRigidContact)
   ASSERT_FALSE(world.collide().empty());
   auto& registry = world.getRegistry();
   const double verticalBefore
-      = registry.get<sx::comps::Transform>(ball.getEntity()).position.z();
+      = registry
+            .get<sx::comps::Transform>(
+                dart::simulation::experimental::detail::toRegistryEntity(
+                    ball.getEntity()))
+            .position.z();
 
   sx::compute::UnifiedConstraintStage stage;
   sx::compute::SequentialExecutor executor;
@@ -60,12 +65,20 @@ TEST(UnifiedConstraintStage, ArrestsAndSeparatesOverlappingRigidContact)
 
   // No restitution: the approaching normal velocity is driven to zero.
   EXPECT_NEAR(
-      registry.get<sx::comps::Velocity>(ball.getEntity()).linear.z(),
+      registry
+          .get<sx::comps::Velocity>(
+              dart::simulation::experimental::detail::toRegistryEntity(
+                  ball.getEntity()))
+          .linear.z(),
       0.0,
       1e-9);
   // The positional projection pushes the penetrating sphere upward.
   EXPECT_GT(
-      registry.get<sx::comps::Transform>(ball.getEntity()).position.z(),
+      registry
+          .get<sx::comps::Transform>(
+              dart::simulation::experimental::detail::toRegistryEntity(
+                  ball.getEntity()))
+          .position.z(),
       verticalBefore);
 }
 
@@ -89,7 +102,9 @@ TEST(UnifiedConstraintStage, LeavesContactFreeBodiesUntouched)
   stage.execute(world, executor);
 
   EXPECT_TRUE(world.getRegistry()
-                  .get<sx::comps::Velocity>(body.getEntity())
+                  .get<sx::comps::Velocity>(
+                      dart::simulation::experimental::detail::toRegistryEntity(
+                          body.getEntity()))
                   .linear.isApprox(Eigen::Vector3d(1.0, -2.0, 3.0), 1e-12));
 }
 

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -756,9 +756,15 @@ TEST(World, SyncKinematicsRefreshesFrameHierarchy)
   world.enterSimulationMode();
 
   auto& registry = world.getRegistry();
-  EXPECT_FALSE(registry.get<sx::comps::FrameCache>(parent.getEntity())
+  EXPECT_FALSE(registry
+                   .get<sx::comps::FrameCache>(
+                       dart::simulation::experimental::detail::toRegistryEntity(
+                           parent.getEntity()))
                    .needTransformUpdate);
-  EXPECT_FALSE(registry.get<sx::comps::FrameCache>(child.getEntity())
+  EXPECT_FALSE(registry
+                   .get<sx::comps::FrameCache>(
+                       dart::simulation::experimental::detail::toRegistryEntity(
+                           child.getEntity()))
                    .needTransformUpdate);
   EXPECT_TRUE(child.getTransform().isApprox(parentTransform * childOffset));
 
@@ -768,9 +774,15 @@ TEST(World, SyncKinematicsRefreshesFrameHierarchy)
 
   world.sync(sx::WorldSyncStage::Kinematics);
 
-  EXPECT_FALSE(registry.get<sx::comps::FrameCache>(parent.getEntity())
+  EXPECT_FALSE(registry
+                   .get<sx::comps::FrameCache>(
+                       dart::simulation::experimental::detail::toRegistryEntity(
+                           parent.getEntity()))
                    .needTransformUpdate);
-  EXPECT_FALSE(registry.get<sx::comps::FrameCache>(child.getEntity())
+  EXPECT_FALSE(registry
+                   .get<sx::comps::FrameCache>(
+                       dart::simulation::experimental::detail::toRegistryEntity(
+                           child.getEntity()))
                    .needTransformUpdate);
   EXPECT_TRUE(
       child.getTransform().isApprox(updatedParentTransform * childOffset));
@@ -909,9 +921,15 @@ TEST(World, FrameReadsRefreshDescendantsAfterParentLocalTransformChange)
   parent.setLocalTransform(updatedParentTransform);
 
   auto& registry = world.getRegistry();
-  EXPECT_TRUE(registry.get<sx::comps::FrameCache>(parent.getEntity())
+  EXPECT_TRUE(registry
+                  .get<sx::comps::FrameCache>(
+                      dart::simulation::experimental::detail::toRegistryEntity(
+                          parent.getEntity()))
                   .needTransformUpdate);
-  EXPECT_TRUE(registry.get<sx::comps::FrameCache>(child.getEntity())
+  EXPECT_TRUE(registry
+                  .get<sx::comps::FrameCache>(
+                      dart::simulation::experimental::detail::toRegistryEntity(
+                          child.getEntity()))
                   .needTransformUpdate);
   EXPECT_TRUE(
       child.getTransform().isApprox(updatedParentTransform * childOffset));
@@ -943,9 +961,15 @@ TEST(World, StepRefreshesFrameHierarchy)
   EXPECT_TRUE(world.isSimulationMode());
 
   auto& registry = world.getRegistry();
-  EXPECT_FALSE(registry.get<sx::comps::FrameCache>(parent.getEntity())
+  EXPECT_FALSE(registry
+                   .get<sx::comps::FrameCache>(
+                       dart::simulation::experimental::detail::toRegistryEntity(
+                           parent.getEntity()))
                    .needTransformUpdate);
-  EXPECT_FALSE(registry.get<sx::comps::FrameCache>(child.getEntity())
+  EXPECT_FALSE(registry
+                   .get<sx::comps::FrameCache>(
+                       dart::simulation::experimental::detail::toRegistryEntity(
+                           child.getEntity()))
                    .needTransformUpdate);
   EXPECT_TRUE(
       child.getTransform().isApprox(updatedParentTransform * childOffset));
@@ -3783,15 +3807,10 @@ TEST(World, RigidBodyContactIgnoresStoredStaticVelocity)
   ASSERT_FALSE(contacts.empty());
   const auto& contact = contacts.front();
   constexpr double staticSpeed = 5.0;
-  if (contact.bodyA.getEntity()
-      == dart::simulation::experimental::detail::fromRegistryEntity(
-          obstacle.getEntity())) {
+  if (contact.bodyA.getEntity() == obstacle.getEntity()) {
     obstacle.setLinearVelocity(staticSpeed * contact.normal);
   } else {
-    ASSERT_EQ(
-        contact.bodyB.getEntity(),
-        dart::simulation::experimental::detail::fromRegistryEntity(
-            obstacle.getEntity()));
+    ASSERT_EQ(contact.bodyB.getEntity(), obstacle.getEntity());
     obstacle.setLinearVelocity(-staticSpeed * contact.normal);
   }
 
@@ -4485,12 +4504,14 @@ TEST(World, RigidIpcContactStageSkipsInvalidRuntimeGeometry)
       {Eigen::Vector3i(0, 1, 2)});
 
   auto& registry = world.getRegistry();
+  const auto& toReg = dart::simulation::experimental::detail::toRegistryEntity;
   registry.emplace_or_replace<sx::comps::CollisionGeometry>(
-      invalidBox.getEntity(), sx::comps::CollisionGeometry{{box}});
+      toReg(invalidBox.getEntity()), sx::comps::CollisionGeometry{{box}});
   registry.emplace_or_replace<sx::comps::CollisionGeometry>(
-      invalidMesh.getEntity(), sx::comps::CollisionGeometry{{mesh}});
+      toReg(invalidMesh.getEntity()), sx::comps::CollisionGeometry{{mesh}});
   registry.emplace_or_replace<sx::comps::CollisionGeometry>(
-      nonFiniteMesh.getEntity(), sx::comps::CollisionGeometry{{nonFinite}});
+      toReg(nonFiniteMesh.getEntity()),
+      sx::comps::CollisionGeometry{{nonFinite}});
 
   sx::compute::SequentialExecutor executor;
   sx::compute::RigidIpcContactStage ipcStage;


### PR DESCRIPTION
## Summary

- Removes `EntityObjectWith<...comps...>` public inheritance from `Frame`, `FreeFrame`, and `FixedFrame`
- Replaces with a minimal non-template base storing an opaque `Entity` token and `World*`
- All registry access moved to `.cpp` files via the internal `detail::toRegistryEntity()` seam
- Promotion-surface audit: **26/27 headers clean**, only `world.hpp` remains (U-WS5-WORLD scope)

## Motivation / Problem

The `Frame` hierarchy leaked ECS internals through three paths in the public headers: `EntityObjectWith<TagComps<comps::FrameTag>, ...>` base naming component types, `entt::entity` in constructor signatures, and transitive `entt`/`comps` includes. This was the keystone blocker per the audit (8 transitive leaks, all flowing through `frame.hpp`).

## Changes / Key Changes

- `frame/frame.hpp`: `Frame` is now a plain class (no template base); `m_entity` is `Entity`, `getEntity()` returns `Entity`, `isWorld()` is non-inline
- `frame/free_frame.hpp` / `frame/fixed_frame.hpp`: second `EntityObjectWith<>` base removed
- `frame/frame.cpp`, `free_frame.cpp`, `fixed_frame.cpp`: all registry access via `detail::toRegistryEntity(m_entity)`
- `body/rigid_body.cpp`, `multibody/link.cpp`: `Frame(entity, world)` init updated; `getEntity()` wrapped at each registry call site
- `world.cpp`, `multibody/multibody.cpp`, `multibody/joint.cpp`, `constraint/loop_closure.cpp`, `io/skeleton_loader.cpp`: callers updated
- Internal tests updated to use `detail::toRegistryEntity()` at registry call sites
- `docs/onboarding/api-boundary-inventory.md` regenerated

## Testing

- `pixi run build-simulation-experimental-tests` — clean
- `ctest -L simulation-experimental` — **59/59 passed**
- `pixi run audit-dart7-promotion-surface` — 26 clean, 1 leaking (world.hpp only)
- `pixi run check-api-boundaries` — passed
- `pixi run lint` — passed
- `pixi run update-api-boundary-inventory` — run and committed

## Breaking Changes

- [x] Internal API change: `Frame::getEntity()` now returns `Entity` (opaque token) instead of `entt::entity`. Internal code that needs the registry entity must call `detail::toRegistryEntity(frame.getEntity())`.

## Related Issues / PRs (backports)

- Stacks on #2844 (PLAN-041 WS1/WS5 facade prep — audit + Entity seam)
- Part of PLAN-041 Track C (U-WS5-BASE); unblocks U-WS5-WORLD

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable

@codex review