### PR TITLE
Avoid heap allocations for sequential cross-link contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -874,7 +874,8 @@ py-demos` now builds a CUDA-enabled dartpy + Filament GUI and offloads the
     articulated link resting-contact steps.
   - Added a default sequential shortcut for cross-multibody articulated link
     contact impulses, keeping repeated baked cross-link contact steps off the
-    global heap while leaving the boxed-LCP unified solve path opt-in.
+    global heap for isolated same-DOF pairs while leaving mixed, stacked, and
+    boxed-LCP unified solve paths on the fallback.
   - Fixed the experimental World's sequential articulated-contact shortcut to
     preflight zero-DOF multibody contacts before applying shortcut impulses, so
     mixed zero-DOF and solvable link-contact scenes fall back to the unified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -874,8 +874,8 @@ py-demos` now builds a CUDA-enabled dartpy + Filament GUI and offloads the
     articulated link resting-contact steps.
   - Added a default sequential shortcut for cross-multibody articulated link
     contact impulses, keeping repeated baked cross-link contact steps off the
-    global heap for isolated same-DOF pairs while leaving mixed, stacked, and
-    boxed-LCP unified solve paths on the fallback.
+    global heap for isolated same-DOF pairs while leaving mixed, stacked,
+    coupled multi-row, and boxed-LCP unified solve paths on the fallback.
   - Fixed the experimental World's sequential articulated-contact shortcut to
     preflight zero-DOF multibody contacts before applying shortcut impulses, so
     mixed zero-DOF and solvable link-contact scenes fall back to the unified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -872,6 +872,9 @@ py-demos` now builds a CUDA-enabled dartpy + Filament GUI and offloads the
   - Reused baked semi-implicit multibody dynamics/contact scratch and persistent
     staged velocity buffers, extending the baked global-heap guard to
     articulated link resting-contact steps.
+  - Added a default sequential shortcut for cross-multibody articulated link
+    contact impulses, keeping repeated baked cross-link contact steps off the
+    global heap while leaving the boxed-LCP unified solve path opt-in.
   - Made experimental rigid-body external force/torque components persistent
     applied loads: each step reads them into the transient force buffer and
     leaves the components intact for callers to clear or update explicitly.

--- a/dart/simulation/experimental/compute/multibody_dynamics.cpp
+++ b/dart/simulation/experimental/compute/multibody_dynamics.cpp
@@ -2837,6 +2837,7 @@ bool tryResolveSequentialMultibodyContacts(
   bool hasHandledLinkContact = false;
   bool hasCrossMultibodyLinkContact = false;
   bool hasNonCrossLinkContact = false;
+  std::size_t crossMultibodyLinkContactCount = 0;
   for (auto entity : view) {
     const auto& structure = view.get<comps::MultibodyStructure>(entity);
     auto& scratch = registry.get_or_emplace<MultibodyDynamicsScratch>(entity);
@@ -2845,6 +2846,7 @@ bool tryResolveSequentialMultibodyContacts(
     for (const auto& contact : scratch.linkContacts) {
       if (contact.otherMultibody != entt::null) {
         hasCrossMultibodyLinkContact = true;
+        ++crossMultibodyLinkContactCount;
       } else {
         hasNonCrossLinkContact = true;
       }
@@ -2855,7 +2857,8 @@ bool tryResolveSequentialMultibodyContacts(
   if (!hasHandledLinkContact) {
     return false;
   }
-  if (hasCrossMultibodyLinkContact && hasNonCrossLinkContact) {
+  if (hasCrossMultibodyLinkContact
+      && (hasNonCrossLinkContact || crossMultibodyLinkContactCount != 1)) {
     return false;
   }
 

--- a/dart/simulation/experimental/compute/multibody_dynamics.cpp
+++ b/dart/simulation/experimental/compute/multibody_dynamics.cpp
@@ -2907,6 +2907,24 @@ bool tryResolveSequentialMultibodyContacts(
     }
   }
 
+  if (hasCrossMultibodyLinkContact) {
+    for (auto entity : view) {
+      const auto& scratch = registry.get<MultibodyDynamicsScratch>(entity);
+      for (const auto& contact : scratch.linkContacts) {
+        if (contact.otherMultibody == entt::null) {
+          continue;
+        }
+
+        const auto* otherScratch = registry.try_get<MultibodyDynamicsScratch>(
+            contact.otherMultibody);
+        if (otherScratch == nullptr
+            || scratch.tree.dofCount != otherScratch->tree.dofCount) {
+          return false;
+        }
+      }
+    }
+  }
+
   for (auto entity : view) {
     const auto& structure = view.get<comps::MultibodyStructure>(entity);
     auto& scratch = registry.get<MultibodyDynamicsScratch>(entity);

--- a/dart/simulation/experimental/compute/multibody_dynamics.cpp
+++ b/dart/simulation/experimental/compute/multibody_dynamics.cpp
@@ -1125,9 +1125,12 @@ void resetMultibodyLinkContactRow(
   row.tangentJacobian1.setZero();
   row.tangentJacobian2.resize(dof);
   row.tangentJacobian2.setZero();
-  row.otherNormalJacobian.resize(0);
-  row.otherTangentJacobian1.resize(0);
-  row.otherTangentJacobian2.resize(0);
+  row.otherNormalJacobian.resize(dof);
+  row.otherNormalJacobian.setZero();
+  row.otherTangentJacobian1.resize(dof);
+  row.otherTangentJacobian1.setZero();
+  row.otherTangentJacobian2.resize(dof);
+  row.otherTangentJacobian2.setZero();
   row.normal = Eigen::Vector3d::UnitZ();
   row.tangent1.setZero();
   row.tangent2.setZero();
@@ -1445,6 +1448,208 @@ void solveMultibodyLinkContacts(
             row.tangent2,
             newImpulse - row.tangentImpulse2);
         row.tangentImpulse2 = newImpulse;
+      }
+    }
+  }
+}
+
+//==============================================================================
+void completeSequentialCrossMultibodyLinkRows(
+    detail::WorldRegistry& registry,
+    Eigen::VectorXd& primaryVelocity,
+    MultibodyDynamicsScratch& scratch)
+{
+  auto& problem = scratch.contactProblem;
+  const auto rowCount = scratch.activeContactRowCount;
+  if (rowCount == 0 || problem.inverseMass.size() == 0) {
+    return;
+  }
+
+  constexpr double restitutionThreshold = 1e-2;
+  for (auto& row :
+       std::span<MultibodyLinkContactRow>(problem.rows.data(), rowCount)) {
+    if (row.otherMultibody == entt::null) {
+      continue;
+    }
+
+    auto* otherScratch
+        = registry.try_get<MultibodyDynamicsScratch>(row.otherMultibody);
+    auto* otherPending
+        = registry.try_get<PendingMultibodyVelocity>(row.otherMultibody);
+    if (otherScratch == nullptr || otherPending == nullptr
+        || !otherPending->active) {
+      continue;
+    }
+
+    const auto& otherStructure
+        = registry.get<comps::MultibodyStructure>(row.otherMultibody);
+    const auto otherIndex = linkIndexOf(otherStructure, row.otherLink);
+    pointLinearJacobianInto(
+        otherScratch->tree,
+        otherScratch->bodyJacobian,
+        otherIndex,
+        row.point,
+        otherScratch->otherPointJacobian);
+
+    multiplyPointJacobianTransposeInto(
+        otherScratch->otherPointJacobian, row.normal, row.otherNormalJacobian);
+    multiplyPointJacobianTransposeInto(
+        otherScratch->otherPointJacobian,
+        row.tangent1,
+        row.otherTangentJacobian1);
+    multiplyPointJacobianTransposeInto(
+        otherScratch->otherPointJacobian,
+        row.tangent2,
+        row.otherTangentJacobian2);
+
+    const auto& otherInverseMass = otherScratch->contactProblem.inverseMass;
+    row.normalDenominator += jointSpaceDenominator(
+        otherInverseMass, row.otherNormalJacobian, otherScratch->contactWork);
+    row.tangentDenominator1 += jointSpaceDenominator(
+        otherInverseMass, row.otherTangentJacobian1, otherScratch->contactWork);
+    row.tangentDenominator2 += jointSpaceDenominator(
+        otherInverseMass, row.otherTangentJacobian2, otherScratch->contactWork);
+
+    const auto relativeVelocity = [&](const Eigen::VectorXd& primaryJacobian,
+                                      const Eigen::VectorXd& otherJacobian) {
+      return primaryJacobian.dot(primaryVelocity)
+             - otherJacobian.dot(otherPending->velocity);
+    };
+
+    const double approachingVelocity
+        = relativeVelocity(row.normalJacobian, row.otherNormalJacobian);
+    row.restitutionTarget = (approachingVelocity < -restitutionThreshold)
+                                ? -row.restitution * approachingVelocity
+                                : 0.0;
+    row.normalRhs
+        = -approachingVelocity + std::max(row.bias, row.restitutionTarget);
+    row.tangentRhs1
+        = -relativeVelocity(row.tangentJacobian1, row.otherTangentJacobian1);
+    row.tangentRhs2
+        = -relativeVelocity(row.tangentJacobian2, row.otherTangentJacobian2);
+    row.active = row.normalDenominator > 0.0;
+  }
+}
+
+//==============================================================================
+void applyMultibodyImpulse(
+    Eigen::VectorXd& velocity,
+    const Eigen::MatrixXd& inverseMass,
+    const Eigen::VectorXd& jacobian,
+    double deltaImpulse,
+    Eigen::VectorXd& work)
+{
+  if (jacobian.size() == 0) {
+    return;
+  }
+  if (jacobian.size() == 1) {
+    velocity[0] += inverseMass(0, 0) * jacobian[0] * deltaImpulse;
+    return;
+  }
+
+  work.resize(jacobian.size());
+  work.noalias() = inverseMass * jacobian;
+  velocity.noalias() += work * deltaImpulse;
+}
+
+//==============================================================================
+void solveSequentialCrossMultibodyLinkRows(detail::WorldRegistry& registry)
+{
+  constexpr int contactIterations = 8;
+  auto view = registry.view<comps::MultibodyStructure>();
+
+  for (int iteration = 0; iteration < contactIterations; ++iteration) {
+    for (auto entity : view) {
+      auto* pendingVelocity
+          = registry.try_get<PendingMultibodyVelocity>(entity);
+      if (pendingVelocity == nullptr || !pendingVelocity->active) {
+        continue;
+      }
+
+      auto& scratch = registry.get<MultibodyDynamicsScratch>(entity);
+      auto& problem = scratch.contactProblem;
+      const auto rowCount = scratch.activeContactRowCount;
+      if (rowCount == 0 || problem.inverseMass.size() == 0) {
+        continue;
+      }
+
+      for (auto& row :
+           std::span<MultibodyLinkContactRow>(problem.rows.data(), rowCount)) {
+        if (!row.active || row.otherMultibody == entt::null) {
+          continue;
+        }
+
+        auto* otherPending
+            = registry.try_get<PendingMultibodyVelocity>(row.otherMultibody);
+        auto* otherScratch
+            = registry.try_get<MultibodyDynamicsScratch>(row.otherMultibody);
+        if (otherPending == nullptr || !otherPending->active
+            || otherScratch == nullptr) {
+          continue;
+        }
+
+        const auto relativeVelocity
+            = [&](const Eigen::VectorXd& primaryJacobian,
+                  const Eigen::VectorXd& otherJacobian) {
+                return primaryJacobian.dot(pendingVelocity->velocity)
+                       - otherJacobian.dot(otherPending->velocity);
+              };
+        const auto applyImpulse = [&](const Eigen::VectorXd& primaryJacobian,
+                                      const Eigen::VectorXd& otherJacobian,
+                                      double deltaImpulse) {
+          applyMultibodyImpulse(
+              pendingVelocity->velocity,
+              problem.inverseMass,
+              primaryJacobian,
+              deltaImpulse,
+              scratch.contactImpulseDelta);
+          applyMultibodyImpulse(
+              otherPending->velocity,
+              otherScratch->contactProblem.inverseMass,
+              otherJacobian,
+              -deltaImpulse,
+              otherScratch->contactImpulseDelta);
+        };
+
+        const double normalVelocity
+            = relativeVelocity(row.normalJacobian, row.otherNormalJacobian);
+        const double deltaNormal
+            = (-normalVelocity + std::max(row.bias, row.restitutionTarget))
+              / row.normalDenominator;
+        const double newNormal = std::max(0.0, row.normalImpulse + deltaNormal);
+        applyImpulse(
+            row.normalJacobian,
+            row.otherNormalJacobian,
+            newNormal - row.normalImpulse);
+        row.normalImpulse = newNormal;
+
+        const double bound = row.friction * row.normalImpulse;
+        if (row.tangentDenominator1 > 0.0) {
+          const double tangentVelocity = relativeVelocity(
+              row.tangentJacobian1, row.otherTangentJacobian1);
+          const double newImpulse = std::clamp(
+              row.tangentImpulse1 - tangentVelocity / row.tangentDenominator1,
+              -bound,
+              bound);
+          applyImpulse(
+              row.tangentJacobian1,
+              row.otherTangentJacobian1,
+              newImpulse - row.tangentImpulse1);
+          row.tangentImpulse1 = newImpulse;
+        }
+        if (row.tangentDenominator2 > 0.0) {
+          const double tangentVelocity = relativeVelocity(
+              row.tangentJacobian2, row.otherTangentJacobian2);
+          const double newImpulse = std::clamp(
+              row.tangentImpulse2 - tangentVelocity / row.tangentDenominator2,
+              -bound,
+              bound);
+          applyImpulse(
+              row.tangentJacobian2,
+              row.otherTangentJacobian2,
+              newImpulse - row.tangentImpulse2);
+          row.tangentImpulse2 = newImpulse;
+        }
       }
     }
   }
@@ -2609,6 +2814,7 @@ bool tryResolveSequentialMultibodyContacts(
 
   auto view = registry.view<comps::MultibodyStructure>();
   bool hasHandledLinkContact = false;
+  bool hasCrossMultibodyLinkContact = false;
   for (auto entity : view) {
     const auto& structure = view.get<comps::MultibodyStructure>(entity);
     auto& scratch = registry.get_or_emplace<MultibodyDynamicsScratch>(entity);
@@ -2616,7 +2822,7 @@ bool tryResolveSequentialMultibodyContacts(
         registry, structure, contacts, scratch.linkContacts);
     for (const auto& contact : scratch.linkContacts) {
       if (contact.otherMultibody != entt::null) {
-        return false;
+        hasCrossMultibodyLinkContact = true;
       }
     }
     hasHandledLinkContact
@@ -2626,10 +2832,28 @@ bool tryResolveSequentialMultibodyContacts(
     return false;
   }
 
+  const auto isRequiredCrossMultibody = [&](entt::entity candidate) {
+    if (!hasCrossMultibodyLinkContact) {
+      return false;
+    }
+    for (auto entity : view) {
+      const auto* scratch = registry.try_get<MultibodyDynamicsScratch>(entity);
+      if (scratch == nullptr) {
+        continue;
+      }
+      for (const auto& contact : scratch->linkContacts) {
+        if (contact.otherMultibody == candidate) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
   for (auto entity : view) {
     const auto& structure = view.get<comps::MultibodyStructure>(entity);
     auto& scratch = registry.get<MultibodyDynamicsScratch>(entity);
-    if (scratch.linkContacts.empty()) {
+    if (scratch.linkContacts.empty() && !isRequiredCrossMultibody(entity)) {
       continue;
     }
 
@@ -2658,6 +2882,20 @@ bool tryResolveSequentialMultibodyContacts(
         timeStep,
         scratch.linkContacts,
         scratch);
+  }
+  if (hasCrossMultibodyLinkContact) {
+    for (auto entity : view) {
+      auto* pendingVelocity
+          = registry.try_get<PendingMultibodyVelocity>(entity);
+      if (pendingVelocity == nullptr || !pendingVelocity->active) {
+        continue;
+      }
+
+      auto& scratch = registry.get<MultibodyDynamicsScratch>(entity);
+      completeSequentialCrossMultibodyLinkRows(
+          registry, pendingVelocity->velocity, scratch);
+    }
+    solveSequentialCrossMultibodyLinkRows(registry);
   }
   return true;
 }

--- a/dart/simulation/experimental/compute/multibody_dynamics.cpp
+++ b/dart/simulation/experimental/compute/multibody_dynamics.cpp
@@ -2836,6 +2836,7 @@ bool tryResolveSequentialMultibodyContacts(
   auto view = registry.view<comps::MultibodyStructure>();
   bool hasHandledLinkContact = false;
   bool hasCrossMultibodyLinkContact = false;
+  bool hasNonCrossLinkContact = false;
   for (auto entity : view) {
     const auto& structure = view.get<comps::MultibodyStructure>(entity);
     auto& scratch = registry.get_or_emplace<MultibodyDynamicsScratch>(entity);
@@ -2844,12 +2845,17 @@ bool tryResolveSequentialMultibodyContacts(
     for (const auto& contact : scratch.linkContacts) {
       if (contact.otherMultibody != entt::null) {
         hasCrossMultibodyLinkContact = true;
+      } else {
+        hasNonCrossLinkContact = true;
       }
     }
     hasHandledLinkContact
         = hasHandledLinkContact || !scratch.linkContacts.empty();
   }
   if (!hasHandledLinkContact) {
+    return false;
+  }
+  if (hasCrossMultibodyLinkContact && hasNonCrossLinkContact) {
     return false;
   }
 

--- a/dart/simulation/experimental/compute/multibody_dynamics.cpp
+++ b/dart/simulation/experimental/compute/multibody_dynamics.cpp
@@ -2883,8 +2883,12 @@ bool tryResolveSequentialMultibodyContacts(
   for (auto entity : view) {
     const auto& structure = view.get<comps::MultibodyStructure>(entity);
     auto& scratch = registry.get<MultibodyDynamicsScratch>(entity);
-    if (scratch.linkContacts.empty() && !isRequiredCrossMultibody(entity)) {
+    const bool hasOwnedLinkContacts = !scratch.linkContacts.empty();
+    if (!hasOwnedLinkContacts && !isRequiredCrossMultibody(entity)) {
       continue;
+    }
+    if (!hasOwnedLinkContacts) {
+      scratch.activeContactRowCount = 0;
     }
 
     auto* pendingVelocity = registry.try_get<PendingMultibodyVelocity>(entity);

--- a/docs/dev_tasks/hierarchical_memory_manager/README.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/README.md
@@ -73,9 +73,10 @@
       kinematic IPC rigid-body, box-obstacle, multibody variational,
       deformable, rigid-body resting-contact, and non-cross articulated
       resting-contact steps. The default sequential articulated contact path
-      also covers a same-DOF cross-multibody link contact scene without global
-      heap allocation, while mixed/different-DOF and stacked cross-contact
-      scenes stay on the boxed-LCP fallback. Broader solver coverage, including
+      also covers an isolated same-DOF cross-multibody link contact scene
+      without global heap allocation, while mixed/different-DOF, stacked, and
+      coupled multi-row cross-contact scenes stay on the boxed-LCP fallback.
+      Broader solver coverage, including
       boxed-LCP unified contact assembly, larger contact sets, and remaining
       solver-owned scratch, remains open before making a full zero-allocation
       claim.
@@ -208,9 +209,10 @@ debugging, profiling, optimization experiments, and ImGui visualization.
    allocation tests to contact-heavy scenes and remaining solver scratch step
    paths. The initial rigid-body, non-cross articulated, and same-DOF
    sequential cross-articulated resting-contact global heap guards are in
-   place; mixed/different-DOF and stacked cross-articulated contacts stay on
-   the boxed-LCP fallback. Continue broadening boxed-LCP unified contact
-   assembly, larger contact sets, and remaining
+   place; mixed/different-DOF, stacked, and coupled multi-row
+   cross-articulated contacts stay on the boxed-LCP fallback. Continue
+   broadening boxed-LCP unified contact assembly, larger contact sets, and
+   remaining
    solver/deformable candidate buffers before making the full zero-allocation
    claim.
 5. Start replacing per-step `std::vector`/`Eigen` temporaries in hot stages with

--- a/docs/dev_tasks/hierarchical_memory_manager/README.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/README.md
@@ -72,9 +72,12 @@
       deformable ECS paths; a first global heap guard now covers baked
       kinematic IPC rigid-body, box-obstacle, multibody variational,
       deformable, rigid-body resting-contact, and non-cross articulated
-      resting-contact steps. Broader solver coverage, including boxed-LCP/cross
-      articulated contact assembly, remains open before making a full
-      zero-allocation claim.
+      resting-contact steps. The default sequential articulated contact path
+      also covers a same-DOF cross-multibody link contact scene without global
+      heap allocation. Broader solver coverage, including boxed-LCP unified
+      contact assembly, mixed/different-DOF cross contacts, larger contact
+      stacks, and remaining solver-owned scratch, remains open before making a
+      full zero-allocation claim.
 - [ ] Phase 6: Add memory-layout profiler/debugger surfaces and GUI
       visualization. `MemoryAllocatorDebugger` now exposes structured live
       bytes, peak live bytes, and live allocation count; `MemoryManager` and
@@ -202,10 +205,12 @@ debugging, profiling, optimization experiments, and ImGui visualization.
 
 4. Extend bake-time registry/component storage reservation and no-growth
    allocation tests to contact-heavy scenes and remaining solver scratch step
-   paths. The initial rigid-body and non-cross articulated resting-contact
-   global heap guards are in place; continue broadening to larger stacks,
-   boxed-LCP/cross articulated contacts, and remaining solver/deformable
-   candidate buffers before making the full zero-allocation claim.
+   paths. The initial rigid-body, non-cross articulated, and same-DOF
+   sequential cross-articulated resting-contact global heap guards are in
+   place; continue broadening to larger stacks, boxed-LCP unified contact
+   assembly, mixed/different-DOF cross articulated contacts, and remaining
+   solver/deformable candidate buffers before making the full zero-allocation
+   claim.
 5. Start replacing per-step `std::vector`/`Eigen` temporaries in hot stages with
    world-frame or world-pool backed storage only after the allocator evidence
    gate proves the DART allocator path is better for that workload. The

--- a/docs/dev_tasks/hierarchical_memory_manager/README.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/README.md
@@ -74,10 +74,11 @@
       deformable, rigid-body resting-contact, and non-cross articulated
       resting-contact steps. The default sequential articulated contact path
       also covers a same-DOF cross-multibody link contact scene without global
-      heap allocation. Broader solver coverage, including boxed-LCP unified
-      contact assembly, mixed/different-DOF cross contacts, larger contact
-      stacks, and remaining solver-owned scratch, remains open before making a
-      full zero-allocation claim.
+      heap allocation, while mixed/different-DOF and stacked cross-contact
+      scenes stay on the boxed-LCP fallback. Broader solver coverage, including
+      boxed-LCP unified contact assembly, larger contact sets, and remaining
+      solver-owned scratch, remains open before making a full zero-allocation
+      claim.
 - [ ] Phase 6: Add memory-layout profiler/debugger surfaces and GUI
       visualization. `MemoryAllocatorDebugger` now exposes structured live
       bytes, peak live bytes, and live allocation count; `MemoryManager` and
@@ -207,8 +208,9 @@ debugging, profiling, optimization experiments, and ImGui visualization.
    allocation tests to contact-heavy scenes and remaining solver scratch step
    paths. The initial rigid-body, non-cross articulated, and same-DOF
    sequential cross-articulated resting-contact global heap guards are in
-   place; continue broadening to larger stacks, boxed-LCP unified contact
-   assembly, mixed/different-DOF cross articulated contacts, and remaining
+   place; mixed/different-DOF and stacked cross-articulated contacts stay on
+   the boxed-LCP fallback. Continue broadening boxed-LCP unified contact
+   assembly, larger contact sets, and remaining
    solver/deformable candidate buffers before making the full zero-allocation
    claim.
 5. Start replacing per-step `std::vector`/`Eigen` temporaries in hot stages with

--- a/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
@@ -37,9 +37,10 @@ kinematics graph cache at `enterSimulationMode()`, reuse rigid IPC kinematic
 scratch storage, and add global `operator new` guards proving baked kinematic
 IPC rigid-body, box-obstacle, rigid-body resting-contact, non-cross articulated
 resting-contact, and same-DOF sequential cross-articulated link-contact steps do
-not allocate from the global heap. Boxed-LCP unified contact assembly,
-mixed/different-DOF cross contacts, larger stacks, and remaining solver-owned
-scratch remain open.
+not allocate from the global heap. Mixed/different-DOF and stacked
+cross-articulated contacts stay on the boxed-LCP fallback; boxed-LCP unified
+contact assembly, larger contact sets, and remaining solver-owned scratch remain
+open.
 
 The EnTT benchmark slice (`bench/entt-registry-allocator`, PR #2890) adds
 comparative EnTT registry/component-storage rows against foonathan/memory and
@@ -114,7 +115,7 @@ full zero-dynamic-allocation claim.
   `build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.Multibody*'`
 - On `feature/world-cross-contact-heap-guard` after the sequential
   cross-multibody contact heap guard:
