### PR TITLE
Free disk space before Linux debug tests

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -340,6 +340,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # The Debug build keeps full debug info for every test executable. Recent
+      # full-CI runs can exhaust the GitHub-hosted runner before the final test
+      # links complete, so reclaim large preinstalled toolchains we do not use.
+      - name: Free up disk space
+        run: |
+          set -x
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Setup pixi (CI)
         uses: ./.github/actions/setup-pixi-ci
         with:


### PR DESCRIPTION
## Summary

- Free unused hosted-runner toolchains before the Linux `Debug Tests` job sets up Pixi, matching the existing disk-space mitigation used by the coverage job.

## Motivation / Problem

- The `CI Linux / Debug Tests` job in https://github.com/dartsim/dart/actions/runs/27423402468/job/81054996799 exhausted runner disk space while linking Debug test executables.
- The log showed GitHub's disk-space warning at 1 MB remaining, followed by repeated `/usr/bin/ld: final link failed: No space left on device` failures.

## Changes / Key Changes

- Add a `Free up disk space` step to `build-debug` before Pixi setup.
- Remove preinstalled toolchains and Docker images that DART's Linux Debug job does not use.

## Testing

- `pixi run lint`
- `git diff --check`

## Breaking Changes

- [x] None
- CI workflow-only change.

## Related Issues / PRs (backports)

- Failed job: https://github.com/dartsim/dart/actions/runs/27423402468/job/81054996799
- Backports: None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required (N/A: CI workflow-only fix)
- [x] Add unit tests for new functionality (N/A: no product code change)
- [x] Document new methods and classes (N/A: no API change)
- [x] Add Python bindings (dartpy) if applicable (N/A: no binding change)
