### PR TITLE
Share Phase 3 benchmark and CCD diagnostics contracts

### DIFF
--- a/dart/simulation/detail/newton_barrier/line_search.hpp
+++ b/dart/simulation/detail/newton_barrier/line_search.hpp
@@ -188,6 +188,9 @@ struct LineSearchCcdOutcome
     ++stats.indeterminate;
     outcome.indeterminate = true;
     outcome.stepBound = std::clamp(primitive.timeOfImpact, 0.0, 1.0);
+    if (outcome.stepBound <= 0.0) {
+      ++stats.zeroStepCount;
+    }
     return outcome;
   }
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -67,6 +67,10 @@
         miss, indeterminate, and step-bound clamping through it while keeping
         limiting-payload ownership and indeterminate-result policy
         variant-local.
+  - [x] Count zero-step indeterminate native-CCD outcomes through the shared
+        line-search accounting helper so rigid IPC and deformable CCD
+        diagnostics report blocking indeterminate queries consistently while
+        keeping their limiting payloads variant-local.
   - [x] Promote the shared Armijo sufficient-decrease and backtracking scalar
         policy into `detail/newton_barrier` and route rigid IPC plus deformable
         projected-Newton line-search checks through it while keeping
@@ -146,10 +150,11 @@ storage, or backend resources as public API.
    and ABD evidence after the fixed-size PSD projection helper, first
    line-search option/stat helper, shared line-search positive-step predicate,
    shared conservative native-CCD option adapter, shared line-search step-scale
-   helper, and shared Google Benchmark packet row identity helper. Promote
-   projected-Newton result/status terminology, line-search result semantics,
-   diagnostics, or additional benchmark-schema contracts only when a second
-   consumer proves identical behavior.
+   helper, shared native-CCD zero-step diagnostic accounting, and shared Google
+   Benchmark packet row identity helper. Promote projected-Newton result/status
+   terminology, line-search result semantics, diagnostics, or additional
+   benchmark-schema contracts only when a second consumer proves identical
+   behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.
@@ -245,6 +250,11 @@ Phase 3 native-CCD primitive outcome accounting slice local evidence:
 - `pixi run test-all`
 - `pixi run -e cuda test-all` (docs passed with the existing
   `dartpy._world_render_bridge` autodoc warnings)
+
+Phase 3 native-CCD zero-step diagnostic accounting slice local evidence:
+
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives --parallel 8`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_newton_barrier_primitives$'`
 
 Phase 3 sufficient-decrease policy slice local evidence:
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -75,6 +75,9 @@
         `scripts/benchmark_packet_utils.py` and route the ABD comparison packet
         checker plus the Phase 5 GPU packet checker through it while keeping
         packet-specific metadata rules in their owners.
+  - [x] Route the Phase 5 CUDA packet writer through the shared Google
+        Benchmark canonical row identity helper, removing its duplicate row
+        parser while keeping packet-specific max-error extraction local.
   - [ ] Continue scouting projected-Newton, line-search result, diagnostics, or
         benchmark-schema contracts only when another variant needs identical
         behavior.
@@ -137,7 +140,8 @@ storage, or backend resources as public API.
    deformable IPC, and ABD evidence after the fixed-size PSD projection helper,
    first line-search option/stat helper, shared line-search positive-step
    predicate, shared conservative native-CCD option adapter, shared
-   line-search step-scale helper, and shared Google Benchmark packet row parser.
+   line-search step-scale helper, and shared Google Benchmark packet row
+   identity helper.
    Promote projected-Newton result/status terminology, line-search result
    semantics, diagnostics, or additional benchmark-schema contracts only when a
    second consumer proves identical behavior.
@@ -209,6 +213,11 @@ Phase 3 line-search positive-step predicate slice local evidence:
 - `pixi run lint`
 
 Phase 3 benchmark packet utility slice local evidence:
