### PR TITLE
PLAN-091: WP-091.12 retire multibody string selector for typed enum

### DIFF
--- a/dart/simulation/compute/multibody_dynamics.cpp
+++ b/dart/simulation/compute/multibody_dynamics.cpp
@@ -3478,7 +3478,6 @@ UnifiedConstraintStage::UnifiedConstraintStage(std::size_t frictionIterations)
 UnifiedConstraintStage::UnifiedConstraintStage(
     std::size_t frictionIterations, common::MemoryManager* memoryManager)
   : m_frictionIterations(std::max<std::size_t>(1, frictionIterations)),
-    m_memoryManager(memoryManager),
     m_scratch(
         memoryManager != nullptr
             ? constructStageOwnedScratch<Scratch>(

--- a/dart/simulation/compute/multibody_dynamics.hpp
+++ b/dart/simulation/compute/multibody_dynamics.hpp
@@ -681,7 +681,6 @@ private:
       World& world, std::span<const Contact> contacts);
 
   std::size_t m_frictionIterations;
-  common::MemoryManager* m_memoryManager = nullptr;
   ScratchPtr m_scratch;
 };
 

--- a/dart/simulation/multibody/multibody_options.hpp
+++ b/dart/simulation/multibody/multibody_options.hpp
@@ -10,18 +10,34 @@
 
 #pragma once
 
