### PR TITLE
Document scalar precision deferral plan

### DIFF
--- a/docs/design/simulation_experimental_cpp_api.md
+++ b/docs/design/simulation_experimental_cpp_api.md
@@ -96,6 +96,40 @@ benchmark reports, or developer docs. They should not become required public
 type names, solver names, namespace names, or object identities unless a later
 design promotes a backend API intentionally.
 
+### Scalar Precision Policy
+
+The DART 7 promotion path should treat the current `World` facade as
+double-precision unless a later scalar-instantiation plan proves otherwise.
+Public scalar-type support is lower priority than getting the DART 7
+rigid-body and multibody simulation stack into good shape for humanoid
+locomotion and manipulation. Until that baseline is strong, scalar precision is
+a deferred design track, not a release-blocking API feature.
+
+The existing scalar-generic compute lessons remain useful for internal kernels,
+SIMD, autodiff experiments, and future explicit instantiations, but they are not
+themselves a public `World` precision contract. Keep those internal choices
+non-one-way-door where reasonable: avoid hard-coding storage, handle, package,
+or boundary decisions that would make a future scalar-instantiation plan
+unnecessarily invasive, but do not spend DART 7 promotion effort on public
+scalar families before the locomotion/manipulation baseline is ready.
+
+Do not promote scalar precision by forking the user-facing `World` identity or
+by making backend/runtime precision names part of the required public type name.
+A later public scalar-precision design must first define:
+
+- concrete C++ instantiation ownership for `World`, options, handles, state,
+  derivative, serialization, and package/export symbols;
+- finite-difference, determinism, collision, Python, and installed-package
+  gates for every advertised scalar;
+- migration behavior for existing double-backed code; and
+- API-boundary checks proving no solver, backend, ECS, or tensor-framework
+  implementation type leaks into promoted headers.
+
+Until those gates exist, scalar-generic rewrites should instantiate only the
+supported public scalar and keep alternate precision or autodiff scalar choices
+behind internal tests, benchmarks, or explicitly experimental developer
+surfaces.
+
 ### One World, Multiple Runtime Intents
 
 The same `World` should support full physics and kinematics-only workflows.

--- a/docs/design/simulation_experimental_cpp_api.md
+++ b/docs/design/simulation_experimental_cpp_api.md
@@ -98,20 +98,15 @@ design promotes a backend API intentionally.
 
 ### Scalar Precision Policy
 
-The DART 7 promotion path should treat the current `World` facade as
-double-precision unless a later scalar-instantiation plan proves otherwise.
-Public scalar-type support is lower priority than getting the DART 7
-rigid-body and multibody simulation stack into good shape for humanoid
-locomotion and manipulation. Until that baseline is strong, scalar precision is
-a deferred design track, not a release-blocking API feature.
+The current `World` facade should remain double-precision unless a later
+scalar-instantiation design proves otherwise. The existing scalar-generic
+compute lessons remain useful for internal kernels, SIMD, autodiff experiments,
+and future explicit instantiations, but they are not themselves a public
+`World` precision contract.
 
-The existing scalar-generic compute lessons remain useful for internal kernels,
-SIMD, autodiff experiments, and future explicit instantiations, but they are not
-themselves a public `World` precision contract. Keep those internal choices
-non-one-way-door where reasonable: avoid hard-coding storage, handle, package,
-or boundary decisions that would make a future scalar-instantiation plan
-unnecessarily invasive, but do not spend DART 7 promotion effort on public
-scalar families before the locomotion/manipulation baseline is ready.
+Keep scalar-generic internals from becoming a one-way door where reasonable:
+avoid hard-coding storage, handle, package, or boundary decisions that would
+make a future scalar-instantiation plan unnecessarily invasive.
 
 Do not promote scalar precision by forking the user-facing `World` identity or
 by making backend/runtime precision names part of the required public type name.

--- a/docs/design/simulation_experimental_python_api.md
+++ b/docs/design/simulation_experimental_python_api.md
@@ -138,18 +138,17 @@ Adding a backend should be an implementation improvement, not an API fork.
 
 ### World Scalar Precision
 
