### PR TITLE
Optimize DART 6 constraint-solver hot path (boxes ~1.28x faster, bit-exact)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,15 @@ endif()
 dart_option(DART_BUILD_DARTPY "Build dartpy" OFF)
 dart_option(DART_BUILD_GUI_OSG "Build osgDart library" ON)
 dart_option(DART_BUILD_PROFILE "Build DART with profiling options" OFF)
+dart_option(DART_PROFILE_BUILTIN "Enable the built-in text profiling backend" ON)
+dart_option(DART_PROFILE_TRACY "Enable the Tracy profiling backend for local developer profiling" OFF)
+# Keep legacy variable names in scope for consumers (the profile macros expect
+# DART_PROFILE_ENABLE_*). Accept the legacy DART_PROFILE_TEXT spelling too.
+if(DEFINED DART_PROFILE_TEXT)
+  set(DART_PROFILE_BUILTIN "${DART_PROFILE_TEXT}")
+endif()
+set(DART_PROFILE_ENABLE_TEXT "${DART_PROFILE_BUILTIN}")
+set(DART_PROFILE_ENABLE_TRACY "${DART_PROFILE_TRACY}")
 dart_option(DART_CODECOV "Turn on codecov support" OFF)
 # Warning: DART_ENABLE_SIMD should be ON only when you build DART and the DART
 # dependent projects on the same machine. If this option is on, then compile

--- a/cmake/DARTFindDependencies.cmake
+++ b/cmake/DARTFindDependencies.cmake
@@ -110,7 +110,7 @@ endif()
 # Optional dependencies
 #=======================
 
-if(DART_BUILD_PROFILE)
+if(DART_BUILD_PROFILE AND DART_PROFILE_TRACY)
   if(DART_USE_SYSTEM_TRACY)
     find_package(Tracy CONFIG REQUIRED)
   else()

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -244,7 +244,16 @@ if(DART_CODECOV)
 endif()
 
 if(DART_BUILD_PROFILE)
-  target_link_libraries(dart PUBLIC Tracy::TracyClient)
+  target_compile_definitions(
+    dart
+    PUBLIC
+      DART_PROFILE_ENABLE_TEXT=$<BOOL:${DART_PROFILE_BUILTIN}>
+      DART_PROFILE_ENABLE_TRACY=$<BOOL:${DART_PROFILE_TRACY}>
+  )
+
+  if(DART_PROFILE_TRACY)
+    target_link_libraries(dart PUBLIC Tracy::TracyClient)
+  endif()
 endif()
 
 install(FILES dart.hpp DESTINATION include/dart/ COMPONENT headers)

--- a/dart/common/Profile.hpp
+++ b/dart/common/Profile.hpp
@@ -34,8 +34,8 @@
 
 // DART 6 profiling front-end, backported from DART 7 (dart/common/profile.hpp).
 //
-// DART_PROFILE_* macros compile to nothing unless DART_BUILD_PROFILE is on. When
-// enabled, two backends can be active independently:
+// DART_PROFILE_* macros compile to nothing unless DART_BUILD_PROFILE is on.
+// When enabled, two backends can be active independently:
 //   * a built-in text backend (DART_PROFILE_ENABLE_TEXT, default 1) that needs
 //     no GUI and no special kernel permissions -- ideal for headless,
 //     evidence-based performance work, and
@@ -100,7 +100,7 @@
 
   #define DART_PROFILE_CONCAT_IMPL(a, b) a##b
   #define DART_PROFILE_CONCAT(a, b) DART_PROFILE_CONCAT_IMPL(a, b)
-  #define DART_PROFILE_SCOPE_NAME(prefix)                                       \
+  #define DART_PROFILE_SCOPE_NAME(prefix)                                      \
     DART_PROFILE_CONCAT(prefix, DART_PROFILE_UNIQUE_ID)
 
   #if DART_PROFILE_HAS_TRACY
@@ -110,24 +110,24 @@
   #endif
 
   #if DART_PROFILE_ENABLE_TEXT
-    #define DART_PROFILE_TEXT_FRAME                                             \
+    #define DART_PROFILE_TEXT_FRAME                                            \
       ::dart::common::profile::Profiler::instance().markFrame()
     #define DART_PROFILE_TEXT_SCOPED(name_literal)                             \
-      ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(            \
+      ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(           \
           _dart_profile_scope_)(name_literal, __FILE__, __LINE__)
-    #define DART_PROFILE_TEXT_SCOPED_F()                                        \
-      ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(            \
+    #define DART_PROFILE_TEXT_SCOPED_F()                                       \
+      ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(           \
           _dart_profile_scope_func_)(__func__, __FILE__, __LINE__)
-    #define DART_PROFILE_TEXT_DUMP()                                            \
+    #define DART_PROFILE_TEXT_DUMP()                                           \
       ::dart::common::profile::Profiler::instance().printSummary()
-    #define DART_PROFILE_TEXT_SUMMARY()                                         \
+    #define DART_PROFILE_TEXT_SUMMARY()                                        \
       ::dart::common::profile::Profiler::instance().toSummaryText()
   #else
     #define DART_PROFILE_TEXT_FRAME
     #define DART_PROFILE_TEXT_SCOPED(name_literal)
     #define DART_PROFILE_TEXT_SCOPED_F()
     #define DART_PROFILE_TEXT_DUMP()
-    #define DART_PROFILE_TEXT_SUMMARY()                                         \
+    #define DART_PROFILE_TEXT_SUMMARY()                                        \
       ::std::string {}
   #endif
 
@@ -142,27 +142,27 @@ public:
       const char* name, const char* file, int line, const char* function)
     #if DART_PROFILE_HAS_TRACY && DART_PROFILE_ENABLE_TEXT
     : m_tracy(
-          static_cast<std::uint32_t>(line),
-          file,
-          std::strlen(file),
-          function,
-          std::strlen(function),
-          name,
-          std::strlen(name),
-          TRACY_CALLSTACK,
-          true),
+        static_cast<std::uint32_t>(line),
+        file,
+        std::strlen(file),
+        function,
+        std::strlen(function),
+        name,
+        std::strlen(name),
+        TRACY_CALLSTACK,
+        true),
       m_text(name, file, line)
     #elif DART_PROFILE_HAS_TRACY
     : m_tracy(
-          static_cast<std::uint32_t>(line),
-          file,
-          std::strlen(file),
-          function,
-          std::strlen(function),
-          name,
-          std::strlen(name),
-          TRACY_CALLSTACK,
-          true)
+        static_cast<std::uint32_t>(line),
+        file,
+        std::strlen(file),
+        function,
+        std::strlen(function),
+        name,
+        std::strlen(name),
+        TRACY_CALLSTACK,
+        true)
     #elif DART_PROFILE_ENABLE_TEXT
     : m_text(name, file, line)
     #endif
@@ -188,20 +188,20 @@ private:
 
   #endif
 
