### PR TITLE
Add discussion guidance and regression coverage

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,26 @@
+body:
+  - type: markdown
+    attributes:
+      value: |
+        DeepWiki may help with quick DART codebase and API questions:
+        https://deepwiki.com/dartsim/dart
+
+        It is optional and experimental. Questions are welcome here whenever you want maintainer or community input.
+  - type: input
+    id: version
+    attributes:
+      label: DART version or branch
+      description: For example, main, 6.17.x, 6.18.x, or a package version.
+      placeholder: main
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to do, and what result or error did you see?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Links, code snippets, logs, or what DeepWiki/docs said if useful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: DeepWiki
+    url: https://deepwiki.com/dartsim/dart
+    about: Optional AI-assisted DART Q&A. Use Discussions for maintainer or community help.
   - name: Discussions
     url: https://github.com/dartsim/dart/discussions
     about: Questions, usage help, and ideas belong here.

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -281,7 +281,7 @@ jobs:
           PYTHONPATH=build/default/cpp/Release/python \
             pixi run -- pytest -q \
               python/tests/unit/collision/test_collision.py \
-              python/tests/unit/simulation/test_world.py
+              python/tests/unit/simulation/test_experimental_world.py::test_experimental_world_smoke
 
   collision-benchmark-guard:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ pixi run ex headless_simulation --steps 1
 ## Documentation
 
 - **Static Docs**: [English](https://dart.readthedocs.io/) | [한국어](https://dart-ko.readthedocs.io/)
-- **AI Docs (interactive Q&A; experimental)**: [DeepWiki](https://deepwiki.com/dartsim/dart) | [NotebookLM](https://notebooklm.google.com/notebook/c0cfc8ce-17ae-415a-a615-44c4342f0da6) (Google account required)
+- **AI Docs (experimental)**: [DeepWiki](https://deepwiki.com/dartsim/dart) for quick codebase Q&A | [NotebookLM](https://notebooklm.google.com/notebook/c0cfc8ce-17ae-415a-a615-44c4342f0da6) (Google account required)
+- **Questions**: Ask in [GitHub Discussions](https://github.com/dartsim/dart/discussions) when you want maintainer or community input.
 
 ### Developer Resources
 

--- a/python/tests/unit/dynamics/test_polymorphic_casts.py
+++ b/python/tests/unit/dynamics/test_polymorphic_casts.py
@@ -1,0 +1,44 @@
+import dartpy as dart
+
+from dartpy._dartpy import dynamics as _dyn
+
+
+def _make_body():
+    skel = dart.Skeleton("polymorphic_cast_skel")
+    _, body = skel.create_revolute_joint_and_body_node_pair()
+    return skel, body
+
+
+def test_body_node_casts_across_frame_and_jacobian_bases():
+    skel, body = _make_body()
+
+    assert isinstance(body, dart.BodyNode)
+    assert isinstance(body, _dyn.JacobianNode)
+    assert isinstance(body, _dyn.Frame)
+
+    child_frame = dart.SimpleFrame(body, "body_child_frame")
+    parent = child_frame.get_parent_frame()
+
+    assert isinstance(parent, dart.BodyNode)
+    assert parent.get_name() == body.get_name()
+
+    ik = body.get_or_create_ik()
+    assert ik.is_active()
+
+
+def test_end_effector_casts_across_frame_and_jacobian_bases():
+    skel, body = _make_body()
+    end_effector = body.create_end_effector("tool")
+
+    assert isinstance(end_effector, dart.EndEffector)
+    assert isinstance(end_effector, _dyn.JacobianNode)
+    assert isinstance(end_effector, _dyn.Frame)
+
+    child_frame = dart.SimpleFrame(end_effector, "tool_child_frame")
+    parent = child_frame.get_parent_frame()
+
+    assert isinstance(parent, dart.EndEffector)
+    assert parent.get_name() == end_effector.get_name()
+
+    ik = end_effector.get_or_create_ik()
+    assert ik.is_active()

--- a/tests/integration/constraint/test_contact_constraint.cpp
+++ b/tests/integration/constraint/test_contact_constraint.cpp
@@ -32,6 +32,7 @@
 
 #include "helpers/gtest_utils.hpp"
 
+#include "dart/collision/dart/dart_collision_detector.hpp"
 #include "dart/common/All.hpp"
 #include "dart/constraint/All.hpp"
 #include "dart/dynamics/All.hpp"
@@ -219,4 +220,56 @@ TEST(ContactConstraint, MalformedContactGuardedCallbacksAreNoops)
   EXPECT_DOUBLE_EQ(values[0], 1.0);
   EXPECT_DOUBLE_EQ(values[1], 2.0);
   EXPECT_DOUBLE_EQ(values[2], 3.0);
+}
+
+//==============================================================================
+TEST(ContactConstraint, FrictionRowsUseCoefficientBoundsCoupledToNormalRow)
+{
+  auto skeleton1 = dynamics::Skeleton::create("skeleton1");
+  auto pair1 = skeleton1->createJointAndBodyNodePair<dynamics::FreeJoint>();
+  auto bodyNode1 = pair1.second;
+  bodyNode1->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones()));
+  skeleton1->setPosition(3, 0.0);
+
+  auto skeleton2 = dynamics::Skeleton::create("skeleton2");
+  auto pair2 = skeleton2->createJointAndBodyNodePair<dynamics::FreeJoint>();
+  auto bodyNode2 = pair2.second;
+  bodyNode2->createShapeNodeWith<VisualAspect, CollisionAspect, DynamicsAspect>(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones()));
+  skeleton2->setPosition(3, 0.9);
+
+  auto detector = collision::DartCollisionDetector::create();
+  auto group = detector->createCollisionGroup();
+  group->addShapeFramesOf(skeleton1.get());
+  group->addShapeFramesOf(skeleton2.get());
+
+  collision::CollisionOption option;
+  option.maxNumContacts = 1;
+  collision::CollisionResult result;
+  group->collide(option, &result);
+  ASSERT_GT(result.getNumContacts(), 0u);
+
+  auto contact = result.getContact(0);
+
+  constraint::ContactSurfaceParams params;
+  params.mPrimaryFrictionCoeff = 2.5;
+  params.mSecondaryFrictionCoeff = 2.5;
+
+  ExposedContactConstraint constraint(contact, 0.001, params);
+  ASSERT_EQ(constraint.getDimension(), 3u);
+
+  ConstraintInfoStorage storage(constraint.getDimension());
+  constraint.getInformation(&storage.info);
+
+  EXPECT_DOUBLE_EQ(storage.lo[0], 0.0);
+  EXPECT_EQ(storage.findex[0], -1);
+
+  EXPECT_DOUBLE_EQ(storage.lo[1], -2.5);
+  EXPECT_DOUBLE_EQ(storage.hi[1], 2.5);
+  EXPECT_EQ(storage.findex[1], 0);
+
+  EXPECT_DOUBLE_EQ(storage.lo[2], -2.5);
+  EXPECT_DOUBLE_EQ(storage.hi[2], 2.5);
+  EXPECT_EQ(storage.findex[2], 0);
 }

