### PR TITLE
Share Newton barrier PSD projection

### DIFF
--- a/dart/simulation/experimental/detail/affine_body_dynamics.cpp
+++ b/dart/simulation/experimental/detail/affine_body_dynamics.cpp
@@ -32,9 +32,8 @@
 
 #include <dart/simulation/experimental/detail/affine_body_dynamics.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/friction_kernel.hpp>
+#include <dart/simulation/experimental/detail/newton_barrier/psd_projection.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/tangent_stencil.hpp>
-
-#include <Eigen/Eigenvalues>
 
 #include <array>
 
@@ -43,22 +42,6 @@
 
 namespace dart::simulation::experimental::detail {
 namespace {
-
-template <int Size>
-[[nodiscard]] Eigen::Matrix<double, Size, Size> projectSymmetricMatrixToPsd(
-    const Eigen::Matrix<double, Size, Size>& matrix)
-{
-  const Eigen::Matrix<double, Size, Size> symmetric
-      = 0.5 * (matrix + Eigen::Matrix<double, Size, Size>(matrix.transpose()));
-  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, Size, Size>> solver(
-      symmetric);
-  if (solver.info() != Eigen::Success) {
-    return symmetric;
-  }
-
-  return solver.eigenvectors() * solver.eigenvalues().cwiseMax(0.0).asDiagonal()
-         * solver.eigenvectors().transpose();
-}
 
 [[nodiscard]] bool hasValidBarrierOptions(const AffineBarrierOptions& options)
 {
@@ -127,7 +110,8 @@ template <int Size>
   result.hessian
       = 0.5 * (result.hessian + AffineMatrix24d(result.hessian.transpose()));
   if (options.projectHessianToPsd) {
-    result.hessian = projectSymmetricMatrixToPsd<24>(result.hessian);
+    result.hessian
+        = newton_barrier::projectSymmetricMatrixToPsd<24>(result.hessian);
   }
   return result;
 }
@@ -174,7 +158,8 @@ chainPrimitiveFrictionToAffineBodies(
   result.hessian
       = 0.5 * (result.hessian + AffineMatrix24d(result.hessian.transpose()));
   if (options.projectHessianToPsd) {
-    result.hessian = projectSymmetricMatrixToPsd<24>(result.hessian);
+    result.hessian
+        = newton_barrier::projectSymmetricMatrixToPsd<24>(result.hessian);
   }
   return result;
 }
@@ -652,7 +637,8 @@ AffineOrthogonalityEnergyResult affineOrthogonalityEnergy(
   result.hessian
       = 0.5 * (result.hessian + AffineMatrix12d(result.hessian.transpose()));
   if (projectHessianToPsd) {
-    result.hessian = projectSymmetricMatrixToPsd<12>(result.hessian);
+    result.hessian
+        = newton_barrier::projectSymmetricMatrixToPsd<12>(result.hessian);
   }
   return result;
 }

--- a/dart/simulation/experimental/detail/newton_barrier/psd_projection.hpp
+++ b/dart/simulation/experimental/detail/newton_barrier/psd_projection.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice and this list of conditions in the documentation
+ *     and/or other materials provided with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+
+namespace dart::simulation::experimental::detail::newton_barrier {
+
+template <int Size>
+[[nodiscard]] Eigen::Matrix<double, Size, Size> projectSymmetricMatrixToPsd(
+    const Eigen::Matrix<double, Size, Size>& matrix)
+{
+  const Eigen::Matrix<double, Size, Size> symmetric
+      = 0.5 * (matrix + Eigen::Matrix<double, Size, Size>(matrix.transpose()));
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, Size, Size>> solver(
+      symmetric);
+  if (solver.info() != Eigen::Success) {
+    return symmetric;
+  }
+
+  return solver.eigenvectors() * solver.eigenvalues().cwiseMax(0.0).asDiagonal()
+         * solver.eigenvectors().transpose();
+}
+
+} // namespace dart::simulation::experimental::detail::newton_barrier

--- a/dart/simulation/experimental/detail/rigid_ipc_barrier.cpp
+++ b/dart/simulation/experimental/detail/rigid_ipc_barrier.cpp
@@ -31,11 +31,11 @@
 
 #include <dart/simulation/experimental/detail/deformable_contact/candidate_set.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/friction_kernel.hpp>
+#include <dart/simulation/experimental/detail/newton_barrier/psd_projection.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/tangent_stencil.hpp>
 #include <dart/simulation/experimental/detail/rigid_ipc_barrier.hpp>
 
 #include <Eigen/Cholesky>
-#include <Eigen/Eigenvalues>
 
 #include <algorithm>
 #include <array>
@@ -292,19 +292,6 @@ PointTransformDerivatives pointTransformDerivatives(
   return derivatives;
 }
 
-RigidIpcMatrix12d projectToPsd(const RigidIpcMatrix12d& matrix)
-{
-  const RigidIpcMatrix12d symmetric
-      = 0.5 * (matrix + RigidIpcMatrix12d(matrix.transpose()));
-  Eigen::SelfAdjointEigenSolver<RigidIpcMatrix12d> solver(symmetric);
-  if (solver.info() != Eigen::Success) {
-    return symmetric;
-  }
-
-  return solver.eigenvectors() * solver.eigenvalues().cwiseMax(0.0).asDiagonal()
-         * solver.eigenvectors().transpose();
-}
-
 template <int Columns>
 RigidIpcFrictionPotentialResult computeProjectedFrictionPotential(
     const Eigen::Matrix<double, 2, Columns>& projection,
@@ -368,7 +355,8 @@ RigidIpcReducedFrictionResult chainFrictionPotentialToReducedCoordinates(
   result.hessian
       = 0.5 * (result.hessian + RigidIpcMatrix12d(result.hessian.transpose()));
   if (projectHessianToPsd) {
-    result.hessian = projectToPsd(result.hessian);
+    result.hessian
+        = newton_barrier::projectSymmetricMatrixToPsd<12>(result.hessian);
   }
   return result;
 }
@@ -409,7 +397,8 @@ RigidIpcReducedBarrierResult chainPrimitiveBarrierToReducedCoordinates(
   result.hessian
       = 0.5 * (result.hessian + RigidIpcMatrix12d(result.hessian.transpose()));
   if (options.projectReducedHessianToPsd) {
-    result.hessian = projectToPsd(result.hessian);
+    result.hessian
+        = newton_barrier::projectSymmetricMatrixToPsd<12>(result.hessian);
   }
   return result;
 }

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -40,6 +40,12 @@
       contract; use the PLAN-083 variant consolidation map to keep IPC-family
       responsibilities in the right owner while promoting only proven
       second-use contracts.
+  - [x] Promote the first second-use PSD projection contract into
+        `detail/newton_barrier` and route rigid IPC plus ABD Hessian projection
+        through it with shared tests.
+  - [ ] Continue scouting projected-Newton, line-search, diagnostics, or
+        benchmark-schema contracts only when another variant needs identical
+        behavior.
 - [ ] Phase 4: expand the unified manifest into diagnostics, benchmark packets,
       CPU/GPU evidence, and visual evidence rows.
 - [ ] Phase 5: add runtime and py-demos scenes only after the relevant solver
@@ -90,10 +96,11 @@ resources as public API.
 
 ## Immediate Next Steps
 
-1. Begin Phase 3 shared-contract scouting from the existing rigid IPC,
-   deformable IPC, and ABD evidence, and identify the first PSD,
-   projected-Newton, line-search, diagnostics, or benchmark-schema contract
-   with a real second consumer.
+1. Continue Phase 3 shared-contract scouting from the existing rigid IPC,
+   deformable IPC, and ABD evidence after the first fixed-size PSD projection
+   helper. Promote projected-Newton, line-search, diagnostics, or
+   benchmark-schema contracts only when a second consumer proves identical
+   behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -9,6 +9,12 @@ Newton-barrier work should continue by promoting shared primitives and solver
 contracts consumed by rigid IPC, deformable IPC, ABD, and future couplers rather
 than adding another public solver stack.
 
+The first Phase 3 shared-contract slice promotes fixed-size symmetric PSD
+projection into `detail/newton_barrier`. Rigid IPC and ABD now use the same
+helper for reduced/affine Hessian projection; this is intentionally smaller
+than the existing deformable batched CPU/CUDA PSD backend and does not rename or
+generalize that backend yet.
+
 ## Last Session Summary
 
 Current slice: the first ABD benchmark packet has been promoted from
@@ -34,21 +40,27 @@ through the shared tangent-displacement friction kernel,
 `test_affine_body_dynamics`, and the first `bm_affine_body_dynamics` benchmark
 packet.
 
+The first Phase 3 contract slice lives on `simx/shared-newton-barrier-psd`: it
+adds a shared fixed-size PSD projection helper, routes rigid IPC and ABD Hessian
+projection through it, and adds focused Newton-barrier primitive tests for
+eigenvalue clamping and input symmetrization.
+
 ## Current Branch
 
-`docs/plan083-abd-next-slice-decision` - current checkout is expected to
-contain the PLAN-083 decision update that defers a two-body affine contact
-micro-solve until a broader ABD packet needs a solved-state residual.
+`simx/shared-newton-barrier-psd` - contains the Phase 3 fixed-size PSD
+projection helper slice. Verify the exact status with `git status --short
+--branch` because this section is a resume snapshot.
 
 ## Immediate Next Step
 
-Continue Phase 2/3 from
+Continue Phase 3 from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-do not add a two-body affine contact micro-solve for the current
-`abd-alg-affine-body` micro-packet. Start Phase 3 shared-contract scouting from
-the existing rigid IPC, deformable IPC, and ABD evidence, and promote PSD,
-projected-Newton, line-search, diagnostics, or benchmark-schema contracts only
-after second-use behavior is proven identical across variants. Use
+finish validating and publishing the fixed-size PSD projection helper, then
+resume shared-contract scouting from the existing rigid IPC, deformable IPC, and
+ABD evidence. Do not add a two-body affine contact micro-solve for the current
+`abd-alg-affine-body` micro-packet; add projected-Newton, line-search,
+diagnostics, or benchmark-schema contracts only after second-use behavior is
+proven identical across variants. Use
 [`../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md`](../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md)
 to keep the Phase 2 packet, shared solver contracts, articulation rows,
 restitution work, mixed-domain coupling, CPU/GPU parity, and py-demos rows

--- a/tests/unit/simulation/experimental/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/experimental/contact/test_newton_barrier_primitives.cpp
@@ -35,6 +35,7 @@
 #include <dart/simulation/experimental/detail/newton_barrier/barrier_kernel.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/friction_kernel.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/primitive_distance.hpp>
+#include <dart/simulation/experimental/detail/newton_barrier/psd_projection.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/tangent_stencil.hpp>
 #include <dart/simulation/experimental/detail/rigid_ipc_barrier.hpp>
 
@@ -274,6 +275,30 @@ TEST(NewtonBarrierPrimitives, TangentForwardingMatchesSharedOwner)
   expectMatrixNear(oldPointPoint.basis, newPointPoint.basis);
   expectMatrixNear(oldPointPoint.projection, newPointPoint.projection);
   expectMatrixNear(oldPointPoint.metric, newPointPoint.metric);
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, PsdProjectionClampsNegativeEigenvalues)
+{
+  Eigen::Matrix3d matrix = Eigen::Matrix3d::Zero();
+  matrix.diagonal() << 4.0, -2.0, 1.0;
+
+  Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
+  expected.diagonal() << 4.0, 0.0, 1.0;
+
+  expectMatrixNear(nb::projectSymmetricMatrixToPsd<3>(matrix), expected);
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, PsdProjectionSymmetrizesBeforeProjection)
+{
+  Eigen::Matrix3d matrix = Eigen::Matrix3d::Zero();
+  matrix << 1.0, 2.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, -3.0;
+
+  Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
+  expected << 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+
+  expectMatrixNear(nb::projectSymmetricMatrixToPsd<3>(matrix), expected);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Promotes the fixed-size symmetric PSD projection used by PLAN-083 ABD and PLAN-082 rigid IPC into `detail/newton_barrier`.
- Routes rigid IPC and ABD Hessian projection through the shared internal helper.
- Records the completed Phase 3 micro-slice in the active PLAN-083 dev-task handoff.

## Motivation / Problem

- Rigid IPC and ABD had duplicate local implementations of the same Hessian PSD projection contract: symmetrize the reduced/affine Hessian, eigensolve it, and clamp negative eigenvalues to zero.
- PLAN-083 Phase 3 calls for promoting only proven second-use contracts. This keeps the scope to the fixed-size CPU helper and deliberately does not rename or generalize the existing deformable batched CPU/CUDA PSD backend.

## Changes / Key Changes

- Adds `detail/newton_barrier/psd_projection.hpp` with `projectSymmetricMatrixToPsd<Size>()`.
- Removes duplicate local PSD projection helpers from `affine_body_dynamics.cpp` and `rigid_ipc_barrier.cpp`.
- Adds Newton-barrier primitive tests for negative eigenvalue clamping and input symmetrization.
- Updates `docs/dev_tasks/unified_newton_barrier_multibody/` with the Phase 3 slice status and resume handoff.

## Testing

- `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run build-simulation-experimental-tests`
- `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 ctest --test-dir build/default/cpp/Release --output-on-failure -R test_newton_barrier_primitives`
- `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-simulation-experimental` (65/65 passed)
- `pixi run check-api-boundaries`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows PLAN-083 work in #2933.
- No release-6.17 backport: this is internal DART 7 experimental infrastructure.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (N/A: internal experimental refactor, no user-facing feature or bug fix)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: internal detail helper; dev-task handoff updated)
- [x] Add Python bindings (dartpy) if applicable (N/A)