-  #define DART_PROFILE_FRAME                                                    \
-    do {                                                                        \
-      DART_PROFILE_TRACY_FRAME;                                                 \
-      DART_PROFILE_TEXT_FRAME;                                                  \
+  #define DART_PROFILE_FRAME                                                   \
+    do {                                                                       \
+      DART_PROFILE_TRACY_FRAME;                                                \
+      DART_PROFILE_TEXT_FRAME;                                                 \
     } while (false)
 
   #if DART_PROFILE_HAS_TRACY || DART_PROFILE_ENABLE_TEXT
 
-    #define DART_PROFILE_SCOPED                                                 \
-      ::dart::common::profile::detail::ScopedProfile DART_PROFILE_SCOPE_NAME(   \
+    #define DART_PROFILE_SCOPED                                                \
+      ::dart::common::profile::detail::ScopedProfile DART_PROFILE_SCOPE_NAME(  \
           _dart_profile_scope_)(__func__, __FILE__, __LINE__, __func__)
 
     #define DART_PROFILE_SCOPED_N(name_literal)                                \
-      ::dart::common::profile::detail::ScopedProfile DART_PROFILE_SCOPE_NAME(   \
+      ::dart::common::profile::detail::ScopedProfile DART_PROFILE_SCOPE_NAME(  \
           _dart_profile_scope_)(name_literal, __FILE__, __LINE__, __func__)
 
   #else
@@ -217,7 +217,7 @@ private:
   #define DART_PROFILE_SCOPED
   #define DART_PROFILE_SCOPED_N(name_literal)
   #define DART_PROFILE_TEXT_DUMP()
-  #define DART_PROFILE_TEXT_SUMMARY()                                           \
+  #define DART_PROFILE_TEXT_SUMMARY()                                          \
     ::std::string {}
 
 #endif

--- a/dart/common/Profile.hpp
+++ b/dart/common/Profile.hpp
@@ -32,25 +32,252 @@
 
 #pragma once
 
+// DART 6 profiling front-end, backported from DART 7 (dart/common/profile.hpp).
+//
+// DART_PROFILE_* macros compile to nothing unless DART_BUILD_PROFILE is on. When
+// enabled, two backends can be active independently:
+//   * a built-in text backend (DART_PROFILE_ENABLE_TEXT, default 1) that needs
+//     no GUI and no special kernel permissions -- ideal for headless,
+//     evidence-based performance work, and
+//   * the optional Tracy GUI backend (DART_PROFILE_ENABLE_TRACY, only used if
+//     the Tracy headers are available).
+// The selector macros default sensibly and can be overridden by compile
+// definitions wired from CMake (see DART_PROFILE_BUILTIN / DART_PROFILE_TRACY).
+
 #include <dart/config.hpp>
 
-#if DART_BUILD_PROFILE
-  #include <tracy/Tracy.hpp>
+#include <iosfwd>
+#include <string>
 
-  #define DART_PROFILE_FRAME FrameMark
-  #define DART_PROFILE_SCOPED ZoneScoped
-  #define DART_PROFILE_SCOPED_N(name) ZoneScopedN(name)
+#if DART_BUILD_PROFILE
+
+  //-------------------------------------------------------------------------
+  // Backend selection
+  //-------------------------------------------------------------------------
+
+  // Defaults can be overridden via compile definitions or CMake options:
+  // -D DART_PROFILE_ENABLE_TEXT=0 to disable the text backend
+  // -D DART_PROFILE_ENABLE_TRACY=0 to skip Tracy (even if headers are present)
+  #if !defined(DART_PROFILE_ENABLE_TEXT)
+    #define DART_PROFILE_ENABLE_TEXT 1
+  #endif
+  #if !defined(DART_PROFILE_ENABLE_TRACY)
+    #define DART_PROFILE_ENABLE_TRACY 1
+  #endif
+
+  // Tracy (optional GUI backend)
+  #if DART_PROFILE_ENABLE_TRACY
+    #if defined(__has_include)
+      #if __has_include(<tracy/Tracy.hpp>)
+        #define DART_PROFILE_HAS_TRACY 1
+      #else
+        #define DART_PROFILE_HAS_TRACY 0
+      #endif
+    #else
+      #define DART_PROFILE_HAS_TRACY 1
+    #endif
+  #else
+    #define DART_PROFILE_HAS_TRACY 0
+  #endif
+
+  #if DART_PROFILE_HAS_TRACY
+    #include <tracy/Tracy.hpp>
+
+    #include <cstdint>
+    #include <cstring>
+  #endif
+
+  // Built-in text backend (readable console summaries)
+  #if DART_PROFILE_ENABLE_TEXT
+    #include <dart/common/detail/profiler.hpp>
+  #endif
+
+  #if defined(__COUNTER__)
+    #define DART_PROFILE_UNIQUE_ID __COUNTER__
+  #else
+    #define DART_PROFILE_UNIQUE_ID __LINE__
+  #endif
+
+  #define DART_PROFILE_CONCAT_IMPL(a, b) a##b
+  #define DART_PROFILE_CONCAT(a, b) DART_PROFILE_CONCAT_IMPL(a, b)
+  #define DART_PROFILE_SCOPE_NAME(prefix)                                       \
+    DART_PROFILE_CONCAT(prefix, DART_PROFILE_UNIQUE_ID)
+
+  #if DART_PROFILE_HAS_TRACY
+    #define DART_PROFILE_TRACY_FRAME FrameMark
+  #else
+    #define DART_PROFILE_TRACY_FRAME
+  #endif
+
+  #if DART_PROFILE_ENABLE_TEXT
+    #define DART_PROFILE_TEXT_FRAME                                             \
+      ::dart::common::profile::Profiler::instance().markFrame()
+    #define DART_PROFILE_TEXT_SCOPED(name_literal)                             \
+      ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(            \
+          _dart_profile_scope_)(name_literal, __FILE__, __LINE__)
+    #define DART_PROFILE_TEXT_SCOPED_F()                                        \
+      ::dart::common::profile::ProfileScope DART_PROFILE_SCOPE_NAME(            \
+          _dart_profile_scope_func_)(__func__, __FILE__, __LINE__)
+    #define DART_PROFILE_TEXT_DUMP()                                            \
+      ::dart::common::profile::Profiler::instance().printSummary()
+    #define DART_PROFILE_TEXT_SUMMARY()                                         \
+      ::dart::common::profile::Profiler::instance().toSummaryText()
+  #else
+    #define DART_PROFILE_TEXT_FRAME
+    #define DART_PROFILE_TEXT_SCOPED(name_literal)
+    #define DART_PROFILE_TEXT_SCOPED_F()
+    #define DART_PROFILE_TEXT_DUMP()
+    #define DART_PROFILE_TEXT_SUMMARY()                                         \
+      ::std::string {}
+  #endif
+
+  #if DART_PROFILE_HAS_TRACY || DART_PROFILE_ENABLE_TEXT
+
+namespace dart::common::profile::detail {
+
+class ScopedProfile
+{
+public:
+  ScopedProfile(
+      const char* name, const char* file, int line, const char* function)
+    #if DART_PROFILE_HAS_TRACY && DART_PROFILE_ENABLE_TEXT
+    : m_tracy(
+          static_cast<std::uint32_t>(line),
+          file,
+          std::strlen(file),
+          function,
+          std::strlen(function),
+          name,
+          std::strlen(name),
+          TRACY_CALLSTACK,
+          true),
+      m_text(name, file, line)
+    #elif DART_PROFILE_HAS_TRACY
+    : m_tracy(
+          static_cast<std::uint32_t>(line),
+          file,
+          std::strlen(file),
+          function,
+          std::strlen(function),
+          name,
+          std::strlen(name),
+          TRACY_CALLSTACK,
+          true)
+    #elif DART_PROFILE_ENABLE_TEXT
+    : m_text(name, file, line)
+    #endif
+  {
+    #if !DART_PROFILE_HAS_TRACY
+    (void)function;
+    #endif
+  }
+
+  ScopedProfile(const ScopedProfile&) = delete;
+  ScopedProfile& operator=(const ScopedProfile&) = delete;
+
+private:
+    #if DART_PROFILE_HAS_TRACY
+  tracy::ScopedZone m_tracy;
+    #endif
+    #if DART_PROFILE_ENABLE_TEXT
+  ProfileScope m_text;
+    #endif
+};
+
+} // namespace dart::common::profile::detail
+
+  #endif
+
+  #define DART_PROFILE_FRAME                                                    \
+    do {                                                                        \
+      DART_PROFILE_TRACY_FRAME;                                                 \
+      DART_PROFILE_TEXT_FRAME;                                                  \
+    } while (false)
+
+  #if DART_PROFILE_HAS_TRACY || DART_PROFILE_ENABLE_TEXT
+
+    #define DART_PROFILE_SCOPED                                                 \
+      ::dart::common::profile::detail::ScopedProfile DART_PROFILE_SCOPE_NAME(   \
+          _dart_profile_scope_)(__func__, __FILE__, __LINE__, __func__)
+
+    #define DART_PROFILE_SCOPED_N(name_literal)                                \
+      ::dart::common::profile::detail::ScopedProfile DART_PROFILE_SCOPE_NAME(   \
+          _dart_profile_scope_)(name_literal, __FILE__, __LINE__, __func__)
+
+  #else
+
+    #define DART_PROFILE_SCOPED
+    #define DART_PROFILE_SCOPED_N(name_literal)
+
+  #endif
 
 #else // no-op
 
   #define DART_PROFILE_FRAME
   #define DART_PROFILE_SCOPED
-  #define DART_PROFILE_SCOPED_N(name)
+  #define DART_PROFILE_SCOPED_N(name_literal)
+  #define DART_PROFILE_TEXT_DUMP()
+  #define DART_PROFILE_TEXT_SUMMARY()                                           \
+    ::std::string {}
 
 #endif
 
-namespace dart::common {
+namespace dart::common::profile {
 
-//
+/// Return whether DART was built with profiling support.
+[[nodiscard]] constexpr bool isProfilingEnabled() noexcept
+{
+#if DART_BUILD_PROFILE
+  return true;
+#else
+  return false;
+#endif
+}
 
-} // namespace dart::common
+/// Return whether the built-in text profiling backend is available.
+[[nodiscard]] constexpr bool isTextProfilingEnabled() noexcept
+{
+#if DART_BUILD_PROFILE && DART_PROFILE_ENABLE_TEXT
+  return true;
+#else
+  return false;
+#endif
+}
+
+/// Mark a frame in the built-in text profiler.
+inline void markProfileFrame()
+{
+#if DART_BUILD_PROFILE && DART_PROFILE_ENABLE_TEXT
+  Profiler::instance().markFrame();
+#endif
+}
+
+/// Clear the built-in text profiler state.
+inline void resetProfile()
+{
+#if DART_BUILD_PROFILE && DART_PROFILE_ENABLE_TEXT
+  Profiler::instance().reset();
+#endif
+}
+
+/// Write the built-in text profiler summary to a stream.
+inline void printProfileSummary(std::ostream& os)
+{
+#if DART_BUILD_PROFILE && DART_PROFILE_ENABLE_TEXT
+  Profiler::instance().printSummary(os);
+#else
+  (void)os;
+#endif
+}
+
+/// Return the built-in text profiler summary.
+[[nodiscard]] inline std::string getProfileSummaryText()
+{
+#if DART_BUILD_PROFILE && DART_PROFILE_ENABLE_TEXT
+  return Profiler::instance().toSummaryText();
+#else
+  return {};
+#endif
+}
+
+} // namespace dart::common::profile

--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -1,0 +1,599 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/common/detail/profiler.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <thread>
+#include <unordered_map>
+
+namespace dart::common::profile {
+
+struct Profiler::ProfileNode
+{
+  std::string label;
+  std::string source;
+  std::uint64_t callCount{0};
+  std::uint64_t inclusiveNs{0};
+  std::uint64_t selfNs{0};
+  std::uint64_t minNs{std::numeric_limits<std::uint64_t>::max()};
+  std::uint64_t maxNs{0};
+  std::unordered_map<std::string, std::unique_ptr<ProfileNode>> children;
+};
+
+struct Profiler::ActiveScope
+{
+  ProfileNode* node{nullptr};
+  std::chrono::steady_clock::time_point start{};
+  std::uint64_t childTimeNs{0};
+};
+
+struct Profiler::ThreadRecord
+{
+  std::string label;
+  std::thread::id id;
+  ProfileNode root{};
+  std::vector<ActiveScope> stack;
+};
+
+struct Profiler::Flattened
+{
+  std::string path;
+  std::string threadLabel;
+  std::string source;
+  std::uint64_t inclusiveNs{0};
+  std::uint64_t selfNs{0};
+  std::uint64_t callCount{0};
+};
+
+Profiler::Profiler() : m_frameCount(0), m_frameTimeSumNs(0) {}
+
+Profiler& Profiler::instance()
+{
+  static Profiler profiler;
+  return profiler;
+}
+
+std::shared_ptr<Profiler::ThreadRecord> Profiler::threadRecord()
+{
+  thread_local std::shared_ptr<ThreadRecord> record
+      = Profiler::instance().registerThread();
+  return record;
+}
+
+std::shared_ptr<Profiler::ThreadRecord> Profiler::registerThread()
+{
+  auto record = std::make_shared<ThreadRecord>();
+  record->id = std::this_thread::get_id();
+  {
+    std::ostringstream oss;
+    oss << record->id;
+    record->label = oss.str();
+    record->root.label = "thread " + record->label;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(m_threadRegistryMutex);
+    m_threads.push_back(record);
+  }
+
+  return record;
+}
+
+Profiler::ProfileNode* Profiler::findOrCreateChild(
+    ProfileNode& parent, std::string_view label, std::string_view source)
+{
+  const std::string key = std::string(label) + " @ " + std::string(source);
+  auto it = parent.children.find(key);
+  if (it == parent.children.end()) {
+    auto child = std::make_unique<ProfileNode>();
+    child->label = std::string(label);
+    child->source = std::string(source);
+    it = parent.children.emplace(key, std::move(child)).first;
+  }
+  return it->second.get();
+}
+
+void Profiler::pushScope(
+    Profiler::ThreadRecord& record,
+    std::string_view label,
+    std::string_view file,
+    int line)
+{
+  auto* parent = record.stack.empty() ? &record.root : record.stack.back().node;
+  const std::string source
+      = std::string(file) + ":" + std::to_string(static_cast<long long>(line));
+  auto* node = findOrCreateChild(*parent, label, source);
+  record.stack.push_back(
+      {node, std::chrono::steady_clock::now(), /*childTimeNs=*/0});
+}
+
+void Profiler::popScope(Profiler::ThreadRecord& record)
+{
+  if (record.stack.empty()) {
+    return;
+  }
+
+  const auto active = record.stack.back();
+  record.stack.pop_back();
+
+  const auto end = std::chrono::steady_clock::now();
+  const auto durationNs = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - active.start)
+          .count());
+
+  auto* node = active.node;
+  ++node->callCount;
+  node->inclusiveNs += durationNs;
+
+  const auto selfNs
+      = durationNs > active.childTimeNs ? durationNs - active.childTimeNs : 0;
+
+  node->selfNs += selfNs;
+  node->minNs = std::min(node->minNs, durationNs);
+  node->maxNs = std::max(node->maxNs, durationNs);
+
+  if (!record.stack.empty()) {
+    record.stack.back().childTimeNs += durationNs;
+  }
+}
+
+std::uint64_t Profiler::sumInclusiveChildren(const ProfileNode& node)
+{
+  std::uint64_t total = 0;
+  for (const auto& entry : node.children) {
+    total += entry.second->inclusiveNs;
+  }
+  return total;
+}
+
+void Profiler::markFrame()
+{
+  const auto now = std::chrono::steady_clock::now();
+  const auto count = m_frameCount.load(std::memory_order_relaxed);
+  if (count == 0) {
+    m_lastFrameTime = now;
+  } else {
+    const auto deltaNs = static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now - m_lastFrameTime)
+            .count());
+    m_lastFrameTime = now;
+    m_frameTimeSumNs.fetch_add(deltaNs, std::memory_order_relaxed);
+    m_frameSamplesNs.push_back(deltaNs);
+  }
+  m_frameCount.fetch_add(1, std::memory_order_relaxed);
+}
+
+std::string Profiler::formatDuration(std::uint64_t ns)
+{
+  std::ostringstream oss;
+  if (ns >= 1'000'000'000ULL) {
+    const double s = static_cast<double>(ns) / 1'000'000'000.0;
+    oss << std::fixed << std::setprecision(s >= 10.0 ? 1 : 3) << s << " s";
+  } else if (ns >= 1'000'000ULL) {
+    const double ms = static_cast<double>(ns) / 1'000'000.0;
+    oss << std::fixed << std::setprecision(ms >= 10.0 ? 2 : 3) << ms << " ms";
+  } else {
+    const double us = static_cast<double>(ns) / 1'000.0;
+    oss << std::fixed << std::setprecision(us >= 10.0 ? 2 : 3) << us << " µs";
+  }
+  return oss.str();
+}
+
+std::string Profiler::formatDurationAligned(std::uint64_t ns)
+{
+  std::ostringstream oss;
+  if (ns >= 1'000'000'000ULL) {
+    const double s = static_cast<double>(ns) / 1'000'000'000.0;
+    oss << std::setw(8) << std::fixed << std::setprecision(s >= 10.0 ? 2 : 3)
+        << s << " s ";
+  } else if (ns >= 1'000'000ULL) {
+    const double ms = static_cast<double>(ns) / 1'000'000.0;
+    oss << std::setw(8) << std::fixed << std::setprecision(ms >= 10.0 ? 2 : 3)
+        << ms << " ms";
+  } else if (ns >= 1'000ULL) {
+    const double us = static_cast<double>(ns) / 1'000.0;
+    oss << std::setw(8) << std::fixed << std::setprecision(us >= 10.0 ? 2 : 3)
+        << us << " µs";
+  } else {
+    oss << std::setw(8) << ns << " ns";
+  }
+  return oss.str();
+}
+
+std::string Profiler::formatFps(double fps)
+{
+  std::ostringstream oss;
+  if (fps >= 1000000.0) {
+    oss << std::fixed << std::setprecision(1) << fps / 1000000.0 << "M";
+  } else if (fps >= 1000.0) {
+    oss << std::fixed << std::setprecision(1) << fps / 1000.0 << "k";
+  } else {
+    oss << std::fixed << std::setprecision(fps >= 100.0 ? 0 : 1) << fps;
+  }
+  return oss.str();
+}
+
+std::string Profiler::formatCount(std::uint64_t v)
+{
+  std::ostringstream oss;
+  if (v >= 1'000'000'000ULL) {
+    oss << std::fixed << std::setprecision(1)
+        << static_cast<double>(v) / 1'000'000'000.0 << "B";
+  } else if (v >= 1'000'000ULL) {
+    oss << std::fixed << std::setprecision(1)
+        << static_cast<double>(v) / 1'000'000.0 << "M";
+  } else if (v >= 1'000ULL) {
+    oss << std::fixed << std::setprecision(1)
+        << static_cast<double>(v) / 1'000.0 << "K";
+  } else {
+    oss << v;
+  }
+  return oss.str();
+}
+
+std::size_t Profiler::maxLabelWidth(
+    const ProfileNode& node, std::size_t minWidth, std::size_t maxWidth)
+{
+  std::size_t width = node.label.size();
+  for (const auto& entry : node.children) {
+    width = std::max(width, maxLabelWidth(*entry.second, minWidth, maxWidth));
+  }
+  return std::clamp<std::size_t>(width, minWidth, maxWidth);
+}
+
+double Profiler::percentage(std::uint64_t part, std::uint64_t total)
+{
+  if (total == 0) {
+    return 0.0;
+  }
+  return (static_cast<double>(part) / static_cast<double>(total)) * 100.0;
+}
+
+std::string Profiler::formatPercent(double pct)
+{
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(pct >= 10.0 ? 1 : 2) << pct << '%';
+  return oss.str();
+}
+
+std::string Profiler::padRight(std::string_view text, std::size_t width)
+{
+  if (text.size() >= width) {
+    return std::string(text);
+  }
+  std::string padded;
+  padded.reserve(width);
+  padded.append(text);
+  padded.append(width - text.size(), ' ');
+  return padded;
+}
+
+bool Profiler::useColor()
+{
+  const char* env = std::getenv("DART_PROFILE_COLOR");
+  if (!env) {
+    return true; // enabled by default
+  }
+  std::string val(env);
+  for (auto& c : val) {
+    c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  }
+  return (val == "1" || val == "ON" || val == "TRUE" || val == "YES");
+}
+
+std::string Profiler::colorize(std::string_view text, const char* code)
+{
+  if (!useColor()) {
+    return std::string(text);
+  }
+  return std::string(code) + std::string(text) + "\033[0m";
+}
+
+const char* Profiler::heatColor(double pct)
+{
+  if (!useColor()) {
+    return "";
+  }
+  if (pct >= 20.0) {
+    return "\033[31m"; // red
+  }
+  if (pct >= 5.0) {
+    return "\033[33m"; // yellow
+  }
+  return "\033[36m"; // cyan for low-but-present
+}
+
+void Profiler::collectHotspots(
+    const ProfileNode& node,
+    const std::string& path,
+    const std::string& threadLabel,
+    std::vector<Flattened>& out) const
+{
+  out.push_back(
+      {path,
+       threadLabel,
+       node.source,
+       node.inclusiveNs,
+       node.selfNs,
+       node.callCount});
+  for (const auto& entry : node.children) {
+    const auto& child = entry.second;
+    const auto childPath
+        = path.empty() ? child->label : (path + " > " + child->label);
+    collectHotspots(*child, childPath, threadLabel, out);
+  }
+}
+
+void Profiler::printNode(
+    std::ostream& os,
+    const ProfileNode& node,
+    std::uint64_t threadTotalNs,
+    const std::string& indent,
+    double minPercent,
+    std::size_t labelWidth) const
+{
+  std::vector<const ProfileNode*> children;
+  children.reserve(node.children.size());
+  for (const auto& entry : node.children) {
+    children.push_back(entry.second.get());
+  }
+
+  std::sort(
+      children.begin(),
+      children.end(),
+      [](const ProfileNode* lhs, const ProfileNode* rhs) {
+        return lhs->inclusiveNs > rhs->inclusiveNs;
+      });
+
+  for (std::size_t idx = 0; idx < children.size(); ++idx) {
+    const auto* child = children[idx];
+    const auto pct = percentage(child->inclusiveNs, threadTotalNs);
+    if (pct < minPercent && child->inclusiveNs < 1'000'000) {
+      continue; // Skip insignificant nodes (<minPercent and <1ms total).
+    }
+
+    const auto avgNs
+        = child->callCount > 0 ? child->inclusiveNs / child->callCount : 0;
+
+    const bool isLast = (idx + 1 == children.size());
+    const std::string connector = isLast ? "`-- " : "|-- ";
+    const std::string childIndent = indent + (isLast ? "    " : "|   ");
+    const auto color = heatColor(pct);
+
+    std::ostringstream line;
+    line << indent << connector
+         << colorize(padRight(child->label, labelWidth), color) << ' '
+         << "total " << formatDurationAligned(child->inclusiveNs) << ' '
+         << "self " << formatDurationAligned(child->selfNs) << ' '
+         << "per-call " << formatDurationAligned(avgNs) << ' ' << "calls "
+         << std::setw(8) << child->callCount << ' ' << "share "
+         << padRight(colorize(formatPercent(pct), color), 6);
+    if (!child->source.empty()) {
+      line << " src " << child->source;
+    }
+
+    os << line.str() << '\n';
+
+    printNode(
+        os, *child, threadTotalNs, childIndent, minPercent * 0.65, labelWidth);
+  }
+}
+
+void Profiler::printThreadTree(
+    std::ostream& os,
+    const ThreadRecord& record,
+    std::uint64_t threadTotalNs,
+    double minPercent,
+    std::size_t labelWidth) const
+{
+  printNode(os, record.root, threadTotalNs, "", minPercent, labelWidth);
+}
+
+void Profiler::printSummary(std::ostream& os)
+{
+  std::vector<std::shared_ptr<ThreadRecord>> threads;
+  {
+    std::lock_guard<std::mutex> lock(m_threadRegistryMutex);
+    threads = m_threads;
+  }
+
+  if (threads.empty()) {
+    os << "DART profiler (text): no scoped regions were recorded.\n";
+    return;
+  }
+
+  std::uint64_t totalNs = 0;
+  for (const auto& record : threads) {
+    totalNs += sumInclusiveChildren(record->root);
+  }
+
+  const auto frameCount = m_frameCount.load(std::memory_order_relaxed);
+
+  os << "\nDART profiler (text backend)\n";
+  os << "Threads: " << threads.size() << " | Frames marked: " << frameCount
+     << " | Total scoped time: " << formatDuration(totalNs);
+
+  const auto frameSumNs = m_frameTimeSumNs.load(std::memory_order_relaxed);
+  if (frameCount > 1 && frameSumNs > 0 && !m_frameSamplesNs.empty()) {
+    const double avgFps
+        = (static_cast<double>(frameCount - 1) * 1e9) / frameSumNs;
+    std::vector<std::uint64_t> samples = m_frameSamplesNs;
+    std::sort(samples.begin(), samples.end());
+    const auto pickIndex = [&](double pct) -> std::size_t {
+      if (samples.empty()) {
+        return 0;
+      }
+      const auto maxIndex = static_cast<std::ptrdiff_t>(samples.size()) - 1;
+      const double pos = pct * static_cast<double>(maxIndex);
+      return static_cast<std::size_t>(std::clamp(
+          static_cast<std::ptrdiff_t>(std::lround(pos)),
+          static_cast<std::ptrdiff_t>(0),
+          maxIndex));
+    };
+    const auto bestIdx = pickIndex(0.1);  // 10th percentile (short frames)
+    const auto worstIdx = pickIndex(0.9); // 90th percentile (long frames)
+    const double bestFps = 1e9 / static_cast<double>(samples[bestIdx]);
+    const double worstFps = 1e9 / static_cast<double>(samples[worstIdx]);
+    os << " | Avg FPS: " << formatFps(avgFps)
+       << " | Best 10%: " << formatFps(bestFps)
+       << " | Worst 10%: " << formatFps(worstFps);
+  }
+  os << '\n';
+
+  // Build hotspot list.
+  std::vector<Flattened> hotspots;
+  for (const auto& record : threads) {
+    for (const auto& entry : record->root.children) {
+      const auto& child = entry.second;
+      collectHotspots(*child, child->label, record->label, hotspots);
+    }
+  }
+
+  std::sort(
+      hotspots.begin(),
+      hotspots.end(),
+      [](const Flattened& lhs, const Flattened& rhs) {
+        return lhs.inclusiveNs > rhs.inclusiveNs;
+      });
+
+  const std::size_t hotspotCount = std::min<std::size_t>(hotspots.size(), 10);
+
+  os << "Hotspots (inclusive time):\n";
+  if (hotspotCount == 0) {
+    os << "  (no measured scopes)\n";
+  } else {
+    std::size_t maxHotLabel = 0;
+    for (const auto& entry : hotspots) {
+      maxHotLabel = std::max(maxHotLabel, entry.path.size());
+    }
+    const std::size_t hotLabelWidth
+        = std::clamp<std::size_t>(maxHotLabel, 16, 48);
+
+    for (std::size_t i = 0; i < hotspotCount; ++i) {
+      const auto& entry = hotspots[i];
+      const auto pct = percentage(entry.inclusiveNs, totalNs);
+      const bool isHot = (i < 3) || (pct >= 20.0);
+
+      const auto avgNs
+          = entry.callCount > 0 ? entry.inclusiveNs / entry.callCount : 0;
+
+      const auto color = heatColor(pct);
+      const std::string tag = isHot ? colorize("[HOT]", color) : "     ";
+      os << "  " << tag << " "
+         << colorize(padRight(entry.path, hotLabelWidth), color) << " "
+         << padRight(("thr " + entry.threadLabel), 12) << " total "
+         << formatDurationAligned(entry.inclusiveNs) << " self "
+         << formatDurationAligned(entry.selfNs) << " per-call "
+         << formatDurationAligned(avgNs) << " calls " << entry.callCount
+         << " share " << colorize(formatPercent(pct), color);
+      if (!entry.source.empty()) {
+        os << " src " << entry.source;
+      }
+      os << '\n';
+    }
+  }
+
+  if (threads.size() > 1) {
+    os << "Per-thread breakdown (inclusive):\n";
+  }
+
+  for (const auto& record : threads) {
+    const auto threadTotal = sumInclusiveChildren(record->root);
+    if (threadTotal == 0) {
+      continue;
+    }
+
+    const auto labelWidth
+        = maxLabelWidth(record->root, /*minWidth=*/16, /*maxWidth=*/48);
+
+    os << "- thread " << record->label << " total "
+       << formatDuration(threadTotal) << '\n';
+    printThreadTree(os, *record, threadTotal, /*minPercent=*/0.25, labelWidth);
+  }
+  os << std::flush;
+}
+
+std::string Profiler::toSummaryText()
+{
+  std::ostringstream os;
+  printSummary(os);
+  return os.str();
+}
+
+void Profiler::reset()
+{
+  std::lock_guard<std::mutex> lock(m_threadRegistryMutex);
+  for (auto& record : m_threads) {
+    clearNode(record->root);
+  }
+  m_frameCount.store(0, std::memory_order_relaxed);
+  m_frameTimeSumNs.store(0, std::memory_order_relaxed);
+  m_frameSamplesNs.clear();
+  m_lastFrameTime = {};
+}
+
+void Profiler::clearNode(ProfileNode& node)
+{
+  node.callCount = 0;
+  node.inclusiveNs = 0;
+  node.selfNs = 0;
+  node.minNs = Profiler::kUnsetDuration;
+  node.maxNs = 0;
+  for (auto& entry : node.children) {
+    clearNode(*entry.second);
+  }
+  node.children.clear();
+}
+
+ProfileScope::ProfileScope(
+    std::string_view name, std::string_view file, int line)
+  : m_record(Profiler::threadRecord())
+{
+  Profiler::instance().pushScope(*m_record, name, file, line);
+}
+
+ProfileScope::~ProfileScope()
+{
+  if (m_record) {
+    Profiler::instance().popScope(*m_record);
+  }
+}
+
+} // namespace dart::common::profile

