### PR TITLE
Add private CUDA scene parity packet

### DIFF
--- a/docs/dev_tasks/unified_newton_barrier_multibody/README.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/README.md
@@ -176,6 +176,11 @@
         CPU/GPU step parity; keep the row in-progress because off-diagonal
         sparse blocks, equality reduction, global factorization, runtime scene
         rows, and speedup remain unproven.
+  - [x] Add a private reduced scene state-batch parity packet with exact
+        CPU/GPU rollout parity and speedup; keep the row in-progress because
+        GPU `World::step`, contact candidate construction, CCD,
+        barrier/friction assembly, sparse equality reduction, and global Newton
+        solving remain unproven.
 - [ ] Implementation-roadmap Phase 8: complete the PLAN-083 audit and retire
       temporary task state.
   - [x] Add a checked completion audit sidecar that records the current
@@ -296,12 +301,12 @@ storage, or backend resources as public API.
 
 1. Use merged PRs #2960, #2961, #2970, and #2971 as the baseline for remaining
    work; do not reopen the old phase-scoped stack.
-2. Continue private GPU scene-level parity only after
-   `simx/plan083-gpu-assembly-solve-packet` lands. Keep the landed
-   assembly/solve packet limited to reduced diagonal row assembly and
-   independent regularized Newton steps; do not mark the row measured until
-   off-diagonal sparse blocks, equality reduction, global factorization,
-   runtime scene rows, and speedup have concrete evidence.
+2. Continue private GPU scene-level parity on
+   `simx/plan083-gpu-scene-parity-packet`. Keep the packet limited to reduced
+   scene state-batch rollout parity; do not mark the row measured until GPU
+   `World::step`, contact candidate construction, CCD, barrier/friction
+   assembly, sparse equality reduction, and global Newton solving have concrete
+   evidence.
 3. Use the reduced ABD runtime-step and GPU contact-stencil packets only as
    internal runtime evidence;
    broader ABD CPU packets still require scene-level runtime residuals, scene

--- a/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
+++ b/docs/dev_tasks/unified_newton_barrier_multibody/RESUME.md
@@ -155,8 +155,8 @@ packet tests, `pixi run lint`, `pixi run build`, and
 Implementation-roadmap Phases 3-8 landed together in PR #2960. The Phase 8
 audit at
 `docs/plans/083-unified-newton-barrier-multibody/completion-audit.md` records
-that PLAN-083 is not complete because planned manifest, CPU scene corpus, and
-GPU parity packet rows remain. The audit intentionally blocks retiring
+that PLAN-083 is not complete because planned manifest rows and explicit
+CPU/GPU scene-packet limitations remain. The audit intentionally blocks retiring
 `docs/dev_tasks/unified_newton_barrier_multibody/` until a maintainer decides
 whether the remaining work stays active there or moves fully into durable plan
 sidecars.
@@ -167,9 +167,10 @@ The follow-up PSD projection packet slice adds
 `pixi run -e cuda bm-plan083-gpu-psd-packet` measured the 4096-block 12x12 PSD
 row with max error `2.4868995751603507e-14` and `4.451557656446166x` speedup
 over the CPU reference. This moves only the local PSD projection row to
-`measured`; contact candidates, CCD/line search, barrier/friction kernels, and
-assembly/solve now have in-progress private packets, while scene-level GPU
-speedups remain planned.
+`measured`; contact candidates, CCD/line search, barrier/friction kernels,
+assembly/solve, and reduced scene state-batch rollout now have in-progress
+private packets, while full scene-level GPU `World::step` speedups remain
+unproven.
 
 The follow-up barrier-force diagnostic slice adds
 `NewtonBarrierPrimitives.BarrierForceCurveCapturesKappaSensitivity`, which
@@ -320,22 +321,21 @@ build/CTest entries.
 
 ## Current Branch
 
-`simx/plan083-gpu-assembly-solve-packet` - continues private GPU parity
-evidence after the barrier/friction packet branch. This branch adds a private
-reduced diagonal assembly/solve packet, CUDA unit test, benchmark smoke, and
-packet writer for per-body diagonal row assembly plus independent regularized
-Newton steps only. Keep the packet row `in-progress`: off-diagonal sparse
-blocks, equality reduction, global factorization, runtime scene rows, and
-speedup remain future evidence.
+`simx/plan083-gpu-scene-parity-packet` - continues private GPU parity evidence
+after the assembly/solve packet branch. This branch adds a reduced
+hanging-bridge scene state-batch packet through DART scene extraction plus the
+private rigid-body state-batch CUDA rollout. Keep the packet row
+`in-progress`: GPU `World::step`, contact candidate construction, CCD,
+barrier/friction assembly, sparse equality reduction, and global Newton solving
+remain future evidence.
 
 ## Immediate Next Step
 
-Finish and review `simx/plan083-gpu-assembly-solve-packet`, then continue the
-remaining private GPU row in roadmap order: scene-level parity/speedup. Leave
-the dev-task folder active because PLAN-083 acceptance criteria are still unmet;
-if the task later moves out of this folder, get maintainer direction before
-deleting it and keep the remaining planned CPU/GPU/scene rows in durable
-sidecars.
+Finish and review `simx/plan083-gpu-scene-parity-packet`, then keep the
+dev-task folder active because PLAN-083 acceptance criteria are still unmet. If
+the task later moves out of this folder, get maintainer direction before
+deleting it and keep the remaining planned manifest plus in-progress
+CPU/GPU/scene limitations in durable sidecars.
 
 ## Context That Would Be Lost
 

--- a/docs/plans/083-unified-newton-barrier-multibody/completion-audit.md
+++ b/docs/plans/083-unified-newton-barrier-multibody/completion-audit.md
@@ -6,19 +6,20 @@ Verdict: NOT COMPLETE.
 
 PLAN-083 has completed the implementation-roadmap Phase 8 audit step and now has
 branch-local runtime smoke coverage for several landed Newton-barrier contracts,
-but the plan itself cannot be called complete yet. The manifest, CPU scene
-corpus, and private GPU parity packet still contain planned rows and explicit
-limitations. Do not retire `docs/dev_tasks/unified_newton_barrier_multibody/`
+but the plan itself cannot be called complete yet. The manifest still contains
+planned rows, and the CPU scene corpus plus private GPU parity packet still
+carry explicit limitations. Do not retire
+`docs/dev_tasks/unified_newton_barrier_multibody/`
 until a maintainer decides whether the remaining work stays tracked there or
 moves entirely into durable plan sidecars.
 
 ## Evidence Snapshot
 
