### PR TITLE
Share Newton barrier line-search stats

### DIFF
--- a/dart/simulation/experimental/compute/world_step_stage.cpp
+++ b/dart/simulation/experimental/compute/world_step_stage.cpp
@@ -101,6 +101,7 @@ namespace dart::simulation::experimental::compute {
 namespace dc = dart::simulation::experimental::detail::deformable_contact;
 namespace dvbd = dart::simulation::experimental::detail::deformable_vbd;
 namespace fem = dart::simulation::experimental::detail::deformable_elasticity;
+namespace nb = dart::simulation::experimental::detail::newton_barrier;
 namespace sxdetail = dart::simulation::experimental::detail;
 
 struct RigidIpcRuntimeBody
@@ -1580,24 +1581,11 @@ bool surfaceContactPointAllowed(
 }
 
 //==============================================================================
-void accumulateCcdStats(
-    dc::ContinuousCollisionStepStats& total,
-    const dc::ContinuousCollisionStepStats& addend)
-{
-  total.pointTriangleChecks += addend.pointTriangleChecks;
-  total.edgeEdgeChecks += addend.edgeEdgeChecks;
-  total.hits += addend.hits;
-  total.misses += addend.misses;
-  total.indeterminate += addend.indeterminate;
-  total.zeroStepCount += addend.zeroStepCount;
-}
-
-//==============================================================================
 void considerInterBodyContactResult(
     InterBodySurfaceContactResult& aggregate,
     const dc::ContinuousCollisionStepResult& candidate)
 {
-  accumulateCcdStats(aggregate.stats, candidate.stats);
+  nb::accumulateLineSearchStats(aggregate.stats, candidate.stats);
   aggregate.indeterminate = aggregate.indeterminate || candidate.indeterminate;
   if (candidate.indeterminate) {
     aggregate.stepBound = 0.0;

--- a/dart/simulation/experimental/detail/deformable_contact/continuous_collision_step.cpp
+++ b/dart/simulation/experimental/detail/deformable_contact/continuous_collision_step.cpp
@@ -69,25 +69,12 @@ void recordHit(
 }
 
 //==============================================================================
-void accumulateStats(
-    ContinuousCollisionStepStats& total,
-    const ContinuousCollisionStepStats& addend)
-{
-  total.pointTriangleChecks += addend.pointTriangleChecks;
-  total.edgeEdgeChecks += addend.edgeEdgeChecks;
-  total.hits += addend.hits;
-  total.misses += addend.misses;
-  total.indeterminate += addend.indeterminate;
-  total.zeroStepCount += addend.zeroStepCount;
-}
-
-//==============================================================================
 void considerCandidate(
     ContinuousCollisionStepResult& aggregate,
     const ContinuousCollisionStepResult& candidate,
     const std::size_t candidateIndex)
 {
-  accumulateStats(aggregate.stats, candidate.stats);
+  newton_barrier::accumulateLineSearchStats(aggregate.stats, candidate.stats);
   if (!candidate.hit) {
     aggregate.indeterminate
         = aggregate.indeterminate || candidate.indeterminate;

--- a/dart/simulation/experimental/detail/deformable_contact/continuous_collision_step.hpp
+++ b/dart/simulation/experimental/detail/deformable_contact/continuous_collision_step.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <dart/simulation/experimental/detail/deformable_contact/candidate_set.hpp>
+#include <dart/simulation/experimental/detail/newton_barrier/line_search.hpp>
 #include <dart/simulation/experimental/export.hpp>
 
 #include <Eigen/Core>
@@ -51,22 +52,8 @@ enum class ContinuousCollisionPrimitive
   EdgeEdge,
 };
 
-struct ContinuousCollisionStepOptions
-{
-  double minSeparation = 0.0;
-  double tolerance = 1e-6;
-  int maxIterations = 64;
-};
-
-struct ContinuousCollisionStepStats
-{
-  std::size_t pointTriangleChecks = 0;
-  std::size_t edgeEdgeChecks = 0;
-  std::size_t hits = 0;
-  std::size_t misses = 0;
-  std::size_t indeterminate = 0;
-  std::size_t zeroStepCount = 0;
-};
+using ContinuousCollisionStepOptions = newton_barrier::LineSearchOptions;
+using ContinuousCollisionStepStats = newton_barrier::LineSearchStats;
 
 struct ContinuousCollisionStepResult
 {

--- a/dart/simulation/experimental/detail/newton_barrier/line_search.hpp
+++ b/dart/simulation/experimental/detail/newton_barrier/line_search.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice and this list of conditions in the documentation
+ *     and/or other materials provided with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *   ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ *   TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ *   THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *   SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace dart::simulation::experimental::detail::newton_barrier {
+
+struct LineSearchOptions
+{
+  double minSeparation = 0.0;
+  double tolerance = 1e-6;
+  int maxIterations = 64;
+};
+
+struct LineSearchStats
+{
+  std::size_t pointPointChecks = 0;
+  std::size_t pointEdgeChecks = 0;
+  std::size_t edgeEdgeChecks = 0;
+  std::size_t pointTriangleChecks = 0;
+  std::size_t hits = 0;
+  std::size_t misses = 0;
+  std::size_t indeterminate = 0;
+  std::size_t zeroStepCount = 0;
+};
+
+inline void accumulateLineSearchStats(
+    LineSearchStats& total, const LineSearchStats& addend)
+{
+  total.pointPointChecks += addend.pointPointChecks;
+  total.pointEdgeChecks += addend.pointEdgeChecks;
+  total.edgeEdgeChecks += addend.edgeEdgeChecks;
+  total.pointTriangleChecks += addend.pointTriangleChecks;
+  total.hits += addend.hits;
+  total.misses += addend.misses;
+  total.indeterminate += addend.indeterminate;
+  total.zeroStepCount += addend.zeroStepCount;
+}
+
+} // namespace dart::simulation::experimental::detail::newton_barrier

--- a/dart/simulation/experimental/detail/rigid_ipc_barrier.hpp
+++ b/dart/simulation/experimental/detail/rigid_ipc_barrier.hpp
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <dart/simulation/experimental/detail/newton_barrier/barrier_kernel.hpp>
+#include <dart/simulation/experimental/detail/newton_barrier/line_search.hpp>
 #include <dart/simulation/experimental/detail/rigid_ipc_ccd.hpp>
 #include <dart/simulation/experimental/export.hpp>
 
@@ -187,24 +188,8 @@ struct RigidIpcBodyDynamicsState
   RigidIpcVector6d generalizedForce = RigidIpcVector6d::Zero();
 };
 
-struct RigidIpcLineSearchOptions
-{
-  double minSeparation = 0.0;
-  double tolerance = 1e-6;
-  int maxIterations = 64;
-};
-
-struct RigidIpcLineSearchStats
-{
-  std::size_t pointPointChecks = 0;
-  std::size_t pointEdgeChecks = 0;
-  std::size_t edgeEdgeChecks = 0;
-  std::size_t pointTriangleChecks = 0;
-  std::size_t hits = 0;
-  std::size_t misses = 0;
-  std::size_t indeterminate = 0;
-  std::size_t zeroStepCount = 0;
-};
+using RigidIpcLineSearchOptions = newton_barrier::LineSearchOptions;
+using RigidIpcLineSearchStats = newton_barrier::LineSearchStats;
 
 struct RigidIpcLineSearchResult
 {

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -43,7 +43,10 @@
   - [x] Promote the first second-use PSD projection contract into
         `detail/newton_barrier` and route rigid IPC plus ABD Hessian projection
         through it with shared tests.
-  - [ ] Continue scouting projected-Newton, line-search, diagnostics, or
+  - [x] Promote the first shared line-search option/stat contract into
+        `detail/newton_barrier` and route rigid IPC plus deformable CCD stats
+        accumulation through it with shared tests.
+  - [ ] Continue scouting projected-Newton, line-search result, diagnostics, or
         benchmark-schema contracts only when another variant needs identical
         behavior.
 - [ ] Phase 4: expand the unified manifest into diagnostics, benchmark packets,
@@ -97,10 +100,10 @@ resources as public API.
 ## Immediate Next Steps
 
 1. Continue Phase 3 shared-contract scouting from the existing rigid IPC,
-   deformable IPC, and ABD evidence after the first fixed-size PSD projection
-   helper. Promote projected-Newton, line-search, diagnostics, or
-   benchmark-schema contracts only when a second consumer proves identical
-   behavior.
+   deformable IPC, and ABD evidence after the fixed-size PSD projection helper
+   and first line-search option/stat helper. Promote projected-Newton,
+   line-search result semantics, diagnostics, or benchmark-schema contracts only
+   when a second consumer proves identical behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.
@@ -146,6 +149,13 @@ Phase 2 local evidence so far:
 - `pixi run test-simulation-experimental` (64/64)
 - `pixi run bm bm_affine_body_dynamics -- --benchmark_min_time=0.05s`
 - `pixi run bm-abd-comparison-packet`
+
+Phase 3 line-search option/stat slice local evidence:
+
+- `pixi run lint`
+- `pixi run build-simulation-experimental-tests`
+- `pixi run test-simulation-experimental` (65/65)
+- `pixi run check-api-boundaries`
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -15,6 +15,12 @@ helper for reduced/affine Hessian projection; this is intentionally smaller
 than the existing deformable batched CPU/CUDA PSD backend and does not rename or
 generalize that backend yet.
 
+The next Phase 3 slice promotes the first shared line-search option/stat
+contract into `detail/newton_barrier`. Rigid IPC and deformable continuous
+collision detection now share option defaults, primitive check counters, and the
+stats accumulation helper while keeping their distinct result semantics and CCD
+implementations in variant-local owners.
+
 ## Last Session Summary
 
 Current slice: the first ABD benchmark packet has been promoted from
@@ -40,27 +46,33 @@ through the shared tangent-displacement friction kernel,
 `test_affine_body_dynamics`, and the first `bm_affine_body_dynamics` benchmark
 packet.
 
-The first Phase 3 contract slice lives on `simx/shared-newton-barrier-psd`: it
-adds a shared fixed-size PSD projection helper, routes rigid IPC and ABD Hessian
-projection through it, and adds focused Newton-barrier primitive tests for
-eigenvalue clamping and input symmetrization.
+The first Phase 3 contract slice was merged as PR #2936. It added a shared
+fixed-size PSD projection helper, routed rigid IPC and ABD Hessian projection
+through it, and added focused Newton-barrier primitive tests for eigenvalue
+clamping and input symmetrization.
+
+The current line-search stats slice lives on
+`simx/shared-newton-barrier-line-search-stats`. It adds
+`detail/newton_barrier/line_search.hpp`, aliases rigid IPC and deformable CCD
+option/stat types to the shared owner, and keeps line-search result semantics
+variant-local.
 
 ## Current Branch
 
-`simx/shared-newton-barrier-psd` - contains the Phase 3 fixed-size PSD
-projection helper slice. Verify the exact status with `git status --short
---branch` because this section is a resume snapshot.
+`simx/shared-newton-barrier-line-search-stats` - contains the Phase 3
+line-search option/stat helper slice. Verify the exact status with
+`git status --short --branch` because this section is a resume snapshot.
 
 ## Immediate Next Step
 
 Continue Phase 3 from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-finish validating and publishing the fixed-size PSD projection helper, then
-resume shared-contract scouting from the existing rigid IPC, deformable IPC, and
-ABD evidence. Do not add a two-body affine contact micro-solve for the current
-`abd-alg-affine-body` micro-packet; add projected-Newton, line-search,
-diagnostics, or benchmark-schema contracts only after second-use behavior is
-proven identical across variants. Use
+validate and publish the line-search option/stat helper, then resume
+shared-contract scouting from the existing rigid IPC, deformable IPC, and ABD
+evidence. Do not add a two-body affine contact micro-solve for the current
+`abd-alg-affine-body` micro-packet; add projected-Newton, line-search result
+semantics, diagnostics, or benchmark-schema contracts only after second-use
+behavior is proven identical across variants. Use
 [`../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md`](../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md)
 to keep the Phase 2 packet, shared solver contracts, articulation rows,
 restitution work, mixed-domain coupling, CPU/GPU parity, and py-demos rows

--- a/tests/unit/simulation/experimental/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/experimental/contact/test_newton_barrier_primitives.cpp
@@ -30,10 +30,12 @@
  */
 
 #include <dart/simulation/experimental/detail/deformable_contact/barrier_kernel.hpp>
+#include <dart/simulation/experimental/detail/deformable_contact/continuous_collision_step.hpp>
 #include <dart/simulation/experimental/detail/deformable_contact/primitive_distance.hpp>
 #include <dart/simulation/experimental/detail/deformable_contact/tangent_stencil.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/barrier_kernel.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/friction_kernel.hpp>
+#include <dart/simulation/experimental/detail/newton_barrier/line_search.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/primitive_distance.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/psd_projection.hpp>
 #include <dart/simulation/experimental/detail/newton_barrier/tangent_stencil.hpp>
@@ -121,6 +123,14 @@ TEST(NewtonBarrierPrimitives, DeformableContactHeadersForwardSharedTypes)
   static_assert(std::is_same_v<
                 dc::PointTriangleTangentStencil,
                 nb::PointTriangleTangentStencil>);
+  using DcLineSearchOptions = dc::ContinuousCollisionStepOptions;
+  using DcLineSearchStats = dc::ContinuousCollisionStepStats;
+  using RigidLineSearchOptions = rigid::RigidIpcLineSearchOptions;
+  using RigidLineSearchStats = rigid::RigidIpcLineSearchStats;
+  static_assert(std::is_same_v<DcLineSearchOptions, nb::LineSearchOptions>);
+  static_assert(std::is_same_v<DcLineSearchStats, nb::LineSearchStats>);
+  static_assert(std::is_same_v<RigidLineSearchOptions, nb::LineSearchOptions>);
+  static_assert(std::is_same_v<RigidLineSearchStats, nb::LineSearchStats>);
 
   EXPECT_DOUBLE_EQ(dc::detail::kRelativeEpsilon, nb::detail::kRelativeEpsilon);
   EXPECT_DOUBLE_EQ(
@@ -128,6 +138,38 @@ TEST(NewtonBarrierPrimitives, DeformableContactHeadersForwardSharedTypes)
       nb::detail::kBarrierDistanceFloorScale);
   EXPECT_DOUBLE_EQ(
       dc::detail::kTangentBasisEpsilon, nb::detail::kTangentBasisEpsilon);
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, LineSearchStatsAccumulateSharedCounters)
+{
+  const nb::LineSearchOptions options;
+  EXPECT_DOUBLE_EQ(options.minSeparation, 0.0);
+  EXPECT_DOUBLE_EQ(options.tolerance, 1e-6);
+  EXPECT_EQ(options.maxIterations, 64);
+
+  nb::LineSearchStats total;
+  nb::LineSearchStats addend;
+  addend.pointPointChecks = 1;
+  addend.pointEdgeChecks = 2;
+  addend.edgeEdgeChecks = 3;
+  addend.pointTriangleChecks = 4;
+  addend.hits = 5;
+  addend.misses = 6;
+  addend.indeterminate = 7;
+  addend.zeroStepCount = 8;
+
+  nb::accumulateLineSearchStats(total, addend);
+  nb::accumulateLineSearchStats(total, addend);
+
+  EXPECT_EQ(total.pointPointChecks, 2u);
+  EXPECT_EQ(total.pointEdgeChecks, 4u);
+  EXPECT_EQ(total.edgeEdgeChecks, 6u);
+  EXPECT_EQ(total.pointTriangleChecks, 8u);
+  EXPECT_EQ(total.hits, 10u);
+  EXPECT_EQ(total.misses, 12u);
+  EXPECT_EQ(total.indeterminate, 14u);
+  EXPECT_EQ(total.zeroStepCount, 16u);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Add `detail/newton_barrier/line_search.hpp` as the shared owner for line-search options, primitive check counters, and stats accumulation.
- Alias rigid IPC and deformable CCD line-search option/stat types to the shared contract while keeping their result semantics and CCD implementations variant-local.
- Update PLAN-083 dev-task handoff notes with the merged PSD slice and this line-search stats slice.

## Motivation / Problem

- PLAN-083 Phase 3 needs shared contracts only after second-use evidence. Rigid IPC and deformable CCD already had duplicate option defaults, overlapping counters, and duplicate accumulation helpers.

## Changes / Key Changes

- Introduce `newton_barrier::LineSearchOptions`, `LineSearchStats`, and `accumulateLineSearchStats()`.
- Route `RigidIpcLineSearchOptions` / `RigidIpcLineSearchStats` and `ContinuousCollisionStepOptions` / `ContinuousCollisionStepStats` through aliases to the shared owner.
- Use the shared accumulator in deformable CCD candidate aggregation and surface-contact inter-body aggregation.
- Add Newton-barrier primitive tests for alias parity and shared counter accumulation.

## Testing

- `pixi run lint`
- `pixi run build-simulation-experimental-tests`
- `pixi run test-simulation-experimental` (65/65)
- `pixi run check-api-boundaries`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows #2936

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
