### PR TITLE
Finalize DART 6.17.0 release metadata

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -2,10 +2,16 @@
 #
 # This replaces the former Docker-wrapped QEMU harness (docker/freebsd/* +
 # scripts/freebsd.py, which built and ran a `dartsim/freebsd-vm` image). The
-# vmactions/freebsd-vm action boots a real FreeBSD VM directly on the hosted
+# cross-platform-actions action boots a real FreeBSD VM directly on the hosted
 # runner with no Docker, syncs the checkout in, and runs the build/test inline.
 # Dependencies come from pkg; the cmake/ctest invocation mirrors the previous
 # job's configuration.
+#
+# Uses cross-platform-actions rather than vmactions/freebsd-vm: the latter
+# downloads its `anyvm` provisioning helper at run time, which started failing
+# the host dependency install with a fast `sudo` exit 1. cross-platform-actions
+# provisions from a pinned, prebuilt VM image instead, so there is no run-time
+# download of a mutable helper.
 
 name: CI FreeBSD (VM)
 
@@ -42,19 +48,21 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build and test DART on FreeBSD
-        uses: vmactions/freebsd-vm@v1
+        uses: cross-platform-actions/action@v1.2.0
         with:
-          release: "15.0"
-          usesh: true
-          copyback: false
-          prepare: |
-            ASSUME_ALWAYS_YES=yes pkg update -f
-            ASSUME_ALWAYS_YES=yes pkg install -y \
+          operating_system: freebsd
+          version: "15.0"
+          memory: 6G
+          # Commands run as a passwordless-sudo user via the default (sh) shell;
+          # the checkout is synced into the VM automatically.
+          run: |
+            set -e
+            # Install build dependencies from pkg.
+            sudo pkg update -f
+            sudo pkg install -y \
               assimp boost-libs cmake eigen fcl libfmt git gmake googletest \
               libccd ninja octomap ode-double pkgconf spdlog tinyxml2 \
               ros-urdfdom ros-urdfdom_headers
-          run: |
-            set -e
             # DART's source tree does not natively target FreeBSD, so apply the
             # FreeBSD source-compatibility patches (formerly applied by the
             # docker/freebsd harness) before configuring. They are -p0 patches

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -51,7 +51,10 @@ jobs:
         uses: cross-platform-actions/action@v1.2.0
         with:
           operating_system: freebsd
-          version: "15.0"
+          # 14.3 is a stable production release with a prebuilt image in the
+          # builder version this action pins. (15.0's image is not published to
+          # the action's storage yet, so it fails setup with BlobNotFound.)
+          version: "14.3"
           memory: 6G
           # Sync the checkout into the VM only; nothing downstream consumes the
           # build tree, so skip the (slow, timeout-risking under TCG) copy back

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -47,6 +47,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # cross-platform-actions runs host tools (notably `fdisk`) to create and
+      # size the VM disk image, but the `fdisk` package is not present on the
+      # ubuntu-24.04 runner image by default, so the action fails immediately
+      # with "Unable to locate executable file: fdisk". Install it and make sure
+      # /usr/sbin is on PATH for the action.
+      - name: Install host tools for the FreeBSD VM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fdisk
+          echo /usr/sbin >> "$GITHUB_PATH"
+
       - name: Build and test DART on FreeBSD
         uses: cross-platform-actions/action@v1.2.0
         with:

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -53,8 +53,11 @@ jobs:
           operating_system: freebsd
           version: "15.0"
           memory: 6G
-          # Commands run as a passwordless-sudo user via the default (sh) shell;
-          # the checkout is synced into the VM automatically.
+          # Sync the checkout into the VM only; nothing downstream consumes the
+          # build tree, so skip the (slow, timeout-risking under TCG) copy back
+          # from the VM. Mirrors the former vmactions `copyback: false`.
+          sync_files: runner-to-vm
+          # Commands run as a passwordless-sudo user via the default (sh) shell.
           run: |
             set -e
             # Install build dependencies from pkg.

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -104,4 +104,7 @@ jobs:
               -DDART_USE_SYSTEM_GOOGLETEST=ON \
               -DDART_VERBOSE=ON
             cmake --build build/freebsd/cpp/Release --target tests -j2
-            ctest --test-dir build/freebsd/cpp/Release --output-on-failure --timeout 600
+            # Some dynamics tests are much slower under hosted-runner VM
+            # emulation; keep the test coverage but avoid the inherited
+            # 10-minute per-test cap from failing a still-progressing run.
+            ctest --test-dir build/freebsd/cpp/Release --output-on-failure --timeout 1800

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -51,10 +51,12 @@ jobs:
         uses: cross-platform-actions/action@v1.2.0
         with:
           operating_system: freebsd
-          # 14.3 is a stable production release with a prebuilt image in the
-          # builder version this action pins. (15.0's image is not published to
-          # the action's storage yet, so it fails setup with BlobNotFound.)
-          version: "14.3"
+          # Latest FreeBSD 14.x production release. The action's pinned builder
+          # publishes a 14.4 image, and matching the current production minor
+          # keeps `pkg install` aligned with the binary package repository
+          # (older minors can hit pkg OS-version mismatches once the repo is
+          # rebuilt for a newer minor).
+          version: "14.4"
           memory: 6G
           # Sync the checkout into the VM only; nothing downstream consumes the
           # build tree, so skip the (slow, timeout-risking under TCG) copy back

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -76,7 +76,11 @@ jobs:
           # build tree, so skip the (slow, timeout-risking under TCG) copy back
           # from the VM. Mirrors the former vmactions `copyback: false`.
           sync_files: runner-to-vm