-| Artifact                 | Row count | Status counts                                 |
-| ------------------------ | --------- | --------------------------------------------- |
-| `paper-deck-manifest.md` | 48        | `in-progress`: 45, `planned`: 3               |
-| `cpu-scene-corpus.json`  | 26        | `in-progress`: 25, `not-applicable`: 1        |
-| `gpu-parity-packet.json` | 6         | `in-progress`: 4, `measured`: 1, `planned`: 1 |
+| Artifact                 | Row count | Status counts                          |
+| ------------------------ | --------- | -------------------------------------- |
+| `paper-deck-manifest.md` | 48        | `in-progress`: 45, `planned`: 3        |
+| `cpu-scene-corpus.json`  | 26        | `in-progress`: 25, `not-applicable`: 1 |
+| `gpu-parity-packet.json` | 6         | `in-progress`: 5, `measured`: 1        |
 
 ## Phase 8 Checklist
 
@@ -27,7 +28,7 @@ moves entirely into durable plan sidecars.
 | `paper-deck-manifest.md` has zero unclassified rows           | Pass         | Every manifest row has an explicit status. The current statuses are `planned` or `in-progress`; none are unclassified.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | Every non-planned row links to concrete evidence or rationale | Partial      | In-progress rows name branch-local artifacts, tests, packets, or limitations. Runtime wiring now covers point/hinge constraints, BDF-2, deformable surface obstacles, reduced lying-flat, hanging-bridge, pulley, umbrella, terrain vehicle, ragdoll, nunchaku, nunchaku scaling, windmill, Candy, precession, reduced timing-breakdown packets, reduced Table 2 setup/statistics packets, the sparse equality change-of-variable rigid IPC path, reduced ABD house-of-cards and wrecking-ball runtime-step packets, reduced ABD chain-net runtime-step packets, and reduced ABD gears/Bullet comparison runtime-step packets, but not paper-scale behavior or performance parity. |
 | CPU packets exist for performance rows                        | Partial      | `cpu-scene-corpus.json` records commands and artifact paths for every row, but many entries remain reduced packets or placeholders rather than paper-scale reproductions, accepted Bullet/reference comparisons, or GPU parity evidence.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| GPU packets exist for GPU claims                              | Blocked      | `gpu-parity-packet.json` has a measured PSD projection packet plus in-progress point-triangle contact-stencil, endpoint-linear point-triangle CCD/line-search, scalar barrier/friction local-kernel, and reduced diagonal assembly/solve parity packets, but the scene-level row remains `planned` and no scene-level GPU speed claim exists.                                                                                                                                                                                                                                                                                                                                      |
+| GPU packets exist for GPU claims                              | Blocked      | `gpu-parity-packet.json` has a measured PSD projection packet plus in-progress point-triangle contact-stencil, endpoint-linear point-triangle CCD/line-search, scalar barrier/friction local-kernel, reduced diagonal assembly/solve, and reduced scene state-batch parity packets, but no full scene-level GPU `World::step` speed claim exists.                                                                                                                                                                                                                                                                                                                                  |
 | Public headers and dartpy remain backend-neutral              | Pass         | Phase 8 validation keeps API-boundary gates in the local evidence set; no public CUDA/backend/solver-registry API is added by this audit.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Durable docs own landed architecture                          | Partial      | Durable plan sidecars own the manifest, CPU corpus, GPU packet, and this audit. The temporary dev-task folder remains active because acceptance is unmet.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | Temporary dev-task folder retired                             | Blocked      | Retirement requires maintainer direction because material planned work remains.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -51,8 +52,8 @@ moves entirely into durable plan sidecars.
   Bullet/reference baselines and paper-scale assets remain unproven.
 - Private GPU packets do not yet prove same-scene CPU/GPU speedups for contact
   candidates, full CCD/line search, full local barrier/friction kernels, full
-  sparse assembly/linear solve, or scene-level workloads. The PSD projection
-  local-kernel row is
+  sparse assembly/linear solve, or full scene-level workloads. The PSD
+  projection local-kernel row is
   measured separately. The point-triangle contact-stencil filter packet is
   in-progress because parity exists for preassembled stencils but broad-phase,
   edge-edge, runtime scene filtering, and speedup remain unproven. The
@@ -67,7 +68,11 @@ moves entirely into durable plan sidecars.
   because parity exists for diagonal per-body row assembly and independent
   regularized Newton steps only, but off-diagonal sparse blocks, equality
   reduction, global factorization, runtime scene rows, and speedup remain
-  unproven.
+  unproven. The reduced scene parity/speed packet is in-progress because
+  parity and speedup exist only for DART scene state extraction plus private
+  rigid-body state-batch CUDA rollout; GPU `World::step`, contact candidate
+  construction, CCD, barrier/friction assembly, sparse equality reduction, and
+  global Newton solving remain unproven.
 - Launchable py-demo placeholders exist, and the reduced lying-flat,
   hanging-bridge, pulley, umbrella, terrain vehicle, ragdoll, nunchaku,
   windmill, Candy, and precession scenes have local headless smoke/capture