-  `cmake --build build/default/cpp/Release --target test_world -j8 && build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.CrossMultibodyLinksResolveContact:World.BakedArticulatedContactStepsDoNotAllocateGlobalHeap:World.BakedRigidBodyContactStepsDoNotAllocateGlobalHeap:World.BakedMultibodyAndDeformableStepsDoNotAllocateGlobalHeap:World.BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths:World.Multibody*'`
+  `cmake --build build/default/cpp/Release --target test_world -j8 && build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.CrossMultibodyLinksResolveContact:World.CrossMultibodyDifferentDofLinksUseUnifiedFallback:World.CrossMultibodyStackedContactsUseUnifiedFallback:World.BakedArticulatedContactStepsDoNotAllocateGlobalHeap:World.BakedRigidBodyContactStepsDoNotAllocateGlobalHeap:World.BakedMultibodyAndDeformableStepsDoNotAllocateGlobalHeap:World.BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths:World.Multibody*'`
 - `pixi run lint`
 - `cmake --build build/default/cpp/Release --target UNIT_common_stl_allocator -j2 && ctest --test-dir build/default/cpp/Release -R '^UNIT_common_stl_allocator$' --output-on-failure`
 - `clang++ --gcc-toolchain=/usr -std=gnu++20 -I. -Ibuild/default/cpp/Release -I.pixi/envs/default/include -fsyntax-only` with an allocator-aware `entt::basic_registry` multi-component `view` instantiation.

