### PR TITLE
ci(gui-smoke): fix Clang std::expected build (libstdc++ concepts-macro gap)

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -555,6 +555,33 @@ jobs:
       - name: Configure environment for compiler cache
         uses: ./.github/actions/configure-compiler-cache
 
+      # Diagnostic only: the Clang variant fails to find std::expected. Print
+      # how the compiler resolves the C++ standard library inside the pixi env
+      # so the real fix can be grounded in evidence rather than guesswork.
+      # Read-only and continue-on-error so it never affects the job result.
+      - name: Diagnose Clang stdlib resolution
+        if: matrix.compiler.name == 'Clang'
+        continue-on-error: true
+        env:
+          CC: ${{ matrix.compiler.cc }}
+          CXX: ${{ matrix.compiler.cxx }}
+        run: |
+          pixi run bash -c '
+            set -x
+            command -v "$CXX"; "$CXX" --version
+            printf "#include <expected>\nstd::expected<int,int> e{1};\nint main(){ return e.has_value() ? 0 : 1; }\n" > /tmp/exp.cpp
+            echo "== include search list (-v) =="
+            "$CXX" -std=gnu++23 -v -c /tmp/exp.cpp -o /tmp/exp.o 2>&1 | sed -n "/search starts here/,/End of search list/p" || true
+            echo "== std::expected compile result =="
+            "$CXX" -std=gnu++23 -c /tmp/exp.cpp -o /tmp/exp.o && echo "std::expected OK" || echo "std::expected FAILED"
+            echo "== key feature macros =="
+            "$CXX" -dM -E -std=gnu++23 -x c++ /dev/null | grep -iE "cpp_concepts|cpp_lib_expected|_LIBCPP_VERSION|GLIBCXX|__cplusplus" || true
+            echo "== toolchains visible =="
+            ls -d /usr/include/c++/* /usr/lib/gcc/x86_64-linux-gnu/* 2>/dev/null || true
+            ls -d "$PWD"/.pixi/envs/default/include/c++/* 2>/dev/null || echo "(no conda c++ headers)"
+            ls "$PWD"/.pixi/envs/default/bin/*g++* "$PWD"/.pixi/envs/default/bin/*clang* 2>/dev/null || echo "(no conda compilers in env)"
+          '
+
       - name: Build and run DART GUI smoke tests
         env:
           CC: ${{ matrix.compiler.cc }}

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -531,9 +531,17 @@ jobs:
           - name: GCC
             cc: gcc
             cxx: g++
+            extra_cxxflags: ""
           - name: Clang
             cc: clang
             cxx: clang++
+            # Clang 18 reports __cpp_concepts=201907L, but libstdc++ 14 gates
+            # std::expected (and other C++20/23 library features) behind
+            # __cpp_concepts>=202002L, so std::expected is hidden and the build
+            # fails (dart/common/result.hpp). Advertise the final C++20 concepts
+            # value so libstdc++ exposes <expected>. This keeps the build on
+            # libstdc++ -- ABI-matching the conda deps -- unlike -stdlib=libc++.
+            extra_cxxflags: "-D__cpp_concepts=202002L -Wno-builtin-macro-redefined"
     env:
       DART_PARALLEL_JOBS: 2
       LIBCXX_PREFIX: ${{ github.workspace }}/.pixi/envs/default
@@ -555,37 +563,11 @@ jobs:
       - name: Configure environment for compiler cache
         uses: ./.github/actions/configure-compiler-cache
 
-      # Diagnostic only: the Clang variant fails to find std::expected. Print
-      # how the compiler resolves the C++ standard library inside the pixi env
-      # so the real fix can be grounded in evidence rather than guesswork.
-      # Read-only and continue-on-error so it never affects the job result.
-      - name: Diagnose Clang stdlib resolution
-        if: matrix.compiler.name == 'Clang'
-        continue-on-error: true
-        env:
-          CC: ${{ matrix.compiler.cc }}
-          CXX: ${{ matrix.compiler.cxx }}
-        run: |
-          pixi run bash -c '
-            set -x
-            command -v "$CXX"; "$CXX" --version
-            printf "#include <expected>\nstd::expected<int,int> e{1};\nint main(){ return e.has_value() ? 0 : 1; }\n" > /tmp/exp.cpp
-            echo "== include search list (-v) =="
-            "$CXX" -std=gnu++23 -v -c /tmp/exp.cpp -o /tmp/exp.o 2>&1 | sed -n "/search starts here/,/End of search list/p" || true
-            echo "== std::expected compile result =="
-            "$CXX" -std=gnu++23 -c /tmp/exp.cpp -o /tmp/exp.o && echo "std::expected OK" || echo "std::expected FAILED"
-            echo "== key feature macros =="
-            "$CXX" -dM -E -std=gnu++23 -x c++ /dev/null | grep -iE "cpp_concepts|cpp_lib_expected|_LIBCPP_VERSION|GLIBCXX|__cplusplus" || true
-            echo "== toolchains visible =="
-            ls -d /usr/include/c++/* /usr/lib/gcc/x86_64-linux-gnu/* 2>/dev/null || true
-            ls -d "$PWD"/.pixi/envs/default/include/c++/* 2>/dev/null || echo "(no conda c++ headers)"
-            ls "$PWD"/.pixi/envs/default/bin/*g++* "$PWD"/.pixi/envs/default/bin/*clang* 2>/dev/null || echo "(no conda compilers in env)"
-          '
-
       - name: Build and run DART GUI smoke tests
         env:
           CC: ${{ matrix.compiler.cc }}
           CXX: ${{ matrix.compiler.cxx }}
+          CXXFLAGS: ${{ matrix.compiler.extra_cxxflags }}
         run: |
           DART_VERBOSE=ON \
           pixi run test-dart-gui-smoke


### PR DESCRIPTION
## Problem

`DART GUI Smoke (Clang)` has been chronically red — clang 18 on `ubuntu-latest` fails to compile `std::expected` (`dart/common/result.hpp`), while the GCC variant passes.

## Root cause (confirmed by an in-CI diagnostic)

```
__cplusplus      = 202302L      # C++23 on
__cpp_concepts   = 201907L      # clang 18 reports the OLD value
__cpp_lib_expected = (undefined)
```

clang 18 uses **libstdc++ 14** (which ships `<expected>`), but libstdc++ gates `std::expected` behind `__cpp_concepts >= 202002L`. Clang 18 conservatively still reports `201907L`, so the guard fails and `std::expected` is hidden. g++ reports `202002L`, which is why the GCC variant builds.

## Fix

For the Clang matrix entry only, advertise the final C++20 concepts value:

```
-D__cpp_concepts=202002L -Wno-builtin-macro-redefined
```

(`-Wno-builtin-macro-redefined` is required because the build uses `-Werror`.) This keeps the build on **libstdc++** — ABI-matching the libstdc++ conda dependencies (sdformat/urdfdom/…) — rather than switching to `-stdlib=libc++`, which would clash at link time. GCC carries an empty flag and is unchanged.

The earlier diagnostic step that established the root cause has been removed; the green Clang job is the proof.