### PR TITLE
PLAN-091: WP-091.20a — split comps::Joint into Model/State/Control components

### DIFF
--- a/dart/simulation/comps/joint.cpp
+++ b/dart/simulation/comps/joint.cpp
@@ -36,6 +36,8 @@
 
 namespace dart::simulation::comps {
 
-DART_SIMULATION_REGISTER_COMPONENT(Joint)
+DART_SIMULATION_REGISTER_COMPONENT(JointModel)
+DART_SIMULATION_REGISTER_COMPONENT(JointState)
+DART_SIMULATION_REGISTER_COMPONENT(JointActuation)
 
 } // namespace dart::simulation::comps

--- a/dart/simulation/comps/joint.hpp
+++ b/dart/simulation/comps/joint.hpp
@@ -185,10 +185,16 @@ struct JointLimits
   JointVector effortUpper;   ///< Actuation effort upper bounds
 };
 
-/// Joint component (single joint in articulated body)
+/// Joint **Model** component: static topology, geometry, and solver parameters
+/// of a single joint, frozen at finalization (the design-mode configuration).
 ///
-/// Stores all joint properties in a unified structure. Different fields
-/// are used depending on the joint type:
+/// This is the canonical "this entity is a joint" component and the one that
+/// carries the kinematic-tree topology (`parentLink`/`childLink`), so iterating
+/// joints is a view over `JointModel`. Per the Model/State/Control/Contracts
+/// data contract (WP-091.20), it holds only design-frozen data: the geometric
+/// parameters, the limits, and the passive/solver parameters (spring, damping,
+/// armature, friction, rest position, break threshold). Per-step dynamic values
+/// live in `JointState`; commanded inputs live in `JointActuation`.
 ///
 /// Field usage by joint type:
 /// - Fixed:      rigidBodyFixedJointLocalAnchor* for public rigid-body joints
@@ -201,18 +207,12 @@ struct JointLimits
 /// - Floating:       (no geometric parameters - 6-DOF position)
 ///
 /// **Internal Implementation Detail** - Not exposed in public API
-struct Joint
+struct JointModel
 {
-  DART_SIMULATION_STATE_COMPONENT(Joint, "comps.Joint");
+  DART_SIMULATION_STATE_COMPONENT(JointModel, "comps.JointModel");
 
   JointType type = JointType::Revolute;
-  ActuatorType actuatorType = ActuatorType::Force;
   std::string name;
-
-  JointVector position;
-  JointVector velocity;
-  JointVector acceleration;
-  JointVector torque;
 
   /// Passive joint dynamics (per generalized coordinate).
   JointVector springStiffness;
@@ -227,16 +227,9 @@ struct Joint
   /// (per generalized coordinate).
   JointVector coulombFriction;
 
-  /// Commanded target velocity used by the Velocity actuator type (per
-  /// generalized coordinate).
-  JointVector commandVelocity;
-
   /// Maximum AVBD constraint force before the joint is marked broken. A value
   /// of 0 disables automatic breakage.
   double breakForce = 0.0;
-
-  /// Whether the joint has been broken by an AVBD break-force threshold.
-  bool broken = false;
 
   JointLimits limits;
 
@@ -258,7 +251,7 @@ struct Joint
 
   static constexpr auto entityFields()
   {
-    return std::make_tuple(&Joint::parentLink, &Joint::childLink);
+    return std::make_tuple(&JointModel::parentLink, &JointModel::childLink);
   }
 
   [[nodiscard]] std::size_t getDOF() const
@@ -286,6 +279,45 @@ struct Joint
         return 0;
     }
   }
+};
+
+/// Joint **State** component: the per-step dynamic values of a joint that the
+/// integrator advances every step (generalized position/velocity/acceleration)
+/// plus the runtime break flag. Per the Model/State/Control/Contracts contract
+/// (WP-091.20), this holds only mutable per-step data; design-frozen parameters
+/// live in `JointModel` and commanded inputs live in `JointActuation`.
+///
+/// **Internal Implementation Detail** - Not exposed in public API
+struct JointState
+{
+  DART_SIMULATION_PROPERTY_COMPONENT(JointState, "comps.JointState");
+
+  JointVector position;
+  JointVector velocity;
+  JointVector acceleration;
+
+  /// Whether the joint has been broken by an AVBD break-force threshold.
+  bool broken = false;
+};
+
+/// Joint **Control** component: the commanded inputs that drive the joint
+/// during forward dynamics (actuator mode, commanded effort, commanded
+/// velocity). Per the Model/State/Control/Contracts contract (WP-091.20), this
+/// holds only user/controller inputs; design-frozen parameters live in
+/// `JointModel` and per-step dynamic values live in `JointState`.
+///
+/// **Internal Implementation Detail** - Not exposed in public API
+struct JointActuation
+{
+  DART_SIMULATION_PROPERTY_COMPONENT(JointActuation, "comps.JointActuation");
+
+  ActuatorType actuatorType = ActuatorType::Force;
+
+  JointVector torque;
+
+  /// Commanded target velocity used by the Velocity actuator type (per
+  /// generalized coordinate).
+  JointVector commandVelocity;
 };
 
 /// Family-owned AVBD point-joint stiffness sidecar.