--- a/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
@@ -32,11 +32,14 @@ base-allocator no-growth guards for baked kinematic IPC rigid-body, multibody
 variational, and single-deformable step loops, plus inline default step-pipeline
 storage. These are not the final global zero-allocation proof.
 
-The first global heap guard branch, PR #2888, has merged to `main`. It pre-bakes
-the default step stage bundle and kinematics graph cache at
-`enterSimulationMode()`, reuses rigid IPC kinematic scratch storage, and adds a
-global `operator new` guard proving baked kinematic IPC rigid-body and
-box-obstacle steps do not allocate from the global heap.
+The global heap guard branches pre-bake the default step stage bundle and
+kinematics graph cache at `enterSimulationMode()`, reuse rigid IPC kinematic
+scratch storage, and add global `operator new` guards proving baked kinematic
+IPC rigid-body, box-obstacle, rigid-body resting-contact, non-cross articulated
+resting-contact, and same-DOF sequential cross-articulated link-contact steps do
+not allocate from the global heap. Boxed-LCP unified contact assembly,
+mixed/different-DOF cross contacts, larger stacks, and remaining solver-owned
+scratch remain open.
 
 The EnTT benchmark slice (`bench/entt-registry-allocator`, PR #2890) adds
 comparative EnTT registry/component-storage rows against foonathan/memory and
@@ -80,8 +83,9 @@ Next allocator work should broaden allocator correctness coverage, extend
 no-growth tests to contact-heavy scenes and remaining solver scratch paths, and
 continue optimizing allocator paths until DART beats standard C++ allocators and
 foonathan/memory on required workloads. The active zero-allocation guard work
-should broaden beyond the covered rigid-body and non-cross articulated
-resting-contact scenes before making a full zero-dynamic-allocation claim.
+should broaden beyond the covered rigid-body, non-cross articulated, and
+same-DOF sequential cross-articulated resting-contact scenes before making a
+full zero-dynamic-allocation claim.
 
 ## Latest Local Validation
 
@@ -108,6 +112,9 @@ resting-contact scenes before making a full zero-dynamic-allocation claim.
 - On `feature/world-step-global-heap-guard-broader` after the semi-implicit
   multibody scratch update:
   `build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.Multibody*'`
+- On `feature/world-cross-contact-heap-guard` after the sequential
+  cross-multibody contact heap guard:
+  `cmake --build build/default/cpp/Release --target test_world -j8 && build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.CrossMultibodyLinksResolveContact:World.BakedArticulatedContactStepsDoNotAllocateGlobalHeap:World.BakedRigidBodyContactStepsDoNotAllocateGlobalHeap:World.BakedMultibodyAndDeformableStepsDoNotAllocateGlobalHeap:World.BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths:World.Multibody*'`
 - `pixi run lint`
 - `cmake --build build/default/cpp/Release --target UNIT_common_stl_allocator -j2 && ctest --test-dir build/default/cpp/Release -R '^UNIT_common_stl_allocator$' --output-on-failure`
 - `clang++ --gcc-toolchain=/usr -std=gnu++20 -I. -Ibuild/default/cpp/Release -I.pixi/envs/default/include -fsyntax-only` with an allocator-aware `entt::basic_registry` multi-component `view` instantiation.

--- a/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
+++ b/docs/dev_tasks/hierarchical_memory_manager/RESUME.md
@@ -37,10 +37,10 @@ kinematics graph cache at `enterSimulationMode()`, reuse rigid IPC kinematic
 scratch storage, and add global `operator new` guards proving baked kinematic
 IPC rigid-body, box-obstacle, rigid-body resting-contact, non-cross articulated
 resting-contact, and same-DOF sequential cross-articulated link-contact steps do
-not allocate from the global heap. Mixed/different-DOF and stacked
-cross-articulated contacts stay on the boxed-LCP fallback; boxed-LCP unified
-contact assembly, larger contact sets, and remaining solver-owned scratch remain
-open.
+not allocate from the global heap. Mixed/different-DOF, stacked, and coupled
+multi-row cross-articulated contacts stay on the boxed-LCP fallback; boxed-LCP
+unified contact assembly, larger contact sets, and remaining solver-owned
+scratch remain open.
 
 The EnTT benchmark slice (`bench/entt-registry-allocator`, PR #2890) adds
 comparative EnTT registry/component-storage rows against foonathan/memory and
@@ -115,7 +115,7 @@ full zero-dynamic-allocation claim.
   `build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.Multibody*'`
 - On `feature/world-cross-contact-heap-guard` after the sequential
   cross-multibody contact heap guard:
-  `cmake --build build/default/cpp/Release --target test_world -j8 && build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.CrossMultibodyLinksResolveContact:World.CrossMultibodyDifferentDofLinksUseUnifiedFallback:World.CrossMultibodyStackedContactsUseUnifiedFallback:World.BakedArticulatedContactStepsDoNotAllocateGlobalHeap:World.BakedRigidBodyContactStepsDoNotAllocateGlobalHeap:World.BakedMultibodyAndDeformableStepsDoNotAllocateGlobalHeap:World.BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths:World.Multibody*'`
+  `cmake --build build/default/cpp/Release --target test_world -j8 && build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.CrossMultibodyLinksResolveContact:World.CrossMultibodyDifferentDofLinksUseUnifiedFallback:World.CrossMultibodyStackedContactsUseUnifiedFallback:World.CrossMultibodyCoupledRowsUseUnifiedFallback:World.BakedArticulatedContactStepsDoNotAllocateGlobalHeap:World.BakedRigidBodyContactStepsDoNotAllocateGlobalHeap:World.BakedMultibodyAndDeformableStepsDoNotAllocateGlobalHeap:World.BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths:World.Multibody*'`
 - `pixi run lint`
 - `cmake --build build/default/cpp/Release --target UNIT_common_stl_allocator -j2 && ctest --test-dir build/default/cpp/Release -R '^UNIT_common_stl_allocator$' --output-on-failure`
 - `clang++ --gcc-toolchain=/usr -std=gnu++20 -I. -Ibuild/default/cpp/Release -I.pixi/envs/default/include -fsyntax-only` with an allocator-aware `entt::basic_registry` multi-component `view` instantiation.

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -5080,6 +5080,82 @@ TEST(World, CrossMultibodyLinksResolveContact)
   }
 }
 
