### PR TITLE
WP-091.1: Record AVBD solver identity and relabel contact-scene evidence

### DIFF
--- a/docs/dev_tasks/avbd_solver/README.md
+++ b/docs/dev_tasks/avbd_solver/README.md
@@ -9,6 +9,26 @@ Corpus matrix:
 
 ## Current Status
 
+- Latest local follow-up: PLAN-091 WP-091.1 relabels the AVBD contact-scene
+  evidence rows: no `avbd-demo2d`/`avbd-demo3d` benchmark or py-demo scene
+  emplaces the internal AVBD rigid-contact opt-in config
+  (`comps::RigidAvbdContactConfig`), because AVBD contact is not
+  facade-selectable, so every rigid contact in those scenes ran DART's default
+  sequential-impulse contact path. The pure-contact rows (2D Dynamic Friction,
+  Static Friction, Pyramid, Cards, Stack, and Stack Ratio; 3D Ground, Dynamic
+  Friction, Static Friction, Pyramid, Stack, and Stack Ratio) timed no AVBD
+  rows at all; the joint-plus-contact rows (2D Fracture, Soft Body, Joint
+  Grid, and Net; 3D Soft Body, Bridge, and Breakable) timed AVBD
+  point-joint/motor/spring rows while their ordinary contacts ran sequential
+  impulse; incidental link-link contacts in the chain rows (2D Rod, Rope,
+  Heavy Rope, and Hanging Rope; 3D Rope and Heavy Rope) also ran sequential
+  impulse. Their faster/slower-than-native ratios are whole-pipeline
+  `World::step` comparisons, not AVBD-contact-solver comparisons. New AVBD
+  evidence packets must machine-record `resolved_solver_identity` at AVBD
+  packet schema version 2 (`scripts/avbd_packet_schema.py`, enforced by
+  `pixi run check-avbd-packets`); committed packet bytes are unchanged. This
+  is an evidence-integrity relabel only; it does not close or reopen any AVBD
+  solver, source-corpus CPU-win, GPU, or paper-number gate.
 - Latest local follow-up: C++ and dartpy public articulated AVBD stiffness
   persistence coverage now exercises fixed, revolute, prismatic, and spherical
   public articulated facades for both same-multibody link pairs and world-link

--- a/docs/dev_tasks/avbd_solver/RESUME.md
+++ b/docs/dev_tasks/avbd_solver/RESUME.md
@@ -2,6 +2,27 @@
 
 ## Last Session Summary
 
+Latest local follow-up: PLAN-091 WP-091.1 relabels the AVBD contact-scene
+evidence rows: no `avbd-demo2d`/`avbd-demo3d` benchmark or py-demo scene
+emplaces the internal AVBD rigid-contact opt-in config
+(`comps::RigidAvbdContactConfig`), because AVBD contact is not
+facade-selectable, so every rigid contact in those scenes ran DART's default
+sequential-impulse contact path. The pure-contact rows (2D Dynamic Friction,
+Static Friction, Pyramid, Cards, Stack, and Stack Ratio; 3D Ground, Dynamic
+Friction, Static Friction, Pyramid, Stack, and Stack Ratio) timed no AVBD rows
+at all; the joint-plus-contact rows (2D Fracture, Soft Body, Joint Grid, and
+Net; 3D Soft Body, Bridge, and Breakable) timed AVBD point-joint/motor/spring
+rows while their ordinary contacts ran sequential impulse; incidental
+link-link contacts in the chain rows (2D Rod, Rope, Heavy Rope, and Hanging
+Rope; 3D Rope and Heavy Rope) also ran sequential impulse. Their
+faster/slower-than-native ratios are whole-pipeline `World::step` comparisons,
+not AVBD-contact-solver comparisons. New AVBD evidence packets must
+machine-record `resolved_solver_identity` at AVBD packet schema version 2
+(`scripts/avbd_packet_schema.py`, enforced by `pixi run check-avbd-packets`);
+committed packet bytes are unchanged. This is an evidence-integrity relabel
+only; it does not close or reopen any AVBD solver, source-corpus CPU-win, GPU,
+or paper-number gate.
+
 Latest local follow-up: C++ and dartpy public articulated AVBD stiffness
 persistence coverage now exercises fixed, revolute, prismatic, and spherical
 public articulated facades for both same-multibody link pairs and world-link

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -58,7 +58,7 @@ contracts this plan is landing.
 
 ### WS0 — Evidence integrity and guardrails
 
-#### WP-091.1 Solver-identity recording and AVBD evidence relabel
+#### WP-091.1 Solver-identity recording and AVBD evidence relabel [claimed]
 
 - Objective: every benchmark evidence packet machine-records the resolved
   solver configuration, and the AVBD contact-scene rows that timed the
@@ -95,6 +95,40 @@ contracts this plan is landing.
   all six sites; some warm-started AVBD contact paths do run through the
   default step, so classify rows by config-component presence, not by scene
   name.
