### PR TITLE
Close PLAN-083 Phase 3 shared-contract scouting

### DIFF
--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -6818,6 +6818,8 @@ void advanceDeformableBody(
     constexpr double gradientToleranceSquared = 1e-18;
     constexpr double armijo = nb::kDefaultSufficientDecreaseFactor;
     constexpr double minStep = 1e-12;
+    const double backtrackingScale
+        = nb::sanitizeBacktrackingScale(nb::kDefaultBacktrackingScale);
 
     double lastGradSquared = 0.0;
     double lastAcceptedStepInfinityNorm = 0.0;
@@ -7079,7 +7081,7 @@ void advanceDeformableBody(
           }
 
           ++stats.rejectedLineSearchCandidates;
-          step *= 0.5;
+          step *= backtrackingScale;
           if (step < minStep) {
             break;
           }

--- a/dart/simulation/detail/rigid_ipc_barrier.hpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.hpp
@@ -251,8 +251,9 @@ struct RigidIpcProjectedNewtonOptions
   /// candidate, the solve accepts that best decreasing candidate rather than
   /// treating the step as an unsafe CCD block.
   bool useSufficientDecreaseLineSearch = true;
-  double sufficientDecreaseFactor = 1e-4;
-  double backtrackingScale = 0.5;
+  double sufficientDecreaseFactor
+      = newton_barrier::kDefaultSufficientDecreaseFactor;
+  double backtrackingScale = newton_barrier::kDefaultBacktrackingScale;
   std::size_t maxBacktrackingIterations = 16;
 };
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -35,7 +35,7 @@
         `abd-alg-affine-body` comparison row. Add
         `pixi run bm-abd-comparison-packet` to generate/validate
         `.benchmark_results/abd_comparison_packet.json`.
-- [ ] Phase 3: generalize second-use PSD projection and projected-Newton
+- [x] Phase 3: generalize second-use PSD projection and projected-Newton
       contracts when ABD or another solver-family slice needs the shared
       contract; use the PLAN-083 variant consolidation map to keep IPC-family
       responsibilities in the right owner while promoting only proven
@@ -82,9 +82,12 @@
   - [x] Route the Phase 5 CUDA packet writer through the shared Google
         Benchmark canonical row identity helper, removing its duplicate row
         parser while keeping packet-specific max-error extraction local.
-  - [ ] Continue scouting projected-Newton, line-search result, diagnostics, or
-        benchmark-schema contracts only when another variant needs identical
-        behavior.
+  - [x] Close the remaining Phase 3 scouting by routing deformable
+        projected-Newton backtracking through the shared Newton-barrier default
+        scale while leaving projected-Newton result/status terminology,
+        line-search result semantics, diagnostics, and additional
+        benchmark-schema contracts variant-local until another consumer proves
+        identical behavior.
 - [ ] Phase 4: expand the unified manifest into diagnostics, benchmark packets,
       CPU/GPU evidence, and visual evidence rows.
 - [ ] Phase 5: add runtime and py-demos scenes only after the relevant solver
@@ -145,16 +148,12 @@ storage, or backend resources as public API.
 
 ## Immediate Next Steps
 
-1. Collect remaining Phase 3 shared-contract scouting into the current branch
-   and open one PR for the phase. Use the existing rigid IPC, deformable IPC,
-   and ABD evidence after the fixed-size PSD projection helper, first
-   line-search option/stat helper, shared line-search positive-step predicate,
-   shared conservative native-CCD option adapter, shared line-search step-scale
-   helper, shared native-CCD zero-step diagnostic accounting, and shared Google
-   Benchmark packet row identity helper. Promote projected-Newton result/status
-   terminology, line-search result semantics, diagnostics, or additional
-   benchmark-schema contracts only when a second consumer proves identical
-   behavior.
+1. Start Phase 4 manifest expansion: add diagnostics and benchmark-packet rows
+   only where the current rigid IPC, deformable IPC, and ABD evidence has a
+   concrete artifact to validate. Keep projected-Newton result/status
+   terminology, line-search result semantics, diagnostics, and additional
+   benchmark-schema contracts variant-local until a second consumer proves
+   identical behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.
@@ -261,6 +260,12 @@ Phase 3 sufficient-decrease policy slice local evidence:
 - `pixi run lint`
 - `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel <safe-jobs>`
 - `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
+
+Phase 3 closeout local evidence:
+
+- `pixi run lint`
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_world --parallel 8`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_world)$'`
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -84,7 +84,8 @@
         parser while keeping packet-specific max-error extraction local.
   - [x] Close the remaining Phase 3 scouting by routing deformable
         projected-Newton backtracking through the shared Newton-barrier default
-        scale while leaving projected-Newton result/status terminology,
+        scale and rigid IPC's option defaults through the same shared scalar
+        constants while leaving projected-Newton result/status terminology,
         line-search result semantics, diagnostics, and additional
         benchmark-schema contracts variant-local until another consumer proves
         identical behavior.
