### PR TITLE
Share line-search CCD outcome accounting

### DIFF
--- a/dart/simulation/detail/deformable_contact/continuous_collision_step.cpp
+++ b/dart/simulation/detail/deformable_contact/continuous_collision_step.cpp
@@ -44,16 +44,12 @@ namespace {
 //==============================================================================
 void recordHit(
     ContinuousCollisionStepResult& result,
-    const double timeOfImpact,
+    const newton_barrier::LineSearchCcdOutcome& outcome,
     const ContinuousCollisionPrimitive primitive)
 {
   result.hit = true;
-  result.stepBound = std::clamp(timeOfImpact, 0.0, 1.0);
+  result.stepBound = outcome.stepBound;
   result.limitingPrimitive = primitive;
-  ++result.stats.hits;
-  if (result.stepBound <= 0.0) {
-    ++result.stats.zeroStepCount;
-  }
 }
 
 //==============================================================================
@@ -113,20 +109,14 @@ ContinuousCollisionStepResult pointTriangleStepBound(
       cEnd,
       newton_barrier::makeLineSearchCcdOption(options),
       nativeResult);
+  const auto outcome
+      = newton_barrier::recordLineSearchCcdOutcome(result.stats, nativeResult);
 
   if (hit) {
-    recordHit(
-        result,
-        nativeResult.timeOfImpact,
-        ContinuousCollisionPrimitive::PointTriangle);
-  } else if (
-      nativeResult.status
-      == collision::native::CcdPrimitiveStatus::Indeterminate) {
+    recordHit(result, outcome, ContinuousCollisionPrimitive::PointTriangle);
+  } else if (outcome.indeterminate) {
     result.indeterminate = true;
     result.stepBound = 0.0;
-    ++result.stats.indeterminate;
-  } else {
-    ++result.stats.misses;
   }
 
   return result;
@@ -159,20 +149,14 @@ ContinuousCollisionStepResult edgeEdgeStepBound(
       dEnd,
       newton_barrier::makeLineSearchCcdOption(options),
       nativeResult);
+  const auto outcome
+      = newton_barrier::recordLineSearchCcdOutcome(result.stats, nativeResult);
 
   if (hit) {
-    recordHit(
-        result,
-        nativeResult.timeOfImpact,
-        ContinuousCollisionPrimitive::EdgeEdge);
-  } else if (
-      nativeResult.status
-      == collision::native::CcdPrimitiveStatus::Indeterminate) {
+    recordHit(result, outcome, ContinuousCollisionPrimitive::EdgeEdge);
+  } else if (outcome.indeterminate) {
     result.indeterminate = true;
     result.stepBound = 0.0;
-    ++result.stats.indeterminate;
-  } else {
-    ++result.stats.misses;
   }
 
   return result;

--- a/dart/simulation/detail/newton_barrier/line_search.hpp
+++ b/dart/simulation/detail/newton_barrier/line_search.hpp
@@ -59,6 +59,13 @@ struct LineSearchStats
   std::size_t zeroStepCount = 0;
 };
 
+struct LineSearchCcdOutcome
+{
+  bool hit = false;
+  bool indeterminate = false;
+  double stepBound = 1.0;
+};
+
 [[nodiscard]] inline collision::native::CcdOption makeLineSearchCcdOption(
     const LineSearchOptions& options)
 {
@@ -104,6 +111,40 @@ struct LineSearchStats
   }
 
   return interiorStepScale;
