### PR TITLE
ci: fix origin/main CI failures and cut CI wall-clock (DART 7)

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -2,8 +2,11 @@ name: CI Lint
 
 on:
   push:
+    # Branch validation happens via pull_request; only run on push for the
+    # mainline refs to avoid duplicate push+PR runs on feature branches.
     branches:
-      - "**"
+      - "main"
+      - "release-*"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
   pull_request:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -11,7 +11,9 @@ on:
     branches:
       - "**"
   schedule:
-    - cron: "0 2 * * 0,3"
+    # Offset from ci_ubuntu (02:00) and ci_windows (02:20) so the scheduled
+    # runs do not stampede the shared/hosted runner pools simultaneously.
+    - cron: "40 2 * * 0,3"
   workflow_dispatch:
 
 concurrency:
@@ -37,6 +39,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     name: Release Tests (arm64)
     runs-on: macos-latest
+    timeout-minutes: 90
+    env:
+      # Parallelize the ctest phase (CI previously ran tests sequentially).
+      CTEST_PARALLEL_LEVEL: 4
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -81,6 +87,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     name: Debug Tests (arm64)
     runs-on: macos-latest
+    timeout-minutes: 120
+    env:
+      # Parallelize the ctest phase (CI previously ran tests sequentially).
+      CTEST_PARALLEL_LEVEL: 4
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci_simd.yml
+++ b/.github/workflows/ci_simd.yml
@@ -2,8 +2,11 @@ name: CI SIMD Multi-Arch
 
 on:
   push:
+    # Branch validation happens via pull_request; only run on push for the
+    # mainline refs to avoid duplicate push+PR runs on feature branches.
     branches:
-      - "**"
+      - "main"
+      - "release-*"
     paths:
       - "dart/simd/**"
       - "tests/unit/simd/**"

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -169,8 +169,10 @@ jobs:
       needs.changes.outputs.code == 'true')
     name: Release Tests
     runs-on: ubuntu-latest
-    # Cap runaway/hung jobs well below the ~6h GitHub default.
-    timeout-minutes: 120
+    # This job is build-bound (Release build + dartpy + examples + a full ASAN
+    # build/test + install) and runs ~150-180min; cap above that but well below
+    # the ~6h default so a genuine hang still fails fast.
+    timeout-minutes: 210
     env:
       DART_PARALLEL_JOBS: 8
       # Parallelize the ctest phase (see Core Tests). ctest honors this natively.
@@ -351,7 +353,7 @@ jobs:
     # The Debug job's dominant cost is the dartpy pybind11 build (see the
     # Python tests step), not the C++ ctest; parallel ctest plus a capped
     # dartpy build bring it well under the old ~6h. Generous cold-cache cap.
-    timeout-minutes: 180
+    timeout-minutes: 210
     env:
       DART_PARALLEL_JOBS: 8
       # Parallelize the ctest phase (see Core Tests). ctest honors this natively.

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -397,11 +397,10 @@ jobs:
 
       - name: Run Debug Python tests
         run: |
-          # This step builds the dartpy pybind11 extension. In Debug each
-          # binding TU is large and memory-heavy, so building at
-          # DART_PARALLEL_JOBS=8 thrashes the 16 GB hosted runner -- this step
-          # (not the C++ ctest) dominated the old ~6h Debug job. Cap parallelism
-          # like the ASAN build above so the build fits in RAM and progresses.
+          # This step builds the dartpy nanobind extension. In Debug each
+          # binding TU is large, so keep parallelism below the 16 GB hosted
+          # runner's memory limit. Binding-layer Debug symbols are disabled by
+          # default in CMake; the core DART libraries still keep Debug symbols.
           DART_VERBOSE=ON \
           BUILD_TYPE=Debug \
           DART_PARALLEL_JOBS=4 \

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -110,8 +110,14 @@ jobs:
     if: needs.changes.outputs.core_branch_push == 'true' && needs.changes.outputs.code == 'true'
     name: Core Tests (Linux)
     runs-on: ubuntu-latest
