### PR TITLE
Add AVBD rigid row solver core

### DIFF
--- a/dart/simulation/comps/joint.hpp
+++ b/dart/simulation/comps/joint.hpp
@@ -37,6 +37,7 @@
 #include <Eigen/Dense>
 #include <entt/entt.hpp>
 
+#include <limits>
 #include <string>
 
 namespace dart::simulation::comps {
@@ -225,6 +226,23 @@ struct Joint
 
   /// Whether the joint has been broken by an AVBD break-force threshold.
   bool broken = false;
+
+  /// Whether AVBD point-joint stiffness fields were materialized or loaded.
+  /// Legacy binaries derive start/max defaults from endpoint AVBD config on
+  /// first use.
+  bool hasAvbdStiffnessState = false;
+
+  /// AVBD point-joint row starting stiffness.
+  double avbdStartStiffness = 1.0;
+
+  /// AVBD linear point-joint material stiffness. Infinity keeps hard rows.
+  double avbdLinearStiffness = std::numeric_limits<double>::infinity();
+
+  /// AVBD angular point-joint material stiffness. Infinity keeps hard rows.
+  double avbdAngularStiffness = std::numeric_limits<double>::infinity();
+
+  /// AVBD point-joint maximum ramp stiffness.
+  double avbdMaxStiffness = std::numeric_limits<double>::infinity();
 
   JointLimits limits;
 

--- a/dart/simulation/detail/deformable_vbd/avbd_row_inventory.hpp
+++ b/dart/simulation/detail/deformable_vbd/avbd_row_inventory.hpp
@@ -34,6 +34,8 @@
 
 #include <dart/simulation/detail/deformable_vbd/avbd_constraint.hpp>
 
+#include <Eigen/Core>
+
 #include <algorithm>
 #include <limits>
 #include <map>
@@ -61,6 +63,7 @@ enum class AvbdScalarRowRole : std::uint8_t
   FrictionTangent,
   JointLinear,
   JointAngular,
+  RigidDistanceSpring,
   Motor,
   Fracture,
 };
@@ -136,6 +139,7 @@ struct AvbdScalarRowRecord
 {
   AvbdScalarRowDescriptor descriptor;
   AvbdScalarRowState state;
+  Eigen::Vector3d direction = Eigen::Vector3d::Zero();
 };
 
 //==============================================================================
