### PR TITLE
Update PLAN-031 CUDA substrate status

### DIFF
--- a/docs/design/shared_cuda_device_substrate.md
+++ b/docs/design/shared_cuda_device_substrate.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposal. This document owns the durable rationale for sharing GPU
+Implemented baseline. PR #2875 landed the shared CUDA runtime helpers,
+`DeviceBuffer`, and single-sourced rigid orientation core on `main`. This
+document now owns the durable rationale and extraction triggers for sharing GPU
 device-runtime code across DART 7's experimental CUDA solvers instead of
 reinventing it per solver. Operating state (priority, horizon, next step, gate)
 lives in `docs/plans/dashboard.md` under PLAN-031. This design is scoped to
@@ -255,42 +257,49 @@ The hard guardrails from `scalable_compute_decisions.md` and
 
 ## Phased Roadmap
 
-Operating sequence (canonical priority/next-step/gate live in PLAN-031):
+The build-now sequence below is complete on `main` in PR #2875. Future work uses
+the deferral table above and must promote only real second-use extractions.
+Canonical priority, next step, and gate live in PLAN-031.
 
-- **P0 — pin parity baselines.** Record CPU/GPU parity for all three modules at
-  the existing tolerance (Phase-5 reference 1.78e-15) before any extraction, and
-  confirm the default no-GPU build + `dartpy` import are unchanged. Exit evidence:
-  baselines committed; all boundary/packaging checks green as the starting line.
-- **P1 — `cuda_runtime.cuh/.cpp` + refactor all three modules onto it.** Exit
-  evidence: the three module parity tests stay green within recorded tolerance;
-  `.cuh`-only confirmed (no `.hpp` gains a backend token); the `-cuda` library
-  stays build-only.
-- **P1b — VBD error-type unification (separate reviewed commit).** Moving VBD's
+- **P0 — pin parity baselines (complete).** Record CPU/GPU parity for all three
+  modules at the existing tolerance (Phase-5 reference 1.78e-15) before any
+  extraction, and confirm the default no-GPU build + `dartpy` import are
+  unchanged. Exit evidence: baselines committed; all boundary/packaging checks
+  green as the starting line.
+- **P1 — `cuda_runtime.cuh/.cpp` + refactor all three modules onto it
+  (complete).** Exit evidence: the three module parity tests stay green within
+  recorded tolerance; `.cuh`-only confirmed (no `.hpp` gains a backend token);
+  the `-cuda` library stays build-only.
+- **P1b — VBD error-type unification (complete).** Moving VBD's
   `std::runtime_error` onto `DART_EXPERIMENTAL_THROW_T` changes the thrown type at
   the `World::step` boundary, so it ships as its own commit with an explicit
   PR-body note and any downstream catcher updated in the same PR.
-- **P2 — `device_buffer.cuh` + migrate the three buffer classes.** Exit evidence:
-  outputs identical pre/post; PSD's `allocationCount()` invariant preserved; no
-  benchmark regression.
-- **P3 — single-source the rigid integration kernel.** Exit evidence: rigid
-  CPU/GPU parity passes (and ideally tightens); the macro expands to empty in the
-  default no-CUDA build; boundary checks green.
+- **P2 — `device_buffer.cuh` + migrate the three buffer classes (complete).**
+  Exit evidence: outputs identical pre/post; PSD's `allocationCount()` invariant
+  preserved; no benchmark regression.
+- **P3 — single-source the rigid integration kernel (complete).** Exit evidence:
+  rigid CPU/GPU parity passes (and ideally tightens); the macro expands to empty
+  in the default no-CUDA build; boundary checks green.
 - **Future — extract on documented second use.** Per the deferral table; each
   extraction requires its real second consumer, a separate review, a
   pre-extraction parity pin, and an unchanged public-API/sidecar guarantee.
 
-## Open Questions
+## Resolved Build-Now Questions
 
-- `DeviceBuffer<T>` resident-reuse shape: is opt-in `ensure(count)` inside one
-  thin type acceptable, or should PSD's resident behavior stay a thin wrapper to
-  keep the base type pure RAII? Decide in P2 by measuring type complexity.
-- Host/device macro home and spelling: confirm the exact experimental-scoped
-  header and a backend-token-free spelling that survives the boundary scanner and
-  compiles under `nvcc --expt-relaxed-constexpr` while expanding to empty in host
+PR #2875 resolved the questions that affected the landed substrate:
+
+- `DeviceBuffer<T>` uses opt-in `ensure(count)` / `allocationCount()` resident
+  reuse inside the shared type, preserving the PSD invariant without adding a
+  second buffer wrapper.
+- The host/device annotation lives in the experimental-scoped
+  `compute/detail/rigid_integration_core.hpp` header as `DART_EXPERIMENTAL_HD`,
+  expanding to `__host__ __device__` only under `nvcc` and to empty under host
   builds.
-- VBD error-type change: confirm by grep across tests and any downstream
-  (`gz-physics`) catchers that nothing relies on the `std::runtime_error` type
-  before P1b merges.
+- The VBD error-type divergence is unified onto the shared CUDA error helper and
+  `InvalidOperationException` path.
+
+## Deferred Questions
+
 - Rigid CUDA-graph amortization: does the maintainer want it as a standalone
   reviewed change soon, or left until the rollout helper's second consumer
   naturally triggers extraction?

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -137,45 +137,28 @@ its own line so status updates remain git-history friendly.
 
 - Owner doc:
   [`../design/shared_cuda_device_substrate.md`](../design/shared_cuda_device_substrate.md)
