### PR TITLE
Demote duplicate-name rename message to debug verbosity (DART 6.17)

### DIFF
--- a/dart/common/detail/NameManager.hpp
+++ b/dart/common/detail/NameManager.hpp
@@ -36,6 +36,7 @@
 #include "dart/common/Macros.hpp"
 
 #include <dart/common/Console.hpp>
+#include <dart/common/Logging.hpp>
 #include <dart/common/NameManager.hpp>
 
 #include <sstream>
@@ -102,9 +103,18 @@ std::string NameManager<T>::issueNewName(const std::string& _name) const
     newName = ss.str();
   } while (hasName(newName));
 
-  dtmsg << "[NameManager::issueNewName] (" << mManagerName << ") The name ["
-        << _name << "] is a duplicate, so it has been renamed to [" << newName
-        << "]\n";
+  // Use a level-gated debug logger (dtdbg/dtmsg always write to stdout, so they
+  // would not actually quiet the output). Automatic renaming of duplicate names
+  // is routine for legitimate use cases such as loading nested models whose
+  // links share a base name, where this message is noise rather than a problem.
+  // See https://github.com/gazebosim/gz-physics/issues/725
+  DART_DEBUG(
+      "[NameManager::issueNewName] ({}) The name [{}] is a duplicate, so it "
+      "has "
+      "been renamed to [{}]",
+      mManagerName,
+      _name,
+      newName);
 
   return newName;
 }


### PR DESCRIPTION
## Summary

`NameManager::issueNewName` logs at message (`Msg`) level every time it
auto-renames a duplicate name. Automatic renaming is routine for legitimate use
cases — most notably loading nested models whose links share a base name, as
reported downstream in
[gazebosim/gz-physics#725](https://github.com/gazebosim/gz-physics/issues/725) —
so the message is log noise rather than a signal of a problem.

## Change

Demote the message from `dtmsg` to `dtdbg`, so it stays available at debug
verbosity for diagnostics but no longer spams normal runs. No behavior change
beyond log level.

Relates to gazebosim/gz-physics#725. Dual-PR: `main` forward-port linked separately.
