### PR TITLE
Add AI docs knowledge graph guardrails

### DIFF
--- a/.claude/commands/dart-retrospect.md
+++ b/.claude/commands/dart-retrospect.md
@@ -39,12 +39,16 @@ command as the hindsight workflow; do not duplicate the routing table here.
 3. Decide whether each lesson is general enough for shared AI infra. Do not
    update AI components after every session.
 4. Prefer update, remove, consolidate, or restructure over adding new files.
-5. Keep `docs/ai/principles.md` compact; put procedures in the owner docs it
+5. Make every durable learning discoverable from its owner surface: update an
+   existing owner doc when possible, and when a new durable file is justified,
+   link it from the relevant owner index or plan before retiring temporary
+   context.
+6. Keep `docs/ai/principles.md` compact; put procedures in the owner docs it
    links to.
-6. Avoid ephemeral branch, PR, commit, or username details.
-7. If adding a workflow command or skill, edit `.claude/` source files and run
+7. Avoid ephemeral branch, PR, commit, or username details.
+8. If adding a workflow command or skill, edit `.claude/` source files and run
    `pixi run sync-ai-commands`.
-8. Run `pixi run lint` before committing. For AI docs or adapter changes, also
+9. Run `pixi run lint` before committing. For AI docs or adapter changes, also
    run the verification gates from `docs/ai/verification.md`: `pixi run
 lint-md`, `pixi run check-lint-md`, `pixi run sync-ai-commands`, `pixi run
 check-ai-commands`, `pixi run check-docs-policy`, and `pixi run

--- a/.codex/skills/dart-retrospect/SKILL.md
+++ b/.codex/skills/dart-retrospect/SKILL.md
@@ -60,12 +60,16 @@ command as the hindsight workflow; do not duplicate the routing table here.
 3. Decide whether each lesson is general enough for shared AI infra. Do not
    update AI components after every session.
 4. Prefer update, remove, consolidate, or restructure over adding new files.
-5. Keep `docs/ai/principles.md` compact; put procedures in the owner docs it
+5. Make every durable learning discoverable from its owner surface: update an
+   existing owner doc when possible, and when a new durable file is justified,
+   link it from the relevant owner index or plan before retiring temporary
+   context.
+6. Keep `docs/ai/principles.md` compact; put procedures in the owner docs it
    links to.
-6. Avoid ephemeral branch, PR, commit, or username details.
-7. If adding a workflow command or skill, edit `.claude/` source files and run
+7. Avoid ephemeral branch, PR, commit, or username details.
+8. If adding a workflow command or skill, edit `.claude/` source files and run
    `pixi run sync-ai-commands`.
-8. Run `pixi run lint` before committing. For AI docs or adapter changes, also
+9. Run `pixi run lint` before committing. For AI docs or adapter changes, also
    run the verification gates from `docs/ai/verification.md`: `pixi run
 lint-md`, `pixi run check-lint-md`, `pixi run sync-ai-commands`, `pixi run
 check-ai-commands`, `pixi run check-docs-policy`, and `pixi run

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ docs/plans/104-vertex-block-descent-solver/*.json
 
 # AI tool local state
 .omc/
+.omx/
 .sisyphus/
 
 # Benchmark result artifacts

--- a/.opencode/command/dart-retrospect.md
+++ b/.opencode/command/dart-retrospect.md
@@ -43,12 +43,16 @@ command as the hindsight workflow; do not duplicate the routing table here.
 3. Decide whether each lesson is general enough for shared AI infra. Do not
    update AI components after every session.
 4. Prefer update, remove, consolidate, or restructure over adding new files.
-5. Keep `docs/ai/principles.md` compact; put procedures in the owner docs it
+5. Make every durable learning discoverable from its owner surface: update an
+   existing owner doc when possible, and when a new durable file is justified,
+   link it from the relevant owner index or plan before retiring temporary
+   context.
+6. Keep `docs/ai/principles.md` compact; put procedures in the owner docs it
    links to.
-6. Avoid ephemeral branch, PR, commit, or username details.
-7. If adding a workflow command or skill, edit `.claude/` source files and run
+7. Avoid ephemeral branch, PR, commit, or username details.
+8. If adding a workflow command or skill, edit `.claude/` source files and run
    `pixi run sync-ai-commands`.
-8. Run `pixi run lint` before committing. For AI docs or adapter changes, also
+9. Run `pixi run lint` before committing. For AI docs or adapter changes, also
    run the verification gates from `docs/ai/verification.md`: `pixi run
 lint-md`, `pixi run check-lint-md`, `pixi run sync-ai-commands`, `pixi run
 check-ai-commands`, `pixi run check-docs-policy`, and `pixi run

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,3 +1,8 @@
+---
+type: ai-entrypoint
+owner: self
+---
+
 # AI Agent Entrypoint
 
 This directory is the shared AI-native starting point for DART. It keeps

--- a/docs/ai/components.md
+++ b/docs/ai/components.md
@@ -1,3 +1,8 @@
+---
+type: ai-component-policy
+owner: self
+---
+
 # AI Components
 
 This document defines how DART maintains AI-facing components.
@@ -11,6 +16,11 @@ source is `.claude/skills/`.
 `docs/ai/capabilities.json` owns machine-readable capability status, category,
 and gate profile; `docs/ai/workflows.md` owns the human-readable public paths
 and gate details.
+
+The Markdown files directly under `docs/ai/` use a narrow frontmatter pilot
+with only stable identity fields: `type` and `owner`. The pilot does not carry
+mutable status, freshness, or relationship lists; those stay in the owner docs,
+the plan dashboard, or generated manifests with an explicit consumer.
 
 Generated surfaces are first-class entrypoints for their tools:
 
@@ -75,6 +85,11 @@ Prefer improving or consolidating an existing component over adding a new
 surface. If two docs would need the same changing fact, pick one owner and make
 the other a pointer.
 
+Durable retrospect learnings must be discoverable from the owner surface they
+improve. Prefer editing an existing owner doc. If a learning justifies a new
+durable file, link that file from the relevant owner index or plan before the
+temporary session or dev-task context is retired.
+
 ## Public Path Requirement
 
 Every AI workflow must map back to public docs and `pixi run ...` commands so a
@@ -107,7 +122,11 @@ faster; it must not be the only path.
 
 `pixi run check-docs-policy` also enforces documentation lifecycle rules that
 are outside generated-adapter sync, including docs bucket visibility,
-dev-task shape, and plan cleanup invariants.
+dev-task shape, plan cleanup invariants, the `docs/ai/` frontmatter pilot, and
+the `docs/readthedocs/papers.md` catalog schema. It also reports advisory
+signals for pilot-scoped internal Markdown links, conservative owner-index
+discoverability, and north-star evidence freshness while those checks are in
+their report-only rollout.
 
 These checks are structural. The principle audit in `docs/ai/principles.md`
 owns judgment calls such as source-of-truth placement, public path quality, and

--- a/docs/ai/north-star.md
+++ b/docs/ai/north-star.md
@@ -1,3 +1,8 @@
+---
+type: ai-north-star
+owner: self
+---
+
 # AI-Native North Star
 
 This file is the repo-level source of truth for DART's mission and current
@@ -81,6 +86,8 @@ These map onto two distribution surfaces:
 - `dartsim/` is the **standalone application** distribution serving mode 3. It
   ships as a runtime executable (via package managers), not as a library, so it
   is not consumed by downstream code and keeps minimal runtime dependencies.
+
+<!-- docs-policy: evidence-last-verified=2026-06-16 -->
 
 ## Current State
 

--- a/docs/ai/orchestration.md
+++ b/docs/ai/orchestration.md
@@ -1,3 +1,8 @@
+---
+type: ai-operating-model
+owner: self
+---
+
 # Orchestrator / Executor Operating Model
 
 This file owns DART's two-role AI operating model and the work-packet

--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -1,3 +1,8 @@
+---
+type: ai-principles
+owner: self
+---
+
 # AI Principles
 
 This compact file is loaded for every DART agent session. It owns DART's

--- a/docs/ai/sessions.md
+++ b/docs/ai/sessions.md
@@ -1,3 +1,8 @@
+---
+type: ai-session-policy
+owner: self
+---
+
 # AI Sessions
 
 Multi-session AI work uses the existing `docs/dev_tasks/` lifecycle. Do not add

--- a/docs/ai/verification.md
+++ b/docs/ai/verification.md
@@ -1,3 +1,8 @@
+---
+type: ai-verification-policy
+owner: self
+---
+
 # AI Verification
 
 AI work is complete only when the requested outcome is mapped to concrete

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -1,3 +1,8 @@
+---
+type: ai-workflow-map
+owner: self
+---
+
 # AI Workflow Map
 
 DART exposes the same effective workflow set across supported AI tools:

--- a/docs/plans/121-ai-docs-knowledge-graph.md
+++ b/docs/plans/121-ai-docs-knowledge-graph.md
@@ -1,0 +1,138 @@
+# PLAN-121: AI Docs Knowledge Graph Guardrails
+
+- Operating state: `PLAN-121` in [`dashboard.md`](dashboard.md)
+- Outcome: DART's existing AI-native documentation remains the source of
+  truth, while lightweight structural checks make links, owner indexes,
+  AI-doc identity metadata, research-reference catalog shape, and north-star
+  evidence freshness visible to both humans and agents.
+- Current evidence: `docs/ai/principles.md` owns the single-source and
+  evidence axioms, `docs/ai/components.md` owns generated-surface checks,
+  `scripts/check_docs_policy.py` already owns docs lifecycle policy, and
+  `docs/readthedocs/papers.md` already declares itself the research catalog's
+  single source of truth.
+
+## Scope Decisions
+
+This plan intentionally adapts the LLM-wiki / OKF-style graph idea without
+adding a new documentation platform.
+
+- Keep durable Markdown docs as the source of truth.
+- Add strict metadata only for the small `docs/ai/*.md` pilot, and only for
+  stable identity fields: `type` and `owner`.
+- Keep mutable operating state in `docs/plans/dashboard.md`, research status
+  in `docs/readthedocs/papers.md`, and generated adapter state in
+  `docs/ai/capabilities.json`.
+- Start graph-health checks on pilot-owned surfaces as advisory signals before
+  expanding their scope or making any of them blocking.
+- Do not commit derived graph JSON until a concrete consumer exists and CI
+  verifies it regenerates byte-identically.
+- Treat consequential ambiguity as owner-local planning state rather than a
+  global queue.
+
+## Work Packets
+
+#### WP-121.1 Graph resolver and report-only internal-link lint [done — local implementation]
+
+- Objective: pilot-owned Markdown surfaces report broken internal links without
+  blocking unrelated changes during the first rollout.
+- Scope: `scripts/check_docs_policy.py` and focused tests under `tests/`.
+- Non-goals: external link checking, anchor validation, or making the signal
+  blocking before the inventory is clean.
+- Acceptance evidence: the shared resolver handles relative paths,
+  repo-root-style paths, fragments, and external-link skips; the policy check
+  scans top-level docs indexes and the new AI-graph guardrail surfaces as
+  advisories while returning success when no blocking failures exist.
+- Gates: `pixi run python -m pytest tests/test_check_docs_policy.py`,
+  `pixi run check-docs-policy`, `pixi run lint`.
+- Dependencies: none.
+
+#### WP-121.2 Conservative owner-index discoverability [done — local implementation]
+
+- Objective: pilot orphan/discoverability reporting where ownership is already
+  clear, starting with direct `docs/ai/*.md` files and their owner index.
+- Scope: `scripts/check_docs_policy.py`, `docs/ai/README.md`, and focused
+  tests.
+- Non-goals: repo-wide reachability, README link dumps, or enforcing every
+  nested documentation page through one global index.
+- Acceptance evidence: direct `docs/ai/*.md` files are checked against
+  `docs/ai/README.md` as an advisory signal.
+- Gates: `pixi run python -m pytest tests/test_check_docs_policy.py`,
+  `pixi run check-docs-policy`, `pixi run lint`.
+- Dependencies: WP-121.1.
+
+#### WP-121.3 AI-doc frontmatter pilot [done — local implementation]
+
+- Objective: the eight Markdown docs under `docs/ai/` carry a minimal,
+  machine-checkable identity header.
+- Scope: `docs/ai/*.md` and `scripts/check_docs_policy.py`.
+- Non-goals: mutable `status`, mutable `last_verified`, relationship lists,
+  generated `docs/ai/index.json`, or frontmatter rollout beyond `docs/ai/`.
+- Acceptance evidence: `check-docs-policy` rejects missing or unsupported
+  fields for the pilot and `docs/ai/components.md` documents the boundary.
+- Gates: `pixi run python -m pytest tests/test_check_docs_policy.py`,
+  `pixi run check-docs-policy`, `pixi run lint`.
+- Dependencies: none.
+
+#### WP-121.4 Papers catalog validation [done — local implementation]
+
+- Objective: the existing `papers.md` catalog is structurally validated in
+  place without introducing a second source of truth.
+- Scope: `scripts/check_docs_policy.py`,
+  `docs/readthedocs/papers.md`, and focused tests.
+- Non-goals: generated `papers_graph.json`, mandatory new frontmatter on the
+  catalog, or external URL health checks.
+- Acceptance evidence: summary/detail ID and shared-field parity, enum
+  legality, duplicate IDs, detail property lines, and local catalog links are
+  checked.
+- Gates: `pixi run python -m pytest tests/test_check_docs_policy.py`,
+  `pixi run check-docs-policy`, `pixi run lint`.
+- Dependencies: none.
+
+#### WP-121.5 North-star freshness advisory [done — local implementation]
+
+- Objective: the north-star status evidence table exposes when cited local
+  evidence has changed after its last manual verification.
+- Scope: `docs/ai/north-star.md` and `scripts/check_docs_policy.py`.
+- Non-goals: blocking CI on git-date freshness, parsing every dashboard code
+  span as evidence, or moving freshness into frontmatter.
+- Acceptance evidence: `docs/ai/north-star.md` carries an advisory
+  `evidence-last-verified` marker and `check-docs-policy` reports newer
+  cited evidence paths as advisories.
+- Gates: `pixi run python -m pytest tests/test_check_docs_policy.py`,
+  `pixi run check-docs-policy`, `pixi run lint`.
+- Dependencies: none.
+
+#### WP-121.6 Retrospect compounding rule [done — local implementation]
+
+- Objective: durable lessons captured by `dart-retrospect` become linked owner
+  doc improvements instead of orphaned session prose.
+- Scope: `.claude/commands/dart-retrospect.md`, generated adapters, and
+  `docs/ai/components.md`.
+- Non-goals: requiring a new file for every learning or adding section-level
+  frontmatter.
+- Acceptance evidence: the source command and generated adapters instruct
+  agents to update existing owner docs first and link any new durable file
+  from the relevant owner index or plan.
+- Gates: `pixi run sync-ai-commands`, `pixi run check-ai-commands`,
+  `pixi run check-docs-policy`, `pixi run lint`.
+- Dependencies: WP-121.2 and WP-121.3.
+
+#### WP-121.7 Decision-needed block pattern [done — local implementation]
+
+- Objective: blocked roadmap or owner-doc work records the exact missing
+  decision, default, evidence need, and unblock condition where future agents
+  will look.
+- Scope: `docs/plans/README.md`.
+- Non-goals: a global decision queue, session log, or mandatory block for
+  routine uncertainty.
+- Acceptance evidence: the planning workflow documents a compact
+  owner-local `Decision needed` block and the cleanup rule after the decision
+  is made.
+- Gates: `pixi run check-docs-policy`, `pixi run lint`.
+- Dependencies: none.
+
+## Follow-Up Trigger
+
+After at least one clean cycle with no advisory output from the report-only
+checks, decide whether any advisory should become blocking. Make that decision
+in this plan and keep the flip separate from ordinary docs cleanup.

--- a/docs/plans/121-ai-docs-knowledge-graph.md
+++ b/docs/plans/121-ai-docs-knowledge-graph.md
@@ -81,17 +81,17 @@ adding a new documentation platform.
   `docs/readthedocs/papers.md`, and focused tests.
 - Non-goals: generated `papers_graph.json`, mandatory new frontmatter on the
   catalog, or external URL health checks.
-- Acceptance evidence: summary/detail ID and shared-field parity, enum
-  legality, duplicate IDs, detail property lines, and local catalog links are
-  checked.
+- Acceptance evidence: summary/detail ID and shared-field parity,
+  legend-owned enum legality, duplicate IDs, detail property lines, and local
+  catalog links are checked.
 - Gates: `pixi run python -m pytest tests/test_check_docs_policy.py`,
   `pixi run check-docs-policy`, `pixi run lint`.
 - Dependencies: none.
 
 #### WP-121.5 North-star freshness advisory [done — local implementation]
 
-- Objective: the north-star status evidence table exposes when cited local
-  evidence has changed after its last manual verification.
+- Objective: the north-star status evidence table exposes when cited committed
+  local evidence has changed after its last manual verification.
 - Scope: `docs/ai/north-star.md` and `scripts/check_docs_policy.py`.
 - Non-goals: blocking CI on git-date freshness, parsing every dashboard code
   span as evidence, or moving freshness into frontmatter.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -245,6 +245,24 @@ Plan discussions can be exploratory. Plan edits should leave the files in a
 state where the next agent can immediately tell what changed, why it changed,
 and what to do next.
 
+## Decision Needed Blocks
+
+When consequential ambiguity blocks roadmap or owner-doc work, record the
+decision locally instead of creating a global queue. Use this compact block in
+the owning plan, design doc, or onboarding doc:
+
+```markdown
+> **Decision needed:** <question>
+> **Choices:** <option A>; <option B>; <option C if needed>
+> **Current default:** <what agents should assume until decided>
+> **Evidence needed:** <repo evidence, maintainer input, CI/benchmark result>
+> **Unblocks:** <plan packet, owner-doc update, or implementation path>
+```
+
+Keep these blocks for live ambiguity only. Once the decision is made, replace
+the block with the decision and rationale in the owner doc, then update the
+dashboard if plan state changes.
+
 ## Structural Checks
 
 The living plan system relies on repository checks instead of manual memory:

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -67,6 +67,21 @@ its own line so status updates remain git-history friendly.
 - Gate: `check-ai-commands`, `check-docs-policy`, and `sync-ai-commands` cover
   adapter sync, required-reading coverage, and dev-task shape.
 
+### PLAN-121: AI Docs Knowledge Graph Guardrails
+
+- Owner doc:
+  [`121-ai-docs-knowledge-graph.md`](121-ai-docs-knowledge-graph.md)
+- Status: Active
+- Horizon: Now
+- Dimension: AI-native execution
+- Next step: Land the first guardrail wave as pilot-scoped graph-health
+  advisories plus strict low-risk metadata/catalog checks, then watch for one
+  clean cycle before deciding whether any advisory should become blocking.
+- Gate: `pixi run python -m pytest tests/test_check_docs_policy.py`,
+  `pixi run check-docs-policy`, `pixi run check-ai-commands`, and
+  `pixi run lint` prove the local checker, AI adapter sync, and docs formatting
+  surfaces.
+
 ### PLAN-010: Easy-Start API And Package Readiness
 
 - Owner doc: [`../../README.md#quick-start`](../../README.md#quick-start)

--- a/docs/readthedocs/papers.md
+++ b/docs/readthedocs/papers.md
@@ -1256,6 +1256,159 @@ algorithm-family choices. These are baselines/comparisons, not dependencies.
 | `ppf-contact-solver` | ZOZO's Contact Solver                     | GPU shell/solid/rod contact stack and API/platform baseline (`ando-2024-cubic-barrier`) | referenced | baseline  |
 | `dojo`               | Dojo.jl                                   | Dojo-style differentiable rigid-body solver evaluation (`howell-2022-dojo`)             | referenced | evaluate  |
 
+### `drake`
+
+Drake `MultibodyPlant`. <https://drake.mit.edu/doxygen_cxx/group__multibody__plant.html>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** terminology and stepping comparisons in
+  [`simulation_cpp_api.md`](../design/simulation_cpp_api.md) and
+  [`simulation_python_api.md`](../design/simulation_python_api.md).
+- **Notes:** Mature robotics-dynamics baseline for multibody terminology,
+  constraint vocabulary, and stepping API shape. DART borrows field-standard
+  terms where they match the literature, not Drake-specific API names.
+
+### `pinocchio`
+
+Pinocchio. <https://github.com/stack-of-tasks/pinocchio>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** terminology comparisons in
+  [`simulation_cpp_api.md`](../design/simulation_cpp_api.md).
+- **Notes:** Baseline for robotics dynamics algorithms and the
+  Spherical/FreeFlyer naming comparison. DART uses the terminology evidence
+  without adopting Pinocchio's API topology.
+
+### `rbdl`
+
+Rigid Body Dynamics Library. <https://github.com/rbdl/rbdl>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** dynamics and terminology comparisons in
+  [`simulation_cpp_api.md`](../design/simulation_cpp_api.md).
+- **Notes:** Baseline for ABA/RNEA/CRBA-style dynamics algorithms and
+  FloatingBase/Helical terminology. DART keeps DART-owned public API names.
+
+### `mujoco`
+
+MuJoCo / MJX. <https://mujoco.readthedocs.io/>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** stepping, state vocabulary, and equality-constraint
+  comparisons in [`simulation_cpp_api.md`](../design/simulation_cpp_api.md).
+- **Notes:** Baseline for compact simulation state, model/data separation, and
+  equality-constraint vocabulary. DART compares behavior and API shape without
+  copying MuJoCo-specific names.
+
+### `physx-isaac`
+
+NVIDIA PhysX / Isaac Sim / Isaac Lab. <https://nvidia-omniverse.github.io/PhysX/>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** reference
+- **Where used:** articulation and closed-loop rigging comparison in
+  [`simulation_cpp_api.md`](../design/simulation_cpp_api.md).
+- **Notes:** Useful reference for production articulation concepts and
+  tool-facing rigging, but DART avoids engine-specific names such as
+  "Articulation" when robotics literature has clearer terms.
+
+### `newton`
+
+NVIDIA Newton. <https://github.com/newton-physics/newton>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** reference
+- **Where used:** model/solver split and GPU-direction comparisons in
+  [`simulation_solver_architecture.md`](../design/simulation_solver_architecture.md).
+- **Notes:** Reference for GPU-oriented model/solver separation and batched
+  execution ideas. DART treats it as design evidence, not a dependency.
+
+### `genesis`
+
+Genesis. <https://github.com/Genesis-Embodied-AI/Genesis>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** reference
+- **Where used:** entity/morph and batched-simulation comparisons in
+  [`simulation_cpp_api.md`](../design/simulation_cpp_api.md).
+- **Notes:** Reference for high-level scene/entity modeling and batched
+  simulation. DART keeps its own model/component vocabulary.
+
+### `bullet`
+
+Bullet / PyBullet. <https://github.com/bulletphysics/bullet3>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** reference
+- **Where used:** facade-over-engine and rigid-body terminology comparisons in
+  [`simulation_cpp_api.md`](../design/simulation_cpp_api.md).
+- **Notes:** Reference for a facade layered over multiple engine paths and for
+  `btMultiBody` terminology. DART keeps "RigidBody" as a public term while
+  preserving DART-owned API structure.
+
+### `gazebo`
+
+Gazebo / gz-physics / SDFormat. <https://gazebosim.org/>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** downstream integration and kinematic-loop evidence in
+  [`simulation_cpp_api.md`](../design/simulation_cpp_api.md).
+- **Notes:** DART's primary downstream integration baseline. SDFormat and
+  gz-physics needs stay important compatibility evidence for model loading and
+  kinematic-loop support.
+
+### `gaia`
+
+Gaia VBD research framework. <https://github.com/AnkaChan/Gaia>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** VBD correctness and performance comparison under
+  [`PLAN-104`](../plans/104-vertex-block-descent-solver.md).
+- **Notes:** Reference implementation for `chen-2024-vbd` and related VBD
+  work. DART compares against it but reimplements VBD independently.
+
+### `tinyvbd`
+
+TinyVBD. <https://github.com/AnkaChan/TinyVBD>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** minimal VBD algorithm comparison under
+  [`PLAN-104`](../plans/104-vertex-block-descent-solver.md).
+- **Notes:** Minimal reference for the VBD update structure. It is useful for
+  source audit and small-scene comparison, not as vendored runtime code.
+
+### `kaolin-simplicits`
+
+NVIDIA Kaolin `kaolin.physics.simplicits`.
+<https://kaolin.readthedocs.io/en/latest/notes/simplicits.html>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** Simplicits method/API/code comparison under
+  [`PLAN-105`](../plans/105-simplicits-geometry-agnostic-elastic-solver.md).
+- **Notes:** Public implementation and tutorial baseline for
+  `modi-2024-simplicits`. DART should compare tests, demos, and benchmarks
+  without making Kaolin, Warp, Torch, or notebook infrastructure dependencies.
+
+### `ppf-contact-solver`
+
+ZOZO's Contact Solver. <https://github.com/st-tech/ppf-contact-solver>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** baseline
+- **Where used:** GPU contact-stack comparison under
+  [`PLAN-083`](../plans/083-unified-newton-barrier-multibody.md).
+- **Notes:** Independent Apache-2.0 software stack around
+  `ando-2024-cubic-barrier`. DART should use it for API, diagnostics,
+  precision, examples, and GPU-performance lessons without exposing
+  PPF/ZOZO/frontend-specific concepts through public APIs.
+
+### `dojo`
+
+Dojo.jl. <https://github.com/dojo-sim/Dojo.jl>
+
+- **Type:** engine · **Topic:** comparative-implementation · **Status:** referenced · **Priority:** — · **Verdict:** evaluate
+- **Where used:** differentiable solver comparison under
+  [`PLAN-110`](../plans/110-differentiable-simulation.md).
+- **Notes:** Julia implementation and paper/site reference for a
+  differentiable maximal-coordinate variational hard-contact solver. DART uses
+  it as method evidence for a possible second solver family after the active
+  Nimble-style path is de-risked.
+
 ### Notes on engine verdicts
 
 - **`drake`, `pinocchio`, `rbdl`, `mujoco`, `gazebo` — baseline:** mature

--- a/scripts/check_docs_policy.py
+++ b/scripts/check_docs_policy.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -53,15 +54,93 @@ DASHBOARD_REQUIRED_FIELDS = (
 )
 DASHBOARD_STATUS_VALUES = {"Proposed", "Active", "Blocked", "Complete", "Parked"}
 DASHBOARD_HORIZON_VALUES = {"Now", "Next", "Later", "Parked"}
+DOCS_AI_FRONTMATTER_FILES = {
+    "README.md",
+    "components.md",
+    "north-star.md",
+    "orchestration.md",
+    "principles.md",
+    "sessions.md",
+    "verification.md",
+    "workflows.md",
+}
+DOCS_AI_FRONTMATTER_KEYS = {"type", "owner"}
+DISCOVERABILITY_INDEXES = {
+    "docs/ai": "docs/ai/README.md",
+}
+MARKDOWN_LINK_ADVISORY_PATTERNS = (
+    ":(glob)docs/*.md",
+    ":(glob)docs/ai/*.md",
+    "docs/plans/121-ai-docs-knowledge-graph.md",
+    "docs/readthedocs/papers.md",
+)
+NORTH_STAR_FRESHNESS_MARKER_RE = re.compile(
+    r"<!--\s*docs-policy:\s*evidence-last-verified=(?P<date>\d{4}-\d{2}-\d{2})\s*-->"
+)
+PAPERS_STATUS_VALUES = {
+    "referenced",
+    "planned",
+    "in-progress",
+    "implemented",
+    "deferred",
+    "rejected",
+}
+PAPERS_PRIORITY_VALUES = {"high", "medium", "low", "—"}
+PAPERS_VERDICT_VALUES = {"adopt", "baseline", "reference", "evaluate", "reject"}
+PAPERS_TYPE_VALUES = {"textbook", "paper", "standard", "engine"}
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\((?P<link>[^)]+)\)")
 
 
 def iter_markdown_files(repo_root: Path) -> list[Path]:
-    files: list[Path] = []
-    for path in repo_root.rglob("*.md"):
-        if any(part in SKIP_DIRS for part in path.parts):
+    return iter_tracked_files(repo_root, ["*.md"])
+
+
+def iter_tracked_files(repo_root: Path, patterns: list[str]) -> list[Path]:
+    """Return git-tracked files for the requested pathspecs.
+
+    The fallback keeps unit tests and source archives usable outside a git
+    checkout, while the normal path avoids linting ignored local research notes.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "ls-files",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+                *patterns,
+            ],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except OSError, subprocess.CalledProcessError:
+        files: list[Path] = []
+        for pattern in patterns:
+            fallback_pattern = pattern.removeprefix(":(glob)")
+            for path in repo_root.glob(fallback_pattern):
+                if any(part in SKIP_DIRS for part in path.parts):
+                    continue
+                files.append(path)
+        return sorted(set(files))
+
+    files = []
+    for line in result.stdout.splitlines():
+        if not line:
             continue
-        files.append(path)
+        path = repo_root / line
+        if path.exists():
+            files.append(path)
     return sorted(files)
+
+
+def _display_path(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
 
 
 def check_file(path: Path, repo_root: Path) -> list[str]:
@@ -174,7 +253,20 @@ def _normalize_plan_owner(owner: str) -> str:
 
 
 def _is_external_link(link: str) -> bool:
-    return "://" in link or link.startswith("mailto:")
+    return "://" in link or link.startswith(("mailto:", "tel:"))
+
+
+def _strip_markdown_link_target(link: str) -> str:
+    target = link.strip()
+    if target.startswith("<") and ">" in target:
+        return target[1 : target.index(">")]
+    return target.split(None, maxsplit=1)[0] if target else ""
+
+
+def _normalize_markdown_link(link: str) -> str:
+    target = _strip_markdown_link_target(link)
+    target = target.split("?", maxsplit=1)[0]
+    return target.split("#", maxsplit=1)[0].strip()
 
 
 def _resolve_dashboard_owner(
@@ -206,15 +298,47 @@ def _direct_numbered_plan_file(owner_path: Path, plans_dir: Path) -> str | None:
     return None
 
 
-def _resolve_markdown_link(link: str, base_dir: Path) -> Path | None:
-    target = _normalize_plan_owner(link)
+def _resolve_markdown_link(
+    link: str,
+    base_dir: Path,
+    repo_root: Path | None = None,
+    current_file: Path | None = None,
+) -> Path | None:
+    target = _normalize_markdown_link(link)
+    raw_target = _strip_markdown_link_target(link)
+    if raw_target.startswith("#"):
+        return current_file.resolve() if current_file else base_dir.resolve()
     if not target or _is_external_link(target):
         return None
+
+    if target.startswith("/"):
+        if repo_root is None:
+            return Path(target).resolve()
+        return (repo_root / target.lstrip("/")).resolve()
 
     target_path = Path(target)
     if target_path.is_absolute():
         return target_path.resolve()
+    if repo_root is not None and target_path.parts[:1] in {
+        ("docs",),
+        ("scripts",),
+        ("tests",),
+        ("dart",),
+        ("python",),
+        ("examples",),
+        ("tutorials",),
+        (".github",),
+    }:
+        return (repo_root / target_path).resolve()
     return (base_dir / target_path).resolve()
+
+
+def _iter_markdown_links(text: str) -> list[tuple[int, str]]:
+    links: list[tuple[int, str]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for match in MARKDOWN_LINK_RE.finditer(line):
+            links.append((line_number, match.group("link")))
+    return links
 
 
 def check_plan_id_uniqueness(entries: list[dict[str, str]]) -> list[str]:
@@ -372,15 +496,476 @@ def check_design_docs_index(repo_root: Path) -> list[str]:
     return failures
 
 
+def check_markdown_internal_links(repo_root: Path) -> list[str]:
+    """Report broken internal links in tracked pilot markdown docs.
+
+    This is intentionally advisory and pilot-scoped for the first rollout: it
+    catches regressions in the new AI-graph guardrail surfaces without making
+    the existing repository-wide link inventory noisy on every policy run.
+    """
+    warnings: list[str] = []
+    for path in iter_tracked_files(repo_root, list(MARKDOWN_LINK_ADVISORY_PATTERNS)):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for line_number, raw_link in _iter_markdown_links(text):
+            target = _strip_markdown_link_target(raw_link)
+            if not target or _is_external_link(target):
+                continue
+            resolved = _resolve_markdown_link(
+                raw_link,
+                path.parent,
+                repo_root=repo_root,
+                current_file=path,
+            )
+            if resolved is None:
+                continue
+            try:
+                resolved.relative_to(repo_root.resolve())
+            except ValueError:
+                warnings.append(
+                    f"{path.relative_to(repo_root)}:{line_number}: internal link "
+                    f"escapes repository: `{raw_link}`"
+                )
+                continue
+            if not resolved.exists():
+                warnings.append(
+                    f"{path.relative_to(repo_root)}:{line_number}: broken internal "
+                    f"link `{raw_link}` -> `{_display_path(resolved, repo_root)}`"
+                )
+    return warnings
+
+
+def check_docs_discoverability(repo_root: Path) -> list[str]:
+    """Report owner-index discoverability gaps for conservative pilot buckets."""
+    warnings: list[str] = []
+    for directory, index in DISCOVERABILITY_INDEXES.items():
+        docs_dir = repo_root / directory
+        index_path = repo_root / index
+        if not docs_dir.exists() or not index_path.exists():
+            continue
+
+        index_text = index_path.read_text(encoding="utf-8", errors="replace")
+        linked_targets: set[Path] = set()
+        for _, raw_link in _iter_markdown_links(index_text):
+            resolved = _resolve_markdown_link(
+                raw_link,
+                index_path.parent,
+                repo_root=repo_root,
+                current_file=index_path,
+            )
+            if resolved:
+                linked_targets.add(resolved)
+
+        for doc in sorted(docs_dir.glob("*.md")):
+            if doc.name in {"README.md"}:
+                continue
+            repo_relative = str(doc.relative_to(repo_root))
+            text_mentions_doc = repo_relative in index_text or doc.name in index_text
+            if doc.resolve() not in linked_targets and not text_mentions_doc:
+                warnings.append(
+                    f"{doc.relative_to(repo_root)}: not linked from `{index}`"
+                )
+    return warnings
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n", text, re.DOTALL)
+    if not match:
+        return {}
+
+    frontmatter: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        key_value = re.match(r"^([A-Za-z0-9_-]+):\s*(.+)$", line)
+        if key_value:
+            frontmatter[key_value.group(1)] = key_value.group(2).strip()
+    return frontmatter
+
+
+def check_ai_doc_frontmatter(repo_root: Path) -> list[str]:
+    """Enforce the narrow docs/ai frontmatter pilot."""
+    failures: list[str] = []
+    ai_dir = repo_root / "docs" / "ai"
+    for filename in sorted(DOCS_AI_FRONTMATTER_FILES):
+        path = ai_dir / filename
+        rel_path = path.relative_to(repo_root)
+        if not path.exists():
+            failures.append(f"{rel_path}: missing required AI policy document")
+            continue
+
+        frontmatter = _parse_frontmatter(
+            path.read_text(encoding="utf-8", errors="replace")
+        )
+        if not frontmatter:
+            failures.append(f"{rel_path}: missing required docs/ai frontmatter")
+            continue
+
+        for key in DOCS_AI_FRONTMATTER_KEYS:
+            if not frontmatter.get(key):
+                failures.append(f"{rel_path}: missing frontmatter field `{key}`")
+
+        unknown_keys = set(frontmatter) - DOCS_AI_FRONTMATTER_KEYS
+        if unknown_keys:
+            failures.append(
+                f"{rel_path}: unsupported docs/ai frontmatter field(s): "
+                + ", ".join(f"`{key}`" for key in sorted(unknown_keys))
+            )
+
+        owner = frontmatter.get("owner", "")
+        if owner and owner != "self":
+            owner_path = _resolve_markdown_link(owner, path.parent, repo_root=repo_root)
+            if owner_path is None or not owner_path.exists():
+                failures.append(
+                    f"{rel_path}: frontmatter owner does not resolve: `{owner}`"
+                )
+
+    return failures
+
+
+def _line_number_for_offset(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _parse_markdown_tables(text: str) -> list[tuple[int, list[str], list[list[str]]]]:
+    lines = text.splitlines()
+    tables: list[tuple[int, list[str], list[list[str]]]] = []
+    index = 0
+    while index + 1 < len(lines):
+        header = lines[index]
+        divider = lines[index + 1]
+        if not (header.startswith("|") and divider.startswith("|")):
+            index += 1
+            continue
+        if not re.match(r"^\|\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$", divider):
+            index += 1
+            continue
+
+        headers = [cell.strip() for cell in header.strip("|").split("|")]
+        rows: list[list[str]] = []
+        row_index = index + 2
+        while row_index < len(lines) and lines[row_index].startswith("|"):
+            rows.append(
+                [cell.strip() for cell in lines[row_index].strip("|").split("|")]
+            )
+            row_index += 1
+        tables.append((index + 1, headers, rows))
+        index = row_index
+    return tables
+
+
+def _strip_code_ticks(value: str) -> str:
+    value = value.strip()
+    if value.startswith("`") and value.endswith("`"):
+        return value[1:-1]
+    return value
+
+
+def check_papers_catalog(repo_root: Path) -> list[str]:
+    """Validate the papers catalog shape without generating a second source."""
+    failures: list[str] = []
+    path = repo_root / "docs" / "readthedocs" / "papers.md"
+    if not path.exists():
+        return failures
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    summary_entries: dict[str, dict[str, str]] = {}
+    for table_line, headers, rows in _parse_markdown_tables(text):
+        if "ID" not in headers:
+            continue
+        for row_offset, row in enumerate(rows, start=2):
+            if len(row) != len(headers):
+                failures.append(
+                    f"docs/readthedocs/papers.md:{table_line + row_offset}: "
+                    "summary table row has the wrong number of cells"
+                )
+                continue
+            row_data = dict(zip(headers, row, strict=True))
+            entry_id = _strip_code_ticks(row_data["ID"])
+            if not entry_id:
+                continue
+            if entry_id in summary_entries:
+                failures.append(
+                    "docs/readthedocs/papers.md: duplicate summary entry "
+                    f"`{entry_id}`"
+                )
+            else:
+                summary_entries[entry_id] = {
+                    "Status": _strip_code_ticks(row_data.get("Status", "")),
+                    "Priority": _strip_code_ticks(row_data.get("Priority", "")),
+                    "Verdict": _strip_code_ticks(row_data.get("Verdict", "")),
+                }
+            _validate_papers_table_value(
+                failures,
+                table_line + row_offset,
+                entry_id,
+                "Status",
+                row_data.get("Status", ""),
+                PAPERS_STATUS_VALUES,
+            )
+            _validate_papers_table_value(
+                failures,
+                table_line + row_offset,
+                entry_id,
+                "Priority",
+                row_data.get("Priority", ""),
+                PAPERS_PRIORITY_VALUES,
+            )
+            _validate_papers_table_value(
+                failures,
+                table_line + row_offset,
+                entry_id,
+                "Verdict",
+                row_data.get("Verdict", ""),
+                PAPERS_VERDICT_VALUES,
+            )
+
+    detail_matches = list(re.finditer(r"^### `(?P<id>[^`]+)`\s*$", text, re.MULTILINE))
+    detail_ids: set[str] = set()
+    for index, match in enumerate(detail_matches):
+        entry_id = match.group("id")
+        if entry_id in detail_ids:
+            failures.append(
+                f"docs/readthedocs/papers.md:{_line_number_for_offset(text, match.start())}: "
+                f"duplicate detail entry `{entry_id}`"
+            )
+        detail_ids.add(entry_id)
+        next_start = (
+            detail_matches[index + 1].start()
+            if index + 1 < len(detail_matches)
+            else len(text)
+        )
+        next_section = re.search(r"^## ", text[match.end() :], re.MULTILINE)
+        if next_section:
+            next_start = min(next_start, match.end() + next_section.start())
+        block = text[match.end() : next_start]
+        line_number = _line_number_for_offset(text, match.start())
+        detail_fields = _validate_papers_detail_block(
+            failures,
+            repo_root,
+            path,
+            text,
+            block,
+            entry_id,
+            line_number,
+        )
+        if detail_fields and entry_id in summary_entries:
+            _validate_papers_summary_detail_parity(
+                failures,
+                line_number,
+                entry_id,
+                summary_entries[entry_id],
+                detail_fields,
+            )
+
+    summary_ids = set(summary_entries)
+    for entry_id in sorted(summary_ids - detail_ids):
+        failures.append(
+            f"docs/readthedocs/papers.md: summary entry `{entry_id}` has no detail block"
+        )
+    for entry_id in sorted(detail_ids - summary_ids):
+        failures.append(
+            f"docs/readthedocs/papers.md: detail entry `{entry_id}` has no summary row"
+        )
+
+    return failures
+
+
+def _validate_papers_table_value(
+    failures: list[str],
+    line_number: int,
+    entry_id: str,
+    field: str,
+    value: str,
+    allowed_values: set[str],
+) -> None:
+    if not value:
+        return
+    normalized = _strip_code_ticks(value)
+    if normalized not in allowed_values:
+        failures.append(
+            f"docs/readthedocs/papers.md:{line_number}: `{entry_id}` has invalid "
+            f"{field} `{normalized}`"
+        )
+
+
+def _validate_papers_detail_block(
+    failures: list[str],
+    repo_root: Path,
+    path: Path,
+    full_text: str,
+    block: str,
+    entry_id: str,
+    heading_line: int,
+) -> dict[str, str] | None:
+    property_match = re.search(
+        r"- \*\*Type:\*\*\s*(?P<type>[^·\n]+)"
+        r"\s*·\s*\*\*Topic:\*\*\s*(?P<topic>[^·\n]+)"
+        r"\s*·\s*\*\*Status:\*\*\s*(?P<status>[^·\n]+)"
+        r"\s*·\s*\*\*Priority:\*\*\s*(?P<priority>[^·\n]+)"
+        r"\s*·\s*\*\*Verdict:\*\*\s*(?P<verdict>[^\n]+)",
+        block,
+    )
+    if not property_match:
+        failures.append(
+            f"docs/readthedocs/papers.md:{heading_line}: detail entry `{entry_id}` "
+            "is missing the Type/Topic/Status/Priority/Verdict property line"
+        )
+        return None
+
+    field_values = {
+        "Type": (property_match.group("type").strip(), PAPERS_TYPE_VALUES),
+        "Status": (property_match.group("status").strip(), PAPERS_STATUS_VALUES),
+        "Priority": (property_match.group("priority").strip(), PAPERS_PRIORITY_VALUES),
+        "Verdict": (property_match.group("verdict").strip(), PAPERS_VERDICT_VALUES),
+    }
+    property_line = heading_line + block[: property_match.start()].count("\n") + 1
+    for field, (value, allowed_values) in field_values.items():
+        if value not in allowed_values:
+            failures.append(
+                f"docs/readthedocs/papers.md:{property_line}: `{entry_id}` has "
+                f"invalid {field} `{value}`"
+            )
+
+    block_offset = full_text.find(block)
+    for relative_line, raw_link in _iter_markdown_links(block):
+        target = _strip_markdown_link_target(raw_link)
+        if not target or _is_external_link(target):
+            continue
+        resolved = _resolve_markdown_link(
+            raw_link,
+            path.parent,
+            repo_root=repo_root,
+            current_file=path,
+        )
+        if resolved is None:
+            continue
+        if not resolved.exists():
+            line_number = (
+                _line_number_for_offset(full_text, block_offset) + relative_line - 1
+            )
+            failures.append(
+                f"docs/readthedocs/papers.md:{line_number}: `{entry_id}` has "
+                f"broken local link `{raw_link}`"
+            )
+    return {field: value for field, (value, _) in field_values.items()}
+
+
+def _validate_papers_summary_detail_parity(
+    failures: list[str],
+    line_number: int,
+    entry_id: str,
+    summary_fields: dict[str, str],
+    detail_fields: dict[str, str],
+) -> None:
+    for field in ("Status", "Priority", "Verdict"):
+        summary_value = summary_fields.get(field, "")
+        detail_value = detail_fields.get(field, "")
+        if summary_value and detail_value and summary_value != detail_value:
+            failures.append(
+                f"docs/readthedocs/papers.md:{line_number}: `{entry_id}` has "
+                f"mismatched {field}: summary `{summary_value}`, detail "
+                f"`{detail_value}`"
+            )
+
+
+def check_north_star_evidence_freshness(repo_root: Path) -> list[str]:
+    """Report north-star evidence paths newer than the verification marker."""
+    path = repo_root / "docs" / "ai" / "north-star.md"
+    if not path.exists():
+        return []
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    marker = NORTH_STAR_FRESHNESS_MARKER_RE.search(text)
+    if not marker:
+        return [
+            "docs/ai/north-star.md: missing advisory evidence freshness marker "
+            "`<!-- docs-policy: evidence-last-verified=YYYY-MM-DD -->`"
+        ]
+    last_verified = marker.group("date")
+
+    current_state = re.search(
+        r"## Current State(?P<body>.*?)(?=^## What Is Missing|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not current_state:
+        return []
+
+    warnings: list[str] = []
+    candidates = _extract_repo_path_candidates(current_state.group("body"))
+    for candidate in sorted(candidates):
+        candidate_path = repo_root / candidate
+        if not candidate_path.exists():
+            continue
+        last_commit_date = _git_last_commit_date(repo_root, candidate)
+        if last_commit_date and last_commit_date > last_verified:
+            warnings.append(
+                "docs/ai/north-star.md: evidence path "
+                f"`{candidate}` changed on {last_commit_date}, newer than "
+                f"evidence-last-verified={last_verified}"
+            )
+    return warnings
+
+
+def _extract_repo_path_candidates(text: str) -> set[str]:
+    candidates: set[str] = set()
+    path_re = re.compile(
+        r"(?<![\w/.-])"
+        r"(?P<path>"
+        r"(?:docs|dart|python|scripts|tests|examples|tutorials|\.github)"
+        r"/[A-Za-z0-9_./*-]+"
+        r"|README\.md|CHANGELOG\.md|AGENTS\.md|pixi\.toml"
+        r")"
+    )
+    for match in path_re.finditer(text):
+        candidate = match.group("path").rstrip(".,;:)")
+        if "*" not in candidate:
+            candidates.add(candidate)
+    return candidates
+
+
+def _git_last_commit_date(repo_root: Path, repo_relative_path: str) -> str | None:
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                "-1",
+                "--date=short",
+                "--format=%ad",
+                "--",
+                repo_relative_path,
+            ],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except OSError, subprocess.CalledProcessError:
+        return None
+    return result.stdout.strip() or None
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     failures: list[str] = []
+    warnings: list[str] = []
     for path in iter_markdown_files(repo_root):
         failures.extend(check_file(path, repo_root))
     failures.extend(check_docs_indexes(repo_root))
     failures.extend(check_dev_task_shape(repo_root))
     failures.extend(check_plan_lifecycle(repo_root))
     failures.extend(check_design_docs_index(repo_root))
+    failures.extend(check_ai_doc_frontmatter(repo_root))
+    failures.extend(check_papers_catalog(repo_root))
+    warnings.extend(check_markdown_internal_links(repo_root))
+    warnings.extend(check_docs_discoverability(repo_root))
+    warnings.extend(check_north_star_evidence_freshness(repo_root))
+
+    if warnings:
+        print("Documentation policy advisories:", file=sys.stderr)
+        for warning in warnings:
+            print(f"  - {warning}", file=sys.stderr)
 
     if not failures:
         return 0

--- a/scripts/check_docs_policy.py
+++ b/scripts/check_docs_policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
@@ -77,17 +78,7 @@ MARKDOWN_LINK_ADVISORY_PATTERNS = (
 NORTH_STAR_FRESHNESS_MARKER_RE = re.compile(
     r"<!--\s*docs-policy:\s*evidence-last-verified=(?P<date>\d{4}-\d{2}-\d{2})\s*-->"
 )
-PAPERS_STATUS_VALUES = {
-    "referenced",
-    "planned",
-    "in-progress",
-    "implemented",
-    "deferred",
-    "rejected",
-}
-PAPERS_PRIORITY_VALUES = {"high", "medium", "low", "—"}
-PAPERS_VERDICT_VALUES = {"adopt", "baseline", "reference", "evaluate", "reject"}
-PAPERS_TYPE_VALUES = {"textbook", "paper", "standard", "engine"}
+PAPERS_CLOSED_VALUE_FIELDS = ("Type", "Status", "Priority", "Verdict")
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\((?P<link>[^)]+)\)")
 
 
@@ -502,6 +493,8 @@ def check_markdown_internal_links(repo_root: Path) -> list[str]:
     This is intentionally advisory and pilot-scoped for the first rollout: it
     catches regressions in the new AI-graph guardrail surfaces without making
     the existing repository-wide link inventory noisy on every policy run.
+    Fragments are normalized to their owning file; heading anchors are not
+    validated yet.
     """
     warnings: list[str] = []
     for path in iter_tracked_files(repo_root, list(MARKDOWN_LINK_ADVISORY_PATTERNS)):
@@ -578,14 +571,38 @@ def _parse_frontmatter(text: str) -> dict[str, str]:
             continue
         key_value = re.match(r"^([A-Za-z0-9_-]+):\s*(.+)$", line)
         if key_value:
-            frontmatter[key_value.group(1)] = key_value.group(2).strip()
+            frontmatter[key_value.group(1)] = _normalize_frontmatter_value(
+                key_value.group(2).strip()
+            )
     return frontmatter
+
+
+def _normalize_frontmatter_value(value: str) -> str:
+    """Normalize the single-line YAML scalars used in DART frontmatter."""
+    if len(value) < 2:
+        return value
+    if value[0] == '"' and value[-1] == '"':
+        try:
+            return str(json.loads(value))
+        except json.JSONDecodeError:
+            return value[1:-1]
+    if value[0] == "'" and value[-1] == "'":
+        return value[1:-1].replace("''", "'")
+    return value
 
 
 def check_ai_doc_frontmatter(repo_root: Path) -> list[str]:
     """Enforce the narrow docs/ai frontmatter pilot."""
     failures: list[str] = []
     ai_dir = repo_root / "docs" / "ai"
+    actual_docs = (
+        {path.name for path in ai_dir.glob("*.md")} if ai_dir.exists() else set()
+    )
+    for filename in sorted(actual_docs - DOCS_AI_FRONTMATTER_FILES):
+        failures.append(
+            f"docs/ai/{filename}: docs/ai frontmatter pilot roster is missing "
+            "this Markdown file"
+        )
     for filename in sorted(DOCS_AI_FRONTMATTER_FILES):
         path = ai_dir / filename
         rel_path = path.relative_to(repo_root)
@@ -660,6 +677,26 @@ def _strip_code_ticks(value: str) -> str:
     return value
 
 
+def _strip_markdown_cell_markup(value: str) -> str:
+    return re.sub(r"[*_`]", "", value).strip()
+
+
+def _parse_papers_property_values(text: str) -> dict[str, set[str]]:
+    values_by_property: dict[str, set[str]] = {}
+    for _, headers, rows in _parse_markdown_tables(text):
+        if "Property" not in headers or "Values" not in headers:
+            continue
+        for row in rows:
+            if len(row) != len(headers):
+                continue
+            row_data = dict(zip(headers, row, strict=True))
+            property_name = _strip_markdown_cell_markup(row_data["Property"])
+            values = set(re.findall(r"`([^`]+)`", row_data.get("Values", "")))
+            if values:
+                values_by_property[property_name] = values
+    return values_by_property
+
+
 def check_papers_catalog(repo_root: Path) -> list[str]:
     """Validate the papers catalog shape without generating a second source."""
     failures: list[str] = []
@@ -668,6 +705,14 @@ def check_papers_catalog(repo_root: Path) -> list[str]:
         return failures
 
     text = path.read_text(encoding="utf-8", errors="replace")
+    allowed_values_by_field = _parse_papers_property_values(text)
+    for field in PAPERS_CLOSED_VALUE_FIELDS:
+        if not allowed_values_by_field.get(field):
+            failures.append(
+                "docs/readthedocs/papers.md: property legend is missing "
+                f"closed values for `{field}`"
+            )
+
     summary_entries: dict[str, dict[str, str]] = {}
     for table_line, headers, rows in _parse_markdown_tables(text):
         if "ID" not in headers:
@@ -700,7 +745,7 @@ def check_papers_catalog(repo_root: Path) -> list[str]:
                 entry_id,
                 "Status",
                 row_data.get("Status", ""),
-                PAPERS_STATUS_VALUES,
+                allowed_values_by_field.get("Status", set()),
             )
             _validate_papers_table_value(
                 failures,
@@ -708,7 +753,7 @@ def check_papers_catalog(repo_root: Path) -> list[str]:
                 entry_id,
                 "Priority",
                 row_data.get("Priority", ""),
-                PAPERS_PRIORITY_VALUES,
+                allowed_values_by_field.get("Priority", set()),
             )
             _validate_papers_table_value(
                 failures,
@@ -716,7 +761,7 @@ def check_papers_catalog(repo_root: Path) -> list[str]:
                 entry_id,
                 "Verdict",
                 row_data.get("Verdict", ""),
-                PAPERS_VERDICT_VALUES,
+                allowed_values_by_field.get("Verdict", set()),
             )
 
     detail_matches = list(re.finditer(r"^### `(?P<id>[^`]+)`\s*$", text, re.MULTILINE))
@@ -747,6 +792,7 @@ def check_papers_catalog(repo_root: Path) -> list[str]:
             block,
             entry_id,
             line_number,
+            allowed_values_by_field,
         )
         if detail_fields and entry_id in summary_entries:
             _validate_papers_summary_detail_parity(
@@ -781,7 +827,7 @@ def _validate_papers_table_value(
     if not value:
         return
     normalized = _strip_code_ticks(value)
-    if normalized not in allowed_values:
+    if allowed_values and normalized not in allowed_values:
         failures.append(
             f"docs/readthedocs/papers.md:{line_number}: `{entry_id}` has invalid "
             f"{field} `{normalized}`"
@@ -796,6 +842,7 @@ def _validate_papers_detail_block(
     block: str,
     entry_id: str,
     heading_line: int,
+    allowed_values_by_field: dict[str, set[str]],
 ) -> dict[str, str] | None:
     property_match = re.search(
         r"- \*\*Type:\*\*\s*(?P<type>[^·\n]+)"
@@ -813,14 +860,26 @@ def _validate_papers_detail_block(
         return None
 
     field_values = {
-        "Type": (property_match.group("type").strip(), PAPERS_TYPE_VALUES),
-        "Status": (property_match.group("status").strip(), PAPERS_STATUS_VALUES),
-        "Priority": (property_match.group("priority").strip(), PAPERS_PRIORITY_VALUES),
-        "Verdict": (property_match.group("verdict").strip(), PAPERS_VERDICT_VALUES),
+        "Type": (
+            _strip_code_ticks(property_match.group("type").strip()),
+            allowed_values_by_field.get("Type", set()),
+        ),
+        "Status": (
+            _strip_code_ticks(property_match.group("status").strip()),
+            allowed_values_by_field.get("Status", set()),
+        ),
+        "Priority": (
+            _strip_code_ticks(property_match.group("priority").strip()),
+            allowed_values_by_field.get("Priority", set()),
+        ),
+        "Verdict": (
+            _strip_code_ticks(property_match.group("verdict").strip()),
+            allowed_values_by_field.get("Verdict", set()),
+        ),
     }
     property_line = heading_line + block[: property_match.start()].count("\n") + 1
     for field, (value, allowed_values) in field_values.items():
-        if value not in allowed_values:
+        if allowed_values and value not in allowed_values:
             failures.append(
                 f"docs/readthedocs/papers.md:{property_line}: `{entry_id}` has "
                 f"invalid {field} `{value}`"
@@ -869,7 +928,7 @@ def _validate_papers_summary_detail_parity(
 
 
 def check_north_star_evidence_freshness(repo_root: Path) -> list[str]:
-    """Report north-star evidence paths newer than the verification marker."""
+    """Report committed evidence paths newer than the verification marker."""
     path = repo_root / "docs" / "ai" / "north-star.md"
     if not path.exists():
         return []

--- a/tests/test_check_docs_policy.py
+++ b/tests/test_check_docs_policy.py
@@ -32,6 +32,18 @@ def _entry(plan_id):
     }
 
 
+def _papers_legend():
+    return """### Property legend
+
+| Property | Values | Meaning |
+| --- | --- | --- |
+| **Type** | `textbook`, `paper`, `standard`, `engine` | Kind. |
+| **Status** | `referenced`, `planned`, `in-progress`, `implemented`, `deferred`, `rejected` | Relationship. |
+| **Priority** | `high`, `medium`, `low`, `—` | Importance. |
+| **Verdict** | `adopt`, `baseline`, `reference`, `evaluate`, `reject` | Decision. |
+"""
+
+
 def test_unique_ids_pass():
     module = _load_module()
     entries = [_entry("PLAN-080"), _entry("PLAN-082"), _entry("PLAN-090")]
@@ -68,6 +80,90 @@ def test_uniqueness_parses_real_dashboard_block_format():
     ids = [e["id"] for e in entries]
     assert ids == ["PLAN-080", "PLAN-080"]
     assert module.check_plan_id_uniqueness(entries)
+
+
+def test_complete_plan_pointing_to_numbered_file_is_rejected(tmp_path):
+    module = _load_module()
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "001-finished.md").write_text("# Finished\n", encoding="utf-8")
+    (plans / "dashboard.md").write_text(
+        """### PLAN-001: Finished
+
+- Owner doc: [`001-finished.md`](001-finished.md)
+- Status: Complete
+- Horizon: Now
+- Dimension: AI-native execution
+- Next step: None.
+- Gate: `pixi run check-docs-policy`
+""",
+        encoding="utf-8",
+    )
+
+    failures = module.check_plan_lifecycle(tmp_path)
+
+    assert any(
+        "completed PLAN-001 still points to numbered plan file" in failure
+        for failure in failures
+    )
+
+
+def test_unreferenced_plan_file_is_reported(tmp_path):
+    module = _load_module()
+    plans = tmp_path / "docs" / "plans"
+    ai = tmp_path / "docs" / "ai"
+    plans.mkdir(parents=True)
+    ai.mkdir(parents=True)
+    (ai / "principles.md").write_text("# Principles\n", encoding="utf-8")
+    (plans / "002-orphan.md").write_text("# Orphan\n", encoding="utf-8")
+    (plans / "dashboard.md").write_text(
+        """### PLAN-002: Active
+
+- Owner doc: [`../ai/principles.md`](../ai/principles.md)
+- Status: Active
+- Horizon: Now
+- Dimension: AI-native execution
+- Next step: Keep policy current.
+- Gate: `pixi run check-docs-policy`
+""",
+        encoding="utf-8",
+    )
+
+    failures = module.check_plan_lifecycle(tmp_path)
+
+    assert any(
+        "docs/plans/002-orphan.md: numbered plan file is not referenced" in failure
+        for failure in failures
+    )
+
+
+def test_plan_file_repeating_dashboard_field_is_rejected(tmp_path):
+    module = _load_module()
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "003-active.md").write_text(
+        "# Active\n\n- Status: Active\n", encoding="utf-8"
+    )
+    (plans / "dashboard.md").write_text(
+        """### PLAN-003: Active
+
+- Owner doc: [`003-active.md`](003-active.md)
+- Status: Active
+- Horizon: Now
+- Dimension: AI-native execution
+- Next step: Keep policy current.
+- Gate: `pixi run check-docs-policy`
+""",
+        encoding="utf-8",
+    )
+
+    failures = module.check_plan_lifecycle(tmp_path)
+
+    assert any(
+        "docs/plans/003-active.md:3: plan file repeats dashboard field `Status`"
+        in failure
+        for failure in failures
+    )
 
 
 def test_markdown_link_resolver_handles_repo_root_relative_and_anchor(tmp_path):
@@ -127,6 +223,18 @@ def test_report_only_link_check_includes_top_level_docs_indexes(tmp_path, monkey
     assert any("broken internal link `missing.md`" in warning for warning in warnings)
 
 
+def test_report_only_link_check_ignores_valid_internal_link(tmp_path):
+    module = _load_module()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "target.md").write_text("# Target\n", encoding="utf-8")
+    (docs / "README.md").write_text("[target](target.md)\n", encoding="utf-8")
+
+    warnings = module.check_markdown_internal_links(tmp_path)
+
+    assert warnings == []
+
+
 def test_docs_ai_frontmatter_pilot_requires_type_and_owner(tmp_path):
     module = _load_module()
     ai_dir = tmp_path / "docs" / "ai"
@@ -170,12 +278,80 @@ def test_docs_ai_frontmatter_rejects_extra_mutable_fields(tmp_path):
     )
 
 
+def test_docs_ai_frontmatter_normalizes_quoted_owner_self(tmp_path):
+    module = _load_module()
+    ai_dir = tmp_path / "docs" / "ai"
+    ai_dir.mkdir(parents=True)
+    for filename in module.DOCS_AI_FRONTMATTER_FILES:
+        owner = '"self"' if filename == "principles.md" else "self"
+        (ai_dir / filename).write_text(
+            f"---\ntype: ai-policy\nowner: {owner}\n---\n# Title\n",
+            encoding="utf-8",
+        )
+
+    assert module.check_ai_doc_frontmatter(tmp_path) == []
+
+
+def test_docs_ai_frontmatter_resolves_owner_links(tmp_path):
+    module = _load_module()
+    ai_dir = tmp_path / "docs" / "ai"
+    ai_dir.mkdir(parents=True)
+    (ai_dir / "README.md").write_text("# AI\n", encoding="utf-8")
+    for filename in module.DOCS_AI_FRONTMATTER_FILES:
+        owner = "README.md" if filename == "principles.md" else "self"
+        (ai_dir / filename).write_text(
+            f"---\ntype: ai-policy\nowner: {owner}\n---\n# Title\n",
+            encoding="utf-8",
+        )
+
+    assert module.check_ai_doc_frontmatter(tmp_path) == []
+
+
+def test_docs_ai_frontmatter_roster_rejects_unlisted_markdown_doc(tmp_path):
+    module = _load_module()
+    ai_dir = tmp_path / "docs" / "ai"
+    ai_dir.mkdir(parents=True)
+    for filename in module.DOCS_AI_FRONTMATTER_FILES:
+        (ai_dir / filename).write_text(
+            "---\ntype: ai-policy\nowner: self\n---\n# Title\n",
+            encoding="utf-8",
+        )
+    (ai_dir / "extra.md").write_text(
+        "---\ntype: ai-policy\nowner: self\n---\n# Extra\n",
+        encoding="utf-8",
+    )
+
+    failures = module.check_ai_doc_frontmatter(tmp_path)
+
+    assert any(
+        "docs/ai/extra.md: docs/ai frontmatter pilot roster is missing" in failure
+        for failure in failures
+    )
+
+
+def test_docs_discoverability_reports_unlinked_ai_doc(tmp_path):
+    module = _load_module()
+    ai_dir = tmp_path / "docs" / "ai"
+    ai_dir.mkdir(parents=True)
+    (ai_dir / "README.md").write_text("# AI\n", encoding="utf-8")
+    (ai_dir / "principles.md").write_text("# Principles\n", encoding="utf-8")
+
+    warnings = module.check_docs_discoverability(tmp_path)
+
+    assert any(
+        "docs/ai/principles.md: not linked from `docs/ai/README.md`" in w
+        for w in warnings
+    )
+
+
 def test_papers_catalog_validator_checks_summary_detail_parity_and_values(tmp_path):
     module = _load_module()
     papers = tmp_path / "docs" / "readthedocs" / "papers.md"
     papers.parent.mkdir(parents=True)
     papers.write_text(
-        """# Papers
+        f"""# Papers
+
+{_papers_legend()}
 
 | ID | Reference | Topic | Status | Priority | Verdict |
 | --- | --- | --- | --- | --- | --- |
@@ -202,7 +378,9 @@ def test_papers_catalog_validator_checks_summary_detail_field_parity(tmp_path):
     papers = tmp_path / "docs" / "readthedocs" / "papers.md"
     papers.parent.mkdir(parents=True)
     papers.write_text(
-        """# Papers
+        f"""# Papers
+
+{_papers_legend()}
 
 | ID | Reference | Topic | Status | Priority | Verdict |
 | --- | --- | --- | --- | --- | --- |
@@ -229,6 +407,94 @@ def test_papers_catalog_validator_checks_summary_detail_field_parity(tmp_path):
     )
 
 
+def test_papers_catalog_validator_uses_property_legend_values(tmp_path):
+    module = _load_module()
+    papers = tmp_path / "docs" / "readthedocs" / "papers.md"
+    papers.parent.mkdir(parents=True)
+    papers.write_text(
+        """# Papers
+
+### Property legend
+
+| Property | Values | Meaning |
+| --- | --- | --- |
+| **Type** | `paper` | Kind. |
+| **Status** | `planned` | Relationship. |
+| **Priority** | `high` | Importance. |
+| **Verdict** | `adopt` | Decision. |
+
+| ID | Reference | Topic | Status | Priority | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| `paper-1` | Example | contact | implemented | high | adopt |
+
+### `paper-1`
+
+- **Type:** paper · **Topic:** contact · **Status:** implemented · **Priority:** high · **Verdict:** adopt
+""",
+        encoding="utf-8",
+    )
+
+    failures = module.check_papers_catalog(tmp_path)
+
+    assert any("`paper-1` has invalid Status `implemented`" in f for f in failures)
+
+
+def test_papers_catalog_validator_checks_duplicate_detail_and_property_line(tmp_path):
+    module = _load_module()
+    papers = tmp_path / "docs" / "readthedocs" / "papers.md"
+    papers.parent.mkdir(parents=True)
+    papers.write_text(
+        f"""# Papers
+
+{_papers_legend()}
+
+| ID | Reference | Topic | Status | Priority | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| `paper-1` | Example | contact | implemented | high | adopt |
+
+### `paper-1`
+
+- Missing property line.
+
+### `paper-1`
+
+- **Type:** paper · **Topic:** contact · **Status:** implemented · **Priority:** high · **Verdict:** adopt
+""",
+        encoding="utf-8",
+    )
+
+    failures = module.check_papers_catalog(tmp_path)
+
+    assert any("duplicate detail entry `paper-1`" in f for f in failures)
+    assert any(
+        "detail entry `paper-1` is missing the Type/Topic/Status/Priority/Verdict" in f
+        for f in failures
+    )
+
+
+def test_papers_catalog_detail_values_allow_code_ticks(tmp_path):
+    module = _load_module()
+    papers = tmp_path / "docs" / "readthedocs" / "papers.md"
+    papers.parent.mkdir(parents=True)
+    papers.write_text(
+        f"""# Papers
+
+{_papers_legend()}
+
+| ID | Reference | Topic | Status | Priority | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| `paper-1` | Example | contact | implemented | high | adopt |
+
+### `paper-1`
+
+- **Type:** `paper` · **Topic:** contact · **Status:** `implemented` · **Priority:** `high` · **Verdict:** `adopt`
+""",
+        encoding="utf-8",
+    )
+
+    assert module.check_papers_catalog(tmp_path) == []
+
+
 def test_north_star_freshness_warns_when_marker_missing(tmp_path):
     module = _load_module()
     north_star = tmp_path / "docs" / "ai" / "north-star.md"
@@ -239,4 +505,37 @@ def test_north_star_freshness_warns_when_marker_missing(tmp_path):
 
     assert any(
         "missing advisory evidence freshness marker" in warning for warning in warnings
+    )
+
+
+def test_north_star_freshness_warns_for_newer_committed_evidence(tmp_path, monkeypatch):
+    module = _load_module()
+    north_star = tmp_path / "docs" / "ai" / "north-star.md"
+    evidence = tmp_path / "docs" / "ai" / "principles.md"
+    north_star.parent.mkdir(parents=True)
+    evidence.write_text("# Principles\n", encoding="utf-8")
+    north_star.write_text(
+        """<!-- docs-policy: evidence-last-verified=2026-01-01 -->
+
+# North Star
+
+## Current State
+
+| Evidence |
+| --- |
+| `docs/ai/principles.md` |
+
+## What Is Missing
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        module, "_git_last_commit_date", lambda repo_root, path: "2026-01-02"
+    )
+
+    warnings = module.check_north_star_evidence_freshness(tmp_path)
+
+    assert any(
+        "`docs/ai/principles.md` changed on 2026-01-02" in warning
+        for warning in warnings
     )

--- a/tests/test_check_docs_policy.py
+++ b/tests/test_check_docs_policy.py
@@ -68,3 +68,175 @@ def test_uniqueness_parses_real_dashboard_block_format():
     ids = [e["id"] for e in entries]
     assert ids == ["PLAN-080", "PLAN-080"]
     assert module.check_plan_id_uniqueness(entries)
+
+
+def test_markdown_link_resolver_handles_repo_root_relative_and_anchor(tmp_path):
+    module = _load_module()
+    repo = tmp_path
+    docs = repo / "docs"
+    docs.mkdir()
+    current = docs / "README.md"
+    current.write_text("# Docs\n", encoding="utf-8")
+    target = docs / "ai" / "README.md"
+    target.parent.mkdir()
+    target.write_text("# AI\n", encoding="utf-8")
+
+    assert (
+        module._resolve_markdown_link(
+            "docs/ai/README.md", docs, repo_root=repo, current_file=current
+        )
+        == target.resolve()
+    )
+    assert (
+        module._resolve_markdown_link(
+            "#local-heading", docs, repo_root=repo, current_file=current
+        )
+        == current.resolve()
+    )
+    assert module._resolve_markdown_link("https://example.com", docs, repo) is None
+
+
+def test_report_only_link_check_detects_broken_internal_link(tmp_path):
+    module = _load_module()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "README.md").write_text("[missing](missing.md)\n", encoding="utf-8")
+
+    warnings = module.check_markdown_internal_links(tmp_path)
+
+    assert any("broken internal link `missing.md`" in warning for warning in warnings)
+
+
+def test_report_only_link_check_includes_top_level_docs_indexes(tmp_path, monkeypatch):
+    module = _load_module()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    readme = docs / "README.md"
+    readme.write_text("[missing](missing.md)\n", encoding="utf-8")
+    requested_patterns = []
+
+    def fake_iter_tracked_files(repo_root, patterns):
+        requested_patterns.extend(patterns)
+        return [readme] if ":(glob)docs/*.md" in patterns else []
+
+    monkeypatch.setattr(module, "iter_tracked_files", fake_iter_tracked_files)
+
+    warnings = module.check_markdown_internal_links(tmp_path)
+
+    assert ":(glob)docs/*.md" in requested_patterns
+    assert any("broken internal link `missing.md`" in warning for warning in warnings)
+
+
+def test_docs_ai_frontmatter_pilot_requires_type_and_owner(tmp_path):
+    module = _load_module()
+    ai_dir = tmp_path / "docs" / "ai"
+    ai_dir.mkdir(parents=True)
+    for filename in module.DOCS_AI_FRONTMATTER_FILES:
+        (ai_dir / filename).write_text(
+            "---\ntype: ai-policy\nowner: self\n---\n# Title\n",
+            encoding="utf-8",
+        )
+
+    assert module.check_ai_doc_frontmatter(tmp_path) == []
+
+    (ai_dir / "principles.md").write_text(
+        "---\ntype: ai-policy\n---\n# Principles\n",
+        encoding="utf-8",
+    )
+    failures = module.check_ai_doc_frontmatter(tmp_path)
+    assert any(
+        "principles.md: missing frontmatter field `owner`" in f for f in failures
+    )
+
+
+def test_docs_ai_frontmatter_rejects_extra_mutable_fields(tmp_path):
+    module = _load_module()
+    ai_dir = tmp_path / "docs" / "ai"
+    ai_dir.mkdir(parents=True)
+    for filename in module.DOCS_AI_FRONTMATTER_FILES:
+        (ai_dir / filename).write_text(
+            "---\ntype: ai-policy\nowner: self\n---\n# Title\n",
+            encoding="utf-8",
+        )
+    (ai_dir / "north-star.md").write_text(
+        "---\ntype: ai-policy\nowner: self\nstatus: active\n---\n# North Star\n",
+        encoding="utf-8",
+    )
+
+    failures = module.check_ai_doc_frontmatter(tmp_path)
+
+    assert any(
+        "unsupported docs/ai frontmatter field(s): `status`" in f for f in failures
+    )
+
+
+def test_papers_catalog_validator_checks_summary_detail_parity_and_values(tmp_path):
+    module = _load_module()
+    papers = tmp_path / "docs" / "readthedocs" / "papers.md"
+    papers.parent.mkdir(parents=True)
+    papers.write_text(
+        """# Papers
+
+| ID | Reference | Topic | Status | Priority | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| `paper-1` | Example | contact | implemented | high | adopt |
+| `paper-2` | Missing detail | contact | unknown | high | adopt |
+
+### `paper-1`
+
+- **Type:** paper · **Topic:** contact · **Status:** implemented · **Priority:** high · **Verdict:** adopt
+- **Where used:** [missing](missing.md)
+""",
+        encoding="utf-8",
+    )
+
+    failures = module.check_papers_catalog(tmp_path)
+
+    assert any("`paper-2` has invalid Status `unknown`" in f for f in failures)
+    assert any("summary entry `paper-2` has no detail block" in f for f in failures)
+    assert any("`paper-1` has broken local link `missing.md`" in f for f in failures)
+
+
+def test_papers_catalog_validator_checks_summary_detail_field_parity(tmp_path):
+    module = _load_module()
+    papers = tmp_path / "docs" / "readthedocs" / "papers.md"
+    papers.parent.mkdir(parents=True)
+    papers.write_text(
+        """# Papers
+
+| ID | Reference | Topic | Status | Priority | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| `paper-1` | Example | contact | planned | high | adopt |
+
+### `paper-1`
+
+- **Type:** paper · **Topic:** contact · **Status:** implemented · **Priority:** high · **Verdict:** reference
+""",
+        encoding="utf-8",
+    )
+
+    failures = module.check_papers_catalog(tmp_path)
+
+    assert any(
+        "`paper-1` has mismatched Status: summary `planned`, detail `implemented`"
+        in failure
+        for failure in failures
+    )
+    assert any(
+        "`paper-1` has mismatched Verdict: summary `adopt`, detail `reference`"
+        in failure
+        for failure in failures
+    )
+
+
+def test_north_star_freshness_warns_when_marker_missing(tmp_path):
+    module = _load_module()
+    north_star = tmp_path / "docs" / "ai" / "north-star.md"
+    north_star.parent.mkdir(parents=True)
+    north_star.write_text("# North Star\n", encoding="utf-8")
+
+    warnings = module.check_north_star_evidence_freshness(tmp_path)
+
+    assert any(
+        "missing advisory evidence freshness marker" in warning for warning in warnings
+    )


### PR DESCRIPTION
## Summary

- Adds PLAN-121 guardrails for DART's AI-native documentation graph without introducing derived manifests or mutable duplicated frontmatter.
- Extends `check-docs-policy` with strict low-risk checks for `docs/ai` frontmatter and the `papers.md` catalog, plus pilot-scoped report-only advisories for link health, discoverability, and north-star evidence freshness.
- Updates `dart-retrospect` guidance so durable learnings land in linked owner docs instead of orphaned session prose.

## Motivation / Problem

DART already has strong AI-native docs and generated tool adapters, but several structural expectations were enforced by convention rather than by machine-checkable policy. This PR adds a thin guardrail layer that keeps Markdown as the source of truth, avoids committed derived graph artifacts, and makes drift visible early.

## Changes / Key Changes

- Add minimal `type` / `owner` frontmatter to the eight `docs/ai` pilot docs and enforce the roster in `scripts/check_docs_policy.py`.
- Add pilot-scoped internal Markdown link advisories, conservative `docs/ai` owner-index discoverability checks, and committed-history north-star evidence freshness advisories.
- Validate `docs/readthedocs/papers.md` in place: summary/detail parity, legend-owned enum values, duplicate IDs, detail property lines, shared-field consistency, and local links.
- Add PLAN-121 and dashboard entries describing the rollout, non-goals, gates, and follow-up trigger before any advisory becomes blocking.
- Update `dart-retrospect` source and generated adapters to require discoverable durable learnings.
- Expand `tests/test_check_docs_policy.py` coverage for lifecycle checks, frontmatter normalization, roster drift, papers validation, discoverability, link advisory behavior, and freshness warnings.

## Testing

- `pixi run lint`
- `pixi run python -m pytest tests/test_check_docs_policy.py` (24 passed)
- `pixi run check-docs-policy`
- `pixi run check-ai-commands`
- `pixi run check-lint-py`
- `pixi run check-lint-md`
- `pixi run check-lint-spell`
- `git diff --check`
- `pixi run build` was started after merging latest `origin/main`; configure completed, but the full 504-target C++ build was interrupted at 94/504 because this PR's diff against `main` is docs/checker-only and the build was not expected to finish promptly.

## Breaking Changes

- [x] None
- No runtime API, Python binding, or release behavior changes.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required — N/A, docs/checker/AI-infra guardrails only
- [x] Add unit tests for new functionality
- [x] Document new methods and classes — N/A, no public API methods/classes
- [x] Add Python bindings (dartpy) if applicable — N/A