+}
+
+[[nodiscard]] inline double recordLineSearchHit(
+    LineSearchStats& stats, const double timeOfImpact) noexcept
+{
+  ++stats.hits;
+  const double stepBound = std::clamp(timeOfImpact, 0.0, 1.0);
+  if (stepBound <= 0.0) {
+    ++stats.zeroStepCount;
+  }
+  return stepBound;
+}
+
+[[nodiscard]] inline LineSearchCcdOutcome recordLineSearchCcdOutcome(
+    LineSearchStats& stats,
+    const collision::native::CcdPrimitiveResult& primitive) noexcept
+{
+  LineSearchCcdOutcome outcome;
+  if (primitive.hit) {
+    outcome.hit = true;
+    outcome.stepBound = recordLineSearchHit(stats, primitive.timeOfImpact);
+    return outcome;
+  }
+
+  if (primitive.status
+      == collision::native::CcdPrimitiveStatus::Indeterminate) {
+    ++stats.indeterminate;
+    outcome.indeterminate = true;
+    outcome.stepBound = std::clamp(primitive.timeOfImpact, 0.0, 1.0);
+    return outcome;
+  }
+
+  ++stats.misses;
+  return outcome;
 }
 
 inline void accumulateLineSearchStats(

--- a/dart/simulation/detail/rigid_ipc_barrier.cpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.cpp
@@ -809,12 +809,10 @@ void recordLineSearchCandidate(
     const std::size_t bodyB,
     const std::array<std::size_t, 4>& vertices)
 {
-  if (candidate.hit) {
-    ++aggregate.stats.hits;
-    const double candidateStep = std::clamp(candidate.timeOfImpact, 0.0, 1.0);
-    if (candidateStep <= 0.0) {
-      ++aggregate.stats.zeroStepCount;
-    }
+  const auto outcome
+      = newton_barrier::recordLineSearchCcdOutcome(aggregate.stats, candidate);
+  if (outcome.hit) {
+    const double candidateStep = outcome.stepBound;
     if (!aggregate.limited || candidateStep < aggregate.stepBound) {
       aggregate.limited = true;
       aggregate.stepBound = candidateStep;
@@ -826,9 +824,7 @@ void recordLineSearchCandidate(
     return;
   }
 
-  if (candidate.status
-      == collision::native::CcdPrimitiveStatus::Indeterminate) {
-    ++aggregate.stats.indeterminate;
+  if (outcome.indeterminate) {
     // The ACCD could not prove a definitive hit/miss within its budget, but
     // each conservative advance it took was a provably contact-free sub-step,
     // so it did prove the pair separated over [0, timeOfImpact]. Use that as a
@@ -838,7 +834,7 @@ void recordLineSearchCandidate(
     // true TOI) while letting dense resting contacts -- where a couple of tight
     // pairs never fully resolve -- still advance. Only if no safe progress was
     // proven (timeOfImpact == 0) do we fall back to the blocking zero step.
-    const double safeTime = std::clamp(candidate.timeOfImpact, 0.0, 1.0);
+    const double safeTime = outcome.stepBound;
     if (safeTime <= 0.0) {
       aggregate.indeterminate = true;
       aggregate.limited = true;
@@ -859,8 +855,6 @@ void recordLineSearchCandidate(
     }
     return;
   }
-
-  ++aggregate.stats.misses;
 }
 
 RigidIpcProjectedNewtonStep computeRigidIpcProjectedNewtonStepImpl(

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -58,6 +58,11 @@
         `detail/newton_barrier` and route rigid IPC Newton step scaling plus
         deformable/world CCD limiters through it while keeping their result
         payloads and zero-step diagnostics variant-local.
+  - [x] Promote the shared native-CCD primitive outcome accounting policy into
+        `detail/newton_barrier` and route rigid IPC plus deformable CCD hit,
+        miss, indeterminate, and step-bound clamping through it while keeping
+        limiting-payload ownership and indeterminate-result policy
+        variant-local.
   - [x] Promote the first shared Google Benchmark packet row parser into
         `scripts/benchmark_packet_utils.py` and route the ABD comparison packet
         checker plus the Phase 5 GPU packet checker through it while keeping
@@ -197,6 +202,17 @@ Phase 3 line-search step-scale slice local evidence:
 - `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
 - `pixi run build`
 - `pixi run test-unit`
+
+Phase 3 native-CCD primitive outcome accounting slice local evidence:
+
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_continuous_collision_step test_rigid_ipc_barrier --parallel 8`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_continuous_collision_step|test_rigid_ipc_barrier)$'`
+- `pixi run lint`
+- `pixi run build`
+- `pixi run test-unit`
+- `pixi run test-all`
+- `pixi run -e cuda test-all` (docs passed with the existing
+  `dartpy._world_render_bridge` autodoc warnings)
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -49,6 +49,13 @@ Phase 5 GPU packet checker share those row-level rules while keeping their
 packet-specific expected rows, metadata, speedup gates, and evidence flags in
 their variant owners.
 
+The current Phase 3 scout promotes only the native-CCD primitive outcome
+accounting that is identical across rigid IPC and deformable CCD: hit/miss/
+indeterminate counter updates, hit and indeterminate time-of-impact clamping to
+`[0, 1]`, and zero-step counting. Limiting-payload ownership,
+indeterminate-result policy, and line-search result structs remain
+variant-local.
+
 ## Last Session Summary
 
 Current slice: the first ABD benchmark packet has been promoted from
@@ -97,32 +104,43 @@ owners. Focused local validation passed
 `pixi run python -m pytest tests/test_benchmark_packet_utils.py` and
 `pixi run lint`.
 
-The current line-search step-scale slice lives on
-`simx/shared-newton-barrier-step-scale`. It is intentionally smaller than a
-line-search result or projected-Newton diagnostics merge: current evidence
-shows rigid and deformable share finite step-bound scaling and the
-strictly-interior CCD fraction, but not yet full line-search result payloads,
-projected-Newton status terminology, or solver-loop diagnostics.
+The line-search step-scale slice merged as PR #2943. It is intentionally
+smaller than a line-search result or projected-Newton diagnostics merge:
+current evidence shows rigid and deformable share finite step-bound scaling and
+the strictly-interior CCD fraction, but not yet full line-search result
+payloads, projected-Newton status terminology, or solver-loop diagnostics.
 Focused local validation passed `pixi run lint`, the focused
 `test_newton_barrier_primitives` / `test_rigid_ipc_barrier` / `test_world`
 CTest entries, `pixi run build`, and `pixi run test-unit`.
 
+The native-CCD primitive outcome accounting slice is on
+`simx/shared-newton-barrier-ccd-hit-accounting`, rebased directly onto
+`origin/main` after PR #2943 landed. Focused local validation passed the
+`test_newton_barrier_primitives`, `test_continuous_collision_step`, and
+`test_rigid_ipc_barrier` build/CTest entries plus `pixi run lint`. Stronger
+local validation also passed `pixi run build`, `pixi run test-unit`,
+`pixi run test-all`, and `pixi run -e cuda test-all`. Both full gates passed;
+the docs phase still emits the existing `dartpy._world_render_bridge` autodoc
+warnings.
+
 ## Current Branch
 
-`simx/shared-newton-barrier-step-scale` - contains the Phase 3 shared
-line-search step-scale policy slice. Verify the exact status with
+`simx/shared-newton-barrier-ccd-hit-accounting` - contains the Phase 3 shared
+native-CCD primitive outcome accounting slice, rebased directly onto
+`origin/main` after PR #2943 landed. Verify the exact status with
 `git status --short --branch` because this section is a resume snapshot.
 
 ## Immediate Next Step
 
 Continue Phase 3 from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-validate and publish the line-search step-scale policy, then resume
-shared-contract scouting from the existing rigid IPC, deformable IPC, ABD, and
-benchmark-packet evidence. Do not add a two-body affine contact micro-solve for
-the current `abd-alg-affine-body` micro-packet; add projected-Newton,
-line-search result semantics, diagnostics, or benchmark-schema contracts only
-after second-use behavior is proven identical across variants. Use
+publish the native-CCD primitive outcome accounting slice against `main`, then
+resume shared-contract scouting from the existing rigid IPC, deformable IPC,
+ABD, and benchmark-packet evidence. Do not add a two-body affine contact
+micro-solve for the current `abd-alg-affine-body` micro-packet; add
+projected-Newton, line-search result semantics, diagnostics, or
+benchmark-schema contracts only after second-use behavior is proven identical
+across variants. Use
 [`../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md`](../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md)
 to keep the Phase 2 packet, shared solver contracts, articulation rows,
 restitution work, mixed-domain coupling, CPU/GPU parity, and py-demos rows

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -253,6 +253,65 @@ TEST(NewtonBarrierPrimitives, InteriorLineSearchStepScaleStaysInsideBound)
 }
 
 //==============================================================================
+TEST(NewtonBarrierPrimitives, LineSearchHitAccountingClampsSharedStepBound)
+{
+  nb::LineSearchStats stats;
+
+  EXPECT_DOUBLE_EQ(nb::recordLineSearchHit(stats, 0.25), 0.25);
+  EXPECT_EQ(stats.hits, 1u);
+  EXPECT_EQ(stats.zeroStepCount, 0u);
+
+  EXPECT_DOUBLE_EQ(nb::recordLineSearchHit(stats, 2.0), 1.0);
+  EXPECT_EQ(stats.hits, 2u);
+  EXPECT_EQ(stats.zeroStepCount, 0u);
+
+  EXPECT_DOUBLE_EQ(nb::recordLineSearchHit(stats, -0.5), 0.0);
+  EXPECT_EQ(stats.hits, 3u);
+  EXPECT_EQ(stats.zeroStepCount, 1u);
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, LineSearchCcdOutcomeAccountsNativeStatus)
+{
+  nb::LineSearchStats stats;
+
+  dart::collision::native::CcdPrimitiveResult hit;
+  hit.hit = true;
+  hit.status = dart::collision::native::CcdPrimitiveStatus::Hit;
+  hit.timeOfImpact = 1.25;
+  const auto hitOutcome = nb::recordLineSearchCcdOutcome(stats, hit);
+  EXPECT_TRUE(hitOutcome.hit);
+  EXPECT_FALSE(hitOutcome.indeterminate);
+  EXPECT_DOUBLE_EQ(hitOutcome.stepBound, 1.0);
+  EXPECT_EQ(stats.hits, 1u);
+  EXPECT_EQ(stats.misses, 0u);
+  EXPECT_EQ(stats.indeterminate, 0u);
+
+  dart::collision::native::CcdPrimitiveResult miss;
+  miss.status = dart::collision::native::CcdPrimitiveStatus::Miss;
+  const auto missOutcome = nb::recordLineSearchCcdOutcome(stats, miss);
+  EXPECT_FALSE(missOutcome.hit);
+  EXPECT_FALSE(missOutcome.indeterminate);
+  EXPECT_DOUBLE_EQ(missOutcome.stepBound, 1.0);
+  EXPECT_EQ(stats.hits, 1u);
+  EXPECT_EQ(stats.misses, 1u);
+  EXPECT_EQ(stats.indeterminate, 0u);
+
+  dart::collision::native::CcdPrimitiveResult indeterminate;
+  indeterminate.status
+      = dart::collision::native::CcdPrimitiveStatus::Indeterminate;
+  indeterminate.timeOfImpact = 0.25;
+  const auto indeterminateOutcome
+      = nb::recordLineSearchCcdOutcome(stats, indeterminate);
+  EXPECT_FALSE(indeterminateOutcome.hit);
+  EXPECT_TRUE(indeterminateOutcome.indeterminate);
+  EXPECT_DOUBLE_EQ(indeterminateOutcome.stepBound, 0.25);
+  EXPECT_EQ(stats.hits, 1u);
+  EXPECT_EQ(stats.misses, 1u);
+  EXPECT_EQ(stats.indeterminate, 1u);
+}
+
+//==============================================================================
 TEST(NewtonBarrierPrimitives, LineSearchResultsUseSharedPositiveStepPredicate)
 {
   dc::ContinuousCollisionStepResult deformable;


### PR DESCRIPTION
## Summary

- Share Newton-barrier native CCD primitive outcome accounting in `detail/newton_barrier`.
- Route rigid IPC and deformable continuous-collision primitive accounting through the shared helper.
- Keep limiting payload ownership, line-search result structs, and indeterminate-result policy variant-local.

## Motivation / Problem

- PLAN-083 Phase 3 promotes only proven second-use solver contracts.
- Rigid IPC and deformable CCD both account native CCD hit/miss/indeterminate outcomes by clamping time of impact into `[0, 1]` and counting zero-step hits.
- Sharing this narrow accounting policy removes duplicate counter/clamping code without moving variant-specific result payload semantics.

## Changes / Key Changes

- Added `newton_barrier::LineSearchCcdOutcome`, `recordLineSearchHit()`, and `recordLineSearchCcdOutcome()`.
- Updated deformable point-triangle and edge-edge CCD reducers to use the shared outcome helper.
- Updated rigid IPC line-search primitive checks to use the shared outcome helper.
- Added focused Newton-barrier primitive tests for hit clamping, zero-step accounting, and native CCD status accounting.
- Updated PLAN-083 dev-task handoff/evidence after #2943 landed.

## Testing

Current head after rebasing onto `origin/main` with #2943 merged:

- `pixi run lint`
- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_continuous_collision_step test_rigid_ipc_barrier --parallel 8`
- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_continuous_collision_step|test_rigid_ipc_barrier)$'`
- `git diff --check`

Earlier same child slice before the final parent rebase:

- `pixi run build`
- `pixi run test-unit`
- `pixi run test-all`
- `pixi run -e cuda test-all`

## Breaking Changes

- [x] None
- Internal detail-only helper; no public API or migration required.

## Related Issues / PRs (backports)

- Follows #2943.
- Part of PLAN-083 / `docs/dev_tasks/unified_newton_barrier_multibody`.
- Backport: N/A; DART 7 simulation work targeting `main`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (N/A: internal detail helper and dev-task evidence only)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: internal detail helper; dev-task evidence updated)
- [x] Add Python bindings (dartpy) if applicable (N/A)