@@ -264,8 +265,8 @@ Phase 3 sufficient-decrease policy slice local evidence:
 Phase 3 closeout local evidence:
 
 - `pixi run lint`
-- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_world --parallel 8`
-- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_world)$'`
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel 8`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -86,10 +86,10 @@ the same zero-step counter used for zero-time hits. Rigid IPC and deformable CCD
 still own their distinct limiting payloads and indeterminate-result policies.
 
 The Phase 3 closeout routes deformable projected-Newton backtracking through
-the shared Newton-barrier default scale, matching rigid IPC's shared
-backtracking scalar policy without moving projected-Newton result/status
-terminology, line-search result payloads, solver diagnostics, or additional
-benchmark-schema contracts out of their variant owners.
+the shared Newton-barrier default scale and routes rigid IPC's option defaults
+through the same shared scalar constants without moving projected-Newton
+result/status terminology, line-search result payloads, solver diagnostics, or
+additional benchmark-schema contracts out of their variant owners.
 
 ## Last Session Summary
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -85,6 +85,12 @@ only prove an indeterminate zero step, `detail/newton_barrier` now increments
 the same zero-step counter used for zero-time hits. Rigid IPC and deformable CCD
 still own their distinct limiting payloads and indeterminate-result policies.
 
+The Phase 3 closeout routes deformable projected-Newton backtracking through
+the shared Newton-barrier default scale, matching rigid IPC's shared
+backtracking scalar policy without moving projected-Newton result/status
+terminology, line-search result payloads, solver diagnostics, or additional
+benchmark-schema contracts out of their variant owners.
+
 ## Last Session Summary
 
 Current slice: the first ABD benchmark packet has been promoted from
@@ -172,13 +178,13 @@ resume snapshot.
 
 ## Immediate Next Step
 
-With the sufficient-decrease policy slice merged to `main`, collect remaining
-Phase 3 work into the current branch and open one PR for the phase. Continue
-from
+With Phase 3 shared-contract scouting closed, start Phase 4 manifest expansion.
+Continue from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-resume shared-contract scouting from the existing rigid IPC, deformable IPC,
-ABD, and benchmark-packet evidence. Do not add a two-body affine contact
-micro-solve for the current
+use the existing rigid IPC, deformable IPC, ABD, and benchmark-packet evidence
+to add diagnostics and benchmark-packet rows only where a concrete artifact can
+validate the row. Do not add a two-body affine contact micro-solve for the
+current
 `abd-alg-affine-body` micro-packet; add
 projected-Newton, line-search result semantics, diagnostics, or
 benchmark-schema contracts only after second-use behavior is proven identical

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -289,7 +289,10 @@ its own line so status updates remain git-history friendly.
   sidecar to keep deformable IPC, codimensional IPC, rigid IPC, ABD, PD-IPC,
   SPB, and VBD/OGC-adjacent obligations in the right owners. Generalize PSD
   projection, projected-Newton, line-search, diagnostics, and benchmark schemas
-  only when second-use evidence proves a shared contract.
+  only when second-use evidence proves a shared contract. With Phase 3
+  shared-contract scouting closed, start Phase 4 manifest expansion by adding
+  diagnostics and benchmark-packet rows only where a concrete artifact can
+  validate the row.
 - Gate: Unified Newton-barrier progress is not complete until every cited
   paper/deck figure, unit test, benchmark table, and comparison scene is mapped
   to DART-owned tests, py-demos examples, benchmark/profiling packets, CPU and


### PR DESCRIPTION
## Summary

- Route deformable projected-Newton backtracking through the shared Newton-barrier default backtracking scale.
- Route rigid IPC line-search option defaults through the same shared Newton-barrier scalar constants.
- Mark PLAN-083 Phase 3 shared-contract scouting complete and move the handoff to Phase 4 manifest expansion.

## Motivation / Problem

- Phase 3 had one remaining shared-contract scouting item after the merged line-search and benchmark contract slices.
- Deformable projected-Newton still used a literal `0.5` trial-step reduction, and rigid IPC option defaults still spelled out the same shared sufficient-decrease/backtracking defaults, even though the shared Newton-barrier owner already defines those scalar policies.

## Changes / Key Changes

- Use `newton_barrier::sanitizeBacktrackingScale(kDefaultBacktrackingScale)` for the deformable projected-Newton line-search step reduction.
- Use the shared Newton-barrier sufficient-decrease and backtracking default constants in rigid IPC projected-Newton options.
- Update the PLAN-083 dev-task README and RESUME to close Phase 3 and point next work at Phase 4 diagnostics/benchmark manifest rows.
- Update the PLAN dashboard PLAN-083 next step to reflect the Phase 4 handoff.

## Testing

- `pixi run lint`
- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel 8`
- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- PLAN-083 follow-up after #2948

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
