### PR TITLE
Share benchmark packet row parsing

### DIFF
--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -50,6 +50,10 @@
         `detail/newton_barrier` and route rigid IPC plus deformable CCD result
         methods through it while keeping hit/limited result ownership
         variant-local.
+  - [x] Promote the first shared Google Benchmark packet row parser into
+        `scripts/benchmark_packet_utils.py` and route the ABD comparison packet
+        checker plus the Phase 5 GPU packet checker through it while keeping
+        packet-specific metadata rules in their owners.
   - [ ] Continue scouting projected-Newton, line-search result, diagnostics, or
         benchmark-schema contracts only when another variant needs identical
         behavior.
@@ -105,10 +109,11 @@ resources as public API.
 
 1. Continue Phase 3 shared-contract scouting from the existing rigid IPC,
    deformable IPC, and ABD evidence after the fixed-size PSD projection helper,
-   first line-search option/stat helper, and shared line-search positive-step
-   predicate. Promote projected-Newton result/status terminology, diagnostics,
-   or benchmark-schema contracts only when a second consumer proves identical
-   behavior.
+   first line-search option/stat helper, shared line-search positive-step
+   predicate, and shared Google Benchmark packet row parser. Promote
+   projected-Newton result/status terminology, line-search result semantics,
+   diagnostics, or additional benchmark-schema contracts only when a second
+   consumer proves identical behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.
@@ -169,6 +174,11 @@ Phase 3 line-search positive-step predicate slice local evidence:
 - `pixi run build-simulation-tests`
 - `pixi run test-simulation` (65/65)
 - `pixi run check-api-boundaries`
+- `pixi run lint`
+
+Phase 3 benchmark packet utility slice local evidence:
+
+- `pixi run python -m pytest tests/test_benchmark_packet_utils.py`
 - `pixi run lint`
 
 ## Owner Docs

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -21,11 +21,19 @@ collision detection now share option defaults, primitive check counters, and the
 stats accumulation helper while keeping their distinct result semantics and CCD
 implementations in variant-local owners.
 
-The current Phase 3 slice promotes only the shared line-search positive-step
-predicate, `allowsPositiveLineSearchStep(stepBound, indeterminate)`, into
+The positive-step predicate slice promoted only
+`allowsPositiveLineSearchStep(stepBound, indeterminate)` into
 `detail/newton_barrier`. Rigid IPC and deformable continuous collision result
 methods route through it, but hit/limited fields and limiting-primitive payloads
 remain variant-local.
+
+The current Phase 3 slice promotes the first shared benchmark-packet contract:
+Google Benchmark row-name canonicalization, timing-unit conversion, median-row
+lookup, and timing-field validation now live in
+`scripts/benchmark_packet_utils.py`. The ABD comparison packet checker and the
+Phase 5 GPU packet checker share those row-level rules while keeping their
+packet-specific expected rows, metadata, speedup gates, and evidence flags in
+their variant owners.
 
 ## Last Session Summary
 
@@ -62,31 +70,32 @@ The line-search stats slice merged as PR #2937. It added
 option/stat types to the shared owner, and keeps line-search result semantics
 variant-local.
 
-The current positive-step predicate slice lives on
-`simx/shared-newton-barrier-positive-step`. It is intentionally smaller than a
-projected-Newton diagnostics merge: current evidence shows rigid and deformable
-share the positive-step predicate, but not yet a full projected-Newton status
-or solver-loop contract. Local validation passed `test_newton_barrier_primitives`,
-`build-simulation-tests`, `test-simulation`, `check-api-boundaries`, and
-`lint` after the DART 7 simulation promotion moved this code out of the
-`experimental` path.
+The benchmark-packet utility slice lives on
+`simx/shared-newton-barrier-benchmark-packet-utils`. It is intentionally
+smaller than a projected-Newton diagnostics merge: current evidence shows rigid
+and deformable do not yet share full projected-Newton status/result semantics,
+while the ABD and Phase 5 packet checkers already need identical Google
+Benchmark row parsing. Focused local validation passed
+`pixi run python -m pytest tests/test_benchmark_packet_utils.py` and
+`pixi run lint`.
 
 ## Current Branch
 
