### PR TITLE
docs(ci): document self-hosted runner parity for "lost communication" failures

### DIFF
--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -95,7 +95,18 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
   executable.
 - Unit test crashes or segfaults: isolate the failing test from job logs, reproduce locally, and add a regression for the edge case.
 - Job logs are missing or return 404: re-run the single job and/or download the run-level logs archive to inspect failures.
-- Infrastructure failures (runner connectivity lost, self-hosted runner issues): re-run only the failed jobs with `gh run rerun <RUN_ID> --failed`.
+- Infrastructure failures (self-hosted runner "lost communication"): the
+  `dartsim-mark*` self-hosted runners advertise the `ubuntu-latest` label as
+  parity replacements for GitHub-hosted runners, so each one must be capped to a
+  GitHub-hosted envelope — **4 vCPU / 16 GB** per runner — and the total kept
+  within host capacity with headroom. An uncapped runner on an oversubscribed
+  host starves its `Runner.Listener` heartbeat, and GitHub fails the job with
+  "The self-hosted runner lost communication with the server" — a host-resource
+  issue, not a code defect. Tell-tale: the job logs contain only the setup steps
+  because the failing step (e.g. `Build wheel`) died mid-run and never produced a
+  log. Re-run once the host is calm (`gh run rerun <RUN_ID> --failed`) and make
+  sure every runner is resource-capped per the runner-setup gist
+  (https://gist.github.com/jslee02/c0a6b0e4af18e4ecb2f2e8fb5b715f78).
 - FreeBSD RTTI failures: `dynamic_cast` across shared library boundaries can fail silently; use type enums + `static_cast` instead.
 - macOS ARM64 sporadic SEGFAULT: `alloca()` or VLAs may cause alignment violations; use `std::vector<T>` for proper alignment.
 - RTD build failures: Sphinx extension compatibility issues; use defensive `.get(key, default)` patterns.


### PR DESCRIPTION
## Summary

- Documents why `dartsim-mark*` self-hosted runners (which advertise the
  `ubuntu-latest` label as parity replacements for GitHub-hosted runners) must be
  capped to a GitHub-hosted envelope — **4 vCPU / 16 GB** per runner, total within
  host capacity — and how the "The self-hosted runner lost communication with the
  server" failure is diagnosed and cleared.

## Motivation / Problem

On 2026-06-06 the `Wheels | ubuntu-latest Py313/Py314` jobs failed on main. Root
cause was **not** code: the jobs landed on uncapped self-hosted runners
(`dartsim-mark13-*`) on an oversubscribed host; the `Runner.Listener` heartbeat
was starved of CPU/memory and GitHub dropped the jobs mid-`Build wheel` (no
build-step log). The Py312 job passed only because it landed on a GitHub-hosted
runner. Re-running the failed jobs on a calm host passed cleanly.

The runner-setup gist has been updated to cap each runner (`cpuset` 4 cores +
`mem_limit: 16g`) with a capacity rule; this PR makes the root cause discoverable
from the repo CI docs.

## Changes / Key Changes

- `docs/onboarding/ci-cd.md`: expand the infrastructure-failure entry under
  "Common CI Failure Modes" with the parity requirement, the tell-tale (only
  setup-step logs), the re-run remedy, and a pointer to the runner-setup gist.

## Testing

- `pixi run lint-md`, `pixi run check-docs-policy`, `pixi run check-lint-md`,
  `pixi run check-lint-spell` (all pass). Docs-only change.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated if required (docs-only; not required)
- [ ] Add unit tests for new functionality (N/A)
- [x] Document new methods and classes (this PR is documentation)
- [ ] Add Python bindings (dartpy) if applicable (N/A)