### PR TITLE
Fix GLUT examples failing to open a window on modern Mesa/Xwayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
     benchmarks, dartpy bindings, and an ImGui-based GUI example:
     [#2985](https://github.com/dartsim/dart/pull/2985)
 
+* GUI
+
+  * Fix every GLUT example failing to open a window on modern Mesa/Xwayland:
+    the shared GLUT window no longer requests a legacy, now-unavailable
+    accumulation buffer, selecting the framebuffer with a relaxable
+    `glutInitDisplayString` instead, while `MotionBlurSimWindow` opts back into
+    an accumulation buffer on its own:
+    [#3017](https://github.com/dartsim/dart/pull/3017)
+
 * Simulation
 
   * Add automatic body deactivation ("sleeping") for resting solver islands,

--- a/dart/gui/glut/GlutWindow.cpp
+++ b/dart/gui/glut/GlutWindow.cpp
@@ -81,6 +81,14 @@ Window::~Window()
   delete mRI;
 }
 
+const char* Window::getDisplayString() const
+{
+  // RGBA, double-buffered, with a depth buffer and relaxable (~) multisampling.
+  // No accumulation buffer is requested here -- see Window::getDisplayString()
+  // in the header for why requesting one breaks modern Mesa/Xwayland.
+  return "rgba double depth>=16 samples~4";
+}
+
 void Window::initWindow(int _w, int _h, const char* _name)
 {
   mWindows.push_back(this);
@@ -88,8 +96,7 @@ void Window::initWindow(int _w, int _h, const char* _name)
   mWinWidth = _w;
   mWinHeight = _h;
 
-  glutInitDisplayMode(
-      GLUT_DEPTH | GLUT_DOUBLE | GLUT_RGBA | GLUT_MULTISAMPLE | GLUT_ACCUM);
+  glutInitDisplayString(getDisplayString());
   glutInitWindowPosition(150, 100);
   glutInitWindowSize(_w, _h);
   mWinIDs.push_back(glutCreateWindow(_name));

--- a/dart/gui/glut/MotionBlurSimWindow.cpp
+++ b/dart/gui/glut/MotionBlurSimWindow.cpp
@@ -38,6 +38,14 @@ MotionBlurSimWindow::~MotionBlurSimWindow()
 }
 
 //==============================================================================
+const char* MotionBlurSimWindow::getDisplayString() const
+{
+  // Same as the base window, plus a relaxable accumulation buffer for the
+  // motion-blur frame compositing.
+  return "rgba double depth>=16 samples~4 acca~16";
+}
+
+//==============================================================================
 void MotionBlurSimWindow::setMotionBlurQuality(int _val)
 {
   int numIter = mDisplayTimeout / (mWorld->getTimeStep() * 1000);

--- a/dart/gui/glut/MotionBlurSimWindow.hpp
+++ b/dart/gui/glut/MotionBlurSimWindow.hpp
@@ -77,6 +77,12 @@ public:
   void displayTimer(int _val) override;
 
 protected:
+  // Motion blur composites successive frames in an accumulation buffer, so opt
+  // back into one. The '~' qualifier keeps it relaxable, so the window still
+  // opens (without true accum) on drivers that expose no accum-capable
+  // FBConfig instead of aborting.
+  const char* getDisplayString() const override;
+
   // Determines the frequency of the motion blur
   // Default is 1, which means motion blur effect has the highest quality
   // When set to m, motion blur record data every m frames

--- a/dart/gui/glut/Window.hpp
+++ b/dart/gui/glut/Window.hpp
@@ -81,6 +81,19 @@ protected:
 
   virtual bool screenshot();
 
+  /// Returns the freeglut display string passed to glutInitDisplayString() to
+  /// choose the framebuffer configuration. The base window requests an RGBA,
+  /// double-buffered visual with a depth buffer and relaxable multisampling
+  /// (the '~' qualifier degrades gracefully when MSAA is unavailable).
+  ///
+  /// It deliberately does NOT request an accumulation buffer: modern
+  /// Mesa/NVIDIA/Xwayland drivers expose no accum-capable GLXFBConfig, so
+  /// requesting one makes glutCreateWindow() abort with "FBConfig with
+  /// necessary capabilities not found" and every GLUT window fails to open.
+  /// Subclasses that genuinely need an accumulation buffer (e.g.
+  /// MotionBlurSimWindow) override this to opt back in.
+  virtual const char* getDisplayString() const;
+
   int mWinWidth;
   int mWinHeight;
   int mMouseX;


### PR DESCRIPTION
## Problem

Every GLUT example (e.g. `glut_add_delete_skels`) aborts at window creation on a
modern Linux desktop:

```
freeglut: ERROR: Internal error <FBConfig with necessary capabilities not found> in function fgOpenWindow
```

## Root cause

The shared `glut::Window::initWindow` requested an **accumulation buffer**
(`GLUT_ACCUM`) for *every* GLUT window:

```cpp
glutInitDisplayMode(GLUT_DEPTH | GLUT_DOUBLE | GLUT_RGBA | GLUT_MULTISAMPLE | GLUT_ACCUM);
```

…but only `MotionBlurSimWindow` actually uses one. Modern Mesa / NVIDIA /
Xwayland drivers expose **no accum-capable `GLXFBConfig`**, so
`glXChooseFBConfig` matches nothing and freeglut aborts in `fgOpenWindow`. One
niche example's legacy requirement was breaking all 16 GLUT examples.

## Fix

- Route the framebuffer request through a new `virtual Window::getDisplayString()`
  hook that uses a **relaxable** `glutInitDisplayString("rgba double depth>=16 samples~4")`
  — no accumulation buffer, and MSAA degrades gracefully (`~`) instead of
  hard-failing.
- `MotionBlurSimWindow` overrides the hook to opt back into a relaxable
  accumulation buffer (`acca~16`), so it still gets accum where available and
  still opens (without it) where not.

## Verification

Rebuilt `dart-gui` + `glut_add_delete_skels` and ran it on `DISPLAY=:0`
(Wayland → Xwayland):

- **Before:** exit 1, `FBConfig with necessary capabilities not found`.
- **After:** window opens and enters the GLUT main loop (survives to timeout),
  **0** FBConfig errors.

## Scope

Bug exists only on the DART 6.x LTS line — `main` (DART 7) has already removed
the legacy `dart/gui/glut` GUI, so **no main backport is needed**. Targets
`release-6.19` so the fix ships with 6.19.0.