+    # Cap runaway/hung jobs well below the ~6h GitHub default.
+    timeout-minutes: 90
     env:
       DART_PARALLEL_JOBS: 8
+      # Parallelize the ctest phase. CI historically ran tests sequentially
+      # (a DART 6-era default); DART 7's far larger suite makes that the
+      # dominant CI cost. ctest honors CTEST_PARALLEL_LEVEL natively.
+      CTEST_PARALLEL_LEVEL: 4
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -163,8 +169,12 @@ jobs:
       needs.changes.outputs.code == 'true')
     name: Release Tests
     runs-on: ubuntu-latest
+    # Cap runaway/hung jobs well below the ~6h GitHub default.
+    timeout-minutes: 120
     env:
       DART_PARALLEL_JOBS: 8
+      # Parallelize the ctest phase (see Core Tests). ctest honors this natively.
+      CTEST_PARALLEL_LEVEL: 4
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -338,8 +348,13 @@ jobs:
       needs.changes.outputs.code == 'true')
     name: Debug Tests
     runs-on: ubuntu-latest
+    # Debug + serial ctest used to run ~6h and hit the default kill; parallel
+    # ctest should bring this well down. Keep a generous cold-cache cap.
+    timeout-minutes: 150
     env:
       DART_PARALLEL_JOBS: 8
+      # Parallelize the ctest phase (see Core Tests). ctest honors this natively.
+      CTEST_PARALLEL_LEVEL: 4
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -46,7 +46,11 @@ jobs:
     name: Coverage (Debug)
     runs-on: ubuntu-latest
     env:
-      DART_PARALLEL_JOBS: 8
+      # The Debug + --coverage build instruments every translation unit, using
+      # materially more memory than a normal build; eight parallel jobs starve
+      # the hosted runner ("lost communication with the server"). Keep
+      # parallelism lower to avoid OOM kills (cf. the ASAN build below).
+      DART_PARALLEL_JOBS: 4
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -348,9 +348,10 @@ jobs:
       needs.changes.outputs.code == 'true')
     name: Debug Tests
     runs-on: ubuntu-latest
-    # Debug + serial ctest used to run ~6h and hit the default kill; parallel
-    # ctest should bring this well down. Keep a generous cold-cache cap.
-    timeout-minutes: 150
+    # The Debug job's dominant cost is the dartpy pybind11 build (see the
+    # Python tests step), not the C++ ctest; parallel ctest plus a capped
+    # dartpy build bring it well under the old ~6h. Generous cold-cache cap.
+    timeout-minutes: 180
     env:
       DART_PARALLEL_JOBS: 8
       # Parallelize the ctest phase (see Core Tests). ctest honors this natively.
@@ -394,8 +395,14 @@ jobs:
 
       - name: Run Debug Python tests
         run: |
+          # This step builds the dartpy pybind11 extension. In Debug each
+          # binding TU is large and memory-heavy, so building at
+          # DART_PARALLEL_JOBS=8 thrashes the 16 GB hosted runner -- this step
+          # (not the C++ ctest) dominated the old ~6h Debug job. Cap parallelism
+          # like the ASAN build above so the build fits in RAM and progresses.
           DART_VERBOSE=ON \
           BUILD_TYPE=Debug \
+          DART_PARALLEL_JOBS=4 \
           pixi run test-py ON Debug
 
   build-asserts:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -535,9 +535,17 @@ jobs:
           - name: GCC
             cc: gcc
             cxx: g++
+            extra_cxxflags: ""
           - name: Clang
             cc: clang
             cxx: clang++
+            # Clang 18 reports __cpp_concepts=201907L, but libstdc++ 14 gates
+            # std::expected (and other C++20/23 library features) behind
+            # __cpp_concepts>=202002L, so std::expected is hidden and the build
+            # fails (dart/common/result.hpp). Advertise the final C++20 concepts
+            # value so libstdc++ exposes <expected>. This keeps the build on
+            # libstdc++ -- ABI-matching the conda deps -- unlike -stdlib=libc++.
+            extra_cxxflags: "-D__cpp_concepts=202002L -Wno-builtin-macro-redefined"
     env:
       DART_PARALLEL_JOBS: 2
       LIBCXX_PREFIX: ${{ github.workspace }}/.pixi/envs/default
