### PR TITLE
Wire AVBD rows into World integration

### DIFF
--- a/dart/simulation/body/contact.hpp
+++ b/dart/simulation/body/contact.hpp
@@ -61,7 +61,9 @@ struct Contact
   double depth = 0.0;
   std::size_t shapeIndexA = UnknownShapeIndex;
   std::size_t shapeIndexB = UnknownShapeIndex;
+  /// Shape-local contact point for shapeIndexA when the shape index is known.
   Eigen::Vector3d localPointA = Eigen::Vector3d::Zero();
+  /// Shape-local contact point for shapeIndexB when the shape index is known.
   Eigen::Vector3d localPointB = Eigen::Vector3d::Zero();
 };
 

--- a/dart/simulation/compute/world_kinematics_graph.cpp
+++ b/dart/simulation/compute/world_kinematics_graph.cpp
@@ -149,6 +149,18 @@ std::string frameCacheResource(entt::entity entity)
          + std::to_string(static_cast<std::uint32_t>(entity));
 }
 
+//==============================================================================
+bool hasDirtyFrameCaches(const detail::WorldRegistry& registry)
+{
+  const auto frameView = registry.view<comps::FrameCache>();
+  for (const auto entity : frameView) {
+    if (frameView.get<comps::FrameCache>(entity).needTransformUpdate) {
+      return true;
+    }
+  }
+  return false;
+}
+
 } // namespace
 
 //==============================================================================
@@ -233,6 +245,10 @@ bool WorldKinematicsGraph::isTopologyCurrent() const noexcept
 //==============================================================================
 void WorldKinematicsGraph::execute(ComputeExecutor& executor)
 {
+  if (!m_world.isStepProfilingEnabled()
+      && !hasDirtyFrameCaches(dart::simulation::detail::registryOf(m_world))) {
+    return;
+  }
   executor.execute(m_graph);
 }
 

--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -764,7 +764,9 @@ void KinematicsStage::prepare(World& world)
     return;
   }
 
-  m_cachedGraph->rebuild();
+  if (!m_cachedGraph->isTopologyCurrent()) {
+    m_cachedGraph->rebuild();
+  }
 }
 
 //==============================================================================
@@ -1052,9 +1054,18 @@ struct RigidBodyForceBatch
   std::vector<double> torque;
 };
 
