### PR TITLE
PLAN-091: WP-091.20b — split comps::Link into Model/State/Control components

### DIFF
--- a/dart/simulation/body/collision_body.cpp
+++ b/dart/simulation/body/collision_body.cpp
@@ -94,8 +94,8 @@ bool CollisionBody::isRigidBody() const
 bool CollisionBody::isLink() const
 {
   return isValid()
-         && dart::simulation::detail::registryOf(*m_world).all_of<comps::Link>(
-             detail::toRegistryEntity(m_entity));
+         && dart::simulation::detail::registryOf(*m_world)
+                .all_of<comps::LinkModel>(detail::toRegistryEntity(m_entity));
 }
 
 //==============================================================================

--- a/dart/simulation/comps/link.hpp
+++ b/dart/simulation/comps/link.hpp
@@ -46,12 +46,18 @@
 
 namespace dart::simulation::comps {
 
-/// Link component (body in articulated chain)
+/// Link **Model** component: the static topology, geometry, and inertial
+/// parameters of a body in an articulated chain, frozen at finalization. Per
+/// the Model/State/Control/Contracts data contract (WP-091.20), it holds only
+/// design-frozen data and the kinematic-tree topology (`parentJoint`/
+/// `childJoints`), so it is the canonical "is a link" component. The per-step
+/// world pose lives in `LinkState`; user-applied external forces live in
+/// `LinkControl`.
 ///
 /// **Internal Implementation Detail** - Not exposed in public API
-struct Link
+struct LinkModel
 {
-  DART_SIMULATION_STATE_COMPONENT(Link, "comps.Link");
+  DART_SIMULATION_STATE_COMPONENT(LinkModel, "comps.LinkModel");
 
   using EntityVector
       = std::vector<entt::entity, dart::common::StlAllocator<entt::entity>>;
@@ -69,7 +75,34 @@ struct Link
   entt::entity parentJoint = entt::null;
   EntityVector childJoints;
 
+  static constexpr auto entityFields()
+  {
+    return std::make_tuple(&LinkModel::parentJoint, &LinkModel::childJoints);
+  }
+};
+
+/// Link **State** component: the per-step world pose of the link, advanced by
+/// the kinematics stage every step. Per the Model/State/Control/Contracts
+/// contract (WP-091.20), this holds only mutable per-step data; design-frozen
+/// parameters live in `LinkModel` and applied forces live in `LinkControl`.
+///
+/// **Internal Implementation Detail** - Not exposed in public API
+struct LinkState
+{
+  DART_SIMULATION_PROPERTY_COMPONENT(LinkState, "comps.LinkState");
+
   Eigen::Isometry3d worldTransform = Eigen::Isometry3d::Identity();
+};
+
+/// Link **Control** component: the user-applied external force on the link. Per
+/// the Model/State/Control/Contracts contract (WP-091.20), this holds only the
+/// commanded/applied input (the articulated analog of the rigid `Force`
+/// component); per-step kinematic state lives in `LinkState`.
+///
+/// **Internal Implementation Detail** - Not exposed in public API
+struct LinkControl
+{
+  DART_SIMULATION_PROPERTY_COMPONENT(LinkControl, "comps.LinkControl");
 
   /// Accumulated external spatial force (wrench) expressed in the link frame,
   /// using the `[angular; linear]` = `[torque; force]` convention shared by the
@@ -78,11 +111,6 @@ struct Link
   /// world step (one-shot per step, mirroring legacy `BodyNode::addExtForce`).
   Eigen::Matrix<double, 6, 1> externalForce
       = Eigen::Matrix<double, 6, 1>::Zero();
-
-  static constexpr auto entityFields()
-  {
-    return std::make_tuple(&Link::parentJoint, &Link::childJoints);
-  }
 };
 
 } // namespace dart::simulation::comps