--- a/tests/unit/constraint/test_contact_surface.cpp
+++ b/tests/unit/constraint/test_contact_surface.cpp
@@ -337,6 +337,35 @@ TEST(ContactSurface, ValidFrictionPassesThrough)
   EXPECT_DOUBLE_EQ(params.mPrimaryFrictionCoeff, 0.3);
 }
 
+TEST(ContactSurface, FrictionAboveOnePassesThroughAndUsesLowerSurface)
+{
+  auto setup = createCollidingBoxes(2.5, 3.0);
+  auto result = setup.runCollision();
+  ASSERT_GT(result.getNumContacts(), 0u);
+
+  const auto* shapeNode1 = setup.skel1->getBodyNode(0)->getShapeNode(0);
+  const auto* shapeNode2 = setup.skel2->getBodyNode(0)->getShapeNode(0);
+  ASSERT_NE(shapeNode1, nullptr);
+  ASSERT_NE(shapeNode2, nullptr);
+  ASSERT_NE(shapeNode1->getDynamicsAspect(), nullptr);
+  ASSERT_NE(shapeNode2->getDynamicsAspect(), nullptr);
+
+  EXPECT_DOUBLE_EQ(
+      shapeNode1->getDynamicsAspect()->getPrimaryFrictionCoeff(), 2.5);
+  EXPECT_DOUBLE_EQ(
+      shapeNode1->getDynamicsAspect()->getSecondaryFrictionCoeff(), 2.5);
+  EXPECT_DOUBLE_EQ(
+      shapeNode2->getDynamicsAspect()->getPrimaryFrictionCoeff(), 3.0);
+  EXPECT_DOUBLE_EQ(
+      shapeNode2->getDynamicsAspect()->getSecondaryFrictionCoeff(), 3.0);
+
+  DefaultContactSurfaceHandler handler;
+  auto params = handler.createParams(result.getContact(0), 1);
+
+  EXPECT_DOUBLE_EQ(params.mPrimaryFrictionCoeff, 2.5);
+  EXPECT_DOUBLE_EQ(params.mSecondaryFrictionCoeff, 2.5);
+}
+
 TEST(ContactSurface, ZeroFrictionIsValid)
 {
   auto setup = createCollidingBoxes(0.0, 0.5);

--- a/tests/unit/constraint/test_joint_constraint.cpp
+++ b/tests/unit/constraint/test_joint_constraint.cpp
@@ -358,6 +358,44 @@ TEST(JointConstraintTests, RevoluteJointConstraintSingleBodyInformation)
   EXPECT_FALSE(inactiveConstraint.isActive());
 }
 