+TEST(World, CrossMultibodyDifferentDofLinksUseUnifiedFallback)
+{
+  namespace sx = dart::simulation::experimental;
+
+  struct StepState
+  {
+    double lowerVelocity{0.0};
+    double upperRootVelocity{0.0};
+    double upperTipVelocity{0.0};
+  };
+
+  const auto runScene = [](bool boxedLcp) {
+    sx::WorldOptions options;
+    if (boxedLcp) {
+      options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
+    }
+    sx::World world(options);
+    world.setGravity(Eigen::Vector3d::Zero());
+
+    auto lowerRobot = world.addMultibody("lower_robot");
+    auto lowerBase = lowerRobot.addLink("base");
+    sx::JointSpec lowerSpec;
+    lowerSpec.name = "lower_slider";
+    lowerSpec.type = sx::JointType::Prismatic;
+    lowerSpec.axis = Eigen::Vector3d::UnitZ();
+    auto lowerLink = lowerRobot.addLink("link", lowerBase, lowerSpec);
+    lowerLink.setMass(1.0);
+    lowerLink.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+    auto lowerJoint = lowerLink.getParentJoint();
+    lowerJoint.setPosition(Eigen::VectorXd::Constant(1, 0.0));
+    lowerJoint.setVelocity(Eigen::VectorXd::Constant(1, 0.5));
+
+    auto upperRobot = world.addMultibody("upper_robot");
+    auto upperBase = upperRobot.addLink("base");
+    sx::JointSpec rootSpec;
+    rootSpec.name = "upper_root_slider";
+    rootSpec.type = sx::JointType::Prismatic;
+    rootSpec.axis = Eigen::Vector3d::UnitZ();
+    auto upperMid = upperRobot.addLink("mid", upperBase, rootSpec);
+    upperMid.setMass(1.0);
+    auto upperRootJoint = upperMid.getParentJoint();
+    upperRootJoint.setPosition(Eigen::VectorXd::Constant(1, 0.15));
+    upperRootJoint.setVelocity(Eigen::VectorXd::Constant(1, -0.25));
+
+    sx::JointSpec tipSpec;
+    tipSpec.name = "upper_tip_slider";
+    tipSpec.type = sx::JointType::Prismatic;
+    tipSpec.axis = Eigen::Vector3d::UnitZ();
+    auto upperTip = upperRobot.addLink("tip", upperMid, tipSpec);
+    upperTip.setMass(1.0);
+    upperTip.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+    auto upperTipJoint = upperTip.getParentJoint();
+    upperTipJoint.setPosition(Eigen::VectorXd::Constant(1, 0.20));
+    upperTipJoint.setVelocity(Eigen::VectorXd::Constant(1, -0.25));
+
+    world.setTimeStep(0.001);
+    world.enterSimulationMode();
+    EXPECT_FALSE(world.collide().empty());
+
+    world.step();
+
+    return StepState{
+        lowerJoint.getVelocity()[0],
+        upperRootJoint.getVelocity()[0],
+        upperTipJoint.getVelocity()[0]};
+  };
+
+  const StepState defaultPath = runScene(false);
+  const StepState boxedPath = runScene(true);
+
+  EXPECT_NEAR(defaultPath.lowerVelocity, boxedPath.lowerVelocity, 1e-12);
+  EXPECT_NEAR(
+      defaultPath.upperRootVelocity, boxedPath.upperRootVelocity, 1e-12);
+  EXPECT_NEAR(defaultPath.upperTipVelocity, boxedPath.upperTipVelocity, 1e-12);
+}
+
 // Test that Coulomb friction at a link contact decelerates a sliding link. A
 // vertical prismatic carries a horizontal prismatic link whose sphere rests on
 // the ground; an initial horizontal velocity is braked to rest by friction.

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -1198,6 +1198,33 @@ TEST(World, BakedArticulatedContactStepsDoNotAllocateGlobalHeap)
         world.setTimeStep(0.002);
       },
       true);