--- a/dart/common/detail/profiler.hpp
+++ b/dart/common/detail/profiler.hpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// Hierarchical, dependency-free text profiler backported from DART 7
+// (dart/common/detail/profiler.hpp). It captures scoped timings into a
+// per-thread call tree and prints an easy-to-skim, hotspot-focused summary for
+// headless, text-based inspection -- no GUI and no special kernel permissions
+// required. DART 6 targets C++17, so the DART 7 C++20 conveniences
+// (std::source_location, std::ranges) are intentionally omitted here; the
+// macros in dart/common/Profile.hpp always pass file/line explicitly.
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+
+namespace dart::common::profile {
+
+/// Hierarchical text profiler: captures scoped timings and prints an
+/// easy-to-skim, hotspot-focused summary for text-based inspection.
+/// Collection is thread-local; call printSummary() after worker threads
+/// settle to avoid reading while they are still updating their stacks.
+class Profiler
+{
+public:
+  static Profiler& instance();
+
+  void markFrame();
+
+  /// Dump a summary suitable for quick textual review (hotspots + per-thread
+  /// tree).
+  void printSummary(std::ostream& os = std::cout);
+
+  /// Return the same summary text produced by printSummary().
+  [[nodiscard]] std::string toSummaryText();
+
+  /// Clear collected statistics while keeping thread registrations intact.
+  void reset();
+
+private:
+  struct ProfileNode;
+  struct ActiveScope;
+  struct ThreadRecord;
+  struct Flattened;
+
+  friend class ProfileScope;
+  friend class ProfilerTestAccess;
+
+  static constexpr std::uint64_t kUnsetDuration
+      = std::numeric_limits<std::uint64_t>::max();
+
+  Profiler();
+
+  static std::shared_ptr<ThreadRecord> threadRecord();
+
+  std::shared_ptr<ThreadRecord> registerThread();
+  void pushScope(
+      ThreadRecord& record,
+      std::string_view label,
+      std::string_view file,
+      int line);
+  void popScope(ThreadRecord& record);
+
+  ProfileNode* findOrCreateChild(
+      ProfileNode& parent, std::string_view label, std::string_view source);
+  static std::string padRight(std::string_view text, std::size_t width);
+  static bool useColor();
+  static std::string colorize(std::string_view text, const char* code);
+  static const char* heatColor(double pct);
+  static std::string formatDurationAligned(std::uint64_t ns);
+  static std::string formatFps(double fps);
+  static std::string formatCount(std::uint64_t v);
+  static std::size_t maxLabelWidth(
+      const ProfileNode& node, std::size_t minWidth, std::size_t maxWidth);
+
+  static std::uint64_t sumInclusiveChildren(const ProfileNode& node);
+  static void clearNode(ProfileNode& node);
+  static std::string formatDuration(std::uint64_t ns);
+  static std::string formatPercent(double pct);
+  static double percentage(std::uint64_t part, std::uint64_t total);
+
+  void collectHotspots(
+      const ProfileNode& node,
+      const std::string& path,
+      const std::string& threadLabel,
+      std::vector<Flattened>& out) const;
+
+  void printThreadTree(
+      std::ostream& os,
+      const ThreadRecord& record,
+      std::uint64_t threadTotalNs,
+      double minPercent,
+      std::size_t labelWidth) const;
+
+  void printNode(
+      std::ostream& os,
+      const ProfileNode& node,
+      std::uint64_t threadTotalNs,
+      const std::string& indent,
+      double minPercent,
+      std::size_t labelWidth) const;
+
+  std::mutex m_threadRegistryMutex;
+  std::vector<std::shared_ptr<ThreadRecord>> m_threads;
+  std::atomic<std::uint64_t> m_frameCount;
+  std::atomic<std::uint64_t> m_frameTimeSumNs;
+  std::vector<std::uint64_t> m_frameSamplesNs;
+  std::chrono::steady_clock::time_point m_lastFrameTime{};
+};
+
+class ProfileScope
+{
+public:
+  explicit ProfileScope(std::string_view name, std::string_view file, int line);
+  ~ProfileScope();
+
+  ProfileScope(const ProfileScope&) = delete;
+  ProfileScope& operator=(const ProfileScope&) = delete;
+
+private:
+  std::shared_ptr<Profiler::ThreadRecord> m_record;
+};
+
+} // namespace dart::common::profile

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -152,6 +152,18 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
   if (0u == n)
     return;
 
