### PR TITLE
ci: move setup-pixi-ci actions off deprecated Node.js 20

### DIFF
--- a/.github/actions/setup-pixi-ci/action.yml
+++ b/.github/actions/setup-pixi-ci/action.yml
@@ -45,7 +45,7 @@ runs:
   using: composite
   steps:
     - name: Setup pixi
-      uses: prefix-dev/setup-pixi@v0.9.4
+      uses: prefix-dev/setup-pixi@v0.9.6
       with:
         pixi-version: ${{ inputs.pixi-version }}
         cache: ${{ inputs.cache == 'true' && startsWith(runner.name, 'GitHub Actions') }}
@@ -92,6 +92,6 @@ runs:
     - name: Setup sccache
       if: ${{ inputs.enable-sccache == 'true' && startsWith(runner.name, 'GitHub Actions') }}
       continue-on-error: ${{ inputs.sccache-continue-on-error == 'true' }}
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.10
       with:
         disable_annotations: ${{ inputs.sccache-disable-annotations }}


### PR DESCRIPTION
## Summary

Every pixi-based CI job — on **macOS, Linux, and the rest** — currently emits:

> `##[warning]` Node.js 20 actions are deprecated … will be forced to Node.js 24 by default starting **June 16th, 2026**: `mozilla-actions/sccache-action@v0.0.9`, `actions/cache/restore@<sha>`

Bump the two actions pinned in the shared `setup-pixi-ci` composite to their latest **Node 24** releases (verified `using: node24`):

| action | from | to |
|---|---|---|
| `mozilla-actions/sccache-action` | v0.0.9 | **v0.0.10** |
| `prefix-dev/setup-pixi` | v0.9.4 | **v0.9.6** |

`setup-pixi@v0.9.6` is already used by `.github/workflows/update_lockfiles.yml`, so this just aligns the CI composite. The `actions/cache/restore@<sha>` node-20 invocation is pulled in transitively by these pinned actions; their latest releases carry the Node-24 update.

## Why

GitHub force-migrates Node.js 20 javascript actions to Node 24 on **2026-06-16**; this clears the warning ahead of that and keeps caching/sccache working.

## Scope

One file (`.github/actions/setup-pixi-ci/action.yml`, 2 lines). Surfaced on PR #3012's `Coverage (Debug)` job but it's repo-wide CI hygiene, so it's a standalone PR. prettier-clean.