### PR TITLE
Document PLAN-083 phase PR discipline

### DIFF
--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -105,6 +105,11 @@ storage, or backend resources as public API.
 ## Key Decisions
 
 - Phase 1 is an internal ownership and contract slice, not a behavior change.
+- Batch all work within one implementation-roadmap phase into a single branch
+  and PR. Commits within the branch stay atomic and self-describing, but the PR
+  is the review unit, not the commit. A phase may split into at most two PRs
+  only if it crosses a public-API boundary or touches unrelated CI/build
+  infrastructure.
 - The old `deformable_contact` include paths remain as forwarding
   compatibility headers to avoid unnecessary PLAN-081 merge conflicts.
 - Rigid IPC should include the new Newton-barrier owner directly because it is
@@ -133,14 +138,15 @@ storage, or backend resources as public API.
 
 ## Immediate Next Steps
 
-1. Continue Phase 3 shared-contract scouting from the existing rigid IPC,
-   deformable IPC, and ABD evidence after the fixed-size PSD projection helper,
-   first line-search option/stat helper, shared line-search positive-step
-   predicate, shared conservative native-CCD option adapter, shared
-   line-search step-scale helper, and shared Google Benchmark packet row parser.
-   Promote projected-Newton result/status terminology, line-search result
-   semantics, diagnostics, or additional benchmark-schema contracts only when a
-   second consumer proves identical behavior.
+1. Collect remaining Phase 3 shared-contract scouting into the current branch
+   and open one PR for the phase. Use the existing rigid IPC, deformable IPC,
+   and ABD evidence after the fixed-size PSD projection helper, first
+   line-search option/stat helper, shared line-search positive-step predicate,
+   shared conservative native-CCD option adapter, shared line-search step-scale
+   helper, and shared Google Benchmark packet row parser. Promote
+   projected-Newton result/status terminology, line-search result semantics,
+   diagnostics, or additional benchmark-schema contracts only when a second
+   consumer proves identical behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -2,6 +2,11 @@
 
 ## Current Reality (2026-06-08)
 
+PR granularity: batch all work within one implementation-roadmap phase into a
+single branch and PR. Keep commits atomic within the branch. A phase may split
+into at most two PRs only when it crosses a public-API boundary or touches
+unrelated CI/build infrastructure.
+
 Use this folder's `README.md`, PLAN-083, `docs/plans/dashboard.md`, and the
 current code as the live status. The branch-local "Current Branch" section below
 is historical handoff context, not current checkout state. Treat IPC as the
@@ -158,8 +163,9 @@ resume snapshot.
 
 ## Immediate Next Step
 
-Finish the sufficient-decrease policy slice against `main`, then continue Phase
-3 from
+With the sufficient-decrease policy slice merged to `main`, collect remaining
+Phase 3 work into the current branch and open one PR for the phase. Continue
+from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
 resume shared-contract scouting from the existing rigid IPC, deformable IPC,
 ABD, and benchmark-packet evidence. Do not add a two-body affine contact

--- a/docs/plans/083-unified-newton-barrier-multibody/implementation-roadmap.md
+++ b/docs/plans/083-unified-newton-barrier-multibody/implementation-roadmap.md
@@ -29,6 +29,15 @@ CPU-only work may land first when that keeps reviewable slices small. It is not
 the final target. GPU work stays private and benchmark-gated until same-scene
 CPU/GPU parity and timing packets exist.
 
+## PR Discipline
+
+Each implementation-roadmap phase should produce one PR. Commits within the
+phase branch stay atomic and self-describing. A second PR per phase is justified
+only if the phase crosses a public-API boundary or touches unrelated CI/build
+infrastructure that would confuse review. This avoids the review overhead
+observed during Phase 3 (9 PRs for one checklist phase) while preserving
+git-bisect-friendly commit history.
+
 ## Phase 0: Current Foundation
 
 Current branch evidence:


### PR DESCRIPTION
## Summary

- Add PLAN-083 guidance that future implementation-roadmap phases should be reviewed as one PR per phase.
- Record the same rule in the active dev-task README, resume handoff, and implementation roadmap.

## Motivation / Problem

- Phase 3 produced many small internal shared-contract PRs for one checklist phase.
- Future PLAN-083 work should keep commits atomic while using the phase PR as the review unit, reducing review overhead without losing bisect-friendly history.

## Changes / Key Changes

- Adds a `Key Decisions` bullet in the active PLAN-083 dev task for phase-scoped PRs.
- Rewords the active Phase 3 next step to collect remaining Phase 3 work into one branch and PR.
- Adds a `PR Discipline` section to the PLAN-083 implementation roadmap.

## Testing

- `pixi run lint`
- `git diff --check`
- `git diff --stat`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows the PLAN-083 Phase 3 PR series.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (N/A: docs-only steering guidance)
- [x] Add unit tests for new functionality (N/A: docs-only steering guidance)
- [x] Document new methods and classes (N/A: no API changes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no API changes)