+
+- `pixi run python -m pytest tests/test_benchmark_packet_utils.py`
+- `pixi run lint`
+
+Phase 3 benchmark row identity slice local evidence:
 
 - `pixi run python -m pytest tests/test_benchmark_packet_utils.py`
 - `pixi run lint`

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -108,6 +108,11 @@ storage, or backend resources as public API.
 ## Key Decisions
 
 - Phase 1 is an internal ownership and contract slice, not a behavior change.
+- Batch all work within one implementation-roadmap phase into a single branch
+  and PR. Commits within the branch stay atomic and self-describing, but the PR
+  is the review unit, not the commit. A phase may split into at most two PRs
+  only if it crosses a public-API boundary or touches unrelated CI/build
+  infrastructure.
 - The old `deformable_contact` include paths remain as forwarding
   compatibility headers to avoid unnecessary PLAN-081 merge conflicts.
 - Rigid IPC should include the new Newton-barrier owner directly because it is
@@ -136,15 +141,15 @@ storage, or backend resources as public API.
 
 ## Immediate Next Steps
 
-1. Continue Phase 3 shared-contract scouting from the existing rigid IPC,
-   deformable IPC, and ABD evidence after the fixed-size PSD projection helper,
-   first line-search option/stat helper, shared line-search positive-step
-   predicate, shared conservative native-CCD option adapter, shared
-   line-search step-scale helper, and shared Google Benchmark packet row
-   identity helper.
-   Promote projected-Newton result/status terminology, line-search result
-   semantics, diagnostics, or additional benchmark-schema contracts only when a
-   second consumer proves identical behavior.
+1. Collect remaining Phase 3 shared-contract scouting into the current branch
+   and open one PR for the phase. Use the existing rigid IPC, deformable IPC,
+   and ABD evidence after the fixed-size PSD projection helper, first
+   line-search option/stat helper, shared line-search positive-step predicate,
+   shared conservative native-CCD option adapter, shared line-search step-scale
+   helper, and shared Google Benchmark packet row identity helper. Promote
+   projected-Newton result/status terminology, line-search result semantics,
+   diagnostics, or additional benchmark-schema contracts only when a second
+   consumer proves identical behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -63,7 +63,9 @@ lookup, and timing-field validation now live in
 `scripts/benchmark_packet_utils.py`. The ABD comparison packet checker and the
 Phase 5 GPU packet checker share those row-level rules while keeping their
 packet-specific expected rows, metadata, speedup gates, and evidence flags in
-their variant owners.
+their variant owners. The shared canonical row identity helper is also consumed
+by the Phase 5 CUDA packet writer so packet generation and validation strip
+Google Benchmark repeat/aggregate suffixes the same way.
 
 The native-CCD primitive outcome accounting scout promoted only the outcome
 accounting that is identical across rigid IPC and deformable CCD: hit/miss/
@@ -116,9 +118,10 @@ The benchmark-packet utility slice merged as PR #2940. It promoted
 Google Benchmark row parsing into `scripts/benchmark_packet_utils.py`, routing
 the ABD comparison packet checker plus the Phase 5 GPU packet checker through
 the shared utility while keeping packet-specific metadata and gates in their
-owners. Focused local validation passed
-`pixi run python -m pytest tests/test_benchmark_packet_utils.py` and
-`pixi run lint`.
+owners. The follow-up row-identity slice routes the Phase 5 CUDA packet writer
+through the same canonical row identity helper and removes its duplicate parser.
+Focused local validation passed `pixi run python -m pytest
+tests/test_benchmark_packet_utils.py` and `pixi run lint`.
 
 The line-search step-scale slice merged as PR #2943. It is intentionally
 smaller than a line-search result or projected-Newton diagnostics merge:
@@ -208,8 +211,9 @@ VBD/OGC-adjacent work, or shared Newton-barrier infrastructure.
   result structs there until rigid, deformable, ABD, or another variant prove
   identical result semantics.
 - `scripts/benchmark_packet_utils.py` owns the shared Google Benchmark row
