### PR TITLE
Reset stale CMake compiler cache before CUDA py-demos configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,9 @@ py-demos` now builds a CUDA-enabled dartpy + Filament GUI and offloads the
     flags and a `DART_PY_DEMOS_GPU` env override (default `auto`: on when a CUDA
     device is present), an in-viewer GPU toggle panel, and a startup status
     line. The `config-py` build task forwards the experimental CUDA opt-in so
-    the lean compute-only `build-cuda`/`test-cuda` paths are unaffected.
+    the lean compute-only `build-cuda`/`test-cuda` paths are unaffected, and it
+    resets stale CMake compiler cache metadata before CMake can auto-rerun with
+    default options and drop the `dartpy` target.
   - Made `dart::gui` UI scaling DPI-aware: `--gui-scale` now acts as a manual
     user multiplier on top of GLFW content-scale detection, `DART_GUI_DPI_SCALE`
     can override misreported DPI, implicit interactive app windows now use a

--- a/pixi.toml
+++ b/pixi.toml
@@ -754,6 +754,31 @@ if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ]; then
   # only); override with DART_CUDA_HOST_LIBDIR if your distro differs.
   DART_CUDA_HOST_LIBDIR_VALUE=${DART_CUDA_HOST_LIBDIR:-/usr/lib/x86_64-linux-gnu}
   export LDFLAGS="-L${DART_CUDA_HOST_LIBDIR_VALUE} ${LDFLAGS:-}"
+  CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/${BUILD_DIR_NAME}
+  CMAKE_CACHE=${CMAKE_BUILD_DIR}/CMakeCache.txt
+  if [ -f "${CMAKE_CACHE}" ]; then
+    cached_c_compiler=
+    cached_cxx_compiler=
+    cached_cuda_compiler=
+    cached_cuda_host_compiler=
+    while IFS='=' read -r cache_key cache_value; do
+      case "${cache_key}" in
+        CMAKE_C_COMPILER:*) cached_c_compiler=${cache_value} ;;
+        CMAKE_CXX_COMPILER:*) cached_cxx_compiler=${cache_value} ;;
+        CMAKE_CUDA_COMPILER:*) cached_cuda_compiler=${cache_value} ;;
+        CMAKE_CUDA_HOST_COMPILER:*) cached_cuda_host_compiler=${cache_value} ;;
+      esac
+    done < "${CMAKE_CACHE}"
+    if [ "${cached_c_compiler}" != "${DART_CUDA_HOST_CC_VALUE}" ] \
+      || [ "${cached_cxx_compiler}" != "${DART_CUDA_HOST_CXX_VALUE}" ] \
+      || [ "${cached_cuda_compiler}" != "${CONDA_PREFIX}/bin/nvcc" ] \
+      || { [ -n "${cached_cuda_host_compiler}" ] \
+        && [ "${cached_cuda_host_compiler}" != "${DART_CUDA_HOST_CXX_VALUE}" ]; }; then
+      echo "CMake compiler cache changed for ${CMAKE_BUILD_DIR}; resetting cache metadata."
+      rm -f "${CMAKE_CACHE}"
+      rm -rf "${CMAKE_BUILD_DIR}/CMakeFiles"
+    fi
+  fi
 fi
 DART_BUILD_COLLISION_REFERENCE_TESTS_VALUE=${DART_BUILD_COLLISION_REFERENCE_TESTS_OVERRIDE:-OFF}
 DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_VALUE=${DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_OVERRIDE:-OFF}

--- a/python/tests/unit/test_pixi_cuda_py_demos_task.py
+++ b/python/tests/unit/test_pixi_cuda_py_demos_task.py
@@ -1,0 +1,65 @@
+"""Regression checks for the CUDA py-demos Pixi build path."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PIXI = ROOT / "pixi.toml"
+
+
+def _tasks() -> dict:
+    return tomllib.loads(PIXI.read_text(encoding="utf-8"))["tasks"]
+
+
+def _task_script(task_name: str) -> str:
+    task = _tasks()[task_name]
+    return "\n".join(str(part) for part in task["cmd"])
+
+
+def test_config_py_honors_dartpy_on_for_cuda_py_demos() -> None:
+    script = _task_script("config-py")
+
+    assert (
+        'if [ "${DART_BUILD_DARTPY_VALUE}" = "OFF" ] '
+        '&& [ "{{ dartpy }}" = "ON" ]; then'
+    ) in script
+    assert "DART_BUILD_DARTPY_VALUE=ON" in script
+
+
+def test_config_py_resets_stale_cuda_compiler_cache_before_cmake() -> None:
+    script = _task_script("config-py")
+
+    reset_index = script.index("CMake compiler cache changed")
+    cmake_index = script.index("cmake -G Ninja")
+    assert reset_index < cmake_index
+
+    assert "CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/${BUILD_DIR_NAME}" in script
+    assert "CMAKE_C_COMPILER:*)" in script
+    assert "CMAKE_CXX_COMPILER:*)" in script
+    assert "CMAKE_CUDA_COMPILER:*)" in script
+    assert "CMAKE_CUDA_HOST_COMPILER:*)" in script
+    assert 'rm -f "${CMAKE_CACHE}"' in script
+    assert 'rm -rf "${CMAKE_BUILD_DIR}/CMakeFiles"' in script
+
+
+def test_py_demos_depends_on_docking_dartpy_build() -> None:
+    tasks = _tasks()
+
+    assert tasks["py-demos"]["depends-on"] == ["build-py-dev-docking"]
+
+    build_task = tasks["build-py-dev-docking"]
+    defaults = {arg["arg"]: arg["default"] for arg in build_task["args"]}
+    assert defaults["dartpy"] == "ON"
+    assert defaults["build_dir"] == "Release-docking"
+
+    config_dependency = build_task["depends-on"][0]
+    assert config_dependency["task"] == "config-py"
+    assert config_dependency["args"] == [
+        "{{ dartpy }}",
+        "{{ build_type }}",
+        "OFF",
+        "{{ build_dir }}",
+    ]


### PR DESCRIPTION
## Summary

Fixes the CUDA-enabled `pixi run -e cuda py-demos` build so it doesn't silently lose the `dartpy` target when a build directory was previously configured with different compilers.

The `config-py` task pins the host and CUDA compilers for the CUDA build (system `cc`/`c++` for the Filament GUI link, conda `nvcc` for CUDA). When the target build directory already holds a `CMakeCache.txt` from an earlier configure that used different compilers, CMake refuses to change the compiler in place and **silently re-runs with default options**, dropping `DART_BUILD_DARTPY` — so the demos can no longer import `dartpy`.

This adds a guard in the CUDA branch of `config-py` that, before invoking `cmake`:
- reads the cached `CMAKE_C_COMPILER` / `CMAKE_CXX_COMPILER` / `CMAKE_CUDA_COMPILER` / `CMAKE_CUDA_HOST_COMPILER` from `CMakeCache.txt`,
- compares them against the pinned CUDA host toolchain, and
- removes the stale `CMakeCache.txt` and `CMakeFiles/` when they diverge, so the reconfigure adopts the pinned compilers and keeps the `dartpy` target.

Scoped entirely to the CUDA opt-in (`DART_ENABLE_EXPERIMENTAL_CUDA_VALUE = ON`); the default and lean compute-only `build-cuda`/`test-cuda` paths are untouched.

## Changes

- `pixi.toml` — reset stale CMake compiler-cache metadata in the `config-py` CUDA branch before `cmake` runs.
- `python/tests/unit/test_pixi_cuda_py_demos_task.py` — new regression tests covering the `dartpy=ON` honoring, the stale-cache reset ordering (reset runs before `cmake -G Ninja`), and the `py-demos` → `build-py-dev-docking` dependency wiring.
- `CHANGELOG.md` — note the cache-reset behavior under the existing CUDA py-demos entry.

## Testing

- `pixi run pytest python/tests/unit/test_pixi_cuda_py_demos_task.py` — 3 passed.
- `pixi run ruff check python/tests/unit/test_pixi_cuda_py_demos_task.py` — clean.