+- Evidence: affected rows were classified by config-component presence —
+  `tests/benchmark/simulation/bm_avbd_rigid_fixed_joint.cpp` and the py-demo
+  scenes never emplace `comps::RigidAvbdContactConfig` (the benchmark TU's
+  only internal-AVBD use is `classifyAvbdRigidWorldEndpoint`), and
+  `dart/simulation/compute/world_step_stage.cpp` routes every contact set
+  without that config to the sequential-impulse path while keeping AVBD
+  joint rows active. Affected contact rows: pure-contact (no AVBD code in
+  the timed solve) — `avbd-demo2d-{dynamic-friction, static-friction,
+pyramid, cards, stack, stack-ratio}` and `avbd-demo3d-{ground,
+dynamic-friction, static-friction, pyramid, stack, stack-ratio}`;
+  joint-plus-contact (AVBD point-joint/motor/spring rows with
+  sequential-impulse contacts) — `avbd-demo2d-{fracture, soft-body,
+joint-grid, net}` and `avbd-demo3d-{soft-body, bridge, breakable}`; chain
+  rows whose edge-touching links' incidental contacts also ran sequential
+  impulse — `avbd-demo2d-{rod, rope, heavy-rope, hanging-rope}` and
+  `avbd-demo3d-{rope, heavy-rope}`. Fifteen of these carried "faster than
+  native" claims (2D Fracture, Dynamic Friction, Static Friction, Pyramid,
+  Stack, Stack Ratio; 3D Ground, Dynamic Friction, Static Friction, Pyramid,
+  Stack, Stack Ratio, Soft Body, Bridge, Breakable). Schema:
+  `scripts/avbd_packet_schema.py` bumps the AVBD packet family to schema
+  version 2 with the required `resolved_solver_identity` field contract;
+  `scripts/check_avbd_packets.py` (`pixi run check-avbd-packets`, in the
+  `check-lint` aggregate) rejects identity-less packets at version >= 2 and
+  new packet files below version 2 while the 48 committed v1 packets stay
+  readable; `tests/test_check_avbd_packets.py` (9 pytest cases via
+  `pixi run python -m pytest`) proves the rejection and acceptance paths,
+  including the avbd-claim-without-emplaced-config consistency rule. All six
+  mirrored claim sites relabeled consistently (dashboard PLAN-104 entry,
+  `104-vertex-block-descent-solver.md`, the demo-corpus sidecar, the AVBD
+  paper-gap audit, and the dev-task `README.md`/`RESUME.md` status entries
+  with the does-not-close-gates disclaimer); committed `avbd-*-packet.json`
+  bytes untouched. Gates: `pixi run lint`, `pixi run check-docs-policy`,
+  `pixi run check-avbd-packets`, and
+  `pixi run python -m pytest tests/test_check_avbd_packets.py` green.
 
 #### WP-091.2 Golden trajectories for the default step
 

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -129,6 +129,23 @@ joint-grid, net}` and `avbd-demo3d-{soft-body, bridge, breakable}`; chain
   bytes untouched. Gates: `pixi run lint`, `pixi run check-docs-policy`,
   `pixi run check-avbd-packets`, and
   `pixi run python -m pytest tests/test_check_avbd_packets.py` green.
+  Writer-migration scope: per packet Scope (b) ("do not sweep all writer
+  scripts here"), this packet establishes the shared schema contract
+  (`scripts/avbd_packet_schema.py`), the enforcing checker, and the relabel
+  only. The `scripts/write_avbd_*_packet.py` scripts still emit
+  `schema_version: 1` and do not yet import the shared schema module or write
+  `resolved_solver_identity`; the 48 committed v1 packets stay valid through
+  the checker's legacy allowlist. Wiring the writer family to emit schema
+  version 2 with a machine-captured identity (which requires running each
+  scene under instrumentation and regenerating its packet bytes) is deferred
+  follow-up work, not done here — track it as a follow-up packet before the
+  next AVBD evidence refresh; until then, the contract binds new packet files
+  via the checker rather than via the writers. Acceptance status: implemented
+  by this session with the focused gates above green; per
+  `docs/ai/orchestration.md` the implementing session does not self-approve,
+  so the packet stays `[claimed]` awaiting an independent/maintainer
+  acceptance pass (a critic subagent self-review run this session found no
+  blocking issues but is not the independent acceptance check).
 
 #### WP-091.2 Golden trajectories for the default step
 

--- a/docs/plans/104-vertex-block-descent-solver.md
+++ b/docs/plans/104-vertex-block-descent-solver.md
@@ -321,6 +321,24 @@ end-to-end dashboard benchmark rows for the public motor paths, and tracked
 and
 [`avbd-rigid-prismatic-motor-packet.json`](104-vertex-block-descent-solver/avbd-rigid-prismatic-motor-packet.json)
 visual/benchmark evidence.
+Solver-identity relabel (PLAN-091 WP-091.1): no `avbd-demo2d`/`avbd-demo3d`
+benchmark or py-demo scene emplaces the internal AVBD rigid-contact opt-in
+config (`comps::RigidAvbdContactConfig`), because AVBD contact is not
+facade-selectable, so every rigid contact in the source-row scenes below ran
+DART's default sequential-impulse contact path. The native-runner timing
+ratios for contact scenes are whole-pipeline `World::step` comparisons, not
+AVBD-contact-solver comparisons: the pure-contact rows (2D Dynamic Friction,
+Static Friction, Pyramid, Cards, Stack, and Stack Ratio; 3D Ground, Dynamic
+Friction, Static Friction, Pyramid, Stack, and Stack Ratio) timed no AVBD rows
+at all; the joint-plus-contact rows (2D Fracture, Soft Body, Joint Grid, and
+Net; 3D Soft Body, Bridge, and Breakable) timed AVBD
+point-joint/motor/spring rows while their ordinary contacts ran sequential
+impulse; and incidental link-link contacts in the chain rows (2D Rod, Rope,
+Heavy Rope, and Hanging Rope; 3D Rope and Heavy Rope) also ran sequential
+impulse. This relabel changes no committed packet bytes and neither closes nor
+reopens any PLAN-104 completion gate; new AVBD evidence packets must
+machine-record `resolved_solver_identity` at AVBD packet schema version 2,
+enforced by `pixi run check-avbd-packets`.
 The `avbd_empty_baseline` py-demo and `BM_AvbdEmptyWorldStep` row now provide a
 first runnable baseline for the 2D/3D source-demo empty rows, with source
 revision/default metadata and a `sceneEmpty` zero-count reference invariant.

--- a/docs/plans/104-vertex-block-descent-solver/avbd-demo-corpus.md
+++ b/docs/plans/104-vertex-block-descent-solver/avbd-demo-corpus.md
@@ -32,6 +32,28 @@ Status values:
 - `Complete`: all evidence in the contract above exists and is linked from this
   matrix.
 
+## Solver-Identity Relabel (PLAN-091 WP-091.1)
+
+No `avbd-demo2d`/`avbd-demo3d` benchmark or py-demo scene in this matrix
+emplaces the internal AVBD rigid-contact opt-in config
+(`comps::RigidAvbdContactConfig`), because AVBD contact is not
+facade-selectable, so every rigid contact in those scenes ran DART's default
+sequential-impulse contact path. The native-runner timing ratios for contact
+scenes are whole-pipeline `World::step` comparisons, not AVBD-contact-solver
+comparisons: the pure-contact rows (2D Dynamic Friction, Static Friction,
+Pyramid, Cards, Stack, and Stack Ratio; 3D Ground, Dynamic Friction, Static
+Friction, Pyramid, Stack, and Stack Ratio) timed no AVBD rows at all; the
+joint-plus-contact rows (2D Fracture, Soft Body, Joint Grid, and Net; 3D Soft
+Body, Bridge, and Breakable) timed AVBD point-joint/motor/spring rows while
+their ordinary contacts ran sequential impulse; and incidental link-link
+contacts in the chain rows (2D Rod, Rope, Heavy Rope, and Hanging Rope; 3D
+Rope and Heavy Rope) also ran sequential impulse. A `Complete` status below
+covers the row's evidence contract, not an AVBD-contact-solver claim. This
+relabel changes no committed packet bytes and neither closes nor reopens any
+PLAN-104 completion gate; new AVBD evidence packets must machine-record
+`resolved_solver_identity` at AVBD packet schema version 2, enforced by
+`pixi run check-avbd-packets`.
+
 ## Current Narrow DART Surfaces
 
 These surfaces are useful foundations, but they do not complete the overall

--- a/docs/plans/104-vertex-block-descent-solver/avbd-paper-gap-audit.md
+++ b/docs/plans/104-vertex-block-descent-solver/avbd-paper-gap-audit.md
@@ -46,6 +46,28 @@ paper-inspired row update. For this paper, "implemented" means:
 - API and pipeline refactors are allowed when they make the DART 7/8
   experimental architecture cleaner and more scalable.
 
+## Solver-Identity Relabel (PLAN-091 WP-091.1)
+
+No `avbd-demo2d`/`avbd-demo3d` benchmark or py-demo scene cited by this audit
+emplaces the internal AVBD rigid-contact opt-in config
+(`comps::RigidAvbdContactConfig`), because AVBD contact is not
+facade-selectable, so every rigid contact in those scenes ran DART's default
+sequential-impulse contact path. The native-runner timing ratios for contact
+scenes are whole-pipeline `World::step` comparisons, not AVBD-contact-solver
+comparisons: the pure-contact rows (2D Dynamic Friction, Static Friction,
+Pyramid, Cards, Stack, and Stack Ratio; 3D Ground, Dynamic Friction, Static
+Friction, Pyramid, Stack, and Stack Ratio) timed no AVBD rows at all; the
+joint-plus-contact rows (2D Fracture, Soft Body, Joint Grid, and Net; 3D Soft
+Body, Bridge, and Breakable) timed AVBD point-joint/motor/spring rows while
+their ordinary contacts ran sequential impulse; and incidental link-link
+contacts in the chain rows (2D Rod, Rope, Heavy Rope, and Hanging Rope; 3D
+Rope and Heavy Rope) also ran sequential impulse. Faster-than-native rows in
+the gap matrix and performance targets below carry this classification. This
+relabel changes no committed packet bytes and neither closes nor reopens any
+PLAN-104 completion gate; new AVBD evidence packets must machine-record
+`resolved_solver_identity` at AVBD packet schema version 2, enforced by
+`pixi run check-avbd-packets`.
+
 ## Verified Reference Details
 
 - **Hard constraints:** Each scalar row carries finite stiffness `k` and dual

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -616,7 +616,25 @@ its own line so status updates remain git-history friendly.
   fields with
   [`avbd-paper-scale-high-ratio-chain-packet.json`](104-vertex-block-descent-solver/avbd-paper-scale-high-ratio-chain-packet.json)
   visual/benchmark evidence, while keeping the same-hardware comparison and GPU
-  gates open. Public
+  gates open. Solver-identity relabel (PLAN-091 WP-091.1): no
+  `avbd-demo2d`/`avbd-demo3d` benchmark or py-demo scene emplaces the internal
+  AVBD rigid-contact opt-in config (`comps::RigidAvbdContactConfig`), because
+  AVBD contact is not facade-selectable, so every rigid contact in the
+  source-row scenes below ran DART's default sequential-impulse contact path.
+  The native-runner timing ratios for contact scenes are whole-pipeline
+  `World::step` comparisons, not AVBD-contact-solver comparisons: the
+  pure-contact rows (2D Dynamic Friction, Static Friction, Pyramid, Cards,
+  Stack, and Stack Ratio; 3D Ground, Dynamic Friction, Static Friction,
+  Pyramid, Stack, and Stack Ratio) timed no AVBD rows at all; the
+  joint-plus-contact rows (2D Fracture, Soft Body, Joint Grid, and Net; 3D
+  Soft Body, Bridge, and Breakable) timed AVBD point-joint/motor/spring rows
+  while their ordinary contacts ran sequential impulse; and incidental
+  link-link contacts in the chain rows (2D Rod, Rope, Heavy Rope, and Hanging
+  Rope; 3D Rope and Heavy Rope) also ran sequential impulse. This relabel
+  changes no committed packet bytes and neither closes nor reopens any
+  PLAN-104 completion gate; new AVBD evidence packets must machine-record
+  `resolved_solver_identity` at AVBD packet schema version 2, enforced by
+  `pixi run check-avbd-packets`. Public
   empty-scene corpus baseline coverage is now visible through
   `avbd_empty_baseline`, a focused Python smoke that checks source revisions,
   default source parameters, and the `sceneEmpty` zero-count invariant, and

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -22,11 +22,20 @@ its own line so status updates remain git-history friendly.
 - Status: Active
 - Horizon: Now
 - Dimension: Algorithm extensibility
-- Next step: Execute all five WS0 evidence-integrity packets first, in plan
-  document order (WP-091.1 solver-identity recording and AVBD relabel,
-  WP-091.2 golden trajectories, WP-091.3 architecture-claim lint, WP-091.4
-  legacy freeze, WP-091.5 plan-ID renumber), then open WS1 with WP-091.10
-  (virtual finalize/prepare on the stage contract). Packets are
+- Next step: WP-091.1 (solver-identity recording and AVBD relabel) is
+  `[claimed]` — implemented and awaiting an independent/maintainer acceptance
+  pass. The AVBD packet family now has a shared schema contract that
+  machine-records resolved solver identity at schema version 2, enforced for
+  new packet files by `pixi run check-avbd-packets` in the `check-lint`
+  aggregate, and the six mirrored contact-scene claim sites are relabeled;
+  writer-script migration to emit the new field is a recorded follow-up (see
+  the packet Evidence bullet). After WP-091.1 is accepted, execute the
+  remaining four WS0 evidence-integrity packets in plan document order:
+  WP-091.2 golden trajectories (next; behavior-lock guardrail that hard-gates
+  the refactor-heavy packets), WP-091.3 architecture-claim lint, WP-091.4
+  legacy freeze (blocked on maintainer Decision 5 direction), WP-091.5
+  plan-ID renumber. Then open WS1 with WP-091.10 (virtual finalize/prepare on
+  the stage contract). Packets are
   orchestrator-authored per [`../ai/orchestration.md`](../ai/orchestration.md)
   and picked up via `dart-execute-packet`; availability follows each packet's
   own Dependencies line. The standing rule applies now: new solver-family

--- a/pixi.toml
+++ b/pixi.toml
@@ -275,6 +275,7 @@ lint-plan083-completion-audit = { cmd = [
   "python",
   "scripts/check_plan083_completion_audit.py",
 ] }
+lint-avbd-packets = { cmd = ["python", "scripts/check_avbd_packets.py"] }
 
 update-api-boundary-inventory = { cmd = [
   "python",
@@ -304,6 +305,7 @@ lint = { depends-on = [
   "lint-plan083-cpu-scene-corpus",
   "lint-plan083-gpu-parity-packet",
   "lint-plan083-completion-audit",
+  "lint-avbd-packets",
   "sync-ai-commands",
 ] }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -372,6 +372,7 @@ check-plan083-completion-audit = { cmd = [
   "python",
   "scripts/check_plan083_completion_audit.py",
 ] }
+check-avbd-packets = { cmd = ["python", "scripts/check_avbd_packets.py"] }
 
 check-api-boundary-inventory = { cmd = [
   "python",
@@ -410,6 +411,7 @@ check-lint = { depends-on = [
   "check-phase5-cuda-workflow",
   "check-plan083-gpu-parity-packet",
   "check-plan083-completion-audit",
+  "check-avbd-packets",
   "check-api-boundary-inventory",
   "check-ai-commands",
 ] }

--- a/scripts/avbd_packet_schema.py
+++ b/scripts/avbd_packet_schema.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Shared schema contract for AVBD evidence packets (PLAN-091 WP-091.1).
+
+This module owns the AVBD packet-writer family's shared packet schema
+version and the resolved-solver-identity field contract. From
+``AVBD_PACKET_SCHEMA_VERSION`` onward a packet is valid only when it
+machine-records the solver configuration that actually ran; committed
+packets at older versions stay readable, and their contact rows are
+relabeled in prose instead (see the standing rule in
+``docs/design/dart7_architecture_assessment.md`` and item 10 of
+``docs/plans/solver-family-intake.md``).
+
+Writer scripts adopt this contract the next time their packet is
+regenerated; ``scripts/check_avbd_packets.py`` enforces it for
+committed packets. Other packet families adopt the same field contract
+in follow-up PLAN-091 packets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+# Current AVBD packet schema version. Packets written at this version or
+# newer must carry RESOLVED_SOLVER_IDENTITY_KEY.
+AVBD_PACKET_SCHEMA_VERSION = 2
+
+# First schema version that requires the resolved-solver-identity field.
+SOLVER_IDENTITY_MIN_SCHEMA_VERSION = 2
+
+RESOLVED_SOLVER_IDENTITY_KEY = "resolved_solver_identity"
+
+# The contact path that actually resolved rigid-rigid contacts in the timed
+# scene. "avbd" is valid only when the scene emplaces the internal AVBD
+# rigid-contact opt-in config so that every active contact has a configured
+# body; contact-free scenes record "none".
+ALLOWED_RIGID_CONTACT_SOLVERS = (
+    "avbd",
+    "boxed_lcp",
+    "none",
+    "sequential_impulse",
+)
+
+# The solver family that resolved rigid-body point-joint/motor/distance-spring
+# rows; joint-free scenes record "none".
+ALLOWED_RIGID_POINT_JOINT_SOLVERS = ("avbd", "none")
+
+_REQUIRED_ENUM_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("rigid_contact_solver", ALLOWED_RIGID_CONTACT_SOLVERS),
+    ("rigid_point_joint_solver", ALLOWED_RIGID_POINT_JOINT_SOLVERS),
+)
+
+
+def packet_schema_version_errors(
+    packet: Mapping[str, Any], packet_name: str
+) -> list[str]:
+    """Validate the packet's schema_version field."""
+    version = packet.get("schema_version")
+    if not isinstance(version, int) or isinstance(version, bool):
+        return [f"{packet_name}: schema_version must be an integer"]
+    if version < 1:
+        return [f"{packet_name}: schema_version must be >= 1"]
+    return []
+
+
+def resolved_solver_identity_errors(
+    packet: Mapping[str, Any], packet_name: str
+) -> list[str]:
+    """Validate the resolved-solver-identity contract for one packet.
+
+    Packets at SOLVER_IDENTITY_MIN_SCHEMA_VERSION or newer must carry the
+    identity object; older packets may omit it, but a present identity is
+    validated at any version.
+    """
+    errors = packet_schema_version_errors(packet, packet_name)
+    if errors:
+        return errors
+    version = packet["schema_version"]
+
+    identity = packet.get(RESOLVED_SOLVER_IDENTITY_KEY)
+    if identity is None:
+        if version >= SOLVER_IDENTITY_MIN_SCHEMA_VERSION:
+            return [
+                f"{packet_name}: schema_version {version} requires "
+                f"{RESOLVED_SOLVER_IDENTITY_KEY}"
+            ]
+        return []
+    if not isinstance(identity, Mapping):
+        return [f"{packet_name}: {RESOLVED_SOLVER_IDENTITY_KEY} must be an object"]
+
+    for field, allowed in _REQUIRED_ENUM_FIELDS:
+        value = identity.get(field)
+        if not isinstance(value, str) or not value:
+            errors.append(
+                f"{packet_name}: {RESOLVED_SOLVER_IDENTITY_KEY}.{field} "
+                "must be a non-empty string"
+            )
+        elif value not in allowed:
+            errors.append(
+                f"{packet_name}: {RESOLVED_SOLVER_IDENTITY_KEY}.{field} "
+                f"must be one of {sorted(allowed)}, got {value!r}"
+            )
+
+    emplaced = identity.get("avbd_rigid_contact_config_emplaced")
+    if not isinstance(emplaced, bool):
+        errors.append(
+            f"{packet_name}: {RESOLVED_SOLVER_IDENTITY_KEY}."
+            "avbd_rigid_contact_config_emplaced must be a boolean"
+        )
+
+    recorded_from = identity.get("recorded_from")
+    if not isinstance(recorded_from, str) or not recorded_from:
+        errors.append(
+            f"{packet_name}: {RESOLVED_SOLVER_IDENTITY_KEY}.recorded_from "
+            "must be a non-empty string naming how the identity was captured"
+        )
+
+    if (
+        isinstance(emplaced, bool)
+        and not emplaced
+        and identity.get("rigid_contact_solver") == "avbd"
+    ):
+        errors.append(
+            f"{packet_name}: {RESOLVED_SOLVER_IDENTITY_KEY}."
+            "rigid_contact_solver cannot be 'avbd' when "
+            "avbd_rigid_contact_config_emplaced is false"
+        )
+
+    return errors

--- a/scripts/check_avbd_packets.py
+++ b/scripts/check_avbd_packets.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Validate committed AVBD evidence packets against the shared schema.
+
+Enforces PLAN-091 WP-091.1: AVBD packets at the current schema version
+must machine-record the resolved solver configuration that actually ran
+(``resolved_solver_identity``). Packets committed before the identity
+contract stay readable through a legacy allowlist, but new packet files
+must be written at the current schema version. The field contract lives
+in ``scripts/avbd_packet_schema.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from avbd_packet_schema import (  # noqa: E402
+    AVBD_PACKET_SCHEMA_VERSION,
+    packet_schema_version_errors,
+    resolved_solver_identity_errors,
+)
+
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_PACKET_DIR = REPO_ROOT / "docs" / "plans" / "104-vertex-block-descent-solver"
+PACKET_GLOB = "avbd-*-packet.json"
+
+# Packets committed before the resolved-solver-identity contract
+# (WP-091.1). They remain readable at schema_version 1; their
+# sequential-impulse contact rows are relabeled in prose instead of
+# being rewritten. Do not add new packets here: new packet files must
+# be written at AVBD_PACKET_SCHEMA_VERSION with a recorded identity.
+LEGACY_IDENTITY_EXEMPT_PACKETS = frozenset(
+    {
+        "avbd-articulated-breakable-joint-packet.json",
+        "avbd-articulated-breakable-motor-packet.json",
+        "avbd-articulated-fixed-pair-breakable-joint-packet.json",
+        "avbd-articulated-high-ratio-chain-packet.json",
+        "avbd-articulated-prismatic-motor-packet.json",
+        "avbd-articulated-prismatic-pair-breakable-motor-packet.json",
+        "avbd-articulated-revolute-motor-packet.json",
+        "avbd-articulated-spherical-breakable-joint-packet.json",
+        "avbd-articulated-spherical-pair-breakable-joint-packet.json",
+        "avbd-articulated-world-prismatic-breakable-motor-packet.json",
+        "avbd-articulated-world-revolute-breakable-motor-packet.json",
+        "avbd-demo2d-cards-packet.json",
+        "avbd-demo2d-dynamic-friction-packet.json",
+        "avbd-demo2d-fracture-packet.json",
+        "avbd-demo2d-ground-packet.json",
+        "avbd-demo2d-hanging-rope-packet.json",
+        "avbd-demo2d-heavy-rope-packet.json",
+        "avbd-demo2d-joint-grid-packet.json",
+        "avbd-demo2d-motor-packet.json",
+        "avbd-demo2d-net-packet.json",
+        "avbd-demo2d-pyramid-packet.json",
+        "avbd-demo2d-rod-packet.json",
+        "avbd-demo2d-rope-packet.json",
+        "avbd-demo2d-soft-body-packet.json",
+        "avbd-demo2d-spring-packet.json",
+        "avbd-demo2d-spring-ratio-packet.json",
+        "avbd-demo2d-stack-packet.json",
+        "avbd-demo2d-stack-ratio-packet.json",
+        "avbd-demo2d-static-friction-packet.json",
+        "avbd-demo3d-breakable-packet.json",
+        "avbd-demo3d-bridge-packet.json",
+        "avbd-demo3d-dynamic-friction-packet.json",
+        "avbd-demo3d-ground-packet.json",
+        "avbd-demo3d-heavy-rope-packet.json",
+        "avbd-demo3d-pyramid-packet.json",
+        "avbd-demo3d-rope-packet.json",
+        "avbd-demo3d-soft-body-packet.json",
+        "avbd-demo3d-spring-packet.json",
+        "avbd-demo3d-spring-ratio-packet.json",
+        "avbd-demo3d-stack-packet.json",
+        "avbd-demo3d-stack-ratio-packet.json",
+        "avbd-demo3d-static-friction-packet.json",
+        "avbd-empty-baseline-packet.json",
+        "avbd-paper-scale-high-ratio-chain-packet.json",
+        "avbd-rigid-breakable-joint-packet.json",
+        "avbd-rigid-prismatic-motor-packet.json",
+        "avbd-rigid-revolute-motor-packet.json",
+        "avbd-rigid-spherical-breakable-joint-packet.json",
+    }
+)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--packet",
+        action="append",
+        type=Path,
+        default=None,
+        help="Explicit packet file to validate (repeatable); defaults to "
+        "every avbd-*-packet.json under --packet-dir.",
+    )
+    parser.add_argument(
+        "--packet-dir",
+        type=Path,
+        default=DEFAULT_PACKET_DIR,
+        help="Directory scanned for avbd-*-packet.json files.",
+    )
+    return parser.parse_args(argv)
+
+
+def packet_errors(path: Path) -> list[str]:
+    name = path.name
+    if not path.is_file():
+        return [f"{name}: packet file not found at {path}"]
+    try:
+        packet = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        return [f"{name}: invalid JSON ({exc})"]
+    if not isinstance(packet, dict):
+        return [f"{name}: packet must be a JSON object"]
+
+    errors = packet_schema_version_errors(packet, name)
+    if errors:
+        return errors
+
+    version = packet["schema_version"]
+    if (
+        version < AVBD_PACKET_SCHEMA_VERSION
+        and name not in LEGACY_IDENTITY_EXEMPT_PACKETS
+    ):
+        errors.append(
+            f"{name}: new AVBD packets must be written at schema_version "
+            f"{AVBD_PACKET_SCHEMA_VERSION} with a recorded "
+            "resolved_solver_identity (legacy allowlist covers only packets "
+            "committed before WP-091.1)"
+        )
+    errors.extend(resolved_solver_identity_errors(packet, name))
+    return errors
+
+
+def collect_packets(args: argparse.Namespace) -> list[Path]:
+    if args.packet:
+        return list(args.packet)
+    return sorted(args.packet_dir.glob(PACKET_GLOB))
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    packets = collect_packets(args)
+    if not packets:
+        print(f"No {PACKET_GLOB} packets found under {args.packet_dir}")
+        return 1
+
+    all_errors: list[str] = []
+    for path in packets:
+        all_errors.extend(packet_errors(path))
+
+    if all_errors:
+        for error in all_errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print(f"Validated {len(packets)} AVBD packet(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_check_avbd_packets.py
+++ b/tests/test_check_avbd_packets.py
@@ -1,0 +1,136 @@
+"""Tests for scripts/check_avbd_packets.py (PLAN-091 WP-091.1)."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_avbd_packets.py"
+PACKET_DIR = ROOT / "docs" / "plans" / "104-vertex-block-descent-solver"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_avbd_packets", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _identity(**overrides):
+    identity = {
+        "rigid_contact_solver": "sequential_impulse",
+        "rigid_point_joint_solver": "avbd",
+        "avbd_rigid_contact_config_emplaced": False,
+        "recorded_from": "scene-construction audit (WP-091.1)",
+    }
+    identity.update(overrides)
+    return identity
+
+
+def _write_packet(tmp_path, name, packet):
+    path = tmp_path / name
+    path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def test_committed_packet_corpus_passes():
+    module = _load_module()
+    assert module.main([]) == 0
+
+
+def test_new_version_packet_without_identity_is_rejected(tmp_path):
+    module = _load_module()
+    path = _write_packet(
+        tmp_path,
+        "avbd-new-scene-packet.json",
+        {"schema_version": module.AVBD_PACKET_SCHEMA_VERSION},
+    )
+    errors = module.packet_errors(path)
+    assert any("requires resolved_solver_identity" in error for error in errors)
+
+
+def test_new_version_packet_with_identity_passes(tmp_path):
+    module = _load_module()
+    path = _write_packet(
+        tmp_path,
+        "avbd-new-scene-packet.json",
+        {
+            "schema_version": module.AVBD_PACKET_SCHEMA_VERSION,
+            "resolved_solver_identity": _identity(),
+        },
+    )
+    assert module.packet_errors(path) == []
+    assert module.main(["--packet", str(path)]) == 0
+
+
+def test_avbd_contact_claim_without_emplaced_config_is_rejected(tmp_path):
+    module = _load_module()
+    path = _write_packet(
+        tmp_path,
+        "avbd-new-scene-packet.json",
+        {
+            "schema_version": module.AVBD_PACKET_SCHEMA_VERSION,
+            "resolved_solver_identity": _identity(
+                rigid_contact_solver="avbd",
+                avbd_rigid_contact_config_emplaced=False,
+            ),
+        },
+    )
+    errors = module.packet_errors(path)
+    assert any("cannot be 'avbd' when" in error for error in errors), errors
+
+
+def test_unknown_solver_name_is_rejected(tmp_path):
+    module = _load_module()
+    path = _write_packet(
+        tmp_path,
+        "avbd-new-scene-packet.json",
+        {
+            "schema_version": module.AVBD_PACKET_SCHEMA_VERSION,
+            "resolved_solver_identity": _identity(
+                rigid_contact_solver="warm_started_magic"
+            ),
+        },
+    )
+    errors = module.packet_errors(path)
+    assert any("rigid_contact_solver" in error for error in errors)
+
+
+def test_new_packet_file_below_current_version_is_rejected(tmp_path):
+    module = _load_module()
+    path = _write_packet(
+        tmp_path,
+        "avbd-new-scene-packet.json",
+        {"schema_version": 1},
+    )
+    errors = module.packet_errors(path)
+    assert any("must be written at schema_version" in error for error in errors)
+
+
+def test_legacy_allowlisted_packet_stays_readable(tmp_path):
+    module = _load_module()
+    name = "avbd-demo2d-pyramid-packet.json"
+    assert name in module.LEGACY_IDENTITY_EXEMPT_PACKETS
+    path = _write_packet(tmp_path, name, {"schema_version": 1})
+    assert module.packet_errors(path) == []
+
+
+def test_non_integer_schema_version_is_rejected(tmp_path):
+    module = _load_module()
+    path = _write_packet(
+        tmp_path,
+        "avbd-new-scene-packet.json",
+        {"schema_version": "two"},
+    )
+    errors = module.packet_errors(path)
+    assert any("schema_version must be an integer" in error for error in errors)
+
+
+def test_legacy_allowlist_matches_committed_corpus():
+    module = _load_module()
+    committed = {path.name for path in PACKET_DIR.glob("avbd-*-packet.json")}
+    assert committed <= module.LEGACY_IDENTITY_EXEMPT_PACKETS


### PR DESCRIPTION
## Summary

- Lands PLAN-091 WP-091.1: AVBD evidence packets now have a shared schema
  contract (version 2) that machine-records the resolved solver
  configuration, an enforcing checker wired into `check-lint`, and a prose
  relabel of the AVBD contact-scene rows whose "vs native" ratios actually
  ran the default sequential-impulse contact path. Affects DART 7 evidence
  integrity (architecture-assessment finding F4); no runtime/physics change.

## Motivation / Problem

- No AVBD `avbd-demo2d`/`avbd-demo3d` benchmark or py-demo scene emplaces the
  internal `comps::RigidAvbdContactConfig`, because AVBD contact is not
  facade-selectable, so every rigid contact in those scenes ran the default
  sequential-impulse path. Several packets nonetheless recorded
  "DART beats native" rows on those scenes, conflating a whole-pipeline
  `World::step` comparison with an AVBD-contact-solver win. Packets also did
  not machine-record which solver actually ran, so the claim was
  unverifiable.

## Changes / Key Changes

- `scripts/avbd_packet_schema.py`: shared AVBD packet schema, version bumped
  to 2, with a required `resolved_solver_identity` field contract
  (rigid_contact_solver / rigid_point_joint_solver enums, emplaced-flag, and
  an avbd-claim-without-emplaced-config consistency rule).
- `scripts/check_avbd_packets.py` (+ `pixi run check-avbd-packets`, added to
  the `check-lint` aggregate): rejects identity-less packets at schema
  version >= 2 and new packet files below version 2; the 48 committed v1
  packets stay readable via a legacy allowlist.
- `tests/test_check_avbd_packets.py`: 9 cases proving the
  rejection/acceptance paths, the legacy allowlist, and that the allowlist
  covers the committed corpus.
- Relabels six mirrored claim sites (dashboard PLAN-104 entry, the PLAN-104
  plan file, the demo-corpus sidecar, the AVBD paper-gap audit, and the AVBD
  dev-task README/RESUME) with the sequential-impulse classification and a
  does-not-close-gates disclaimer. Committed `avbd-*-packet.json` bytes are
  untouched.
- Writer-script migration to emit the new field at schema version 2 is
  recorded as deferred follow-up (the writers still emit v1).

## Testing

- `pixi run check-avbd-packets` (48 packets), `pixi run python -m pytest
  tests/test_check_avbd_packets.py` (9 passed), `pixi run check-docs-policy`,
  `pixi run check-lint-md`, `pixi run check-lint-spell`,
  `pixi run check-lint-py`, `pixi run lint` — all green.
- `pixi run check-lint` fails only in `check-dartpy-import-layout` on a
  pre-existing local stale-dartpy-runtime drift (12 `*World*` parser
  symbols); this branch changes no dartpy/binding files, so the failure is
  unrelated.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- PLAN-091 WP-091.1 (`docs/plans/091-architecture-hardening.md`); follows
  #2986. No backport (DART 7 `main`-only architecture work).

## Status

- The packet stays `[claimed]` in the plan, awaiting an independent/maintainer
  acceptance pass (the implementing session does not self-approve).

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated if required — not required (internal
      evidence-integrity tooling + docs; no user-facing feature/bug/breaking
      change; consistent with the #2986 harness PR)
- [x] Add unit tests for new functionality — `tests/test_check_avbd_packets.py`
- [x] Document new methods and classes — module/checker docstrings + packet
      Evidence bullet
- [x] Add Python bindings (dartpy) if applicable — N/A