-`simx/shared-newton-barrier-positive-step` - contains the Phase 3 shared
-line-search positive-step predicate slice. Verify the exact status with
+`simx/shared-newton-barrier-benchmark-packet-utils` - contains the Phase 3
+shared benchmark-packet row parsing utility slice. Verify the exact status with
 `git status --short --branch` because this section is a resume snapshot.
 
 ## Immediate Next Step
 
 Continue Phase 3 from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-validate and publish the line-search positive-step predicate helper, then
-resume shared-contract scouting from the existing rigid IPC, deformable IPC,
-and ABD evidence. Do not add a two-body affine contact micro-solve for the
-current `abd-alg-affine-body` micro-packet; add projected-Newton,
-line-search result semantics, diagnostics, or benchmark-schema contracts only
-after second-use behavior is proven identical across variants. Use
+validate and publish the benchmark-packet utility slice, then resume
+shared-contract scouting from the existing rigid IPC, deformable IPC, ABD, and
+benchmark-packet evidence. Do not add a two-body affine contact micro-solve for
+the current `abd-alg-affine-body` micro-packet; add projected-Newton,
+line-search result semantics, diagnostics, or additional benchmark-schema
+contracts only after second-use behavior is proven identical across variants.
+Use
 [`../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md`](../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md)
 to keep the Phase 2 packet, shared solver contracts, articulation rows,
 restitution work, mixed-domain coupling, CPU/GPU parity, and py-demos rows
@@ -125,6 +134,9 @@ VBD/OGC-adjacent work, or shared Newton-barrier infrastructure.
   option/stat types plus the positive-step predicate. Do not move full
   line-search result structs there until rigid, deformable, ABD, or another
   variant prove identical result semantics.
+- `scripts/benchmark_packet_utils.py` owns the shared Google Benchmark row
+  parsing utilities for packet validators. Keep packet-specific metadata and
+  go/no-go gates in each checker until more variants prove identical semantics.
 - `bm_affine_body_dynamics` currently contains the first ABD benchmark packet:
   affine point-triangle barrier mapping, matched rigid IPC point-triangle oracle
   row, and orthogonality energy.
