### PR TITLE
Preflight zero-DOF multibody contact fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -872,6 +872,10 @@ py-demos` now builds a CUDA-enabled dartpy + Filament GUI and offloads the
   - Reused baked semi-implicit multibody dynamics/contact scratch and persistent
     staged velocity buffers, extending the baked global-heap guard to
     articulated link resting-contact steps.
+  - Fixed the experimental World's sequential articulated-contact shortcut to
+    preflight zero-DOF multibody contacts before applying shortcut impulses, so
+    mixed zero-DOF and solvable link-contact scenes fall back to the unified
+    solve without double-applying impulses.
   - Made experimental rigid-body external force/torque components persistent
     applied loads: each step reads them into the transient force buffer and
     leaves the components intact for callers to clear or update explicitly.

--- a/dart/simulation/experimental/compute/multibody_dynamics.cpp
+++ b/dart/simulation/experimental/compute/multibody_dynamics.cpp
@@ -2634,6 +2634,29 @@ bool tryResolveSequentialMultibodyContacts(
     }
 
     auto* pendingVelocity = registry.try_get<PendingMultibodyVelocity>(entity);
+    if (pendingVelocity != nullptr && pendingVelocity->active) {
+      continue;
+    }
+
+    buildDynamicsTreeInto(
+        registry,
+        structure,
+        scratch.tree,
+        scratch.linkIndexOf,
+        scratch.jointFrameSubspace);
+    if (scratch.tree.dofCount == 0) {
+      return false;
+    }
+  }
+
+  for (auto entity : view) {
+    const auto& structure = view.get<comps::MultibodyStructure>(entity);
+    auto& scratch = registry.get<MultibodyDynamicsScratch>(entity);
+    if (scratch.linkContacts.empty()) {
+      continue;
+    }
+
+    auto* pendingVelocity = registry.try_get<PendingMultibodyVelocity>(entity);
     if (pendingVelocity == nullptr || !pendingVelocity->active) {
       buildDynamicsTreeInto(
           registry,

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -4901,6 +4901,104 @@ TEST(World, ZeroDofMultibodyLinkContactStopsRigidBody)
   EXPECT_TRUE(dynamic.getAngularVelocity().isZero(1e-12));
 }
 
+TEST(World, ZeroDofMultibodyFallbackDoesNotDoubleApplyShortcutImpulses)
+{
+  namespace sx = dart::simulation::experimental;
+
+  struct StepState
+  {
+    double sliderVelocity{0.0};
+    Eigen::Vector3d sliderRigidVelocity{Eigen::Vector3d::Zero()};
+    Eigen::Vector3d fixedRigidVelocity{Eigen::Vector3d::Zero()};
+  };
+
+  const auto runScene = [](bool boxedLcp, bool fixedFixtureFirst) -> StepState {
+    sx::WorldOptions options;
+    if (boxedLcp) {
+      options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
+    }
+    sx::World world(options);
+    world.setGravity(Eigen::Vector3d::Zero());
+    world.setTimeStep(0.001);
+
+    sx::Joint sliderJoint(sx::Entity{}, nullptr);
+    sx::RigidBody sliderTarget(sx::Entity{}, nullptr);
+    sx::RigidBody fixedTarget(sx::Entity{}, nullptr);
+
+    const auto addFixedFixture = [&]() {
+      auto fixture = world.addMultibody("fixed_fixture");
+      auto base = fixture.addLink("base");
+
+      sx::JointSpec fixed;
+      fixed.name = "weld";
+      fixed.type = sx::JointType::Fixed;
+      auto obstacle = fixture.addLink("obstacle", base, fixed);
+      auto obstacleShape = sx::CollisionShape::makeSphere(0.5);
+      obstacleShape.localTransform.translation()
+          = Eigen::Vector3d(3.0, 0.0, 0.0);
+      obstacle.setCollisionShape(obstacleShape);
+
+      sx::RigidBodyOptions dynamicOptions;
+      dynamicOptions.position = Eigen::Vector3d(3.9, 0.0, 0.0);
+      dynamicOptions.linearVelocity = Eigen::Vector3d(-1.0, 0.0, 0.0);
+      fixedTarget = world.addRigidBody("fixed_target", dynamicOptions);
+      fixedTarget.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
+      EXPECT_EQ(fixture.getDOFCount(), 0u);
+    };
+
+    const auto addSolvableSlider = [&]() {
+      auto robot = world.addMultibody("slider_robot");
+      auto base = robot.addLink("base");
+      sx::JointSpec spec;
+      spec.name = "rail";
+      spec.type = sx::JointType::Prismatic;
+      spec.axis = Eigen::Vector3d::UnitX();
+      auto link = robot.addLink("slider", base, spec);
+      link.setMass(1.0);
+      link.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+      sliderJoint = link.getParentJoint();
+      sliderJoint.setVelocity(Eigen::VectorXd::Constant(1, 1.0));
+
+      sx::RigidBodyOptions targetOptions;
+      targetOptions.position = Eigen::Vector3d(0.35, 0.0, 0.0);
+      sliderTarget = world.addRigidBody("slider_target", targetOptions);
+      sliderTarget.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+    };
+
+    if (fixedFixtureFirst) {
+      addFixedFixture();
+      addSolvableSlider();
+    } else {
+      addSolvableSlider();
+      addFixedFixture();
+    }
+
+    EXPECT_GE(world.collide().size(), 2u);
+    world.step();
+
+    return StepState{
+        sliderJoint.getVelocity()[0],
+        sliderTarget.getLinearVelocity(),
+        fixedTarget.getLinearVelocity()};
+  };
+
+  for (const bool fixedFixtureFirst : {false, true}) {
+    SCOPED_TRACE(fixedFixtureFirst ? "fixed first" : "slider first");
+    const StepState defaultPath = runScene(false, fixedFixtureFirst);
+    const StepState boxedPath = runScene(true, fixedFixtureFirst);
+
+    EXPECT_NEAR(defaultPath.sliderVelocity, boxedPath.sliderVelocity, 1e-12);
+    EXPECT_TRUE(defaultPath.sliderRigidVelocity.isApprox(
+        boxedPath.sliderRigidVelocity, 1e-12))
+        << defaultPath.sliderRigidVelocity.transpose() << " vs "
+        << boxedPath.sliderRigidVelocity.transpose();
+    EXPECT_TRUE(defaultPath.fixedRigidVelocity.isApprox(
+        boxedPath.fixedRigidVelocity, 1e-12))
+        << defaultPath.fixedRigidVelocity.transpose() << " vs "
+        << boxedPath.fixedRigidVelocity.transpose();
+  }
+}
+
 // Test cross-multibody link-vs-link contact: two separate fixed-base
 // articulated bodies overlap and approach along their prismatic rails. The
 // unified row carries both articulated ends, so the impulse changes both


### PR DESCRIPTION
## Summary

- Preflight zero-DOF multibody link contacts before applying the sequential articulated-contact shortcut.
- Add a mixed zero-DOF and solvable link-contact regression to prove fallback does not double-apply shortcut impulses.
- Update the changelog for the experimental World contact fallback fix.

## Motivation / Problem

- Follow-up to #2899. A late Codex review finding identified that mixed scenes could apply shortcut impulses to an earlier solvable multibody before a later zero-DOF multibody forced fallback to the unified solve.

## Changes / Key Changes

- `tryResolveSequentialMultibodyContacts()` now scans contacted multibodies for zero-DOF fallback requirements before mutating any shortcut-solved velocities.
- The new regression compares the default path with the boxed-LCP fallback path in both fixture-first and slider-first entity creation orders.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --target test_world -j8`
- `build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.ZeroDofMultibodyLinkContactStopsRigidBody:World.ZeroDofMultibodyFallbackDoesNotDoubleApplyShortcutImpulses'`
- `build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.IpcBakeDoesNotPrewarmRigidBodyContactQuery:World.SequentialImpulseBakeDoesNotPrewarmRigidIpcCollisionSurfaces:World.BakedKinematicIpcStepsDoNotAllocateGlobalHeap:World.BakedRigidBodyContactStepsDoNotAllocateGlobalHeap:World.BakedArticulatedContactStepsDoNotAllocateGlobalHeap:World.ZeroDofMultibodyLinkContactStopsRigidBody:World.ZeroDofMultibodyFallbackDoesNotDoubleApplyShortcutImpulses:World.RigidIpcContactStageReportsUnsupportedShapes:World.ReplayRestoreRebuildsCachedKinematicsAfterFrameParentRestore:World.ReplayRecordingRestoresPublicFrameState:World.StepRebuildsCachedKinematicsAfterFrameReparenting'`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #2899
- Addresses the late Codex review finding on #2899 about preflighting zero-DOF contacts before applying shortcut impulses.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (not applicable; no public API changes)
- [x] Add Python bindings (dartpy) if applicable (not applicable; no binding changes)