### PR TITLE
Improve glut_add_delete_skels: larger floor and FPS/RTF HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
     benchmarks, dartpy bindings, and an ImGui-based GUI example:
     [#2985](https://github.com/dartsim/dart/pull/2985)
 
+* Examples and Tutorials
+
+  * Enlarge the floor and add an FPS / physics real-time-factor HUD to the
+    `glut_add_delete_skels` example, so spawned cubes keep room on the ground
+    and the effect of adding skeletons on real-time performance is visible:
+    [#3019](https://github.com/dartsim/dart/pull/3019)
+
 * GUI
 
   * Fix every GLUT example failing to open a window on modern Mesa/Xwayland:

--- a/data/skel/ground.skel
+++ b/data/skel/ground.skel
@@ -8,7 +8,7 @@
           <transformation>0 0 0 0 0 0</transformation>
           <geometry>
             <box>
-              <size>2.5 0.05 2.5</size>
+              <size>4 0.05 4</size>
             </box>
           </geometry>
           <color>0.95 0.95 0.95</color>
@@ -17,7 +17,7 @@
           <transformation>0 0 0 0 0 0</transformation>
           <geometry>
             <box>
-              <size>2.5 0.05 2.5</size>
+              <size>4 0.05 4</size>
             </box>
           </geometry>
         </collision_shape>

--- a/examples/deprecated_examples/glut_add_delete_skels/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_add_delete_skels/MyWindow.cpp
@@ -82,7 +82,10 @@ void MyWindow::draw()
 
   if (mSimulating)
     std::snprintf(
-        line, sizeof(line), "Physics RTF: %.2fx", mRtfEma < 0.0 ? 0.0 : mRtfEma);
+        line,
+        sizeof(line),
+        "Physics RTF: %.2fx",
+        mRtfEma < 0.0 ? 0.0 : mRtfEma);
   else
     std::snprintf(line, sizeof(line), "Physics RTF: paused");
   dart::gui::glut::drawStringOnScreen(0.02f, 0.91f, line);

--- a/examples/deprecated_examples/glut_add_delete_skels/MyWindow.cpp
+++ b/examples/deprecated_examples/glut_add_delete_skels/MyWindow.cpp
@@ -32,9 +32,66 @@
 
 #include "MyWindow.hpp"
 
+#include <chrono>
+
+#include <cstdio>
+
 MyWindow::MyWindow() : SimWindow() {}
 
 MyWindow::~MyWindow() {}
+
+void MyWindow::draw()
+{
+  // Render the world plus the base class's 2D simulation-frame counter.
+  SimWindow::draw();
+
+  // --- Update the HUD timing readouts -------------------------------------
+  const auto now = std::chrono::steady_clock::now();
+  const double simTime = mWorld->getTime();
+  if (mHudInitialized) {
+    const double wallDt
+        = std::chrono::duration<double>(now - mLastDrawWall).count();
+    if (wallDt > 1e-6) {
+      // Exponential moving averages keep both readouts steady frame-to-frame.
+      const double fps = 1.0 / wallDt;
+      mFpsEma = (mFpsEma < 0.0) ? fps : 0.9 * mFpsEma + 0.1 * fps;
+      if (mSimulating) {
+        // Real-time factor: simulated seconds advanced per wall-clock second.
+        // < 1 means the physics cannot keep up with real time.
+        const double rtf = (simTime - mLastSimTime) / wallDt;
+        mRtfEma = (mRtfEma < 0.0) ? rtf : 0.9 * mRtfEma + 0.1 * rtf;
+      }
+    }
+  }
+  mLastDrawWall = now;
+  mLastSimTime = simTime;
+  mHudInitialized = true;
+
+  // Dynamic cubes = every skeleton except the static ground.
+  const std::size_t numSkeletons = mWorld->getNumSkeletons();
+  const std::size_t numCubes = (numSkeletons > 0) ? numSkeletons - 1 : 0;
+
+  // --- Draw the HUD in the top-left corner --------------------------------
+  // SimWindow::draw() re-enables lighting, so disable it for flat text.
+  glDisable(GL_LIGHTING);
+  glColor3f(0.0f, 0.0f, 0.0f);
+
+  char line[96];
+  std::snprintf(line, sizeof(line), "FPS: %.1f", mFpsEma < 0.0 ? 0.0 : mFpsEma);
+  dart::gui::glut::drawStringOnScreen(0.02f, 0.95f, line);
+
+  if (mSimulating)
+    std::snprintf(
+        line, sizeof(line), "Physics RTF: %.2fx", mRtfEma < 0.0 ? 0.0 : mRtfEma);
+  else
+    std::snprintf(line, sizeof(line), "Physics RTF: paused");
+  dart::gui::glut::drawStringOnScreen(0.02f, 0.91f, line);
+
+  std::snprintf(line, sizeof(line), "Cubes: %zu", numCubes);
+  dart::gui::glut::drawStringOnScreen(0.02f, 0.87f, line);
+
+  glEnable(GL_LIGHTING);
+}
 
 void MyWindow::drawWorld() const
 {

--- a/examples/deprecated_examples/glut_add_delete_skels/MyWindow.hpp
+++ b/examples/deprecated_examples/glut_add_delete_skels/MyWindow.hpp
@@ -37,6 +37,8 @@
 
 #include <dart/dart.hpp>
 
+#include <chrono>
+
 /// \brief
 class MyWindow : public dart::gui::glut::SimWindow
 {
@@ -50,6 +52,10 @@ public:
   /// \brief
   void drawWorld() const override;
 
+  /// Renders the world and overlays a small HUD (render FPS, physics real-time
+  /// factor, and the current cube count).
+  void draw() override;
+
   /// \brief
   void keyboard(unsigned char _key, int _x, int _y) override;
 
@@ -58,6 +64,15 @@ public:
       const Eigen::Vector3d& _position = Eigen::Vector3d(0.0, 1.0, 0.0),
       const Eigen::Vector3d& _size = Eigen::Vector3d(0.1, 0.1, 0.1),
       double _mass = 0.1);
+
+private:
+  // Wall-clock and simulated-time samples from the previous draw(), used to
+  // derive the smoothed FPS and real-time-factor readouts.
+  std::chrono::steady_clock::time_point mLastDrawWall;
+  double mLastSimTime = 0.0;
+  double mFpsEma = -1.0;
+  double mRtfEma = -1.0;
+  bool mHudInitialized = false;
 };
 
 #endif // EXAMPLES_ADDDELETESKELS_MYWINDOW_HPP_


### PR DESCRIPTION
Quality-of-life improvements to the `glut_add_delete_skels` example.

> [!NOTE]
> **Depends on #3017** (the GLUT FBConfig fix). This PR is based on that
> branch so the example can actually open a window; please merge #3017 first.
> GitHub will retarget this PR to `release-6.19` automatically once #3017 lands.

## 1. Larger floor

Cubes spawn at center `±1.0` with up to `0.5` size, so their footprint reached
**exactly** the old `2.5 m` floor edge (`±1.25`) — they tumbled off as they
piled up and spread. Enlarged the ground to a `4.0 m` square for margin.
`data/skel/ground.skel` is loaded only by this example.

## 2. FPS / RTF HUD

Overrode `MyWindow::draw()` to overlay a small top-left HUD:

- **FPS** — smoothed render rate.
- **Physics RTF** — real-time factor = simulated seconds advanced per
  wall-clock second (`< 1` means the solver can't keep up with real time;
  shows `paused` when stopped).
- **Cubes** — live count.

Both readouts are EMA-smoothed. Adding cubes (`q`) now visibly drops the RTF
once the solver saturates, which answers "is it running in real time, and how
does adding skeletons change that?" at a glance.

## Verification

Clean Release build; a 5 s run on Xwayland (`DISPLAY=:0`) opened the window with
the enlarged floor parsed and the HUD path running, zero errors.