@@ -156,8 +168,8 @@ sed -n '1,220p' docs/dev_tasks/unified_newton_barrier_multibody/README.md
 sed -n '1,220p' docs/plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md
 ```
 
-Then verify the current branch with the focused simulation tests,
-API-boundary check, lint, and `pixi run bm-abd-comparison-packet` if that has
-not already been done. After this slice, continue with Phase 3 shared-contract
-scouting; do not describe the micro-packet as a runtime ABD solver or a
-paper-scale performance row.
+Then verify the current branch with the focused Python packet tests, lint, and
+`pixi run bm-abd-comparison-packet` if the ABD checker behavior changed beyond
+row parsing. After this slice, continue with Phase 3 shared-contract scouting;
+do not describe the micro-packet as a runtime ABD solver or a paper-scale
+performance row.

--- a/scripts/benchmark_packet_utils.py
+++ b/scripts/benchmark_packet_utils.py
@@ -1,0 +1,68 @@
+"""Shared Google Benchmark packet helpers for DART evidence scripts."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+_AGGREGATE_SUFFIX_RE = re.compile(r"_(?:mean|median|stddev|cv)$")
+_REPEATS_SUFFIX_RE = re.compile(r"/repeats:\d+")
+_UNIT_TO_NS = {"ns": 1.0, "us": 1e3, "ms": 1e6, "s": 1e9}
+
+
+def canonical_benchmark_name(name: str) -> str:
+    """Strip Google Benchmark repeat and aggregate suffixes from a row name."""
+    return _AGGREGATE_SUFFIX_RE.sub("", _REPEATS_SUFFIX_RE.sub("", name))
+
+
+def benchmark_row_name(row: Mapping[str, Any]) -> str:
+    """Return the stable Google Benchmark row name, preferring run_name."""
+    name = row.get("run_name", row.get("name", ""))
+    return name if isinstance(name, str) else ""
+
+
+def timing_to_ns(value: float, unit: str) -> float:
+    return value * _UNIT_TO_NS.get(unit, 1.0)
+
+
+def benchmark_timing_ns(row: Mapping[str, Any]) -> float:
+    value = row.get("real_time", row.get("cpu_time"))
+    if value is None:
+        return math.nan
+    try:
+        return timing_to_ns(float(value), str(row.get("time_unit", "ns")))
+    except (TypeError, ValueError):
+        return math.nan
+
+
+def median_timing_by_name(rows: Iterable[Mapping[str, Any]]) -> dict[str, float]:
+    timings: dict[str, float] = {}
+    for row in rows:
+        if row.get("aggregate_name") != "median":
+            continue
+        name = canonical_benchmark_name(benchmark_row_name(row))
+        if not name:
+            continue
+        timing = benchmark_timing_ns(row)
+        if math.isfinite(timing) and timing > 0.0:
+            timings[name] = timing
+    return timings
+
+
+def benchmark_timing_field_errors(
+    row: Mapping[str, Any], name: str, fields: Iterable[str] = ("real_time", "cpu_time")
+) -> list[str]:
+    errors: list[str] = []
+    for field in fields:
+        value = row.get(field)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            errors.append(f"{name} has non-finite {field}: {value!r}")
+        elif not math.isfinite(value):
+            errors.append(f"{name} has non-finite {field}: {value!r}")
+        elif value <= 0:
+            errors.append(f"{name} has non-positive {field}: {value!r}")
+    if not isinstance(row.get("time_unit"), str):
+        errors.append(f"{name} is missing time_unit")
+    return errors

--- a/scripts/check_abd_comparison_packet.py
+++ b/scripts/check_abd_comparison_packet.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import subprocess
 import sys
 from pathlib import Path
+
+from benchmark_packet_utils import (
+    benchmark_row_name,
+    benchmark_timing_field_errors,
+    canonical_benchmark_name,
+)
 
 EXPECTED_BENCHMARKS = {
     "BM_AffineBodyPointTriangleBarrier",
@@ -72,13 +77,6 @@ def run_benchmark(args: argparse.Namespace) -> None:
     subprocess.run(command, check=True)
 
 
-def base_benchmark_name(name: str) -> str:
-    for suffix in ("_mean", "_median", "_stddev", "_cv"):
-        if name.endswith(suffix):
-            return name[: -len(suffix)]
-    return name
-
-
 def validate_packet(path: Path) -> None:
     with path.open(encoding="utf-8") as stream:
         payload = json.load(stream)
@@ -93,24 +91,16 @@ def validate_packet(path: Path) -> None:
         if not isinstance(row, dict):
             errors.append("benchmark row is not an object")
             continue
-        name = row.get("name")
-        if not isinstance(name, str):
+        name = benchmark_row_name(row)
+        if not name:
             errors.append("benchmark row is missing a string name")
             continue
-        base_name = base_benchmark_name(name)
+        base_name = canonical_benchmark_name(name)
         if base_name not in EXPECTED_BENCHMARKS:
             errors.append(f"unexpected benchmark row: {name}")
             continue
         seen.add(base_name)
-
-        for field in ("real_time", "cpu_time"):
-            value = row.get(field)
-            if not isinstance(value, (int, float)) or not math.isfinite(value):
-                errors.append(f"{name} has non-finite {field}: {value!r}")
-            elif value <= 0:
-                errors.append(f"{name} has non-positive {field}: {value!r}")
-        if not isinstance(row.get("time_unit"), str):
-            errors.append(f"{name} is missing time_unit")
+        errors.extend(benchmark_timing_field_errors(row, name))
 
     missing = sorted(EXPECTED_BENCHMARKS - seen)
     if missing:

--- a/scripts/check_phase5_gpu_packet.py
+++ b/scripts/check_phase5_gpu_packet.py
@@ -33,9 +33,10 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import re
 import sys
 from pathlib import Path
+
+from benchmark_packet_utils import median_timing_by_name
 
 DEFAULT_CPU_PREFIX = "BM_Phase5RigidBodyBatchCpuBaseline"
 DEFAULT_GPU_PREFIX = "BM_Phase5RigidBodyBatchGpu"
@@ -50,10 +51,6 @@ REQUIRED_EVIDENCE_FLAGS = (
     "no_gpu_runtime_dependencies_passed",
     "phase5_benchmark_contract_passed",
 )
-
-_AGGREGATE_SUFFIX_RE = re.compile(r"_(?:mean|median|stddev|cv)$")
-_REPEATS_SUFFIX_RE = re.compile(r"/repeats:\d+")
-_UNIT_TO_NS = {"ns": 1.0, "us": 1e3, "ms": 1e6, "s": 1e9}
 
 
 class Phase5PacketError(RuntimeError):
@@ -115,29 +112,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Maximum allowed CPU/GPU final-state absolute error.",
     )
     return parser.parse_args(argv)
-
-
-def _canonical_name(name: str) -> str:
-    return _AGGREGATE_SUFFIX_RE.sub("", _REPEATS_SUFFIX_RE.sub("", name))
-
-
-def _row_name(row: dict) -> str:
-    name = row.get("run_name", row.get("name", ""))
-    return name if isinstance(name, str) else ""
-
-
-def _to_ns(value: float, unit: str) -> float:
-    return value * _UNIT_TO_NS.get(unit, 1.0)
-
-
-def _timing_ns(row: dict) -> float:
-    value = row.get("real_time", row.get("cpu_time"))
-    if value is None:
-        return math.nan
-    try:
-        return _to_ns(float(value), str(row.get("time_unit", "ns")))
-    except (TypeError, ValueError):
-        return math.nan
 
 
 def _require_bool(metadata: dict, key: str) -> bool:
@@ -244,20 +218,6 @@ def write_packet_template(path: Path, template: dict) -> None:
     path.write_text(json.dumps(template, indent=2) + "\n", encoding="utf-8")
 
 
-def _median_timing_by_name(rows: list[dict]) -> dict[str, float]:
-    timings = {}
-    for row in rows:
-        if row.get("aggregate_name") != "median":
-            continue
-        name = _canonical_name(_row_name(row))
-        if not name:
-            continue
-        timing = _timing_ns(row)
-        if math.isfinite(timing) and timing > 0.0:
-            timings[name] = timing
-    return timings
-
-
 def _validate_metadata(
     metadata: dict,
     min_world_count: int,
@@ -335,7 +295,7 @@ def validate_packet(
 
     cpu_name = f"{cpu_prefix}/{world_count}/{actual_body_count}/{actual_step_count}"
     gpu_name = f"{gpu_prefix}/{world_count}/{actual_body_count}/{actual_step_count}"
-    timings = _median_timing_by_name(rows)
+    timings = median_timing_by_name(rows)
     missing = [name for name in (cpu_name, gpu_name) if name not in timings]
     if missing:
         raise Phase5PacketError("missing median benchmark rows: " + ", ".join(missing))

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -1,0 +1,110 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+
+def load_script_module(name):
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    script_path = SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def aggregate_row(name, aggregate, real_time, *, run_name=True, time_unit="ns"):
+    row = {
+        "aggregate_name": aggregate,
+        "cpu_time": real_time,
+        "real_time": real_time,
+        "time_unit": time_unit,
+    }
+    row["run_name" if run_name else "name"] = name
+    return row
+
+
+def test_canonical_benchmark_name_strips_google_benchmark_suffixes():
+    utils = load_script_module("benchmark_packet_utils")
+
+    assert utils.canonical_benchmark_name("BM_Test/repeats:3_median") == "BM_Test"
+    assert utils.canonical_benchmark_name("BM_Test_mean") == "BM_Test"
+    assert utils.canonical_benchmark_name("BM_Test/8/4_cv") == "BM_Test/8/4"
+
+
+def test_median_timing_by_name_prefers_positive_median_rows():
+    utils = load_script_module("benchmark_packet_utils")
+    rows = [
+        aggregate_row("BM_Test/repeats:3_mean", "mean", 10.0),
+        aggregate_row("BM_Test/repeats:3_median", "median", 3.0, time_unit="us"),
+        aggregate_row("BM_Bad_median", "median", 0.0),
+    ]
+
+    assert utils.median_timing_by_name(rows) == {"BM_Test": 3000.0}
+
+
+def test_benchmark_timing_field_errors_reject_bad_google_rows():
+    utils = load_script_module("benchmark_packet_utils")
+
+    errors = utils.benchmark_timing_field_errors(
+        {"real_time": float("nan"), "cpu_time": -1.0}, "BM_Bad"
+    )
+
+    assert errors == [
+        "BM_Bad has non-finite real_time: nan",
+        "BM_Bad has non-positive cpu_time: -1.0",
+        "BM_Bad is missing time_unit",
+    ]
+
+
+def test_phase5_packet_validator_uses_shared_canonical_rows():
+    phase5 = load_script_module("check_phase5_gpu_packet")
+    data = phase5.make_packet_template()
+    metadata = data["phase5_gpu_packet"]
+    metadata["includes_transfer_setup_compute_readback"] = True
+    metadata["max_final_state_abs_error"] = 1e-12
+    for key in phase5.REQUIRED_EVIDENCE_FLAGS:
+        metadata[key] = True
+    data["benchmarks"] = [
+        aggregate_row(
+            "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100/repeats:3_median",
+            "median",
+            4.0,
+            time_unit="ms",
+        ),
+        aggregate_row(
+            "BM_Phase5RigidBodyBatchGpu/4096/128/100/repeats:3_median",
+            "median",
+            2.0,
+            time_unit="ms",
+        ),
+    ]
+
+    summary = phase5.validate_packet(data)
+
+    assert summary["cpu_median_ns"] == 4_000_000.0
+    assert summary["gpu_median_ns"] == 2_000_000.0
+    assert summary["speedup"] == 2.0
+
+
+def test_abd_packet_validator_uses_shared_row_validation(tmp_path, capsys):
+    abd = load_script_module("check_abd_comparison_packet")
+    packet = {
+        "benchmarks": [
+            aggregate_row(f"{name}_median", "median", 1.0)
+            for name in sorted(abd.EXPECTED_BENCHMARKS)
+        ]
+    }
+    path = tmp_path / "abd_packet.json"
+    path.write_text(json.dumps(packet), encoding="utf-8")
+
+    abd.validate_packet(path)
+
+    assert "ABD comparison packet OK" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- Add a shared `scripts/benchmark_packet_utils.py` helper for Google Benchmark packet row parsing.
- Route the PLAN-083 ABD comparison packet checker and Phase 5 GPU packet checker through the shared row parser.
- Record the benchmark-packet utility slice in the active PLAN-083 dev-task notes.

## Motivation / Problem

- PLAN-083 Phase 3 should only promote shared contracts once a second consumer proves identical behavior. Projected-Newton status/result semantics still differ across rigid, deformable, and ABD paths, but the ABD and Phase 5 packet validators already share Google Benchmark row parsing rules.

## Changes / Key Changes

- Share row-name canonicalization, timing-unit conversion, median-row lookup, and timing-field validation for benchmark packet validators.
- Keep packet-specific metadata, expected row sets, speedup gates, and evidence flags in their existing owner scripts.
- Add focused Python tests for the shared helper and both consuming validators.

## Testing

- `pixi run python -m pytest tests/test_benchmark_packet_utils.py`
- `pixi run lint`
- `pixi run test-all`
- `pixi run -e cuda test-all` (exited 0 on the CUDA host)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows #2938.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (not required: internal script/test/docs change)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (not applicable: internal script utility)
- [x] Add Python bindings (dartpy) if applicable (not applicable)