### PR TITLE
Share Newton barrier line-search step scaling

### DIFF
--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -4188,13 +4188,9 @@ bool applySurfaceContactCcdLimit(
     return true;
   }
 
-  const double stepBound = std::clamp(result.stepBound, 0.0, 1.0);
-  if (stepBound <= 0.0) {
-    return false;
-  }
-
-  const double safeFraction = std::nextafter(stepBound, 0.0);
-  if (safeFraction <= 0.0 || !std::isfinite(safeFraction)) {
+  const double safeFraction
+      = nb::makeInteriorLineSearchStepScale(result.stepBound);
+  if (safeFraction <= 0.0) {
     return false;
   }
 
@@ -4290,13 +4286,8 @@ bool applyInterBodySurfaceContactCcdLimit(
     return true;
   }
 
-  stepBound = std::clamp(stepBound, 0.0, 1.0);
-  if (stepBound <= 0.0) {
-    return false;
-  }
-
-  const double safeFraction = std::nextafter(stepBound, 0.0);
-  if (safeFraction <= 0.0 || !std::isfinite(safeFraction)) {
+  const double safeFraction = nb::makeInteriorLineSearchStepScale(stepBound);
+  if (safeFraction <= 0.0) {
     return false;
   }
 
@@ -4477,14 +4468,8 @@ bool applyStaticRigidSurfaceCcdLimit(
     return true;
   }
 
-  stepBound = std::clamp(stepBound, 0.0, 1.0);
-  if (stepBound <= 0.0) {
-    ++stats.staticRigidSurfaceCcdZeroStepCount;
-    return false;
-  }
-
-  const double safeFraction = std::nextafter(stepBound, 0.0);
-  if (safeFraction <= 0.0 || !std::isfinite(safeFraction)) {
+  const double safeFraction = nb::makeInteriorLineSearchStepScale(stepBound);
+  if (safeFraction <= 0.0) {
     ++stats.staticRigidSurfaceCcdZeroStepCount;
     return false;
   }
@@ -4624,14 +4609,8 @@ bool applyMovingRigidSurfaceCcdLimit(
     return true;
   }
 
-  stepBound = std::clamp(stepBound, 0.0, 1.0);
-  if (stepBound <= 0.0) {
-    ++stats.movingRigidSurfaceCcdZeroStepCount;
-    return false;
-  }
-
-  const double safeFraction = std::nextafter(stepBound, 0.0);
-  if (safeFraction <= 0.0 || !std::isfinite(safeFraction)) {
+  const double safeFraction = nb::makeInteriorLineSearchStepScale(stepBound);
+  if (safeFraction <= 0.0) {
     ++stats.movingRigidSurfaceCcdZeroStepCount;
     return false;
   }
@@ -4686,14 +4665,8 @@ bool applyStaticGroundBarrierCcdLimit(
     return true;
   }
 
-  stepBound = std::clamp(stepBound, 0.0, 1.0);
-  if (stepBound <= 0.0) {
-    ++stats.staticGroundBarrierCcdZeroStepCount;
-    return false;
-  }
-
-  const double safeFraction = std::nextafter(stepBound, 0.0);
-  if (safeFraction <= 0.0 || !std::isfinite(safeFraction)) {
+  const double safeFraction = nb::makeInteriorLineSearchStepScale(stepBound);
+  if (safeFraction <= 0.0) {
     ++stats.staticGroundBarrierCcdZeroStepCount;
     return false;
   }

--- a/dart/simulation/detail/newton_barrier/line_search.hpp
+++ b/dart/simulation/detail/newton_barrier/line_search.hpp
@@ -35,6 +35,7 @@
 
 #include <algorithm>
 
+#include <cmath>
 #include <cstddef>
 
 namespace dart::simulation::detail::newton_barrier {
@@ -73,6 +74,36 @@ struct LineSearchStats
     const double stepBound, const bool indeterminate) noexcept
 {
   return stepBound > 0.0 && !indeterminate;
+}
+
+[[nodiscard]] inline double makeLineSearchStepScale(
+    const double stepBound, const double safetyScale = 1.0) noexcept
+{
+  const double clampedStepBound = std::clamp(stepBound, 0.0, 1.0);
+  const double clampedSafetyScale = std::clamp(safetyScale, 0.0, 1.0);
+  if (!std::isfinite(clampedStepBound) || !std::isfinite(clampedSafetyScale)) {
+    return 0.0;
+  }
+
+  const double stepScale
+      = std::clamp(clampedStepBound * clampedSafetyScale, 0.0, 1.0);
+  return std::isfinite(stepScale) ? stepScale : 0.0;
+}
+
+[[nodiscard]] inline double makeInteriorLineSearchStepScale(
+    const double stepBound) noexcept
+{
+  const double stepScale = makeLineSearchStepScale(stepBound);
+  if (stepScale <= 0.0) {
+    return 0.0;
+  }
+
+  const double interiorStepScale = std::nextafter(stepScale, 0.0);
+  if (interiorStepScale <= 0.0 || !std::isfinite(interiorStepScale)) {
+    return 0.0;
+  }
+
+  return interiorStepScale;
 }
 
 inline void accumulateLineSearchStats(

--- a/dart/simulation/detail/rigid_ipc_barrier.cpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.cpp
@@ -939,11 +939,8 @@ RigidIpcProjectedNewtonStep computeRigidIpcProjectedNewtonStepImpl(
 
     if (lineSearch->limited) {
       result.stats.lineSearchLimited = true;
-      const double safeBound = std::clamp(
-          lineSearch->stepBound
-              * std::clamp(options.lineSearchSafetyScale, 0.0, 1.0),
-          0.0,
-          1.0);
+      const double safeBound = newton_barrier::makeLineSearchStepScale(
+          lineSearch->stepBound, options.lineSearchSafetyScale);
       if (safeBound <= 0.0) {
         result.status = RigidIpcProjectedNewtonStatus::LineSearchBlocked;
         result.lineSearchBlocked = true;

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -54,6 +54,10 @@
         `detail/newton_barrier` and route rigid IPC plus deformable CCD
         line-search queries through it while keeping their CCD implementations
         and limiting-primitive payloads variant-local.
+  - [x] Promote the shared line-search step-scale policy into
+        `detail/newton_barrier` and route rigid IPC Newton step scaling plus
+        deformable/world CCD limiters through it while keeping their result
+        payloads and zero-step diagnostics variant-local.
   - [x] Promote the first shared Google Benchmark packet row parser into
         `scripts/benchmark_packet_utils.py` and route the ABD comparison packet
         checker plus the Phase 5 GPU packet checker through it while keeping
@@ -114,11 +118,11 @@ resources as public API.
 1. Continue Phase 3 shared-contract scouting from the existing rigid IPC,
    deformable IPC, and ABD evidence after the fixed-size PSD projection helper,
    first line-search option/stat helper, shared line-search positive-step
-   predicate, shared conservative native-CCD option adapter, and shared Google
-   Benchmark packet row parser. Promote projected-Newton result/status
-   terminology, line-search result semantics, diagnostics, or additional
-   benchmark-schema contracts only when a second consumer proves identical
-   behavior.
+   predicate, shared conservative native-CCD option adapter, shared
+   line-search step-scale helper, and shared Google Benchmark packet row parser.
+   Promote projected-Newton result/status terminology, line-search result
+   semantics, diagnostics, or additional benchmark-schema contracts only when a
+   second consumer proves identical behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.
@@ -185,6 +189,14 @@ Phase 3 benchmark packet utility slice local evidence:
 
 - `pixi run python -m pytest tests/test_benchmark_packet_utils.py`
 - `pixi run lint`
+
+Phase 3 line-search step-scale slice local evidence:
+
+- `pixi run lint`
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel 8`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
+- `pixi run build`
+- `pixi run test-unit`
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -27,13 +27,19 @@ The positive-step predicate slice promoted only
 methods route through it, but hit/limited fields and limiting-primitive payloads
 remain variant-local.
 
-The current Phase 3 slice promotes the shared conservative native-CCD option
-adapter into `detail/newton_barrier`. Rigid IPC and deformable continuous
-collision detection now use one `LineSearchOptions` -> `CcdOption` adapter for
-non-negative separation/tolerance clamping, positive iteration count clamping,
-and conservative advancement selection, while their CCD implementations,
-hit/limited result fields, and limiting-primitive payloads remain
-variant-local.
+The native-CCD option adapter slice merged as PR #2942. Rigid IPC and
+deformable continuous collision detection now use one `LineSearchOptions` ->
+`CcdOption` adapter for non-negative separation/tolerance clamping, positive
+iteration count clamping, and conservative advancement selection, while their
+CCD implementations, hit/limited result fields, and limiting-primitive payloads
+remain variant-local.
+
+The current Phase 3 slice promotes the shared line-search step-scale policy into
+`detail/newton_barrier`. Rigid IPC Newton step scaling and deformable/world CCD
+limiters now share finite `[0, 1]` step-bound clamping, safety-scale handling,
+and the strictly-interior CCD fraction used before applying a line-search
+candidate. Variant-local owners still keep their hit/limited payloads,
+candidate identities, and zero-step diagnostic counters.
 
 The benchmark-packet utility slice promoted the first shared packet contract:
 Google Benchmark row-name canonicalization, timing-unit conversion, median-row
@@ -91,23 +97,27 @@ owners. Focused local validation passed
 `pixi run python -m pytest tests/test_benchmark_packet_utils.py` and
 `pixi run lint`.
 
-The current native-CCD option adapter slice lives on
-`simx/shared-newton-barrier-ccd-option`. It is intentionally smaller than a
-projected-Newton diagnostics merge: current evidence shows rigid and deformable
-share the line-search option conversion to native conservative CCD options, but
-not yet a full projected-Newton status or solver-loop contract.
+The current line-search step-scale slice lives on
+`simx/shared-newton-barrier-step-scale`. It is intentionally smaller than a
+line-search result or projected-Newton diagnostics merge: current evidence
+shows rigid and deformable share finite step-bound scaling and the
+strictly-interior CCD fraction, but not yet full line-search result payloads,
+projected-Newton status terminology, or solver-loop diagnostics.
+Focused local validation passed `pixi run lint`, the focused
+`test_newton_barrier_primitives` / `test_rigid_ipc_barrier` / `test_world`
+CTest entries, `pixi run build`, and `pixi run test-unit`.
 
 ## Current Branch
 
-`simx/shared-newton-barrier-ccd-option` - contains the Phase 3 shared
-line-search native-CCD option adapter slice. Verify the exact status with
+`simx/shared-newton-barrier-step-scale` - contains the Phase 3 shared
+line-search step-scale policy slice. Verify the exact status with
 `git status --short --branch` because this section is a resume snapshot.
 
 ## Immediate Next Step
 
 Continue Phase 3 from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-validate and publish the line-search native-CCD option adapter, then resume
+validate and publish the line-search step-scale policy, then resume
 shared-contract scouting from the existing rigid IPC, deformable IPC, ABD, and
 benchmark-packet evidence. Do not add a two-body affine contact micro-solve for
 the current `abd-alg-affine-body` micro-packet; add projected-Newton,
@@ -148,9 +158,10 @@ VBD/OGC-adjacent work, or shared Newton-barrier infrastructure.
   `detail/newton_barrier` so rigid IPC and ABD share the same Coulomb smoothing
   branch before reduced/affine chain rules.
 - `detail/newton_barrier/line_search.hpp` owns the shared line-search
-  option/stat types, the positive-step predicate, and the conservative native
-  CCD option adapter. Do not move full line-search result structs there until
-  rigid, deformable, ABD, or another variant prove identical result semantics.
+  option/stat types, the positive-step predicate, the conservative native CCD
+  option adapter, and the step-scale helpers. Do not move full line-search
+  result structs there until rigid, deformable, ABD, or another variant prove
+  identical result semantics.
 - `scripts/benchmark_packet_utils.py` owns the shared Google Benchmark row
   parsing utilities for packet validators. Keep packet-specific metadata and
   go/no-go gates in each checker until more variants prove identical semantics.
@@ -185,7 +196,7 @@ sed -n '1,220p' docs/dev_tasks/unified_newton_barrier_multibody/README.md
 sed -n '1,220p' docs/plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md
 ```
 
-Then verify the current branch with lint and the focused native-CCD adapter
+Then verify the current branch with lint and the focused line-search helper
 simulation tests. Re-run the focused Python packet tests or
 `pixi run bm-abd-comparison-packet` only if packet utility or ABD checker
 behavior changes beyond the merge. After this slice, continue with Phase 3

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -244,6 +244,10 @@ TEST(NewtonBarrierPrimitives, InteriorLineSearchStepScaleStaysInsideBound)
   EXPECT_DOUBLE_EQ(nb::makeInteriorLineSearchStepScale(0.0), 0.0);
   EXPECT_DOUBLE_EQ(
       nb::makeInteriorLineSearchStepScale(
+          std::numeric_limits<double>::denorm_min()),
+      0.0);
+  EXPECT_DOUBLE_EQ(
+      nb::makeInteriorLineSearchStepScale(
           std::numeric_limits<double>::quiet_NaN()),
       0.0);
 }

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -43,6 +43,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <type_traits>
 
 namespace dc = dart::simulation::detail::deformable_contact;
@@ -210,6 +211,41 @@ TEST(NewtonBarrierPrimitives, LineSearchPositiveStepPredicateIsShared)
   EXPECT_FALSE(nb::allowsPositiveLineSearchStep(0.0, false));
   EXPECT_FALSE(nb::allowsPositiveLineSearchStep(-1.0, false));
   EXPECT_FALSE(nb::allowsPositiveLineSearchStep(0.5, true));
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, LineSearchStepScaleUsesSharedClampingPolicy)
+{
+  EXPECT_NEAR(nb::makeLineSearchStepScale(0.25, 0.8), 0.2, 1e-15);
+  EXPECT_DOUBLE_EQ(nb::makeLineSearchStepScale(2.0, 2.0), 1.0);
+  EXPECT_DOUBLE_EQ(nb::makeLineSearchStepScale(-0.5, 1.0), 0.0);
+  EXPECT_DOUBLE_EQ(nb::makeLineSearchStepScale(0.5, -0.5), 0.0);
+  EXPECT_DOUBLE_EQ(
+      nb::makeLineSearchStepScale(
+          std::numeric_limits<double>::quiet_NaN(), 1.0),
+      0.0);
+  EXPECT_DOUBLE_EQ(
+      nb::makeLineSearchStepScale(
+          0.5, std::numeric_limits<double>::quiet_NaN()),
+      0.0);
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, InteriorLineSearchStepScaleStaysInsideBound)
+{
+  const double fullStep = nb::makeInteriorLineSearchStepScale(1.0);
+  EXPECT_GT(fullStep, 0.0);
+  EXPECT_LT(fullStep, 1.0);
+
+  const double partialStep = nb::makeInteriorLineSearchStepScale(0.25);
+  EXPECT_GT(partialStep, 0.0);
+  EXPECT_LT(partialStep, 0.25);
+
+  EXPECT_DOUBLE_EQ(nb::makeInteriorLineSearchStepScale(0.0), 0.0);
+  EXPECT_DOUBLE_EQ(
+      nb::makeInteriorLineSearchStepScale(
+          std::numeric_limits<double>::quiet_NaN()),
+      0.0);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Share Newton-barrier line-search step-scale normalization in `detail/newton_barrier`.
- Route rigid IPC Newton step scaling and deformable/world CCD limiters through the shared helper.
- Keep line-search result payloads, limiting candidate identities, and zero-step diagnostics variant-local.

## Motivation / Problem

- PLAN-083 Phase 3 promotes only proven second-use solver contracts.
- Rigid IPC and deformable/world CCD limiters already shared the same finite `[0, 1]` step-bound normalization shape, with deformable paths also stepping strictly inside the CCD bound before applying a candidate.
- Sharing this narrow policy removes duplicated feasibility plumbing without promoting full projected-Newton status or line-search result semantics.

## Changes / Key Changes

- Added `newton_barrier::makeLineSearchStepScale()` for finite clamping plus optional safety scaling.
- Added `newton_barrier::makeInteriorLineSearchStepScale()` for the strictly-inside CCD fraction used by deformable/world line searches.
- Replaced duplicate rigid IPC and world-step local calculations with the shared helpers.
- Added focused Newton-barrier primitive tests and updated the active PLAN-083 dev-task handoff evidence.

## Testing

- `pixi run lint`
- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel 8`
- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`
- `pixi run -e cuda test-all`

## Breaking Changes

- [x] None
- Internal detail-only helper; no public API or migration required.

## Related Issues / PRs (backports)

- Follows #2942.
- Part of PLAN-083 / `docs/dev_tasks/unified_newton_barrier_multibody`.
- Backport: N/A; DART 7 simulation work targeting `main`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (N/A: internal detail helper and dev-task evidence only)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: internal detail helper; dev-task evidence updated)
- [x] Add Python bindings (dartpy) if applicable (N/A)