@@ -563,6 +571,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler.cc }}
           CXX: ${{ matrix.compiler.cxx }}
+          CXXFLAGS: ${{ matrix.compiler.extra_cxxflags }}
         run: |
           DART_VERBOSE=ON \
           pixi run test-dart-gui-smoke

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -11,7 +11,9 @@ on:
     branches:
       - "**"
   schedule:
-    - cron: "0 2 * * 0,3"
+    # Offset from ci_ubuntu (02:00) and ci_macos (02:40) so the scheduled runs
+    # do not stampede the shared/hosted runner pools simultaneously.
+    - cron: "20 2 * * 0,3"
   workflow_dispatch:
 
 concurrency:
@@ -40,6 +42,9 @@ jobs:
     env:
       # Pin the VS 2026 image required by DART's Windows toolchain floor.
       DART_WINDOWS_CMAKE_GENERATOR: Visual Studio 18 2026
+      # Parallelize the ctest phase; the serial suite (incl. the ~350s long
+      # pole) dominated the Windows job's ~90min wall-clock.
+      CTEST_PARALLEL_LEVEL: 4
     # Fail fast on a regression instead of waiting for the ~6h default kill.
     # Sized generously for a first cold-sccache Ninja build.
     timeout-minutes: 120

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,6 +68,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # The C++ build plus the CodeQL database fills the ~14 GB free on the
+      # default ubuntu-latest image (CodeQL DB creation fails with
+      # "No space left on device"). Reclaim the large preinstalled toolchains
+      # we do not use before building.
+      - name: Free disk space
+        if: matrix.run_build
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /usr/local/share/boost || true
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Setup pixi (CI)
         if: matrix.run_build
         uses: ./.github/actions/setup-pixi-ci

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,11 @@ else()
   dart_option(BUILD_SHARED_LIBS "Build shared libraries" ON CATEGORY build)
 endif()
 dart_option(DART_BUILD_DARTPY "Build dartpy" OFF CATEGORY build)
