### PR TITLE
Remove per-step allocations in disturbance check + contact normals (boxes -37.7% allocs, ~1.6% faster, bit-exact)

### DIFF
--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -261,11 +261,16 @@ private:
   /// Whether this contact is self-collision.
   bool mIsSelfCollision;
 
-  /// Local body jacobians for mBodyNode1
-  Eigen::Matrix<double, 6, Eigen::Dynamic> mSpatialNormalA;
+  /// Local body jacobians for mBodyNode1. The column count is dynamic (1 for a
+  /// frictionless contact, 3 with friction) but capped at 3, so the matrix uses
+  /// fixed inline storage and the per-contact resize() during construction
+  /// allocates no heap.
+  Eigen::Matrix<double, 6, Eigen::Dynamic, Eigen::ColMajor, 6, 3>
+      mSpatialNormalA;
 
-  /// Local body jacobians for mBodyNode2
-  Eigen::Matrix<double, 6, Eigen::Dynamic> mSpatialNormalB;
+  /// Local body jacobians for mBodyNode2 (see mSpatialNormalA).
+  Eigen::Matrix<double, 6, Eigen::Dynamic, Eigen::ColMajor, 6, 3>
+      mSpatialNormalB;
 
   ///
   bool mIsFrictionOn;

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -3926,14 +3926,33 @@ bool Skeleton::hasExternalDisturbance() const
   // and defeat sleeping.
   const double tolerance = 1e-9;
 
+  // getExternalForces() returns a cached const reference (no allocation).
   if (getExternalForces().cwiseAbs().maxCoeff() > tolerance)
     return true;
 
-  if (getForces().cwiseAbs().maxCoeff() > tolerance)
-    return true;
-
-  if (getCommands().cwiseAbs().maxCoeff() > tolerance)
-    return true;
+  // Scan generalized forces and commands per-DOF instead of materializing
+  // getForces()/getCommands(): each returns an Eigen::VectorXd by value (a heap
+  // allocation) and this runs per mobile skeleton every step. getForces()[i] is
+  // exactly getDof(i)->getForce() (MetaSkeleton::getValuesFromAllDofs), and
+  // `|x| > tol` is `x > tol || x < -tol`, so the disturbance decision is
+  // identical -- just without the temporaries.
+  const std::size_t nDofs = getNumDofs();
+  for (std::size_t i = 0; i < nDofs; ++i) {
+    const DegreeOfFreedom* dof = getDof(i);
+    if (!dof)
+      continue;
+    const double f = dof->getForce();
+    if (f > tolerance || f < -tolerance)
+      return true;
+  }
+  for (std::size_t i = 0; i < nDofs; ++i) {
+    const DegreeOfFreedom* dof = getDof(i);
+    if (!dof)
+      continue;
+    const double c = dof->getCommand();
+    if (c > tolerance || c < -tolerance)
+      return true;
+  }
 
   return false;
 }


### PR DESCRIPTION
## Summary

Bundles the remaining cleanly-removable per-step heap allocators in the
simulation hot path into one bit-exact PR, after #3033 / #3037 took the largest
ones individually. On the contact-heavy boxes scene this cuts per-step heap
allocations **1,881 → 1,171 (−710/step, −37.7%)**, with the libdart share down
**−72%**.

Two independent, bit-exact changes:

### 1. `Skeleton::hasExternalDisturbance`: scan DOFs instead of materializing vectors
This runs per mobile skeleton every step (it gates automatic body deactivation).
It called `getForces().cwiseAbs().maxCoeff()` and `getCommands()...`, each of
which returns an `Eigen::VectorXd` **by value** — a heap allocation per call
(~410 allocs/step on the boxes scene). Replace with a per-DOF scalar scan:
`getForces()[i]` is exactly `getDof(i)->getForce()`
(`MetaSkeleton::getValuesFromAllDofs`), and `|x| > tol` is `x > tol || x < -tol`,
so the disturbance decision is identical — just without the temporaries.
`getExternalForces()` already returns a cached `const&` and is left unchanged.

### 2. `ContactConstraint::mSpatialNormalA/B`: cap the column count for inline storage
These are `Matrix<double, 6, Eigen::Dynamic>` resized to 6×3 (friction) or 6×1
(frictionless) per contact each step — a heap buffer per `resize()` (~300
allocs/step). The column count is always ≤ 3, so change the type to
`Matrix<double, 6, Eigen::Dynamic, Eigen::ColMajor, 6, 3>` (dynamic columns,
`MaxCols = 3`): the matrix now uses fixed inline storage and `resize()` allocates
no heap. Every use site is unchanged (the runtime column count is still dynamic).

## Correctness (bit-exact)

Both changes preserve results exactly for all finite simulation state:
(1) is the identical boolean decision over the same scalar values
(`getForces()[i] == getDof(i)->getForce()`); (2) stores the same numbers with
the same dimensions, only relocating the buffer from heap to inline. Full
**100/100 `ctest`** passes (including `IslandDeactivation`, which exercises the
disturbance gate via 6-DOF free bodies), the boxes-step state checksum is
**bit-for-bit identical** before/after, and a 2,000,000-case fuzz over finite
force/command vectors found zero divergence.

One disclosed, NaN-only difference in (1): `Eigen::maxCoeff()` can be poisoned to
`NaN` by a `NaN` in the reduction-seed position (so a real >tolerance value
elsewhere in the vector is masked and the old code reports *no* disturbance),
whereas the per-DOF scan detects it. This differs only when a force/command
vector literally contains `NaN` — a pathological, already-broken input — and it
affects only the body-sleep/wake gate, never any physics value (the disturbance
flag feeds `setResting`/`setSleepCandidate` only). The new behavior is the more
defensible one (a `NaN` should not silently suppress a real disturbance).

## Backward compatibility (gz-physics)

Change (1) is a `.cpp`-only edit (no API/ABI surface). Change (2) alters a
**private** member's storage of `ContactConstraint`; gz-physics holds the class
via `shared_ptr` (it subclasses `ContactSurfaceHandler`, never `ContactConstraint`)
and never assumes its size, so the layout change is covered by the per-minor
SONAME bump — the same class of change as the cached members added in #3023/#3028.
`ContactConstraint` already contains a fixed-size Eigen member (`mTangentBasis`),
so inline storage introduces no new allocation/alignment category.

## Results

- **Allocations:** boxes (125 boxes) per-step heap allocations
  **1,881 → 1,171 (−710/step, −37.7%)**; libdart share 989 → 279/step (−72%).
  `hasExternalDisturbance`/`getForces`/`getCommands` and the `ContactConstraint`
  spatial-normal resizes all leave the allocation profile.
- **Wall-clock:** boxes A/B (216 boxes, 1500 steps, 9 interleaved reps, pinned
  core, checksum-gated): **median 1.016× (~1.6% faster)**, 7 of 9 reps faster.
  Modest but consistent — the cumulative −710/step delta is enough to clear the
  benchmark noise floor (where the individual −125/step change in #3037 was
  neutral).
- **Correctness:** 100/100 ctest; bit-for-bit identical boxes checksum.

## Remaining (follow-ups)

`GenericJoint::getRelativeJacobian()` still returns a dynamic `Matrix<6,N>` by
value (~125/step); removing it needs an in-place Jacobian accessor (a new
virtual on base `Joint`) and is deliberately deferred. The bulk of what remains
(~890/step) is `libstdc++`/`make_shared` control-block churn.