+TEST(JointConstraintTests, RevoluteJointConstraintUsesFiveBilateralRows)
+{
+  auto skelA = createBox(
+      Eigen::Vector3d(0.2, 0.2, 0.2), Eigen::Vector3d(0.0, 0.1, 0.0));
+  auto skelB = createBox(
+      Eigen::Vector3d(0.2, 0.2, 0.2), Eigen::Vector3d(0.0, 0.3, 0.0));
+  auto* bodyA = skelA->getBodyNode(0);
+  auto* bodyB = skelB->getBodyNode(0);
+  ASSERT_NE(bodyA, nullptr);
+  ASSERT_NE(bodyB, nullptr);
+
+  const Eigen::Vector3d jointPos(0.0, 0.2, 0.0);
+  const Eigen::Vector3d axis = Eigen::Vector3d::UnitY();
+  ExposedRevoluteJointConstraint constraint(bodyA, bodyB, jointPos, axis, axis);
+  constraint.update();
+
+  ASSERT_EQ(constraint.getDimension(), 5u);
+
+  constraint::ConstraintInfo info{};
+  LcpBuffers buffers;
+  prepareConstraintInfo(
+      info,
+      buffers,
+      constraint.getDimension(),
+      1000.0,
+      constraint::ConstraintPhase::Velocity,
+      false);
+  constraint.getInformation(&info);
+
+  for (std::size_t i = 0; i < constraint.getDimension(); ++i) {
+    EXPECT_TRUE(std::isinf(buffers.lo[i]));
+    EXPECT_TRUE(std::isinf(buffers.hi[i]));
+    EXPECT_LT(buffers.lo[i], 0.0);
+    EXPECT_GT(buffers.hi[i], 0.0);
+    EXPECT_EQ(buffers.findex[i], -1);
+  }
+}
+
 TEST(JointConstraintTests, RevoluteJointConstraintSingleBodyImpulseVelocity)
 {
   auto skel = createBox(

--- a/tests/unit/dynamics/test_body_node_external_force.cpp
+++ b/tests/unit/dynamics/test_body_node_external_force.cpp
@@ -233,3 +233,89 @@ TEST(BodyNodeExternalForce, SimulationDoesNotCrashWithNaNForce)
         << "Position " << i << " should not be NaN";
   }
 }