+
+  expectNoGlobalHeapAllocationsDuringBakedSteps(
+      "cross articulated link contact",
+      [](sx::World& world) {
+        world.setGravity(Eigen::Vector3d::Zero());
+
+        const auto addRobot
+            = [&](std::string_view name, double z, double velocity) {
+                auto robot = world.addMultibody(name);
+                auto base = robot.addLink("base");
+                sx::JointSpec spec;
+                spec.name = "slider";
+                spec.type = sx::JointType::Prismatic;
+                spec.axis = Eigen::Vector3d::UnitZ();
+                auto link = robot.addLink("link", base, spec);
+                link.setMass(1.0);
+                link.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+                auto joint = link.getParentJoint();
+                joint.setPosition(Eigen::VectorXd::Constant(1, z));
+                joint.setVelocity(Eigen::VectorXd::Constant(1, velocity));
+              };
+
+        addRobot("lower_robot", 0.0, 0.5);
+        addRobot("upper_robot", 0.35, -0.5);
+        world.setTimeStep(0.001);
+      },
+      true);
 }
 
 TEST(World, BakedMultibodyAndDeformableStepsDoNotAllocateGlobalHeap)
@@ -4909,43 +4936,50 @@ TEST(World, CrossMultibodyLinksResolveContact)
 {
   namespace sx = dart::simulation::experimental;
 
-  sx::WorldOptions options;
-  options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
-  sx::World world(options);
-  world.setGravity(Eigen::Vector3d::Zero());
+  for (const bool boxedLcp : {false, true}) {
+    SCOPED_TRACE(boxedLcp ? "boxed LCP" : "sequential shortcut");
 
-  const auto addRobot = [&](std::string_view name, double z, double velocity) {
-    auto robot = world.addMultibody(name);
-    auto base = robot.addLink("base");
-    sx::JointSpec spec;
-    spec.name = "slider";
-    spec.type = sx::JointType::Prismatic;
-    spec.axis = Eigen::Vector3d::UnitZ();
-    auto link = robot.addLink("link", base, spec);
-    link.setMass(1.0);
-    link.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
-    auto joint = link.getParentJoint();
-    joint.setPosition(Eigen::VectorXd::Constant(1, z));
-    joint.setVelocity(Eigen::VectorXd::Constant(1, velocity));
-    return link;
-  };
+    sx::WorldOptions options;
+    if (boxedLcp) {
+      options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
+    }
+    sx::World world(options);
+    world.setGravity(Eigen::Vector3d::Zero());
 
-  auto lower = addRobot("lower_robot", 0.0, 0.5);
-  auto upper = addRobot("upper_robot", 0.35, -0.5);
-  auto lowerJoint = lower.getParentJoint();
-  auto upperJoint = upper.getParentJoint();
+    const auto addRobot
+        = [&](std::string_view name, double z, double velocity) {
+            auto robot = world.addMultibody(name);
+            auto base = robot.addLink("base");
+            sx::JointSpec spec;
+            spec.name = "slider";
+            spec.type = sx::JointType::Prismatic;
+            spec.axis = Eigen::Vector3d::UnitZ();
+            auto link = robot.addLink("link", base, spec);
+            link.setMass(1.0);
+            link.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+            auto joint = link.getParentJoint();
+            joint.setPosition(Eigen::VectorXd::Constant(1, z));
+            joint.setVelocity(Eigen::VectorXd::Constant(1, velocity));
+            return link;
+          };
 
-  world.setTimeStep(0.001);
-  world.enterSimulationMode();
-  ASSERT_FALSE(world.collide().empty());
+    auto lower = addRobot("lower_robot", 0.0, 0.5);
+    auto upper = addRobot("upper_robot", 0.35, -0.5);
+    auto lowerJoint = lower.getParentJoint();
+    auto upperJoint = upper.getParentJoint();
 
-  world.step();
+    world.setTimeStep(0.001);
+    world.enterSimulationMode();
+    ASSERT_FALSE(world.collide().empty());
 
-  const double relativeVelocity
-      = upperJoint.getVelocity()[0] - lowerJoint.getVelocity()[0];
-  EXPECT_GE(relativeVelocity, -1e-9);
-  EXPECT_LT(lowerJoint.getVelocity()[0], 0.5);
-  EXPECT_GT(upperJoint.getVelocity()[0], -0.5);
+    world.step();
+
+    const double relativeVelocity
+        = upperJoint.getVelocity()[0] - lowerJoint.getVelocity()[0];
+    EXPECT_GE(relativeVelocity, -1e-9);
+    EXPECT_LT(lowerJoint.getVelocity()[0], 0.5);
+    EXPECT_GT(upperJoint.getVelocity()[0], -0.5);
+  }
 }
 
 // Test that Coulomb friction at a link contact decelerates a sliding link. A

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -5219,6 +5219,70 @@ TEST(World, CrossMultibodyStackedContactsUseUnifiedFallback)
   EXPECT_NEAR(defaultPath.upperVelocity, boxedPath.upperVelocity, 1e-12);
 }
 