-For DART 7 promotion, `sx.World()` and `sx.World(time_step=...)` remain the
-double-backed public path. Do not add a public precision selector until the C++
-core, bindings, stubs, serialization, collision, differentiability, and package
-gates can prove that every advertised scalar is real end to end. Public scalar
-type support is deferred until the DART 7 rigid-body and multibody simulation
-stack is in good shape for humanoid locomotion and manipulation; precision
-syntax should not distract from that baseline.
+`sx.World()` and `sx.World(time_step=...)` remain the double-backed public path
+unless a later scalar-instantiation design proves otherwise. Do not add a public
+precision selector until the C++ core, bindings, stubs, serialization,
+collision, differentiability, and package gates can prove that every advertised
+scalar is real end to end.
 
-While deferred, keep the API shape from becoming a one-way door. Avoid binding,
-stub, serialization, and package decisions that would make later scalar support
-unnecessarily invasive, but keep the user-facing path simple and double-backed
-until a dedicated scalar-instantiation plan starts.
+Keep the API shape from becoming a one-way door. Avoid binding, stub,
+serialization, and package decisions that would make later scalar support
+unnecessarily invasive, while keeping the user-facing path simple and
+double-backed until a dedicated scalar-instantiation design changes the public
+contract.
 
 If scalar precision becomes public later, prefer constructor or options syntax:
 

--- a/docs/design/simulation_experimental_python_api.md
+++ b/docs/design/simulation_experimental_python_api.md
@@ -136,6 +136,51 @@ should configure physics intent, algorithm family, accuracy/performance policy,
 and fallback behavior through DART-owned value objects and capability queries.
 Adding a backend should be an implementation improvement, not an API fork.
 
+### World Scalar Precision
+
+For DART 7 promotion, `sx.World()` and `sx.World(time_step=...)` remain the
+double-backed public path. Do not add a public precision selector until the C++
+core, bindings, stubs, serialization, collision, differentiability, and package
+gates can prove that every advertised scalar is real end to end. Public scalar
+type support is deferred until the DART 7 rigid-body and multibody simulation
+stack is in good shape for humanoid locomotion and manipulation; precision
+syntax should not distract from that baseline.
+
+While deferred, keep the API shape from becoming a one-way door. Avoid binding,
+stub, serialization, and package decisions that would make later scalar support
+unnecessarily invasive, but keep the user-facing path simple and double-backed
+until a dedicated scalar-instantiation plan starts.
+
+If scalar precision becomes public later, prefer constructor or options syntax:
+
+```python
+world = sx.World(dtype=sx.float64)
+```
+
+or the equivalent `sx.WorldOptions(dtype=...)` spelling once `WorldOptions`
+itself is part of the Python facade. This keeps the common construction path
+Pythonic, discoverable in signatures, and aligned with array/tensor conventions.
+The binding may still dispatch to concrete scalar-specific implementation
+classes underneath; `dtype=` is a public factory contract, not a requirement
+that nanobind represent every scalar as one runtime C++ class.
+
+Do not make `sx.World[sx.float64]` the primary runtime construction API. Class
+subscription reads like typing/generic specialization in Python and would make
+precision part of public `World` identity before DART has committed to a scalar
+type family. If maintainers later need scalar-specialized aliases for advanced
+users or type checkers, they should be secondary to `dtype=` and covered by the
+same identity, `isinstance`, stub, and migration tests.
+
+Any future `dtype` contract must be explicit:
+
+- default to `sx.float64` and expose a read-only `world.dtype`;
+- accept only documented DART or NumPy-compatible dtype tokens;
+- reject mixed-world operations and mismatched caller-provided output buffers
+  unless an explicit conversion API exists;
+- guarantee state, control, rollout, derivative, and bridge array dtypes; and
+- reject unsupported dtypes with clear errors instead of silently computing in
+  double and casting results.
+
 ### One World, Multiple Runtime Intents
 
 The same `World` should support full physics and kinematics-only workflows.

--- a/docs/plans/041-official-simulation-api-promotion.md
+++ b/docs/plans/041-official-simulation-api-promotion.md
@@ -68,13 +68,28 @@ The plan incorporates three focused review perspectives before implementation:
   old `DART_BUILD_SIMULATION_EXPERIMENTAL` option or require a
   `simulation-experimental` target to link. Keep reduced-build and package smoke
   tests in the gate while the old option still exists.
