### PR TITLE
Demote duplicate-name rename message to debug verbosity (DART 7)

### DIFF
--- a/dart/common/detail/name_manager.hpp
+++ b/dart/common/detail/name_manager.hpp
@@ -108,7 +108,11 @@ std::string NameManager<T>::issueNewName(std::string_view name) const
     newName = ss.str();
   } while (hasName(newName));
 
-  DART_INFO(
+  // Demoted to debug verbosity: automatic renaming of duplicate names is
+  // routine for legitimate use cases (e.g. loading nested models whose links
+  // share a base name), where this message is noise rather than a problem.
+  // See https://github.com/gazebosim/gz-physics/issues/725
+  DART_DEBUG(
       "({}) The name [{}] is a duplicate, so it has been renamed to [{}]",
       mManagerName,
       name,


### PR DESCRIPTION
## Summary

Forward-port of #2895 (DART 6.17) to `main` / DART 7.

`NameManager::issueNewName` logs at `DART_INFO` level every time it auto-renames
a duplicate name. Automatic renaming is routine for legitimate use cases — most
notably loading nested models whose links share a base name, as reported in
[gazebosim/gz-physics#725](https://github.com/gazebosim/gz-physics/issues/725) —
so the message is log noise.

## Change

Demote the message from `DART_INFO` to `DART_DEBUG`. No behavior change beyond
log level.

Relates to gazebosim/gz-physics#725. Dual-PR: release-6.17 counterpart is #2895.