@@ -198,6 +202,30 @@ public:
       std::span<const AvbdScalarRowDescriptor> descriptors,
       const AvbdRowWarmStartOptions& options)
   {
+    if (descriptors.empty()) {
+      mRecords.clear();
+      return;
+    }
+
+    if (mRecords.size() == descriptors.size()) {
+      bool sameOrder = true;
+      for (std::size_t i = 0; i < descriptors.size(); ++i) {
+        if (!(mRecords[i].descriptor.key == descriptors[i].key)) {
+          sameOrder = false;
+          break;
+        }
+      }
+
+      if (sameOrder) {
+        for (std::size_t i = 0; i < descriptors.size(); ++i) {
+          const AvbdScalarRowState state = warmStartAvbdScalarRowState(
+              mRecords[i].state, descriptors[i], options);
+          mRecords[i] = AvbdScalarRowRecord{descriptors[i], state};
+        }
+        return;
+      }
+    }
+
     std::map<AvbdScalarRowKey, AvbdScalarRowState> previous;
     for (const AvbdScalarRowRecord& record : mRecords) {
       previous.emplace(record.descriptor.key, record.state);
@@ -215,6 +243,61 @@ public:
   }
 
   //==============================================================================
+  template <typename DescriptorAt>
+  void syncActiveRowsByIndex(
+      std::size_t descriptorCount,
+      DescriptorAt descriptorAt,
+      const AvbdRowWarmStartOptions& options)
+  {
+    syncActiveRowsByIndex(
+        descriptorCount,
+        [&](std::size_t index) { return descriptorAt(index).key; },
+        descriptorAt,
+        options);
+  }
+
+  //==============================================================================
+  template <typename KeyAt, typename DescriptorAt>
+  void syncActiveRowsByIndex(
+      std::size_t descriptorCount,
+      KeyAt keyAt,
+      DescriptorAt descriptorAt,
+      const AvbdRowWarmStartOptions& options)
+  {
+    if (descriptorCount == 0u) {
+      mRecords.clear();
+      return;
+    }
+
+    if (mRecords.size() == descriptorCount) {
+      bool sameOrder = true;
+      for (std::size_t i = 0; i < descriptorCount; ++i) {
+        if (!(mRecords[i].descriptor.key == keyAt(i))) {
+          sameOrder = false;
+          break;
+        }
+      }
+
+      if (sameOrder) {
+        for (std::size_t i = 0; i < descriptorCount; ++i) {
+          const AvbdScalarRowDescriptor descriptor = descriptorAt(i);
+          const AvbdScalarRowState state = warmStartAvbdScalarRowState(
+              mRecords[i].state, descriptor, options);
+          mRecords[i] = AvbdScalarRowRecord{descriptor, state};
+        }
+        return;
+      }
+    }
+
+    std::vector<AvbdScalarRowDescriptor> descriptors;
+    descriptors.reserve(descriptorCount);
+    for (std::size_t i = 0; i < descriptorCount; ++i) {
+      descriptors.push_back(descriptorAt(i));
+    }
+    syncActiveRows(descriptors, options);
+  }
+
+  //==============================================================================
   [[nodiscard]] std::size_t size() const noexcept
   {
     return mRecords.size();
@@ -224,6 +307,12 @@ public:
   [[nodiscard]] bool empty() const noexcept
   {
     return mRecords.empty();
+  }
+
+  //==============================================================================
+  void clear() noexcept
+  {
+    mRecords.clear();
   }
 
   //==============================================================================

--- a/dart/simulation/detail/deformable_vbd/rigid_block_kernel.hpp
+++ b/dart/simulation/detail/deformable_vbd/rigid_block_kernel.hpp
@@ -40,6 +40,7 @@
 #include <Eigen/Geometry>
 
 #include <algorithm>
+#include <array>
 #include <limits>
 #include <span>
 #include <vector>
@@ -51,10 +52,12 @@
 namespace dart::simulation::detail::deformable_vbd {
 
 using Vector6d = Eigen::Matrix<double, 6, 1>;
+using Matrix3x6d = Eigen::Matrix<double, 3, 6>;
 using Matrix6d = Eigen::Matrix<double, 6, 6>;
 
 inline constexpr double kAvbdRigidPi = 3.141592653589793238462643383279502884;
 inline constexpr std::uint8_t kAvbdRigidJointAllAxesMask = 0x7u;
+inline constexpr double kAvbdRigidMinDistanceSpringLength = 1e-12;
 
 //==============================================================================
 inline Eigen::Quaterniond normalizeAvbdRigidOrientation(
@@ -142,10 +145,20 @@ struct AvbdRigidPointPairRow
   Eigen::Vector3d axis = Eigen::Vector3d::UnitX();
   double offset = 0.0;
   AvbdScalarRowState state;
+  double materialStiffness = std::numeric_limits<double>::infinity();
   double previousConstraintValue = 0.0;
   AvbdScalarRowBounds bounds{
       -std::numeric_limits<double>::infinity(),
       std::numeric_limits<double>::infinity()};
+};
+
+struct AvbdRigidPointPairDistanceSpringRow
+{
+  Eigen::Vector3d localPointA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d localPointB = Eigen::Vector3d::Zero();
+  double restLength = 0.0;
+  AvbdScalarRowState state;
+  double materialStiffness = std::numeric_limits<double>::infinity();
 };
 
 struct AvbdRigidAngularPairRow
@@ -154,6 +167,7 @@ struct AvbdRigidAngularPairRow
   Eigen::Vector3d axis = Eigen::Vector3d::UnitX();
   double offset = 0.0;
   AvbdScalarRowState state;
+  double materialStiffness = std::numeric_limits<double>::infinity();
   double previousConstraintValue = 0.0;
   AvbdScalarRowBounds bounds{
       -std::numeric_limits<double>::infinity(),
@@ -171,6 +185,18 @@ struct AvbdRigidBodyPointPairRow
   std::uint32_t bodyA = 0;
   std::uint32_t bodyB = 0;
   AvbdRigidPointPairRow row;
+};
+
+struct AvbdRigidBodyPointPairDistanceSpringRow
+{
+  std::uint32_t bodyA = 0;
+  std::uint32_t bodyB = 0;
+  AvbdContactEndpointId endpointA;
+  AvbdContactEndpointId endpointB;
+  std::uint32_t rowIndex = 0;
+  AvbdRigidPointPairDistanceSpringRow row;
+  double startStiffness = 1.0;
+  double maxStiffness = std::numeric_limits<double>::infinity();
 };
 
 struct AvbdRigidBodyAngularPairRow
@@ -202,6 +228,8 @@ struct AvbdRigidPointJoint
   std::uint8_t linearAxisMask = kAvbdRigidJointAllAxesMask;
   std::uint8_t angularAxisMask = kAvbdRigidJointAllAxesMask;
   double startStiffness = 1.0;
+  double linearMaterialStiffness = std::numeric_limits<double>::infinity();
+  double angularMaterialStiffness = std::numeric_limits<double>::infinity();
   double maxStiffness = std::numeric_limits<double>::infinity();
   double fractureThreshold = 0.0;
   std::uint32_t row = 0;
@@ -217,6 +245,22 @@ struct AvbdRigidAngularMotor
   Eigen::Vector3d axis = Eigen::Vector3d::UnitZ();
   double targetSpeed = 0.0;
   double maxTorque = std::numeric_limits<double>::infinity();
+  double startStiffness = 1.0;
+  double maxStiffness = std::numeric_limits<double>::infinity();
+  std::uint32_t row = 0;
+};
+
+struct AvbdRigidLinearMotor
+{
+  std::uint32_t bodyA = 0;
+  std::uint32_t bodyB = 0;
+  AvbdContactEndpointId endpointA;
+  AvbdContactEndpointId endpointB;
+  Eigen::Vector3d localPointA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d localPointB = Eigen::Vector3d::Zero();
+  Eigen::Vector3d axis = Eigen::Vector3d::UnitX();
+  double targetSpeed = 0.0;
+  double maxForce = std::numeric_limits<double>::infinity();
   double startStiffness = 1.0;
   double maxStiffness = std::numeric_limits<double>::infinity();
   std::uint32_t row = 0;
@@ -252,6 +296,12 @@ struct AvbdRigidPointPairFrictionOptions
   double staticFrictionTolerance = 1e-12;
 };
 
+struct AvbdRigidPointPairDistanceSpringOptions
+{
+  double beta = 1.0;
+  double maxStiffness = std::numeric_limits<double>::infinity();
+};
+
 struct AvbdRigidBlockDescentOptions
 {
   std::size_t iterations = 20;
@@ -263,6 +313,64 @@ struct AvbdRigidBlockDescentStats
 {
   std::size_t iterations = 0;
   std::size_t bodyUpdates = 0;
+};
+
+struct AvbdRigidBodyRowIndexScratch
+{
+  void clear()
+  {
+    attachmentRowOffsets.clear();
+    attachmentRowIndices.clear();
+    attachmentRowCursor.clear();
+    attachmentRowBodyKeys.clear();
+    attachmentRowBodyCount = 0u;
+    pointPairRowOffsets.clear();
+    pointPairRowIndices.clear();
+    pointPairRowCursor.clear();
+    pointPairRowBodyKeys.clear();
+    pointPairRowBodyCount = 0u;
+    distanceSpringRowOffsets.clear();
+    distanceSpringRowIndices.clear();
+    distanceSpringRowCursor.clear();
+    distanceSpringRowBodyKeys.clear();
+    distanceSpringRowBodyCount = 0u;
+    angularPairRowOffsets.clear();
+    angularPairRowIndices.clear();
+    angularPairRowCursor.clear();
+    angularPairRowBodyKeys.clear();
+    angularPairRowBodyCount = 0u;
+    frictionPairRowOffsets.clear();
+    frictionPairRowIndices.clear();
+    frictionPairRowCursor.clear();
+    frictionPairRowBodyKeys.clear();
+    frictionPairRowBodyCount = 0u;
+  }
+
+  std::vector<std::size_t> attachmentRowOffsets;
+  std::vector<std::size_t> attachmentRowIndices;
+  std::vector<std::size_t> attachmentRowCursor;
+  std::vector<std::uint64_t> attachmentRowBodyKeys;
+  std::size_t attachmentRowBodyCount = 0u;
+  std::vector<std::size_t> pointPairRowOffsets;
+  std::vector<std::size_t> pointPairRowIndices;
+  std::vector<std::size_t> pointPairRowCursor;
+  std::vector<std::uint64_t> pointPairRowBodyKeys;
+  std::size_t pointPairRowBodyCount = 0u;
+  std::vector<std::size_t> distanceSpringRowOffsets;
+  std::vector<std::size_t> distanceSpringRowIndices;
+  std::vector<std::size_t> distanceSpringRowCursor;
+  std::vector<std::uint64_t> distanceSpringRowBodyKeys;
+  std::size_t distanceSpringRowBodyCount = 0u;
+  std::vector<std::size_t> angularPairRowOffsets;
+  std::vector<std::size_t> angularPairRowIndices;
+  std::vector<std::size_t> angularPairRowCursor;
+  std::vector<std::uint64_t> angularPairRowBodyKeys;
+  std::size_t angularPairRowBodyCount = 0u;
+  std::vector<std::size_t> frictionPairRowOffsets;
+  std::vector<std::size_t> frictionPairRowIndices;
+  std::vector<std::size_t> frictionPairRowCursor;
+  std::vector<std::uint64_t> frictionPairRowBodyKeys;
+  std::size_t frictionPairRowBodyCount = 0u;
 };
 
 //==============================================================================
@@ -312,6 +420,51 @@ inline void addAvbdRigidBodyInertiaTerm(
 
   block.force.noalias() -= invDt2 * massMatrix * error;
   block.hessian.noalias() += invDt2 * massMatrix;
+}
+
+//==============================================================================
+inline void addAvbdRigidBodyInertiaTermLowerTriangle(
+    AvbdRigidBodyBlock& block,
+    double mass,
+    const Eigen::Matrix3d& bodyInertia,
+    double timeStep,
+    const AvbdRigidBodyState& state,
+    const AvbdRigidBodyState& inertialTarget)
+{
+  const double invDt2 = 1.0 / (timeStep * timeStep);
+  const Eigen::Quaterniond orientation
+      = normalizeAvbdRigidOrientation(state.orientation);
+  const Eigen::Matrix3d rotation = orientation.toRotationMatrix();
+  const Eigen::Matrix3d worldInertia
+      = rotation * bodyInertia * rotation.transpose();
+  const Eigen::Vector3d orientationError = avbdRigidBodyOrientationError(
+      state.orientation, inertialTarget.orientation);
+
+  block.force.head<3>().noalias()
+      -= invDt2 * mass * (state.position - inertialTarget.position);
+  block.force.tail<3>().noalias() -= invDt2 * worldInertia * orientationError;
+
+  block.hessian.topLeftCorner<3, 3>().diagonal().array() += invDt2 * mass;
+  const Eigen::Matrix3d scaledWorldInertia = invDt2 * worldInertia;
+  block.hessian.bottomRightCorner<3, 3>()
+      .template triangularView<Eigen::Lower>() += scaledWorldInertia;
+}
+
+//==============================================================================
+inline void addAvbdRigidBlockHessianRankOneLowerTriangle(
+    AvbdRigidBodyBlock& block, const Vector6d& direction, double scale)
+{
+  block.hessian.template selfadjointView<Eigen::Lower>().rankUpdate(
+      direction, scale);
+}
+
+//==============================================================================
+inline Eigen::Matrix3d avbdRigidSkewMatrix(const Eigen::Vector3d& value)
+{
+  Eigen::Matrix3d result;
+  result << 0.0, -value.z(), value.y(), value.z(), 0.0, -value.x(), -value.y(),
+      value.x(), 0.0;
+  return result;
 }
 
 //==============================================================================
@@ -385,6 +538,16 @@ inline Eigen::Vector3d avbdRigidPointPairRelativePosition(
 }
 
 //==============================================================================
+inline Eigen::Vector3d avbdRigidPointPairDistanceSpringRelativePosition(
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairDistanceSpringRow& row)
+{
+  return avbdRigidBodyWorldPoint(stateB, row.localPointB)
+         - avbdRigidBodyWorldPoint(stateA, row.localPointA);
+}
+
+//==============================================================================
 inline Eigen::Quaterniond avbdRigidAngularPairTargetOrientationB(
     const AvbdRigidBodyState& stateA, const AvbdRigidAngularPairRow& row)
 {
@@ -440,6 +603,13 @@ inline Eigen::Matrix<double, 3, 2> avbdRigidContactTangentBasis(
 }
 
 //==============================================================================
+inline bool isValidAvbdRigidContactFrictionDirection(
+    const Eigen::Vector3d& direction)
+{
+  return direction.allFinite() && direction.squaredNorm() > 0.0;
+}
+
+//==============================================================================
 inline AvbdRigidPointPairRow makeAvbdRigidContactFrictionTangentRow(
     const Eigen::Vector3d& localPointA,
     const Eigen::Vector3d& localPointB,
@@ -492,6 +662,26 @@ inline AvbdRigidAngularPairRow makeAvbdRigidAngularMotorRow(
 }
 
 //==============================================================================
+inline AvbdRigidPointPairRow makeAvbdRigidLinearMotorRow(
+    const Eigen::Vector3d& localPointA,
+    const Eigen::Vector3d& localPointB,
+    const Eigen::Vector3d& axis,
+    const Eigen::Vector3d& stepStartRelativePosition,
+    double targetSpeed,
+    double timeStep,
+    AvbdScalarRowState state)
+{
+  AvbdRigidPointPairRow row;
+  row.localPointA = localPointA;
+  row.localPointB = localPointB;
+  row.axis = normalizedAvbdRigidPointPairAxis(axis, Eigen::Vector3d::UnitX());
+  row.offset
+      = -row.axis.dot(stepStartRelativePosition) - targetSpeed * timeStep;
+  row.state = state;
+  return row;
+}
+
+//==============================================================================
 inline AvbdRigidAngularMotor makeAvbdRigidAngularMotor(
     std::uint32_t bodyA,
     std::uint32_t bodyB,
@@ -515,6 +705,37 @@ inline AvbdRigidAngularMotor makeAvbdRigidAngularMotor(
   motor.axis = normalizedAvbdRigidPointPairAxis(axis, Eigen::Vector3d::UnitZ());
   motor.targetSpeed = targetSpeed;
   motor.maxTorque = std::max(0.0, maxTorque);
+  motor.startStiffness = std::max(0.0, startStiffness);
+  motor.maxStiffness = std::max(motor.startStiffness, maxStiffness);
+  motor.row = row;
+  return motor;
+}
+
+//==============================================================================
+inline AvbdRigidLinearMotor makeAvbdRigidLinearMotor(
+    std::uint32_t bodyA,
+    std::uint32_t bodyB,
+    AvbdContactEndpointId endpointA,
+    AvbdContactEndpointId endpointB,
+    const Eigen::Vector3d& localPointA,
+    const Eigen::Vector3d& localPointB,
+    const Eigen::Vector3d& axis,
+    double targetSpeed,
+    double maxForce,
+    double startStiffness = 1.0,
+    double maxStiffness = std::numeric_limits<double>::infinity(),
+    std::uint32_t row = 0)
+{
+  AvbdRigidLinearMotor motor;
+  motor.bodyA = bodyA;
+  motor.bodyB = bodyB;
+  motor.endpointA = endpointA;
+  motor.endpointB = endpointB;
+  motor.localPointA = localPointA;
+  motor.localPointB = localPointB;
+  motor.axis = normalizedAvbdRigidPointPairAxis(axis, Eigen::Vector3d::UnitX());
+  motor.targetSpeed = targetSpeed;
+  motor.maxForce = std::max(0.0, maxForce);
   motor.startStiffness = std::max(0.0, startStiffness);
   motor.maxStiffness = std::max(motor.startStiffness, maxStiffness);
   motor.row = row;
@@ -588,6 +809,22 @@ inline AvbdRigidPointJoint makeAvbdRigidPrismaticPointJoint(
 
 namespace detail {
 
+inline constexpr std::size_t kAvbdRigidSmallRowStackCapacity = 16u;
+
+//==============================================================================
+inline bool avbdRigidVectorExactEqual(
+    const Eigen::Vector3d& a, const Eigen::Vector3d& b)
+{
+  return (a.array() == b.array()).all();
+}
+
+//==============================================================================
+inline bool avbdRigidQuaternionExactEqual(
+    const Eigen::Quaterniond& a, const Eigen::Quaterniond& b)
+{
+  return (a.coeffs().array() == b.coeffs().array()).all();
+}
+
 //==============================================================================
 inline bool avbdRigidJointAxisEnabled(std::uint8_t mask, std::uint8_t axis)
 {
@@ -634,7 +871,14 @@ inline bool isValidAvbdRigidPointJoint(
          && hasValidActiveAvbdRigidJointAxes(
              joint.linearAxes, joint.linearAxisMask)
          && hasValidActiveAvbdRigidJointAxes(
-             joint.angularAxes, joint.angularAxisMask);
+             joint.angularAxes, joint.angularAxisMask)
+         && !std::isnan(joint.startStiffness) && joint.startStiffness >= 0.0
+         && !std::isnan(joint.linearMaterialStiffness)
+         && joint.linearMaterialStiffness >= 0.0
+         && !std::isnan(joint.angularMaterialStiffness)
+         && joint.angularMaterialStiffness >= 0.0
+         && !std::isnan(joint.maxStiffness)
+         && joint.maxStiffness >= joint.startStiffness;
 }
 
 //==============================================================================
@@ -652,10 +896,39 @@ inline bool isValidAvbdRigidAngularMotor(
 }
 
 //==============================================================================
+inline bool isValidAvbdRigidLinearMotor(
+    const AvbdRigidLinearMotor& motor, std::size_t bodyCount, double timeStep)
+{
+  return motor.bodyA < bodyCount && motor.bodyB < bodyCount
+         && motor.bodyA != motor.bodyB && motor.localPointA.allFinite()
+         && motor.localPointB.allFinite() && motor.axis.allFinite()
+         && motor.axis.squaredNorm() > 0.0 && std::isfinite(motor.targetSpeed)
+         && timeStep > 0.0 && std::isfinite(timeStep) && motor.maxForce > 0.0
+         && !std::isnan(motor.maxForce);
+}
+
+//==============================================================================
+inline bool isValidAvbdRigidDistanceSpring(
+    const AvbdRigidBodyPointPairDistanceSpringRow& spring,
+    std::size_t bodyCount)
+{
+  return spring.bodyA < bodyCount && spring.bodyB < bodyCount
+         && spring.bodyA != spring.bodyB && spring.row.localPointA.allFinite()
+         && spring.row.localPointB.allFinite()
+         && std::isfinite(spring.row.restLength) && spring.row.restLength >= 0.0
+         && !std::isnan(spring.startStiffness) && spring.startStiffness >= 0.0
+         && !std::isnan(spring.row.materialStiffness)
+         && spring.row.materialStiffness >= 0.0
+         && !std::isnan(spring.maxStiffness)
+         && spring.maxStiffness >= spring.startStiffness;
+}
+
+//==============================================================================
 inline AvbdScalarRowDescriptor makeAvbdRigidJointLinearRowDescriptor(
     AvbdContactEndpointId first,
     AvbdContactEndpointId second,
     double startStiffness,
+    double materialStiffness,
     double maxStiffness,
     std::uint32_t row = 0,
     std::uint8_t axis = 0)
@@ -663,11 +936,14 @@ inline AvbdScalarRowDescriptor makeAvbdRigidJointLinearRowDescriptor(
   AvbdScalarRowDescriptor descriptor;
   descriptor.key = makeAvbdEndpointPairRowKey(
       AvbdScalarRowRole::JointLinear, first, second, row, axis);
-  descriptor.kind = AvbdScalarRowKind::HardConstraint;
+  descriptor.kind = std::isfinite(materialStiffness)
+                        ? AvbdScalarRowKind::FiniteStiffness
+                        : AvbdScalarRowKind::HardConstraint;
   descriptor.bounds
       = {-std::numeric_limits<double>::infinity(),
          std::numeric_limits<double>::infinity()};
   descriptor.startStiffness = startStiffness;
+  descriptor.materialStiffness = materialStiffness;
   descriptor.maxStiffness = maxStiffness;
   return descriptor;
 }
@@ -677,6 +953,7 @@ inline AvbdScalarRowDescriptor makeAvbdRigidJointAngularRowDescriptor(
     AvbdContactEndpointId first,
     AvbdContactEndpointId second,
     double startStiffness,
+    double materialStiffness,
     double maxStiffness,
     std::uint32_t row = 0,
     std::uint8_t axis = 0)
@@ -684,11 +961,33 @@ inline AvbdScalarRowDescriptor makeAvbdRigidJointAngularRowDescriptor(
   AvbdScalarRowDescriptor descriptor;
   descriptor.key = makeAvbdEndpointPairRowKey(
       AvbdScalarRowRole::JointAngular, first, second, row, axis);
-  descriptor.kind = AvbdScalarRowKind::HardConstraint;
+  descriptor.kind = std::isfinite(materialStiffness)
+                        ? AvbdScalarRowKind::FiniteStiffness
+                        : AvbdScalarRowKind::HardConstraint;
   descriptor.bounds
       = {-std::numeric_limits<double>::infinity(),
          std::numeric_limits<double>::infinity()};
   descriptor.startStiffness = startStiffness;
+  descriptor.materialStiffness = materialStiffness;
+  descriptor.maxStiffness = maxStiffness;
+  return descriptor;
+}
+
+//==============================================================================
+inline AvbdScalarRowDescriptor makeAvbdRigidDistanceSpringRowDescriptor(
+    AvbdContactEndpointId first,
+    AvbdContactEndpointId second,
+    double startStiffness,
+    double materialStiffness,
+    double maxStiffness,
+    std::uint32_t row = 0)
+{
+  AvbdScalarRowDescriptor descriptor;
+  descriptor.key = makeAvbdEndpointPairRowKey(
+      AvbdScalarRowRole::RigidDistanceSpring, first, second, row, /*axis=*/0);
+  descriptor.kind = AvbdScalarRowKind::FiniteStiffness;
+  descriptor.startStiffness = startStiffness;
+  descriptor.materialStiffness = materialStiffness;
   descriptor.maxStiffness = maxStiffness;
   return descriptor;
 }
@@ -707,6 +1006,25 @@ inline AvbdScalarRowDescriptor makeAvbdRigidAngularMotorRowDescriptor(
       AvbdScalarRowRole::Motor, first, second, row, /*axis=*/0);
   descriptor.kind = AvbdScalarRowKind::HardConstraint;
   descriptor.bounds = {-maxTorque, maxTorque};
+  descriptor.startStiffness = startStiffness;
+  descriptor.maxStiffness = maxStiffness;
+  return descriptor;
+}
+
+//==============================================================================
+inline AvbdScalarRowDescriptor makeAvbdRigidLinearMotorRowDescriptor(
+    AvbdContactEndpointId first,
+    AvbdContactEndpointId second,
+    double maxForce,
+    double startStiffness,
+    double maxStiffness,
+    std::uint32_t row = 0)
+{
+  AvbdScalarRowDescriptor descriptor;
+  descriptor.key = makeAvbdEndpointPairRowKey(
+      AvbdScalarRowRole::Motor, first, second, row, /*axis=*/0);
+  descriptor.kind = AvbdScalarRowKind::HardConstraint;
+  descriptor.bounds = {-maxForce, maxForce};
   descriptor.startStiffness = startStiffness;
   descriptor.maxStiffness = maxStiffness;
   return descriptor;
@@ -747,6 +1065,63 @@ inline double avbdRigidPointPairConstraintValue(
 }
 
 //==============================================================================
+inline double avbdRigidPointPairConstraintValueAtWorldPoints(
+    const AvbdRigidPointPairRow& row,
+    const Eigen::Vector3d& worldPointA,
+    const Eigen::Vector3d& worldPointB)
+{
+  return row.offset + row.axis.dot(worldPointB - worldPointA);
+}
+
+//==============================================================================
+inline Eigen::Vector2d avbdRigidPointPairConstraintValuesAtWorldPoints(
+    const AvbdRigidPointPairRow& first,
+    const AvbdRigidPointPairRow& second,
+    const Eigen::Vector3d& firstWorldPointA,
+    const Eigen::Vector3d& firstWorldPointB,
+    const Eigen::Vector3d& secondWorldPointA,
+    const Eigen::Vector3d& secondWorldPointB,
+    double alpha)
+{
+  return Eigen::Vector2d(
+      regularizeAvbdConstraintValue(
+          avbdRigidPointPairConstraintValueAtWorldPoints(
+              first, firstWorldPointA, firstWorldPointB),
+          first.previousConstraintValue,
+          alpha),
+      regularizeAvbdConstraintValue(
+          avbdRigidPointPairConstraintValueAtWorldPoints(
+              second, secondWorldPointA, secondWorldPointB),
+          second.previousConstraintValue,
+          alpha));
+}
+
+//==============================================================================
+inline bool avbdRigidPointPairRowsShareLocalPoints(
+    const AvbdRigidPointPairRow& first, const AvbdRigidPointPairRow& second)
+{
+  return detail::avbdRigidVectorExactEqual(
+             first.localPointA, second.localPointA)
+         && detail::avbdRigidVectorExactEqual(
+             first.localPointB, second.localPointB);
+}
+
+//==============================================================================
+inline double avbdRigidPointPairDistanceSpringConstraintValue(
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairDistanceSpringRow& row)
+{
+  const double length
+      = avbdRigidPointPairDistanceSpringRelativePosition(stateA, stateB, row)
+            .norm();
+  if (!std::isfinite(length)) {
+    return 0.0;
+  }
+  return length - row.restLength;
+}
+
+//==============================================================================
 inline double avbdRigidAngularPairConstraintValue(
     const AvbdRigidBodyState& stateA,
     const AvbdRigidBodyState& stateB,
@@ -766,15 +1141,26 @@ inline Eigen::Vector2d avbdRigidPointPairConstraintValues(
     const AvbdRigidPointPairRow& second,
     double alpha)
 {
-  return Eigen::Vector2d(
-      regularizeAvbdConstraintValue(
-          avbdRigidPointPairConstraintValue(stateA, stateB, first),
-          first.previousConstraintValue,
-          alpha),
-      regularizeAvbdConstraintValue(
-          avbdRigidPointPairConstraintValue(stateA, stateB, second),
-          second.previousConstraintValue,
-          alpha));
+  const Eigen::Vector3d firstWorldPointA
+      = avbdRigidBodyWorldPoint(stateA, first.localPointA);
+  const Eigen::Vector3d firstWorldPointB
+      = avbdRigidBodyWorldPoint(stateB, first.localPointB);
+  const bool sharedAnchors
+      = avbdRigidPointPairRowsShareLocalPoints(first, second);
+  const Eigen::Vector3d secondWorldPointA
+      = sharedAnchors ? firstWorldPointA
+                      : avbdRigidBodyWorldPoint(stateA, second.localPointA);
+  const Eigen::Vector3d secondWorldPointB
+      = sharedAnchors ? firstWorldPointB
+                      : avbdRigidBodyWorldPoint(stateB, second.localPointB);
+  return avbdRigidPointPairConstraintValuesAtWorldPoints(
+      first,
+      second,
+      firstWorldPointA,
+      firstWorldPointB,
+      secondWorldPointA,
+      secondWorldPointB,
+      alpha);
 }
 
 //==============================================================================
@@ -854,9 +1240,9 @@ inline bool avbdRigidPointPairFrictionPreviousDualInsideCone(
 }
 
 //==============================================================================
-inline Eigen::Vector2d avbdRigidPointPairFrictionTangentPairForce(
-    const AvbdRigidBodyState& stateA,
-    const AvbdRigidBodyState& stateB,
+inline Eigen::Vector2d
+avbdRigidPointPairFrictionTangentPairForceFromConstraintValues(
+    const Eigen::Vector2d& constraintValues,
     const AvbdRigidPointPairRow& first,
     const AvbdRigidPointPairRow& second,
     const AvbdRigidPointPairFrictionOptions& options,
@@ -874,8 +1260,6 @@ inline Eigen::Vector2d avbdRigidPointPairFrictionTangentPairForce(
     return Eigen::Vector2d::Zero();
   }
 
-  const Eigen::Vector2d constraintValues = avbdRigidPointPairConstraintValues(
-      stateA, stateB, first, second, options.alpha);
   const bool staticMode = avbdRigidPointPairFrictionPreviousDualInsideCone(
       first, second, options.staticFrictionTolerance);
   if (!staticMode && std::isfinite(limit)) {
@@ -904,6 +1288,24 @@ inline Eigen::Vector2d avbdRigidPointPairFrictionTangentPairForce(
 }
 
 //==============================================================================
+inline Eigen::Vector2d avbdRigidPointPairFrictionTangentPairForce(
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairRow& first,
+    const AvbdRigidPointPairRow& second,
+    const AvbdRigidPointPairFrictionOptions& options,
+    bool* clamped = nullptr)
+{
+  return avbdRigidPointPairFrictionTangentPairForceFromConstraintValues(
+      avbdRigidPointPairConstraintValues(
+          stateA, stateB, first, second, options.alpha),
+      first,
+      second,
+      options,
+      clamped);
+}
+
+//==============================================================================
 inline Vector6d avbdRigidPointPairDirectionA(
     const AvbdRigidBodyState& stateA, const AvbdRigidPointPairRow& row)
 {
@@ -927,6 +1329,126 @@ inline Vector6d avbdRigidPointPairDirectionB(
   direction.head<3>() = -row.axis;
   direction.tail<3>() = arm.cross(-row.axis);
   return direction;
+}
+
+//==============================================================================
+inline Eigen::Vector3d avbdRigidPointPairDistanceSpringAxis(
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairDistanceSpringRow& row)
+{
+  const Eigen::Vector3d relative
+      = avbdRigidPointPairDistanceSpringRelativePosition(stateA, stateB, row);
+  const double length = relative.norm();
+  if (!relative.allFinite() || length <= kAvbdRigidMinDistanceSpringLength) {
+    return Eigen::Vector3d::Zero();
+  }
+  return relative / length;
+}
+
+//==============================================================================
+inline Vector6d avbdRigidPointPairDistanceSpringDirectionA(
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairDistanceSpringRow& row)
+{
+  const Eigen::Vector3d axis
+      = avbdRigidPointPairDistanceSpringAxis(stateA, stateB, row);
+  const Eigen::Vector3d arm
+      = avbdRigidBodyWorldPoint(stateA, row.localPointA) - stateA.position;
+
+  Vector6d direction = Vector6d::Zero();
+  direction.head<3>() = axis;
+  direction.tail<3>() = arm.cross(axis);
+  return direction;
+}
+
+//==============================================================================
+inline Vector6d avbdRigidPointPairDistanceSpringDirectionB(
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairDistanceSpringRow& row)
+{
+  const Eigen::Vector3d axis
+      = avbdRigidPointPairDistanceSpringAxis(stateA, stateB, row);
+  const Eigen::Vector3d arm
+      = avbdRigidBodyWorldPoint(stateB, row.localPointB) - stateB.position;
+
+  Vector6d direction = Vector6d::Zero();
+  direction.head<3>() = -axis;
+  direction.tail<3>() = arm.cross(-axis);
+  return direction;
+}
+
+//==============================================================================
+inline Matrix3x6d avbdRigidWorldPointJacobianAtWorldPoint(
+    const AvbdRigidBodyState& state, const Eigen::Vector3d& worldPoint)
+{
+  const Eigen::Vector3d arm = worldPoint - state.position;
+
+  Matrix3x6d jacobian = Matrix3x6d::Zero();
+  jacobian.leftCols<3>().setIdentity();
+  jacobian.rightCols<3>() = -avbdRigidSkewMatrix(arm);
+  return jacobian;
+}
+
+//==============================================================================
+inline Matrix3x6d avbdRigidWorldPointJacobian(
+    const AvbdRigidBodyState& state, const Eigen::Vector3d& localPoint)
+{
+  return avbdRigidWorldPointJacobianAtWorldPoint(
+      state, avbdRigidBodyWorldPoint(state, localPoint));
+}
+
+//==============================================================================
+inline void addAvbdRigidDistanceSpringHessianAtWorldPoint(
+    AvbdRigidBodyBlock& block,
+    const AvbdRigidBodyState& state,
+    const Eigen::Vector3d& worldPoint,
+    const Eigen::Vector3d& axis,
+    double length,
+    double restLength,
+    double stiffness,
+    bool clampToPsd)
+{
+  if (!axis.allFinite() || length <= kAvbdRigidMinDistanceSpringLength
+      || !std::isfinite(stiffness)) {
+    return;
+  }
+
+  double transverse = 1.0 - restLength / length;
+  if (clampToPsd) {
+    transverse = std::max(0.0, transverse);
+  }
+
+  const Eigen::Matrix3d nnT = axis * axis.transpose();
+  const Eigen::Matrix3d pointHessian
+      = stiffness * (nnT + transverse * (Eigen::Matrix3d::Identity() - nnT));
+  const Matrix3x6d jacobian
+      = avbdRigidWorldPointJacobianAtWorldPoint(state, worldPoint);
+  block.hessian.noalias() += jacobian.transpose() * pointHessian * jacobian;
+}
+
+//==============================================================================
+inline void addAvbdRigidDistanceSpringHessian(
+    AvbdRigidBodyBlock& block,
+    const AvbdRigidBodyState& state,
+    const Eigen::Vector3d& localPoint,
+    const Eigen::Vector3d& axis,
+    double length,
+    double restLength,
+    double stiffness,
+    bool clampToPsd)
+{
+  addAvbdRigidDistanceSpringHessianAtWorldPoint(
+      block,
+      state,
+      avbdRigidBodyWorldPoint(state, localPoint),
+      axis,
+      length,
+      restLength,
+      stiffness,
+      clampToPsd);
 }
 
 //==============================================================================
@@ -968,6 +1490,26 @@ inline double addAvbdRigidPointAttachment(
 }
 
 //==============================================================================
+inline bool avbdRigidRowUsesFiniteMaterial(double materialStiffness) noexcept
+{
+  return std::isfinite(materialStiffness);
+}
+
+//==============================================================================
+inline double avbdRigidScalarRowForce(
+    const AvbdScalarRowState& state,
+    double constraintValue,
+    const AvbdScalarRowBounds& bounds,
+    double materialStiffness)
+{
+  if (avbdRigidRowUsesFiniteMaterial(materialStiffness)) {
+    return state.stiffness * constraintValue;
+  }
+
+  return computeAvbdHardConstraintForce(state, constraintValue, bounds);
+}
+
+//==============================================================================
 inline double addAvbdRigidPointPair(
     AvbdRigidBodyBlock& blockA,
     AvbdRigidBodyBlock& blockB,
@@ -976,14 +1518,25 @@ inline double addAvbdRigidPointPair(
     const AvbdRigidPointPairRow& row,
     double alpha)
 {
-  const double constraintValue = regularizeAvbdConstraintValue(
-      avbdRigidPointPairConstraintValue(stateA, stateB, row),
-      row.previousConstraintValue,
-      alpha);
-  const double forceMagnitude
-      = computeAvbdHardConstraintForce(row.state, constraintValue, row.bounds);
-  const Vector6d firstDirection = avbdRigidPointPairDirectionA(stateA, row);
-  const Vector6d secondDirection = avbdRigidPointPairDirectionB(stateB, row);
+  const Eigen::Vector3d worldPointA
+      = avbdRigidBodyWorldPoint(stateA, row.localPointA);
+  const Eigen::Vector3d worldPointB
+      = avbdRigidBodyWorldPoint(stateB, row.localPointB);
+  const double rawConstraintValue
+      = row.offset + row.axis.dot(worldPointB - worldPointA);
+  const double constraintValue
+      = avbdRigidRowUsesFiniteMaterial(row.materialStiffness)
+            ? rawConstraintValue
+            : regularizeAvbdConstraintValue(
+                  rawConstraintValue, row.previousConstraintValue, alpha);
+  const double forceMagnitude = avbdRigidScalarRowForce(
+      row.state, constraintValue, row.bounds, row.materialStiffness);
+  Vector6d firstDirection = Vector6d::Zero();
+  firstDirection.head<3>() = row.axis;
+  firstDirection.tail<3>() = (worldPointA - stateA.position).cross(row.axis);
+  Vector6d secondDirection = Vector6d::Zero();
+  secondDirection.head<3>() = -row.axis;
+  secondDirection.tail<3>() = (worldPointB - stateB.position).cross(-row.axis);
 
   // AVBD solves per-body blocks; coupling is carried by the shared scalar dual.
   blockA.force.noalias() += forceMagnitude * firstDirection;
@@ -996,6 +1549,58 @@ inline double addAvbdRigidPointPair(
 }
 
 //==============================================================================
+inline double addAvbdRigidPointPairDistanceSpring(
+    AvbdRigidBodyBlock& blockA,
+    AvbdRigidBodyBlock& blockB,
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairDistanceSpringRow& row,
+    bool clampToPsd = true)
+{
+  const Eigen::Vector3d worldPointA
+      = avbdRigidBodyWorldPoint(stateA, row.localPointA);
+  const Eigen::Vector3d worldPointB
+      = avbdRigidBodyWorldPoint(stateB, row.localPointB);
+  const Eigen::Vector3d relative = worldPointB - worldPointA;
+  const double length = relative.norm();
+  if (!relative.allFinite() || length <= kAvbdRigidMinDistanceSpringLength) {
+    return 0.0;
+  }
+
+  const Eigen::Vector3d axis = relative / length;
+  const double constraintValue = length - row.restLength;
+  const double forceMagnitude = row.state.stiffness * constraintValue;
+  Vector6d firstDirection = Vector6d::Zero();
+  firstDirection.head<3>() = axis;
+  firstDirection.tail<3>() = (worldPointA - stateA.position).cross(axis);
+  Vector6d secondDirection = Vector6d::Zero();
+  secondDirection.head<3>() = -axis;
+  secondDirection.tail<3>() = (worldPointB - stateB.position).cross(-axis);
+
+  blockA.force.noalias() += forceMagnitude * firstDirection;
+  blockB.force.noalias() += forceMagnitude * secondDirection;
+  addAvbdRigidDistanceSpringHessianAtWorldPoint(
+      blockA,
+      stateA,
+      worldPointA,
+      axis,
+      length,
+      row.restLength,
+      row.state.stiffness,
+      clampToPsd);
+  addAvbdRigidDistanceSpringHessianAtWorldPoint(
+      blockB,
+      stateB,
+      worldPointB,
+      axis,
+      length,
+      row.restLength,
+      row.state.stiffness,
+      clampToPsd);
+  return forceMagnitude;
+}
+
+//==============================================================================
 inline double addAvbdRigidAngularPair(
     AvbdRigidBodyBlock& blockA,
     AvbdRigidBodyBlock& blockB,
@@ -1004,12 +1609,15 @@ inline double addAvbdRigidAngularPair(
     const AvbdRigidAngularPairRow& row,
     double alpha)
 {
-  const double constraintValue = regularizeAvbdConstraintValue(
-      avbdRigidAngularPairConstraintValue(stateA, stateB, row),
-      row.previousConstraintValue,
-      alpha);
-  const double forceMagnitude
-      = computeAvbdHardConstraintForce(row.state, constraintValue, row.bounds);
+  const double rawConstraintValue
+      = avbdRigidAngularPairConstraintValue(stateA, stateB, row);
+  const double constraintValue
+      = avbdRigidRowUsesFiniteMaterial(row.materialStiffness)
+            ? rawConstraintValue
+            : regularizeAvbdConstraintValue(
+                  rawConstraintValue, row.previousConstraintValue, alpha);
+  const double forceMagnitude = avbdRigidScalarRowForce(
+      row.state, constraintValue, row.bounds, row.materialStiffness);
   const Vector6d firstDirection = avbdRigidAngularPairDirectionA(row);
   const Vector6d secondDirection = avbdRigidAngularPairDirectionB(row);
 
@@ -1032,14 +1640,46 @@ inline Eigen::Vector2d addAvbdRigidPointPairFrictionTangentPair(
     const AvbdRigidPointPairRow& second,
     const AvbdRigidPointPairFrictionOptions& options)
 {
-  const Eigen::Vector2d force = avbdRigidPointPairFrictionTangentPairForce(
-      stateA, stateB, first, second, options);
-  const Vector6d firstDirectionA = avbdRigidPointPairDirectionA(stateA, first);
-  const Vector6d firstDirectionB = avbdRigidPointPairDirectionB(stateB, first);
-  const Vector6d secondDirectionA
-      = avbdRigidPointPairDirectionA(stateA, second);
-  const Vector6d secondDirectionB
-      = avbdRigidPointPairDirectionB(stateB, second);
+  const Eigen::Vector3d firstWorldPointA
+      = avbdRigidBodyWorldPoint(stateA, first.localPointA);
+  const Eigen::Vector3d firstWorldPointB
+      = avbdRigidBodyWorldPoint(stateB, first.localPointB);
+  const bool sharedAnchors
+      = avbdRigidPointPairRowsShareLocalPoints(first, second);
+  const Eigen::Vector3d secondWorldPointA
+      = sharedAnchors ? firstWorldPointA
+                      : avbdRigidBodyWorldPoint(stateA, second.localPointA);
+  const Eigen::Vector3d secondWorldPointB
+      = sharedAnchors ? firstWorldPointB
+                      : avbdRigidBodyWorldPoint(stateB, second.localPointB);
+  const Eigen::Vector2d constraintValues
+      = avbdRigidPointPairConstraintValuesAtWorldPoints(
+          first,
+          second,
+          firstWorldPointA,
+          firstWorldPointB,
+          secondWorldPointA,
+          secondWorldPointB,
+          options.alpha);
+  const Eigen::Vector2d force
+      = avbdRigidPointPairFrictionTangentPairForceFromConstraintValues(
+          constraintValues, first, second, options);
+  Vector6d firstDirectionA = Vector6d::Zero();
+  firstDirectionA.head<3>() = first.axis;
+  firstDirectionA.tail<3>()
+      = (firstWorldPointA - stateA.position).cross(first.axis);
+  Vector6d firstDirectionB = Vector6d::Zero();
+  firstDirectionB.head<3>() = -first.axis;
+  firstDirectionB.tail<3>()
+      = (firstWorldPointB - stateB.position).cross(-first.axis);
+  Vector6d secondDirectionA = Vector6d::Zero();
+  secondDirectionA.head<3>() = second.axis;
+  secondDirectionA.tail<3>()
+      = (secondWorldPointA - stateA.position).cross(second.axis);
+  Vector6d secondDirectionB = Vector6d::Zero();
+  secondDirectionB.head<3>() = -second.axis;
+  secondDirectionB.tail<3>()
+      = (secondWorldPointB - stateB.position).cross(-second.axis);
 
   blockA.force.noalias()
       += force.x() * firstDirectionA + force.y() * secondDirectionA;
@@ -1081,12 +1721,51 @@ inline AvbdScalarRowState updateAvbdRigidPointPairRow(
     const AvbdRigidPointPairRow& row,
     const AvbdRigidPointAttachmentOptions& options)
 {
+  if (avbdRigidRowUsesFiniteMaterial(row.materialStiffness)) {
+    state.lambda = 0.0;
+    const double maxStiffness
+        = std::min(row.materialStiffness, options.maxStiffness);
+    if (options.beta >= 0.0 && state.stiffness >= maxStiffness) {
+      state.stiffness = maxStiffness;
+      return state;
+    }
+
+    const double rawConstraintValue
+        = avbdRigidPointPairConstraintValue(stateA, stateB, row);
+    state.stiffness = updateAvbdFiniteStiffness(
+        state.stiffness, rawConstraintValue, options.beta, maxStiffness);
+    return state;
+  }
+
+  const double rawConstraintValue
+      = avbdRigidPointPairConstraintValue(stateA, stateB, row);
   const double constraintValue = regularizeAvbdConstraintValue(
-      avbdRigidPointPairConstraintValue(stateA, stateB, row),
-      row.previousConstraintValue,
-      options.alpha);
+      rawConstraintValue, row.previousConstraintValue, options.alpha);
   return updateAvbdHardConstraintRow(
       state, constraintValue, options.beta, row.bounds, options.maxStiffness);
+}
+
+//==============================================================================
+inline AvbdScalarRowState updateAvbdRigidPointPairDistanceSpringRow(
+    AvbdScalarRowState state,
+    const AvbdRigidBodyState& stateA,
+    const AvbdRigidBodyState& stateB,
+    const AvbdRigidPointPairDistanceSpringRow& row,
+    const AvbdRigidPointPairDistanceSpringOptions& options)
+{
+  state.lambda = 0.0;
+  const double maxStiffness
+      = std::min(row.materialStiffness, options.maxStiffness);
+  if (options.beta >= 0.0 && state.stiffness >= maxStiffness) {
+    state.stiffness = maxStiffness;
+    return state;
+  }
+
+  const double constraintValue
+      = avbdRigidPointPairDistanceSpringConstraintValue(stateA, stateB, row);
+  state.stiffness = updateAvbdFiniteStiffness(
+      state.stiffness, constraintValue, options.beta, maxStiffness);
+  return state;
 }
 
 //==============================================================================
@@ -1097,10 +1776,26 @@ inline AvbdScalarRowState updateAvbdRigidAngularPairRow(
     const AvbdRigidAngularPairRow& row,
     const AvbdRigidPointAttachmentOptions& options)
 {
+  if (avbdRigidRowUsesFiniteMaterial(row.materialStiffness)) {
+    state.lambda = 0.0;
+    const double maxStiffness
+        = std::min(row.materialStiffness, options.maxStiffness);
+    if (options.beta >= 0.0 && state.stiffness >= maxStiffness) {
+      state.stiffness = maxStiffness;
+      return state;
+    }
+
+    const double rawConstraintValue
+        = avbdRigidAngularPairConstraintValue(stateA, stateB, row);
+    state.stiffness = updateAvbdFiniteStiffness(
+        state.stiffness, rawConstraintValue, options.beta, maxStiffness);
+    return state;
+  }
+
+  const double rawConstraintValue
+      = avbdRigidAngularPairConstraintValue(stateA, stateB, row);
   const double constraintValue = regularizeAvbdConstraintValue(
-      avbdRigidAngularPairConstraintValue(stateA, stateB, row),
-      row.previousConstraintValue,
-      options.alpha);
+      rawConstraintValue, row.previousConstraintValue, options.alpha);
   return updateAvbdHardConstraintRow(
       state, constraintValue, options.beta, row.bounds, options.maxStiffness);
 }
@@ -1114,10 +1809,30 @@ inline void updateAvbdRigidPointPairFrictionTangentPair(
     const AvbdRigidPointPairFrictionOptions& options)
 {
   bool clamped = false;
-  const Eigen::Vector2d force = avbdRigidPointPairFrictionTangentPairForce(
-      stateA, stateB, first, second, options, &clamped);
-  const Eigen::Vector2d constraintValues = avbdRigidPointPairConstraintValues(
-      stateA, stateB, first, second, options.alpha);
+  const Eigen::Vector3d firstWorldPointA
+      = avbdRigidBodyWorldPoint(stateA, first.localPointA);
+  const Eigen::Vector3d firstWorldPointB
+      = avbdRigidBodyWorldPoint(stateB, first.localPointB);
+  const bool sharedAnchors
+      = avbdRigidPointPairRowsShareLocalPoints(first, second);
+  const Eigen::Vector3d secondWorldPointA
+      = sharedAnchors ? firstWorldPointA
+                      : avbdRigidBodyWorldPoint(stateA, second.localPointA);
+  const Eigen::Vector3d secondWorldPointB
+      = sharedAnchors ? firstWorldPointB
+                      : avbdRigidBodyWorldPoint(stateB, second.localPointB);
+  const Eigen::Vector2d constraintValues
+      = avbdRigidPointPairConstraintValuesAtWorldPoints(
+          first,
+          second,
+          firstWorldPointA,
+          firstWorldPointB,
+          secondWorldPointA,
+          secondWorldPointB,
+          options.alpha);
+  const Eigen::Vector2d force
+      = avbdRigidPointPairFrictionTangentPairForceFromConstraintValues(
+          constraintValues, first, second, options, &clamped);
 
   first.state.lambda = force.x();
   second.state.lambda = force.y();
@@ -1193,16 +1908,29 @@ inline void buildAvbdRigidContactManifoldRows(
         contact.row));
   }
 
+  std::map<AvbdScalarRowKey, Eigen::Vector3d> previousFrictionDirections;
+  for (const AvbdScalarRowRecord& record : frictionInventory.records()) {
+    if (isValidAvbdRigidContactFrictionDirection(record.direction)) {
+      previousFrictionDirections.emplace(
+          record.descriptor.key, record.direction);
+    }
+  }
+
   normalInventory.syncActiveRows(normalDescriptors, warmStartOptions);
 
   std::vector<AvbdScalarRowDescriptor> frictionDescriptors;
   frictionDescriptors.reserve(2 * activeContacts.size());
   for (std::size_t i = 0; i < activeContacts.size(); ++i) {
     const AvbdRigidContactManifoldPoint& contact = activeContacts[i];
-    const double laggedNormalForce
+    double laggedNormalForce
         = i < normalInventory.size()
               ? std::max(0.0, normalInventory[i].state.lambda)
               : 0.0;
+    if (laggedNormalForce <= 0.0) {
+      // Moving manifolds can keep penetrating after their row identity changes;
+      // keep Coulomb rows bounded by the active normal penalty in that case.
+      laggedNormalForce = std::max(0.0, contact.startStiffness * contact.depth);
+    }
     const double forceLimit
         = std::max(0.0, contact.frictionCoefficient) * laggedNormalForce;
     frictionDescriptors.push_back(makeAvbdContactFrictionRowDescriptor(
@@ -1256,10 +1984,8 @@ inline void buildAvbdRigidContactManifoldRows(
     }
 
     const AvbdRigidContactManifoldPoint& contact = activeContacts[contactIndex];
-    const AvbdScalarRowRecord& firstRecord
-        = frictionInventory[firstRecordIndex];
-    const AvbdScalarRowRecord& secondRecord
-        = frictionInventory[secondRecordIndex];
+    AvbdScalarRowRecord& firstRecord = frictionInventory[firstRecordIndex];
+    AvbdScalarRowRecord& secondRecord = frictionInventory[secondRecordIndex];
     const Eigen::Vector3d localPointA
         = avbdRigidBodyLocalPoint(states[contact.bodyA], contact.point);
     const Eigen::Vector3d localPointB
@@ -1271,6 +1997,27 @@ inline void buildAvbdRigidContactManifoldRows(
         states[contact.bodyA], states[contact.bodyB], seed);
     const Eigen::Matrix<double, 3, 2> basis
         = avbdRigidContactTangentBasis(contact.normalFromAtoB);
+    if (const auto previousFirst
+        = previousFrictionDirections.find(firstRecord.descriptor.key);
+        previousFirst != previousFrictionDirections.end()) {
+      if (const auto previousSecond
+          = previousFrictionDirections.find(secondRecord.descriptor.key);
+          previousSecond != previousFrictionDirections.end()) {
+        const Eigen::Vector2d projected = projectAvbdFrictionDualToTangentPair(
+            firstRecord.state.lambda,
+            secondRecord.state.lambda,
+            previousFirst->second,
+            previousSecond->second,
+            basis.col(0),
+            basis.col(1));
+        firstRecord.state.lambda
+            = clampAvbdRowForce(projected.x(), firstRecord.descriptor.bounds);
+        secondRecord.state.lambda
+            = clampAvbdRowForce(projected.y(), secondRecord.descriptor.bounds);
+      }
+    }
+    firstRecord.direction = basis.col(0);
+    secondRecord.direction = basis.col(1);
     const auto forceLimitFromBounds = [](AvbdScalarRowBounds bounds) {
       const double lowerLimit = bounds.lower < 0.0 ? -bounds.lower : 0.0;
       const double upperLimit = bounds.upper > 0.0 ? bounds.upper : 0.0;
@@ -1312,14 +2059,82 @@ inline void buildAvbdRigidPointJointRows(
 {
   struct ActiveJointAxis
   {
-    AvbdRigidPointJoint joint;
+    const AvbdRigidPointJoint* joint = nullptr;
     std::uint8_t axis = 0;
   };
 
+  const auto appendLinearRows = [&](const auto& activeRows,
+                                    std::size_t activeRowCount) {
+    linearRows.clear();
+    linearRows.reserve(linearInventory.size());
+    for (std::size_t recordIndex = 0; recordIndex < activeRowCount;
+         ++recordIndex) {
+      if (recordIndex >= linearInventory.size()) {
+        return;
+      }
+
+      const AvbdRigidPointJoint& joint = *activeRows[recordIndex].joint;
+      const std::uint8_t axis = activeRows[recordIndex].axis;
+      const AvbdScalarRowRecord& record = linearInventory[recordIndex];
+      AvbdRigidBodyPointPairRow indexedRow;
+      indexedRow.bodyA = joint.bodyA;
+      indexedRow.bodyB = joint.bodyB;
+      indexedRow.row.localPointA = joint.localPointA;
+      indexedRow.row.localPointB = joint.localPointB;
+      indexedRow.row.axis = normalizedAvbdRigidPointPairAxis(
+          joint.linearAxes.col(axis), Eigen::Vector3d::Unit(axis));
+      indexedRow.row.state = record.state;
+      indexedRow.row.materialStiffness = record.descriptor.materialStiffness;
+      indexedRow.row.bounds = record.descriptor.bounds;
+      if (!avbdRigidRowUsesFiniteMaterial(indexedRow.row.materialStiffness)) {
+        indexedRow.row.previousConstraintValue
+            = avbdRigidPointPairConstraintValue(
+                states[joint.bodyA], states[joint.bodyB], indexedRow.row);
+      }
+      linearRows.push_back(indexedRow);
+    }
+  };
+
+  const std::size_t maxActiveRows = 3u * joints.size();
+  if (maxActiveRows <= detail::kAvbdRigidSmallRowStackCapacity) {
+    std::array<ActiveJointAxis, detail::kAvbdRigidSmallRowStackCapacity>
+        activeRows;
+    std::array<AvbdScalarRowDescriptor, detail::kAvbdRigidSmallRowStackCapacity>
+        descriptors;
+    std::size_t activeRowCount = 0u;
+    for (const AvbdRigidPointJoint& joint : joints) {
+      if (!detail::isValidAvbdRigidPointJoint(joint, states.size())) {
+        continue;
+      }
+
+      for (std::uint8_t axis = 0; axis < 3u; ++axis) {
+        if (!detail::avbdRigidJointAxisEnabled(joint.linearAxisMask, axis)) {
+          continue;
+        }
+
+        activeRows[activeRowCount] = ActiveJointAxis{&joint, axis};
+        descriptors[activeRowCount]
+            = detail::makeAvbdRigidJointLinearRowDescriptor(
+                joint.endpointA,
+                joint.endpointB,
+                joint.startStiffness,
+                joint.linearMaterialStiffness,
+                joint.maxStiffness,
+                joint.row,
+                axis);
+        ++activeRowCount;
+      }
+    }
+
+    linearInventory.syncActiveRows(
+        std::span<const AvbdScalarRowDescriptor>{
+            descriptors.data(), activeRowCount},
+        warmStartOptions);
+    appendLinearRows(activeRows, activeRowCount);
+    return;
+  }
+
   std::vector<ActiveJointAxis> activeRows;
-  activeRows.reserve(3 * joints.size());
-  std::vector<AvbdScalarRowDescriptor> descriptors;
-  descriptors.reserve(3 * joints.size());
   for (const AvbdRigidPointJoint& joint : joints) {
     if (!detail::isValidAvbdRigidPointJoint(joint, states.size())) {
       continue;
@@ -1330,44 +2145,39 @@ inline void buildAvbdRigidPointJointRows(
         continue;
       }
 
-      activeRows.push_back(ActiveJointAxis{joint, axis});
-      descriptors.push_back(
-          detail::makeAvbdRigidJointLinearRowDescriptor(
-              joint.endpointA,
-              joint.endpointB,
-              joint.startStiffness,
-              joint.maxStiffness,
-              joint.row,
-              axis));
+      if (activeRows.empty()) {
+        activeRows.reserve(maxActiveRows);
+      }
+      activeRows.push_back(ActiveJointAxis{&joint, axis});
     }
   }
 
-  linearInventory.syncActiveRows(descriptors, warmStartOptions);
-
-  linearRows.clear();
-  linearRows.reserve(linearInventory.size());
-  for (std::size_t recordIndex = 0; recordIndex < activeRows.size();
-       ++recordIndex) {
-    if (recordIndex >= linearInventory.size()) {
-      return;
-    }
-
-    const AvbdRigidPointJoint& joint = activeRows[recordIndex].joint;
-    const std::uint8_t axis = activeRows[recordIndex].axis;
-    const AvbdScalarRowRecord& record = linearInventory[recordIndex];
-    AvbdRigidBodyPointPairRow indexedRow;
-    indexedRow.bodyA = joint.bodyA;
-    indexedRow.bodyB = joint.bodyB;
-    indexedRow.row.localPointA = joint.localPointA;
-    indexedRow.row.localPointB = joint.localPointB;
-    indexedRow.row.axis = normalizedAvbdRigidPointPairAxis(
-        joint.linearAxes.col(axis), Eigen::Vector3d::Unit(axis));
-    indexedRow.row.state = record.state;
-    indexedRow.row.bounds = record.descriptor.bounds;
-    indexedRow.row.previousConstraintValue = avbdRigidPointPairConstraintValue(
-        states[joint.bodyA], states[joint.bodyB], indexedRow.row);
-    linearRows.push_back(indexedRow);
-  }
+  linearInventory.syncActiveRowsByIndex(
+      activeRows.size(),
+      [&](std::size_t index) {
+        const ActiveJointAxis& activeRow = activeRows[index];
+        const AvbdRigidPointJoint& joint = *activeRow.joint;
+        return makeAvbdEndpointPairRowKey(
+            AvbdScalarRowRole::JointLinear,
+            joint.endpointA,
+            joint.endpointB,
+            joint.row,
+            activeRow.axis);
+      },
+      [&](std::size_t index) {
+        const ActiveJointAxis& activeRow = activeRows[index];
+        const AvbdRigidPointJoint& joint = *activeRow.joint;
+        return detail::makeAvbdRigidJointLinearRowDescriptor(
+            joint.endpointA,
+            joint.endpointB,
+            joint.startStiffness,
+            joint.linearMaterialStiffness,
+            joint.maxStiffness,
+            joint.row,
+            activeRow.axis);
+      },
+      warmStartOptions);
+  appendLinearRows(activeRows, activeRows.size());
 }
 
 //==============================================================================
@@ -1380,14 +2190,81 @@ inline void buildAvbdRigidPointJointAngularRows(
 {
   struct ActiveJointAxis
   {
-    AvbdRigidPointJoint joint;
+    const AvbdRigidPointJoint* joint = nullptr;
     std::uint8_t axis = 0;
   };
 
+  const auto appendAngularRows = [&](const auto& activeRows,
+                                     std::size_t activeRowCount) {
+    angularRows.clear();
+    angularRows.reserve(angularInventory.size());
+    for (std::size_t recordIndex = 0; recordIndex < activeRowCount;
+         ++recordIndex) {
+      if (recordIndex >= angularInventory.size()) {
+        return;
+      }
+
+      const AvbdRigidPointJoint& joint = *activeRows[recordIndex].joint;
+      const std::uint8_t axis = activeRows[recordIndex].axis;
+      const AvbdScalarRowRecord& record = angularInventory[recordIndex];
+      AvbdRigidBodyAngularPairRow indexedRow;
+      indexedRow.bodyA = joint.bodyA;
+      indexedRow.bodyB = joint.bodyB;
+      indexedRow.row = makeAvbdRigidJointAngularRow(
+          joint.targetRelativeOrientation,
+          joint.angularAxes.col(axis),
+          record.state);
+      indexedRow.row.materialStiffness = record.descriptor.materialStiffness;
+      indexedRow.row.bounds = record.descriptor.bounds;
+      if (!avbdRigidRowUsesFiniteMaterial(indexedRow.row.materialStiffness)) {
+        indexedRow.row.previousConstraintValue
+            = avbdRigidAngularPairConstraintValue(
+                states[joint.bodyA], states[joint.bodyB], indexedRow.row);
+      }
+      angularRows.push_back(indexedRow);
+    }
+  };
+
+  const std::size_t maxActiveRows = 3u * joints.size();
+  if (maxActiveRows <= detail::kAvbdRigidSmallRowStackCapacity) {
+    std::array<ActiveJointAxis, detail::kAvbdRigidSmallRowStackCapacity>
+        activeRows;
+    std::array<AvbdScalarRowDescriptor, detail::kAvbdRigidSmallRowStackCapacity>
+        descriptors;
+    std::size_t activeRowCount = 0u;
+    for (const AvbdRigidPointJoint& joint : joints) {
+      if (!detail::isValidAvbdRigidPointJoint(joint, states.size())) {
+        continue;
+      }
+
+      for (std::uint8_t axis = 0; axis < 3u; ++axis) {
+        if (!detail::avbdRigidJointAxisEnabled(joint.angularAxisMask, axis)) {
+          continue;
+        }
+
+        activeRows[activeRowCount] = ActiveJointAxis{&joint, axis};
+        descriptors[activeRowCount]
+            = detail::makeAvbdRigidJointAngularRowDescriptor(
+                joint.endpointA,
+                joint.endpointB,
+                joint.startStiffness,
+                joint.angularMaterialStiffness,
+                joint.maxStiffness,
+                joint.row,
+                axis);
+        ++activeRowCount;
+      }
+    }
+
+    angularInventory.syncActiveRows(
+        std::span<const AvbdScalarRowDescriptor>{
+            descriptors.data(), activeRowCount},
+        warmStartOptions);
+    appendAngularRows(activeRows, activeRowCount);
+    return;
+  }
+
   std::vector<ActiveJointAxis> activeRows;
-  activeRows.reserve(3 * joints.size());
-  std::vector<AvbdScalarRowDescriptor> descriptors;
-  descriptors.reserve(3 * joints.size());
   for (const AvbdRigidPointJoint& joint : joints) {
     if (!detail::isValidAvbdRigidPointJoint(joint, states.size())) {
       continue;
@@ -1398,44 +2275,39 @@ inline void buildAvbdRigidPointJointAngularRows(
         continue;
       }
 
-      activeRows.push_back(ActiveJointAxis{joint, axis});
-      descriptors.push_back(
-          detail::makeAvbdRigidJointAngularRowDescriptor(
-              joint.endpointA,
-              joint.endpointB,
-              joint.startStiffness,
-              joint.maxStiffness,
-              joint.row,
-              axis));
+      if (activeRows.empty()) {
+        activeRows.reserve(maxActiveRows);
+      }
+      activeRows.push_back(ActiveJointAxis{&joint, axis});
     }
   }
 
-  angularInventory.syncActiveRows(descriptors, warmStartOptions);
-
-  angularRows.clear();
-  angularRows.reserve(angularInventory.size());
-  for (std::size_t recordIndex = 0; recordIndex < activeRows.size();
-       ++recordIndex) {
-    if (recordIndex >= angularInventory.size()) {
-      return;
-    }
-
-    const AvbdRigidPointJoint& joint = activeRows[recordIndex].joint;
-    const std::uint8_t axis = activeRows[recordIndex].axis;
-    const AvbdScalarRowRecord& record = angularInventory[recordIndex];
-    AvbdRigidBodyAngularPairRow indexedRow;
-    indexedRow.bodyA = joint.bodyA;
-    indexedRow.bodyB = joint.bodyB;
-    indexedRow.row = makeAvbdRigidJointAngularRow(
-        joint.targetRelativeOrientation,
-        joint.angularAxes.col(axis),
-        record.state);
-    indexedRow.row.bounds = record.descriptor.bounds;
-    indexedRow.row.previousConstraintValue
-        = avbdRigidAngularPairConstraintValue(
-            states[joint.bodyA], states[joint.bodyB], indexedRow.row);
-    angularRows.push_back(indexedRow);
-  }
+  angularInventory.syncActiveRowsByIndex(
+      activeRows.size(),
+      [&](std::size_t index) {
+        const ActiveJointAxis& activeRow = activeRows[index];
+        const AvbdRigidPointJoint& joint = *activeRow.joint;
+        return makeAvbdEndpointPairRowKey(
+            AvbdScalarRowRole::JointAngular,
+            joint.endpointA,
+            joint.endpointB,
+            joint.row,
+            activeRow.axis);
+      },
+      [&](std::size_t index) {
+        const ActiveJointAxis& activeRow = activeRows[index];
+        const AvbdRigidPointJoint& joint = *activeRow.joint;
+        return detail::makeAvbdRigidJointAngularRowDescriptor(
+            joint.endpointA,
+            joint.endpointB,
+            joint.startStiffness,
+            joint.angularMaterialStiffness,
+            joint.maxStiffness,
+            joint.row,
+            activeRow.axis);
+      },
+      warmStartOptions);
+  appendAngularRows(activeRows, activeRows.size());
 }
 
 //==============================================================================
@@ -1449,25 +2321,36 @@ inline void buildAvbdRigidAngularMotorRows(
 {
   std::vector<AvbdRigidAngularMotor> activeRows;
   activeRows.reserve(motors.size());
-  std::vector<AvbdScalarRowDescriptor> descriptors;
-  descriptors.reserve(motors.size());
   for (const AvbdRigidAngularMotor& motor : motors) {
     if (!detail::isValidAvbdRigidAngularMotor(motor, states.size(), timeStep)) {
       continue;
     }
 
     activeRows.push_back(motor);
-    descriptors.push_back(
-        detail::makeAvbdRigidAngularMotorRowDescriptor(
+  }
+
+  motorInventory.syncActiveRowsByIndex(
+      activeRows.size(),
+      [&](std::size_t index) {
+        const AvbdRigidAngularMotor& motor = activeRows[index];
+        return makeAvbdEndpointPairRowKey(
+            AvbdScalarRowRole::Motor,
+            motor.endpointA,
+            motor.endpointB,
+            motor.row,
+            /*axis=*/0);
+      },
+      [&](std::size_t index) {
+        const AvbdRigidAngularMotor& motor = activeRows[index];
+        return detail::makeAvbdRigidAngularMotorRowDescriptor(
             motor.endpointA,
             motor.endpointB,
             motor.maxTorque,
             motor.startStiffness,
             motor.maxStiffness,
-            motor.row));
-  }
-
-  motorInventory.syncActiveRows(descriptors, warmStartOptions);
+            motor.row);
+      },
+      warmStartOptions);
 
   motorRows.clear();
   motorRows.reserve(motorInventory.size());
@@ -1494,6 +2377,205 @@ inline void buildAvbdRigidAngularMotorRows(
 }
 
 //==============================================================================
+inline void buildAvbdRigidMotorRows(
+    const std::vector<AvbdRigidBodyState>& states,
+    std::span<const AvbdRigidLinearMotor> linearMotors,
+    std::span<const AvbdRigidAngularMotor> angularMotors,
+    AvbdScalarRowInventory& motorInventory,
+    std::vector<AvbdRigidBodyPointPairRow>& linearMotorRows,
+    std::vector<AvbdRigidBodyAngularPairRow>& angularMotorRows,
+    double timeStep,
+    const AvbdRowWarmStartOptions& warmStartOptions = {})
+{
+  const auto appendMotorRows = [&](const auto& activeLinearRows,
+                                   std::size_t activeLinearCount,
+                                   const auto& activeAngularRows,
+                                   std::size_t activeAngularCount) {
+    linearMotorRows.clear();
+    linearMotorRows.reserve(activeLinearCount);
+    std::size_t recordIndex = 0;
+    for (std::size_t motorIndex = 0; motorIndex < activeLinearCount;
+         ++motorIndex) {
+      if (recordIndex >= motorInventory.size()) {
+        return;
+      }
+
+      const AvbdRigidLinearMotor& motor = *activeLinearRows[motorIndex];
+      const AvbdScalarRowRecord& record = motorInventory[recordIndex++];
+      AvbdRigidBodyPointPairRow indexedRow;
+      indexedRow.bodyA = motor.bodyA;
+      indexedRow.bodyB = motor.bodyB;
+      const Eigen::Vector3d stepStartRelativePosition
+          = avbdRigidBodyWorldPoint(states[motor.bodyB], motor.localPointB)
+            - avbdRigidBodyWorldPoint(states[motor.bodyA], motor.localPointA);
+      indexedRow.row = makeAvbdRigidLinearMotorRow(
+          motor.localPointA,
+          motor.localPointB,
+          motor.axis,
+          stepStartRelativePosition,
+          motor.targetSpeed,
+          timeStep,
+          record.state);
+      indexedRow.row.bounds = record.descriptor.bounds;
+      linearMotorRows.push_back(indexedRow);
+    }
+
+    angularMotorRows.clear();
+    angularMotorRows.reserve(activeAngularCount);
+    for (std::size_t motorIndex = 0; motorIndex < activeAngularCount;
+         ++motorIndex) {
+      if (recordIndex >= motorInventory.size()) {
+        return;
+      }
+
+      const AvbdRigidAngularMotor& motor = *activeAngularRows[motorIndex];
+      const AvbdScalarRowRecord& record = motorInventory[recordIndex++];
+      AvbdRigidBodyAngularPairRow indexedRow;
+      indexedRow.bodyA = motor.bodyA;
+      indexedRow.bodyB = motor.bodyB;
+      indexedRow.row = makeAvbdRigidAngularMotorRow(
+          motor.targetRelativeOrientation,
+          motor.axis,
+          motor.targetSpeed,
+          timeStep,
+          record.state);
+      indexedRow.row.bounds = record.descriptor.bounds;
+      angularMotorRows.push_back(indexedRow);
+    }
+  };
+
+  const std::size_t maxActiveRows = linearMotors.size() + angularMotors.size();
+  if (maxActiveRows <= detail::kAvbdRigidSmallRowStackCapacity) {
+    std::array<
+        const AvbdRigidLinearMotor*,
+        detail::kAvbdRigidSmallRowStackCapacity>
+        activeLinearRows;
+    std::array<
+        const AvbdRigidAngularMotor*,
+        detail::kAvbdRigidSmallRowStackCapacity>
+        activeAngularRows;
+    std::array<AvbdScalarRowDescriptor, detail::kAvbdRigidSmallRowStackCapacity>
+        descriptors;
+    std::size_t activeLinearCount = 0u;
+    std::size_t activeAngularCount = 0u;
+    std::size_t descriptorCount = 0u;
+    for (const AvbdRigidLinearMotor& motor : linearMotors) {
+      if (!detail::isValidAvbdRigidLinearMotor(
+              motor, states.size(), timeStep)) {
+        continue;
+      }
+
+      activeLinearRows[activeLinearCount++] = &motor;
+      descriptors[descriptorCount++]
+          = detail::makeAvbdRigidLinearMotorRowDescriptor(
+              motor.endpointA,
+              motor.endpointB,
+              motor.maxForce,
+              motor.startStiffness,
+              motor.maxStiffness,
+              motor.row);
+    }
+    for (const AvbdRigidAngularMotor& motor : angularMotors) {
+      if (!detail::isValidAvbdRigidAngularMotor(
+              motor, states.size(), timeStep)) {
+        continue;
+      }
+
+      activeAngularRows[activeAngularCount++] = &motor;
+      descriptors[descriptorCount++]
+          = detail::makeAvbdRigidAngularMotorRowDescriptor(
+              motor.endpointA,
+              motor.endpointB,
+              motor.maxTorque,
+              motor.startStiffness,
+              motor.maxStiffness,
+              motor.row);
+    }
+
+    motorInventory.syncActiveRows(
+        std::span<const AvbdScalarRowDescriptor>{
+            descriptors.data(), descriptorCount},
+        warmStartOptions);
+    appendMotorRows(
+        activeLinearRows,
+        activeLinearCount,
+        activeAngularRows,
+        activeAngularCount);
+    return;
+  }
+
+  std::vector<const AvbdRigidLinearMotor*> activeLinearRows;
+  activeLinearRows.reserve(linearMotors.size());
+  std::vector<const AvbdRigidAngularMotor*> activeAngularRows;
+  activeAngularRows.reserve(angularMotors.size());
+  for (const AvbdRigidLinearMotor& motor : linearMotors) {
+    if (!detail::isValidAvbdRigidLinearMotor(motor, states.size(), timeStep)) {
+      continue;
+    }
+
+    activeLinearRows.push_back(&motor);
+  }
+  for (const AvbdRigidAngularMotor& motor : angularMotors) {
+    if (!detail::isValidAvbdRigidAngularMotor(motor, states.size(), timeStep)) {
+      continue;
+    }
+
+    activeAngularRows.push_back(&motor);
+  }
+
+  motorInventory.syncActiveRowsByIndex(
+      activeLinearRows.size() + activeAngularRows.size(),
+      [&](std::size_t index) {
+        if (index < activeLinearRows.size()) {
+          const AvbdRigidLinearMotor& motor = *activeLinearRows[index];
+          return makeAvbdEndpointPairRowKey(
+              AvbdScalarRowRole::Motor,
+              motor.endpointA,
+              motor.endpointB,
+              motor.row,
+              /*axis=*/0);
+        }
+
+        const AvbdRigidAngularMotor& motor
+            = *activeAngularRows[index - activeLinearRows.size()];
+        return makeAvbdEndpointPairRowKey(
+            AvbdScalarRowRole::Motor,
+            motor.endpointA,
+            motor.endpointB,
+            motor.row,
+            /*axis=*/0);
+      },
+      [&](std::size_t index) {
+        if (index < activeLinearRows.size()) {
+          const AvbdRigidLinearMotor& motor = *activeLinearRows[index];
+          return detail::makeAvbdRigidLinearMotorRowDescriptor(
+              motor.endpointA,
+              motor.endpointB,
+              motor.maxForce,
+              motor.startStiffness,
+              motor.maxStiffness,
+              motor.row);
+        }
+
+        const AvbdRigidAngularMotor& motor
+            = *activeAngularRows[index - activeLinearRows.size()];
+        return detail::makeAvbdRigidAngularMotorRowDescriptor(
+            motor.endpointA,
+            motor.endpointB,
+            motor.maxTorque,
+            motor.startStiffness,
+            motor.maxStiffness,
+            motor.row);
+      },
+      warmStartOptions);
+  appendMotorRows(
+      activeLinearRows,
+      activeLinearRows.size(),
+      activeAngularRows,
+      activeAngularRows.size());
+}
+
+//==============================================================================
 inline void buildAvbdRigidPointJointConstraintRows(
     const std::vector<AvbdRigidBodyState>& states,
     std::span<const AvbdRigidPointJoint> joints,
@@ -1510,12 +2592,163 @@ inline void buildAvbdRigidPointJointConstraintRows(
 }
 
 //==============================================================================
+inline void buildAvbdRigidDistanceSpringRows(
+    const std::vector<AvbdRigidBodyState>& states,
+    std::span<const AvbdRigidBodyPointPairDistanceSpringRow> springs,
+    AvbdScalarRowInventory& springInventory,
+    std::vector<AvbdRigidBodyPointPairDistanceSpringRow>& springRows,
+    const AvbdRowWarmStartOptions& warmStartOptions = {})
+{
+  const auto appendSpringRows = [&](const auto& activeRows,
+                                    std::size_t activeRowCount) {
+    springRows.clear();
+    springRows.reserve(springInventory.size());
+    for (std::size_t recordIndex = 0; recordIndex < activeRowCount;
+         ++recordIndex) {
+      if (recordIndex >= springInventory.size()) {
+        return;
+      }
+
+      AvbdRigidBodyPointPairDistanceSpringRow indexedRow
+          = *activeRows[recordIndex];
+      const AvbdScalarRowRecord& record = springInventory[recordIndex];
+      indexedRow.row.state = record.state;
+      indexedRow.row.materialStiffness = record.descriptor.materialStiffness;
+      springRows.push_back(indexedRow);
+    }
+  };
+
+  if (springs.size() <= detail::kAvbdRigidSmallRowStackCapacity) {
+    std::array<
+        const AvbdRigidBodyPointPairDistanceSpringRow*,
+        detail::kAvbdRigidSmallRowStackCapacity>
+        activeRows;
+    std::array<AvbdScalarRowDescriptor, detail::kAvbdRigidSmallRowStackCapacity>
+        descriptors;
+    std::size_t activeRowCount = 0u;
+    for (const AvbdRigidBodyPointPairDistanceSpringRow& spring : springs) {
+      if (!detail::isValidAvbdRigidDistanceSpring(spring, states.size())) {
+        continue;
+      }
+
+      activeRows[activeRowCount] = &spring;
+      descriptors[activeRowCount]
+          = detail::makeAvbdRigidDistanceSpringRowDescriptor(
+              spring.endpointA,
+              spring.endpointB,
+              spring.startStiffness,
+              spring.row.materialStiffness,
+              spring.maxStiffness,
+              spring.rowIndex);
+      ++activeRowCount;
+    }
+
+    springInventory.syncActiveRows(
+        std::span<const AvbdScalarRowDescriptor>{
+            descriptors.data(), activeRowCount},
+        warmStartOptions);
+    appendSpringRows(activeRows, activeRowCount);
+    return;
+  }
+
+  std::vector<const AvbdRigidBodyPointPairDistanceSpringRow*> activeRows;
+  activeRows.reserve(springs.size());
+  for (const AvbdRigidBodyPointPairDistanceSpringRow& spring : springs) {
+    if (!detail::isValidAvbdRigidDistanceSpring(spring, states.size())) {
+      continue;
+    }
+
+    activeRows.push_back(&spring);
+  }
+
+  springInventory.syncActiveRowsByIndex(
+      activeRows.size(),
+      [&](std::size_t index) {
+        const AvbdRigidBodyPointPairDistanceSpringRow& spring
+            = *activeRows[index];
+        return makeAvbdEndpointPairRowKey(
+            AvbdScalarRowRole::RigidDistanceSpring,
+            spring.endpointA,
+            spring.endpointB,
+            spring.rowIndex,
+            /*axis=*/0);
+      },
+      [&](std::size_t index) {
+        const AvbdRigidBodyPointPairDistanceSpringRow& spring
+            = *activeRows[index];
+        return detail::makeAvbdRigidDistanceSpringRowDescriptor(
+            spring.endpointA,
+            spring.endpointB,
+            spring.startStiffness,
+            spring.row.materialStiffness,
+            spring.maxStiffness,
+            spring.rowIndex);
+      },
+      warmStartOptions);
+  appendSpringRows(activeRows, activeRows.size());
+}
+
+//==============================================================================
+inline std::uint64_t avbdRigidBodyRowKey(std::uint32_t body) noexcept
+{
+  return static_cast<std::uint64_t>(body);
+}
+
+//==============================================================================
+inline std::uint64_t avbdRigidBodyPairRowKey(
+    std::uint32_t bodyA, std::uint32_t bodyB) noexcept
+{
+  return (static_cast<std::uint64_t>(bodyA) << 32u)
+         | static_cast<std::uint64_t>(bodyB);
+}
+
+//==============================================================================
+template <typename Rows, typename KeyFn>
+inline bool avbdRigidRowIndexLayoutMatches(
+    const Rows& rows,
+    std::size_t bodyCount,
+    std::size_t cachedBodyCount,
+    const std::vector<std::uint64_t>& cachedKeys,
+    const std::vector<std::size_t>& offsets,
+    KeyFn keyOf)
+{
+  if (cachedBodyCount != bodyCount || offsets.size() != bodyCount + 1u
+      || cachedKeys.size() != rows.size()) {
+    return false;
+  }
+
+  for (std::size_t rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
+    if (cachedKeys[rowIndex] != keyOf(rows[rowIndex])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+//==============================================================================
+template <typename Rows, typename KeyFn>
+inline void avbdRigidRefreshRowIndexLayoutKeys(
+    const Rows& rows,
+    std::size_t bodyCount,
+    std::size_t& cachedBodyCount,
+    std::vector<std::uint64_t>& cachedKeys,
+    KeyFn keyOf)
+{
+  cachedBodyCount = bodyCount;
+  cachedKeys.clear();
+  cachedKeys.reserve(rows.size());
+  for (std::size_t rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
+    cachedKeys.push_back(keyOf(rows[rowIndex]));
+  }
+}
+
+//==============================================================================
 inline AvbdRigidBlockDescentStats blockDescentRigidBodiesAvbdRows(
     std::vector<AvbdRigidBodyState>& states,
     const std::vector<double>& masses,
     const std::vector<Eigen::Matrix3d>& bodyInertias,
     const std::vector<std::uint8_t>& fixed,
-    const std::vector<AvbdRigidBodyState>& inertialTargets,
+    std::span<const AvbdRigidBodyState> inertialTargets,
     double timeStep,
     std::vector<AvbdRigidBodyPointAttachmentRow>& attachmentRows,
     std::vector<AvbdRigidBodyPointPairRow>& pointPairRows,
@@ -1523,7 +2756,10 @@ inline AvbdRigidBlockDescentStats blockDescentRigidBodiesAvbdRows(
     std::vector<AvbdRigidBodyPointPairFrictionRows>& frictionPairRows,
     const AvbdRigidBlockDescentOptions& options,
     const AvbdRigidPointAttachmentOptions& rowOptions,
-    const AvbdRigidPointPairFrictionOptions& frictionOptions)
+    const AvbdRigidPointPairFrictionOptions& frictionOptions,
+    AvbdRigidBodyRowIndexScratch* rowIndexScratch = nullptr,
+    std::span<AvbdRigidBodyPointPairDistanceSpringRow> distanceSpringRows = {},
+    const AvbdRigidPointPairDistanceSpringOptions& distanceSpringOptions = {})
 {
   AvbdRigidBlockDescentStats stats;
   const std::size_t bodyCount = states.size();
@@ -1537,119 +2773,571 @@ inline AvbdRigidBlockDescentStats blockDescentRigidBodiesAvbdRows(
     return body < bodyCount;
   };
 
+  AvbdRigidBodyRowIndexScratch localRowIndexScratch;
+  AvbdRigidBodyRowIndexScratch& rowIndexData
+      = rowIndexScratch != nullptr ? *rowIndexScratch : localRowIndexScratch;
+
+  auto& attachmentRowOffsets = rowIndexData.attachmentRowOffsets;
+  auto& attachmentRowIndices = rowIndexData.attachmentRowIndices;
+  auto& attachmentRowCursor = rowIndexData.attachmentRowCursor;
+  const auto attachmentRowKeyOf
+      = [](const AvbdRigidBodyPointAttachmentRow& row) {
+          return avbdRigidBodyRowKey(row.body);
+        };
+  const auto clearAttachmentRowLayout = [&]() {
+    attachmentRowOffsets.clear();
+    attachmentRowIndices.clear();
+    attachmentRowCursor.clear();
+    rowIndexData.attachmentRowBodyKeys.clear();
+    rowIndexData.attachmentRowBodyCount = 0u;
+  };
+  if (attachmentRows.empty()) {
+    clearAttachmentRowLayout();
+  } else if (!avbdRigidRowIndexLayoutMatches(
+                 attachmentRows,
+                 bodyCount,
+                 rowIndexData.attachmentRowBodyCount,
+                 rowIndexData.attachmentRowBodyKeys,
+                 attachmentRowOffsets,
+                 attachmentRowKeyOf)) {
+    attachmentRowOffsets.assign(bodyCount + 1u, 0u);
+    for (std::size_t rowIndex = 0; rowIndex < attachmentRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointAttachmentRow& indexedRow
+          = attachmentRows[rowIndex];
+      if (validBody(indexedRow.body)) {
+        ++attachmentRowOffsets[indexedRow.body + 1u];
+      }
+    }
+    for (std::size_t body = 1; body < attachmentRowOffsets.size(); ++body) {
+      attachmentRowOffsets[body] += attachmentRowOffsets[body - 1u];
+    }
+    attachmentRowIndices.resize(attachmentRowOffsets.back());
+    attachmentRowCursor.assign(
+        attachmentRowOffsets.begin(), attachmentRowOffsets.end());
+    for (std::size_t rowIndex = 0; rowIndex < attachmentRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointAttachmentRow& indexedRow
+          = attachmentRows[rowIndex];
+      if (validBody(indexedRow.body)) {
+        attachmentRowIndices[attachmentRowCursor[indexedRow.body]++] = rowIndex;
+      }
+    }
+    avbdRigidRefreshRowIndexLayoutKeys(
+        attachmentRows,
+        bodyCount,
+        rowIndexData.attachmentRowBodyCount,
+        rowIndexData.attachmentRowBodyKeys,
+        attachmentRowKeyOf);
+  }
+
+  auto& pointPairRowOffsets = rowIndexData.pointPairRowOffsets;
+  auto& pointPairRowIndices = rowIndexData.pointPairRowIndices;
+  auto& pointPairRowCursor = rowIndexData.pointPairRowCursor;
+  const auto pointPairRowKeyOf = [](const AvbdRigidBodyPointPairRow& row) {
+    return avbdRigidBodyPairRowKey(row.bodyA, row.bodyB);
+  };
+  const auto clearPointPairRowLayout = [&]() {
+    pointPairRowOffsets.clear();
+    pointPairRowIndices.clear();
+    pointPairRowCursor.clear();
+    rowIndexData.pointPairRowBodyKeys.clear();
+    rowIndexData.pointPairRowBodyCount = 0u;
+  };
+  if (pointPairRows.empty()) {
+    clearPointPairRowLayout();
+  } else if (!avbdRigidRowIndexLayoutMatches(
+                 pointPairRows,
+                 bodyCount,
+                 rowIndexData.pointPairRowBodyCount,
+                 rowIndexData.pointPairRowBodyKeys,
+                 pointPairRowOffsets,
+                 pointPairRowKeyOf)) {
+    pointPairRowOffsets.assign(bodyCount + 1u, 0u);
+    for (std::size_t rowIndex = 0; rowIndex < pointPairRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointPairRow& indexedRow = pointPairRows[rowIndex];
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)) {
+        ++pointPairRowOffsets[indexedRow.bodyA + 1u];
+        if (indexedRow.bodyB != indexedRow.bodyA) {
+          ++pointPairRowOffsets[indexedRow.bodyB + 1u];
+        }
+      }
+    }
+    for (std::size_t body = 1; body < pointPairRowOffsets.size(); ++body) {
+      pointPairRowOffsets[body] += pointPairRowOffsets[body - 1u];
+    }
+    pointPairRowIndices.resize(pointPairRowOffsets.back());
+    pointPairRowCursor.assign(
+        pointPairRowOffsets.begin(), pointPairRowOffsets.end());
+    for (std::size_t rowIndex = 0; rowIndex < pointPairRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointPairRow& indexedRow = pointPairRows[rowIndex];
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)) {
+        pointPairRowIndices[pointPairRowCursor[indexedRow.bodyA]++] = rowIndex;
+        if (indexedRow.bodyB != indexedRow.bodyA) {
+          pointPairRowIndices[pointPairRowCursor[indexedRow.bodyB]++]
+              = rowIndex;
+        }
+      }
+    }
+    avbdRigidRefreshRowIndexLayoutKeys(
+        pointPairRows,
+        bodyCount,
+        rowIndexData.pointPairRowBodyCount,
+        rowIndexData.pointPairRowBodyKeys,
+        pointPairRowKeyOf);
+  }
+
+  auto& distanceSpringRowOffsets = rowIndexData.distanceSpringRowOffsets;
+  auto& distanceSpringRowIndices = rowIndexData.distanceSpringRowIndices;
+  auto& distanceSpringRowCursor = rowIndexData.distanceSpringRowCursor;
+  const auto distanceSpringRowKeyOf
+      = [](const AvbdRigidBodyPointPairDistanceSpringRow& row) {
+          return avbdRigidBodyPairRowKey(row.bodyA, row.bodyB);
+        };
+  const auto clearDistanceSpringRowLayout = [&]() {
+    distanceSpringRowOffsets.clear();
+    distanceSpringRowIndices.clear();
+    distanceSpringRowCursor.clear();
+    rowIndexData.distanceSpringRowBodyKeys.clear();
+    rowIndexData.distanceSpringRowBodyCount = 0u;
+  };
+  if (distanceSpringRows.empty()) {
+    clearDistanceSpringRowLayout();
+  } else if (!avbdRigidRowIndexLayoutMatches(
+                 distanceSpringRows,
+                 bodyCount,
+                 rowIndexData.distanceSpringRowBodyCount,
+                 rowIndexData.distanceSpringRowBodyKeys,
+                 distanceSpringRowOffsets,
+                 distanceSpringRowKeyOf)) {
+    distanceSpringRowOffsets.assign(bodyCount + 1u, 0u);
+    for (std::size_t rowIndex = 0; rowIndex < distanceSpringRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointPairDistanceSpringRow& indexedRow
+          = distanceSpringRows[rowIndex];
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)
+          && indexedRow.bodyB != indexedRow.bodyA) {
+        ++distanceSpringRowOffsets[indexedRow.bodyA + 1u];
+        ++distanceSpringRowOffsets[indexedRow.bodyB + 1u];
+      }
+    }
+    for (std::size_t body = 1; body < distanceSpringRowOffsets.size(); ++body) {
+      distanceSpringRowOffsets[body] += distanceSpringRowOffsets[body - 1u];
+    }
+    distanceSpringRowIndices.resize(distanceSpringRowOffsets.back());
+    distanceSpringRowCursor.assign(
+        distanceSpringRowOffsets.begin(), distanceSpringRowOffsets.end());
+    for (std::size_t rowIndex = 0; rowIndex < distanceSpringRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointPairDistanceSpringRow& indexedRow
+          = distanceSpringRows[rowIndex];
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)
+          && indexedRow.bodyB != indexedRow.bodyA) {
+        distanceSpringRowIndices[distanceSpringRowCursor[indexedRow.bodyA]++]
+            = rowIndex;
+        distanceSpringRowIndices[distanceSpringRowCursor[indexedRow.bodyB]++]
+            = rowIndex;
+      }
+    }
+    avbdRigidRefreshRowIndexLayoutKeys(
+        distanceSpringRows,
+        bodyCount,
+        rowIndexData.distanceSpringRowBodyCount,
+        rowIndexData.distanceSpringRowBodyKeys,
+        distanceSpringRowKeyOf);
+  }
+
+  auto& angularPairRowOffsets = rowIndexData.angularPairRowOffsets;
+  auto& angularPairRowIndices = rowIndexData.angularPairRowIndices;
+  auto& angularPairRowCursor = rowIndexData.angularPairRowCursor;
+  const auto angularPairRowKeyOf = [](const AvbdRigidBodyAngularPairRow& row) {
+    return avbdRigidBodyPairRowKey(row.bodyA, row.bodyB);
+  };
+  const auto clearAngularPairRowLayout = [&]() {
+    angularPairRowOffsets.clear();
+    angularPairRowIndices.clear();
+    angularPairRowCursor.clear();
+    rowIndexData.angularPairRowBodyKeys.clear();
+    rowIndexData.angularPairRowBodyCount = 0u;
+  };
+  if (angularPairRows.empty()) {
+    clearAngularPairRowLayout();
+  } else if (!avbdRigidRowIndexLayoutMatches(
+                 angularPairRows,
+                 bodyCount,
+                 rowIndexData.angularPairRowBodyCount,
+                 rowIndexData.angularPairRowBodyKeys,
+                 angularPairRowOffsets,
+                 angularPairRowKeyOf)) {
+    angularPairRowOffsets.assign(bodyCount + 1u, 0u);
+    for (std::size_t rowIndex = 0; rowIndex < angularPairRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyAngularPairRow& indexedRow = angularPairRows[rowIndex];
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)) {
+        ++angularPairRowOffsets[indexedRow.bodyA + 1u];
+        if (indexedRow.bodyB != indexedRow.bodyA) {
+          ++angularPairRowOffsets[indexedRow.bodyB + 1u];
+        }
+      }
+    }
+    for (std::size_t body = 1; body < angularPairRowOffsets.size(); ++body) {
+      angularPairRowOffsets[body] += angularPairRowOffsets[body - 1u];
+    }
+    angularPairRowIndices.resize(angularPairRowOffsets.back());
+    angularPairRowCursor.assign(
+        angularPairRowOffsets.begin(), angularPairRowOffsets.end());
+    for (std::size_t rowIndex = 0; rowIndex < angularPairRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyAngularPairRow& indexedRow = angularPairRows[rowIndex];
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)) {
+        angularPairRowIndices[angularPairRowCursor[indexedRow.bodyA]++]
+            = rowIndex;
+        if (indexedRow.bodyB != indexedRow.bodyA) {
+          angularPairRowIndices[angularPairRowCursor[indexedRow.bodyB]++]
+              = rowIndex;
+        }
+      }
+    }
+    avbdRigidRefreshRowIndexLayoutKeys(
+        angularPairRows,
+        bodyCount,
+        rowIndexData.angularPairRowBodyCount,
+        rowIndexData.angularPairRowBodyKeys,
+        angularPairRowKeyOf);
+  }
+
+  auto& frictionPairRowOffsets = rowIndexData.frictionPairRowOffsets;
+  auto& frictionPairRowIndices = rowIndexData.frictionPairRowIndices;
+  auto& frictionPairRowCursor = rowIndexData.frictionPairRowCursor;
+  const auto frictionPairRowKeyOf
+      = [](const AvbdRigidBodyPointPairFrictionRows& row) {
+          return avbdRigidBodyPairRowKey(row.bodyA, row.bodyB);
+        };
+  const auto clearFrictionPairRowLayout = [&]() {
+    frictionPairRowOffsets.clear();
+    frictionPairRowIndices.clear();
+    frictionPairRowCursor.clear();
+    rowIndexData.frictionPairRowBodyKeys.clear();
+    rowIndexData.frictionPairRowBodyCount = 0u;
+  };
+  if (frictionPairRows.empty()) {
+    clearFrictionPairRowLayout();
+  } else if (!avbdRigidRowIndexLayoutMatches(
+                 frictionPairRows,
+                 bodyCount,
+                 rowIndexData.frictionPairRowBodyCount,
+                 rowIndexData.frictionPairRowBodyKeys,
+                 frictionPairRowOffsets,
+                 frictionPairRowKeyOf)) {
+    frictionPairRowOffsets.assign(bodyCount + 1u, 0u);
+    for (std::size_t rowIndex = 0; rowIndex < frictionPairRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointPairFrictionRows& indexedRows
+          = frictionPairRows[rowIndex];
+      if (validBody(indexedRows.bodyA) && validBody(indexedRows.bodyB)) {
+        ++frictionPairRowOffsets[indexedRows.bodyA + 1u];
+        if (indexedRows.bodyB != indexedRows.bodyA) {
+          ++frictionPairRowOffsets[indexedRows.bodyB + 1u];
+        }
+      }
+    }
+    for (std::size_t body = 1; body < frictionPairRowOffsets.size(); ++body) {
+      frictionPairRowOffsets[body] += frictionPairRowOffsets[body - 1u];
+    }
+    frictionPairRowIndices.resize(frictionPairRowOffsets.back());
+    frictionPairRowCursor.assign(
+        frictionPairRowOffsets.begin(), frictionPairRowOffsets.end());
+    for (std::size_t rowIndex = 0; rowIndex < frictionPairRows.size();
+         ++rowIndex) {
+      const AvbdRigidBodyPointPairFrictionRows& indexedRows
+          = frictionPairRows[rowIndex];
+      if (validBody(indexedRows.bodyA) && validBody(indexedRows.bodyB)) {
+        frictionPairRowIndices[frictionPairRowCursor[indexedRows.bodyA]++]
+            = rowIndex;
+        if (indexedRows.bodyB != indexedRows.bodyA) {
+          frictionPairRowIndices[frictionPairRowCursor[indexedRows.bodyB]++]
+              = rowIndex;
+        }
+      }
+    }
+    avbdRigidRefreshRowIndexLayoutKeys(
+        frictionPairRows,
+        bodyCount,
+        rowIndexData.frictionPairRowBodyCount,
+        rowIndexData.frictionPairRowBodyKeys,
+        frictionPairRowKeyOf);
+  }
+
+  struct PointPairWorldPointCache
+  {
+    bool valid = false;
+    std::uint32_t bodyA = std::numeric_limits<std::uint32_t>::max();
+    std::uint32_t bodyB = std::numeric_limits<std::uint32_t>::max();
+    Eigen::Vector3d localPointA = Eigen::Vector3d::Zero();
+    Eigen::Vector3d localPointB = Eigen::Vector3d::Zero();
+    Eigen::Vector3d worldPointA = Eigen::Vector3d::Zero();
+    Eigen::Vector3d worldPointB = Eigen::Vector3d::Zero();
+  };
+
+  const auto pointPairWorldPoints =
+      [&](const AvbdRigidBodyPointPairRow& indexedRow,
+          PointPairWorldPointCache& cache) -> const PointPairWorldPointCache& {
+    const AvbdRigidPointPairRow& row = indexedRow.row;
+    if (!cache.valid || cache.bodyA != indexedRow.bodyA
+        || cache.bodyB != indexedRow.bodyB
+        || !detail::avbdRigidVectorExactEqual(
+            cache.localPointA, row.localPointA)
+        || !detail::avbdRigidVectorExactEqual(
+            cache.localPointB, row.localPointB)) {
+      cache.valid = true;
+      cache.bodyA = indexedRow.bodyA;
+      cache.bodyB = indexedRow.bodyB;
+      cache.localPointA = row.localPointA;
+      cache.localPointB = row.localPointB;
+      cache.worldPointA
+          = avbdRigidBodyWorldPoint(states[indexedRow.bodyA], row.localPointA);
+      cache.worldPointB
+          = avbdRigidBodyWorldPoint(states[indexedRow.bodyB], row.localPointB);
+    }
+    return cache;
+  };
+
   const auto addPointPairToBlock =
       [&](AvbdRigidBodyBlock& block,
           std::uint32_t body,
-          const AvbdRigidBodyPointPairRow& indexedRow) {
-        if (!validBody(indexedRow.bodyA) || !validBody(indexedRow.bodyB)) {
-          return;
-        }
-
+          const AvbdRigidBodyPointPairRow& indexedRow,
+          PointPairWorldPointCache& cache) {
         const AvbdRigidPointPairRow& row = indexedRow.row;
-        const double constraintValue = regularizeAvbdConstraintValue(
-            avbdRigidPointPairConstraintValue(
-                states[indexedRow.bodyA], states[indexedRow.bodyB], row),
-            row.previousConstraintValue,
-            rowOptions.alpha);
-        const double forceMagnitude = computeAvbdHardConstraintForce(
-            row.state, constraintValue, row.bounds);
+        const AvbdRigidBodyState& stateA = states[indexedRow.bodyA];
+        const AvbdRigidBodyState& stateB = states[indexedRow.bodyB];
+        const PointPairWorldPointCache& points
+            = pointPairWorldPoints(indexedRow, cache);
+        const Eigen::Vector3d& worldPointA = points.worldPointA;
+        const Eigen::Vector3d& worldPointB = points.worldPointB;
+        const double rawConstraintValue
+            = row.offset + row.axis.dot(worldPointB - worldPointA);
+        const double constraintValue
+            = avbdRigidRowUsesFiniteMaterial(row.materialStiffness)
+                  ? rawConstraintValue
+                  : regularizeAvbdConstraintValue(
+                        rawConstraintValue,
+                        row.previousConstraintValue,
+                        rowOptions.alpha);
+        const double forceMagnitude = avbdRigidScalarRowForce(
+            row.state, constraintValue, row.bounds, row.materialStiffness);
 
         if (indexedRow.bodyA == body) {
-          const Vector6d direction
-              = avbdRigidPointPairDirectionA(states[body], row);
+          Vector6d direction = Vector6d::Zero();
+          direction.head<3>() = row.axis;
+          direction.tail<3>() = (worldPointA - stateA.position).cross(row.axis);
           block.force.noalias() += forceMagnitude * direction;
-          block.hessian.noalias()
-              += row.state.stiffness * (direction * direction.transpose());
+          addAvbdRigidBlockHessianRankOneLowerTriangle(
+              block, direction, row.state.stiffness);
         }
         if (indexedRow.bodyB == body && indexedRow.bodyB != indexedRow.bodyA) {
-          const Vector6d direction
-              = avbdRigidPointPairDirectionB(states[body], row);
+          Vector6d direction = Vector6d::Zero();
+          direction.head<3>() = -row.axis;
+          direction.tail<3>()
+              = (worldPointB - stateB.position).cross(-row.axis);
           block.force.noalias() += forceMagnitude * direction;
-          block.hessian.noalias()
-              += row.state.stiffness * (direction * direction.transpose());
+          addAvbdRigidBlockHessianRankOneLowerTriangle(
+              block, direction, row.state.stiffness);
         }
       };
+
+  const auto addDistanceSpringToBlock
+      = [&](AvbdRigidBodyBlock& block,
+            std::uint32_t body,
+            const AvbdRigidBodyPointPairDistanceSpringRow& indexedRow) {
+          const AvbdRigidPointPairDistanceSpringRow& row = indexedRow.row;
+          const AvbdRigidBodyState& stateA = states[indexedRow.bodyA];
+          const AvbdRigidBodyState& stateB = states[indexedRow.bodyB];
+          const Eigen::Vector3d worldPointA
+              = avbdRigidBodyWorldPoint(stateA, row.localPointA);
+          const Eigen::Vector3d worldPointB
+              = avbdRigidBodyWorldPoint(stateB, row.localPointB);
+          const Eigen::Vector3d relative = worldPointB - worldPointA;
+          const double length = relative.norm();
+          if (!relative.allFinite()
+              || length <= kAvbdRigidMinDistanceSpringLength) {
+            return;
+          }
+
+          const Eigen::Vector3d axis = relative / length;
+          const double forceMagnitude
+              = row.state.stiffness * (length - row.restLength);
+          if (indexedRow.bodyA == body) {
+            Vector6d direction = Vector6d::Zero();
+            direction.head<3>() = axis;
+            direction.tail<3>() = (worldPointA - stateA.position).cross(axis);
+            block.force.noalias() += forceMagnitude * direction;
+            addAvbdRigidDistanceSpringHessianAtWorldPoint(
+                block,
+                stateA,
+                worldPointA,
+                axis,
+                length,
+                row.restLength,
+                row.state.stiffness,
+                /*clampToPsd=*/true);
+          }
+          if (indexedRow.bodyB == body) {
+            Vector6d direction = Vector6d::Zero();
+            direction.head<3>() = -axis;
+            direction.tail<3>() = (worldPointB - stateB.position).cross(-axis);
+            block.force.noalias() += forceMagnitude * direction;
+            addAvbdRigidDistanceSpringHessianAtWorldPoint(
+                block,
+                stateB,
+                worldPointB,
+                axis,
+                length,
+                row.restLength,
+                row.state.stiffness,
+                /*clampToPsd=*/true);
+          }
+        };
+
+  struct AngularPairConstraintCache
+  {
+    bool valid = false;
+    std::uint32_t bodyA = std::numeric_limits<std::uint32_t>::max();
+    std::uint32_t bodyB = std::numeric_limits<std::uint32_t>::max();
+    Eigen::Quaterniond targetRelativeOrientation
+        = Eigen::Quaterniond::Identity();
+    Eigen::Vector3d orientationError = Eigen::Vector3d::Zero();
+  };
+
+  const auto angularPairOrientationError
+      = [&](const AvbdRigidBodyAngularPairRow& indexedRow,
+            AngularPairConstraintCache& cache) -> const Eigen::Vector3d& {
+    const AvbdRigidAngularPairRow& row = indexedRow.row;
+    if (!cache.valid || cache.bodyA != indexedRow.bodyA
+        || cache.bodyB != indexedRow.bodyB
+        || !detail::avbdRigidQuaternionExactEqual(
+            cache.targetRelativeOrientation, row.targetRelativeOrientation)) {
+      cache.valid = true;
+      cache.bodyA = indexedRow.bodyA;
+      cache.bodyB = indexedRow.bodyB;
+      cache.targetRelativeOrientation = row.targetRelativeOrientation;
+      cache.orientationError = avbdRigidBodyOrientationError(
+          states[indexedRow.bodyB].orientation,
+          avbdRigidAngularPairTargetOrientationB(
+              states[indexedRow.bodyA], row));
+    }
+    return cache.orientationError;
+  };
 
   const auto addAngularPairToBlock =
       [&](AvbdRigidBodyBlock& block,
           std::uint32_t body,
-          const AvbdRigidBodyAngularPairRow& indexedRow) {
-        if (!validBody(indexedRow.bodyA) || !validBody(indexedRow.bodyB)) {
-          return;
-        }
-
+          const AvbdRigidBodyAngularPairRow& indexedRow,
+          AngularPairConstraintCache& cache) {
         const AvbdRigidAngularPairRow& row = indexedRow.row;
-        const double constraintValue = regularizeAvbdConstraintValue(
-            avbdRigidAngularPairConstraintValue(
-                states[indexedRow.bodyA], states[indexedRow.bodyB], row),
-            row.previousConstraintValue,
-            rowOptions.alpha);
-        const double forceMagnitude = computeAvbdHardConstraintForce(
-            row.state, constraintValue, row.bounds);
+        const double rawConstraintValue
+            = row.offset
+              + row.axis.dot(angularPairOrientationError(indexedRow, cache));
+        const double constraintValue
+            = avbdRigidRowUsesFiniteMaterial(row.materialStiffness)
+                  ? rawConstraintValue
+                  : regularizeAvbdConstraintValue(
+                        rawConstraintValue,
+                        row.previousConstraintValue,
+                        rowOptions.alpha);
+        const double forceMagnitude = avbdRigidScalarRowForce(
+            row.state, constraintValue, row.bounds, row.materialStiffness);
 
         if (indexedRow.bodyA == body) {
           const Vector6d direction = avbdRigidAngularPairDirectionA(row);
           block.force.noalias() += forceMagnitude * direction;
-          block.hessian.noalias()
-              += row.state.stiffness * (direction * direction.transpose());
+          addAvbdRigidBlockHessianRankOneLowerTriangle(
+              block, direction, row.state.stiffness);
         }
         if (indexedRow.bodyB == body && indexedRow.bodyB != indexedRow.bodyA) {
           const Vector6d direction = avbdRigidAngularPairDirectionB(row);
           block.force.noalias() += forceMagnitude * direction;
-          block.hessian.noalias()
-              += row.state.stiffness * (direction * direction.transpose());
+          addAvbdRigidBlockHessianRankOneLowerTriangle(
+              block, direction, row.state.stiffness);
         }
       };
 
-  const auto addFrictionPairToBlock =
-      [&](AvbdRigidBodyBlock& block,
-          std::uint32_t body,
-          const AvbdRigidBodyPointPairFrictionRows& indexedRows) {
-        if (!validBody(indexedRows.bodyA) || !validBody(indexedRows.bodyB)) {
-          return;
-        }
-
-        const Eigen::Vector2d force
-            = avbdRigidPointPairFrictionTangentPairForce(
-                states[indexedRows.bodyA],
-                states[indexedRows.bodyB],
-                indexedRows.first,
-                indexedRows.second,
-                frictionOptions);
-        if (indexedRows.bodyA == body) {
-          const Vector6d firstDirection
-              = avbdRigidPointPairDirectionA(states[body], indexedRows.first);
-          const Vector6d secondDirection
-              = avbdRigidPointPairDirectionA(states[body], indexedRows.second);
-          block.force.noalias()
-              += force.x() * firstDirection + force.y() * secondDirection;
-          block.hessian.noalias()
-              += indexedRows.first.state.stiffness
-                 * (firstDirection * firstDirection.transpose());
-          block.hessian.noalias()
-              += indexedRows.second.state.stiffness
-                 * (secondDirection * secondDirection.transpose());
-        }
-        if (indexedRows.bodyB == body
-            && indexedRows.bodyB != indexedRows.bodyA) {
-          const Vector6d firstDirection
-              = avbdRigidPointPairDirectionB(states[body], indexedRows.first);
-          const Vector6d secondDirection
-              = avbdRigidPointPairDirectionB(states[body], indexedRows.second);
-          block.force.noalias()
-              += force.x() * firstDirection + force.y() * secondDirection;
-          block.hessian.noalias()
-              += indexedRows.first.state.stiffness
-                 * (firstDirection * firstDirection.transpose());
-          block.hessian.noalias()
-              += indexedRows.second.state.stiffness
-                 * (secondDirection * secondDirection.transpose());
-        }
-      };
+  const auto addFrictionPairToBlock
+      = [&](AvbdRigidBodyBlock& block,
+            std::uint32_t body,
+            const AvbdRigidBodyPointPairFrictionRows& indexedRows) {
+          const AvbdRigidBodyState& stateA = states[indexedRows.bodyA];
+          const AvbdRigidBodyState& stateB = states[indexedRows.bodyB];
+          const Eigen::Vector3d firstWorldPointA
+              = avbdRigidBodyWorldPoint(stateA, indexedRows.first.localPointA);
+          const Eigen::Vector3d firstWorldPointB
+              = avbdRigidBodyWorldPoint(stateB, indexedRows.first.localPointB);
+          const bool sharedAnchors = avbdRigidPointPairRowsShareLocalPoints(
+              indexedRows.first, indexedRows.second);
+          const Eigen::Vector3d secondWorldPointA
+              = sharedAnchors ? firstWorldPointA
+                              : avbdRigidBodyWorldPoint(
+                                    stateA, indexedRows.second.localPointA);
+          const Eigen::Vector3d secondWorldPointB
+              = sharedAnchors ? firstWorldPointB
+                              : avbdRigidBodyWorldPoint(
+                                    stateB, indexedRows.second.localPointB);
+          const Eigen::Vector2d constraintValues
+              = avbdRigidPointPairConstraintValuesAtWorldPoints(
+                  indexedRows.first,
+                  indexedRows.second,
+                  firstWorldPointA,
+                  firstWorldPointB,
+                  secondWorldPointA,
+                  secondWorldPointB,
+                  frictionOptions.alpha);
+          const Eigen::Vector2d force
+              = avbdRigidPointPairFrictionTangentPairForceFromConstraintValues(
+                  constraintValues,
+                  indexedRows.first,
+                  indexedRows.second,
+                  frictionOptions);
+          if (indexedRows.bodyA == body) {
+            Vector6d firstDirection = Vector6d::Zero();
+            firstDirection.head<3>() = indexedRows.first.axis;
+            firstDirection.tail<3>() = (firstWorldPointA - stateA.position)
+                                           .cross(indexedRows.first.axis);
+            Vector6d secondDirection = Vector6d::Zero();
+            secondDirection.head<3>() = indexedRows.second.axis;
+            secondDirection.tail<3>() = (secondWorldPointA - stateA.position)
+                                            .cross(indexedRows.second.axis);
+            block.force.noalias()
+                += force.x() * firstDirection + force.y() * secondDirection;
+            addAvbdRigidBlockHessianRankOneLowerTriangle(
+                block, firstDirection, indexedRows.first.state.stiffness);
+            addAvbdRigidBlockHessianRankOneLowerTriangle(
+                block, secondDirection, indexedRows.second.state.stiffness);
+          }
+          if (indexedRows.bodyB == body
+              && indexedRows.bodyB != indexedRows.bodyA) {
+            Vector6d firstDirection = Vector6d::Zero();
+            firstDirection.head<3>() = -indexedRows.first.axis;
+            firstDirection.tail<3>() = (firstWorldPointB - stateB.position)
+                                           .cross(-indexedRows.first.axis);
+            Vector6d secondDirection = Vector6d::Zero();
+            secondDirection.head<3>() = -indexedRows.second.axis;
+            secondDirection.tail<3>() = (secondWorldPointB - stateB.position)
+                                            .cross(-indexedRows.second.axis);
+            block.force.noalias()
+                += force.x() * firstDirection + force.y() * secondDirection;
+            addAvbdRigidBlockHessianRankOneLowerTriangle(
+                block, firstDirection, indexedRows.first.state.stiffness);
+            addAvbdRigidBlockHessianRankOneLowerTriangle(
+                block, secondDirection, indexedRows.second.state.stiffness);
+          }
+        };
 
   const auto assemble = [&](std::uint32_t body) {
     AvbdRigidBodyBlock block;
-    addAvbdRigidBodyInertiaTerm(
+    PointPairWorldPointCache pointPairCache;
+    AngularPairConstraintCache angularPairCache;
+    addAvbdRigidBodyInertiaTermLowerTriangle(
         block,
         masses[body],
         bodyInertias[body],
@@ -1657,21 +3345,51 @@ inline AvbdRigidBlockDescentStats blockDescentRigidBodiesAvbdRows(
         states[body],
         inertialTargets[body]);
 
-    for (const AvbdRigidBodyPointAttachmentRow& indexedRow : attachmentRows) {
-      if (indexedRow.body == body) {
+    if (!attachmentRows.empty()) {
+      for (std::size_t cursor = attachmentRowOffsets[body];
+           cursor < attachmentRowOffsets[body + 1u];
+           ++cursor) {
+        const AvbdRigidBodyPointAttachmentRow& indexedRow
+            = attachmentRows[attachmentRowIndices[cursor]];
         addAvbdRigidPointAttachment(
             block, states[body], indexedRow.row, rowOptions.alpha);
       }
     }
-    for (const AvbdRigidBodyPointPairRow& indexedRow : pointPairRows) {
-      addPointPairToBlock(block, body, indexedRow);
+    if (!pointPairRows.empty()) {
+      for (std::size_t cursor = pointPairRowOffsets[body];
+           cursor < pointPairRowOffsets[body + 1u];
+           ++cursor) {
+        const AvbdRigidBodyPointPairRow& indexedRow
+            = pointPairRows[pointPairRowIndices[cursor]];
+        addPointPairToBlock(block, body, indexedRow, pointPairCache);
+      }
     }
-    for (const AvbdRigidBodyAngularPairRow& indexedRow : angularPairRows) {
-      addAngularPairToBlock(block, body, indexedRow);
+    if (!distanceSpringRows.empty()) {
+      for (std::size_t cursor = distanceSpringRowOffsets[body];
+           cursor < distanceSpringRowOffsets[body + 1u];
+           ++cursor) {
+        const AvbdRigidBodyPointPairDistanceSpringRow& indexedRow
+            = distanceSpringRows[distanceSpringRowIndices[cursor]];
+        addDistanceSpringToBlock(block, body, indexedRow);
+      }
     }
-    for (const AvbdRigidBodyPointPairFrictionRows& indexedRows :
-         frictionPairRows) {
-      addFrictionPairToBlock(block, body, indexedRows);
+    if (!angularPairRows.empty()) {
+      for (std::size_t cursor = angularPairRowOffsets[body];
+           cursor < angularPairRowOffsets[body + 1u];
+           ++cursor) {
+        const AvbdRigidBodyAngularPairRow& indexedRow
+            = angularPairRows[angularPairRowIndices[cursor]];
+        addAngularPairToBlock(block, body, indexedRow, angularPairCache);
+      }
+    }
+    if (!frictionPairRows.empty()) {
+      for (std::size_t cursor = frictionPairRowOffsets[body];
+           cursor < frictionPairRowOffsets[body + 1u];
+           ++cursor) {
+        const AvbdRigidBodyPointPairFrictionRows& indexedRows
+            = frictionPairRows[frictionPairRowIndices[cursor]];
+        addFrictionPairToBlock(block, body, indexedRows);
+      }
     }
     return block;
   };
@@ -1703,24 +3421,97 @@ inline AvbdRigidBlockDescentStats blockDescentRigidBodiesAvbdRows(
             rowOptions);
       }
     }
+    PointPairWorldPointCache pointPairUpdateCache;
     for (AvbdRigidBodyPointPairRow& indexedRow : pointPairRows) {
       if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)) {
-        indexedRow.row.state = updateAvbdRigidPointPairRow(
-            indexedRow.row.state,
-            states[indexedRow.bodyA],
-            states[indexedRow.bodyB],
-            indexedRow.row,
-            rowOptions);
+        if (avbdRigidRowUsesFiniteMaterial(indexedRow.row.materialStiffness)) {
+          indexedRow.row.state.lambda = 0.0;
+          const double maxStiffness = std::min(
+              indexedRow.row.materialStiffness, rowOptions.maxStiffness);
+          if (rowOptions.beta >= 0.0
+              && indexedRow.row.state.stiffness >= maxStiffness) {
+            indexedRow.row.state.stiffness = maxStiffness;
+            continue;
+          }
+        }
+
+        const PointPairWorldPointCache& points
+            = pointPairWorldPoints(indexedRow, pointPairUpdateCache);
+        const double rawConstraintValue
+            = indexedRow.row.offset
+              + indexedRow.row.axis.dot(
+                  points.worldPointB - points.worldPointA);
+        if (avbdRigidRowUsesFiniteMaterial(indexedRow.row.materialStiffness)) {
+          const double maxStiffness = std::min(
+              indexedRow.row.materialStiffness, rowOptions.maxStiffness);
+          indexedRow.row.state.stiffness = updateAvbdFiniteStiffness(
+              indexedRow.row.state.stiffness,
+              rawConstraintValue,
+              rowOptions.beta,
+              maxStiffness);
+        } else {
+          const double constraintValue = regularizeAvbdConstraintValue(
+              rawConstraintValue,
+              indexedRow.row.previousConstraintValue,
+              rowOptions.alpha);
+          indexedRow.row.state = updateAvbdHardConstraintRow(
+              indexedRow.row.state,
+              constraintValue,
+              rowOptions.beta,
+              indexedRow.row.bounds,
+              rowOptions.maxStiffness);
+        }
       }
     }
-    for (AvbdRigidBodyAngularPairRow& indexedRow : angularPairRows) {
-      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)) {
-        indexedRow.row.state = updateAvbdRigidAngularPairRow(
+    for (AvbdRigidBodyPointPairDistanceSpringRow& indexedRow :
+         distanceSpringRows) {
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)
+          && indexedRow.bodyB != indexedRow.bodyA) {
+        indexedRow.row.state = updateAvbdRigidPointPairDistanceSpringRow(
             indexedRow.row.state,
             states[indexedRow.bodyA],
             states[indexedRow.bodyB],
             indexedRow.row,
-            rowOptions);
+            distanceSpringOptions);
+      }
+    }
+    AngularPairConstraintCache angularPairUpdateCache;
+    for (AvbdRigidBodyAngularPairRow& indexedRow : angularPairRows) {
+      if (validBody(indexedRow.bodyA) && validBody(indexedRow.bodyB)) {
+        if (avbdRigidRowUsesFiniteMaterial(indexedRow.row.materialStiffness)) {
+          indexedRow.row.state.lambda = 0.0;
+          const double maxStiffness = std::min(
+              indexedRow.row.materialStiffness, rowOptions.maxStiffness);
+          if (rowOptions.beta >= 0.0
+              && indexedRow.row.state.stiffness >= maxStiffness) {
+            indexedRow.row.state.stiffness = maxStiffness;
+            continue;
+          }
+        }
+
+        const double rawConstraintValue
+            = indexedRow.row.offset
+              + indexedRow.row.axis.dot(angularPairOrientationError(
+                  indexedRow, angularPairUpdateCache));
+        if (avbdRigidRowUsesFiniteMaterial(indexedRow.row.materialStiffness)) {
+          indexedRow.row.state.stiffness = updateAvbdFiniteStiffness(
+              indexedRow.row.state.stiffness,
+              rawConstraintValue,
+              rowOptions.beta,
+              std::min(
+                  indexedRow.row.materialStiffness, rowOptions.maxStiffness));
+        } else {
+          const double constraintValue = regularizeAvbdConstraintValue(
+              rawConstraintValue,
+              indexedRow.row.previousConstraintValue,
+              rowOptions.alpha);
+          indexedRow.row.state = updateAvbdHardConstraintRow(
+              indexedRow.row.state,
+              constraintValue,
+              rowOptions.beta,
+              indexedRow.row.bounds,
+              rowOptions.maxStiffness);
+        }
       }
     }
     for (AvbdRigidBodyPointPairFrictionRows& indexedRows : frictionPairRows) {

--- a/dart/simulation/detail/deformable_vbd/rigid_world_contact.hpp
+++ b/dart/simulation/detail/deformable_vbd/rigid_world_contact.hpp
@@ -47,10 +47,11 @@
 #include <entt/entt.hpp>
 
 #include <algorithm>
+#include <functional>
 #include <iterator>
 #include <limits>
-#include <map>
 #include <span>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -64,26 +65,6 @@ struct AvbdRigidWorldContactOptions
 {
   double startStiffness = 1.0;
   double maxStiffness = std::numeric_limits<double>::infinity();
-};
-
-struct AvbdRigidWorldPointJointInput
-{
-  entt::entity joint = entt::null;
-  entt::entity bodyA = entt::null;
-  entt::entity bodyB = entt::null;
-  Eigen::Vector3d anchorA = Eigen::Vector3d::Zero();
-  Eigen::Vector3d anchorB = Eigen::Vector3d::Zero();
-  Eigen::Quaterniond targetRelativeOrientation = Eigen::Quaterniond::Identity();
-  Eigen::Matrix3d linearAxes = Eigen::Matrix3d::Identity();
-  Eigen::Matrix3d angularAxes = Eigen::Matrix3d::Identity();
-  std::uint8_t linearAxisMask = kAvbdRigidJointAllAxesMask;
-  std::uint8_t angularAxisMask = kAvbdRigidJointAllAxesMask;
-  bool useAngularMotor = false;
-  double motorTargetSpeed = 0.0;
-  double motorMaxTorque = std::numeric_limits<double>::infinity();
-  double startStiffness = 1.0;
-  double maxStiffness = std::numeric_limits<double>::infinity();
-  double fractureThreshold = 0.0;
 };
 
 enum class AvbdRigidWorldEndpointKind
@@ -100,6 +81,61 @@ struct AvbdRigidWorldEndpoint
   bool canProjectAsRigidBody = false;
 };
 
+struct AvbdRigidWorldProjectableBodyView
+{
+  const comps::Transform* transform = nullptr;
+  const comps::MassProperties* mass = nullptr;
+  bool isStatic = false;
+
+  explicit operator bool() const noexcept
+  {
+    return transform != nullptr && mass != nullptr;
+  }
+};
+
+struct AvbdRigidWorldPointJointInput
+{
+  entt::entity joint = entt::null;
+  entt::entity bodyA = entt::null;
+  entt::entity bodyB = entt::null;
+  AvbdRigidWorldProjectableBodyView bodyAView;
+  AvbdRigidWorldProjectableBodyView bodyBView;
+  Eigen::Vector3d anchorA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d anchorB = Eigen::Vector3d::Zero();
+  bool anchorsAreLocal = false;
+  Eigen::Quaterniond targetRelativeOrientation = Eigen::Quaterniond::Identity();
+  Eigen::Matrix3d linearAxes = Eigen::Matrix3d::Identity();
+  Eigen::Matrix3d angularAxes = Eigen::Matrix3d::Identity();
+  std::uint8_t linearAxisMask = kAvbdRigidJointAllAxesMask;
+  std::uint8_t angularAxisMask = kAvbdRigidJointAllAxesMask;
+  bool useLinearMotor = false;
+  bool useAngularMotor = false;
+  double motorTargetSpeed = 0.0;
+  double motorMaxForce = std::numeric_limits<double>::infinity();
+  double motorMaxTorque = std::numeric_limits<double>::infinity();
+  double startStiffness = 1.0;
+  double linearMaterialStiffness = std::numeric_limits<double>::infinity();
+  double angularMaterialStiffness = std::numeric_limits<double>::infinity();
+  double maxStiffness = std::numeric_limits<double>::infinity();
+  double fractureThreshold = 0.0;
+};
+
+struct AvbdRigidWorldDistanceSpringInput
+{
+  entt::entity spring = entt::null;
+  entt::entity bodyA = entt::null;
+  entt::entity bodyB = entt::null;
+  AvbdRigidWorldProjectableBodyView bodyAView;
+  AvbdRigidWorldProjectableBodyView bodyBView;
+  Eigen::Vector3d anchorA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d anchorB = Eigen::Vector3d::Zero();
+  bool anchorsAreLocal = false;
+  double restLength = 0.0;
+  double startStiffness = 1.0;
+  double materialStiffness = std::numeric_limits<double>::infinity();
+  double maxStiffness = std::numeric_limits<double>::infinity();
+};
+
 struct AvbdRigidWorldPointJointConfig
 {
   bool enabled = true;
@@ -111,12 +147,28 @@ struct AvbdRigidWorldPointJointConfig
   std::uint8_t linearAxisMask = kAvbdRigidJointAllAxesMask;
   std::uint8_t angularAxisMask = kAvbdRigidJointAllAxesMask;
   double startStiffness = 1.0;
+  double linearMaterialStiffness = std::numeric_limits<double>::infinity();
+  double angularMaterialStiffness = std::numeric_limits<double>::infinity();
+  double maxStiffness = std::numeric_limits<double>::infinity();
+};
+
+struct AvbdRigidWorldDistanceSpringConfig
+{
+  bool enabled = true;
+  entt::entity bodyA = entt::null;
+  entt::entity bodyB = entt::null;
+  Eigen::Vector3d localAnchorA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d localAnchorB = Eigen::Vector3d::Zero();
+  double restLength = 0.0;
+  double startStiffness = 1.0;
+  double materialStiffness = std::numeric_limits<double>::infinity();
   double maxStiffness = std::numeric_limits<double>::infinity();
 };
 
 struct AvbdRigidWorldContactSnapshot
 {
   std::vector<entt::entity> entities;
+  std::unordered_map<entt::entity, std::uint32_t> entityBodyIndices;
   std::vector<AvbdRigidBodyState> states;
   std::vector<AvbdRigidBodyState> inertialTargets;
   std::vector<double> masses;
@@ -125,14 +177,38 @@ struct AvbdRigidWorldContactSnapshot
   std::vector<AvbdRigidContactManifoldPoint> contacts;
   std::vector<AvbdRigidPointJoint> joints;
   std::vector<entt::entity> jointEntities;
+  std::vector<AvbdRigidLinearMotor> linearMotors;
   std::vector<AvbdRigidAngularMotor> motors;
+  std::vector<AvbdRigidBodyPointPairDistanceSpringRow> distanceSprings;
+  std::vector<entt::entity> distanceSpringEntities;
 };
+
+//==============================================================================
+inline void clearAvbdRigidWorldContactSnapshot(
+    AvbdRigidWorldContactSnapshot& snapshot)
+{
+  snapshot.entities.clear();
+  snapshot.entityBodyIndices.clear();
+  snapshot.states.clear();
+  snapshot.inertialTargets.clear();
+  snapshot.masses.clear();
+  snapshot.bodyInertias.clear();
+  snapshot.fixed.clear();
+  snapshot.contacts.clear();
+  snapshot.joints.clear();
+  snapshot.jointEntities.clear();
+  snapshot.linearMotors.clear();
+  snapshot.motors.clear();
+  snapshot.distanceSprings.clear();
+  snapshot.distanceSpringEntities.clear();
+}
 
 struct AvbdRigidWorldContactSolveOptions
 {
   AvbdRowWarmStartOptions warmStart;
   AvbdRigidPointAttachmentOptions row;
   AvbdRigidPointPairFrictionOptions friction;
+  AvbdRigidPointPairDistanceSpringOptions distanceSpring;
   AvbdRigidBlockDescentOptions descent;
 };
 
@@ -144,8 +220,42 @@ struct AvbdRigidWorldContactSolveResult
   std::size_t jointLinearRows = 0;
   std::size_t jointAngularRows = 0;
   std::size_t motorRows = 0;
+  std::size_t distanceSpringRows = 0;
   std::size_t fracturedJoints = 0;
   std::vector<std::size_t> fracturedJointIndices;
+};
+
+struct AvbdRigidWorldContactSolveScratch
+{
+  void clear()
+  {
+    normalRows.clear();
+    frictionRows.clear();
+    jointLinearRows.clear();
+    jointAngularRows.clear();
+    linearMotorRows.clear();
+    motorRows.clear();
+    distanceSpringRows.clear();
+    pointPairRows.clear();
+    angularRows.clear();
+    attachmentRows.clear();
+    fallbackInertialTargets.clear();
+    // Keep row-index layout scratch warm across frames; blockDescent rebuilds
+    // any family whose body layout changed and clears absent families.
+  }
+
+  std::vector<AvbdRigidBodyPointPairRow> normalRows;
+  std::vector<AvbdRigidBodyPointPairFrictionRows> frictionRows;
+  std::vector<AvbdRigidBodyPointPairRow> jointLinearRows;
+  std::vector<AvbdRigidBodyAngularPairRow> jointAngularRows;
+  std::vector<AvbdRigidBodyPointPairRow> linearMotorRows;
+  std::vector<AvbdRigidBodyAngularPairRow> motorRows;
+  std::vector<AvbdRigidBodyPointPairDistanceSpringRow> distanceSpringRows;
+  std::vector<AvbdRigidBodyPointPairRow> pointPairRows;
+  std::vector<AvbdRigidBodyAngularPairRow> angularRows;
+  std::vector<AvbdRigidBodyPointAttachmentRow> attachmentRows;
+  std::vector<AvbdRigidBodyState> fallbackInertialTargets;
+  AvbdRigidBodyRowIndexScratch rowIndexScratch;
 };
 
 struct AvbdRigidWorldContactApplyResult
@@ -166,6 +276,7 @@ struct AvbdRigidWorldContactStepResult
   std::size_t contacts = 0;
   std::size_t joints = 0;
   std::size_t motors = 0;
+  std::size_t distanceSprings = 0;
   std::size_t fracturedJoints = 0;
   AvbdRigidWorldContactSolveResult solve;
   AvbdRigidWorldContactApplyResult apply;
@@ -208,6 +319,54 @@ inline AvbdContactEndpointId avbdRigidWorldBodyEndpointId(
 }
 
 //==============================================================================
+inline AvbdRigidWorldProjectableBodyView avbdRigidWorldProjectableBody(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    entt::entity entity)
+{
+  if (entity == entt::null || !registry.valid(entity)
+      || !registry.all_of<comps::RigidBodyTag>(entity)) {
+    return {};
+  }
+
+  const auto* transform = registry.try_get<comps::Transform>(entity);
+  const auto* mass = registry.try_get<comps::MassProperties>(entity);
+  if (transform == nullptr || mass == nullptr) {
+    return {};
+  }
+
+  return AvbdRigidWorldProjectableBodyView{
+      transform,
+      mass,
+      registry.all_of<comps::StaticBodyTag>(entity)
+          || registry.all_of<comps::KinematicBodyTag>(entity)};
+}
+
+//==============================================================================
+inline AvbdRigidWorldProjectableBodyView avbdRigidWorldCachedProjectableBody(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    entt::entity entity,
+    const AvbdRigidWorldProjectableBodyView& cached)
+{
+  if (cached) {
+    return cached;
+  }
+  return avbdRigidWorldProjectableBody(registry, entity);
+}
+
+//==============================================================================
+inline const comps::Transform* avbdRigidWorldProjectableBodyTransform(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    entt::entity entity)
+{
+  const AvbdRigidWorldProjectableBodyView body
+      = avbdRigidWorldProjectableBody(registry, entity);
+  if (!body) {
+    return nullptr;
+  }
+  return body.transform;
+}
+
+//==============================================================================
 inline AvbdRigidWorldEndpoint classifyAvbdRigidWorldEndpoint(
     const ::dart::simulation::detail::WorldRegistry& registry,
     entt::entity entity)
@@ -219,9 +378,7 @@ inline AvbdRigidWorldEndpoint classifyAvbdRigidWorldEndpoint(
     return endpoint;
   }
 
-  if (registry
-          .all_of<comps::RigidBodyTag, comps::Transform, comps::MassProperties>(
-              entity)) {
+  if (avbdRigidWorldProjectableBodyTransform(registry, entity) != nullptr) {
     endpoint.kind = AvbdRigidWorldEndpointKind::FreeRigidBody;
     endpoint.canProjectAsRigidBody = true;
     return endpoint;
@@ -240,7 +397,7 @@ inline bool canProjectAvbdRigidWorldEndpointAsRigidBody(
     const ::dart::simulation::detail::WorldRegistry& registry,
     entt::entity entity)
 {
-  return classifyAvbdRigidWorldEndpoint(registry, entity).canProjectAsRigidBody;
+  return avbdRigidWorldProjectableBodyTransform(registry, entity) != nullptr;
 }
 
 //==============================================================================
@@ -258,7 +415,119 @@ inline Eigen::Isometry3d avbdRigidWorldContactToIsometry(
 inline bool isAvbdRigidWorldPointJointType(comps::JointType type)
 {
   return type == comps::JointType::Fixed || type == comps::JointType::Revolute
-         || type == comps::JointType::Prismatic;
+         || type == comps::JointType::Prismatic
+         || type == comps::JointType::Spherical;
+}
+
+//==============================================================================
+inline bool isAvbdRigidWorldPointJointFacade(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    entt::entity jointEntity,
+    const comps::Joint& joint)
+{
+  if (!isAvbdRigidWorldPointJointType(joint.type)
+      || joint.parentLink == joint.childLink) {
+    return false;
+  }
+
+  const bool worldA = joint.parentLink == entt::null;
+  const bool worldB = joint.childLink == entt::null;
+  if (worldA && worldB) {
+    return false;
+  }
+
+  const auto* childLink = registry.try_get<comps::Link>(joint.childLink);
+  if (childLink != nullptr && childLink->parentJoint == jointEntity) {
+    return false;
+  }
+
+  const auto endpointSupported = [&](entt::entity entity, bool worldEndpoint) {
+    if (worldEndpoint) {
+      return true;
+    }
+    const AvbdRigidWorldEndpoint endpoint
+        = classifyAvbdRigidWorldEndpoint(registry, entity);
+    return endpoint.kind == AvbdRigidWorldEndpointKind::FreeRigidBody
+           || endpoint.kind == AvbdRigidWorldEndpointKind::MultibodyLink;
+  };
+
+  return endpointSupported(joint.parentLink, worldA)
+         && endpointSupported(joint.childLink, worldB);
+}
+
+//==============================================================================
+inline bool computeAvbdRigidWorldPointJointDefaultStiffness(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    const comps::Joint& joint,
+    double& startStiffnessOut,
+    double& maxStiffnessOut)
+{
+  const bool worldA = joint.parentLink == entt::null;
+  const bool worldB = joint.childLink == entt::null;
+  if (worldA && worldB) {
+    return false;
+  }
+
+  const AvbdRigidWorldEndpoint endpointA
+      = worldA
+            ? AvbdRigidWorldEndpoint{joint.parentLink, AvbdRigidWorldEndpointKind::Unsupported, false}
+            : classifyAvbdRigidWorldEndpoint(registry, joint.parentLink);
+  const AvbdRigidWorldEndpoint endpointB
+      = worldB
+            ? AvbdRigidWorldEndpoint{joint.childLink, AvbdRigidWorldEndpointKind::Unsupported, false}
+            : classifyAvbdRigidWorldEndpoint(registry, joint.childLink);
+  if ((!worldA && endpointA.kind == AvbdRigidWorldEndpointKind::Unsupported)
+      || (!worldB
+          && endpointB.kind == AvbdRigidWorldEndpointKind::Unsupported)) {
+    return false;
+  }
+
+  const bool hasMultibodyEndpoint
+      = (!worldA && endpointA.kind == AvbdRigidWorldEndpointKind::MultibodyLink)
+        || (!worldB
+            && endpointB.kind == AvbdRigidWorldEndpointKind::MultibodyLink);
+  const auto* configA
+      = worldA
+            ? nullptr
+            : registry.try_get<comps::RigidAvbdContactConfig>(joint.parentLink);
+  const auto* configB
+      = worldB
+            ? nullptr
+            : registry.try_get<comps::RigidAvbdContactConfig>(joint.childLink);
+  double startStiffness = 0.0;
+  double maxStiffness = std::numeric_limits<double>::infinity();
+  bool hasEnabledConfig = false;
+  const auto absorb = [&](const comps::RigidAvbdContactConfig& config) {
+    if (!config.enabled) {
+      return;
+    }
+    hasEnabledConfig = true;
+    startStiffness = std::max(startStiffness, config.startStiffness);
+    maxStiffness = std::min(maxStiffness, config.maxStiffness);
+  };
+  if (configA != nullptr) {
+    absorb(*configA);
+  }
+  if (configB != nullptr) {
+    absorb(*configB);
+  }
+  if (!hasEnabledConfig) {
+    if (hasMultibodyEndpoint) {
+      startStiffness = std::numeric_limits<double>::infinity();
+      maxStiffness = std::numeric_limits<double>::infinity();
+    } else {
+      const comps::RigidAvbdContactConfig defaultConfig;
+      startStiffness = defaultConfig.startStiffness;
+      maxStiffness = defaultConfig.maxStiffness;
+    }
+  }
+  if (maxStiffness < startStiffness) {
+    maxStiffness = startStiffness;
+  }
+
+  startStiffnessOut = startStiffness;
+  maxStiffnessOut = maxStiffness;
+  return true;
 }
 
 //==============================================================================
@@ -292,7 +561,7 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
     double startStiffness = 1.0,
     double maxStiffness = std::numeric_limits<double>::infinity())
 {
-  if (!registry.valid(jointEntity) || !std::isfinite(startStiffness)
+  if (!registry.valid(jointEntity) || std::isnan(startStiffness)
       || startStiffness < 0.0 || std::isnan(maxStiffness)
       || maxStiffness < startStiffness) {
     return false;
@@ -300,22 +569,81 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
 
   auto* joint = registry.try_get<comps::Joint>(jointEntity);
   if (joint == nullptr || !isAvbdRigidWorldPointJointType(joint->type)
-      || joint->parentLink == entt::null || joint->childLink == entt::null
       || joint->parentLink == joint->childLink) {
     return false;
   }
 
-  if (!canProjectAvbdRigidWorldEndpointAsRigidBody(registry, joint->parentLink)
-      || !canProjectAvbdRigidWorldEndpointAsRigidBody(
-          registry, joint->childLink)) {
+  const bool worldA = joint->parentLink == entt::null;
+  const bool worldB = joint->childLink == entt::null;
+  if (worldA && worldB) {
+    return false;
+  }
+  const auto* childLink = registry.try_get<comps::Link>(joint->childLink);
+  if (childLink != nullptr && childLink->parentJoint == jointEntity) {
     return false;
   }
 
-  const auto& transformA = registry.get<comps::Transform>(joint->parentLink);
-  const auto& transformB = registry.get<comps::Transform>(joint->childLink);
-  if (!transformA.position.allFinite() || !transformB.position.allFinite()
-      || !transformA.orientation.coeffs().allFinite()
-      || !transformB.orientation.coeffs().allFinite()) {
+  const auto endpointTransform = [&](entt::entity entity,
+                                     bool worldEndpoint,
+                                     Eigen::Isometry3d& transformOut) -> bool {
+    transformOut = Eigen::Isometry3d::Identity();
+    if (worldEndpoint) {
+      return true;
+    }
+
+    const AvbdRigidWorldEndpoint endpoint
+        = classifyAvbdRigidWorldEndpoint(registry, entity);
+    if (endpoint.kind != AvbdRigidWorldEndpointKind::FreeRigidBody
+        && endpoint.kind != AvbdRigidWorldEndpointKind::MultibodyLink) {
+      return false;
+    }
+
+    if (const auto* transform = registry.try_get<comps::Transform>(entity)) {
+      if (!transform->position.allFinite()
+          || !transform->orientation.coeffs().allFinite()) {
+        return false;
+      }
+      transformOut = avbdRigidWorldContactToIsometry(
+          AvbdRigidBodyState{transform->position, transform->orientation});
+      return transformOut.matrix().allFinite();
+    }
+
+    const auto* cache = registry.try_get<comps::FrameCache>(entity);
+    if (cache != nullptr && !cache->needTransformUpdate
+        && cache->worldTransform.matrix().allFinite()) {
+      transformOut = cache->worldTransform;
+      return true;
+    }
+
+    if (const auto* link = registry.try_get<comps::Link>(entity)) {
+      if (!link->worldTransform.matrix().allFinite()) {
+        return false;
+      }
+      transformOut = link->worldTransform;
+      return true;
+    }
+
+    return false;
+  };
+
+  Eigen::Isometry3d worldAFromEndpoint = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d worldBFromEndpoint = Eigen::Isometry3d::Identity();
+  if (!endpointTransform(joint->parentLink, worldA, worldAFromEndpoint)
+      || !endpointTransform(joint->childLink, worldB, worldBFromEndpoint)) {
+    return false;
+  }
+
+  const double effectiveStartStiffness = joint->hasAvbdStiffnessState
+                                             ? joint->avbdStartStiffness
+                                             : startStiffness;
+  const double effectiveMaxStiffness
+      = joint->hasAvbdStiffnessState ? joint->avbdMaxStiffness : maxStiffness;
+  if (std::isnan(effectiveStartStiffness) || effectiveStartStiffness < 0.0
+      || std::isnan(joint->avbdLinearStiffness)
+      || joint->avbdLinearStiffness < 0.0
+      || std::isnan(joint->avbdAngularStiffness)
+      || joint->avbdAngularStiffness < 0.0 || std::isnan(effectiveMaxStiffness)
+      || effectiveMaxStiffness < effectiveStartStiffness) {
     return false;
   }
 
@@ -335,17 +663,15 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
     targetRelativeOrientation = normalizeAvbdRigidOrientation(
         joint->rigidBodyFixedJointTargetRelativeOrientation);
   } else {
-    const Eigen::Quaterniond orientationA
-        = normalizeAvbdRigidOrientation(transformA.orientation);
-    const Eigen::Quaterniond orientationB
-        = normalizeAvbdRigidOrientation(transformB.orientation);
-    const Eigen::Isometry3d worldA = avbdRigidWorldContactToIsometry(
-        AvbdRigidBodyState{transformA.position, orientationA});
-    const Eigen::Isometry3d worldB = avbdRigidWorldContactToIsometry(
-        AvbdRigidBodyState{transformB.position, orientationB});
-    const Eigen::Vector3d worldAnchor = worldB.translation();
-    localAnchorA = worldA.inverse() * worldAnchor;
-    localAnchorB = worldB.inverse() * worldAnchor;
+    const Eigen::Quaterniond orientationA = normalizeAvbdRigidOrientation(
+        Eigen::Quaterniond(worldAFromEndpoint.linear()));
+    const Eigen::Quaterniond orientationB = normalizeAvbdRigidOrientation(
+        Eigen::Quaterniond(worldBFromEndpoint.linear()));
+    const Eigen::Vector3d worldAnchor = !worldB
+                                            ? worldBFromEndpoint.translation()
+                                            : worldAFromEndpoint.translation();
+    localAnchorA = worldAFromEndpoint.inverse() * worldAnchor;
+    localAnchorB = worldBFromEndpoint.inverse() * worldAnchor;
     targetRelativeOrientation = normalizeAvbdRigidOrientation(
         orientationA.conjugate() * orientationB);
 
@@ -362,6 +688,8 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
   std::uint8_t angularAxisMask = kAvbdRigidJointAllAxesMask;
   if (joint->type == comps::JointType::Fixed) {
     // Defaults already represent a fixed joint.
+  } else if (joint->type == comps::JointType::Spherical) {
+    angularAxisMask = 0u;
   } else {
     if (!joint->axis.allFinite() || joint->axis.squaredNorm() <= 0.0) {
       return false;
@@ -389,8 +717,14 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
   config.angularAxes = angularAxes;
   config.linearAxisMask = linearAxisMask;
   config.angularAxisMask = angularAxisMask;
-  config.startStiffness = startStiffness;
-  config.maxStiffness = maxStiffness;
+  config.startStiffness = effectiveStartStiffness;
+  config.linearMaterialStiffness = joint->avbdLinearStiffness;
+  config.angularMaterialStiffness = joint->avbdAngularStiffness;
+  config.maxStiffness = effectiveMaxStiffness;
+
+  joint->hasAvbdStiffnessState = true;
+  joint->avbdStartStiffness = effectiveStartStiffness;
+  joint->avbdMaxStiffness = effectiveMaxStiffness;
   return true;
 }
 
@@ -421,45 +755,24 @@ inline std::size_t configureAvbdRigidWorldPointJointsFromCurrentPoses(
   for (const entt::entity entity : view) {
     const auto& joint = view.get<comps::Joint>(entity);
     if (!isAvbdRigidWorldPointJointType(joint.type)
-        || joint.parentLink == entt::null || joint.childLink == entt::null
         || joint.parentLink == joint.childLink) {
       continue;
     }
 
-    if (!canProjectAvbdRigidWorldEndpointAsRigidBody(registry, joint.parentLink)
-        || !canProjectAvbdRigidWorldEndpointAsRigidBody(
-            registry, joint.childLink)) {
+    const bool worldA = joint.parentLink == entt::null;
+    const bool worldB = joint.childLink == entt::null;
+    if (worldA && worldB) {
       continue;
     }
-
-    const auto* configA
-        = registry.try_get<comps::RigidAvbdContactConfig>(joint.parentLink);
-    const auto* configB
-        = registry.try_get<comps::RigidAvbdContactConfig>(joint.childLink);
+    const auto* childLink = registry.try_get<comps::Link>(joint.childLink);
+    if (childLink != nullptr && childLink->parentJoint == entity) {
+      continue;
+    }
     double startStiffness = 0.0;
     double maxStiffness = std::numeric_limits<double>::infinity();
-    bool hasEnabledConfig = false;
-    const auto absorb = [&](const comps::RigidAvbdContactConfig& config) {
-      if (!config.enabled) {
-        return;
-      }
-      hasEnabledConfig = true;
-      startStiffness = std::max(startStiffness, config.startStiffness);
-      maxStiffness = std::min(maxStiffness, config.maxStiffness);
-    };
-    if (configA != nullptr) {
-      absorb(*configA);
-    }
-    if (configB != nullptr) {
-      absorb(*configB);
-    }
-    if (!hasEnabledConfig) {
-      const comps::RigidAvbdContactConfig defaultConfig;
-      startStiffness = defaultConfig.startStiffness;
-      maxStiffness = defaultConfig.maxStiffness;
-    }
-    if (maxStiffness < startStiffness) {
-      maxStiffness = startStiffness;
+    if (!computeAvbdRigidWorldPointJointDefaultStiffness(
+            registry, joint, startStiffness, maxStiffness)) {
+      continue;
     }
 
     if (configureAvbdRigidWorldPointJointFromCurrentPose(
@@ -549,17 +862,21 @@ inline void avbdRigidWorldContactMarkFrameSubtreeDirty(
 }
 
 // All shapes of a compound body share one contact-feature id namespace, so each
-// shape is given a disjoint block of feature ids of this size (the full
-// single-shape box+cylinder+capsule range). The per-type packer offsets only
-// reserve room for a single shape of each type, so a box at one shape index
-// would otherwise alias a cylinder/capsule at another and collapse distinct
-// shapes onto the same warm-start row.
+// shape is given a large disjoint per-shape block. The low portion of a block
+// keeps the fixed primitive feature ranges from contact_kernel.hpp; mesh
+// triangle/edge/vertex features use the remaining per-shape space.
 inline constexpr std::uint64_t kAvbdRigidWorldShapeFeatureStride
+    = std::uint64_t{1} << 40;
+inline constexpr std::uint64_t kAvbdRigidWorldPlaneContactFeatureIdOffset
     = kAvbdCapsuleContactFeatureIdOffset + kAvbdCapsuleContactFeatureCodeCount;
+inline constexpr std::uint64_t kAvbdRigidWorldMeshContactFeatureIdOffset
+    = kAvbdRigidWorldPlaneContactFeatureIdOffset + 1u;
+inline constexpr std::uint64_t kAvbdRigidWorldMeshIndexBits = 20;
+inline constexpr std::uint64_t kAvbdRigidWorldMeshIndexMask
+    = (std::uint64_t{1} << kAvbdRigidWorldMeshIndexBits) - 1u;
 
 namespace detail {
 
-//==============================================================================
 inline double avbdRigidWorldContactFriction(
     const ::dart::simulation::detail::WorldRegistry& registry,
     entt::entity entity)
@@ -587,12 +904,292 @@ inline Eigen::Vector3d avbdRigidWorldContactLocalPoint(
 }
 
 //==============================================================================
+inline bool avbdRigidWorldShapeContainsLocalPoint(
+    const CollisionShape& shape, const Eigen::Vector3d& localPoint)
+{
+  constexpr double kContainmentTolerance = 1e-9;
+  if (!localPoint.allFinite()) {
+    return false;
+  }
+
+  switch (shape.type) {
+    case CollisionShapeType::Sphere:
+      return std::isfinite(shape.radius) && shape.radius > 0.0
+             && localPoint.norm() <= shape.radius + kContainmentTolerance;
+    case CollisionShapeType::Box:
+      return shape.halfExtents.allFinite()
+             && (shape.halfExtents.array() > 0.0).all()
+             && (localPoint.cwiseAbs().array()
+                 <= shape.halfExtents.array() + kContainmentTolerance)
+                    .all();
+    case CollisionShapeType::Capsule: {
+      if (!std::isfinite(shape.radius) || shape.radius <= 0.0
+          || !shape.halfExtents.allFinite() || shape.halfExtents.z() <= 0.0) {
+        return false;
+      }
+      const double axial = std::clamp(
+          localPoint.z(), -shape.halfExtents.z(), shape.halfExtents.z());
+      const Eigen::Vector3d axisPoint(0.0, 0.0, axial);
+      return (localPoint - axisPoint).norm()
+             <= shape.radius + kContainmentTolerance;
+    }
+    case CollisionShapeType::Cylinder:
+      return std::isfinite(shape.radius) && shape.radius > 0.0
+             && shape.halfExtents.allFinite() && shape.halfExtents.z() > 0.0
+             && localPoint.head<2>().norm()
+                    <= shape.radius + kContainmentTolerance
+             && std::abs(localPoint.z())
+                    <= shape.halfExtents.z() + kContainmentTolerance;
+    case CollisionShapeType::Plane: {
+      if (!shape.normal.allFinite() || shape.normal.squaredNorm() <= 0.0
+          || !std::isfinite(shape.offset)) {
+        return false;
+      }
+      const Eigen::Vector3d normal = shape.normal.normalized();
+      return std::abs(normal.dot(localPoint) - shape.offset)
+             <= kContainmentTolerance;
+    }
+    case CollisionShapeType::Mesh:
+      for (const Eigen::Vector3i& triangle : shape.triangles) {
+        if ((triangle.array() < 0).any()
+            || triangle.x() >= static_cast<Eigen::Index>(shape.vertices.size())
+            || triangle.y() >= static_cast<Eigen::Index>(shape.vertices.size())
+            || triangle.z()
+                   >= static_cast<Eigen::Index>(shape.vertices.size())) {
+          continue;
+        }
+
+        const Eigen::Vector3d& a = shape.vertices[triangle.x()];
+        const Eigen::Vector3d& b = shape.vertices[triangle.y()];
+        const Eigen::Vector3d& c = shape.vertices[triangle.z()];
+        if (!a.allFinite() || !b.allFinite() || !c.allFinite()) {
+          continue;
+        }
+
+        const Eigen::Vector3d edge0 = b - a;
+        const Eigen::Vector3d edge1 = c - a;
+        const Eigen::Vector3d normal = edge0.cross(edge1);
+        const double normalNorm = normal.norm();
+        if (normalNorm <= kContainmentTolerance) {
+          continue;
+        }
+        if (std::abs(normal.dot(localPoint - a)) / normalNorm
+            > kContainmentTolerance) {
+          continue;
+        }
+
+        const Eigen::Vector3d pointOffset = localPoint - a;
+        const double d00 = edge0.dot(edge0);
+        const double d01 = edge0.dot(edge1);
+        const double d11 = edge1.dot(edge1);
+        const double d20 = pointOffset.dot(edge0);
+        const double d21 = pointOffset.dot(edge1);
+        const double denom = d00 * d11 - d01 * d01;
+        if (std::abs(denom) <= kContainmentTolerance) {
+          continue;
+        }
+
+        const double v = (d11 * d20 - d01 * d21) / denom;
+        const double w = (d00 * d21 - d01 * d20) / denom;
+        const double u = 1.0 - v - w;
+        if (u >= -kContainmentTolerance && v >= -kContainmentTolerance
+            && w >= -kContainmentTolerance && u <= 1.0 + kContainmentTolerance
+            && v <= 1.0 + kContainmentTolerance
+            && w <= 1.0 + kContainmentTolerance) {
+          return true;
+        }
+      }
+      return false;
+  }
+
+  return false;
+}
+
+//==============================================================================
+inline std::size_t inferAvbdRigidWorldContactShapeIndex(
+    const std::vector<CollisionShape>& shapes,
+    const Eigen::Vector3d& bodyLocalPoint)
+{
+  std::size_t match = Contact::UnknownShapeIndex;
+  for (std::size_t i = 0; i < shapes.size(); ++i) {
+    const CollisionShape& shape = shapes[i];
+    if (!shape.localTransform.matrix().allFinite()) {
+      continue;
+    }
+
+    const Eigen::Vector3d shapeLocalPoint
+        = shape.localTransform.inverse() * bodyLocalPoint;
+    if (!avbdRigidWorldShapeContainsLocalPoint(shape, shapeLocalPoint)) {
+      continue;
+    }
+
+    if (match != Contact::UnknownShapeIndex) {
+      return Contact::UnknownShapeIndex;
+    }
+    match = i;
+  }
+  return match;
+}
+
+//==============================================================================
+inline bool avbdRigidWorldShapeFeatureBlock(
+    std::size_t shapeIndex, std::uint64_t& shapeBlock)
+{
+  constexpr std::uint64_t kMaxShapeIndex
+      = kAvbdContactFeatureIndexMask / kAvbdRigidWorldShapeFeatureStride;
+  if (shapeIndex > kMaxShapeIndex) {
+    return false;
+  }
+  shapeBlock = static_cast<std::uint64_t>(shapeIndex)
+               * kAvbdRigidWorldShapeFeatureStride;
+  return true;
+}
+
+//==============================================================================
+struct AvbdRigidWorldMeshContactFeature
+{
+  AvbdContactFeatureKind kind = AvbdContactFeatureKind::Body;
+  std::uint64_t localIndex = 0;
+  bool valid = false;
+};
+
+//==============================================================================
+inline bool avbdRigidWorldPackMeshEdgeFeature(
+    int first, int second, std::uint64_t& localIndex)
+{
+  if (first < 0 || second < 0) {
+    return false;
+  }
+
+  const std::uint64_t a = static_cast<std::uint64_t>(std::min(first, second));
+  const std::uint64_t b = static_cast<std::uint64_t>(std::max(first, second));
+  if (a > kAvbdRigidWorldMeshIndexMask || b > kAvbdRigidWorldMeshIndexMask) {
+    return false;
+  }
+
+  localIndex = (a << kAvbdRigidWorldMeshIndexBits) | b;
+  return true;
+}
+
+//==============================================================================
+inline AvbdRigidWorldMeshContactFeature avbdRigidWorldMeshContactFeature(
+    const CollisionShape& shape, const Eigen::Vector3d& localPoint)
+{
+  constexpr double kMeshFeatureTolerance = 1e-9;
+  AvbdRigidWorldMeshContactFeature feature;
+  if (shape.type != CollisionShapeType::Mesh || !localPoint.allFinite()) {
+    return feature;
+  }
+
+  for (std::size_t triangleIndex = 0; triangleIndex < shape.triangles.size();
+       ++triangleIndex) {
+    const Eigen::Vector3i& triangle = shape.triangles[triangleIndex];
+    if ((triangle.array() < 0).any()
+        || triangle.x() >= static_cast<Eigen::Index>(shape.vertices.size())
+        || triangle.y() >= static_cast<Eigen::Index>(shape.vertices.size())
+        || triangle.z() >= static_cast<Eigen::Index>(shape.vertices.size())) {
+      continue;
+    }
+
+    const Eigen::Vector3d& a = shape.vertices[triangle.x()];
+    const Eigen::Vector3d& b = shape.vertices[triangle.y()];
+    const Eigen::Vector3d& c = shape.vertices[triangle.z()];
+    if (!a.allFinite() || !b.allFinite() || !c.allFinite()) {
+      continue;
+    }
+
+    const Eigen::Vector3d edge0 = b - a;
+    const Eigen::Vector3d edge1 = c - a;
+    const Eigen::Vector3d normal = edge0.cross(edge1);
+    const double normalNorm = normal.norm();
+    if (normalNorm <= kMeshFeatureTolerance) {
+      continue;
+    }
+    if (std::abs(normal.dot(localPoint - a)) / normalNorm
+        > kMeshFeatureTolerance) {
+      continue;
+    }
+
+    const Eigen::Vector3d pointOffset = localPoint - a;
+    const double d00 = edge0.dot(edge0);
+    const double d01 = edge0.dot(edge1);
+    const double d11 = edge1.dot(edge1);
+    const double d20 = pointOffset.dot(edge0);
+    const double d21 = pointOffset.dot(edge1);
+    const double denom = d00 * d11 - d01 * d01;
+    if (std::abs(denom) <= kMeshFeatureTolerance) {
+      continue;
+    }
+
+    const double v = (d11 * d20 - d01 * d21) / denom;
+    const double w = (d00 * d21 - d01 * d20) / denom;
+    const double u = 1.0 - v - w;
+    if (u < -kMeshFeatureTolerance || v < -kMeshFeatureTolerance
+        || w < -kMeshFeatureTolerance || u > 1.0 + kMeshFeatureTolerance
+        || v > 1.0 + kMeshFeatureTolerance || w > 1.0 + kMeshFeatureTolerance) {
+      continue;
+    }
+
+    const bool nearU = std::abs(u) <= kMeshFeatureTolerance;
+    const bool nearV = std::abs(v) <= kMeshFeatureTolerance;
+    const bool nearW = std::abs(w) <= kMeshFeatureTolerance;
+    const int nearCount = static_cast<int>(nearU) + static_cast<int>(nearV)
+                          + static_cast<int>(nearW);
+    if (nearCount >= 2) {
+      int vertex = triangle.x();
+      if (!nearV) {
+        vertex = triangle.y();
+      } else if (!nearW) {
+        vertex = triangle.z();
+      }
+      if (vertex >= 0
+          && static_cast<std::uint64_t>(vertex)
+                 <= kAvbdRigidWorldMeshIndexMask) {
+        feature.kind = AvbdContactFeatureKind::Vertex;
+        feature.localIndex = static_cast<std::uint64_t>(vertex);
+        feature.valid = true;
+        return feature;
+      }
+      return feature;
+    }
+
+    if (nearCount == 1) {
+      int first = triangle.x();
+      int second = triangle.y();
+      if (nearU) {
+        first = triangle.y();
+        second = triangle.z();
+      } else if (nearV) {
+        first = triangle.z();
+        second = triangle.x();
+      }
+
+      std::uint64_t edgeIndex = 0;
+      if (avbdRigidWorldPackMeshEdgeFeature(first, second, edgeIndex)) {
+        feature.kind = AvbdContactFeatureKind::Edge;
+        feature.localIndex = edgeIndex;
+        feature.valid = true;
+        return feature;
+      }
+      return feature;
+    }
+
+    feature.kind = AvbdContactFeatureKind::Face;
+    feature.localIndex = static_cast<std::uint64_t>(triangleIndex);
+    feature.valid = true;
+    return feature;
+  }
+
+  return feature;
+}
+
+//==============================================================================
 inline AvbdContactEndpointId avbdRigidWorldContactEndpointId(
     const ::dart::simulation::detail::WorldRegistry& registry,
     entt::entity entity,
     std::size_t shapeIndex,
-    const Eigen::Vector3d& localPoint,
-    const Eigen::Vector3d& point)
+    const Eigen::Vector3d& point,
+    const Eigen::Vector3d& shapeLocalPointHint)
 {
   AvbdContactEndpointId endpoint = avbdRigidWorldBodyEndpointId(entity);
 
@@ -601,13 +1198,23 @@ inline AvbdContactEndpointId avbdRigidWorldContactEndpointId(
     return endpoint;
   }
 
-  Eigen::Vector3d shapeLocalPoint = localPoint;
+  const Eigen::Vector3d bodyLocalPoint
+      = avbdRigidWorldContactLocalPoint(registry, entity, point);
+  if (!bodyLocalPoint.allFinite()) {
+    return endpoint;
+  }
+
+  const bool hasExplicitShapeIndex = shapeIndex != Contact::UnknownShapeIndex;
   if (shapeIndex == Contact::UnknownShapeIndex) {
-    if (geometry->shapes.size() != 1u) {
-      return endpoint;
+    if (geometry->shapes.size() == 1u) {
+      shapeIndex = 0u;
+    } else {
+      shapeIndex = inferAvbdRigidWorldContactShapeIndex(
+          geometry->shapes, bodyLocalPoint);
+      if (shapeIndex == Contact::UnknownShapeIndex) {
+        return endpoint;
+      }
     }
-    shapeIndex = 0u;
-    shapeLocalPoint = avbdRigidWorldContactLocalPoint(registry, entity, point);
   }
 
   if (shapeIndex >= geometry->shapes.size()) {
@@ -615,6 +1222,13 @@ inline AvbdContactEndpointId avbdRigidWorldContactEndpointId(
   }
 
   const CollisionShape& shape = geometry->shapes[shapeIndex];
+  if (!shape.localTransform.matrix().allFinite()) {
+    return endpoint;
+  }
+  const Eigen::Vector3d shapeLocalPoint
+      = hasExplicitShapeIndex && shapeLocalPointHint.allFinite()
+            ? shapeLocalPointHint
+            : shape.localTransform.inverse() * bodyLocalPoint;
   if (!shapeLocalPoint.allFinite()) {
     return endpoint;
   }
@@ -622,12 +1236,14 @@ inline AvbdContactEndpointId avbdRigidWorldContactEndpointId(
   // Offset every shape's feature id into its own disjoint block so distinct
   // shapes of one compound body never share a warm-start row. Default to a
   // shape-scoped body feature so shape types without a specialized face/edge
-  // code (sphere, plane, mesh) are still distinguished per shape; the per-type
+  // code (sphere) are still distinguished per shape; the per-type
   // packers below are called with local index 0 — their box/cylinder/capsule
   // offsets keep the shape types disjoint within a block — and refine it for
-  // box/cylinder/capsule.
-  const std::uint64_t shapeBlock
-      = shapeIndex * kAvbdRigidWorldShapeFeatureStride;
+  // box/cylinder/capsule/plane/mesh.
+  std::uint64_t shapeBlock = 0;
+  if (!avbdRigidWorldShapeFeatureBlock(shapeIndex, shapeBlock)) {
+    return endpoint;
+  }
   endpoint.feature
       = packAvbdContactFeatureId(AvbdContactFeatureKind::Body, shapeBlock);
   if (shape.type == CollisionShapeType::Box && shape.halfExtents.allFinite()
@@ -655,6 +1271,24 @@ inline AvbdContactEndpointId avbdRigidWorldContactEndpointId(
     endpoint.feature = packAvbdContactFeatureId(
         avbdCapsuleContactFeatureKind(featureCode),
         shapeBlock + packAvbdCapsuleContactFeatureId(0, featureCode));
+  } else if (
+      shape.type == CollisionShapeType::Plane && shape.normal.allFinite()
+      && shape.normal.squaredNorm() > 0.0 && std::isfinite(shape.offset)) {
+    endpoint.feature = packAvbdContactFeatureId(
+        AvbdContactFeatureKind::Face,
+        shapeBlock + kAvbdRigidWorldPlaneContactFeatureIdOffset);
+  } else if (shape.type == CollisionShapeType::Mesh) {
+    const AvbdRigidWorldMeshContactFeature feature
+        = avbdRigidWorldMeshContactFeature(shape, shapeLocalPoint);
+    const std::uint64_t maxMeshLocalIndex
+        = kAvbdRigidWorldShapeFeatureStride
+          - kAvbdRigidWorldMeshContactFeatureIdOffset - 1u;
+    if (feature.valid && feature.localIndex <= maxMeshLocalIndex) {
+      endpoint.feature = packAvbdContactFeatureId(
+          feature.kind,
+          shapeBlock + kAvbdRigidWorldMeshContactFeatureIdOffset
+              + feature.localIndex);
+    }
   }
   return endpoint;
 }
@@ -663,6 +1297,17 @@ inline AvbdContactEndpointId avbdRigidWorldContactEndpointId(
 inline std::uint32_t findAvbdRigidWorldBodyIndex(
     const AvbdRigidWorldContactSnapshot& snapshot, entt::entity entity)
 {
+  if (!snapshot.entityBodyIndices.empty()) {
+    const auto found = snapshot.entityBodyIndices.find(entity);
+    if (found != snapshot.entityBodyIndices.end()) {
+      const std::uint32_t index = found->second;
+      if (index < snapshot.entities.size()
+          && snapshot.entities[index] == entity) {
+        return index;
+      }
+    }
+  }
+
   const auto it
       = std::find(snapshot.entities.begin(), snapshot.entities.end(), entity);
   if (it == snapshot.entities.end()) {
@@ -673,52 +1318,215 @@ inline std::uint32_t findAvbdRigidWorldBodyIndex(
 }
 
 //==============================================================================
+inline void reserveAvbdRigidWorldBodyIndexMap(
+    AvbdRigidWorldContactSnapshot& snapshot, std::size_t bodyCapacity)
+{
+  if (bodyCapacity > kAvbdRigidSmallRowStackCapacity) {
+    snapshot.entityBodyIndices.reserve(bodyCapacity);
+  }
+}
+
+//==============================================================================
+inline void recordAvbdRigidWorldBodyIndex(
+    AvbdRigidWorldContactSnapshot& snapshot,
+    entt::entity entity,
+    std::uint32_t index)
+{
+  if (!snapshot.entityBodyIndices.empty()
+      || snapshot.entityBodyIndices.bucket_count()
+             > kAvbdRigidSmallRowStackCapacity) {
+    snapshot.entityBodyIndices[entity] = index;
+    return;
+  }
+
+  if (snapshot.entities.size() <= kAvbdRigidSmallRowStackCapacity) {
+    return;
+  }
+
+  snapshot.entityBodyIndices.reserve(snapshot.entities.size());
+  for (std::size_t body = 0; body < snapshot.entities.size(); ++body) {
+    snapshot.entityBodyIndices[snapshot.entities[body]]
+        = static_cast<std::uint32_t>(body);
+  }
+}
+
+//==============================================================================
+inline std::uint32_t ensureAvbdRigidWorldBodyIndex(
+    AvbdRigidWorldContactSnapshot& snapshot,
+    entt::entity entity,
+    const AvbdRigidWorldProjectableBodyView& body)
+{
+  const std::uint32_t existing = findAvbdRigidWorldBodyIndex(snapshot, entity);
+  if (existing != std::numeric_limits<std::uint32_t>::max()) {
+    recordAvbdRigidWorldBodyIndex(snapshot, entity, existing);
+    return existing;
+  }
+
+  if (!body) {
+    return std::numeric_limits<std::uint32_t>::max();
+  }
+
+  snapshot.entities.push_back(entity);
+  snapshot.states.push_back(
+      AvbdRigidBodyState{
+          body.transform->position,
+          normalizeAvbdRigidOrientation(body.transform->orientation)});
+  snapshot.masses.push_back(body.mass->mass);
+  snapshot.bodyInertias.push_back(body.mass->inertia);
+  snapshot.fixed.push_back(body.isStatic ? 1u : 0u);
+  const auto index = static_cast<std::uint32_t>(snapshot.entities.size() - 1u);
+  recordAvbdRigidWorldBodyIndex(snapshot, entity, index);
+  return index;
+}
+
+//==============================================================================
 inline std::uint32_t ensureAvbdRigidWorldBodyIndex(
     const ::dart::simulation::detail::WorldRegistry& registry,
     AvbdRigidWorldContactSnapshot& snapshot,
     entt::entity entity)
 {
-  const std::uint32_t existing = findAvbdRigidWorldBodyIndex(snapshot, entity);
-  if (existing != std::numeric_limits<std::uint32_t>::max()) {
-    return existing;
-  }
-
-  if (!registry.all_of<
-          comps::RigidBodyTag,
-          comps::Transform,
-          comps::MassProperties>(entity)) {
+  const AvbdRigidWorldProjectableBodyView body
+      = avbdRigidWorldProjectableBody(registry, entity);
+  if (!body) {
     return std::numeric_limits<std::uint32_t>::max();
   }
+  return ensureAvbdRigidWorldBodyIndex(snapshot, entity, body);
+}
 
-  const auto& transform = registry.get<comps::Transform>(entity);
-  const auto& mass = registry.get<comps::MassProperties>(entity);
+//==============================================================================
+inline bool avbdRigidWorldContactPointLess(
+    const Eigen::Vector3d& lhs, const Eigen::Vector3d& rhs)
+{
+  for (Eigen::Index axis = 0; axis < 3; ++axis) {
+    if (lhs[axis] < rhs[axis]) {
+      return true;
+    }
+    if (rhs[axis] < lhs[axis]) {
+      return false;
+    }
+  }
+  return false;
+}
 
-  snapshot.entities.push_back(entity);
-  snapshot.states.push_back(
-      AvbdRigidBodyState{
-          transform.position,
-          normalizeAvbdRigidOrientation(transform.orientation)});
-  snapshot.masses.push_back(mass.mass);
-  snapshot.bodyInertias.push_back(mass.inertia);
-  snapshot.fixed.push_back(
-      registry.all_of<comps::StaticBodyTag>(entity) ? 1u : 0u);
-  return static_cast<std::uint32_t>(snapshot.entities.size() - 1u);
+//==============================================================================
+inline Eigen::Vector3d avbdRigidWorldContactCanonicalLocalPoint(
+    const AvbdRigidWorldContactSnapshot& snapshot,
+    const AvbdRigidContactManifoldPoint& contact)
+{
+  const auto rowKey
+      = canonicalizeAvbdContactEndpoints(contact.endpointA, contact.endpointB);
+  if (rowKey.first == contact.endpointA
+      && contact.bodyA < snapshot.states.size()) {
+    return avbdRigidBodyLocalPoint(
+        snapshot.states[contact.bodyA], contact.point);
+  }
+  if (rowKey.first == contact.endpointB
+      && contact.bodyB < snapshot.states.size()) {
+    return avbdRigidBodyLocalPoint(
+        snapshot.states[contact.bodyB], contact.point);
+  }
+  return contact.point;
+}
+
+//==============================================================================
+struct AvbdRigidWorldContactRowOrder
+{
+  std::pair<AvbdContactEndpointId, AvbdContactEndpointId> rowKey;
+  Eigen::Vector3d localPoint = Eigen::Vector3d::Zero();
+  std::size_t contact = 0u;
+};
+
+using AvbdRigidWorldEndpointPairKey
+    = std::pair<AvbdContactEndpointId, AvbdContactEndpointId>;
+
+struct AvbdRigidWorldEndpointPairKeyHash
+{
+  std::size_t operator()(
+      const AvbdRigidWorldEndpointPairKey& key) const noexcept
+  {
+    std::size_t seed = 0u;
+    const auto combine = [&seed](std::uint64_t value) {
+      seed ^= std::hash<std::uint64_t>{}(value) + 0x9e3779b97f4a7c15ull
+              + (seed << 6u) + (seed >> 2u);
+    };
+    combine(key.first.object);
+    combine(key.first.feature);
+    combine(key.second.object);
+    combine(key.second.feature);
+    return seed;
+  }
+};
+
+using AvbdRigidWorldRowCounterMap = std::unordered_map<
+    AvbdRigidWorldEndpointPairKey,
+    std::uint32_t,
+    AvbdRigidWorldEndpointPairKeyHash>;
+
+//==============================================================================
+inline void assignAvbdRigidWorldContactRows(
+    AvbdRigidWorldContactSnapshot& snapshot)
+{
+  std::vector<AvbdRigidWorldContactRowOrder> rows;
+  rows.reserve(snapshot.contacts.size());
+  for (std::size_t contact = 0; contact < snapshot.contacts.size(); ++contact) {
+    const AvbdRigidContactManifoldPoint& manifoldPoint
+        = snapshot.contacts[contact];
+    rows.push_back(
+        AvbdRigidWorldContactRowOrder{
+            canonicalizeAvbdContactEndpoints(
+                manifoldPoint.endpointA, manifoldPoint.endpointB),
+            avbdRigidWorldContactCanonicalLocalPoint(snapshot, manifoldPoint),
+            contact});
+  }
+
+  std::sort(
+      rows.begin(),
+      rows.end(),
+      [](const AvbdRigidWorldContactRowOrder& lhs,
+         const AvbdRigidWorldContactRowOrder& rhs) {
+        if (lhs.rowKey < rhs.rowKey) {
+          return true;
+        }
+        if (rhs.rowKey < lhs.rowKey) {
+          return false;
+        }
+        if (avbdRigidWorldContactPointLess(lhs.localPoint, rhs.localPoint)) {
+          return true;
+        }
+        if (avbdRigidWorldContactPointLess(rhs.localPoint, lhs.localPoint)) {
+          return false;
+        }
+        return lhs.contact < rhs.contact;
+      });
+
+  AvbdRigidWorldRowCounterMap rowCounters;
+  rowCounters.reserve(rows.size());
+  for (const AvbdRigidWorldContactRowOrder& row : rows) {
+    std::uint32_t& nextRow = rowCounters[row.rowKey];
+    snapshot.contacts[row.contact].row = nextRow;
+    if (nextRow < std::numeric_limits<std::uint32_t>::max()) {
+      ++nextRow;
+    }
+  }
 }
 
 } // namespace detail
 
 //==============================================================================
-inline AvbdRigidWorldContactSnapshot buildAvbdRigidWorldContactSnapshot(
+inline void buildAvbdRigidWorldContactSnapshotInto(
     const ::dart::simulation::detail::WorldRegistry& registry,
     std::span<const Contact> contacts,
+    AvbdRigidWorldContactSnapshot& snapshot,
     const AvbdRigidWorldContactOptions& options = {})
 {
-  AvbdRigidWorldContactSnapshot snapshot;
+  clearAvbdRigidWorldContactSnapshot(snapshot);
   snapshot.contacts.reserve(contacts.size());
-  std::map<
-      std::pair<AvbdContactEndpointId, AvbdContactEndpointId>,
-      std::uint32_t>
-      rowCounters;
+  snapshot.entities.reserve(2u * contacts.size());
+  detail::reserveAvbdRigidWorldBodyIndexMap(snapshot, 2u * contacts.size());
+  snapshot.states.reserve(2u * contacts.size());
+  snapshot.masses.reserve(2u * contacts.size());
+  snapshot.bodyInertias.reserve(2u * contacts.size());
+  snapshot.fixed.reserve(2u * contacts.size());
 
   for (std::size_t contactIndex = 0; contactIndex < contacts.size();
        ++contactIndex) {
@@ -732,21 +1540,22 @@ inline AvbdRigidWorldContactSnapshot buildAvbdRigidWorldContactSnapshot(
       continue;
     }
 
-    if (!canProjectAvbdRigidWorldEndpointAsRigidBody(registry, entityA)
-        || !canProjectAvbdRigidWorldEndpointAsRigidBody(registry, entityB)) {
+    const AvbdRigidWorldProjectableBodyView bodyAView
+        = avbdRigidWorldProjectableBody(registry, entityA);
+    const AvbdRigidWorldProjectableBodyView bodyBView
+        = avbdRigidWorldProjectableBody(registry, entityB);
+    if (!bodyAView || !bodyBView) {
       continue;
     }
 
-    const bool staticA = registry.all_of<comps::StaticBodyTag>(entityA);
-    const bool staticB = registry.all_of<comps::StaticBodyTag>(entityB);
-    if (staticA && staticB) {
+    if (bodyAView.isStatic && bodyBView.isStatic) {
       continue;
     }
 
     const std::uint32_t bodyA
-        = detail::ensureAvbdRigidWorldBodyIndex(registry, snapshot, entityA);
+        = detail::ensureAvbdRigidWorldBodyIndex(snapshot, entityA, bodyAView);
     const std::uint32_t bodyB
-        = detail::ensureAvbdRigidWorldBodyIndex(registry, snapshot, entityB);
+        = detail::ensureAvbdRigidWorldBodyIndex(snapshot, entityB, bodyBView);
     if (bodyA == std::numeric_limits<std::uint32_t>::max()
         || bodyB == std::numeric_limits<std::uint32_t>::max()) {
       continue;
@@ -759,14 +1568,14 @@ inline AvbdRigidWorldContactSnapshot buildAvbdRigidWorldContactSnapshot(
         registry,
         entityA,
         contact.shapeIndexA,
-        contact.localPointA,
-        contact.point);
+        contact.point,
+        contact.localPointA);
     manifoldPoint.endpointB = detail::avbdRigidWorldContactEndpointId(
         registry,
         entityB,
         contact.shapeIndexB,
-        contact.localPointB,
-        contact.point);
+        contact.point,
+        contact.localPointB);
     manifoldPoint.point = contact.point;
     manifoldPoint.normalFromAtoB = contact.normal;
     manifoldPoint.depth = contact.depth;
@@ -775,15 +1584,20 @@ inline AvbdRigidWorldContactSnapshot buildAvbdRigidWorldContactSnapshot(
         * detail::avbdRigidWorldContactFriction(registry, entityB));
     manifoldPoint.startStiffness = options.startStiffness;
     manifoldPoint.maxStiffness = options.maxStiffness;
-    const auto rowKey = canonicalizeAvbdContactEndpoints(
-        manifoldPoint.endpointA, manifoldPoint.endpointB);
-    std::uint32_t& nextRow = rowCounters[rowKey];
-    manifoldPoint.row = nextRow;
-    if (nextRow < std::numeric_limits<std::uint32_t>::max()) {
-      ++nextRow;
-    }
     snapshot.contacts.push_back(manifoldPoint);
   }
+
+  detail::assignAvbdRigidWorldContactRows(snapshot);
+}
+
+//==============================================================================
+inline AvbdRigidWorldContactSnapshot buildAvbdRigidWorldContactSnapshot(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    std::span<const Contact> contacts,
+    const AvbdRigidWorldContactOptions& options = {})
+{
+  AvbdRigidWorldContactSnapshot snapshot;
+  buildAvbdRigidWorldContactSnapshotInto(registry, contacts, snapshot, options);
 
   return snapshot;
 }
@@ -794,18 +1608,34 @@ inline std::size_t appendAvbdRigidWorldPointJoints(
     std::span<const AvbdRigidWorldPointJointInput> inputs,
     AvbdRigidWorldContactSnapshot& snapshot)
 {
-  std::map<
-      std::pair<AvbdContactEndpointId, AvbdContactEndpointId>,
-      std::uint32_t>
-      rowCounters;
-  for (const AvbdRigidPointJoint& joint : snapshot.joints) {
-    const auto rowKey
-        = canonicalizeAvbdContactEndpoints(joint.endpointA, joint.endpointB);
-    std::uint32_t& nextRow = rowCounters[rowKey];
-    if (joint.row < std::numeric_limits<std::uint32_t>::max()) {
-      nextRow = std::max(nextRow, joint.row + 1u);
-    } else {
-      nextRow = std::numeric_limits<std::uint32_t>::max();
+  const bool singleNewRow = snapshot.joints.empty() && inputs.size() == 1u;
+  detail::AvbdRigidWorldRowCounterMap rowCounters;
+  if (!singleNewRow) {
+    rowCounters.reserve(snapshot.joints.size() + inputs.size());
+  }
+  if (!inputs.empty()) {
+    const std::size_t maxNewBodies = 2u * inputs.size();
+    snapshot.entities.reserve(snapshot.entities.size() + maxNewBodies);
+    detail::reserveAvbdRigidWorldBodyIndexMap(
+        snapshot, snapshot.entities.size() + maxNewBodies);
+    snapshot.states.reserve(snapshot.states.size() + maxNewBodies);
+    snapshot.masses.reserve(snapshot.masses.size() + maxNewBodies);
+    snapshot.bodyInertias.reserve(snapshot.bodyInertias.size() + maxNewBodies);
+    snapshot.fixed.reserve(snapshot.fixed.size() + maxNewBodies);
+    snapshot.joints.reserve(snapshot.joints.size() + inputs.size());
+    snapshot.jointEntities.reserve(
+        snapshot.jointEntities.size() + inputs.size());
+  }
+  if (!singleNewRow) {
+    for (const AvbdRigidPointJoint& joint : snapshot.joints) {
+      const auto rowKey
+          = canonicalizeAvbdContactEndpoints(joint.endpointA, joint.endpointB);
+      std::uint32_t& nextRow = rowCounters[rowKey];
+      if (joint.row < std::numeric_limits<std::uint32_t>::max()) {
+        nextRow = std::max(nextRow, joint.row + 1u);
+      } else {
+        nextRow = std::numeric_limits<std::uint32_t>::max();
+      }
     }
   }
 
@@ -813,14 +1643,32 @@ inline std::size_t appendAvbdRigidWorldPointJoints(
   for (const AvbdRigidWorldPointJointInput& input : inputs) {
     if (input.bodyA == entt::null || input.bodyB == entt::null
         || input.bodyA == input.bodyB || !input.anchorA.allFinite()
-        || !input.anchorB.allFinite()) {
+        || !input.anchorB.allFinite() || std::isnan(input.startStiffness)
+        || input.startStiffness < 0.0
+        || std::isnan(input.linearMaterialStiffness)
+        || input.linearMaterialStiffness < 0.0
+        || std::isnan(input.angularMaterialStiffness)
+        || input.angularMaterialStiffness < 0.0
+        || std::isnan(input.maxStiffness)
+        || input.maxStiffness < input.startStiffness) {
+      continue;
+    }
+
+    const AvbdRigidWorldProjectableBodyView bodyAView
+        = avbdRigidWorldCachedProjectableBody(
+            registry, input.bodyA, input.bodyAView);
+    const AvbdRigidWorldProjectableBodyView bodyBView
+        = avbdRigidWorldCachedProjectableBody(
+            registry, input.bodyB, input.bodyBView);
+    if (!bodyAView || !bodyBView
+        || (bodyAView.isStatic && bodyBView.isStatic)) {
       continue;
     }
 
     const std::uint32_t bodyA = detail::ensureAvbdRigidWorldBodyIndex(
-        registry, snapshot, input.bodyA);
+        snapshot, input.bodyA, bodyAView);
     const std::uint32_t bodyB = detail::ensureAvbdRigidWorldBodyIndex(
-        registry, snapshot, input.bodyB);
+        snapshot, input.bodyB, bodyBView);
     if (bodyA == std::numeric_limits<std::uint32_t>::max()
         || bodyB == std::numeric_limits<std::uint32_t>::max()) {
       continue;
@@ -832,9 +1680,13 @@ inline std::size_t appendAvbdRigidWorldPointJoints(
     joint.endpointA = avbdRigidWorldBodyEndpointId(input.bodyA);
     joint.endpointB = avbdRigidWorldBodyEndpointId(input.bodyB);
     joint.localPointA
-        = avbdRigidBodyLocalPoint(snapshot.states[bodyA], input.anchorA);
+        = input.anchorsAreLocal
+              ? input.anchorA
+              : avbdRigidBodyLocalPoint(snapshot.states[bodyA], input.anchorA);
     joint.localPointB
-        = avbdRigidBodyLocalPoint(snapshot.states[bodyB], input.anchorB);
+        = input.anchorsAreLocal
+              ? input.anchorB
+              : avbdRigidBodyLocalPoint(snapshot.states[bodyB], input.anchorB);
     joint.targetRelativeOrientation
         = normalizeAvbdRigidOrientation(input.targetRelativeOrientation);
     joint.linearAxes = input.linearAxes;
@@ -842,15 +1694,21 @@ inline std::size_t appendAvbdRigidWorldPointJoints(
     joint.linearAxisMask = input.linearAxisMask;
     joint.angularAxisMask = input.angularAxisMask;
     joint.startStiffness = std::max(0.0, input.startStiffness);
+    joint.linearMaterialStiffness = input.linearMaterialStiffness;
+    joint.angularMaterialStiffness = input.angularMaterialStiffness;
     joint.maxStiffness = std::max(joint.startStiffness, input.maxStiffness);
     joint.fractureThreshold = input.fractureThreshold;
 
-    const auto rowKey
-        = canonicalizeAvbdContactEndpoints(joint.endpointA, joint.endpointB);
-    std::uint32_t& nextRow = rowCounters[rowKey];
-    joint.row = nextRow;
-    if (nextRow < std::numeric_limits<std::uint32_t>::max()) {
-      ++nextRow;
+    if (singleNewRow) {
+      joint.row = 0u;
+    } else {
+      const auto rowKey
+          = canonicalizeAvbdContactEndpoints(joint.endpointA, joint.endpointB);
+      std::uint32_t& nextRow = rowCounters[rowKey];
+      joint.row = nextRow;
+      if (nextRow < std::numeric_limits<std::uint32_t>::max()) {
+        ++nextRow;
+      }
     }
 
     if (input.useAngularMotor && input.angularAxes.allFinite()
@@ -873,9 +1731,136 @@ inline std::size_t appendAvbdRigidWorldPointJoints(
           joint.maxStiffness,
           joint.row));
     }
+    if (input.useLinearMotor && input.linearAxes.allFinite()
+        && std::isfinite(input.motorTargetSpeed) && input.motorMaxForce > 0.0
+        && !std::isnan(input.motorMaxForce)) {
+      snapshot.linearMotors.push_back(makeAvbdRigidLinearMotor(
+          joint.bodyA,
+          joint.bodyB,
+          joint.endpointA,
+          joint.endpointB,
+          joint.localPointA,
+          joint.localPointB,
+          input.linearAxes.col(2),
+          input.motorTargetSpeed,
+          input.motorMaxForce,
+          joint.startStiffness,
+          joint.maxStiffness,
+          joint.row));
+    }
 
     snapshot.joints.push_back(joint);
     snapshot.jointEntities.push_back(input.joint);
+    ++appended;
+  }
+
+  return appended;
+}
+
+//==============================================================================
+inline std::size_t appendAvbdRigidWorldDistanceSprings(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    std::span<const AvbdRigidWorldDistanceSpringInput> inputs,
+    AvbdRigidWorldContactSnapshot& snapshot)
+{
+  const bool singleNewRow
+      = snapshot.distanceSprings.empty() && inputs.size() == 1u;
+  detail::AvbdRigidWorldRowCounterMap rowCounters;
+  if (!singleNewRow) {
+    rowCounters.reserve(snapshot.distanceSprings.size() + inputs.size());
+  }
+  if (!inputs.empty()) {
+    const std::size_t maxNewBodies = 2u * inputs.size();
+    snapshot.entities.reserve(snapshot.entities.size() + maxNewBodies);
+    detail::reserveAvbdRigidWorldBodyIndexMap(
+        snapshot, snapshot.entities.size() + maxNewBodies);
+    snapshot.states.reserve(snapshot.states.size() + maxNewBodies);
+    snapshot.masses.reserve(snapshot.masses.size() + maxNewBodies);
+    snapshot.bodyInertias.reserve(snapshot.bodyInertias.size() + maxNewBodies);
+    snapshot.fixed.reserve(snapshot.fixed.size() + maxNewBodies);
+    snapshot.distanceSprings.reserve(
+        snapshot.distanceSprings.size() + inputs.size());
+    snapshot.distanceSpringEntities.reserve(
+        snapshot.distanceSpringEntities.size() + inputs.size());
+  }
+  if (!singleNewRow) {
+    for (const AvbdRigidBodyPointPairDistanceSpringRow& spring :
+         snapshot.distanceSprings) {
+      const auto rowKey = canonicalizeAvbdContactEndpoints(
+          spring.endpointA, spring.endpointB);
+      std::uint32_t& nextRow = rowCounters[rowKey];
+      if (spring.rowIndex < std::numeric_limits<std::uint32_t>::max()) {
+        nextRow = std::max(nextRow, spring.rowIndex + 1u);
+      } else {
+        nextRow = std::numeric_limits<std::uint32_t>::max();
+      }
+    }
+  }
+
+  std::size_t appended = 0;
+  for (const AvbdRigidWorldDistanceSpringInput& input : inputs) {
+    if (input.bodyA == entt::null || input.bodyB == entt::null
+        || input.bodyA == input.bodyB || !input.anchorA.allFinite()
+        || !input.anchorB.allFinite() || !std::isfinite(input.restLength)
+        || input.restLength < 0.0 || std::isnan(input.startStiffness)
+        || input.startStiffness < 0.0 || std::isnan(input.materialStiffness)
+        || input.materialStiffness < 0.0 || std::isnan(input.maxStiffness)
+        || input.maxStiffness < input.startStiffness) {
+      continue;
+    }
+
+    const AvbdRigidWorldProjectableBodyView bodyAView
+        = avbdRigidWorldCachedProjectableBody(
+            registry, input.bodyA, input.bodyAView);
+    const AvbdRigidWorldProjectableBodyView bodyBView
+        = avbdRigidWorldCachedProjectableBody(
+            registry, input.bodyB, input.bodyBView);
+    if (!bodyAView || !bodyBView
+        || (bodyAView.isStatic && bodyBView.isStatic)) {
+      continue;
+    }
+
+    const std::uint32_t bodyA = detail::ensureAvbdRigidWorldBodyIndex(
+        snapshot, input.bodyA, bodyAView);
+    const std::uint32_t bodyB = detail::ensureAvbdRigidWorldBodyIndex(
+        snapshot, input.bodyB, bodyBView);
+    if (bodyA == std::numeric_limits<std::uint32_t>::max()
+        || bodyB == std::numeric_limits<std::uint32_t>::max()) {
+      continue;
+    }
+
+    AvbdRigidBodyPointPairDistanceSpringRow spring;
+    spring.bodyA = bodyA;
+    spring.bodyB = bodyB;
+    spring.endpointA = avbdRigidWorldBodyEndpointId(input.bodyA);
+    spring.endpointB = avbdRigidWorldBodyEndpointId(input.bodyB);
+    spring.row.localPointA
+        = input.anchorsAreLocal
+              ? input.anchorA
+              : avbdRigidBodyLocalPoint(snapshot.states[bodyA], input.anchorA);
+    spring.row.localPointB
+        = input.anchorsAreLocal
+              ? input.anchorB
+              : avbdRigidBodyLocalPoint(snapshot.states[bodyB], input.anchorB);
+    spring.row.restLength = input.restLength;
+    spring.row.materialStiffness = input.materialStiffness;
+    spring.startStiffness = std::max(0.0, input.startStiffness);
+    spring.maxStiffness = std::max(spring.startStiffness, input.maxStiffness);
+
+    if (singleNewRow) {
+      spring.rowIndex = 0u;
+    } else {
+      const auto rowKey = canonicalizeAvbdContactEndpoints(
+          spring.endpointA, spring.endpointB);
+      std::uint32_t& nextRow = rowCounters[rowKey];
+      spring.rowIndex = nextRow;
+      if (nextRow < std::numeric_limits<std::uint32_t>::max()) {
+        ++nextRow;
+      }
+    }
+
+    snapshot.distanceSprings.push_back(spring);
+    snapshot.distanceSpringEntities.push_back(input.spring);
     ++appended;
   }
 
@@ -932,6 +1917,8 @@ inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
     AvbdScalarRowInventory& jointLinearInventory,
     AvbdScalarRowInventory& jointAngularInventory,
     AvbdScalarRowInventory& motorInventory,
+    AvbdScalarRowInventory& distanceSpringInventory,
+    AvbdRigidWorldContactSolveScratch& scratch,
     double timeStep,
     const AvbdRigidWorldContactSolveOptions& options = {})
 {
@@ -940,60 +1927,147 @@ inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
     return result;
   }
 
-  std::vector<AvbdRigidBodyPointPairRow> normalRows;
-  std::vector<AvbdRigidBodyPointPairFrictionRows> frictionRows;
-  buildAvbdRigidContactManifoldRows(
-      snapshot.states,
-      snapshot.contacts,
-      normalInventory,
-      frictionInventory,
-      normalRows,
-      frictionRows,
-      options.warmStart);
+  scratch.clear();
+  auto& normalRows = scratch.normalRows;
+  auto& frictionRows = scratch.frictionRows;
+  if (snapshot.contacts.empty()) {
+    normalInventory.clear();
+    frictionInventory.clear();
+    normalRows.clear();
+    frictionRows.clear();
+  } else {
+    buildAvbdRigidContactManifoldRows(
+        snapshot.states,
+        snapshot.contacts,
+        normalInventory,
+        frictionInventory,
+        normalRows,
+        frictionRows,
+        options.warmStart);
+  }
   result.normalRows = normalRows.size();
   result.frictionRows = 2u * frictionRows.size();
 
-  std::vector<AvbdRigidBodyPointPairRow> jointLinearRows;
-  std::vector<AvbdRigidBodyAngularPairRow> jointAngularRows;
-  buildAvbdRigidPointJointConstraintRows(
-      snapshot.states,
-      snapshot.joints,
-      jointLinearInventory,
-      jointAngularInventory,
-      jointLinearRows,
-      jointAngularRows,
-      options.warmStart);
+  auto& jointLinearRows = scratch.jointLinearRows;
+  auto& jointAngularRows = scratch.jointAngularRows;
+  if (snapshot.joints.empty()) {
+    jointLinearInventory.clear();
+    jointAngularInventory.clear();
+    jointLinearRows.clear();
+    jointAngularRows.clear();
+  } else {
+    buildAvbdRigidPointJointConstraintRows(
+        snapshot.states,
+        snapshot.joints,
+        jointLinearInventory,
+        jointAngularInventory,
+        jointLinearRows,
+        jointAngularRows,
+        options.warmStart);
+  }
   result.jointLinearRows = jointLinearRows.size();
   result.jointAngularRows = jointAngularRows.size();
 
-  std::vector<AvbdRigidBodyAngularPairRow> motorRows;
-  buildAvbdRigidAngularMotorRows(
-      snapshot.states,
-      snapshot.motors,
-      motorInventory,
-      motorRows,
-      timeStep,
-      options.warmStart);
-  result.motorRows = motorRows.size();
+  auto& linearMotorRows = scratch.linearMotorRows;
+  auto& motorRows = scratch.motorRows;
+  if (snapshot.linearMotors.empty() && snapshot.motors.empty()) {
+    motorInventory.clear();
+    linearMotorRows.clear();
+    motorRows.clear();
+  } else {
+    buildAvbdRigidMotorRows(
+        snapshot.states,
+        snapshot.linearMotors,
+        snapshot.motors,
+        motorInventory,
+        linearMotorRows,
+        motorRows,
+        timeStep,
+        options.warmStart);
+  }
+  result.motorRows = linearMotorRows.size() + motorRows.size();
 
-  std::vector<AvbdRigidBodyPointPairRow> pointPairRows;
-  pointPairRows.reserve(normalRows.size() + jointLinearRows.size());
-  pointPairRows.insert(
-      pointPairRows.end(), normalRows.begin(), normalRows.end());
-  pointPairRows.insert(
-      pointPairRows.end(), jointLinearRows.begin(), jointLinearRows.end());
+  auto& distanceSpringRows = scratch.distanceSpringRows;
+  if (snapshot.distanceSprings.empty()) {
+    distanceSpringInventory.clear();
+    distanceSpringRows.clear();
+  } else {
+    buildAvbdRigidDistanceSpringRows(
+        snapshot.states,
+        snapshot.distanceSprings,
+        distanceSpringInventory,
+        distanceSpringRows,
+        options.warmStart);
+  }
+  result.distanceSpringRows = distanceSpringRows.size();
 
-  std::vector<AvbdRigidBodyAngularPairRow> angularRows;
-  angularRows.reserve(jointAngularRows.size() + motorRows.size());
-  angularRows.insert(
-      angularRows.end(), jointAngularRows.begin(), jointAngularRows.end());
-  angularRows.insert(angularRows.end(), motorRows.begin(), motorRows.end());
+  const std::size_t normalRowCount = normalRows.size();
+  const std::size_t jointLinearRowCount = jointLinearRows.size();
+  const std::size_t jointAngularRowCount = jointAngularRows.size();
+  const std::size_t linearMotorRowCount = linearMotorRows.size();
+  const std::size_t angularMotorRowCount = motorRows.size();
+  const std::size_t distanceSpringRowCount = distanceSpringRows.size();
 
-  std::vector<AvbdRigidBodyPointAttachmentRow> attachmentRows;
-  const std::vector<AvbdRigidBodyState> inertialTargets
-      = snapshot.inertialTargets.size() == snapshot.states.size()
-            ? snapshot.inertialTargets
-            : snapshot.states;
+  auto& pointPairRows = scratch.pointPairRows;
+  std::vector<AvbdRigidBodyPointPairRow>* solvePointPairRows = &pointPairRows;
+  std::size_t normalOffset = 0u;
+  std::size_t jointLinearOffset = normalRowCount;
+  std::size_t linearMotorOffset = normalRowCount + jointLinearRowCount;
+  const std::size_t pointPairFamilyCount
+      = static_cast<std::size_t>(normalRowCount != 0u)
+        + static_cast<std::size_t>(jointLinearRowCount != 0u)
+        + static_cast<std::size_t>(linearMotorRowCount != 0u);
+  if (pointPairFamilyCount == 1u) {
+    if (normalRowCount != 0u) {
+      solvePointPairRows = &normalRows;
+      normalOffset = 0u;
+    } else if (jointLinearRowCount != 0u) {
+      solvePointPairRows = &jointLinearRows;
+      jointLinearOffset = 0u;
+    } else {
+      solvePointPairRows = &linearMotorRows;
+      linearMotorOffset = 0u;
+    }
+  } else {
+    pointPairRows.reserve(
+        normalRowCount + jointLinearRowCount + linearMotorRowCount);
+    pointPairRows.insert(
+        pointPairRows.end(), normalRows.begin(), normalRows.end());
+    pointPairRows.insert(
+        pointPairRows.end(), jointLinearRows.begin(), jointLinearRows.end());
+    pointPairRows.insert(
+        pointPairRows.end(), linearMotorRows.begin(), linearMotorRows.end());
+  }
+
+  auto& angularRows = scratch.angularRows;
+  std::vector<AvbdRigidBodyAngularPairRow>* solveAngularRows = &angularRows;
+  std::size_t angularMotorOffset = jointAngularRowCount;
+  const std::size_t angularFamilyCount
+      = static_cast<std::size_t>(jointAngularRowCount != 0u)
+        + static_cast<std::size_t>(angularMotorRowCount != 0u);
+  if (angularFamilyCount == 1u) {
+    if (jointAngularRowCount != 0u) {
+      solveAngularRows = &jointAngularRows;
+    } else {
+      solveAngularRows = &motorRows;
+      angularMotorOffset = 0u;
+    }
+  } else {
+    angularRows.reserve(jointAngularRowCount + angularMotorRowCount);
+    angularRows.insert(
+        angularRows.end(), jointAngularRows.begin(), jointAngularRows.end());
+    angularRows.insert(angularRows.end(), motorRows.begin(), motorRows.end());
+  }
+
+  auto& attachmentRows = scratch.attachmentRows;
+  auto& fallbackInertialTargets = scratch.fallbackInertialTargets;
+  std::span<const AvbdRigidBodyState> inertialTargets;
+  if (snapshot.inertialTargets.size() == snapshot.states.size()) {
+    inertialTargets = snapshot.inertialTargets;
+  } else {
+    fallbackInertialTargets = snapshot.states;
+    inertialTargets = fallbackInertialTargets;
+  }
   result.stats = blockDescentRigidBodiesAvbdRows(
       snapshot.states,
       snapshot.masses,
@@ -1002,33 +2076,44 @@ inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
       inertialTargets,
       timeStep,
       attachmentRows,
-      pointPairRows,
-      angularRows,
+      *solvePointPairRows,
+      *solveAngularRows,
       frictionRows,
       options.descent,
       options.row,
-      options.friction);
+      options.friction,
+      &scratch.rowIndexScratch,
+      distanceSpringRows,
+      options.distanceSpring);
 
-  for (std::size_t i = 0; i < normalRows.size() && i < normalInventory.size();
+  for (std::size_t i = 0; i < normalRowCount && i < normalInventory.size();
        ++i) {
-    normalInventory[i].state = pointPairRows[i].row.state;
+    normalInventory[i].state
+        = (*solvePointPairRows)[normalOffset + i].row.state;
   }
-  const std::size_t jointLinearOffset = normalRows.size();
   for (std::size_t i = 0;
-       i < jointLinearRows.size() && i < jointLinearInventory.size();
+       i < jointLinearRowCount && i < jointLinearInventory.size();
        ++i) {
     jointLinearInventory[i].state
-        = pointPairRows[jointLinearOffset + i].row.state;
+        = (*solvePointPairRows)[jointLinearOffset + i].row.state;
   }
   for (std::size_t i = 0;
-       i < jointAngularRows.size() && i < jointAngularInventory.size();
+       i < jointAngularRowCount && i < jointAngularInventory.size();
        ++i) {
-    jointAngularInventory[i].state = angularRows[i].row.state;
+    jointAngularInventory[i].state = (*solveAngularRows)[i].row.state;
   }
-  const std::size_t motorOffset = jointAngularRows.size();
-  for (std::size_t i = 0; i < motorRows.size() && i < motorInventory.size();
-       ++i) {
-    motorInventory[i].state = angularRows[motorOffset + i].row.state;
+  std::size_t motorRecordIndex = 0;
+  for (std::size_t i = 0;
+       i < linearMotorRowCount && motorRecordIndex < motorInventory.size();
+       ++i, ++motorRecordIndex) {
+    motorInventory[motorRecordIndex].state
+        = (*solvePointPairRows)[linearMotorOffset + i].row.state;
+  }
+  for (std::size_t i = 0;
+       i < angularMotorRowCount && motorRecordIndex < motorInventory.size();
+       ++i, ++motorRecordIndex) {
+    motorInventory[motorRecordIndex].state
+        = (*solveAngularRows)[angularMotorOffset + i].row.state;
   }
   for (std::size_t i = 0; i < frictionRows.size(); ++i) {
     const std::size_t first = 2u * i;
@@ -1038,6 +2123,11 @@ inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
     }
     frictionInventory[first].state = frictionRows[i].first.state;
     frictionInventory[second].state = frictionRows[i].second.state;
+  }
+  for (std::size_t i = 0;
+       i < distanceSpringRowCount && i < distanceSpringInventory.size();
+       ++i) {
+    distanceSpringInventory[i].state = distanceSpringRows[i].row.state;
   }
 
   std::size_t linearCursor = 0;
@@ -1055,16 +2145,17 @@ inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
         = avbdRigidWorldActiveJointAxisCount(joint.angularAxisMask);
     double lambdaSquared = 0.0;
     for (std::size_t i = 0;
-         i < linearRows && linearCursor + i < jointLinearRows.size();
+         i < linearRows && linearCursor + i < jointLinearRowCount;
          ++i) {
       lambdaSquared += avbdRigidWorldJointRowLambdaSquared(
-          pointPairRows[jointLinearOffset + linearCursor + i].row.state.lambda);
+          (*solvePointPairRows)[jointLinearOffset + linearCursor + i]
+              .row.state.lambda);
     }
     for (std::size_t i = 0;
-         i < angularRowsForJoint && angularCursor + i < jointAngularRows.size();
+         i < angularRowsForJoint && angularCursor + i < jointAngularRowCount;
          ++i) {
       lambdaSquared += avbdRigidWorldJointRowLambdaSquared(
-          angularRows[angularCursor + i].row.state.lambda);
+          (*solveAngularRows)[angularCursor + i].row.state.lambda);
     }
     if (joint.fractureThreshold > 0.0 && std::isfinite(joint.fractureThreshold)
         && std::sqrt(lambdaSquared) >= joint.fractureThreshold) {
@@ -1077,6 +2168,58 @@ inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
   result.fracturedJoints = result.fracturedJointIndices.size();
 
   return result;
+}
+
+//==============================================================================
+inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
+    AvbdRigidWorldContactSnapshot& snapshot,
+    AvbdScalarRowInventory& normalInventory,
+    AvbdScalarRowInventory& frictionInventory,
+    AvbdScalarRowInventory& jointLinearInventory,
+    AvbdScalarRowInventory& jointAngularInventory,
+    AvbdScalarRowInventory& motorInventory,
+    AvbdRigidWorldContactSolveScratch& scratch,
+    double timeStep,
+    const AvbdRigidWorldContactSolveOptions& options = {})
+{
+  AvbdScalarRowInventory distanceSpringInventory;
+  return solveAvbdRigidWorldContactSnapshot(
+      snapshot,
+      normalInventory,
+      frictionInventory,
+      jointLinearInventory,
+      jointAngularInventory,
+      motorInventory,
+      distanceSpringInventory,
+      scratch,
+      timeStep,
+      options);
+}
+
+//==============================================================================
+inline AvbdRigidWorldContactSolveResult solveAvbdRigidWorldContactSnapshot(
+    AvbdRigidWorldContactSnapshot& snapshot,
+    AvbdScalarRowInventory& normalInventory,
+    AvbdScalarRowInventory& frictionInventory,
+    AvbdScalarRowInventory& jointLinearInventory,
+    AvbdScalarRowInventory& jointAngularInventory,
+    AvbdScalarRowInventory& motorInventory,
+    double timeStep,
+    const AvbdRigidWorldContactSolveOptions& options = {})
+{
+  AvbdRigidWorldContactSolveScratch scratch;
+  AvbdScalarRowInventory distanceSpringInventory;
+  return solveAvbdRigidWorldContactSnapshot(
+      snapshot,
+      normalInventory,
+      frictionInventory,
+      jointLinearInventory,
+      jointAngularInventory,
+      motorInventory,
+      distanceSpringInventory,
+      scratch,
+      timeStep,
+      options);
 }
 
 //==============================================================================
@@ -1275,11 +2418,13 @@ inline AvbdRigidWorldContactStepResult runAvbdRigidWorldContactStep(
     ::dart::simulation::detail::WorldRegistry& registry,
     std::span<const Contact> contacts,
     std::span<const AvbdRigidWorldPointJointInput> joints,
+    std::span<const AvbdRigidWorldDistanceSpringInput> distanceSprings,
     AvbdScalarRowInventory& normalInventory,
     AvbdScalarRowInventory& frictionInventory,
     AvbdScalarRowInventory& jointLinearInventory,
     AvbdScalarRowInventory& jointAngularInventory,
     AvbdScalarRowInventory& motorInventory,
+    AvbdScalarRowInventory& distanceSpringInventory,
     double timeStep,
     const AvbdRigidWorldContactStepOptions& options = {})
 {
@@ -1287,18 +2432,22 @@ inline AvbdRigidWorldContactStepResult runAvbdRigidWorldContactStep(
   AvbdRigidWorldContactSnapshot snapshot
       = buildAvbdRigidWorldContactSnapshot(registry, contacts, options.contact);
   result.joints = appendAvbdRigidWorldPointJoints(registry, joints, snapshot);
-  result.motors = snapshot.motors.size();
+  result.distanceSprings = appendAvbdRigidWorldDistanceSprings(
+      registry, distanceSprings, snapshot);
+  result.motors = snapshot.linearMotors.size() + snapshot.motors.size();
   result.bodies = snapshot.states.size();
   result.contacts = snapshot.contacts.size();
   if (snapshot.states.empty()
       || (snapshot.contacts.empty() && snapshot.joints.empty()
-          && snapshot.motors.empty())) {
+          && snapshot.linearMotors.empty() && snapshot.motors.empty()
+          && snapshot.distanceSprings.empty())) {
     return result;
   }
   if (options.useVelocityInertialTargets) {
     predictAvbdRigidWorldContactInertialTargets(registry, snapshot, timeStep);
   }
 
+  AvbdRigidWorldContactSolveScratch scratch;
   result.solve = solveAvbdRigidWorldContactSnapshot(
       snapshot,
       normalInventory,
@@ -1306,13 +2455,16 @@ inline AvbdRigidWorldContactStepResult runAvbdRigidWorldContactStep(
       jointLinearInventory,
       jointAngularInventory,
       motorInventory,
+      distanceSpringInventory,
+      scratch,
       timeStep,
       options.solve);
   result.fracturedJoints = markAvbdRigidWorldFracturedPointJoints(
       registry, snapshot, result.solve.fracturedJointIndices);
   if (result.solve.normalRows == 0u && result.solve.frictionRows == 0u
       && result.solve.jointLinearRows == 0u
-      && result.solve.jointAngularRows == 0u && result.solve.motorRows == 0u) {
+      && result.solve.jointAngularRows == 0u && result.solve.motorRows == 0u
+      && result.solve.distanceSpringRows == 0u) {
     return result;
   }
 
@@ -1330,29 +2482,62 @@ inline AvbdRigidWorldContactStepResult runAvbdRigidWorldContactStep(
     AvbdScalarRowInventory& frictionInventory,
     AvbdScalarRowInventory& jointLinearInventory,
     AvbdScalarRowInventory& jointAngularInventory,
+    AvbdScalarRowInventory& motorInventory,
     double timeStep,
     const AvbdRigidWorldContactStepOptions& options = {})
 {
-  AvbdScalarRowInventory motorInventory;
+  AvbdScalarRowInventory distanceSpringInventory;
   return runAvbdRigidWorldContactStep(
       registry,
       contacts,
       joints,
+      std::span<const AvbdRigidWorldDistanceSpringInput>{},
       normalInventory,
       frictionInventory,
       jointLinearInventory,
       jointAngularInventory,
       motorInventory,
+      distanceSpringInventory,
       timeStep,
       options);
 }
 
 //==============================================================================
-inline std::vector<AvbdRigidWorldPointJointInput>
-extractAvbdRigidWorldPointJointInputs(
-    const ::dart::simulation::detail::WorldRegistry& registry)
+inline AvbdRigidWorldContactStepResult runAvbdRigidWorldContactStep(
+    ::dart::simulation::detail::WorldRegistry& registry,
+    std::span<const Contact> contacts,
+    std::span<const AvbdRigidWorldPointJointInput> joints,
+    AvbdScalarRowInventory& normalInventory,
+    AvbdScalarRowInventory& frictionInventory,
+    AvbdScalarRowInventory& jointLinearInventory,
+    AvbdScalarRowInventory& jointAngularInventory,
+    double timeStep,
+    const AvbdRigidWorldContactStepOptions& options = {})
 {
-  std::vector<AvbdRigidWorldPointJointInput> inputs;
+  AvbdScalarRowInventory motorInventory;
+  AvbdScalarRowInventory distanceSpringInventory;
+  return runAvbdRigidWorldContactStep(
+      registry,
+      contacts,
+      joints,
+      std::span<const AvbdRigidWorldDistanceSpringInput>{},
+      normalInventory,
+      frictionInventory,
+      jointLinearInventory,
+      jointAngularInventory,
+      motorInventory,
+      distanceSpringInventory,
+      timeStep,
+      options);
+}
+
+//==============================================================================
+inline void extractAvbdRigidWorldPointJointInputsInto(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    std::vector<AvbdRigidWorldPointJointInput>& inputs,
+    bool includeWorldAnchors = true)
+{
+  inputs.clear();
   const auto view
       = registry.view<comps::Joint, AvbdRigidWorldPointJointConfig>();
   inputs.reserve(view.size_hint());
@@ -1370,42 +2555,86 @@ extractAvbdRigidWorldPointJointInputs(
       continue;
     }
 
-    if (!canProjectAvbdRigidWorldEndpointAsRigidBody(registry, joint.parentLink)
-        || !canProjectAvbdRigidWorldEndpointAsRigidBody(
-            registry, joint.childLink)) {
+    const AvbdRigidWorldProjectableBodyView bodyA
+        = avbdRigidWorldProjectableBody(registry, joint.parentLink);
+    const AvbdRigidWorldProjectableBodyView bodyB
+        = avbdRigidWorldProjectableBody(registry, joint.childLink);
+    if (!bodyA || !bodyB || (bodyA.isStatic && bodyB.isStatic)) {
       continue;
     }
+    const auto* transformA = bodyA.transform;
+    const auto* transformB = bodyB.transform;
 
     if (!config.localAnchorA.allFinite() || !config.localAnchorB.allFinite()
         || !config.targetRelativeOrientation.coeffs().allFinite()
-        || !config.linearAxes.allFinite() || !config.angularAxes.allFinite()) {
+        || !config.linearAxes.allFinite() || !config.angularAxes.allFinite()
+        || std::isnan(config.startStiffness) || config.startStiffness < 0.0
+        || std::isnan(config.linearMaterialStiffness)
+        || config.linearMaterialStiffness < 0.0
+        || std::isnan(config.angularMaterialStiffness)
+        || config.angularMaterialStiffness < 0.0
+        || std::isnan(config.maxStiffness)
+        || config.maxStiffness < config.startStiffness) {
       continue;
     }
 
-    const auto& transformA = registry.get<comps::Transform>(joint.parentLink);
-    const auto& transformB = registry.get<comps::Transform>(joint.childLink);
-    const Eigen::Isometry3d worldA = avbdRigidWorldContactToIsometry(
-        AvbdRigidBodyState{transformA.position, transformA.orientation});
-    const Eigen::Isometry3d worldB = avbdRigidWorldContactToIsometry(
-        AvbdRigidBodyState{transformB.position, transformB.orientation});
+    if (!transformA->position.allFinite()
+        || !transformA->orientation.coeffs().allFinite()
+        || !transformB->position.allFinite()
+        || !transformB->orientation.coeffs().allFinite()) {
+      continue;
+    }
+
+    const bool hasAngularVelocityMotor
+        = joint.type == comps::JointType::Revolute
+          && joint.actuatorType == comps::ActuatorType::Velocity
+          && joint.commandVelocity.size() == 1
+          && joint.commandVelocity.allFinite();
+    const bool hasLinearVelocityMotor
+        = joint.type == comps::JointType::Prismatic
+          && joint.actuatorType == comps::ActuatorType::Velocity
+          && joint.commandVelocity.size() == 1
+          && joint.commandVelocity.allFinite();
+    const bool useStableFullLinearBasis
+        = !includeWorldAnchors
+          && config.linearAxisMask == kAvbdRigidJointAllAxesMask
+          && config.angularAxisMask == 0u && !hasAngularVelocityMotor
+          && !hasLinearVelocityMotor
+          && config.linearAxes.isApprox(Eigen::Matrix3d::Identity(), 0.0);
+    Eigen::Quaterniond orientationA = Eigen::Quaterniond::Identity();
+    Eigen::Matrix3d parentRotation = Eigen::Matrix3d::Identity();
+    if (!useStableFullLinearBasis || includeWorldAnchors) {
+      orientationA = normalizeAvbdRigidOrientation(transformA->orientation);
+      parentRotation = orientationA.toRotationMatrix();
+    }
 
     AvbdRigidWorldPointJointInput input;
     input.joint = entity;
     input.bodyA = joint.parentLink;
     input.bodyB = joint.childLink;
-    input.anchorA = worldA * config.localAnchorA;
-    input.anchorB = worldB * config.localAnchorB;
+    input.bodyAView = bodyA;
+    input.bodyBView = bodyB;
+    if (includeWorldAnchors) {
+      const Eigen::Quaterniond orientationB
+          = normalizeAvbdRigidOrientation(transformB->orientation);
+      input.anchorA = transformA->position + orientationA * config.localAnchorA;
+      input.anchorB = transformB->position + orientationB * config.localAnchorB;
+    } else {
+      input.anchorA = config.localAnchorA;
+      input.anchorB = config.localAnchorB;
+      input.anchorsAreLocal = true;
+    }
     input.targetRelativeOrientation
         = normalizeAvbdRigidOrientation(config.targetRelativeOrientation);
-    const Eigen::Matrix3d parentRotation = worldA.linear();
-    input.linearAxes = parentRotation * config.linearAxes;
-    input.angularAxes = parentRotation * config.angularAxes;
+    input.linearAxes = useStableFullLinearBasis
+                           ? config.linearAxes
+                           : parentRotation * config.linearAxes;
+    input.angularAxes = useStableFullLinearBasis
+                            ? config.angularAxes
+                            : parentRotation * config.angularAxes;
     input.linearAxisMask = config.linearAxisMask;
     input.angularAxisMask = config.angularAxisMask;
-    if (joint.type == comps::JointType::Revolute
-        && joint.actuatorType == comps::ActuatorType::Velocity
-        && joint.commandVelocity.size() == 1
-        && joint.commandVelocity.allFinite()) {
+    if (hasAngularVelocityMotor) {
       const double maxTorque = avbdRigidWorldSymmetricEffortLimit(joint);
       if (maxTorque > 0.0 && !std::isnan(maxTorque)) {
         input.useAngularMotor = true;
@@ -1413,12 +2642,133 @@ extractAvbdRigidWorldPointJointInputs(
         input.motorMaxTorque = maxTorque;
       }
     }
+    if (hasLinearVelocityMotor) {
+      const double maxForce = avbdRigidWorldSymmetricEffortLimit(joint);
+      if (maxForce > 0.0 && !std::isnan(maxForce)) {
+        input.useLinearMotor = true;
+        input.motorTargetSpeed = joint.commandVelocity[0];
+        input.motorMaxForce = maxForce;
+      }
+    }
     input.startStiffness = config.startStiffness;
+    input.linearMaterialStiffness = config.linearMaterialStiffness;
+    input.angularMaterialStiffness = config.angularMaterialStiffness;
     input.maxStiffness = config.maxStiffness;
     input.fractureThreshold = joint.breakForce;
     inputs.push_back(input);
   }
+}
 
+//==============================================================================
+inline bool hasAvbdRigidWorldPointJointConfigs(
+    const ::dart::simulation::detail::WorldRegistry& registry)
+{
+  const auto view
+      = registry.view<comps::Joint, AvbdRigidWorldPointJointConfig>();
+  return view.begin() != view.end();
+}
+
+//==============================================================================
+inline void extractAvbdRigidWorldDistanceSpringInputsInto(
+    const ::dart::simulation::detail::WorldRegistry& registry,
+    std::vector<AvbdRigidWorldDistanceSpringInput>& inputs,
+    bool includeWorldAnchors = true)
+{
+  inputs.clear();
+  const auto view = registry.view<AvbdRigidWorldDistanceSpringConfig>();
+
+  for (const entt::entity entity : view) {
+    const auto& config = view.get<AvbdRigidWorldDistanceSpringConfig>(entity);
+    if (!config.enabled || config.bodyA == entt::null
+        || config.bodyB == entt::null || config.bodyA == config.bodyB) {
+      continue;
+    }
+
+    const AvbdRigidWorldProjectableBodyView bodyA
+        = avbdRigidWorldProjectableBody(registry, config.bodyA);
+    const AvbdRigidWorldProjectableBodyView bodyB
+        = avbdRigidWorldProjectableBody(registry, config.bodyB);
+    if (!bodyA || !bodyB || (bodyA.isStatic && bodyB.isStatic)) {
+      continue;
+    }
+    const auto* transformA = bodyA.transform;
+    const auto* transformB = bodyB.transform;
+
+    if (!config.localAnchorA.allFinite() || !config.localAnchorB.allFinite()
+        || !std::isfinite(config.restLength) || config.restLength < 0.0
+        || std::isnan(config.startStiffness) || config.startStiffness < 0.0
+        || std::isnan(config.materialStiffness)
+        || config.materialStiffness < 0.0 || std::isnan(config.maxStiffness)
+        || config.maxStiffness < config.startStiffness) {
+      continue;
+    }
+
+    if (!transformA->position.allFinite()
+        || !transformA->orientation.coeffs().allFinite()
+        || !transformB->position.allFinite()
+        || !transformB->orientation.coeffs().allFinite()) {
+      continue;
+    }
+
+    AvbdRigidWorldDistanceSpringInput input;
+    input.spring = entity;
+    input.bodyA = config.bodyA;
+    input.bodyB = config.bodyB;
+    input.bodyAView = bodyA;
+    input.bodyBView = bodyB;
+    if (includeWorldAnchors) {
+      const Eigen::Quaterniond orientationA
+          = normalizeAvbdRigidOrientation(transformA->orientation);
+      const Eigen::Quaterniond orientationB
+          = normalizeAvbdRigidOrientation(transformB->orientation);
+      input.anchorA = transformA->position + orientationA * config.localAnchorA;
+      input.anchorB = transformB->position + orientationB * config.localAnchorB;
+    } else {
+      input.anchorA = config.localAnchorA;
+      input.anchorB = config.localAnchorB;
+      input.anchorsAreLocal = true;
+    }
+    input.restLength = config.restLength;
+    input.startStiffness = config.startStiffness;
+    input.materialStiffness = config.materialStiffness;
+    input.maxStiffness = config.maxStiffness;
+    inputs.push_back(input);
+  }
+}
+
+//==============================================================================
+inline bool hasAvbdRigidWorldDistanceSpringConfigs(
+    const ::dart::simulation::detail::WorldRegistry& registry)
+{
+  const auto view = registry.view<AvbdRigidWorldDistanceSpringConfig>();
+  return view.begin() != view.end();
+}
+
+//==============================================================================
+inline bool hasAvbdRigidWorldPairConstraintConfigs(
+    const ::dart::simulation::detail::WorldRegistry& registry)
+{
+  return hasAvbdRigidWorldPointJointConfigs(registry)
+         || hasAvbdRigidWorldDistanceSpringConfigs(registry);
+}
+
+//==============================================================================
+inline std::vector<AvbdRigidWorldPointJointInput>
+extractAvbdRigidWorldPointJointInputs(
+    const ::dart::simulation::detail::WorldRegistry& registry)
+{
+  std::vector<AvbdRigidWorldPointJointInput> inputs;
+  extractAvbdRigidWorldPointJointInputsInto(registry, inputs);
+  return inputs;
+}
+
+//==============================================================================
+inline std::vector<AvbdRigidWorldDistanceSpringInput>
+extractAvbdRigidWorldDistanceSpringInputs(
+    const ::dart::simulation::detail::WorldRegistry& registry)
+{
+  std::vector<AvbdRigidWorldDistanceSpringInput> inputs;
+  extractAvbdRigidWorldDistanceSpringInputsInto(registry, inputs);
   return inputs;
 }
 
@@ -1434,18 +2784,26 @@ inline AvbdRigidWorldContactStepResult runAvbdRigidWorldContactStep(
     double timeStep,
     const AvbdRigidWorldContactStepOptions& options = {})
 {
-  const std::vector<AvbdRigidWorldPointJointInput> joints
-      = extractAvbdRigidWorldPointJointInputs(registry);
+  std::vector<AvbdRigidWorldPointJointInput> joints;
+  extractAvbdRigidWorldPointJointInputsInto(
+      registry, joints, /*includeWorldAnchors=*/false);
+  std::vector<AvbdRigidWorldDistanceSpringInput> distanceSprings;
+  extractAvbdRigidWorldDistanceSpringInputsInto(
+      registry, distanceSprings, /*includeWorldAnchors=*/false);
+  AvbdScalarRowInventory distanceSpringInventory;
   return runAvbdRigidWorldContactStep(
       registry,
       contacts,
       std::span<const AvbdRigidWorldPointJointInput>(
           joints.data(), joints.size()),
+      std::span<const AvbdRigidWorldDistanceSpringInput>(
+          distanceSprings.data(), distanceSprings.size()),
       normalInventory,
       frictionInventory,
       jointLinearInventory,
       jointAngularInventory,
       motorInventory,
+      distanceSpringInventory,
       timeStep,
       options);
 }
@@ -1461,17 +2819,15 @@ inline AvbdRigidWorldContactStepResult runAvbdRigidWorldContactStep(
     double timeStep,
     const AvbdRigidWorldContactStepOptions& options = {})
 {
-  const std::vector<AvbdRigidWorldPointJointInput> joints
-      = extractAvbdRigidWorldPointJointInputs(registry);
+  AvbdScalarRowInventory motorInventory;
   return runAvbdRigidWorldContactStep(
       registry,
       contacts,
-      std::span<const AvbdRigidWorldPointJointInput>(
-          joints.data(), joints.size()),
       normalInventory,
       frictionInventory,
       jointLinearInventory,
       jointAngularInventory,
+      motorInventory,
       timeStep,
       options);
 }


### PR DESCRIPTION
## Summary

- Adds the internal AVBD rigid row inventory and block-kernel foundation split out of the raw checkpoint.
- Adds the joint-side metadata needed by later AVBD row assembly work.

## Motivation / Problem

- The 33h AVBD checkpoint was too large to review safely. This PR isolates the core internal row-solver pieces so later world integration, tests, Python demos, and docs can be reviewed separately.

## Changes / Key Changes

- Introduce AVBD row inventory types for rigid rows.
- Add rigid block-kernel and rigid world-contact internal helpers.
- Add AVBD-specific joint component state required by the row solver.

## Testing

- `pixi run lint`
- `pixi run build`
- `git diff --cached --check` before commit

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Split from raw checkpoint branch `feature/avbd-articulated-masked-rows` commit `d25e5177d9c`.
- Follow-up split PRs: world integration, variational integration, tests/benchmarks, Python demos, docs/plans.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (isolated in the docs/plans split PR)
- [x] Add unit tests for new functionality (isolated in the tests/benchmarks split PR)
- [x] Document new methods and classes (isolated in the docs/plans split PR)
- [x] Add Python bindings (dartpy) if applicable (isolated in the Python demos split PR)
