### PR TITLE
Validate HeightmapShape scale and height field inputs (DART 6.17)

### DIFF
--- a/dart/dynamics/detail/HeightmapShape-impl.hpp
+++ b/dart/dynamics/detail/HeightmapShape-impl.hpp
@@ -74,9 +74,18 @@ const std::string& HeightmapShape<S>::getStaticType()
 template <typename S>
 void HeightmapShape<S>::setScale(const Vector3& scale)
 {
-  DART_ASSERT(scale[0] > 0.0);
-  DART_ASSERT(scale[1] > 0.0);
-  DART_ASSERT(scale[2] > 0.0);
+  // Reject non-finite or non-positive scales. DART_ASSERT is compiled out in
+  // release builds (NDEBUG), so without this runtime guard a NaN/Inf or
+  // non-positive scale would flow into the collision backend (e.g. ODE) and
+  // trigger an internal assertion or undefined behavior.
+  // See https://github.com/gazebosim/gz-physics/issues/847
+  if (!scale.allFinite() || (scale.array() <= S(0)).any()) {
+    dtwarn << "[HeightmapShape::setScale] Invalid scale [" << scale[0] << ", "
+           << scale[1] << ", " << scale[2]
+           << "]. Each component must be a positive finite value. Ignoring "
+              "request.\n";
+    return;
+  }
   mScale = scale;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -119,6 +128,19 @@ void HeightmapShape<S>::setHeightField(
 template <typename S>
 void HeightmapShape<S>::setHeightField(const HeightField& heights)
 {
+  if (heights.size() == 0) {
+    dtwarn << "[HeightmapShape::setHeightField] Empty height field makes no "
+              "sense. Ignoring request.\n";
+    return;
+  }
+  // Reject non-finite height values so they never reach the collision backend.
+  // See https://github.com/gazebosim/gz-physics/issues/847
+  if (!heights.allFinite()) {
+    dtwarn << "[HeightmapShape::setHeightField] Height field contains "
+              "non-finite values (NaN or Inf). Ignoring request.\n";
+    return;
+  }
+
   mHeights = heights;
 
   mMinHeight = heights.minCoeff();

--- a/tests/unit/dynamics/test_HeightmapShape.cpp
+++ b/tests/unit/dynamics/test_HeightmapShape.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/HeightmapShape.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <vector>
+
+using namespace dart::dynamics;
+
+// HeightmapShape::setScale and setHeightField guard against non-finite
+// (NaN/Inf) and non-positive inputs so they never reach the collision backend
+// (e.g. ODE) where they would trip an internal assertion or undefined
+// behavior. See https://github.com/gazebosim/gz-physics/issues/847
+
+//==============================================================================
+TEST(HeightmapShapeValidation, AcceptsValidPositiveFiniteScale)
+{
+  auto heightmap = std::make_shared<HeightmapShape<double>>();
+
+  // Default scale is (1, 1, 1).
+  EXPECT_EQ(heightmap->getScale(), Eigen::Vector3d(1.0, 1.0, 1.0));
+
+  heightmap->setScale(Eigen::Vector3d(2.0, 3.0, 0.5));
+  EXPECT_EQ(heightmap->getScale(), Eigen::Vector3d(2.0, 3.0, 0.5));
+}
+
+//==============================================================================
+TEST(HeightmapShapeValidation, RejectsNonFiniteScaleAndPreservesOriginal)
+{
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+
+  auto heightmap = std::make_shared<HeightmapShape<double>>();
+  heightmap->setScale(Eigen::Vector3d(2.0, 2.0, 2.0));
+  const Eigen::Vector3d original = heightmap->getScale();
+
+  heightmap->setScale(Eigen::Vector3d(inf, 1.0, 1.0));
+  EXPECT_EQ(heightmap->getScale(), original);
+
+  heightmap->setScale(Eigen::Vector3d(1.0, -inf, 1.0));
+  EXPECT_EQ(heightmap->getScale(), original);
+
+  heightmap->setScale(Eigen::Vector3d(1.0, 1.0, nan));
+  EXPECT_EQ(heightmap->getScale(), original);
+}
+
+//==============================================================================
+TEST(HeightmapShapeValidation, RejectsNonPositiveScaleAndPreservesOriginal)
+{
+  auto heightmap = std::make_shared<HeightmapShape<double>>();
+  heightmap->setScale(Eigen::Vector3d(2.0, 2.0, 2.0));
+  const Eigen::Vector3d original = heightmap->getScale();
+
+  heightmap->setScale(Eigen::Vector3d(0.0, 1.0, 1.0));
+  EXPECT_EQ(heightmap->getScale(), original);
+
+  heightmap->setScale(Eigen::Vector3d(1.0, -1.0, 1.0));
+  EXPECT_EQ(heightmap->getScale(), original);
+}
+
+//==============================================================================
+TEST(HeightmapShapeValidation, RejectsNonFiniteHeightFieldAndPreservesOriginal)
+{
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+
+  auto heightmap = std::make_shared<HeightmapShape<double>>();
+  heightmap->setHeightField(2u, 2u, std::vector<double>{0.0, 1.0, 2.0, 3.0});
+  EXPECT_DOUBLE_EQ(heightmap->getMaxHeight(), 3.0);
+  EXPECT_DOUBLE_EQ(heightmap->getMinHeight(), 0.0);
+
+  // A height field carrying a non-finite value must be rejected, leaving the
+  // previously set (valid) field intact.
+  heightmap->setHeightField(2u, 2u, std::vector<double>{0.0, nan, 2.0, 3.0});
+  EXPECT_DOUBLE_EQ(heightmap->getMaxHeight(), 3.0);
+  EXPECT_DOUBLE_EQ(heightmap->getMinHeight(), 0.0);
+
+  heightmap->setHeightField(2u, 2u, std::vector<double>{0.0, 1.0, inf, 3.0});
+  EXPECT_DOUBLE_EQ(heightmap->getMaxHeight(), 3.0);
+  EXPECT_DOUBLE_EQ(heightmap->getMinHeight(), 0.0);
+}
+
+//==============================================================================
+TEST(HeightmapShapeValidation, InvalidInputsDoNotThrow)
+{
+  const float inf = std::numeric_limits<float>::infinity();
+
+  auto heightmap = std::make_shared<HeightmapShape<float>>();
+
+  EXPECT_NO_THROW(heightmap->setScale(Eigen::Vector3f(inf, inf, inf)));
+  EXPECT_NO_THROW(heightmap->setHeightField(
+      2u, 2u, std::vector<float>{0.0f, 1.0f, 2.0f, 3.0f}));
+  EXPECT_NO_THROW(heightmap->setHeightField(
+      2u, 2u, std::vector<float>{0.0f, inf, 2.0f, 3.0f}));
+}


### PR DESCRIPTION
## Summary

`HeightmapShape::setScale` guarded its scale only with `DART_ASSERT`, which is
compiled out in release builds (`NDEBUG`). As a result, non-finite (`NaN`/`Inf`)
or non-positive scale values — and non-finite height values — flowed unchecked
into the collision backend (ODE), where they trip an internal heightfield
assertion / undefined behavior. Reported downstream via
[gazebosim/gz-physics#847](https://github.com/gazebosim/gz-physics/issues/847).

## Changes

- `HeightmapShape::setScale` now rejects non-finite or non-positive scale with a
  warning, preserving the previous valid state (mirrors the existing
  `SphereShape::setRadius` validation precedent).
- `HeightmapShape::setHeightField(const HeightField&)` now rejects empty and
  non-finite height fields. Both `setHeightField` overloads funnel through it.

## Testing

- New `tests/unit/dynamics/test_HeightmapShape.cpp` (`HeightmapShapeValidation`)
  covering valid/NaN/Inf/non-positive scale and non-finite height fields, for
  both `float` and `double`.
- Verified in a **Debug (asserts-enabled)** build. Regression suite green
  (`test_Collision` incl. `testHeightmapBox`, plus dynamics/constraint suites).

## Scope / follow-up

This closes the **non-finite** (`NaN`/`Inf`) manifestation. A finite-but-
astronomical scale (e.g. `1e308`) on a large field can still overflow to `Inf`
*inside* ODE's heightfield extent computation; addressing that needs an
ODE-boundary extent guard (separate, to be scoped). See the issue thread.

Forward-port to `main` (DART 7) is a paired dual-PR (linked separately).