+  // Cache raw constraint pointers once so the assembly loops below index a flat
+  // array instead of calling ConstrainedGroup::getConstraint() (which returns a
+  // ConstraintBasePtr by value, i.e. an atomic refcount bump) on every access.
+  // The off-diagonal fill below touches getConstraint(k) O(n^2) times. The
+  // group owns these constraints for the whole solve, so the pointers stay
+  // valid. A reused thread_local scratch buffer keeps the solver's class layout
+  // (and therefore its ABI) unchanged while still avoiding per-call allocation.
+  static thread_local std::vector<ConstraintBase*> constraintPtrs;
+  constraintPtrs.resize(numConstraints);
+  for (std::size_t i = 0; i < numConstraints; ++i)
+    constraintPtrs[i] = group.getConstraint(i).get();
+
   const int nSkip = dPAD(n);
 #if DART_BUILD_MODE_RELEASE
   mA.resize(n, nSkip);
@@ -170,7 +182,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
   mOffset.resize(numConstraints);
   mOffset[0] = 0;
   for (std::size_t i = 1; i < numConstraints; ++i) {
-    const ConstraintBasePtr& constraint = group.getConstraint(i - 1);
+    const ConstraintBase* constraint = constraintPtrs[i - 1];
     DART_ASSERT(constraint->getDimension() > 0);
     mOffset[i] = mOffset[i - 1] + constraint->getDimension();
   }
@@ -181,7 +193,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
     ConstraintInfo constInfo;
     constInfo.invTimeStep = 1.0 / mTimeStep;
     for (std::size_t i = 0; i < numConstraints; ++i) {
-      const ConstraintBasePtr& constraint = group.getConstraint(i);
+      ConstraintBase* constraint = constraintPtrs[i];
 
       constInfo.x = mX.data() + mOffset[i];
       constInfo.lo = mLo.data() + mOffset[i];
@@ -218,8 +230,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
             constraint->getVelocityChange(mA.data() + index, true);
             for (std::size_t k = i + 1; k < numConstraints; ++k) {
               index = nSkip * (mOffset[i] + j) + mOffset[k];
-              group.getConstraint(k)->getVelocityChange(
-                  mA.data() + index, false);
+              constraintPtrs[k]->getVelocityChange(mA.data() + index, false);
             }
           }
         }
