### PR TITLE
Complete PLAN-083 Phase 2 shared solver contracts

### DIFF
--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -6818,6 +6818,8 @@ void advanceDeformableBody(
     constexpr double gradientToleranceSquared = 1e-18;
     constexpr double armijo = nb::kDefaultSufficientDecreaseFactor;
     constexpr double minStep = 1e-12;
+    const double backtrackingScale
+        = nb::sanitizeBacktrackingScale(nb::kDefaultBacktrackingScale);
 
     double lastGradSquared = 0.0;
     double lastAcceptedStepInfinityNorm = 0.0;
@@ -7079,7 +7081,7 @@ void advanceDeformableBody(
           }
 
           ++stats.rejectedLineSearchCandidates;
-          step *= 0.5;
+          step *= backtrackingScale;
           if (step < minStep) {
             break;
           }

--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -58,6 +58,7 @@
 #include "dart/simulation/detail/deformable_vbd/parallel_block_descent.hpp"
 #include "dart/simulation/detail/deformable_vbd/rigid_world_contact.hpp"
 #include "dart/simulation/detail/entity_conversion.hpp"
+#include "dart/simulation/detail/newton_barrier/friction_kernel.hpp"
 #include "dart/simulation/detail/newton_barrier/projected_newton.hpp"
 #include "dart/simulation/detail/newton_barrier/psd_backend.hpp"
 #include "dart/simulation/detail/rigid_ipc_barrier.hpp"
@@ -3845,9 +3846,12 @@ void accumulateFrictionDiagnostics(
                                   : Eigen::Vector3d::UnitZ();
     const Eigen::Vector3d u = positions[i] - stepStart[i];
     const double y = (u - n.dot(u) * n).norm();
-    dissipation += frictionCoefficient * groundNormalForce[i]
-                   * frictionF1(y, epsilon) * y;
-    ++activeContacts;
+    const auto contribution = nb::frictionWorkContribution(
+        y, frictionCoefficient * groundNormalForce[i], epsilon);
+    if (contribution.active) {
+      dissipation += contribution.work;
+      ++activeContacts;
+    }
   }
 
   for (const auto& contact : selfContacts) {
@@ -3860,9 +3864,12 @@ void accumulateFrictionDiagnostics(
           = positions[contact.nodes[k]] - stepStart[contact.nodes[k]];
     }
     const double y = (contact.projection * displacement).norm();
-    dissipation += frictionCoefficient * contact.normalForce
-                   * frictionF1(y, epsilon) * y;
-    ++activeContacts;
+    const auto contribution = nb::frictionWorkContribution(
+        y, frictionCoefficient * contact.normalForce, epsilon);
+    if (contribution.active) {
+      dissipation += contribution.work;
+      ++activeContacts;
+    }
   }
 }
 

--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -58,6 +58,7 @@
 #include "dart/simulation/detail/deformable_vbd/parallel_block_descent.hpp"
 #include "dart/simulation/detail/deformable_vbd/rigid_world_contact.hpp"
 #include "dart/simulation/detail/entity_conversion.hpp"
+#include "dart/simulation/detail/newton_barrier/projected_newton.hpp"
 #include "dart/simulation/detail/newton_barrier/psd_backend.hpp"
 #include "dart/simulation/detail/rigid_ipc_barrier.hpp"
 #include "dart/simulation/detail/world_registry_access.hpp"