+TEST(World, CrossMultibodyCoupledRowsUseUnifiedFallback)
+{
+  namespace sx = dart::simulation::experimental;
+
+  struct StepState
+  {
+    double lowerVelocity{0.0};
+    double middleVelocity{0.0};
+    double upperVelocity{0.0};
+  };
+
+  const auto runScene = [](bool boxedLcp) {
+    sx::WorldOptions options;
+    if (boxedLcp) {
+      options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
+    }
+    sx::World world(options);
+    world.setGravity(Eigen::Vector3d::Zero());
+
+    const auto addRobot
+        = [&](std::string_view name, double z, double velocity) {
+            auto robot = world.addMultibody(name);
+            auto base = robot.addLink("base");
+            sx::JointSpec spec;
+            spec.name = "slider";
+            spec.type = sx::JointType::Prismatic;
+            spec.axis = Eigen::Vector3d::UnitZ();
+            auto link = robot.addLink("link", base, spec);
+            link.setMass(1.0);
+            link.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+            auto joint = link.getParentJoint();
+            joint.setPosition(Eigen::VectorXd::Constant(1, z));
+            joint.setVelocity(Eigen::VectorXd::Constant(1, velocity));
+            return link;
+          };
+
+    auto lower = addRobot("lower_robot", 0.0, 0.5);
+    auto middle = addRobot("middle_robot", 0.35, 0.0);
+    auto upper = addRobot("upper_robot", 0.70, -0.5);
+
+    auto lowerJoint = lower.getParentJoint();
+    auto middleJoint = middle.getParentJoint();
+    auto upperJoint = upper.getParentJoint();
+
+    world.setTimeStep(0.001);
+    world.enterSimulationMode();
+    EXPECT_GE(world.collide().size(), 2u);
+
+    world.step();
+
+    return StepState{
+        lowerJoint.getVelocity()[0],
+        middleJoint.getVelocity()[0],
+        upperJoint.getVelocity()[0]};
+  };
+
+  const StepState defaultPath = runScene(false);
+  const StepState boxedPath = runScene(true);
+
+  EXPECT_NEAR(defaultPath.lowerVelocity, boxedPath.lowerVelocity, 1e-12);
+  EXPECT_NEAR(defaultPath.middleVelocity, boxedPath.middleVelocity, 1e-12);
+  EXPECT_NEAR(defaultPath.upperVelocity, boxedPath.upperVelocity, 1e-12);
+}
+
 // Test that Coulomb friction at a link contact decelerates a sliding link. A
 // vertical prismatic carries a horizontal prismatic link whose sphere rests on
 // the ground; an initial horizontal velocity is braked to rest by friction.