@@ -350,7 +361,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
   {
     DART_PROFILE_SCOPED_N("Apply constraint impulses");
     for (std::size_t i = 0; i < numConstraints; ++i) {
-      const ConstraintBasePtr& constraint = group.getConstraint(i);
+      ConstraintBase* constraint = constraintPtrs[i];
       constraint->applyImpulse(mX.data() + mOffset[i]);
       constraint->excite();
     }

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -484,7 +484,10 @@ void ConstraintSolver::updateConstraints()
   //----------------------------------------------------------------------------
   mCollisionResult.clear();
 
-  mCollisionGroup->collide(mCollisionOption, &mCollisionResult);
+  {
+    DART_PROFILE_SCOPED_N("collide");
+    mCollisionGroup->collide(mCollisionOption, &mCollisionResult);
+  }
 
   // Destroy previous contact constraints
   mContactConstraints.clear();

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -56,6 +56,9 @@
 
 #include <algorithm>
 #include <unordered_map>
+#include <utility>
+
+#include <cstdint>
 
 namespace dart {
 namespace constraint {
@@ -499,25 +502,43 @@ void ConstraintSolver::updateConstraints()
   using ContactPair
       = std::pair<collision::CollisionObject*, collision::CollisionObject*>;
 
-  // Compare contact pairs while ignoring their order in the pair.
-  struct ContactPairCompare
+  // Hash and equality that ignore the order within a contact pair, so that the
+  // (objA, objB) and (objB, objA) orderings map to the same entry. This matches
+  // the order-independent counting the previous std::map comparator provided,
+  // but with O(1) average lookups instead of O(log n) tree operations.
+  struct ContactPairHash
   {
-    ContactPair getSortedPair(const ContactPair& a) const
+    std::size_t operator()(const ContactPair& pair) const
     {
-      if (a.first < a.second)
-        return std::make_pair(a.second, a.first);
-      return a;
+      auto a = reinterpret_cast<std::uintptr_t>(pair.first);
+      auto b = reinterpret_cast<std::uintptr_t>(pair.second);
+      if (a > b)
+        std::swap(a, b);
+      const std::size_t h1 = std::hash<std::uintptr_t>()(a);
+      const std::size_t h2 = std::hash<std::uintptr_t>()(b);
+      return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
     }
-
-    bool operator()(const ContactPair& a, const ContactPair& b) const
+  };
+  struct ContactPairEqual
+  {
+    bool operator()(const ContactPair& x, const ContactPair& y) const
     {
-      // Sort each pair and then do a lexicographical comparison
-      return getSortedPair(a) < getSortedPair(b);
+      return (x.first == y.first && x.second == y.second)
+             || (x.first == y.second && x.second == y.first);
     }
   };
 
-  std::map<ContactPair, size_t, ContactPairCompare> contactPairMap;
-  std::vector<collision::Contact*> contacts;
+  // Reused across steps so the per-step contact bookkeeping does not allocate.
+  // thread_local keeps concurrent solves on different threads independent while
+  // leaving the solver's class layout (ABI) untouched. unordered_map::clear()
+  // and vector::clear() retain their buckets/capacity, so steady-state stepping
+  // performs no contact-pair allocation at all.
+  static thread_local std::
+      unordered_map<ContactPair, std::size_t, ContactPairHash, ContactPairEqual>
+          contactPairMap;
+  contactPairMap.clear();
+  static thread_local std::vector<collision::Contact*> contacts;
+  contacts.clear();
 
   // Create new contact constraints
   for (auto i = 0u; i < mCollisionResult.getNumContacts(); ++i) {

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -120,6 +120,14 @@ ContactConstraint::ContactConstraint(
     return;
   }
 
+  // Resolve skeleton pointers and reactivity once; the LCP-assembly hot path
+  // reads these cached values instead of repeatedly calling getSkeleton()
+  // (shared_ptr churn) and isReactive() (ancestor-joint walk). See header.
+  mSkeletonA = mBodyNodeA->getSkeleton().get();
+  mSkeletonB = mBodyNodeB->getSkeleton().get();
+  mIsReactiveA = mBodyNodeA->isReactive();
+  mIsReactiveB = mBodyNodeB->isReactive();
+
   DART_ASSERT(
       contact.normal.squaredNorm() >= DART_CONTACT_CONSTRAINT_EPSILON_SQUARED);
 
@@ -374,7 +382,7 @@ void ContactConstraint::update()
     return;
   }
 
-  if (mBodyNodeA->isReactive() || mBodyNodeB->isReactive())
+  if (mIsReactiveA || mIsReactiveB)
     mActive = true;
   else
     mActive = false;
@@ -510,18 +518,18 @@ void ContactConstraint::applyUnitImpulse(std::size_t index)
 
   DART_ASSERT(index < mDim && "Invalid Index.");
   // DART_ASSERT(isActive());
-  DART_ASSERT(mBodyNodeA->isReactive() || mBodyNodeB->isReactive());
+  DART_ASSERT(mIsReactiveA || mIsReactiveB);
 
-  dynamics::Skeleton* skelA = mBodyNodeA->getSkeleton().get();
-  dynamics::Skeleton* skelB = mBodyNodeB->getSkeleton().get();
+  dynamics::Skeleton* skelA = mSkeletonA;
+  dynamics::Skeleton* skelB = mSkeletonB;
 
   // Self collision case
   if (mIsSelfCollision) {
     skelA->clearConstraintImpulses();
 
-    if (mBodyNodeA->isReactive()) {
+    if (mIsReactiveA) {
       // Both bodies are reactive
-      if (mBodyNodeB->isReactive()) {
+      if (mIsReactiveB) {
         skelA->updateBiasImpulse(
             mBodyNodeA,
             mSpatialNormalA.col(index),
@@ -534,7 +542,7 @@ void ContactConstraint::applyUnitImpulse(std::size_t index)
       }
     } else {
       // Only body2 is reactive
-      if (mBodyNodeB->isReactive()) {
+      if (mIsReactiveB) {
         skelB->updateBiasImpulse(mBodyNodeB, mSpatialNormalB.col(index));
       }
       // Both bodies are not reactive
@@ -548,13 +556,13 @@ void ContactConstraint::applyUnitImpulse(std::size_t index)
   }
   // Colliding two distinct skeletons
   else {
-    if (mBodyNodeA->isReactive()) {
+    if (mIsReactiveA) {
       skelA->clearConstraintImpulses();
       skelA->updateBiasImpulse(mBodyNodeA, mSpatialNormalA.col(index));
       skelA->updateVelocityChange();
     }
 
-    if (mBodyNodeB->isReactive()) {
+    if (mIsReactiveB) {
       skelB->clearConstraintImpulses();
       skelB->updateBiasImpulse(mBodyNodeB, mSpatialNormalB.col(index));
       skelB->updateVelocityChange();
@@ -575,10 +583,10 @@ void ContactConstraint::getVelocityChange(double* vel, bool withCfm)
   Eigen::Map<Eigen::VectorXd> velMap(vel, static_cast<int>(mDim));
   velMap.setZero();
 
-  if (mBodyNodeA->getSkeleton()->isImpulseApplied() && mBodyNodeA->isReactive())
+  if (mIsReactiveA && mSkeletonA->isImpulseApplied())
     velMap += mSpatialNormalA.transpose() * mBodyNodeA->getBodyVelocityChange();
 
-  if (mBodyNodeB->getSkeleton()->isImpulseApplied() && mBodyNodeB->isReactive())
+  if (mIsReactiveB && mSkeletonB->isImpulseApplied())
     velMap += mSpatialNormalB.transpose() * mBodyNodeB->getBodyVelocityChange();
 
   // Add small values to the diagnal to keep it away from singular, similar to
@@ -605,11 +613,11 @@ void ContactConstraint::excite()
   if (!hasValidBodyNodes())
     return;
 
-  if (mBodyNodeA->isReactive())
-    mBodyNodeA->getSkeleton()->setImpulseApplied(true);
+  if (mIsReactiveA)
+    mSkeletonA->setImpulseApplied(true);
 
-  if (mBodyNodeB->isReactive())
-    mBodyNodeB->getSkeleton()->setImpulseApplied(true);
+  if (mIsReactiveB)
+    mSkeletonB->setImpulseApplied(true);
 }
 
 //==============================================================================
@@ -618,11 +626,11 @@ void ContactConstraint::unexcite()
   if (!hasValidBodyNodes())
     return;
 
-  if (mBodyNodeA->isReactive())
-    mBodyNodeA->getSkeleton()->setImpulseApplied(false);
+  if (mIsReactiveA)
+    mSkeletonA->setImpulseApplied(false);
 
-  if (mBodyNodeB->isReactive())
-    mBodyNodeB->getSkeleton()->setImpulseApplied(false);
+  if (mIsReactiveB)
+    mSkeletonB->setImpulseApplied(false);
 }
 
 //==============================================================================
@@ -643,9 +651,9 @@ void ContactConstraint::applyImpulse(double* lambda)
     mContact.force = mContact.normal * lambda[0] / mTimeStep;
 
     // Normal impulsive force
-    if (mBodyNodeA->isReactive())
+    if (mIsReactiveA)
       mBodyNodeA->addConstraintImpulse(mSpatialNormalA.col(0) * lambda[0]);
-    if (mBodyNodeB->isReactive())
+    if (mIsReactiveB)
       mBodyNodeB->addConstraintImpulse(mSpatialNormalB.col(0) * lambda[0]);
 
     // Add contact impulse (force) toward the tangential w.r.t. world frame
@@ -653,18 +661,18 @@ void ContactConstraint::applyImpulse(double* lambda)
     mContact.force += D.col(0) * lambda[1] / mTimeStep;
 
     // Tangential direction-1 impulsive force
-    if (mBodyNodeA->isReactive())
+    if (mIsReactiveA)
       mBodyNodeA->addConstraintImpulse(mSpatialNormalA.col(1) * lambda[1]);
-    if (mBodyNodeB->isReactive())
+    if (mIsReactiveB)
       mBodyNodeB->addConstraintImpulse(mSpatialNormalB.col(1) * lambda[1]);
 
     // Add contact impulse (force) toward the tangential w.r.t. world frame
     mContact.force += D.col(1) * lambda[2] / mTimeStep;
 
     // Tangential direction-2 impulsive force
-    if (mBodyNodeA->isReactive())
+    if (mIsReactiveA)
       mBodyNodeA->addConstraintImpulse(mSpatialNormalA.col(2) * lambda[2]);
-    if (mBodyNodeB->isReactive())
+    if (mIsReactiveB)
       mBodyNodeB->addConstraintImpulse(mSpatialNormalB.col(2) * lambda[2]);
   }
   //----------------------------------------------------------------------------
@@ -672,10 +680,10 @@ void ContactConstraint::applyImpulse(double* lambda)
   //----------------------------------------------------------------------------
   else {
     // Normal impulsive force
-    if (mBodyNodeA->isReactive())
+    if (mIsReactiveA)
       mBodyNodeA->addConstraintImpulse(mSpatialNormalA * lambda[0]);
 
-    if (mBodyNodeB->isReactive())
+    if (mIsReactiveB)
       mBodyNodeB->addConstraintImpulse(mSpatialNormalB * lambda[0]);
 
     // Store contact impulse (force) toward the normal w.r.t. world frame

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -190,7 +190,8 @@ ContactConstraint::ContactConstraint(
     collision::Contact& ct = mContact;
 
     // TODO(JS): Assumed that the number of tangent basis is 2.
-    const TangentBasisMatrix D = getTangentBasisMatrixODE(ct.normal);
+    mTangentBasis = getTangentBasisMatrixODE(ct.normal);
+    const TangentBasisMatrix& D = mTangentBasis;
 
     DART_ASSERT(std::abs(ct.normal.dot(D.col(0))) < DART_EPSILON);
     DART_ASSERT(std::abs(ct.normal.dot(D.col(1))) < DART_EPSILON);
@@ -656,8 +657,9 @@ void ContactConstraint::applyImpulse(double* lambda)
     if (mIsReactiveB)
       mBodyNodeB->addConstraintImpulse(mSpatialNormalB.col(0) * lambda[0]);
 
-    // Add contact impulse (force) toward the tangential w.r.t. world frame
-    const Eigen::MatrixXd D = getTangentBasisMatrixODE(mContact.normal);
+    // Add contact impulse (force) toward the tangential w.r.t. world frame.
+    // Reuse the tangent basis computed at construction (see mTangentBasis).
+    const TangentBasisMatrix& D = mTangentBasis;
     mContact.force += D.col(0) * lambda[1] / mTimeStep;
 
     // Tangential direction-1 impulsive force

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -218,6 +218,19 @@ private:
   /// Second body node
   dynamics::BodyNode* mBodyNodeB;
 
+  /// Cached skeleton raw pointers and reactivity of the two body nodes,
+  /// resolved once when the constraint is (re)constructed each step. Caching
+  /// them keeps the LCP-assembly hot path (applyUnitImpulse / getVelocityChange
+  /// are each invoked O(contacts^2) times per step) off two avoidable costs per
+  /// call: constructing/destroying the SkeletonPtr (shared_ptr) returned by
+  /// BodyNode::getSkeleton() (atomic refcounting) and the ancestor-joint walk
+  /// inside BodyNode::isReactive(). The cached values are exactly what those
+  /// accessors would return during the solve, so results are unchanged.
+  dynamics::Skeleton* mSkeletonA = nullptr;
+  dynamics::Skeleton* mSkeletonB = nullptr;
+  bool mIsReactiveA = false;
+  bool mIsReactiveB = false;
+
   /// Contact between mBodyNode1 and mBodyNode2
   collision::Contact& mContact;
 

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -270,6 +270,13 @@ private:
   ///
   bool mIsFrictionOn;
 
+  /// ODE-style tangent basis for the contact normal, cached at construction
+  /// (only when friction is on) so applyImpulse() reuses it instead of calling
+  /// getTangentBasisMatrixODE() a second time. It is a deterministic function
+  /// of mContact.normal, which is fixed for the duration of this step, so the
+  /// cached value is identical to recomputing it.
+  TangentBasisMatrix mTangentBasis;
+
   /// Index of applied impulse
   std::size_t mAppliedImpulseIndex;
 

--- a/scripts/ab_boxes.sh
+++ b/scripts/ab_boxes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# A/B micro-benchmark for the headless "boxes" scene.
+#
+# Compares a frozen BASELINE build against the CURRENT build by running the
+# boxes_headless driver interleaved (A,B,A,B,...) so the *ratio* stays stable
+# even when CPU frequency scaling / turbo make absolute wall-clock noisy. It
+# first gates on a bit-for-bit checksum match (correctness must be preserved),
+# then reports min/median elapsed for each side and the speedup.
+#
+# Usage: scripts/ab_boxes.sh [dim] [steps] [reps] [core]
+#   dim    box grid dimension (dim^3 boxes), default 8
+#   steps  simulation steps,                 default 2000
+#   reps   interleaved repetitions,          default 7
+#   core   CPU core to pin to,               default 4
+#
+# Env: BASELINE_DIR (default /tmp/dart_baseline), OPT_DIR (current build).
+set -u
+
+DIM=${1:-8}
+STEPS=${2:-2000}
+REPS=${3:-7}
+CORE=${4:-4}
+
+BASELINE_DIR=${BASELINE_DIR:-/tmp/dart_baseline}
+OPT_DIR=${OPT_DIR:-build/perf/Release/tests/benchmark/integration}
+
+BASE_BIN="$BASELINE_DIR/boxes_headless"
+OPT_BIN="$OPT_DIR/boxes_headless"
+
+if [[ ! -x "$BASE_BIN" ]]; then echo "missing baseline: $BASE_BIN" >&2; exit 2; fi
+if [[ ! -x "$OPT_BIN" ]]; then echo "missing current:  $OPT_BIN" >&2; exit 2; fi
+
+run_base() { LD_LIBRARY_PATH="$BASELINE_DIR" taskset -c "$CORE" "$BASE_BIN" "$@"; }
+run_opt()  { taskset -c "$CORE" "$OPT_BIN" "$@"; }
+
+echo "== correctness gate (dim=$DIM steps=$STEPS) =="
+bsum=$(run_base "$DIM" "$STEPS" "$STEPS" 2>/dev/null | grep '^step')
+osum=$(run_opt  "$DIM" "$STEPS" "$STEPS" 2>/dev/null | grep '^step')
+if [[ "$bsum" == "$osum" ]]; then
+  echo "CHECKSUM OK (results bit-for-bit identical)"
+else
+  echo "CHECKSUM MISMATCH:"; diff <(echo "$bsum") <(echo "$osum"); echo "ABORTING"; exit 1
+fi
+
+elapsed() { sed -n 's/^elapsed_ms \([0-9.]*\).*/\1/p'; }
+median() { sort -n | awk '{a[NR]=$1} END{print (NR%2)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}'; }
+min()    { sort -n | head -1; }
+
+echo "== timing: $REPS interleaved reps (dim=$DIM steps=$STEPS core=$CORE) =="
+bvals=""; ovals=""
+for ((i=1;i<=REPS;i++)); do
+  b=$(run_base "$DIM" "$STEPS" 0 2>/dev/null | elapsed)
+  o=$(run_opt  "$DIM" "$STEPS" 0 2>/dev/null | elapsed)
+  bvals+="$b"$'\n'; ovals+="$o"$'\n'
+  printf "  rep %2d  baseline %9s ms   optimized %9s ms   ratio %.4f\n" \
+    "$i" "$b" "$o" "$(awk -v a="$b" -v c="$o" 'BEGIN{print (c>0)?a/c:0}')"
+done
+
+bmin=$(echo "$bvals" | grep . | min);  omin=$(echo "$ovals" | grep . | min)
+bmed=$(echo "$bvals" | grep . | median); omed=$(echo "$ovals" | grep . | median)
+echo "-----------------------------------------------------------------"
+printf "baseline   min %9s ms   median %9s ms\n" "$bmin" "$bmed"
+printf "optimized  min %9s ms   median %9s ms\n" "$omin" "$omed"
+awk -v bm="$bmin" -v om="$omin" -v bd="$bmed" -v od="$omed" 'BEGIN{
+  printf "speedup    min-based %.3fx (%.1f%%)   median-based %.3fx (%.1f%%)\n",
+    bm/om, 100*(bm-om)/bm, bd/od, 100*(bd-od)/bd }'

--- a/tests/benchmark/integration/CMakeLists.txt
+++ b/tests/benchmark/integration/CMakeLists.txt
@@ -53,6 +53,12 @@ if(TARGET dart-collision-bullet)
       dart-collision-bullet
   )
 
+  # Headless boxes driver: doubles as a determinism/correctness oracle (prints
+  # state checksums) and a headless profiling target (dumps the built-in text
+  # profiler when DART_BUILD_PROFILE is on). Not a Google Benchmark target.
+  add_executable(boxes_headless boxes_headless.cpp)
+  target_link_libraries(boxes_headless PRIVATE dart dart-collision-bullet)
+
 endif()
 
 if(TARGET dart-utils)

--- a/tests/benchmark/integration/bm_boxes.cpp
+++ b/tests/benchmark/integration/bm_boxes.cpp
@@ -30,103 +30,16 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <dart/simulation/simulation.hpp>
-
-#include <dart/constraint/constraint.hpp>
-
-#include <dart/collision/bullet/bullet.hpp>
-
-#include <dart/dynamics/dynamics.hpp>
-
-#include <dart/math/math.hpp>
+#include "boxes_scene.hpp"
 
 #include <benchmark/benchmark.h>
 
 using namespace dart;
 
-namespace {
-
-[[nodiscard]] dynamics::SkeletonPtr createBox(
-    const Eigen::Vector3d& position,
-    const Eigen::Vector3d& size = Eigen::Vector3d(1, 1, 1),
-    const Eigen::Vector3d& color
-    = dart::math::Random::uniform<Eigen::Vector3d>(0.0, 1.0))
-{
-  static size_t index = 0;
-  auto boxSkel = dynamics::Skeleton::create("box" + std::to_string(index++));
-
-  // Give the floor a body
-  auto boxBody
-      = boxSkel->createJointAndBodyNodePair<dynamics::FreeJoint>(nullptr)
-            .second;
-
-  // Give the body a shape
-  auto boxShape = std::make_shared<dynamics::BoxShape>(size);
-  dynamics::ShapeNode* shapeNode = boxBody->createShapeNodeWith<
-      dynamics::VisualAspect,
-      dynamics::CollisionAspect,
-      dynamics::DynamicsAspect>(boxShape);
-  shapeNode->getVisualAspect()->setColor(color);
-  shapeNode->getDynamicsAspect()->setRestitutionCoeff(0.9);
-
-  // Put the body into position
-  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
-  tf.translation() = position;
-  boxBody->getParentJoint()->setTransformFromParentBodyNode(tf);
-
-  return boxSkel;
-}
-
-[[nodiscard]] simulation::WorldPtr createWorld(size_t dim)
-{
-  // Create an empty world
-  auto world = simulation::World::create();
-
-  // Set collision detector type
-  world->getConstraintSolver()->setCollisionDetector(
-      collision::BulletCollisionDetector::create());
-
-  // Create dim x dim x dim boxes
-  for (auto i = 0u; i < dim; ++i) {
-    for (auto j = 0u; j < dim; ++j) {
-      for (auto k = 0u; k < dim; ++k) {
-        auto x = i - dim / 2;
-        auto y = j - dim / 2;
-        auto z = k + 5;
-        auto position = Eigen::Vector3d(x, y, z);
-        auto size = Eigen::Vector3d(0.9, 0.9, 0.9);
-        auto color = Eigen::Vector3d(
-            static_cast<double>(i) / dim,
-            static_cast<double>(j) / dim,
-            static_cast<double>(k) / dim);
-        auto box = createBox(position, size, color);
-        world->addSkeleton(box);
-      }
-    }
-  }
-
-  // Create ground
-  auto ground = dynamics::Skeleton::create("ground");
-  auto groundBody
-      = ground->createJointAndBodyNodePair<dynamics::WeldJoint>().second;
-  auto groundShapeNode = groundBody->createShapeNodeWith<
-      dynamics::VisualAspect,
-      dynamics::CollisionAspect,
-      dynamics::DynamicsAspect>(
-      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d(10.0, 10.0, 0.1)));
-  groundShapeNode->getVisualAspect()->setColor(dart::Color::LightGray());
-  groundShapeNode->getDynamicsAspect()->setRestitutionCoeff(0.9);
-  world->addSkeleton(ground);
-
-  return world;
-}
-
-} // namespace
-
 static void BM_RunBoxes(benchmark::State& state)
 {
   const auto steps = 2000u;
-  auto world = createWorld(state.range(0));
+  auto world = test::createBoxesWorld(static_cast<std::size_t>(state.range(0)));
 
   for (auto _ : state) {
     for (size_t i = 0; i < steps; ++i) {

--- a/tests/benchmark/integration/boxes_headless.cpp
+++ b/tests/benchmark/integration/boxes_headless.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Headless driver for the "boxes" scene. It serves two evidence-based roles
+// with no rendering in the measured loop:
+//
+//   1. Determinism / correctness oracle. It prints a high-precision checksum of
+//      every skeleton's positions and velocities at fixed checkpoints, so an
+//      optimized build can be proven to produce byte-for-byte identical
+//      simulation results as a baseline build (`diff` the two outputs).
+//
+//   2. Headless profiling target. When DART is built with -DDART_BUILD_PROFILE,
+//      it dumps the built-in text profiler summary at the end so hot paths can
+//      be inspected without a GUI.
+//
+// Usage: boxes_headless [dim=8] [steps=2000] [checkpoint=500]
+
+#include "boxes_scene.hpp"
+
+#include <dart/common/Profile.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+using namespace dart;
+
+namespace {
+
+struct Checksum
+{
+  double posL1 = 0.0;
+  double posSq = 0.0;
+  double velL1 = 0.0;
+  double velSq = 0.0;
+  std::size_t dofs = 0;
+};
+
+[[nodiscard]] Checksum computeChecksum(const simulation::WorldPtr& world)
+{
+  Checksum c;
+  for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
+    const auto skel = world->getSkeleton(i);
+    const Eigen::VectorXd q = skel->getPositions();
+    const Eigen::VectorXd dq = skel->getVelocities();
+    c.posL1 += q.cwiseAbs().sum();
+    c.posSq += q.squaredNorm();
+    c.velL1 += dq.cwiseAbs().sum();
+    c.velSq += dq.squaredNorm();
+    c.dofs += static_cast<std::size_t>(q.size());
+  }
+  return c;
+}
+
+void printChecksum(std::size_t step, const Checksum& c)
+{
+  // %.17g round-trips a double exactly, enabling bit-for-bit comparison.
+  std::printf(
+      "step %6zu  dofs %5zu  posL1 %.17g  posSq %.17g  velL1 %.17g  velSq "
+      "%.17g\n",
+      step,
+      c.dofs,
+      c.posL1,
+      c.posSq,
+      c.velL1,
+      c.velSq);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  const std::size_t dim
+      = argc > 1 ? static_cast<std::size_t>(std::atoi(argv[1])) : 8u;
+  const std::size_t steps
+      = argc > 2 ? static_cast<std::size_t>(std::atoi(argv[2])) : 2000u;
+  const std::size_t checkpoint
+      = argc > 3 ? static_cast<std::size_t>(std::atoi(argv[3])) : 500u;
+
+  auto world = test::createBoxesWorld(dim);
+
+  std::printf(
+      "# boxes_headless dim=%zu steps=%zu boxes=%zu\n",
+      dim,
+      steps,
+      dim * dim * dim);
+
+  const auto t0 = std::chrono::steady_clock::now();
+  for (std::size_t s = 0; s < steps; ++s) {
+    world->step();
+    const std::size_t done = s + 1;
+    if ((checkpoint != 0 && done % checkpoint == 0) || done == steps)
+      printChecksum(done, computeChecksum(world));
+  }
+  const auto t1 = std::chrono::steady_clock::now();
+  const double elapsedMs
+      = std::chrono::duration<double, std::milli>(t1 - t0).count();
+  // Stepping-loop wall time only (world construction excluded), so this is a
+  // clean signal for A/B before/after comparison of the physics hot path.
+  std::printf(
+      "elapsed_ms %.3f  steps_per_s %.1f\n",
+      elapsedMs,
+      elapsedMs > 0.0 ? (1000.0 * static_cast<double>(steps) / elapsedMs)
+                      : 0.0);
+
+  // No-op unless DART was built with -DDART_BUILD_PROFILE (text backend on).
+  DART_PROFILE_TEXT_DUMP();
+
+  return 0;
+}

--- a/tests/benchmark/integration/boxes_headless.cpp
+++ b/tests/benchmark/integration/boxes_headless.cpp
@@ -49,9 +49,10 @@
 #include <dart/common/Profile.hpp>
 
 #include <chrono>
+#include <string>
+
 #include <cstdio>
 #include <cstdlib>
-#include <string>
 
 using namespace dart;
 
@@ -111,7 +112,8 @@ int main(int argc, char** argv)
   // ab_boxes.sh harness) unchanged. SCENE=chains runs the articulated-contact
   // scenario; LINKS controls the chain length (default 4).
   const char* sceneEnv = std::getenv("SCENE");
-  const bool chains = (sceneEnv != nullptr && std::string(sceneEnv) == "chains");
+  const bool chains
+      = (sceneEnv != nullptr && std::string(sceneEnv) == "chains");
 
   simulation::WorldPtr world;
   if (chains) {
@@ -121,7 +123,8 @@ int main(int argc, char** argv)
                               : 4u;
     world = test::createChainsWorld(dim, links);
     std::printf(
-        "# boxes_headless scene=chains dim=%zu links=%zu chains=%zu steps=%zu\n",
+        "# boxes_headless scene=chains dim=%zu links=%zu chains=%zu "
+        "steps=%zu\n",
         dim,
         links,
         dim * dim,

--- a/tests/benchmark/integration/boxes_headless.cpp
+++ b/tests/benchmark/integration/boxes_headless.cpp
@@ -107,13 +107,33 @@ int main(int argc, char** argv)
   const std::size_t checkpoint
       = argc > 3 ? static_cast<std::size_t>(std::atoi(argv[3])) : 500u;
 
-  auto world = test::createBoxesWorld(dim);
+  // Scene selection via the SCENE env var keeps the positional CLI (and the
+  // ab_boxes.sh harness) unchanged. SCENE=chains runs the articulated-contact
+  // scenario; LINKS controls the chain length (default 4).
+  const char* sceneEnv = std::getenv("SCENE");
+  const bool chains = (sceneEnv != nullptr && std::string(sceneEnv) == "chains");
 
-  std::printf(
-      "# boxes_headless dim=%zu steps=%zu boxes=%zu\n",
-      dim,
-      steps,
-      dim * dim * dim);
+  simulation::WorldPtr world;
+  if (chains) {
+    const char* linksEnv = std::getenv("LINKS");
+    const std::size_t links
+        = linksEnv != nullptr ? static_cast<std::size_t>(std::atoi(linksEnv))
+                              : 4u;
+    world = test::createChainsWorld(dim, links);
+    std::printf(
+        "# boxes_headless scene=chains dim=%zu links=%zu chains=%zu steps=%zu\n",
+        dim,
+        links,
+        dim * dim,
+        steps);
+  } else {
+    world = test::createBoxesWorld(dim);
+    std::printf(
+        "# boxes_headless scene=boxes dim=%zu steps=%zu boxes=%zu\n",
+        dim,
+        steps,
+        dim * dim * dim);
+  }
 
   const auto t0 = std::chrono::steady_clock::now();
   for (std::size_t s = 0; s < steps; ++s) {

--- a/tests/benchmark/integration/boxes_scene.hpp
+++ b/tests/benchmark/integration/boxes_scene.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_BENCHMARK_INTEGRATION_BOXES_SCENE_HPP_
+#define DART_BENCHMARK_INTEGRATION_BOXES_SCENE_HPP_
+
+#include <dart/simulation/simulation.hpp>
+
+#include <dart/constraint/constraint.hpp>
+
+#include <dart/collision/bullet/bullet.hpp>
+
+#include <dart/dynamics/dynamics.hpp>
+
+#include <dart/math/math.hpp>
+
+#include <cstddef>
+#include <string>
+
+namespace dart::test {
+
+/// Builds one free-falling box skeleton. The geometry is fully deterministic;
+/// the color is irrelevant to dynamics and is kept only so the scene matches
+/// the GUI `boxes` example. Shared by the headless benchmark and the
+/// determinism verifier so both exercise byte-for-byte identical setups.
+[[nodiscard]] inline dynamics::SkeletonPtr createBox(
+    std::size_t index,
+    const Eigen::Vector3d& position,
+    const Eigen::Vector3d& size,
+    const Eigen::Vector3d& color)
+{
+  auto boxSkel = dynamics::Skeleton::create("box" + std::to_string(index));
+
+  auto boxBody
+      = boxSkel->createJointAndBodyNodePair<dynamics::FreeJoint>(nullptr)
+            .second;
+
+  auto boxShape = std::make_shared<dynamics::BoxShape>(size);
+  dynamics::ShapeNode* shapeNode = boxBody->createShapeNodeWith<
+      dynamics::VisualAspect,
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(boxShape);
+  shapeNode->getVisualAspect()->setColor(color);
+  shapeNode->getDynamicsAspect()->setRestitutionCoeff(0.9);
+
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = position;
+  boxBody->getParentJoint()->setTransformFromParentBodyNode(tf);
+
+  return boxSkel;
+}
+
+/// Builds the `dim x dim x dim` stack-of-boxes world used by the boxes
+/// benchmark/example: a Bullet collision detector, dim^3 free boxes dropped
+/// above a welded ground plane.
+[[nodiscard]] inline simulation::WorldPtr createBoxesWorld(std::size_t dim)
+{
+  auto world = simulation::World::create();
+
+  world->getConstraintSolver()->setCollisionDetector(
+      collision::BulletCollisionDetector::create());
+
+  std::size_t index = 0;
+  for (auto i = 0u; i < dim; ++i) {
+    for (auto j = 0u; j < dim; ++j) {
+      for (auto k = 0u; k < dim; ++k) {
+        auto x = i - dim / 2;
+        auto y = j - dim / 2;
+        auto z = k + 5;
+        auto position = Eigen::Vector3d(x, y, z);
+        auto size = Eigen::Vector3d(0.9, 0.9, 0.9);
+        auto color = Eigen::Vector3d(
+            static_cast<double>(i) / static_cast<double>(dim),
+            static_cast<double>(j) / static_cast<double>(dim),
+            static_cast<double>(k) / static_cast<double>(dim));
+        world->addSkeleton(createBox(index++, position, size, color));
+      }
+    }
+  }
+
+  auto ground = dynamics::Skeleton::create("ground");
+  auto groundBody
+      = ground->createJointAndBodyNodePair<dynamics::WeldJoint>().second;
+  auto groundShapeNode = groundBody->createShapeNodeWith<
+      dynamics::VisualAspect,
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d(10.0, 10.0, 0.1)));
+  groundShapeNode->getVisualAspect()->setColor(dart::Color::LightGray());
+  groundShapeNode->getDynamicsAspect()->setRestitutionCoeff(0.9);
+  world->addSkeleton(ground);
+
+  return world;
+}
+
+} // namespace dart::test
+
+#endif // DART_BENCHMARK_INTEGRATION_BOXES_SCENE_HPP_

--- a/tests/benchmark/integration/boxes_scene.hpp
+++ b/tests/benchmark/integration/boxes_scene.hpp
@@ -122,6 +122,97 @@ namespace dart::test {
   return world;
 }
 
+/// Builds one articulated chain: a free-floating root box link followed by
+/// `links - 1` revolute-jointed box links extending along +z. Deterministic.
+[[nodiscard]] inline dynamics::SkeletonPtr createChain(
+    std::size_t index,
+    const Eigen::Vector3d& basePosition,
+    std::size_t links)
+{
+  auto skel = dynamics::Skeleton::create("chain" + std::to_string(index));
+  const Eigen::Vector3d linkSize(0.3, 0.3, 0.5);
+
+  dynamics::BodyNode* parent = nullptr;
+  for (std::size_t l = 0; l < links; ++l) {
+    dynamics::BodyNode* body = nullptr;
+    if (l == 0) {
+      auto pair
+          = skel->createJointAndBodyNodePair<dynamics::FreeJoint>(nullptr);
+      body = pair.second;
+      Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+      tf.translation() = basePosition;
+      pair.first->setTransformFromParentBodyNode(tf);
+    } else {
+      auto pair = skel->createJointAndBodyNodePair<dynamics::RevoluteJoint>(
+          parent);
+      auto* joint = pair.first;
+      body = pair.second;
+      // Alternate the hinge axis so the chain folds in a non-planar way.
+      joint->setAxis(
+          (l % 2 == 0) ? Eigen::Vector3d::UnitX() : Eigen::Vector3d::UnitY());
+      Eigen::Isometry3d parentToJoint = Eigen::Isometry3d::Identity();
+      parentToJoint.translation() = Eigen::Vector3d(0.0, 0.0, linkSize.z());
+      joint->setTransformFromParentBodyNode(parentToJoint);
+    }
+
+    auto shape = std::make_shared<dynamics::BoxShape>(linkSize);
+    auto* shapeNode = body->createShapeNodeWith<
+        dynamics::VisualAspect,
+        dynamics::CollisionAspect,
+        dynamics::DynamicsAspect>(shape);
+    shapeNode->getVisualAspect()->setColor(Eigen::Vector3d(
+        static_cast<double>(l) / static_cast<double>(links), 0.4, 0.6));
+    shapeNode->getDynamicsAspect()->setRestitutionCoeff(0.6);
+    parent = body;
+  }
+
+  return skel;
+}
+
+/// Builds a `dim x dim` grid of articulated chains (each `links` box links long)
+/// dropped above a welded ground plane. This exercises contact constraints on
+/// articulated bodies: the cost of resolving a contact scales with how far the
+/// solver must propagate impulses along each chain, which is exactly the
+/// rigid-body case plus articulation depth.
+[[nodiscard]] inline simulation::WorldPtr createChainsWorld(
+    std::size_t dim, std::size_t links)
+{
+  auto world = simulation::World::create();
+
+  world->getConstraintSolver()->setCollisionDetector(
+      collision::BulletCollisionDetector::create());
+
+  // Pack the chains closely (0.5 m grid for 0.3 m-wide links) and stagger their
+  // drop height so they buckle and tangle into a dense pile of articulated
+  // bodies in mutual contact, rather than falling as isolated columns.
+  std::size_t index = 0;
+  for (auto i = 0u; i < dim; ++i) {
+    for (auto j = 0u; j < dim; ++j) {
+      const double x
+          = (static_cast<double>(i) - static_cast<double>(dim) / 2.0) * 0.5;
+      const double y
+          = (static_cast<double>(j) - static_cast<double>(dim) / 2.0) * 0.5;
+      const double z = 3.0 + 0.25 * static_cast<double>((i + j) % 4);
+      world->addSkeleton(
+          createChain(index++, Eigen::Vector3d(x, y, z), links));
+    }
+  }
+
+  auto ground = dynamics::Skeleton::create("ground");
+  auto groundBody
+      = ground->createJointAndBodyNodePair<dynamics::WeldJoint>().second;
+  auto groundShapeNode = groundBody->createShapeNodeWith<
+      dynamics::VisualAspect,
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d(10.0, 10.0, 0.1)));
+  groundShapeNode->getVisualAspect()->setColor(dart::Color::LightGray());
+  groundShapeNode->getDynamicsAspect()->setRestitutionCoeff(0.6);
+  world->addSkeleton(ground);
+
+  return world;
+}
+
 } // namespace dart::test
 
 #endif // DART_BENCHMARK_INTEGRATION_BOXES_SCENE_HPP_

--- a/tests/benchmark/integration/boxes_scene.hpp
+++ b/tests/benchmark/integration/boxes_scene.hpp
@@ -43,8 +43,9 @@
 
 #include <dart/math/math.hpp>
 
-#include <cstddef>
 #include <string>
+
+#include <cstddef>
 
 namespace dart::test {
 
@@ -125,9 +126,7 @@ namespace dart::test {
 /// Builds one articulated chain: a free-floating root box link followed by
 /// `links - 1` revolute-jointed box links extending along +z. Deterministic.
 [[nodiscard]] inline dynamics::SkeletonPtr createChain(
-    std::size_t index,
-    const Eigen::Vector3d& basePosition,
-    std::size_t links)
+    std::size_t index, const Eigen::Vector3d& basePosition, std::size_t links)
 {
   auto skel = dynamics::Skeleton::create("chain" + std::to_string(index));
   const Eigen::Vector3d linkSize(0.3, 0.3, 0.5);
@@ -143,8 +142,8 @@ namespace dart::test {
       tf.translation() = basePosition;
       pair.first->setTransformFromParentBodyNode(tf);
     } else {
-      auto pair = skel->createJointAndBodyNodePair<dynamics::RevoluteJoint>(
-          parent);
+      auto pair
+          = skel->createJointAndBodyNodePair<dynamics::RevoluteJoint>(parent);
       auto* joint = pair.first;
       body = pair.second;
       // Alternate the hinge axis so the chain folds in a non-planar way.
@@ -169,11 +168,11 @@ namespace dart::test {
   return skel;
 }
 
-/// Builds a `dim x dim` grid of articulated chains (each `links` box links long)
-/// dropped above a welded ground plane. This exercises contact constraints on
-/// articulated bodies: the cost of resolving a contact scales with how far the
-/// solver must propagate impulses along each chain, which is exactly the
-/// rigid-body case plus articulation depth.
+/// Builds a `dim x dim` grid of articulated chains (each `links` box links
+/// long) dropped above a welded ground plane. This exercises contact
+/// constraints on articulated bodies: the cost of resolving a contact scales
+/// with how far the solver must propagate impulses along each chain, which is
+/// exactly the rigid-body case plus articulation depth.
 [[nodiscard]] inline simulation::WorldPtr createChainsWorld(
     std::size_t dim, std::size_t links)
 {
@@ -193,8 +192,7 @@ namespace dart::test {
       const double y
           = (static_cast<double>(j) - static_cast<double>(dim) / 2.0) * 0.5;
       const double z = 3.0 + 0.25 * static_cast<double>((i + j) % 4);
-      world->addSkeleton(
-          createChain(index++, Eigen::Vector3d(x, y, z), links));
+      world->addSkeleton(createChain(index++, Eigen::Vector3d(x, y, z), links));
     }
   }
 

--- a/tests/unit/common/test_Profile.cpp
+++ b/tests/unit/common/test_Profile.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/common/Profile.hpp>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+
+#if DART_BUILD_PROFILE && DART_PROFILE_ENABLE_TEXT
+  #include <dart/common/detail/profiler.hpp>
+
+  #include <chrono>
+  #include <thread>
+
+using dart::common::profile::Profiler;
+using dart::common::profile::ProfileScope;
+
+  #define DART_TEST_PROFILE_IF_ELSE(profile_statement, marker_value)            \
+    if (true)                                                                   \
+      profile_statement;                                                        \
+    else                                                                        \
+      marker = marker_value
+
+TEST(ProfileMacro, ScopedMacrosAreSingleStatements)
+{
+  int marker = 0;
+
+  DART_TEST_PROFILE_IF_ELSE(DART_PROFILE_SCOPED, 1);
+  DART_TEST_PROFILE_IF_ELSE(
+      DART_PROFILE_SCOPED_N("single-statement named scope"), 2);
+
+  EXPECT_EQ(marker, 0);
+}
+
+  #undef DART_TEST_PROFILE_IF_ELSE
+
+class ProfileTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    Profiler::instance().reset();
+  }
+};
+
+TEST_F(ProfileTest, CapturesHierarchyAndHotspots)
+{
+  {
+    ProfileScope root("root", __FILE__, __LINE__);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    {
+      ProfileScope child("child", __FILE__, __LINE__);
+      std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    }
+  }
+
+  std::stringstream ss;
+  Profiler::instance().printSummary(ss);
+  const auto summary = ss.str();
+
+  EXPECT_NE(summary.find("root"), std::string::npos);
+  EXPECT_NE(summary.find("root > child"), std::string::npos);
+  EXPECT_NE(summary.find("Hotspots"), std::string::npos);
+  EXPECT_NE(summary.find("[HOT]"), std::string::npos);
+
+  // Print once for manual inspection when running the test standalone.
+  std::cout << summary;
+}
+
+TEST_F(ProfileTest, TextSummaryMacroReturnsString)
+{
+  {
+    DART_PROFILE_SCOPED_N("macro-summary");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  const auto summary = DART_PROFILE_TEXT_SUMMARY();
+  EXPECT_NE(summary.find("macro-summary"), std::string::npos);
+  EXPECT_NE(summary.find("DART profiler (text backend)"), std::string::npos);
+}
+
+TEST_F(ProfileTest, CommonHelperApiReturnsTextSummary)
+{
+  EXPECT_TRUE(dart::common::profile::isProfilingEnabled());
+  EXPECT_TRUE(dart::common::profile::isTextProfilingEnabled());
+
+  dart::common::profile::resetProfile();
+  {
+    DART_PROFILE_SCOPED_N("helper-api-summary");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  dart::common::profile::markProfileFrame();
+
+  std::stringstream ss;
+  dart::common::profile::printProfileSummary(ss);
+  const auto printed = ss.str();
+  const auto summary = dart::common::profile::getProfileSummaryText();
+
+  EXPECT_NE(printed.find("helper-api-summary"), std::string::npos);
+  EXPECT_NE(summary.find("helper-api-summary"), std::string::npos);
+  EXPECT_NE(summary.find("DART profiler (text backend)"), std::string::npos);
+}
+
+TEST_F(ProfileTest, CapturesMultipleThreads)
+{
+  {
+    ProfileScope mainScope("main-work", __FILE__, __LINE__);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+
+  {
+    std::thread worker([] {
+      ProfileScope workerScope("worker-work", __FILE__, __LINE__);
+      std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    });
+    worker.join();
+  }
+
+  std::stringstream ss;
+  Profiler::instance().printSummary(ss);
+  const auto summary = ss.str();
+
+  EXPECT_NE(summary.find("Threads:"), std::string::npos);
+  EXPECT_NE(summary.find("main-work"), std::string::npos);
+  EXPECT_NE(summary.find("worker-work"), std::string::npos);
+}
+
+#else
+
+TEST(ProfileBackendDisabled, TextProfilerUnavailable)
+{
+  EXPECT_EQ(
+      dart::common::profile::isProfilingEnabled(),
+      static_cast<bool>(DART_BUILD_PROFILE));
+  EXPECT_FALSE(dart::common::profile::isTextProfilingEnabled());
+  dart::common::profile::resetProfile();
+  dart::common::profile::markProfileFrame();
+
+  std::stringstream ss;
+  dart::common::profile::printProfileSummary(ss);
+  EXPECT_TRUE(ss.str().empty());
+  EXPECT_TRUE(dart::common::profile::getProfileSummaryText().empty());
+  EXPECT_TRUE(DART_PROFILE_TEXT_SUMMARY().empty());
+  GTEST_SKIP() << "Text profiling backend disabled at build time.";
+}
+
+#endif

--- a/tests/unit/common/test_Profile.cpp
+++ b/tests/unit/common/test_Profile.cpp
@@ -46,10 +46,10 @@
 using dart::common::profile::Profiler;
 using dart::common::profile::ProfileScope;
 
-  #define DART_TEST_PROFILE_IF_ELSE(profile_statement, marker_value)            \
-    if (true)                                                                   \
-      profile_statement;                                                        \
-    else                                                                        \
+  #define DART_TEST_PROFILE_IF_ELSE(profile_statement, marker_value)           \
+    if (true)                                                                  \
+      profile_statement;                                                       \
+    else                                                                       \
       marker = marker_value
 
 TEST(ProfileMacro, ScopedMacrosAreSingleStatements)


### PR DESCRIPTION
## Summary

Evidence-based performance optimization of the DART 6 constraint-solver hot
path, driven by the most contact-heavy GUI example (`boxes`) run **headless**
(no rendering in the measured loop). Three bit-for-bit-exact optimizations make
the dim=8 box pile (512 rigid bodies, Bullet collision, 2000 steps) **~1.28×
faster (21.5%)**, with the speedup scaling with contact density. Correctness is
preserved exactly — every change is gated by a bit-for-bit state checksum and
the full 100-test suite passes.

This PR also **backports DART 7's built-in text profiler** to DART 6 so this
kind of headless, evidence-based performance work needs no GUI and no special
kernel permissions (`perf` is frequently unavailable on CI / locked-down hosts).

## Backward compatibility (gz-physics)

DART 6 stamps a distinct SONAME per minor version (`libdart.so.6.18` → `6.19`,
`cmake/DARTMacros.cmake`), so consumers relink across minor bumps by design.
The public/virtual API is unchanged (only private data members and
function-local buffers were added). gz-physics holds the two modified classes
only via pointer/`shared_ptr` and calls public methods — it never subclasses or
sizes `ContactConstraint`/`BoxedLcpConstraintSolver` (it subclasses
`ContactSurfaceHandler`, which is untouched). So this is source- and
link-compatible after a normal rebuild.

## Methodology

- **Headless driver** `boxes_headless` runs the scene with no rendering, timing
  only the stepping loop.
- **Correctness oracle**: the driver prints high-precision (`%.17g`) checksums
  of all positions/velocities at fixed checkpoints. Every optimization is gated
  on these matching the baseline bit-for-bit (`scripts/ab_boxes.sh`).
- **Robust timing**: baseline and optimized binaries are run **interleaved**
  (A,B,A,B,…) on a pinned core, so the reported *ratio* is stable despite CPU
  frequency scaling (turbo/powersave could not be disabled on the test host).
- Profiling uses the ported text profiler; it does **not** perturb results
  (clean and instrumented builds produce identical checksums).

## Baseline hot-path breakdown (dim=8, inclusive)

```
Solve constraints                                84.6%
  Construct LCP (impulse-test A-matrix assembly)   56.3%
    Fill A                                         46.9%
      Fill upper triangle of A                     23.8%   <- O(n^2) coupling fill
      Unit impulse test                            10.5%
    Dantzig LCP solve (the actual solve)            2.1%   <- not the bottleneck
  updateConstraints                                16.1%
    collide (Bullet)                                7.2%
    contact-constraint creation (self)              8.9%
Integrate velocity (forward dynamics)              12.7%
```

The LCP *construction* (assembling A by impulse tests), not the LCP *solve*,
dominates — and a large share was `shared_ptr` refcount churn and redundant
recomputation around the dynamics, which is what these patches remove.

## Optimizations (each bit-for-bit exact)

1. **Cache skeleton pointer + reactivity in `ContactConstraint`.**
   `getVelocityChange`/`applyUnitImpulse` run O(contacts²) per step (6M calls
   each at dim=8) and each went through `BodyNode::getSkeleton()` (returns a
   `SkeletonPtr` by value → atomic refcount) and `isReactive()` (walks the
   ancestor-joint chain — its own comment asks for this precomputation).
   Resolve both once at construction.
   **dim=8: 1.24× (19.5%). dim=4: 1.16× (13.8%).**

2. **Avoid `shared_ptr` churn in the boxed-LCP assembly loop.**
   `ConstrainedGroup::getConstraint(k)` returns a `ConstraintBasePtr` by value
   and was called inside the O(n²) inner loop. Resolve raw pointers once into a
   reused `thread_local` buffer (no class-layout/ABI change). **+~1.5%.**

3. **Cut per-step contact-setup overhead.** Replace the per-step `std::map`
   contact-pair counter (tree-node allocation + a re-sorting comparator) with a
   reused `thread_local` `unordered_map`; reuse the contact scratch vector; and
   cache the ODE tangent basis that `ContactConstraint` recomputed in both its
   constructor and `applyImpulse`. **+~1.5%.**

## Results (A/B interleaved, before → after, bit-for-bit identical)

| Scene | Size | Baseline | Optimized | Speedup |
|---|---|---|---|---|
| boxes (rigid) | dim=2 (8 bodies) | ~47 ms | ~47 ms | ~flat (few contacts) |
| boxes (rigid) | dim=4 (64 bodies) | 900 ms | 786 ms | 1.16× (13.5%) |
| boxes (rigid) | dim=8 (512 bodies) | 8932 ms | 7026 ms | **1.28× (21.5%)** |
| chains (articulated) | dense, links=3 | 386 ms | 367 ms | 1.05× (5.0%) |
| chains (articulated) | dense, links=5 | 372 ms | 357 ms | 1.04× (4.0%) |

The speedup scales with contact density (it targets the per-contact /
O(contacts²) constraint cost). Articulated scenes benefit less because their
cost is dominated by impulse propagation along each chain — an irreducible
dynamics cost these patches deliberately do not touch. After the patches, the
remaining dim=8 hot spots are the impulse-test A-matrix construction (~50%,
algorithmic), Bullet collision, and forward dynamics.

## Correctness

- All **100** ctest cases pass (constraint, dynamics, collision, integration,
  regression, math, utils), including `test_ContactConstraint`, `test_Dynamics`,
  `test_World`.
- Every A/B run gates on a bit-for-bit checksum match — results are unchanged,
  not merely "close", on both rigid and articulated scenes.

## New tooling (reusable)

- `dart::common::profile::Profiler` text backend (`DART_BUILD_PROFILE` +
  `DART_PROFILE_BUILTIN`; Tracy is now opt-in via `DART_PROFILE_TRACY`) +
  `test_Profile.cpp`.
- `boxes_headless` (checksum oracle + stepping-loop timer + profiler dump),
  shared `boxes_scene.hpp` (rigid + articulated scenes), `scripts/ab_boxes.sh`.

## Commits

1. Add headless text profiler and boxes profiling harness (DART 6)
2. Cache skeleton pointer and reactivity in ContactConstraint
3. Avoid shared_ptr churn in the boxed-LCP assembly loop
4. Cut per-step contact-setup overhead in the constraint solver
5. Add articulated-chains scenario to the headless boxes driver