-  parsing utilities for packet validators. Keep packet-specific metadata and
-  go/no-go gates in each checker until more variants prove identical semantics.
+  parsing utilities for packet validators and writers. Keep packet-specific
+  metadata and go/no-go gates in each checker until more variants prove
+  identical semantics.
 - `bm_affine_body_dynamics` currently contains the first ABD benchmark packet:
   affine point-triangle barrier mapping, matched rigid IPC point-triangle oracle
   row, and orthogonality energy.

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -2,6 +2,11 @@
 
 ## Current Reality (2026-06-08)
 
+PR granularity: batch all work within one implementation-roadmap phase into a
+single branch and PR. Keep commits atomic within the branch. A phase may split
+into at most two PRs only when it crosses a public-API boundary or touches
+unrelated CI/build infrastructure.
+
 Use this folder's `README.md`, PLAN-083, `docs/plans/dashboard.md`, and the
 current code as the live status. The branch-local "Current Branch" section below
 is historical handoff context, not current checkout state. Treat IPC as the
@@ -161,8 +166,9 @@ resume snapshot.
 
 ## Immediate Next Step
 
-Finish the sufficient-decrease policy slice against `main`, then continue Phase
-3 from
+With the sufficient-decrease policy slice merged to `main`, collect remaining
+Phase 3 work into the current branch and open one PR for the phase. Continue
+from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
 resume shared-contract scouting from the existing rigid IPC, deformable IPC,
 ABD, and benchmark-packet evidence. Do not add a two-body affine contact

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -79,6 +79,12 @@ indeterminate counter updates, hit and indeterminate time-of-impact clamping to
 indeterminate-result policy, and line-search result structs remain
 variant-local.
 
+The native-CCD zero-step diagnostic follow-up keeps that shared accounting
+contract honest for indeterminate primitive queries: if a native CCD backend can
+only prove an indeterminate zero step, `detail/newton_barrier` now increments
+the same zero-step counter used for zero-time hits. Rigid IPC and deformable CCD
+still own their distinct limiting payloads and indeterminate-result policies.
+
 ## Last Session Summary
 
 Current slice: the first ABD benchmark packet has been promoted from

--- a/docs/plans/083-unified-newton-barrier-multibody/implementation-roadmap.md
+++ b/docs/plans/083-unified-newton-barrier-multibody/implementation-roadmap.md
@@ -29,6 +29,15 @@ CPU-only work may land first when that keeps reviewable slices small. It is not
 the final target. GPU work stays private and benchmark-gated until same-scene
 CPU/GPU parity and timing packets exist.
 
+## PR Discipline
+
+Each implementation-roadmap phase should produce one PR. Commits within the
+phase branch stay atomic and self-describing. A second PR per phase is justified
+only if the phase crosses a public-API boundary or touches unrelated CI/build
+infrastructure that would confuse review. This avoids the review overhead
+observed during Phase 3 (9 PRs for one checklist phase) while preserving
+git-bisect-friendly commit history.
+
 ## Phase 0: Current Foundation
 
 Current branch evidence:

--- a/scripts/benchmark_packet_utils.py
+++ b/scripts/benchmark_packet_utils.py
@@ -23,6 +23,11 @@ def benchmark_row_name(row: Mapping[str, Any]) -> str:
     return name if isinstance(name, str) else ""
 
 
+def canonical_benchmark_row_name(row: Mapping[str, Any]) -> str:
+    """Return the canonical Google Benchmark row identity."""
+    return canonical_benchmark_name(benchmark_row_name(row))
+
+
 def timing_to_ns(value: float, unit: str) -> float:
     return value * _UNIT_TO_NS.get(unit, 1.0)
 
@@ -42,7 +47,7 @@ def median_timing_by_name(rows: Iterable[Mapping[str, Any]]) -> dict[str, float]
     for row in rows:
         if row.get("aggregate_name") != "median":
             continue