--- a/tests/unit/simulation/experimental/world/test_world.cpp
+++ b/tests/unit/simulation/experimental/world/test_world.cpp
@@ -5156,6 +5156,69 @@ TEST(World, CrossMultibodyDifferentDofLinksUseUnifiedFallback)
   EXPECT_NEAR(defaultPath.upperTipVelocity, boxedPath.upperTipVelocity, 1e-12);
 }
 
+TEST(World, CrossMultibodyStackedContactsUseUnifiedFallback)
+{
+  namespace sx = dart::simulation::experimental;
+
+  struct StepState
+  {
+    double lowerVelocity{0.0};
+    double upperVelocity{0.0};
+  };
+
+  const auto runScene = [](bool boxedLcp) {
+    sx::WorldOptions options;
+    if (boxedLcp) {
+      options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
+    }
+    sx::World world(options);
+    world.setGravity(Eigen::Vector3d::Zero());
+
+    const auto addRobot
+        = [&](std::string_view name, double z, double velocity) {
+            auto robot = world.addMultibody(name);
+            auto base = robot.addLink("base");
+            sx::JointSpec spec;
+            spec.name = "slider";
+            spec.type = sx::JointType::Prismatic;
+            spec.axis = Eigen::Vector3d::UnitZ();
+            auto link = robot.addLink("link", base, spec);
+            link.setMass(1.0);
+            link.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+            auto joint = link.getParentJoint();
+            joint.setPosition(Eigen::VectorXd::Constant(1, z));
+            joint.setVelocity(Eigen::VectorXd::Constant(1, velocity));
+            return link;
+          };
+
+    auto lower = addRobot("lower_robot", 0.0, -0.2);
+    auto upper = addRobot("upper_robot", 0.35, -0.8);
+
+    sx::RigidBodyOptions fixtureOptions;
+    fixtureOptions.isStatic = true;
+    fixtureOptions.position = Eigen::Vector3d(0.0, 0.0, -0.35);
+    auto fixture = world.addRigidBody("fixture", fixtureOptions);
+    fixture.setCollisionShape(sx::CollisionShape::makeSphere(0.2));
+
+    auto lowerJoint = lower.getParentJoint();
+    auto upperJoint = upper.getParentJoint();
+
+    world.setTimeStep(0.001);
+    world.enterSimulationMode();
+    EXPECT_GE(world.collide().size(), 2u);
+
+    world.step();
+
+    return StepState{lowerJoint.getVelocity()[0], upperJoint.getVelocity()[0]};
+  };
+
+  const StepState defaultPath = runScene(false);
+  const StepState boxedPath = runScene(true);
+
+  EXPECT_NEAR(defaultPath.lowerVelocity, boxedPath.lowerVelocity, 1e-12);
+  EXPECT_NEAR(defaultPath.upperVelocity, boxedPath.upperVelocity, 1e-12);
+}
+
 // Test that Coulomb friction at a link contact decelerates a sliding link. A
 // vertical prismatic carries a horizontal prismatic link whose sphere rests on
 // the ground; an initial horizontal velocity is braked to rest by friction.