+
+//==============================================================================
+TEST(BodyNodeExternalForce, ExternalSpringCanConnectSeparateSkeletons)
+{
+  auto skelA = createSimpleSkeleton();
+  auto skelB = createSimpleSkeleton();
+  skelA->setName("spring_body_a");
+  skelB->setName("spring_body_b");
+
+  auto* bodyA = skelA->getBodyNode(0);
+  auto* bodyB = skelB->getBodyNode(0);
+  auto* jointA = dynamic_cast<FreeJoint*>(bodyA->getParentJoint());
+  auto* jointB = dynamic_cast<FreeJoint*>(bodyB->getParentJoint());
+  ASSERT_NE(nullptr, jointA);
+  ASSERT_NE(nullptr, jointB);
+  bodyA->setMomentOfInertia(1.0, 1.0, 1.0);
+  bodyB->setMomentOfInertia(1.0, 1.0, 1.0);
+
+  Eigen::Isometry3d tfA = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d tfB = Eigen::Isometry3d::Identity();
+  tfB.linear()
+      = Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  tfB.translation() = Eigen::Vector3d(2.0, 0.0, 0.0);
+  jointA->setTransform(tfA);
+  jointB->setTransform(tfB);
+
+  auto world = simulation::World::create();
+  world->setGravity(Eigen::Vector3d::Zero());
+  world->setTimeStep(1e-3);
+  world->addSkeleton(skelA);
+  world->addSkeleton(skelB);
+
+  const Eigen::Vector3d localA = Eigen::Vector3d::Zero();
+  const Eigen::Vector3d localB = Eigen::Vector3d::Zero();
+  const double restLength = 1.0;
+  const double stiffness = 10.0;
+
+  const Eigen::Vector3d pA = bodyA->getWorldTransform() * localA;
+  const Eigen::Vector3d pB = bodyB->getWorldTransform() * localB;
+  const Eigen::Vector3d displacement = pB - pA;
+  const double length = displacement.norm();
+  ASSERT_GT(length, 1e-12);
+
+  const Eigen::Vector3d direction = displacement / length;
+  const Eigen::Vector3d force = stiffness * (length - restLength) * direction;
+
+  bodyA->addExtForce(force, localA, false, true);
+  bodyB->addExtForce(-force, localB, false, true);
+
+  const double rotationalStiffness = 2.0;
+  const Eigen::Matrix3d restRelativeRotation = Eigen::Matrix3d::Identity();
+  const Eigen::Matrix3d currentRelativeRotation
+      = bodyA->getWorldTransform().linear().transpose()
+        * bodyB->getWorldTransform().linear();
+  const Eigen::Vector3d rotationErrorInA = math::logMap(
+      restRelativeRotation.transpose() * currentRelativeRotation);
+  const Eigen::Vector3d torqueOnA = bodyA->getWorldTransform().linear()
+                                    * (rotationalStiffness * rotationErrorInA);
+  bodyA->addExtTorque(torqueOnA, false);
+  bodyB->addExtTorque(-torqueOnA, false);
+
+  world->step();
+
+  const Eigen::Vector3d velocityA = bodyA->getLinearVelocity(localA);
+  const Eigen::Vector3d velocityB = bodyB->getLinearVelocity(localB);
+  EXPECT_GT(velocityA.x(), 0.0);
+  EXPECT_LT(velocityB.x(), 0.0);
+  EXPECT_NEAR(velocityA.x(), -velocityB.x(), 1e-12);
+  EXPECT_NEAR(velocityA.y(), 0.0, 1e-12);
+  EXPECT_NEAR(velocityB.y(), 0.0, 1e-12);
+  EXPECT_NEAR(velocityA.z(), 0.0, 1e-12);
+  EXPECT_NEAR(velocityB.z(), 0.0, 1e-12);
+
+  const Eigen::Vector3d angularVelocityA = bodyA->getAngularVelocity();
+  const Eigen::Vector3d angularVelocityB = bodyB->getAngularVelocity();
+  EXPECT_GT(angularVelocityA.z(), 0.0);
+  EXPECT_LT(angularVelocityB.z(), 0.0);
+  EXPECT_NEAR(angularVelocityA.z(), -angularVelocityB.z(), 1e-12);
+  EXPECT_NEAR(angularVelocityA.x(), 0.0, 1e-12);
+  EXPECT_NEAR(angularVelocityB.x(), 0.0, 1e-12);
+  EXPECT_NEAR(angularVelocityA.y(), 0.0, 1e-12);
+  EXPECT_NEAR(angularVelocityB.y(), 0.0, 1e-12);
+
+  EXPECT_TRUE(bodyA->getExternalForceLocal().isZero(1e-12));
+  EXPECT_TRUE(bodyB->getExternalForceLocal().isZero(1e-12));
+}

--- a/tests/unit/dynamics/test_skeleton_accessors.cpp
+++ b/tests/unit/dynamics/test_skeleton_accessors.cpp
@@ -1989,6 +1989,37 @@ TEST(SkeletonForces, GravityForces)
   EXPECT_GT(gravityForces.norm(), 0.0);
 }
 