--- a/docs/plans/083-unified-newton-barrier-multibody/gpu-parity-packet.json
+++ b/docs/plans/083-unified-newton-barrier-multibody/gpu-parity-packet.json
@@ -16,9 +16,8 @@
   "summary": {
     "row_count": 6,
     "status_counts": {
-      "in-progress": 4,
-      "measured": 1,
-      "planned": 1
+      "in-progress": 5,
+      "measured": 1
     }
   },
   "rows": [
@@ -196,9 +195,9 @@
       "row_id": "scene-parity-speedup",
       "roadmap_item": "same-scene CPU/GPU result parity and speedup",
       "owner": "PLAN-083 + PLAN-030",
-      "status": "planned",
-      "cpu_evidence_command": "not-ready: CPU scene-corpus placeholders are launchable but not runtime paper-scene reproductions",
-      "gpu_evidence_command": "not-ready: private PLAN-083 GPU same-scene packet depends on the staged rows above",
+      "status": "in-progress",
+      "cpu_evidence_command": "pixi run -e cuda bm-plan083-gpu-scene-parity-packet",
+      "gpu_evidence_command": "pixi run -e cuda bm-plan083-gpu-scene-parity-packet",
       "parity_evidence_artifact": ".benchmark_results/plan083/gpu/scene_parity_speedup.json",
       "benchmark_profile_artifact": ".benchmark_results/plan083/gpu/scene_parity_profile.json",
       "same_scene_policy": "Use the same DART scene id, timestep, material parameters, contact geometry, initial state, and acceptance invariant for CPU and GPU.",
@@ -206,8 +205,20 @@
       "timing_policy": "Report setup, transfer, candidate/CCD/local-kernel/assembly/solve subphase timings, readback, and full CPU step timing.",
       "speedup_policy": "Require speedup over DART CPU at matched accuracy; if the paper source lacks a GPU number, compare only against DART CPU and record that limitation.",
       "public_api_policy": "No public CUDA or backend exposure; scene evidence stays private/manual until a separate public promotion gate exists.",
-      "limitation_status": "Waiting for runtime CPU scene reproduction plus the private staged GPU rows above.",
-      "notes_or_gap": "This is the final Phase 7 go/no-go row and intentionally cannot pass from placeholder py-demos alone."
+      "limitation_status": "Reduced state-batch scene parity packet exists, but it covers DART scene state extraction plus private rigid-body state-batch CUDA rollout only. It does not run a GPU World::step path, contact candidate construction, CCD, barrier/friction assembly, sparse equality reduction, or global Newton solve.",
+      "notes_or_gap": "The reduced hanging-bridge state-batch packet measured max_result_abs_error=1.1102230246251565e-16 and speedup=18.792052761946252x for 4096 replicated scenes, 7 bodies per scene, and 64 steps on 2026-06-11. Because it bypasses the GPU contact/constraint/Newton solver path, this row remains in-progress rather than measured.",
+      "same_scene_cpu_gpu": true,
+      "scene_id": "plan083_hanging_bridge_reduced_state_batch",
+      "state_path": "private rigid-body state-batch CUDA rollout",
+      "world_count": 4096,
+      "scene_body_count": 7,
+      "body_count": 7,
+      "step_count": 64,
+      "time_step": 0.005,
+      "max_result_abs_error": 1.1102230246251565e-16,
+      "result_abs_error_tolerance": 1e-9,
+      "speedup": 18.792052761946252,
+      "min_speedup": 1.25
     }
   ]
 }

--- a/docs/plans/083-unified-newton-barrier-multibody/paper-deck-manifest.md
+++ b/docs/plans/083-unified-newton-barrier-multibody/paper-deck-manifest.md
@@ -60,8 +60,9 @@ the staged kernels and scene packets are measured.
 Phase 8 tracks the current completion audit in
 [`completion-audit.md`](completion-audit.md), validated by
 `scripts/check_plan083_completion_audit.py`. The audit records that PLAN-083 is
-not complete while planned CPU/GPU/scene rows remain, and it blocks temporary
-dev-task retirement pending maintainer direction.
+not complete while planned manifest rows and in-progress CPU/GPU/scene
+limitations remain, and it blocks temporary dev-task retirement pending
+maintainer direction.
 
 ## Cross-Plan Classification Policy
 

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -302,15 +302,19 @@ its own line so status updates remain git-history friendly.
   speedup as future evidence. PR #2979 adds endpoint-linear
   point-triangle CCD/line-search parity for static-triangle fixtures, while
   keeping edge-edge CCD, rigid curved trajectories, runtime candidate sets, and
-  scene-level line-search feasibility as future evidence. The current follow-up
-  adds scalar barrier/friction local-kernel parity, while keeping primitive
-  gradients, tangent-basis construction, Hessian assembly, PSD coupling,
-  runtime contact rows, and speedup as future evidence. The current follow-up
-  adds reduced diagonal assembly/solve parity, while keeping off-diagonal sparse blocks,
-  equality reduction, global factorization, runtime scene rows, and speedup as
-  future evidence. The completion audit still records PLAN-083 as incomplete
-  while planned manifest and scene-level GPU parity rows remain, so dev-task
-  retirement needs maintainer direction before deletion.
+  scene-level line-search feasibility as future evidence. PR #2980 adds scalar
+  barrier/friction local-kernel parity, while keeping primitive gradients,
+  tangent-basis construction, Hessian assembly, PSD coupling, runtime contact
+  rows, and speedup as future evidence. PR #2981 adds reduced diagonal
+  assembly/solve parity, while keeping off-diagonal sparse blocks, equality
+  reduction, global factorization, runtime scene rows, and speedup as future
+  evidence. The current follow-up adds reduced hanging-bridge scene state-batch
+  CPU/GPU parity and speedup, while keeping GPU `World::step`, contact
+  candidate construction, CCD, barrier/friction assembly, sparse equality
+  reduction, and global Newton solving as future evidence. The completion audit
+  still records PLAN-083 as incomplete while planned manifest rows and
+  in-progress CPU/GPU/scene limitations remain, so dev-task retirement needs
+  maintainer direction before deletion.
 - Gate: Unified Newton-barrier progress is not complete until every cited
   paper/deck figure, unit test, benchmark table, and comparison scene is mapped
   to DART-owned tests, py-demos examples, benchmark/profiling packets, CPU and

--- a/pixi.toml
+++ b/pixi.toml
@@ -707,6 +707,7 @@ CMAKE_BUILD_DIR=${BUILD_DIR} python scripts/cmake_build.py \
   --target bm_plan083_gpu_ccd_line_search \
   --target bm_plan083_gpu_barrier_friction \
   --target bm_newton_assembly_solve_cuda \
