### PR TITLE
Loosen Issue1184 resting-accuracy tolerance for cross-platform FP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## DART 6
 
+### [DART 6.19.1 (TBD)](https://github.com/dartsim/dart/milestone/98?closed=1)
+
+* Tests
+
+  * Loosen the `Issue1184` resting-accuracy regression tolerance from `1e-3` to
+    `2e-3` so it is not flipped by micrometer-scale cross-platform
+    floating-point differences in the steady-state contact penetration (~1 mm),
+    which sat exactly on the old bound; fixes the macOS build of the
+    conda-forge feedstock:
+    [#3031](https://github.com/dartsim/dart/pull/3031)
+
 ### [DART 6.19.0 (2026-06-14)](https://github.com/dartsim/dart/milestone/97?closed=1)
 
 DART 6.19.0 is a minor release on the DART 6 LTS line. It adds automatic body

--- a/tests/regression/test_Issue1184.cpp
+++ b/tests/regression/test_Issue1184.cpp
@@ -79,20 +79,27 @@ TEST(Issue1184, Accuracy)
     return std::make_shared<dart::dynamics::SphereShape>(s);
   };
 
+  // `tolerance` below bounds the allowed error between the object's resting
+  // height and its half-size. A resting object sits ~1 mm into the ground
+  // (DART's steady-state contact penetration), which is right at the old 1e-3
+  // bound; use 2e-3 so small cross-platform floating-point differences near
+  // that bound do not flip the assertion, while still catching real failures
+  // (fall-through / not-settling is centimeter-scale). See
+  // https://github.com/dartsim/dart/issues/1184.
 #if DART_BUILD_MODE_DEBUG
   const auto groundInfoFunctions = {makePlaneGround};
   const auto objectShapeFunctions = {makeSphereObject};
   const auto halfsizes = {10.0};
   const auto fallingModes = {true};
   const double dropHeight = 0.1;
-  const double tolerance = 1e-3;
+  const double tolerance = 2e-3;
 #else
   const auto groundInfoFunctions = {makePlaneGround, makeBoxGround};
   const auto objectShapeFunctions = {makeBoxObject, makeSphereObject};
   const auto halfsizes = {0.25, 1.0, 5.0, 10.0, 20.0};
   const auto fallingModes = {true, false};
   const double dropHeight = 1.0;
-  const double tolerance = 1e-3;
+  const double tolerance = 2e-3;
 #endif
 
   for (const auto& groundInfoFunction : groundInfoFunctions) {


### PR DESCRIPTION
## Problem

`test_Issue1184` (`Issue1184.Accuracy`) drops an object onto a ground plane and
asserts the settled resting height equals the object's half-size within
`tolerance = 1e-3`. But a resting object sits ~1 mm into the ground — DART's
steady-state contact penetration — which lands **exactly on** the 1e-3 bound.
Small cross-platform floating-point differences then flip the assertion: on
macOS the object settles ~5e-7 *over* 1e-3 and the test fails, while it passes
on all Linux arches.

This surfaced as the only failure in the macOS build of the conda-forge
feedstock's v6.19.0 bump (conda-forge/dartsim-feedstock#172), which currently
skips the test on osx as a workaround.

## Fix

Loosen `tolerance` from `1e-3` to `2e-3` (both the Debug and Release
configuration paths in the test), with a comment explaining why. This is a
test-only change — no library/behavior change. 2e-3 still rejects genuine
failures, since fall-through or failure-to-settle produces centimeter-scale
errors, far larger than the ~1 mm resting penetration.

## Notes

- The test exists only on the DART 6.x line (`release-6.19`); `main` (DART 7)
  does not carry it, so no forward-port is needed.
- Once released in 6.19.1, the feedstock can drop its osx `-E test_Issue1184`
  skip.