### PR TITLE
Speed up articulated-body forward dynamics (~18% on BM_Dynamics, bit-exact)

### DIFF
--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -633,7 +633,10 @@ const Inertia& BodyNode::getInertia() const
 //==============================================================================
 const math::Inertia& BodyNode::getArticulatedInertia() const
 {
-  const ConstSkeletonPtr& skel = getSkeleton();
+  // Use the cached raw Skeleton pointer (see mSkeletonRawPtr) rather than
+  // getSkeleton(), which locks a weak_ptr (atomic refcount) on every call. This
+  // accessor is on the articulated-body forward-dynamics hot path.
+  const Skeleton* skel = mSkeletonRawPtr;
   if (skel && CHECK_FLAG(mArticulatedInertia))
     skel->updateArticulatedInertia(mTreeIndex);
 
@@ -643,7 +646,7 @@ const math::Inertia& BodyNode::getArticulatedInertia() const
 //==============================================================================
 const math::Inertia& BodyNode::getArticulatedInertiaImplicit() const
 {
-  const ConstSkeletonPtr& skel = getSkeleton();
+  const Skeleton* skel = mSkeletonRawPtr;
   if (skel && CHECK_FLAG(mArticulatedInertia))
     skel->updateArticulatedInertia(mTreeIndex);
 
@@ -1497,6 +1500,7 @@ Node* BodyNode::cloneNode(BodyNode* /*bn*/) const
 void BodyNode::init(const SkeletonPtr& _skeleton)
 {
   mSkeleton = _skeleton;
+  mSkeletonRawPtr = _skeleton.get();
   DART_ASSERT(_skeleton);
   if (mReferenceCount > 0) {
     mReferenceSkeleton = mSkeleton.lock();

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -1140,6 +1140,14 @@ protected:
   /// Index of this BodyNode's tree
   std::size_t mTreeIndex;
 
+  /// Non-owning cache of the Skeleton this BodyNode belongs to. Mirrors
+  /// mSkeleton (the weak_ptr in SkeletonRefCountingBase) as a raw pointer so
+  /// the hot articulated-inertia accessors can reach the tree's dirty flags
+  /// without a weak_ptr::lock() (an atomic refcount operation) on every call.
+  /// Set in init(); the owning Skeleton outlives its BodyNodes, so the pointer
+  /// stays valid for as long as this BodyNode is alive.
+  Skeleton* mSkeletonRawPtr{nullptr};
+
   /// Parent joint
   Joint* mParentJoint;
 

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -1837,7 +1837,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaToDynamic(
   JacobianMatrix AIS = childArtInertia * getRelativeJacobianStatic();
   Eigen::Matrix6d PI = childArtInertia;
   PI.noalias() -= AIS * mInvProjArtInertia * AIS.transpose();
-  if (math::isNan(PI) || math::isInf(PI)) {
+  if (!PI.allFinite()) {
     dtwarn << "[GenericJoint::addChildArtInertiaToDynamic] Non-finite "
               "articulated inertia detected for joint ["
            << this->getName() << "]. Skipping child inertia contribution.\n";
@@ -1848,7 +1848,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaToDynamic(
   // Note that mT should be updated.
   const Eigen::Matrix6d contribution
       = math::transformInertia(this->getRelativeTransform().inverse(), PI);
-  if (math::isNan(contribution) || math::isInf(contribution)) {
+  if (!contribution.allFinite()) {
     dtwarn << "[GenericJoint::addChildArtInertiaToDynamic] Non-finite "
               "transformed inertia detected for joint ["
            << this->getName() << "]. Skipping child inertia contribution.\n";
@@ -1866,7 +1866,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaToKinematic(
   // Note that mT should be updated.
   const Eigen::Matrix6d contribution = math::transformInertia(
       this->getRelativeTransform().inverse(), childArtInertia);
-  if (math::isNan(contribution) || math::isInf(contribution)) {
+  if (!contribution.allFinite()) {
     dtwarn << "[GenericJoint::addChildArtInertiaToKinematic] Non-finite "
               "transformed inertia detected for joint ["
            << this->getName() << "]. Skipping child inertia contribution.\n";
@@ -1907,7 +1907,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaImplicitToDynamic(
   JacobianMatrix AIS = childArtInertia * getRelativeJacobianStatic();
   Eigen::Matrix6d PI = childArtInertia;
   PI.noalias() -= AIS * mInvProjArtInertiaImplicit * AIS.transpose();
-  if (math::isNan(PI) || math::isInf(PI)) {
+  if (!PI.allFinite()) {
     dtwarn << "[GenericJoint::addChildArtInertiaImplicitToDynamic] Non-finite "
               "articulated inertia detected for joint ["
            << this->getName() << "]. Skipping child inertia contribution.\n";
@@ -1918,7 +1918,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaImplicitToDynamic(
   // Note that mT should be updated.
   const Eigen::Matrix6d contribution
       = math::transformInertia(this->getRelativeTransform().inverse(), PI);
-  if (math::isNan(contribution) || math::isInf(contribution)) {
+  if (!contribution.allFinite()) {
     dtwarn << "[GenericJoint::addChildArtInertiaImplicitToDynamic] Non-finite "
               "transformed inertia detected for joint ["
            << this->getName() << "]. Skipping child inertia contribution.\n";
@@ -1936,7 +1936,7 @@ void GenericJoint<ConfigSpaceT>::addChildArtInertiaImplicitToKinematic(
   // Note that mT should be updated.
   const Eigen::Matrix6d contribution = math::transformInertia(
       this->getRelativeTransform().inverse(), childArtInertia);
-  if (math::isNan(contribution) || math::isInf(contribution)) {
+  if (!contribution.allFinite()) {
     dtwarn
         << "[GenericJoint::addChildArtInertiaImplicitToKinematic] Non-finite "
            "transformed inertia detected for joint ["
@@ -1982,7 +1982,7 @@ void GenericJoint<ConfigSpaceT>::updateInvProjArtInertiaDynamic(
   mInvProjArtInertia = math::inverse<ConfigSpaceT>(projAI);
 
   // Verification
-  if (math::isNan(mInvProjArtInertia) || math::isInf(mInvProjArtInertia)) {
+  if (!mInvProjArtInertia.allFinite()) {
     dtwarn
         << "[GenericJoint::updateInvProjArtInertiaDynamic] Non-finite inverse "
            "projected articulated inertia detected for joint ["
@@ -2111,7 +2111,7 @@ void GenericJoint<ConfigSpaceT>::addChildBiasForceToDynamic(
   //    getInvProjArtInertiaImplicit() * mTotalForce;
 
   // Verification
-  if (math::isNan(beta) || math::isInf(beta)) {
+  if (!beta.allFinite()) {
     dtwarn << "[GenericJoint::addChildBiasForceToDynamic] Non-finite bias "
               "force detected for joint ["
            << this->getName() << "]. Skipping bias force contribution.\n";
@@ -2364,7 +2364,7 @@ void GenericJoint<ConfigSpaceT>::updateAccelerationDynamic(
 
   // Guard: check for non-finite values BEFORE calling the setter, which
   // asserts finiteness (assertFiniteState) under debug builds.
-  if (math::isNan(accelerations) || math::isInf(accelerations)) {
+  if (!accelerations.allFinite()) {
     dtwarn << "[GenericJoint::updateAccelerationDynamic] Non-finite joint "
               "accelerations detected for joint ["
            << this->getName()

--- a/dart/math/Helpers.hpp
+++ b/dart/math/Helpers.hpp
@@ -189,15 +189,17 @@ inline bool isNan(double _v)
 #endif
 }
 
-/// \brief Returns whether _m is a NaN (Not-A-Number) matrix
-inline bool isNan(const Eigen::MatrixXd& _m)
+/// \brief Returns whether any entry of _m is a NaN (Not-A-Number) value.
+///
+/// Templated on the Eigen expression type so that fixed-size matrices (e.g.
+/// Eigen::Matrix6d) bind directly instead of being converted to a dynamic
+/// Eigen::MatrixXd, which would heap-allocate a temporary on every call. This
+/// matters because the articulated-body dynamics and constraint solver call
+/// isNan/isInf on small fixed-size matrices in their inner loops.
+template <typename Derived>
+inline bool isNan(const Eigen::MatrixBase<Derived>& _m)
 {
-  for (int i = 0; i < _m.rows(); ++i)
-    for (int j = 0; j < _m.cols(); ++j)
-      if (isNan(_m(i, j)))
-        return true;
-
-  return false;
+  return _m.hasNaN();
 }
 
 /// \brief Returns whether _v is an infinity value (either positive infinity or
@@ -211,16 +213,13 @@ inline bool isInf(double _v)
 #endif
 }
 
-/// \brief Returns whether _m is an infinity matrix (either positive infinity or
-/// negative infinity).
-inline bool isInf(const Eigen::MatrixXd& _m)
+/// \brief Returns whether any entry of _m is an infinity value (positive or
+/// negative). Templated for the same fixed-size, allocation-free reason as the
+/// isNan() matrix overload above.
+template <typename Derived>
+inline bool isInf(const Eigen::MatrixBase<Derived>& _m)
 {
-  for (int i = 0; i < _m.rows(); ++i)
-    for (int j = 0; j < _m.cols(); ++j)
-      if (isInf(_m(i, j)))
-        return true;
-
-  return false;
+  return _m.array().isInf().any();
 }
 
 /// \brief Returns whether _m is symmetric or not


### PR DESCRIPTION
## Summary

`perf`-driven optimization of the articulated-body forward-dynamics (ABA) hot
path — the core of every `world->step()`. Two bit-exact, API-compatible changes
make the `BM_Dynamics` benchmark **~1.22× faster (18%)**, with the full
100-test suite passing.

This is follow-on dynamics work after the boxes/contact optimization in #3023;
it targets the pure-dynamics path that the boxes work deliberately did not
touch.

## Backward compatibility (gz-physics)

Public/virtual API is unchanged: one new **private** `BodyNode` member, and
`math::isNan`/`isInf` are templated but still accept `Eigen::MatrixXd` (existing
calls compile unchanged). Source- and link-compatible after a normal rebuild;
the per-minor SONAME covers the `BodyNode` layout change.

## Methodology

Profiled `BM_Dynamics` with `perf` (function-level sampling — zone profiling
distorts the tight ABA recursion). Before/after measured by **A/B-interleaving**
a frozen baseline against the optimized build on a pinned core (the ratio is
robust to CPU frequency scaling and background load), gated on `ctest`.

## Changes

**1. Cache a raw `Skeleton` pointer in `BodyNode` (avoid `weak_ptr::lock()` in
the ABA accessors).** `getArticulatedInertia()` / `…Implicit()` ran
`getSkeleton() == mSkeleton.lock()` — an atomic refcount operation — per body
per step, purely to reach a dirty flag that lives in the skeleton's tree cache.
perf attributed ~8.5% of `BM_Dynamics` to these two accessors. Cache a
non-owning raw pointer set once in `init()` (the sole assignment site); the
skeleton owns and outlives its bodies, so the pointer stays valid. Behavior is
unchanged. After: both accessors drop out of the hot list.

**2. Template `math::isNan`/`isInf` to avoid allocating on fixed-size matrices.**
The matrix overloads took `const Eigen::MatrixXd&`, so every fixed-size call —
e.g. `isNan(Matrix6d)` in `GenericJoint::addChildArtInertia(Implicit)ToDynamic`,
4× per body per step — implicitly converted to a dynamic `MatrixXd`, a heap
allocation. perf attributed ~6% to `malloc`/`free` plus the
`MatrixXd`-from-`6×6` conversion-construction. Template both on
`Eigen::MatrixBase<Derived>` (fixed-size, expressions, and `MatrixXd` all bind
with no conversion) using Eigen's vectorized `hasNaN()`/`isInf()`.

## Results (`BM_Dynamics/1000`, A/B interleaved, before → after)

~706 ms → ~577 ms per benchmark iteration = **1.22× (18.3% faster)**, ratios
1.13–1.25× across 7 reps. In the perf profile, `getArticulatedInertia` /
`…Implicit` and `malloc`/`free`/`MatrixXd`-from-`6×6` all disappear from the hot
list; the remaining cost is the irreducible spatial algebra (`transformInertia`,
`AdInvT`).

## Correctness

All **100** `ctest` cases pass (dynamics, constraint, collision, kinematics,
integration, math, regression). Both changes are bit-exact: the cached pointer
returns the same `Skeleton`, and the templated `isNan`/`isInf` return the same
result as the loops they replace.