@@ -6815,7 +6816,7 @@ void advanceDeformableBody(
   } else {
     constexpr std::size_t maxIterations = 64;
     constexpr std::size_t maxLineSearchIterations = 16;
-    constexpr double gradientToleranceSquared = 1e-18;
+    constexpr double gradientTolerance = 1e-9;
     constexpr double armijo = nb::kDefaultSufficientDecreaseFactor;
     constexpr double minStep = 1e-12;
     const double backtrackingScale
@@ -6944,7 +6945,8 @@ void advanceDeformableBody(
       const double gradSquared
           = gradientNormSquared(scratch.gradient, scratch.activeFixed);
       lastGradSquared = gradSquared;
-      if (gradSquared <= gradientToleranceSquared) {
+      if (nb::projectedNewtonSquaredResidualConverged(
+              gradSquared, gradientTolerance)) {
         brokeEarly = true;
         break;
       }
@@ -7239,8 +7241,9 @@ void advanceDeformableBody(
     // Record the worst-case solve residual across the step's bodies (the
     // gradient norm at termination), a convergence diagnostic for the
     // benchmark statistics.
-    stats.finalGradientResidualNorm
-        = std::max(stats.finalGradientResidualNorm, std::sqrt(lastGradSquared));
+    stats.finalGradientResidualNorm = std::max(
+        stats.finalGradientResidualNorm,
+        nb::projectedNewtonResidualNormFromSquared(lastGradSquared));
     // Converged-ness measure that stays meaningful for stiff barrier problems:
     // the worst-case last accepted step (infinity norm) across the step's
     // bodies. It tends to zero at equilibrium even when the gradient residual

--- a/dart/simulation/detail/affine_body_dynamics.cpp
+++ b/dart/simulation/detail/affine_body_dynamics.cpp
@@ -129,6 +129,7 @@ chainPrimitiveFrictionToAffineBodies(
 {
   AffinePrimitiveFrictionResult result;
   result.value = potential.value;
+  result.work = potential.work;
   result.tangentialDisplacement = potential.tangentialDisplacement;
   result.tangentialDisplacementNorm = potential.tangentialDisplacementNorm;
   result.weight = potential.weight;

--- a/dart/simulation/detail/affine_body_dynamics.hpp
+++ b/dart/simulation/detail/affine_body_dynamics.hpp
@@ -105,6 +105,7 @@ struct AffinePrimitiveBarrierResult
 struct AffinePrimitiveFrictionResult
 {
   double value = 0.0;
+  double work = 0.0;
   AffineVector24d gradient = AffineVector24d::Zero();
   AffineMatrix24d hessian = AffineMatrix24d::Zero();
   Eigen::Vector2d tangentialDisplacement = Eigen::Vector2d::Zero();

--- a/dart/simulation/detail/deformable_contact/continuous_collision_step.hpp
+++ b/dart/simulation/detail/deformable_contact/continuous_collision_step.hpp
@@ -70,6 +70,12 @@ struct ContinuousCollisionStepResult
     return newton_barrier::allowsPositiveLineSearchStep(
         stepBound, indeterminate);
   }
+
+  [[nodiscard]] bool allowsFullStep() const noexcept
+  {
+    return newton_barrier::allowsFullLineSearchStep(
+        stepBound, hit, indeterminate);
+  }
 };
 
 /// Conservative step bound for one moving point-triangle pair.

--- a/dart/simulation/detail/newton_barrier/friction_kernel.hpp
+++ b/dart/simulation/detail/newton_barrier/friction_kernel.hpp
@@ -49,6 +49,7 @@ template <int Columns>
 struct FrictionPotentialResult
 {
   double value = 0.0;
+  double work = 0.0;
   Eigen::Matrix<double, Columns, 1> gradient
       = Eigen::Matrix<double, Columns, 1>::Zero();
   Eigen::Matrix<double, Columns, Columns> hessian
@@ -56,6 +57,13 @@ struct FrictionPotentialResult
   Eigen::Vector2d tangentialDisplacement = Eigen::Vector2d::Zero();
   double tangentialDisplacementNorm = 0.0;
   double weight = 0.0;
+  bool active = false;
+  bool dynamicBranch = false;
+};
+
+struct FrictionWorkContribution
+{
+  double work = 0.0;
   bool active = false;
   bool dynamicBranch = false;
 };
@@ -88,6 +96,33 @@ inline SmoothFrictionNormResult smoothFrictionNorm(
 }
 
 //==============================================================================
+inline FrictionWorkContribution frictionWorkContribution(
+    const double tangentialDisplacementNorm,
+    const double weight,
+    const double staticDisplacement)
+{
+  FrictionWorkContribution contribution;
+  if (!(tangentialDisplacementNorm >= 0.0)
+      || !std::isfinite(tangentialDisplacementNorm) || !(weight > 0.0)
+      || !std::isfinite(weight) || !(staticDisplacement > 0.0)
+      || !std::isfinite(staticDisplacement)) {
+    return contribution;
+  }
+
+  const SmoothFrictionNormResult smooth
+      = smoothFrictionNorm(tangentialDisplacementNorm, staticDisplacement);
+  if (!std::isfinite(smooth.firstDerivative)) {
+    return contribution;
+  }
+
+  contribution.work
+      = weight * smooth.firstDerivative * tangentialDisplacementNorm;
+  contribution.active = true;
+  contribution.dynamicBranch = smooth.dynamicBranch;
+  return contribution;
+}
+
+//==============================================================================
 template <int Columns>
 inline FrictionPotentialResult<Columns> projectedFrictionPotential(
     const Eigen::Matrix<double, 2, Columns>& projection,
@@ -109,6 +144,8 @@ inline FrictionPotentialResult<Columns> projectedFrictionPotential(
       result.tangentialDisplacementNorm, staticDisplacement);
   result.weight = weight;
   result.value = weight * smooth.value;
+  result.work
+      = weight * smooth.firstDerivative * result.tangentialDisplacementNorm;
   result.active = true;
   result.dynamicBranch = smooth.dynamicBranch;
 

--- a/dart/simulation/detail/newton_barrier/line_search.hpp
+++ b/dart/simulation/detail/newton_barrier/line_search.hpp
@@ -86,6 +86,15 @@ struct LineSearchCcdOutcome
   return stepBound > 0.0 && !indeterminate;
 }
 
+[[nodiscard]] inline bool allowsFullLineSearchStep(
+    const double stepBound,
+    const bool limited,
+    const bool indeterminate) noexcept
+{
+  return allowsPositiveLineSearchStep(stepBound, indeterminate)
+         && (!limited || stepBound >= 1.0);
+}
+
 [[nodiscard]] inline double makeLineSearchStepScale(
     const double stepBound, const double safetyScale = 1.0) noexcept
 {

--- a/dart/simulation/detail/newton_barrier/projected_newton.hpp
+++ b/dart/simulation/detail/newton_barrier/projected_newton.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary form, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice and this list of conditions in the documentation
+ *     and/or other materials provided with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+
+#include <cmath>
+
+namespace dart::simulation::detail::newton_barrier {
+
+[[nodiscard]] inline double sanitizeProjectedNewtonTolerance(
+    const double tolerance) noexcept
+{
+  return std::isfinite(tolerance) ? std::max(0.0, tolerance) : 0.0;
+}
+
+[[nodiscard]] inline double projectedNewtonResidualNormFromSquared(
+    const double squaredResidual) noexcept
+{
+  if (!(std::isfinite(squaredResidual) && squaredResidual > 0.0)) {
+    return 0.0;
+  }
+
+  return std::sqrt(squaredResidual);
+}
+
+[[nodiscard]] inline bool projectedNewtonResidualConverged(
+    const double residualNorm, const double tolerance) noexcept
+{
+  return std::isfinite(residualNorm)
+         && residualNorm <= sanitizeProjectedNewtonTolerance(tolerance);
+}
+
+[[nodiscard]] inline bool projectedNewtonSquaredResidualConverged(
+    const double squaredResidual, const double tolerance) noexcept
+{
+  const double sanitizedTolerance = sanitizeProjectedNewtonTolerance(tolerance);
+  return std::isfinite(squaredResidual)
+         && squaredResidual <= sanitizedTolerance * sanitizedTolerance;
+}
+
+[[nodiscard]] inline double projectedNewtonEffectiveGradientTolerance(
+    const double absoluteTolerance,
+    const double relativeTolerance,
+    const double initialGradientNorm) noexcept
+{
+  const double absolute = sanitizeProjectedNewtonTolerance(absoluteTolerance);
+  const double relative = sanitizeProjectedNewtonTolerance(relativeTolerance);
+  const double initial = std::isfinite(initialGradientNorm)
+                             ? std::max(0.0, initialGradientNorm)
+                             : 0.0;
+  return std::max(absolute, relative * initial);
+}
+
+} // namespace dart::simulation::detail::newton_barrier

--- a/dart/simulation/detail/rigid_ipc_barrier.cpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.cpp
@@ -31,6 +31,7 @@
 
 #include <dart/simulation/detail/deformable_contact/candidate_set.hpp>
 #include <dart/simulation/detail/newton_barrier/friction_kernel.hpp>
+#include <dart/simulation/detail/newton_barrier/projected_newton.hpp>
 #include <dart/simulation/detail/newton_barrier/psd_projection.hpp>
 #include <dart/simulation/detail/newton_barrier/tangent_stencil.hpp>
 #include <dart/simulation/detail/rigid_ipc_barrier.hpp>
@@ -883,8 +884,8 @@ RigidIpcProjectedNewtonStep computeRigidIpcProjectedNewtonStepImpl(
     return result;
   }
 
-  const double gradientTolerance = std::max(0.0, options.gradientTolerance);
-  if (result.stats.gradientNorm <= gradientTolerance) {
+  if (newton_barrier::projectedNewtonResidualConverged(
+          result.stats.gradientNorm, options.gradientTolerance)) {
     result.status = RigidIpcProjectedNewtonStatus::Converged;
     result.success = true;
     result.converged = true;
@@ -2365,11 +2366,11 @@ RigidIpcProjectedNewtonSolveResult solveRigidIpcProjectedNewtonBarrierSystem(
       recordSolveAssemblyStats(
           result, frictionIteration == 0u && iteration == 0u);
       if (frictionIteration == 0u && iteration == 0u) {
-        const double relativeFloor
-            = std::max(0.0, options.newton.relativeGradientTolerance)
-              * result.stats.initialGradientNorm;
         newtonOptions.gradientTolerance
-            = std::max(options.newton.gradientTolerance, relativeFloor);
+            = newton_barrier::projectedNewtonEffectiveGradientTolerance(
+                options.newton.gradientTolerance,
+                options.newton.relativeGradientTolerance,
+                result.stats.initialGradientNorm);
       }
 
       RigidIpcProjectedNewtonStep step

--- a/dart/simulation/detail/rigid_ipc_barrier.cpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.cpp
@@ -2289,8 +2289,7 @@ RigidIpcProjectedNewtonSolveResult solveRigidIpcProjectedNewtonBarrierSystem(
     if (result.lineSearch.limited) {
       ++result.stats.lineSearchLimitedSteps;
     }
-    if (!result.lineSearch.allowsPositiveStep()
-        || (result.lineSearch.limited && result.lineSearch.stepBound < 1.0)) {
+    if (!result.lineSearch.allowsFullStep()) {
       result.status = RigidIpcProjectedNewtonSolveStatus::LineSearchBlocked;
       result.failed = true;
       return false;
@@ -2321,9 +2320,7 @@ RigidIpcProjectedNewtonSolveResult solveRigidIpcProjectedNewtonBarrierSystem(
           if (result.lineSearch.limited) {
             ++result.stats.lineSearchLimitedSteps;
           }
-          return result.lineSearch.allowsPositiveStep()
-                 && (!result.lineSearch.limited
-                     || result.lineSearch.stepBound >= 1.0);
+          return result.lineSearch.allowsFullStep();
         };
 
   for (std::size_t frictionIteration = 0;

--- a/dart/simulation/detail/rigid_ipc_barrier.cpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.cpp
@@ -308,6 +308,7 @@ RigidIpcFrictionPotentialResult computeProjectedFrictionPotential(
   }
 
   result.value = potential.value;
+  result.work = potential.work;
   result.gradient.template head<Columns>() = potential.gradient;
   result.hessian.template topLeftCorner<Columns, Columns>() = potential.hessian;
   result.tangentialDisplacement = potential.tangentialDisplacement;

--- a/dart/simulation/detail/rigid_ipc_barrier.hpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.hpp
@@ -212,6 +212,12 @@ struct RigidIpcLineSearchResult
     return newton_barrier::allowsPositiveLineSearchStep(
         stepBound, indeterminate);
   }
+
+  [[nodiscard]] bool allowsFullStep() const noexcept
+  {
+    return newton_barrier::allowsFullLineSearchStep(
+        stepBound, limited, indeterminate);
+  }
 };
 
 enum class RigidIpcProjectedNewtonStatus

--- a/dart/simulation/detail/rigid_ipc_barrier.hpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.hpp
@@ -78,6 +78,7 @@ struct RigidIpcFrictionOptions
 struct RigidIpcFrictionPotentialResult
 {
   double value = 0.0;
+  double work = 0.0;
   RigidIpcVector12d gradient = RigidIpcVector12d::Zero();
   RigidIpcMatrix12d hessian = RigidIpcMatrix12d::Zero();
   Eigen::Vector2d tangentialDisplacement = Eigen::Vector2d::Zero();

--- a/dart/simulation/detail/rigid_ipc_barrier.hpp
+++ b/dart/simulation/detail/rigid_ipc_barrier.hpp
@@ -251,8 +251,9 @@ struct RigidIpcProjectedNewtonOptions
   /// candidate, the solve accepts that best decreasing candidate rather than
   /// treating the step as an unsafe CCD block.
   bool useSufficientDecreaseLineSearch = true;
-  double sufficientDecreaseFactor = 1e-4;
-  double backtrackingScale = 0.5;
+  double sufficientDecreaseFactor
+      = newton_barrier::kDefaultSufficientDecreaseFactor;
+  double backtrackingScale = newton_barrier::kDefaultBacktrackingScale;
   std::size_t maxBacktrackingIterations = 16;
 };
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -75,6 +75,17 @@
         policy into `detail/newton_barrier` and route rigid IPC plus deformable
         projected-Newton line-search checks through it while keeping
         variant-specific acceptance/fallback semantics local.
+  - [x] Promote the shared full-step line-search feasibility predicate into
+        `detail/newton_barrier` and route rigid IPC kinematic feasibility plus
+        deformable CCD result methods through it while keeping limited/hit
+        payloads variant-local.
+  - [x] Promote shared projected-Newton residual/tolerance helpers into
+        `detail/newton_barrier` and route rigid IPC plus deformable
+        convergence diagnostics through them while keeping solver status enums
+        variant-local.
+  - [x] Promote shared lagged-friction work diagnostics into
+        `detail/newton_barrier` and route deformable, rigid IPC, and ABD
+        friction diagnostics through the same smoothed Coulomb work contract.
   - [x] Promote the first shared Google Benchmark packet row parser into
         `scripts/benchmark_packet_utils.py` and route the ABD comparison packet
         checker plus the Phase 5 GPU packet checker through it while keeping
@@ -82,12 +93,16 @@
   - [x] Route the Phase 5 CUDA packet writer through the shared Google
         Benchmark canonical row identity helper, removing its duplicate row
         parser while keeping packet-specific max-error extraction local.
+  - [x] Promote the first benchmark packet timing schema for per-step counts
+        and solver-subphase timing fields into `scripts/benchmark_packet_utils.py`
+        while keeping packet-specific required subphases and go/no-go gates in
+        their owners.
   - [x] Close the remaining Phase 3 scouting by routing deformable
         projected-Newton backtracking through the shared Newton-barrier default
         scale and rigid IPC's option defaults through the same shared scalar
-        constants while leaving projected-Newton result/status terminology,
-        line-search result semantics, diagnostics, and additional
-        benchmark-schema contracts variant-local until another consumer proves
+        constants. The implementation-roadmap Phase 2 shared solver contracts
+        are complete; remaining solver result/status payloads and
+        packet-specific gates stay variant-local until another phase proves
         identical behavior.
 - [ ] Phase 4: expand the unified manifest into diagnostics, benchmark packets,
       CPU/GPU evidence, and visual evidence rows.
@@ -149,12 +164,11 @@ storage, or backend resources as public API.
 
 ## Immediate Next Steps
 
-1. Start Phase 4 manifest expansion: add diagnostics and benchmark-packet rows
-   only where the current rigid IPC, deformable IPC, and ABD evidence has a
-   concrete artifact to validate. Keep projected-Newton result/status
-   terminology, line-search result semantics, diagnostics, and additional
-   benchmark-schema contracts variant-local until a second consumer proves
-   identical behavior.
+1. Merge the latest `origin/main`, run the Phase 2 validation gates, and open
+   one phase-scoped PR for implementation-roadmap Phase 2: Shared Solver
+   Contracts. After that PR lands, start implementation-roadmap Phase 3:
+   Unified Articulation Constraints; do not treat dev-task Phase 4 manifest
+   expansion as the next implementation-roadmap phase.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.
@@ -267,6 +281,13 @@ Phase 3 closeout local evidence:
 - `pixi run lint`
 - `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel 8`
 - `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
+
+Implementation-roadmap Phase 2 branch-local closeout evidence:
+
+- `pixi run lint`
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_affine_body_dynamics test_rigid_ipc_barrier test_world test_deformable_body --parallel <safe-jobs>`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -j <safe-jobs> -R '^(test_newton_barrier_primitives|test_affine_body_dynamics|test_rigid_ipc_barrier|test_world|test_deformable_body)$'`
+- `pixi run python -m pytest tests/test_benchmark_packet_utils.py`
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -35,7 +35,7 @@
         `abd-alg-affine-body` comparison row. Add
         `pixi run bm-abd-comparison-packet` to generate/validate
         `.benchmark_results/abd_comparison_packet.json`.
-- [ ] Phase 3: generalize second-use PSD projection and projected-Newton
+- [x] Phase 3: generalize second-use PSD projection and projected-Newton
       contracts when ABD or another solver-family slice needs the shared
       contract; use the PLAN-083 variant consolidation map to keep IPC-family
       responsibilities in the right owner while promoting only proven
@@ -82,9 +82,12 @@
   - [x] Route the Phase 5 CUDA packet writer through the shared Google
         Benchmark canonical row identity helper, removing its duplicate row
         parser while keeping packet-specific max-error extraction local.
-  - [ ] Continue scouting projected-Newton, line-search result, diagnostics, or
-        benchmark-schema contracts only when another variant needs identical
-        behavior.
+  - [x] Close the remaining Phase 3 scouting by routing deformable
+        projected-Newton backtracking through the shared Newton-barrier default
+        scale while leaving projected-Newton result/status terminology,
+        line-search result semantics, diagnostics, and additional
+        benchmark-schema contracts variant-local until another consumer proves
+        identical behavior.
 - [ ] Phase 4: expand the unified manifest into diagnostics, benchmark packets,
       CPU/GPU evidence, and visual evidence rows.
 - [ ] Phase 5: add runtime and py-demos scenes only after the relevant solver
@@ -145,16 +148,12 @@ storage, or backend resources as public API.
 
 ## Immediate Next Steps
 
-1. Collect remaining Phase 3 shared-contract scouting into the current branch
-   and open one PR for the phase. Use the existing rigid IPC, deformable IPC,
-   and ABD evidence after the fixed-size PSD projection helper, first
-   line-search option/stat helper, shared line-search positive-step predicate,
-   shared conservative native-CCD option adapter, shared line-search step-scale
-   helper, shared native-CCD zero-step diagnostic accounting, and shared Google
-   Benchmark packet row identity helper. Promote projected-Newton result/status
-   terminology, line-search result semantics, diagnostics, or additional
-   benchmark-schema contracts only when a second consumer proves identical
-   behavior.
+1. Start Phase 4 manifest expansion: add diagnostics and benchmark-packet rows
+   only where the current rigid IPC, deformable IPC, and ABD evidence has a
+   concrete artifact to validate. Keep projected-Newton result/status
+   terminology, line-search result semantics, diagnostics, and additional
+   benchmark-schema contracts variant-local until a second consumer proves
+   identical behavior.
 2. Keep the two-body affine contact micro-solve deferred until the
    `abd-alg-affine-body` row expands beyond the primitive/oracle micro-packet
    and needs a solved-state residual or runtime stepping diagnostic.
@@ -261,6 +260,12 @@ Phase 3 sufficient-decrease policy slice local evidence:
 - `pixi run lint`
 - `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel <safe-jobs>`
 - `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
+
+Phase 3 closeout local evidence:
+
+- `pixi run lint`
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_world --parallel 8`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_world)$'`
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -84,7 +84,8 @@
         parser while keeping packet-specific max-error extraction local.
   - [x] Close the remaining Phase 3 scouting by routing deformable
         projected-Newton backtracking through the shared Newton-barrier default
-        scale while leaving projected-Newton result/status terminology,
+        scale and rigid IPC's option defaults through the same shared scalar
+        constants while leaving projected-Newton result/status terminology,
         line-search result semantics, diagnostics, and additional
         benchmark-schema contracts variant-local until another consumer proves
         identical behavior.
@@ -264,8 +265,8 @@ Phase 3 sufficient-decrease policy slice local evidence:
 Phase 3 closeout local evidence:
 
 - `pixi run lint`
-- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_world --parallel 8`
-- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_world)$'`
+- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_rigid_ipc_barrier test_world --parallel 8`
+- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_newton_barrier_primitives|test_rigid_ipc_barrier|test_world)$'`
 
 ## Owner Docs
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -86,10 +86,10 @@ the same zero-step counter used for zero-time hits. Rigid IPC and deformable CCD
 still own their distinct limiting payloads and indeterminate-result policies.
 
 The Phase 3 closeout routes deformable projected-Newton backtracking through
-the shared Newton-barrier default scale, matching rigid IPC's shared
-backtracking scalar policy without moving projected-Newton result/status
-terminology, line-search result payloads, solver diagnostics, or additional
-benchmark-schema contracts out of their variant owners.
+the shared Newton-barrier default scale and routes rigid IPC's option defaults
+through the same shared scalar constants without moving projected-Newton
+result/status terminology, line-search result payloads, solver diagnostics, or
+additional benchmark-schema contracts out of their variant owners.
 
 ## Last Session Summary
 

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -85,6 +85,12 @@ only prove an indeterminate zero step, `detail/newton_barrier` now increments
 the same zero-step counter used for zero-time hits. Rigid IPC and deformable CCD
 still own their distinct limiting payloads and indeterminate-result policies.
 
+The Phase 3 closeout routes deformable projected-Newton backtracking through
+the shared Newton-barrier default scale, matching rigid IPC's shared
+backtracking scalar policy without moving projected-Newton result/status
+terminology, line-search result payloads, solver diagnostics, or additional
+benchmark-schema contracts out of their variant owners.
+
 ## Last Session Summary
 
 Current slice: the first ABD benchmark packet has been promoted from
@@ -172,13 +178,13 @@ resume snapshot.
 
 ## Immediate Next Step
 
-With the sufficient-decrease policy slice merged to `main`, collect remaining
-Phase 3 work into the current branch and open one PR for the phase. Continue
-from
+With Phase 3 shared-contract scouting closed, start Phase 4 manifest expansion.
+Continue from
 [`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-resume shared-contract scouting from the existing rigid IPC, deformable IPC,
-ABD, and benchmark-packet evidence. Do not add a two-body affine contact
-micro-solve for the current
+use the existing rigid IPC, deformable IPC, ABD, and benchmark-packet evidence
+to add diagnostics and benchmark-packet rows only where a concrete artifact can
+validate the row. Do not add a two-body affine contact micro-solve for the
+current
 `abd-alg-affine-body` micro-packet; add
 projected-Newton, line-search result semantics, diagnostics, or
 benchmark-schema contracts only after second-use behavior is proven identical

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -91,6 +91,13 @@ through the same shared scalar constants without moving projected-Newton
 result/status terminology, line-search result payloads, solver diagnostics, or
 additional benchmark-schema contracts out of their variant owners.
 
+The implementation-roadmap Phase 2 closeout is now branch-local on
+`simx/plan083-phase-2-shared-solver-contracts`: full-step line-search
+feasibility, projected-Newton residual/tolerance diagnostics, lagged-friction
+work diagnostics, and benchmark packet timing schema helpers are shared under
+their internal owners with focused cross-variant tests. This completes the
+Shared Solver Contracts phase; do not open more sub-item PRs for this phase.
+
 ## Last Session Summary
 
 Current slice: the first ABD benchmark packet has been promoted from
@@ -171,34 +178,19 @@ build/CTest entries.
 
 ## Current Branch
 
-`simx/shared-newton-barrier-sufficient-decrease` - contains the Phase 3
-Newton-barrier sufficient-decrease policy slice after PR #2946 landed. Verify
-the exact status with `git status --short --branch` because this section is a
-resume snapshot.
+`simx/plan083-phase-2-shared-solver-contracts` - contains the
+implementation-roadmap Phase 2 shared solver contract closeout. It should become
+one phase-scoped PR after merging the latest `origin/main` and rerunning the
+required gates.
 
 ## Immediate Next Step
 
-With Phase 3 shared-contract scouting closed, start Phase 4 manifest expansion.
-Continue from
-[`../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md`](../../plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md):
-use the existing rigid IPC, deformable IPC, ABD, and benchmark-packet evidence
-to add diagnostics and benchmark-packet rows only where a concrete artifact can
-validate the row. Do not add a two-body affine contact micro-solve for the
-current
-`abd-alg-affine-body` micro-packet; add
-projected-Newton, line-search result semantics, diagnostics, or
-benchmark-schema contracts only after second-use behavior is proven identical
-across variants. Use
-[`../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md`](../../plans/083-unified-newton-barrier-multibody/implementation-roadmap.md)
-to keep the Phase 2 packet, shared solver contracts, articulation rows,
-restitution work, mixed-domain coupling, CPU/GPU parity, and py-demos rows
-sequenced without lowering the final completion target. Add a two-body affine
-contact micro-solve only if a later manifest row needs a solved-state residual
-or runtime stepping diagnostic. Use the new
-[`../../plans/083-unified-newton-barrier-multibody/ipc-variant-consolidation.md`](../../plans/083-unified-newton-barrier-multibody/ipc-variant-consolidation.md)
-sidecar when deciding whether a primitive/API/benchmark row belongs to
-deformable IPC, codimensional IPC, rigid IPC, ABD, PD-IPC GPU, SPB recovery,
-VBD/OGC-adjacent work, or shared Newton-barrier infrastructure.
+Merge the latest `origin/main` into
+`simx/plan083-phase-2-shared-solver-contracts`, rerun lint and the focused Phase
+2 validation gates, then open one phase-scoped PR for implementation-roadmap
+Phase 2. After that PR lands, start implementation-roadmap Phase 3: Unified
+Articulation Constraints. Do not start dev-task Phase 4 manifest expansion as a
+substitute for the roadmap Phase 3 articulation work.
 
 ## Context That Would Be Lost
 
@@ -224,14 +216,14 @@ VBD/OGC-adjacent work, or shared Newton-barrier infrastructure.
   `detail/newton_barrier` so rigid IPC and ABD share the same Coulomb smoothing
   branch before reduced/affine chain rules.
 - `detail/newton_barrier/line_search.hpp` owns the shared line-search
-  option/stat types, the positive-step predicate, the conservative native CCD
+  option/stat types, positive/full-step predicates, the conservative native CCD
   option adapter, and the step-scale helpers. Do not move full line-search
   result structs there until rigid, deformable, ABD, or another variant prove
   identical result semantics.
 - `scripts/benchmark_packet_utils.py` owns the shared Google Benchmark row
-  parsing utilities for packet validators and writers. Keep packet-specific
-  metadata and go/no-go gates in each checker until more variants prove
-  identical semantics.
+  parsing utilities plus the per-step/subphase timing schema for packet
+  validators and writers. Keep packet-specific metadata and go/no-go gates in
+  each checker until more variants prove identical semantics.
 - `bm_affine_body_dynamics` currently contains the first ABD benchmark packet:
   affine point-triangle barrier mapping, matched rigid IPC point-triangle oracle
   row, and orthogonality energy.
@@ -263,9 +255,8 @@ sed -n '1,220p' docs/dev_tasks/unified_newton_barrier_multibody/README.md
 sed -n '1,220p' docs/plans/083-unified-newton-barrier-multibody/abd-first-slice-design.md
 ```
 
-Then verify the current branch with lint and the focused line-search helper
-simulation tests. Re-run the focused Python packet tests or
-`pixi run bm-abd-comparison-packet` only if packet utility or ABD checker
-behavior changes beyond the merge. After this slice, continue with Phase 3
-shared-contract scouting; do not describe the micro-packet as a runtime ABD
+Then merge the latest `origin/main`, verify the current branch with lint and
+the focused Phase 2 simulation/Python tests, and open one PR for the whole
+implementation-roadmap Phase 2. After that PR lands, continue with roadmap Phase
+3 articulation constraints; do not describe the micro-packet as a runtime ABD
 solver or a paper-scale performance row.

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -287,12 +287,12 @@ its own line so status updates remain git-history friendly.
   row until a broader ABD packet needs runtime residual evidence. Use the PLAN-083
   [`ipc-variant-consolidation.md`](083-unified-newton-barrier-multibody/ipc-variant-consolidation.md)
   sidecar to keep deformable IPC, codimensional IPC, rigid IPC, ABD, PD-IPC,
-  SPB, and VBD/OGC-adjacent obligations in the right owners. Generalize PSD
-  projection, projected-Newton, line-search, diagnostics, and benchmark schemas
-  only when second-use evidence proves a shared contract. With Phase 3
-  shared-contract scouting closed, start Phase 4 manifest expansion by adding
-  diagnostics and benchmark-packet rows only where a concrete artifact can
-  validate the row.
+  SPB, and VBD/OGC-adjacent obligations in the right owners. Implementation-
+  roadmap Phase 2 shared solver contracts are complete on the active phase
+  branch; merge the latest `origin/main`, validate, and open one phase-scoped PR
+  for that phase. After it lands, start implementation-roadmap Phase 3 Unified
+  Articulation Constraints; do not substitute dev-task Phase 4 manifest
+  expansion for the roadmap Phase 3 work.
 - Gate: Unified Newton-barrier progress is not complete until every cited
   paper/deck figure, unit test, benchmark table, and comparison scene is mapped
   to DART-owned tests, py-demos examples, benchmark/profiling packets, CPU and

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -289,7 +289,10 @@ its own line so status updates remain git-history friendly.
   sidecar to keep deformable IPC, codimensional IPC, rigid IPC, ABD, PD-IPC,
   SPB, and VBD/OGC-adjacent obligations in the right owners. Generalize PSD
   projection, projected-Newton, line-search, diagnostics, and benchmark schemas
-  only when second-use evidence proves a shared contract.
+  only when second-use evidence proves a shared contract. With Phase 3
+  shared-contract scouting closed, start Phase 4 manifest expansion by adding
+  diagnostics and benchmark-packet rows only where a concrete artifact can
+  validate the row.
 - Gate: Unified Newton-barrier progress is not complete until every cited
   paper/deck figure, unit test, benchmark table, and comparison scene is mapped
   to DART-owned tests, py-demos examples, benchmark/profiling packets, CPU and

--- a/scripts/benchmark_packet_utils.py
+++ b/scripts/benchmark_packet_utils.py
@@ -10,6 +10,7 @@ from typing import Any
 _AGGREGATE_SUFFIX_RE = re.compile(r"_(?:mean|median|stddev|cv)$")
 _REPEATS_SUFFIX_RE = re.compile(r"/repeats:\d+")
 _UNIT_TO_NS = {"ns": 1.0, "us": 1e3, "ms": 1e6, "s": 1e9}
+SOLVER_SUBPHASE_TIMINGS_KEY = "solver_subphase_timings_ns"
 
 
 def canonical_benchmark_name(name: str) -> str:
@@ -70,4 +71,53 @@ def benchmark_timing_field_errors(
             errors.append(f"{name} has non-positive {field}: {value!r}")
     if not isinstance(row.get("time_unit"), str):
         errors.append(f"{name} is missing time_unit")
+    return errors
+
+
+def benchmark_packet_timing_schema_errors(
+    metadata: Mapping[str, Any],
+    packet_name: str,
+    *,
+    required_subphases: Iterable[str] = (),
+) -> list[str]:
+    errors: list[str] = []
+    step_count = metadata.get("step_count")
+    if not isinstance(step_count, int) or isinstance(step_count, bool):
+        errors.append(f"{packet_name}.step_count must be an integer")
+    elif step_count <= 0:
+        errors.append(f"{packet_name}.step_count must be positive")
+
+    required = tuple(required_subphases)
+    subphases = metadata.get(SOLVER_SUBPHASE_TIMINGS_KEY)
+    if subphases is None:
+        if required:
+            errors.append(f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY} is missing")
+        return errors
+    if not isinstance(subphases, Mapping):
+        errors.append(f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY} must be an object")
+        return errors
+
+    for subphase in required:
+        if subphase not in subphases:
+            errors.append(
+                f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY}.{subphase} is missing"
+            )
+
+    for subphase, value in sorted(subphases.items()):
+        if not isinstance(subphase, str) or not subphase:
+            errors.append(
+                f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY} has an invalid key"
+            )
+            continue
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            errors.append(
+                f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY}.{subphase} "
+                f"must be numeric"
+            )
+            continue
+        if not math.isfinite(float(value)) or float(value) < 0.0:
+            errors.append(
+                f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY}.{subphase} "
+                f"must be finite and non-negative"
+            )
     return errors

--- a/scripts/benchmark_packet_utils.py
+++ b/scripts/benchmark_packet_utils.py
@@ -103,7 +103,7 @@ def benchmark_packet_timing_schema_errors(
                 f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY}.{subphase} is missing"
             )
 
-    for subphase, value in sorted(subphases.items()):
+    for subphase, value in sorted(subphases.items(), key=lambda item: str(item[0])):
         if not isinstance(subphase, str) or not subphase:
             errors.append(
                 f"{packet_name}.{SOLVER_SUBPHASE_TIMINGS_KEY} has an invalid key"

--- a/scripts/check_phase5_gpu_packet.py
+++ b/scripts/check_phase5_gpu_packet.py
@@ -36,7 +36,10 @@ import math
 import sys
 from pathlib import Path
 
-from benchmark_packet_utils import median_timing_by_name
+from benchmark_packet_utils import (
+    benchmark_packet_timing_schema_errors,
+    median_timing_by_name,
+)
 
 DEFAULT_CPU_PREFIX = "BM_Phase5RigidBodyBatchCpuBaseline"
 DEFAULT_GPU_PREFIX = "BM_Phase5RigidBodyBatchGpu"
@@ -228,6 +231,11 @@ def _validate_metadata(
     world_count = _require_int(metadata, "world_count")
     actual_body_count = _require_int(metadata, "body_count")
     actual_step_count = _require_int(metadata, "step_count")
+    timing_schema_errors = benchmark_packet_timing_schema_errors(
+        metadata, "phase5_gpu_packet"
+    )
+    if timing_schema_errors:
+        raise Phase5PacketError(timing_schema_errors[0])
     includes_full_workload = _require_bool(
         metadata, "includes_transfer_setup_compute_readback"
     )

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -74,6 +74,49 @@ def test_benchmark_timing_field_errors_reject_bad_google_rows():
     ]
 
 
+def test_benchmark_packet_timing_schema_accepts_per_step_subphases():
+    utils = load_script_module("benchmark_packet_utils")
+
+    errors = utils.benchmark_packet_timing_schema_errors(
+        {
+            "step_count": 100,
+            "solver_subphase_timings_ns": {
+                "assembly": 125.0,
+                "linear_solve": 250,
+            },
+        },
+        "phase_packet",
+        required_subphases=("assembly", "linear_solve"),
+    )
+
+    assert errors == []
+
+
+def test_benchmark_packet_timing_schema_rejects_bad_fields():
+    utils = load_script_module("benchmark_packet_utils")
+
+    errors = utils.benchmark_packet_timing_schema_errors(
+        {
+            "step_count": 0,
+            "solver_subphase_timings_ns": {
+                "assembly": -1.0,
+                "": 1.0,
+                "linear_solve": True,
+            },
+        },
+        "phase_packet",
+        required_subphases=("assembly", "ccd"),
+    )
+
+    assert errors == [
+        "phase_packet.step_count must be positive",
+        "phase_packet.solver_subphase_timings_ns.ccd is missing",
+        "phase_packet.solver_subphase_timings_ns has an invalid key",
+        "phase_packet.solver_subphase_timings_ns.assembly must be finite and non-negative",
+        "phase_packet.solver_subphase_timings_ns.linear_solve must be numeric",
+    ]
+
+
 def test_phase5_packet_validator_uses_shared_canonical_rows():
     phase5 = load_script_module("check_phase5_gpu_packet")
     data = phase5.make_packet_template()

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -101,6 +101,7 @@ def test_benchmark_packet_timing_schema_rejects_bad_fields():
             "solver_subphase_timings_ns": {
                 "assembly": -1.0,
                 "": 1.0,
+                7: 2.0,
                 "linear_solve": True,
             },
         },
@@ -111,6 +112,7 @@ def test_benchmark_packet_timing_schema_rejects_bad_fields():
     assert errors == [
         "phase_packet.step_count must be positive",
         "phase_packet.solver_subphase_timings_ns.ccd is missing",
+        "phase_packet.solver_subphase_timings_ns has an invalid key",
         "phase_packet.solver_subphase_timings_ns has an invalid key",
         "phase_packet.solver_subphase_timings_ns.assembly must be finite and non-negative",
         "phase_packet.solver_subphase_timings_ns.linear_solve must be numeric",

--- a/tests/unit/simulation/contact/test_affine_body_dynamics.cpp
+++ b/tests/unit/simulation/contact/test_affine_body_dynamics.cpp
@@ -287,6 +287,7 @@ void expectRigidFrictionOracleMatches(
   ASSERT_TRUE(affine.active);
   ASSERT_TRUE(rigid.active);
   EXPECT_NEAR(affine.value, rigid.value, 1e-14);
+  EXPECT_NEAR(affine.work, rigid.potential.work, 1e-14);
   expectVectorNear(
       affine.tangentialDisplacement,
       rigid.potential.tangentialDisplacement,

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -649,9 +649,27 @@ TEST(NewtonBarrierPrimitives, RigidIpcConsumesSharedPrimitiveOwner)
   expectMatrixNear(
       potential.tangentialDisplacement, stencil.projection * displacement);
   EXPECT_NEAR(potential.value, expectedPotential.value, 1e-14);
+  EXPECT_NEAR(potential.work, expectedPotential.work, 1e-14);
   expectMatrixNear(potential.gradient.head<6>(), expectedPotential.gradient);
   expectMatrixNear(
       potential.hessian.topLeftCorner<6, 6>(), expectedPotential.hessian);
   EXPECT_TRUE(potential.active);
   EXPECT_GT(potential.value, 0.0);
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, FrictionWorkUsesSharedMollifier)
+{
+  const auto staticContribution = nb::frictionWorkContribution(0.05, 4.0, 0.2);
+  EXPECT_TRUE(staticContribution.active);
+  EXPECT_FALSE(staticContribution.dynamicBranch);
+  EXPECT_NEAR(staticContribution.work, 4.0 * (0.5 - 0.0625) * 0.05, 1e-15);
+
+  const auto dynamicContribution = nb::frictionWorkContribution(0.4, 4.0, 0.2);
+  EXPECT_TRUE(dynamicContribution.active);
+  EXPECT_TRUE(dynamicContribution.dynamicBranch);
+  EXPECT_NEAR(dynamicContribution.work, 4.0 * 0.4, 1e-15);
+
+  EXPECT_FALSE(nb::frictionWorkContribution(0.1, 0.0, 0.2).active);
+  EXPECT_FALSE(nb::frictionWorkContribution(0.1, 4.0, 0.0).active);
 }

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -216,6 +216,27 @@ TEST(NewtonBarrierPrimitives, LineSearchPositiveStepPredicateIsShared)
 }
 
 //==============================================================================
+TEST(NewtonBarrierPrimitives, LineSearchFullStepPredicateIsShared)
+{
+  EXPECT_TRUE(nb::allowsFullLineSearchStep(1.0, true, false));
+  EXPECT_TRUE(nb::allowsFullLineSearchStep(0.25, false, false));
+  EXPECT_FALSE(nb::allowsFullLineSearchStep(0.25, true, false));
+  EXPECT_FALSE(nb::allowsFullLineSearchStep(1.0, true, true));
+
+  dc::ContinuousCollisionStepResult deformable;
+  rigid::RigidIpcLineSearchResult rigidResult;
+  EXPECT_TRUE(deformable.allowsFullStep());
+  EXPECT_TRUE(rigidResult.allowsFullStep());
+
+  deformable.hit = true;
+  deformable.stepBound = 0.25;
+  rigidResult.limited = true;
+  rigidResult.stepBound = 0.25;
+  EXPECT_FALSE(deformable.allowsFullStep());
+  EXPECT_FALSE(rigidResult.allowsFullStep());
+}
+
+//==============================================================================
 TEST(NewtonBarrierPrimitives, LineSearchStepScaleUsesSharedClampingPolicy)
 {
   EXPECT_NEAR(nb::makeLineSearchStepScale(0.25, 0.8), 0.2, 1e-15);

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -37,6 +37,7 @@
 #include <dart/simulation/detail/newton_barrier/friction_kernel.hpp>
 #include <dart/simulation/detail/newton_barrier/line_search.hpp>
 #include <dart/simulation/detail/newton_barrier/primitive_distance.hpp>
+#include <dart/simulation/detail/newton_barrier/projected_newton.hpp>
 #include <dart/simulation/detail/newton_barrier/psd_projection.hpp>
 #include <dart/simulation/detail/newton_barrier/tangent_stencil.hpp>
 #include <dart/simulation/detail/rigid_ipc_barrier.hpp>
@@ -408,6 +409,30 @@ TEST(NewtonBarrierPrimitives, LineSearchResultsUseSharedPositiveStepPredicate)
   rigidResult.indeterminate = true;
   EXPECT_FALSE(deformable.allowsPositiveStep());
   EXPECT_FALSE(rigidResult.allowsPositiveStep());
+}
+
+//==============================================================================
+TEST(NewtonBarrierPrimitives, ProjectedNewtonDiagnosticsUseSharedPolicy)
+{
+  EXPECT_DOUBLE_EQ(nb::sanitizeProjectedNewtonTolerance(-1.0), 0.0);
+  EXPECT_DOUBLE_EQ(
+      nb::sanitizeProjectedNewtonTolerance(
+          std::numeric_limits<double>::quiet_NaN()),
+      0.0);
+  EXPECT_DOUBLE_EQ(nb::sanitizeProjectedNewtonTolerance(1e-8), 1e-8);
+
+  EXPECT_DOUBLE_EQ(nb::projectedNewtonResidualNormFromSquared(-1.0), 0.0);
+  EXPECT_DOUBLE_EQ(nb::projectedNewtonResidualNormFromSquared(4.0), 2.0);
+
+  EXPECT_TRUE(nb::projectedNewtonResidualConverged(1e-9, 1e-8));
+  EXPECT_FALSE(nb::projectedNewtonResidualConverged(1e-7, 1e-8));
+  EXPECT_TRUE(nb::projectedNewtonSquaredResidualConverged(1e-18, 1e-9));
+  EXPECT_FALSE(nb::projectedNewtonSquaredResidualConverged(1e-16, 1e-9));
+
+  EXPECT_DOUBLE_EQ(
+      nb::projectedNewtonEffectiveGradientTolerance(1e-8, 1e-3, 2.0), 2e-3);
+  EXPECT_DOUBLE_EQ(
+      nb::projectedNewtonEffectiveGradientTolerance(1e-8, -1.0, 2.0), 1e-8);
 }
 
 //==============================================================================

--- a/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
+++ b/tests/unit/simulation/contact/test_newton_barrier_primitives.cpp
@@ -670,6 +670,13 @@ TEST(NewtonBarrierPrimitives, FrictionWorkUsesSharedMollifier)
   EXPECT_TRUE(dynamicContribution.dynamicBranch);
   EXPECT_NEAR(dynamicContribution.work, 4.0 * 0.4, 1e-15);
 
+  const double tinyStaticDisplacement
+      = std::numeric_limits<double>::denorm_min();
+  const auto nonFiniteSmoothContribution = nb::frictionWorkContribution(
+      tinyStaticDisplacement, 4.0, tinyStaticDisplacement);
+  EXPECT_FALSE(nonFiniteSmoothContribution.active);
+  EXPECT_DOUBLE_EQ(nonFiniteSmoothContribution.work, 0.0);
+
   EXPECT_FALSE(nb::frictionWorkContribution(0.1, 0.0, 0.2).active);
   EXPECT_FALSE(nb::frictionWorkContribution(0.1, 4.0, 0.0).active);
 }


### PR DESCRIPTION
## Summary

- Complete implementation-roadmap Phase 2 shared solver contracts for PLAN-083 in one phase-scoped PR.
- Add shared internal contracts for full-step line-search feasibility, projected-Newton convergence diagnostics, lagged-friction work diagnostics, and benchmark packet timing schema.
- Update PLAN-083 tracking docs to make roadmap Phase 3 articulation constraints the next implementation phase after this PR lands.

## Motivation / Problem

- Phase 2 needed the remaining shared-contract closeout before moving to roadmap Phase 3.
- Prior Phase 3/dev-task sub-item PRs were too granular; this PR collects the remaining Shared Solver Contracts work into one review unit while keeping commits atomic.

## Changes / Key Changes

- Route rigid IPC and deformable CCD full-step feasibility through `detail/newton_barrier` while keeping result payloads variant-local.
- Route rigid IPC and deformable projected-Newton residual/tolerance checks through shared diagnostics helpers while keeping solver statuses variant-local.
- Share smoothed Coulomb friction work diagnostics across deformable, rigid IPC, and ABD internal friction paths.
- Add shared benchmark packet timing-schema validation for per-step counts and solver subphase timings.
- Record the Phase 2 closeout and next roadmap step in the PLAN-083 dev-task docs and dashboard.

## Testing

- `pixi run lint`
- `pixi run -- cmake --build build/default/cpp/Release --target test_newton_barrier_primitives test_affine_body_dynamics test_rigid_ipc_barrier test_world test_deformable_body --parallel <safe-jobs>`
- `pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -j <safe-jobs> -R '^(test_newton_barrier_primitives|test_affine_body_dynamics|test_rigid_ipc_barrier|test_world|test_deformable_body)$'`
- `pixi run python -m pytest tests/test_benchmark_packet_utils.py`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- PLAN-083: `docs/plans/083-unified-newton-barrier-multibody/implementation-roadmap.md`
- Supersedes the closed premature PR #2950 review shape; this is the phase-scoped replacement.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required: not required for internal shared contracts/docs
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable: not applicable, internal-only shared contracts
