### PR TITLE
Include <cassert> before FCL headers (fix Eigen 5 / new-toolchain build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### [DART 6.19.0 (TBD)](https://github.com/dartsim/dart/milestone/TBD?closed=1)
 
+* Build
+
+  * Include `<cassert>` before the FCL headers in the FCL compatibility shim so
+    DART builds against Eigen 5 and current GCC/Clang toolchains, which no
+    longer pull `<cassert>` in transitively (FCL's shape headers call `assert`
+    without including it): [#3021](https://github.com/dartsim/dart/pull/3021)
+
 * Constraint
 
   * Add `CylindricalJointConstraint` for runtime slide-and-rotate attachments

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -50,6 +50,13 @@
   (FCL_MINOR_VERSION < y || (FCL_MINOR_VERSION <= y))))
 // clang-format on
 
+// FCL's shape headers (e.g. geometry/shape/convex-inl.h) call assert() without
+// including <cassert> themselves, relying on it being pulled in transitively.
+// Newer toolchains and Eigen versions (e.g. Eigen 5) no longer provide that
+// transitive include, so make the declaration available before the FCL headers
+// are parsed. See conda-forge/dartsim-feedstock#171.
+#include <cassert>
+
 #include <fcl/broadphase/broadphase_dynamic_AABB_tree.h>
 #include <fcl/config.h>
 #include <fcl/geometry/bvh/BVH_model.h>

--- a/dart/collision/fcl/BackwardCompatibility.hpp
+++ b/dart/collision/fcl/BackwardCompatibility.hpp
@@ -53,9 +53,12 @@
 // FCL's shape headers (e.g. geometry/shape/convex-inl.h) call assert() without
 // including <cassert> themselves, relying on it being pulled in transitively.
 // Newer toolchains and Eigen versions (e.g. Eigen 5) no longer provide that
-// transitive include, so make the declaration available before the FCL headers
-// are parsed. See conda-forge/dartsim-feedstock#171.
+// transitive include, so it must be included before the FCL headers below.
+// Guarded so clang-format's include sorting does not move it past them.
+// See conda-forge/dartsim-feedstock#171.
+// clang-format off
 #include <cassert>
+// clang-format on
 
 #include <fcl/broadphase/broadphase_dynamic_AABB_tree.h>
 #include <fcl/config.h>


### PR DESCRIPTION
## Problem

Building DART fails on newer toolchains / Eigen 5 while compiling
`dart/dynamics/VoxelGridShape.cpp`:

```
$PREFIX/include/fcl/geometry/shape/convex-inl.h:68:3: error: there are no
arguments to 'assert' that depend on a template parameter, so a declaration of
'assert' must be available [-fpermissive]
   68 |   assert(faces != nullptr);
```

## Root cause

FCL's shape headers use `assert()` but do not `#include <cassert>`; historically
the declaration arrived transitively (older Eigen headers pulled it in). Eigen 5
and current GCC/Clang no longer provide that transitive include, so `assert` is
undeclared when FCL's template header is parsed through DART's FCL shim
(`VoxelGridShape.cpp` → `VoxelGridShape.hpp` → `collision/fcl/BackwardCompatibility.hpp`
→ FCL).

## Fix

`#include <cassert>` in `dart/collision/fcl/BackwardCompatibility.hpp` before the
FCL headers, so the declaration is available wherever DART pulls FCL in (the
central FCL include shim). One standard include; no behavior change.

## Verification

- Confirmed the same source-level error on `linux_64`, `linux_aarch64`, and
  `linux_ppc64le` (and osx) — it is platform-independent and originates in DART's
  include of FCL.
- Locally rebuilt the `VoxelGridShape` translation unit with the change: clean
  compile, no regression.

## Context

Surfaced by **conda-forge/dartsim-feedstock#171** (which moves to Eigen 5 via
`eigen-abi-devel`). This is the upstream-DART change needed so 6.19.0 builds
cleanly against Eigen 5 / current toolchains. A forward-port to `main` (DART 7)
is advisable since the same FCL include path exists there.

> Note: the Eigen-5 `JacobiSVD::compute(matrix, computationOptions)` deprecation
> warnings are separate (non-fatal) and not addressed here.