### PR TITLE
Disable EXAMPLE_dart_demos_list under AddressSanitizer (SDL3 dlopen abort)

### DIFF
--- a/examples/demos/CMakeLists.txt
+++ b/examples/demos/CMakeLists.txt
@@ -54,9 +54,14 @@ if(TARGET dart-demos)
 
   if(BUILD_TESTING AND DART_BUILD_TESTS)
     add_test(NAME EXAMPLE_dart_demos_list COMMAND dart-demos --list)
+    # dart-demos links Filament, whose prebuilt runtime dlopen's SDL3 at process
+    # startup. Under AddressSanitizer that load fails ("Failed loading SDL3
+    # library") and aborts before `--list` can print, so disable this runtime
+    # smoke test in ASan builds. It still runs in Release/Debug, and dart-demos
+    # is still built under ASan (the failure is purely at runtime startup).
     set_tests_properties(
       EXAMPLE_dart_demos_list
-      PROPERTIES LABELS "examples;gui;catalog"
+      PROPERTIES LABELS "examples;gui;catalog" DISABLED ${DART_ENABLE_ASAN}
     )
     if(NOT APPLE)
       if(WIN32)


### PR DESCRIPTION
## Problem

The `Release Tests` CI job's **Test with AddressSanitizer** step fails deterministically on `EXAMPLE_dart_demos_list`:

```
284 - EXAMPLE_dart_demos_list (Subprocess aborted)   catalog examples gui
Failed loading SDL3 library.
```

`dart-demos` links Filament, whose prebuilt runtime `dlopen`s a bundled **SDL3** at process startup (before `dart-demos --list` returns). Under AddressSanitizer that load fails — a known incompatibility between ASan instrumentation and `dlopen` of a non-instrumented prebuilt library — and the process aborts (ctest exit code 8).

Notes:
- The same test **passes in the non-ASan Release/Debug ctest runs** (SDL3 loads fine).
- DART's own windowing uses **GLFW, not SDL3**; the SDL3 load is internal to the Filament prebuilt and happens at library init, so it is not reachable from the `--list` code path.
- This has been failing on `main` independently of any feature work (the ASan job is the only place it surfaces).

## Fix

Disable `EXAMPLE_dart_demos_list` in ASan builds only, via `DISABLED ${DART_ENABLE_ASAN}`. The test remains enabled in Release/Debug for full coverage, and `dart-demos` is still built under ASan (the failure is purely at runtime startup, not a build/link issue).

## Verification

- **Release** (`DART_ENABLE_ASAN=OFF`): `Test #286: EXAMPLE_dart_demos_list` — enabled.
- **ASan** (`DART_ENABLE_ASAN=ON`): `Test #286: EXAMPLE_dart_demos_list (Disabled)` → `***Not Run (Disabled)` — ctest skips it (not a failure).
- `check-lint-cmake` passes.