+- **Scalar precision**: DART 7 promotion keeps the public `World` facade
+  double-backed. Public scalar-type support is deferred until the promoted
+  rigid-body and multibody stack is in good shape for humanoid locomotion and
+  manipulation. The promotion work should keep scalar support from becoming a
+  one-way door by avoiding unnecessary storage, handle, package, and API-boundary
+  commitments, but it should not add `sx.World(dtype=...)` or
+  `sx.World[...]` during promotion unless a dedicated scalar-instantiation plan
+  proves C++ ownership, bindings, stubs, serialization, collision,
+  differentiability, and package gates for every advertised scalar. If that
+  future plan makes precision public, the primary Python construction spelling
+  is `sx.World(dtype=sx.float64)` (or `WorldOptions(dtype=...)`) with concrete
+  scalar-specific implementation classes underneath as needed;
+  `sx.World[sx.float64]` is not the common runtime API.
 
 ## Workstreams
 
 1. **Promotion contract and readiness audit** - freeze the initial supported
    public subset, record the headers/modules to promote, list public-looking
-   internals to hide, and map parity evidence that blocks the promotion claim.
-   This step edits docs and boundary inventories; it does not move source files.
+   internals to hide, map parity evidence that blocks the promotion claim, and
+   record the scalar-precision policy from the simulation experimental API
+   design docs. This step edits docs and boundary inventories; it does not move
+   source files.
 2. **Build and package shape** - choose the final target/component/export-macro
    shape before the first promoted API PR. Make the official baseline API
    non-optional in default builds, update install/export rules, and add package
@@ -137,6 +152,11 @@ Open maintainer decisions before implementation:
   (recommended) versus a deprecate-then-remove transition.
 - Confirm the classic-world quarantine target name and that it stops exporting
   `dart::simulation::World`, or remove the classic implementation outright.
+- Confirm no public scalar-precision selector is added during DART 7 promotion.
+  A later scalar-instantiation plan may reopen precision after the DART 7
+  rigid-body and multibody baseline is ready for humanoid locomotion and
+  manipulation, but must keep the promoted `World` identity stable and prove its
+  own scalar-specific gates first.
 
 Current intended sequence:
 
@@ -229,6 +249,13 @@ Review these before implementation PRs:
 - The top-level `dartpy.World` decision is explicit: removed, deprecated, or
   identical to `dartpy.simulation.World`, with tests, stubs, docs, and wheel
   import smokes covering the chosen behavior.
+- The promoted DART 7 `World` API is documented as double-backed. No
+  `sx.World(dtype=...)`, `sx.World[...]`, scalar-specific `World` aliases, or
+  public C++ scalar-template facade is shipped unless a separate
+  scalar-instantiation plan supplies concrete ownership, dtype, identity,
+  serialization, collision, differentiability, package, and migration gates
+  after the DART 7 rigid-body and multibody locomotion/manipulation baseline is
+  strong enough to make scalar precision the next bounded design priority.
 - If migration aliases exist, the compatibility matrix covers
   `import dartpy.simulation`, `import dartpy.simulation_experimental`,
   `from dartpy import simulation_experimental as sx`, `sx.diff`, and

--- a/docs/plans/110-differentiable-simulation.md
+++ b/docs/plans/110-differentiable-simulation.md
@@ -27,6 +27,8 @@
   - `compute_backend_research.md` recorded differentiability as _deferred_ with an
     explicit promotion question; this plan answers it (analytic method committed
     for contact; autodiff-scalar templating reserved for smooth terms only).
