### PR TITLE
Skip Dantzig interior fast path for allocator-backed scratch

### DIFF
--- a/dart/math/lcp/pivoting/dantzig_solver.cpp
+++ b/dart/math/lcp/pivoting/dantzig_solver.cpp
@@ -93,7 +93,8 @@ LcpResult DantzigSolver::solve(
 
   Eigen::VectorXd fastW;
   bool exactFastPath = false;
-  if (problem.size() > 0 && !options.warmStart) {
+  if (problem.size() > 0 && !options.warmStart
+      && !scratch.usesProvidedAllocator) {
     const double validationTolerance = std::max(absTol, compTol);
     if (problem.isStandardLcp(absTol)) {
       exactFastPath = detail::trySolveStrictInteriorStandardLcpLltFirst(

--- a/dart/math/lcp/pivoting/dantzig_solver.hpp
+++ b/dart/math/lcp/pivoting/dantzig_solver.hpp
@@ -67,6 +67,7 @@ public:
         hiEff(DoubleAllocator{allocator}),
         lcp(allocator)
     {
+      usesProvidedAllocator = true;
     }
 
     std::vector<double, DoubleAllocator> Adata;
@@ -80,6 +81,13 @@ public:
     std::vector<double, DoubleAllocator> loEff;
     std::vector<double, DoubleAllocator> hiEff;
     DantzigLcpScratch<double> lcp;
+
+    /// True when this scratch was constructed with a caller-provided allocator.
+    /// In that case `DantzigSolver::solve` skips the default-allocating
+    /// interior fast path so every work-buffer allocation routes through the
+    /// provided allocator (allocator correctness for real-time / deterministic
+    /// callers).
+    bool usesProvidedAllocator = false;
 
     void clear() noexcept;
   };


### PR DESCRIPTION
## Summary

- The `DantzigSolver` cold-start interior fast path (`solve(problem, x, scratch,
  options)` when `!warmStart`) solves simple Standard/Boxed/FrictionIndex
  problems using **local, default-heap-allocated `Eigen::VectorXd` temporaries**
  and returns without touching the allocator-backed `Scratch`. When a caller
  supplies an allocator-backed `Scratch` (for real-time / deterministic
  allocation), this **bypasses the provided allocator**, violating the
  allocator-correctness contract.
- Fix: `Scratch` now records whether it was constructed with a caller-provided
  allocator (`usesProvidedAllocator`), and `solve` **skips the interior fast
  path** in that case, so every work-buffer allocation routes through the
  provided allocator. The fast path is unchanged for the common default-scratch
  case (e.g. `solve(problem, x, options)`), preserving its performance.

## Motivation / Problem

`tests/unit/math/lcp/test_dantzig_solver.cpp` →
`DantzigSolver.ScratchUsesProvidedAllocatorForDantzigWorkBuffers` asserts that an
allocator-backed scratch routes all work-buffer allocations through the provided
allocator and performs **zero global heap allocations** after warmup. The
cold-start interior fast path violates both. The violation is latent: whether
the fast path triggers for a given problem is numerically sensitive, so it
surfaces only on some CPU/FP environments (it reproduces locally; CI's runners
fall through to the scratch path, so the test is green there). This change makes
the behavior deterministic and contract-correct on all environments.

## Changes / Key Changes

- `dart/math/lcp/pivoting/dantzig_solver.hpp`: add
  `Scratch::usesProvidedAllocator` (default `false`; set `true` in the
  allocator-taking constructor).
- `dart/math/lcp/pivoting/dantzig_solver.cpp`: gate the interior fast path on
  `!scratch.usesProvidedAllocator`.

## Testing

- `cmake --build … --target UNIT_math_lcp_math_lcp_dantzig_solver` then the full
  `DantzigSolver` suite → **7/7 pass** (previously
  `ScratchUsesProvidedAllocatorForDantzigWorkBuffers` failed locally).
- `pixi run test-all`: lint, build, and **all 220 unit tests pass** with this
  change (no regressions). `clang-format --dry-run --Werror` and
  `git diff --check` clean.

## Breaking Changes

- [x] None — behavior changes only for callers that supply an allocator-backed
  `DantzigSolver::Scratch`, and only to route their allocations through that
  allocator (the intended contract). Default `solve()` and default-scratch
  callers keep the fast path.

## Related Issues / PRs (backports)

- Surfaced while locally verifying the merged LCP work (#3001, #3007) on a CPU
  whose FP behavior triggers the interior fast path. Internal allocator-
  correctness fix; no public API change (let me know if a CHANGELOG entry is
  desired).

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`)
- [ ] CHANGELOG.md updated if required (internal allocator-correctness fix)
- [x] Add unit tests for new functionality (existing allocator test now passes)
- [x] Document new methods and classes (Scratch flag documented)
- [x] Add Python bindings (dartpy) if applicable (n/a)