+enum class RigidBodyForceAssemblyMode
+{
+  AllBodies,
+  AdvanceableOnly,
+};
+
 //==============================================================================
 void assembleRigidBodyForces(
-    const World& world, bool includeGravity, RigidBodyForceBatch& batch)
+    const World& world,
+    bool includeGravity,
+    RigidBodyForceBatch& batch,
+    RigidBodyForceAssemblyMode mode = RigidBodyForceAssemblyMode::AllBodies)
 {
   const auto& registry = dart::simulation::detail::registryOf(world);
   auto view
@@ -1064,13 +1075,19 @@ void assembleRigidBodyForces(
   const Eigen::Vector3d gravity
       = includeGravity ? world.getGravity() : Eigen::Vector3d::Zero();
   for (const auto entity : view) {
+    const bool prescribedBody
+        = isPrescribedRigidBodyIntegrationBody(registry, entity);
+    if (mode == RigidBodyForceAssemblyMode::AdvanceableOnly && prescribedBody) {
+      continue;
+    }
+
     batch.entities.push_back(entity);
 
     const auto& applied = registry.get<comps::Force>(entity);
     Eigen::Vector3d assembledForce = applied.force;
     Eigen::Vector3d assembledTorque = applied.torque;
 
-    if (isPrescribedRigidBodyIntegrationBody(registry, entity)) {
+    if (prescribedBody) {
       assembledForce.setZero();
       assembledTorque.setZero();
     } else if (includeGravity) {
@@ -1091,10 +1108,12 @@ void assembleRigidBodyForces(
 
 //==============================================================================
 RigidBodyForceBatch assembleRigidBodyForces(
-    const World& world, bool includeGravity)
+    const World& world,
+    bool includeGravity,
+    RigidBodyForceAssemblyMode mode = RigidBodyForceAssemblyMode::AllBodies)
 {
   RigidBodyForceBatch batch;
-  assembleRigidBodyForces(world, includeGravity, batch);
+  assembleRigidBodyForces(world, includeGravity, batch, mode);
   return batch;
 }
 
@@ -1174,6 +1193,24 @@ bool hasPrescribedRigidBodyContactResponse(
 {
   return registry.all_of<comps::StaticBodyTag>(entity)
          || registry.all_of<comps::KinematicBodyTag>(entity);
+}
+
+//==============================================================================
+bool shouldSkipRigidBodyContactQuery(const detail::WorldRegistry& registry)
+{
+  const auto collisionGeometryView = registry.view<comps::CollisionGeometry>();
+  for (const entt::entity entity : collisionGeometryView) {
+    if (hasPrescribedRigidBodyContactResponse(registry, entity)) {
+      continue;
+    }
+
+    if (registry.all_of<comps::RigidBodyTag>(entity)
+        || registry.all_of<comps::Link>(entity)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 //==============================================================================
@@ -8159,7 +8196,11 @@ void RigidBodyVelocityStage::prepare(World& world)
     m_scratch = std::make_unique<Scratch>();
   }
 
-  assembleRigidBodyForces(world, true, m_scratch->forces);
+  assembleRigidBodyForces(
+      world,
+      true,
+      m_scratch->forces,
+      RigidBodyForceAssemblyMode::AdvanceableOnly);
 }
 
 //==============================================================================
@@ -8172,7 +8213,8 @@ void RigidBodyVelocityStage::execute(
     m_scratch = std::make_unique<Scratch>();
   }
   auto& forces = m_scratch->forces;
-  assembleRigidBodyForces(world, true, forces);
+  assembleRigidBodyForces(
+      world, true, forces, RigidBodyForceAssemblyMode::AdvanceableOnly);
 
   for (std::size_t i = 0; i < forces.entities.size(); ++i) {
     const auto entity = forces.entities[i];
@@ -8241,6 +8283,12 @@ struct RigidBodyContactStage::AvbdScratch
     jointLinearInventory.records().clear();
     jointAngularInventory.records().clear();
     motorInventory.records().clear();
+    distanceSpringInventory.records().clear();
+    pointJointInputs.clear();
+    distanceSpringInputs.clear();
+    dvbd::clearAvbdRigidWorldContactSnapshot(pointJointSnapshot);
+    dvbd::clearAvbdRigidWorldContactSnapshot(contactSnapshot);
+    solveScratch.clear();
   }
 
   dvbd::AvbdScalarRowInventory normalInventory;
@@ -8248,6 +8296,12 @@ struct RigidBodyContactStage::AvbdScratch
   dvbd::AvbdScalarRowInventory jointLinearInventory;
   dvbd::AvbdScalarRowInventory jointAngularInventory;
   dvbd::AvbdScalarRowInventory motorInventory;
+  dvbd::AvbdScalarRowInventory distanceSpringInventory;
+  std::vector<dvbd::AvbdRigidWorldPointJointInput> pointJointInputs;
+  std::vector<dvbd::AvbdRigidWorldDistanceSpringInput> distanceSpringInputs;
+  dvbd::AvbdRigidWorldContactSnapshot pointJointSnapshot;
+  dvbd::AvbdRigidWorldContactSnapshot contactSnapshot;
+  dvbd::AvbdRigidWorldContactSolveScratch solveScratch;
 };
 
 //==============================================================================
@@ -8314,21 +8368,36 @@ void RigidBodyContactStage::prepare(World& world)
   if (m_contactScratch == nullptr) {
     m_contactScratch = std::make_unique<ContactScratch>();
   }
+  auto& constraints = m_contactScratch->constraints;
+  constraints.clear();
 
-  const auto& contacts = world.queryContacts(CollisionQueryOptions{});
-  m_contactScratch->constraints.reserve(contacts.size());
+  std::size_t collisionShapeCount = 0;
+  const auto& registry = dart::simulation::detail::registryOf(world);
+  const auto geometryView = registry.view<comps::CollisionGeometry>();
+  for (const entt::entity entity : geometryView) {
+    collisionShapeCount
+        += geometryView.get<comps::CollisionGeometry>(entity).shapes.size();
+  }
+  constexpr std::size_t kContactConstraintCapacityPerShape = 4u;
+  const std::size_t contactConstraintCapacity
+      = collisionShapeCount <= std::numeric_limits<std::size_t>::max()
+                                   / kContactConstraintCapacityPerShape
+            ? collisionShapeCount * kContactConstraintCapacityPerShape
+            : std::numeric_limits<std::size_t>::max();
+  constraints.reserve(contactConstraintCapacity);
 }
 
 //==============================================================================
 void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
 {
-  const auto& contacts = world.queryContacts(CollisionQueryOptions{});
   auto& registry = dart::simulation::detail::registryOf(world);
 
   const auto projectAvbdRigidPointJoints = [&]() {
-    const std::vector<dvbd::AvbdRigidWorldPointJointInput> joints
-        = dvbd::extractAvbdRigidWorldPointJointInputs(registry);
-    if (joints.empty()) {
+    const bool hasPointJointConfigs
+        = dvbd::hasAvbdRigidWorldPointJointConfigs(registry);
+    const bool hasDistanceSpringConfigs
+        = dvbd::hasAvbdRigidWorldDistanceSpringConfigs(registry);
+    if (!hasPointJointConfigs && !hasDistanceSpringConfigs) {
       return false;
     }
 
@@ -8336,10 +8405,35 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
       m_avbdScratch = std::make_unique<AvbdScratch>();
     }
 
-    dvbd::AvbdRigidWorldContactSnapshot snapshot;
+    auto& joints = m_avbdScratch->pointJointInputs;
+    if (hasPointJointConfigs) {
+      dvbd::extractAvbdRigidWorldPointJointInputsInto(
+          registry, joints, /*includeWorldAnchors=*/false);
+    } else {
+      joints.clear();
+    }
+    auto& distanceSprings = m_avbdScratch->distanceSpringInputs;
+    if (hasDistanceSpringConfigs) {
+      dvbd::extractAvbdRigidWorldDistanceSpringInputsInto(
+          registry, distanceSprings, /*includeWorldAnchors=*/false);
+    } else {
+      distanceSprings.clear();
+    }
+    if (joints.empty() && distanceSprings.empty()) {
+      return false;
+    }
+
+    auto& snapshot = m_avbdScratch->pointJointSnapshot;
+    dvbd::clearAvbdRigidWorldContactSnapshot(snapshot);
     const std::size_t appendedJoints
-        = dvbd::appendAvbdRigidWorldPointJoints(registry, joints, snapshot);
-    if (appendedJoints == 0u) {
+        = joints.empty() ? 0u
+                         : dvbd::appendAvbdRigidWorldPointJoints(
+                               registry, joints, snapshot);
+    const std::size_t appendedDistanceSprings
+        = distanceSprings.empty() ? 0u
+                                  : dvbd::appendAvbdRigidWorldDistanceSprings(
+                                        registry, distanceSprings, snapshot);
+    if (appendedJoints == 0u && appendedDistanceSprings == 0u) {
       return false;
     }
 
@@ -8358,12 +8452,15 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
             m_avbdScratch->jointLinearInventory,
             m_avbdScratch->jointAngularInventory,
             m_avbdScratch->motorInventory,
+            m_avbdScratch->distanceSpringInventory,
+            m_avbdScratch->solveScratch,
             timeStep,
             solveOptions);
     (void)dvbd::markAvbdRigidWorldFracturedPointJoints(
         registry, snapshot, solveResult.fracturedJointIndices);
     if (solveResult.jointLinearRows == 0u && solveResult.jointAngularRows == 0u
-        && solveResult.motorRows == 0u) {
+        && solveResult.motorRows == 0u
+        && solveResult.distanceSpringRows == 0u) {
       return false;
     }
 
@@ -8373,6 +8470,18 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
     return projection.bodies != 0u;
   };
 
+  if (shouldSkipRigidBodyContactQuery(registry)) {
+    if (projectAvbdRigidPointJoints()) {
+      return;
+    }
+
+    if (m_avbdScratch != nullptr) {
+      m_avbdScratch->clear();
+    }
+    return;
+  }
+
+  const auto& contacts = world.queryContacts(CollisionQueryOptions{});
   if (contacts.empty()) {
     if (projectAvbdRigidPointJoints()) {
       return;
@@ -8400,16 +8509,41 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
     contactOptions.startStiffness = std::max(0.0, avbdConfig->startStiffness);
     contactOptions.maxStiffness
         = std::max(contactOptions.startStiffness, avbdConfig->maxStiffness);
-    dvbd::AvbdRigidWorldContactSnapshot snapshot
-        = dvbd::buildAvbdRigidWorldContactSnapshot(
-            registry, contacts, contactOptions);
-    const std::vector<dvbd::AvbdRigidWorldPointJointInput> joints
-        = dvbd::extractAvbdRigidWorldPointJointInputs(registry);
-    const std::size_t appendedJoints
-        = dvbd::appendAvbdRigidWorldPointJoints(registry, joints, snapshot);
+    auto& snapshot = m_avbdScratch->contactSnapshot;
+    dvbd::buildAvbdRigidWorldContactSnapshotInto(
+        registry, contacts, snapshot, contactOptions);
+    std::size_t appendedJoints = 0u;
+    std::size_t appendedDistanceSprings = 0u;
+    auto& joints = m_avbdScratch->pointJointInputs;
+    auto& distanceSprings = m_avbdScratch->distanceSpringInputs;
+    const bool hasPointJointConfigs
+        = dvbd::hasAvbdRigidWorldPointJointConfigs(registry);
+    const bool hasDistanceSpringConfigs
+        = dvbd::hasAvbdRigidWorldDistanceSpringConfigs(registry);
+    if (hasPointJointConfigs) {
+      dvbd::extractAvbdRigidWorldPointJointInputsInto(
+          registry, joints, /*includeWorldAnchors=*/false);
+      if (!joints.empty()) {
+        appendedJoints
+            = dvbd::appendAvbdRigidWorldPointJoints(registry, joints, snapshot);
+      }
+    } else {
+      joints.clear();
+    }
+    if (hasDistanceSpringConfigs) {
+      dvbd::extractAvbdRigidWorldDistanceSpringInputsInto(
+          registry, distanceSprings, /*includeWorldAnchors=*/false);
+      if (!distanceSprings.empty()) {
+        appendedDistanceSprings = dvbd::appendAvbdRigidWorldDistanceSprings(
+            registry, distanceSprings, snapshot);
+      }
+    } else {
+      distanceSprings.clear();
+    }
 
     if (snapshot.contacts.size() == contacts.size()
-        && (!snapshot.contacts.empty() || appendedJoints != 0u)) {
+        && (!snapshot.contacts.empty() || appendedJoints != 0u
+            || appendedDistanceSprings != 0u)) {
       const double timeStep = world.getTimeStep();
       dvbd::predictAvbdRigidWorldContactInertialTargets(
           registry, snapshot, timeStep);
@@ -8424,6 +8558,8 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
       solveOptions.friction.alpha = avbdConfig->alpha;
       solveOptions.friction.beta = avbdConfig->beta;
       solveOptions.friction.maxStiffness = contactOptions.maxStiffness;
+      solveOptions.distanceSpring.beta = avbdConfig->beta;
+      solveOptions.distanceSpring.maxStiffness = contactOptions.maxStiffness;
       solveOptions.descent.iterations = m_iterations;
       solveOptions.descent.regularization = 1e-12;
 
@@ -8435,14 +8571,16 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
               m_avbdScratch->jointLinearInventory,
               m_avbdScratch->jointAngularInventory,
               m_avbdScratch->motorInventory,
+              m_avbdScratch->distanceSpringInventory,
+              m_avbdScratch->solveScratch,
               timeStep,
               solveOptions);
       (void)dvbd::markAvbdRigidWorldFracturedPointJoints(
           registry, snapshot, solveResult.fracturedJointIndices);
       if (solveResult.normalRows != 0u || solveResult.frictionRows != 0u
           || solveResult.jointLinearRows != 0u
-          || solveResult.jointAngularRows != 0u
-          || solveResult.motorRows != 0u) {
+          || solveResult.jointAngularRows != 0u || solveResult.motorRows != 0u
+          || solveResult.distanceSpringRows != 0u) {
         const dvbd::AvbdRigidWorldContactApplyResult projection
             = dvbd::applyAvbdRigidWorldContactVelocityProjection(
                 registry, snapshot, timeStep);

--- a/dart/simulation/detail/world_storage.hpp
+++ b/dart/simulation/detail/world_storage.hpp
@@ -39,6 +39,7 @@
 #include <dart/common/stl_allocator.hpp>
 
 #include <optional>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -57,6 +58,7 @@ struct WorldStorage
   using DifferentiableParameter = std::pair<entt::entity, PhysicalParameter>;
   using DifferentiableParameterAllocator
       = dart::common::StlAllocator<DifferentiableParameter>;
+  using CollisionPairKey = std::pair<entt::entity, entt::entity>;
 
   explicit WorldStorage(dart::common::MemoryAllocator& allocator);
 
@@ -76,6 +78,11 @@ struct WorldStorage
   /// differentiable support is compiled (`DART_HAS_DIFF`); always empty
   /// otherwise.
   std::optional<StepDerivatives> stepDerivatives;
+
+  /// Persistent pair-level collision-query exclusions, stored with canonical
+  /// endpoint ordering. This scene-level filter is applied after broad-phase
+  /// candidate generation and before narrow-phase contact generation.
+  std::set<CollisionPairKey> ignoredCollisionPairs;
 };
 
 } // namespace dart::simulation::detail

--- a/dart/simulation/io/binary_io.hpp
+++ b/dart/simulation/io/binary_io.hpp
@@ -90,7 +90,12 @@ using EntityMap = std::unordered_map<entt::entity, entt::entity>;
 //   15: World solver-family metadata serialized after the differentiable flag
 //      (rigid-body solver, contact method, contact-gradient mode, and
 //      multibody integration method).
-constexpr std::uint32_t kBinaryFormatVersion = 15;
+//   16: World stores persistent ignored collision pairs after solver-family
+//      metadata.
+//   17: Joint stores public AVBD point-joint stiffness facade fields.
+//   18: World stores variational multibody solve budget metadata.
+//   19: Private AVBD rigid-world point-joint configs are serializable.
+constexpr std::uint32_t kBinaryFormatVersion = 19;
 
 //==============================================================================
 // Low-level Binary I/O for POD types

--- a/dart/simulation/io/serializer.cpp
+++ b/dart/simulation/io/serializer.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/simulation/comps/all.hpp"
 #include "dart/simulation/compute/variational_integration.hpp"
+#include "dart/simulation/detail/deformable_vbd/rigid_world_contact.hpp"
 #include "dart/simulation/io/binary_io.hpp"
 #include "dart/simulation/io/category_serializer.hpp"
 
@@ -137,6 +138,54 @@ Eigen::VectorXd symmetricUpperBound(const Eigen::VectorXd& upperBound)
   return upperBound.cwiseAbs();
 }
 
+void writeMatrix3d(std::ostream& output, const Eigen::Matrix3d& matrix)
+{
+  for (Eigen::Index row = 0; row < 3; ++row) {
+    for (Eigen::Index col = 0; col < 3; ++col) {
+      writePOD(output, matrix(row, col));
+    }
+  }
+}
+
+void readMatrix3d(std::istream& input, Eigen::Matrix3d& matrix)
+{
+  for (Eigen::Index row = 0; row < 3; ++row) {
+    for (Eigen::Index col = 0; col < 3; ++col) {
+      readPOD(input, matrix(row, col));
+    }
+  }
+}
+
+void writeQuaterniond(std::ostream& output, const Eigen::Quaterniond& q)
+{
+  writePOD(output, q.w());
+  writePOD(output, q.x());
+  writePOD(output, q.y());
+  writePOD(output, q.z());
+}
+
+void readQuaterniond(std::istream& input, Eigen::Quaterniond& q)
+{
+  double w = 1.0;
+  double x = 0.0;
+  double y = 0.0;
+  double z = 0.0;
+  readPOD(input, w);
+  readPOD(input, x);
+  readPOD(input, y);
+  readPOD(input, z);
+  q = Eigen::Quaterniond(w, x, y, z);
+}
+
+void resetJointAvbdStiffnessState(comps::Joint& joint)
+{
+  joint.hasAvbdStiffnessState = false;
+  joint.avbdStartStiffness = 1.0;
+  joint.avbdLinearStiffness = std::numeric_limits<double>::infinity();
+  joint.avbdAngularStiffness = std::numeric_limits<double>::infinity();
+  joint.avbdMaxStiffness = std::numeric_limits<double>::infinity();
+}
+
 void deserializeJointV1(std::istream& input, comps::Joint& joint)
 {
   readPOD(input, joint.type);
@@ -175,6 +224,7 @@ void deserializeJointV1(std::istream& input, comps::Joint& joint)
   joint.commandVelocity = Eigen::VectorXd::Zero(dof);
   joint.breakForce = 0.0;
   joint.broken = false;
+  resetJointAvbdStiffnessState(joint);
 
   const double infinity = std::numeric_limits<double>::infinity();
   if (joint.limits.lower.size() != dof) {
@@ -217,6 +267,7 @@ void deserializeJointV2ToV13(
 
   joint.breakForce = 0.0;
   joint.broken = false;
+  resetJointAvbdStiffnessState(joint);
 
   readVectorXd(input, joint.limits.lower);
   readVectorXd(input, joint.limits.upper);
@@ -257,6 +308,61 @@ void deserializeJointV2ToV13(
     joint.rigidBodyFixedJointLocalAnchorChild.setZero();
     joint.rigidBodyFixedJointTargetRelativeOrientation.setIdentity();
   }
+}
+
+void deserializeJointV14ToV16(std::istream& input, comps::Joint& joint)
+{
+  readPOD(input, joint.type);
+  readPOD(input, joint.actuatorType);
+  readString(input, joint.name);
+  readVectorXd(input, joint.position);
+  readVectorXd(input, joint.velocity);
+  readVectorXd(input, joint.acceleration);
+  readVectorXd(input, joint.torque);
+
+  readVectorXd(input, joint.springStiffness);
+  readVectorXd(input, joint.dampingCoefficient);
+  readVectorXd(input, joint.restPosition);
+  readVectorXd(input, joint.armature);
+  readVectorXd(input, joint.coulombFriction);
+  readVectorXd(input, joint.commandVelocity);
+
+  readPOD(input, joint.breakForce);
+  readPOD(input, joint.broken);
+  resetJointAvbdStiffnessState(joint);
+
+  readVectorXd(input, joint.limits.lower);
+  readVectorXd(input, joint.limits.upper);
+  readVectorXd(input, joint.limits.velocityLower);
+  readVectorXd(input, joint.limits.velocityUpper);
+  readVectorXd(input, joint.limits.effortLower);
+  readVectorXd(input, joint.limits.effortUpper);
+
+  readVector3d(input, joint.axis);
+  readVector3d(input, joint.axis2);
+  readPOD(input, joint.pitch);
+
+  std::uint32_t parentLink = static_cast<std::uint32_t>(entt::null);
+  std::uint32_t childLink = static_cast<std::uint32_t>(entt::null);
+  readPOD(input, parentLink);
+  readPOD(input, childLink);
+  joint.parentLink = static_cast<entt::entity>(parentLink);
+  joint.childLink = static_cast<entt::entity>(childLink);
+
+  readPOD(input, joint.hasRigidBodyFixedJointAnchors);
+  readVector3d(input, joint.rigidBodyFixedJointLocalAnchorParent);
+  readVector3d(input, joint.rigidBodyFixedJointLocalAnchorChild);
+
+  double w = 1.0;
+  double x = 0.0;
+  double y = 0.0;
+  double z = 0.0;
+  readPOD(input, w);
+  readPOD(input, x);
+  readPOD(input, y);
+  readPOD(input, z);
+  joint.rigidBodyFixedJointTargetRelativeOrientation
+      = Eigen::Quaterniond(w, x, y, z);
 }
 
 void initializeCollisionShapeDefaults(CollisionShape& shape)
@@ -475,6 +581,10 @@ private:
       deserializeJointV2ToV13(input, component, formatVersion);
       return;
     }
+    if (formatVersion < 17u) {
+      deserializeJointV14ToV16(input, component);
+      return;
+    }
 
     loadComponent(input, component);
   }
@@ -487,6 +597,70 @@ void registerJointSerializer(SerializerRegistry& registry)
   }
 
   registry.registerSerializer(std::make_unique<JointComponentSerializer>());
+}
+
+class AvbdRigidWorldPointJointConfigComponentSerializer final
+  : public TypedComponentSerializer<::dart::simulation::detail::deformable_vbd::
+                                        AvbdRigidWorldPointJointConfig>
+{
+public:
+  using Component = ::dart::simulation::detail::deformable_vbd::
+      AvbdRigidWorldPointJointConfig;
+
+  [[nodiscard]] std::string_view getTypeName() const override
+  {
+    return "dart::simulation::detail::deformable_vbd::"
+           "AvbdRigidWorldPointJointConfig";
+  }
+
+protected:
+  void saveComponent(
+      std::ostream& output,
+      const Component& config,
+      const EntityMap& entityMap) const override
+  {
+    (void)entityMap;
+    writePOD(output, config.enabled);
+    writeVector3d(output, config.localAnchorA);
+    writeVector3d(output, config.localAnchorB);
+    writeQuaterniond(output, config.targetRelativeOrientation);
+    writeMatrix3d(output, config.linearAxes);
+    writeMatrix3d(output, config.angularAxes);
+    writePOD(output, config.linearAxisMask);
+    writePOD(output, config.angularAxisMask);
+    writePOD(output, config.startStiffness);
+    writePOD(output, config.linearMaterialStiffness);
+    writePOD(output, config.angularMaterialStiffness);
+    writePOD(output, config.maxStiffness);
+  }
+
+  void loadComponent(std::istream& input, Component& config) const override
+  {
+    readPOD(input, config.enabled);
+    readVector3d(input, config.localAnchorA);
+    readVector3d(input, config.localAnchorB);
+    readQuaterniond(input, config.targetRelativeOrientation);
+    readMatrix3d(input, config.linearAxes);
+    readMatrix3d(input, config.angularAxes);
+    readPOD(input, config.linearAxisMask);
+    readPOD(input, config.angularAxisMask);
+    readPOD(input, config.startStiffness);
+    readPOD(input, config.linearMaterialStiffness);
+    readPOD(input, config.angularMaterialStiffness);
+    readPOD(input, config.maxStiffness);
+  }
+};
+
+void registerAvbdRigidWorldPointJointConfigSerializer(
+    SerializerRegistry& registry)
+{
+  AvbdRigidWorldPointJointConfigComponentSerializer serializerProbe;
+  if (registry.getSerializer(serializerProbe.getTypeName()) != nullptr) {
+    return;
+  }
+
+  registry.registerSerializer(
+      std::make_unique<AvbdRigidWorldPointJointConfigComponentSerializer>());
 }
 
 class CollisionGeometryComponentSerializer final
@@ -630,6 +804,7 @@ void registerBuiltInSerializers(SerializerRegistry& registry)
 
   registerLinkSerializer(registry);
   registerJointSerializer(registry);
+  registerAvbdRigidWorldPointJointConfigSerializer(registry);
 
   registerComponentIfNeeded<comps::Transform>(registry);
   registerComponentIfNeeded<comps::Velocity>(registry);

--- a/dart/simulation/multibody/joint.cpp
+++ b/dart/simulation/multibody/joint.cpp
@@ -35,6 +35,7 @@
 #include "dart/simulation/body/rigid_body.hpp"
 #include "dart/simulation/common/exceptions.hpp"
 #include "dart/simulation/comps/all.hpp"
+#include "dart/simulation/detail/deformable_vbd/rigid_world_contact.hpp"
 #include "dart/simulation/detail/entity_conversion.hpp"
 #include "dart/simulation/detail/world_registry_access.hpp"
 #include "dart/simulation/multibody/link.hpp"
@@ -131,6 +132,84 @@ comps::Joint& getJointComponent(World* world, Entity entityToken)
       "Invalid joint handle");
 
   return registry.get<comps::Joint>(entity);
+}
+
+detail::deformable_vbd::AvbdRigidWorldPointJointConfig*
+tryGetAvbdRigidWorldPointJointConfig(World* world, Entity entityToken)
+{
+  (void)getJointComponent(world, entityToken);
+  auto& registry = dart::simulation::detail::registryOf(*world);
+  const auto entity = detail::toRegistryEntity(entityToken);
+  return registry
+      .try_get<detail::deformable_vbd::AvbdRigidWorldPointJointConfig>(entity);
+}
+
+void validateAvbdRigidWorldPointJointFacade(
+    const dart::simulation::detail::WorldRegistry& registry,
+    entt::entity jointEntity,
+    const comps::Joint& joint)
+{
+  DART_SIMULATION_THROW_T_IF(
+      !detail::deformable_vbd::isAvbdRigidWorldPointJointFacade(
+          registry, jointEntity, joint),
+      InvalidArgumentException,
+      "Joint is not an AVBD point-joint facade");
+}
+
+void materializeAvbdStiffnessState(
+    const dart::simulation::detail::WorldRegistry& registry,
+    entt::entity jointEntity,
+    comps::Joint& joint)
+{
+  if (joint.hasAvbdStiffnessState) {
+    return;
+  }
+
+  if (const auto* config
+      = registry
+            .try_get<detail::deformable_vbd::AvbdRigidWorldPointJointConfig>(
+                jointEntity)) {
+    joint.avbdStartStiffness = config->startStiffness;
+    joint.avbdLinearStiffness = config->linearMaterialStiffness;
+    joint.avbdAngularStiffness = config->angularMaterialStiffness;
+    joint.avbdMaxStiffness = config->maxStiffness;
+    joint.hasAvbdStiffnessState = true;
+    return;
+  }
+
+  double startStiffness = 0.0;
+  double maxStiffness = 0.0;
+  DART_SIMULATION_THROW_T_IF(
+      !detail::deformable_vbd::computeAvbdRigidWorldPointJointDefaultStiffness(
+          registry, joint, startStiffness, maxStiffness),
+      InvalidArgumentException,
+      "Joint is not an AVBD point-joint facade");
+
+  joint.avbdStartStiffness = startStiffness;
+  joint.avbdMaxStiffness = maxStiffness;
+  joint.hasAvbdStiffnessState = true;
+}
+
+void validateFiniteNonnegative(
+    double value, std::string_view fieldName, std::string_view jointName)
+{
+  DART_SIMULATION_THROW_T_IF(
+      !std::isfinite(value) || value < 0.0,
+      InvalidArgumentException,
+      "Joint '{}' {} must be finite and non-negative",
+      jointName,
+      fieldName);
+}
+
+void validateMaterialStiffness(
+    double value, std::string_view fieldName, std::string_view jointName)
+{
+  DART_SIMULATION_THROW_T_IF(
+      std::isnan(value) || value < 0.0,
+      InvalidArgumentException,
+      "Joint '{}' {} must be non-negative or infinity",
+      jointName,
+      fieldName);
 }
 
 void validateJointStateVector(
@@ -574,6 +653,124 @@ bool Joint::isBroken() const
 void Joint::resetBreakage()
 {
   getJointComponent(m_world, m_entity).broken = false;
+}
+
+//==============================================================================
+void Joint::setAvbdStartStiffness(double stiffness)
+{
+  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& registry = dart::simulation::detail::registryOf(*m_world);
+  const auto entity = detail::toRegistryEntity(m_entity);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  validateFiniteNonnegative(stiffness, "AVBD start stiffness", jointComp.name);
+  materializeAvbdStiffnessState(registry, entity, jointComp);
+
+  DART_SIMULATION_THROW_T_IF(
+      stiffness > jointComp.avbdMaxStiffness,
+      InvalidArgumentException,
+      "Joint '{}' AVBD start stiffness must not exceed max stiffness",
+      jointComp.name);
+  jointComp.avbdStartStiffness = stiffness;
+  if (auto* config = tryGetAvbdRigidWorldPointJointConfig(m_world, m_entity)) {
+    config->startStiffness = stiffness;
+  }
+}
+
+//==============================================================================
+double Joint::getAvbdStartStiffness() const
+{
+  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& registry = dart::simulation::detail::registryOf(*m_world);
+  const auto entity = detail::toRegistryEntity(m_entity);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  if (!jointComp.hasAvbdStiffnessState) {
+    if (const auto* config
+        = registry
+              .try_get<detail::deformable_vbd::AvbdRigidWorldPointJointConfig>(
+                  entity)) {
+      return config->startStiffness;
+    }
+
+    double startStiffness = 0.0;
+    double maxStiffness = 0.0;
+    DART_SIMULATION_THROW_T_IF(
+        !detail::deformable_vbd::
+            computeAvbdRigidWorldPointJointDefaultStiffness(
+                registry, jointComp, startStiffness, maxStiffness),
+        InvalidArgumentException,
+        "Joint is not an AVBD point-joint facade");
+    return startStiffness;
+  }
+  return jointComp.avbdStartStiffness;
+}
+
+//==============================================================================
+void Joint::setAvbdLinearStiffness(double stiffness)
+{
+  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& registry = dart::simulation::detail::registryOf(*m_world);
+  const auto entity = detail::toRegistryEntity(m_entity);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  validateMaterialStiffness(stiffness, "AVBD linear stiffness", jointComp.name);
+  materializeAvbdStiffnessState(registry, entity, jointComp);
+
+  jointComp.avbdLinearStiffness = stiffness;
+  if (auto* config = tryGetAvbdRigidWorldPointJointConfig(m_world, m_entity)) {
+    config->linearMaterialStiffness = stiffness;
+  }
+}
+
+//==============================================================================
+double Joint::getAvbdLinearStiffness() const
+{
+  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& registry = dart::simulation::detail::registryOf(*m_world);
+  const auto entity = detail::toRegistryEntity(m_entity);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  if (!jointComp.hasAvbdStiffnessState) {
+    if (const auto* config
+        = registry
+              .try_get<detail::deformable_vbd::AvbdRigidWorldPointJointConfig>(
+                  entity)) {
+      return config->linearMaterialStiffness;
+    }
+  }
+  return jointComp.avbdLinearStiffness;
+}
+
+//==============================================================================
+void Joint::setAvbdAngularStiffness(double stiffness)
+{
+  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& registry = dart::simulation::detail::registryOf(*m_world);
+  const auto entity = detail::toRegistryEntity(m_entity);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  validateMaterialStiffness(
+      stiffness, "AVBD angular stiffness", jointComp.name);
+  materializeAvbdStiffnessState(registry, entity, jointComp);
+
+  jointComp.avbdAngularStiffness = stiffness;
+  if (auto* config = tryGetAvbdRigidWorldPointJointConfig(m_world, m_entity)) {
+    config->angularMaterialStiffness = stiffness;
+  }
+}
+
+//==============================================================================
+double Joint::getAvbdAngularStiffness() const
+{
+  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& registry = dart::simulation::detail::registryOf(*m_world);
+  const auto entity = detail::toRegistryEntity(m_entity);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  if (!jointComp.hasAvbdStiffnessState) {
+    if (const auto* config
+        = registry
+              .try_get<detail::deformable_vbd::AvbdRigidWorldPointJointConfig>(
+                  entity)) {
+      return config->angularMaterialStiffness;
+    }
+  }
+  return jointComp.avbdAngularStiffness;
 }
 
 //==============================================================================

--- a/dart/simulation/multibody/joint.hpp
+++ b/dart/simulation/multibody/joint.hpp
@@ -334,6 +334,35 @@ public:
   /// again.
   void resetBreakage();
 
+  /// Set the AVBD point-joint row starting stiffness.
+  ///
+  /// This applies to public rigid-body/articulated point-joint facades that
+  /// extract into AVBD rows. Values must be finite and non-negative.
+  void setAvbdStartStiffness(double stiffness);
+
+  /// Get the AVBD point-joint row starting stiffness.
+  [[nodiscard]] double getAvbdStartStiffness() const;
+
+  /// Set the AVBD linear point-joint material stiffness.
+  ///
+  /// A finite value makes the point-joint linear rows finite-stiffness rows
+  /// that ramp up to this material stiffness and do not carry persistent duals.
+  /// Infinity keeps the default hard-constraint row behavior.
+  void setAvbdLinearStiffness(double stiffness);
+
+  /// Get the AVBD linear point-joint material stiffness.
+  [[nodiscard]] double getAvbdLinearStiffness() const;
+
+  /// Set the AVBD angular point-joint material stiffness.
+  ///
+  /// A finite value makes the point-joint angular rows finite-stiffness rows
+  /// that ramp up to this material stiffness and do not carry persistent duals.
+  /// Infinity keeps the default hard-constraint row behavior.
+  void setAvbdAngularStiffness(double stiffness);
+
+  /// Get the AVBD angular point-joint material stiffness.
+  [[nodiscard]] double getAvbdAngularStiffness() const;
+
   /// Get the parent link
   ///
   /// @return Parent Link handle

--- a/dart/simulation/multibody/multibody_options.hpp
+++ b/dart/simulation/multibody/multibody_options.hpp
@@ -12,6 +12,8 @@
 
 #include <string>
 
+#include <cstddef>
+
 namespace dart::simulation {
 
 /// World-level solver/integration configuration for the multibody domain.
@@ -32,6 +34,14 @@ struct MultibodyOptions
   /// discrete-mechanics integrator). `World::setMultibodyOptions()` throws
   /// InvalidArgumentException for unknown names.
   std::string integrationFamily = "semi-implicit";
+
+  /// Maximum RIQN iterations for the variational integrator on the default
+  /// `World::step()` path. Must be positive.
+  std::size_t variationalMaxIterations = 100;
+
+  /// Per-coordinate convergence tolerance for the variational integrator on
+  /// the default `World::step()` path. Must be positive and finite.
+  double variationalTolerance = 1e-10;
 };
 
 } // namespace dart::simulation

--- a/dart/simulation/world.cpp
+++ b/dart/simulation/world.cpp
@@ -66,6 +66,7 @@
 #include "dart/simulation/io/binary_io.hpp"
 #include "dart/simulation/io/serializer.hpp"
 #include "dart/simulation/multibody/joint.hpp"
+#include "dart/simulation/multibody/link.hpp"
 #include "dart/simulation/multibody/multibody.hpp"
 #include "dart/simulation/world_options.hpp"
 
@@ -85,6 +86,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <set>
 #include <span>
@@ -211,6 +213,7 @@ struct World::CollisionQueryCache
   {
     clearObjectsAndResultsPreservingSpecs();
     specs.clear();
+    liveRigidBodyJointPairs.clear();
   }
 
   ncol::CollisionWorld collisionWorld;
@@ -219,6 +222,7 @@ struct World::CollisionQueryCache
   std::vector<std::size_t> entryByObjectId;
   std::vector<ShapeEntrySpec> specs;
   ncol::BroadPhaseSnapshot candidatePairs;
+  std::vector<detail::WorldStorage::CollisionPairKey> liveRigidBodyJointPairs;
   std::vector<Contact> contacts;
   ncol::CollisionResult pairResult;
 };
@@ -239,6 +243,11 @@ struct World::ReplayState
     Eigen::VectorXd armature;
     Eigen::VectorXd coulombFriction;
     double breakForce = 0.0;
+    bool hasAvbdStiffnessState = true;
+    double avbdStartStiffness = 1.0;
+    double avbdLinearStiffness = std::numeric_limits<double>::infinity();
+    double avbdAngularStiffness = std::numeric_limits<double>::infinity();
+    double avbdMaxStiffness = std::numeric_limits<double>::infinity();
     comps::JointLimits limits;
     Eigen::Vector3d axis = Eigen::Vector3d::UnitZ();
     Eigen::Vector3d axis2 = Eigen::Vector3d::UnitX();
@@ -323,6 +332,8 @@ struct World::ReplayState
     double rigidIpcAdaptiveBarrierStiffnessLowerBound = 1.0;
     MultibodyIntegrationMethod multibodyIntegrationMethod{
         MultibodyIntegrationMethod::SemiImplicit};
+    std::size_t variationalIntegratorMaxIterations = 100;
+    double variationalIntegratorTolerance = 1e-10;
     std::optional<StepDerivatives> stepDerivatives;
     std::vector<std::pair<entt::entity, PhysicalParameter>>
         differentiableParameters;
@@ -387,6 +398,11 @@ bool sameReplayJointLayout(const comps::Joint& joint, const JointLayout& layout)
          && sameReplayVector(joint.armature, layout.armature)
          && sameReplayVector(joint.coulombFriction, layout.coulombFriction)
          && joint.breakForce == layout.breakForce
+         && joint.hasAvbdStiffnessState == layout.hasAvbdStiffnessState
+         && joint.avbdStartStiffness == layout.avbdStartStiffness
+         && joint.avbdLinearStiffness == layout.avbdLinearStiffness
+         && joint.avbdAngularStiffness == layout.avbdAngularStiffness
+         && joint.avbdMaxStiffness == layout.avbdMaxStiffness
          && sameReplayJointLimits(joint.limits, layout.limits)
          && joint.axis.isApprox(layout.axis, 0.0)
          && joint.axis2.isApprox(layout.axis2, 0.0)
@@ -1071,10 +1087,53 @@ bool hasMultibodyStructures(const World& world)
 }
 
 //==============================================================================