-          # Commands run as a passwordless-sudo user via the default (sh) shell.
+          # Run the build script under sh: the action otherwise uses the guest
+          # account's default shell (csh on FreeBSD), which cannot execute this
+          # POSIX `set -e` script. Mirrors the former vmactions `usesh: true`.
+          shell: sh
+          # Commands run as a passwordless-sudo user.
           run: |
             set -e
             # Install build dependencies from pkg.

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -37,7 +37,13 @@ concurrency:
 jobs:
   freebsd:
     name: FreeBSD repro (VM)
-    runs-on: ubuntu-latest
+    # Pin the versioned GitHub-hosted label, NOT `ubuntu-latest`: the dartsim
+    # self-hosted runners are *also* labeled `ubuntu-latest`, so an
+    # `ubuntu-latest` job can be scheduled onto those locked-down Docker
+    # containers (no fdisk, no usable apt, no nested virtualization) and fail in
+    # host setup. They do not carry the `ubuntu-24.04` label, so pinning it keeps
+    # this job on GitHub-hosted runners where the VM action works.
+    runs-on: ubuntu-24.04
     # Advisory: hosted runners lack nested KVM so the VM runs under slower TCG
     # emulation, and a few tests are known-flaky under emulation. Keep it
     # non-blocking, as the former job was.
@@ -47,15 +53,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # cross-platform-actions runs host tools (notably `fdisk`) to create and
-      # size the VM disk image, but the `fdisk` package is not present on the
-      # ubuntu-24.04 runner image by default, so the action fails immediately
-      # with "Unable to locate executable file: fdisk". Install it and make sure
-      # /usr/sbin is on PATH for the action.
-      - name: Install host tools for the FreeBSD VM
+      # cross-platform-actions invokes `fdisk` on the host to size the VM disk.
+      # It is present on GitHub-hosted runners; install it only as a fallback,
+      # and make sure /usr/sbin is on PATH for the action.
+      - name: Ensure fdisk is available for the FreeBSD VM
         run: |
-          sudo apt-get update
-          sudo apt-get install -y fdisk
+          command -v fdisk >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y fdisk; }
           echo /usr/sbin >> "$GITHUB_PATH"
 
       - name: Build and test DART on FreeBSD

--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -148,7 +148,7 @@ jobs:
           case "${DARTPY_REF}" in
             v*|refs/tags/v*) ;;
             *)
-              echo "::error::When publish=true, ref must be a version tag (e.g. v6.16.1). Got '${DARTPY_REF}'."
+              echo "::error::When publish=true, ref must be a version tag (e.g. v6.17.0). Got '${DARTPY_REF}'."
               exit 1
               ;;
           esac

--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base: [main, release-6.16]
+        base: [main, release-6.17]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## DART 6
 
-### [DART 6.17.0 (2026-06-01)](https://github.com/dartsim/dart/milestone/85?closed=1)
+### [DART 6.17.0 (2026-06-03)](https://github.com/dartsim/dart/milestone/85?closed=1)
 
 DART 6.17.0 is a maintenance release on the DART 6 LTS compatibility line. It
 backports bug fixes and additive improvements to the classic DART 6 API that were


### PR DESCRIPTION
Final touches for the DART 6.17.0 release, now that all backport PRs (the last being #2850) have landed on `release-6.17`. This is metadata only — no library/build code changes.

## Changes
- **CHANGELOG.md** — set the 6.17.0 heading date to the actual release date (2026-06-03). The previous value (2026-06-01) was a placeholder that predated the completed backport set.
- **`.github/workflows/publish_dartpy.yml`** — update the version-tag example in the publish guard's error message from `v6.16.1` to `v6.17.0` (illustrative string only; the guard already validates `package.xml` against the pushed tag).
- **`.github/workflows/update_lockfiles.yml`** — move the automated lockfile-update rotation from `release-6.16` to `release-6.17`, the active DART 6 LTS branch.

## Release readiness
With this merged, DART 6.17.0 is ready to tag:
- Version is `6.17.0` consistently across `package.xml`, `pixi.toml`, all `examples/`/`tutorials/` `find_package(DART 6.17 …)`, and the Doxyfile (`@DART_VERSION@`).
- CHANGELOG 6.17.0 section is complete (milestone 85).
- `publish_dartpy.yml` is tag-driven and validates `package.xml == tag`, so pushing `v6.17.0` will publish wheels.

---

**Also in this PR (added):** fix the `FreeBSD repro (VM)` CI job. `vmactions/freebsd-vm@v1` began failing the host dependency install (`sudo` exit 1, ~20 ms in) because it downloads its `anyvm` provisioning helper at run time; switched to `cross-platform-actions/action@v1.2.0`, which provisions FreeBSD from a pinned, prebuilt image. The migrated job pins the GitHub-hosted runner, syncs runner-to-vm only, runs under `sh`, and uses a longer VM CTest per-test timeout so the slow `test_Dynamics` run can keep coverage under hosted-runner VM emulation.