### PR TITLE
PLAN-091: Close WP-091.2 as done (PR #2994)

### DIFF
--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -146,7 +146,7 @@ joint-grid, net}` and `avbd-demo3d-{soft-body, bridge, breakable}`; chain
   self-approve; the maintainer merge is the independent acceptance recorded by
   the `[done]` heading marker.
 
-#### WP-091.2 Golden trajectories for the default step [claimed]
+#### WP-091.2 Golden trajectories for the default step [done — PR #2994, merged 2026-06-14]
 
 - Objective: committed reference trajectories (states, contact counts,
   tolerances) for a small scene matrix lock the default `World::step`

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -28,15 +28,19 @@ its own line so status updates remain git-history friendly.
   version 2, enforced for new packet files by `pixi run check-avbd-packets` in
   both the `lint` and `check-lint` aggregates, and the six mirrored
   contact-scene claim sites are relabeled; writer-script migration to emit the
-  new field is a recorded follow-up (see the packet Evidence bullet). Execute
-  the remaining four WS0 evidence-integrity packets in plan document order:
-  WP-091.2 golden trajectories (next available; behavior-lock guardrail that
-  hard-gates the refactor-heavy packets), WP-091.3 architecture-claim lint
-  (acceptance-criteria clarified — adds test citations to the marked rows
-  before linting them), WP-091.4 legacy freeze (blocked: PLAN-042 Decision 5
-  has no recorded maintainer direction yet), WP-091.5 plan-ID renumber
-  (PLAN-080 and PLAN-082 collisions confirmed real; the packet hazard owns the
-  exact `git grep` scope across docs and code). Then
+  new field is a recorded follow-up (see the packet Evidence bullet).
+  WP-091.2 (golden trajectories) is `[done]` (PR #2994, merged 2026-06-14) —
+  `test_world_default_step_golden` locks the default `World::step` over a
+  three-scene matrix with a two-oracle design (analytical closed-form/physical
+  invariants plus the committed-snapshot behavior lock), so the refactor-heavy
+  WS1+ packets now have behavior-lock evidence to diff against. Execute the
+  remaining WS0 evidence-integrity packets in plan document order: WP-091.3
+  architecture-claim lint (next available; acceptance-criteria clarified —
+  adds test citations to the marked rows before linting them), WP-091.4 legacy
+  freeze (blocked: PLAN-042 Decision 5 has no recorded maintainer direction
+  yet), WP-091.5 plan-ID renumber (PLAN-080 and PLAN-082 collisions confirmed
+  real; the packet hazard owns the exact `git grep` scope across docs and
+  code). Then
   open WS1 with WP-091.10 (virtual finalize/prepare on the stage contract).
   Packets are
   orchestrator-authored per [`../ai/orchestration.md`](../ai/orchestration.md)


### PR DESCRIPTION
## Summary

- Lifecycle close for PLAN-091 WP-091.2 (golden trajectories for the default `World::step`), merged in #2994. Replaces the `[claimed]` marker with `[done — PR #2994, merged 2026-06-14]` and advances the PLAN-091 dashboard next step to WP-091.3 (architecture-claim lint). Docs-only.

## Motivation / Problem

- After #2994 merged, the packet marker on `main` was still `[claimed]`, which mis-signals the packet-execution harness (a `[claimed]` packet reads as in-progress). The maintainer merge is the acceptance.

## Changes / Key Changes

- `docs/plans/091-architecture-hardening.md`: WP-091.2 `[claimed]` → `[done — PR #2994, merged 2026-06-14]`.
- `docs/plans/dashboard.md`: record WP-091.2 done; next available WS0 packet is WP-091.3.

## Testing

- `pixi run check-docs-policy`, `pixi run check-lint-md` green. Docs-only; no build/test impact.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Closes the lifecycle of #2994. PLAN-091. No backport (DART 7 `main`-only).

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated if required — not required (plan state only)
- [x] Add unit tests for new functionality — N/A (docs-only)
- [x] Document new methods and classes — N/A
- [x] Add Python bindings (dartpy) if applicable — N/A