+TEST(SkeletonForces, GravityForcesCancelForwardDynamicsAcceleration)
+{
+  auto skeleton = Skeleton::create("gravity_compensation_test");
+
+  RevoluteJoint::Properties jointProps;
+  jointProps.mAxis = Eigen::Vector3d::UnitY();
+
+  BodyNode::Properties bodyProps;
+  bodyProps.mInertia.setMass(2.0);
+  bodyProps.mInertia.setLocalCOM(Eigen::Vector3d(0.5, 0.0, 0.0));
+  bodyProps.mInertia.setMoment(0.1, 0.1, 0.1, 0.0, 0.0, 0.0);
+
+  skeleton->createJointAndBodyNodePair<RevoluteJoint>(
+      nullptr, jointProps, bodyProps);
+  skeleton->setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  skeleton->setPosition(0, 0.4);
+  skeleton->setVelocity(0, 0.0);
+
+  const auto gravityForces = skeleton->getGravityForces();
+  ASSERT_EQ(gravityForces.size(), 1);
+  ASSERT_GT(std::abs(gravityForces[0]), 1e-6);
+
+  skeleton->setForces(gravityForces);
+  skeleton->computeForwardDynamics();
+  EXPECT_NEAR(skeleton->getAcceleration(0), 0.0, 1e-12);
+
+  skeleton->setForces(Eigen::VectorXd::Zero(1));
+  skeleton->computeForwardDynamics();
+  EXPECT_GT(std::abs(skeleton->getAcceleration(0)), 1e-6);
+}
+
 // ============================================================================
 // Skeleton Forward Kinematics
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds compact DeepWiki/Discussions guidance to the README, issue contact links, and the Q&A discussion form.
- Adds focused regression tests for DART behaviors that were verified while answering recent Discussions.

## Motivation / Problem

Recent maintainer answers clarified existing support for contact friction coefficients, bilateral joint constraints, external forces between separate skeletons, dartpy polymorphic casting, and gravity-force compensation. Capturing those checks in tests keeps the answers evidence-based and guards against regressions, while the DeepWiki guidance gives users a friendly optional starting point before or alongside maintainer/community help.

## Changes / Key Changes

- `README.md`: points to DeepWiki for quick codebase Q&A and GitHub Discussions for maintainer/community input.
- `.github/ISSUE_TEMPLATE/config.yml`: adds DeepWiki as an optional support contact.
- `.github/DISCUSSION_TEMPLATE/q-a.yml`: adds a concise Q&A form with version context and optional DeepWiki/docs context.
- C++ tests: cover friction coefficients above 1.0, contact friction row bounds, revolute bilateral constraint rows, external spring-style forces between separate skeletons, and gravity-force compensation in forward dynamics.
- Python tests: cover dartpy polymorphic casts across `BodyNode`/`EndEffector`, `Frame`, and `JacobianNode` bases.

## Testing

- `pixi run lint` (before both commits)
- `pixi run build`
- `pixi run cmake --build build/default/cpp/Release --target INTEGRATION_constraint_ContactConstraint UNIT_constraint_ContactSurface UNIT_constraint_JointConstraint UNIT_dynamics_BodyNodeExternalForce --parallel 4`
- `pixi run ctest --test-dir build/default/cpp/Release -R '^(INTEGRATION_constraint_ContactConstraint|UNIT_constraint_ContactSurface|UNIT_constraint_JointConstraint|UNIT_dynamics_BodyNodeExternalForce)$' --output-on-failure`
- `PYTHONPATH=build/default/cpp/Release/python pixi run python -m pytest python/tests/unit/dynamics/test_polymorphic_casts.py -q`
- `pixi run cmake --build build/default/cpp/Release --target UNIT_dynamics_SkeletonAccessors --parallel 4`
- `pixi run ctest --test-dir build/default/cpp/Release -R '^UNIT_dynamics_SkeletonAccessors$' --output-on-failure`
- `git diff --check`
- Before each push: fetched latest `main` over HTTPS and merged locally; latest push was already up to date.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Related discussions: #1761, #1946, #2211, #2226, #2450, #2521
- Related follow-up issue: #2918
- Backports: None; docs/tests only for `main`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated if required (not required: docs/test-only change)
- [x] Add unit tests for new functionality (regression coverage for existing behavior)
- [x] Document new methods and classes (N/A: no new API)
- [x] Add Python bindings (dartpy) if applicable (N/A: no binding changes)
