### PR TITLE
Add baked World memory no-growth guard

### DIFF
--- a/docs/dev_tasks/hierarchical_memory_manager/README.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/README.md
@@ -20,7 +20,10 @@
       buffers and avoid growth after simulation is baked.
 - [ ] Phase 5: Add allocation/debug accounting gates for "no dynamic allocation
       during the step loop" on representative rigid, multibody, contact, and
-      deformable scenes.
+      deformable scenes. Initial World base-allocator no-growth guards now
+      cover baked kinematic IPC rigid-body, multibody variational, and
+      deformable ECS paths; global heap allocation guards and broader solver
+      coverage remain open.
 - [ ] Phase 6: Add memory-layout profiler/debugger surfaces and GUI
       visualization.
 
@@ -107,8 +110,10 @@ debugging, profiling, optimization experiments, and ImGui visualization.
 2. Extend allocator correctness tests for `FixedPoolAllocator` and the existing
    pool/free-list/frame allocators across invalid sizes, over-alignment,
    overflow, reuse-after-free, leak/debug accounting, and bounded failure.
-3. Extend bake-time registry/component storage reservation and no-growth ECS
-   tests to broader contact and remaining solver scratch step paths.
+3. Extend bake-time registry/component storage reservation and no-growth
+   allocation tests to contact-heavy scenes and remaining solver scratch step
+   paths, then add a separate global heap guard for the full zero-allocation
+   claim.
 4. Benchmark the allocator-backed EnTT registry/component-storage path against
    standard C++ allocators and foonathan/memory on DART-relevant workloads.
 5. Start replacing per-step `std::vector`/`Eigen` temporaries in hot stages with

--- a/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
@@ -25,6 +25,12 @@ World's active free allocator. It also adds initial
 storage and first private step-scratch component paths. Broader solver scratch
 coverage and EnTT allocator benchmarks remain open.
 
+The next stacked no-growth guard adds a counting base allocator test proving
+that baked kinematic IPC rigid-body, multibody variational, and single
+deformable paths do not request more World base-allocator allocations or
+deallocations during repeated `World::step()` calls. This is not the final
+global zero-allocation proof; it covers the World-owned memory hierarchy only.
+
 ## Current Branch
 
 `feature/world-registry-allocator` - stacked PR #2872 branch for the
@@ -37,8 +43,9 @@ Finish review/CI for PR #2871, keep this stacked branch rebased-by-merge onto
 that allocator branch, and resolve any #2872 CI failures. Next allocator work
 should land the strict comparative benchmark gate, broaden
 `FixedPoolAllocator` correctness coverage, benchmark allocator-backed EnTT
-registry/component storage, and extend no-growth ECS tests to broader contact
-and remaining solver scratch step paths.
+registry/component storage, extend no-growth ECS tests to broader contact and
+remaining solver scratch step paths, and add a separate global heap allocation
+guard before claiming zero dynamic allocation for the full simulation loop.
 
 ## Latest Local Validation
 
@@ -54,6 +61,8 @@ and remaining solver scratch step paths.
   vector workloads.
 - `cmake --build build/default/cpp/Release --target dartsim -j2`
 - `pixi run test-simulation-experimental` (61/61 passed)
+- `cmake --build build/default/cpp/Release --target test_world -j2`
+- `ctest --test-dir build/default/cpp/Release -R '^test_world$' --output-on-failure`
 
 ## Context That Would Be Lost
 

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -204,8 +204,28 @@ public:
 
   [[nodiscard]] void* allocate(std::size_t bytes) noexcept override
   {
+    if (bytes == 0) {
+      return nullptr;
+    }
+
     ++allocationCount;
     return ::operator new(bytes, std::nothrow);
+  }
+
+  [[nodiscard]] void* allocate(
+      std::size_t bytes, std::size_t alignment) noexcept override
+  {
+    if (bytes == 0 || alignment == 0 || (alignment & (alignment - 1)) != 0) {
+      return nullptr;
+    }
+
+    ++allocationCount;
+    ++alignedAllocationCount;
+    if (alignment <= __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
+      return ::operator new(bytes, std::nothrow);
+    }
+
+    return ::operator new(bytes, std::align_val_t(alignment), std::nothrow);
   }
 
   void deallocate(void* pointer, std::size_t /*bytes*/) override
@@ -214,8 +234,23 @@ public:
     ::operator delete(pointer);
   }
 
+  void deallocate(
+      void* pointer, std::size_t /*bytes*/, std::size_t alignment) override
+  {
+    ++deallocationCount;
+    ++alignedDeallocationCount;
+    if (alignment <= __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
+      ::operator delete(pointer);
+      return;
+    }
+
+    ::operator delete(pointer, std::align_val_t(alignment));
+  }
+
   std::size_t allocationCount{0};
+  std::size_t alignedAllocationCount{0};
   std::size_t deallocationCount{0};