+    Public scalar precision selection remains out of scope for this plan and is
+    governed by the simulation experimental API design docs plus PLAN-041.
   - Forward-pass ingredients DART already owns: boxed-LCP library `dart/math/lcp/`
     (`LcpResult LcpSolver::solve(const LcpProblem&, VectorXd& x, const LcpOptions&)`),
     articulated-body dynamics `compute/multibody_dynamics.*` (`M, C, g`, link
@@ -132,6 +134,16 @@ system-identification example programs, the torch-autograd end-to-end test (need
 torch in-env), a `DART_BUILD_DIFF` CI job, and minor robustness/coverage items —
 tracked in `docs/dev_tasks/differentiable_simulation/`.
 
+This plan must not add a public `World` precision selector as a differentiability
+shortcut. Autodiff-scalar templating may remain an internal smooth-term or spike
+mechanism, but public `sx.World(dtype=...)`, `sx.World[...]`, or scalar-specific
+`World` aliases belong to a separate scalar-instantiation plan with its own API,
+binding, serialization, collision, determinism, and package gates. That separate
+plan should wait until the DART 7 rigid-body and multibody stack is already in
+good shape for humanoid locomotion and manipulation; PLAN-110 may keep internal
+scalar-generic seams open, but should not turn them into a user-facing precision
+family.
+
 ## Acceptance Criteria
 
 - Each workstream lands as small verifiable slices with focused tests; gap-audit
@@ -164,6 +176,10 @@ tracked in `docs/dev_tasks/differentiable_simulation/`.
   or a tensor framework in the C++ core; `pixi run check-api-boundaries` stays
   green. Owner commands per slice: `pixi run lint`, `pixi run build` (diff on/off),
   the focused C++ FD/parity tests, `check-api-boundaries`, `pixi run test-py`.
+- The differentiability surface does not imply a public scalar-specialized
+  `World` family. Any future scalar precision API is planned and gated outside
+  PLAN-110 after the rigid-body and multibody locomotion/manipulation baseline
+  is ready, before it reaches user-facing C++ or Python names.
 - Gradient-correctness limits (mode-switch/limit subgradients, elastic
   approximation) are documented; saddle-escape and pre-contact surrogates are
   opt-in only.

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -487,12 +487,21 @@ its own line so status updates remain git-history friendly.
 - Dimension: Release transition
 - Next step: Land the reviewed promotion contract, then start the readiness
   audit and package-facade work before any broad `experimental/` source-tree
-  move. The intended path is DART 7 official API promotion, not a DART 8 middle
-  step.
+  move. The readiness audit must keep the promoted `World` double-backed and
+  explicitly defer public scalar precision selectors (`sx.World(dtype=...)`,
+  `sx.World[...]`, scalar-specific aliases, or a public C++ scalar-template
+  facade) until DART 7 rigid-body and multibody simulation is in good shape for
+  humanoid locomotion and manipulation and a separate scalar-instantiation plan
+  proves the required ownership, binding, serialization, collision,
+  differentiability, package, and migration gates. Keep implementation choices
+  from becoming a one-way door for future scalar support where this is cheap,
+  but do not spend the promotion cycle on public scalar families. The intended
+  path is DART 7 official API promotion, not a DART 8 middle step.
 - Gate: The planning PR passes the docs-only gates; implementation PRs must keep
   API-boundary checks, C++/Python tests, package/export smokes, and CUDA/full
   gates green according to the touched scope. The promoted public API must hide
-  ECS, component, solver-registry, backend, and implementation-folder details.
+  ECS, component, solver-registry, backend, implementation-folder, tensor
+  framework, and unplanned scalar-instantiation details.
 
 ### PLAN-050: Experimental World Split
 


### PR DESCRIPTION
## Summary

- Documents that public scalar type support for the experimental `World` is deferred until DART 7 rigid-body and multibody simulation is in good shape for humanoid locomotion and manipulation.
- Records the future API direction: keep the promoted `World` double-backed now; if precision becomes public later, prefer `sx.World(dtype=...)` / `WorldOptions(dtype=...)` over `sx.World[...]` as the primary Python construction surface.
- Adds plan gates so PLAN-041 and PLAN-110 keep scalar support from becoming a one-way door without making it a DART 7 promotion blocker.

## Motivation / Problem

- The scalar-precision decision needs to live in durable owner docs, not only in discussion context.
- DART 7 promotion should focus on getting the rigid-body and multibody baseline ready for humanoid locomotion and manipulation before adding public scalar-family API surface.
- Future scalar support still needs to remain feasible, so the docs now call out storage, handle, binding, serialization, package, and API-boundary choices that should not become accidental blockers.

## Changes / Key Changes

- Adds a C++ scalar precision policy to `docs/design/simulation_experimental_cpp_api.md`.
- Adds a Python `World` scalar precision policy to `docs/design/simulation_experimental_python_api.md`.
- Updates PLAN-041 with scalar precision deferral, open-decision, and acceptance-gate language.
- Updates PLAN-110 to prevent differentiability work from becoming a backdoor public scalar-`World` API.
- Updates the plan dashboard so the active PLAN-041 next step carries the deferral priority and non-one-way-door constraint.

## Testing

- `pixi run lint-md`
- `pixi run check-lint-md`
- `pixi run check-docs-policy`
- `pixi run check-lint-spell`
- `git diff --check`
- `pixi run lint`

## Breaking Changes

- [x] None
- Docs-only planning update; no code, package, or public API behavior changed.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (N/A: docs-only planning update)
- [x] Add unit tests for new functionality (N/A: no code or behavior change)
- [x] Document new methods and classes (N/A: no new methods or classes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no binding change)
