### PR TITLE
Clamp ODE heightfield extents to prevent collision abort on huge scale (DART 6.17)

### DIFF
--- a/dart/collision/ode/detail/OdeHeightmap-impl.hpp
+++ b/dart/collision/ode/detail/OdeHeightmap-impl.hpp
@@ -36,13 +36,51 @@
 
 #include <dart/dynamics/HeightmapShape.hpp>
 
+#include <algorithm>
+#include <limits>
 #include <type_traits>
+
+#include <cmath>
 
 namespace dart {
 namespace collision {
 namespace detail {
 
 #define HF_THICKNESS 0.05
+
+//==============================================================================
+// A HeightmapShape scale/heights can be finite (so they pass the shape-level
+// validation guard) yet make the values DART hands to ODE non-finite: e.g.
+// (width-1)*scale.x() overflows to +/-Inf for a large field, or
+// maxHeight*scale.z overflows ODE's vertical AABB. ODE then derives a
+// non-finite sample spacing / AABB, collapses its per-cell index range, and
+// aborts via dIASSERT((nMinX < nMaxX) && (nMinZ < nMaxZ)) in
+// dCollideHeightfield. We intervene ONLY on an actual overflow (a non-finite
+// value), clamping to a finite bound well below sqrt(DBL_MAX); finite values
+// (even large but valid terrains) are passed through unchanged.
+// See https://github.com/gazebosim/gz-physics/issues/847
+constexpr double kOdeHeightfieldMaxExtent = 1.0e12;
+
+// Replaces a non-finite extent (the result of an overflowed product) with a
+// finite fallback so ODE's heightfield index math stays valid; finite inputs
+// are returned unchanged. Finiteness is validated AFTER the dReal cast: when
+// ODE is built single precision (dReal == float), a finite double larger than
+// FLT_MAX overflows to +/-Inf on the cast and would still abort.
+template <typename S>
+dReal finiteOdeExtentOr(S value, const char* what)
+{
+  const dReal r = static_cast<dReal>(value);
+  if (std::isfinite(r))
+    return r;
+
+  const double v = static_cast<double>(value);
+  const dReal fallback
+      = static_cast<dReal>(std::copysign(kOdeHeightfieldMaxExtent, v));
+  dtwarn << "[OdeHeightmap] Non-finite " << what
+         << " (likely from an extreme HeightmapShape scale); clamping to "
+         << fallback << " to avoid an ODE heightfield collision abort.\n";
+  return fallback;
+}
 
 //==============================================================================
 // creates the ODE height field. Only enabled if the height data type is float.
@@ -66,14 +104,14 @@ void setOdeHeightfieldDetails(
       odeHeightfieldId,
       heights,
       0,
-      (width - 1) * scale.x(),  // width (in meters)
-      (height - 1) * scale.y(), // height (in meters)
-      width,                    // width (sampling size)
-      height,                   // height (sampling size)
-      scale.z(),                // vertical scaling
-      0.0,                      // vertical offset
-      HF_THICKNESS,             // vertical thickness for closing the mesh
-      0);                       // wrap mode
+      finiteOdeExtentOr((width - 1) * scale.x(), "width extent"),
+      finiteOdeExtentOr((height - 1) * scale.y(), "depth extent"),
+      width,                                          // width (sampling size)
+      height,                                         // height (sampling size)
+      finiteOdeExtentOr(scale.z(), "vertical scale"), // clamped by the ctor too
+      0.0,                                            // vertical offset
+      HF_THICKNESS, // vertical thickness for closing the mesh
+      0);           // wrap mode
 }
 
 //==============================================================================
@@ -99,14 +137,14 @@ void setOdeHeightfieldDetails(
       odeHeightfieldId,
       heights,
       0,
-      (width - 1) * scale.x(),  // width (in meters)
-      (height - 1) * scale.y(), // height (in meters)
-      width,                    // width (sampling size)
-      height,                   // height (sampling size)
-      scale.z(),                // vertical scaling
-      0.0,                      // vertical offset
-      HF_THICKNESS,             // vertical thickness for closing the mesh
-      0);                       // wrap mode
+      finiteOdeExtentOr((width - 1) * scale.x(), "width extent"),
+      finiteOdeExtentOr((height - 1) * scale.y(), "depth extent"),
+      width,                                          // width (sampling size)
+      height,                                         // height (sampling size)
+      finiteOdeExtentOr(scale.z(), "vertical scale"), // clamped by the ctor too
+      0.0,                                            // vertical offset
+      HF_THICKNESS, // vertical thickness for closing the mesh
+      0);           // wrap mode
 }
 
 //==============================================================================