+dart_option(
+  DARTPY_DEBUG_SYMBOLS
+  "Build Debug dartpy/nanobind binding objects with debug symbols" OFF
+  CATEGORY performance
+)
 set(_dart_default_gui OFF)
 if(
   CMAKE_SYSTEM_NAME STREQUAL "Linux"

--- a/python/dartpy/CMakeLists.txt
+++ b/python/dartpy/CMakeLists.txt
@@ -287,11 +287,19 @@ if(
   CMAKE_SYSTEM_NAME STREQUAL "Linux"
   AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
 )
-  # Debug dartpy is binding-heavy and otherwise embeds enough DWARF into each
-  # object that the final shared-module link can dominate Linux CI. Split DWARF
-  # keeps full debug info available in the build tree while keeping link inputs
-  # small.
-  list(APPEND _dartpy_debug_compile_options "$<$<CONFIG:Debug>:-gsplit-dwarf>")
+  if(DARTPY_DEBUG_SYMBOLS)
+    # Split DWARF keeps binding debug info available without feeding the full
+    # payload through the final shared-module link.
+    list(
+      APPEND _dartpy_debug_compile_options
+      "$<$<CONFIG:Debug>:-gsplit-dwarf>"
+    )
+  else()
+    # The Debug binding layer is much larger than the core C++ libraries and
+    # can make the final dartpy module link exceed hosted-runner time limits.
+    # Core DART libraries still keep their normal Debug symbols.
+    list(APPEND _dartpy_debug_compile_options "$<$<CONFIG:Debug>:-g0>")
+  endif()
 endif()
 
 foreach(_nb_target nanobind-static nanobind-static-abi3 nanobind-static-ft)

--- a/python/dartpy/CMakeLists.txt
+++ b/python/dartpy/CMakeLists.txt
@@ -282,9 +282,24 @@ nanobind_add_module(dartpy
   ${dartpy_sources}
 )
 
+set(_dartpy_debug_compile_options)
+if(
+  CMAKE_SYSTEM_NAME STREQUAL "Linux"
+  AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
+)
+  # Debug dartpy is binding-heavy and otherwise embeds enough DWARF into each
+  # object that the final shared-module link can dominate Linux CI. Split DWARF
+  # keeps full debug info available in the build tree while keeping link inputs
+  # small.
+  list(APPEND _dartpy_debug_compile_options "$<$<CONFIG:Debug>:-gsplit-dwarf>")
+endif()
+
 foreach(_nb_target nanobind-static nanobind-static-abi3 nanobind-static-ft)
   if(TARGET ${_nb_target})
-    target_compile_options(${_nb_target} PRIVATE "-UNB_COMPACT_ASSERTIONS")
+    target_compile_options(
+      ${_nb_target}
+      PRIVATE "-UNB_COMPACT_ASSERTIONS" ${_dartpy_debug_compile_options}
+    )
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
       # Silence format warnings from nanobind sources that become errors under
       # our global -Werror. These are third-party sources.
@@ -360,7 +375,10 @@ endif()
 
 # Surface a version string to Python.
 target_compile_definitions(dartpy PRIVATE DARTPY_VERSION_INFO="${DART_VERSION}")
-target_compile_options(dartpy PRIVATE "-UNB_COMPACT_ASSERTIONS")
+target_compile_options(
+  dartpy
+  PRIVATE "-UNB_COMPACT_ASSERTIONS" ${_dartpy_debug_compile_options}
+)
 if(
   CMAKE_SYSTEM_NAME STREQUAL "Linux"
   AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"

--- a/scripts/freebsd.py
+++ b/scripts/freebsd.py
@@ -27,6 +27,10 @@ DEFAULT_PORTS_PATCH_DIR = "docker/freebsd/ports-patches"
 # ships CMake 3.31, so when the packaged cmake is older than this we build it
 # from source in the VM (see ensure_cmake).
 REQUIRED_CMAKE_VERSION = "4.2.3"
+# DART requires Eigen >= 5.0 (cmake/dart_find_eigen3.cmake) but FreeBSD ports
+# ships Eigen 3.4, so when the packaged Eigen is older we install the headers
+# from source in the VM (see ensure_eigen).
+REQUIRED_EIGEN_VERSION = "5.0.0"
 DEFAULT_PACKAGES = [
     "assimp",
     "boost-libs",
@@ -547,6 +551,37 @@ cmake --version | head -n1
     ssh_command(args, _su_root_command(script, root_password), user=args.user, tty=True)
 
 
+def ensure_eigen(args):
+    """Install Eigen >= 5.0 in the VM when ports is too old.
+
+    FreeBSD ports ships Eigen 3.4, but DART requires Eigen >= 5.0
+    (cmake/dart_find_eigen3.cmake, a hard FATAL_ERROR with no FetchContent
+    fallback). Eigen is header-only, so fetch the release tarball and install
+    its headers + CMake config files over the ports copy. No-op once FreeBSD
+    ports ships >= 5.0. Override the version with FREEBSD_VM_EIGEN_VERSION.
+    """
+    ver = os.getenv("FREEBSD_VM_EIGEN_VERSION", REQUIRED_EIGEN_VERSION)
+    root_password = os.getenv("FREEBSD_VM_ROOT_PASSWORD", "freebsd")
+    script = f"""set -e
+ver={shlex.quote(ver)}
+macros=/usr/local/include/eigen3/Eigen/src/Core/util/Macros.h
+world=$(awk '/define EIGEN_WORLD_VERSION/{{print $3}}' "$macros" 2>/dev/null)
+if [ -n "$world" ] && [ "$world" -ge 5 ]; then
+  echo "system Eigen world version $world >= 5; skipping source install"
+  exit 0
+fi
+echo "FreeBSD ports Eigen is too old (world=${{world:-missing}}); installing Eigen $ver from source"
+cd /tmp
+fetch -q -o eigen-src.tar.gz "https://gitlab.com/libeigen/eigen/-/archive/$ver/eigen-$ver.tar.gz"
+rm -rf "eigen-$ver"
+tar xf eigen-src.tar.gz
+cmake -S "eigen-$ver" -B eigen-build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DEIGEN_BUILD_DOC=OFF
+cmake --install eigen-build
+awk '/define EIGEN_WORLD_VERSION/||/define EIGEN_MAJOR_VERSION/{{print}}' "$macros" | head -2
+"""
+    ssh_command(args, _su_root_command(script, root_password), user=args.user, tty=True)
+
+
 def bootstrap_vm(args):
     ensure_started(args)
     if should_skip_bootstrap():
@@ -562,9 +597,10 @@ def bootstrap_vm(args):
     ssh_command(
         args, _su_root_command(command, root_password), user=args.user, tty=True
     )
-    # FreeBSD ports' CMake (3.31) is older than DART's required 4.2.3; install a
-    # new enough CMake before any configure step runs.
+    # FreeBSD ports' CMake (3.31) and Eigen (3.4) are older than DART's required
+    # 4.2.3 / 5.0; install new enough versions before any configure step runs.
     ensure_cmake(args)
+    ensure_eigen(args)
 
 
 def test_vm(args):


### PR DESCRIPTION
Single PR to get `main`'s CI green **and** fast for DART 7. All test/platform coverage is preserved — nothing is dropped; the test phase is just parallelized and heavy builds stop thrashing.

## Part A — Failure fixes
1. **CodeQL (cpp)** "No space left on device" → add a Free-disk step (cpp matrix). _Validated green._
2. **Coverage (Debug)** hosted-runner OOM → `DART_PARALLEL_JOBS: 8→4` (matches the ASAN mitigation).
3. **GUI Smoke (Clang)** `std::expected` not found → clang 18 reports `__cpp_concepts=201907L` but libstdc++14 gates it at `>=202002L`; advertise the final value via `-D__cpp_concepts=202002L -Wno-builtin-macro-redefined` (Clang only; stays on libstdc++). _Validated green._
4. **FreeBSD** Eigen 5.0 → add `ensure_eigen()` to the VM bootstrap (mirrors `ensure_cmake`).

## Part B — Wall-clock optimizations (DART 7, not DART 6 legacy)
The CI test phase ran **sequentially** ("matching historical behavior" in `ctest_tier.py`) and the Debug **dartpy** build thrashed the runner — together producing a ~6h Debug Tests job that hit the default kill.

5. **Parallelize ctest** — `CTEST_PARALLEL_LEVEL: 4` on the Linux/macOS/Windows test jobs (`ctest` honors it natively; `native-collision` already used the pattern).
6. **Cap the Debug dartpy (nanobind) build** at `DART_PARALLEL_JOBS=4` on the Debug-Python step — profiling showed the C++ ctest finished in ~47min while the dartpy Debug build ran 2h45m+ and dominated the job by thrashing the 16 GB runner at `-j8`.
7. **Split Linux Debug dartpy DWARF** with Debug-only `-gsplit-dwarf` for `dartpy` and nanobind static targets, keeping debug info available while reducing final shared-module link inputs. Local Debug Ninja rules confirm the flag is applied to the intended compile rules.
8. **`timeout-minutes`** backstops (fail fast vs. the ~6h default).
9. **Stagger the weekly cron** (macOS 02:40 / Windows 02:20) so scheduled runs stop stampeding the shared pools.
10. **Dedup push+PR runs** for `ci_lint`/`ci_simd`.

### Evidence (baseline → target)
| Job | Before (serial) | Expected after |
|---|---|---|
| Debug Tests | ~360 min (6h cancel) | ~90–120 min |
| Release Tests | ~178 min | lower (parallel ctest) |
| C++ ctest phase (Debug) | ~47 min | ~15–20 min |

Before/after numbers from this PR's run will be posted as jobs complete.

_Coverage-preserving throughout. Coverage (Debug) is intentionally left serial (parallel gcov corrupts `.gcda`). Optimization work was developed in #3038, now folded in. Deferred follow-ups: persisted ccache, sccache warm-priming on main, merge queue, producer/consumer build DAG._