-#include <string>
-
 #include <cstddef>
 
 namespace dart::simulation {
+
+/// Integration family used for multibody dynamics on the default
+/// `World::step()` path.
+///
+/// This is a typed, documented selector on the public facade surface (mirroring
+/// `RigidBodySolver` and `ContactSolverMethod`): it names the discretization
+/// family without exposing any solver, stage, registry, or backend type, and it
+/// is resolved once when the configuration is applied so the per-step path
+/// carries no parsing cost.
+enum class MultibodyIntegrationFamily
+{
+  /// Semi-implicit (articulated-body forward dynamics) integration. The
+  /// long-standing default.
+  SemiImplicit,
+
+  /// The linear-time discrete-mechanics (variational) integrator.
+  Variational,
+};
 
 /// World-level solver/integration configuration for the multibody domain.
 ///
 /// A value object set as a whole via `World::setMultibodyOptions()` rather than
 /// one setter/getter per setting, so new capabilities are added as fields here
-/// instead of accumulating World methods. Configuration is by documented
-/// method-family name (the public-facade "Solver And Execution Policy"
+/// instead of accumulating World methods. Configuration is by typed
+/// method-family selector (the public-facade "Solver And Execution Policy"
 /// capability matrix); no solver, stage, or backend types are exposed.
 ///
 /// This is the multibody **solver** configuration, distinct from any future
@@ -29,11 +45,11 @@ namespace dart::simulation {
 struct MultibodyOptions
 {
   /// Integration family used for multibody dynamics on the default `step()`
-  /// path. Documented values: `"semi-implicit"` (default; articulated-body
-  /// forward dynamics) and `"variational integrator"` (the linear-time
-  /// discrete-mechanics integrator). `World::setMultibodyOptions()` throws
-  /// InvalidArgumentException for unknown names.
-  std::string integrationFamily = "semi-implicit";
+  /// path. Defaults to `SemiImplicit` (articulated-body forward dynamics); the
+  /// other documented value is `Variational` (the linear-time discrete-
+  /// mechanics integrator).
+  MultibodyIntegrationFamily integrationFamily
+      = MultibodyIntegrationFamily::SemiImplicit;
 
   /// Maximum RIQN iterations for the variational integrator on the default
   /// `World::step()` path. Must be positive.

--- a/dart/simulation/world.cpp
+++ b/dart/simulation/world.cpp
@@ -1472,6 +1472,18 @@ bool isValidContactGradientMode(ContactGradientMode mode)
 }
 
 //==============================================================================
+bool isValidMultibodyIntegrationFamily(MultibodyIntegrationFamily family)
+{
+  switch (family) {
+    case MultibodyIntegrationFamily::SemiImplicit:
+    case MultibodyIntegrationFamily::Variational:
+      return true;
+  }
+
+  return false;
+}
+
+//==============================================================================
 std::uint8_t encodeRigidBodySolver(RigidBodySolver solver)
 {
   switch (solver) {
@@ -5598,18 +5610,18 @@ void World::step(std::size_t count)
 //==============================================================================
 void World::setMultibodyOptions(const MultibodyOptions& options)
 {
-  const std::string& family = options.integrationFamily;
+  DART_SIMULATION_THROW_T_IF(
+      !isValidMultibodyIntegrationFamily(options.integrationFamily),
+      InvalidArgumentException,
+      "MultibodyOptions.integrationFamily is invalid");
   MultibodyIntegrationMethod method = MultibodyIntegrationMethod::SemiImplicit;
-  if (family == "semi-implicit" || family == "semi-implicit Euler") {
-    method = MultibodyIntegrationMethod::SemiImplicit;
-  } else if (family == "variational integrator" || family == "variational") {
-    method = MultibodyIntegrationMethod::Variational;
-  } else {
-    DART_SIMULATION_THROW_T(
-        InvalidArgumentException,
-        "Unknown multibody integrationFamily '{}'; supported method-family "
-        "names are 'semi-implicit' and 'variational integrator'",
-        family);
+  switch (options.integrationFamily) {
+    case MultibodyIntegrationFamily::SemiImplicit:
+      method = MultibodyIntegrationMethod::SemiImplicit;
+      break;
+    case MultibodyIntegrationFamily::Variational:
+      method = MultibodyIntegrationMethod::Variational;
+      break;
   }
   DART_SIMULATION_THROW_T_IF(
       options.variationalMaxIterations == 0,
@@ -5641,8 +5653,8 @@ MultibodyOptions World::getMultibodyOptions() const
   MultibodyOptions options;
   options.integrationFamily
       = m_multibodyIntegrationMethod == MultibodyIntegrationMethod::Variational
-            ? "variational integrator"
-            : "semi-implicit";
+            ? MultibodyIntegrationFamily::Variational
+            : MultibodyIntegrationFamily::SemiImplicit;
   options.variationalMaxIterations = m_variationalIntegratorMaxIterations;
   options.variationalTolerance = m_variationalIntegratorTolerance;
   return options;

--- a/dart/simulation/world.hpp
+++ b/dart/simulation/world.hpp
@@ -943,16 +943,16 @@ public:
   //--------------------------------------------------------------------------
 
   /// Set the multibody solver/integration configuration as a whole (see
-  /// `MultibodyOptions`). Configuration is by documented method-family name, so
+  /// `MultibodyOptions`). Configuration is by typed method-family selector, so
   /// new capabilities are added as `MultibodyOptions` fields rather than as new
-  /// World methods, and no solver/stage types are exposed. Throws
-  /// InvalidArgumentException for an unknown `integrationFamily`. Selection is
-  /// parsed to an internal representation here, so the per-step path carries no
-  /// configuration-parsing cost.
+  /// World methods, and no solver/stage types are exposed. Selection is mapped
+  /// to an internal representation here, so the per-step path carries no
+  /// configuration-resolution cost.
   void setMultibodyOptions(const MultibodyOptions& options);
 
   /// The current multibody solver/integration configuration. The
-  /// `integrationFamily` defaults to `"semi-implicit"`.
+  /// `integrationFamily` defaults to
+  /// `MultibodyIntegrationFamily::SemiImplicit`.
   [[nodiscard]] MultibodyOptions getMultibodyOptions() const;
 
   //--------------------------------------------------------------------------

--- a/docs/design/dart7_architecture_assessment.md
+++ b/docs/design/dart7_architecture_assessment.md
@@ -67,11 +67,12 @@ already 7/8 deep on its densest branch. Adding one method family costs ~9
 files and ~10 hand-synchronized edit sites across two monolithic translation
 units (`world_step_stage.cpp` ~10.9k lines, `world.cpp` ~6.2k lines).
 
-Four inconsistent selection idioms coexist: the `RigidBodySolver` enum
-(runtime-mutable, alters the schedule), the `ContactSolverMethod` enum
-(construction-only, a branch inside one stage), the
-`MultibodyOptions.integrationFamily` parsed string, and AVBD rigid contact
-selected by a private ECS component invisible to the facade. Scene content
+The domain selectors now share a typed-enum idiom on the facade: the
+`RigidBodySolver` enum (runtime-mutable, alters the schedule), the
+`ContactSolverMethod` enum (construction-only, a branch inside one stage), and
+the `MultibodyOptions.integrationFamily` enum (`MultibodyIntegrationFamily`,
+resolved once at finalize). AVBD rigid contact remains selected by a private ECS
+component invisible to the facade. Scene content
 silently swaps algorithms (VBD falls back per body to projected Newton on
 unsupported scene features with no facade-visible diagnostic; mixed scenes
 reroute contact solves across structurally different assemblies).

--- a/docs/design/simulation_cpp_api.md
+++ b/docs/design/simulation_cpp_api.md
@@ -902,10 +902,11 @@ world-level construction grouping for defaults and policies
 `WorldOptions::differentiable`) plus the existing interactive setters for the
 policies that are safe to switch after construction (`World::setRigidBodySolver`,
 `World::setMultibodyOptions` / `getMultibodyOptions`, and
-`World::setContactGradientMode`). `MultibodyOptions { std::string
-integrationFamily; }` maps onto the "Integration family" matrix row. Selection
-is parsed to an internal representation on construction or set, so the per-step
-path carries no configuration cost when a non-default family is not in use.
+`World::setContactGradientMode`). `MultibodyOptions {
+MultibodyIntegrationFamily integrationFamily; }` maps onto the "Integration
+family" matrix row. Selection is a typed enum mapped to an internal
+representation on construction or set, so the per-step path carries no
+configuration cost when a non-default family is not in use.
 
 ## Future Capability Shapes
 

--- a/docs/design/simulation_python_api.md
+++ b/docs/design/simulation_python_api.md
@@ -951,7 +951,9 @@ world = sx.World(
     time_step=0.001,
     gravity=(0.0, 0.0, -9.81),
     rigid_body_solver=sx.RigidBodySolver.SEQUENTIAL_IMPULSE,
-    multibody_options=sx.MultibodyOptions(integration_family="semi-implicit"),
+    multibody_options=sx.MultibodyOptions(
+        integration_family=sx.MultibodyIntegrationFamily.SEMI_IMPLICIT
+    ),
     contact_solver_method=sx.ContactSolverMethod.SEQUENTIAL_IMPULSE,
     contact_gradient_mode=sx.ContactGradientMode.ANALYTIC,
 )

--- a/docs/dev_tasks/variational_integrator_solver/README.md
+++ b/docs/dev_tasks/variational_integrator_solver/README.md
@@ -14,7 +14,7 @@ semi-implicit Euler for multibody systems, faithful to Lee/Liu/Park/Srinivasa
 (WAFR 2016, arXiv:1609.02898) and extended to DART's needs. It lives entirely
 behind the DART 7 World's method-name facade
 (`WorldOptions::multibodyOptions` at construction or
-`World::setMultibodyOptions({.integrationFamily = "variational integrator"})`),
+`World::setMultibodyOptions({.integrationFamily = MultibodyIntegrationFamily::Variational})`),
 never exposing solver / stage / component / backend types, and adds **zero
 runtime overhead** when not selected (the default path stays semi-implicit
 Euler).

--- a/docs/dev_tasks/variational_integrator_solver/graduation-criteria.md
+++ b/docs/dev_tasks/variational_integrator_solver/graduation-criteria.md
@@ -10,7 +10,7 @@ enough to commit to API stability and user-facing support.
 deprecation cycle, CI gates that keep it green, user-facing docs, and a
 maintainer who owns regressions. The VI is opt-in behind the method-name facade
 (`WorldOptions::multibodyOptions` at construction or
-`World::setMultibodyOptions({.integrationFamily = "variational integrator"})`),
+`World::setMultibodyOptions({.integrationFamily = MultibodyIntegrationFamily::Variational})`),
 so graduation does not change defaults — it changes the _promise_ we make about
 the family.
 
@@ -65,8 +65,9 @@ rigor). `[x]` = met today, `[ ]` = open.
       two-step history without re-bootstrapping.
 - [x] **API frozen with a deprecation policy (surface declared; committed at the
       graduation flip).** The stable public surface is: the
-      `"variational integrator"` `integrationFamily` name; the `MultibodyOptions`
-      value-object fields; the loop-closure API (`add_loop_closure` /
+      `MultibodyIntegrationFamily::Variational` `integrationFamily` selector; the
+      `MultibodyOptions` value-object fields; the loop-closure API
+      (`add_loop_closure` /
       `LoopClosureSpec`); the ground/link-contact API
       (`Multibody::setGroundContact` / `addGroundContactPoint`, dartpy
       `set_ground_contact` / `add_ground_contact_point`); and the non-convergence

--- a/docs/dev_tasks/variational_integrator_solver/supported-envelope.md
+++ b/docs/dev_tasks/variational_integrator_solver/supported-envelope.md
@@ -2,7 +2,7 @@
 
 The variational integrator (VI) is an **experimental** `World` integration family
 (opt-in via `WorldOptions::multibodyOptions` at construction or
-`World::setMultibodyOptions({.integrationFamily = "variational integrator"})`).
+`World::setMultibodyOptions({.integrationFamily = MultibodyIntegrationFamily::Variational})`).
 "Experimental" means we do not yet make the API-stability
 promise (see [`graduation-criteria.md`](graduation-criteria.md)), but the solver
 is fully functional **within the envelope below**. This file states that envelope

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -523,7 +523,7 @@ tests/test_avbd_packet_schema.py`, `pixi run lint` green. The live
   a previously-silent-substitution scene erroring under strict resolution —
   already landed in slice 2 (`StrictResolutionRejectsSubstitution`).
 
-#### WP-091.12 Single selection idiom
+#### WP-091.12 Single selection idiom [claimed]
 
 - Objective: every domain selects its method family through one idiom —
   typed per-domain policy value objects on `WorldOptions` resolved once at
@@ -541,6 +541,28 @@ tests/test_avbd_packet_schema.py`, `pixi run lint` green. The live
 - Gates: `pixi run lint`, `pixi run build`, `pixi run test-unit`,
   `pixi run test-py`, `pixi run check-api-boundaries`.
 - Dependencies: WP-091.11.
+- Evidence: `MultibodyOptions::integrationFamily` is now the typed
+  `MultibodyIntegrationFamily` enum (`SemiImplicit` default, `Variational`) in
+  `multibody/multibody_options.hpp`, replacing the parsed `std::string`; the
+  string parse and its `InvalidArgumentException` are gone, and
+  `setMultibodyOptions` validates the value by enum range
+  (`isValidMultibodyIntegrationFamily`) and converts it once to the internal
+  `MultibodyIntegrationMethod`. All four selection mechanisms — the
+  `RigidBodySolver` enum, the `ContactSolverMethod` enum, this multibody family
+  enum, and the AVBD `RigidAvbdContactConfig` component — resolve through the
+  single finalize-time policy path: each is recorded as a note in
+  `m_resolvedConfiguration` and gated by `m_strictSolverResolution &&
+hasSubstitution()`. Python surface matches: nanobind exposes
+  `MultibodyIntegrationFamily` (`SEMI_IMPLICIT`/`VARIATIONAL`), the stub,
+  examples, and the constructor default use the enum. Serialization round-trips
+  the enum (`test_serialization` 57/57). Gates: `pixi run lint` and
+  `check-api-boundaries` clean; the default-step golden trajectories stay 3/3
+  bit-identical (behavior-preserving — the resolved family is unchanged);
+  `test_world` 371/372 (the lone failure,
+  `BakedDynamicRigidIpcStepsDoNotGrowWorldBaseAllocator`, is the known
+  pre-existing post-#2996 rigid-IPC allocator issue, orthogonal to this change);
+  `test_variational_integration` 178/178; cross-family + corpus green;
+  `pixi run test-py` green (1382 passed, 11 skipped).
 
 #### WP-091.13 Canonical contact assembly [claimed]
 

--- a/python/dartpy/simulation/module.cpp
+++ b/python/dartpy/simulation/module.cpp
@@ -542,6 +542,9 @@ void defSimulationModule(nb::module_& m)
   nb::enum_<sim::ContactSolverMethod>(m, "ContactSolverMethod")
       .value("SEQUENTIAL_IMPULSE", sim::ContactSolverMethod::SequentialImpulse)
       .value("BOXED_LCP", sim::ContactSolverMethod::BoxedLcp);
+  nb::enum_<sim::MultibodyIntegrationFamily>(m, "MultibodyIntegrationFamily")
+      .value("SEMI_IMPLICIT", sim::MultibodyIntegrationFamily::SemiImplicit)
+      .value("VARIATIONAL", sim::MultibodyIntegrationFamily::Variational);
 
   nb::enum_<sim::ContactGradientMode>(m, "ContactGradientMode")
       .value("ANALYTIC", sim::ContactGradientMode::Analytic)
@@ -1276,7 +1279,7 @@ void defSimulationModule(nb::module_& m)
 
   nb::class_<sim::MultibodyOptions>(m, "MultibodyOptions")
       .def(
-          nb::new_([](const std::string& integrationFamily,
+          nb::new_([](sim::MultibodyIntegrationFamily integrationFamily,
                       std::size_t variationalMaxIterations,
                       double variationalTolerance) {
             return sim::MultibodyOptions{
@@ -1284,7 +1287,8 @@ void defSimulationModule(nb::module_& m)
                 .variationalMaxIterations = variationalMaxIterations,
                 .variationalTolerance = variationalTolerance};
           }),
-          nb::arg("integration_family") = "semi-implicit",
+          nb::arg("integration_family")
+          = sim::MultibodyIntegrationFamily::SemiImplicit,
           nb::arg("variational_max_iterations") = 100,
           nb::arg("variational_tolerance") = 1e-10)
       .def_rw("integration_family", &sim::MultibodyOptions::integrationFamily)

--- a/python/examples/demos/scenes/avbd_articulated_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_breakable_joint.py
@@ -56,7 +56,7 @@ def _connector_transform(start: np.ndarray, end: np.ndarray) -> np.ndarray:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("avbd_articulated_breakable_arm")

--- a/python/examples/demos/scenes/avbd_articulated_fixed_pair_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_fixed_pair_breakable_joint.py
@@ -63,7 +63,7 @@ def _relative_transform(parent: sx.Link, child: sx.Link) -> np.ndarray:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("avbd_articulated_fixed_pair_breakable_arm")

--- a/python/examples/demos/scenes/avbd_articulated_high_ratio_chain.py
+++ b/python/examples/demos/scenes/avbd_articulated_high_ratio_chain.py
@@ -56,7 +56,7 @@ def _build_high_ratio_chain(
 ) -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, -9.81))
     multibody_options: dict[str, object] = {
-        "integration_family": "variational integrator"
+        "integration_family": sx.MultibodyIntegrationFamily.VARIATIONAL
     }
     if variational_max_iterations is not None:
         multibody_options["variational_max_iterations"] = variational_max_iterations

--- a/python/examples/demos/scenes/avbd_articulated_motor_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_motor_breakable_joint.py
@@ -39,7 +39,7 @@ def _yaw(link: object) -> float:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("avbd_articulated_breakable_motor_arm")

--- a/python/examples/demos/scenes/avbd_articulated_prismatic_motor.py
+++ b/python/examples/demos/scenes/avbd_articulated_prismatic_motor.py
@@ -37,7 +37,7 @@ def _command_for_time(time: float) -> float:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     slider = world.add_multibody("avbd_articulated_prismatic_motor")

--- a/python/examples/demos/scenes/avbd_articulated_prismatic_motor_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_prismatic_motor_breakable_joint.py
@@ -39,7 +39,7 @@ def _orthogonal(position: np.ndarray, axis: np.ndarray) -> np.ndarray:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     slider = world.add_multibody("avbd_articulated_prismatic_breakable_motor")

--- a/python/examples/demos/scenes/avbd_articulated_prismatic_pair_motor_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_prismatic_pair_motor_breakable_joint.py
@@ -39,7 +39,7 @@ def _orthogonal(position: np.ndarray, axis: np.ndarray) -> np.ndarray:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     slider = world.add_multibody("avbd_articulated_prismatic_pair_breakable_motor")

--- a/python/examples/demos/scenes/avbd_articulated_revolute_motor.py
+++ b/python/examples/demos/scenes/avbd_articulated_revolute_motor.py
@@ -41,7 +41,7 @@ def _command_for_time(time: float) -> float:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("avbd_articulated_motor_arm")

--- a/python/examples/demos/scenes/avbd_articulated_spherical_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_spherical_breakable_joint.py
@@ -64,7 +64,7 @@ def _world_anchor(link: sx.Link, child_anchor: np.ndarray) -> np.ndarray:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("avbd_articulated_spherical_breakable_arm")

--- a/python/examples/demos/scenes/avbd_articulated_spherical_pair_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_spherical_pair_breakable_joint.py
@@ -70,7 +70,7 @@ def _local_anchor_for_world(link: sx.Link, world_point: np.ndarray) -> np.ndarra
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("avbd_articulated_spherical_pair_breakable_arm")

--- a/python/examples/demos/scenes/avbd_articulated_world_revolute_motor_breakable_joint.py
+++ b/python/examples/demos/scenes/avbd_articulated_world_revolute_motor_breakable_joint.py
@@ -39,7 +39,7 @@ def _yaw(link: object) -> float:
 def build() -> SceneSetup:
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("avbd_articulated_world_revolute_breakable_motor")

--- a/python/examples/demos/scenes/avbd_empty_baseline.py
+++ b/python/examples/demos/scenes/avbd_empty_baseline.py
@@ -107,7 +107,7 @@ def _axis_transform(axis: np.ndarray) -> np.ndarray:
 def build() -> SceneSetup:
     world = sx.World(time_step=_SOURCE_TIME_STEP, gravity=(0.0, 0.0, _SOURCE_GRAVITY))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     world.enter_simulation_mode()
 

--- a/python/examples/demos/scenes/loop_closure.py
+++ b/python/examples/demos/scenes/loop_closure.py
@@ -2,7 +2,7 @@
 
 A planar 4-link revolute arm (joints about +Z, links along +X) swings under
 gravity on the World with the **variational integrator** selected
-(``MultibodyOptions(integration_family="variational integrator")``). A holonomic
+(``MultibodyOptions(integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL)``). A holonomic
 ``DISTANCE`` loop closure ties the end of the last link to a fixed world anchor
 (a point carried on the root/base link, which never moves) at the exact
 tip-to-anchor separation of the rest pose. With the closure's dynamics policy set
@@ -61,7 +61,7 @@ def build() -> SceneSetup:
     # Select the variational integrator before entering simulation mode; the VI
     # is the integrator that Newton-projects onto the loop-closure manifold.
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     world.gravity = (0.0, 0.0, -9.81)
     world.time_step = 0.005

--- a/python/examples/demos/scenes/rigid_loop_closure.py
+++ b/python/examples/demos/scenes/rigid_loop_closure.py
@@ -168,7 +168,7 @@ class _RigidLoopClosureVerifier:
         offset_y = _FAMILY_BASE_Y[family_label] + _POLICY_OFFSET_Y[policy_label]
         world = sx.World(time_step=_TIME_STEP)
         world.multibody_options = sx.MultibodyOptions(
-            integration_family="variational integrator"
+            integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
         )
         world.step_profiling_enabled = True
 

--- a/python/examples/demos/scenes/rigid_multibody_solver_family.py
+++ b/python/examples/demos/scenes/rigid_multibody_solver_family.py
@@ -156,12 +156,17 @@ class _RigidMultibodySolverFamily:
         color: tuple[float, float, float],
     ) -> _SolverFamilyCase:
         offset_y = _CASE_Y[key]
+        # The case identifies its family by the documented label; map that label
+        # to the typed selector for the World configuration.
+        family = (
+            sx.MultibodyIntegrationFamily.VARIATIONAL
+            if integration_family == "variational integrator"
+            else sx.MultibodyIntegrationFamily.SEMI_IMPLICIT
+        )
         world = sx.World(
             time_step=_TIME_STEP,
             gravity=(0.0, 0.0, -_GRAVITY),
-            multibody_options=sx.MultibodyOptions(
-                integration_family=integration_family
-            ),
+            multibody_options=sx.MultibodyOptions(integration_family=family),
         )
         world.step_profiling_enabled = True
 

--- a/python/examples/demos/scenes/variational_chain.py
+++ b/python/examples/demos/scenes/variational_chain.py
@@ -2,7 +2,7 @@
 
 A 5-link revolute chain is released from horizontal under gravity on the
 World with the **variational integrator** selected
-(``MultibodyOptions(integration_family="variational integrator")``). Because the
+(``MultibodyOptions(integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL)``). Because the
 integrator is symplectic, the chain keeps swinging with no secular energy
 loss — visually it does not slowly wind down the way a dissipative
 (semi-implicit Euler) step would. This is the headline visual check for the VI.
@@ -39,7 +39,7 @@ def build() -> SceneSetup:
     # Select the variational integrator before entering simulation mode; the
     # default path stays semi-implicit Euler when this is left unset.
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     world.gravity = (0.0, 0.0, -9.81)
     world.time_step = 0.005

--- a/python/examples/demos/scenes/variational_contact.py
+++ b/python/examples/demos/scenes/variational_contact.py
@@ -44,7 +44,7 @@ def _translation(x: float, y: float, z: float) -> np.ndarray:
 def build() -> SceneSetup:
     world = sx.World()
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     world.gravity = (0.0, 0.0, -9.81)
     world.time_step = 0.002

--- a/python/examples/demos/scenes/variational_endpoint_loop_closure.py
+++ b/python/examples/demos/scenes/variational_endpoint_loop_closure.py
@@ -41,7 +41,7 @@ def _isometry(transform: np.ndarray) -> dart.Isometry3:
 def build() -> SceneSetup:
     world = sx.World()
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     world.gravity = (0.0, 0.0, -9.81)
     world.time_step = 0.005

--- a/python/examples/demos/scenes/variational_tumbler.py
+++ b/python/examples/demos/scenes/variational_tumbler.py
@@ -27,7 +27,7 @@ from ..runner import PythonDemoScene, ScenePanel, SceneSetup
 def build() -> SceneSetup:
     world = sx.World()
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     # Torque-free: zero gravity so the only motion is the conserved tumble.
     world.gravity = (0.0, 0.0, 0.0)

--- a/python/stubs/dartpy/simulation.pyi
+++ b/python/stubs/dartpy/simulation.pyi
@@ -158,6 +158,11 @@ class ContactGradientMode(enum.Enum):
 
     PRE_CONTACT_SURROGATE = 2
 
+class MultibodyIntegrationFamily(enum.Enum):
+    SEMI_IMPLICIT = 0
+
+    VARIATIONAL = 1
+
 class PhysicalParameter(enum.Enum):
     MASS = 0
 
@@ -867,16 +872,16 @@ class LoopClosureRuntimePolicy:
 class MultibodyOptions:
     def __init__(
         self,
-        integration_family: str = ...,
+        integration_family: MultibodyIntegrationFamily = ...,
         variational_max_iterations: int = ...,
         variational_tolerance: float = ...,
     ) -> None: ...
 
     @property
-    def integration_family(self) -> str: ...
+    def integration_family(self) -> MultibodyIntegrationFamily: ...
 
     @integration_family.setter
-    def integration_family(self, arg: str, /) -> None: ...
+    def integration_family(self, arg: MultibodyIntegrationFamily, /) -> None: ...
 
     @property
     def variational_max_iterations(self) -> int: ...

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -8008,7 +8008,7 @@ def test_avbd_empty_baseline_demo_steps_empty_world() -> None:
     assert sx_world.num_rigid_bodies == 0
     assert sx_world.num_multibodies == 0
     assert sx_world.num_articulated_joints == 0
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert setup.info["source_demo_rows"] == (
         "avbd-demo2d empty",
         "avbd-demo3d empty",
@@ -11397,7 +11397,7 @@ def test_avbd_articulated_revolute_motor_demo_reverses_command() -> None:
     switch_time = float(setup.info["command_switch_time"])
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.actuator_type == sx.ActuatorType.VELOCITY
     assert np.asarray(joint.command_velocity, dtype=float).reshape(1)[0] == pytest.approx(
         target_speed
@@ -11441,7 +11441,7 @@ def test_avbd_articulated_prismatic_motor_demo_reverses_command() -> None:
     switch_time = float(setup.info["command_switch_time"])
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.actuator_type == sx.ActuatorType.VELOCITY
     assert np.asarray(joint.command_velocity, dtype=float).reshape(1)[0] == pytest.approx(
         target_speed
@@ -11485,7 +11485,7 @@ def test_avbd_articulated_motor_breakable_joint_demo_resets_motor_rows() -> None
     target_speed = float(setup.info["target_speed"])
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.type == sx.JointType.REVOLUTE
     assert joint.actuator_type == sx.ActuatorType.VELOCITY
     assert joint.break_force == pytest.approx(float(setup.info["break_force"]))
@@ -11556,7 +11556,7 @@ def test_avbd_articulated_prismatic_motor_breakable_joint_demo_resets_rows() -> 
     target_speed = float(setup.info["target_speed"])
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.type == sx.JointType.PRISMATIC
     assert joint.num_dofs == 1
     assert joint.child_link == carriage
@@ -11631,7 +11631,7 @@ def test_avbd_articulated_prismatic_pair_motor_breakable_joint_demo_resets_rows(
     target_speed = float(setup.info["target_speed"])
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.type == sx.JointType.PRISMATIC
     assert joint.actuator_type == sx.ActuatorType.VELOCITY
     assert joint.break_force == pytest.approx(float(setup.info["break_force"]))
@@ -11701,7 +11701,7 @@ def test_avbd_articulated_world_revolute_motor_breakable_joint_demo_resets_rows(
     target_speed = float(setup.info["target_speed"])
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.type == sx.JointType.REVOLUTE
     assert joint.num_dofs == 1
     assert joint.child_link == rotor
@@ -11777,7 +11777,7 @@ def test_avbd_articulated_high_ratio_chain_demo_swings_and_resets() -> None:
     replay_state = setup.info["replay_state"]
     initial_tip = np.asarray(setup.info["initial_tip"], dtype=float).reshape(3)
 
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert sx_world.num_articulated_joints == 0
     assert multibody.num_dofs == len(joints)
     assert len(links) == 5
@@ -11819,7 +11819,7 @@ def test_avbd_paper_scale_high_ratio_chain_demo_builds_and_resets() -> None:
     reset_chain = setup.info["reset_chain"]
     initial_tip = np.asarray(setup.info["initial_tip"], dtype=float).reshape(3)
 
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert sx_world.multibody_options.variational_max_iterations == 200
     assert sx_world.multibody_options.variational_tolerance == pytest.approx(1.0e-9)
     assert multibody.num_dofs == len(joints)
@@ -12014,6 +12014,7 @@ def test_avbd_rigid_spherical_breakable_joint_demo_resets_anchor_only() -> None:
 
 
 def test_avbd_articulated_breakable_joint_demo_marks_and_resets_joint() -> None:
+    import dartpy as sx
     import numpy as np
 
     _require_simulation_experimental_symbols("World", "MultibodyOptions")
@@ -12030,7 +12031,7 @@ def test_avbd_articulated_breakable_joint_demo_marks_and_resets_joint() -> None:
     ).reshape(3)
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.break_force == pytest.approx(float(setup.info["break_force"]))
     assert not joint.is_broken
     with pytest.raises(Exception, match="parent endpoint"):
@@ -12085,7 +12086,7 @@ def test_avbd_articulated_fixed_pair_breakable_joint_demo_resets_relative_pose()
     relative_transform = setup.info["relative_transform"]
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.type == sx.JointType.FIXED
     assert joint.num_dofs == 0
     assert joint.parent_link == base
@@ -12154,7 +12155,7 @@ def test_avbd_articulated_spherical_breakable_joint_demo_resets_anchor_only() ->
     )
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.type == sx.JointType.SPHERICAL
     assert joint.num_dofs == 3
     assert joint.break_force == pytest.approx(float(setup.info["break_force"]))
@@ -12220,7 +12221,7 @@ def test_avbd_articulated_spherical_pair_breakable_joint_demo_resets_anchor_only
     )
 
     assert sx_world.num_articulated_joints == 1
-    assert sx_world.multibody_options.integration_family == "variational integrator"
+    assert sx_world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert joint.type == sx.JointType.SPHERICAL
     assert joint.num_dofs == 3
     assert joint.parent_link == base

--- a/python/tests/unit/simulation/test_world.py
+++ b/python/tests/unit/simulation/test_world.py
@@ -34,7 +34,7 @@ def _translation_transform(x: float, y: float, z: float):
 def _floating_link_world(sx, name: str):
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     arm = world.add_multibody(name)
     base = arm.add_link("base")
@@ -51,7 +51,7 @@ def _floating_link_world(sx, name: str):
 def _floating_link_pair_world(sx, name: str):
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     arm = world.add_multibody(name)
     base = arm.add_link("base")
@@ -582,7 +582,7 @@ def test_simulation_world_clear_invalidates_articulated_joint_handles_from_pytho
 
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
 
     arm = world.add_multibody("clear_arm")
@@ -632,7 +632,7 @@ def test_simulation_world_clear_invalidates_articulated_joint_handles_from_pytho
     world.gravity = (0.0, 0.0, 0.0)
     world.time_step = 0.005
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     rebuilt_arm = world.add_multibody("rebuilt_clear_arm")
     rebuilt_base = rebuilt_arm.add_link("base")
@@ -960,7 +960,7 @@ def test_simulation_world_articulated_joint_list_keeps_world_alive():
     def build_joints_from_temporary_world():
         world = sx.World()
         world.multibody_options = sx.MultibodyOptions(
-            integration_family="variational integrator"
+            integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
         )
         arm = world.add_multibody("arm")
         base = arm.add_link("base")
@@ -992,7 +992,7 @@ def test_simulation_world_articulated_point_joint_facade_exposes_link_endpoints(
 
     world = sx.World(time_step=0.005, gravity=(0.0, 0.0, 0.0))
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     arm = world.add_multibody("arm")
     base = arm.add_link("base")
@@ -1168,7 +1168,7 @@ def test_simulation_world_articulated_point_joint_facade_exposes_link_endpoints(
     )
     foreign_world = sx.World()
     foreign_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     foreign_arm = foreign_world.add_multibody("foreign_arm")
     foreign_base = foreign_arm.add_link("foreign_base")
@@ -1223,7 +1223,7 @@ def test_simulation_world_articulated_point_joints_generate_unique_names():
 
     world = sx.World()
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     arm = world.add_multibody("generated_joint_arm")
     base = arm.add_link("base")
@@ -1271,7 +1271,7 @@ def test_simulation_world_articulated_generated_names_resume_after_binary_roundt
 
     world = sx.World()
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     arm = world.add_multibody("serialized_generated_joint_arm")
     base = arm.add_link("base")
@@ -1317,7 +1317,7 @@ def test_simulation_world_articulated_avbd_stiffness_roundtrip_from_python(
 
     world = sx.World()
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     arm = world.add_multibody("serialized_articulated_stiffness_arm")
     base = arm.add_link("base")
@@ -1455,7 +1455,7 @@ def test_simulation_world_clear_resets_articulated_generated_names():
 
     world = sx.World()
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     arm = world.add_multibody("clear_generated_joint_arm")
     base = arm.add_link("base")
@@ -2823,7 +2823,7 @@ def test_simulation_world_articulated_binary_roundtrip_from_python(tmp_path: Pat
     restored_pair_world = sx.World()
     restored_pair_world.load_binary(pair_path)
     restored_pair_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_pair_arm = restored_pair_world.get_multibody(
         "python_serialized_pair_slider"
@@ -2963,7 +2963,7 @@ def test_simulation_world_articulated_binary_roundtrip_from_python(tmp_path: Pat
     restored_hinge_world = sx.World()
     restored_hinge_world.load_binary(hinge_path)
     restored_hinge_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_hinge_arm = restored_hinge_world.get_multibody(
         "python_serialized_world_hinge"
@@ -3106,7 +3106,7 @@ def test_simulation_world_articulated_binary_roundtrip_from_python_completes_one
     restored_pair_hinge_world = sx.World()
     restored_pair_hinge_world.load_binary(pair_hinge_path)
     restored_pair_hinge_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_pair_hinge_arm = restored_pair_hinge_world.get_multibody(
         "python_serialized_pair_hinge_broken"
@@ -3288,7 +3288,7 @@ def test_simulation_world_articulated_binary_roundtrip_from_python_completes_one
     restored_world_slider_world = sx.World()
     restored_world_slider_world.load_binary(world_slider_path)
     restored_world_slider_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_world_slider_arm = restored_world_slider_world.get_multibody(
         "python_serialized_world_slider_broken"
@@ -3454,7 +3454,7 @@ def test_simulation_world_articulated_fixed_spherical_binary_roundtrip_from_pyth
     restored_fixed_world = sx.World()
     restored_fixed_world.load_binary(fixed_path)
     restored_fixed_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_fixed_arm = restored_fixed_world.get_multibody(
         "python_serialized_pair_fixed"
@@ -3574,7 +3574,7 @@ def test_simulation_world_articulated_fixed_spherical_binary_roundtrip_from_pyth
     restored_socket_world = sx.World()
     restored_socket_world.load_binary(socket_path)
     restored_socket_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_socket_arm = restored_socket_world.get_multibody(
         "python_serialized_world_socket"
@@ -3684,7 +3684,7 @@ def test_simulation_world_articulated_fixed_spherical_binary_roundtrip_from_pyth
     restored_fixed_world = sx.World()
     restored_fixed_world.load_binary(fixed_path)
     restored_fixed_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_fixed_arm = restored_fixed_world.get_multibody(
         "python_serialized_world_fixed"
@@ -3796,7 +3796,7 @@ def test_simulation_world_articulated_fixed_spherical_binary_roundtrip_from_pyth
     restored_socket_world = sx.World()
     restored_socket_world.load_binary(socket_path)
     restored_socket_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     restored_socket_arm = restored_socket_world.get_multibody(
         "python_serialized_pair_socket"
@@ -3911,7 +3911,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python(
     restored_fixed_world = sx.World()
     restored_fixed_world.load_binary(fixed_path)
     restored_fixed_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_fixed_world.is_simulation_mode
     restored_fixed_arm = restored_fixed_world.get_multibody(
@@ -4016,7 +4016,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python(
     restored_slider_world = sx.World()
     restored_slider_world.load_binary(slider_path)
     restored_slider_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_slider_world.is_simulation_mode
     restored_slider_arm = restored_slider_world.get_multibody(
@@ -4129,7 +4129,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python(
     restored_hinge_world = sx.World()
     restored_hinge_world.load_binary(hinge_path)
     restored_hinge_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_hinge_world.is_simulation_mode
     restored_hinge_arm = restored_hinge_world.get_multibody(
@@ -4252,7 +4252,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python(
     restored_world_slider_world = sx.World()
     restored_world_slider_world.load_binary(world_slider_path)
     restored_world_slider_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_world_slider_world.is_simulation_mode
     restored_world_slider_arm = restored_world_slider_world.get_multibody(
@@ -4375,7 +4375,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python(
     restored_world_hinge_world = sx.World()
     restored_world_hinge_world.load_binary(world_hinge_path)
     restored_world_hinge_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_world_hinge_world.is_simulation_mode
     restored_world_hinge_arm = restored_world_hinge_world.get_multibody(
@@ -4481,7 +4481,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python(
     restored_socket_world = sx.World()
     restored_socket_world.load_binary(socket_path)
     restored_socket_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_socket_world.is_simulation_mode
     restored_socket_arm = restored_socket_world.get_multibody(
@@ -4573,7 +4573,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python_complete
     restored_fixed_world = sx.World()
     restored_fixed_world.load_binary(fixed_path)
     restored_fixed_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_fixed_world.is_simulation_mode
     restored_fixed_arm = restored_fixed_world.get_multibody(
@@ -4659,7 +4659,7 @@ def test_simulation_world_articulated_design_binary_rebuild_from_python_complete
     restored_socket_world = sx.World()
     restored_socket_world.load_binary(socket_path)
     restored_socket_world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator"
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL
     )
     assert not restored_socket_world.is_simulation_mode
     restored_socket_arm = restored_socket_world.get_multibody(
@@ -6003,13 +6003,13 @@ def test_simulation_multibody_options_selector():
     configured = sx.World(
         rigid_body_solver=sx.RigidBodySolver.IPC,
         multibody_options=sx.MultibodyOptions(
-            integration_family="variational integrator",
+            integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL,
             variational_max_iterations=200,
             variational_tolerance=1.0e-9,
         ),
     )
     assert configured.rigid_body_solver == sx.RigidBodySolver.IPC
-    assert configured.multibody_options.integration_family == "variational integrator"
+    assert configured.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert configured.multibody_options.variational_max_iterations == 200
     assert configured.multibody_options.variational_tolerance == pytest.approx(1.0e-9)
 
@@ -6031,32 +6031,32 @@ def test_simulation_multibody_options_selector():
         sx.World(multibody_options=sx.MultibodyOptions(integration_family="nonsense"))
 
     world = sx.World()
-    # Multibody solver config is a value object; selection is by documented
-    # method-family name only.
-    assert world.multibody_options.integration_family == "semi-implicit"
+    # Multibody solver config is a value object; selection is by the typed
+    # method-family enum (MultibodyIntegrationFamily).
+    assert world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.SEMI_IMPLICIT
     assert world.multibody_options.variational_max_iterations == 100
     assert world.multibody_options.variational_tolerance == pytest.approx(1.0e-10)
     world.multibody_options = sx.MultibodyOptions(
-        integration_family="variational integrator",
+        integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL,
         variational_max_iterations=120,
         variational_tolerance=2.0e-9,
     )
-    assert world.multibody_options.integration_family == "variational integrator"
+    assert world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert world.multibody_options.variational_max_iterations == 120
     assert world.multibody_options.variational_tolerance == pytest.approx(2.0e-9)
     with pytest.raises(Exception):
         world.multibody_options = sx.MultibodyOptions(integration_family="nonsense")
     # A rejected assignment leaves the previous valid selection in place.
-    assert world.multibody_options.integration_family == "variational integrator"
+    assert world.multibody_options.integration_family == sx.MultibodyIntegrationFamily.VARIATIONAL
     assert world.multibody_options.variational_max_iterations == 120
     with pytest.raises(Exception):
         world.multibody_options = sx.MultibodyOptions(
-            integration_family="variational integrator",
+            integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL,
             variational_max_iterations=0,
         )
     with pytest.raises(Exception):
         world.multibody_options = sx.MultibodyOptions(
-            integration_family="variational integrator",
+            integration_family=sx.MultibodyIntegrationFamily.VARIATIONAL,
             variational_tolerance=0.0,
         )
 

--- a/tests/benchmark/simulation/bm_avbd_rigid_fixed_joint.cpp
+++ b/tests/benchmark/simulation/bm_avbd_rigid_fixed_joint.cpp
@@ -69,7 +69,8 @@ std::unique_ptr<sx::World> makeAvbdEmptyWorld()
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
   return world;
 }
@@ -1936,7 +1937,8 @@ std::unique_ptr<sx::World> makeArticulatedRevoluteMotorWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot = world->addMultibody("articulated_revolute_motor_robot");
@@ -1995,7 +1997,8 @@ std::unique_ptr<sx::World> makeArticulatedBreakableMotorWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot = world->addMultibody("articulated_breakable_motor_robot");
@@ -2058,7 +2061,8 @@ std::unique_ptr<sx::World> makeArticulatedPrismaticMotorWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot = world->addMultibody("articulated_prismatic_motor_robot");
@@ -2117,7 +2121,8 @@ std::unique_ptr<sx::World> makeArticulatedPrismaticBreakableMotorWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot
@@ -2181,7 +2186,8 @@ std::unique_ptr<sx::World> makeArticulatedWorldPrismaticBreakableMotorWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot = world->addMultibody(
@@ -2244,7 +2250,8 @@ std::unique_ptr<sx::World> makeArticulatedWorldRevoluteBreakableMotorWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot
@@ -2307,7 +2314,8 @@ std::unique_ptr<sx::World> makeArticulatedBreakableJointWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot = world->addMultibody("articulated_breakable_robot");
@@ -2360,7 +2368,8 @@ std::unique_ptr<sx::World> makeArticulatedWorldSphericalBreakableJointWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot
@@ -2416,7 +2425,8 @@ std::unique_ptr<sx::World> makeArticulatedSphericalPairBreakableJointWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   world->setMultibodyOptions(multibodyOptions);
 
   auto robot
@@ -2494,7 +2504,8 @@ ArticulatedHighRatioChainFixture makeArticulatedHighRatioChainWorld(
   auto world = std::make_unique<sx::World>(options);
 
   sx::MultibodyOptions multibodyOptions;
-  multibodyOptions.integrationFamily = "variational integrator";
+  multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   multibodyOptions.variationalMaxIterations = maxIterations;
   multibodyOptions.variationalTolerance = tolerance;
   world->setMultibodyOptions(multibodyOptions);

--- a/tests/unit/simulation/compute/test_cross_family_corpus.cpp
+++ b/tests/unit/simulation/compute/test_cross_family_corpus.cpp
@@ -457,7 +457,13 @@ CorpusRow runCaseFamily(const SceneCase& c, const std::string& family)
 
   if (c.axis == FamilyAxis::MultibodyIntegration) {
     // The integration family is selected on the World, before bodies exist.
-    world.setMultibodyOptions({.integrationFamily = family});
+    // The corpus identifies families by their documented label; map that label
+    // to the typed selector here.
+    world.setMultibodyOptions(
+        {.integrationFamily
+         = (family == "variational integrator")
+               ? sx::MultibodyIntegrationFamily::Variational
+               : sx::MultibodyIntegrationFamily::SemiImplicit});
   }
 
   c.build(world);

--- a/tests/unit/simulation/compute/test_cross_family_metrics.cpp
+++ b/tests/unit/simulation/compute/test_cross_family_metrics.cpp
@@ -294,7 +294,8 @@ struct PendulumRollout
   sxc::StepMetrics afterRoll;
 };
 
-PendulumRollout runPendulum(const std::string& integrationFamily, int steps)
+PendulumRollout runPendulum(
+    sx::MultibodyIntegrationFamily integrationFamily, int steps)
 {
   sx::World world;
   buildPendulum(world);
@@ -328,9 +329,10 @@ TEST(CrossFamilyMetrics, MultibodyIntegrationFamiliesAgreeOnConservedEnergy)
   constexpr int kSteps = 20000;
 
   std::vector<std::pair<std::string, PendulumRollout>> runs
-      = {{"multibody:semi-implicit", runPendulum("semi-implicit", kSteps)},
+      = {{"multibody:semi-implicit",
+          runPendulum(sx::MultibodyIntegrationFamily::SemiImplicit, kSteps)},
          {"multibody:variational integrator",
-          runPendulum("variational integrator", kSteps)}};
+          runPendulum(sx::MultibodyIntegrationFamily::Variational, kSteps)}};
 
   std::ostringstream table;
   for (const auto& [family, run] : runs) {

--- a/tests/unit/simulation/compute/test_variational_integration.cpp
+++ b/tests/unit/simulation/compute/test_variational_integration.cpp
@@ -237,7 +237,8 @@ TEST(VariationalIntegration, VelocityActuatorSinglePrismaticCommandsVelocity)
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("slider");
   auto base = robot.addLink("base");
 
@@ -267,7 +268,8 @@ TEST(VariationalIntegration, VelocityActuatorCoupledRevoluteCommandsVelocity)
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world.addMultibody("double_pendulum");
   auto base = robot.addLink("base");
@@ -420,26 +422,31 @@ TEST(VariationalIntegration, PendulumConservesEnergyOverLongHorizon)
 TEST(VariationalIntegration, SelectableThroughWorldStep)
 {
   sx::World world;
-  EXPECT_EQ(world.getMultibodyOptions().integrationFamily, "semi-implicit");
+  EXPECT_EQ(
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::SemiImplicit);
   EXPECT_THROW(
-      world.setMultibodyOptions({.integrationFamily = "nonsense"}),
+      world.setMultibodyOptions(
+          {.integrationFamily
+           = static_cast<sx::MultibodyIntegrationFamily>(99)}),
       sx::InvalidArgumentException);
   EXPECT_THROW(
       world.setMultibodyOptions(
-          {.integrationFamily = "variational integrator",
+          {.integrationFamily = sx::MultibodyIntegrationFamily::Variational,
            .variationalMaxIterations = 0}),
       sx::InvalidArgumentException);
   EXPECT_THROW(
       world.setMultibodyOptions(
-          {.integrationFamily = "variational integrator",
+          {.integrationFamily = sx::MultibodyIntegrationFamily::Variational,
            .variationalTolerance = 0.0}),
       sx::InvalidArgumentException);
   world.setMultibodyOptions(
-      {.integrationFamily = "variational integrator",
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational,
        .variationalMaxIterations = 120,
        .variationalTolerance = 2e-9});
   EXPECT_EQ(
-      world.getMultibodyOptions().integrationFamily, "variational integrator");
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::Variational);
   EXPECT_EQ(world.getMultibodyOptions().variationalMaxIterations, 120u);
   EXPECT_DOUBLE_EQ(world.getMultibodyOptions().variationalTolerance, 2e-9);
 
@@ -551,7 +558,8 @@ TEST(VariationalIntegration, DeterministicAcrossRuns)
 {
   const auto rollout = []() {
     sx::World world;
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     auto robot = world.addMultibody("chain");
     auto parent = robot.addLink("base");
     for (int i = 0; i < 3; ++i) {
@@ -945,7 +953,7 @@ TEST(VariationalIntegration, PaperScaleHighRatioChainStaysFiniteAndResets)
   world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
   world.setTimeStep(kDt);
   world.setMultibodyOptions(
-      {.integrationFamily = "variational integrator",
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational,
        .variationalMaxIterations = 200,
        .variationalTolerance = 1e-9});
 
@@ -1124,7 +1132,8 @@ TEST(VariationalIntegration, FloatingBaseConservesMomentum)
 TEST(VariationalIntegration, LoopClosureSolvedThroughWorldStep)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("arm");
   auto parent = robot.addLink("base");
   const double bend[5] = {0.0, 0.5, -0.5, 0.5, -0.5};
@@ -1181,7 +1190,8 @@ TEST(VariationalIntegration, LoopClosureSolvedThroughWorldStep)
 TEST(VariationalIntegration, LoopClosureConstraintScratchIsBaked)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("arm");
   auto parent = robot.addLink("base");
   const double bend[5] = {0.0, 0.5, -0.5, 0.5, -0.5};
@@ -1294,7 +1304,8 @@ TEST(VariationalIntegration, LoopClosureConstraintScratchIsBaked)
 TEST(VariationalIntegration, LoopClosureCrossMultibodyRejectedUnderVariational)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const auto makeArm = [&](const char* name) {
     auto robot = world.addMultibody(name);
     auto base = robot.addLink(std::string(name) + "_base");
@@ -1421,7 +1432,8 @@ TEST(VariationalIntegration, RigidConstraintJacobianMatchesFiniteDifference)
 TEST(VariationalIntegration, LoopClosureRigidSolvedThroughWorldStep)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("arm");
   auto parent = robot.addLink("base");
   const Eigen::Vector3d axes[7]
@@ -1489,7 +1501,8 @@ TEST(VariationalIntegration, LoopClosureRigidSolvedThroughWorldStep)
 TEST(VariationalIntegration, AvbdFixedPointJointConfigSolvesLinkEndpoint)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("arm");
   auto parent = robot.addLink("base");
   const Eigen::Vector3d axes[7]
@@ -1569,7 +1582,8 @@ TEST(VariationalIntegration, AvbdBreakablePointJointConfigMarksLinkEndpoint)
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("pendulum");
   auto base = robot.addLink("base");
 
@@ -1630,7 +1644,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("resettable_private_breakable_pendulum");
   auto base = robot.addLink("base");
 
@@ -1688,7 +1703,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("resettable_private_breakable_pendulum");
@@ -1747,7 +1763,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("serialized_private_parent_fixed_body");
@@ -1825,7 +1842,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("serialized_private_parent_fixed_body");
@@ -1904,7 +1922,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("floater");
@@ -1981,7 +2000,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floater");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -2058,7 +2078,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("serialized_private_spherical_socket_body");
@@ -2119,7 +2140,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("serialized_private_spherical_socket_body");
@@ -2218,7 +2240,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot
@@ -2280,7 +2303,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("serialized_private_child_spherical_socket_body");
@@ -2383,7 +2407,8 @@ TEST(VariationalIntegration, AvbdCompliantPointJointConfigPullsLinkEndpoint)
   const auto rollout = [](bool compliant) {
     sx::World world;
     world.setGravity(Eigen::Vector3d::Zero());
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     world.setTimeStep(0.002);
 
     auto robot = world.addMultibody("floater");
@@ -2447,7 +2472,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.002);
 
   auto robot = world.addMultibody("floater");
@@ -2515,7 +2541,8 @@ TEST(
   const auto rollout = [](double startStiffness, double maxStiffness) {
     sx::World world;
     world.setGravity(Eigen::Vector3d::Zero());
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     world.setTimeStep(0.002);
 
     auto robot = world.addMultibody("floater");
@@ -2588,7 +2615,8 @@ TEST(
                           bool driveAngular) {
     sx::World world;
     world.setGravity(Eigen::Vector3d::Zero());
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     world.setTimeStep(0.002);
 
     auto robot = world.addMultibody("floater");
@@ -2679,7 +2707,8 @@ TEST(
 TEST(VariationalIntegration, AvbdPointJointConfigSkipsTopologyJoint)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("pendulum");
   auto base = robot.addLink("base");
 
@@ -2716,7 +2745,8 @@ TEST(VariationalIntegration, AvbdPointJointConfigSkipsTopologyJoint)
 TEST(VariationalIntegration, LoopClosureDistanceSolvedThroughWorldStep)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("arm");
   auto base = robot.addLink("base");
   const auto offset = [](double x) {
@@ -2786,7 +2816,8 @@ TEST(VariationalIntegration, LoopClosureDistanceSolvedThroughWorldStep)
 TEST(VariationalIntegration, StateSerializationRoundTripsTrajectory)
 {
   const auto buildPendulum = [](sx::World& world) {
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     auto robot = world.addMultibody("pendulum");
     auto base = robot.addLink("base");
     Eigen::Isometry3d offset = Eigen::Isometry3d::Identity();
@@ -2829,7 +2860,8 @@ TEST(VariationalIntegration, StateSerializationRoundTripsTrajectory)
   sx::World loaded;
   buffer.seekg(0);
   loaded.loadBinary(buffer);
-  loaded.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  loaded.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   ASSERT_TRUE(loaded.getMultibody("pendulum").has_value());
   for (int k = 0; k < 50; ++k) {
     loaded.step();
@@ -2973,7 +3005,9 @@ TEST(VariationalIntegration, LongChainExactPreconditionerConvergesWithinBudget)
 TEST(VariationalIntegration, DefaultPathDoesNotEngageVariationalIntegrator)
 {
   sx::World world; // default family is "semi-implicit"
-  ASSERT_EQ(world.getMultibodyOptions().integrationFamily, "semi-implicit");
+  ASSERT_EQ(
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::SemiImplicit);
   auto robot = world.addMultibody("pendulum");
   auto base = robot.addLink("base");
   Eigen::Isometry3d offset = Eigen::Isometry3d::Identity();
@@ -3377,7 +3411,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -3434,7 +3469,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -3507,7 +3543,8 @@ TEST(
 
     sx::World world;
     world.setGravity(Eigen::Vector3d::Zero());
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     world.setTimeStep(0.005);
 
     auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -3597,7 +3634,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -3665,7 +3703,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -3733,7 +3772,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_fixed_facade");
@@ -3802,7 +3842,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -3865,7 +3906,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -3888,7 +3930,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -3965,7 +4008,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
 
@@ -4110,7 +4154,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto& registry = dart::simulation::detail::registryOf(restored);
   for (const ExpectedJoint& joint : expected) {
@@ -4159,7 +4204,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_spherical_facade");
@@ -4226,7 +4272,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_spherical_offset_facade");
@@ -4294,7 +4341,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("serialized_world_spherical_facade");
@@ -4321,7 +4369,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("serialized_world_spherical_facade");
@@ -4388,7 +4437,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -4411,7 +4461,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -4489,7 +4540,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_spherical_breakable_skip");
@@ -4535,7 +4587,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_spherical_breakable_reset");
@@ -4607,7 +4660,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_spherical_save_load_breakage");
@@ -4645,7 +4699,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("public_world_spherical_save_load_breakage");
@@ -4719,7 +4774,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -4756,7 +4812,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -4857,7 +4914,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -4927,7 +4985,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_revolute_tiny_limit_facade");
@@ -4999,7 +5058,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5069,7 +5129,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5137,7 +5198,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -5216,7 +5278,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5298,7 +5361,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5330,7 +5394,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -5414,7 +5479,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5483,7 +5549,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_prismatic_tiny_limit_facade");
@@ -5560,7 +5627,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5632,7 +5700,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5700,7 +5769,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -5779,7 +5849,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5860,7 +5931,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -5892,7 +5964,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -5976,7 +6049,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_breakable_facade");
@@ -6017,7 +6091,8 @@ TEST(VariationalIntegration, AvbdPublicArticulatedBreakForceResetReengagesJoint)
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_breakable_reset_facade");
@@ -6078,7 +6153,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_breakable_save_load_facade");
@@ -6114,7 +6190,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("public_breakable_save_load_facade");
@@ -6183,7 +6260,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -6241,7 +6319,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -6337,7 +6416,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -6432,7 +6512,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -6469,7 +6550,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -6561,7 +6643,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -6600,7 +6683,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -6702,7 +6786,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -6742,7 +6827,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -6850,7 +6936,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -6915,7 +7002,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -6983,7 +7071,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -7027,7 +7116,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("public_revolute_save_load_breakage");
@@ -7115,7 +7205,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -7188,7 +7279,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -7256,7 +7348,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -7301,7 +7394,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("public_prismatic_save_load_breakage");
@@ -7396,7 +7490,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_fixed_facade");
@@ -7450,7 +7545,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_fixed_offset_facade");
@@ -7515,7 +7611,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("serialized_world_fixed_facade");
@@ -7541,7 +7638,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("serialized_world_fixed_facade");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -7609,7 +7707,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_fixed_breakable_facade");
@@ -7679,7 +7778,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_fixed_save_load_breakage");
@@ -7715,7 +7815,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("public_world_fixed_save_load_breakage");
@@ -7790,7 +7891,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -7860,7 +7962,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -7937,7 +8040,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -7972,7 +8076,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("serialized_world_revolute_facade");
@@ -8050,7 +8155,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_revolute_tiny_limit_facade");
@@ -8119,7 +8225,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8189,7 +8296,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8254,7 +8362,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8321,7 +8430,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8364,7 +8474,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("public_world_revolute_save_load_breakage");
@@ -8453,7 +8564,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   constexpr double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8514,13 +8626,16 @@ TEST(
   EXPECT_EQ(world.getFrame(), 0u);
   EXPECT_EQ(world.getMultibodyCount(), 0u);
   EXPECT_EQ(world.getArticulatedJointCount(), 0u);
-  EXPECT_EQ(world.getMultibodyOptions().integrationFamily, "semi-implicit");
+  EXPECT_EQ(
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::SemiImplicit);
   EXPECT_FALSE(world.hasMultibody("clear_revolute_world_facade"));
   EXPECT_FALSE(world.hasArticulatedJoint("clear_hinge"));
   EXPECT_FALSE(world.getArticulatedJoint("clear_hinge").has_value());
 
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(dt);
 
   auto rebuiltRobot = world.addMultibody("clear_prismatic_world_facade");
@@ -8588,7 +8703,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8658,7 +8774,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8737,7 +8854,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8773,7 +8891,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("serialized_world_prismatic_facade");
@@ -8851,7 +8970,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto robot = world.addMultibody("public_world_prismatic_tiny_limit_facade");
@@ -8925,7 +9045,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -8997,7 +9118,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9070,7 +9192,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9138,7 +9261,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9182,7 +9306,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot
       = restored.getMultibody("public_world_prismatic_save_load_breakage");
@@ -9279,7 +9404,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -9341,7 +9467,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9405,7 +9532,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -9468,7 +9596,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -9529,7 +9658,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -9589,7 +9719,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -9650,7 +9781,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9729,7 +9861,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9805,7 +9938,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9880,7 +10014,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -9956,7 +10091,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10020,7 +10156,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10101,7 +10238,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10183,7 +10321,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10264,7 +10403,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10346,7 +10486,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -10408,7 +10549,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -10471,7 +10613,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -10533,7 +10676,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -10596,7 +10740,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -10656,7 +10801,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   auto body = addFloatingBody(world, /*mass=*/2.0);
@@ -10708,7 +10854,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10774,7 +10921,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10837,7 +10985,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10895,7 +11044,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -10983,7 +11133,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -11072,7 +11223,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -11119,7 +11271,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto restoredRobot = restored.getMultibody("floater");
   ASSERT_TRUE(restoredRobot.has_value());
   auto restoredBody = restoredRobot->getLink("body");
@@ -11210,7 +11363,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -11258,7 +11412,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto restoredRobot = restored.getMultibody("floater");
   ASSERT_TRUE(restoredRobot.has_value());
   auto restoredBody = restoredRobot->getLink("body");
@@ -11348,7 +11503,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -11401,7 +11557,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto restoredRobot = restored.getMultibody("floater");
   ASSERT_TRUE(restoredRobot.has_value());
   auto restoredBody = restoredRobot->getLink("body");
@@ -11505,7 +11662,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -11558,7 +11716,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto restoredRobot = restored.getMultibody("floater");
   ASSERT_TRUE(restoredRobot.has_value());
   auto restoredBody = restoredRobot->getLink("body");
@@ -11662,7 +11821,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -11762,7 +11922,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -11874,7 +12035,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -12001,7 +12163,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -12101,7 +12264,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -12177,7 +12341,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -12260,7 +12425,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -12293,7 +12459,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -12377,7 +12544,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -12411,7 +12579,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -12507,7 +12676,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -12606,7 +12776,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -12677,7 +12848,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -12790,7 +12962,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -12906,7 +13079,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -13026,7 +13200,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -13086,7 +13261,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -13217,7 +13393,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   const double dt = 0.005;
   world.setTimeStep(dt);
 
@@ -13279,7 +13456,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -13417,7 +13595,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -13481,7 +13660,8 @@ TEST(
 
   sx::World restored;
   restored.loadBinary(data);
-  restored.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  restored.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto restoredRobot = restored.getMultibody("floating_pair");
   ASSERT_TRUE(restoredRobot.has_value());
@@ -13594,7 +13774,8 @@ TEST(
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setTimeStep(0.005);
 
   FloatingLinkPair pair = addFloatingLinkPair(world);
@@ -13803,7 +13984,8 @@ TEST(ExternalForce, VariationalChainTipDeflectsInForceDirection)
 {
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero()); // isolate the applied force
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world.addMultibody("chain");
   auto parent = robot.addLink("base");
@@ -13892,7 +14074,8 @@ TEST(ExternalForce, VariationalForceIsClearedAfterStep)
 
   sx::World world;
   world.setGravity(Eigen::Vector3d::Zero());
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto body = addFloatingBody(world, mass);
   world.setTimeStep(dt);
   world.enterSimulationMode();
@@ -14569,7 +14752,8 @@ TEST(VariationalGroundContact, WorldSurfaceCompliantContactRestsOnGround)
   const int steps = 3000;
 
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("slider");
   auto base = robot.addLink("base");
   sx::JointSpec spec;
@@ -14628,7 +14812,7 @@ TEST(VariationalGroundContact, ConfigRoundTripsThroughBinarySaveLoad)
 
   sx::World reference;
   reference.setMultibodyOptions(
-      {.integrationFamily = "variational integrator"});
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = reference.addMultibody("slider");
   auto base = robot.addLink("base"); // link index 0.
   sx::JointSpec spec;
@@ -14660,7 +14844,8 @@ TEST(VariationalGroundContact, ConfigRoundTripsThroughBinarySaveLoad)
   sx::World loaded;
   buffer.seekg(0);
   loaded.loadBinary(buffer);
-  loaded.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  loaded.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   ASSERT_TRUE(loaded.getMultibody("slider").has_value());
 
   // The contact config came back field-for-field, including the std::vector
@@ -14709,7 +14894,8 @@ TEST(VariationalGroundContact, WorldSurfaceAugmentedLagrangianCentersContact)
 
   const auto run = [&](std::size_t dualUpdateCadence) {
     sx::World world;
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     auto carriage = addVerticalSlider(world, mass);
     world.setTimeStep(dt);
     world.enterSimulationMode();
@@ -14763,7 +14949,7 @@ TEST(VariationalGroundContact, AugmentedLagrangianDualStateRoundTrips)
 
   sx::World reference;
   reference.setMultibodyOptions(
-      {.integrationFamily = "variational integrator"});
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto carriage = addVerticalSlider(reference, mass);
   reference.setTimeStep(dt);
   reference.enterSimulationMode();
@@ -14799,7 +14985,8 @@ TEST(VariationalGroundContact, AugmentedLagrangianDualStateRoundTrips)
   sx::World loaded;
   buffer.seekg(0);
   loaded.loadBinary(buffer);
-  loaded.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  loaded.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   ASSERT_TRUE(loaded.getMultibody("slider").has_value());
   for (int step = 0; step < 100; ++step) {
     loaded.step();
@@ -14830,7 +15017,8 @@ TEST(VariationalGroundContact, DampingSettlesContactOnDefaultPath)
   // Highest point the slider reaches after first crossing into the half-space.
   const auto reboundHeight = [&](double damping) {
     sx::World world;
-    world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
     auto carriage = addVerticalSlider(world, mass);
     world.setTimeStep(dt);
     world.enterSimulationMode();
@@ -14880,7 +15068,8 @@ TEST(VariationalGroundContact, DampingSettlesContactOnDefaultPath)
 TEST(VariationalGroundContact, RejectsContactPointFromForeignWorld)
 {
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   auto robot = world.addMultibody("slider");
   auto base = robot.addLink("base");
   robot.setGroundContact(

--- a/tests/unit/simulation/world/test_serialization.cpp
+++ b/tests/unit/simulation/world/test_serialization.cpp
@@ -306,7 +306,7 @@ void expectBrokenArticulatedPointJointRoundTrips(
 
   sx::World world1;
   world1.setGravity(Eigen::Vector3d::Zero());
-  world1.setMultibodyOptions({"variational integrator"});
+  world1.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world1.addMultibody("robot");
   auto base = robot.addLink("base");
@@ -343,7 +343,8 @@ void expectBrokenArticulatedPointJointRoundTrips(
 
   EXPECT_TRUE(world2.isSimulationMode());
   EXPECT_EQ(
-      world2.getMultibodyOptions().integrationFamily, "variational integrator");
+      world2.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::Variational);
   EXPECT_EQ(world2.getArticulatedJointCount(), 1u);
   auto restoredJoint = world2.getArticulatedJoint(jointName);
   ASSERT_TRUE(restoredJoint.has_value());
@@ -1287,7 +1288,8 @@ TEST(Serialization, PreservesWorldSolverOptions)
 
   sx::WorldOptions options;
   options.rigidBodySolver = sx::RigidBodySolver::Ipc;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   options.multibodyOptions.variationalMaxIterations = 200;
   options.multibodyOptions.variationalTolerance = 1e-9;
   options.differentiable = true;
@@ -1304,7 +1306,8 @@ TEST(Serialization, PreservesWorldSolverOptions)
 
   EXPECT_EQ(world2.getRigidBodySolver(), sx::RigidBodySolver::Ipc);
   EXPECT_EQ(
-      world2.getMultibodyOptions().integrationFamily, "variational integrator");
+      world2.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::Variational);
   EXPECT_EQ(world2.getMultibodyOptions().variationalMaxIterations, 200u);
   EXPECT_DOUBLE_EQ(world2.getMultibodyOptions().variationalTolerance, 1e-9);
   EXPECT_TRUE(world2.isDifferentiable());
@@ -1350,7 +1353,8 @@ TEST(Serialization, LegacyV15WorldSolverOptionsLoadBeforeIgnoredPairs)
   EXPECT_TRUE(world.isDifferentiable());
   EXPECT_EQ(world.getRigidBodySolver(), sx::RigidBodySolver::Ipc);
   EXPECT_EQ(
-      world.getMultibodyOptions().integrationFamily, "variational integrator");
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::Variational);
   EXPECT_EQ(world.getMultibodyOptions().variationalMaxIterations, 100u);
   EXPECT_DOUBLE_EQ(world.getMultibodyOptions().variationalTolerance, 1e-10);
   EXPECT_EQ(world.getContactSolverMethod(), sx::ContactSolverMethod::BoxedLcp);
@@ -1420,7 +1424,8 @@ TEST(Serialization, LegacyLoadResetsMissingWorldSolverOptionsToDefaults)
 
   sx::WorldOptions options;
   options.rigidBodySolver = sx::RigidBodySolver::Ipc;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   options.multibodyOptions.variationalMaxIterations = 200;
   options.multibodyOptions.variationalTolerance = 1e-9;
   options.differentiable = true;
@@ -1432,7 +1437,9 @@ TEST(Serialization, LegacyLoadResetsMissingWorldSolverOptionsToDefaults)
 
   EXPECT_EQ(
       loaded.getRigidBodySolver(), sx::RigidBodySolver::SequentialImpulse);
-  EXPECT_EQ(loaded.getMultibodyOptions().integrationFamily, "semi-implicit");
+  EXPECT_EQ(
+      loaded.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::SemiImplicit);
   EXPECT_EQ(loaded.getMultibodyOptions().variationalMaxIterations, 100u);
   EXPECT_DOUBLE_EQ(loaded.getMultibodyOptions().variationalTolerance, 1e-10);
   EXPECT_FALSE(loaded.isDifferentiable());
@@ -1522,7 +1529,7 @@ TEST(Serialization, PreservesJointCounterAcrossArticulatedGeneratedNames)
   namespace sx = dart::simulation;
 
   sx::World world1;
-  world1.setMultibodyOptions({"variational integrator"});
+  world1.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world1.addMultibody("robot");
   auto base = robot.addLink("base");
@@ -2081,7 +2088,7 @@ TEST(Serialization, ArticulatedJointAvbdStiffnessRoundTripsDesignMode)
   namespace sx = dart::simulation;
 
   sx::World world1;
-  world1.setMultibodyOptions({"variational integrator"});
+  world1.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world1.addMultibody("robot");
   auto base = robot.addLink("base");
@@ -2179,7 +2186,8 @@ TEST(Serialization, ArticulatedJointAvbdStiffnessRoundTripsDesignMode)
 
   ASSERT_FALSE(world2.isSimulationMode());
   EXPECT_EQ(
-      world2.getMultibodyOptions().integrationFamily, "variational integrator");
+      world2.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::Variational);
   for (const auto& expected : expectedBeforeMutation) {
     SCOPED_TRACE(expected.name);
     auto restoredJoint = world2.getArticulatedJoint(expected.name);

--- a/tests/unit/simulation/world/test_world.cpp
+++ b/tests/unit/simulation/world/test_world.cpp
@@ -4786,13 +4786,15 @@ TEST(World, WorldOptionsConfigureDomainSolverFamilies)
 
   sx::WorldOptions options;
   options.rigidBodySolver = sx::RigidBodySolver::Ipc;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
 
   sx::World world(options);
 
   EXPECT_EQ(world.getRigidBodySolver(), sx::RigidBodySolver::Ipc);
   EXPECT_EQ(
-      world.getMultibodyOptions().integrationFamily, "variational integrator");
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::Variational);
 }
 
 TEST(World, ClearResetsWorldOptionPoliciesToDefaults)
@@ -4801,7 +4803,8 @@ TEST(World, ClearResetsWorldOptionPoliciesToDefaults)
 
   sx::WorldOptions options;
   options.rigidBodySolver = sx::RigidBodySolver::Ipc;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   options.differentiable = true;
   options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
   options.contactGradientMode = sx::ContactGradientMode::PreContactSurrogate;
@@ -4810,7 +4813,9 @@ TEST(World, ClearResetsWorldOptionPoliciesToDefaults)
   world.clear();
 
   EXPECT_EQ(world.getRigidBodySolver(), sx::RigidBodySolver::SequentialImpulse);
-  EXPECT_EQ(world.getMultibodyOptions().integrationFamily, "semi-implicit");
+  EXPECT_EQ(
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::SemiImplicit);
   EXPECT_FALSE(world.isDifferentiable());
   EXPECT_EQ(
       world.getContactSolverMethod(),
@@ -4832,7 +4837,8 @@ TEST(World, WorldOptionsRejectInvalidDomainSolverFamilies)
       sx::InvalidArgumentException);
 
   sx::WorldOptions invalidMultibody;
-  invalidMultibody.multibodyOptions.integrationFamily = "unknown-family";
+  invalidMultibody.multibodyOptions.integrationFamily
+      = static_cast<sx::MultibodyIntegrationFamily>(99);
   EXPECT_THROW(
       {
         sx::World world(invalidMultibody);
@@ -5588,7 +5594,7 @@ TEST(World, SetMultibodyOptionsReservesVariationalStateAfterBake)
 
   world.setTimeStep(0.01);
   world.enterSimulationMode();
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   const auto& registry = sx::detail::registryOf(world);
   const auto capacities = registryStorageCapacities(registry);
@@ -5643,7 +5649,7 @@ TEST(World, SolverMethodSwitchesAfterBakeSharePreparationPath)
   world.enterSimulationMode();
 
   world.setRigidBodySolver(sx::RigidBodySolver::Ipc);
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   const auto& registry = sx::detail::registryOf(world);
   auto capacities = registryStorageCapacities(registry);
@@ -5663,7 +5669,7 @@ TEST(World, SolverMethodSwitchesAfterBakeSharePreparationPath)
   EXPECT_EQ(
       allocator.alignedDeallocationCount, alignedDeallocationsAfterSwitch);
 
-  world.setMultibodyOptions({"semi-implicit"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::SemiImplicit});
   world.setRigidBodySolver(sx::RigidBodySolver::SequentialImpulse);
 
   capacities = registryStorageCapacities(registry);
@@ -5714,7 +5720,7 @@ void configureVariationalLoopClosureChainScene(dart::simulation::World& world)
 {
   namespace sx = dart::simulation;
 
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
   world.setGravity(Eigen::Vector3d::Zero());
   world.setTimeStep(1.0e-3);
 
@@ -5759,7 +5765,7 @@ void configureLongVariationalArticulatedPointJointScene(
 {
   namespace sx = dart::simulation;
 
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
   world.setGravity(Eigen::Vector3d::Zero());
   world.setTimeStep(1.0e-3);
 
@@ -5786,7 +5792,7 @@ void configureCompliantVariationalContactSliderScene(
 {
   namespace sx = dart::simulation;
 
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
   world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
   world.setTimeStep(1.0e-3);
 
@@ -5824,7 +5830,7 @@ void configureVariationalContactDualStateSliderScene(
 {
   namespace sx = dart::simulation;
 
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
   world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
   world.setTimeStep(1.0e-3);
 
@@ -6155,7 +6161,8 @@ TEST(World, EnterSimulationModeReservesContactHeavyVariationalDualState)
   CountingMemoryAllocator allocator;
   sx::WorldOptions options;
   options.baseAllocator = &allocator;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   sx::World world(options);
   configureVariationalContactDualStateSliderScene(world);
   auto& registry = sx::detail::registryOf(world);
@@ -6227,7 +6234,8 @@ TEST(World, VariationalContactDualStateRegistryStorageRebuildsAfterClear)
   CountingMemoryAllocator allocator;
   sx::WorldOptions options;
   options.baseAllocator = &allocator;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   sx::World world(options);
   const common::StlAllocator<double> expectedDualAllocator{
       world.getMemoryManager().getFreeAllocator()};
@@ -6305,7 +6313,8 @@ TEST(World, EnterSimulationModeReservesCompliantVariationalContactScratch)
   CountingMemoryAllocator allocator;
   sx::WorldOptions options;
   options.baseAllocator = &allocator;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   sx::World world(options);
   configureCompliantVariationalContactSliderScene(world);
 
@@ -6340,7 +6349,8 @@ TEST(World, VariationalArticulatedPointJointLinkIndexScratchUsesWorldAllocator)
   CountingMemoryAllocator allocator;
   sx::WorldOptions options;
   options.baseAllocator = &allocator;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   sx::World world(options);
   configureLongVariationalArticulatedPointJointScene(world);
 
@@ -6373,7 +6383,8 @@ TEST(World, VariationalLoopClosureRegistryStorageRebuildsAfterClear)
   CountingMemoryAllocator allocator;
   sx::WorldOptions options;
   options.baseAllocator = &allocator;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   sx::World world(options);
 
   const auto bakeAndCheckStableSteps = [&]() {
@@ -6536,7 +6547,8 @@ TEST(World, ContactHeavyRegistryStorageRebuildsAfterClear)
   CountingMemoryAllocator allocator;
   sx::WorldOptions options;
   options.baseAllocator = &allocator;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   sx::World world(options);
 
   const auto bakeAndCheckStableSteps = [&]() {
@@ -6865,7 +6877,8 @@ TEST(World, BakedStepsDoNotGrowWorldBaseAllocatorForReservedEcsPaths)
         spec.axis = Eigen::Vector3d::UnitZ();
         auto carriage = robot.addLink("carriage", base, spec);
         carriage.setMass(3.0);
-        world.setMultibodyOptions({"variational integrator"});
+        world.setMultibodyOptions(
+            {sx::MultibodyIntegrationFamily::Variational});
         world.setTimeStep(0.01);
       });
   expectNoWorldBaseAllocatorActivityDuringBakedSteps(
@@ -8334,7 +8347,8 @@ TEST(World, BakedMultibodyAndDeformableStepsDoNotAllocateGlobalHeap)
         spec.axis = Eigen::Vector3d::UnitZ();
         auto carriage = robot.addLink("carriage", base, spec);
         carriage.setMass(3.0);
-        world.setMultibodyOptions({"variational integrator"});
+        world.setMultibodyOptions(
+            {sx::MultibodyIntegrationFamily::Variational});
         world.setTimeStep(0.01);
       });
   expectNoGlobalHeapAllocationsDuringBakedSteps(
@@ -19399,7 +19413,7 @@ TEST(World, ArticulatedPointJointsExposeAvbdFiniteStiffness)
   namespace sx = dart::simulation;
 
   sx::World world;
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world.addMultibody("robot");
   auto base = robot.addLink("base");
@@ -19458,7 +19472,7 @@ TEST(World, ArticulatedPointJointsGenerateUniqueFacadeNames)
   namespace sx = dart::simulation;
 
   sx::World world;
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world.addMultibody("robot");
   auto base = robot.addLink("base");
@@ -19510,7 +19524,7 @@ TEST(World, ClearResetsArticulatedPointJointGeneratedNames)
   namespace sx = dart::simulation;
 
   sx::World world;
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world.addMultibody("robot");
   auto base = robot.addLink("base");
@@ -19552,7 +19566,7 @@ TEST(World, ArticulatedPointJointsRejectInvalidEndpointOwnership)
   namespace sx = dart::simulation;
 
   sx::World world;
-  world.setMultibodyOptions({"variational integrator"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::Variational});
 
   auto robot = world.addMultibody("robot");
   auto base = robot.addLink("base");
@@ -19571,7 +19585,8 @@ TEST(World, ArticulatedPointJointsRejectInvalidEndpointOwnership)
   auto otherChild = otherRobot.addLink("child", otherBase, otherSpec);
 
   sx::World foreignWorld;
-  foreignWorld.setMultibodyOptions({"variational integrator"});
+  foreignWorld.setMultibodyOptions(
+      {sx::MultibodyIntegrationFamily::Variational});
   auto foreignRobot = foreignWorld.addMultibody("foreign");
   auto foreignBase = foreignRobot.addLink("base");
 
@@ -21469,7 +21484,8 @@ TEST(World, ReplayRecordingRestoresSolverOptions)
 
   sx::WorldOptions options;
   options.rigidBodySolver = sx::RigidBodySolver::Ipc;
-  options.multibodyOptions.integrationFamily = "variational integrator";
+  options.multibodyOptions.integrationFamily
+      = sx::MultibodyIntegrationFamily::Variational;
   options.differentiable = true;
   options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
   options.contactGradientMode = sx::ContactGradientMode::PreContactSurrogate;
@@ -21485,7 +21501,7 @@ TEST(World, ReplayRecordingRestoresSolverOptions)
   ASSERT_EQ(world.getReplayFrameCount(), 2u);
 
   world.setRigidBodySolver(sx::RigidBodySolver::SequentialImpulse);
-  world.setMultibodyOptions({"semi-implicit"});
+  world.setMultibodyOptions({sx::MultibodyIntegrationFamily::SemiImplicit});
   world.setContactGradientMode(sx::ContactGradientMode::Analytic);
 
   world.restoreReplayFrame(1);
@@ -21493,7 +21509,8 @@ TEST(World, ReplayRecordingRestoresSolverOptions)
   EXPECT_TRUE(world.isSimulationMode());
   EXPECT_EQ(world.getRigidBodySolver(), sx::RigidBodySolver::Ipc);
   EXPECT_EQ(
-      world.getMultibodyOptions().integrationFamily, "variational integrator");
+      world.getMultibodyOptions().integrationFamily,
+      sx::MultibodyIntegrationFamily::Variational);
   EXPECT_TRUE(world.isDifferentiable());
   EXPECT_EQ(world.getContactSolverMethod(), sx::ContactSolverMethod::BoxedLcp);
   EXPECT_EQ(
@@ -21628,7 +21645,8 @@ TEST(World, ReplayRecordingRestoresTransientVariationalComponents)
   namespace compute = dart::simulation::compute;
 
   sx::World world;
-  world.setMultibodyOptions({.integrationFamily = "variational integrator"});
+  world.setMultibodyOptions(
+      {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
   world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
   world.setTimeStep(1e-3);
 


### PR DESCRIPTION
## WP-091.12 — Single selection idiom

Replaces the parsed `std::string integrationFamily` selector on
`MultibodyOptions` with a typed `MultibodyIntegrationFamily` enum
(`SemiImplicit` default, `Variational`). This retires the last string-based
method-family selector, so every domain now selects through one typed-policy
idiom resolved once at finalize.

### What changed
- **Core:** `multibody_options.hpp` gains the typed `MultibodyIntegrationFamily`
  field; `world.cpp/.hpp` resolve it via an enum switch to the internal
  `MultibodyIntegrationMethod`, validate by enum range
  (`isValidMultibodyIntegrationFamily`), and record it as a resolved-config note.
  The string parse and its `InvalidArgumentException` are gone.
- **One finalize-time policy path:** all four selectors — `RigidBodySolver`
  enum, `ContactSolverMethod` enum, this multibody-family enum, and the AVBD
  `RigidAvbdContactConfig` component — push a note into `m_resolvedConfiguration`
  and are gated by `m_strictSolverResolution && hasSubstitution()`.
- **Python:** nanobind exposes `MultibodyIntegrationFamily`
  (`SEMI_IMPLICIT`/`VARIATIONAL`); stub, demo scenes, and unit/integration tests
  migrated; constructor default is the enum.
- **Tests/benchmark:** serialization round-trips the enum; every call site
  (designated and positional brace-init) migrated across `test_world`,
  `test_serialization`, `test_variational_integration`, and the AVBD benchmark.
- **Docs:** design + variational-integrator dev-task docs updated.

### Verification (local, on this branch rebased onto current `main`)
- `lint` ✅ · `check-api-boundaries` ✅
- Default-step **golden trajectories 3/3 bit-identical** (behavior-preserving —
  the resolved family is unchanged)
- `test_serialization` 57/57 · `test_variational_integration` 178/178 ·
  cross-family 2/2 · corpus 1/1
- `test-py` **1382 passed, 11 skipped**
- `test_world` 371/372 — the lone failure
  `BakedDynamicRigidIpcStepsDoNotGrowWorldBaseAllocator` is a **known
  pre-existing** post-#2996 rigid-IPC allocator issue (the test never touches
  `setMultibodyOptions`/the enum), orthogonal to this change.