### PR TITLE
Reject non-finite mass and inertia inputs (DART 6.17)

### DIFF
--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -35,6 +35,8 @@
 #include "dart/common/Console.hpp"
 #include "dart/math/Geometry.hpp"
 
+#include <cmath>
+
 namespace dart {
 namespace dynamics {
 
@@ -112,6 +114,15 @@ double Inertia::getParameter(Param _param) const
 //==============================================================================
 void Inertia::setMass(double _mass)
 {
+  // Reject non-finite mass at the ingest boundary. A NaN/Inf mass propagates
+  // into the spatial inertia tensor and then poisons the forward-dynamics
+  // recursion (bias force, articulated inertia), aborting asserts-enabled
+  // builds. See https://github.com/gazebosim/gz-physics/issues/854
+  if (!std::isfinite(_mass)) {
+    dtwarn << "[Inertia::setMass] Attempting to set a non-finite mass ["
+           << _mass << "]. Ignoring request.\n";
+    return;
+  }
   mMass = _mass;
   computeSpatialTensor();
 }
@@ -138,6 +149,15 @@ const Eigen::Vector3d& Inertia::getLocalCOM() const
 //==============================================================================
 void Inertia::setMoment(const Eigen::Matrix3d& _moment)
 {
+  // Reject a non-finite moment of inertia at the ingest boundary so NaN/Inf
+  // never reaches the forward-dynamics recursion.
+  // See https://github.com/gazebosim/gz-physics/issues/854
+  if (!_moment.allFinite()) {
+    dtwarn << "[Inertia::setMoment] Attempting to set a non-finite moment of "
+              "inertia matrix. Ignoring request.\n";
+    return;
+  }
+
   if (!verifyMoment(_moment, true))
     dtwarn << "[Inertia::setMoment] Passing in an invalid moment of inertia "
            << "matrix. Results might not by physically accurate or "
@@ -162,6 +182,16 @@ void Inertia::setMoment(
     double _Ixz,
     double _Iyz)
 {
+  // Reject a non-finite moment of inertia at the ingest boundary so NaN/Inf
+  // never reaches the forward-dynamics recursion.
+  // See https://github.com/gazebosim/gz-physics/issues/854
+  if (!std::isfinite(_Ixx) || !std::isfinite(_Iyy) || !std::isfinite(_Izz)
+      || !std::isfinite(_Ixy) || !std::isfinite(_Ixz) || !std::isfinite(_Iyz)) {
+    dtwarn << "[Inertia::setMoment] Attempting to set a non-finite moment of "
+              "inertia. Ignoring request.\n";
+    return;
+  }
+
   mMoment[I_XX - 4] = _Ixx;
   mMoment[I_YY - 4] = _Iyy;
   mMoment[I_ZZ - 4] = _Izz;

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -2041,7 +2041,15 @@ void GenericJoint<ConfigSpaceT>::updateInvProjArtInertiaImplicitDynamic(
   mInvProjArtInertiaImplicit = math::inverse<ConfigSpaceT>(projAI);
 
   // Verification
-  DART_ASSERT(!math::isNan(mInvProjArtInertiaImplicit));
+  if (math::isNan(mInvProjArtInertiaImplicit)
+      || math::isInf(mInvProjArtInertiaImplicit)) {
+    dtwarn << "[GenericJoint::updateInvProjArtInertiaImplicitDynamic] "
+              "Non-finite inverse projected articulated inertia detected for "
+              "joint ["
+           << this->getName()
+           << "]. Setting inverse inertia to zero to avoid instability.\n";
+    mInvProjArtInertiaImplicit.setZero();
+  }
 }
 
 //==============================================================================

--- a/tests/integration/test_InvalidDynamicsInputs.cpp
+++ b/tests/integration/test_InvalidDynamicsInputs.cpp
@@ -181,3 +181,44 @@ TEST(InvalidDynamicsInputs, ZeroMassContactDoesNotCrash)
   EXPECT_TRUE(dynamicBox->getPositions().allFinite());
   EXPECT_TRUE(zeroMassBox->getPositions().allFinite());
 }
+
+// A non-finite moment of inertia must not abort forward dynamics. Without the
+// guard in GenericJoint::updateInvProjArtInertiaImplicitDynamic, the NaN
+// inertia produces a non-finite inverse projected articulated inertia that
+// trips a raw assertion in asserts-enabled builds.
+// See https://github.com/gazebosim/gz-physics/issues/854
+TEST(InvalidDynamicsInputs, NanInertiaDoesNotCrash)
+{
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  auto world = World::create();
+  auto skeleton = createTwoLinkSkeleton(1.0, nan);
+  world->addSkeleton(skeleton);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 5; ++i) {
+      world->step();
+    }
+  });
+
+  EXPECT_TRUE(skeleton->getPositions().allFinite());
+  EXPECT_TRUE(skeleton->getVelocities().allFinite());
+}
+
+// A non-finite (infinite) mass must not abort forward dynamics.
+// See https://github.com/gazebosim/gz-physics/issues/854
+TEST(InvalidDynamicsInputs, InfMassDoesNotCrash)
+{
+  const double inf = std::numeric_limits<double>::infinity();
+  auto world = World::create();
+  auto skeleton = createTwoLinkSkeleton(inf, 1.0);
+  world->addSkeleton(skeleton);
+
+  EXPECT_NO_THROW({
+    for (int i = 0; i < 5; ++i) {
+      world->step();
+    }
+  });
+
+  EXPECT_TRUE(skeleton->getPositions().allFinite());
+  EXPECT_TRUE(skeleton->getVelocities().allFinite());
+}


