### PR TITLE
Release DART 6.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## DART 6
 
-### [DART 6.19.0 (TBD)](https://github.com/dartsim/dart/milestone/TBD?closed=1)
+### [DART 6.19.0 (2026-06-14)](https://github.com/dartsim/dart/milestone/97?closed=1)
+
+DART 6.19.0 is a minor release on the DART 6 LTS line. It adds automatic body
+deactivation ("sleeping"), contact-aware inverse dynamics, and a cylindrical
+dynamic joint constraint, together with a constraint-solver hot-path
+optimization and build/example fixes for modern toolchains.
 
 * Build
 
@@ -16,7 +21,12 @@
   * Add `CylindricalJointConstraint` for runtime slide-and-rotate attachments
     that leave translation along an axis and rotation about that axis free,
     with headless and GUI examples covering DART 6.x dynamic joint constraints:
-    [#2918](https://github.com/dartsim/dart/issues/2918)
+    [#2923](https://github.com/dartsim/dart/pull/2923)
+
+  * Optimize the DART 6 constraint-solver hot path (box-stacking benchmarks
+    ~1.28x faster) with bit-exact results, adding a lightweight profiling-scope
+    helper used to measure it:
+    [#3023](https://github.com/dartsim/dart/pull/3023)
 
 * Dynamics
 
@@ -24,8 +34,9 @@
     compute joint torques together with friction-cone-consistent contact
     forces for tracked motions with contacts, so floating-base inverse
     dynamics no longer requires an external QP solver, with unit tests,
-    benchmarks, dartpy bindings, and an ImGui-based GUI example:
-    [#2985](https://github.com/dartsim/dart/pull/2985)
+    benchmarks, dartpy bindings for `ContactInverseDynamics` (the
+    `math::solveNonNegativeLeastSquares` solver is C++-only), and an ImGui-based
+    GUI example: [#2985](https://github.com/dartsim/dart/pull/2985)
 
 * Examples and Tutorials
 
@@ -46,9 +57,11 @@
 * Simulation
 
   * Add automatic body deactivation ("sleeping") for resting solver islands,
-    enabled by default with an opt-out option, including wake-on-contact/force
-    handling and island-index diagnostics:
-    [#2920](https://github.com/dartsim/dart/pull/2920)
+    including wake-on-contact/force handling and island-index diagnostics. It is
+    enabled by default, so resting bodies now freeze automatically; the
+    detection is a deterministic no-op while bodies are active, and it can be
+    turned off via `World::setDeactivationOptions` to retain the previous
+    always-active behavior: [#2920](https://github.com/dartsim/dart/pull/2920)
 
 ### [DART 6.18.0 (2026-06-05)](https://github.com/dartsim/dart/milestone/94?closed=1)
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.18.0</version>
+  <version>6.19.0</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.18.0"
+version = "6.19.0"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
Packaging PR for **DART 6.19.0** (milestone 97).

## Changes
- Bump version `6.18.0 → 6.19.0` in `package.xml` (the regex-parsed source of `DART_VERSION`) and `pixi.toml`.
- Finalize the `CHANGELOG.md` 6.19.0 section:
  - real release date `2026-06-14` and `milestone/97` link (were `TBD`);
  - intro summary paragraph;
  - new **Constraint** entry for the constraint-solver hot-path optimization (#3023), which merged without a changelog entry;
  - corrected the **Dynamics** entry so it no longer implies `math::solveNonNegativeLeastSquares` has dartpy bindings (it is C++-only; `ContactInverseDynamics` is bound);
  - clarified the **Simulation** sleeping entry to flag that it is **on by default** (resting bodies now freeze) and how to opt out via `World::setDeactivationOptions`.

## Verification
- `cmake` reconfigure prints `DART 6.19.0` and the generated `config.hpp` has `DART_VERSION "6.19.0"`.
- No other in-repo files hardcode the version (`CMakeLists.txt` and the Doxyfile derive it from `package.xml`; `pyproject.toml` carries none; no in-repo conda recipe).

After this merges, tag `v6.19.0` and close milestone 97.