### PR TITLE
Release DART 6.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## DART 6
 
+### [DART 6.17.1 (2026-06-05)](https://github.com/dartsim/dart/milestone/95?closed=1)
+
+DART 6.17.1 is a patch release on the DART 6 LTS line. It hardens the classic
+DART 6 API against non-finite and degenerate inputs surfaced through gz-physics,
+so invalid SDF data degrades gracefully (with a warning) instead of aborting.
+
+* Collision
+
+  * Clamp the ODE heightfield extents, vertical scale, and bounds so an extreme `HeightmapShape` scale no longer aborts `dCollideHeightfield`: [#2894](https://github.com/dartsim/dart/pull/2894), [gazebosim/gz-physics#847](https://github.com/gazebosim/gz-physics/issues/847)
+
+* Dynamics
+
+  * Validate `HeightmapShape` scale and height-field values, rejecting non-finite and non-positive inputs: [#2884](https://github.com/dartsim/dart/pull/2884), [gazebosim/gz-physics#847](https://github.com/gazebosim/gz-physics/issues/847)
+  * Reject non-finite mass and moment of inertia at the `Inertia` ingest boundary: [#2885](https://github.com/dartsim/dart/pull/2885), [gazebosim/gz-physics#854](https://github.com/gazebosim/gz-physics/issues/854)
+  * Initialize `Inertia` to a valid state before applying a rejected moment, and check only the consumed inertia entries: [#2898](https://github.com/dartsim/dart/pull/2898)
+
+* Common
+
+  * Demote the duplicate-name auto-rename message to debug verbosity: [#2895](https://github.com/dartsim/dart/pull/2895), [gazebosim/gz-physics#725](https://github.com/gazebosim/gz-physics/issues/725)
+
+* Build
+
+  * Use pixi for the DART 6 Windows wheel dependencies: [#2882](https://github.com/dartsim/dart/pull/2882)
+
 ### [DART 6.17.0 (2026-06-03)](https://github.com/dartsim/dart/milestone/85?closed=1)
 
 DART 6.17.0 is a maintenance release on the DART 6 LTS compatibility line. It

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.17.0</version>
+  <version>6.17.1</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.17.0"
+version = "6.17.1"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
## Summary

Cuts the **DART 6.17.1** patch release on the DART 6 LTS line.

- `package.xml` / `pixi.toml`: `6.17.0` → `6.17.1`
- `CHANGELOG.md`: new 6.17.1 section

## Contents (all already merged to `release-6.17`)

Hardens the classic DART 6 API against non-finite / degenerate inputs surfaced
through gz-physics, so invalid SDF data degrades gracefully (with a warning)
instead of aborting:

- HeightmapShape scale/height-field validation: #2884 (gz-physics#847)
- ODE heightfield extent clamp: #2894 (gz-physics#847)
- Reject non-finite mass/inertia: #2885 (gz-physics#854/#851/#849)
- Inertia constructor + consumed-triangle hardening: #2898
- Demote duplicate-name message to debug: #2895 (gz-physics#725)
- pixi for DART 6 Windows wheel deps: #2882

After merge: tag `v6.17.1` and publish the GitHub release; refresh downstream
packaging (PPA/conda) as usual.
