### PR TITLE
Stabilize ODE capsule contacts (DART 6.18)

### DIFF
--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -104,20 +104,55 @@ OdeCollisionDetector::CollObjPair MakeNewPair(
   return std::make_pair(o1, o2);
 }
 
-std::deque<Contact>& FindPairInHist(
+bool hasTransformMoved(
+    const Eigen::Isometry3d& previous, const Eigen::Isometry3d& current)
+{
+  constexpr double translationTolerance = 5e-2;
+  constexpr double rotationTolerance = 5e-2;
+  return (previous.translation() - current.translation()).norm()
+             > translationTolerance
+         || !previous.linear().isApprox(current.linear(), rotationTolerance);
+}
+
+void refreshHistoryTransforms(OdeCollisionDetector::ContactHistoryItem& item)
+{
+  const auto& transform1 = item.pair.first->getTransform();
+  const auto& transform2 = item.pair.second->getTransform();
+
+  if (!item.hasTransforms) {
+    item.transform1 = transform1;
+    item.transform2 = transform2;
+    item.hasTransforms = true;
+    return;
+  }
+
+  const bool moved = hasTransformMoved(item.transform1, transform1)
+                     || hasTransformMoved(item.transform2, transform2);
+  if (moved)
+    item.history.clear();
+
+  item.transform1 = transform1;
+  item.transform2 = transform2;
+}
+
+OdeCollisionDetector::ContactHistoryItem& FindPairInHist(
     std::vector<OdeCollisionDetector::ContactHistoryItem>& cache,
     const OdeCollisionDetector::CollObjPair& pair)
 {
   for (auto& item : cache) {
     if (pair.first == item.pair.first && pair.second == item.pair.second) {
-      return item.history;
+      return item;
     }
   }
-  auto newItem
-      = OdeCollisionDetector::ContactHistoryItem{pair, std::deque<Contact>()};
+
+  OdeCollisionDetector::ContactHistoryItem newItem;
+  newItem.pair = pair;
+  newItem.transform1 = Eigen::Isometry3d::Identity();
+  newItem.transform2 = Eigen::Isometry3d::Identity();
+  newItem.hasTransforms = false;
   cache.push_back(newItem);
 
-  return cache.back().history;
+  return cache.back();
 }
 
 void eraseHistoryForObject(
@@ -417,11 +452,10 @@ void reportContacts(
   if (1 == numContacts && option.enableContact) {
     const auto* shapeA = b1->getShape().get();
     const auto* shapeB = b2->getShape().get();
-    const bool boxCylinderPair
-        = (shapeA->as<dynamics::BoxShape>()
-           && shapeB->as<dynamics::CylinderShape>())
-          || (shapeA->as<dynamics::CylinderShape>()
-              && shapeB->as<dynamics::BoxShape>());
+    const bool boxCylinderPair = (shapeA->as<dynamics::BoxShape>()
+                                  && shapeB->as<dynamics::CylinderShape>())
+                                 || (shapeA->as<dynamics::CylinderShape>()
+                                     && shapeB->as<dynamics::BoxShape>());
     if (boxCylinderPair) {
       auto baseContact = convertContact(contactGeoms[0], b1, b2, option);
       alignBoxCylinderNormal(baseContact);
@@ -455,7 +489,9 @@ void reportContacts(
   }
 
   const auto pair = MakeNewPair(b1, b2);
-  auto& pastContacsVec = FindPairInHist(*history, pair);
+  auto& historyItem = FindPairInHist(*history, pair);
+  refreshHistoryTransforms(historyItem);
+  auto& pastContacsVec = historyItem.history;
   auto results_vec_copy = result.getContacts();
 
   bool sliding = false;

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/ode/OdeCollisionDetector.hpp"
 
 #include "dart/collision/CollisionFilter.hpp"
+#include "dart/collision/Contact.hpp"
 #include "dart/collision/ode/OdeCollisionGroup.hpp"
 #include "dart/collision/ode/OdeCollisionObject.hpp"
 #include "dart/collision/ode/OdeTypes.hpp"
@@ -40,9 +41,21 @@
 #include "dart/config.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/EllipsoidShape.hpp"
+#include "dart/dynamics/Frame.hpp"
+#include "dart/dynamics/MeshShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
+#include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/ShapeNode.hpp"
+#include "dart/dynamics/SoftMeshShape.hpp"
+#include "dart/dynamics/SphereShape.hpp"
 
 #include <ode/ode.h>
 
+#include <algorithm>
+#include <deque>
+#include <functional>
+#include <utility>
 #include <vector>
 
 namespace dart {
@@ -58,7 +71,8 @@ void reportContacts(
     OdeCollisionObject* b1,
     OdeCollisionObject* b2,
     const CollisionOption& option,
-    CollisionResult& result);
+    CollisionResult& result,
+    std::vector<OdeCollisionDetector::ContactHistoryItem>* history);
 
 Contact convertContact(
     const dContactGeom& fclContact,
@@ -76,6 +90,53 @@ bool expandBoxCylinderContact(
     CollisionResult& result);
 #endif
 
+double computeTangentialSpeed(const Contact& contact);
+
+bool shouldUseContactHistory(
+    const CollisionObject* object1, const CollisionObject* object2);
+
+OdeCollisionDetector::CollObjPair MakeNewPair(
+    CollisionObject* o1, CollisionObject* o2)
+{
+  if (std::less<CollisionObject*>()(o2, o1)) {
+    std::swap(o1, o2);
+  }
+  return std::make_pair(o1, o2);
+}
+
+std::deque<Contact>& FindPairInHist(
+    std::vector<OdeCollisionDetector::ContactHistoryItem>& cache,
+    const OdeCollisionDetector::CollObjPair& pair)
+{
+  for (auto& item : cache) {
+    if (pair.first == item.pair.first && pair.second == item.pair.second) {
+      return item.history;
+    }
+  }
+  auto newItem
+      = OdeCollisionDetector::ContactHistoryItem{pair, std::deque<Contact>()};
+  cache.push_back(newItem);
+
+  return cache.back().history;
+}
+
+void eraseHistoryForObject(
+    std::vector<OdeCollisionDetector::ContactHistoryItem>& cache,
+    const CollisionObject* object)
+{
+  if (!object)
+    return;
+
+  cache.erase(
+      std::remove_if(
+          cache.begin(),
+          cache.end(),
+          [object](const OdeCollisionDetector::ContactHistoryItem& item) {
+            return item.pair.first == object || item.pair.second == object;
+          }),
+      cache.end());
+}
+
 struct OdeCollisionCallbackData
 {
   dContactGeom* contactGeoms;
@@ -85,6 +146,7 @@ struct OdeCollisionCallbackData
 
   /// Collision result of DART
   CollisionResult* result;
+  std::vector<OdeCollisionDetector::ContactHistoryItem>* history;
 
   /// Whether the collision iteration can stop
   bool done;
@@ -96,7 +158,11 @@ struct OdeCollisionCallbackData
 
   OdeCollisionCallbackData(
       const CollisionOption& option, CollisionResult* result)
-    : option(option), result(result), done(false), numContacts(0u)
+    : option(option),
+      result(result),
+      history(nullptr),
+      done(false),
+      numContacts(0u)
   {
     // Do nothing
   }
@@ -164,8 +230,13 @@ bool OdeCollisionDetector::collide(
 
   OdeCollisionCallbackData data(option, result);
   data.contactGeoms = contactCollisions;
+  data.history = &mContactHistory;
 
   dSpaceCollide(odeGroup->getOdeSpaceId(), &data, CollisionCallback);
+
+  if (result) {
+    pruneContactHistory(*result);
+  }
 
   return data.numContacts > 0;
 }
@@ -185,12 +256,17 @@ bool OdeCollisionDetector::collide(
 
   OdeCollisionCallbackData data(option, result);
   data.contactGeoms = contactCollisions;
+  data.history = &mContactHistory;
 
   dSpaceCollide2(
       reinterpret_cast<dGeomID>(odeGroup1->getOdeSpaceId()),
       reinterpret_cast<dGeomID>(odeGroup2->getOdeSpaceId()),
       &data,
       CollisionCallback);
+
+  if (result) {
+    pruneContactHistory(*result);
+  }
 
   return data.numContacts > 0;
 }
@@ -256,6 +332,7 @@ dWorldID OdeCollisionDetector::getOdeWorldId() const
   return mWorldId;
 }
 
+//==============================================================================
 namespace {
 
 //==============================================================================
@@ -291,8 +368,10 @@ void CollisionCallback(void* data, dGeomID o1, dGeomID o2)
 
   cdData->numContacts += numc;
 
-  if (result)
-    reportContacts(numc, odeResult, collObj1, collObj2, option, *result);
+  if (result) {
+    reportContacts(
+        numc, odeResult, collObj1, collObj2, option, *result, cdData->history);
+  }
 }
 
 //==============================================================================
@@ -302,9 +381,16 @@ void reportContacts(
     OdeCollisionObject* b1,
     OdeCollisionObject* b2,
     const CollisionOption& option,
-    CollisionResult& result)
+    CollisionResult& result,
+    std::vector<OdeCollisionDetector::ContactHistoryItem>* history)
 {
   if (0u == numContacts)
+    return;
+
+  if (0u == option.maxNumContacts)
+    return;
+
+  if (result.getNumContacts() >= option.maxNumContacts)
     return;
 
   // For binary check, return after adding the first contact point to the result
@@ -322,25 +408,123 @@ void reportContacts(
     return;
   }
 
-  if (1 == numContacts) {
-    auto baseContact = convertContact(contactGeoms[0], b1, b2, option);
+  // Box-cylinder pairs keep release-6.17's libccd single-contact stabilization
+  // and return here. Every OTHER single-contact pair (e.g. a resting capsule)
+  // must fall through to the contact-history path below so it is supplemented
+  // to a stable manifold; otherwise the capsule sinks through the ground.
+  // See gazebosim/gz-physics#692 / dartsim/dart#1654.
 #if DART_ODE_HAS_LIBCCD_BOX_CYL
-    if (option.enableContact) {
+  if (1 == numContacts && option.enableContact) {
+    const auto* shapeA = b1->getShape().get();
+    const auto* shapeB = b2->getShape().get();
+    const bool boxCylinderPair
+        = (shapeA->as<dynamics::BoxShape>()
+           && shapeB->as<dynamics::CylinderShape>())
+          || (shapeA->as<dynamics::CylinderShape>()
+              && shapeB->as<dynamics::BoxShape>());
+    if (boxCylinderPair) {
+      auto baseContact = convertContact(contactGeoms[0], b1, b2, option);
       alignBoxCylinderNormal(baseContact);
       stabilizeBoxCylinderContactPoint(baseContact);
       if (expandBoxCylinderContact(baseContact, option, result))
         return;
+      result.addContact(baseContact);
+      return;
     }
+  }
 #endif
-    result.addContact(baseContact);
+
+  const auto available = option.maxNumContacts - result.getNumContacts();
+  const auto requested = static_cast<std::size_t>(numContacts);
+  const auto contactsToCopy = static_cast<int>(std::min(requested, available));
+
+  for (auto i = 0; i < contactsToCopy; ++i) {
+    result.addContact(convertContact(contactGeoms[i], b1, b2, option));
+  }
+
+  if (result.getNumContacts() >= option.maxNumContacts) {
     return;
   }
 
-  for (auto i = 0; i < numContacts; ++i) {
-    result.addContact(convertContact(contactGeoms[i], b1, b2, option));
+  if (!history || !shouldUseContactHistory(b1, b2)) {
+    return;
+  }
 
-    if (result.getNumContacts() >= option.maxNumContacts)
-      return;
+  const auto pair = MakeNewPair(b1, b2);
+  auto& pastContacsVec = FindPairInHist(*history, pair);
+  auto results_vec_copy = result.getContacts();
+
+  bool sliding = false;
+  constexpr double slidingThreshold = 1e-3;
+  std::size_t pairContactCount = 0u;
+  for (const auto& curr_cont : results_vec_copy) {
+    const auto current_pair
+        = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
+    if (current_pair != pair)
+      continue;
+
+    ++pairContactCount;
+
+    if (computeTangentialSpeed(curr_cont) > slidingThreshold) {
+      sliding = true;
+      break;
+    }
+  }
+
+  if (sliding) {
+    return;
+  }
+
+  const std::size_t pairTarget
+      = std::min<std::size_t>(3u, option.maxNumContacts);
+  if (pairContactCount >= pairTarget) {
+    return;
+  }
+
+  std::size_t missing = pairTarget - pairContactCount;
+  const auto globalRemaining = option.maxNumContacts - result.getNumContacts();
+  missing = std::min(missing, globalRemaining);
+  if (missing == 0u) {
+    return;
+  }
+
+  for (auto it = pastContacsVec.rbegin();
+       it != pastContacsVec.rend() && missing > 0u;
+       ++it) {
+    auto past_cont = *it;
+    for (const auto& curr_cont : results_vec_copy) {
+      const auto res_pair
+          = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
+      if (res_pair != pair) {
+        continue;
+      }
+      auto dist_v = past_cont.point - curr_cont.point;
+      const auto dist_m = (dist_v.transpose() * dist_v).coeff(0, 0);
+      if (dist_m < 0.01) {
+        continue;
+      }
+      if (result.getNumContacts() >= option.maxNumContacts) {
+        return;
+      }
+      result.addContact(past_cont);
+      if (--missing == 0u)
+        break;
+    }
+    if (missing == 0u) {
+      break;
+    }
+  }
+  for (const auto& item : results_vec_copy) {
+    const auto res_pair
+        = MakeNewPair(item.collisionObject1, item.collisionObject2);
+    if (res_pair == pair) {
+      pastContacsVec.push_back(item);
+    }
+  }
+
+  const auto size = pastContacsVec.size();
+  if (size > 11) {
+    pastContacsVec.erase(pastContacsVec.begin(), pastContacsVec.end() - 5);
   }
 }
 
@@ -597,7 +781,97 @@ bool expandBoxCylinderContact(
 }
 #endif
 
+double computeTangentialSpeed(const Contact& contact)
+{
+  const auto* frame1 = contact.collisionObject1
+                           ? contact.collisionObject1->getShapeFrame()
+                           : nullptr;
+  const auto* frame2 = contact.collisionObject2
+                           ? contact.collisionObject2->getShapeFrame()
+                           : nullptr;
+
+  const dynamics::BodyNode* bn1 = (frame1 && frame1->isShapeNode())
+                                      ? frame1->asShapeNode()->getBodyNodePtr()
+                                      : nullptr;
+  const dynamics::BodyNode* bn2 = (frame2 && frame2->isShapeNode())
+                                      ? frame2->asShapeNode()->getBodyNodePtr()
+                                      : nullptr;
+
+  const Eigen::Vector3d worldPoint = contact.point;
+
+  Eigen::Vector3d v1 = Eigen::Vector3d::Zero();
+  if (bn1) {
+    const Eigen::Vector3d localPoint
+        = bn1->getWorldTransform().inverse() * worldPoint;
+    v1 = bn1->getLinearVelocity(
+        localPoint, dynamics::Frame::World(), dynamics::Frame::World());
+  }
+
+  Eigen::Vector3d v2 = Eigen::Vector3d::Zero();
+  if (bn2) {
+    const Eigen::Vector3d localPoint
+        = bn2->getWorldTransform().inverse() * worldPoint;
+    v2 = bn2->getLinearVelocity(
+        localPoint, dynamics::Frame::World(), dynamics::Frame::World());
+  }
+
+  const Eigen::Vector3d rel = v1 - v2;
+  Eigen::Vector3d normal = contact.normal;
+  const double normalNorm = normal.norm();
+  if (normalNorm > 0.0) {
+    normal /= normalNorm;
+  } else {
+    normal.setZero();
+  }
+  const Eigen::Vector3d tangential = rel - rel.dot(normal) * normal;
+  return tangential.norm();
+}
+
+bool shouldUseContactHistory(
+    const CollisionObject* object1, const CollisionObject* object2)
+{
+  // Persist contacts for any shape pair so resting contacts stay stable across
+  // detector runs. The sliding/tangential-speed checks later will filter cases
+  // where the cache should not be re-used.
+  return object1 != nullptr && object2 != nullptr;
+}
+
 } // anonymous namespace
+
+//==============================================================================
+void OdeCollisionDetector::pruneContactHistory(const CollisionResult& result)
+{
+  if (mContactHistory.empty())
+    return;
+
+  const auto& contacts = result.getContacts();
+  for (auto& pastContact : mContactHistory) {
+    bool clear = true;
+    for (const auto& current : contacts) {
+      auto currentPair
+          = MakeNewPair(current.collisionObject1, current.collisionObject2);
+      if (pastContact.pair == currentPair) {
+        clear = false;
+        break;
+      }
+    }
+    if (clear) {
+      pastContact.history.clear();
+    }
+  }
+}
+
+//==============================================================================
+void OdeCollisionDetector::clearContactHistoryFor(const CollisionObject* object)
+{
+  eraseHistoryForObject(mContactHistory, object);
+}
+
+//==============================================================================
+void OdeCollisionDetector::clearContactHistory()
+{
+  mContactHistory.clear();
+}
 
 } // namespace collision
 } // namespace dart

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -539,27 +539,33 @@ void reportContacts(
        it != pastContacsVec.rend() && missing > 0u;
        ++it) {
     auto past_cont = *it;
+    bool matchesCurrentContact = false;
+    bool hasCurrentContactForPair = false;
     for (const auto& curr_cont : results_vec_copy) {
       const auto res_pair
           = MakeNewPair(curr_cont.collisionObject1, curr_cont.collisionObject2);
       if (res_pair != pair) {
         continue;
       }
+      hasCurrentContactForPair = true;
       auto dist_v = past_cont.point - curr_cont.point;
       const auto dist_m = (dist_v.transpose() * dist_v).coeff(0, 0);
       if (dist_m < 0.01) {
-        continue;
-      }
-      if (result.getNumContacts() >= option.maxNumContacts) {
-        return;
-      }
-      result.addContact(past_cont);
-      if (--missing == 0u)
+        matchesCurrentContact = true;
         break;
+      }
     }
-    if (missing == 0u) {
+
+    if (matchesCurrentContact || !hasCurrentContactForPair) {
+      continue;
+    }
+
+    if (result.getNumContacts() >= option.maxNumContacts) {
+      return;
+    }
+    result.addContact(past_cont);
+    if (--missing == 0u)
       break;
-    }
   }
   for (const auto& item : results_vec_copy) {
     const auto res_pair

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -119,7 +119,7 @@ void refreshHistoryTransforms(OdeCollisionDetector::ContactHistoryItem& item)
   const auto& transform1 = item.pair.first->getTransform();
   const auto& transform2 = item.pair.second->getTransform();
 
-  if (!item.hasTransforms) {
+  if (!item.hasTransforms || item.history.empty()) {
     item.transform1 = transform1;
     item.transform2 = transform2;
     item.hasTransforms = true;
@@ -128,11 +128,13 @@ void refreshHistoryTransforms(OdeCollisionDetector::ContactHistoryItem& item)
 
   const bool moved = hasTransformMoved(item.transform1, transform1)
                      || hasTransformMoved(item.transform2, transform2);
-  if (moved)
+  if (moved) {
     item.history.clear();
-
-  item.transform1 = transform1;
-  item.transform2 = transform2;
+    item.transform1 = transform1;
+    item.transform2 = transform2;
+  }
+  // Otherwise keep the previous transforms as the contact-history anchor so
+  // several small kinematic pose changes still invalidate stale world points.
 }
 
 OdeCollisionDetector::ContactHistoryItem& FindPairInHist(

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -446,7 +446,11 @@ void reportContacts(
     return;
   }
 
-  if (!history || !shouldUseContactHistory(b1, b2)) {
+  // Skip the contact-history path entirely for binary queries
+  // (enableContact == false): convertContact() leaves point/normal/depth at
+  // their defaults for those, so caching them would later supplement a real
+  // manifold with stale zero-depth contacts at the world origin.
+  if (!history || !option.enableContact || !shouldUseContactHistory(b1, b2)) {
     return;
   }
 

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -476,6 +476,11 @@ void reportContacts(
   }
 
   if (sliding) {
+    // The pair is moving tangentially, so the cached world-space contacts no
+    // longer describe the current contact patch. Drop them instead of leaving
+    // stale points that a later resting query could resurface far from the new
+    // patch.
+    pastContacsVec.clear();
     return;
   }
 
@@ -834,10 +839,20 @@ double computeTangentialSpeed(const Contact& contact)
 bool shouldUseContactHistory(
     const CollisionObject* object1, const CollisionObject* object2)
 {
-  // Persist contacts for any shape pair so resting contacts stay stable across
-  // detector runs. The sliding/tangential-speed checks later will filter cases
-  // where the cache should not be re-used.
-  return object1 != nullptr && object2 != nullptr;
+  // Only persist contacts for pairs whose tangential motion we can actually
+  // track: both objects must be ShapeNodes backed by a BodyNode. The
+  // sliding/tangential-speed check that filters stale cache entries relies on
+  // body velocities (computeTangentialSpeed), so for frames without a BodyNode
+  // (e.g. a kinematically moved SimpleFrame) it always reads zero speed and
+  // could resurface world-space contact points from a previous pose.
+  const auto hasTrackedBody = [](const CollisionObject* object) {
+    if (object == nullptr)
+      return false;
+    const auto* frame = object->getShapeFrame();
+    return frame != nullptr && frame->isShapeNode()
+           && frame->asShapeNode()->getBodyNodePtr() != nullptr;
+  };
+  return hasTrackedBody(object1) && hasTrackedBody(object2);
 }
 
 } // anonymous namespace

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -37,6 +37,10 @@
 
 #include <ode/ode.h>
 
+#include <deque>
+#include <utility>
+#include <vector>
+
 #define MAX_COLLIDE_RETURNS 250
 
 namespace dart {
@@ -47,6 +51,11 @@ namespace collision {
 /// The supported collision shape types are sphere, box, capsule, cylinder,
 /// plane, and trimesh.
 ///
+/// The detector keeps a short history of contact manifolds per shape pair in
+/// order to stabilize resting configurations (for example, capsules lying on a
+/// plane). This improves parity with Bullet while maintaining ODE as the
+/// narrow-phase backend.
+///
 /// ODE additionally supports ray and heightfiled, but DART doesn't support them
 /// yet.
 class OdeCollisionDetector : public CollisionDetector
@@ -55,6 +64,14 @@ public:
   using CollisionDetector::createCollisionGroup;
 
   friend class OdeCollisionObject;
+  friend class OdeCollisionGroup;
+  using CollObjPair = std::pair<CollisionObject*, CollisionObject*>;
+
+  struct ContactHistoryItem
+  {
+    CollObjPair pair;
+    std::deque<Contact> history;
+  };
 
   static std::shared_ptr<OdeCollisionDetector> create();
 
@@ -120,8 +137,13 @@ protected:
 private:
   dGeomID createOdeCollisionGeometry(const dynamics::ConstShapePtr& shape);
 
+  void clearContactHistoryFor(const CollisionObject* object);
+  void clearContactHistory();
+  void pruneContactHistory(const CollisionResult& result);
+
 private:
   dContactGeom contactCollisions[MAX_COLLIDE_RETURNS];
+  std::vector<ContactHistoryItem> mContactHistory;
   static Registrar<OdeCollisionDetector> mRegistrar;
 };
 

--- a/dart/collision/ode/OdeCollisionDetector.hpp
+++ b/dart/collision/ode/OdeCollisionDetector.hpp
@@ -70,6 +70,9 @@ public:
   struct ContactHistoryItem
   {
     CollObjPair pair;
+    Eigen::Isometry3d transform1;
+    Eigen::Isometry3d transform2;
+    bool hasTransforms;
     std::deque<Contact> history;
   };
 

--- a/dart/collision/ode/OdeCollisionGroup.cpp
+++ b/dart/collision/ode/OdeCollisionGroup.cpp
@@ -32,8 +32,11 @@
 
 #include "dart/collision/ode/OdeCollisionGroup.hpp"
 
+#include "dart/collision/ode/OdeCollisionDetector.hpp"
 #include "dart/collision/ode/OdeCollisionObject.hpp"
 #include "dart/common/Macros.hpp"
+
+#include <memory>
 
 namespace dart {
 namespace collision {
@@ -98,6 +101,11 @@ void OdeCollisionGroup::addCollisionObjectsToEngine(
 //==============================================================================
 void OdeCollisionGroup::removeCollisionObjectFromEngine(CollisionObject* object)
 {
+  if (auto detector = std::static_pointer_cast<OdeCollisionDetector>(
+          getCollisionDetector())) {
+    detector->clearContactHistoryFor(object);
+  }
+
   auto casted = static_cast<OdeCollisionObject*>(object);
   auto geomId = casted->getOdeGeomId();
   dSpaceRemove(mSpaceId, geomId);
@@ -108,6 +116,11 @@ void OdeCollisionGroup::removeCollisionObjectFromEngine(CollisionObject* object)
 //==============================================================================
 void OdeCollisionGroup::removeAllCollisionObjectsFromEngine()
 {
+  if (auto detector = std::static_pointer_cast<OdeCollisionDetector>(
+          getCollisionDetector())) {
+    detector->clearContactHistory();
+  }
+
   dSpaceClean(mSpaceId);
 
   initializeEngineData();

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -67,11 +67,10 @@ if(TARGET dart-utils)
   dart_add_test("integration" test_SkelParser)
   target_link_libraries(test_SkelParser dart-utils)
 
-  if(NOT MSVC) 
+  if(NOT MSVC)
     dart_add_test("integration" test_VskParser)
     target_link_libraries(test_VskParser dart-utils)
   endif()
-
 endif()
 
 if(TARGET dart-utils-urdf)
@@ -123,6 +122,13 @@ if(TARGET dart-collision-ode)
   # it difficult to come up with correct test expectations.
   dart_add_test("integration" test_ForceDependentSlip)
   target_link_libraries(test_ForceDependentSlip dart-collision-ode)
+endif()
+
+if(TARGET dart-collision-bullet AND TARGET dart-collision-ode)
+  dart_add_test("integration" test_CapsuleGroundContact)
+  target_link_libraries(test_CapsuleGroundContact
+    dart-collision-bullet
+    dart-collision-ode)
 endif()
 
 if(TARGET dart-utils)

--- a/tests/integration/test_CapsuleGroundContact.cpp
+++ b/tests/integration/test_CapsuleGroundContact.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dart.hpp"
+
+#include "dart/collision/bullet/bullet.hpp"
+#include "dart/collision/ode/ode.hpp"
+
+#include <gtest/gtest.h>
+
+#include "TestHelpers.hpp"
+
+#include <functional>
+#include <tuple>
+
+using namespace dart::dynamics;
+using namespace dart::simulation;
+
+namespace {
+
+constexpr double kCapsuleRadius = 0.2;
+constexpr double kCapsuleHeight = 0.6;
+constexpr double kTolerance = 0.05;
+constexpr int kNumSteps = 50000;
+
+using DetectorFactory = std::function<dart::collision::CollisionDetectorPtr()>;
+
+//==============================================================================
+void runCapsuleGroundContactTest(const DetectorFactory& factory)
+{
+  auto world = World::create();
+  world->getConstraintSolver()->setCollisionDetector(factory());
+
+  auto ground = createBox({10000, 1000, 0.1}, {0, 0, -0.05});
+  ground->setMobile(false);
+  world->addSkeleton(ground);
+
+  auto skeleton = Skeleton::create("capsule");
+  FreeJoint* joint;
+  BodyNode* bodyNode;
+  std::tie(joint, bodyNode) = skeleton->createJointAndBodyNodePair<FreeJoint>();
+
+  Eigen::Isometry3d placement
+      = Eigen::Translation3d(0, 0, 0.5)
+        * Eigen::AngleAxisd(
+            dart::math::constantsd::half_pi(), Eigen::Vector3d::UnitY());
+  joint->setRelativeTransform(placement);
+
+  auto capsuleShape
+      = std::make_shared<CapsuleShape>(kCapsuleRadius, kCapsuleHeight);
+  auto* capsuleNode
+      = bodyNode->createShapeNodeWith<CollisionAspect, DynamicsAspect>(
+          capsuleShape);
+
+  dart::dynamics::Inertia inertia;
+  inertia.setMass(1.0);
+  inertia.setMoment(capsuleNode->getShape()->computeInertia(inertia.getMass()));
+  bodyNode->setInertia(inertia);
+
+  world->addSkeleton(skeleton);
+
+  for (int i = 0; i < kNumSteps; ++i) {
+    world->step();
+    const auto position = bodyNode->getWorldTransform().translation();
+    ASSERT_GT(position.z(), kCapsuleRadius - kTolerance);
+  }
+}
+
+} // namespace
+
+//==============================================================================
+TEST(Issue1654, BulletCapsuleGroundContact)
+{
+  runCapsuleGroundContactTest(
+      [] { return dart::collision::BulletCollisionDetector::create(); });
+}
+
+//==============================================================================
+TEST(Issue1654, ODECapsuleGroundContact)
+{
+  runCapsuleGroundContactTest(
+      [] { return dart::collision::OdeCollisionDetector::create(); });
+}

--- a/tests/integration/test_CapsuleGroundContact.cpp
+++ b/tests/integration/test_CapsuleGroundContact.cpp
@@ -30,14 +30,12 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "dart/dart.hpp"
-
+#include "TestHelpers.hpp"
 #include "dart/collision/bullet/bullet.hpp"
 #include "dart/collision/ode/ode.hpp"
+#include "dart/dart.hpp"
 
 #include <gtest/gtest.h>
-
-#include "TestHelpers.hpp"
 
 #include <functional>
 #include <tuple>

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -2164,6 +2164,49 @@ TEST(Issue1654, OdeContactHistoryClearsAfterIncrementalKinematicPoseChanges)
 }
 
 //==============================================================================
+TEST(Issue1654, OdeContactHistorySkipsDuplicateCurrentContacts)
+{
+  auto detector = OdeCollisionDetector::create();
+  auto group = detector->createCollisionGroup();
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 4u;
+
+  auto skeleton1 = Skeleton::create("duplicate_contact1");
+  auto skeleton2 = Skeleton::create("duplicate_contact2");
+
+  auto pair1 = skeleton1->createJointAndBodyNodePair<FreeJoint>();
+  auto pair2 = skeleton2->createJointAndBodyNodePair<FreeJoint>();
+  auto* joint1 = pair1.first;
+  auto* body1 = pair1.second;
+  auto* joint2 = pair2.first;
+  auto* body2 = pair2.second;
+
+  body1->createShapeNodeWith<CollisionAspect>(
+      std::make_shared<CapsuleShape>(1.0, 1.0));
+  body2->createShapeNodeWith<CollisionAspect>(
+      std::make_shared<CapsuleShape>(0.5, 1.0));
+
+  Eigen::Isometry3d pose1 = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose2 = Eigen::Isometry3d::Identity();
+  pose2.translate(Eigen::Vector3d(0.74, 0.0, 0.0));
+  joint1->setRelativeTransform(pose1);
+  joint2->setRelativeTransform(pose2);
+
+  group->addShapeFramesOf(body1);
+  group->addShapeFramesOf(body2);
+
+  CollisionResult result;
+  ASSERT_TRUE(group->collide(option, &result));
+  ASSERT_EQ(2u, result.getNumContacts());
+
+  result.clear();
+  ASSERT_TRUE(group->collide(option, &result));
+  EXPECT_EQ(2u, result.getNumContacts());
+}
+
+//==============================================================================
 TEST(Issue1654, OdeHonorsMaxNumContacts)
 {
   auto detector = OdeCollisionDetector::create();

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -2115,6 +2115,55 @@ TEST(Issue1654, OdeContactHistoryClearsAfterKinematicPoseJump)
 }
 
 //==============================================================================
+TEST(Issue1654, OdeContactHistoryClearsAfterIncrementalKinematicPoseChanges)
+{
+  auto detector = OdeCollisionDetector::create();
+  auto group = detector->createCollisionGroup();
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 4u;
+
+  auto skeleton1 = Skeleton::create("incremental_pose1");
+  auto skeleton2 = Skeleton::create("incremental_pose2");
+
+  auto pair1 = skeleton1->createJointAndBodyNodePair<FreeJoint>();
+  auto pair2 = skeleton2->createJointAndBodyNodePair<FreeJoint>();
+  auto* joint1 = pair1.first;
+  auto* body1 = pair1.second;
+  auto* joint2 = pair2.first;
+  auto* body2 = pair2.second;
+
+  auto sphere = std::make_shared<SphereShape>(1.0);
+  body1->createShapeNodeWith<CollisionAspect>(sphere);
+  body2->createShapeNodeWith<CollisionAspect>(sphere);
+
+  Eigen::Isometry3d pose1 = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose2 = Eigen::Isometry3d::Identity();
+  pose2.translate(Eigen::Vector3d::UnitX() * 0.4);
+  joint1->setRelativeTransform(pose1);
+  joint2->setRelativeTransform(pose2);
+
+  group->addShapeFramesOf(body1);
+  group->addShapeFramesOf(body2);
+
+  CollisionResult result;
+  ASSERT_TRUE(group->collide(option, &result));
+  ASSERT_EQ(1u, result.getNumContacts());
+
+  for (auto step = 0u; step < 3u; ++step) {
+    pose1.translation() += Eigen::Vector3d::UnitY() * 0.04;
+    pose2.translation() += Eigen::Vector3d::UnitY() * 0.04;
+    joint1->setRelativeTransform(pose1);
+    joint2->setRelativeTransform(pose2);
+
+    result.clear();
+    ASSERT_TRUE(group->collide(option, &result));
+    EXPECT_EQ(1u, result.getNumContacts());
+  }
+}
+
+//==============================================================================
 TEST(Issue1654, OdeHonorsMaxNumContacts)
 {
   auto detector = OdeCollisionDetector::create();

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -484,10 +484,9 @@ void testSphereSphere(
     EXPECT_TRUE(group->collide(option, &result));
     // TODO(JS): BulletCollisionDetector includes a bug related to this.
     // (see #876)
-#if HAVE_BULLET
-    if (cd->getType() != BulletCollisionDetector::getStaticType())
-#endif
-    {
+
+    constexpr auto hasBullet = (HAVE_BULLET == 1);
+    if constexpr (!hasBullet) {
       EXPECT_EQ(result.getNumContacts(), 1u);
     }
     for (auto i = 0u; i < result.getNumContacts(); ++i) {
@@ -1979,6 +1978,127 @@ TEST_F(Collision, Factory)
   EXPECT_TRUE(!collision::CollisionDetector::getFactory()->canCreate("ode"));
 #endif
 }
+
+#if HAVE_ODE
+//==============================================================================
+TEST(Issue1654, OdeContactHistoryClearsOnObjectRemoval)
+{
+  auto detector = OdeCollisionDetector::create();
+  auto group = detector->createCollisionGroup();
+  auto otherGroup = detector->createCollisionGroup();
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 4u;
+
+  CollisionResult result;
+
+  // Initial collision using SimpleFrames to populate the cache.
+  auto simpleFrame1 = std::make_shared<SimpleFrame>(Frame::World(), "f1");
+  auto simpleFrame2 = std::make_shared<SimpleFrame>(Frame::World(), "f2");
+  auto sphere = std::make_shared<SphereShape>(1.0);
+  simpleFrame1->setShape(sphere);
+  simpleFrame2->setShape(sphere);
+  simpleFrame2->setTranslation(Eigen::Vector3d::UnitX() * 0.5);
+
+  group->addShapeFrame(simpleFrame1.get());
+  group->addShapeFrame(simpleFrame2.get());
+
+  ASSERT_TRUE(group->collide(option, &result));
+  ASSERT_FALSE(result.getContacts().empty());
+
+  group->removeAllShapeFrames();
+  otherGroup->removeAllShapeFrames();
+  result.clear();
+
+  // Recreate collision objects using BodyNodes (mirroring the Python repro).
+  auto skeleton1 = Skeleton::create("reuse1");
+  auto skeleton2 = Skeleton::create("reuse2");
+
+  auto pair1 = skeleton1->createJointAndBodyNodePair<FreeJoint>();
+  auto pair2 = skeleton2->createJointAndBodyNodePair<FreeJoint>();
+  auto* joint1 = pair1.first;
+  auto* body1 = pair1.second;
+  auto* joint2 = pair2.first;
+  auto* body2 = pair2.second;
+
+  auto bodySphere = std::make_shared<SphereShape>(1.0);
+  body1->createShapeNodeWith<CollisionAspect>(bodySphere);
+  body2->createShapeNodeWith<CollisionAspect>(bodySphere);
+
+  Eigen::Isometry3d pose1 = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose2 = Eigen::Isometry3d::Identity();
+  pose2.translate(Eigen::Vector3d::UnitX() * 0.4);
+  joint1->setRelativeTransform(pose1);
+  joint2->setRelativeTransform(pose2);
+
+  group->addShapeFramesOf(body1);
+  group->addShapeFramesOf(body2);
+
+  // Collide within a single group using the new objects.
+  EXPECT_TRUE(group->collide(option, &result));
+  EXPECT_GE(result.getNumContacts(), 1u);
+
+  // Cross-group collision should also remain stable.
+  result.clear();
+  group->removeAllShapeFrames();
+  otherGroup->removeAllShapeFrames();
+
+  group->addShapeFramesOf(body1);
+  otherGroup->addShapeFramesOf(body2);
+
+  EXPECT_TRUE(group->collide(otherGroup.get(), option, &result));
+  EXPECT_GE(result.getNumContacts(), 1u);
+
+  // Move bodies apart to ensure history drops them cleanly.
+  pose2.setIdentity();
+  pose2.translate(Eigen::Vector3d::UnitX() * 3.0);
+  joint2->setRelativeTransform(pose2);
+  result.clear();
+  EXPECT_FALSE(group->collide(otherGroup.get(), option, &result));
+  EXPECT_TRUE(result.getContacts().empty());
+
+  // Move back into contact and verify we still collide without crashing.
+  pose2.setIdentity();
+  pose2.translate(Eigen::Vector3d::UnitX() * 0.25);
+  joint2->setRelativeTransform(pose2);
+  result.clear();
+  EXPECT_TRUE(group->collide(otherGroup.get(), option, &result));
+  EXPECT_GE(result.getNumContacts(), 1u);
+}
+
+//==============================================================================
+TEST(Issue1654, OdeHonorsMaxNumContacts)
+{
+  auto detector = OdeCollisionDetector::create();
+  auto group = detector->createCollisionGroup();
+
+  auto capsuleFrame = std::make_shared<SimpleFrame>(Frame::World(), "capsule");
+  auto planeFrame = std::make_shared<SimpleFrame>(Frame::World(), "plane");
+
+  auto capsuleShape = std::make_shared<CapsuleShape>(0.2, 0.6);
+  capsuleFrame->setShape(capsuleShape);
+  capsuleFrame->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.2));
+
+  auto planeShape = std::make_shared<PlaneShape>(Eigen::Vector3d::UnitZ(), 0.0);
+  planeFrame->setShape(planeShape);
+
+  group->addShapeFrame(capsuleFrame.get());
+  group->addShapeFrame(planeFrame.get());
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 1u;
+  CollisionResult result;
+
+  ASSERT_TRUE(group->collide(option, &result));
+  EXPECT_EQ(1u, result.getNumContacts());
+
+  result.clear();
+  ASSERT_TRUE(group->collide(option, &result));
+  EXPECT_EQ(1u, result.getNumContacts());
+}
+#endif // HAVE_ODE
 
 //==============================================================================
 #if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -2068,6 +2068,53 @@ TEST(Issue1654, OdeContactHistoryClearsOnObjectRemoval)
 }
 
 //==============================================================================
+TEST(Issue1654, OdeContactHistoryClearsAfterKinematicPoseJump)
+{
+  auto detector = OdeCollisionDetector::create();
+  auto group = detector->createCollisionGroup();
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 4u;
+
+  auto skeleton1 = Skeleton::create("pose_jump1");
+  auto skeleton2 = Skeleton::create("pose_jump2");
+
+  auto pair1 = skeleton1->createJointAndBodyNodePair<FreeJoint>();
+  auto pair2 = skeleton2->createJointAndBodyNodePair<FreeJoint>();
+  auto* joint1 = pair1.first;
+  auto* body1 = pair1.second;
+  auto* joint2 = pair2.first;
+  auto* body2 = pair2.second;
+
+  auto sphere = std::make_shared<SphereShape>(1.0);
+  body1->createShapeNodeWith<CollisionAspect>(sphere);
+  body2->createShapeNodeWith<CollisionAspect>(sphere);
+
+  Eigen::Isometry3d pose1 = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d pose2 = Eigen::Isometry3d::Identity();
+  pose2.translate(Eigen::Vector3d::UnitX() * 0.4);
+  joint1->setRelativeTransform(pose1);
+  joint2->setRelativeTransform(pose2);
+
+  group->addShapeFramesOf(body1);
+  group->addShapeFramesOf(body2);
+
+  CollisionResult result;
+  ASSERT_TRUE(group->collide(option, &result));
+  ASSERT_EQ(1u, result.getNumContacts());
+
+  pose1.translation() += Eigen::Vector3d::UnitY();
+  pose2.translation() += Eigen::Vector3d::UnitY();
+  joint1->setRelativeTransform(pose1);
+  joint2->setRelativeTransform(pose2);
+
+  result.clear();
+  ASSERT_TRUE(group->collide(option, &result));
+  EXPECT_EQ(1u, result.getNumContacts());
+}
+
+//==============================================================================
 TEST(Issue1654, OdeHonorsMaxNumContacts)
 {
   auto detector = OdeCollisionDetector::create();

--- a/tests/integration/test_Issue719.cpp
+++ b/tests/integration/test_Issue719.cpp
@@ -51,11 +51,11 @@
 //
 // The default solver (Dantzig primary + PGS secondary) already kept the loop
 // closed: on a singular pivot Dantzig terminates early and the existing PGS
-// fallback in BoxedLcpConstraintSolver takes over. PART A guards that invariant.
-// PART B disables the secondary so only Dantzig runs and the regularization has
-// to do the work alone: without the floor the loop drifts ~6 mm; with it the
-// loop stays closed to ~1e-9. That makes PART B the discriminating regression
-// guard.
+// fallback in BoxedLcpConstraintSolver takes over. PART A guards that
+// invariant. PART B disables the secondary so only Dantzig runs and the
+// regularization has to do the work alone: without the floor the loop drifts ~6
+// mm; with it the loop stays closed to ~1e-9. That makes PART B the
+// discriminating regression guard.
 
 #include "dart/constraint/BallJointConstraint.hpp"
 #include "dart/constraint/BoxedLcpConstraintSolver.hpp"
@@ -156,14 +156,16 @@ SkeletonPtr createNonAxisAlignedFourBar(
 // must not drift away from its anchor on the base by more than
 // kMaxLoopClosureError. Without the fix, the Dantzig-only configuration scrubs
 // the singular solution to zero and the loop drifts open, violating (b).
-void stepAndCheckLoopClosed(const WorldPtr& world, const SkeletonPtr& skel,
-                            BodyNode* base, BodyNode* lastLink,
-                            const Eigen::Vector3d& loopAnchor)
+void stepAndCheckLoopClosed(
+    const WorldPtr& world,
+    const SkeletonPtr& skel,
+    BodyNode* base,
+    BodyNode* lastLink,
+    const Eigen::Vector3d& loopAnchor)
 {
   const Eigen::Vector3d off1
       = lastLink->getWorldTransform().inverse() * loopAnchor;
-  const Eigen::Vector3d off2
-      = base->getWorldTransform().inverse() * loopAnchor;
+  const Eigen::Vector3d off2 = base->getWorldTransform().inverse() * loopAnchor;
   const std::size_t numSteps = 100;
   for (std::size_t i = 0; i < numSteps; ++i) {
     // Apply a small actuation/perturbation on the first revolute joint.
@@ -194,8 +196,7 @@ TEST(Issue719, NonAxisAlignedClosedLoopDefaultSolver)
   BodyNode* base = nullptr;
   BodyNode* lastLink = nullptr;
   Eigen::Vector3d loopAnchor = Eigen::Vector3d::Zero();
-  SkeletonPtr skel
-      = createNonAxisAlignedFourBar(&base, &lastLink, loopAnchor);
+  SkeletonPtr skel = createNonAxisAlignedFourBar(&base, &lastLink, loopAnchor);
 
   WorldPtr world = World::create();
   world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
@@ -207,7 +208,8 @@ TEST(Issue719, NonAxisAlignedClosedLoopDefaultSolver)
       lastLink, base, loopAnchor);
   world->getConstraintSolver()->addConstraint(loopConstraint);
 
-  EXPECT_NO_FATAL_FAILURE(stepAndCheckLoopClosed(world, skel, base, lastLink, loopAnchor));
+  EXPECT_NO_FATAL_FAILURE(
+      stepAndCheckLoopClosed(world, skel, base, lastLink, loopAnchor));
 }
 
 //==============================================================================
@@ -220,8 +222,7 @@ TEST(Issue719, NonAxisAlignedClosedLoopDantzigOnly)
   BodyNode* base = nullptr;
   BodyNode* lastLink = nullptr;
   Eigen::Vector3d loopAnchor = Eigen::Vector3d::Zero();
-  SkeletonPtr skel
-      = createNonAxisAlignedFourBar(&base, &lastLink, loopAnchor);
+  SkeletonPtr skel = createNonAxisAlignedFourBar(&base, &lastLink, loopAnchor);
 
   WorldPtr world = World::create();
   world->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
@@ -237,5 +238,6 @@ TEST(Issue719, NonAxisAlignedClosedLoopDantzigOnly)
       lastLink, base, loopAnchor);
   world->getConstraintSolver()->addConstraint(loopConstraint);
 
-  EXPECT_NO_FATAL_FAILURE(stepAndCheckLoopClosed(world, skel, base, lastLink, loopAnchor));
+  EXPECT_NO_FATAL_FAILURE(
+      stepAndCheckLoopClosed(world, skel, base, lastLink, loopAnchor));
 }


### PR DESCRIPTION
## Summary

Backport of #2125 to the DART 6 LTS line, targeting the **6.18 minor**.

A capsule resting on a box reported a single ODE contact point, which is insufficient to form a stable support manifold, so the capsule slowly sank through the ground. This adds a per-pair **contact-history cache** to the ODE collision detector that supplements sparse single-contact results into a stable manifold, alongside the existing box-cylinder libccd stabilization that release-6.17 already carries.

The single-contact early-return is now gated on **box-cylinder pairs only**, so every other single-contact pair (notably a resting capsule) falls through to the contact-history path and is supplemented to a stable manifold instead of sinking.

## Validation

`test_CapsuleGroundContact` (Bullet + ODE) reproduces the gz issue: a capsule lying on its side is dropped onto a ground box and stepped for 50k steps.

- **Before** this change (ODE): the capsule sinks to `minZ ≈ 0.026` (radius is `0.2`).
- **After** this change (ODE): `minZ ≈ 0.197`, matching Bullet (`≈ 0.195`) and staying above the `0.15` threshold.

`test_Collision` is extended with contact-history coverage.

## Related

Fixes gazebosim/gz-physics#692.