-- Status: Active
-- Horizon: Now
+- Status: Complete
+- Horizon: Later
 - Dimension: Scalable compute
-- Next step: The build-now scope is implemented locally and verified (pending
-  maintainer review/commit). It de-duplicates the three existing experimental
-  CUDA modules (`rigid_body_state_batch_cuda`, `vbd_block_descent_cuda`,
-  `deformable_psd_projection_cuda`) before AVBD-CUDA (PLAN-104), rigid-IPC GPU
-  (PLAN-082), and PD-IPC GPU (PLAN-081) multiply the duplication. Landed: a shared
-  `compute/cuda/cuda_runtime.cuh` + host `cuda_runtime.cpp` (one
-  `isCudaRuntimeAvailable`, one `throwIfCudaError`, `checkLastError`, inline
-  `launchGrid1D`), replacing the triplicated probe, three error helpers (VBD's
-  divergent `std::runtime_error` unified onto `InvalidOperationException`), and
-  7+ hand-rolled launch sites; `compute/cuda/device_buffer.cuh`
-  (`DeviceBuffer<T=double>` with opt-in resident `ensure()`/`allocationCount()`)
-  subsuming `DeviceDoubleBuffer`/`DeviceArray<T>`/`ResidentDeviceBuffer`; and a
-  per-body `__host__ __device__` orientation core in
-  `compute/detail/rigid_integration_core.hpp` (macro `DART_EXPERIMENTAL_HD`) that
-  the CPU `rigid_body_integration_kernel.hpp` loop and the CUDA kernel now share,
-  deleting the drifted `__device__ integrateOrientation`. Deferred behind
-  documented second-use triggers: rollout/graph-capture/precision/colored-sweep, a
-  generic accelerator registry, a device IPC barrier/distance mirror, a residency
-  owner, and device reductions; the existing `deformable_psd_backend.hpp`
-  registrar is reused by example. No new general library — `dart/math`,
-  `dart/optimizer`, `detail/newton_barrier`, and `deformable_psd_backend` are
-  reused, and device IPC math will promote the same PLAN-083 cores
-  host/device-portable rather than forking a GPU copy. Remaining: maintainer
-  review and the dual-commit split (the VBD thrown-type change as its own
-  reviewed commit).
-- Gate: Verified locally — the three module CUDA parity tests pass within the
-  recorded tolerance (`pixi run -e cuda test-cuda`, 3/3), the default no-GPU
-  experimental suite passes (`pixi run test-simulation-experimental`, 61/61,
-  including `test_compute_graph` over the single-sourced kernel), and
-  `check-api-boundaries`, `check-compute-backend-boundaries`, and
-  `check-no-gpu-runtime-dependencies` stay green. Shared device code stays
-  `.cuh`/`.cpp`-only under `compute/cuda/` (plus the `detail/` core header) in the
-  build-only `dart-simulation-experimental-cuda` STATIC library (never added to
-  `add_component_targets`, never installed/exported, never in a default Pixi
-  feature or wheel manifest); and the VBD thrown-type change is reviewed
-  separately with any downstream catcher updated in the same PR.
+- Next step: The build-now substrate landed on `main` in PR #2875. Use
+  [`../design/shared_cuda_device_substrate.md`](../design/shared_cuda_device_substrate.md)
+  as the extraction contract when AVBD-CUDA (PLAN-104), rigid-IPC GPU
+  (PLAN-082), PD-IPC GPU (PLAN-081), or broadened Phase-6 compute work
+  introduces a real second consumer for deferred rollout, graph-capture,
+  precision, colored-sweep, accelerator-registry, device IPC math, residency, or
+  reduction helpers. No new general library is planned: reuse `dart/math`,
+  `dart/optimizer`, `detail/newton_barrier`, and
+  `deformable_psd_backend`, and promote the same PLAN-083 cores
+  host/device-portable only when a GPU IPC consumer lands.
+- Gate: Future substrate changes must keep shared device code `.cuh`/`.cpp`-only
+  under `compute/cuda/` (plus scanner-skipped `detail/` kernel cores), leave the
+  CUDA sidecar build-only and uninstalled, preserve the default no-GPU path, and
+  keep `pixi run -e cuda test-cuda`,
+  `pixi run test-simulation-experimental`,
+  `pixi run check-api-boundaries`,
+  `pixi run check-compute-backend-boundaries`, and
+  `pixi run check-no-gpu-runtime-dependencies` green for any promoted second-use
+  extraction.
 
 ### PLAN-080: Rigid-Body Dynamics Solver
 


### PR DESCRIPTION
## Summary

- Mark PLAN-031 complete/later now that PR #2875 landed the shared CUDA substrate.
- Update the owner doc status, roadmap, and question split to distinguish the landed baseline from deferred second-use extractions.

## Motivation / Problem

- The dashboard still described the PLAN-031 build-now scope as pending review/commit even though the shared CUDA runtime helpers, `DeviceBuffer`, and single-sourced rigid orientation core are already on `main`.
- Leaving that stale state in place makes future task selection chase completed CUDA substrate work.

## Changes / Key Changes

- Update `docs/plans/dashboard.md` so PLAN-031 is complete and points future work at second-use extraction triggers.
- Update `docs/design/shared_cuda_device_substrate.md` from proposal status to implemented baseline, mark P0-P3 complete, and move unresolved future CUDA questions under deferred work.

## Testing

- `pixi run lint-md`
- `pixi run check-lint-md`
- `pixi run check-docs-policy`
- `pixi run check-lint-spell`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows PR #2875.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable