### PR TITLE
Remove per-pivot heap allocation in ContactConstraint (boxes ~6% faster, bit-exact)

### DIFF
--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -584,11 +584,18 @@ void ContactConstraint::getVelocityChange(double* vel, bool withCfm)
   Eigen::Map<Eigen::VectorXd> velMap(vel, static_cast<int>(mDim));
   velMap.setZero();
 
+  // noalias(): the destination (velMap over the caller's buffer) does not alias
+  // the operands, so Eigen evaluates the matrix-vector product directly into
+  // it. mSpatialNormalA has dynamic column count, so without this the product
+  // is materialized into a heap-allocated temporary on every call -- and this
+  // is the LCP solver's hottest per-pivot routine.
   if (mIsReactiveA && mSkeletonA->isImpulseApplied())
-    velMap += mSpatialNormalA.transpose() * mBodyNodeA->getBodyVelocityChange();
+    velMap.noalias()
+        += mSpatialNormalA.transpose() * mBodyNodeA->getBodyVelocityChange();
 
   if (mIsReactiveB && mSkeletonB->isImpulseApplied())
-    velMap += mSpatialNormalB.transpose() * mBodyNodeB->getBodyVelocityChange();
+    velMap.noalias()
+        += mSpatialNormalB.transpose() * mBodyNodeB->getBodyVelocityChange();
 
   // Add small values to the diagnal to keep it away from singular, similar to
   // cfm variable in ODE
@@ -703,8 +710,12 @@ void ContactConstraint::getRelVelocity(double* relVel)
 
   Eigen::Map<Eigen::VectorXd> relVelMap(relVel, static_cast<int>(mDim));
   relVelMap.setZero();
-  relVelMap -= mSpatialNormalA.transpose() * mBodyNodeA->getSpatialVelocity();
-  relVelMap -= mSpatialNormalB.transpose() * mBodyNodeB->getSpatialVelocity();
+  // noalias(): evaluate the dynamic-sized product directly into the caller's
+  // buffer instead of a heap-allocated temporary (see getVelocityChange).
+  relVelMap.noalias()
+      -= mSpatialNormalA.transpose() * mBodyNodeA->getSpatialVelocity();
+  relVelMap.noalias()
+      -= mSpatialNormalB.transpose() * mBodyNodeB->getSpatialVelocity();
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

Removes the single largest source of per-step heap churn in the contact
constraint hot path. In a contact-heavy scene (`boxes`), `world->step()`
allocated **~4,700 heap blocks per step at 125 boxes** (≈38k at 512), and an
allocation-attribution profile showed **~81% of those come from DART code, 0%
from Bullet** — so this is squarely a DART-side problem. A single routine,
`ContactConstraint::getVelocityChange`, accounted for **~51% of all per-step
allocations**.

This is follow-on work after the constraint-solver (#3023) and ABA
forward-dynamics (#3028) hot-path optimizations; it targets per-step *allocation*
rather than arithmetic.

## Root cause

`getVelocityChange` (the LCP solver's hottest per-pivot routine) and its sibling
`getRelVelocity` compute, per call:

```cpp
velMap += mSpatialNormalA.transpose() * mBodyNodeA->getBodyVelocityChange();
```

`mSpatialNormalA` is `Eigen::Matrix<double, 6, Eigen::Dynamic>`, so the product
type is dynamic-sized. Without `noalias()`, Eigen materializes the product into a
**heap-allocated temporary** before the compound assignment — on every call, deep
inside the Dantzig/PGS pivot loop.

## Change

Add `.noalias()` to the four matrix-vector accumulations in `getVelocityChange`
and `getRelVelocity`. Eigen then evaluates the gemv directly into the caller's
output buffer (`velMap` / `relVelMap`, an `Eigen::Map` over a plain `double*`),
with no temporary. This is **bit-exact**: the destination buffer does not alias
`mSpatialNormal*` or the body velocity, so eliminating the temporary cannot
change the result.

## Backward compatibility (gz-physics)

No API/ABI change: the edit is entirely inside two `.cpp` method bodies. Public
signatures, class layout, and behavior are unchanged.

## Results

- **Allocations:** `boxes` (125 boxes) per-step heap allocations drop
  **4,736 → 2,006 (−57.6%)**; the libdart share drops 3,844 → 1,114/step
  (−71%). `ContactConstraint::getVelocityChange` disappears from the allocation
  profile entirely (it was ~51% of all per-step allocations).
- **Wall-clock:** `boxes` A/B (216 boxes, 1500 steps, 9 interleaved reps, pinned
  core): **median 1.06× (5.7% faster)**; every rep is faster (ratios
  1.03–1.14×).
- **Correctness:** full **100/100 `ctest`** suite passes; the `boxes` step
  checksum is **bit-for-bit identical** before and after
  (`098c47a9e2262a2e`).

## Methodology

Per-step allocation counts measured with an `LD_PRELOAD` malloc shim
(deterministic, load-independent) bracketing the step loop after warmup;
call-site attribution via `backtrace`+`dladdr` per allocation. Wall-clock by
A/B-interleaving the baseline and patched `libdart` (selected via
`LD_LIBRARY_PATH`) on a pinned core, gated on a bit-for-bit state checksum.
