### PR TITLE
Release DART 6.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## DART 6
 
+### [DART 6.18.0 (2026-06-05)](https://github.com/dartsim/dart/milestone/94?closed=1)
+
+DART 6.18.0 is a minor release on the DART 6 LTS line. It adds two contact and
+constraint robustness improvements surfaced through gz-physics, so resting
+capsules/cylinders and non-axis-aligned closed kinematic chains behave correctly
+on the classic DART 6 API.
+
+* Collision
+
+  * Stabilize ODE capsule and cylinder resting contacts with a per-pair contact-history manifold (invalidated on sliding and kinematic pose changes) so they no longer sink through the supporting surface: [#2902](https://github.com/dartsim/dart/pull/2902), [gazebosim/gz-physics#692](https://github.com/gazebosim/gz-physics/issues/692)
+
+* Constraint
+
+  * Regularize rank-deficient closed-loop constraints with an additive Constraint Force Mixing floor on the `BallJointConstraint`/`WeldJointConstraint` loop-closure constraints, so non-axis-aligned closed kinematic chains stay enforced instead of drifting open: [#2903](https://github.com/dartsim/dart/pull/2903), [gazebosim/gz-physics#719](https://github.com/gazebosim/gz-physics/issues/719)
+
 ### [DART 6.17.1 (2026-06-05)](https://github.com/dartsim/dart/milestone/95?closed=1)
 
 DART 6.17.1 is a patch release on the DART 6 LTS line. It hardens the classic

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.17.1</version>
+  <version>6.18.0</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.17.1"
+version = "6.18.0"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
Release **DART 6.18.0** — a minor release on the DART 6 LTS line.

Bumps `package.xml` and `pixi.toml` to `6.18.0` and adds the CHANGELOG entry. No code changes (the two fixes already merged to `release-6.18` and passed CI).

## Included since 6.17.1
- **#2902** — Stabilize ODE capsule/cylinder resting contacts (per-pair contact-history manifold) · gazebosim/gz-physics#692
- **#2903** — Regularize rank-deficient closed-loop constraints (additive CFM floor on Ball/Weld) · gazebosim/gz-physics#719

Tag `v6.18.0` will be pushed after merge to trigger the PyPI/Docker publish.