--- a/dart/simulation/compute/multibody_constraint.cpp
+++ b/dart/simulation/compute/multibody_constraint.cpp
@@ -109,7 +109,7 @@ void integrateMultibodyPositions(
 {
   Eigen::Index expectedDof = 0;
   for (const auto linkEntity : structure.links) {
-    const auto& link = registry.get<comps::Link>(linkEntity);
+    const auto& link = registry.get<comps::LinkModel>(linkEntity);
     if (link.parentJoint == entt::null) {
       continue;
     }
@@ -129,7 +129,7 @@ void integrateMultibodyPositions(
   Eigen::Index velocityOffset = 0;
   bool wroteJointPosition = false;
   for (const auto linkEntity : structure.links) {
-    const auto& link = registry.get<comps::Link>(linkEntity);
+    const auto& link = registry.get<comps::LinkModel>(linkEntity);
     if (link.parentJoint == entt::null) {
       continue;
     }

--- a/dart/simulation/compute/multibody_dynamics.cpp
+++ b/dart/simulation/compute/multibody_dynamics.cpp
@@ -488,7 +488,7 @@ void buildDynamicsTreeInto(
 
   for (std::size_t i = 0; i < linkEntities.size(); ++i) {
     const auto linkEntity = linkEntities[i];
-    const auto& linkComp = registry.get<comps::Link>(linkEntity);
+    const auto& linkComp = registry.get<comps::LinkModel>(linkEntity);
     auto& dynamics = tree.links[i];
     dynamics.parentIndex = -1;
     dynamics.jointEntity = entt::null;
@@ -1000,7 +1000,8 @@ bool computeUnconstrainedMultibodyVelocityInto(
   {
     bool anyExternalForce = false;
     for (const auto linkEntity : structure.links) {
-      if (!registry.get<comps::Link>(linkEntity).externalForce.isZero()) {
+      if (!registry.get<comps::LinkControl>(linkEntity)
+               .externalForce.isZero()) {
         anyExternalForce = true;
         break;
       }
@@ -1009,7 +1010,8 @@ bool computeUnconstrainedMultibodyVelocityInto(
       linkBodyJacobiansInto(scratch.tree, scratch.bodyJacobian);
       for (std::size_t i = 0; i < scratch.tree.links.size(); ++i) {
         const Vector6 wrench
-            = registry.get<comps::Link>(structure.links[i]).externalForce;
+            = registry.get<comps::LinkControl>(structure.links[i])
+                  .externalForce;
         if (!wrench.isZero()) {
           scratch.appliedForce.noalias()
               += scratch.bodyJacobian[i].transpose() * wrench;
@@ -1804,7 +1806,7 @@ void enforceMultibodyVelocityLimits(
 {
   Eigen::Index expectedDof = 0;
   for (const auto linkEntity : structure.links) {
-    const auto& link = registry.get<comps::Link>(linkEntity);
+    const auto& link = registry.get<comps::LinkModel>(linkEntity);
     if (link.parentJoint == entt::null) {
       continue;
     }
@@ -1824,7 +1826,7 @@ void enforceMultibodyVelocityLimits(
   // Enforce velocity limits by clamping the generalized velocity.
   Eigen::Index velocityOffset = 0;
   for (const auto linkEntity : structure.links) {
-    const auto& link = registry.get<comps::Link>(linkEntity);
+    const auto& link = registry.get<comps::LinkModel>(linkEntity);
     if (link.parentJoint == entt::null) {
       continue;
     }
@@ -1863,7 +1865,7 @@ void collectMultibodyLinkContactsInto(
     return registry.all_of<comps::RigidBodyTag>(entity);
   };
   const auto isLink = [&](entt::entity entity) {
-    return registry.all_of<comps::Link>(entity);
+    return registry.all_of<comps::LinkModel>(entity);
   };
   const auto isDynamic = [&](entt::entity entity) {
     return !hasPrescribedRigidBodyContactResponse(registry, entity);
@@ -1964,7 +1966,7 @@ void clearMultibodyExternalForces(
     detail::WorldRegistry& registry, const comps::MultibodyStructure& structure)
 {
   for (const auto linkEntity : structure.links) {
-    registry.get<comps::Link>(linkEntity).externalForce.setZero();
+    registry.get<comps::LinkControl>(linkEntity).externalForce.setZero();
   }
 }
 
@@ -3595,7 +3597,7 @@ bool tryResolveSequentialMultibodyContacts(
     return registry.all_of<comps::RigidBodyTag>(entity);
   };
   const auto isLink = [&](entt::entity entity) {
-    return registry.all_of<comps::Link>(entity);
+    return registry.all_of<comps::LinkModel>(entity);
   };
 
   for (const auto& contact : contacts) {

--- a/dart/simulation/compute/variational_integration.cpp
+++ b/dart/simulation/compute/variational_integration.cpp
@@ -454,14 +454,15 @@ void buildVarTreeInto(
 
   for (std::size_t i = 0; i < linkEntities.size(); ++i) {
     const auto linkEntity = linkEntities[i];
-    const auto& linkComp = registry.get<comps::Link>(linkEntity);
+    const auto& linkModel = registry.get<comps::LinkModel>(linkEntity);
+    const auto& linkControl = registry.get<comps::LinkControl>(linkEntity);
     auto& link = tree.links[i];
-    link.inertia = spatialInertia(linkComp.mass);
-    link.parentToJoint = linkComp.transformFromParentToJoint;
-    link.offset = linkComp.transformFromParentJoint;
-    link.externalForce = linkComp.externalForce;
+    link.inertia = spatialInertia(linkModel.mass);
+    link.parentToJoint = linkModel.transformFromParentToJoint;
+    link.offset = linkModel.transformFromParentJoint;
+    link.externalForce = linkControl.externalForce;
 
-    if (linkComp.parentJoint == entt::null) {
+    if (linkModel.parentJoint == entt::null) {
       const auto& cache = registry.get<comps::FrameCache>(linkEntity);
       link.worldTransform = cache.worldTransform;
       link.subspace.resize(6, 0);
@@ -470,10 +471,10 @@ void buildVarTreeInto(
     }
 
     const auto& jointModel
-        = registry.get<comps::JointModel>(linkComp.parentJoint);
+        = registry.get<comps::JointModel>(linkModel.parentJoint);
     const auto& jointState
-        = registry.get<comps::JointState>(linkComp.parentJoint);
-    link.joint = linkComp.parentJoint;
+        = registry.get<comps::JointState>(linkModel.parentJoint);
+    link.joint = linkModel.parentJoint;
     const auto parentIt = indexOf.find(jointModel.parentLink);
     DART_SIMULATION_THROW_T_IF(
         parentIt == indexOf.end(),
@@ -618,7 +619,7 @@ bool isTopologyMultibodyJoint(
     entt::entity jointEntity,
     const comps::JointModel& joint)
 {
-  const auto* childLink = registry.try_get<comps::Link>(joint.childLink);
+  const auto* childLink = registry.try_get<comps::LinkModel>(joint.childLink);
   return childLink != nullptr && childLink->parentJoint == jointEntity;
 }
 
@@ -1491,8 +1492,9 @@ std::optional<VariationalSolveReport> tryIntegrateSinglePrismaticVariational(
 
   const entt::entity baseEntity = structure.links[0];
   const entt::entity childEntity = structure.links[1];
-  const auto& baseLink = registry.get<comps::Link>(baseEntity);
-  const auto& childLink = registry.get<comps::Link>(childEntity);
+  const auto& baseLink = registry.get<comps::LinkModel>(baseEntity);
+  const auto& childLink = registry.get<comps::LinkModel>(childEntity);
+  const auto& childLinkControl = registry.get<comps::LinkControl>(childEntity);
   if (baseLink.parentJoint != entt::null
       || childLink.parentJoint == entt::null) {
     return std::nullopt;
@@ -1553,7 +1555,7 @@ std::optional<VariationalSolveReport> tryIntegrateSinglePrismaticVariational(
         * childLink.transformFromParentToJoint.linear() * jointModel.axis;
   const double generalizedGravity = effectiveMass * axisWorld.dot(gravity);
   const double generalizedExternal
-      = linkFrameSubspace.dot(childLink.externalForce);
+      = linkFrameSubspace.dot(childLinkControl.externalForce);
   const double noContactGeneralizedForce
       = effort + generalizedExternal + generalizedGravity;
 
@@ -4111,7 +4113,7 @@ double computeMultibodyMechanicalEnergy(
     const auto& link = tree.links[i];
     const Vector6& spatialVelocity = stepScratch.currentSpatialVelocities[i];
     kinetic += 0.5 * spatialVelocity.dot(link.inertia * spatialVelocity);
-    const auto& linkComp = registry.get<comps::Link>(structure.links[i]);
+    const auto& linkComp = registry.get<comps::LinkModel>(structure.links[i]);
     const Eigen::Vector3d comWorld
         = link.worldTransform * linkComp.mass.localCenterOfMass;
     potential -= linkComp.mass.mass * gravity.dot(comWorld);
@@ -4146,7 +4148,7 @@ MultibodyMechanicalEnergyTerms computeMultibodyMechanicalEnergyTerms(
     const auto& link = tree.links[i];
     const Vector6& spatialVelocity = stepScratch.currentSpatialVelocities[i];
     terms.kinetic += 0.5 * spatialVelocity.dot(link.inertia * spatialVelocity);
-    const auto& linkComp = registry.get<comps::Link>(structure.links[i]);
+    const auto& linkComp = registry.get<comps::LinkModel>(structure.links[i]);
     const Eigen::Vector3d comWorld
         = link.worldTransform * linkComp.mass.localCenterOfMass;
     terms.potential -= linkComp.mass.mass * gravity.dot(comWorld);
@@ -4263,7 +4265,7 @@ VariationalLoopClosureBinding bindVariationalLoopClosure(
       structureOut = entt::null; // world anchor
       return true;
     }
-    if (!registry.all_of<comps::Link>(frame)) {
+    if (!registry.all_of<comps::LinkModel>(frame)) {
       return false; // rigid-body or other non-link frame
     }
     for (auto entity : registry.view<comps::MultibodyStructure>()) {
@@ -4668,7 +4670,7 @@ void MultibodyVariationalIntegrationStage::execute(
     // BodyNode::addExtForce): clear them after they have been consumed by this
     // step's dynamics.
     for (const auto linkEntity : structure.links) {
-      registry.get<comps::Link>(linkEntity).externalForce.setZero();
+      registry.get<comps::LinkControl>(linkEntity).externalForce.setZero();
     }
   }
 }

--- a/dart/simulation/compute/variational_integration.hpp
+++ b/dart/simulation/compute/variational_integration.hpp
@@ -741,9 +741,9 @@ DART_SIMULATION_API VariationalSolveReport integrateMultibodyVariational(
 /// from the same forward-kinematics world transforms as
 /// `computeMultibodyMechanicalEnergy` (so `kinetic + potential` equals it). Use
 /// this for a physical per-domain energy split: deriving the split from the
-/// stored `comps::Link::worldTransform` cache is unreliable (it is not always
-/// refreshed for the current configuration), which is why the metrics layer
-/// routes through this helper instead.
+/// stored `comps::LinkState::worldTransform` cache is unreliable (it is not
+/// always refreshed for the current configuration), which is why the metrics
+/// layer routes through this helper instead.
 struct MultibodyMechanicalEnergyTerms
 {
   double kinetic = 0.0;

--- a/dart/simulation/compute/world_kinematics_graph.cpp
+++ b/dart/simulation/compute/world_kinematics_graph.cpp
@@ -123,7 +123,7 @@ Eigen::Isometry3d getJointTransform(
 Eigen::Isometry3d getLocalTransform(
     const detail::WorldRegistry& registry, entt::entity entity)
 {
-  if (const auto* link = registry.try_get<comps::Link>(entity)) {
+  if (const auto* link = registry.try_get<comps::LinkModel>(entity)) {
     if (link->parentJoint != entt::null) {
       const auto* jointModel
           = registry.try_get<comps::JointModel>(link->parentJoint);

--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -1917,7 +1917,7 @@ bool isRigidContactCandidate(
   }
 
   return registry.all_of<comps::RigidBodyTag>(entity)
-         || registry.all_of<comps::Link>(entity);
+         || registry.all_of<comps::LinkModel>(entity);
 }
 
 //==============================================================================

--- a/dart/simulation/detail/rigid_avbd/rigid_world_contact.hpp
+++ b/dart/simulation/detail/rigid_avbd/rigid_world_contact.hpp
@@ -694,7 +694,7 @@ inline AvbdRigidWorldEndpoint classifyAvbdRigidWorldEndpoint(
     return endpoint;
   }
 
-  if (registry.all_of<comps::Link>(entity)) {
+  if (registry.all_of<comps::LinkModel>(entity)) {
     endpoint.kind = AvbdRigidWorldEndpointKind::MultibodyLink;
     return endpoint;
   }
@@ -746,7 +746,7 @@ inline bool isAvbdRigidWorldPointJointFacade(
     return false;
   }
 
-  const auto* childLink = registry.try_get<comps::Link>(joint.childLink);
+  const auto* childLink = registry.try_get<comps::LinkModel>(joint.childLink);
   if (childLink != nullptr && childLink->parentJoint == jointEntity) {
     return false;
   }
@@ -888,7 +888,7 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
   if (worldA && worldB) {
     return false;
   }
-  const auto* childLink = registry.try_get<comps::Link>(joint->childLink);
+  const auto* childLink = registry.try_get<comps::LinkModel>(joint->childLink);
   if (childLink != nullptr && childLink->parentJoint == jointEntity) {
     return false;
   }
@@ -925,7 +925,7 @@ inline bool configureAvbdRigidWorldPointJointFromCurrentPose(
       return true;
     }
 
-    if (const auto* link = registry.try_get<comps::Link>(entity)) {
+    if (const auto* link = registry.try_get<comps::LinkState>(entity)) {
       if (!link->worldTransform.matrix().allFinite()) {
         return false;
       }
@@ -1089,7 +1089,7 @@ inline std::size_t configureAvbdRigidWorldPointJointsFromCurrentPoses(
     if (worldA && worldB) {
       continue;
     }
-    const auto* childLink = registry.try_get<comps::Link>(joint.childLink);
+    const auto* childLink = registry.try_get<comps::LinkModel>(joint.childLink);
     if (childLink != nullptr && childLink->parentJoint == entity) {
       continue;
     }

--- a/dart/simulation/detail/smooth_jacobians.cpp
+++ b/dart/simulation/detail/smooth_jacobians.cpp
@@ -117,7 +117,7 @@ void collectCoordinatesInto(
   coordinates.clear();
   coordinates.reserve(structure.links.size());
   for (const auto linkEntity : structure.links) {
-    const auto& link = registry.get<comps::Link>(linkEntity);
+    const auto& link = registry.get<comps::LinkModel>(linkEntity);
     if (link.parentJoint == entt::null) {
       continue;
     }

--- a/dart/simulation/frame/frame.cpp
+++ b/dart/simulation/frame/frame.cpp
@@ -174,7 +174,7 @@ Eigen::Isometry3d getJointTransform(
 Eigen::Isometry3d getFrameLocalTransform(
     const auto& registry, entt::entity entity)
 {
-  if (const auto* link = registry.template try_get<comps::Link>(entity)) {
+  if (const auto* link = registry.template try_get<comps::LinkModel>(entity)) {
     if (link->parentJoint != entt::null) {
       const auto* jointModel
           = registry.template try_get<comps::JointModel>(link->parentJoint);
@@ -206,7 +206,7 @@ Eigen::Isometry3d getFrameLocalTransform(
     return props->localTransform;
   }
 
-  if (const auto* link = registry.template try_get<comps::Link>(entity)) {
+  if (const auto* link = registry.template try_get<comps::LinkModel>(entity)) {
     return link->transformFromParentToJoint * link->transformFromParentJoint;
   }
 
@@ -308,7 +308,8 @@ void Frame::setParentFrame(const Frame& parent)
       "Cannot change parent frame of Link. Links are connected through "
       "joints in a fixed tree structure.");
 
-  if (registry.valid(enttEntity) && registry.all_of<comps::Link>(enttEntity)) {
+  if (registry.valid(enttEntity)
+      && registry.all_of<comps::LinkModel>(enttEntity)) {
     DART_SIMULATION_THROW_T(
         InvalidOperationException,
         "Cannot change parent frame of Link. Links are connected through "

--- a/dart/simulation/io/auto_serialization.hpp
+++ b/dart/simulation/io/auto_serialization.hpp
@@ -361,6 +361,11 @@ void autoSerialize(
           writePOD(out, field(i, j));
         }
       }
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix<double, 6, 1>>) {
+      // Fixed 6-vector (e.g. a spatial force/wrench).
+      for (int i = 0; i < 6; ++i) {
+        writePOD(out, field[i]);
+      }
     } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       // POD types (int, double, bool, enums, etc.)
       writePOD(out, field);
@@ -409,6 +414,11 @@ void autoDeserialize(std::istream& in, T& component)
             field(j, i) = field(i, j); // Symmetric
           }
         }
+      }
+    } else if constexpr (std::same_as<FieldType, Eigen::Matrix<double, 6, 1>>) {
+      // Fixed 6-vector (e.g. a spatial force/wrench).
+      for (int i = 0; i < 6; ++i) {
+        readPOD(in, field[i]);
       }
     } else if constexpr (detail::TriviallyCopyable<FieldType>) {
       // POD types

--- a/dart/simulation/io/binary_io.hpp
+++ b/dart/simulation/io/binary_io.hpp
@@ -112,7 +112,13 @@ using EntityMap = std::unordered_map<entt::entity, entt::entity>;
 //      commanded effort, commanded velocity). Clean break: DART 7 has no
 //      compatibility debt, so packets written with the unified comps.Joint
 //      record (versions <= 21) no longer round-trip the joint. See WP-091.20.
-constexpr std::uint32_t kBinaryFormatVersion = 22;
+//   23: The unified comps.Link record is split into three contract-aligned
+//      components: comps.LinkModel (frozen topology, geometry, and inertia),
+//      comps.LinkState (per-step world pose), and comps.LinkControl (the
+//      user-applied external force). Clean break: DART 7 has no compatibility
+//      debt, so packets written with the unified comps.Link record
+//      (versions <= 22) no longer round-trip the link. See WP-091.20 (20b).
+constexpr std::uint32_t kBinaryFormatVersion = 23;
 
 //==============================================================================
 // Low-level Binary I/O for POD types

--- a/dart/simulation/io/serializer.cpp
+++ b/dart/simulation/io/serializer.cpp
@@ -293,53 +293,6 @@ void deserializeBranchV11CollisionGeometry(
   geometry.revision = 0;
 }
 
-void deserializeLegacyMassProperties(
-    std::istream& input, comps::MassProperties& mass)
-{
-  readPOD(input, mass.mass);
-  for (int i = 0; i < 3; ++i) {
-    for (int j = i; j < 3; ++j) {
-      readPOD(input, mass.inertia(i, j));
-      if (i != j) {
-        mass.inertia(j, i) = mass.inertia(i, j);
-      }
-    }
-  }
-  readVector3d(input, mass.localCenterOfMass);
-}
-
-void deserializeLinkV8(
-    std::istream& input, comps::Link& link, std::uint32_t formatVersion)
-{
-  readString(input, link.name);
-  deserializeLegacyMassProperties(input, link.mass);
-
-  link.transformFromParentToJoint = Eigen::Isometry3d::Identity();
-  readIsometry3d(input, link.transformFromParentJoint);
-
-  std::uint32_t parentJoint = static_cast<std::uint32_t>(entt::null);
-  readPOD(input, parentJoint);
-  link.parentJoint = static_cast<entt::entity>(parentJoint);
-
-  std::size_t childJointCount = 0;
-  readPOD(input, childJointCount);
-  link.childJoints.resize(childJointCount);
-  for (entt::entity& childJoint : link.childJoints) {
-    std::uint32_t entityId = static_cast<std::uint32_t>(entt::null);
-    readPOD(input, entityId);
-    childJoint = static_cast<entt::entity>(entityId);
-  }
-
-  readIsometry3d(input, link.worldTransform);
-
-  link.externalForce.setZero();
-  if (formatVersion >= 5u) {
-    for (Eigen::Index i = 0; i < link.externalForce.size(); ++i) {
-      readPOD(input, link.externalForce[i]);
-    }
-  }
-}
-
 class AvbdRigidWorldPointJointConfigComponentSerializer final
   : public TypedComponentSerializer<::dart::simulation::detail::deformable_vbd::
                                         AvbdRigidWorldPointJointConfig>
@@ -533,52 +486,6 @@ void registerCollisionGeometrySerializer(SerializerRegistry& registry)
       std::make_unique<CollisionGeometryComponentSerializer>());
 }
 
-class LinkComponentSerializer final
-  : public TypedComponentSerializer<comps::Link>
-{
-public:
-  [[nodiscard]] std::string_view getTypeName() const override
-  {
-    return comps::Link::getTypeName();
-  }
-
-private:
-  void saveComponent(
-      std::ostream& output,
-      const comps::Link& component,
-      const EntityMap& entityMap) const override
-  {
-    autoSerialize(output, component, entityMap);
-  }
-
-  void loadComponent(std::istream& input, comps::Link& component) const override
-  {
-    autoDeserialize(input, component);
-  }
-
-  void loadComponent(
-      std::istream& input,
-      comps::Link& component,
-      std::uint32_t formatVersion) const override
-  {
-    if (formatVersion < 9u) {
-      deserializeLinkV8(input, component, formatVersion);
-      return;
-    }
-
-    loadComponent(input, component);
-  }
-};
-
-void registerLinkSerializer(SerializerRegistry& registry)
-{
-  if (registry.getSerializer(comps::Link::getTypeName()) != nullptr) {
-    return;
-  }
-
-  registry.registerSerializer(std::make_unique<LinkComponentSerializer>());
-}
-
 void registerBuiltInSerializers(SerializerRegistry& registry)
 {
   registerComponentIfNeeded<comps::Name>(registry);
@@ -615,7 +522,9 @@ void registerBuiltInSerializers(SerializerRegistry& registry)
 
   registerComponentIfNeeded<comps::LoopClosure>(registry);
 
-  registerLinkSerializer(registry);
+  registerComponentIfNeeded<comps::LinkModel>(registry);
+  registerComponentIfNeeded<comps::LinkState>(registry);
+  registerComponentIfNeeded<comps::LinkControl>(registry);
   registerComponentIfNeeded<comps::JointModel>(registry);
   registerComponentIfNeeded<comps::JointState>(registry);
   registerComponentIfNeeded<comps::JointActuation>(registry);
@@ -808,9 +717,9 @@ void SerializerRegistry::loadAllEntities(
     }
   }
 
-  auto linkView = registry.view<comps::Link>();
+  auto linkView = registry.view<comps::LinkModel>();
   for (auto entity : linkView) {
-    auto& comp = linkView.get<comps::Link>(entity);
+    auto& comp = linkView.get<comps::LinkModel>(entity);
     if (comp.parentJoint != entt::null) {
       comp.parentJoint = entityMap.at(comp.parentJoint);
     }

--- a/dart/simulation/io/skeleton_loader.cpp
+++ b/dart/simulation/io/skeleton_loader.cpp
@@ -525,9 +525,9 @@ void setParentToJointTransform(Link& link, const Eigen::Isometry3d& transform)
       "Cannot set parent-to-joint transform on an invalid loaded Link");
 
   auto& registry = dart::simulation::detail::registryOf(*world);
-  auto& linkComp = registry.get<comps::Link>(
+  auto& linkModel = registry.get<comps::LinkModel>(
       dart::simulation::detail::toRegistryEntity(link.getEntity()));
-  linkComp.transformFromParentToJoint = transform;
+  linkModel.transformFromParentToJoint = transform;
 }
 
 void copyBodyInertia(const dynamics::BodyNode& source, Link& target)

--- a/dart/simulation/multibody/joint.cpp
+++ b/dart/simulation/multibody/joint.cpp
@@ -835,7 +835,7 @@ Link Joint::getParentLink() const
   DART_SIMULATION_THROW_T_IF(
       jointModel.parentLink == entt::null
           || !dart::simulation::detail::registryOf(*m_world)
-                  .all_of<comps::Link>(jointModel.parentLink),
+                  .all_of<comps::LinkModel>(jointModel.parentLink),
       InvalidArgumentException,
       "Joint '{}' parent endpoint is not a multibody Link",
       jointModel.name);
@@ -849,7 +849,7 @@ Link Joint::getChildLink() const
   DART_SIMULATION_THROW_T_IF(
       jointModel.childLink == entt::null
           || !dart::simulation::detail::registryOf(*m_world)
-                  .all_of<comps::Link>(jointModel.childLink),
+                  .all_of<comps::LinkModel>(jointModel.childLink),
       InvalidArgumentException,
       "Joint '{}' child endpoint is not a multibody Link",
       jointModel.name);

--- a/dart/simulation/multibody/link.cpp
+++ b/dart/simulation/multibody/link.cpp
@@ -167,26 +167,26 @@ Link::Link(Entity entity, World* world) : Frame(entity, world) {}
 //==============================================================================
 std::string_view Link::getName() const
 {
-  const auto& linkComp
+  const auto& linkModel
       = dart::simulation::detail::registryOf(*getWorld())
-            .get<comps::Link>(detail::toRegistryEntity(getEntity()));
-  return linkComp.name;
+            .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()));
+  return linkModel.name;
 }
 
 //==============================================================================
 Joint Link::getParentJoint() const
 {
-  const auto& linkComp
+  const auto& linkModel
       = dart::simulation::detail::registryOf(*getWorld())
-            .get<comps::Link>(detail::toRegistryEntity(getEntity()));
-  return Joint(detail::fromRegistryEntity(linkComp.parentJoint), getWorld());
+            .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()));
+  return Joint(detail::fromRegistryEntity(linkModel.parentJoint), getWorld());
 }
 
 //==============================================================================
 double Link::getMass() const
 {
   return dart::simulation::detail::registryOf(*getWorld())
-      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.mass;
 }
 
@@ -199,7 +199,7 @@ void Link::setMass(double mass)
       "Link mass must be positive and finite");
 
   dart::simulation::detail::registryOf(*getWorld())
-      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.mass = mass;
 }
 
@@ -207,7 +207,7 @@ void Link::setMass(double mass)
 Eigen::Matrix3d Link::getInertia() const
 {
   return dart::simulation::detail::registryOf(*getWorld())
-      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.inertia;
 }
 
@@ -220,7 +220,7 @@ void Link::setInertia(const Eigen::Matrix3d& inertia)
       "Link inertia must be symmetric positive definite");
 
   dart::simulation::detail::registryOf(*getWorld())
-      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.inertia = inertia;
 }
 
@@ -228,7 +228,7 @@ void Link::setInertia(const Eigen::Matrix3d& inertia)
 Eigen::Vector3d Link::getCenterOfMass() const
 {
   return dart::simulation::detail::registryOf(*getWorld())
-      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.localCenterOfMass;
 }
 
@@ -241,7 +241,7 @@ void Link::setCenterOfMass(const Eigen::Vector3d& centerOfMass)
       "Link center of mass must contain only finite values");
 
   dart::simulation::detail::registryOf(*getWorld())
-      .get<comps::Link>(detail::toRegistryEntity(getEntity()))
+      .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.localCenterOfMass = centerOfMass;
 }
 
@@ -265,8 +265,9 @@ void Link::applyForce(
   // point into the link frame, build the wrench [torque; force] at the point,
   // then transport it to the link origin and accumulate in the link frame.
   const Eigen::Isometry3d& worldTransform = getWorldTransform();
-  auto& linkComp = dart::simulation::detail::registryOf(*getWorld())
-                       .get<comps::Link>(detail::toRegistryEntity(getEntity()));
+  auto& linkControl
+      = dart::simulation::detail::registryOf(*getWorld())
+            .get<comps::LinkControl>(detail::toRegistryEntity(getEntity()));
 
   Eigen::Isometry3d pointTransform = Eigen::Isometry3d::Identity();
   pointTransform.translation()
@@ -276,7 +277,7 @@ void Link::applyForce(
   wrench.tail<3>()
       = forceInWorldFrame ? worldTransform.linear().transpose() * force : force;
 
-  linkComp.externalForce += dm::dAdInvT(pointTransform, wrench);
+  linkControl.externalForce += dm::dAdInvT(pointTransform, wrench);
 }
 
 //==============================================================================

--- a/dart/simulation/multibody/multibody.cpp
+++ b/dart/simulation/multibody/multibody.cpp
@@ -391,9 +391,11 @@ Link Multibody::addLink(std::string_view name)
   registry.emplace<comps::FreeFrameProperties>(linkEntity).localTransform
       = Eigen::Isometry3d::Identity();
 
-  auto& linkComp = registry.emplace<comps::Link>(linkEntity);
+  auto& linkComp = registry.emplace<comps::LinkModel>(linkEntity);
+  registry.emplace<comps::LinkState>(linkEntity);
+  registry.emplace<comps::LinkControl>(linkEntity);
   linkComp.childJoints
-      = comps::Link::EntityVector{dart::common::StlAllocator<entt::entity>{
+      = comps::LinkModel::EntityVector{dart::common::StlAllocator<entt::entity>{
           m_world->getMemoryManager().getFreeAllocator()}};
   linkComp.name = std::move(actualName);
   linkComp.parentJoint = entt::null;
@@ -486,9 +488,11 @@ Link Multibody::addLink(std::string_view name, const LinkOptions& options)
       = Eigen::Isometry3d::Identity();
 
   // Add link component
-  auto& linkComp = registry.emplace<comps::Link>(linkEntity);
+  auto& linkComp = registry.emplace<comps::LinkModel>(linkEntity);
+  registry.emplace<comps::LinkState>(linkEntity);
+  registry.emplace<comps::LinkControl>(linkEntity);
   linkComp.childJoints
-      = comps::Link::EntityVector{dart::common::StlAllocator<entt::entity>{
+      = comps::LinkModel::EntityVector{dart::common::StlAllocator<entt::entity>{
           m_world->getMemoryManager().getFreeAllocator()}};
   linkComp.name = std::move(actualLinkName);
 
@@ -577,7 +581,7 @@ Link Multibody::addLink(std::string_view name, const LinkOptions& options)
   jointModel.limits.effortUpper = comps::makeJointVector(dof, infinity);
 
   // Link the parent link to this joint
-  auto& parentLinkComp = safeGet<comps::Link>(registry, parentEntity);
+  auto& parentLinkComp = safeGet<comps::LinkModel>(registry, parentEntity);
   parentLinkComp.childJoints.push_back(jointEntity);
 
   // Link this link to the parent joint

--- a/dart/simulation/world.cpp
+++ b/dart/simulation/world.cpp
@@ -1169,7 +1169,7 @@ bool isReplayPublicFrameEntity(
 {
   return registry.all_of<comps::FrameState, comps::FrameCache>(entity)
          && !registry.all_of<comps::RigidBodyTag>(entity)
-         && !registry.all_of<comps::Link>(entity)
+         && !registry.all_of<comps::LinkModel>(entity)
          && (registry.all_of<comps::FreeFrameTag, comps::FreeFrameProperties>(
                  entity)
              || registry
@@ -1667,7 +1667,8 @@ bool hasDeformableBodies(const World& world)
 entt::entity findOwningMultibodyStructure(
     const detail::WorldRegistry& registry, entt::entity linkEntity)
 {
-  if (linkEntity == entt::null || !registry.all_of<comps::Link>(linkEntity)) {
+  if (linkEntity == entt::null
+      || !registry.all_of<comps::LinkModel>(linkEntity)) {
     return entt::null;
   }
 
@@ -1798,15 +1799,15 @@ bool isArticulatedPointJoint(
   }
 
   if (joint.parentLink != entt::null
-      && !registry.template all_of<comps::Link>(joint.parentLink)) {
+      && !registry.template all_of<comps::LinkModel>(joint.parentLink)) {
     return false;
   }
-  if (!registry.template all_of<comps::Link>(joint.childLink)) {
+  if (!registry.template all_of<comps::LinkModel>(joint.childLink)) {
     return false;
   }
 
   const auto* childLink
-      = registry.template try_get<comps::Link>(joint.childLink);
+      = registry.template try_get<comps::LinkModel>(joint.childLink);
   if (childLink != nullptr && childLink->parentJoint == jointEntity) {
     return false;
   }
@@ -2289,7 +2290,7 @@ entt::entity resolveCollisionPairFrame(
   const auto& registry = detail::registryOf(world);
   DART_SIMULATION_THROW_T_IF(
       !registry.all_of<comps::RigidBodyTag>(entity)
-          && !registry.all_of<comps::Link>(entity),
+          && !registry.all_of<comps::LinkModel>(entity),
       InvalidArgumentException,
       "Collision pair {} frame must be a rigid body or multibody link",
       fieldName);
@@ -3148,9 +3149,9 @@ void rebindLoadedWorldComponentAllocators(
     rebindLoadedVectorAllocator(structure.joints, allocator);
   }
 
-  auto linkView = registry.view<comps::Link>();
+  auto linkView = registry.view<comps::LinkModel>();
   for (const auto entity : linkView) {
-    auto& link = linkView.get<comps::Link>(entity);
+    auto& link = linkView.get<comps::LinkModel>(entity);
     rebindLoadedVectorAllocator(link.childJoints, allocator);
   }
 
@@ -3534,7 +3535,9 @@ void World::reserveRegistryStorageForSimulation()
       comps::MultibodyTag,
       comps::MultibodyStructure,
       comps::LoopClosure,
-      comps::Link,
+      comps::LinkModel,
+      comps::LinkState,
+      comps::LinkControl,
       comps::JointModel,
       comps::JointState,
       comps::JointActuation,
@@ -5978,7 +5981,7 @@ void World::captureStepDerivatives()
     torques.clear();
     torques.reserve(structure.links.size());
     for (const auto linkEntity : structure.links) {
-      const auto& link = m_storage->registry.get<comps::Link>(linkEntity);
+      const auto& link = m_storage->registry.get<comps::LinkModel>(linkEntity);
       if (link.parentJoint == entt::null) {
         continue;
       }
@@ -6124,7 +6127,7 @@ compute::StepMetrics World::computeStepMetrics() const
   // kinetic and potential terms are taken from the variational integrator's own
   // energy helper, which evaluates them on the VarTree's forward-kinematics
   // world transforms. This makes the per-domain split physical -- an earlier
-  // version derived potential from the stored comps::Link::worldTransform
+  // version derived potential from the stored comps::LinkState::worldTransform
   // cache, whose gauge did not match the helper (yielding negative kinetic
   // energy at rest). World-frame multibody-link momentum aggregation still
   // needs the link Jacobian and is deferred to a later WP-091.24 slice.
@@ -6289,17 +6292,17 @@ void World::restoreReplayFrame(std::size_t index)
   }
 
   DART_SIMULATION_THROW_T_IF(
-      countReplayView(m_storage->registry.view<comps::Link>())
+      countReplayView(m_storage->registry.view<comps::LinkModel>())
           != replayFrame.links.size(),
       InvalidOperationException,
       "Cannot restore replay frame: Link component count changed");
   for (const auto& state : replayFrame.links) {
     DART_SIMULATION_THROW_T_IF(
         !m_storage->registry.valid(state.entity)
-            || !m_storage->registry.all_of<comps::Link>(state.entity),
+            || !m_storage->registry.all_of<comps::LinkModel>(state.entity),
         InvalidOperationException,
         "Cannot restore replay frame: Link entity layout changed");
-    const auto& link = m_storage->registry.get<comps::Link>(state.entity);
+    const auto& link = m_storage->registry.get<comps::LinkModel>(state.entity);
     DART_SIMULATION_THROW_T_IF(
         !sameReplayMassProperties(link.mass, state.massProperties)
             || !sameReplayCollisionGeometry(
@@ -6334,7 +6337,7 @@ void World::restoreReplayFrame(std::size_t index)
           || !m_storage->registry.all_of<comps::FrameState, comps::FrameCache>(
               state.entity)
           || m_storage->registry.all_of<comps::RigidBodyTag>(state.entity)
-          || m_storage->registry.all_of<comps::Link>(state.entity)
+          || m_storage->registry.all_of<comps::LinkModel>(state.entity)
           || currentFree != expectedFree || currentFixed != expectedFixed
           || currentFree == currentFixed;
     DART_SIMULATION_THROW_T_IF(
@@ -6481,7 +6484,7 @@ void World::restoreReplayFrame(std::size_t index)
   }
 
   for (const auto& state : replayFrame.links) {
-    m_storage->registry.get<comps::Link>(state.entity).externalForce
+    m_storage->registry.get<comps::LinkControl>(state.entity).externalForce
         = state.externalForce;
   }
 
@@ -6670,17 +6673,19 @@ void World::recordReplayFrame()
            < static_cast<std::uint32_t>(rhs.entity);
   });
 
-  auto linkView = m_storage->registry.view<comps::Link>();
+  auto linkView = m_storage->registry.view<comps::LinkModel>();
   replayFrame.links.reserve(countReplayView(linkView));
   for (auto entity : linkView) {
-    const auto& link = linkView.get<comps::Link>(entity);
+    const auto& link = linkView.get<comps::LinkModel>(entity);
+    const auto& linkControl
+        = m_storage->registry.get<comps::LinkControl>(entity);
     replayFrame.links.push_back(
         ReplayState::LinkState{
             entity,
             link.mass,
             captureReplayOptionalComponent<comps::CollisionGeometry>(
                 m_storage->registry, entity),
-            link.externalForce});
+            linkControl.externalForce});
   }
   std::ranges::sort(replayFrame.links, [](const auto& lhs, const auto& rhs) {
     return static_cast<std::uint32_t>(lhs.entity)
@@ -6986,9 +6991,10 @@ std::span<const Contact> World::updateCollisionQueryCache(
 
   // Multibody links pose their collision shapes through the frame accessor so
   // dirty joint-driven caches are refreshed before the query.
-  auto linkView
-      = m_storage->registry
-            .view<comps::CollisionGeometry, comps::Link, comps::FrameCache>();
+  auto linkView = m_storage->registry.view<
+      comps::CollisionGeometry,
+      comps::LinkModel,
+      comps::FrameCache>();
   for (auto entity : linkView) {
     const auto& geometry = linkView.get<comps::CollisionGeometry>(entity);
     const Link link(detail::fromRegistryEntity(entity), this);
@@ -7321,7 +7327,7 @@ void World::resetCountersFromRegistry()
       m_deformableBodyCounter,
       countEntities<comps::DeformableBodyTag>(m_storage->registry));
   m_linkCounter = std::max(
-      m_linkCounter, countEntities<comps::Link>(m_storage->registry));
+      m_linkCounter, countEntities<comps::LinkModel>(m_storage->registry));
   m_jointCounter = std::max(
       m_jointCounter, countEntities<comps::JointModel>(m_storage->registry));
 }

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -701,7 +701,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
 
 ### WS2 — Physical data architecture
 
-#### WP-091.20 Model/State/Control component split [partial — joint slice landed]
+#### WP-091.20 Model/State/Control component split [partial — joint+link slices landed]
 
 - Objective: the articulated and deformable component fusion is split so
   storage matches the documented Model/State/Control/Contacts contract (the
@@ -741,9 +741,28 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   `check-api-boundaries` clean; default-step golden trajectories stay **3/3
   bit-identical** (behavior-preserving); `pixi run test-unit` 163/163 binaries
   pass (serialization round-trip + the three new stable IDs; variational 178/178;
-  cross-family; AVBD 107/107; boxed-LCP 122/122). Remaining: slice 20b
-  (`comps::Link` → LinkModel/LinkState) and slice 20c (`DeformableNodeState` →
-  model/state).
+  cross-family; AVBD 107/107; boxed-LCP 122/122).
+- Evidence (slice 20b — link, landed): `comps::Link` is split into three
+  contract-aligned components in `comps/link.hpp` — `LinkModel` (frozen
+  topology, geometry, and inertia: name, mass, transformFromParentToJoint,
+  transformFromParentJoint, parentJoint, childJoints; carries entityFields();
+  the canonical "is a link" component), `LinkState` (per-step worldTransform),
+  and `LinkControl` (the user-applied externalForce, the articulated analog of
+  the rigid `Force` component). Every consumer (the Link facade, the two bake
+  paths in `multibody.cpp`, the multibody-dynamics/variational/constraint/stage/
+  kinematics-graph hot paths, world.cpp readers + `ensureRegistryStorages`, AVBD
+  contact, frame, skeleton-loader, collision-body, and tests) reads each field
+  through its owning component. Serialization registers the three via the
+  generic `registerComponentIfNeeded` path; the property-component
+  auto-serializer gained a fixed `Eigen::Matrix<double,6,1>` branch (it
+  previously existed only on the state path the unified `Link` used) so
+  `LinkControl` round-trips. The unified `comps.Link` serializer and the legacy
+  v8 link deserializer are removed (clean break); binary format bumped 22 → 23.
+  Gates: `pixi run lint` and `check-api-boundaries` clean; default-step golden
+  trajectories stay **3/3 bit-identical**; `pixi run test-unit` green
+  (serialization round-trip + the three new stable IDs; variational 178/178;
+  cross-family; boxed-LCP 122/122; test_world 372/372). Remaining: slice 20c
+  (`DeformableNodeState` → model/state).
 
 #### WP-091.21 Baked dense-index Model artifact
 

--- a/tests/unit/simulation/compute/test_cross_family_metrics.cpp
+++ b/tests/unit/simulation/compute/test_cross_family_metrics.cpp
@@ -353,8 +353,8 @@ TEST(CrossFamilyMetrics, MultibodyIntegrationFamiliesAgreeOnConservedEnergy)
     // variational integrator's own forward-kinematics terms (PLAN-091 WP-091.24
     // fix), so it is physical: released from rest, the kinetic energy is ~0 and
     // the potential carries the total. (An earlier version derived the split
-    // from the stored comps::Link transform cache, whose frame gauge differed,
-    // giving a non-physical negative kinetic energy at rest.)
+    // from the stored comps::LinkState transform cache, whose frame gauge
+    // differed, giving a non-physical negative kinetic energy at rest.)
     ASSERT_GT(std::abs(run.atRelease.totalEnergy), 1e-6) << family;
     EXPECT_NEAR(run.atRelease.kineticEnergy, 0.0, 1e-6)
         << family << " released-from-rest multibody kinetic energy must be ~0";

--- a/tests/unit/simulation/contact/test_boxed_lcp_contact.cpp
+++ b/tests/unit/simulation/contact/test_boxed_lcp_contact.cpp
@@ -8013,8 +8013,8 @@ ArticulatedGroundStepResult runArticulatedGroundStep(
     const entt::entity entityB
         = sx::detail::toRegistryEntity(contact.bodyB.getEntity());
     contactTouchesLink = contactTouchesLink
-                         || registry.all_of<sx::comps::Link>(entityA)
-                         || registry.all_of<sx::comps::Link>(entityB);
+                         || registry.all_of<sx::comps::LinkModel>(entityA)
+                         || registry.all_of<sx::comps::LinkModel>(entityB);
   }
 
   world->step(400);
@@ -8057,8 +8057,8 @@ MultiArticulatedGroundStepResult runMultiArticulatedGroundStep(
         = sx::detail::toRegistryEntity(contact.bodyA.getEntity());
     const entt::entity entityB
         = sx::detail::toRegistryEntity(contact.bodyB.getEntity());
-    if (registry.all_of<sx::comps::Link>(entityA)
-        || registry.all_of<sx::comps::Link>(entityB)) {
+    if (registry.all_of<sx::comps::LinkModel>(entityA)
+        || registry.all_of<sx::comps::LinkModel>(entityB)) {
       ++linkContactCount;
     }
   }
@@ -8114,8 +8114,8 @@ CartesianArticulatedGroundStepResult runCartesianArticulatedGroundStep(
         = sx::detail::toRegistryEntity(contact.bodyA.getEntity());
     const entt::entity entityB
         = sx::detail::toRegistryEntity(contact.bodyB.getEntity());
-    if (registry.all_of<sx::comps::Link>(entityA)
-        || registry.all_of<sx::comps::Link>(entityB)) {
+    if (registry.all_of<sx::comps::LinkModel>(entityA)
+        || registry.all_of<sx::comps::LinkModel>(entityB)) {
       ++linkContactCount;
     }
   }
@@ -8211,8 +8211,8 @@ ArticulatedRigidImpactResult runArticulatedRigidImpactStep(
     const entt::entity entityB
         = sx::detail::toRegistryEntity(contact.bodyB.getEntity());
     contactTouchesLink = contactTouchesLink
-                         || registry.all_of<sx::comps::Link>(entityA)
-                         || registry.all_of<sx::comps::Link>(entityB);
+                         || registry.all_of<sx::comps::LinkModel>(entityA)
+                         || registry.all_of<sx::comps::LinkModel>(entityB);
     contactTouchesRigidBody
         = contactTouchesRigidBody
           || registry.all_of<sx::comps::RigidBodyTag>(entityA)
@@ -8266,8 +8266,8 @@ MultiArticulatedRigidImpactResult runMultiArticulatedRigidImpactStep(
         = sx::detail::toRegistryEntity(contact.bodyA.getEntity());
     const entt::entity entityB
         = sx::detail::toRegistryEntity(contact.bodyB.getEntity());
-    if (registry.all_of<sx::comps::Link>(entityA)
-        || registry.all_of<sx::comps::Link>(entityB)) {
+    if (registry.all_of<sx::comps::LinkModel>(entityA)
+        || registry.all_of<sx::comps::LinkModel>(entityB)) {
       ++linkContactCount;
     }
     if (registry.all_of<sx::comps::RigidBodyTag>(entityA)
@@ -8360,9 +8360,10 @@ ArticulatedLinkImpactResult runArticulatedLinkImpactStep(
         = sx::detail::toRegistryEntity(contact.bodyA.getEntity());
     const entt::entity entityB
         = sx::detail::toRegistryEntity(contact.bodyB.getEntity());
-    contactTouchesTwoLinks = contactTouchesTwoLinks
-                             || (registry.all_of<sx::comps::Link>(entityA)
-                                 && registry.all_of<sx::comps::Link>(entityB));
+    contactTouchesTwoLinks
+        = contactTouchesTwoLinks
+          || (registry.all_of<sx::comps::LinkModel>(entityA)
+              && registry.all_of<sx::comps::LinkModel>(entityB));
   }
 
   world->step();
@@ -8412,8 +8413,8 @@ MultiArticulatedLinkImpactResult runMultiArticulatedLinkImpactStep(
         = sx::detail::toRegistryEntity(contact.bodyA.getEntity());
     const entt::entity entityB
         = sx::detail::toRegistryEntity(contact.bodyB.getEntity());
-    if (registry.all_of<sx::comps::Link>(entityA)
-        && registry.all_of<sx::comps::Link>(entityB)) {
+    if (registry.all_of<sx::comps::LinkModel>(entityA)
+        && registry.all_of<sx::comps::LinkModel>(entityB)) {
       ++twoLinkContactCount;
     }
   }

--- a/tests/unit/simulation/world/test_serialization.cpp
+++ b/tests/unit/simulation/world/test_serialization.cpp
@@ -380,55 +380,6 @@ void expectBrokenArticulatedPointJointRoundTrips(
   EXPECT_FALSE(restoredJoint->isBroken());
 }
 
-void writeMassPropertiesV8(
-    std::ostream& output, const dart::simulation::comps::MassProperties& mass)
-{
-  namespace io = dart::simulation::io;
-
-  io::writePOD(output, mass.mass);
-  for (int i = 0; i < 3; ++i) {
-    for (int j = i; j < 3; ++j) {
-      io::writePOD(output, mass.inertia(i, j));
-    }
-  }
-  io::writeVector3d(output, mass.localCenterOfMass);
-}
-
-void writeLegacyLinkV8(
-    std::ostream& output,
-    const dart::simulation::comps::Link& link,
-    const dart::simulation::io::EntityMap& entityMap,
-    bool includeExternalForce)
-{
-  namespace io = dart::simulation::io;
-
-  io::writeString(output, link.name);
-  writeMassPropertiesV8(output, link.mass);
-  io::writeIsometry3d(output, link.transformFromParentJoint);
-
-  const auto mappedParent
-      = link.parentJoint != entt::null
-            ? static_cast<std::uint32_t>(entityMap.at(link.parentJoint))
-            : static_cast<std::uint32_t>(entt::null);
-  io::writePOD(output, mappedParent);
-
-  io::writePOD(output, link.childJoints.size());
-  for (const auto childJoint : link.childJoints) {
-    const auto mappedChild
-        = childJoint != entt::null
-              ? static_cast<std::uint32_t>(entityMap.at(childJoint))
-              : static_cast<std::uint32_t>(entt::null);
-    io::writePOD(output, mappedChild);
-  }
-
-  io::writeIsometry3d(output, link.worldTransform);
-  if (includeExternalForce) {
-    for (Eigen::Index i = 0; i < link.externalForce.size(); ++i) {
-      io::writePOD(output, link.externalForce[i]);
-    }
-  }
-}
-
 void saveLegacyWorldWithCurrentEntities(
     std::ostream& output,
     const dart::simulation::World& world,
@@ -474,23 +425,9 @@ void saveLegacyWorldWithCurrentEntities(
     io::writePOD(output, componentTypes.size());
     for (const auto& typeName : componentTypes) {
       io::writeString(output, typeName);
-      if (typeName == comps::Link::getTypeName()) {
-        writeLegacyLinkV8(
-            output,
-            registry.get<comps::Link>(entity),
-            entityMap,
-            legacyVersion >= 5u);
-      } else {
-        serializers.at(typeName)->save(output, entity, registry, entityMap);
-      }
+      serializers.at(typeName)->save(output, entity, registry, entityMap);
     }
   }
-}
-
-void saveLegacyV8WorldWithCurrentEntities(
-    std::ostream& output, const dart::simulation::World& world)
-{
-  saveLegacyWorldWithCurrentEntities(output, world, /*legacyVersion=*/8u);
 }
 
 void writeLegacyV15EmptyWorldWithSolverOptions(std::ostream& output)
@@ -766,80 +703,6 @@ TEST(Serialization, PreservesJointLimits)
   EXPECT_DOUBLE_EQ(joint_restored->getVelocityUpperLimits()[0], 2.5);
   EXPECT_DOUBLE_EQ(joint_restored->getEffortLowerLimits()[0], -3.0);
   EXPECT_DOUBLE_EQ(joint_restored->getEffortUpperLimits()[0], 4.0);
-}
-
-TEST(Serialization, LoadsLegacyV8LinkRecord)
-{
-  namespace sx = dart::simulation;
-  namespace comps = dart::simulation::comps;
-
-  sx::World world1;
-  auto mb = world1.addMultibody("robot");
-  auto base = mb.addLink("base");
-  auto link = mb.addLink(
-      "link",
-      base,
-      sx::JointSpec{.name = "joint", .type = sx::JointType::Revolute});
-
-  Eigen::Isometry3d legacyJointToLink = Eigen::Isometry3d::Identity();
-  legacyJointToLink.translate(Eigen::Vector3d(0.25, -0.5, 0.75));
-  legacyJointToLink.rotate(Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitZ()));
-
-  Eigen::Isometry3d unsavedParentToJoint = Eigen::Isometry3d::Identity();
-  unsavedParentToJoint.translate(Eigen::Vector3d(1.0, 2.0, 3.0));
-
-  Eigen::Isometry3d worldTransform = Eigen::Isometry3d::Identity();
-  worldTransform.translate(Eigen::Vector3d(-1.0, 0.5, 2.0));
-
-  Eigen::Matrix<double, 6, 1> externalForce;
-  externalForce << 1.0, -2.0, 3.0, -4.0, 5.0, -6.0;
-
-  auto& linkComp
-      = dart::simulation::detail::registryOf(world1).get<comps::Link>(
-          dart::simulation::detail::toRegistryEntity(link.getEntity()));
-  linkComp.transformFromParentToJoint = unsavedParentToJoint;
-  linkComp.transformFromParentJoint = legacyJointToLink;
-  linkComp.worldTransform = worldTransform;
-  linkComp.externalForce = externalForce;
-
-  std::stringstream legacy;
-  saveLegacyV8WorldWithCurrentEntities(legacy, world1);
-
-  sx::World world2;
-  world2.loadBinary(legacy);
-
-  auto mbRestored = world2.getMultibody("robot");
-  ASSERT_TRUE(mbRestored.has_value());
-  auto linkRestored = mbRestored->getLink("link");
-  ASSERT_TRUE(linkRestored.has_value());
-
-  const auto& restoredLinkComp
-      = dart::simulation::detail::registryOf(world2).get<comps::Link>(
-          dart::simulation::detail::toRegistryEntity(
-              linkRestored->getEntity()));
-  EXPECT_TRUE(restoredLinkComp.transformFromParentToJoint.isApprox(
-      Eigen::Isometry3d::Identity()));
-  EXPECT_TRUE(
-      restoredLinkComp.transformFromParentJoint.isApprox(legacyJointToLink));
-  EXPECT_TRUE(restoredLinkComp.worldTransform.isApprox(worldTransform));
-  EXPECT_TRUE(restoredLinkComp.externalForce.isApprox(externalForce));
-
-  auto jointRestored = mbRestored->getJoint("joint");
-  ASSERT_TRUE(jointRestored.has_value());
-  EXPECT_EQ(
-      restoredLinkComp.parentJoint,
-      dart::simulation::detail::toRegistryEntity(jointRestored->getEntity()));
-
-  auto baseRestored = mbRestored->getLink("base");
-  ASSERT_TRUE(baseRestored.has_value());
-  const auto& restoredBaseComp
-      = dart::simulation::detail::registryOf(world2).get<comps::Link>(
-          dart::simulation::detail::toRegistryEntity(
-              baseRestored->getEntity()));
-  ASSERT_EQ(restoredBaseComp.childJoints.size(), 1u);
-  EXPECT_EQ(
-      restoredBaseComp.childJoints.front(),
-      dart::simulation::detail::toRegistryEntity(jointRestored->getEntity()));
 }
 
 // Test save/load preserves names
@@ -2954,7 +2817,9 @@ TEST(StableComponentIds, ComponentsReturnExplicitStableId)
   EXPECT_EQ(comps::JointActuation::getTypeName(), "comps.JointActuation");
   EXPECT_EQ(
       comps::AvbdJointStiffness::getTypeName(), "comps.AvbdJointStiffness");
-  EXPECT_EQ(comps::Link::getTypeName(), "comps.Link");
+  EXPECT_EQ(comps::LinkModel::getTypeName(), "comps.LinkModel");
+  EXPECT_EQ(comps::LinkState::getTypeName(), "comps.LinkState");
+  EXPECT_EQ(comps::LinkControl::getTypeName(), "comps.LinkControl");
   EXPECT_EQ(comps::FrameTag::getTypeName(), "comps.FrameTag");
   EXPECT_EQ(comps::FrameState::getTypeName(), "comps.FrameState");
   EXPECT_EQ(comps::FrameCache::getTypeName(), "comps.FrameCache");
@@ -3016,7 +2881,9 @@ TEST(StableComponentIds, RegisteredIdsAreUniqueAndNotMangled)
   EXPECT_TRUE(seen.contains("comps.JointModel"));
   EXPECT_TRUE(seen.contains("comps.JointState"));
   EXPECT_TRUE(seen.contains("comps.JointActuation"));
-  EXPECT_TRUE(seen.contains("comps.Link"));
+  EXPECT_TRUE(seen.contains("comps.LinkModel"));
+  EXPECT_TRUE(seen.contains("comps.LinkState"));
+  EXPECT_TRUE(seen.contains("comps.LinkControl"));
   EXPECT_TRUE(seen.contains("comps.AvbdJointStiffness"));
 }
 

--- a/tests/unit/simulation/world/test_world.cpp
+++ b/tests/unit/simulation/world/test_world.cpp
@@ -3602,11 +3602,11 @@ TEST(World, WorldPersistentStorageUsesWorldFreeAllocator)
     }
     ASSERT_EQ(structureCount, 1u);
 
-    auto links = registry.view<sx::comps::Link>();
+    auto links = registry.view<sx::comps::LinkModel>();
     std::size_t linkCount = 0;
     for (const auto entity : links) {
       ++linkCount;
-      const auto& link = links.get<sx::comps::Link>(entity);
+      const auto& link = links.get<sx::comps::LinkModel>(entity);
       expectWorldAllocator(loadedMultibodyWorld, link.childJoints);
     }
     ASSERT_GE(linkCount, 2u);
@@ -22346,7 +22346,7 @@ TEST(World, ReplayRecordingRestoresMultibodyRuntimeState)
   jointState.broken = false;
   const entt::entity linkEntity
       = sx::detail::toRegistryEntity(link.getEntity());
-  auto& linkComponent = registry.get<sx::comps::Link>(linkEntity);
+  auto& linkComponent = registry.get<sx::comps::LinkControl>(linkEntity);
   const Eigen::Matrix<double, 6, 1> initialExternalForce
       = (Eigen::Matrix<double, 6, 1>() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
             .finished();
@@ -22370,7 +22370,7 @@ TEST(World, ReplayRecordingRestoresMultibodyRuntimeState)
   EXPECT_TRUE(joint.getCommandVelocity().isApprox(initialCommandVelocity));
   EXPECT_DOUBLE_EQ(joint.getBreakForce(), initialBreakForce);
   EXPECT_FALSE(joint.isBroken());
-  EXPECT_TRUE(registry.get<sx::comps::Link>(linkEntity)
+  EXPECT_TRUE(registry.get<sx::comps::LinkControl>(linkEntity)
                   .externalForce.isApprox(initialExternalForce));
 
   jointState.broken = true;


### PR DESCRIPTION
## WP-091.20b — Link component split (Model/State/Control)

Second slice of **WP-091.20** (Model/State/Control component split), following the
merged Joint slice (20a, #3026). Splits the fused `comps::Link` into three
contract-aligned components, mirroring the rigid domain's single-contract
components:

- **`comps::LinkModel`** — frozen topology, geometry, and inertia (name, mass,
  transformFromParentToJoint, transformFromParentJoint, parentJoint,
  childJoints); carries `entityFields()`; the canonical "is a link" component.
- **`comps::LinkState`** — per-step world pose (worldTransform).
- **`comps::LinkControl`** — the user-applied external force (externalForce),
  the articulated analog of the rigid `Force` component.

### What changed
- Every consumer reads each field through its owning component: the Link facade,
  the two bake paths (`multibody.cpp`), the multibody-dynamics / variational /
  constraint / world-step-stage / kinematics-graph hot paths, `world.cpp`
  readers (plus `ensureRegistryStorages` materializing all three pools), AVBD
  contact, frame, skeleton-loader, collision-body, and `smooth_jacobians`.
- **Serialization:** the three register via the generic `registerComponentIfNeeded`
  path (Boost.PFR; `LinkModel` entity refs remapped via `entityFields`). The
  property-component auto-serializer gained a fixed `Eigen::Matrix<double,6,1>`
  branch (it previously existed only on the state path the unified `Link` used),
  so `LinkControl` round-trips. The unified `comps.Link` serializer and the
  legacy v8 link deserializer are removed (**clean break**); binary format bumped
  **22 → 23**. `test_serialization` drops the now-invalid `LoadsLegacyV8LinkRecord`
  and asserts the three new stable IDs.

### Verification (local, on current `main` = #3025)
- **Default-step golden trajectories 3/3 bit-identical** (behavior-preserving)
- `lint` ✅ · `check-api-boundaries` ✅
- **`test-unit` 163/163 test binaries pass** — serialization round-trip,
  variational 178/178, cross-family, boxed-LCP 122/122, test_world 372/372

### Notes
- Follow-on slice: **20c** (`DeformableNodeState`).