--- a/dart/simulation/compute/multibody_constraint.cpp
+++ b/dart/simulation/compute/multibody_constraint.cpp
@@ -66,21 +66,24 @@ Eigen::Vector3d rotationLog(const Eigen::Matrix3d& rotation)
 
 //==============================================================================
 void applyPositionLimits(
-    comps::Joint& joint, Eigen::Index firstDof, Eigen::Index dofCount)
+    const comps::JointModel& jointModel,
+    comps::JointState& jointState,
+    Eigen::Index firstDof,
+    Eigen::Index dofCount)
 {
-  if (joint.limits.lower.size() != joint.position.size()
-      || joint.limits.upper.size() != joint.position.size()) {
+  if (jointModel.limits.lower.size() != jointState.position.size()
+      || jointModel.limits.upper.size() != jointState.position.size()) {
     return;
   }
 
   const Eigen::Index endDof = firstDof + dofCount;
   for (Eigen::Index d = firstDof; d < endDof; ++d) {
-    if (joint.position[d] < joint.limits.lower[d]) {
-      joint.position[d] = joint.limits.lower[d];
-      joint.velocity[d] = std::max(joint.velocity[d], 0.0);
-    } else if (joint.position[d] > joint.limits.upper[d]) {
-      joint.position[d] = joint.limits.upper[d];
-      joint.velocity[d] = std::min(joint.velocity[d], 0.0);
+    if (jointState.position[d] < jointModel.limits.lower[d]) {
+      jointState.position[d] = jointModel.limits.lower[d];
+      jointState.velocity[d] = std::max(jointState.velocity[d], 0.0);
+    } else if (jointState.position[d] > jointModel.limits.upper[d]) {
+      jointState.position[d] = jointModel.limits.upper[d];
+      jointState.velocity[d] = std::min(jointState.velocity[d], 0.0);
     }
   }
 }
@@ -111,8 +114,8 @@ void integrateMultibodyPositions(
       continue;
     }
 
-    const auto& joint = registry.get<comps::Joint>(link.parentJoint);
-    expectedDof += static_cast<Eigen::Index>(joint.getDOF());
+    const auto& jointModel = registry.get<comps::JointModel>(link.parentJoint);
+    expectedDof += static_cast<Eigen::Index>(jointModel.getDOF());
   }
 
   DART_SIMULATION_THROW_T_IF(
@@ -131,45 +134,49 @@ void integrateMultibodyPositions(
       continue;
     }
 
-    auto& joint = registry.get<comps::Joint>(link.parentJoint);
-    const auto dof = static_cast<Eigen::Index>(joint.getDOF());
+    const auto& jointModel = registry.get<comps::JointModel>(link.parentJoint);
+    auto& jointState = registry.get<comps::JointState>(link.parentJoint);
+    const auto dof = static_cast<Eigen::Index>(jointModel.getDOF());
     if (dof == 0) {
       continue;
     }
     wroteJointPosition = true;
 
-    joint.acceleration = joint.velocity;
-    joint.velocity = nextVelocity.segment(velocityOffset, dof);
+    jointState.acceleration = jointState.velocity;
+    jointState.velocity = nextVelocity.segment(velocityOffset, dof);
     velocityOffset += dof;
 
     const auto updateAccelerationFromVelocityDelta = [&]() {
-      joint.acceleration = (joint.velocity - joint.acceleration) / timeStep;
+      jointState.acceleration
+          = (jointState.velocity - jointState.acceleration) / timeStep;
     };
 
-    if (joint.type == comps::JointType::Spherical) {
+    if (jointModel.type == comps::JointType::Spherical) {
       // Body angular velocity integrated by right multiplication on SO(3).
-      const Eigen::Matrix3d rotation = rotationExp(joint.position.head<3>());
-      joint.position.head<3>() = rotationLog(
-          rotation * rotationExp(joint.velocity.head<3>() * timeStep));
+      const Eigen::Matrix3d rotation
+          = rotationExp(jointState.position.head<3>());
+      jointState.position.head<3>() = rotationLog(
+          rotation * rotationExp(jointState.velocity.head<3>() * timeStep));
       updateAccelerationFromVelocityDelta();
       continue;
     }
 
-    if (joint.type == comps::JointType::Floating) {
+    if (jointModel.type == comps::JointType::Floating) {
       // Velocity is [linear; angular] body twist. Translation advances in the
       // parent frame (R * v) and orientation integrates on SO(3).
-      const Eigen::Matrix3d rotation = rotationExp(joint.position.tail<3>());
-      joint.position.head<3>()
-          += rotation * joint.velocity.head<3>() * timeStep;
-      joint.position.tail<3>() = rotationLog(
-          rotation * rotationExp(joint.velocity.tail<3>() * timeStep));
-      applyPositionLimits(joint, 0, 3);
+      const Eigen::Matrix3d rotation
+          = rotationExp(jointState.position.tail<3>());
+      jointState.position.head<3>()
+          += rotation * jointState.velocity.head<3>() * timeStep;
+      jointState.position.tail<3>() = rotationLog(
+          rotation * rotationExp(jointState.velocity.tail<3>() * timeStep));
+      applyPositionLimits(jointModel, jointState, 0, 3);
       updateAccelerationFromVelocityDelta();
       continue;
     }
 
-    joint.position += joint.velocity * timeStep;
-    applyPositionLimits(joint, 0, joint.position.size());
+    jointState.position += jointState.velocity * timeStep;
+    applyPositionLimits(jointModel, jointState, 0, jointState.position.size());
     updateAccelerationFromVelocityDelta();
   }
 

--- a/dart/simulation/compute/multibody_dynamics.cpp
+++ b/dart/simulation/compute/multibody_dynamics.cpp
@@ -158,55 +158,60 @@ inline Vector6 crossForce(const Vector6& v, const Vector6& f)
 }
 
 //==============================================================================
-Eigen::Isometry3d jointMotionTransform(const comps::Joint& joint)
+Eigen::Isometry3d jointMotionTransform(
+    const comps::JointModel& jointModel, const comps::JointState& jointState)
 {
   Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
-  switch (joint.type) {
+  switch (jointModel.type) {
     case comps::JointType::Fixed:
       return transform;
     case comps::JointType::Revolute:
       transform.linear()
-          = Eigen::AngleAxisd(joint.position[0], joint.axis).toRotationMatrix();
+          = Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+                .toRotationMatrix();
       return transform;
     case comps::JointType::Prismatic:
-      transform.translation() = joint.axis * joint.position[0];
+      transform.translation() = jointModel.axis * jointState.position[0];
       return transform;
     case comps::JointType::Screw:
       // Coupled rotation + translation along the axis: theta rotates and
       // advances by pitch * theta.
       transform.linear()
-          = Eigen::AngleAxisd(joint.position[0], joint.axis).toRotationMatrix();
-      transform.translation() = joint.axis * (joint.pitch * joint.position[0]);
+          = Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+                .toRotationMatrix();
+      transform.translation()
+          = jointModel.axis * (jointModel.pitch * jointState.position[0]);
       return transform;
     case comps::JointType::Universal:
       // Two sequential rotations: theta1 about axis, then theta2 about axis2
       // (axis2 expressed in the intermediate frame).
-      transform.linear() = (Eigen::AngleAxisd(joint.position[0], joint.axis)
-                            * Eigen::AngleAxisd(joint.position[1], joint.axis2))
-                               .toRotationMatrix();
+      transform.linear()
+          = (Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+             * Eigen::AngleAxisd(jointState.position[1], jointModel.axis2))
+                .toRotationMatrix();
       return transform;
     case comps::JointType::Planar: {
       // In-plane translation (position[0], position[1]) along two orthogonal
       // directions plus rotation (position[2]) about the plane normal. This
       // matches the kinematics convention in world_kinematics_graph/frame.
-      const Eigen::Vector3d normal = joint.axis.normalized();
-      const Eigen::Vector3d inPlane1 = joint.axis2.normalized();
+      const Eigen::Vector3d normal = jointModel.axis.normalized();
+      const Eigen::Vector3d inPlane1 = jointModel.axis2.normalized();
       const Eigen::Vector3d inPlane2 = normal.cross(inPlane1).normalized();
-      transform.linear()
-          = Eigen::AngleAxisd(joint.position[2], normal).toRotationMatrix();
-      transform.translation()
-          = inPlane1 * joint.position[0] + inPlane2 * joint.position[1];
+      transform.linear() = Eigen::AngleAxisd(jointState.position[2], normal)
+                               .toRotationMatrix();
+      transform.translation() = inPlane1 * jointState.position[0]
+                                + inPlane2 * jointState.position[1];
       return transform;
     }
     case comps::JointType::Spherical:
       // Orientation stored as a rotation vector (exponential coordinates).
-      transform.linear() = rotationExp(joint.position.head<3>());
+      transform.linear() = rotationExp(jointState.position.head<3>());
       return transform;
     case comps::JointType::Floating:
       // 6-DOF pose: translation (position[0..2]) then orientation as a rotation
       // vector (position[3..5]), matching the kinematics convention.
-      transform.linear() = rotationExp(joint.position.tail<3>());
-      transform.translation() = joint.position.head<3>();
+      transform.linear() = rotationExp(jointState.position.tail<3>());
+      transform.translation() = jointState.position.head<3>();
       return transform;
     default:
       DART_SIMULATION_THROW_T(
@@ -220,29 +225,32 @@ Eigen::Isometry3d jointMotionTransform(const comps::Joint& joint)
 //==============================================================================
 // Joint motion subspace expressed in the joint frame (before the post-joint
 // link offset), in the [angular; linear] convention.
-void setJointSubspaceInJointFrame(const comps::Joint& joint, Subspace& subspace)
+void setJointSubspaceInJointFrame(
+    const comps::JointModel& jointModel,
+    const comps::JointState& jointState,
+    Subspace& subspace)
 {
-  switch (joint.type) {
+  switch (jointModel.type) {
     case comps::JointType::Fixed:
       subspace.resize(6, 0);
       return;
     case comps::JointType::Revolute: {
       subspace.resize(6, 1);
-      subspace.col(0).head<3>() = joint.axis;
+      subspace.col(0).head<3>() = jointModel.axis;
       subspace.col(0).tail<3>().setZero();
       return;
     }
     case comps::JointType::Prismatic: {
       subspace.resize(6, 1);
       subspace.col(0).head<3>().setZero();
-      subspace.col(0).tail<3>() = joint.axis;
+      subspace.col(0).tail<3>() = jointModel.axis;
       return;
     }
     case comps::JointType::Screw: {
       // Twist of a screw: angular = axis, linear = pitch * axis.
       subspace.resize(6, 1);
-      subspace.col(0).head<3>() = joint.axis;
-      subspace.col(0).tail<3>() = joint.axis * joint.pitch;
+      subspace.col(0).head<3>() = jointModel.axis;
+      subspace.col(0).tail<3>() = jointModel.axis * jointModel.pitch;
       return;
     }
     case comps::JointType::Universal: {
@@ -253,11 +261,11 @@ void setJointSubspaceInJointFrame(const comps::Joint& joint, Subspace& subspace)
       // dependent, which the velocity-product term cJ accounts for.
       subspace.resize(6, 2);
       const Eigen::Matrix3d secondRotation
-          = Eigen::AngleAxisd(joint.position[1], joint.axis2)
+          = Eigen::AngleAxisd(jointState.position[1], jointModel.axis2)
                 .toRotationMatrix();
-      subspace.col(0).head<3>() = secondRotation.transpose() * joint.axis;
+      subspace.col(0).head<3>() = secondRotation.transpose() * jointModel.axis;
       subspace.col(0).tail<3>().setZero();
-      subspace.col(1).head<3>() = joint.axis2;
+      subspace.col(1).head<3>() = jointModel.axis2;
       subspace.col(1).tail<3>().setZero();
       return;
     }
@@ -266,11 +274,12 @@ void setJointSubspaceInJointFrame(const comps::Joint& joint, Subspace& subspace)
       // output frame. The translation directions are carried by the rotation
       // (R(theta_rot, normal)^T * in-plane axis), making them configuration
       // dependent; the rotation column is the constant normal.
-      const Eigen::Vector3d normal = joint.axis.normalized();
-      const Eigen::Vector3d inPlane1 = joint.axis2.normalized();
+      const Eigen::Vector3d normal = jointModel.axis.normalized();
+      const Eigen::Vector3d inPlane1 = jointModel.axis2.normalized();
       const Eigen::Vector3d inPlane2 = normal.cross(inPlane1).normalized();
       const Eigen::Matrix3d rotation
-          = Eigen::AngleAxisd(joint.position[2], normal).toRotationMatrix();
+          = Eigen::AngleAxisd(jointState.position[2], normal)
+                .toRotationMatrix();
       subspace.resize(6, 3);
       subspace.col(0).head<3>().setZero();
       subspace.col(0).tail<3>() = rotation.transpose() * inPlane1;
@@ -327,22 +336,23 @@ struct JointBiasTerm
 // the motion subspace).
 template <typename JointBiasTermVector>
 void setJointBiasTerms(
-    const comps::Joint& joint,
+    const comps::JointModel& jointModel,
+    const comps::JointState& jointState,
     const Matrix6& offsetAdjoint,
     JointBiasTermVector& terms)
 {
   terms.clear();
-  switch (joint.type) {
+  switch (jointModel.type) {
     case comps::JointType::Universal: {
       // d/dt(col0) = (s1 x axis2) * theta2dot with s1 = R(theta2, axis2)^T
       // axis, so cJ = (s1 x axis2) * theta1dot * theta2dot (angular; linear
       // zero).
       const Eigen::Matrix3d secondRotation
-          = Eigen::AngleAxisd(joint.position[1], joint.axis2)
+          = Eigen::AngleAxisd(jointState.position[1], jointModel.axis2)
                 .toRotationMatrix();
-      const Eigen::Vector3d s1 = secondRotation.transpose() * joint.axis;
+      const Eigen::Vector3d s1 = secondRotation.transpose() * jointModel.axis;
       Vector6 coeff = Vector6::Zero();
-      coeff.head<3>() = s1.cross(joint.axis2);
+      coeff.head<3>() = s1.cross(jointModel.axis2);
       terms.push_back(JointBiasTerm{0, 1, offsetAdjoint * coeff});
       return;
     }
@@ -350,11 +360,11 @@ void setJointBiasTerms(
       // The two in-plane translation columns rotate with position[2], so
       // d/dt(col_t) = -theta_rot_dot * R^T (normal x inplane_t). Each couples a
       // translation rate with the rotation rate (angular part zero).
-      const Eigen::Vector3d normal = joint.axis.normalized();
-      const Eigen::Vector3d inPlane1 = joint.axis2.normalized();
+      const Eigen::Vector3d normal = jointModel.axis.normalized();
+      const Eigen::Vector3d inPlane1 = jointModel.axis2.normalized();
       const Eigen::Vector3d inPlane2 = normal.cross(inPlane1).normalized();
       const Eigen::Matrix3d rotationTranspose
-          = Eigen::AngleAxisd(joint.position[2], normal)
+          = Eigen::AngleAxisd(jointState.position[2], normal)
                 .toRotationMatrix()
                 .transpose();
       Vector6 coeff0 = Vector6::Zero();
@@ -500,10 +510,13 @@ void buildDynamicsTreeInto(
       continue;
     }
 
-    const auto& joint = registry.get<comps::Joint>(linkComp.parentJoint);
+    const auto& jointModel
+        = registry.get<comps::JointModel>(linkComp.parentJoint);
+    const auto& jointState
+        = registry.get<comps::JointState>(linkComp.parentJoint);
     const auto parentIt
         = std::find_if(indexOf.begin(), indexOf.end(), [&](const auto& entry) {
-            return entry.first == joint.parentLink;
+            return entry.first == jointModel.parentLink;
           });
     DART_SIMULATION_THROW_T_IF(
         parentIt == indexOf.end(),
@@ -513,20 +526,22 @@ void buildDynamicsTreeInto(
     dynamics.jointEntity = linkComp.parentJoint;
     tree.jointOf[i] = linkComp.parentJoint;
 
-    const Eigen::Isometry3d childInParent = linkComp.transformFromParentToJoint
-                                            * jointMotionTransform(joint)
-                                            * linkComp.transformFromParentJoint;
+    const Eigen::Isometry3d childInParent
+        = linkComp.transformFromParentToJoint
+          * jointMotionTransform(jointModel, jointState)
+          * linkComp.transformFromParentJoint;
     dynamics.parentToChild = adjoint(childInParent.inverse());
     dynamics.childToParentForce = dynamics.parentToChild.transpose();
     dynamics.worldTransform
         = tree.links[parentIt->second].worldTransform * childInParent;
 
-    setJointSubspaceInJointFrame(joint, jointFrameSubspace);
+    setJointSubspaceInJointFrame(jointModel, jointState, jointFrameSubspace);
     const Matrix6 offsetAdjoint
         = adjoint(linkComp.transformFromParentJoint.inverse());
     dynamics.subspace.resize(6, jointFrameSubspace.cols());
     dynamics.subspace.noalias() = offsetAdjoint * jointFrameSubspace;
-    setJointBiasTerms(joint, offsetAdjoint, dynamics.biasTerms);
+    setJointBiasTerms(
+        jointModel, jointState, offsetAdjoint, dynamics.biasTerms);
     dynamics.dof = static_cast<std::size_t>(jointFrameSubspace.cols());
     dynamics.dofOffset = tree.dofCount;
     tree.dofCount += dynamics.dof;
@@ -541,9 +556,9 @@ void buildDynamicsTreeInto(
     if (dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(tree.jointOf[i]);
-    if (joint.armature.size() == static_cast<Eigen::Index>(dof)) {
-      tree.armature.segment(tree.links[i].dofOffset, dof) = joint.armature;
+    const auto& jointModel = registry.get<comps::JointModel>(tree.jointOf[i]);
+    if (jointModel.armature.size() == static_cast<Eigen::Index>(dof)) {
+      tree.armature.segment(tree.links[i].dofOffset, dof) = jointModel.armature;
     }
   }
 }
@@ -885,8 +900,9 @@ void gatherMultibodyVelocityInto(
     if (tree.links[i].dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(tree.jointOf[i]);
-    qdot.segment(tree.links[i].dofOffset, tree.links[i].dof) = joint.velocity;
+    const auto& jointState = registry.get<comps::JointState>(tree.jointOf[i]);
+    qdot.segment(tree.links[i].dofOffset, tree.links[i].dof)
+        = jointState.velocity;
   }
 }
 
@@ -923,27 +939,34 @@ bool computeUnconstrainedMultibodyVelocityInto(
     if (scratch.tree.links[i].dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(scratch.tree.jointOf[i]);
+    const auto& jointModel
+        = registry.get<comps::JointModel>(scratch.tree.jointOf[i]);
+    const auto& jointState
+        = registry.get<comps::JointState>(scratch.tree.jointOf[i]);
+    const auto& jointActuation
+        = registry.get<comps::JointActuation>(scratch.tree.jointOf[i]);
 
     // Determine the commanded actuation effort by actuator type. Force applies
     // the clamped joint effort; Passive applies none. Passive spring and
     // damping forces are not subject to the effort limits and always apply.
     const auto dof = scratch.tree.links[i].dof;
-    switch (joint.actuatorType) {
+    switch (jointActuation.actuatorType) {
       case comps::ActuatorType::Force:
         for (std::size_t d = 0; d < dof; ++d) {
           const auto local = static_cast<Eigen::Index>(d);
           const auto global
               = static_cast<Eigen::Index>(scratch.tree.links[i].dofOffset + d);
           const double effort = std::clamp(
-              joint.torque[local],
-              joint.limits.effortLower[local],
-              joint.limits.effortUpper[local]);
+              jointActuation.torque[local],
+              jointModel.limits.effortLower[local],
+              jointModel.limits.effortUpper[local]);
           scratch.appliedForce[global]
               = effort
-                - joint.springStiffness[local]
-                      * (joint.position[local] - joint.restPosition[local])
-                - joint.dampingCoefficient[local] * joint.velocity[local];
+                - jointModel.springStiffness[local]
+                      * (jointState.position[local]
+                         - jointModel.restPosition[local])
+                - jointModel.dampingCoefficient[local]
+                      * jointState.velocity[local];
         }
         break;
       case comps::ActuatorType::Passive:
@@ -955,9 +978,11 @@ bool computeUnconstrainedMultibodyVelocityInto(
           const auto global
               = static_cast<Eigen::Index>(scratch.tree.links[i].dofOffset + d);
           scratch.appliedForce[global]
-              = -joint.springStiffness[local]
-                    * (joint.position[local] - joint.restPosition[local])
-                - joint.dampingCoefficient[local] * joint.velocity[local];
+              = -jointModel.springStiffness[local]
+                    * (jointState.position[local]
+                       - jointModel.restPosition[local])
+                - jointModel.dampingCoefficient[local]
+                      * jointState.velocity[local];
         }
         break;
       default:
@@ -1030,13 +1055,14 @@ bool computeUnconstrainedMultibodyVelocityInto(
     if (dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(scratch.tree.jointOf[i]);
-    if (joint.coulombFriction.size() != static_cast<Eigen::Index>(dof)) {
+    const auto& jointModel
+        = registry.get<comps::JointModel>(scratch.tree.jointOf[i]);
+    if (jointModel.coulombFriction.size() != static_cast<Eigen::Index>(dof)) {
       continue;
     }
     for (std::size_t d = 0; d < dof; ++d) {
       const double bound
-          = joint.coulombFriction[static_cast<Eigen::Index>(d)] * timeStep;
+          = jointModel.coulombFriction[static_cast<Eigen::Index>(d)] * timeStep;
       if (bound <= 0.0) {
         continue;
       }
@@ -1062,16 +1088,18 @@ bool computeUnconstrainedMultibodyVelocityInto(
     if (dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(scratch.tree.jointOf[i]);
-    if (joint.actuatorType != comps::ActuatorType::Velocity) {
+    const auto& jointActuation
+        = registry.get<comps::JointActuation>(scratch.tree.jointOf[i]);
+    if (jointActuation.actuatorType != comps::ActuatorType::Velocity) {
       continue;
     }
     for (std::size_t d = 0; d < dof; ++d) {
       scratch.constrainedDof.push_back(
           static_cast<Eigen::Index>(scratch.tree.links[i].dofOffset + d));
       scratch.constrainedTarget.push_back(
-          joint.commandVelocity.size() == static_cast<Eigen::Index>(dof)
-              ? joint.commandVelocity[static_cast<Eigen::Index>(d)]
+          jointActuation.commandVelocity.size()
+                  == static_cast<Eigen::Index>(dof)
+              ? jointActuation.commandVelocity[static_cast<Eigen::Index>(d)]
               : 0.0);
     }
   }
@@ -1781,8 +1809,8 @@ void enforceMultibodyVelocityLimits(
       continue;
     }
 
-    const auto& joint = registry.get<comps::Joint>(link.parentJoint);
-    expectedDof += static_cast<Eigen::Index>(joint.getDOF());
+    const auto& jointModel = registry.get<comps::JointModel>(link.parentJoint);
+    expectedDof += static_cast<Eigen::Index>(jointModel.getDOF());
   }
 
   DART_SIMULATION_THROW_T_IF(
@@ -1801,13 +1829,13 @@ void enforceMultibodyVelocityLimits(
       continue;
     }
 
-    const auto& joint = registry.get<comps::Joint>(link.parentJoint);
-    const auto dof = static_cast<Eigen::Index>(joint.getDOF());
+    const auto& jointModel = registry.get<comps::JointModel>(link.parentJoint);
+    const auto dof = static_cast<Eigen::Index>(jointModel.getDOF());
     if (dof == 0) {
       continue;
     }
-    if (joint.limits.velocityLower.size() != static_cast<Eigen::Index>(dof)
-        || joint.limits.velocityUpper.size()
+    if (jointModel.limits.velocityLower.size() != static_cast<Eigen::Index>(dof)
+        || jointModel.limits.velocityUpper.size()
                != static_cast<Eigen::Index>(dof)) {
       velocityOffset += dof;
       continue;
@@ -1816,8 +1844,8 @@ void enforceMultibodyVelocityLimits(
       const auto globalDof = velocityOffset + d;
       nextVelocity[globalDof] = std::clamp(
           nextVelocity[globalDof],
-          joint.limits.velocityLower[d],
-          joint.limits.velocityUpper[d]);
+          jointModel.limits.velocityLower[d],
+          jointModel.limits.velocityUpper[d]);
     }
     velocityOffset += dof;
   }
@@ -2109,10 +2137,10 @@ bool treeSupportsAnalyticDerivatives(
     if (tree.links[i].dof != 1) {
       return false;
     }
-    const auto& joint = registry.get<comps::Joint>(tree.jointOf[i]);
-    if (joint.type != comps::JointType::Revolute
-        && joint.type != comps::JointType::Prismatic
-        && joint.type != comps::JointType::Screw) {
+    const auto& jointModel = registry.get<comps::JointModel>(tree.jointOf[i]);
+    if (jointModel.type != comps::JointType::Revolute
+        && jointModel.type != comps::JointType::Prismatic
+        && jointModel.type != comps::JointType::Screw) {
       return false;
     }
   }

--- a/dart/simulation/compute/multibody_dynamics.cpp
+++ b/dart/simulation/compute/multibody_dynamics.cpp
@@ -3478,7 +3478,6 @@ UnifiedConstraintStage::UnifiedConstraintStage(std::size_t frictionIterations)
 UnifiedConstraintStage::UnifiedConstraintStage(
     std::size_t frictionIterations, common::MemoryManager* memoryManager)
   : m_frictionIterations(std::max<std::size_t>(1, frictionIterations)),
-    m_memoryManager(memoryManager),
     m_scratch(
         memoryManager != nullptr
             ? constructStageOwnedScratch<Scratch>(

--- a/dart/simulation/compute/multibody_dynamics.hpp
+++ b/dart/simulation/compute/multibody_dynamics.hpp
@@ -681,7 +681,6 @@ private:
       World& world, std::span<const Contact> contacts);
 
   std::size_t m_frictionIterations;
-  common::MemoryManager* m_memoryManager = nullptr;
   ScratchPtr m_scratch;
 };
 

--- a/dart/simulation/compute/variational_integration.cpp
+++ b/dart/simulation/compute/variational_integration.cpp
@@ -183,7 +183,7 @@ Eigen::Vector3d rotationLog3(const Eigen::Matrix3d& rotation)
 // Relative transform produced by a joint at the given generalized position
 // (Phase A1: fixed/revolute/prismatic), before the post-joint link offset.
 Eigen::Isometry3d jointMotionTransform(
-    const comps::Joint& joint,
+    const comps::JointModel& joint,
     const Eigen::Ref<const Eigen::VectorXd>& position)
 {
   Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
@@ -221,7 +221,7 @@ Eigen::Isometry3d jointMotionTransform(
 // manifold, matching the semi-implicit integration convention
 // (R_new = R exp(omega), p_new = p + R v).
 void jointRetractInto(
-    const comps::Joint& joint,
+    const comps::JointModel& joint,
     const Eigen::Ref<const Eigen::VectorXd>& q,
     const Eigen::Ref<const Eigen::VectorXd>& delta,
     Eigen::Ref<Eigen::VectorXd> result)
@@ -247,7 +247,7 @@ void jointRetractInto(
 // The generalized-coordinate tangent `tau` with `jointRetract(q, tau) == qNext`
 // (so the generalized velocity is `tau / dt`). Inverse of jointRetract.
 void jointLogDifferenceInto(
-    const comps::Joint& joint,
+    const comps::JointModel& joint,
     const Eigen::Ref<const Eigen::VectorXd>& qNext,
     const Eigen::Ref<const Eigen::VectorXd>& q,
     Eigen::Ref<Eigen::VectorXd> result)
@@ -369,7 +369,7 @@ void resetVarLinkForBuild(
 }
 
 void setLinkFrameJointSubspaceInto(
-    const comps::Joint& joint,
+    const comps::JointModel& joint,
     const Eigen::Isometry3d& linkFromJoint,
     Subspace& subspace)
 {
@@ -469,22 +469,25 @@ void buildVarTreeInto(
       continue;
     }
 
-    const auto& joint = registry.get<comps::Joint>(linkComp.parentJoint);
+    const auto& jointModel
+        = registry.get<comps::JointModel>(linkComp.parentJoint);
+    const auto& jointState
+        = registry.get<comps::JointState>(linkComp.parentJoint);
     link.joint = linkComp.parentJoint;
-    const auto parentIt = indexOf.find(joint.parentLink);
+    const auto parentIt = indexOf.find(jointModel.parentLink);
     DART_SIMULATION_THROW_T_IF(
         parentIt == indexOf.end(),
         InvalidOperationException,
         "Multibody link parent is not part of the same multibody");
     link.parent = static_cast<int>(parentIt->second);
 
-    setLinkFrameJointSubspaceInto(joint, link.offset, link.subspace);
+    setLinkFrameJointSubspaceInto(jointModel, link.offset, link.subspace);
     link.dof = static_cast<std::size_t>(link.subspace.cols());
     link.dofOffset = tree.dofCount;
     tree.dofCount += link.dof;
-    link.currentRelative = link.parentToJoint
-                           * jointMotionTransform(joint, joint.position)
-                           * link.offset;
+    link.currentRelative
+        = link.parentToJoint
+          * jointMotionTransform(jointModel, jointState.position) * link.offset;
     link.worldTransform
         = tree.links[static_cast<std::size_t>(link.parent)].worldTransform
           * link.currentRelative;
@@ -514,12 +517,13 @@ void updateVarTreeConfigurationInto(
     if (link.parent < 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
     const auto seg = static_cast<Eigen::Index>(link.dofOffset);
     const auto n = static_cast<Eigen::Index>(link.dof);
     link.currentRelative
         = link.parentToJoint
-          * jointMotionTransform(joint, position.segment(seg, n)) * link.offset;
+          * jointMotionTransform(jointModel, position.segment(seg, n))
+          * link.offset;
     link.worldTransform
         = tree.links[static_cast<std::size_t>(link.parent)].worldTransform
           * link.currentRelative;
@@ -612,7 +616,7 @@ void reserveVariationalStepScratch(
 bool isTopologyMultibodyJoint(
     const detail::WorldRegistry& registry,
     entt::entity jointEntity,
-    const comps::Joint& joint)
+    const comps::JointModel& joint)
 {
   const auto* childLink = registry.try_get<comps::Link>(joint.childLink);
   return childLink != nullptr && childLink->parentJoint == jointEntity;
@@ -880,7 +884,7 @@ VariationalCompliantLoopScratch& getOrCreateVariationalCompliantLoopScratch(
 dvbd::AvbdScalarRowDescriptor makeVariationalCompliantLoopRowDescriptor(
     dvbd::AvbdScalarRowRole role,
     entt::entity jointEntity,
-    const comps::Joint& joint,
+    const comps::JointModel& joint,
     const dvbd::AvbdRigidWorldPointJointConfig& config,
     std::uint8_t axis)
 {
@@ -954,23 +958,27 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
   };
 
   auto view
-      = registry.view<comps::Joint, dvbd::AvbdRigidWorldPointJointConfig>();
+      = registry
+            .view<comps::JointModel, dvbd::AvbdRigidWorldPointJointConfig>();
   for (const entt::entity jointEntity : view) {
-    const auto& joint = view.get<comps::Joint>(jointEntity);
+    const auto& jointModel = view.get<comps::JointModel>(jointEntity);
+    const auto& jointState = registry.get<comps::JointState>(jointEntity);
+    const auto& jointActuation
+        = registry.get<comps::JointActuation>(jointEntity);
     const auto& config
         = view.get<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);
 
     const bool hard = isHardAvbdRigidWorldPointJointConfig(config);
     const std::optional<double> compliantStiffness
         = avbdRigidWorldCompliantPointJointStiffness(config);
-    if (!config.enabled || joint.broken
-        || !dvbd::isAvbdRigidWorldPointJointType(joint.type)
-        || isTopologyMultibodyJoint(registry, jointEntity, joint)) {
+    if (!config.enabled || jointState.broken
+        || !dvbd::isAvbdRigidWorldPointJointType(jointModel.type)
+        || isTopologyMultibodyJoint(registry, jointEntity, jointModel)) {
       continue;
     }
     if (!hard
         && (compliantScratch == nullptr || !compliantStiffness.has_value()
-            || joint.type != comps::JointType::Fixed)) {
+            || jointModel.type != comps::JointType::Fixed)) {
       continue;
     }
     if (!dvbd::detail::hasValidActiveAvbdRigidJointAxes(
@@ -992,12 +1000,12 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
       continue;
     }
 
-    const bool worldA = joint.parentLink == entt::null;
-    const bool worldB = joint.childLink == entt::null;
+    const bool worldA = jointModel.parentLink == entt::null;
+    const bool worldB = jointModel.childLink == entt::null;
     const dvbd::AvbdRigidWorldEndpoint endpointA
-        = dvbd::classifyAvbdRigidWorldEndpoint(registry, joint.parentLink);
+        = dvbd::classifyAvbdRigidWorldEndpoint(registry, jointModel.parentLink);
     const dvbd::AvbdRigidWorldEndpoint endpointB
-        = dvbd::classifyAvbdRigidWorldEndpoint(registry, joint.childLink);
+        = dvbd::classifyAvbdRigidWorldEndpoint(registry, jointModel.childLink);
     if ((!worldA
          && endpointA.kind != dvbd::AvbdRigidWorldEndpointKind::MultibodyLink)
         || (!worldB
@@ -1006,8 +1014,10 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
       continue;
     }
 
-    const int linkIndexA = worldA ? -1 : linkIndexInStructure(joint.parentLink);
-    const int linkIndexB = worldB ? -1 : linkIndexInStructure(joint.childLink);
+    const int linkIndexA
+        = worldA ? -1 : linkIndexInStructure(jointModel.parentLink);
+    const int linkIndexB
+        = worldB ? -1 : linkIndexInStructure(jointModel.childLink);
     if ((!worldA && linkIndexA < 0) || (!worldB && linkIndexB < 0)) {
       continue;
     }
@@ -1016,9 +1026,9 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
     }
 
     VariationalLoopConstraint constraint;
-    constraint.linkA = linkIndexA >= 0 ? joint.parentLink : entt::null;
+    constraint.linkA = linkIndexA >= 0 ? jointModel.parentLink : entt::null;
     constraint.pointA = config.localAnchorA;
-    constraint.linkB = linkIndexB >= 0 ? joint.childLink : entt::null;
+    constraint.linkB = linkIndexB >= 0 ? jointModel.childLink : entt::null;
     constraint.pointB = config.localAnchorB;
     constraint.rigid = angularRows > 0u;
     constraint.rotationA
@@ -1028,13 +1038,13 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
     Eigen::Matrix3d worldRotationA = Eigen::Matrix3d::Identity();
     if (!worldA) {
       worldRotationA = dvbd::avbdRigidWorldContactFrameWorldTransform(
-                           registry, joint.parentLink)
+                           registry, jointModel.parentLink)
                            .linear();
     }
     Eigen::Matrix3d worldRotationB = Eigen::Matrix3d::Identity();
     if (!worldB) {
       worldRotationB = dvbd::avbdRigidWorldContactFrameWorldTransform(
-                           registry, joint.childLink)
+                           registry, jointModel.childLink)
                            .linear();
     }
     const Eigen::Matrix3d axisFrame = worldRotationA;
@@ -1067,7 +1077,7 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
                 makeVariationalCompliantLoopRowDescriptor(
                     dvbd::AvbdScalarRowRole::JointLinear,
                     jointEntity,
-                    joint,
+                    jointModel,
                     config,
                     axis),
                 *compliantStiffness});
@@ -1084,7 +1094,7 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
                 makeVariationalCompliantLoopRowDescriptor(
                     dvbd::AvbdScalarRowRole::JointAngular,
                     jointEntity,
-                    joint,
+                    jointModel,
                     config,
                     axis),
                 *compliantStiffness});
@@ -1097,11 +1107,12 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
     constraint.angularAxes = axisFrame * config.angularAxes;
     constraint.linearAxisMask = config.linearAxisMask;
     constraint.angularAxisMask = config.angularAxisMask;
-    if (joint.type == comps::JointType::Prismatic
-        && joint.actuatorType == comps::ActuatorType::Velocity
-        && joint.commandVelocity.size() == 1
-        && joint.commandVelocity.allFinite()) {
-      const double maxForce = dvbd::avbdRigidWorldSymmetricEffortLimit(joint);
+    if (jointModel.type == comps::JointType::Prismatic
+        && jointActuation.actuatorType == comps::ActuatorType::Velocity
+        && jointActuation.commandVelocity.size() == 1
+        && jointActuation.commandVelocity.allFinite()) {
+      const double maxForce
+          = dvbd::avbdRigidWorldSymmetricEffortLimit(jointModel);
       const std::optional<std::uint8_t> freeAxis
           = singleInactiveVariationalLoopAxis(config.linearAxisMask);
       if (maxForce > 0.0 && !std::isnan(maxForce) && freeAxis.has_value()) {
@@ -1111,25 +1122,26 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
         const Eigen::Vector3d pointA
             = (worldA ? Eigen::Isometry3d::Identity()
                       : dvbd::avbdRigidWorldContactFrameWorldTransform(
-                            registry, joint.parentLink))
+                            registry, jointModel.parentLink))
               * constraint.pointA;
         const Eigen::Vector3d pointB
             = (worldB ? Eigen::Isometry3d::Identity()
                       : dvbd::avbdRigidWorldContactFrameWorldTransform(
-                            registry, joint.childLink))
+                            registry, jointModel.childLink))
               * constraint.pointB;
         const Eigen::Vector3d positionResidual = pointA - pointB;
         constraint.linearMotorReferencePosition
             = -constraint.linearMotorAxis.dot(positionResidual);
-        constraint.linearMotorTargetSpeed = joint.commandVelocity[0];
+        constraint.linearMotorTargetSpeed = jointActuation.commandVelocity[0];
         constraint.linearMotorMaxForce = maxForce;
       }
     }
-    if (joint.type == comps::JointType::Revolute
-        && joint.actuatorType == comps::ActuatorType::Velocity
-        && joint.commandVelocity.size() == 1
-        && joint.commandVelocity.allFinite()) {
-      const double maxTorque = dvbd::avbdRigidWorldSymmetricEffortLimit(joint);
+    if (jointModel.type == comps::JointType::Revolute
+        && jointActuation.actuatorType == comps::ActuatorType::Velocity
+        && jointActuation.commandVelocity.size() == 1
+        && jointActuation.commandVelocity.allFinite()) {
+      const double maxTorque
+          = dvbd::avbdRigidWorldSymmetricEffortLimit(jointModel);
       const std::optional<std::uint8_t> freeAxis
           = singleInactiveVariationalLoopAxis(config.angularAxisMask);
       if (maxTorque > 0.0 && !std::isnan(maxTorque) && freeAxis.has_value()) {
@@ -1142,12 +1154,12 @@ void appendAvbdRigidWorldArticulatedPointJointConstraints(
             = rotB * rotationLog3(rotB.transpose() * rotA);
         constraint.angularMotorReferencePosition
             = -constraint.angularMotorAxis.dot(angularResidual);
-        constraint.angularMotorTargetSpeed = joint.commandVelocity[0];
+        constraint.angularMotorTargetSpeed = jointActuation.commandVelocity[0];
         constraint.angularMotorMaxTorque = maxTorque;
       }
     }
     constraint.sourceJoint = jointEntity;
-    constraint.breakForce = joint.breakForce;
+    constraint.breakForce = jointModel.breakForce;
     constraints.push_back(constraint);
   }
 }
@@ -1166,11 +1178,12 @@ void markBrokenAvbdVariationalLoopConstraints(
 
     if (constraint.sourceJoint != entt::null && constraint.breakForce > 0.0
         && std::isfinite(constraint.breakForce) && row + rows <= lambda.size()
-        && registry.all_of<comps::Joint>(constraint.sourceJoint)) {
+        && registry.all_of<comps::JointModel>(constraint.sourceJoint)) {
       const double load = lambda.segment(row, rows).norm();
-      auto& joint = registry.get<comps::Joint>(constraint.sourceJoint);
+      auto& jointState
+          = registry.get<comps::JointState>(constraint.sourceJoint);
       if (load >= constraint.breakForce) {
-        joint.broken = true;
+        jointState.broken = true;
       }
     }
 
@@ -1337,29 +1350,33 @@ void gatherState(
     if (link.dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
+    const auto& jointState = registry.get<comps::JointState>(link.joint);
+    const auto& jointActuation
+        = registry.get<comps::JointActuation>(link.joint);
     const auto seg = static_cast<Eigen::Index>(link.dofOffset);
     const auto n = static_cast<Eigen::Index>(link.dof);
-    position.segment(seg, n) = joint.position;
-    velocity.segment(seg, n) = joint.velocity;
+    position.segment(seg, n) = jointState.position;
+    velocity.segment(seg, n) = jointState.velocity;
 
     auto effort = appliedForce.segment(seg, n);
     effort.setZero();
-    if (joint.actuatorType == comps::ActuatorType::Force
-        && joint.torque.size() == n) {
-      effort = joint.torque;
-      if (joint.limits.effortLower.size() == n
-          && joint.limits.effortUpper.size() == n) {
-        effort = effort.cwiseMax(joint.limits.effortLower)
-                     .cwiseMin(joint.limits.effortUpper);
+    if (jointActuation.actuatorType == comps::ActuatorType::Force
+        && jointActuation.torque.size() == n) {
+      effort = jointActuation.torque;
+      if (jointModel.limits.effortLower.size() == n
+          && jointModel.limits.effortUpper.size() == n) {
+        effort = effort.cwiseMax(jointModel.limits.effortLower)
+                     .cwiseMin(jointModel.limits.effortUpper);
       }
     }
-    if (joint.springStiffness.size() == n && joint.restPosition.size() == n) {
-      effort -= joint.springStiffness.cwiseProduct(
-          joint.position - joint.restPosition);
+    if (jointModel.springStiffness.size() == n
+        && jointModel.restPosition.size() == n) {
+      effort -= jointModel.springStiffness.cwiseProduct(
+          jointState.position - jointModel.restPosition);
     }
-    if (joint.dampingCoefficient.size() == n) {
-      effort -= joint.dampingCoefficient.cwiseProduct(joint.velocity);
+    if (jointModel.dampingCoefficient.size() == n) {
+      effort -= jointModel.dampingCoefficient.cwiseProduct(jointState.velocity);
     }
   }
 }
@@ -1376,18 +1393,20 @@ void gatherVelocity(
     if (link.dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
+    const auto& jointState = registry.get<comps::JointState>(link.joint);
     const auto seg = static_cast<Eigen::Index>(link.dofOffset);
     const auto n = static_cast<Eigen::Index>(link.dof);
-    velocity.segment(seg, n) = joint.velocity;
+    velocity.segment(seg, n) = jointState.velocity;
   }
 }
 
-bool isVariationalVelocityProjectionJoint(const comps::Joint& joint)
+bool isVariationalVelocityProjectionJoint(
+    const comps::JointModel& jointModel,
+    const comps::JointActuation& jointActuation)
 {
-  return joint.actuatorType == comps::ActuatorType::Velocity
-         && (joint.type == comps::JointType::Revolute
-             || joint.type == comps::JointType::Prismatic);
+  return jointActuation.actuatorType == comps::ActuatorType::Velocity
+         && (jointModel.type == comps::JointType::Revolute
+             || jointModel.type == comps::JointType::Prismatic);
 }
 
 Eigen::Index variationalVelocityProjectionRowCount(
@@ -1398,8 +1417,10 @@ Eigen::Index variationalVelocityProjectionRowCount(
     if (link.dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
-    if (!isVariationalVelocityProjectionJoint(joint)) {
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
+    const auto& jointActuation
+        = registry.get<comps::JointActuation>(link.joint);
+    if (!isVariationalVelocityProjectionJoint(jointModel, jointActuation)) {
       continue;
     }
     rows += static_cast<Eigen::Index>(link.dof);
@@ -1422,21 +1443,24 @@ Eigen::Index writeVariationalVelocityProjectionRows(
     if (link.dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
-    if (!isVariationalVelocityProjectionJoint(joint)) {
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
+    const auto& jointActuation
+        = registry.get<comps::JointActuation>(link.joint);
+    if (!isVariationalVelocityProjectionJoint(jointModel, jointActuation)) {
       continue;
     }
 
     const auto seg = static_cast<Eigen::Index>(link.dofOffset);
     const auto n = static_cast<Eigen::Index>(link.dof);
-    const bool useCommand = joint.commandVelocity.size() == n
-                            && joint.commandVelocity.allFinite();
+    const bool useCommand = jointActuation.commandVelocity.size() == n
+                            && jointActuation.commandVelocity.allFinite();
     for (Eigen::Index d = 0; d < n; ++d) {
       if (row >= residual.size()) {
         return row;
       }
       const Eigen::Index dof = seg + d;
-      const double command = useCommand ? joint.commandVelocity[d] : 0.0;
+      const double command
+          = useCommand ? jointActuation.commandVelocity[d] : 0.0;
       residual[row] = nextPosition[dof] - (position[dof] + timeStep * command);
       jacobian(row, dof) = 1.0;
       ++row;
@@ -1474,18 +1498,24 @@ std::optional<VariationalSolveReport> tryIntegrateSinglePrismaticVariational(
     return std::nullopt;
   }
 
-  auto& joint = registry.get<comps::Joint>(childLink.parentJoint);
-  if (joint.type != comps::JointType::Prismatic || joint.position.size() != 1
-      || joint.velocity.size() != 1 || joint.acceleration.size() != 1
-      || joint.parentLink != baseEntity || joint.childLink != childEntity) {
+  const auto& jointModel
+      = registry.get<comps::JointModel>(childLink.parentJoint);
+  auto& jointState = registry.get<comps::JointState>(childLink.parentJoint);
+  const auto& jointActuation
+      = registry.get<comps::JointActuation>(childLink.parentJoint);
+  if (jointModel.type != comps::JointType::Prismatic
+      || jointState.position.size() != 1 || jointState.velocity.size() != 1
+      || jointState.acceleration.size() != 1
+      || jointModel.parentLink != baseEntity
+      || jointModel.childLink != childEntity) {
     return std::nullopt;
   }
-  if (joint.actuatorType == comps::ActuatorType::Velocity) {
+  if (jointActuation.actuatorType == comps::ActuatorType::Velocity) {
     return std::nullopt;
   }
 
   Vector6 jointFrameSubspace = Vector6::Zero();
-  jointFrameSubspace.tail<3>() = joint.axis;
+  jointFrameSubspace.tail<3>() = jointModel.axis;
   const Vector6 linkFrameSubspace
       = adjoint(childLink.transformFromParentJoint.inverse())
         * jointFrameSubspace;
@@ -1497,35 +1527,38 @@ std::optional<VariationalSolveReport> tryIntegrateSinglePrismaticVariational(
   }
 
   double effort = 0.0;
-  if (joint.actuatorType == comps::ActuatorType::Force
-      && joint.torque.size() == 1) {
-    effort = joint.torque[0];
-    if (joint.limits.effortLower.size() == 1
-        && joint.limits.effortUpper.size() == 1) {
+  if (jointActuation.actuatorType == comps::ActuatorType::Force
+      && jointActuation.torque.size() == 1) {
+    effort = jointActuation.torque[0];
+    if (jointModel.limits.effortLower.size() == 1
+        && jointModel.limits.effortUpper.size() == 1) {
       effort = std::clamp(
-          effort, joint.limits.effortLower[0], joint.limits.effortUpper[0]);
+          effort,
+          jointModel.limits.effortLower[0],
+          jointModel.limits.effortUpper[0]);
     }
   }
-  if (joint.springStiffness.size() == 1 && joint.restPosition.size() == 1) {
-    effort -= joint.springStiffness[0]
-              * (joint.position[0] - joint.restPosition[0]);
+  if (jointModel.springStiffness.size() == 1
+      && jointModel.restPosition.size() == 1) {
+    effort -= jointModel.springStiffness[0]
+              * (jointState.position[0] - jointModel.restPosition[0]);
   }
-  if (joint.dampingCoefficient.size() == 1) {
-    effort -= joint.dampingCoefficient[0] * joint.velocity[0];
+  if (jointModel.dampingCoefficient.size() == 1) {
+    effort -= jointModel.dampingCoefficient[0] * jointState.velocity[0];
   }
 
   const auto& baseCache = registry.get<comps::FrameCache>(baseEntity);
   const Eigen::Vector3d axisWorld
       = baseCache.worldTransform.linear()
-        * childLink.transformFromParentToJoint.linear() * joint.axis;
+        * childLink.transformFromParentToJoint.linear() * jointModel.axis;
   const double generalizedGravity = effectiveMass * axisWorld.dot(gravity);
   const double generalizedExternal
       = linkFrameSubspace.dot(childLink.externalForce);
   const double noContactGeneralizedForce
       = effort + generalizedExternal + generalizedGravity;
 
-  const double previousPosition = joint.position[0];
-  const double previousVelocity = joint.velocity[0];
+  const double previousPosition = jointState.position[0];
+  const double previousVelocity = jointState.velocity[0];
   const Eigen::Isometry3d childOffset = childLink.transformFromParentJoint;
   const Eigen::Isometry3d parentToJoint = childLink.transformFromParentToJoint;
 
@@ -1539,7 +1572,7 @@ std::optional<VariationalSolveReport> tryIntegrateSinglePrismaticVariational(
 
     double generalizedForce = 0.0;
     Eigen::Isometry3d jointMotion = Eigen::Isometry3d::Identity();
-    jointMotion.translation() = joint.axis * trialPosition;
+    jointMotion.translation() = jointModel.axis * trialPosition;
     const Eigen::Isometry3d childWorld
         = baseCache.worldTransform * parentToJoint * jointMotion * childOffset;
     const Eigen::Vector3d pointVelocity = axisWorld * previousVelocity;
@@ -1608,9 +1641,9 @@ std::optional<VariationalSolveReport> tryIntegrateSinglePrismaticVariational(
 
   const double nextVelocity = previousVelocity + timeStep * acceleration;
 
-  joint.position[0] = nextPosition;
-  joint.velocity[0] = nextVelocity;
-  joint.acceleration[0] = acceleration;
+  jointState.position[0] = nextPosition;
+  jointState.velocity[0] = nextVelocity;
+  jointState.acceleration[0] = acceleration;
 
   state.previousDeltaTransform.resize(
       structure.links.size(), Eigen::Isometry3d::Identity());
@@ -1619,7 +1652,8 @@ std::optional<VariationalSolveReport> tryIntegrateSinglePrismaticVariational(
   state.previousMomentum[0].setZero();
 
   Eigen::Isometry3d jointDelta = Eigen::Isometry3d::Identity();
-  jointDelta.translation() = joint.axis * (nextPosition - previousPosition);
+  jointDelta.translation()
+      = jointModel.axis * (nextPosition - previousPosition);
   state.previousDeltaTransform[1] = childLink.transformFromParentJoint.inverse()
                                     * jointDelta
                                     * childLink.transformFromParentJoint;
@@ -1683,12 +1717,12 @@ void computeResidualInto(
       link.averageVelocity.setZero();
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
     const auto seg = nextPosition.segment(
         static_cast<Eigen::Index>(link.dofOffset),
         static_cast<Eigen::Index>(link.dof));
-    link.nextRelative
-        = link.parentToJoint * jointMotionTransform(joint, seg) * link.offset;
+    link.nextRelative = link.parentToJoint
+                        * jointMotionTransform(jointModel, seg) * link.offset;
     link.deltaTransform
         = link.currentRelative.inverse()
           * tree.links[static_cast<std::size_t>(link.parent)].deltaTransform
@@ -2373,12 +2407,13 @@ void evaluateContactForceInto(
     if (link.parent < 0) {
       continue; // root keeps its fixed world transform from buildVarTree.
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
     const auto seg = nextPosition.segment(
         static_cast<Eigen::Index>(link.dofOffset),
         static_cast<Eigen::Index>(link.dof));
-    scratch.trialRelativeTransforms[i]
-        = link.parentToJoint * jointMotionTransform(joint, seg) * link.offset;
+    scratch.trialRelativeTransforms[i] = link.parentToJoint
+                                         * jointMotionTransform(jointModel, seg)
+                                         * link.offset;
     scratch.trialWorldTransforms[i]
         = scratch.trialWorldTransforms[static_cast<std::size_t>(link.parent)]
           * scratch.trialRelativeTransforms[i];
@@ -3437,7 +3472,7 @@ VariationalSolveReport integrateMultibodyVariationalImpl(
     if (link.dof == 0) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.joint);
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
     const auto seg = static_cast<Eigen::Index>(link.dofOffset);
     const auto n = static_cast<Eigen::Index>(link.dof);
     linearSolve.jointWork.head(n).noalias()
@@ -3445,7 +3480,7 @@ VariationalSolveReport integrateMultibodyVariationalImpl(
     linearSolve.jointWork.head(n).noalias()
         += timeStep * timeStep * guessAcceleration.segment(seg, n);
     jointRetractInto(
-        joint,
+        jointModel,
         position.segment(seg, n),
         linearSolve.jointWork.head(n),
         nextPosition.segment(seg, n));
@@ -3484,7 +3519,7 @@ VariationalSolveReport integrateMultibodyVariationalImpl(
     if (link.dof == 0) {
       continue;
     }
-    const auto type = registry.get<comps::Joint>(link.joint).type;
+    const auto type = registry.get<comps::JointModel>(link.joint).type;
     if (type == comps::JointType::Spherical
         || type == comps::JointType::Floating) {
       euclideanCoordinates = false;
@@ -3508,12 +3543,12 @@ VariationalSolveReport integrateMultibodyVariationalImpl(
       if (link.dof == 0) {
         continue;
       }
-      const auto& joint = registry.get<comps::Joint>(link.joint);
+      const auto& jointModel = registry.get<comps::JointModel>(link.joint);
       const auto seg = static_cast<Eigen::Index>(link.dofOffset);
       const auto n = static_cast<Eigen::Index>(link.dof);
       anderson.jointDelta.head(n) = -scale * increment.segment(seg, n);
       jointRetractInto(
-          joint,
+          jointModel,
           base.segment(seg, n),
           anderson.jointDelta.head(n),
           result.segment(seg, n));
@@ -3533,11 +3568,11 @@ VariationalSolveReport integrateMultibodyVariationalImpl(
       if (link.dof == 0) {
         continue;
       }
-      const auto& joint = registry.get<comps::Joint>(link.joint);
+      const auto& jointModel = registry.get<comps::JointModel>(link.joint);
       const auto seg = static_cast<Eigen::Index>(link.dofOffset);
       const auto n = static_cast<Eigen::Index>(link.dof);
       jointLogDifferenceInto(
-          joint,
+          jointModel,
           to.segment(seg, n),
           from.segment(seg, n),
           tangent.segment(seg, n));
@@ -3921,11 +3956,11 @@ VariationalSolveReport integrateMultibodyVariationalImpl(
         if (link.dof == 0) {
           continue;
         }
-        const auto& joint = registry.get<comps::Joint>(link.joint);
+        const auto& jointModel = registry.get<comps::JointModel>(link.joint);
         const auto seg = static_cast<Eigen::Index>(link.dofOffset);
         const auto n = static_cast<Eigen::Index>(link.dof);
         jointRetractInto(
-            joint,
+            jointModel,
             nextPosition.segment(seg, n),
             projectionScratchStorage.correction.segment(seg, n),
             anderson.trialPosition.segment(seg, n));
@@ -3957,28 +3992,30 @@ VariationalSolveReport integrateMultibodyVariationalImpl(
       continue;
     }
     wroteJointPosition = true;
-    auto& joint = registry.get<comps::Joint>(link.joint);
+    const auto& jointModel = registry.get<comps::JointModel>(link.joint);
+    auto& jointState = registry.get<comps::JointState>(link.joint);
     const auto seg = static_cast<Eigen::Index>(link.dofOffset);
     const auto n = static_cast<Eigen::Index>(link.dof);
-    const bool hasPreviousVelocity = joint.velocity.size() == n;
+    const bool hasPreviousVelocity = jointState.velocity.size() == n;
     if (hasPreviousVelocity) {
-      stepScratchStorage.previousJointVelocity.head(n) = joint.velocity;
+      stepScratchStorage.previousJointVelocity.head(n) = jointState.velocity;
     }
     // q^k is the captured `position`; loop-closure projection works on the
     // scratch tree and leaves registry joint state unchanged until writeback.
-    joint.velocity.resize(n);
+    jointState.velocity.resize(n);
     jointLogDifferenceInto(
-        joint,
+        jointModel,
         nextPosition.segment(seg, n),
         position.segment(seg, n),
-        joint.velocity);
-    joint.velocity /= timeStep;
-    joint.position = nextPosition.segment(seg, n);
+        jointState.velocity);
+    jointState.velocity /= timeStep;
+    jointState.position = nextPosition.segment(seg, n);
     if (hasPreviousVelocity) {
-      joint.acceleration.resize(n);
-      joint.acceleration = joint.velocity;
-      joint.acceleration -= stepScratchStorage.previousJointVelocity.head(n);
-      joint.acceleration /= timeStep;
+      jointState.acceleration.resize(n);
+      jointState.acceleration = jointState.velocity;
+      jointState.acceleration
+          -= stepScratchStorage.previousJointVelocity.head(n);
+      jointState.acceleration /= timeStep;
     }
   }
   if (wroteJointPosition) {
@@ -4297,7 +4334,8 @@ void reserveMultibodyVariationalRegistryStorage(
   stateStorage.reserve(multibodyCount);
   scratchStorage.reserve(multibodyCount);
   auto pointJointConfigs
-      = registry.view<comps::Joint, dvbd::AvbdRigidWorldPointJointConfig>();
+      = registry
+            .view<comps::JointModel, dvbd::AvbdRigidWorldPointJointConfig>();
   const bool hasPointJointConfigs
       = pointJointConfigs.begin() != pointJointConfigs.end();
   if (hasPointJointConfigs) {
@@ -4464,7 +4502,8 @@ void MultibodyVariationalIntegrationStage::execute(
   // so by here every binding is Ignored or Supported (never Unsupported).
   auto closures = registry.view<comps::LoopClosure>();
   auto pointJointConfigs
-      = registry.view<comps::Joint, dvbd::AvbdRigidWorldPointJointConfig>();
+      = registry
+            .view<comps::JointModel, dvbd::AvbdRigidWorldPointJointConfig>();
   const bool hasPointJointConfigs
       = pointJointConfigs.begin() != pointJointConfigs.end();
 

--- a/dart/simulation/compute/world_kinematics_graph.cpp
+++ b/dart/simulation/compute/world_kinematics_graph.cpp
@@ -64,46 +64,51 @@ Eigen::Isometry3d rotationVectorTransform(const Eigen::Vector3d& rotation)
 }
 
 //==============================================================================
-Eigen::Isometry3d getJointTransform(const comps::Joint& joint)
+Eigen::Isometry3d getJointTransform(
+    const comps::JointModel& jointModel, const comps::JointState& jointState)
 {
   Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
 
-  switch (joint.type) {
+  switch (jointModel.type) {
     case comps::JointType::Fixed:
       return transform;
     case comps::JointType::Revolute:
       transform.linear()
-          = Eigen::AngleAxisd(joint.position[0], joint.axis).toRotationMatrix();
+          = Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+                .toRotationMatrix();
       return transform;
     case comps::JointType::Prismatic:
-      transform.translation() = joint.axis * joint.position[0];
+      transform.translation() = jointModel.axis * jointState.position[0];
       return transform;
     case comps::JointType::Screw:
       transform.linear()
-          = Eigen::AngleAxisd(joint.position[0], joint.axis).toRotationMatrix();
-      transform.translation() = joint.axis * joint.pitch * joint.position[0];
+          = Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+                .toRotationMatrix();
+      transform.translation()
+          = jointModel.axis * jointModel.pitch * jointState.position[0];
       return transform;
     case comps::JointType::Universal:
-      transform.linear() = (Eigen::AngleAxisd(joint.position[0], joint.axis)
-                            * Eigen::AngleAxisd(joint.position[1], joint.axis2))
-                               .toRotationMatrix();
+      transform.linear()
+          = (Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+             * Eigen::AngleAxisd(jointState.position[1], jointModel.axis2))
+                .toRotationMatrix();
       return transform;
     case comps::JointType::Spherical:
-      return rotationVectorTransform(joint.position.head<3>());
+      return rotationVectorTransform(jointState.position.head<3>());
     case comps::JointType::Planar: {
-      const Eigen::Vector3d normal = joint.axis.normalized();
-      const Eigen::Vector3d axis1 = joint.axis2.normalized();
+      const Eigen::Vector3d normal = jointModel.axis.normalized();
+      const Eigen::Vector3d axis1 = jointModel.axis2.normalized();
       const Eigen::Vector3d axis2 = normal.cross(axis1).normalized();
       transform.translation()
-          = axis1 * joint.position[0] + axis2 * joint.position[1];
-      transform.linear()
-          = Eigen::AngleAxisd(joint.position[2], normal).toRotationMatrix();
+          = axis1 * jointState.position[0] + axis2 * jointState.position[1];
+      transform.linear() = Eigen::AngleAxisd(jointState.position[2], normal)
+                               .toRotationMatrix();
       return transform;
     }
     case comps::JointType::Floating:
-      transform.translation() = joint.position.head<3>();
+      transform.translation() = jointState.position.head<3>();
       transform.linear()
-          = rotationVectorTransform(joint.position.tail<3>()).linear();
+          = rotationVectorTransform(jointState.position.tail<3>()).linear();
       return transform;
     case comps::JointType::Custom:
       DART_SIMULATION_THROW_T(
@@ -120,13 +125,22 @@ Eigen::Isometry3d getLocalTransform(
 {
   if (const auto* link = registry.try_get<comps::Link>(entity)) {
     if (link->parentJoint != entt::null) {
-      const auto* joint = registry.try_get<comps::Joint>(link->parentJoint);
+      const auto* jointModel
+          = registry.try_get<comps::JointModel>(link->parentJoint);
       DART_SIMULATION_THROW_T_IF(
-          !joint,
+          !jointModel,
           InvalidOperationException,
           "Link parent joint is missing a Joint component");
 
-      return link->transformFromParentToJoint * getJointTransform(*joint)
+      const auto* jointState
+          = registry.try_get<comps::JointState>(link->parentJoint);
+      DART_SIMULATION_THROW_T_IF(
+          !jointState,
+          InvalidOperationException,
+          "Link parent joint is missing a Joint component");
+
+      return link->transformFromParentToJoint
+             * getJointTransform(*jointModel, *jointState)
              * link->transformFromParentJoint;
     }
   }

--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -9724,12 +9724,14 @@ void collectRigidIpcArticulationConstraints(
   constraints.clear();
 
   auto view
-      = registry.view<comps::Joint, dvbd::AvbdRigidWorldPointJointConfig>();
+      = registry
+            .view<comps::JointModel, dvbd::AvbdRigidWorldPointJointConfig>();
   for (const auto jointEntity : view) {
-    const auto& joint = view.get<comps::Joint>(jointEntity);
+    const auto& joint = view.get<comps::JointModel>(jointEntity);
+    const auto& jointState = registry.get<comps::JointState>(jointEntity);
     const auto& config
         = view.get<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);
-    if (!config.enabled || joint.broken || joint.breakForce > 0.0
+    if (!config.enabled || jointState.broken || joint.breakForce > 0.0
         || joint.parentLink == entt::null || joint.childLink == entt::null
         || (joint.type != comps::JointType::Fixed
             && joint.type != comps::JointType::Revolute)
@@ -10606,7 +10608,9 @@ void RigidBodyContactStage::prepare(World& world)
   const std::size_t jointCapacity
       = mayHavePointJointConfigs
             ? registry
-                  .view<comps::Joint, dvbd::AvbdRigidWorldPointJointConfig>()
+                  .view<
+                      comps::JointModel,
+                      dvbd::AvbdRigidWorldPointJointConfig>()
                   .size_hint()
             : 0u;
   const auto* distanceSpringStorage

--- a/dart/simulation/detail/rigid_avbd/rigid_world_contact.hpp
+++ b/dart/simulation/detail/rigid_avbd/rigid_world_contact.hpp
@@ -733,7 +733,7 @@ inline bool isAvbdRigidWorldPointJointType(comps::JointType type)
 inline bool isAvbdRigidWorldPointJointFacade(
     const ::dart::simulation::detail::WorldRegistry& registry,
     entt::entity jointEntity,
-    const comps::Joint& joint)
+    const comps::JointModel& joint)
 {
   if (!isAvbdRigidWorldPointJointType(joint.type)
       || joint.parentLink == joint.childLink) {
@@ -768,7 +768,7 @@ inline bool isAvbdRigidWorldPointJointFacade(
 //==============================================================================
 inline bool computeAvbdRigidWorldPointJointDefaultStiffness(
     const ::dart::simulation::detail::WorldRegistry& registry,
-    const comps::Joint& joint,
+    const comps::JointModel& joint,
     double& startStiffnessOut,
     double& maxStiffnessOut)
 {
@@ -841,7 +841,7 @@ inline bool computeAvbdRigidWorldPointJointDefaultStiffness(
 }
 
 //==============================================================================
-inline double avbdRigidWorldSymmetricEffortLimit(const comps::Joint& joint)
+inline double avbdRigidWorldSymmetricEffortLimit(const comps::JointModel& joint)
 {
   if (joint.limits.effortLower.size() < 1 || joint.limits.effortUpper.size() < 1
       || std::isnan(joint.limits.effortLower[0])
@@ -877,7 +877,7 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
     return false;
   }
 
-  auto* joint = registry.try_get<comps::Joint>(jointEntity);
+  auto* joint = registry.try_get<comps::JointModel>(jointEntity);
   if (joint == nullptr || !isAvbdRigidWorldPointJointType(joint->type)
       || joint->parentLink == joint->childLink) {
     return false;
@@ -1060,7 +1060,7 @@ inline bool configureAvbdRigidWorldFixedJointFromCurrentPose(
     double startStiffness = 1.0,
     double maxStiffness = std::numeric_limits<double>::infinity())
 {
-  const auto* joint = registry.try_get<comps::Joint>(jointEntity);
+  const auto* joint = registry.try_get<comps::JointModel>(jointEntity);
   if (joint == nullptr || joint->type != comps::JointType::Fixed) {
     return false;
   }
@@ -1074,11 +1074,11 @@ inline std::size_t configureAvbdRigidWorldPointJointsFromCurrentPoses(
     ::dart::simulation::detail::WorldRegistry& registry)
 {
   std::size_t configured = 0;
-  const auto view = registry.view<comps::Joint>(
+  const auto view = registry.view<comps::JointModel>(
       entt::exclude<AvbdRigidWorldPointJointConfig>);
 
   for (const entt::entity entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (!isAvbdRigidWorldPointJointType(joint.type)
         || joint.parentLink == joint.childLink) {
       continue;
@@ -2710,13 +2710,13 @@ inline std::size_t markAvbdRigidWorldFracturedPointJoints(
 
     const entt::entity jointEntity = snapshot.jointEntities[jointIndex];
     if (jointEntity == entt::null
-        || !registry.all_of<comps::Joint>(jointEntity)) {
+        || !registry.all_of<comps::JointState>(jointEntity)) {
       continue;
     }
 
-    auto& joint = registry.get<comps::Joint>(jointEntity);
-    if (!joint.broken) {
-      joint.broken = true;
+    auto& jointState = registry.get<comps::JointState>(jointEntity);
+    if (!jointState.broken) {
+      jointState.broken = true;
       ++marked;
     }
   }
@@ -2946,27 +2946,30 @@ inline void extractAvbdRigidWorldPointJointInputsInto(
     bool includeWorldAnchors = true)
 {
   const auto view
-      = registry.view<comps::Joint, AvbdRigidWorldPointJointConfig>();
+      = registry.view<comps::JointModel, AvbdRigidWorldPointJointConfig>();
   inputs.clear();
   inputs.reserve(view.size_hint());
 
   for (const entt::entity entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& jointModel = view.get<comps::JointModel>(entity);
+    const auto& jointState = registry.get<comps::JointState>(entity);
+    const auto& jointActuation = registry.get<comps::JointActuation>(entity);
     const auto& config = view.get<AvbdRigidWorldPointJointConfig>(entity);
-    if (!config.enabled || joint.broken
-        || !isAvbdRigidWorldPointJointType(joint.type)) {
+    if (!config.enabled || jointState.broken
+        || !isAvbdRigidWorldPointJointType(jointModel.type)) {
       continue;
     }
 
-    if (joint.parentLink == entt::null || joint.childLink == entt::null
-        || joint.parentLink == joint.childLink) {
+    if (jointModel.parentLink == entt::null
+        || jointModel.childLink == entt::null
+        || jointModel.parentLink == jointModel.childLink) {
       continue;
     }
 
     const AvbdRigidWorldProjectableBodyView bodyA
-        = avbdRigidWorldProjectableBody(registry, joint.parentLink);
+        = avbdRigidWorldProjectableBody(registry, jointModel.parentLink);
     const AvbdRigidWorldProjectableBodyView bodyB
-        = avbdRigidWorldProjectableBody(registry, joint.childLink);
+        = avbdRigidWorldProjectableBody(registry, jointModel.childLink);
     if (!bodyA || !bodyB || (bodyA.isStatic && bodyB.isStatic)) {
       continue;
     }
@@ -2994,15 +2997,15 @@ inline void extractAvbdRigidWorldPointJointInputsInto(
     }
 
     const bool hasAngularVelocityMotor
-        = joint.type == comps::JointType::Revolute
-          && joint.actuatorType == comps::ActuatorType::Velocity
-          && joint.commandVelocity.size() == 1
-          && joint.commandVelocity.allFinite();
+        = jointModel.type == comps::JointType::Revolute
+          && jointActuation.actuatorType == comps::ActuatorType::Velocity
+          && jointActuation.commandVelocity.size() == 1
+          && jointActuation.commandVelocity.allFinite();
     const bool hasLinearVelocityMotor
-        = joint.type == comps::JointType::Prismatic
-          && joint.actuatorType == comps::ActuatorType::Velocity
-          && joint.commandVelocity.size() == 1
-          && joint.commandVelocity.allFinite();
+        = jointModel.type == comps::JointType::Prismatic
+          && jointActuation.actuatorType == comps::ActuatorType::Velocity
+          && jointActuation.commandVelocity.size() == 1
+          && jointActuation.commandVelocity.allFinite();
     const bool useStableFullLinearBasis
         = !includeWorldAnchors
           && config.linearAxisMask == kAvbdRigidJointAllAxesMask
@@ -3018,8 +3021,8 @@ inline void extractAvbdRigidWorldPointJointInputsInto(
 
     AvbdRigidWorldPointJointInput input;
     input.joint = entity;
-    input.bodyA = joint.parentLink;
-    input.bodyB = joint.childLink;
+    input.bodyA = jointModel.parentLink;
+    input.bodyB = jointModel.childLink;
     input.bodyAView = bodyA;
     input.bodyBView = bodyB;
     if (includeWorldAnchors) {
@@ -3043,18 +3046,18 @@ inline void extractAvbdRigidWorldPointJointInputsInto(
     input.linearAxisMask = config.linearAxisMask;
     input.angularAxisMask = config.angularAxisMask;
     if (hasAngularVelocityMotor) {
-      const double maxTorque = avbdRigidWorldSymmetricEffortLimit(joint);
+      const double maxTorque = avbdRigidWorldSymmetricEffortLimit(jointModel);
       if (maxTorque > 0.0 && !std::isnan(maxTorque)) {
         input.useAngularMotor = true;
-        input.motorTargetSpeed = joint.commandVelocity[0];
+        input.motorTargetSpeed = jointActuation.commandVelocity[0];
         input.motorMaxTorque = maxTorque;
       }
     }
     if (hasLinearVelocityMotor) {
-      const double maxForce = avbdRigidWorldSymmetricEffortLimit(joint);
+      const double maxForce = avbdRigidWorldSymmetricEffortLimit(jointModel);
       if (maxForce > 0.0 && !std::isnan(maxForce)) {
         input.useLinearMotor = true;
-        input.motorTargetSpeed = joint.commandVelocity[0];
+        input.motorTargetSpeed = jointActuation.commandVelocity[0];
         input.motorMaxForce = maxForce;
       }
     }
@@ -3062,7 +3065,7 @@ inline void extractAvbdRigidWorldPointJointInputsInto(
     input.linearMaterialStiffness = config.linearMaterialStiffness;
     input.angularMaterialStiffness = config.angularMaterialStiffness;
     input.maxStiffness = config.maxStiffness;
-    input.fractureThreshold = joint.breakForce;
+    input.fractureThreshold = jointModel.breakForce;
     inputs.push_back(input);
   }
 }
@@ -3080,7 +3083,7 @@ inline bool hasAvbdRigidWorldPointJointConfigs(
     const ::dart::simulation::detail::WorldRegistry& registry)
 {
   const auto view
-      = registry.view<comps::Joint, AvbdRigidWorldPointJointConfig>();
+      = registry.view<comps::JointModel, AvbdRigidWorldPointJointConfig>();
   return view.begin() != view.end();
 }
 
@@ -3088,7 +3091,7 @@ inline bool hasAvbdRigidWorldPointJointConfigs(
 inline bool mayHaveAvbdRigidWorldPointJointConfigs(
     const ::dart::simulation::detail::WorldRegistry& registry)
 {
-  const auto* jointStorage = registry.storage<comps::Joint>();
+  const auto* jointStorage = registry.storage<comps::JointModel>();
   const auto* configStorage
       = registry.storage<AvbdRigidWorldPointJointConfig>();
   return jointStorage != nullptr && configStorage != nullptr

--- a/dart/simulation/detail/smooth_jacobians.cpp
+++ b/dart/simulation/detail/smooth_jacobians.cpp
@@ -121,8 +121,8 @@ void collectCoordinatesInto(
     if (link.parentJoint == entt::null) {
       continue;
     }
-    const auto& joint = registry.get<comps::Joint>(link.parentJoint);
-    const auto dof = static_cast<Eigen::Index>(joint.getDOF());
+    const auto& jointModel = registry.get<comps::JointModel>(link.parentJoint);
+    const auto dof = static_cast<Eigen::Index>(jointModel.getDOF());
     for (Eigen::Index d = 0; d < dof; ++d) {
       coordinates.push_back({link.parentJoint, d});
     }
@@ -180,8 +180,8 @@ StepDerivatives contactFreeStepDerivatives(
   Eigen::VectorXd qdot = Eigen::VectorXd::Zero(ndof);
   for (Eigen::Index k = 0; k < ndof; ++k) {
     const auto& coordinate = coordinates[static_cast<std::size_t>(k)];
-    const auto& joint = registry.get<comps::Joint>(coordinate.joint);
-    qdot[k] = joint.velocity[coordinate.local];
+    const auto& jointState = registry.get<comps::JointState>(coordinate.joint);
+    qdot[k] = jointState.velocity[coordinate.local];
   }
 
   const Eigen::MatrixXd inverseMass = massMatrix.inverse();
@@ -230,18 +230,18 @@ StepDerivatives contactFreeStepDerivatives(
   } else {
     for (Eigen::Index k = 0; k < ndof; ++k) {
       const auto& coordinate = coordinates[static_cast<std::size_t>(k)];
-      auto& joint = registry.get<comps::Joint>(coordinate.joint);
+      auto& jointState = registry.get<comps::JointState>(coordinate.joint);
 
       // --- Position perturbation: dM/dq_k and dc/dq_k. ---
       {
-        const double original = joint.position[coordinate.local];
+        const double original = jointState.position[coordinate.local];
         const double h = 1e-6 * (1.0 + std::abs(original));
 
-        joint.position[coordinate.local] = original + h;
+        jointState.position[coordinate.local] = original + h;
         const auto& plus = evalTermsInto(plusTerms);
-        joint.position[coordinate.local] = original - h;
+        jointState.position[coordinate.local] = original - h;
         const auto& minus = evalTermsInto(minusTerms);
-        joint.position[coordinate.local] = original; // restore exactly
+        jointState.position[coordinate.local] = original; // restore exactly
 
         const Eigen::MatrixXd dMass
             = (plus.massMatrix - minus.massMatrix) / (2.0 * h);
@@ -258,14 +258,14 @@ StepDerivatives contactFreeStepDerivatives(
       // --- Velocity perturbation: dc/dq̇_k (the Coriolis velocity derivative).
       // ---
       {
-        const double original = joint.velocity[coordinate.local];
+        const double original = jointState.velocity[coordinate.local];
         const double h = 1e-6 * (1.0 + std::abs(original));
 
-        joint.velocity[coordinate.local] = original + h;
+        jointState.velocity[coordinate.local] = original + h;
         const auto& plus = evalTermsInto(plusTerms);
-        joint.velocity[coordinate.local] = original - h;
+        jointState.velocity[coordinate.local] = original - h;
         const auto& minus = evalTermsInto(minusTerms);
-        joint.velocity[coordinate.local] = original; // restore exactly
+        jointState.velocity[coordinate.local] = original; // restore exactly
 
         Eigen::VectorXd dBias = plus.coriolisForces;
         dBias += plus.gravityForces;
@@ -304,14 +304,15 @@ StepDerivatives contactFreeStepDerivatives(
   Eigen::Index offset = 0;
   while (offset < ndof) {
     const auto& coordinate = coordinates[static_cast<std::size_t>(offset)];
-    const auto& joint = registry.get<comps::Joint>(coordinate.joint);
+    const auto& jointModel = registry.get<comps::JointModel>(coordinate.joint);
+    const auto& jointState = registry.get<comps::JointState>(coordinate.joint);
     // Movable joints in `coordinates` always have a positive DOF count, so this
     // advances by at least one each iteration.
-    const auto jointDof = static_cast<Eigen::Index>(joint.getDOF());
+    const auto jointDof = static_cast<Eigen::Index>(jointModel.getDOF());
 
-    if (joint.type == comps::JointType::Spherical) {
+    if (jointModel.type == comps::JointType::Spherical) {
       // q_local is the rotation vector; q̇'_local is the body angular velocity.
-      const Eigen::Vector3d phi = joint.position.head<3>();
+      const Eigen::Vector3d phi = jointState.position.head<3>();
       const Eigen::Vector3d omegaNext = nextVelocity.segment<3>(offset);
       const Eigen::Vector3d twist = omegaNext * timeStep;
       const Eigen::Vector3d phiNext
@@ -322,11 +323,11 @@ StepDerivatives contactFreeStepDerivatives(
           = jrInvNext * rotationExp(-twist) * rotationRightJacobian(phi);
       posPartialVel.block<3, 3>(offset, offset)
           = jrInvNext * rotationRightJacobian(twist) * timeStep;
-    } else if (joint.type == comps::JointType::Floating) {
+    } else if (jointModel.type == comps::JointType::Floating) {
       // q_local = [translation; rotation vector]; q̇'_local = [linear; angular]
       // body twist. Translation advances in the parent frame (R · v), rotation
       // integrates on SO(3).
-      const Eigen::Vector3d theta = joint.position.tail<3>();
+      const Eigen::Vector3d theta = jointState.position.tail<3>();
       const Eigen::Matrix3d rotation = rotationExp(theta);
       const Eigen::Vector3d linearNext = nextVelocity.segment<3>(offset);
       const Eigen::Vector3d angularNext = nextVelocity.segment<3>(offset + 3);

--- a/dart/simulation/frame/frame.cpp
+++ b/dart/simulation/frame/frame.cpp
@@ -115,46 +115,51 @@ Eigen::Isometry3d rotationVectorTransform(const Eigen::Vector3d& rotation)
 }
 
 //==============================================================================
-Eigen::Isometry3d getJointTransform(const comps::Joint& joint)
+Eigen::Isometry3d getJointTransform(
+    const comps::JointModel& jointModel, const comps::JointState& jointState)
 {
   Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
 
-  switch (joint.type) {
+  switch (jointModel.type) {
     case comps::JointType::Fixed:
       return transform;
     case comps::JointType::Revolute:
       transform.linear()
-          = Eigen::AngleAxisd(joint.position[0], joint.axis).toRotationMatrix();
+          = Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+                .toRotationMatrix();
       return transform;
     case comps::JointType::Prismatic:
-      transform.translation() = joint.axis * joint.position[0];
+      transform.translation() = jointModel.axis * jointState.position[0];
       return transform;
     case comps::JointType::Screw:
       transform.linear()
-          = Eigen::AngleAxisd(joint.position[0], joint.axis).toRotationMatrix();
-      transform.translation() = joint.axis * joint.pitch * joint.position[0];
+          = Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+                .toRotationMatrix();
+      transform.translation()
+          = jointModel.axis * jointModel.pitch * jointState.position[0];
       return transform;
     case comps::JointType::Universal:
-      transform.linear() = (Eigen::AngleAxisd(joint.position[0], joint.axis)
-                            * Eigen::AngleAxisd(joint.position[1], joint.axis2))
-                               .toRotationMatrix();
+      transform.linear()
+          = (Eigen::AngleAxisd(jointState.position[0], jointModel.axis)
+             * Eigen::AngleAxisd(jointState.position[1], jointModel.axis2))
+                .toRotationMatrix();
       return transform;
     case comps::JointType::Spherical:
-      return rotationVectorTransform(joint.position.head<3>());
+      return rotationVectorTransform(jointState.position.head<3>());
     case comps::JointType::Planar: {
-      const Eigen::Vector3d normal = joint.axis.normalized();
-      const Eigen::Vector3d axis1 = joint.axis2.normalized();
+      const Eigen::Vector3d normal = jointModel.axis.normalized();
+      const Eigen::Vector3d axis1 = jointModel.axis2.normalized();
       const Eigen::Vector3d axis2 = normal.cross(axis1).normalized();
       transform.translation()
-          = axis1 * joint.position[0] + axis2 * joint.position[1];
-      transform.linear()
-          = Eigen::AngleAxisd(joint.position[2], normal).toRotationMatrix();
+          = axis1 * jointState.position[0] + axis2 * jointState.position[1];
+      transform.linear() = Eigen::AngleAxisd(jointState.position[2], normal)
+                               .toRotationMatrix();
       return transform;
     }
     case comps::JointType::Floating:
-      transform.translation() = joint.position.head<3>();
+      transform.translation() = jointState.position.head<3>();
       transform.linear()
-          = rotationVectorTransform(joint.position.tail<3>()).linear();
+          = rotationVectorTransform(jointState.position.tail<3>()).linear();
       return transform;
     case comps::JointType::Custom:
       DART_SIMULATION_THROW_T(
@@ -171,14 +176,22 @@ Eigen::Isometry3d getFrameLocalTransform(
 {
   if (const auto* link = registry.template try_get<comps::Link>(entity)) {
     if (link->parentJoint != entt::null) {
-      const auto* joint
-          = registry.template try_get<comps::Joint>(link->parentJoint);
+      const auto* jointModel
+          = registry.template try_get<comps::JointModel>(link->parentJoint);
       DART_SIMULATION_THROW_T_IF(
-          !joint,
+          !jointModel,
           InvalidOperationException,
           "Link parent joint is missing a Joint component");
 
-      return link->transformFromParentToJoint * getJointTransform(*joint)
+      const auto* jointState
+          = registry.template try_get<comps::JointState>(link->parentJoint);
+      DART_SIMULATION_THROW_T_IF(
+          !jointState,
+          InvalidOperationException,
+          "Link parent joint is missing a Joint component");
+
+      return link->transformFromParentToJoint
+             * getJointTransform(*jointModel, *jointState)
              * link->transformFromParentJoint;
     }
   }

--- a/dart/simulation/io/binary_io.hpp
+++ b/dart/simulation/io/binary_io.hpp
@@ -105,7 +105,14 @@ using EntityMap = std::unordered_map<entt::entity, entt::entity>;
 //      DART 7 has no compatibility debt, so packets written with mangled-name
 //      component identities (versions <= 20) no longer round-trip their
 //      components. See WP-091.23 and comps/component_category.hpp.
-constexpr std::uint32_t kBinaryFormatVersion = 21;
+//   22: The unified comps.Joint record is split into three contract-aligned
+//      components: comps.JointModel (frozen topology, geometry, and solver
+//      parameters), comps.JointState (per-step position/velocity/acceleration
+//      and the runtime broken flag), and comps.JointActuation (actuator mode,
+//      commanded effort, commanded velocity). Clean break: DART 7 has no
+//      compatibility debt, so packets written with the unified comps.Joint
+//      record (versions <= 21) no longer round-trip the joint. See WP-091.20.
+constexpr std::uint32_t kBinaryFormatVersion = 22;
 
 //==============================================================================
 // Low-level Binary I/O for POD types

--- a/dart/simulation/io/serializer.cpp
+++ b/dart/simulation/io/serializer.cpp
@@ -122,22 +122,6 @@ void setSingleCollisionShape(
   geometry.shapes.push_back(std::move(shape));
 }
 
-Eigen::VectorXd symmetricLowerBound(const Eigen::VectorXd& upperBound)
-{
-  if (upperBound.size() == 0) {
-    return Eigen::VectorXd{};
-  }
-  return -upperBound.cwiseAbs();
-}
-
-Eigen::VectorXd symmetricUpperBound(const Eigen::VectorXd& upperBound)
-{
-  if (upperBound.size() == 0) {
-    return Eigen::VectorXd{};
-  }
-  return upperBound.cwiseAbs();
-}
-
 void writeMatrix3d(std::ostream& output, const Eigen::Matrix3d& matrix)
 {
   for (Eigen::Index row = 0; row < 3; ++row) {
@@ -175,217 +159,6 @@ void readQuaterniond(std::istream& input, Eigen::Quaterniond& q)
   readPOD(input, y);
   readPOD(input, z);
   q = Eigen::Quaterniond(w, x, y, z);
-}
-
-// Staged AVBD point-joint stiffness parsed from a legacy (v17-v19) Joint record
-// where the four stiffness values lived inline on the Joint struct. The Joint
-// component serializer consumes this in postLoadComponent() to materialize the
-// separate comps::AvbdJointStiffness sidecar. When `present` is false the joint
-// had no materialized stiffness, so no sidecar is emplaced and reads fall back
-// to defaults (matching the old hasAvbdStiffnessState == false behavior).
-struct LegacyJointAvbdStiffness
-{
-  bool present = false;
-  comps::AvbdJointStiffness values;
-};
-
-void deserializeJointV1(std::istream& input, comps::Joint& joint)
-{
-  readPOD(input, joint.type);
-  readString(input, joint.name);
-  readVectorXd(input, joint.position);
-  readVectorXd(input, joint.velocity);
-  readVectorXd(input, joint.acceleration);
-  readVectorXd(input, joint.torque);
-
-  readVectorXd(input, joint.limits.lower);
-  readVectorXd(input, joint.limits.upper);
-
-  Eigen::VectorXd legacyVelocityLimit;
-  Eigen::VectorXd legacyEffortLimit;
-  readVectorXd(input, legacyVelocityLimit);
-  readVectorXd(input, legacyEffortLimit);
-
-  readVector3d(input, joint.axis);
-  readVector3d(input, joint.axis2);
-  readPOD(input, joint.pitch);
-
-  std::uint32_t parentLink = static_cast<std::uint32_t>(entt::null);
-  std::uint32_t childLink = static_cast<std::uint32_t>(entt::null);
-  readPOD(input, parentLink);
-  readPOD(input, childLink);
-  joint.parentLink = static_cast<entt::entity>(parentLink);
-  joint.childLink = static_cast<entt::entity>(childLink);
-
-  const auto dof = static_cast<Eigen::Index>(joint.getDOF());
-  joint.actuatorType = comps::ActuatorType::Force;
-  joint.springStiffness = comps::makeJointVector(dof, 0.0);
-  joint.dampingCoefficient = comps::makeJointVector(dof, 0.0);
-  joint.restPosition = comps::makeJointVector(dof, 0.0);
-  joint.armature = comps::makeJointVector(dof, 0.0);
-  joint.coulombFriction = comps::makeJointVector(dof, 0.0);
-  joint.commandVelocity = comps::makeJointVector(dof, 0.0);
-  joint.breakForce = 0.0;
-  joint.broken = false;
-
-  const double infinity = std::numeric_limits<double>::infinity();
-  if (joint.limits.lower.size() != dof) {
-    joint.limits.lower = comps::makeJointVector(dof, -infinity);
-  }
-  if (joint.limits.upper.size() != dof) {
-    joint.limits.upper = comps::makeJointVector(dof, infinity);
-  }
-  if (legacyVelocityLimit.size() == dof) {
-    joint.limits.velocityLower = symmetricLowerBound(legacyVelocityLimit);
-    joint.limits.velocityUpper = symmetricUpperBound(legacyVelocityLimit);
-  } else {
-    joint.limits.velocityLower = comps::makeJointVector(dof, -infinity);
-    joint.limits.velocityUpper = comps::makeJointVector(dof, infinity);
-  }
-
-  if (legacyEffortLimit.size() == dof) {
-    joint.limits.effortLower = symmetricLowerBound(legacyEffortLimit);
-    joint.limits.effortUpper = symmetricUpperBound(legacyEffortLimit);
-  } else {
-    joint.limits.effortLower = comps::makeJointVector(dof, -infinity);
-    joint.limits.effortUpper = comps::makeJointVector(dof, infinity);
-  }
-}
-
-void deserializeJointV2ToV13(
-    std::istream& input, comps::Joint& joint, std::uint32_t formatVersion)
-{
-  readPOD(input, joint.type);
-  readPOD(input, joint.actuatorType);
-  readString(input, joint.name);
-  readVectorXd(input, joint.position);
-  readVectorXd(input, joint.velocity);
-  readVectorXd(input, joint.acceleration);
-  readVectorXd(input, joint.torque);
-
-  readVectorXd(input, joint.springStiffness);
-  readVectorXd(input, joint.dampingCoefficient);
-  readVectorXd(input, joint.restPosition);
-  readVectorXd(input, joint.armature);
-  readVectorXd(input, joint.coulombFriction);
-  readVectorXd(input, joint.commandVelocity);
-
-  joint.breakForce = 0.0;
-  joint.broken = false;
-
-  readVectorXd(input, joint.limits.lower);
-  readVectorXd(input, joint.limits.upper);
-  readVectorXd(input, joint.limits.velocityLower);
-  readVectorXd(input, joint.limits.velocityUpper);
-  readVectorXd(input, joint.limits.effortLower);
-  readVectorXd(input, joint.limits.effortUpper);
-
-  readVector3d(input, joint.axis);
-  readVector3d(input, joint.axis2);
-  readPOD(input, joint.pitch);
-
-  std::uint32_t parentLink = static_cast<std::uint32_t>(entt::null);
-  std::uint32_t childLink = static_cast<std::uint32_t>(entt::null);
-  readPOD(input, parentLink);
-  readPOD(input, childLink);
-  joint.parentLink = static_cast<entt::entity>(parentLink);
-  joint.childLink = static_cast<entt::entity>(childLink);
-
-  if (formatVersion >= 13u) {
-    readPOD(input, joint.hasRigidBodyFixedJointAnchors);
-    readVector3d(input, joint.rigidBodyFixedJointLocalAnchorParent);
-    readVector3d(input, joint.rigidBodyFixedJointLocalAnchorChild);
-
-    double w = 1.0;
-    double x = 0.0;
-    double y = 0.0;
-    double z = 0.0;
-    readPOD(input, w);
-    readPOD(input, x);
-    readPOD(input, y);
-    readPOD(input, z);
-    joint.rigidBodyFixedJointTargetRelativeOrientation
-        = Eigen::Quaterniond(w, x, y, z);
-  } else {
-    joint.hasRigidBodyFixedJointAnchors = false;
-    joint.rigidBodyFixedJointLocalAnchorParent.setZero();
-    joint.rigidBodyFixedJointLocalAnchorChild.setZero();
-    joint.rigidBodyFixedJointTargetRelativeOrientation.setIdentity();
-  }
-}
-
-void deserializeJointV14ToV19(
-    std::istream& input,
-    comps::Joint& joint,
-    std::uint32_t formatVersion,
-    LegacyJointAvbdStiffness& stagedStiffness)
-{
-  readPOD(input, joint.type);
-  readPOD(input, joint.actuatorType);
-  readString(input, joint.name);
-  readVectorXd(input, joint.position);
-  readVectorXd(input, joint.velocity);
-  readVectorXd(input, joint.acceleration);
-  readVectorXd(input, joint.torque);
-
-  readVectorXd(input, joint.springStiffness);
-  readVectorXd(input, joint.dampingCoefficient);
-  readVectorXd(input, joint.restPosition);
-  readVectorXd(input, joint.armature);
-  readVectorXd(input, joint.coulombFriction);
-  readVectorXd(input, joint.commandVelocity);
-
-  readPOD(input, joint.breakForce);
-  readPOD(input, joint.broken);
-
-  // Versions 17-19 stored the AVBD point-joint stiffness inline on the Joint
-  // record (a bool flag plus four doubles). Newer formats keep it in a separate
-  // comps::AvbdJointStiffness sidecar. Read and stage the legacy values so the
-  // serializer can materialize the sidecar after the Joint is emplaced. Earlier
-  // versions (14-16) had no such block, so the joint loads with no sidecar.
-  stagedStiffness = LegacyJointAvbdStiffness{};
-  if (formatVersion >= 17u) {
-    bool hasAvbdStiffnessState = false;
-    readPOD(input, hasAvbdStiffnessState);
-    readPOD(input, stagedStiffness.values.startStiffness);
-    readPOD(input, stagedStiffness.values.linearStiffness);
-    readPOD(input, stagedStiffness.values.angularStiffness);
-    readPOD(input, stagedStiffness.values.maxStiffness);
-    stagedStiffness.present = hasAvbdStiffnessState;
-  }
-
-  readVectorXd(input, joint.limits.lower);
-  readVectorXd(input, joint.limits.upper);
-  readVectorXd(input, joint.limits.velocityLower);
-  readVectorXd(input, joint.limits.velocityUpper);
-  readVectorXd(input, joint.limits.effortLower);
-  readVectorXd(input, joint.limits.effortUpper);
-
-  readVector3d(input, joint.axis);
-  readVector3d(input, joint.axis2);
-  readPOD(input, joint.pitch);
-
-  std::uint32_t parentLink = static_cast<std::uint32_t>(entt::null);
-  std::uint32_t childLink = static_cast<std::uint32_t>(entt::null);
-  readPOD(input, parentLink);
-  readPOD(input, childLink);
-  joint.parentLink = static_cast<entt::entity>(parentLink);
-  joint.childLink = static_cast<entt::entity>(childLink);
-
-  readPOD(input, joint.hasRigidBodyFixedJointAnchors);
-  readVector3d(input, joint.rigidBodyFixedJointLocalAnchorParent);
-  readVector3d(input, joint.rigidBodyFixedJointLocalAnchorChild);
-
-  double w = 1.0;
-  double x = 0.0;
-  double y = 0.0;
-  double z = 0.0;
-  readPOD(input, w);
-  readPOD(input, x);
-  readPOD(input, y);
-  readPOD(input, z);
-  joint.rigidBodyFixedJointTargetRelativeOrientation
-      = Eigen::Quaterniond(w, x, y, z);
 }
 
 void initializeCollisionShapeDefaults(CollisionShape& shape)
@@ -565,85 +338,6 @@ void deserializeLinkV8(
       readPOD(input, link.externalForce[i]);
     }
   }
-}
-
-class JointComponentSerializer final
-  : public TypedComponentSerializer<comps::Joint>
-{
-public:
-  [[nodiscard]] std::string_view getTypeName() const override
-  {
-    return comps::Joint::getTypeName();
-  }
-
-private:
-  void saveComponent(
-      std::ostream& output,
-      const comps::Joint& component,
-      const EntityMap& entityMap) const override
-  {
-    autoSerialize(output, component, entityMap);
-  }
-
-  void loadComponent(
-      std::istream& input, comps::Joint& component) const override
-  {
-    autoDeserialize(input, component);
-  }
-
-  void loadComponent(
-      std::istream& input,
-      comps::Joint& component,
-      std::uint32_t formatVersion) const override
-  {
-    // No legacy inline AVBD stiffness unless an older record explicitly stages
-    // it below.
-    m_stagedStiffness = LegacyJointAvbdStiffness{};
-
-    if (formatVersion == 1u) {
-      deserializeJointV1(input, component);
-      return;
-    }
-    if (formatVersion < 14u) {
-      deserializeJointV2ToV13(input, component, formatVersion);
-      return;
-    }
-    if (formatVersion < 20u) {
-      deserializeJointV14ToV19(
-          input, component, formatVersion, m_stagedStiffness);
-      return;
-    }
-
-    loadComponent(input, component);
-  }
-
-  void postLoadComponent(
-      entt::entity entity,
-      ::dart::simulation::detail::WorldRegistry& registry,
-      std::uint32_t /*formatVersion*/) const override
-  {
-    // Versions 17-19 carried the AVBD point-joint stiffness inline on the Joint
-    // record. Materialize the separate comps::AvbdJointStiffness sidecar from
-    // the staged values when the legacy joint had a materialized state; absence
-    // means the joint loads with no sidecar (defaults), matching the old
-    // hasAvbdStiffnessState == false behavior.
-    if (m_stagedStiffness.present) {
-      registry.emplace_or_replace<comps::AvbdJointStiffness>(
-          entity, m_stagedStiffness.values);
-    }
-    m_stagedStiffness = LegacyJointAvbdStiffness{};
-  }
-
-  mutable LegacyJointAvbdStiffness m_stagedStiffness;
-};
-
-void registerJointSerializer(SerializerRegistry& registry)
-{
-  if (registry.getSerializer(comps::Joint::getTypeName()) != nullptr) {
-    return;
-  }
-
-  registry.registerSerializer(std::make_unique<JointComponentSerializer>());
 }
 
 class AvbdRigidWorldPointJointConfigComponentSerializer final
@@ -922,7 +616,9 @@ void registerBuiltInSerializers(SerializerRegistry& registry)
   registerComponentIfNeeded<comps::LoopClosure>(registry);
 
   registerLinkSerializer(registry);
-  registerJointSerializer(registry);
+  registerComponentIfNeeded<comps::JointModel>(registry);
+  registerComponentIfNeeded<comps::JointState>(registry);
+  registerComponentIfNeeded<comps::JointActuation>(registry);
   registerComponentIfNeeded<comps::AvbdJointStiffness>(registry);
   registerAvbdRigidWorldPointJointConfigSerializer(registry);
   registerAvbdRigidWorldDistanceSpringConfigSerializer(registry);
@@ -1101,9 +797,9 @@ void SerializerRegistry::loadAllEntities(
     }
   }
 
-  auto jointView = registry.view<comps::Joint>();
+  auto jointView = registry.view<comps::JointModel>();
   for (auto entity : jointView) {
-    auto& comp = jointView.get<comps::Joint>(entity);
+    auto& comp = jointView.get<comps::JointModel>(entity);
     if (comp.parentLink != entt::null) {
       comp.parentLink = entityMap.at(comp.parentLink);
     }

--- a/dart/simulation/multibody/joint.cpp
+++ b/dart/simulation/multibody/joint.cpp
@@ -121,7 +121,7 @@ ActuatorType toPublicActuatorType(comps::ActuatorType type)
   return ActuatorType::Force;
 }
 
-comps::Joint& getJointComponent(World* world, Entity entityToken)
+comps::JointModel& getJointModel(World* world, Entity entityToken)
 {
   DART_SIMULATION_THROW_T_IF(
       world == nullptr, InvalidArgumentException, "Invalid joint handle");
@@ -129,17 +129,47 @@ comps::Joint& getJointComponent(World* world, Entity entityToken)
   const auto entity = detail::toRegistryEntity(entityToken);
   auto& registry = dart::simulation::detail::registryOf(*world);
   DART_SIMULATION_THROW_T_IF(
-      !registry.valid(entity) || !registry.all_of<comps::Joint>(entity),
+      !registry.valid(entity) || !registry.all_of<comps::JointModel>(entity),
       InvalidArgumentException,
       "Invalid joint handle");
 
-  return registry.get<comps::Joint>(entity);
+  return registry.get<comps::JointModel>(entity);
+}
+
+comps::JointState& getJointState(World* world, Entity entityToken)
+{
+  DART_SIMULATION_THROW_T_IF(
+      world == nullptr, InvalidArgumentException, "Invalid joint handle");
+
+  const auto entity = detail::toRegistryEntity(entityToken);
+  auto& registry = dart::simulation::detail::registryOf(*world);
+  DART_SIMULATION_THROW_T_IF(
+      !registry.valid(entity) || !registry.all_of<comps::JointModel>(entity),
+      InvalidArgumentException,
+      "Invalid joint handle");
+
+  return registry.get<comps::JointState>(entity);
+}
+
+comps::JointActuation& getJointActuation(World* world, Entity entityToken)
+{
+  DART_SIMULATION_THROW_T_IF(
+      world == nullptr, InvalidArgumentException, "Invalid joint handle");
+
+  const auto entity = detail::toRegistryEntity(entityToken);
+  auto& registry = dart::simulation::detail::registryOf(*world);
+  DART_SIMULATION_THROW_T_IF(
+      !registry.valid(entity) || !registry.all_of<comps::JointModel>(entity),
+      InvalidArgumentException,
+      "Invalid joint handle");
+
+  return registry.get<comps::JointActuation>(entity);
 }
 
 detail::deformable_vbd::AvbdRigidWorldPointJointConfig*
 tryGetAvbdRigidWorldPointJointConfig(World* world, Entity entityToken)
 {
-  (void)getJointComponent(world, entityToken);
+  (void)getJointModel(world, entityToken);
   auto& registry = dart::simulation::detail::registryOf(*world);
   const auto entity = detail::toRegistryEntity(entityToken);
   return registry
@@ -149,7 +179,7 @@ tryGetAvbdRigidWorldPointJointConfig(World* world, Entity entityToken)
 void validateAvbdRigidWorldPointJointFacade(
     const dart::simulation::detail::WorldRegistry& registry,
     entt::entity jointEntity,
-    const comps::Joint& joint)
+    const comps::JointModel& joint)
 {
   DART_SIMULATION_THROW_T_IF(
       !detail::deformable_vbd::isAvbdRigidWorldPointJointFacade(
@@ -163,7 +193,7 @@ void validateAvbdRigidWorldPointJointFacade(
 comps::AvbdJointStiffness& materializeAvbdStiffnessState(
     dart::simulation::detail::WorldRegistry& registry,
     entt::entity jointEntity,
-    comps::Joint& joint)
+    comps::JointModel& joint)
 {
   if (auto* stiffness
       = registry.try_get<comps::AvbdJointStiffness>(jointEntity)) {
@@ -305,98 +335,99 @@ Joint::Joint(Entity entity, World* world) : m_entity(entity), m_world(world) {}
 //==============================================================================
 std::string_view Joint::getName() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.name;
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return jointModel.name;
 }
 
 //==============================================================================
 JointType Joint::getType() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return toPublicJointType(jointComp.type);
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return toPublicJointType(jointModel.type);
 }
 
 //==============================================================================
 ActuatorType Joint::getActuatorType() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return toPublicActuatorType(jointComp.actuatorType);
+  const auto& jointActuation = getJointActuation(m_world, m_entity);
+  return toPublicActuatorType(jointActuation.actuatorType);
 }
 
 //==============================================================================
 void Joint::setActuatorType(ActuatorType actuatorType)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  jointComp.actuatorType = toComponentActuatorType(actuatorType);
+  auto& jointActuation = getJointActuation(m_world, m_entity);
+  jointActuation.actuatorType = toComponentActuatorType(actuatorType);
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getCommandVelocity() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.commandVelocity;
+  const auto& jointActuation = getJointActuation(m_world, m_entity);
+  return jointActuation.commandVelocity;
 }
 
 //==============================================================================
 void Joint::setCommandVelocity(const Eigen::VectorXd& velocity)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(velocity, jointComp.getDOF(), "command velocity");
-  jointComp.commandVelocity = velocity;
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  auto& jointActuation = getJointActuation(m_world, m_entity);
+  validateJointStateVector(velocity, jointModel.getDOF(), "command velocity");
+  jointActuation.commandVelocity = velocity;
 }
 
 //==============================================================================
 Eigen::Vector3d Joint::getAxis() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
+  const auto& jointModel = getJointModel(m_world, m_entity);
 
   // Validate joint type - Spherical and Floating joints don't have axes
   DART_SIMULATION_THROW_T_IF(
-      jointComp.type == comps::JointType::Spherical
-          || jointComp.type == comps::JointType::Floating,
+      jointModel.type == comps::JointType::Spherical
+          || jointModel.type == comps::JointType::Floating,
       InvalidArgumentException,
       "getAxis() is not valid for Spherical and Floating joints (no axis "
       "concept)");
 
-  return jointComp.axis;
+  return jointModel.axis;
 }
 
 //==============================================================================
 Eigen::Vector3d Joint::getAxis2() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
+  const auto& jointModel = getJointModel(m_world, m_entity);
 
   // Validate joint type
   DART_SIMULATION_THROW_T_IF(
-      jointComp.type != comps::JointType::Universal
-          && jointComp.type != comps::JointType::Planar,
+      jointModel.type != comps::JointType::Universal
+          && jointModel.type != comps::JointType::Planar,
       InvalidArgumentException,
       "getAxis2() is only valid for Universal and Planar joints");
 
-  return jointComp.axis2;
+  return jointModel.axis2;
 }
 
 //==============================================================================
 double Joint::getPitch() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
+  const auto& jointModel = getJointModel(m_world, m_entity);
 
   // Validate joint type
   DART_SIMULATION_THROW_T_IF(
-      jointComp.type != comps::JointType::Screw,
+      jointModel.type != comps::JointType::Screw,
       InvalidArgumentException,
       "getPitch() is only valid for Screw joints");
 
-  return jointComp.pitch;
+  return jointModel.pitch;
 }
 
 //==============================================================================
 void Joint::setPitch(double pitch)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& jointModel = getJointModel(m_world, m_entity);
 
   DART_SIMULATION_THROW_T_IF(
-      jointComp.type != comps::JointType::Screw,
+      jointModel.type != comps::JointType::Screw,
       InvalidArgumentException,
       "setPitch() is only valid for Screw joints");
   DART_SIMULATION_THROW_T_IF(
@@ -404,235 +435,238 @@ void Joint::setPitch(double pitch)
       InvalidArgumentException,
       "Joint pitch must be finite");
 
-  jointComp.pitch = pitch;
+  jointModel.pitch = pitch;
 }
 
 //==============================================================================
 std::size_t Joint::getDOFCount() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.getDOF();
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return jointModel.getDOF();
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getPosition() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.position;
+  const auto& jointState = getJointState(m_world, m_entity);
+  return jointState.position;
 }
 
 //==============================================================================
 void Joint::setPosition(const Eigen::VectorXd& position)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(position, jointComp.getDOF(), "position");
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  auto& jointState = getJointState(m_world, m_entity);
+  validateJointStateVector(position, jointModel.getDOF(), "position");
 
-  jointComp.position = position;
+  jointState.position = position;
   markSubtreeTransformCacheDirty(
       dart::simulation::detail::registryOf(*m_world),
-      jointComp.childLink,
+      jointModel.childLink,
       m_world->getMemoryManager().getFreeAllocator());
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getVelocity() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.velocity;
+  const auto& jointState = getJointState(m_world, m_entity);
+  return jointState.velocity;
 }
 
 //==============================================================================
 void Joint::setVelocity(const Eigen::VectorXd& velocity)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(velocity, jointComp.getDOF(), "velocity");
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  auto& jointState = getJointState(m_world, m_entity);
+  validateJointStateVector(velocity, jointModel.getDOF(), "velocity");
 
-  jointComp.velocity = velocity;
+  jointState.velocity = velocity;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getForce() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.torque;
+  const auto& jointActuation = getJointActuation(m_world, m_entity);
+  return jointActuation.torque;
 }
 
 //==============================================================================
 void Joint::setForce(const Eigen::VectorXd& force)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(force, jointComp.getDOF(), "force");
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  auto& jointActuation = getJointActuation(m_world, m_entity);
+  validateJointStateVector(force, jointModel.getDOF(), "force");
 
-  jointComp.torque = force;
+  jointActuation.torque = force;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getAcceleration() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.acceleration;
+  const auto& jointState = getJointState(m_world, m_entity);
+  return jointState.acceleration;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getSpringStiffness() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.springStiffness;
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return jointModel.springStiffness;
 }
 
 //==============================================================================
 void Joint::setSpringStiffness(const Eigen::VectorXd& stiffness)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(stiffness, jointComp.getDOF(), "spring stiffness");
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointStateVector(stiffness, jointModel.getDOF(), "spring stiffness");
   DART_SIMULATION_THROW_T_IF(
       (stiffness.array() < 0.0).any(),
       InvalidArgumentException,
       "Joint spring stiffness must be non-negative");
 
-  jointComp.springStiffness = stiffness;
+  jointModel.springStiffness = stiffness;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getRestPosition() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.restPosition;
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return jointModel.restPosition;
 }
 
 //==============================================================================
 void Joint::setRestPosition(const Eigen::VectorXd& restPosition)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(restPosition, jointComp.getDOF(), "rest position");
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointStateVector(restPosition, jointModel.getDOF(), "rest position");
 
-  jointComp.restPosition = restPosition;
+  jointModel.restPosition = restPosition;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getDampingCoefficient() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.dampingCoefficient;
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return jointModel.dampingCoefficient;
 }
 
 //==============================================================================
 void Joint::setDampingCoefficient(const Eigen::VectorXd& damping)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(damping, jointComp.getDOF(), "damping coefficient");
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointStateVector(damping, jointModel.getDOF(), "damping coefficient");
   DART_SIMULATION_THROW_T_IF(
       (damping.array() < 0.0).any(),
       InvalidArgumentException,
       "Joint damping coefficient must be non-negative");
 
-  jointComp.dampingCoefficient = damping;
+  jointModel.dampingCoefficient = damping;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getArmature() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.armature;
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return jointModel.armature;
 }
 
 //==============================================================================
 void Joint::setArmature(const Eigen::VectorXd& armature)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(armature, jointComp.getDOF(), "armature");
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointStateVector(armature, jointModel.getDOF(), "armature");
   DART_SIMULATION_THROW_T_IF(
       (armature.array() < 0.0).any(),
       InvalidArgumentException,
       "Joint armature must be non-negative");
 
-  jointComp.armature = armature;
+  jointModel.armature = armature;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getCoulombFriction() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
-  return jointComp.coulombFriction;
+  const auto& jointModel = getJointModel(m_world, m_entity);
+  return jointModel.coulombFriction;
 }
 
 //==============================================================================
 void Joint::setCoulombFriction(const Eigen::VectorXd& friction)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointStateVector(friction, jointComp.getDOF(), "Coulomb friction");
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointStateVector(friction, jointModel.getDOF(), "Coulomb friction");
   DART_SIMULATION_THROW_T_IF(
       (friction.array() < 0.0).any(),
       InvalidArgumentException,
       "Joint Coulomb friction must be non-negative");
 
-  jointComp.coulombFriction = friction;
+  jointModel.coulombFriction = friction;
 }
 
 //==============================================================================
 void Joint::setPositionLimits(
     const Eigen::VectorXd& lower, const Eigen::VectorXd& upper)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointLimitPair(lower, upper, jointComp.getDOF(), "position");
-  jointComp.limits.lower = lower;
-  jointComp.limits.upper = upper;
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointLimitPair(lower, upper, jointModel.getDOF(), "position");
+  jointModel.limits.lower = lower;
+  jointModel.limits.upper = upper;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getPositionLowerLimits() const
 {
-  return getJointComponent(m_world, m_entity).limits.lower;
+  return getJointModel(m_world, m_entity).limits.lower;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getPositionUpperLimits() const
 {
-  return getJointComponent(m_world, m_entity).limits.upper;
+  return getJointModel(m_world, m_entity).limits.upper;
 }
 
 //==============================================================================
 void Joint::setVelocityLimits(
     const Eigen::VectorXd& lower, const Eigen::VectorXd& upper)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointLimitPair(lower, upper, jointComp.getDOF(), "velocity");
-  jointComp.limits.velocityLower = lower;
-  jointComp.limits.velocityUpper = upper;
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointLimitPair(lower, upper, jointModel.getDOF(), "velocity");
+  jointModel.limits.velocityLower = lower;
+  jointModel.limits.velocityUpper = upper;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getVelocityLowerLimits() const
 {
-  return getJointComponent(m_world, m_entity).limits.velocityLower;
+  return getJointModel(m_world, m_entity).limits.velocityLower;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getVelocityUpperLimits() const
 {
-  return getJointComponent(m_world, m_entity).limits.velocityUpper;
+  return getJointModel(m_world, m_entity).limits.velocityUpper;
 }
 
 //==============================================================================
 void Joint::setEffortLimits(
     const Eigen::VectorXd& lower, const Eigen::VectorXd& upper)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
-  validateJointLimitPair(lower, upper, jointComp.getDOF(), "effort");
-  jointComp.limits.effortLower = lower;
-  jointComp.limits.effortUpper = upper;
+  auto& jointModel = getJointModel(m_world, m_entity);
+  validateJointLimitPair(lower, upper, jointModel.getDOF(), "effort");
+  jointModel.limits.effortLower = lower;
+  jointModel.limits.effortUpper = upper;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getEffortLowerLimits() const
 {
-  return getJointComponent(m_world, m_entity).limits.effortLower;
+  return getJointModel(m_world, m_entity).limits.effortLower;
 }
 
 //==============================================================================
 Eigen::VectorXd Joint::getEffortUpperLimits() const
 {
-  return getJointComponent(m_world, m_entity).limits.effortUpper;
+  return getJointModel(m_world, m_entity).limits.effortUpper;
 }
 
 //==============================================================================
@@ -644,43 +678,43 @@ void Joint::setBreakForce(double breakForce)
       "Joint '{}' break force must be finite and non-negative",
       getName());
 
-  getJointComponent(m_world, m_entity).breakForce = breakForce;
+  getJointModel(m_world, m_entity).breakForce = breakForce;
 }
 
 //==============================================================================
 double Joint::getBreakForce() const
 {
-  return getJointComponent(m_world, m_entity).breakForce;
+  return getJointModel(m_world, m_entity).breakForce;
 }
 
 //==============================================================================
 bool Joint::isBroken() const
 {
-  return getJointComponent(m_world, m_entity).broken;
+  return getJointState(m_world, m_entity).broken;
 }
 
 //==============================================================================
 void Joint::resetBreakage()
 {
-  getJointComponent(m_world, m_entity).broken = false;
+  getJointState(m_world, m_entity).broken = false;
 }
 
 //==============================================================================
 void Joint::setAvbdStartStiffness(double stiffness)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& jointModel = getJointModel(m_world, m_entity);
   auto& registry = dart::simulation::detail::registryOf(*m_world);
   const auto entity = detail::toRegistryEntity(m_entity);
-  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
-  validateFiniteNonnegative(stiffness, "AVBD start stiffness", jointComp.name);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointModel);
+  validateFiniteNonnegative(stiffness, "AVBD start stiffness", jointModel.name);
   auto& jointStiffness
-      = materializeAvbdStiffnessState(registry, entity, jointComp);
+      = materializeAvbdStiffnessState(registry, entity, jointModel);
 
   DART_SIMULATION_THROW_T_IF(
       stiffness > jointStiffness.maxStiffness,
       InvalidArgumentException,
       "Joint '{}' AVBD start stiffness must not exceed max stiffness",
-      jointComp.name);
+      jointModel.name);
   jointStiffness.startStiffness = stiffness;
   if (auto* config = tryGetAvbdRigidWorldPointJointConfig(m_world, m_entity)) {
     config->startStiffness = stiffness;
@@ -690,10 +724,10 @@ void Joint::setAvbdStartStiffness(double stiffness)
 //==============================================================================
 double Joint::getAvbdStartStiffness() const
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& jointModel = getJointModel(m_world, m_entity);
   auto& registry = dart::simulation::detail::registryOf(*m_world);
   const auto entity = detail::toRegistryEntity(m_entity);
-  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointModel);
   if (const auto* stiffness
       = registry.try_get<comps::AvbdJointStiffness>(entity)) {
     return stiffness->startStiffness;
@@ -710,7 +744,7 @@ double Joint::getAvbdStartStiffness() const
   double maxStiffness = 0.0;
   DART_SIMULATION_THROW_T_IF(
       !detail::deformable_vbd::computeAvbdRigidWorldPointJointDefaultStiffness(
-          registry, jointComp, startStiffness, maxStiffness),
+          registry, jointModel, startStiffness, maxStiffness),
       InvalidArgumentException,
       "Joint is not an AVBD point-joint facade");
   return startStiffness;
@@ -719,13 +753,14 @@ double Joint::getAvbdStartStiffness() const
 //==============================================================================
 void Joint::setAvbdLinearStiffness(double stiffness)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& jointModel = getJointModel(m_world, m_entity);
   auto& registry = dart::simulation::detail::registryOf(*m_world);
   const auto entity = detail::toRegistryEntity(m_entity);
-  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
-  validateMaterialStiffness(stiffness, "AVBD linear stiffness", jointComp.name);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointModel);
+  validateMaterialStiffness(
+      stiffness, "AVBD linear stiffness", jointModel.name);
   auto& jointStiffness
-      = materializeAvbdStiffnessState(registry, entity, jointComp);
+      = materializeAvbdStiffnessState(registry, entity, jointModel);
 
   jointStiffness.linearStiffness = stiffness;
   if (auto* config = tryGetAvbdRigidWorldPointJointConfig(m_world, m_entity)) {
@@ -736,10 +771,10 @@ void Joint::setAvbdLinearStiffness(double stiffness)
 //==============================================================================
 double Joint::getAvbdLinearStiffness() const
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& jointModel = getJointModel(m_world, m_entity);
   auto& registry = dart::simulation::detail::registryOf(*m_world);
   const auto entity = detail::toRegistryEntity(m_entity);
-  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointModel);
   if (const auto* stiffness
       = registry.try_get<comps::AvbdJointStiffness>(entity)) {
     return stiffness->linearStiffness;
@@ -757,14 +792,14 @@ double Joint::getAvbdLinearStiffness() const
 //==============================================================================
 void Joint::setAvbdAngularStiffness(double stiffness)
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& jointModel = getJointModel(m_world, m_entity);
   auto& registry = dart::simulation::detail::registryOf(*m_world);
   const auto entity = detail::toRegistryEntity(m_entity);
-  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointModel);
   validateMaterialStiffness(
-      stiffness, "AVBD angular stiffness", jointComp.name);
+      stiffness, "AVBD angular stiffness", jointModel.name);
   auto& jointStiffness
-      = materializeAvbdStiffnessState(registry, entity, jointComp);
+      = materializeAvbdStiffnessState(registry, entity, jointModel);
 
   jointStiffness.angularStiffness = stiffness;
   if (auto* config = tryGetAvbdRigidWorldPointJointConfig(m_world, m_entity)) {
@@ -775,10 +810,10 @@ void Joint::setAvbdAngularStiffness(double stiffness)
 //==============================================================================
 double Joint::getAvbdAngularStiffness() const
 {
-  auto& jointComp = getJointComponent(m_world, m_entity);
+  auto& jointModel = getJointModel(m_world, m_entity);
   auto& registry = dart::simulation::detail::registryOf(*m_world);
   const auto entity = detail::toRegistryEntity(m_entity);
-  validateAvbdRigidWorldPointJointFacade(registry, entity, jointComp);
+  validateAvbdRigidWorldPointJointFacade(registry, entity, jointModel);
   if (const auto* stiffness
       = registry.try_get<comps::AvbdJointStiffness>(entity)) {
     return stiffness->angularStiffness;
@@ -796,57 +831,57 @@ double Joint::getAvbdAngularStiffness() const
 //==============================================================================
 Link Joint::getParentLink() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
+  const auto& jointModel = getJointModel(m_world, m_entity);
   DART_SIMULATION_THROW_T_IF(
-      jointComp.parentLink == entt::null
+      jointModel.parentLink == entt::null
           || !dart::simulation::detail::registryOf(*m_world)
-                  .all_of<comps::Link>(jointComp.parentLink),
+                  .all_of<comps::Link>(jointModel.parentLink),
       InvalidArgumentException,
       "Joint '{}' parent endpoint is not a multibody Link",
-      jointComp.name);
-  return Link(detail::fromRegistryEntity(jointComp.parentLink), m_world);
+      jointModel.name);
+  return Link(detail::fromRegistryEntity(jointModel.parentLink), m_world);
 }
 
 //==============================================================================
 Link Joint::getChildLink() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
+  const auto& jointModel = getJointModel(m_world, m_entity);
   DART_SIMULATION_THROW_T_IF(
-      jointComp.childLink == entt::null
+      jointModel.childLink == entt::null
           || !dart::simulation::detail::registryOf(*m_world)
-                  .all_of<comps::Link>(jointComp.childLink),
+                  .all_of<comps::Link>(jointModel.childLink),
       InvalidArgumentException,
       "Joint '{}' child endpoint is not a multibody Link",
-      jointComp.name);
-  return Link(detail::fromRegistryEntity(jointComp.childLink), m_world);
+      jointModel.name);
+  return Link(detail::fromRegistryEntity(jointModel.childLink), m_world);
 }
 
 //==============================================================================
 RigidBody Joint::getParentRigidBody() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
+  const auto& jointModel = getJointModel(m_world, m_entity);
   DART_SIMULATION_THROW_T_IF(
-      jointComp.parentLink == entt::null
+      jointModel.parentLink == entt::null
           || !dart::simulation::detail::registryOf(*m_world)
-                  .all_of<comps::RigidBodyTag>(jointComp.parentLink),
+                  .all_of<comps::RigidBodyTag>(jointModel.parentLink),
       InvalidArgumentException,
       "Joint '{}' parent endpoint is not a rigid body",
-      jointComp.name);
-  return RigidBody(detail::fromRegistryEntity(jointComp.parentLink), m_world);
+      jointModel.name);
+  return RigidBody(detail::fromRegistryEntity(jointModel.parentLink), m_world);
 }
 
 //==============================================================================
 RigidBody Joint::getChildRigidBody() const
 {
-  const auto& jointComp = getJointComponent(m_world, m_entity);
+  const auto& jointModel = getJointModel(m_world, m_entity);
   DART_SIMULATION_THROW_T_IF(
-      jointComp.childLink == entt::null
+      jointModel.childLink == entt::null
           || !dart::simulation::detail::registryOf(*m_world)
-                  .all_of<comps::RigidBodyTag>(jointComp.childLink),
+                  .all_of<comps::RigidBodyTag>(jointModel.childLink),
       InvalidArgumentException,
       "Joint '{}' child endpoint is not a rigid body",
-      jointComp.name);
-  return RigidBody(detail::fromRegistryEntity(jointComp.childLink), m_world);
+      jointModel.name);
+  return RigidBody(detail::fromRegistryEntity(jointModel.childLink), m_world);
 }
 
 //==============================================================================
@@ -861,8 +896,8 @@ bool Joint::isValid() const
   const auto entity = detail::toRegistryEntity(m_entity);
   return m_world != nullptr
          && dart::simulation::detail::registryOf(*m_world).valid(entity)
-         && dart::simulation::detail::registryOf(*m_world).all_of<comps::Joint>(
-             entity);
+         && dart::simulation::detail::registryOf(*m_world)
+                .all_of<comps::JointModel>(entity);
 }
 
 } // namespace dart::simulation

--- a/dart/simulation/multibody/multibody.cpp
+++ b/dart/simulation/multibody/multibody.cpp
@@ -216,8 +216,8 @@ std::size_t Multibody::getDOFCount() const
   const auto& registry = dart::simulation::detail::registryOf(*m_world);
 
   for (const auto& jointEntity : structure.joints) {
-    const auto& joint = safeGet<comps::Joint>(registry, jointEntity);
-    dof += joint.getDOF();
+    const auto& jointModel = safeGet<comps::JointModel>(registry, jointEntity);
+    dof += jointModel.getDOF();
   }
 
   return dof;
@@ -510,9 +510,11 @@ Link Multibody::addLink(std::string_view name, const LinkOptions& options)
   registry.emplace<comps::Name>(jointEntity, actualJointName);
 
   // Add Joint with type-specific configuration
-  auto& jointComp = registry.emplace<comps::Joint>(jointEntity);
-  jointComp.type = toComponentJointType(options.jointType);
-  jointComp.name = std::move(actualJointName);
+  auto& jointModel = registry.emplace<comps::JointModel>(jointEntity);
+  auto& jointState = registry.emplace<comps::JointState>(jointEntity);
+  auto& jointActuation = registry.emplace<comps::JointActuation>(jointEntity);
+  jointModel.type = toComponentJointType(options.jointType);
+  jointModel.name = std::move(actualJointName);
 
   DART_SIMULATION_THROW_T_IF(
       !options.axis.allFinite(),
@@ -523,7 +525,7 @@ Link Multibody::addLink(std::string_view name, const LinkOptions& options)
       axisNorm <= 1e-9,
       InvalidArgumentException,
       "Joint axis must be non-zero");
-  jointComp.axis = options.axis / axisNorm;
+  jointModel.axis = options.axis / axisNorm;
 
   DART_SIMULATION_THROW_T_IF(
       !options.axis2.allFinite(),
@@ -534,45 +536,45 @@ Link Multibody::addLink(std::string_view name, const LinkOptions& options)
       axis2Norm <= 1e-9,
       InvalidArgumentException,
       "Joint axis2 must be non-zero");
-  jointComp.axis2 = options.axis2 / axis2Norm;
+  jointModel.axis2 = options.axis2 / axis2Norm;
 
   // Planar and universal joints build a second in-plane/rotation direction from
   // axis2. If axis is parallel to axis2 the derived basis collapses (its cross
   // product is zero), producing degenerate transforms during sync/step, so
   // reject it at construction time.
-  if (jointComp.type == comps::JointType::Planar
-      || jointComp.type == comps::JointType::Universal) {
+  if (jointModel.type == comps::JointType::Planar
+      || jointModel.type == comps::JointType::Universal) {
     DART_SIMULATION_THROW_T_IF(
-        jointComp.axis.cross(jointComp.axis2).norm() <= 1e-6,
+        jointModel.axis.cross(jointModel.axis2).norm() <= 1e-6,
         InvalidArgumentException,
         "Joint axis must not be parallel to axis2 for planar and universal "
         "joints");
   }
 
-  jointComp.parentLink = parentEntity;
-  jointComp.childLink = linkEntity;
+  jointModel.parentLink = parentEntity;
+  jointModel.childLink = linkEntity;
 
   // Initialize state based on joint type
-  const auto dof = static_cast<Eigen::Index>(jointComp.getDOF());
-  jointComp.position = comps::makeJointVector(dof, 0.0);
-  jointComp.velocity = comps::makeJointVector(dof, 0.0);
-  jointComp.acceleration = comps::makeJointVector(dof, 0.0);
-  jointComp.torque = comps::makeJointVector(dof, 0.0);
-  jointComp.springStiffness = comps::makeJointVector(dof, 0.0);
-  jointComp.dampingCoefficient = comps::makeJointVector(dof, 0.0);
-  jointComp.restPosition = comps::makeJointVector(dof, 0.0);
-  jointComp.armature = comps::makeJointVector(dof, 0.0);
-  jointComp.coulombFriction = comps::makeJointVector(dof, 0.0);
-  jointComp.commandVelocity = comps::makeJointVector(dof, 0.0);
+  const auto dof = static_cast<Eigen::Index>(jointModel.getDOF());
+  jointState.position = comps::makeJointVector(dof, 0.0);
+  jointState.velocity = comps::makeJointVector(dof, 0.0);
+  jointState.acceleration = comps::makeJointVector(dof, 0.0);
+  jointActuation.torque = comps::makeJointVector(dof, 0.0);
+  jointModel.springStiffness = comps::makeJointVector(dof, 0.0);
+  jointModel.dampingCoefficient = comps::makeJointVector(dof, 0.0);
+  jointModel.restPosition = comps::makeJointVector(dof, 0.0);
+  jointModel.armature = comps::makeJointVector(dof, 0.0);
+  jointModel.coulombFriction = comps::makeJointVector(dof, 0.0);
+  jointActuation.commandVelocity = comps::makeJointVector(dof, 0.0);
 
   // Position, velocity, and effort limits default to unbounded.
   const double infinity = std::numeric_limits<double>::infinity();
-  jointComp.limits.lower = comps::makeJointVector(dof, -infinity);
-  jointComp.limits.upper = comps::makeJointVector(dof, infinity);
-  jointComp.limits.velocityLower = comps::makeJointVector(dof, -infinity);
-  jointComp.limits.velocityUpper = comps::makeJointVector(dof, infinity);
-  jointComp.limits.effortLower = comps::makeJointVector(dof, -infinity);
-  jointComp.limits.effortUpper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.lower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.upper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.velocityLower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.velocityUpper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.effortLower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.effortUpper = comps::makeJointVector(dof, infinity);
 
   // Link the parent link to this joint
   auto& parentLinkComp = safeGet<comps::Link>(registry, parentEntity);

--- a/dart/simulation/world.cpp
+++ b/dart/simulation/world.cpp
@@ -615,23 +615,25 @@ bool sameReplayJointLimits(
 
 template <typename JointLayout>
 bool sameReplayJointLayout(
-    const comps::Joint& joint,
+    const comps::JointModel& jointModel,
+    const comps::JointActuation& jointActuation,
     const comps::AvbdJointStiffness* avbdStiffness,
     const JointLayout& layout)
 {
   const bool hasAvbdStiffnessState = avbdStiffness != nullptr;
   const comps::AvbdJointStiffness resolvedStiffness
       = hasAvbdStiffnessState ? *avbdStiffness : comps::AvbdJointStiffness{};
-  return joint.type == layout.type && joint.actuatorType == layout.actuatorType
-         && std::string_view{joint.name}
+  return jointModel.type == layout.type
+         && jointActuation.actuatorType == layout.actuatorType
+         && std::string_view{jointModel.name}
                 == std::string_view{layout.name.data(), layout.name.size()}
-         && sameReplayVector(joint.springStiffness, layout.springStiffness)
+         && sameReplayVector(jointModel.springStiffness, layout.springStiffness)
          && sameReplayVector(
-             joint.dampingCoefficient, layout.dampingCoefficient)
-         && sameReplayVector(joint.restPosition, layout.restPosition)
-         && sameReplayVector(joint.armature, layout.armature)
-         && sameReplayVector(joint.coulombFriction, layout.coulombFriction)
-         && joint.breakForce == layout.breakForce
+             jointModel.dampingCoefficient, layout.dampingCoefficient)
+         && sameReplayVector(jointModel.restPosition, layout.restPosition)
+         && sameReplayVector(jointModel.armature, layout.armature)
+         && sameReplayVector(jointModel.coulombFriction, layout.coulombFriction)
+         && jointModel.breakForce == layout.breakForce
          && hasAvbdStiffnessState == layout.hasAvbdStiffnessState
          && resolvedStiffness.startStiffness
                 == layout.avbdStiffness.startStiffness
@@ -640,18 +642,19 @@ bool sameReplayJointLayout(
          && resolvedStiffness.angularStiffness
                 == layout.avbdStiffness.angularStiffness
          && resolvedStiffness.maxStiffness == layout.avbdStiffness.maxStiffness
-         && sameReplayJointLimits(joint.limits, layout.limits)
-         && joint.axis.isApprox(layout.axis, 0.0)
-         && joint.axis2.isApprox(layout.axis2, 0.0)
-         && joint.pitch == layout.pitch && joint.parentLink == layout.parentLink
-         && joint.childLink == layout.childLink
-         && joint.hasRigidBodyFixedJointAnchors
+         && sameReplayJointLimits(jointModel.limits, layout.limits)
+         && jointModel.axis.isApprox(layout.axis, 0.0)
+         && jointModel.axis2.isApprox(layout.axis2, 0.0)
+         && jointModel.pitch == layout.pitch
+         && jointModel.parentLink == layout.parentLink
+         && jointModel.childLink == layout.childLink
+         && jointModel.hasRigidBodyFixedJointAnchors
                 == layout.hasRigidBodyFixedJointAnchors
-         && joint.rigidBodyFixedJointLocalAnchorParent.isApprox(
+         && jointModel.rigidBodyFixedJointLocalAnchorParent.isApprox(
              layout.rigidBodyFixedJointLocalAnchorParent, 0.0)
-         && joint.rigidBodyFixedJointLocalAnchorChild.isApprox(
+         && jointModel.rigidBodyFixedJointLocalAnchorChild.isApprox(
              layout.rigidBodyFixedJointLocalAnchorChild, 0.0)
-         && joint.rigidBodyFixedJointTargetRelativeOrientation.coeffs()
+         && jointModel.rigidBodyFixedJointTargetRelativeOrientation.coeffs()
                 .isApprox(
                     layout.rigidBodyFixedJointTargetRelativeOrientation
                         .coeffs(),
@@ -1633,7 +1636,7 @@ bool canSkipDefaultStepPipelineWhenFramesClean(
   if (loopClosureView.begin() != loopClosureView.end()) {
     return false;
   }
-  const auto jointView = registry.view<comps::Joint>();
+  const auto jointView = registry.view<comps::JointModel>();
   if (jointView.begin() != jointView.end()) {
     return false;
   }
@@ -1747,7 +1750,7 @@ comps::JointType toArticulatedPointJointComponentJointType(JointType type)
 
 //==============================================================================
 template <typename Registry>
-bool isRigidBodyJoint(const Registry& registry, const comps::Joint& joint)
+bool isRigidBodyJoint(const Registry& registry, const comps::JointModel& joint)
 {
   if (!isRigidBodyJointType(joint.type) || joint.parentLink == entt::null
       || joint.childLink == entt::null || joint.parentLink == joint.childLink) {
@@ -1760,7 +1763,8 @@ bool isRigidBodyJoint(const Registry& registry, const comps::Joint& joint)
 
 //==============================================================================
 template <typename Registry>
-bool isRigidBodyFixedJoint(const Registry& registry, const comps::Joint& joint)
+bool isRigidBodyFixedJoint(
+    const Registry& registry, const comps::JointModel& joint)
 {
   if (joint.type != comps::JointType::Fixed) {
     return false;
@@ -1774,7 +1778,7 @@ template <typename Registry>
 bool isArticulatedPointJoint(
     const Registry& registry,
     entt::entity jointEntity,
-    const comps::Joint& joint)
+    const comps::JointModel& joint)
 {
   if (!isRigidBodyJointType(joint.type) || joint.childLink == entt::null
       || joint.parentLink == joint.childLink) {
@@ -1810,10 +1814,10 @@ bool isArticulatedPointJoint(
 bool hasRigidBodyJoints(const World& world)
 {
   const auto& registry = detail::registryOf(world);
-  const auto view = registry.view<comps::Joint>();
+  const auto view = registry.view<comps::JointModel>();
   for (auto entity : view) {
     (void)entity;
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isRigidBodyJoint(registry, joint)) {
       return true;
     }
@@ -1841,9 +1845,9 @@ bool hasRigidBodyAvbdPairConstraints(const World& world)
 bool hasArticulatedPointJoints(const World& world)
 {
   const auto& registry = detail::registryOf(world);
-  const auto view = registry.view<comps::Joint>();
+  const auto view = registry.view<comps::JointModel>();
   for (const entt::entity entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isArticulatedPointJoint(registry, entity, joint)) {
       return true;
     }
@@ -1855,9 +1859,9 @@ bool hasArticulatedPointJoints(const World& world)
 bool hasRigidBodyJointsUnsupportedByIpc(const World& world)
 {
   const auto& registry = detail::registryOf(world);
-  const auto view = registry.view<comps::Joint>();
+  const auto view = registry.view<comps::JointModel>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (!isRigidBodyJoint(registry, joint)) {
       continue;
     }
@@ -2238,10 +2242,11 @@ void collectLivePublicRigidBodyJointPairsInto(
 {
   pairs.clear();
 
-  const auto joints = registry.template view<comps::Joint>();
+  const auto joints = registry.template view<comps::JointModel>();
   for (const entt::entity entity : joints) {
-    const auto& joint = joints.template get<comps::Joint>(entity);
-    if (joint.broken || !isRigidBodyJoint(registry, joint)) {
+    const auto& joint = joints.template get<comps::JointModel>(entity);
+    const auto& jointState = registry.template get<comps::JointState>(entity);
+    if (jointState.broken || !isRigidBodyJoint(registry, joint)) {
       continue;
     }
 
@@ -3518,7 +3523,9 @@ void World::reserveRegistryStorageForSimulation()
       comps::MultibodyStructure,
       comps::LoopClosure,
       comps::Link,
-      comps::Joint,
+      comps::JointModel,
+      comps::JointState,
+      comps::JointActuation,
       comps::FrameTag,
       comps::FixedFrameTag,
       comps::FreeFrameTag,
@@ -3580,7 +3587,8 @@ void World::reserveRegistryStorageForSimulation()
         registry, multibodyCount, m_memoryManager.getFreeAllocator());
   }
 
-  const auto jointCount = existingComponentStorageSize<comps::Joint>(registry);
+  const auto jointCount
+      = existingComponentStorageSize<comps::JointModel>(registry);
   if (jointCount > 0u) {
     registry.storage<detail::deformable_vbd::AvbdRigidWorldPointJointConfig>()
         .reserve(jointCount);
@@ -4181,11 +4189,12 @@ Joint World::addArticulatedJoint(
   if (name.empty()) {
     do {
       actualName = std::format("joint_{:03d}", ++m_jointCounter);
-    } while (hasEntityWithName<comps::Joint>(m_storage->registry, actualName));
+    } while (
+        hasEntityWithName<comps::JointModel>(m_storage->registry, actualName));
   } else {
     actualName = std::string(name);
     DART_SIMULATION_THROW_T_IF(
-        hasEntityWithName<comps::Joint>(m_storage->registry, actualName),
+        hasEntityWithName<comps::JointModel>(m_storage->registry, actualName),
         InvalidArgumentException,
         "Joint '{}' already exists",
         actualName);
@@ -4194,34 +4203,39 @@ Joint World::addArticulatedJoint(
   const entt::entity jointEntity = m_storage->registry.create();
   m_storage->registry.emplace<comps::Name>(jointEntity, actualName);
 
-  auto& joint = m_storage->registry.emplace<comps::Joint>(jointEntity);
-  joint.type = componentType;
-  joint.name = std::move(actualName);
-  joint.parentLink = parentEntity;
-  joint.childLink = childEntity;
+  auto& jointModel
+      = m_storage->registry.emplace<comps::JointModel>(jointEntity);
+  auto& jointState
+      = m_storage->registry.emplace<comps::JointState>(jointEntity);
+  auto& jointActuation
+      = m_storage->registry.emplace<comps::JointActuation>(jointEntity);
+  jointModel.type = componentType;
+  jointModel.name = std::move(actualName);
+  jointModel.parentLink = parentEntity;
+  jointModel.childLink = childEntity;
   if (articulatedPointJointUsesAxis(componentType)) {
-    joint.axis = axis.normalized();
+    jointModel.axis = axis.normalized();
   }
 
-  const Eigen::Index dof = static_cast<Eigen::Index>(joint.getDOF());
-  joint.position = comps::makeJointVector(dof, 0.0);
-  joint.velocity = comps::makeJointVector(dof, 0.0);
-  joint.acceleration = comps::makeJointVector(dof, 0.0);
-  joint.torque = comps::makeJointVector(dof, 0.0);
-  joint.springStiffness = comps::makeJointVector(dof, 0.0);
-  joint.dampingCoefficient = comps::makeJointVector(dof, 0.0);
-  joint.restPosition = comps::makeJointVector(dof, 0.0);
-  joint.armature = comps::makeJointVector(dof, 0.0);
-  joint.coulombFriction = comps::makeJointVector(dof, 0.0);
-  joint.commandVelocity = comps::makeJointVector(dof, 0.0);
+  const Eigen::Index dof = static_cast<Eigen::Index>(jointModel.getDOF());
+  jointState.position = comps::makeJointVector(dof, 0.0);
+  jointState.velocity = comps::makeJointVector(dof, 0.0);
+  jointState.acceleration = comps::makeJointVector(dof, 0.0);
+  jointActuation.torque = comps::makeJointVector(dof, 0.0);
+  jointModel.springStiffness = comps::makeJointVector(dof, 0.0);
+  jointModel.dampingCoefficient = comps::makeJointVector(dof, 0.0);
+  jointModel.restPosition = comps::makeJointVector(dof, 0.0);
+  jointModel.armature = comps::makeJointVector(dof, 0.0);
+  jointModel.coulombFriction = comps::makeJointVector(dof, 0.0);
+  jointActuation.commandVelocity = comps::makeJointVector(dof, 0.0);
 
   const double infinity = std::numeric_limits<double>::infinity();
-  joint.limits.lower = comps::makeJointVector(dof, -infinity);
-  joint.limits.upper = comps::makeJointVector(dof, infinity);
-  joint.limits.velocityLower = comps::makeJointVector(dof, -infinity);
-  joint.limits.velocityUpper = comps::makeJointVector(dof, infinity);
-  joint.limits.effortLower = comps::makeJointVector(dof, -infinity);
-  joint.limits.effortUpper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.lower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.upper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.velocityLower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.velocityUpper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.effortLower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.effortUpper = comps::makeJointVector(dof, infinity);
 
   if (parentAnchor.has_value()) {
     Eigen::Matrix3d parentRotation = Eigen::Matrix3d::Identity();
@@ -4246,12 +4260,12 @@ Joint World::addArticulatedJoint(
     parentOrientation.normalize();
     childOrientation.normalize();
 
-    joint.hasRigidBodyFixedJointAnchors = true;
-    joint.rigidBodyFixedJointLocalAnchorParent = *parentAnchor;
-    joint.rigidBodyFixedJointLocalAnchorChild = *childAnchor;
-    joint.rigidBodyFixedJointTargetRelativeOrientation
+    jointModel.hasRigidBodyFixedJointAnchors = true;
+    jointModel.rigidBodyFixedJointLocalAnchorParent = *parentAnchor;
+    jointModel.rigidBodyFixedJointLocalAnchorChild = *childAnchor;
+    jointModel.rigidBodyFixedJointTargetRelativeOrientation
         = parentOrientation.conjugate() * childOrientation;
-    joint.rigidBodyFixedJointTargetRelativeOrientation.normalize();
+    jointModel.rigidBodyFixedJointTargetRelativeOrientation.normalize();
   }
 
   return Joint(detail::fromRegistryEntity(jointEntity), this);
@@ -4260,9 +4274,9 @@ Joint World::addArticulatedJoint(
 //==============================================================================
 std::optional<Joint> World::getArticulatedJoint(std::string_view name)
 {
-  auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  auto view = m_storage->registry.view<comps::JointModel, comps::Name>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     const auto& info = view.get<comps::Name>(entity);
     if (info.name == name
         && isArticulatedPointJoint(m_storage->registry, entity, joint)) {
@@ -4275,9 +4289,9 @@ std::optional<Joint> World::getArticulatedJoint(std::string_view name)
 //==============================================================================
 bool World::hasArticulatedJoint(std::string_view name) const
 {
-  const auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  const auto view = m_storage->registry.view<comps::JointModel, comps::Name>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     const auto& info = view.get<comps::Name>(entity);
     if (info.name == name
         && isArticulatedPointJoint(m_storage->registry, entity, joint)) {
@@ -4291,9 +4305,9 @@ bool World::hasArticulatedJoint(std::string_view name) const
 std::size_t World::getArticulatedJointCount() const
 {
   std::size_t count = 0;
-  const auto view = m_storage->registry.view<comps::Joint>();
+  const auto view = m_storage->registry.view<comps::JointModel>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isArticulatedPointJoint(m_storage->registry, entity, joint)) {
       ++count;
     }
@@ -4305,9 +4319,9 @@ std::size_t World::getArticulatedJointCount() const
 std::vector<Joint> World::getArticulatedJoints()
 {
   std::vector<Joint> joints;
-  const auto view = m_storage->registry.view<comps::Joint>();
+  const auto view = m_storage->registry.view<comps::JointModel>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isArticulatedPointJoint(m_storage->registry, entity, joint)) {
       joints.emplace_back(detail::fromRegistryEntity(entity), this);
     }
@@ -4768,11 +4782,12 @@ Joint World::addRigidBodyJoint(
   if (name.empty()) {
     do {
       actualName = std::format("joint_{:03d}", ++m_jointCounter);
-    } while (hasEntityWithName<comps::Joint>(m_storage->registry, actualName));
+    } while (
+        hasEntityWithName<comps::JointModel>(m_storage->registry, actualName));
   } else {
     actualName = std::string(name);
     DART_SIMULATION_THROW_T_IF(
-        hasEntityWithName<comps::Joint>(m_storage->registry, actualName),
+        hasEntityWithName<comps::JointModel>(m_storage->registry, actualName),
         InvalidArgumentException,
         "Joint '{}' already exists",
         actualName);
@@ -4781,13 +4796,18 @@ Joint World::addRigidBodyJoint(
   const entt::entity jointEntity = m_storage->registry.create();
   m_storage->registry.emplace<comps::Name>(jointEntity, actualName);
 
-  auto& joint = m_storage->registry.emplace<comps::Joint>(jointEntity);
-  joint.type = componentType;
-  joint.name = std::move(actualName);
-  joint.parentLink = parentEntity;
-  joint.childLink = childEntity;
+  auto& jointModel
+      = m_storage->registry.emplace<comps::JointModel>(jointEntity);
+  auto& jointState
+      = m_storage->registry.emplace<comps::JointState>(jointEntity);
+  auto& jointActuation
+      = m_storage->registry.emplace<comps::JointActuation>(jointEntity);
+  jointModel.type = componentType;
+  jointModel.name = std::move(actualName);
+  jointModel.parentLink = parentEntity;
+  jointModel.childLink = childEntity;
   if (rigidBodyJointUsesAxis(componentType)) {
-    joint.axis = axis.normalized();
+    jointModel.axis = axis.normalized();
   }
 
   if (parentAnchor.has_value()) {
@@ -4807,33 +4827,33 @@ Joint World::addRigidBodyJoint(
     parentOrientation.normalize();
     childOrientation.normalize();
 
-    joint.hasRigidBodyFixedJointAnchors = true;
-    joint.rigidBodyFixedJointLocalAnchorParent = *parentAnchor;
-    joint.rigidBodyFixedJointLocalAnchorChild = *childAnchor;
-    joint.rigidBodyFixedJointTargetRelativeOrientation
+    jointModel.hasRigidBodyFixedJointAnchors = true;
+    jointModel.rigidBodyFixedJointLocalAnchorParent = *parentAnchor;
+    jointModel.rigidBodyFixedJointLocalAnchorChild = *childAnchor;
+    jointModel.rigidBodyFixedJointTargetRelativeOrientation
         = parentOrientation.conjugate() * childOrientation;
-    joint.rigidBodyFixedJointTargetRelativeOrientation.normalize();
+    jointModel.rigidBodyFixedJointTargetRelativeOrientation.normalize();
   }
 
-  const Eigen::Index dof = static_cast<Eigen::Index>(joint.getDOF());
-  joint.position = comps::makeJointVector(dof, 0.0);
-  joint.velocity = comps::makeJointVector(dof, 0.0);
-  joint.acceleration = comps::makeJointVector(dof, 0.0);
-  joint.torque = comps::makeJointVector(dof, 0.0);
-  joint.springStiffness = comps::makeJointVector(dof, 0.0);
-  joint.dampingCoefficient = comps::makeJointVector(dof, 0.0);
-  joint.restPosition = comps::makeJointVector(dof, 0.0);
-  joint.armature = comps::makeJointVector(dof, 0.0);
-  joint.coulombFriction = comps::makeJointVector(dof, 0.0);
-  joint.commandVelocity = comps::makeJointVector(dof, 0.0);
+  const Eigen::Index dof = static_cast<Eigen::Index>(jointModel.getDOF());
+  jointState.position = comps::makeJointVector(dof, 0.0);
+  jointState.velocity = comps::makeJointVector(dof, 0.0);
+  jointState.acceleration = comps::makeJointVector(dof, 0.0);
+  jointActuation.torque = comps::makeJointVector(dof, 0.0);
+  jointModel.springStiffness = comps::makeJointVector(dof, 0.0);
+  jointModel.dampingCoefficient = comps::makeJointVector(dof, 0.0);
+  jointModel.restPosition = comps::makeJointVector(dof, 0.0);
+  jointModel.armature = comps::makeJointVector(dof, 0.0);
+  jointModel.coulombFriction = comps::makeJointVector(dof, 0.0);
+  jointActuation.commandVelocity = comps::makeJointVector(dof, 0.0);
 
   const double infinity = std::numeric_limits<double>::infinity();
-  joint.limits.lower = comps::makeJointVector(dof, -infinity);
-  joint.limits.upper = comps::makeJointVector(dof, infinity);
-  joint.limits.velocityLower = comps::makeJointVector(dof, -infinity);
-  joint.limits.velocityUpper = comps::makeJointVector(dof, infinity);
-  joint.limits.effortLower = comps::makeJointVector(dof, -infinity);
-  joint.limits.effortUpper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.lower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.upper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.velocityLower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.velocityUpper = comps::makeJointVector(dof, infinity);
+  jointModel.limits.effortLower = comps::makeJointVector(dof, -infinity);
+  jointModel.limits.effortUpper = comps::makeJointVector(dof, infinity);
 
   const comps::RigidAvbdContactConfig defaultAvbdConfig;
   comps::AvbdJointStiffness defaultStiffness;
@@ -4859,9 +4879,9 @@ Joint World::addRigidBodyJoint(
 //==============================================================================
 std::optional<Joint> World::getRigidBodyJoint(std::string_view name)
 {
-  auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  auto view = m_storage->registry.view<comps::JointModel, comps::Name>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     const auto& info = view.get<comps::Name>(entity);
     if (info.name == name && isRigidBodyJoint(m_storage->registry, joint)) {
       return Joint(detail::fromRegistryEntity(entity), this);
@@ -4873,9 +4893,9 @@ std::optional<Joint> World::getRigidBodyJoint(std::string_view name)
 //==============================================================================
 bool World::hasRigidBodyJoint(std::string_view name) const
 {
-  const auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  const auto view = m_storage->registry.view<comps::JointModel, comps::Name>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     const auto& info = view.get<comps::Name>(entity);
     if (info.name == name && isRigidBodyJoint(m_storage->registry, joint)) {
       return true;
@@ -4888,10 +4908,10 @@ bool World::hasRigidBodyJoint(std::string_view name) const
 std::size_t World::getRigidBodyJointCount() const
 {
   std::size_t count = 0;
-  const auto view = m_storage->registry.view<comps::Joint>();
+  const auto view = m_storage->registry.view<comps::JointModel>();
   for (auto entity : view) {
     (void)entity;
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isRigidBodyJoint(m_storage->registry, joint)) {
       ++count;
     }
@@ -4904,9 +4924,9 @@ std::vector<Joint> World::getRigidBodyJoints()
 {
   std::vector<Joint> joints;
   joints.reserve(getRigidBodyJointCount());
-  const auto view = m_storage->registry.view<comps::Joint>();
+  const auto view = m_storage->registry.view<comps::JointModel>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isRigidBodyJoint(m_storage->registry, joint)) {
       joints.emplace_back(detail::fromRegistryEntity(entity), this);
     }
@@ -4917,9 +4937,9 @@ std::vector<Joint> World::getRigidBodyJoints()
 //==============================================================================
 std::optional<Joint> World::getRigidBodyFixedJoint(std::string_view name)
 {
-  auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  auto view = m_storage->registry.view<comps::JointModel, comps::Name>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     const auto& info = view.get<comps::Name>(entity);
     if (info.name == name
         && isRigidBodyFixedJoint(m_storage->registry, joint)) {
@@ -4932,9 +4952,9 @@ std::optional<Joint> World::getRigidBodyFixedJoint(std::string_view name)
 //==============================================================================
 bool World::hasRigidBodyFixedJoint(std::string_view name) const
 {
-  const auto view = m_storage->registry.view<comps::Joint, comps::Name>();
+  const auto view = m_storage->registry.view<comps::JointModel, comps::Name>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     const auto& info = view.get<comps::Name>(entity);
     if (info.name == name
         && isRigidBodyFixedJoint(m_storage->registry, joint)) {
@@ -4948,10 +4968,10 @@ bool World::hasRigidBodyFixedJoint(std::string_view name) const
 std::size_t World::getRigidBodyFixedJointCount() const
 {
   std::size_t count = 0;
-  const auto view = m_storage->registry.view<comps::Joint>();
+  const auto view = m_storage->registry.view<comps::JointModel>();
   for (auto entity : view) {
     (void)entity;
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isRigidBodyFixedJoint(m_storage->registry, joint)) {
       ++count;
     }
@@ -4964,9 +4984,9 @@ std::vector<Joint> World::getRigidBodyFixedJoints()
 {
   std::vector<Joint> joints;
   joints.reserve(getRigidBodyFixedJointCount());
-  const auto view = m_storage->registry.view<comps::Joint>();
+  const auto view = m_storage->registry.view<comps::JointModel>();
   for (auto entity : view) {
-    const auto& joint = view.get<comps::Joint>(entity);
+    const auto& joint = view.get<comps::JointModel>(entity);
     if (isRigidBodyFixedJoint(m_storage->registry, joint)) {
       joints.emplace_back(detail::fromRegistryEntity(entity), this);
     }
@@ -5950,10 +5970,10 @@ void World::captureStepDerivatives()
       if (link.parentJoint == entt::null) {
         continue;
       }
-      const auto& joint
-          = m_storage->registry.get<comps::Joint>(link.parentJoint);
-      for (Eigen::Index d = 0; d < joint.torque.size(); ++d) {
-        torques.push_back(joint.torque[d]);
+      const auto& jointActuation
+          = m_storage->registry.get<comps::JointActuation>(link.parentJoint);
+      for (Eigen::Index d = 0; d < jointActuation.torque.size(); ++d) {
+        torques.push_back(jointActuation.torque[d]);
       }
     }
     if (torques.empty()) {
@@ -6235,19 +6255,20 @@ void World::restoreReplayFrame(std::size_t index)
       });
 
   DART_SIMULATION_THROW_T_IF(
-      countReplayView(m_storage->registry.view<comps::Joint>())
+      countReplayView(m_storage->registry.view<comps::JointModel>())
           != replayFrame.joints.size(),
       InvalidOperationException,
       "Cannot restore replay frame: Joint component count changed");
   for (const auto& state : replayFrame.joints) {
     DART_SIMULATION_THROW_T_IF(
         !m_storage->registry.valid(state.entity)
-            || !m_storage->registry.all_of<comps::Joint>(state.entity),
+            || !m_storage->registry.all_of<comps::JointModel>(state.entity),
         InvalidOperationException,
         "Cannot restore replay frame: Joint entity layout changed");
     DART_SIMULATION_THROW_T_IF(
         !sameReplayJointLayout(
-            m_storage->registry.get<comps::Joint>(state.entity),
+            m_storage->registry.get<comps::JointModel>(state.entity),
+            m_storage->registry.get<comps::JointActuation>(state.entity),
             m_storage->registry.try_get<comps::AvbdJointStiffness>(
                 state.entity),
             state.layout),
@@ -6436,13 +6457,15 @@ void World::restoreReplayFrame(std::size_t index)
       });
 
   for (const auto& state : replayFrame.joints) {
-    auto& joint = m_storage->registry.get<comps::Joint>(state.entity);
-    restoreReplayVector(state.position, joint.position);
-    restoreReplayVector(state.velocity, joint.velocity);
-    restoreReplayVector(state.acceleration, joint.acceleration);
-    restoreReplayVector(state.torque, joint.torque);
-    restoreReplayVector(state.commandVelocity, joint.commandVelocity);
-    joint.broken = state.broken;
+    auto& jointState = m_storage->registry.get<comps::JointState>(state.entity);
+    auto& jointActuation
+        = m_storage->registry.get<comps::JointActuation>(state.entity);
+    restoreReplayVector(state.position, jointState.position);
+    restoreReplayVector(state.velocity, jointState.velocity);
+    restoreReplayVector(state.acceleration, jointState.acceleration);
+    restoreReplayVector(state.torque, jointActuation.torque);
+    restoreReplayVector(state.commandVelocity, jointActuation.commandVelocity);
+    jointState.broken = state.broken;
   }
 
   for (const auto& state : replayFrame.links) {
@@ -6581,14 +6604,17 @@ void World::recordReplayFrame()
       = captureReplayComponents<comps::VariationalContactDualState>(
           m_storage->registry, replayAllocator);
 
-  auto jointView = m_storage->registry.view<comps::Joint>();
+  auto jointView = m_storage->registry.view<comps::JointModel>();
   replayFrame.joints.reserve(countReplayView(jointView));
   for (auto entity : jointView) {
-    const auto& joint = jointView.get<comps::Joint>(entity);
+    const auto& joint = jointView.get<comps::JointModel>(entity);
+    const auto& jointState = m_storage->registry.get<comps::JointState>(entity);
+    const auto& jointActuation
+        = m_storage->registry.get<comps::JointActuation>(entity);
     ReplayState::JointState state(replayAllocator);
     state.entity = entity;
     state.layout.type = joint.type;
-    state.layout.actuatorType = joint.actuatorType;
+    state.layout.actuatorType = jointActuation.actuatorType;
     state.layout.name.assign(joint.name.begin(), joint.name.end());
     captureReplayVector(joint.springStiffness, state.layout.springStiffness);
     captureReplayVector(
@@ -6619,12 +6645,12 @@ void World::recordReplayFrame()
         = joint.rigidBodyFixedJointLocalAnchorChild;
     state.layout.rigidBodyFixedJointTargetRelativeOrientation
         = joint.rigidBodyFixedJointTargetRelativeOrientation;
-    captureReplayVector(joint.position, state.position);
-    captureReplayVector(joint.velocity, state.velocity);
-    captureReplayVector(joint.acceleration, state.acceleration);
-    captureReplayVector(joint.torque, state.torque);
-    captureReplayVector(joint.commandVelocity, state.commandVelocity);
-    state.broken = joint.broken;
+    captureReplayVector(jointState.position, state.position);
+    captureReplayVector(jointState.velocity, state.velocity);
+    captureReplayVector(jointState.acceleration, state.acceleration);
+    captureReplayVector(jointActuation.torque, state.torque);
+    captureReplayVector(jointActuation.commandVelocity, state.commandVelocity);
+    state.broken = jointState.broken;
     replayFrame.joints.push_back(std::move(state));
   }
   std::ranges::sort(replayFrame.joints, [](const auto& lhs, const auto& rhs) {
@@ -7285,7 +7311,7 @@ void World::resetCountersFromRegistry()
   m_linkCounter = std::max(
       m_linkCounter, countEntities<comps::Link>(m_storage->registry));
   m_jointCounter = std::max(
-      m_jointCounter, countEntities<comps::Joint>(m_storage->registry));
+      m_jointCounter, countEntities<comps::JointModel>(m_storage->registry));
 }
 
 } // namespace dart::simulation

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -679,7 +679,7 @@ tests/test_avbd_packet_schema.py`, `pixi run lint` green. The live
 
 ### WS2 — Physical data architecture
 
-#### WP-091.20 Model/State/Control component split
+#### WP-091.20 Model/State/Control component split [partial — joint slice landed]
 
 - Objective: the articulated and deformable component fusion is split so
   storage matches the documented Model/State/Control/Contacts contract (the
@@ -694,6 +694,34 @@ tests/test_avbd_packet_schema.py`, `pixi run lint` green. The live
   trajectories unchanged.
 - Gates: `pixi run lint`, `pixi run build`, `pixi run test-unit`.
 - Dependencies: WP-091.2.
+- Slicing: the packet is landed in three independently-verifiable slices —
+  20a `comps::Joint`, 20b `comps::Link`, 20c `DeformableNodeState`. Each follows
+  the rigid-domain reference pattern (single-contract components) and must keep
+  golden trajectories bit-identical and serialization/replay round-trips green.
+- Evidence (slice 20a — joint, landed): `comps::Joint` is split into three
+  contract-aligned components in `comps/joint.hpp` — `JointModel` (frozen
+  topology/geometry and the passive/solver parameters: type, name, axis/axis2/
+  pitch, limits, spring/damping/armature/coulombFriction/restPosition,
+  breakForce, parent/child links, rigid-body-fixed anchors; carries getDOF() and
+  entityFields(), and is the canonical "is a joint" component), `JointState`
+  (per-step position/velocity/acceleration and the runtime broken flag), and
+  `JointActuation` (actuatorType, torque, commandVelocity). Every consumer (the
+  Joint facade's `getJointComponent` split into three accessors, the two bake
+  paths in `world.cpp` + `multibody.cpp`, the multibody-dynamics/variational/
+  stage/constraint/kinematics-graph hot paths, the AVBD contact code in
+  `detail/rigid_avbd/rigid_world_contact.hpp` and `detail/smooth_jacobians.cpp`,
+  replay capture/restore, and serialization) reads each field through its owning
+  component. Serialization registers the three components via the generic
+  `registerComponentIfNeeded` path (PFR auto-serialize; `JointModel` entity refs
+  remapped via `entityFields`); the unified `comps.Joint` serializer and the now
+  clean-break-dropped legacy v1–v19 joint deserializers are removed and the
+  binary format is bumped 21 → 22. Gates: `pixi run lint` and
+  `check-api-boundaries` clean; default-step golden trajectories stay **3/3
+  bit-identical** (behavior-preserving); `pixi run test-unit` 163/163 binaries
+  pass (serialization round-trip + the three new stable IDs; variational 178/178;
+  cross-family; AVBD 107/107; boxed-LCP 122/122). Remaining: slice 20b
+  (`comps::Link` → LinkModel/LinkState) and slice 20c (`DeformableNodeState` →
+  model/state).
 
 #### WP-091.21 Baked dense-index Model artifact
 

--- a/tests/benchmark/simulation/bm_variational_integration.cpp
+++ b/tests/benchmark/simulation/bm_variational_integration.cpp
@@ -85,7 +85,7 @@ Chain makeChain(int n)
   for (const auto jointEntity : chain.structure->joints) {
     chain.joints.push_back(jointEntity);
     chain.initialPositions.push_back(
-        registry.get<sx::comps::Joint>(jointEntity).position);
+        registry.get<sx::comps::JointState>(jointEntity).position);
   }
   return chain;
 }
@@ -93,7 +93,7 @@ Chain makeChain(int n)
 void resetToInitial(sx::detail::WorldRegistry& registry, const Chain& chain)
 {
   for (std::size_t j = 0; j < chain.joints.size(); ++j) {
-    auto& joint = registry.get<sx::comps::Joint>(chain.joints[j]);
+    auto& joint = registry.get<sx::comps::JointState>(chain.joints[j]);
     joint.position = chain.initialPositions[j];
     joint.velocity.setZero();
     joint.acceleration.setZero();

--- a/tests/unit/simulation/compute/test_variational_integration.cpp
+++ b/tests/unit/simulation/compute/test_variational_integration.cpp
@@ -1522,7 +1522,9 @@ TEST(VariationalIntegration, AvbdFixedPointJointConfigSolvesLinkEndpoint)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(tip.getEntity());
   joint.childLink = entt::null;
@@ -1586,7 +1588,9 @@ TEST(VariationalIntegration, AvbdBreakablePointJointConfigMarksLinkEndpoint)
   target.translation() = spec.transformFromParent.translation();
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(link.getEntity());
   joint.childLink = entt::null;
@@ -1606,7 +1610,7 @@ TEST(VariationalIntegration, AvbdBreakablePointJointConfigMarksLinkEndpoint)
   link.applyForce(100.0 * Eigen::Vector3d::UnitZ());
   world.step();
 
-  EXPECT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  EXPECT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
 
   double maxPositionResidual = 0.0;
   for (int k = 0; k < 100; ++k) {
@@ -1649,7 +1653,9 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_resettable_private_fixed");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_resettable_private_fixed";
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(link.getEntity());
@@ -1670,7 +1676,7 @@ TEST(
   link.applyForce(100.0 * Eigen::Vector3d::UnitZ());
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
+  auto& liveJoint = registry.get<sx::comps::JointState>(jointEntity);
   ASSERT_TRUE(liveJoint.broken);
 
   double maxBrokenPositionResidual = 0.0;
@@ -1698,23 +1704,25 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_resettable_private_fixed") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Fixed);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Fixed);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredLink->getEntity()));
-  EXPECT_TRUE(restoredJoint.childLink == entt::null);
+  EXPECT_TRUE(restoredJointModel.childLink == entt::null);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -1726,13 +1734,13 @@ TEST(
   EXPECT_TRUE(std::isinf(restoredConfig.startStiffness));
   EXPECT_TRUE(std::isinf(restoredConfig.maxStiffness));
 
-  restoredJoint.breakForce = std::numeric_limits<double>::infinity();
-  restoredJoint.broken = false;
+  restoredJointModel.breakForce = std::numeric_limits<double>::infinity();
+  restoredJointState.broken = false;
 
   restored.step();
 
   const Eigen::Isometry3d resetTransform = restoredLink->getWorldTransform();
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT((resetTransform.translation() - target.translation()).norm(), 1e-6);
   EXPECT_LT((resetTransform.linear() - target.linear()).norm(), 1e-6);
 }
@@ -1771,7 +1779,9 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_resettable_private_parent_fixed");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_resettable_private_parent_fixed";
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
@@ -1803,7 +1813,7 @@ TEST(
   applyOffCenterForce();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
+  auto& liveJoint = registry.get<sx::comps::JointState>(jointEntity);
   ASSERT_TRUE(liveJoint.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(rotationError(), 1e-6);
@@ -1835,23 +1845,25 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_resettable_private_parent_fixed") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Fixed);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Fixed);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
-  EXPECT_TRUE(restoredJoint.childLink == entt::null);
+  EXPECT_TRUE(restoredJointModel.childLink == entt::null);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -1877,8 +1889,8 @@ TEST(
   };
 
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.breakForce = std::numeric_limits<double>::infinity();
-  restoredJoint.broken = false;
+  restoredJointModel.breakForce = std::numeric_limits<double>::infinity();
+  restoredJointState.broken = false;
 
   restored.step();
 
@@ -1889,7 +1901,7 @@ TEST(
           restoredJointEntity);
   EXPECT_EQ(resetConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(resetConfig.angularAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(restoredAnchorResidual(), 1e-6);
   EXPECT_LT(restoredRotationError(), 1e-6);
 }
@@ -1928,7 +1940,9 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_resettable_private_child_fixed");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_resettable_private_child_fixed";
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = entt::null;
@@ -1959,7 +1973,7 @@ TEST(
   applyOffCenterForce();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
+  auto& liveJoint = registry.get<sx::comps::JointState>(jointEntity);
   ASSERT_TRUE(liveJoint.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(rotationError(), 1e-6);
@@ -1990,22 +2004,24 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_resettable_private_child_fixed") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Fixed);
-  EXPECT_TRUE(restoredJoint.parentLink == entt::null);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Fixed);
+  EXPECT_TRUE(restoredJointModel.parentLink == entt::null);
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
@@ -2032,8 +2048,8 @@ TEST(
   };
 
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.breakForce = std::numeric_limits<double>::infinity();
-  restoredJoint.broken = false;
+  restoredJointModel.breakForce = std::numeric_limits<double>::infinity();
+  restoredJointState.broken = false;
 
   restored.step();
 
@@ -2044,7 +2060,7 @@ TEST(
           restoredJointEntity);
   EXPECT_EQ(resetConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(resetConfig.angularAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(restoredAnchorResidual(), 1e-6);
   EXPECT_LT(restoredRotationError(), 1e-6);
 }
@@ -2082,7 +2098,9 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_private_breakable_socket");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  auto& jointState = registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_private_breakable_socket";
   joint.type = sx::comps::JointType::Spherical;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
@@ -2111,7 +2129,7 @@ TEST(
   applyOffCenterForce();
   world.step();
 
-  ASSERT_TRUE(joint.broken);
+  ASSERT_TRUE(jointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   const Eigen::Isometry3d savedBrokenTransform = body.getWorldTransform();
   std::stringstream data;
@@ -2129,23 +2147,25 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_private_breakable_socket") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Spherical);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Spherical);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
-  EXPECT_TRUE(restoredJoint.childLink == entt::null);
+  EXPECT_TRUE(restoredJointModel.childLink == entt::null);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -2191,8 +2211,8 @@ TEST(
   ASSERT_GT(maxBrokenRotationChange, 1e-4);
 
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.breakForce = std::numeric_limits<double>::infinity();
-  restoredJoint.broken = false;
+  restoredJointModel.breakForce = std::numeric_limits<double>::infinity();
+  restoredJointState.broken = false;
 
   restored.step();
 
@@ -2203,7 +2223,7 @@ TEST(
           restoredJointEntity);
   EXPECT_EQ(resetConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(resetConfig.angularAxisMask, 0u);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(restoredAnchorResidual(), 1e-6);
   EXPECT_GT(restoredRotationChange(), 1e-4);
 }
@@ -2243,7 +2263,9 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_private_child_breakable_socket");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  auto& jointState = registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_private_child_breakable_socket";
   joint.type = sx::comps::JointType::Spherical;
   joint.parentLink = entt::null;
@@ -2272,7 +2294,7 @@ TEST(
   applyOffCenterForce();
   world.step();
 
-  ASSERT_TRUE(joint.broken);
+  ASSERT_TRUE(jointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   const Eigen::Isometry3d savedBrokenTransform = body.getWorldTransform();
   std::stringstream data;
@@ -2290,22 +2312,24 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_private_child_breakable_socket") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Spherical);
-  EXPECT_TRUE(restoredJoint.parentLink == entt::null);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Spherical);
+  EXPECT_TRUE(restoredJointModel.parentLink == entt::null);
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
@@ -2352,8 +2376,8 @@ TEST(
   ASSERT_GT(maxBrokenRotationChange, 1e-4);
 
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.breakForce = std::numeric_limits<double>::infinity();
-  restoredJoint.broken = false;
+  restoredJointModel.breakForce = std::numeric_limits<double>::infinity();
+  restoredJointState.broken = false;
 
   restored.step();
 
@@ -2364,7 +2388,7 @@ TEST(
           restoredJointEntity);
   EXPECT_EQ(resetConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(resetConfig.angularAxisMask, 0u);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(restoredAnchorResidual(), 1e-6);
   EXPECT_GT(restoredRotationChange(), 1e-4);
 }
@@ -2398,7 +2422,9 @@ TEST(VariationalIntegration, AvbdCompliantPointJointConfigPullsLinkEndpoint)
     if (compliant) {
       auto& registry = dart::simulation::detail::registryOf(world);
       const entt::entity jointEntity = registry.create();
-      auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+      auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+      registry.emplace<sx::comps::JointState>(jointEntity);
+      registry.emplace<sx::comps::JointActuation>(jointEntity);
       joint.type = sx::comps::JointType::Fixed;
       joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
       joint.childLink = entt::null;
@@ -2461,7 +2487,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
@@ -2529,7 +2557,9 @@ TEST(
 
     auto& registry = dart::simulation::detail::registryOf(world);
     const entt::entity jointEntity = registry.create();
-    auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+    auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+    registry.emplace<sx::comps::JointState>(jointEntity);
+    registry.emplace<sx::comps::JointActuation>(jointEntity);
     joint.type = sx::comps::JointType::Fixed;
     joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
     joint.childLink = entt::null;
@@ -3387,7 +3417,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
@@ -3445,7 +3477,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
@@ -3518,7 +3552,9 @@ TEST(
 
     auto& registry = dart::simulation::detail::registryOf(world);
     const entt::entity jointEntity = registry.create();
-    auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+    auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+    registry.emplace<sx::comps::JointState>(jointEntity);
+    registry.emplace<sx::comps::JointActuation>(jointEntity);
     joint.type = sx::comps::JointType::Spherical;
     if (linkIsParentEndpoint) {
       joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
@@ -3606,15 +3642,18 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
   const Eigen::Vector3d hingeAxis = Eigen::Vector3d(1.0, 2.0, 3.0).normalized();
   joint.axis = hingeAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -3673,16 +3712,19 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
   const Eigen::Vector3d sliderAxis
       = Eigen::Vector3d(1.0, 2.0, 0.5).normalized();
   joint.axis = sliderAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -9287,7 +9329,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
@@ -9350,13 +9394,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -9413,13 +9460,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -9476,13 +9526,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -9537,13 +9590,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -9597,13 +9653,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -9659,13 +9718,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -9704,7 +9766,7 @@ TEST(
     yawAfterForward = stepAndYaw();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -9738,13 +9800,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -9780,7 +9845,7 @@ TEST(
     yawAfterForward = stepAndYaw();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -9814,13 +9879,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -9855,7 +9923,7 @@ TEST(
     yawAfterForward = stepAndYaw();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -9889,13 +9957,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -9931,7 +10002,7 @@ TEST(
     yawAfterForward = stepAndYaw();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -9964,13 +10035,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -10028,13 +10102,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -10074,7 +10151,7 @@ TEST(
     positionAfterForward = stepAndSliderPosition();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -10109,13 +10186,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -10156,7 +10236,7 @@ TEST(
     positionAfterForward = stepAndSliderPosition();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -10191,13 +10271,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -10237,7 +10320,7 @@ TEST(
     positionAfterForward = stepAndSliderPosition();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -10272,13 +10355,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
 
@@ -10319,7 +10405,7 @@ TEST(
     positionAfterForward = stepAndSliderPosition();
   }
 
-  registry.get<sx::comps::Joint>(jointEntity).commandVelocity
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
       = Eigen::VectorXd::Constant(1, -targetSpeed);
 
   constexpr int reverseSteps = 10;
@@ -10353,12 +10439,15 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -10415,12 +10504,15 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -10478,12 +10570,15 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -10540,12 +10635,15 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -10603,7 +10701,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
@@ -10664,7 +10764,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
@@ -10686,7 +10788,7 @@ TEST(
   body.applyForce(4.0 * Eigen::Vector3d::UnitY());
   world.step();
 
-  EXPECT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  EXPECT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
 
   double maxPositionResidual = 0.0;
   for (int k = 0; k < 20; ++k) {
@@ -10717,13 +10819,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -10742,21 +10847,22 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   auto yaw = [&]() {
     const Eigen::Matrix3d rotation = body.getWorldTransform().linear();
     return std::atan2(rotation(1, 0), rotation(0, 0));
   };
   EXPECT_NEAR(yaw(), targetSpeed * dt, 1e-6);
 
-  liveJoint.broken = false;
-  liveJoint.breakForce = 1e6;
+  liveJointState.broken = false;
+  liveJointModel.breakForce = 1e6;
 
   world.step();
 
   const Eigen::Isometry3d transform = body.getWorldTransform();
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(transform.translation().norm(), 1e-6);
   EXPECT_LT(
       (transform.linear() * Eigen::Vector3d::UnitZ() - Eigen::Vector3d::UnitZ())
@@ -10783,13 +10889,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -10808,21 +10917,22 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   auto yaw = [&]() {
     return signedRotationAroundAxis(
         body.getWorldTransform().linear(), hingeAxis);
   };
   EXPECT_NEAR(yaw(), -targetSpeed * dt, 1e-6);
 
-  liveJoint.broken = false;
-  liveJoint.breakForce = 1e6;
+  liveJointState.broken = false;
+  liveJointModel.breakForce = 1e6;
 
   world.step();
 
   const Eigen::Isometry3d transform = body.getWorldTransform();
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(transform.translation().norm(), 1e-6);
   EXPECT_LT((transform.linear() * hingeAxis - hingeAxis).norm(), 1e-6);
   EXPECT_NEAR(yaw(), -targetSpeed * dt * 2.0, 1e-6);
@@ -10845,12 +10955,15 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -10871,7 +10984,7 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  EXPECT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  EXPECT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
 
   double maxOrthogonalDrift = 0.0;
   for (int k = 0; k < 20; ++k) {
@@ -10903,12 +11016,15 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -10929,8 +11045,11 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  EXPECT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  auto& liveJointActuation
+      = registry.get<sx::comps::JointActuation>(jointEntity);
+  EXPECT_TRUE(liveJointState.broken);
 
   double maxBrokenOrthogonalDrift = 0.0;
   for (int k = 0; k < 20; ++k) {
@@ -10945,8 +11064,8 @@ TEST(
 
   const double sliderPositionBeforeReset
       = body.getWorldTransform().translation().dot(sliderAxis);
-  liveJoint.broken = false;
-  liveJoint.breakForce = 1e6;
+  liveJointState.broken = false;
+  liveJointModel.breakForce = 1e6;
 
   double maxResetOrthogonalDrift = 0.0;
   double maxResetRotationError = 0.0;
@@ -10965,12 +11084,12 @@ TEST(
 
   const double sliderPositionAfterReset
       = body.getWorldTransform().translation().dot(sliderAxis);
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(maxResetOrthogonalDrift, 1e-6);
   EXPECT_LT(maxResetRotationError, 1e-6);
   EXPECT_NEAR(
       sliderPositionAfterReset - sliderPositionBeforeReset,
-      liveJoint.commandVelocity[0] * dt * resetSteps,
+      liveJointActuation.commandVelocity[0] * dt * resetSteps,
       1e-6);
 }
 
@@ -10991,12 +11110,15 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -11017,8 +11139,11 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  EXPECT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  auto& liveJointActuation
+      = registry.get<sx::comps::JointActuation>(jointEntity);
+  EXPECT_TRUE(liveJointState.broken);
 
   double maxBrokenOrthogonalDrift = 0.0;
   for (int k = 0; k < 20; ++k) {
@@ -11033,8 +11158,8 @@ TEST(
 
   const double sliderPositionBeforeReset
       = body.getWorldTransform().translation().dot(sliderAxis);
-  liveJoint.broken = false;
-  liveJoint.breakForce = 1e6;
+  liveJointState.broken = false;
+  liveJointModel.breakForce = 1e6;
 
   double maxResetOrthogonalDrift = 0.0;
   double maxResetRotationError = 0.0;
@@ -11053,12 +11178,12 @@ TEST(
 
   const double sliderPositionAfterReset
       = body.getWorldTransform().translation().dot(sliderAxis);
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(maxResetOrthogonalDrift, 1e-6);
   EXPECT_LT(maxResetRotationError, 1e-6);
   EXPECT_NEAR(
       sliderPositionAfterReset - sliderPositionBeforeReset,
-      -liveJoint.commandVelocity[0] * dt * resetSteps,
+      -liveJointActuation.commandVelocity[0] * dt * resetSteps,
       1e-6);
 }
 
@@ -11083,14 +11208,17 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_private_breakable_hinge");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_private_breakable_hinge";
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -11109,7 +11237,7 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  ASSERT_TRUE(joint.broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_NEAR(
       signedRotationAroundAxis(body.getWorldTransform().linear(), hingeAxis),
       targetSpeed * dt,
@@ -11127,30 +11255,35 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_private_breakable_hinge") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Revolute);
-  EXPECT_TRUE(restoredJoint.parentLink == entt::null);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Revolute);
+  EXPECT_TRUE(restoredJointModel.parentLink == entt::null);
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], targetSpeed);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1000.0);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1000.0);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], targetSpeed);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1000.0);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1000.0);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -11178,9 +11311,10 @@ TEST(
   const double hingeBeforeReset = signedRotationAroundAxis(
       restoredBody->getWorldTransform().linear(), hingeAxis);
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointActuation.commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
@@ -11190,7 +11324,7 @@ TEST(
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const Eigen::Isometry3d resetTransform = restoredBody->getWorldTransform();
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(resetTransform.translation().norm(), 2e-3);
   EXPECT_LT((resetTransform.linear() * hingeAxis - hingeAxis).norm(), 2e-3);
   EXPECT_NEAR(
@@ -11221,14 +11355,17 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_private_parent_breakable_hinge");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_private_parent_breakable_hinge";
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -11248,7 +11385,7 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  ASSERT_TRUE(joint.broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_NEAR(
       signedRotationAroundAxis(body.getWorldTransform().linear(), hingeAxis),
       -targetSpeed * dt,
@@ -11266,30 +11403,35 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_private_parent_breakable_hinge") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Revolute);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Revolute);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
-  EXPECT_TRUE(restoredJoint.childLink == entt::null);
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], targetSpeed);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1000.0);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1000.0);
+  EXPECT_TRUE(restoredJointModel.childLink == entt::null);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], targetSpeed);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1000.0);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1000.0);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -11317,9 +11459,10 @@ TEST(
   const double hingeBeforeReset = signedRotationAroundAxis(
       restoredBody->getWorldTransform().linear(), hingeAxis);
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointActuation.commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
@@ -11329,7 +11472,7 @@ TEST(
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const Eigen::Isometry3d resetTransform = restoredBody->getWorldTransform();
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(resetTransform.translation().norm(), 2e-3);
   EXPECT_LT((resetTransform.linear() * hingeAxis - hingeAxis).norm(), 2e-3);
   EXPECT_NEAR(
@@ -11358,14 +11501,17 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_private_breakable_slider");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_private_breakable_slider";
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = entt::null;
   joint.childLink = sx::detail::toRegistryEntity(body.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -11391,7 +11537,7 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  ASSERT_TRUE(joint.broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_NEAR(
       body.getWorldTransform().translation().dot(sliderAxis),
       targetSpeed * dt,
@@ -11409,30 +11555,35 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_private_breakable_slider") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Prismatic);
-  EXPECT_TRUE(restoredJoint.parentLink == entt::null);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Prismatic);
+  EXPECT_TRUE(restoredJointModel.parentLink == entt::null);
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], targetSpeed);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1000.0);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1000.0);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], targetSpeed);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1000.0);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1000.0);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -11466,9 +11617,10 @@ TEST(
 
   const double sliderBeforeReset = sliderPosition();
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointActuation.commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   constexpr int resetSteps = 10;
   double maxResetOrthogonalDrift = 0.0;
@@ -11486,7 +11638,7 @@ TEST(
 
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(maxResetOrthogonalDrift, 2e-3);
   EXPECT_LT(maxResetRotationError, 1e-6);
   EXPECT_NEAR(
@@ -11515,14 +11667,17 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_private_parent_breakable_slider");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_private_parent_breakable_slider";
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(body.getEntity());
   joint.childLink = entt::null;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -11548,7 +11703,7 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  ASSERT_TRUE(joint.broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_NEAR(
       body.getWorldTransform().translation().dot(sliderAxis),
       -targetSpeed * dt,
@@ -11566,30 +11721,35 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_private_parent_breakable_slider") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Prismatic);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Prismatic);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredBody->getEntity()));
-  EXPECT_TRUE(restoredJoint.childLink == entt::null);
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], targetSpeed);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1000.0);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1000.0);
+  EXPECT_TRUE(restoredJointModel.childLink == entt::null);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], targetSpeed);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1000.0);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1000.0);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -11623,9 +11783,10 @@ TEST(
 
   const double sliderBeforeReset = sliderPosition();
   restoredBody->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointActuation.commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   constexpr int resetSteps = 10;
   double maxResetOrthogonalDrift = 0.0;
@@ -11643,7 +11804,7 @@ TEST(
 
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(maxResetOrthogonalDrift, 2e-3);
   EXPECT_LT(maxResetRotationError, 1e-6);
   EXPECT_NEAR(
@@ -11672,7 +11833,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
@@ -11716,8 +11879,9 @@ TEST(
   applyOpposingOffsetForces();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(relativeRotationError(), 1e-6);
 
@@ -11736,8 +11900,8 @@ TEST(
 
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   world.step();
 
@@ -11747,7 +11911,7 @@ TEST(
       = registry.get<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);
   EXPECT_EQ(resetConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(resetConfig.angularAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(relativeRotationError(), 1e-6);
 }
@@ -11773,13 +11937,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -11821,8 +11988,9 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   const double firstStepHingePosition = relativeHingePosition();
   EXPECT_NEAR(firstStepHingePosition, targetSpeed * dt, 1e-6);
   EXPECT_LT(anchorResidual(), 1e-6);
@@ -11845,16 +12013,17 @@ TEST(
   const double hingeBeforeReset = relativeHingePosition();
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
     world.step();
   }
 
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(axisTilt(), 2e-3);
   EXPECT_NEAR(
@@ -11885,13 +12054,16 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -11940,8 +12112,9 @@ TEST(
   world.enterSimulationMode();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   EXPECT_NEAR(sliderPosition(), targetSpeed * dt, 1e-6);
   EXPECT_LT(orthogonalAnchorResidual(), 2e-6);
   EXPECT_LT(relativeRotationError(), 1e-6);
@@ -11964,9 +12137,10 @@ TEST(
   const double sliderBeforeReset = sliderPosition();
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
@@ -11980,7 +12154,7 @@ TEST(
   EXPECT_EQ(resetConfig.linearAxisMask, dvbd::avbdRigidJointAllButAxisMask(2u));
   EXPECT_EQ(resetConfig.angularAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_NEAR(resetConfig.linearAxes.col(2).dot(sliderAxis), 1.0, 1e-12);
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   const double resetOrthogonalResidual = orthogonalAnchorResidual();
   EXPECT_LT(resetOrthogonalResidual, maxBrokenOrthogonalResidual * 0.05);
   EXPECT_LT(resetOrthogonalResidual, 2e-3);
@@ -12011,7 +12185,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Spherical;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
@@ -12057,8 +12233,9 @@ TEST(
   applyOpposingOffsetForces();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
 
   double maxBrokenAnchorResidual = 0.0;
@@ -12076,8 +12253,8 @@ TEST(
 
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   world.step();
 
@@ -12087,7 +12264,7 @@ TEST(
       = registry.get<dvbd::AvbdRigidWorldPointJointConfig>(jointEntity);
   EXPECT_EQ(resetConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(resetConfig.angularAxisMask, 0u);
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_GT(relativeRotationChange(), 1e-4);
 }
@@ -12111,14 +12288,17 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
   const Eigen::Vector3d hingeAxis = Eigen::Vector3d::UnitZ();
   joint.axis = hingeAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.4);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.4);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -12187,15 +12367,18 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
   const Eigen::Vector3d sliderAxis
       = Eigen::Vector3d(1.0, 2.0, 0.5).normalized();
   joint.axis = sliderAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -12272,15 +12455,18 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_generated_tiny_hinge");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_generated_tiny_hinge";
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
   const Eigen::Vector3d hingeAxis = Eigen::Vector3d(1.0, 2.0, 3.0).normalized();
   joint.axis = hingeAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.4);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.4);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -12304,25 +12490,28 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_generated_tiny_hinge") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  const auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Revolute);
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], 0.4);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1e-9);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1e-9);
+  const auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  const auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Revolute);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], 0.4);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1e-9);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1e-9);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -12389,7 +12578,10 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_generated_tiny_slider");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_generated_tiny_slider";
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
@@ -12397,8 +12589,8 @@ TEST(
   const Eigen::Vector3d sliderAxis
       = Eigen::Vector3d(1.0, 2.0, 0.5).normalized();
   joint.axis = sliderAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, 0.3);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1e-9);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1e-9);
 
@@ -12422,25 +12614,28 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_generated_tiny_slider") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  const auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Prismatic);
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], 0.3);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1e-9);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1e-9);
+  const auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  const auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Prismatic);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], 0.3);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1e-9);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1e-9);
   ASSERT_TRUE(restoredRegistry.all_of<dvbd::AvbdRigidWorldPointJointConfig>(
       restoredJointEntity));
   const auto& restoredConfig
@@ -12517,7 +12712,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
@@ -12566,8 +12763,9 @@ TEST(
   applyOpposingOffsetForces();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(relativeRotationError(), 1e-6);
 
@@ -12586,12 +12784,12 @@ TEST(
 
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   world.step();
 
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(relativeRotationError(), 1e-6);
 }
@@ -12618,7 +12816,9 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_generated_movable_fixed");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_generated_movable_fixed";
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
@@ -12666,7 +12866,7 @@ TEST(
   applyOpposingOffsetForces();
   world.step();
 
-  ASSERT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_LT(relativeRotationError(), 1e-6);
   const Eigen::Isometry3d savedParentTransform
@@ -12688,32 +12888,35 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_generated_movable_fixed") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Fixed);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Fixed);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredParent->getEntity()));
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredChild->getEntity()));
-  EXPECT_TRUE(restoredJoint.hasRigidBodyFixedJointAnchors);
+  EXPECT_TRUE(restoredJointModel.hasRigidBodyFixedJointAnchors);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
           .norm(),
       1e-12);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorChild - childAnchor).norm(),
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorChild - childAnchor)
+          .norm(),
       1e-12);
   EXPECT_LT(
       (restoredParent->getWorldTransform().matrix()
@@ -12763,8 +12966,8 @@ TEST(
 
   restoredParent->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   restoredChild->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   restored.step();
 
@@ -12775,7 +12978,7 @@ TEST(
           restoredJointEntity);
   EXPECT_EQ(restoredConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(restoredConfig.angularAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(restoredAnchorResidual(), 1e-6);
   EXPECT_LT(restoredRelativeRotationError(), 1e-6);
 }
@@ -12801,16 +13004,19 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
   const Eigen::Vector3d hingeAxis
       = Eigen::Vector3d(-2.0, 1.0, 3.0).normalized();
   joint.axis = hingeAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -12853,8 +13059,9 @@ TEST(
 
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   const double firstStepHingePosition = relativeHingePosition();
   EXPECT_NEAR(firstStepHingePosition, targetSpeed * dt, 1e-6);
   EXPECT_LT(anchorResidual(), 1e-6);
@@ -12877,16 +13084,17 @@ TEST(
   const double hingeBeforeReset = relativeHingePosition();
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
     world.step();
   }
 
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 2e-3);
   EXPECT_LT(axisTilt(), 2e-3);
   EXPECT_NEAR(
@@ -12917,16 +13125,19 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
   const Eigen::Vector3d sliderAxis
       = Eigen::Vector3d(0.5, -1.0, 2.0).normalized();
   joint.axis = sliderAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -12973,8 +13184,9 @@ TEST(
 
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   EXPECT_NEAR(sliderPosition(), targetSpeed * dt, 1e-6);
   EXPECT_LT(orthogonalAnchorResidual(), 2e-6);
   EXPECT_LT(relativeRotationError(), 1e-6);
@@ -12997,16 +13209,17 @@ TEST(
   const double sliderBeforeReset = sliderPosition();
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  registry.get<sx::comps::JointActuation>(jointEntity).commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
     world.step();
   }
 
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   const double resetOrthogonalResidual = orthogonalAnchorResidual();
   EXPECT_LT(resetOrthogonalResidual, maxBrokenOrthogonalResidual * 0.05);
   EXPECT_LT(resetOrthogonalResidual, 2e-3);
@@ -13039,16 +13252,19 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_generated_movable_hinge");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_generated_movable_hinge";
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
   const Eigen::Vector3d hingeAxis = Eigen::Vector3d(1.0, 2.0, 3.0).normalized();
   joint.axis = hingeAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.4;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -13076,7 +13292,7 @@ TEST(
 
   world.step();
 
-  ASSERT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_NEAR(relativeHingePosition(), targetSpeed * dt, 1e-6);
   const Eigen::Isometry3d savedParentTransform
       = pair.parent.getWorldTransform();
@@ -13097,40 +13313,46 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_generated_movable_hinge") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Revolute);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Revolute);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredParent->getEntity()));
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredChild->getEntity()));
-  EXPECT_LT((restoredJoint.axis - hingeAxis).norm(), 1e-12);
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], targetSpeed);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1000.0);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1000.0);
-  EXPECT_TRUE(restoredJoint.hasRigidBodyFixedJointAnchors);
+  EXPECT_LT((restoredJointModel.axis - hingeAxis).norm(), 1e-12);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], targetSpeed);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1000.0);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1000.0);
+  EXPECT_TRUE(restoredJointModel.hasRigidBodyFixedJointAnchors);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
           .norm(),
       1e-12);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorChild - childAnchor).norm(),
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorChild - childAnchor)
+          .norm(),
       1e-12);
   EXPECT_LT(
       (restoredParent->getWorldTransform().translation()
@@ -13181,9 +13403,10 @@ TEST(
   const double hingeBeforeReset = restoredRelativeHingePosition();
   restoredParent->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   restoredChild->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointActuation.commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
@@ -13199,7 +13422,7 @@ TEST(
   EXPECT_EQ(
       restoredConfig.angularAxisMask, dvbd::avbdRigidJointAllButAxisMask(2u));
   EXPECT_NEAR(restoredConfig.angularAxes.col(2).dot(hingeAxis), 1.0, 1e-12);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(anchorResidual(), 2e-3);
   EXPECT_LT(axisTilt(), 2e-3);
   EXPECT_NEAR(
@@ -13230,7 +13453,10 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_generated_movable_slider");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  auto& jointActuation
+      = registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_generated_movable_slider";
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
@@ -13238,9 +13464,9 @@ TEST(
   const Eigen::Vector3d sliderAxis
       = Eigen::Vector3d(1.0, 2.0, 0.5).normalized();
   joint.axis = sliderAxis;
-  joint.actuatorType = sx::comps::ActuatorType::Velocity;
+  jointActuation.actuatorType = sx::comps::ActuatorType::Velocity;
   const double targetSpeed = 0.3;
-  joint.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
+  jointActuation.commandVelocity = Eigen::VectorXd::Constant(1, targetSpeed);
   joint.limits.effortLower = Eigen::VectorXd::Constant(1, -1000.0);
   joint.limits.effortUpper = Eigen::VectorXd::Constant(1, 1000.0);
   joint.breakForce = 1e-18;
@@ -13269,7 +13495,7 @@ TEST(
 
   world.step();
 
-  ASSERT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_NEAR(anchorDelta().dot(sliderAxis), targetSpeed * dt, 1e-6);
   const Eigen::Isometry3d savedParentTransform
       = pair.parent.getWorldTransform();
@@ -13290,40 +13516,46 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_generated_movable_slider") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Prismatic);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  auto& restoredJointActuation
+      = restoredRegistry.get<sx::comps::JointActuation>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Prismatic);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredParent->getEntity()));
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredChild->getEntity()));
-  EXPECT_LT((restoredJoint.axis - sliderAxis).norm(), 1e-12);
-  EXPECT_EQ(restoredJoint.actuatorType, sx::comps::ActuatorType::Velocity);
-  ASSERT_EQ(restoredJoint.commandVelocity.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.commandVelocity[0], targetSpeed);
-  ASSERT_EQ(restoredJoint.limits.effortLower.size(), 1);
-  ASSERT_EQ(restoredJoint.limits.effortUpper.size(), 1);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortLower[0], -1000.0);
-  EXPECT_DOUBLE_EQ(restoredJoint.limits.effortUpper[0], 1000.0);
-  EXPECT_TRUE(restoredJoint.hasRigidBodyFixedJointAnchors);
+  EXPECT_LT((restoredJointModel.axis - sliderAxis).norm(), 1e-12);
+  EXPECT_EQ(
+      restoredJointActuation.actuatorType, sx::comps::ActuatorType::Velocity);
+  ASSERT_EQ(restoredJointActuation.commandVelocity.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointActuation.commandVelocity[0], targetSpeed);
+  ASSERT_EQ(restoredJointModel.limits.effortLower.size(), 1);
+  ASSERT_EQ(restoredJointModel.limits.effortUpper.size(), 1);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortLower[0], -1000.0);
+  EXPECT_DOUBLE_EQ(restoredJointModel.limits.effortUpper[0], 1000.0);
+  EXPECT_TRUE(restoredJointModel.hasRigidBodyFixedJointAnchors);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
           .norm(),
       1e-12);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorChild - childAnchor).norm(),
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorChild - childAnchor)
+          .norm(),
       1e-12);
   EXPECT_LT(
       (restoredParent->getWorldTransform().translation()
@@ -13378,9 +13610,10 @@ TEST(
   const double sliderBeforeReset = sliderPosition();
   restoredParent->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   restoredChild->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.commandVelocity = Eigen::VectorXd::Constant(1, -targetSpeed);
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointActuation.commandVelocity
+      = Eigen::VectorXd::Constant(1, -targetSpeed);
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   constexpr int resetSteps = 10;
   for (int k = 0; k < resetSteps; ++k) {
@@ -13396,7 +13629,7 @@ TEST(
       restoredConfig.linearAxisMask, dvbd::avbdRigidJointAllButAxisMask(2u));
   EXPECT_EQ(restoredConfig.angularAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_NEAR(restoredConfig.linearAxes.col(2).dot(sliderAxis), 1.0, 1e-12);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   const double resetOrthogonalResidual = orthogonalAnchorResidual();
   EXPECT_LT(resetOrthogonalResidual, maxBrokenOrthogonalResidual * 0.05);
   EXPECT_LT(resetOrthogonalResidual, 2e-3);
@@ -13429,7 +13662,9 @@ TEST(
   const entt::entity jointEntity = registry.create();
   registry.emplace<sx::comps::Name>(
       jointEntity, "serialized_generated_movable_spherical");
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.name = "serialized_generated_movable_spherical";
   joint.type = sx::comps::JointType::Spherical;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
@@ -13471,7 +13706,7 @@ TEST(
   applyOpposingOffsetForces();
   world.step();
 
-  ASSERT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  ASSERT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   const Eigen::Isometry3d savedParentTransform
       = pair.parent.getWorldTransform();
@@ -13492,32 +13727,35 @@ TEST(
 
   auto& restoredRegistry = dart::simulation::detail::registryOf(restored);
   entt::entity restoredJointEntity = entt::null;
-  auto jointView = restoredRegistry.view<sx::comps::Joint>();
+  auto jointView = restoredRegistry.view<sx::comps::JointModel>();
   for (const entt::entity entity : jointView) {
-    if (jointView.get<sx::comps::Joint>(entity).name
+    if (jointView.get<sx::comps::JointModel>(entity).name
         == "serialized_generated_movable_spherical") {
       restoredJointEntity = entity;
       break;
     }
   }
   ASSERT_TRUE(restoredJointEntity != entt::null);
-  auto& restoredJoint
-      = restoredRegistry.get<sx::comps::Joint>(restoredJointEntity);
-  ASSERT_TRUE(restoredJoint.broken);
-  EXPECT_EQ(restoredJoint.type, sx::comps::JointType::Spherical);
+  auto& restoredJointModel
+      = restoredRegistry.get<sx::comps::JointModel>(restoredJointEntity);
+  auto& restoredJointState
+      = restoredRegistry.get<sx::comps::JointState>(restoredJointEntity);
+  ASSERT_TRUE(restoredJointState.broken);
+  EXPECT_EQ(restoredJointModel.type, sx::comps::JointType::Spherical);
   EXPECT_EQ(
-      restoredJoint.parentLink,
+      restoredJointModel.parentLink,
       sx::detail::toRegistryEntity(restoredParent->getEntity()));
   EXPECT_EQ(
-      restoredJoint.childLink,
+      restoredJointModel.childLink,
       sx::detail::toRegistryEntity(restoredChild->getEntity()));
-  EXPECT_TRUE(restoredJoint.hasRigidBodyFixedJointAnchors);
+  EXPECT_TRUE(restoredJointModel.hasRigidBodyFixedJointAnchors);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorParent - parentAnchor)
           .norm(),
       1e-12);
   EXPECT_LT(
-      (restoredJoint.rigidBodyFixedJointLocalAnchorChild - childAnchor).norm(),
+      (restoredJointModel.rigidBodyFixedJointLocalAnchorChild - childAnchor)
+          .norm(),
       1e-12);
   EXPECT_LT(
       (restoredParent->getWorldTransform().matrix()
@@ -13567,8 +13805,8 @@ TEST(
 
   restoredParent->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   restoredChild->getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  restoredJoint.breakForce = 1e6;
-  restoredJoint.broken = false;
+  restoredJointModel.breakForce = 1e6;
+  restoredJointState.broken = false;
 
   restored.step();
 
@@ -13579,7 +13817,7 @@ TEST(
           restoredJointEntity);
   EXPECT_EQ(restoredConfig.linearAxisMask, dvbd::kAvbdRigidJointAllAxesMask);
   EXPECT_EQ(restoredConfig.angularAxisMask, 0u);
-  EXPECT_FALSE(restoredJoint.broken);
+  EXPECT_FALSE(restoredJointState.broken);
   EXPECT_LT(restoredAnchorResidual(), 1e-6);
   EXPECT_GT(restoredRelativeRotationChange(), 1e-4);
 }
@@ -13604,7 +13842,9 @@ TEST(
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Spherical;
   joint.parentLink = sx::detail::toRegistryEntity(pair.parent.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(pair.child.getEntity());
@@ -13653,8 +13893,9 @@ TEST(
   applyOpposingOffsetForces();
   world.step();
 
-  auto& liveJoint = registry.get<sx::comps::Joint>(jointEntity);
-  ASSERT_TRUE(liveJoint.broken);
+  auto& liveJointModel = registry.get<sx::comps::JointModel>(jointEntity);
+  auto& liveJointState = registry.get<sx::comps::JointState>(jointEntity);
+  ASSERT_TRUE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
 
   double maxBrokenAnchorResidual = 0.0;
@@ -13672,12 +13913,12 @@ TEST(
 
   pair.parent.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
   pair.child.getParentJoint().setVelocity(Eigen::VectorXd::Zero(6));
-  liveJoint.breakForce = 1e6;
-  liveJoint.broken = false;
+  liveJointModel.breakForce = 1e6;
+  liveJointState.broken = false;
 
   world.step();
 
-  EXPECT_FALSE(liveJoint.broken);
+  EXPECT_FALSE(liveJointState.broken);
   EXPECT_LT(anchorResidual(), 1e-6);
   EXPECT_GT(relativeRotationChange(), 1e-4);
 }

--- a/tests/unit/simulation/contact/test_boxed_lcp_contact.cpp
+++ b/tests/unit/simulation/contact/test_boxed_lcp_contact.cpp
@@ -6667,7 +6667,9 @@ TEST(AvbdContact, FixedJointRowsParticipateInProjection)
       toReg(sphere->getEntity()));
 
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = toReg(ground->getEntity());
   joint.childLink = toReg(sphere->getEntity());
@@ -6707,7 +6709,9 @@ TEST(AvbdContact, FixedJointRowsProjectWithoutContacts)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink
       = dart::simulation::detail::toRegistryEntity(base.getEntity());
@@ -6751,7 +6755,9 @@ TEST(AvbdContact, FixedJointPoseBridgeCapturesSimulationEntryPose)
       sx::detail::toRegistryEntity(link.getEntity()));
 
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(base.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(link.getEntity());
@@ -6804,7 +6810,9 @@ TEST(AvbdContact, RevoluteRigidBodyJointPoseBridgeCapturesAxisConfig)
 
   const Eigen::Vector3d hingeAxis = Eigen::Vector3d(1.0, 2.0, 3.0).normalized();
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Revolute;
   joint.parentLink = sx::detail::toRegistryEntity(base.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(link.getEntity());
@@ -6858,7 +6866,9 @@ TEST(AvbdContact, PrismaticRigidBodyJointPoseBridgeCapturesAxisConfig)
   const Eigen::Vector3d translationAxis
       = Eigen::Vector3d(-0.5, 0.25, 1.0).normalized();
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Prismatic;
   joint.parentLink = sx::detail::toRegistryEntity(base.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(link.getEntity());
@@ -7125,7 +7135,8 @@ TEST(AvbdContact, PublicRigidBodyJointBreakStateSurvivesSaveLoad)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   registry
-      .get<sx::comps::Joint>(sx::detail::toRegistryEntity(joint.getEntity()))
+      .get<sx::comps::JointState>(
+          sx::detail::toRegistryEntity(joint.getEntity()))
       .broken = true;
 
   std::stringstream data;
@@ -7277,7 +7288,9 @@ TEST(AvbdContact, FixedJointAngularRowsProjectWithoutContacts)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink
       = dart::simulation::detail::toRegistryEntity(base.getEntity());
@@ -7321,7 +7334,9 @@ TEST(AvbdContact, FixedJointRowsProjectWithFallbackContacts)
 
   auto& registry = dart::simulation::detail::registryOf(*world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink
       = dart::simulation::detail::toRegistryEntity(base.getEntity());

--- a/tests/unit/simulation/deformable_vbd/test_avbd_rigid_block.cpp
+++ b/tests/unit/simulation/deformable_vbd/test_avbd_rigid_block.cpp
@@ -4732,7 +4732,9 @@ TEST(AvbdRigidBlock, RigidWorldPairConstraintRowsSkipStaticStaticPairs)
   auto& registry = dart::simulation::detail::registryOf(world);
 
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = entityA;
   joint.childLink = entityB;
@@ -4991,7 +4993,9 @@ TEST(AvbdRigidBlock, RigidWorldPointJointFractureMarksJointBroken)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
 
   std::vector<vbd::AvbdRigidWorldPointJointInput> joints(1);
@@ -5034,7 +5038,7 @@ TEST(AvbdRigidBlock, RigidWorldPointJointFractureMarksJointBroken)
   ASSERT_EQ(result.solve.fracturedJointIndices.size(), 1u);
   EXPECT_EQ(result.solve.fracturedJointIndices[0], 0u);
   EXPECT_EQ(result.fracturedJoints, 1u);
-  EXPECT_TRUE(registry.get<sx::comps::Joint>(jointEntity).broken);
+  EXPECT_TRUE(registry.get<sx::comps::JointState>(jointEntity).broken);
 }
 
 //==============================================================================
@@ -5055,7 +5059,9 @@ TEST(AvbdRigidBlock, RigidWorldPointJointFractureUsesSolveScratchAllocator)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
 
   vbd::AvbdRigidWorldPointJointInput input;
@@ -5484,7 +5490,9 @@ TEST(AvbdRigidBlock, RigidWorldExtractsFixedJointInputs)
   EXPECT_TRUE(baseEndpoint.canProjectAsRigidBody);
 
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.breakForce = 1.0e12;
   joint.parentLink
@@ -5573,7 +5581,9 @@ TEST(AvbdRigidBlock, RigidWorldPairConstraintConfigPresenceGuardsExtraction)
   EXPECT_FALSE(vbd::hasAvbdRigidWorldPairConstraintConfigs(registry));
 
   const entt::entity jointEntity = registry.create();
-  registry.emplace<sx::comps::Joint>(jointEntity);
+  registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   registry.emplace<vbd::AvbdRigidWorldPointJointConfig>(jointEntity);
 
   EXPECT_TRUE(vbd::hasAvbdRigidWorldPointJointConfigs(registry));
@@ -5686,7 +5696,9 @@ TEST(AvbdRigidBlock, RigidWorldSkipsBrokenPointJointInputs)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.breakForce = 42.0;
   joint.parentLink = sx::detail::toRegistryEntity(base.getEntity());
@@ -5705,7 +5717,7 @@ TEST(AvbdRigidBlock, RigidWorldSkipsBrokenPointJointInputs)
   EXPECT_EQ(joints[0].joint, jointEntity);
   EXPECT_DOUBLE_EQ(joints[0].fractureThreshold, 42.0);
 
-  joint.broken = true;
+  registry.get<sx::comps::JointState>(jointEntity).broken = true;
   joints = vbd::extractAvbdRigidWorldPointJointInputs(registry);
   EXPECT_TRUE(joints.empty());
 }
@@ -5811,7 +5823,9 @@ TEST(AvbdRigidBlock, RigidWorldFixedJointHelperDerivesCurrentPoseConfig)
 
   auto& registry = dart::simulation::detail::registryOf(world);
   const entt::entity jointEntity = registry.create();
-  auto& joint = registry.emplace<sx::comps::Joint>(jointEntity);
+  auto& joint = registry.emplace<sx::comps::JointModel>(jointEntity);
+  registry.emplace<sx::comps::JointState>(jointEntity);
+  registry.emplace<sx::comps::JointActuation>(jointEntity);
   joint.type = sx::comps::JointType::Fixed;
   joint.parentLink = sx::detail::toRegistryEntity(base.getEntity());
   joint.childLink = sx::detail::toRegistryEntity(link.getEntity());

--- a/tests/unit/simulation/world/test_serialization.cpp
+++ b/tests/unit/simulation/world/test_serialization.cpp
@@ -261,7 +261,7 @@ void expectBrokenRigidBodyJointRoundTrips(
   joint.setBreakForce(12.5);
 
   auto& jointComp
-      = dart::simulation::detail::registryOf(world1).get<sx::comps::Joint>(
+      = dart::simulation::detail::registryOf(world1).get<sx::comps::JointState>(
           dart::simulation::detail::toRegistryEntity(joint.getEntity()));
   jointComp.broken = true;
   world1.enterSimulationMode();
@@ -331,7 +331,7 @@ void expectBrokenArticulatedPointJointRoundTrips(
 
   world1.enterSimulationMode();
   auto& jointComp
-      = dart::simulation::detail::registryOf(world1).get<sx::comps::Joint>(
+      = dart::simulation::detail::registryOf(world1).get<sx::comps::JointState>(
           dart::simulation::detail::toRegistryEntity(joint.getEntity()));
   jointComp.broken = true;
 
@@ -377,81 +377,6 @@ void expectBrokenArticulatedPointJointRoundTrips(
 
   restoredJoint->resetBreakage();
   EXPECT_FALSE(restoredJoint->isBroken());
-}
-
-void writeLegacyJointV1(
-    std::ostream& output,
-    const dart::simulation::comps::Joint& joint,
-    const dart::simulation::io::EntityMap& entityMap)
-{
-  namespace io = dart::simulation::io;
-
-  io::writePOD(output, joint.type);
-  io::writeString(output, joint.name);
-  io::writeVectorXd(output, joint.position);
-  io::writeVectorXd(output, joint.velocity);
-  io::writeVectorXd(output, joint.acceleration);
-  io::writeVectorXd(output, joint.torque);
-  io::writeVectorXd(output, joint.limits.lower);
-  io::writeVectorXd(output, joint.limits.upper);
-  io::writeVectorXd(output, joint.limits.velocityUpper);
-  io::writeVectorXd(output, joint.limits.effortUpper);
-  io::writeVector3d(output, joint.axis);
-  io::writeVector3d(output, joint.axis2);
-  io::writePOD(output, joint.pitch);
-
-  const auto mappedParent
-      = joint.parentLink != entt::null
-            ? static_cast<std::uint32_t>(entityMap.at(joint.parentLink))
-            : static_cast<std::uint32_t>(entt::null);
-  const auto mappedChild
-      = joint.childLink != entt::null
-            ? static_cast<std::uint32_t>(entityMap.at(joint.childLink))
-            : static_cast<std::uint32_t>(entt::null);
-  io::writePOD(output, mappedParent);
-  io::writePOD(output, mappedChild);
-}
-
-void writeLegacyJointV2ToV12(
-    std::ostream& output,
-    const dart::simulation::comps::Joint& joint,
-    const dart::simulation::io::EntityMap& entityMap)
-{
-  namespace io = dart::simulation::io;
-
-  io::writePOD(output, joint.type);
-  io::writePOD(output, joint.actuatorType);
-  io::writeString(output, joint.name);
-  io::writeVectorXd(output, joint.position);
-  io::writeVectorXd(output, joint.velocity);
-  io::writeVectorXd(output, joint.acceleration);
-  io::writeVectorXd(output, joint.torque);
-  io::writeVectorXd(output, joint.springStiffness);
-  io::writeVectorXd(output, joint.dampingCoefficient);
-  io::writeVectorXd(output, joint.restPosition);
-  io::writeVectorXd(output, joint.armature);
-  io::writeVectorXd(output, joint.coulombFriction);
-  io::writeVectorXd(output, joint.commandVelocity);
-  io::writeVectorXd(output, joint.limits.lower);
-  io::writeVectorXd(output, joint.limits.upper);
-  io::writeVectorXd(output, joint.limits.velocityLower);
-  io::writeVectorXd(output, joint.limits.velocityUpper);
-  io::writeVectorXd(output, joint.limits.effortLower);
-  io::writeVectorXd(output, joint.limits.effortUpper);
-  io::writeVector3d(output, joint.axis);
-  io::writeVector3d(output, joint.axis2);
-  io::writePOD(output, joint.pitch);
-
-  const auto mappedParent
-      = joint.parentLink != entt::null
-            ? static_cast<std::uint32_t>(entityMap.at(joint.parentLink))
-            : static_cast<std::uint32_t>(entt::null);
-  const auto mappedChild
-      = joint.childLink != entt::null
-            ? static_cast<std::uint32_t>(entityMap.at(joint.childLink))
-            : static_cast<std::uint32_t>(entt::null);
-  io::writePOD(output, mappedParent);
-  io::writePOD(output, mappedChild);
 }
 
 void writeMassPropertiesV8(
@@ -548,14 +473,7 @@ void saveLegacyWorldWithCurrentEntities(
     io::writePOD(output, componentTypes.size());
     for (const auto& typeName : componentTypes) {
       io::writeString(output, typeName);
-      if (legacyVersion == 1u && typeName == comps::Joint::getTypeName()) {
-        writeLegacyJointV1(
-            output, registry.get<comps::Joint>(entity), entityMap);
-      } else if (
-          legacyVersion < 13u && typeName == comps::Joint::getTypeName()) {
-        writeLegacyJointV2ToV12(
-            output, registry.get<comps::Joint>(entity), entityMap);
-      } else if (typeName == comps::Link::getTypeName()) {
+      if (typeName == comps::Link::getTypeName()) {
         writeLegacyLinkV8(
             output,
             registry.get<comps::Link>(entity),
@@ -566,12 +484,6 @@ void saveLegacyWorldWithCurrentEntities(
       }
     }
   }
-}
-
-void saveLegacyV1WorldWithCurrentEntities(
-    std::ostream& output, const dart::simulation::World& world)
-{
-  saveLegacyWorldWithCurrentEntities(output, world, /*legacyVersion=*/1u);
 }
 
 void saveLegacyV8WorldWithCurrentEntities(
@@ -853,75 +765,6 @@ TEST(Serialization, PreservesJointLimits)
   EXPECT_DOUBLE_EQ(joint_restored->getVelocityUpperLimits()[0], 2.5);
   EXPECT_DOUBLE_EQ(joint_restored->getEffortLowerLimits()[0], -3.0);
   EXPECT_DOUBLE_EQ(joint_restored->getEffortUpperLimits()[0], 4.0);
-}
-
-// Test that v1 joint records migrate the legacy single-sided velocity/effort
-// limit vectors and default fields added in later binary formats.
-TEST(Serialization, LoadsLegacyV1JointRecord)
-{
-  namespace sx = dart::simulation;
-  namespace comps = dart::simulation::comps;
-
-  sx::World world1;
-  auto mb = world1.addMultibody("robot");
-  auto base = mb.addLink("base");
-  auto link = mb.addLink(
-      "link",
-      base,
-      sx::JointSpec{
-          .name = "joint",
-          .type = sx::JointType::Revolute,
-          .axis = Eigen::Vector3d::UnitX()});
-
-  auto joint = link.getParentJoint();
-  joint.setPosition(Eigen::VectorXd::Constant(1, 0.25));
-  joint.setVelocity(Eigen::VectorXd::Constant(1, -0.75));
-  dart::simulation::detail::registryOf(world1)
-      .get<comps::Joint>(
-          dart::simulation::detail::toRegistryEntity(joint.getEntity()))
-      .acceleration = Eigen::VectorXd::Constant(1, 1.25);
-  joint.setForce(Eigen::VectorXd::Constant(1, 2.25));
-  joint.setPositionLimits(
-      Eigen::VectorXd::Constant(1, -0.5), Eigen::VectorXd::Constant(1, 0.5));
-  joint.setVelocityLimits(
-      Eigen::VectorXd::Constant(1, -1.5), Eigen::VectorXd::Constant(1, 1.5));
-  joint.setEffortLimits(
-      Eigen::VectorXd::Constant(1, -3.0), Eigen::VectorXd::Constant(1, 3.0));
-
-  std::stringstream legacy;
-  saveLegacyV1WorldWithCurrentEntities(legacy, world1);
-
-  sx::World world2;
-  world2.loadBinary(legacy);
-
-  auto mbRestored = world2.getMultibody("robot");
-  ASSERT_TRUE(mbRestored.has_value());
-  auto jointRestored = mbRestored->getJoint("joint");
-  ASSERT_TRUE(jointRestored.has_value());
-  EXPECT_EQ(jointRestored->getType(), sx::JointType::Revolute);
-  EXPECT_TRUE(jointRestored->getAxis().isApprox(Eigen::Vector3d::UnitX()));
-  EXPECT_DOUBLE_EQ(jointRestored->getPosition()[0], 0.25);
-  EXPECT_DOUBLE_EQ(jointRestored->getVelocity()[0], -0.75);
-  EXPECT_DOUBLE_EQ(jointRestored->getAcceleration()[0], 1.25);
-  EXPECT_DOUBLE_EQ(jointRestored->getForce()[0], 2.25);
-  EXPECT_DOUBLE_EQ(jointRestored->getPositionLowerLimits()[0], -0.5);
-  EXPECT_DOUBLE_EQ(jointRestored->getPositionUpperLimits()[0], 0.5);
-  EXPECT_DOUBLE_EQ(jointRestored->getVelocityLowerLimits()[0], -1.5);
-  EXPECT_DOUBLE_EQ(jointRestored->getVelocityUpperLimits()[0], 1.5);
-  EXPECT_DOUBLE_EQ(jointRestored->getEffortLowerLimits()[0], -3.0);
-  EXPECT_DOUBLE_EQ(jointRestored->getEffortUpperLimits()[0], 3.0);
-
-  const auto& jointComp
-      = dart::simulation::detail::registryOf(world2).get<comps::Joint>(
-          dart::simulation::detail::toRegistryEntity(
-              jointRestored->getEntity()));
-  EXPECT_EQ(jointComp.actuatorType, comps::ActuatorType::Force);
-  EXPECT_TRUE(jointComp.springStiffness.isZero());
-  EXPECT_TRUE(jointComp.dampingCoefficient.isZero());
-  EXPECT_TRUE(jointComp.restPosition.isZero());
-  EXPECT_TRUE(jointComp.armature.isZero());
-  EXPECT_TRUE(jointComp.coulombFriction.isZero());
-  EXPECT_TRUE(jointComp.commandVelocity.isZero());
 }
 
 TEST(Serialization, LoadsLegacyV8LinkRecord)
@@ -3098,7 +2941,9 @@ TEST(StableComponentIds, ComponentsReturnExplicitStableId)
   EXPECT_EQ(comps::MassProperties::getTypeName(), "comps.MassProperties");
   EXPECT_EQ(comps::Force::getTypeName(), "comps.Force");
   EXPECT_EQ(comps::ContactMaterial::getTypeName(), "comps.ContactMaterial");
-  EXPECT_EQ(comps::Joint::getTypeName(), "comps.Joint");
+  EXPECT_EQ(comps::JointModel::getTypeName(), "comps.JointModel");
+  EXPECT_EQ(comps::JointState::getTypeName(), "comps.JointState");
+  EXPECT_EQ(comps::JointActuation::getTypeName(), "comps.JointActuation");
   EXPECT_EQ(
       comps::AvbdJointStiffness::getTypeName(), "comps.AvbdJointStiffness");
   EXPECT_EQ(comps::Link::getTypeName(), "comps.Link");
@@ -3160,7 +3005,9 @@ TEST(StableComponentIds, RegisteredIdsAreUniqueAndNotMangled)
   // Spot-check that the dotted stable IDs are present in the registry, proving
   // the macro-generated identities flow through to the registry key.
   EXPECT_TRUE(seen.contains("comps.Name"));
-  EXPECT_TRUE(seen.contains("comps.Joint"));
+  EXPECT_TRUE(seen.contains("comps.JointModel"));
+  EXPECT_TRUE(seen.contains("comps.JointState"));
+  EXPECT_TRUE(seen.contains("comps.JointActuation"));
   EXPECT_TRUE(seen.contains("comps.Link"));
   EXPECT_TRUE(seen.contains("comps.AvbdJointStiffness"));
 }

--- a/tests/unit/simulation/world/test_world.cpp
+++ b/tests/unit/simulation/world/test_world.cpp
@@ -3325,8 +3325,12 @@ TEST(World, WorldPersistentStorageUsesWorldFreeAllocator)
   auto& liveJointRegistry = sx::detail::registryOf(liveJointStorageWorld);
   const entt::entity liveJointEntity
       = sx::detail::toRegistryEntity(liveJoint.getEntity());
-  auto& liveJointComponent
-      = liveJointRegistry.get<sx::comps::Joint>(liveJointEntity);
+  auto& liveJointModel
+      = liveJointRegistry.get<sx::comps::JointModel>(liveJointEntity);
+  auto& liveJointState
+      = liveJointRegistry.get<sx::comps::JointState>(liveJointEntity);
+  auto& liveJointActuation
+      = liveJointRegistry.get<sx::comps::JointActuation>(liveJointEntity);
   const Eigen::VectorXd livePosition = Eigen::VectorXd::LinSpaced(6, 0.1, 0.6);
   const Eigen::VectorXd liveVelocity = Eigen::VectorXd::LinSpaced(6, 0.7, 1.2);
   const Eigen::VectorXd liveAcceleration
@@ -3357,22 +3361,22 @@ TEST(World, WorldPersistentStorageUsesWorldFreeAllocator)
   }
   {
     ScopedHeapAllocationCounter heapCounter;
-    liveJointComponent.position = livePosition;
-    liveJointComponent.velocity = liveVelocity;
-    liveJointComponent.acceleration = liveAcceleration;
-    liveJointComponent.torque = liveTorque;
-    liveJointComponent.springStiffness = liveUpper;
-    liveJointComponent.dampingCoefficient = liveUpper;
-    liveJointComponent.restPosition = livePosition;
-    liveJointComponent.armature = liveUpper;
-    liveJointComponent.coulombFriction = liveUpper;
-    liveJointComponent.commandVelocity = liveVelocity;
-    liveJointComponent.limits.lower = liveLower;
-    liveJointComponent.limits.upper = liveUpper;
-    liveJointComponent.limits.velocityLower = liveLower;
-    liveJointComponent.limits.velocityUpper = liveUpper;
-    liveJointComponent.limits.effortLower = liveLower;
-    liveJointComponent.limits.effortUpper = liveUpper;
+    liveJointState.position = livePosition;
+    liveJointState.velocity = liveVelocity;
+    liveJointState.acceleration = liveAcceleration;
+    liveJointActuation.torque = liveTorque;
+    liveJointModel.springStiffness = liveUpper;
+    liveJointModel.dampingCoefficient = liveUpper;
+    liveJointModel.restPosition = livePosition;
+    liveJointModel.armature = liveUpper;
+    liveJointModel.coulombFriction = liveUpper;
+    liveJointActuation.commandVelocity = liveVelocity;
+    liveJointModel.limits.lower = liveLower;
+    liveJointModel.limits.upper = liveUpper;
+    liveJointModel.limits.velocityLower = liveLower;
+    liveJointModel.limits.velocityUpper = liveUpper;
+    liveJointModel.limits.effortLower = liveLower;
+    liveJointModel.limits.effortUpper = liveUpper;
     heapCounter.stop();
     EXPECT_EQ(heapCounter.allocationCount(), 0u)
         << "live 6-DOF joint component payload storage should be bounded and "
@@ -12915,9 +12919,9 @@ TEST(World, CollisionQuerySkipsLiveRigidBodyJointPairs)
       || hasContactBetween(filteredContacts, "rigid_b", "rigid_c"));
 
   auto& registry = sx::detail::registryOf(world);
-  auto& jointComponent = registry.get<sx::comps::Joint>(
+  auto& jointState = registry.get<sx::comps::JointState>(
       sx::detail::toRegistryEntity(joint.getEntity()));
-  jointComponent.broken = true;
+  jointState.broken = true;
   EXPECT_TRUE(joint.isBroken());
   EXPECT_TRUE(hasContactBetween(world.collide(), "rigid_a", "rigid_b"));
 
@@ -22162,8 +22166,8 @@ TEST(World, ReplayRecordingRejectsJointRuntimeVectorSizeChanges)
   auto& registry = sx::detail::registryOf(world);
   const entt::entity jointEntity
       = sx::detail::toRegistryEntity(joint.getEntity());
-  auto& jointComponent = registry.get<sx::comps::Joint>(jointEntity);
-  jointComponent.position = sx::comps::makeJointVector(1, 0.0);
+  auto& jointState = registry.get<sx::comps::JointState>(jointEntity);
+  jointState.position = sx::comps::makeJointVector(1, 0.0);
 
   EXPECT_THROW(world.restoreReplayFrame(0), sx::InvalidOperationException);
 }
@@ -22320,8 +22324,8 @@ TEST(World, ReplayRecordingRestoresMultibodyRuntimeState)
   auto& registry = sx::detail::registryOf(world);
   const entt::entity jointEntity
       = sx::detail::toRegistryEntity(joint.getEntity());
-  auto& jointComponent = registry.get<sx::comps::Joint>(jointEntity);
-  jointComponent.broken = false;
+  auto& jointState = registry.get<sx::comps::JointState>(jointEntity);
+  jointState.broken = false;
   const entt::entity linkEntity
       = sx::detail::toRegistryEntity(link.getEntity());
   auto& linkComponent = registry.get<sx::comps::Link>(linkEntity);
@@ -22337,7 +22341,7 @@ TEST(World, ReplayRecordingRestoresMultibodyRuntimeState)
   joint.setVelocity(Eigen::VectorXd::Constant(6, -2.0));
   joint.setForce(Eigen::VectorXd::Constant(6, -3.0));
   joint.setCommandVelocity(Eigen::VectorXd::Constant(6, -4.0));
-  jointComponent.broken = true;
+  jointState.broken = true;
   linkComponent.externalForce.setZero();
 
   world.restoreReplayFrame(0);
@@ -22351,7 +22355,7 @@ TEST(World, ReplayRecordingRestoresMultibodyRuntimeState)
   EXPECT_TRUE(registry.get<sx::comps::Link>(linkEntity)
                   .externalForce.isApprox(initialExternalForce));
 
-  jointComponent.broken = true;
+  jointState.broken = true;
   world.clearReplayRecording();
   ASSERT_EQ(world.getReplayFrameCount(), 1u);
   joint.resetBreakage();


### PR DESCRIPTION
## WP-091.20a — Joint component split (Model/State/Control)

First slice of **WP-091.20** (Model/State/Control component split). Splits the
fused `comps::Joint` into three contract-aligned components, mirroring the
rigid domain's already-compliant single-contract components:

- **`comps::JointModel`** — frozen topology, geometry, and solver parameters
  (type, name, axis/axis2/pitch, limits, spring/damping/armature/coulombFriction/
  restPosition, breakForce, parent/child links, rigid-body-fixed anchors);
  carries `getDOF()`/`entityFields()`; the canonical "is a joint" component.
- **`comps::JointState`** — per-step dynamics (position, velocity, acceleration,
  broken).
- **`comps::JointActuation`** — commanded inputs (actuatorType, torque,
  commandVelocity).

### What changed
- Every consumer reads each field through its owning component: the Joint facade
  (`getJointComponent` → `getJointModel`/`getJointState`/`getJointActuation`),
  the two bake paths (`world.cpp`, `multibody.cpp`), the multibody-dynamics /
  variational / world-step-stage / constraint / kinematics-graph hot paths, the
  AVBD contact code (`detail/rigid_avbd/rigid_world_contact.hpp`,
  `detail/smooth_jacobians.cpp`), and replay capture/restore. Facade helpers that
  read only Model fields take `const comps::JointModel&`.
- **Serialization:** the three components register via the generic
  `registerComponentIfNeeded` path (Boost.PFR auto-serialize; `JointModel`
  entity refs remapped via `entityFields`). The unified `comps.Joint` serializer
  and the legacy v1–v19 joint deserializers are removed (**clean break** — DART 7
  has no compatibility debt); binary format bumped **21 → 22**.
  `test_serialization` drops the now-invalid `LoadsLegacyV1JointRecord` and
  asserts the three new stable IDs.

### Verification (local, on current `main` = #3018)
- **Default-step golden trajectories 3/3 bit-identical** (behavior-preserving)
- `lint` ✅ · `check-api-boundaries` ✅
- **`test-unit` 163/163 test binaries pass** — serialization round-trip,
  variational 178/178, cross-family, AVBD 107/107, boxed-LCP 122/122

### Notes
- The first commit (`Fix AppleClang -Wunused-private-field`) is the same
  pre-existing arm64 Release fix as in #3020; it is required here for this
  branch's arm64 CI and resolves cleanly when #3020 lands.
- Follow-on slices: **20b** (`comps::Link`) and **20c** (`DeformableNodeState`).