@@ -119,13 +157,42 @@ OdeHeightmap<S>::OdeHeightmap(
   DART_ASSERT(heightMap);
 
   // get the heightmap parameters
-  const auto& scale = heightMap->getScale();
+  Eigen::Matrix<S, 3, 1> scale = heightMap->getScale();
   const auto& heights = heightMap->getHeightField();
+  const double minHeight = static_cast<double>(heightMap->getMinHeight());
+  const double maxHeight = static_cast<double>(heightMap->getMaxHeight());
+
+  // ODE derives the heightfield's vertical AABB from the (unscaled) height
+  // bounds multiplied by the vertical scale, while its height callback returns
+  // sample * scale.z. If scale.z * |height bound| overflows to non-finite, the
+  // AABB collapses and dCollideHeightfield aborts. Clamp the vertical scale
+  // ONLY on an actual overflow (not on large-but-finite values) so the AABB
+  // stays consistent with the heights ODE will sample.
+  // See https://github.com/gazebosim/gz-physics/issues/847
+  const double maxAbsBound
+      = std::max(std::max(std::abs(minHeight), std::abs(maxHeight)), 1.0);
+  // Check the product in dReal: ODE forms the vertical AABB as
+  // bound * scale.z in dReal, so two values that are each finite (even in a
+  // single-precision build where dReal == float) can still overflow when
+  // multiplied. A double-only check would miss e.g. scale.z == 1e20 with a
+  // 1e20 bound.
+  const dReal scaledBound
+      = static_cast<dReal>(maxAbsBound) * static_cast<dReal>(scale.z());
+  if (!std::isfinite(scaledBound)) {
+    const double safeZ = std::copysign(
+        kOdeHeightfieldMaxExtent / maxAbsBound, static_cast<double>(scale.z()));
+    dtwarn << "[OdeHeightmap] Vertical scale (" << scale.z()
+           << ") combined with the height bound (" << maxAbsBound
+           << ") overflows ODE's heightfield AABB; clamping vertical scale to "
+           << safeZ << ".\n";
+    scale.z() = static_cast<S>(safeZ);
+  }
 
   // Create the ODE heightfield
   mOdeHeightfieldId = dGeomHeightfieldDataCreate();
 
-  // specify height field details
+  // specify height field details (the width/depth extents are clamped only if
+  // they overflow; the vertical scale was clamped above if needed)
   setOdeHeightfieldDetails(
       mOdeHeightfieldId,
       heights.data(),
@@ -133,14 +200,15 @@ OdeHeightmap<S>::OdeHeightmap(
       heightMap->getDepth(),
       scale);
 
-  // Restrict the bounds of the AABB to improve efficiency
+  // Restrict the bounds of the AABB to improve efficiency.
   //
-  // Note: ODE applies the vertical scale/offset (and thickness to min height)
-  // when computing the AABB, so we pass the unscaled bounds here.
+  // ODE applies the (now finite) vertical scale/offset when computing the AABB,
+  // so we pass the unscaled bounds here. Passing the real bounds keeps the AABB
+  // consistent with the heights ODE samples from the field.
   dGeomHeightfieldDataSetBounds(
       mOdeHeightfieldId,
-      static_cast<dReal>(heightMap->getMinHeight()),
-      static_cast<dReal>(heightMap->getMaxHeight()));
+      finiteOdeExtentOr(minHeight, "min height"),
+      finiteOdeExtentOr(maxHeight, "max height"));
 
   // create the height field
   mGeomId = dCreateHeightfield(0, mOdeHeightfieldId, 1);

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -1413,6 +1413,66 @@ TEST_F(Collision, testHeightmapBox)
 }
 
 //==============================================================================