-bool hasRigidBodyStructures(const World& world)
+bool hasAdvanceableRigidBodyStructures(const World& world)
 {
-  const auto view = detail::registryOf(world).view<comps::RigidBodyTag>();
-  return view.begin() != view.end();
+  const auto& registry = detail::registryOf(world);
+  const auto view = registry.view<comps::RigidBodyTag>();
+  for (const auto entity : view) {
+    if (!registry.all_of<comps::StaticBodyTag>(entity)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//==============================================================================
+bool hasDirtyFrameCaches(const World& world)
+{
+  const auto view = detail::registryOf(world).view<comps::FrameCache>();
+  for (const auto entity : view) {
+    if (view.get<comps::FrameCache>(entity).needTransformUpdate) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//==============================================================================
+bool canSkipDefaultStepPipelineWhenFramesClean(
+    const World& world,
+    bool hasAdvanceableRigidBodies,
+    bool hasMultibodyStructure,
+    bool hasDeformableBodies)
+{
+  if (hasAdvanceableRigidBodies || hasMultibodyStructure
+      || hasDeformableBodies) {
+    return false;
+  }
+
+  const auto& registry = detail::registryOf(world);
+  const auto loopClosureView = registry.view<comps::LoopClosure>();
+  if (loopClosureView.begin() != loopClosureView.end()) {
+    return false;
+  }
+  const auto jointView = registry.view<comps::Joint>();
+  if (jointView.begin() != jointView.end()) {
+    return false;
+  }
+
+  return true;
 }
 
 //==============================================================================
@@ -1085,9 +1144,45 @@ bool hasDeformableBodies(const World& world)
 }
 
 //==============================================================================
+entt::entity findOwningMultibodyStructure(
+    const detail::WorldRegistry& registry, entt::entity linkEntity)
+{
+  if (linkEntity == entt::null || !registry.all_of<comps::Link>(linkEntity)) {
+    return entt::null;
+  }
+
+  const auto structures = registry.view<comps::MultibodyStructure>();
+  for (const entt::entity structureEntity : structures) {
+    const auto& structure
+        = structures.get<comps::MultibodyStructure>(structureEntity);
+    if (std::find(structure.links.begin(), structure.links.end(), linkEntity)
+        != structure.links.end()) {
+      return structureEntity;
+    }
+  }
+
+  return entt::null;
+}
+
+//==============================================================================
 bool isRigidBodyJointType(comps::JointType type)
 {
   return type == comps::JointType::Fixed || type == comps::JointType::Revolute
+         || type == comps::JointType::Prismatic
+         || type == comps::JointType::Spherical;
+}
+
+//==============================================================================
+bool rigidBodyJointUsesAxis(comps::JointType type)
+{
+  return type == comps::JointType::Revolute
+         || type == comps::JointType::Prismatic;
+}
+
+//==============================================================================
+bool articulatedPointJointUsesAxis(comps::JointType type)
+{
+  return type == comps::JointType::Revolute
          || type == comps::JointType::Prismatic;
 }
 
@@ -1101,9 +1196,10 @@ comps::JointType toRigidBodyComponentJointType(JointType type)
       return comps::JointType::Revolute;
     case JointType::Prismatic:
       return comps::JointType::Prismatic;
+    case JointType::Spherical:
+      return comps::JointType::Spherical;
     case JointType::Screw:
     case JointType::Universal:
-    case JointType::Spherical:
     case JointType::Planar:
     case JointType::Floating:
     case JointType::Custom:
@@ -1112,8 +1208,35 @@ comps::JointType toRigidBodyComponentJointType(JointType type)
 
   DART_SIMULATION_THROW_T(
       InvalidArgumentException,
-      "Rigid-body joints currently support only fixed, revolute, and "
-      "prismatic joint types");
+      "Rigid-body joints currently support only fixed, revolute, prismatic, "
+      "and spherical joint types");
+  return comps::JointType::Custom;
+}
+
+//==============================================================================
+comps::JointType toArticulatedPointJointComponentJointType(JointType type)
+{
+  switch (type) {
+    case JointType::Fixed:
+      return comps::JointType::Fixed;
+    case JointType::Revolute:
+      return comps::JointType::Revolute;
+    case JointType::Prismatic:
+      return comps::JointType::Prismatic;
+    case JointType::Spherical:
+      return comps::JointType::Spherical;
+    case JointType::Screw:
+    case JointType::Universal:
+    case JointType::Planar:
+    case JointType::Floating:
+    case JointType::Custom:
+      break;
+  }
+
+  DART_SIMULATION_THROW_T(
+      InvalidArgumentException,
+      "Articulated point joints currently support only fixed, revolute, "
+      "prismatic, and spherical joint types");
   return comps::JointType::Custom;
 }
 
@@ -1142,6 +1265,43 @@ bool isRigidBodyFixedJoint(const Registry& registry, const comps::Joint& joint)
 }
 
 //==============================================================================
+template <typename Registry>
+bool isArticulatedPointJoint(
+    const Registry& registry,
+    entt::entity jointEntity,
+    const comps::Joint& joint)
+{
+  if (!isRigidBodyJointType(joint.type) || joint.childLink == entt::null
+      || joint.parentLink == joint.childLink) {
+    return false;
+  }
+
+  if (joint.parentLink != entt::null
+      && !registry.template all_of<comps::Link>(joint.parentLink)) {
+    return false;
+  }
+  if (!registry.template all_of<comps::Link>(joint.childLink)) {
+    return false;
+  }
+
+  const auto* childLink
+      = registry.template try_get<comps::Link>(joint.childLink);
+  if (childLink != nullptr && childLink->parentJoint == jointEntity) {
+    return false;
+  }
+
+  const entt::entity structureB
+      = findOwningMultibodyStructure(registry, joint.childLink);
+  if (joint.parentLink == entt::null) {
+    return structureB != entt::null;
+  }
+
+  const entt::entity structureA
+      = findOwningMultibodyStructure(registry, joint.parentLink);
+  return structureA != entt::null && structureA == structureB;
+}
+
+//==============================================================================
 bool hasRigidBodyJoints(const World& world)
 {
   const auto& registry = detail::registryOf(world);
@@ -1157,25 +1317,71 @@ bool hasRigidBodyJoints(const World& world)
 }
 
 //==============================================================================
+bool hasRigidBodyDistanceSprings(const World& world)
+{
+  const auto& registry = detail::registryOf(world);
+  const auto view
+      = registry
+            .view<detail::deformable_vbd::AvbdRigidWorldDistanceSpringConfig>();
+  return view.begin() != view.end();
+}
+
+//==============================================================================
+bool hasRigidBodyAvbdPairConstraints(const World& world)
+{
+  return hasRigidBodyJoints(world) || hasRigidBodyDistanceSprings(world);
+}
+
+//==============================================================================
+bool hasArticulatedPointJoints(const World& world)
+{
+  const auto& registry = detail::registryOf(world);
+  const auto view = registry.view<comps::Joint>();
+  for (const entt::entity entity : view) {
+    const auto& joint = view.get<comps::Joint>(entity);
+    if (isArticulatedPointJoint(registry, entity, joint)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//==============================================================================
 void validateRigidBodyJointPipelineSupport(
     const World& world, RigidBodySolver solver)
 {
-  if (!hasRigidBodyJoints(world)) {
+  if (!hasRigidBodyAvbdPairConstraints(world)) {
     return;
   }
 
   if (solver == RigidBodySolver::Ipc) {
     DART_SIMULATION_THROW_T(
         InvalidOperationException,
-        "Rigid-body joints are not supported by the IPC rigid-body "
+        "Rigid-body AVBD pair constraints are not supported by the IPC "
+        "rigid-body "
         "solver");
   }
 
   DART_SIMULATION_THROW_T_IF(
       hasMultibodyStructures(world),
       InvalidOperationException,
-      "Rigid-body joints are not supported in worlds with multibody "
+      "Rigid-body AVBD pair constraints are not supported in worlds with "
+      "multibody "
       "structures");
+}
+
+//==============================================================================
+void validateArticulatedPointJointPipelineSupport(
+    const World& world, bool variationalSelected)
+{
+  if (!hasArticulatedPointJoints(world) || variationalSelected) {
+    return;
+  }
+
+  DART_SIMULATION_THROW_T(
+      InvalidOperationException,
+      "Articulated point joints require the variational multibody "
+      "integration family before stepping");
 }
 
 //==============================================================================
@@ -1499,6 +1705,66 @@ entt::entity resolveLoopClosureFrame(
       fieldName);
 
   return detail::toRegistryEntity(frame.getEntity());
+}
+
+//==============================================================================
+detail::WorldStorage::CollisionPairKey makeCollisionPairKey(
+    entt::entity first, entt::entity second)
+{
+  if (static_cast<std::uint32_t>(second) < static_cast<std::uint32_t>(first)) {
+    std::swap(first, second);
+  }
+  return {first, second};
+}
+
+//==============================================================================
+template <typename Registry>
+void collectLivePublicRigidBodyJointPairsInto(
+    const Registry& registry,
+    std::vector<detail::WorldStorage::CollisionPairKey>& pairs)
+{
+  pairs.clear();
+
+  const auto joints = registry.template view<comps::Joint>();
+  for (const entt::entity entity : joints) {
+    const auto& joint = joints.template get<comps::Joint>(entity);
+    if (joint.broken || !isRigidBodyJoint(registry, joint)) {
+      continue;
+    }
+
+    pairs.push_back(makeCollisionPairKey(joint.parentLink, joint.childLink));
+  }
+
+  std::sort(pairs.begin(), pairs.end());
+  pairs.erase(std::unique(pairs.begin(), pairs.end()), pairs.end());
+}
+
+//==============================================================================
+entt::entity resolveCollisionPairFrame(
+    const World& world, const Frame& frame, std::string_view fieldName)
+{
+  DART_SIMULATION_THROW_T_IF(
+      frame.isWorld() || !frame.isValid(),
+      InvalidArgumentException,
+      "Collision pair {} frame is invalid or has been destroyed",
+      fieldName);
+
+  DART_SIMULATION_THROW_T_IF(
+      frame.getWorld() != &world,
+      InvalidArgumentException,
+      "Collision pair {} frame belongs to a different world",
+      fieldName);
+
+  const entt::entity entity = detail::toRegistryEntity(frame.getEntity());
+  const auto& registry = detail::registryOf(world);
+  DART_SIMULATION_THROW_T_IF(
+      !registry.all_of<comps::RigidBodyTag>(entity)
+          && !registry.all_of<comps::Link>(entity),
+      InvalidArgumentException,
+      "Collision pair {} frame must be a rigid body or multibody link",
+      fieldName);
+
+  return entity;
 }
 
 //==============================================================================
@@ -2255,6 +2521,10 @@ Eigen::Isometry3d toIsometry(
 struct World::StepPipelineCache
 {
   WorldStepPipelineStages stages;
+  bool hasAdvanceableRigidBodies = false;
+  bool hasMultibodyStructure = false;
+  bool hasDeformableBodies = false;
+  bool canSkipDefaultPipelineWhenFramesClean = true;
 };
 
 World::World()
@@ -2369,7 +2639,6 @@ WorldMemoryDiagnostics World::getMemoryDiagnostics() const
   return diagnostics;
 }
 
-//==============================================================================
 void World::clear()
 {
   // Recreate the opaque storage at the rebuild boundary so registry/component
@@ -2382,6 +2651,8 @@ void World::clear()
   m_gravity = Eigen::Vector3d(0.0, 0.0, -9.81);
   m_rigidBodySolver = RigidBodySolver::SequentialImpulse;
   m_multibodyIntegrationMethod = MultibodyIntegrationMethod::SemiImplicit;
+  m_variationalIntegratorMaxIterations = 100;
+  m_variationalIntegratorTolerance = 1e-10;
   m_timeStep = 0.001;
   m_differentiable = false;
   m_contactSolverMethod = ContactSolverMethod::SequentialImpulse;
@@ -2485,7 +2756,8 @@ void World::reserveRegistryStorageForSimulation()
       comps::VariationalContact,
       comps::VariationalContactDualState,
       compute::MultibodyVariationalState,
-      detail::deformable_vbd::AvbdRigidWorldPointJointConfig>(registry);
+      detail::deformable_vbd::AvbdRigidWorldPointJointConfig,
+      detail::deformable_vbd::AvbdRigidWorldDistanceSpringConfig>(registry);
 
   reserveExistingRegistryStorages(registry);
 
@@ -2544,6 +2816,13 @@ void World::reserveRegistryStorageForSimulation()
     registry.storage<detail::deformable_vbd::AvbdRigidWorldPointJointConfig>()
         .reserve(jointCount);
   }
+  const auto springCount = existingComponentStorageSize<
+      detail::deformable_vbd::AvbdRigidWorldDistanceSpringConfig>(registry);
+  if (springCount > 0u) {
+    registry
+        .storage<detail::deformable_vbd::AvbdRigidWorldDistanceSpringConfig>()
+        .reserve(springCount);
+  }
 
   reserveExistingRegistryStorages(registry);
 }
@@ -2552,13 +2831,23 @@ void World::reserveRegistryStorageForSimulation()
 void World::prepareStepPipelineCacheForCurrentConfiguration()
 {
   reserveRegistryStorageForSimulation();
-  m_stepPipelineCache->stages.prepare(
+  auto& cache = *m_stepPipelineCache;
+  cache.hasAdvanceableRigidBodies = hasAdvanceableRigidBodyStructures(*this);
+  cache.hasMultibodyStructure = hasMultibodyStructures(*this);
+  cache.hasDeformableBodies = hasDeformableBodies(*this);
+  cache.canSkipDefaultPipelineWhenFramesClean
+      = canSkipDefaultStepPipelineWhenFramesClean(
+          *this,
+          cache.hasAdvanceableRigidBodies,
+          cache.hasMultibodyStructure,
+          cache.hasDeformableBodies);
+  cache.stages.prepare(
       *this,
       m_rigidBodySolver,
       m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational,
-      hasRigidBodyStructures(*this),
-      hasMultibodyStructures(*this),
-      hasDeformableBodies(*this));
+      cache.hasAdvanceableRigidBodies,
+      cache.hasMultibodyStructure,
+      cache.hasDeformableBodies);
 }
 
 //==============================================================================
@@ -2709,10 +2998,10 @@ Multibody World::addMultibody(std::string_view name)
 {
   ensureDesignMode();
   DART_SIMULATION_THROW_T_IF(
-      hasRigidBodyJoints(*this),
+      hasRigidBodyAvbdPairConstraints(*this),
       InvalidOperationException,
       "Multibody structures are not supported in worlds with rigid-body "
-      "joints");
+      "AVBD pair constraints");
 
   std::string candidateName;
   if (name.empty()) {
@@ -2761,6 +3050,421 @@ bool World::hasMultibody(std::string_view name) const
 std::size_t World::getMultibodyCount() const
 {
   return countEntities<comps::MultibodyTag>(m_storage->registry);
+}
+
+//==============================================================================
+Joint World::addArticulatedFixedJoint(
+    std::string_view name, const Link& parent, const Link& child)
+{
+  return addArticulatedJoint(
+      name, &parent, child, JointType::Fixed, Eigen::Vector3d::UnitZ());
+}
+
+//==============================================================================
+Joint World::addArticulatedFixedJoint(
+    std::string_view name,
+    const Link& parent,
+    const Link& child,
+    const Eigen::Vector3d& parentAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      &parent,
+      child,
+      JointType::Fixed,
+      Eigen::Vector3d::UnitZ(),
+      parentAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedFixedJoint(std::string_view name, const Link& child)
+{
+  return addArticulatedJoint(
+      name, nullptr, child, JointType::Fixed, Eigen::Vector3d::UnitZ());
+}
+
+//==============================================================================
+Joint World::addArticulatedFixedJoint(
+    std::string_view name,
+    const Link& child,
+    const Eigen::Vector3d& worldAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      nullptr,
+      child,
+      JointType::Fixed,
+      Eigen::Vector3d::UnitZ(),
+      worldAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedRevoluteJoint(
+    std::string_view name,
+    const Link& parent,
+    const Link& child,
+    const Eigen::Vector3d& axis)
+{
+  return addArticulatedJoint(name, &parent, child, JointType::Revolute, axis);
+}
+
+//==============================================================================
+Joint World::addArticulatedRevoluteJoint(
+    std::string_view name,
+    const Link& parent,
+    const Link& child,
+    const Eigen::Vector3d& axis,
+    const Eigen::Vector3d& parentAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      &parent,
+      child,
+      JointType::Revolute,
+      axis,
+      parentAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedRevoluteJoint(
+    std::string_view name, const Link& child, const Eigen::Vector3d& axis)
+{
+  return addArticulatedJoint(name, nullptr, child, JointType::Revolute, axis);
+}
+
+//==============================================================================
+Joint World::addArticulatedRevoluteJoint(
+    std::string_view name,
+    const Link& child,
+    const Eigen::Vector3d& axis,
+    const Eigen::Vector3d& worldAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      nullptr,
+      child,
+      JointType::Revolute,
+      axis,
+      worldAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedPrismaticJoint(
+    std::string_view name,
+    const Link& parent,
+    const Link& child,
+    const Eigen::Vector3d& axis)
+{
+  return addArticulatedJoint(name, &parent, child, JointType::Prismatic, axis);
+}
+
+//==============================================================================
+Joint World::addArticulatedPrismaticJoint(
+    std::string_view name,
+    const Link& parent,
+    const Link& child,
+    const Eigen::Vector3d& axis,
+    const Eigen::Vector3d& parentAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      &parent,
+      child,
+      JointType::Prismatic,
+      axis,
+      parentAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedPrismaticJoint(
+    std::string_view name, const Link& child, const Eigen::Vector3d& axis)
+{
+  return addArticulatedJoint(name, nullptr, child, JointType::Prismatic, axis);
+}
+
+//==============================================================================
+Joint World::addArticulatedPrismaticJoint(
+    std::string_view name,
+    const Link& child,
+    const Eigen::Vector3d& axis,
+    const Eigen::Vector3d& worldAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      nullptr,
+      child,
+      JointType::Prismatic,
+      axis,
+      worldAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedSphericalJoint(
+    std::string_view name, const Link& parent, const Link& child)
+{
+  return addArticulatedJoint(
+      name, &parent, child, JointType::Spherical, Eigen::Vector3d::UnitZ());
+}
+
+//==============================================================================
+Joint World::addArticulatedSphericalJoint(
+    std::string_view name,
+    const Link& parent,
+    const Link& child,
+    const Eigen::Vector3d& parentAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      &parent,
+      child,
+      JointType::Spherical,
+      Eigen::Vector3d::UnitZ(),
+      parentAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedSphericalJoint(
+    std::string_view name, const Link& child)
+{
+  return addArticulatedJoint(
+      name, nullptr, child, JointType::Spherical, Eigen::Vector3d::UnitZ());
+}
+
+//==============================================================================
+Joint World::addArticulatedSphericalJoint(
+    std::string_view name,
+    const Link& child,
+    const Eigen::Vector3d& worldAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addArticulatedJoint(
+      name,
+      nullptr,
+      child,
+      JointType::Spherical,
+      Eigen::Vector3d::UnitZ(),
+      worldAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+Joint World::addArticulatedJoint(
+    std::string_view name,
+    const Link* parent,
+    const Link& child,
+    JointType type,
+    const Eigen::Vector3d& axis,
+    std::optional<Eigen::Vector3d> parentAnchor,
+    std::optional<Eigen::Vector3d> childAnchor)
+{
+  ensureDesignMode();
+
+  const comps::JointType componentType
+      = toArticulatedPointJointComponentJointType(type);
+  DART_SIMULATION_THROW_T_IF(
+      articulatedPointJointUsesAxis(componentType)
+          && (!axis.allFinite() || axis.squaredNorm() <= 0.0),
+      InvalidArgumentException,
+      "Articulated point-joint axis must be finite and non-zero");
+  DART_SIMULATION_THROW_T_IF(
+      parent != nullptr && !parent->isValid(),
+      InvalidArgumentException,
+      "Articulated point-joint parent link is invalid or has been destroyed");
+  DART_SIMULATION_THROW_T_IF(
+      !child.isValid(),
+      InvalidArgumentException,
+      "Articulated point-joint child link is invalid or has been destroyed");
+  DART_SIMULATION_THROW_T_IF(
+      (parent != nullptr && parent->getWorld() != this)
+          || child.getWorld() != this,
+      InvalidArgumentException,
+      "Articulated point-joint links must belong to this World");
+  DART_SIMULATION_THROW_T_IF(
+      parent != nullptr && parent->getEntity() == child.getEntity(),
+      InvalidArgumentException,
+      "Articulated point-joint parent and child links must be distinct");
+  DART_SIMULATION_THROW_T_IF(
+      parentAnchor.has_value() != childAnchor.has_value(),
+      InvalidArgumentException,
+      "Articulated point-joint anchors must be provided for both endpoints");
+  DART_SIMULATION_THROW_T_IF(
+      parentAnchor.has_value()
+          && (!parentAnchor->allFinite() || !childAnchor->allFinite()),
+      InvalidArgumentException,
+      "Articulated point-joint anchors must be finite");
+
+  const entt::entity parentEntity
+      = parent == nullptr ? entt::null
+                          : detail::toRegistryEntity(parent->getEntity());
+  const entt::entity childEntity = detail::toRegistryEntity(child.getEntity());
+  const entt::entity parentStructure
+      = parentEntity == entt::null
+            ? entt::null
+            : findOwningMultibodyStructure(m_storage->registry, parentEntity);
+  const entt::entity childStructure
+      = findOwningMultibodyStructure(m_storage->registry, childEntity);
+  DART_SIMULATION_THROW_T_IF(
+      childStructure == entt::null,
+      InvalidArgumentException,
+      "Articulated point-joint child link must belong to a multibody");
+  DART_SIMULATION_THROW_T_IF(
+      parentEntity != entt::null
+          && (parentStructure == entt::null
+              || parentStructure != childStructure),
+      InvalidArgumentException,
+      "Articulated point-joint links must belong to the same multibody");
+
+  std::string actualName;
+  if (name.empty()) {
+    do {
+      actualName = std::format("joint_{:03d}", ++m_jointCounter);
+    } while (hasEntityWithName<comps::Joint>(m_storage->registry, actualName));
+  } else {
+    actualName = std::string(name);
+    DART_SIMULATION_THROW_T_IF(
+        hasEntityWithName<comps::Joint>(m_storage->registry, actualName),
+        InvalidArgumentException,
+        "Joint '{}' already exists",
+        actualName);
+  }
+
+  const entt::entity jointEntity = m_storage->registry.create();
+  m_storage->registry.emplace<comps::Name>(jointEntity, actualName);
+
+  auto& joint = m_storage->registry.emplace<comps::Joint>(jointEntity);
+  joint.type = componentType;
+  joint.name = std::move(actualName);
+  joint.parentLink = parentEntity;
+  joint.childLink = childEntity;
+  joint.hasAvbdStiffnessState = false;
+  if (articulatedPointJointUsesAxis(componentType)) {
+    joint.axis = axis.normalized();
+  }
+
+  const Eigen::Index dof = static_cast<Eigen::Index>(joint.getDOF());
+  joint.position = Eigen::VectorXd::Zero(dof);
+  joint.velocity = Eigen::VectorXd::Zero(dof);
+  joint.acceleration = Eigen::VectorXd::Zero(dof);
+  joint.torque = Eigen::VectorXd::Zero(dof);
+  joint.springStiffness = Eigen::VectorXd::Zero(dof);
+  joint.dampingCoefficient = Eigen::VectorXd::Zero(dof);
+  joint.restPosition = Eigen::VectorXd::Zero(dof);
+  joint.armature = Eigen::VectorXd::Zero(dof);
+  joint.coulombFriction = Eigen::VectorXd::Zero(dof);
+  joint.commandVelocity = Eigen::VectorXd::Zero(dof);
+
+  const double infinity = std::numeric_limits<double>::infinity();
+  joint.limits.lower = Eigen::VectorXd::Constant(dof, -infinity);
+  joint.limits.upper = Eigen::VectorXd::Constant(dof, infinity);
+  joint.limits.velocityLower = Eigen::VectorXd::Constant(dof, -infinity);
+  joint.limits.velocityUpper = Eigen::VectorXd::Constant(dof, infinity);
+  joint.limits.effortLower = Eigen::VectorXd::Constant(dof, -infinity);
+  joint.limits.effortUpper = Eigen::VectorXd::Constant(dof, infinity);
+
+  if (parentAnchor.has_value()) {
+    Eigen::Matrix3d parentRotation = Eigen::Matrix3d::Identity();
+    if (parent != nullptr) {
+      parentRotation = parent->getWorldTransform().linear();
+    }
+    const Eigen::Matrix3d childRotation = child.getWorldTransform().linear();
+    DART_SIMULATION_THROW_T_IF(
+        !parentRotation.allFinite() || !childRotation.allFinite(),
+        InvalidArgumentException,
+        "Articulated point-joint endpoint transforms must be finite");
+
+    Eigen::Quaterniond parentOrientation(parentRotation);
+    Eigen::Quaterniond childOrientation(childRotation);
+    DART_SIMULATION_THROW_T_IF(
+        !parentOrientation.coeffs().allFinite()
+            || !childOrientation.coeffs().allFinite()
+            || parentOrientation.norm() == 0.0
+            || childOrientation.norm() == 0.0,
+        InvalidArgumentException,
+        "Articulated point-joint endpoint orientations must be finite");
+    parentOrientation.normalize();
+    childOrientation.normalize();
+
+    joint.hasRigidBodyFixedJointAnchors = true;
+    joint.rigidBodyFixedJointLocalAnchorParent = *parentAnchor;
+    joint.rigidBodyFixedJointLocalAnchorChild = *childAnchor;
+    joint.rigidBodyFixedJointTargetRelativeOrientation
+        = parentOrientation.conjugate() * childOrientation;
+    joint.rigidBodyFixedJointTargetRelativeOrientation.normalize();
+  }
+
+  return Joint(detail::fromRegistryEntity(jointEntity), this);
+}
+
+//==============================================================================
+std::optional<Joint> World::getArticulatedJoint(std::string_view name)
+{
+  auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  for (auto entity : view) {
+    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& info = view.get<comps::Name>(entity);
+    if (info.name == name
+        && isArticulatedPointJoint(m_storage->registry, entity, joint)) {
+      return Joint(detail::fromRegistryEntity(entity), this);
+    }
+  }
+  return std::nullopt;
+}
+
+//==============================================================================
+bool World::hasArticulatedJoint(std::string_view name) const
+{
+  const auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  for (auto entity : view) {
+    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& info = view.get<comps::Name>(entity);
+    if (info.name == name
+        && isArticulatedPointJoint(m_storage->registry, entity, joint)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//==============================================================================
+std::size_t World::getArticulatedJointCount() const
+{
+  std::size_t count = 0;
+  const auto view = m_storage->registry.view<comps::Joint>();
+  for (auto entity : view) {
+    const auto& joint = view.get<comps::Joint>(entity);
+    if (isArticulatedPointJoint(m_storage->registry, entity, joint)) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+//==============================================================================
+std::vector<Joint> World::getArticulatedJoints()
+{
+  std::vector<Joint> joints;
+  const auto view = m_storage->registry.view<comps::Joint>();
+  for (auto entity : view) {
+    const auto& joint = view.get<comps::Joint>(entity);
+    if (isArticulatedPointJoint(m_storage->registry, entity, joint)) {
+      joints.emplace_back(detail::fromRegistryEntity(entity), this);
+    }
+  }
+  return joints;
 }
 
 //==============================================================================
@@ -2917,21 +3621,198 @@ Joint World::addRigidBodyPrismaticJoint(
 }
 
 //==============================================================================
+Joint World::addRigidBodySphericalJoint(
+    std::string_view name, const RigidBody& parent, const RigidBody& child)
+{
+  return addRigidBodyJoint(
+      name, parent, child, JointType::Spherical, Eigen::Vector3d::UnitZ());
+}
+
+//==============================================================================
+Joint World::addRigidBodySphericalJoint(
+    std::string_view name,
+    const RigidBody& parent,
+    const RigidBody& child,
+    const Eigen::Vector3d& parentAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  return addRigidBodyJoint(
+      name,
+      parent,
+      child,
+      JointType::Spherical,
+      Eigen::Vector3d::UnitZ(),
+      parentAnchor,
+      childAnchor);
+}
+
+//==============================================================================
+void World::addRigidBodyDistanceSpring(
+    std::string_view name,
+    const RigidBody& parent,
+    const RigidBody& child,
+    double restLength,
+    double stiffness)
+{
+  addRigidBodyDistanceSpringImpl(
+      name, parent, child, restLength, stiffness, std::nullopt, std::nullopt);
+}
+
+//==============================================================================
+void World::addRigidBodyDistanceSpring(
+    std::string_view name,
+    const RigidBody& parent,
+    const RigidBody& child,
+    double restLength,
+    double stiffness,
+    const Eigen::Vector3d& parentAnchor,
+    const Eigen::Vector3d& childAnchor)
+{
+  addRigidBodyDistanceSpringImpl(
+      name,
+      parent,
+      child,
+      restLength,
+      stiffness,
+      std::optional<Eigen::Vector3d>{parentAnchor},
+      std::optional<Eigen::Vector3d>{childAnchor});
+}
+
+//==============================================================================
+void World::addRigidBodyDistanceSpringImpl(
+    std::string_view name,
+    const RigidBody& parent,
+    const RigidBody& child,
+    double restLength,
+    double stiffness,
+    std::optional<Eigen::Vector3d> parentAnchor,
+    std::optional<Eigen::Vector3d> childAnchor)
+{
+  ensureDesignMode();
+
+  DART_SIMULATION_THROW_T_IF(
+      !std::isfinite(restLength) || restLength < 0.0,
+      InvalidArgumentException,
+      "Rigid-body distance spring rest length must be finite and non-negative");
+  DART_SIMULATION_THROW_T_IF(
+      !std::isfinite(stiffness) || stiffness <= 0.0,
+      InvalidArgumentException,
+      "Rigid-body distance spring stiffness must be finite and positive");
+  DART_SIMULATION_THROW_T_IF(
+      parentAnchor.has_value() != childAnchor.has_value(),
+      InvalidArgumentException,
+      "Rigid-body distance spring anchors must provide both endpoints");
+  DART_SIMULATION_THROW_T_IF(
+      parentAnchor.has_value()
+          && (!parentAnchor->allFinite() || !childAnchor->allFinite()),
+      InvalidArgumentException,
+      "Rigid-body distance spring anchors must be finite");
+  DART_SIMULATION_THROW_T_IF(
+      !parent.isValid(),
+      InvalidArgumentException,
+      "Distance spring parent rigid body is invalid or has been destroyed");
+  DART_SIMULATION_THROW_T_IF(
+      !child.isValid(),
+      InvalidArgumentException,
+      "Distance spring child rigid body is invalid or has been destroyed");
+  DART_SIMULATION_THROW_T_IF(
+      parent.getWorld() != this || child.getWorld() != this,
+      InvalidArgumentException,
+      "Distance spring rigid bodies must belong to this World");
+  DART_SIMULATION_THROW_T_IF(
+      parent.getEntity() == child.getEntity(),
+      InvalidArgumentException,
+      "Distance spring parent and child rigid bodies must be distinct");
+
+  const entt::entity parentEntity
+      = detail::toRegistryEntity(parent.getEntity());
+  const entt::entity childEntity = detail::toRegistryEntity(child.getEntity());
+  const bool parentIsRigidBody = m_storage->registry.all_of<
+      comps::RigidBodyTag,
+      comps::Transform,
+      comps::MassProperties>(parentEntity);
+  const bool childIsRigidBody = m_storage->registry.all_of<
+      comps::RigidBodyTag,
+      comps::Transform,
+      comps::MassProperties>(childEntity);
+  DART_SIMULATION_THROW_T_IF(
+      !parentIsRigidBody || !childIsRigidBody,
+      InvalidArgumentException,
+      "Distance spring endpoints must be valid rigid bodies");
+  DART_SIMULATION_THROW_T_IF(
+      m_rigidBodySolver == RigidBodySolver::Ipc,
+      InvalidOperationException,
+      "Rigid-body distance springs are not supported by the IPC rigid-body "
+      "solver");
+  DART_SIMULATION_THROW_T_IF(
+      hasMultibodyStructures(*this),
+      InvalidOperationException,
+      "Rigid-body distance springs are not supported in worlds with multibody "
+      "structures");
+
+  std::string actualName;
+  if (name.empty()) {
+    do {
+      actualName
+          = std::format("rigid_distance_spring_{:03d}", ++m_jointCounter);
+    } while (hasEntityWithName<
+             detail::deformable_vbd::AvbdRigidWorldDistanceSpringConfig>(
+        m_storage->registry, actualName));
+  } else {
+    actualName = std::string(name);
+    DART_SIMULATION_THROW_T_IF(
+        hasEntityWithName<
+            detail::deformable_vbd::AvbdRigidWorldDistanceSpringConfig>(
+            m_storage->registry, actualName),
+        InvalidArgumentException,
+        "Rigid-body distance spring '{}' already exists",
+        actualName);
+  }
+
+  const entt::entity springEntity = m_storage->registry.create();
+  m_storage->registry.emplace<comps::Name>(springEntity, actualName);
+  auto& config = m_storage->registry.emplace<
+      detail::deformable_vbd::AvbdRigidWorldDistanceSpringConfig>(springEntity);
+  config.enabled = true;
+  config.bodyA = parentEntity;
+  config.bodyB = childEntity;
+  if (parentAnchor.has_value()) {
+    config.localAnchorA = *parentAnchor;
+    config.localAnchorB = *childAnchor;
+  }
+  config.restLength = restLength;
+  config.startStiffness = stiffness;
+  config.materialStiffness = stiffness;
+  config.maxStiffness = stiffness;
+}
+
+//==============================================================================
 Joint World::addRigidBodyJoint(
     std::string_view name,
     const RigidBody& parent,
     const RigidBody& child,
     JointType type,
-    const Eigen::Vector3d& axis)
+    const Eigen::Vector3d& axis,
+    std::optional<Eigen::Vector3d> parentAnchor,
+    std::optional<Eigen::Vector3d> childAnchor)
 {
   ensureDesignMode();
 
   const comps::JointType componentType = toRigidBodyComponentJointType(type);
   DART_SIMULATION_THROW_T_IF(
-      componentType != comps::JointType::Fixed
+      rigidBodyJointUsesAxis(componentType)
           && (!axis.allFinite() || axis.squaredNorm() <= 0.0),
       InvalidArgumentException,
       "Rigid-body joint axis must be finite and non-zero");
+  DART_SIMULATION_THROW_T_IF(
+      parentAnchor.has_value() != childAnchor.has_value(),
+      InvalidArgumentException,
+      "Rigid-body joint anchors must provide both endpoints");
+  DART_SIMULATION_THROW_T_IF(
+      parentAnchor.has_value()
+          && (!parentAnchor->allFinite() || !childAnchor->allFinite()),
+      InvalidArgumentException,
+      "Rigid-body joint anchors must be finite");
   DART_SIMULATION_THROW_T_IF(
       !parent.isValid(),
       InvalidArgumentException,
@@ -2996,8 +3877,33 @@ Joint World::addRigidBodyJoint(
   joint.name = std::move(actualName);
   joint.parentLink = parentEntity;
   joint.childLink = childEntity;
-  if (componentType != comps::JointType::Fixed) {
+  if (rigidBodyJointUsesAxis(componentType)) {
     joint.axis = axis.normalized();
+  }
+
+  if (parentAnchor.has_value()) {
+    const auto& parentTransform
+        = m_storage->registry.get<comps::Transform>(parentEntity);
+    const auto& childTransform
+        = m_storage->registry.get<comps::Transform>(childEntity);
+    Eigen::Quaterniond parentOrientation = parentTransform.orientation;
+    Eigen::Quaterniond childOrientation = childTransform.orientation;
+    DART_SIMULATION_THROW_T_IF(
+        !parentOrientation.coeffs().allFinite()
+            || !childOrientation.coeffs().allFinite()
+            || parentOrientation.norm() == 0.0
+            || childOrientation.norm() == 0.0,
+        InvalidArgumentException,
+        "Rigid-body joint endpoint orientations must be finite");
+    parentOrientation.normalize();
+    childOrientation.normalize();
+
+    joint.hasRigidBodyFixedJointAnchors = true;
+    joint.rigidBodyFixedJointLocalAnchorParent = *parentAnchor;
+    joint.rigidBodyFixedJointLocalAnchorChild = *childAnchor;
+    joint.rigidBodyFixedJointTargetRelativeOrientation
+        = parentOrientation.conjugate() * childOrientation;
+    joint.rigidBodyFixedJointTargetRelativeOrientation.normalize();
   }
 
   const Eigen::Index dof = static_cast<Eigen::Index>(joint.getDOF());
@@ -3021,6 +3927,9 @@ Joint World::addRigidBodyJoint(
   joint.limits.effortUpper = Eigen::VectorXd::Constant(dof, infinity);
 
   const comps::RigidAvbdContactConfig defaultAvbdConfig;
+  joint.hasAvbdStiffnessState = true;
+  joint.avbdStartStiffness = defaultAvbdConfig.startStiffness;
+  joint.avbdMaxStiffness = defaultAvbdConfig.maxStiffness;
   if (!detail::deformable_vbd::configureAvbdRigidWorldPointJointFromCurrentPose(
           m_storage->registry,
           jointEntity,
@@ -3307,6 +4216,9 @@ void World::enterSimulationMode()
 
   validateLoopClosureKinematicsPolicySupport(*this);
   validateRigidBodyJointPipelineSupport(*this, m_rigidBodySolver);
+  validateArticulatedPointJointPipelineSupport(
+      *this,
+      m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational);
   m_simulationMode = true;
 
   // Initial bake so that cached transforms are up-to-date.
@@ -3711,6 +4623,16 @@ void World::refreshMemoryDiagnostics()
 //==============================================================================
 void World::step()
 {
+#if DART_BUILD_PROFILE
+  if (!m_stepProfilingEnabled && tryStepCleanNoWorkDefaultPipeline()) {
+    return;
+  }
+#else
+  if (tryStepCleanNoWorkDefaultPipeline()) {
+    return;
+  }
+#endif
+
   compute::SequentialExecutor executor;
   step(executor);
 }
@@ -3749,10 +4671,11 @@ void World::step(std::size_t count)
 void World::setMultibodyOptions(const MultibodyOptions& options)
 {
   const std::string& family = options.integrationFamily;
+  MultibodyIntegrationMethod method = MultibodyIntegrationMethod::SemiImplicit;
   if (family == "semi-implicit" || family == "semi-implicit Euler") {
-    m_multibodyIntegrationMethod = MultibodyIntegrationMethod::SemiImplicit;
+    method = MultibodyIntegrationMethod::SemiImplicit;
   } else if (family == "variational integrator" || family == "variational") {
-    m_multibodyIntegrationMethod = MultibodyIntegrationMethod::Variational;
+    method = MultibodyIntegrationMethod::Variational;
   } else {
     DART_SIMULATION_THROW_T(
         InvalidArgumentException,
@@ -3760,6 +4683,24 @@ void World::setMultibodyOptions(const MultibodyOptions& options)
         "names are 'semi-implicit' and 'variational integrator'",
         family);
   }
+  DART_SIMULATION_THROW_T_IF(
+      options.variationalMaxIterations == 0,
+      InvalidArgumentException,
+      "MultibodyOptions.variationalMaxIterations must be positive");
+  DART_SIMULATION_THROW_T_IF(
+      options.variationalMaxIterations
+          > static_cast<std::size_t>(std::numeric_limits<int>::max()),
+      InvalidArgumentException,
+      "MultibodyOptions.variationalMaxIterations must fit in int");
+  DART_SIMULATION_THROW_T_IF(
+      !std::isfinite(options.variationalTolerance)
+          || options.variationalTolerance <= 0.0,
+      InvalidArgumentException,
+      "MultibodyOptions.variationalTolerance must be positive and finite");
+
+  m_multibodyIntegrationMethod = method;
+  m_variationalIntegratorMaxIterations = options.variationalMaxIterations;
+  m_variationalIntegratorTolerance = options.variationalTolerance;
 
   if (m_simulationMode) {
     prepareStepPipelineCacheForCurrentConfiguration();
@@ -3774,23 +4715,62 @@ MultibodyOptions World::getMultibodyOptions() const
       = m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational
             ? "variational integrator"
             : "semi-implicit";
+  options.variationalMaxIterations = m_variationalIntegratorMaxIterations;
+  options.variationalTolerance = m_variationalIntegratorTolerance;
   return options;
+}
+
+//==============================================================================
+bool World::tryStepCleanNoWorkDefaultPipeline()
+{
+  if (!m_simulationMode) {
+    enterSimulationMode();
+  }
+
+  if (m_differentiable
+#if DART_BUILD_PROFILE
+      || m_stepProfilingEnabled
+#endif
+      || !m_stepPipelineCache->canSkipDefaultPipelineWhenFramesClean
+      || hasDirtyFrameCaches(*this)) {
+    return false;
+  }
+
+  m_memoryManager.getFrameAllocator().reset();
+  ++m_memoryDiagnostics.frameScratchResetCount;
+  m_memoryDiagnostics.frameScratchUsedBytes = 0;
+  m_memoryDiagnostics.frameScratchOverflowCount = 0;
+  m_memoryDiagnostics.frameScratchOverflowBytes = 0;
+  m_lastDeformableSolverDiagnostics = {};
+  m_time += m_timeStep;
+  ++m_frame;
+  if (m_replay && m_replay->recordingEnabled) {
+    recordReplayFrame();
+  }
+  return true;
 }
 
 //==============================================================================
 void World::step(compute::ComputeExecutor& executor)
 {
+#if DART_BUILD_PROFILE
+  StepProfileTimer profileTimer(m_stepProfilingEnabled);
+#endif
+
+  if (tryStepCleanNoWorkDefaultPipeline()) {
+#if DART_BUILD_PROFILE
+    profileTimer.finish(m_lastStepProfile);
+#endif
+    return;
+  }
+
   auto& stages = m_stepPipelineCache->stages;
   compute::WorldStepPipeline& pipeline = stages.buildDefault(
       m_rigidBodySolver,
       m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational,
-      hasRigidBodyStructures(*this),
-      hasMultibodyStructures(*this),
-      hasDeformableBodies(*this));
-
-#if DART_BUILD_PROFILE
-  StepProfileTimer profileTimer(m_stepProfilingEnabled);
-#endif
+      m_stepPipelineCache->hasAdvanceableRigidBodies,
+      m_stepPipelineCache->hasMultibodyStructure,
+      m_stepPipelineCache->hasDeformableBodies);
 
   stepPipelineOnce(executor, pipeline);
   m_lastDeformableSolverDiagnostics = makeDeformableSolverDiagnostics(
@@ -3805,18 +4785,29 @@ void World::step(compute::ComputeExecutor& executor)
 void World::step(std::size_t count, compute::ComputeExecutor& executor)
 {
   auto& stages = m_stepPipelineCache->stages;
-  compute::WorldStepPipeline& pipeline = stages.buildDefault(
-      m_rigidBodySolver,
-      m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational,
-      hasRigidBodyStructures(*this),
-      hasMultibodyStructures(*this),
-      hasDeformableBodies(*this));
+  compute::WorldStepPipeline* pipeline = nullptr;
   for (std::size_t i = 0; i < count; ++i) {
 #if DART_BUILD_PROFILE
     StepProfileTimer profileTimer(m_stepProfilingEnabled);
 #endif
 
-    stepPipelineOnce(executor, pipeline);
+    if (tryStepCleanNoWorkDefaultPipeline()) {
+#if DART_BUILD_PROFILE
+      profileTimer.finish(m_lastStepProfile);
+#endif
+      continue;
+    }
+
+    if (pipeline == nullptr) {
+      pipeline = &stages.buildDefault(
+          m_rigidBodySolver,
+          m_multibodyIntegrationMethod
+              == MultibodyIntegrationMethod::Variational,
+          m_stepPipelineCache->hasAdvanceableRigidBodies,
+          m_stepPipelineCache->hasMultibodyStructure,
+          m_stepPipelineCache->hasDeformableBodies);
+    }
+    stepPipelineOnce(executor, *pipeline);
     m_lastDeformableSolverDiagnostics = makeDeformableSolverDiagnostics(
         stages.deformableDynamics.getLastStats());
     recordReplayFrame();
@@ -3834,7 +4825,7 @@ void World::step(
   compute::WorldStepPipeline& pipeline = stages.buildWithFinalStage(
       m_rigidBodySolver,
       m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational,
-      hasRigidBodyStructures(*this),
+      hasAdvanceableRigidBodyStructures(*this),
       hasMultibodyStructures(*this),
       hasDeformableBodies(*this),
       stage);
@@ -3863,7 +4854,7 @@ void World::step(
   compute::WorldStepPipeline& pipeline = stages.buildWithFinalStage(
       m_rigidBodySolver,
       m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational,
-      hasRigidBodyStructures(*this),
+      hasAdvanceableRigidBodyStructures(*this),
       hasMultibodyStructures(*this),
       hasDeformableBodies(*this),
       stage);
@@ -3907,6 +4898,9 @@ void World::stepPipelineOnce(
       *this,
       m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational);
   validateRigidBodyJointPipelineSupport(*this, m_rigidBodySolver);
+  validateArticulatedPointJointPipelineSupport(
+      *this,
+      m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational);
 
   if (!m_simulationMode) {
     enterSimulationMode();
@@ -4433,6 +5427,9 @@ void World::restoreReplayFrame(std::size_t index)
   m_rigidIpcAdaptiveBarrierStiffnessLowerBound
       = replayFrame.rigidIpcAdaptiveBarrierStiffnessLowerBound;
   m_multibodyIntegrationMethod = replayFrame.multibodyIntegrationMethod;
+  m_variationalIntegratorMaxIterations
+      = replayFrame.variationalIntegratorMaxIterations;
+  m_variationalIntegratorTolerance = replayFrame.variationalIntegratorTolerance;
   m_storage->stepDerivatives = replayFrame.stepDerivatives;
   m_storage->differentiableParameters.assign(
       replayFrame.differentiableParameters.begin(),
@@ -4478,6 +5475,9 @@ void World::recordReplayFrame()
   replayFrame.rigidIpcAdaptiveBarrierStiffnessLowerBound
       = m_rigidIpcAdaptiveBarrierStiffnessLowerBound;
   replayFrame.multibodyIntegrationMethod = m_multibodyIntegrationMethod;
+  replayFrame.variationalIntegratorMaxIterations
+      = m_variationalIntegratorMaxIterations;
+  replayFrame.variationalIntegratorTolerance = m_variationalIntegratorTolerance;
   replayFrame.stepDerivatives = m_storage->stepDerivatives;
   replayFrame.differentiableParameters.assign(
       m_storage->differentiableParameters.begin(),
@@ -4513,6 +5513,11 @@ void World::recordReplayFrame()
                 joint.armature,
                 joint.coulombFriction,
                 joint.breakForce,
+                joint.hasAvbdStiffnessState,
+                joint.avbdStartStiffness,
+                joint.avbdLinearStiffness,
+                joint.avbdAngularStiffness,
+                joint.avbdMaxStiffness,
                 joint.limits,
                 joint.axis,
                 joint.axis2,
@@ -4626,6 +5631,56 @@ std::vector<Contact> World::collide()
 }
 
 //==============================================================================
+void World::setCollisionPairIgnored(
+    const Frame& first, const Frame& second, bool ignored)
+{
+  const entt::entity firstEntity
+      = resolveCollisionPairFrame(*this, first, "first");
+  const entt::entity secondEntity
+      = resolveCollisionPairFrame(*this, second, "second");
+  DART_SIMULATION_THROW_T_IF(
+      firstEntity == secondEntity,
+      InvalidArgumentException,
+      "Collision pair frames must be distinct");
+
+  const auto key = makeCollisionPairKey(firstEntity, secondEntity);
+  if (ignored) {
+    m_storage->ignoredCollisionPairs.insert(key);
+  } else {
+    m_storage->ignoredCollisionPairs.erase(key);
+  }
+}
+
+//==============================================================================
+bool World::isCollisionPairIgnored(
+    const Frame& first, const Frame& second) const
+{
+  const entt::entity firstEntity
+      = resolveCollisionPairFrame(*this, first, "first");
+  const entt::entity secondEntity
+      = resolveCollisionPairFrame(*this, second, "second");
+  DART_SIMULATION_THROW_T_IF(
+      firstEntity == secondEntity,
+      InvalidArgumentException,
+      "Collision pair frames must be distinct");
+
+  return m_storage->ignoredCollisionPairs.contains(
+      makeCollisionPairKey(firstEntity, secondEntity));
+}
+
+//==============================================================================
+void World::clearIgnoredCollisionPairs()
+{
+  m_storage->ignoredCollisionPairs.clear();
+}
+
+//==============================================================================
+std::size_t World::getIgnoredCollisionPairCount() const noexcept
+{
+  return m_storage->ignoredCollisionPairs.size();
+}
+
+//==============================================================================
 std::vector<Contact> World::collide(const CollisionQueryOptions& options)
 {
   return queryContacts(options);
@@ -4697,6 +5752,17 @@ const std::vector<Contact>& World::queryContacts(
     return false;
   };
 
+  if (options.includeRigidBodyPairs) {
+    collectLivePublicRigidBodyJointPairsInto(
+        m_storage->registry, cache.liveRigidBodyJointPairs);
+  } else {
+    cache.liveRigidBodyJointPairs.clear();
+  }
+  const bool hasIgnoredCollisionPairs
+      = !m_storage->ignoredCollisionPairs.empty();
+  const bool hasLiveRigidBodyJointPairs
+      = !cache.liveRigidBodyJointPairs.empty();
+
   const auto addSpecs = [&](entt::entity entity,
                             entt::entity multibody,
                             bool isLink,
@@ -4720,6 +5786,22 @@ const std::vector<Contact>& World::queryContacts(
                                 const CollisionQueryCache::ObjectEntry& b) {
     if (a.entity == b.entity) {
       return false;
+    }
+    const bool rigidBodyPair = !a.isLink && !b.isLink;
+    if (hasIgnoredCollisionPairs
+        || (rigidBodyPair && hasLiveRigidBodyJointPairs)) {
+      const auto pairKey = makeCollisionPairKey(a.entity, b.entity);
+      if (hasIgnoredCollisionPairs
+          && m_storage->ignoredCollisionPairs.contains(pairKey)) {
+        return false;
+      }
+      if (rigidBodyPair && hasLiveRigidBodyJointPairs
+          && std::binary_search(
+              cache.liveRigidBodyJointPairs.begin(),
+              cache.liveRigidBodyJointPairs.end(),
+              pairKey)) {
+        return false;
+      }
     }
 
     if (a.isLink && b.isLink) {
@@ -4807,8 +5889,8 @@ const std::vector<Contact>& World::queryContacts(
   }
 
   // Broad-phase-pruned narrow-phase queries. Each candidate pair's bodies are
-  // known here, so the contacts map back to the right experimental bodies
-  // without relying on the result carrying object identity.
+  // known here, so the contacts map back to the right simulation bodies without
+  // relying on the result carrying object identity.
   const auto option = ncol::CollisionOption::fullContacts();
   cache.collisionWorld.buildBroadPhaseSnapshot(cache.candidatePairs);
   auto& contacts = cache.contacts;
@@ -4893,6 +5975,23 @@ void World::saveBinary(std::ostream& output) const
             ? 1u
             : 0u;
   io::writePOD(output, multibodyIntegrationMethod);
+
+  std::vector<detail::WorldStorage::CollisionPairKey> savedIgnoredPairs;
+  savedIgnoredPairs.reserve(m_storage->ignoredCollisionPairs.size());
+  for (const auto& pair : m_storage->ignoredCollisionPairs) {
+    if (entityMap.contains(pair.first) && entityMap.contains(pair.second)) {
+      savedIgnoredPairs.push_back(pair);
+    }
+  }
+
+  io::writePOD(output, savedIgnoredPairs.size());
+  for (const auto& [first, second] : savedIgnoredPairs) {
+    io::writePOD(output, static_cast<std::uint32_t>(entityMap.at(first)));
+    io::writePOD(output, static_cast<std::uint32_t>(entityMap.at(second)));
+  }
+
+  io::writePOD(output, m_variationalIntegratorMaxIterations);
+  io::writePOD(output, m_variationalIntegratorTolerance);
 }
 
 //==============================================================================
@@ -4972,6 +6071,45 @@ void World::loadBinary(std::istream& input)
               InvalidArgumentException,
               "Serialized World multibody integration method value is invalid");
       }
+    }
+
+    if (formatVersion >= 16 && input.peek() != std::char_traits<char>::eof()) {
+      std::size_t ignoredPairCount = 0;
+      io::readPOD(input, ignoredPairCount);
+      for (std::size_t i = 0; i < ignoredPairCount; ++i) {
+        std::uint32_t serializedFirst = 0;
+        std::uint32_t serializedSecond = 0;
+        io::readPOD(input, serializedFirst);
+        io::readPOD(input, serializedSecond);
+        const auto first
+            = entityMap.at(static_cast<entt::entity>(serializedFirst));
+        const auto second
+            = entityMap.at(static_cast<entt::entity>(serializedSecond));
+        m_storage->ignoredCollisionPairs.insert(
+            makeCollisionPairKey(first, second));
+      }
+    }
+
+    if (formatVersion >= 18 && input.peek() != std::char_traits<char>::eof()) {
+      std::size_t variationalMaxIterations = 0;
+      double variationalTolerance = 0.0;
+      io::readPOD(input, variationalMaxIterations);
+      io::readPOD(input, variationalTolerance);
+      DART_SIMULATION_THROW_T_IF(
+          variationalMaxIterations == 0,
+          InvalidArgumentException,
+          "Serialized World variational max-iteration budget is invalid");
+      DART_SIMULATION_THROW_T_IF(
+          variationalMaxIterations
+              > static_cast<std::size_t>(std::numeric_limits<int>::max()),
+          InvalidArgumentException,
+          "Serialized World variational max-iteration budget is too large");
+      DART_SIMULATION_THROW_T_IF(
+          !std::isfinite(variationalTolerance) || variationalTolerance <= 0.0,
+          InvalidArgumentException,
+          "Serialized World variational tolerance is invalid");
+      m_variationalIntegratorMaxIterations = variationalMaxIterations;
+      m_variationalIntegratorTolerance = variationalTolerance;
     }
   }
 

--- a/dart/simulation/world.hpp
+++ b/dart/simulation/world.hpp
@@ -263,6 +263,145 @@ public:
   bool hasMultibody(std::string_view name) const;
   std::size_t getMultibodyCount() const;
 
+  /// Create a fixed non-topology constraint between two links in one
+  /// multibody.
+  ///
+  /// The current relative pose is captured when the World enters simulation
+  /// mode, after kinematics has been baked. During simulation steps the
+  /// variational articulated path projects the child endpoint back toward that
+  /// captured pose. This is design-mode only and requires the variational
+  /// multibody integration family before stepping.
+  Joint addArticulatedFixedJoint(
+      std::string_view name, const Link& parent, const Link& child);
+  Joint addArticulatedFixedJoint(
+      std::string_view name,
+      const Link& parent,
+      const Link& child,
+      const Eigen::Vector3d& parentAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Create a fixed non-topology constraint between world and one link.
+  ///
+  /// The current world pose is captured when the World enters simulation mode.
+  /// During simulation steps the variational articulated path projects the link
+  /// endpoint back toward that captured world pose. This is design-mode only
+  /// and requires the variational multibody integration family before stepping.
+  Joint addArticulatedFixedJoint(std::string_view name, const Link& child);
+  Joint addArticulatedFixedJoint(
+      std::string_view name,
+      const Link& child,
+      const Eigen::Vector3d& worldAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Create a revolute non-topology constraint between two links in one
+  /// multibody.
+  ///
+  /// The captured anchor is preserved while rotation around the parent-frame
+  /// `axis` remains free. This is design-mode only and requires the variational
+  /// multibody integration family before stepping.
+  Joint addArticulatedRevoluteJoint(
+      std::string_view name,
+      const Link& parent,
+      const Link& child,
+      const Eigen::Vector3d& axis = Eigen::Vector3d::UnitZ());
+  Joint addArticulatedRevoluteJoint(
+      std::string_view name,
+      const Link& parent,
+      const Link& child,
+      const Eigen::Vector3d& axis,
+      const Eigen::Vector3d& parentAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Create a revolute non-topology constraint between world and one link.
+  ///
+  /// The captured anchor is preserved while rotation around the world-frame
+  /// `axis` remains free. This is design-mode only and requires the
+  /// variational multibody integration family before stepping.
+  Joint addArticulatedRevoluteJoint(
+      std::string_view name,
+      const Link& child,
+      const Eigen::Vector3d& axis = Eigen::Vector3d::UnitZ());
+  Joint addArticulatedRevoluteJoint(
+      std::string_view name,
+      const Link& child,
+      const Eigen::Vector3d& axis,
+      const Eigen::Vector3d& worldAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Create a prismatic non-topology constraint between two links in one
+  /// multibody.
+  ///
+  /// The captured anchor is preserved while translation along the parent-frame
+  /// `axis` remains free. This is design-mode only and requires the variational
+  /// multibody integration family before stepping.
+  Joint addArticulatedPrismaticJoint(
+      std::string_view name,
+      const Link& parent,
+      const Link& child,
+      const Eigen::Vector3d& axis = Eigen::Vector3d::UnitZ());
+  Joint addArticulatedPrismaticJoint(
+      std::string_view name,
+      const Link& parent,
+      const Link& child,
+      const Eigen::Vector3d& axis,
+      const Eigen::Vector3d& parentAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Create a prismatic non-topology constraint between world and one link.
+  ///
+  /// The captured anchor is preserved while translation along the world-frame
+  /// `axis` remains free. This is design-mode only and requires the
+  /// variational multibody integration family before stepping.
+  Joint addArticulatedPrismaticJoint(
+      std::string_view name,
+      const Link& child,
+      const Eigen::Vector3d& axis = Eigen::Vector3d::UnitZ());
+  Joint addArticulatedPrismaticJoint(
+      std::string_view name,
+      const Link& child,
+      const Eigen::Vector3d& axis,
+      const Eigen::Vector3d& worldAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Create a spherical non-topology point constraint between two links in one
+  /// multibody.
+  ///
+  /// The captured anchor is preserved while relative orientation remains free.
+  /// This is design-mode only and requires the variational multibody
+  /// integration family before stepping.
+  Joint addArticulatedSphericalJoint(
+      std::string_view name, const Link& parent, const Link& child);
+  Joint addArticulatedSphericalJoint(
+      std::string_view name,
+      const Link& parent,
+      const Link& child,
+      const Eigen::Vector3d& parentAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Create a spherical non-topology point constraint between world and one
+  /// link.
+  ///
+  /// The captured anchor is preserved while relative orientation remains free.
+  /// This is design-mode only and requires the variational multibody
+  /// integration family before stepping.
+  Joint addArticulatedSphericalJoint(std::string_view name, const Link& child);
+  Joint addArticulatedSphericalJoint(
+      std::string_view name,
+      const Link& child,
+      const Eigen::Vector3d& worldAnchor,
+      const Eigen::Vector3d& childAnchor);
+
+  /// Get a supported non-topology articulated point joint by name.
+  ///
+  /// This returns fixed, revolute, prismatic, and spherical link-link or
+  /// world-link joints created through the articulated World facade. It does
+  /// not return tree
+  /// topology joints; use Multibody::getJoint() for parent joints.
+  std::optional<Joint> getArticulatedJoint(std::string_view name);
+  bool hasArticulatedJoint(std::string_view name) const;
+  std::size_t getArticulatedJointCount() const;
+  std::vector<Joint> getArticulatedJoints();
+
   //--------------------------------------------------------------------------
   // Loop-closure management
   //--------------------------------------------------------------------------
@@ -316,10 +455,44 @@ public:
       const RigidBody& parent,
       const RigidBody& child,
       const Eigen::Vector3d& axis = Eigen::Vector3d::UnitZ());
+  /// Create a spherical point constraint between two free rigid bodies.
+  ///
+  /// The current anchor is captured when the joint is created. During
+  /// simulation steps the experimental rigid-body constraint path projects the
+  /// child anchor back toward the parent anchor while leaving relative
+  /// orientation free. This is design-mode only.
+  Joint addRigidBodySphericalJoint(
+      std::string_view name, const RigidBody& parent, const RigidBody& child);
+  Joint addRigidBodySphericalJoint(
+      std::string_view name,
+      const RigidBody& parent,
+      const RigidBody& child,
+      const Eigen::Vector3d& parentAnchor,
+      const Eigen::Vector3d& childAnchor);
+  /// Create a finite-stiffness radial spring between two free rigid bodies.
+  ///
+  /// The spring connects each body's origin by default. The overload with
+  /// anchors accepts body-local anchor points. This experimental AVBD path is
+  /// design-mode only and is projected by the rigid-body contact stage.
+  void addRigidBodyDistanceSpring(
+      std::string_view name,
+      const RigidBody& parent,
+      const RigidBody& child,
+      double restLength,
+      double stiffness);
+  void addRigidBodyDistanceSpring(
+      std::string_view name,
+      const RigidBody& parent,
+      const RigidBody& child,
+      double restLength,
+      double stiffness,
+      const Eigen::Vector3d& parentAnchor,
+      const Eigen::Vector3d& childAnchor);
   /// Get any supported public joint between free rigid bodies by name.
   ///
-  /// This returns fixed, revolute, and prismatic rigid-body joints. It does not
-  /// return multibody joints; use Multibody::getJoint() for articulated links.
+  /// This returns fixed, revolute, prismatic, and spherical rigid-body joints.
+  /// It does not return multibody joints; use Multibody::getJoint() for
+  /// articulated links.
   std::optional<Joint> getRigidBodyJoint(std::string_view name);
   bool hasRigidBodyJoint(std::string_view name) const;
   std::size_t getRigidBodyJointCount() const;
@@ -688,6 +861,27 @@ public:
   // Collision queries
   //--------------------------------------------------------------------------
 
+  /// Add or remove a persistent collision-query exclusion between two collision
+  /// bodies.
+  ///
+  /// Endpoints must be valid rigid-body or multibody-link frame handles owned
+  /// by this World. The filter is order-independent and is applied by
+  /// `collide()` and the built-in contact stages before narrow-phase contact
+  /// generation.
+  void setCollisionPairIgnored(
+      const Frame& first, const Frame& second, bool ignored = true);
+
+  /// Return whether a persistent collision-query exclusion exists between two
+  /// rigid-body or multibody-link frame handles.
+  [[nodiscard]] bool isCollisionPairIgnored(
+      const Frame& first, const Frame& second) const;
+
+  /// Clear all persistent collision-query exclusions.
+  void clearIgnoredCollisionPairs();
+
+  /// Return the number of persistent collision-query exclusions.
+  [[nodiscard]] std::size_t getIgnoredCollisionPairCount() const noexcept;
+
   /// Run a collision query over all bodies that have a collision shape.
   ///
   /// This is a query, not a solver: it reports contact points (position,
@@ -760,7 +954,25 @@ private:
       const RigidBody& parent,
       const RigidBody& child,
       JointType type,
-      const Eigen::Vector3d& axis);
+      const Eigen::Vector3d& axis,
+      std::optional<Eigen::Vector3d> parentAnchor = std::nullopt,
+      std::optional<Eigen::Vector3d> childAnchor = std::nullopt);
+  void addRigidBodyDistanceSpringImpl(
+      std::string_view name,
+      const RigidBody& parent,
+      const RigidBody& child,
+      double restLength,
+      double stiffness,
+      std::optional<Eigen::Vector3d> parentAnchor,
+      std::optional<Eigen::Vector3d> childAnchor);
+  Joint addArticulatedJoint(
+      std::string_view name,
+      const Link* parent,
+      const Link& child,
+      JointType type,
+      const Eigen::Vector3d& axis,
+      std::optional<Eigen::Vector3d> parentAnchor = std::nullopt,
+      std::optional<Eigen::Vector3d> childAnchor = std::nullopt);
 
   void ensureDesignMode() const;
   [[nodiscard]] const std::vector<Contact>& queryContacts(
@@ -770,6 +982,7 @@ private:
   void reserveRegistryStorageForSimulation();
   void prepareStepPipelineCacheForCurrentConfiguration();
   void resetCountersFromRegistry();
+  bool tryStepCleanNoWorkDefaultPipeline();
   void stepPipelineOnce(
       compute::ComputeExecutor& executor, compute::WorldStepPipeline& pipeline);
   void recordReplayFrame();
@@ -824,6 +1037,8 @@ private:
   };
   MultibodyIntegrationMethod m_multibodyIntegrationMethod{
       MultibodyIntegrationMethod::SemiImplicit};
+  std::size_t m_variationalIntegratorMaxIterations{100};
+  double m_variationalIntegratorTolerance{1e-10};
   std::size_t m_frame{0};
 
   std::size_t m_freeFrameCounter{0};


### PR DESCRIPTION
## Summary

- Wires the AVBD rigid rows into `World` stepping and serialization.
- Adds AVBD joint/contact state plumbing across world storage, multibody options, binary IO, and serializer code.

## Motivation / Problem

- This is the world-integration slice of the AVBD checkpoint, separated from the row-kernel foundation so review can focus on runtime and persistence behavior.

## Changes / Key Changes

- Connect AVBD row assembly into world step staging.
- Extend world, world storage, joint, multibody, and contact plumbing for AVBD state.
- Serialize AVBD-related state through binary IO and serializer paths.

## Testing

- `pixi run lint`
- `pixi run build`
- `git diff --cached --check` before commit

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Depends on #2964.
- Depends on / conflicts with #2956 — merge #2956 first, then rebase this PR.
- Split from raw checkpoint branch `feature/avbd-articulated-masked-rows` commit `d25e5177d9c`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (isolated in the docs/plans split PR)
- [x] Add unit tests for new functionality (isolated in the tests/benchmarks split PR)
- [x] Document new methods and classes (isolated in the docs/plans split PR)
- [ ] Add Python bindings (dartpy) if applicable
