### PR TITLE
Avoid heap temporary in BodyNode force-aggregation routines (bit-exact)

### DIFF
--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -2243,12 +2243,14 @@ void BodyNode::aggregateGravityForceVector(
         (*it)->mParentJoint->getRelativeTransform(), (*it)->mG_F);
   }
 
-  std::size_t nGenCoords = mParentJoint->getNumDofs();
+  const std::size_t nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0) {
-    Eigen::VectorXd g
-        = -(mParentJoint->getRelativeJacobian().transpose() * mG_F);
-    std::size_t iStart = mParentJoint->getIndexInTree(0);
-    _g.segment(iStart, nGenCoords) = g;
+    const std::size_t iStart = mParentJoint->getIndexInTree(0);
+    // noalias() into the destination, then negate in place: bit-identical to
+    // -(J^T * mG_F) (IEEE-754 negation is exact) with no heap temporary.
+    auto seg = _g.segment(iStart, nGenCoords);
+    seg.noalias() = mParentJoint->getRelativeJacobian().transpose() * mG_F;
+    seg = -seg;
   }
 }
 
@@ -2287,12 +2289,12 @@ void BodyNode::aggregateCombinedVector(
     mCg_F += math::dAdInvT((*it)->getParentJoint()->mT, (*it)->mCg_F);
   }
 
-  std::size_t nGenCoords = mParentJoint->getNumDofs();
+  const std::size_t nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0) {
-    Eigen::VectorXd Cg
+    const std::size_t iStart = mParentJoint->getIndexInTree(0);
+    // noalias(): see aggregateExternalForces -- no heap temporary.
+    _Cg.segment(iStart, nGenCoords).noalias()
         = mParentJoint->getRelativeJacobian().transpose() * mCg_F;
-    std::size_t iStart = mParentJoint->getIndexInTree(0);
-    _Cg.segment(iStart, nGenCoords) = Cg;
   }
 }
 
@@ -2308,12 +2310,14 @@ void BodyNode::aggregateExternalForces(Eigen::VectorXd& _Fext)
         (*it)->mParentJoint->getRelativeTransform(), (*it)->mFext_F);
   }
 
-  std::size_t nGenCoords = mParentJoint->getNumDofs();
+  const std::size_t nGenCoords = mParentJoint->getNumDofs();
   if (nGenCoords > 0) {
-    Eigen::VectorXd Fext
+    const std::size_t iStart = mParentJoint->getIndexInTree(0);
+    // noalias(): evaluate the J^T * F product directly into the destination
+    // segment rather than a heap-allocated Eigen temporary. The destination
+    // (a Skeleton tree-cache view) cannot alias mFext_F or the joint Jacobian.
+    _Fext.segment(iStart, nGenCoords).noalias()
         = mParentJoint->getRelativeJacobian().transpose() * mFext_F;
-    std::size_t iStart = mParentJoint->getIndexInTree(0);
-    _Fext.segment(iStart, nGenCoords) = Fext;
   }
 }
 


### PR DESCRIPTION
## Summary

Continues the DART 6.20 per-step allocation-reduction work (after #3033) with the
same proven, bit-exact technique. The three `BodyNode` force-aggregation
routines each evaluated a dynamic-sized Eigen matrix-vector product into a named
`Eigen::VectorXd` local before copying it into the destination tree-cache
segment — a heap allocation per body. `aggregateExternalForces` runs in the
per-step contact path (reached from `Skeleton`'s external-force reads), and the
allocation profiler attributed ~125 heap allocs/step to it on the boxes scene.

## Change

Add `.noalias()` so Eigen evaluates `J.transpose() * F` directly into the
destination `.segment(...)` (a `Block` view over the Skeleton tree-cache vector),
with no temporary:

- `aggregateExternalForces` — the measured per-step win.
- `aggregateCombinedVector` — same one-liner (Coriolis/gravity + mass-matrix path).
- `aggregateGravityForceVector` — same, with an in-place negation
  (`seg.noalias() = J^T*mG_F; seg = -seg;`) since `.noalias()` cannot prefix the
  original `-(...)`; bit-identical because IEEE-754 negation is an exact sign flip.

## Correctness (bit-exact)

`.noalias()` only removes the temporary Eigen conservatively materializes; it
introduces no aliasing — the destination tree-cache segment is a distinct object
from the per-`BodyNode` `Vector6d` operands and the joint Jacobian, and the gemv
reduction order is unchanged. Full **100/100 `ctest`** passes and the boxes-step
state checksum is **bit-for-bit identical** before/after.

## Backward compatibility (gz-physics)

No API/ABI change: all three are `void` methods edited only in their `.cpp`
bodies. No signature, vtable slot, or class-layout change; the `SoftBodyNode`
overrides are untouched. Source- and link-compatible.

## Results

- **Allocations:** boxes (125 boxes) per-step heap allocations
  **2,006 → 1,881 (−125/step, −6.2%)** on top of #3033;
  `BodyNode::aggregateExternalForces` disappears from the allocation profile.
- **Wall-clock:** boxes A/B (216 boxes, 1500 steps, 9 interleaved reps,
  checksum-gated): **neutral within noise** (median ~0.99×, rep ratios
  0.89–1.11). The −125/step allocation delta is below the wall-clock noise floor
  on this benchmark (unlike #3033's −2,730/step). This ships as a deterministic,
  bit-exact allocation reduction, not a measured speedup.
- **Correctness:** 100/100 ctest; bit-for-bit identical boxes checksum.

## Scope / honesty note

These statements still incur a *second* heap allocation: `getRelativeJacobian()`
returns a dynamic-sized `math::Jacobian` (`Matrix<6,Dynamic>`) by value. This PR
removes only the product temporary (per-body allocs 2 → 1); eliminating the
Jacobian-return temporary needs a separate in-place-Jacobian accessor and is a
deliberate follow-up.