### PR DESCRIPTION
## Summary

- add a default sequential cross-multibody link contact solve path for isolated same-DOF link pairs
- keep mixed/different-DOF, stacked, and coupled multi-row cross-contact scenes on the boxed-LCP fallback
- extend the baked articulated global heap guard and fallback coverage for cross-link contact scenes
- update the hierarchical memory manager task ledger and changelog with the new coverage boundary

## Motivation / Problem

- Cross-multibody articulated link contacts previously fell back to the unified boxed-LCP path on the default solver path, which allocated during baked `World::step()` contact assembly.
- The memory-manager north-star needs representative step-loop heap guards to expand without overstating unsupported solver paths.
- The sequential shortcut is only correct for one isolated same-DOF cross-link row; mixed-DOF pairs, stacked contacts, and coupled cross-only row sets need the boxed-LCP fallback.

## Changes / Key Changes

- Completes one isolated same-DOF cross-multibody link contact row in the default sequential multibody contact path.
- Applies equal-and-opposite articulated impulses to both multibodies using staged velocities and existing multibody scratch.
- Gates the sequential shortcut off when cross-link contacts have incompatible DOF counts, appear with non-cross link contacts in the same batch, or contain multiple cross-link rows.
- Clears stale active row state for required cross-contact bodies that do not own a current row.
- Runs cross-link correctness and fallback tests against both the default path and the boxed-LCP path.
- Documents that boxed-LCP unified contact assembly, larger contact sets, and remaining solver-owned scratch still need follow-up zero-allocation coverage.

## Testing

- `cmake --build build/default/cpp/Release --target test_world -j8 && build/default/cpp/Release/bin/test_world --gtest_color=no --gtest_filter='World.CrossMultibodyLinksResolveContact:World.CrossMultibodyDifferentDofLinksUseUnifiedFallback:World.CrossMultibodyStackedContactsUseUnifiedFallback:World.CrossMultibodyCoupledRowsUseUnifiedFallback:World.BakedArticulatedContactStepsDoNotAllocateGlobalHeap:World.ZeroDofMultibodyLinkContactStopsRigidBody:World.ZeroDofMultibodyFallbackDoesNotDoubleApplyShortcutImpulses'`
- `pixi run lint`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to the hierarchical memory manager zero-allocation work.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable: N/A, no Python-facing API change