+  std::size_t alignedDeallocationCount{0};
 };
 
 class FrameScratchStage final
@@ -292,6 +327,36 @@ void expectRegistryStorageCapacitiesUnchanged(
     ASSERT_NE(it, actual.end()) << "missing storage id " << id;
     EXPECT_EQ(it->second, capacity) << "storage id " << id;
   }
+}
+
+template <typename ConfigureScene>
+void expectNoWorldBaseAllocatorActivityDuringBakedSteps(
+    std::string_view scene, ConfigureScene&& configureScene)
+{
+  namespace sx = dart::simulation::experimental;
+
+  SCOPED_TRACE(scene);
+  CountingMemoryAllocator allocator;
+  sx::WorldOptions worldOptions;
+  worldOptions.baseAllocator = &allocator;
+  sx::World world(worldOptions);
+
+  configureScene(world);
+  world.enterSimulationMode();
+
+  const auto allocationsAfterBake = allocator.allocationCount;
+  const auto deallocationsAfterBake = allocator.deallocationCount;
+  const auto alignedAllocationsAfterBake = allocator.alignedAllocationCount;
+  const auto alignedDeallocationsAfterBake = allocator.alignedDeallocationCount;
+
+  for (int i = 0; i < 4; ++i) {
+    world.step();
+  }
+
+  EXPECT_EQ(allocator.allocationCount, allocationsAfterBake);
+  EXPECT_EQ(allocator.deallocationCount, deallocationsAfterBake);
+  EXPECT_EQ(allocator.alignedAllocationCount, alignedAllocationsAfterBake);
+  EXPECT_EQ(allocator.alignedDeallocationCount, alignedDeallocationsAfterBake);
 }
 
 } // namespace
@@ -456,6 +521,43 @@ TEST(World, EnterSimulationModeReservesRegistryStorageForDeformableSteps)
     world.step();
     expectRegistryStorageCapacitiesUnchanged(capacities, registry);
   }
+}
+
+TEST(World, BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths)
+{
+  namespace sx = dart::simulation::experimental;
+
+  expectNoWorldBaseAllocatorActivityDuringBakedSteps(
+      "kinematic IPC rigid body", [](sx::World& world) {
+        world.setRigidBodySolver(sx::RigidBodySolver::Ipc);
+        auto body = world.addRigidBody("kinematic");
+        body.setKinematic(true);
+        body.setLinearVelocity(Eigen::Vector3d(1.0, 0.0, 0.0));
+      });
+
+  expectNoWorldBaseAllocatorActivityDuringBakedSteps(
+      "multibody variational scratch", [](sx::World& world) {
+        auto robot = world.addMultibody("slider");
+        auto base = robot.addLink("base");
+        sx::JointSpec spec;
+        spec.name = "rail";
+        spec.type = sx::JointType::Prismatic;
+        spec.axis = Eigen::Vector3d::UnitZ();
+        auto carriage = robot.addLink("carriage", base, spec);
+        carriage.setMass(3.0);
+        world.setMultibodyOptions({"variational integrator"});
+        world.setTimeStep(0.01);
+      });
+
+  expectNoWorldBaseAllocatorActivityDuringBakedSteps(
+      "single deformable particle", [](sx::World& world) {
+        sx::DeformableBodyOptions options;
+        options.positions = {Eigen::Vector3d(0.0, 0.0, 1.0)};
+        options.masses = {1.0};
+        options.edgeStiffness = 0.0;
+        world.addDeformableBody("particle", options);
+        world.setTimeStep(0.01);
+      });
 }
 
 TEST(World, FrameScratchCapacityReportsUsableArenaBytes)


### PR DESCRIPTION
## Summary

- Add a baked-step no-growth unit guard for the experimental World-owned memory hierarchy.
- Extend the counting base allocator test helper to cover aligned allocation and deallocation paths.
- Update the hierarchical memory-manager dev-task notes with the new evidence and remaining scope.

## Motivation / Problem

- The zero dynamic allocation goal needs incremental, enforceable evidence. Existing tests proved EnTT storage capacities remain stable after `enterSimulationMode()`, but they did not prove the World memory hierarchy stops requesting additional base allocations during repeated baked steps.

## Changes / Key Changes

- Add `World.BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths` covering baked kinematic IPC rigid-body, multibody variational, and single deformable paths.
- Snapshot base allocator allocation/deallocation counts after bake and assert repeated `World::step()` calls do not change them.
- Keep the claim scoped to World-owned allocator activity; global heap allocation guards and broader contact/solver coverage remain tracked follow-up work.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --target test_world -j2`
- `ctest --test-dir build/default/cpp/Release -R ^test_world --output-on-failure`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Stacked on #2872
- Builds on allocator foundation #2871 and allocator benchmark gate #2870

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required; test and dev-task evidence only)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (not applicable; no new public API)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