-        name = canonical_benchmark_name(benchmark_row_name(row))
+        name = canonical_benchmark_row_name(row)
         if not name:
             continue
         timing = benchmark_timing_ns(row)

--- a/scripts/check_abd_comparison_packet.py
+++ b/scripts/check_abd_comparison_packet.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from benchmark_packet_utils import (
     benchmark_row_name,
     benchmark_timing_field_errors,
-    canonical_benchmark_name,
+    canonical_benchmark_row_name,
 )
 
 EXPECTED_BENCHMARKS = {
@@ -95,7 +95,7 @@ def validate_packet(path: Path) -> None:
         if not name:
             errors.append("benchmark row is missing a string name")
             continue
-        base_name = canonical_benchmark_name(name)
+        base_name = canonical_benchmark_row_name(row)
         if base_name not in EXPECTED_BENCHMARKS:
             errors.append(f"unexpected benchmark row: {name}")
             continue

--- a/scripts/write_phase5_cuda_packet.py
+++ b/scripts/write_phase5_cuda_packet.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import re
 import sys
 from pathlib import Path
 
@@ -15,11 +14,9 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 import check_phase5_gpu_packet as packet_check
+from benchmark_packet_utils import canonical_benchmark_row_name
 
 DEFAULT_OUTPUT = Path(".benchmark_results/phase5_cuda_packet.json")
-
-_AGGREGATE_SUFFIX_RE = re.compile(r"_(?:mean|median|stddev|cv)$")
-_REPEATS_SUFFIX_RE = re.compile(r"/repeats:\d+")
 
 
 class Phase5CudaPacketError(RuntimeError):
@@ -96,15 +93,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _canonical_name(name: str) -> str:
-    return _AGGREGATE_SUFFIX_RE.sub("", _REPEATS_SUFFIX_RE.sub("", name))
-
-
-def _row_name(row: dict) -> str:
-    name = row.get("run_name", row.get("name", ""))
-    return name if isinstance(name, str) else ""
-
-
 def _load_benchmark_json(path: Path) -> dict:
     with path.open(encoding="utf-8") as f:
         data = json.load(f)
@@ -125,7 +113,7 @@ def _matching_rows(
     step_count: int,
 ) -> list[dict]:
     target = f"{prefix}/{world_count}/{body_count}/{step_count}"
-    return [row for row in rows if _canonical_name(_row_name(row)) == target]
+    return [row for row in rows if canonical_benchmark_row_name(row) == target]
 
 
 def _finite_counter(row: dict, key: str) -> float | None:

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -39,6 +39,16 @@ def test_canonical_benchmark_name_strips_google_benchmark_suffixes():
     assert utils.canonical_benchmark_name("BM_Test/8/4_cv") == "BM_Test/8/4"
 
 
+def test_canonical_benchmark_row_name_prefers_run_name():
+    utils = load_script_module("benchmark_packet_utils")
+    row = {
+        "name": "BM_Ignored",
+        "run_name": "BM_Test/8/4/repeats:3_median",
+    }
+
+    assert utils.canonical_benchmark_row_name(row) == "BM_Test/8/4"
+
+
 def test_median_timing_by_name_prefers_positive_median_rows():
     utils = load_script_module("benchmark_packet_utils")
     rows = [
@@ -92,6 +102,35 @@ def test_phase5_packet_validator_uses_shared_canonical_rows():
     assert summary["cpu_median_ns"] == 4_000_000.0
     assert summary["gpu_median_ns"] == 2_000_000.0
     assert summary["speedup"] == 2.0
+
+
+def test_phase5_cuda_packet_writer_uses_shared_canonical_rows():
+    writer = load_script_module("write_phase5_cuda_packet")
+    rows = [
+        aggregate_row(
+            "BM_Phase5RigidBodyBatchGpu/4096/128/100/repeats:3_mean",
+            "mean",
+            1.0,
+        ),
+        aggregate_row(
+            "BM_Phase5RigidBodyBatchGpu/4096/128/100/repeats:3_median",
+            "median",
+            1.0,
+            run_name=False,
+        ),
+    ]
+    rows[0]["max_final_state_abs_error"] = 1e-9
+    rows[1]["max_final_state_abs_error"] = 1e-12
+
+    max_error = writer.extract_max_final_state_abs_error(
+        rows,
+        gpu_prefix="BM_Phase5RigidBodyBatchGpu",
+        world_count=4096,
+        body_count=128,
+        step_count=100,
+    )
+
+    assert max_error == 1e-12
 
 
 def test_abd_packet_validator_uses_shared_row_validation(tmp_path, capsys):

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -350,6 +350,18 @@ TEST(NewtonBarrierPrimitives, LineSearchCcdOutcomeAccountsNativeStatus)
   EXPECT_EQ(stats.hits, 1u);
   EXPECT_EQ(stats.misses, 1u);
   EXPECT_EQ(stats.indeterminate, 1u);
+  EXPECT_EQ(stats.zeroStepCount, 0u);
+
+  indeterminate.timeOfImpact = -0.25;
+  const auto zeroIndeterminateOutcome
+      = nb::recordLineSearchCcdOutcome(stats, indeterminate);
+  EXPECT_FALSE(zeroIndeterminateOutcome.hit);
+  EXPECT_TRUE(zeroIndeterminateOutcome.indeterminate);
+  EXPECT_DOUBLE_EQ(zeroIndeterminateOutcome.stepBound, 0.0);
+  EXPECT_EQ(stats.hits, 1u);
+  EXPECT_EQ(stats.misses, 1u);
+  EXPECT_EQ(stats.indeterminate, 2u);
+  EXPECT_EQ(stats.zeroStepCount, 1u);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Share a canonical Google Benchmark row identity helper in `scripts/benchmark_packet_utils.py`.
- Route the ABD packet checker and Phase 5 CUDA packet writer through that shared helper.
- Count indeterminate native-CCD zero-step outcomes through the shared Newton-barrier line-search accounting helper.
- Add PLAN-083 guidance that future implementation-roadmap phases should be reviewed as one PR per phase.

## Motivation / Problem

- PLAN-083 now has multiple benchmark packet producers and validators that need identical Google Benchmark repeat/aggregate suffix handling.
- `scripts/write_phase5_cuda_packet.py` still had a local duplicate row parser, which could drift from the packet validators.
- Rigid IPC and deformable CCD both consume shared line-search accounting, but indeterminate zero-step outcomes were not counted in the shared zero-step diagnostic.
- Phase 3 also produced many small internal shared-contract PRs for one checklist phase; future PLAN-083 work should keep commits atomic while using the phase PR as the review unit.

## Changes / Key Changes

- Adds `canonical_benchmark_row_name(row)` alongside the existing row-name canonicalizer.
- Uses the shared row identity in median timing lookup, ABD packet row validation, and Phase 5 CUDA max-error extraction.
- Extends focused packet utility tests for `run_name` precedence and Phase 5 CUDA packet writer canonical matching.
- Updates `recordLineSearchCcdOutcome` so zero-step indeterminate native CCD outcomes increment `LineSearchStats::zeroStepCount`, with focused primitive coverage.
- Records phase-scoped PR discipline and the diagnostic follow-up in the active PLAN-083 dev-task docs.

## Testing

- `pixi run test-all`
- `pixi run -e cuda test-all`
- `pixi run python -m pytest tests/test_benchmark_packet_utils.py`
- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives --parallel 8`
- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_newton_barrier_primitives$'`
- `pixi run lint`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows #2947 in the PLAN-083 shared Newton-barrier stack.
- Folded in #2949 per maintainer direction; #2949 is closed and its branch was removed.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (N/A: internal tooling/docs guidance and internal diagnostics, no release-facing change)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: no public API changes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no API changes)
