### PR TITLE
Harden Inertia non-finite moment handling (DART 6.17)

### DIFF
--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -45,8 +45,14 @@ Inertia::Inertia(
     double _mass,
     const Eigen::Vector3d& _com,
     const Eigen::Matrix3d& _momentOfInertia)
-  : mMass(_mass), mCenterOfMass(_com)
+  : mMass(_mass), mCenterOfMass(_com), mMoment{1.0, 1.0, 1.0, 0.0, 0.0, 0.0}
 {
+  // Initialize mMoment to a valid default above and derive the spatial tensor
+  // from it, so that if _momentOfInertia is rejected as non-finite by
+  // setMoment() the object is left in a consistent state rather than with
+  // indeterminate members. See
+  // https://github.com/gazebosim/gz-physics/issues/854
+  computeSpatialTensor();
   setMoment(_momentOfInertia);
 }
 
@@ -150,9 +156,13 @@ const Eigen::Vector3d& Inertia::getLocalCOM() const
 void Inertia::setMoment(const Eigen::Matrix3d& _moment)
 {
   // Reject a non-finite moment of inertia at the ingest boundary so NaN/Inf
-  // never reaches the forward-dynamics recursion.
+  // never reaches the forward-dynamics recursion. Only the diagonal and the
+  // upper-triangle entries are consumed below, so a non-finite value in an
+  // ignored lower-triangle entry must not reject an otherwise valid moment.
   // See https://github.com/gazebosim/gz-physics/issues/854
-  if (!_moment.allFinite()) {
+  if (!std::isfinite(_moment(0, 0)) || !std::isfinite(_moment(1, 1))
+      || !std::isfinite(_moment(2, 2)) || !std::isfinite(_moment(0, 1))
+      || !std::isfinite(_moment(0, 2)) || !std::isfinite(_moment(1, 2))) {
     dtwarn << "[Inertia::setMoment] Attempting to set a non-finite moment of "
               "inertia matrix. Ignoring request.\n";
     return;

--- a/tests/integration/test_Inertia.cpp
+++ b/tests/integration/test_Inertia.cpp
@@ -38,6 +38,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 using namespace dart;
 
 //==============================================================================
@@ -60,4 +62,25 @@ TEST(Inertia, Verification)
 
     EXPECT_TRUE(inertia.verify());
   }
+}
+
+//==============================================================================
+// A non-finite moment of inertia passed to the constructor must leave the
+// object in a valid (finite) state. setMoment() rejects the non-finite matrix
+// and returns early, so the constructor must first establish a valid default
+// rather than leaving mMoment / the spatial tensor indeterminate.
+// See https://github.com/gazebosim/gz-physics/issues/854
+TEST(Inertia, NonFiniteMomentConstructorLeavesValidState)
+{
+  Eigen::Matrix3d nanMoment = Eigen::Matrix3d::Identity();
+  nanMoment(0, 0) = std::numeric_limits<double>::quiet_NaN();
+  const dynamics::Inertia nanInertia(1.0, Eigen::Vector3d::Zero(), nanMoment);
+  EXPECT_TRUE(nanInertia.getMoment().allFinite());
+  EXPECT_TRUE(nanInertia.getSpatialTensor().allFinite());
+
+  Eigen::Matrix3d infMoment = Eigen::Matrix3d::Identity();
+  infMoment(2, 2) = std::numeric_limits<double>::infinity();
+  const dynamics::Inertia infInertia(1.0, Eigen::Vector3d::Zero(), infMoment);
+  EXPECT_TRUE(infInertia.getMoment().allFinite());
+  EXPECT_TRUE(infInertia.getSpatialTensor().allFinite());
 }


### PR DESCRIPTION
## Summary

Follow-up to #2885 (already merged). Codex flagged a P1 on the forward-port
(#2887): the `Inertia(mass, com, matrix)` constructor initializes only `mMass`
and `mCenterOfMass` before delegating to `setMoment()`. Since #2885 made
`setMoment()` reject a non-finite matrix and return early, a non-finite matrix
passed to this constructor leaves `mMoment` and the spatial tensor
**indeterminate**, so a later `getMoment()` / `getSpatialTensor()` (or the
dynamics code) can read uninitialized data.

## Change

Initialize `mMoment` to a valid default and compute the spatial tensor before
applying the requested moment, so a rejected (non-finite) matrix leaves the
object in a consistent state. Adds `Inertia.NonFiniteMomentConstructorLeavesValidState`.

## Testing

Verified in a **Debug (asserts-enabled)** build: `test_Inertia` and
`INTEGRATION_InvalidDynamicsInputs` pass.

Relates to gazebosim/gz-physics#854. The main/DART 7 equivalent is folded into #2887.