+  --target bm_plan083_gpu_scene_parity \
   --target bm_vbd_cuda
 """,
 ], depends-on = [
@@ -1178,6 +1179,9 @@ python scripts/run_benchmark_smoke.py "${BUILD_DIR}/bin/bm_plan083_gpu_barrier_f
 python scripts/run_benchmark_smoke.py "${BUILD_DIR}/bin/bm_newton_assembly_solve_cuda" \
   --benchmark_filter='BM_NewtonAssemblySolve(Cpu|Cuda)/4096(/real_time)?$' \
   --benchmark_min_time=0.001s
+python scripts/run_benchmark_smoke.py "${BUILD_DIR}/bin/bm_plan083_gpu_scene_parity" \
+  --benchmark_filter='BM_Plan083SceneParity(Cpu|Cuda)/1024/16(/real_time)?$' \
+  --benchmark_min_time=0.001s
 python scripts/run_benchmark_smoke.py "${BUILD_DIR}/bin/bm_vbd_cuda" \
   --benchmark_filter='BM_Vbd(Cpu|Cuda)Step/32$' \
   --benchmark_min_time=0.001s
@@ -1568,6 +1572,11 @@ bm-plan083-gpu-barrier-friction-packet = { cmd = "python scripts/write_plan083_g
   ] },
 ] }
 bm-newton-assembly-solve-packet = { cmd = "python scripts/write_newton_assembly_solve_packet.py", depends-on = [
+  { task = "build-cuda", args = [
+    "Release",
+  ] },
+] }
+bm-plan083-gpu-scene-parity-packet = { cmd = "python scripts/write_plan083_gpu_scene_parity_packet.py", depends-on = [
   { task = "build-cuda", args = [
     "Release",
   ] },

--- a/scripts/check_plan083_completion_audit.py
+++ b/scripts/check_plan083_completion_audit.py
@@ -138,12 +138,16 @@ def validate_audit(
         errors.append(
             "audit must block CPU packet completion while CPU rows remain planned"
         )
+    incomplete_gpu_count = gpu_counts.get("planned", 0) + gpu_counts.get(
+        "in-progress",
+        0,
+    )
     if (
-        gpu_counts.get("planned", 0) > 0
+        incomplete_gpu_count > 0
         and _table_status(audit_text, "GPU packets exist for GPU claims") != "Blocked"
     ):
         errors.append(
-            "audit must block GPU packet completion while GPU rows remain planned"
+            "audit must block GPU packet completion while GPU rows remain incomplete"
         )
 
     errors.extend(

--- a/scripts/write_plan083_gpu_scene_parity_packet.py
+++ b/scripts/write_plan083_gpu_scene_parity_packet.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run and validate the private GPU reduced scene-parity packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from benchmark_packet_utils import (  # noqa: E402
+    benchmark_row_name,
+    benchmark_timing_field_errors,
+    benchmark_timing_ns,
+    canonical_benchmark_name,
+)
+
+DEFAULT_BENCHMARK_OUTPUT = Path(
+    ".benchmark_results/plan083/gpu/scene_parity_profile.json"
+)
+DEFAULT_PACKET_OUTPUT = Path(".benchmark_results/plan083/gpu/scene_parity_speedup.json")
+
+DEFAULT_SCENE_ID = "plan083_hanging_bridge_reduced_state_batch"
+DEFAULT_WORLD_COUNT = 4096
+DEFAULT_STEP_COUNT = 64
+DEFAULT_TOLERANCE = 1e-9
+DEFAULT_SPEEDUP_GATE = 1.25
+
+
+class SceneParityPacketError(RuntimeError):
+    pass
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--benchmark-json",
+        type=Path,
+        default=DEFAULT_BENCHMARK_OUTPUT,
+        help="Google Benchmark JSON path.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_PACKET_OUTPUT,
+        help="Validated packet output path.",
+    )
+    parser.add_argument(
+        "--build-type",
+        default="Release",
+        help="CMake build type for the benchmark target.",
+    )
+    parser.add_argument(
+        "--benchmark-min-time",
+        default="0.01s",
+        help="Google Benchmark --benchmark_min_time value.",
+    )
+    parser.add_argument(
+        "--benchmark-repetitions",
+        type=int,
+        default=3,
+        help="Google Benchmark --benchmark_repetitions value.",
+    )
+    parser.add_argument(
+        "--world-count",
+        type=int,
+        default=DEFAULT_WORLD_COUNT,
+        help="Replicated reduced scene count.",
+    )
+    parser.add_argument(
+        "--step-count",
+        type=int,
+        default=DEFAULT_STEP_COUNT,
+        help="Rigid state-batch rollout step count.",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=DEFAULT_TOLERANCE,
+        help="Maximum CPU/GPU state absolute error.",
+    )
+    parser.add_argument(
+        "--speedup-gate",
+        type=float,
+        default=DEFAULT_SPEEDUP_GATE,
+        help="Policy speedup gate recorded in the packet; parity does not require it.",
+    )
+    parser.add_argument(
+        "--skip-run",
+        action="store_true",
+        help="Validate an existing Google Benchmark JSON file.",
+    )
+    return parser.parse_args(argv)
+
+
+def run_benchmark(args: argparse.Namespace) -> None:
+    args.benchmark_json.parent.mkdir(parents=True, exist_ok=True)
+    filter_expr = (
+        "^BM_Plan083SceneParity(Cpu|Cuda)"
+        f"/{args.world_count}/{args.step_count}(/real_time)?$"
+    )
+    command = [
+        sys.executable,
+        "scripts/run_cpp_benchmark.py",
+        "--target",
+        "bm_plan083_gpu_scene_parity",
+        "--build-type",
+        args.build_type,
+        "--",
+        f"--benchmark_filter={filter_expr}",
+        f"--benchmark_min_time={args.benchmark_min_time}",
+        f"--benchmark_repetitions={args.benchmark_repetitions}",
+        "--benchmark_report_aggregates_only=true",
+        f"--benchmark_out={args.benchmark_json.as_posix()}",
+        "--benchmark_out_format=json",
+    ]
+    subprocess.run(command, check=True)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as stream:
+            data = json.load(stream)
+    except json.JSONDecodeError as exc:
+        raise SceneParityPacketError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SceneParityPacketError(f"{path}: JSON root must be an object")
+    return data
+
+
+def _finite_number(value: object) -> float | None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    value = float(value)
+    return value if math.isfinite(value) else None
+
+
+def _counter(row: Mapping[str, Any], key: str) -> float:
+    value = _finite_number(row.get(key))
+    if value is None:
+        raise SceneParityPacketError(
+            f"{benchmark_row_name(row)} is missing finite counter {key}"
+        )
+    return value
+
+
+def _packet_row_name(row: Mapping[str, Any]) -> str:
+    name = canonical_benchmark_name(benchmark_row_name(row))
+    if name.endswith("/real_time"):
+        return name[: -len("/real_time")]
+    return name
+
+
+def _representative_rows(
+    rows: list[Mapping[str, Any]], world_count: int, step_count: int
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    cpu_name = f"BM_Plan083SceneParityCpu/{world_count}/{step_count}"
+    gpu_name = f"BM_Plan083SceneParityCuda/{world_count}/{step_count}"
+    found: dict[str, Mapping[str, Any]] = {}
+    errors: list[str] = []
+
+    for row in rows:
+        name = benchmark_row_name(row)
+        if not name:
+            errors.append("benchmark row is missing a name")
+            continue
+        canonical = _packet_row_name(row)
+        if canonical not in {cpu_name, gpu_name}:
+            errors.append(f"unexpected benchmark row: {name}")
+            continue
+        if row.get("aggregate_name") == "median":
+            found[canonical] = row
+        errors.extend(benchmark_timing_field_errors(row, name))
+
+    for expected in (cpu_name, gpu_name):
+        if expected not in found:
+            errors.append(f"missing median benchmark row: {expected}")
+
+    if errors:
+        raise SceneParityPacketError("\n".join(errors))
+
+    return found[cpu_name], found[gpu_name]
+
+
+def _matching_int_counter(
+    cpu_row: Mapping[str, Any],
+    gpu_row: Mapping[str, Any],
+    key: str,
+) -> int:
+    cpu_count = int(_counter(cpu_row, key))
+    gpu_count = int(_counter(gpu_row, key))
+    if cpu_count != gpu_count:
+        raise SceneParityPacketError(
+            f"{key} count {cpu_count} != GPU {key} count {gpu_count}"
+        )
+    return cpu_count
+
+
+def make_packet(
+    benchmark_data: dict[str, Any],
+    *,
+    world_count: int,
+    step_count: int,
+    tolerance: float,
+    speedup_gate: float,
+) -> dict[str, Any]:
+    rows = benchmark_data.get("benchmarks")
+    if not isinstance(rows, list) or not rows:
+        raise SceneParityPacketError("benchmark JSON has no benchmark rows")
+    typed_rows = [row for row in rows if isinstance(row, Mapping)]
+    if len(typed_rows) != len(rows):
+        raise SceneParityPacketError("benchmark JSON has non-object rows")
+
+    cpu_row, gpu_row = _representative_rows(typed_rows, world_count, step_count)
+    cpu_ns = benchmark_timing_ns(cpu_row)
+    gpu_ns = benchmark_timing_ns(gpu_row)
+    if not math.isfinite(cpu_ns) or cpu_ns <= 0.0:
+        raise SceneParityPacketError("CPU benchmark timing is not positive")
+    if not math.isfinite(gpu_ns) or gpu_ns <= 0.0:
+        raise SceneParityPacketError("GPU benchmark timing is not positive")
+
+    max_error = _counter(gpu_row, "max_result_abs_error")
+    if max_error > tolerance:
+        raise SceneParityPacketError(
+            f"scene parity max error {max_error:.3g} exceeds {tolerance:.3g}"
+        )
+
+    worlds = _matching_int_counter(cpu_row, gpu_row, "worlds")
+    if worlds != world_count:
+        raise SceneParityPacketError(f"expected {world_count} worlds, got {worlds}")
+    steps = _matching_int_counter(cpu_row, gpu_row, "steps")
+    if steps != step_count:
+        raise SceneParityPacketError(f"expected {step_count} steps, got {steps}")
+    bodies = _matching_int_counter(cpu_row, gpu_row, "bodies")
+    scene_bodies = _matching_int_counter(cpu_row, gpu_row, "scene_body_count")
+    speedup = cpu_ns / gpu_ns
+
+    return {
+        "plan083_gpu_scene_parity_packet": {
+            "row_id": "scene-parity-speedup",
+            "scene_id": DEFAULT_SCENE_ID,
+            "same_scene_cpu_gpu": True,
+            "state_path": "private rigid-body state-batch CUDA rollout",
+            "world_count": worlds,
+            "scene_body_count": scene_bodies,
+            "body_count": bodies,
+            "step_count": steps,
+            "time_step": 0.005,
+            "max_result_abs_error": max_error,
+            "result_abs_error_tolerance": tolerance,
+            "speedup": speedup,
+            "speedup_gate": speedup_gate,
+            "meets_speedup_gate": speedup >= speedup_gate,
+            "cpu_benchmark_row": _packet_row_name(cpu_row),
+            "gpu_benchmark_row": _packet_row_name(gpu_row),
+            "limitation_status": (
+                "Reduced state-batch scene parity only; this does not run a "
+                "GPU World::step path, contact candidate construction, CCD, "
+                "barrier/friction assembly, sparse equality reduction, or "
+                "global Newton solve."
+            ),
+        },
+        "benchmarks": rows,
+    }
+
+
+def write_packet(path: Path, packet: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(packet, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if not args.skip_run:
+        run_benchmark(args)
+    try:
+        packet = make_packet(
+            _load_json(args.benchmark_json),
+            world_count=args.world_count,
+            step_count=args.step_count,
+            tolerance=args.tolerance,
+            speedup_gate=args.speedup_gate,
+        )
+    except SceneParityPacketError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    write_packet(args.output, packet)
+    row = packet["plan083_gpu_scene_parity_packet"]
+    print(
+        "Reduced scene parity packet OK: "
+        f"scene={row['scene_id']} worlds={row['world_count']} "
+        f"bodies={row['body_count']} steps={row['step_count']} "
+        f"max_error={row['max_result_abs_error']:.3g} "
+        f"speedup={row['speedup']:.3f}x "
+        f"meets_gate={row['meets_speedup_gate']}"
+    )
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/benchmark/simulation/CMakeLists.txt
+++ b/tests/benchmark/simulation/CMakeLists.txt
@@ -157,6 +157,12 @@ if(DART_SIMULATION_BUILD_BENCHMARKS)
       LABEL "simulation-cuda"
     )
     dart_add_simulation_benchmark(
+      bm_plan083_gpu_scene_parity
+      ${CMAKE_CURRENT_SOURCE_DIR}/bm_plan083_gpu_scene_parity.cpp
+      LIBRARY ${PROJECT_NAME}-simulation-cuda
+      LABEL "simulation-cuda"
+    )
+    dart_add_simulation_benchmark(
       bm_vbd_cuda
       ${CMAKE_CURRENT_SOURCE_DIR}/bm_vbd_cuda.cpp
       LIBRARY ${PROJECT_NAME}-simulation-cuda

--- a/tests/benchmark/simulation/bm_plan083_gpu_scene_parity.cpp
+++ b/tests/benchmark/simulation/bm_plan083_gpu_scene_parity.cpp
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Private reduced GPU scene-parity packet. This intentionally exercises only
+// DART-owned scene state extraction plus the private rigid-body state-batch
+// CUDA rollout. It is not a GPU World::step or contact/constraint solver claim.
+
+#include <dart/simulation/body/collision_shape.hpp>
+#include <dart/simulation/body/rigid_body.hpp>
+#include <dart/simulation/body/rigid_body_options.hpp>
+#include <dart/simulation/compute/rigid_body_state_batch.hpp>
+#include <dart/simulation/multibody/joint.hpp>
+#include <dart/simulation/world.hpp>
+
+#include <Eigen/Core>
+#include <benchmark/benchmark.h>
+#include <dart/simulation/compute/cuda/rigid_body_state_batch_cuda.cuh>
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <vector>
+
+#include <cmath>
+#include <cstddef>
+
+namespace sx = dart::simulation;
+namespace compute = dart::simulation::compute;
+namespace cuda = dart::simulation::compute::cuda;
+
+namespace {
+
+constexpr std::array<double, 4> kBridgeBoardX{-0.45, -0.15, 0.15, 0.45};
+constexpr std::size_t kSceneBodyCount = 7;
+constexpr double kTimeStep = 0.005;
+
+const Eigen::Vector3d kGravity(0.0, 0.0, -9.81);
+const Eigen::Vector3d kBridgeBoardHalfExtents(0.10, 0.16, 0.025);
+const Eigen::Vector3d kBridgePostHalfExtents(0.05, 0.20, 0.08);
+const Eigen::Vector3d kBridgeTravelerHalfExtents(0.07, 0.07, 0.07);
+
+void populateReducedHangingBridgeWorld(sx::World& world)
+{
+  world.setTimeStep(kTimeStep);
+  world.setGravity(kGravity);
+
+  sx::RigidBodyOptions leftPostOptions;
+  leftPostOptions.isStatic = true;
+  leftPostOptions.position = Eigen::Vector3d(-0.65, 0.0, 0.56);
+  sx::RigidBody leftPost
+      = world.addRigidBody("plan083_bridge_left_post", leftPostOptions);
+  leftPost.setCollisionShape(
+      sx::CollisionShape::makeBox(kBridgePostHalfExtents));
+
+  sx::RigidBodyOptions rightPostOptions;
+  rightPostOptions.isStatic = true;
+  rightPostOptions.position = Eigen::Vector3d(0.65, 0.0, 0.56);
+  sx::RigidBody rightPost
+      = world.addRigidBody("plan083_bridge_right_post", rightPostOptions);
+  rightPost.setCollisionShape(
+      sx::CollisionShape::makeBox(kBridgePostHalfExtents));
+
+  sx::RigidBody parent = leftPost;
+  for (std::size_t index = 0; index < kBridgeBoardX.size(); ++index) {
+    sx::RigidBodyOptions boardOptions;
+    boardOptions.mass = 0.25;
+    boardOptions.position = Eigen::Vector3d(kBridgeBoardX[index], 0.0, 0.50);
+    boardOptions.linearVelocity
+        = Eigen::Vector3d(0.02 * static_cast<double>(index), 0.0, -0.02);
+    boardOptions.angularVelocity
+        = Eigen::Vector3d(0.0, 0.04 + 0.01 * static_cast<double>(index), 0.0);
+    sx::RigidBody board = world.addRigidBody(
+        "plan083_bridge_board_" + std::to_string(index), boardOptions);
+    board.setFriction(0.7);
+    board.setCollisionShape(
+        sx::CollisionShape::makeBox(kBridgeBoardHalfExtents));
+    world.addRigidBodyFixedJoint(
+        "plan083_bridge_point_connection_" + std::to_string(index),
+        parent,
+        board);
+    parent = board;
+  }
+
+  sx::RigidBodyOptions travelerOptions;
+  travelerOptions.mass = 0.12;
+  travelerOptions.position = Eigen::Vector3d(-0.60, 0.0, 0.82);
+  travelerOptions.linearVelocity = Eigen::Vector3d(0.35, 0.0, -0.05);
+  travelerOptions.angularVelocity = Eigen::Vector3d(0.0, 0.25, 0.15);
+  sx::RigidBody traveler
+      = world.addRigidBody("plan083_bridge_traveler", travelerOptions);
+  traveler.setFriction(0.4);
+  traveler.setCollisionShape(
+      sx::CollisionShape::makeBox(kBridgeTravelerHalfExtents));
+
+  world.enterSimulationMode();
+}
+
+void replicateArray(
+    const std::vector<double>& singleWorld,
+    const std::size_t componentCount,
+    const std::size_t bodyCount,
+    const std::size_t worldCount,
+    std::vector<double>& replicated)
+{
+  replicated.assign(componentCount * bodyCount * worldCount, 0.0);
+  for (std::size_t world = 0; world < worldCount; ++world) {
+    const std::size_t outputBase = world * componentCount * bodyCount;
+    std::copy(
+        singleWorld.begin(),
+        singleWorld.end(),
+        replicated.begin() + static_cast<std::ptrdiff_t>(outputBase));
+  }
+}
+
+compute::RigidBodyStateBatch replicateState(
+    const compute::RigidBodyStateBatch& singleWorld,
+    const std::size_t worldCount)
+{
+  compute::RigidBodyStateBatch batch;
+  batch.worldCount = worldCount;
+  batch.bodyCount = singleWorld.bodyCount;
+  replicateArray(
+      singleWorld.position,
+      3,
+      singleWorld.bodyCount,
+      worldCount,
+      batch.position);
+  replicateArray(
+      singleWorld.orientation,
+      4,
+      singleWorld.bodyCount,
+      worldCount,
+      batch.orientation);
+  replicateArray(
+      singleWorld.linearVelocity,
+      3,
+      singleWorld.bodyCount,
+      worldCount,
+      batch.linearVelocity);
+  replicateArray(
+      singleWorld.angularVelocity,
+      3,
+      singleWorld.bodyCount,
+      worldCount,
+      batch.angularVelocity);
+  return batch;
+}
+
+compute::RigidBodyModelBatch replicateModel(
+    const compute::RigidBodyModelBatch& singleWorld,
+    const std::size_t worldCount)
+{
+  compute::RigidBodyModelBatch batch;
+  batch.worldCount = worldCount;
+  batch.bodyCount = singleWorld.bodyCount;
+  replicateArray(
+      singleWorld.inverseMass,
+      1,
+      singleWorld.bodyCount,
+      worldCount,
+      batch.inverseMass);
+  replicateArray(
+      singleWorld.inertia, 9, singleWorld.bodyCount, worldCount, batch.inertia);
+  return batch;
+}
+
+std::vector<double> makeGravityForce(const compute::RigidBodyModelBatch& model)
+{
+  std::vector<double> force(3 * model.worldCount * model.bodyCount, 0.0);
+  for (std::size_t world = 0; world < model.worldCount; ++world) {
+    for (std::size_t body = 0; body < model.bodyCount; ++body) {
+      const std::size_t scalarIndex = world * model.bodyCount + body;
+      const double inverseMass = model.inverseMass[scalarIndex];
+      if (inverseMass <= 0.0 || !std::isfinite(inverseMass)) {
+        continue;
+      }
+      const Eigen::Vector3d bodyForce = kGravity / inverseMass;
+      const std::size_t vectorIndex = 3 * scalarIndex;
+      force[vectorIndex + 0] = bodyForce.x();
+      force[vectorIndex + 1] = bodyForce.y();
+      force[vectorIndex + 2] = bodyForce.z();
+    }
+  }
+  return force;
+}
+
+double maxAbsDiff(
+    const std::vector<double>& lhs, const std::vector<double>& rhs)
+{
+  double result = 0.0;
+  for (std::size_t index = 0; index < lhs.size(); ++index) {
+    result = std::max(result, std::abs(lhs[index] - rhs[index]));
+  }
+  return result;
+}
+
+double maxStateAbsDiff(
+    const compute::RigidBodyStateBatch& lhs,
+    const compute::RigidBodyStateBatch& rhs)
+{
+  return std::max(
+      {maxAbsDiff(lhs.position, rhs.position),
+       maxAbsDiff(lhs.orientation, rhs.orientation),
+       maxAbsDiff(lhs.linearVelocity, rhs.linearVelocity),
+       maxAbsDiff(lhs.angularVelocity, rhs.angularVelocity)});
+}
+
+compute::RigidBodyStateBatch rolloutCpu(
+    compute::RigidBodyStateBatch state,
+    const compute::RigidBodyModelBatch& model,
+    const std::vector<double>& force,
+    const std::size_t stepCount)
+{
+  for (std::size_t step = 0; step < stepCount; ++step) {
+    compute::integrateRigidBodyStateBatch(state, model, force, kTimeStep);
+  }
+  return state;
+}
+
+struct ReducedSceneParityFixture
+{
+  ReducedSceneParityFixture(
+      const std::size_t requestedWorldCount, const std::size_t requestedSteps)
+    : worldCount(requestedWorldCount), stepCount(requestedSteps)
+  {
+    sx::World seed;
+    populateReducedHangingBridgeWorld(seed);
+    const compute::RigidBodyStateBatch singleState
+        = compute::extractRigidBodyState(seed);
+    const compute::RigidBodyModelBatch singleModel
+        = compute::extractRigidBodyModelBatch(seed);
+
+    initial = replicateState(singleState, worldCount);
+    model = replicateModel(singleModel, worldCount);
+    force = makeGravityForce(model);
+    expected = rolloutCpu(initial, model, force, stepCount);
+  }
+
+  std::size_t worldCount = 0;
+  std::size_t stepCount = 0;
+  compute::RigidBodyStateBatch initial;
+  compute::RigidBodyModelBatch model;
+  std::vector<double> force;
+  compute::RigidBodyStateBatch expected;
+};
+
+void setCommonCounters(
+    benchmark::State& state,
+    const ReducedSceneParityFixture& fixture,
+    const double maxError)
+{
+  state.counters["worlds"] = static_cast<double>(fixture.worldCount);
+  state.counters["bodies"] = static_cast<double>(fixture.initial.bodyCount);
+  state.counters["steps"] = static_cast<double>(fixture.stepCount);
+  state.counters["scene_body_count"] = static_cast<double>(kSceneBodyCount);
+  state.counters["max_result_abs_error"] = maxError;
+  state.SetItemsProcessed(
+      static_cast<int64_t>(
+          state.iterations() * fixture.worldCount * fixture.initial.bodyCount
+          * fixture.stepCount));
+}
+
+} // namespace
+
+//==============================================================================
+static void BM_Plan083SceneParityCpu(benchmark::State& state)
+{
+  const auto worldCount = static_cast<std::size_t>(state.range(0));
+  const auto stepCount = static_cast<std::size_t>(state.range(1));
+  ReducedSceneParityFixture fixture(worldCount, stepCount);
+  double maxError = 0.0;
+
+  for (auto _ : state) {
+    compute::RigidBodyStateBatch current
+        = rolloutCpu(fixture.initial, fixture.model, fixture.force, stepCount);
+    maxError = maxStateAbsDiff(current, fixture.expected);
+    benchmark::DoNotOptimize(current.position.data());
+    benchmark::DoNotOptimize(maxError);
+    benchmark::ClobberMemory();
+  }
+
+  setCommonCounters(state, fixture, maxError);
+}
+
+//==============================================================================
+static void BM_Plan083SceneParityCuda(benchmark::State& state)
+{
+  if (!cuda::isCudaRuntimeAvailable()) {
+    state.SkipWithError("CUDA runtime has no available device");
+    return;
+  }
+
+  const auto worldCount = static_cast<std::size_t>(state.range(0));
+  const auto stepCount = static_cast<std::size_t>(state.range(1));
+  ReducedSceneParityFixture fixture(worldCount, stepCount);
+  double maxError = 0.0;
+
+  for (auto _ : state) {
+    compute::RigidBodyStateBatch current = fixture.initial;
+    cuda::rolloutRigidBodyStateBatchCuda(
+        current, fixture.model, fixture.force, kTimeStep, stepCount);
+    maxError = maxStateAbsDiff(current, fixture.expected);
+    benchmark::DoNotOptimize(current.position.data());
+    benchmark::DoNotOptimize(maxError);
+    benchmark::ClobberMemory();
+  }
+
+  setCommonCounters(state, fixture, maxError);
+}
+
+BENCHMARK(BM_Plan083SceneParityCpu)->Args({1024, 16})->Args({4096, 64});
+BENCHMARK(BM_Plan083SceneParityCuda)->Args({1024, 16})->Args({4096, 64});

--- a/tests/test_plan083_completion_audit.py
+++ b/tests/test_plan083_completion_audit.py
@@ -124,5 +124,6 @@ def test_plan083_completion_audit_requires_blocked_cpu_and_gpu_rows() -> None:
         "audit must block CPU packet completion while CPU rows remain planned" in errors
     )
     assert (
-        "audit must block GPU packet completion while GPU rows remain planned" in errors
+        "audit must block GPU packet completion while GPU rows remain incomplete"
+        in errors
     )

--- a/tests/test_plan083_gpu_scene_parity_packet.py
+++ b/tests/test_plan083_gpu_scene_parity_packet.py
@@ -1,0 +1,103 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "write_plan083_gpu_scene_parity_packet.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "write_plan083_gpu_scene_parity_packet",
+        SCRIPT,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row(name: str, real_time: float, max_error: float = 0.0) -> dict[str, object]:
+    return {
+        "name": f"{name}_median",
+        "run_name": f"{name}_median",
+        "aggregate_name": "median",
+        "real_time": real_time,
+        "cpu_time": real_time,
+        "time_unit": "ns",
+        "worlds": 4096,
+        "bodies": 7,
+        "scene_body_count": 7,
+        "steps": 64,
+        "max_result_abs_error": max_error,
+    }
+
+
+def _packet_rows(max_error: float = 1e-12) -> dict[str, object]:
+    return {
+        "benchmarks": [
+            _row("BM_Plan083SceneParityCpu/4096/64", 1_000_000.0),
+            _row("BM_Plan083SceneParityCuda/4096/64", 500_000.0, max_error),
+        ]
+    }
+
+
+def test_scene_parity_packet_accepts_reduced_same_scene_rows() -> None:
+    module = _load_module()
+
+    packet = module.make_packet(
+        _packet_rows(),
+        world_count=4096,
+        step_count=64,
+        tolerance=1e-9,
+        speedup_gate=1.25,
+    )
+
+    row = packet["plan083_gpu_scene_parity_packet"]
+    assert row["row_id"] == "scene-parity-speedup"
+    assert row["same_scene_cpu_gpu"] is True
+    assert row["world_count"] == 4096
+    assert row["body_count"] == 7
+    assert row["step_count"] == 64
+    assert row["speedup"] == 2.0
+    assert row["meets_speedup_gate"] is True
+    assert "Reduced state-batch scene parity only" in row["limitation_status"]
+
+
+def test_scene_parity_packet_rejects_missing_gpu_row() -> None:
+    module = _load_module()
+    data = {"benchmarks": [_row("BM_Plan083SceneParityCpu/4096/64", 1_000_000.0)]}
+
+    try:
+        module.make_packet(
+            data,
+            world_count=4096,
+            step_count=64,
+            tolerance=1e-9,
+            speedup_gate=1.25,
+        )
+    except module.SceneParityPacketError as exc:
+        assert "missing median benchmark row: BM_Plan083SceneParityCuda/4096/64" in str(
+            exc
+        )
+    else:
+        raise AssertionError("missing GPU benchmark row should fail")
+
+
+def test_scene_parity_packet_rejects_accuracy_failure() -> None:
+    module = _load_module()
+
+    try:
+        module.make_packet(
+            _packet_rows(max_error=1e-3),
+            world_count=4096,
+            step_count=64,
+            tolerance=1e-9,
+            speedup_gate=1.25,
+        )
+    except module.SceneParityPacketError as exc:
+        assert "scene parity max error" in str(exc)
+    else:
+        raise AssertionError("high scene parity error should fail")


### PR DESCRIPTION
## Summary

- Adds a private reduced scene state-batch CPU/GPU parity packet for a hanging-bridge-style DART rigid scene.
- Keeps the scene speed row in progress because the packet exercises DART scene state extraction plus private rigid-body state-batch CUDA rollout, not a GPU `World::step` contact/constraint/Newton solver path.

## Motivation / Problem

- The GPU evidence map had local contact, CCD, barrier/friction, PSD, and assembly/solve packets, but no scene-level packet.
- This adds bounded scene-state parity evidence without public backend API exposure or default behavior changes.

## Changes / Key Changes

- Adds a CUDA benchmark that extracts a reduced DART scene into rigid body state batches and compares CPU rollout with private CUDA rollout.
- Adds a packet writer and tests for the reduced scene parity evidence.
- Updates the GPU packet, completion audit, dashboard, and dev-task handoff docs to move the row to in progress and record the remaining full-solver gaps.
- Tightens the completion-audit checker so GPU claims remain blocked while GPU rows are incomplete, not only while they are planned.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- focused packet/audit pytest suite: 12 passed
- `pixi run -e cuda build-cuda Release`
- `ctest --test-dir build/cuda/cpp/Release --output-on-failure -L simulation-cuda -E '^test_lcp_jacobi_batch_cuda$'` (7/7 passed)
- CUDA benchmark smoke for the scene-parity benchmark
- `pixi run -e cuda bm-plan083-gpu-scene-parity-packet`
- Final packet: scene=`plan083_hanging_bridge_reduced_state_batch`, worlds=4096, bodies=7, steps=64, max_error=1.1102230246251565e-16, speedup=18.792052761946252x
- Attempted `pixi run -e cuda test-cuda Release`; interrupted after `test_lcp_jacobi_batch_cuda` ran for more than 1h19m with no output. This branch does not change that test; all other CUDA tests and the new CUDA benchmark smoke passed locally.

## Breaking Changes

- [x] None
- Private CUDA evidence only; no public API or behavior changes.

## Related Issues / PRs (backports)

- Stacked on #2981.
- Backports: N/A, private DART 7 implementation evidence only.

---

#### Checklist

- [x] Milestone set (DART 7.0 for main, DART 6.17.1 for release-6.17)
- [x] CHANGELOG.md updated if required: N/A, private evidence packet only.
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no public methods/classes; plan evidence sidecars updated.
- [x] Add Python bindings (dartpy) if applicable: N/A, private CUDA path only.