+// A finite-but-astronomical heightmap scale must not abort ODE heightfield
+// collision. A scale like 1e308 is finite (so it passes the shape-level
+// validation guard), but (width-1)*scale, the vertical scale, and
+// maxHeight*scale.z then overflow to +/-Inf inside ODE, which collapses the
+// per-cell index range and trips dIASSERT((nMinX < nMaxX) && (nMinZ < nMaxZ))
+// in dCollideHeightfield. DART now clamps the extents/scale/bounds handed to
+// ODE to a finite value. See https://github.com/gazebosim/gz-physics/issues/847
+TEST_F(Collision, testHeightmapHugeScaleNoAbort)
+{
+#if HAVE_ODE
+  auto ode = OdeCollisionDetector::create();
+  const double huge = 1e308; // finite but astronomical; passes the shape guard
+
+  auto collideWithBox
+      = [&](const std::shared_ptr<HeightmapShape<double>>& terrain) {
+          auto terrainFrame = SimpleFrame::createShared(Frame::World());
+          auto boxFrame = SimpleFrame::createShared(Frame::World());
+          terrainFrame->setShape(terrain);
+          boxFrame->setShape(
+              std::make_shared<BoxShape>(Eigen::Vector3d::Constant(0.1)));
+          boxFrame->setTranslation(Eigen::Vector3d(0.0, 0.0, 2.0));
+
+          auto group
+              = ode->createCollisionGroup(terrainFrame.get(), boxFrame.get());
+          collision::CollisionOption option;
+          option.enableContact = true;
+          collision::CollisionResult result;
+          // The bug aborted the process here; reaching the next line proves the
+          // extents/scale/bounds were clamped to finite values.
+          EXPECT_NO_FATAL_FAILURE(group->collide(option, &result));
+          for (auto i = 0u; i < result.getNumContacts(); ++i)
+            EXPECT_TRUE(result.getContact(i).point.allFinite());
+        };
+
+  // Extents-overflow path: a >= 3 sample dimension makes (width-1)*scale
+  // overflow ((3-1)*1e308 == Inf).
+  {
+    auto terrain = std::make_shared<HeightmapShape<double>>();
+    std::vector<double> heights = {1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0};
+    terrain->setHeightField(3u, 3u, heights);
+    terrain->setScale(Eigen::Vector3d(huge, huge, huge));
+    // The finite-but-astronomical scale is accepted by the shape-level guard.
+    EXPECT_TRUE(
+        terrain->getScale().isApprox(Eigen::Vector3d(huge, huge, huge)));
+    collideWithBox(terrain);
+  }
+
+  // Bounds/vertical-overflow path: a huge z-scale makes maxHeight*scale.z
+  // overflow even for a 2x2 field.
+  {
+    auto terrain = std::make_shared<HeightmapShape<double>>();
+    std::vector<double> heights = {1.0, 2.0, 2.0, 3.0};
+    terrain->setHeightField(2u, 2u, heights);
+    terrain->setScale(Eigen::Vector3d(2.0, 2.0, huge));
+    collideWithBox(terrain);
+  }
+#endif
+}
+
+//==============================================================================
 // Tests HeightmapShape::flipY();
 TEST_F(Collision, testHeightmapFlipY)
 {


### PR DESCRIPTION
## Summary

Completes the #847 heightmap hardening at the ODE collision boundary.

The shape-level guard merged in #2884 rejects non-finite / non-positive scale and non-finite heights. But a **finite-but-astronomical** scale (e.g. `1e308`, as in the gz-physics#847 repro) is *accepted* by that guard, then `(width-1)*scale`, the vertical scale, and `maxHeight*scale.z` overflow to `±Inf` inside ODE. That collapses ODE's per-cell heightfield index range and aborts via `dIASSERT((nMinX < nMaxX) && (nMinZ < nMaxZ))` in `dCollideHeightfield` — at **collide time**, not build time.

## Changes

- `OdeHeightmap` clamps the width/depth extents, the vertical scale, and the min/max height bounds handed to ODE to a finite cap (`1e12` m — far below `sqrt(DBL_MAX)`, larger than any physical terrain), with a `dtwarn`. `mGeomId` stays a valid, fully-built geom and the height-data pointer is untouched (so no dangling-storage or null-geom hazard — see rationale below).
- Adds `Collision.testHeightmapHugeScaleNoAbort` exercising both the extents (`≥3` samples) and vertical-scale (`2×2`) overflow paths.

## Why clamp (not skip/fallback)

Leaving `mGeomId` null is unsafe — `OdeCollisionObject` and `OdeCollisionGroup` dereference the geom (`dGeomSetData`, `dSpaceAdd`, …) with only `DART_ASSERT` guards (no-ops under `NDEBUG`). A flat-fallback geom would dangle, since `dGeomHeightfieldDataBuild*` is called with `copyHeightData = 0` (ODE holds the height pointer by reference). Clamping keeps every consumer well-defined and changes nothing for valid inputs.

## Testing

Verified in a **Debug (asserts-enabled)** build: `test_Collision` passes; the new test's warnings confirm the clamp fires on both overflow paths and `collide()` completes without aborting.

Relates to gazebosim/gz-physics#847. Dual-PR: `main` forward-port linked separately.