### PR DESCRIPTION
## Summary

A non-finite (`NaN`/`Inf`) mass or moment of inertia propagates into the spatial
inertia tensor and poisons the Featherstone forward-dynamics recursion, aborting
asserts-enabled builds. Reported downstream via the gz-physics robustness
reports ([gz-physics#854](https://github.com/gazebosim/gz-physics/issues/854),
[#851](https://github.com/gazebosim/gz-physics/issues/851),
[#849](https://github.com/gazebosim/gz-physics/issues/849)).

Note: the zero/epsilon-mass cases from those reports already degrade gracefully
in 6.17 (via #2850). This PR closes the remaining **non-finite** sub-case.

## Changes

- `Inertia::setMass` and both `Inertia::setMoment` overloads reject non-finite
  values at the ingest boundary with a warning, preserving the previous valid
  state (mirrors the `SphereShape::setRadius` precedent). This is the
  root-cause fix — `NaN`/`Inf` never enters the spatial tensor.
- `GenericJoint::updateInvProjArtInertiaImplicitDynamic` converts its remaining
  raw finiteness `DART_ASSERT` to the warn-and-zero guard already used by its
  non-implicit sibling (`updateInvProjArtInertiaDynamic`) — defense in depth for
  other entry points (e.g. `setSpatialTensor`).

## Testing

- New regression tests `InvalidDynamicsInputs.NanInertiaDoesNotCrash` and
  `.InfMassDoesNotCrash`.
- Verified in a **Debug (asserts-enabled)** build — both abort before the fix,
  pass after. Full regression suite green (`test_Inertia`, `test_Dynamics`,
  `test_Joints`, `test_GenericJoints`, `test_ForwardKinematics`,
  `test_ConstraintSolver`, `test_Skeleton`, `test_World`, …; 17/17).

## Note

The empirical Debug run showed the `NaN`-inertia path aborts at
`BodyNode::updateBiasForce`, *earlier* than the `GenericJoint` inverse-inertia
assert — which is why the authoritative fix is ingest validation rather than
guarding individual downstream asserts.

Forward-port to `main` (DART 7) is a paired dual-PR (linked separately).
