### PR TITLE
WP-091.21: bake dense model indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1070,6 +1070,11 @@ py-demos` now builds a CUDA-enabled dartpy + Filament GUI and offloads the
   - Routed experimental `World` dynamic rigid-body collection scratch for
     state/control vector helpers through the World free allocator, and added
     no-global-heap plus peak/live coverage through `getNumDofs()`.
+  - Baked experimental `World` dense-index Model artifacts for creation-ordered
+    rigid-body and multibody addressing, routed state/control vectors and
+    rigid-body batch extraction/integration through the cached Model, and
+    replaced name-based multi-world batch validation with dense-index Model
+    identity.
   - Reused experimental differentiable `World` multibody torque collection
     scratch through World-owned free-list storage, passed that scratch into the
     contact-free smooth Jacobian helper without an owning `Eigen::VectorXd`

--- a/dart/simulation/body/rigid_body.cpp
+++ b/dart/simulation/body/rigid_body.cpp
@@ -313,6 +313,7 @@ void RigidBody::setMass(double mass)
   dart::simulation::detail::registryOf(*getWorld())
       .get<comps::MassProperties>(detail::toRegistryEntity(getEntity()))
       .mass = mass;
+  getWorld()->markModelChanged();
 }
 
 //==============================================================================
@@ -337,6 +338,7 @@ void RigidBody::setInertia(const Eigen::Matrix3d& inertia)
   dart::simulation::detail::registryOf(*getWorld())
       .get<comps::MassProperties>(detail::toRegistryEntity(getEntity()))
       .inertia = inertia;
+  getWorld()->markModelChanged();
 }
 
 //==============================================================================
@@ -567,6 +569,7 @@ void RigidBody::setStatic(bool isStatic)
   } else {
     registry.remove<comps::StaticBodyTag>(entity);
   }
+  getWorld()->markModelChanged();
 }
 
 //==============================================================================

--- a/dart/simulation/compute/multibody_dynamics.hpp
+++ b/dart/simulation/compute/multibody_dynamics.hpp
@@ -114,12 +114,12 @@ private:
 
   friend DART_SIMULATION_API void reserveMultibodyDynamicsTermsScratch(
       MultibodyDynamicsTermsScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure);
 
   friend DART_SIMULATION_API void computeMultibodyDynamicsTermsInto(
       MultibodyDynamicsTermsScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure,
       const Eigen::Vector3d& gravity,
       MultibodyDynamicsTerms& result);
@@ -138,14 +138,14 @@ struct InverseDynamicsDerivatives;
 /// degrees of freedom the returned matrix and vectors are empty.
 [[nodiscard]] DART_SIMULATION_API MultibodyDynamicsTerms
 computeMultibodyDynamicsTerms(
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::Vector3d& gravity);
 
 /// Reserve dynamics-terms scratch for the current multibody shape.
 DART_SIMULATION_API void reserveMultibodyDynamicsTermsScratch(
     MultibodyDynamicsTermsScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure);
 
 /// Compute joint-space dynamics terms into reusable caller-owned storage.
@@ -154,7 +154,7 @@ DART_SIMULATION_API void reserveMultibodyDynamicsTermsScratch(
 /// degrees of freedom, the matrix and vectors are empty.
 DART_SIMULATION_API void computeMultibodyDynamicsTermsInto(
     MultibodyDynamicsTermsScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::Vector3d& gravity,
     MultibodyDynamicsTerms& result);
@@ -170,7 +170,7 @@ DART_SIMULATION_API void computeMultibodyDynamicsTermsInto(
 /// multibody with no movable degrees of freedom the result is empty.
 [[nodiscard]] DART_SIMULATION_API Eigen::VectorXd
 computeMultibodyInverseDynamics(
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::Vector3d& gravity,
     const Eigen::VectorXd& desiredAcceleration);
@@ -214,12 +214,12 @@ private:
 
   friend DART_SIMULATION_API void reserveMultibodyInverseDynamicsScratch(
       MultibodyInverseDynamicsScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure);
 
   friend DART_SIMULATION_API void computeMultibodyInverseDynamicsInto(
       MultibodyInverseDynamicsScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure,
       const Eigen::Vector3d& gravity,
       const Eigen::VectorXd& desiredAcceleration,
@@ -228,7 +228,7 @@ private:
   friend DART_SIMULATION_API void
   computeMultibodyInverseDynamicsDerivativesInto(
       MultibodyInverseDynamicsScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure,
       const Eigen::Vector3d& gravity,
       const Eigen::VectorXd& generalizedAcceleration,
@@ -238,7 +238,7 @@ private:
 /// Reserve inverse-dynamics scratch for the current multibody shape.
 DART_SIMULATION_API void reserveMultibodyInverseDynamicsScratch(
     MultibodyInverseDynamicsScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure);
 
 /// Compute inverse dynamics into reusable caller-owned storage.
@@ -247,7 +247,7 @@ DART_SIMULATION_API void reserveMultibodyInverseDynamicsScratch(
 /// multibody with no movable degrees of freedom, `result` is empty.
 DART_SIMULATION_API void computeMultibodyInverseDynamicsInto(
     MultibodyInverseDynamicsScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::Vector3d& gravity,
     const Eigen::VectorXd& desiredAcceleration,
@@ -275,7 +275,7 @@ struct InverseDynamicsDerivatives
 /// differencing. `generalizedAcceleration` must match the movable DOF count.
 [[nodiscard]] DART_SIMULATION_API InverseDynamicsDerivatives
 computeMultibodyInverseDynamicsDerivatives(
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::Vector3d& gravity,
     const Eigen::VectorXd& generalizedAcceleration);
@@ -286,7 +286,7 @@ computeMultibodyInverseDynamicsDerivatives(
 /// false and the matrices are empty, matching the return-by-value wrapper.
 DART_SIMULATION_API void computeMultibodyInverseDynamicsDerivativesInto(
     MultibodyInverseDynamicsScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::Vector3d& gravity,
     const Eigen::VectorXd& generalizedAcceleration,
@@ -302,7 +302,7 @@ DART_SIMULATION_API void computeMultibodyInverseDynamicsDerivativesInto(
 ///
 /// @throws InvalidArgumentException if `linkEntity` is not part of `structure`.
 [[nodiscard]] DART_SIMULATION_API Eigen::MatrixXd computeMultibodyLinkJacobian(
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     entt::entity linkEntity);
 
@@ -343,19 +343,19 @@ private:
 
   friend DART_SIMULATION_API void reserveMultibodyLinkJacobianScratch(
       MultibodyLinkJacobianScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure);
 
   friend DART_SIMULATION_API void computeMultibodyLinkJacobianInto(
       MultibodyLinkJacobianScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure,
       entt::entity linkEntity,
       Eigen::MatrixXd& result);
 
   friend DART_SIMULATION_API void computeMultibodyLinkWorldJacobianInto(
       MultibodyLinkJacobianScratch& scratch,
-      detail::WorldRegistry& registry,
+      dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure,
       entt::entity linkEntity,
       Eigen::MatrixXd& result);
@@ -364,13 +364,13 @@ private:
 /// Reserve link-Jacobian scratch for the current multibody shape.
 DART_SIMULATION_API void reserveMultibodyLinkJacobianScratch(
     MultibodyLinkJacobianScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure);
 
 /// Compute a body-frame link Jacobian into reusable caller-owned storage.
 DART_SIMULATION_API void computeMultibodyLinkJacobianInto(
     MultibodyLinkJacobianScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     entt::entity linkEntity,
     Eigen::MatrixXd& result);
@@ -386,14 +386,14 @@ DART_SIMULATION_API void computeMultibodyLinkJacobianInto(
 /// @throws InvalidArgumentException if `linkEntity` is not part of `structure`.
 [[nodiscard]] DART_SIMULATION_API Eigen::MatrixXd
 computeMultibodyLinkWorldJacobian(
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     entt::entity linkEntity);
 
 /// Compute a world-frame link Jacobian into reusable caller-owned storage.
 DART_SIMULATION_API void computeMultibodyLinkWorldJacobianInto(
     MultibodyLinkJacobianScratch& scratch,
-    detail::WorldRegistry& registry,
+    dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     entt::entity linkEntity,
     Eigen::MatrixXd& result);
@@ -523,7 +523,7 @@ private:
 
   friend DART_SIMULATION_API bool assembleMultibodyLinkContactProblemInto(
       MultibodyLinkContactAssemblyScratch& scratch,
-      const detail::WorldRegistry& registry,
+      const dart::simulation::detail::WorldRegistry& registry,
       const comps::MultibodyStructure& structure,
       const Eigen::VectorXd& nextVelocity,
       double timeStep,
@@ -550,7 +550,7 @@ private:
 ///         multibody's movable degree-of-freedom count.
 [[nodiscard]] DART_SIMULATION_API MultibodyLinkContactProblem
 assembleMultibodyLinkContactProblem(
-    const detail::WorldRegistry& registry,
+    const dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::VectorXd& nextVelocity,
     double timeStep,
@@ -563,7 +563,7 @@ assembleMultibodyLinkContactProblem(
 /// `scratch.getProblem()` even when no active rows remain.
 DART_SIMULATION_API bool assembleMultibodyLinkContactProblemInto(
     MultibodyLinkContactAssemblyScratch& scratch,
-    const detail::WorldRegistry& registry,
+    const dart::simulation::detail::WorldRegistry& registry,
     const comps::MultibodyStructure& structure,
     const Eigen::VectorXd& nextVelocity,
     double timeStep,

--- a/dart/simulation/compute/rigid_body_state_batch.cpp
+++ b/dart/simulation/compute/rigid_body_state_batch.cpp
@@ -34,11 +34,11 @@
 
 #include "dart/simulation/common/exceptions.hpp"
 #include "dart/simulation/comps/dynamics.hpp"
-#include "dart/simulation/comps/name.hpp"
 #include "dart/simulation/comps/rigid_body.hpp"
 #include "dart/simulation/compute/rigid_body_batch_ops.hpp"
 #include "dart/simulation/compute/rigid_body_integration_kernel.hpp"
 #include "dart/simulation/detail/world_registry_access.hpp"
+#include "dart/simulation/detail/world_storage.hpp"
 #include "dart/simulation/world.hpp"
 
 #include <Eigen/Cholesky>
@@ -46,7 +46,6 @@
 #include <entt/entt.hpp>
 
 #include <algorithm>
-#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -69,23 +68,14 @@ bool allFinite(const Eigen::Matrix3d& value)
 }
 
 //==============================================================================
-// Ordered rigid-body names for a world, in the same view order the batch
-// extract/apply uses. The name is the stable per-body identity key: EnTT view
-// iteration order is storage-dependent, so equal body counts alone do not
-// guarantee that two worlds map the same slice index to the same body. A
-// multi-world batch is only well defined when every world yields this same
-// ordered sequence.
-std::vector<std::string> rigidBodyNames(const World& world)
+bool sameRigidBodyModelIdentity(
+    const dart::simulation::detail::BakedWorldModel& lhs,
+    const dart::simulation::detail::BakedWorldModel& rhs)
 {
-  const auto& registry = dart::simulation::detail::registryOf(world);
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
-  std::vector<std::string> names;
-  for (const auto entity : view) {
-    const auto* name = registry.try_get<comps::Name>(entity);
-    names.push_back(name ? name->name : std::string{});
-  }
-  return names;
+  return lhs.rigidBodyEntities.size() == rhs.rigidBodyEntities.size()
+         && lhs.rigidBodyIsDynamic == rhs.rigidBodyIsDynamic
+         && lhs.rigidBodyInverseMass == rhs.rigidBodyInverseMass
+         && lhs.rigidBodyInertia == rhs.rigidBodyInertia;
 }
 
 //==============================================================================
@@ -375,16 +365,19 @@ void integrateRigidBodyStateBatch(
 RigidBodyStateBatch extractRigidBodyState(const World& world)
 {
   const auto& registry = dart::simulation::detail::registryOf(world);
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
+  const auto& model
+      = dart::simulation::detail::ensureBakedWorldModelCurrent(world);
 
   RigidBodyStateBatch batch;
   batch.worldCount = 1;
-  for (const auto entity : view) {
-    ++batch.bodyCount;
-
-    const auto& transform = view.get<comps::Transform>(entity);
-    const auto& velocity = view.get<comps::Velocity>(entity);
+  batch.bodyCount = model.rigidBodyEntities.size();
+  batch.position.reserve(3 * batch.bodyCount);
+  batch.orientation.reserve(4 * batch.bodyCount);
+  batch.linearVelocity.reserve(3 * batch.bodyCount);
+  batch.angularVelocity.reserve(3 * batch.bodyCount);
+  for (const auto entity : model.rigidBodyEntities) {
+    const auto& transform = registry.get<comps::Transform>(entity);
+    const auto& velocity = registry.get<comps::Velocity>(entity);
 
     batch.position.push_back(transform.position.x());
     batch.position.push_back(transform.position.y());
@@ -430,19 +423,19 @@ void applyRigidBodyState(World& world, const RigidBodyStateBatch& state)
       state.bodyCount);
 
   auto& registry = dart::simulation::detail::registryOf(world);
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
+  const auto& model
+      = dart::simulation::detail::ensureBakedWorldModelCurrent(world);
 
   std::size_t index = 0;
-  for (const auto entity : view) {
+  for (const auto entity : model.rigidBodyEntities) {
     DART_SIMULATION_THROW_T_IF(
         index >= state.bodyCount,
         InvalidArgumentException,
         "RigidBodyStateBatch has fewer bodies ({}) than the world",
         state.bodyCount);
 
-    auto& transform = view.get<comps::Transform>(entity);
-    auto& velocity = view.get<comps::Velocity>(entity);
+    auto& transform = registry.get<comps::Transform>(entity);
+    auto& velocity = registry.get<comps::Velocity>(entity);
 
     transform.position = Eigen::Vector3d(
         state.position[3 * index + 0],
@@ -483,7 +476,7 @@ RigidBodyStateBatch extractRigidBodyStateBatch(
     return batch;
   }
 
-  std::vector<std::string> referenceNames;
+  const dart::simulation::detail::BakedWorldModel* referenceModel = nullptr;
   for (std::size_t w = 0; w < worlds.size(); ++w) {
     DART_SIMULATION_THROW_T_IF(
         worlds[w] == nullptr,
@@ -492,10 +485,11 @@ RigidBodyStateBatch extractRigidBodyStateBatch(
         w);
 
     const auto single = extractRigidBodyState(*worlds[w]);
-    auto names = rigidBodyNames(*worlds[w]);
+    const auto& model
+        = dart::simulation::detail::ensureBakedWorldModelCurrent(*worlds[w]);
     if (w == 0) {
       batch.bodyCount = single.bodyCount;
-      referenceNames = std::move(names);
+      referenceModel = &model;
     } else {
       DART_SIMULATION_THROW_T_IF(
           single.bodyCount != batch.bodyCount,
@@ -505,11 +499,11 @@ RigidBodyStateBatch extractRigidBodyStateBatch(
           w,
           single.bodyCount);
       DART_SIMULATION_THROW_T_IF(
-          names != referenceNames,
+          !sameRigidBodyModelIdentity(model, *referenceModel),
           InvalidArgumentException,
           "extractRigidBodyStateBatch lane {} has a different rigid-body "
-          "ordering or identity than lane 0; all worlds must expose the same "
-          "ordered bodies",
+          "dense-index Model identity than lane 0; all worlds must expose the "
+          "same ordered Model",
           w);
     }
 
@@ -565,7 +559,7 @@ void applyRigidBodyStateBatch(
   // (this also makes rolloutWorldsBatched, which applies before stepping, fail
   // atomically on a duplicate world).
   std::unordered_set<const World*> seen;
-  std::vector<std::string> referenceNames;
+  const dart::simulation::detail::BakedWorldModel* referenceModel = nullptr;
   for (std::size_t w = 0; w < worlds.size(); ++w) {
     DART_SIMULATION_THROW_T_IF(
         worlds[w] == nullptr,
@@ -579,24 +573,24 @@ void applyRigidBodyStateBatch(
         "world slice must target a distinct world",
         w);
 
-    auto names = rigidBodyNames(*worlds[w]);
+    const auto& model
+        = dart::simulation::detail::ensureBakedWorldModelCurrent(*worlds[w]);
     DART_SIMULATION_THROW_T_IF(
-        names.size() != bodyCount,
+        model.rigidBodyEntities.size() != bodyCount,
         InvalidArgumentException,
         "applyRigidBodyStateBatch lane {} has {} rigid bodies, expected {}",
         w,
-        names.size(),
+        model.rigidBodyEntities.size(),
         bodyCount);
     if (w == 0) {
-      referenceNames = std::move(names);
+      referenceModel = &model;
     } else {
       DART_SIMULATION_THROW_T_IF(
-          names != referenceNames,
+          !sameRigidBodyModelIdentity(model, *referenceModel),
           InvalidArgumentException,
           "applyRigidBodyStateBatch lane {} has a different rigid-body "
-          "ordering "
-          "or identity than lane 0; all worlds must expose the same ordered "
-          "bodies",
+          "dense-index Model identity than lane 0; all worlds must expose the "
+          "same ordered Model",
           w);
     }
   }
@@ -640,27 +634,17 @@ void integrateRigidBodyStateBatchLinear(
 //==============================================================================
 RigidBodyModelBatch extractRigidBodyModelBatch(const World& world)
 {
-  const auto& registry = dart::simulation::detail::registryOf(world);
-  // Use the same view as extractRigidBodyState so the model order matches the
-  // state order body-for-body, then fetch the mass per entity.
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
+  const auto& bakedModel
+      = dart::simulation::detail::ensureBakedWorldModelCurrent(world);
 
   RigidBodyModelBatch model;
   model.worldCount = 1;
-  for (const auto entity : view) {
-    ++model.bodyCount;
-    const auto& mass = registry.get<comps::MassProperties>(entity);
-    const double inverse
-        = (mass.mass > 0.0 && std::isfinite(mass.mass)) ? 1.0 / mass.mass : 0.0;
-    model.inverseMass.push_back(inverse);
-
-    for (int row = 0; row < 3; ++row) {
-      for (int col = 0; col < 3; ++col) {
-        model.inertia.push_back(mass.inertia(row, col));
-      }
-    }
-  }
+  model.bodyCount = bakedModel.rigidBodyEntities.size();
+  model.inverseMass.assign(
+      bakedModel.rigidBodyInverseMass.begin(),
+      bakedModel.rigidBodyInverseMass.end());
+  model.inertia.assign(
+      bakedModel.rigidBodyInertia.begin(), bakedModel.rigidBodyInertia.end());
 
   return model;
 }

--- a/dart/simulation/compute/rigid_body_state_batch.hpp
+++ b/dart/simulation/compute/rigid_body_state_batch.hpp
@@ -97,13 +97,13 @@ struct DART_SIMULATION_API RigidBodyModelBatch
 };
 
 /// Extract a single-world (`worldCount == 1`) snapshot of all rigid bodies in
-/// the world's rigid-body iteration order.
+/// the World's baked dense rigid-body index order.
 [[nodiscard]] DART_SIMULATION_API RigidBodyStateBatch
 extractRigidBodyState(const World& world);
 
-/// Apply a single-world snapshot back to the world's rigid bodies, matched by
-/// iteration order. Throws if @p state is not single-world or its body count
-/// does not match the world's rigid-body count.
+/// Apply a single-world snapshot back to the World's rigid bodies, matched by
+/// baked dense index. Throws if @p state is not single-world or its body count
+/// does not match the World's rigid-body count.
 DART_SIMULATION_API void applyRigidBodyState(
     World& world, const RigidBodyStateBatch& state);
 
@@ -133,9 +133,9 @@ DART_SIMULATION_API void integrateRigidBodyStateBatchLinear(
     std::span<const double> inverseMass,
     double timeStep);
 
-/// Extract immutable model parameters (per-body inverse mass) from a single
-/// world, in rigid-body iteration order. A non-positive or non-finite mass maps
-/// to zero inverse mass (a static body).
+/// Extract immutable model parameters from a single World in baked dense index
+/// order. A non-positive or non-finite mass maps to zero inverse mass (a static
+/// body).
 [[nodiscard]] DART_SIMULATION_API RigidBodyModelBatch
 extractRigidBodyModelBatch(const World& world);
 

--- a/dart/simulation/compute/world_step_stage.cpp
+++ b/dart/simulation/compute/world_step_stage.cpp
@@ -1559,29 +1559,9 @@ struct BasicRigidBodyStateScratchBatch
   ScalarVector angularVelocity;
 };
 
-template <typename ScalarAllocator>
-struct BasicRigidBodyModelScratchBatch
-{
-  using ScalarVector = std::vector<double, ScalarAllocator>;
-
-  BasicRigidBodyModelScratchBatch() = default;
-
-  explicit BasicRigidBodyModelScratchBatch(const ScalarAllocator& allocator)
-    : inverseMass(allocator), inertia(allocator)
-  {
-  }
-
-  std::size_t worldCount = 1;
-  std::size_t bodyCount = 0;
-  ScalarVector inverseMass;
-  ScalarVector inertia;
-};
-
 using RigidBodyBatchScalarAllocator = common::StlAllocator<double>;
 using AllocatorAwareRigidBodyStateBatch
     = BasicRigidBodyStateScratchBatch<RigidBodyBatchScalarAllocator>;
-using AllocatorAwareRigidBodyModelBatch
-    = BasicRigidBodyModelScratchBatch<RigidBodyBatchScalarAllocator>;
 
 enum class RigidBodyForceAssemblyMode
 {
@@ -1598,13 +1578,13 @@ void assembleRigidBodyForces(
     RigidBodyForceAssemblyMode mode = RigidBodyForceAssemblyMode::AllBodies)
 {
   const auto& registry = dart::simulation::detail::registryOf(world);
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
-  batch.clearAndReserve(view.size_hint());
+  const auto& model
+      = dart::simulation::detail::ensureBakedWorldModelCurrent(world);
+  batch.clearAndReserve(model.rigidBodyEntities.size());
 
   const Eigen::Vector3d gravity
       = includeGravity ? world.getGravity() : Eigen::Vector3d::Zero();
-  for (const auto entity : view) {
+  for (const auto entity : model.rigidBodyEntities) {
     const bool prescribedBody
         = isPrescribedRigidBodyIntegrationBody(registry, entity);
     if (mode == RigidBodyForceAssemblyMode::AdvanceableOnly && prescribedBody) {
@@ -1641,27 +1621,25 @@ template <typename StateBatch>
 void extractRigidBodyStateInto(const World& world, StateBatch& batch)
 {
   const auto& registry = dart::simulation::detail::registryOf(world);
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
+  const auto& model
+      = dart::simulation::detail::ensureBakedWorldModelCurrent(world);
 
   batch.worldCount = 1;
-  batch.bodyCount = 0;
+  batch.bodyCount = model.rigidBodyEntities.size();
   batch.position.clear();
   batch.orientation.clear();
   batch.linearVelocity.clear();
   batch.angularVelocity.clear();
 
-  const auto bodyCount = view.size_hint();
+  const auto bodyCount = model.rigidBodyEntities.size();
   batch.position.reserve(3 * bodyCount);
   batch.orientation.reserve(4 * bodyCount);
   batch.linearVelocity.reserve(3 * bodyCount);
   batch.angularVelocity.reserve(3 * bodyCount);
 
-  for (const auto entity : view) {
-    ++batch.bodyCount;
-
-    const auto& transform = view.get<comps::Transform>(entity);
-    const auto& velocity = view.get<comps::Velocity>(entity);
+  for (const auto entity : model.rigidBodyEntities) {
+    const auto& transform = registry.get<comps::Transform>(entity);
+    const auto& velocity = registry.get<comps::Velocity>(entity);
 
     batch.position.push_back(transform.position.x());
     batch.position.push_back(transform.position.y());
@@ -1682,40 +1660,6 @@ void extractRigidBodyStateInto(const World& world, StateBatch& batch)
   }
 }
 
-//==============================================================================
-template <typename ModelBatch>
-void extractRigidBodyModelBatchInto(const World& world, ModelBatch& model)
-{
-  const auto& registry = dart::simulation::detail::registryOf(world);
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
-
-  model.worldCount = 1;
-  model.bodyCount = 0;
-  model.inverseMass.clear();
-  model.inertia.clear();
-
-  const auto bodyCount = view.size_hint();
-  model.inverseMass.reserve(bodyCount);
-  model.inertia.reserve(9 * bodyCount);
-
-  for (const auto entity : view) {
-    ++model.bodyCount;
-
-    const auto& mass = registry.get<comps::MassProperties>(entity);
-    const double inverse
-        = (mass.mass > 0.0 && std::isfinite(mass.mass)) ? 1.0 / mass.mass : 0.0;
-    model.inverseMass.push_back(inverse);
-
-    for (int row = 0; row < 3; ++row) {
-      for (int col = 0; col < 3; ++col) {
-        model.inertia.push_back(mass.inertia(row, col));
-      }
-    }
-  }
-}
-
-//==============================================================================
 template <typename SourceStateBatch, typename TargetStateBatch>
 void copyRigidBodyStateBatch(
     const SourceStateBatch& source, TargetStateBatch& target)
@@ -1726,6 +1670,19 @@ void copyRigidBodyStateBatch(
   target.orientation = source.orientation;
   target.linearVelocity = source.linearVelocity;
   target.angularVelocity = source.angularVelocity;
+}
+
+//==============================================================================
+rigid_body_batch_ops::RigidBodyModelBatchView rigidBodyModelBatchView(
+    const dart::simulation::detail::BakedWorldModel& model)
+{
+  return {
+      1,
+      model.rigidBodyEntities.size(),
+      std::span<const double>{
+          model.rigidBodyInverseMass.data(), model.rigidBodyInverseMass.size()},
+      std::span<const double>{
+          model.rigidBodyInertia.data(), model.rigidBodyInertia.size()}};
 }
 
 //==============================================================================
@@ -1775,19 +1732,19 @@ void applyRigidBodyStateFromBatch(World& world, const auto& state)
       state.bodyCount);
 
   auto& registry = dart::simulation::detail::registryOf(world);
-  auto view
-      = registry.view<comps::RigidBodyTag, comps::Transform, comps::Velocity>();
+  const auto& model
+      = dart::simulation::detail::ensureBakedWorldModelCurrent(world);
 
   std::size_t index = 0;
-  for (const auto entity : view) {
+  for (const auto entity : model.rigidBodyEntities) {
     DART_SIMULATION_THROW_T_IF(
         index >= state.bodyCount,
         InvalidArgumentException,
         "Rigid-body state scratch has fewer bodies ({}) than the world",
         state.bodyCount);
 
-    auto& transform = view.get<comps::Transform>(entity);
-    auto& velocity = view.get<comps::Velocity>(entity);
+    auto& transform = registry.get<comps::Transform>(entity);
+    auto& velocity = registry.get<comps::Velocity>(entity);
 
     transform.position = Eigen::Vector3d(
         state.position[3 * index + 0],
@@ -10224,7 +10181,6 @@ struct BatchedRigidBodyIntegrationStage::Scratch
     : forces(allocator),
       state(RigidBodyBatchScalarAllocator{allocator}),
       initialState(RigidBodyBatchScalarAllocator{allocator}),
-      model(RigidBodyBatchScalarAllocator{allocator}),
       frameUpdateOrder(common::StlAllocator<entt::entity>{allocator}),
       visitState(common::StlAllocator<int>{allocator})
   {
@@ -10233,7 +10189,6 @@ struct BatchedRigidBodyIntegrationStage::Scratch
   AllocatorAwareRigidBodyForceBatch forces;
   AllocatorAwareRigidBodyStateBatch state;
   AllocatorAwareRigidBodyStateBatch initialState;
-  AllocatorAwareRigidBodyModelBatch model;
   std::vector<entt::entity, common::StlAllocator<entt::entity>>
       frameUpdateOrder;
   std::vector<int, common::StlAllocator<int>> visitState;
@@ -12489,12 +12444,13 @@ void BatchedRigidBodyIntegrationStage::execute(
 
   extractRigidBodyStateInto(world, scratch.state);
   copyRigidBodyStateBatch(scratch.state, scratch.initialState);
-  extractRigidBodyModelBatchInto(world, scratch.model);
   const auto timeStep = world.getTimeStep();
+  const auto& model
+      = dart::simulation::detail::ensureBakedWorldModelCurrent(world);
 
   rigid_body_batch_ops::integrateRigidBodyStateBatch(
       rigid_body_batch_ops::mutableStateBatchView(scratch.state),
-      rigid_body_batch_ops::modelBatchView(scratch.model),
+      rigidBodyModelBatchView(model),
       forces.force,
       forces.torque,
       timeStep);

--- a/dart/simulation/detail/contact_jacobians.cpp
+++ b/dart/simulation/detail/contact_jacobians.cpp
@@ -50,6 +50,7 @@
 #include <Eigen/Geometry>
 #include <entt/entt.hpp>
 
+#include <algorithm>
 #include <limits>
 #include <span>
 #include <unordered_map>
@@ -318,6 +319,30 @@ ContactScene buildScene(
     }
   };
 
+  // Match World's baked dense rigid-body index order. Contact-touching bodies
+  // no longer lead the state layout; every dynamic body is registered by
+  // creation-order index first, then contacts only reference those columns.
+  ContactEntityVector dynamicEntities(ContactEntityAllocator{allocator});
+  auto dynamicView = registry.view<
+      comps::RigidBodyTag,
+      comps::Transform,
+      comps::Velocity,
+      comps::MassProperties,
+      comps::Force>();
+  dynamicEntities.reserve(dynamicView.size_hint());
+  for (const auto entity : dynamicView) {
+    dynamicEntities.push_back(entity);
+  }
+  std::ranges::sort(dynamicEntities, [](auto lhs, auto rhs) {
+    return entt::to_integral(lhs) < entt::to_integral(rhs);
+  });
+  for (const auto entity : dynamicEntities) {
+    if (hasPrescribedRigidBodyContactResponse(registry, entity)) {
+      continue;
+    }
+    registerBody(entity, false);
+  }
+
   for (const auto& contact : contacts) {
     const auto entityA = detail::toRegistryEntity(contact.bodyA.getEntity());
     const auto entityB = detail::toRegistryEntity(contact.bodyB.getEntity());
@@ -356,24 +381,6 @@ ContactScene buildScene(
     registerBody(entityA, prescribedA);
     registerBody(entityB, prescribedB);
     scene.contacts.push_back(frozen);
-  }
-
-  // Also bring every dynamic rigid body with dynamics into scope (appended
-  // after the contact-touching bodies, preserving their order). This keeps the
-  // body in the state vector when it is separated (no active contact), so the
-  // result reduces to the contact-free free-fall Jacobian rather than an empty
-  // matrix.
-  auto dynamicView = registry.view<
-      comps::RigidBodyTag,
-      comps::Transform,
-      comps::Velocity,
-      comps::MassProperties,
-      comps::Force>();
-  for (const auto entity : dynamicView) {
-    if (hasPrescribedRigidBodyContactResponse(registry, entity)) {
-      continue;
-    }
-    registerBody(entity, false);
   }
 
   scene.inverseMass.resize(scene.dynamicBodies.size());

--- a/dart/simulation/detail/world_storage.hpp
+++ b/dart/simulation/detail/world_storage.hpp
@@ -37,6 +37,7 @@
 #include <dart/simulation/detail/world_registry_types.hpp>
 #include <dart/simulation/diff/physical_parameter.hpp>
 #include <dart/simulation/diff/step_derivatives.hpp>
+#include <dart/simulation/export.hpp>
 
 #include <dart/common/stl_allocator.hpp>
 
@@ -45,7 +46,65 @@
 #include <utility>
 #include <vector>
 
+#include <cstdint>
+
+namespace dart::simulation {
+class World;
+} // namespace dart::simulation
+
 namespace dart::simulation::detail {
+
+struct BakedMultibodyModel
+{
+  entt::entity entity = entt::null;
+  std::size_t linkOffset = 0;
+  std::size_t linkCount = 0;
+  std::size_t jointOffset = 0;
+  std::size_t jointCount = 0;
+  std::size_t dofOffset = 0;
+  std::size_t dofCount = 0;
+};
+
+/// Immutable dense-index Model artifact baked at the simulation boundary.
+///
+/// Entity vectors define the canonical creation-ordered dense indices used by
+/// state/control facades and batch extraction. Scalar arrays are Model data
+/// aligned with those indices and are rebuilt only when topology or model
+/// parameters change.
+struct BakedWorldModel
+{
+  using EntityAllocator = dart::common::StlAllocator<entt::entity>;
+  using EntityVector = std::vector<entt::entity, EntityAllocator>;
+  using IndexAllocator = dart::common::StlAllocator<std::size_t>;
+  using IndexVector = std::vector<std::size_t, IndexAllocator>;
+  using ScalarAllocator = dart::common::StlAllocator<double>;
+  using ScalarVector = std::vector<double, ScalarAllocator>;
+  using ByteAllocator = dart::common::StlAllocator<std::uint8_t>;
+  using ByteVector = std::vector<std::uint8_t, ByteAllocator>;
+  using MultibodyAllocator = dart::common::StlAllocator<BakedMultibodyModel>;
+  using MultibodyVector = std::vector<BakedMultibodyModel, MultibodyAllocator>;
+
+  explicit BakedWorldModel(dart::common::MemoryAllocator& allocator);
+
+  void clear() noexcept;
+
+  bool valid = false;
+  std::uint64_t rigidBodyModelBuildCount = 0;
+
+  EntityVector rigidBodyEntities;
+  EntityVector dynamicRigidBodyEntities;
+  ByteVector rigidBodyIsDynamic;
+  ScalarVector rigidBodyInverseMass;
+  ScalarVector rigidBodyInertia;
+
+  MultibodyVector multibodies;
+  EntityVector multibodyLinkEntities;
+  EntityVector multibodyJointEntities;
+  IndexVector multibodyLinkDofOffsets;
+  IndexVector multibodyLinkDofs;
+  ScalarVector multibodyLinkMass;
+  ScalarVector multibodyLinkInertia;
+};
 
 /// Opaque, ECS-typed storage owned by `World` via a `std::unique_ptr`.
 ///
@@ -112,6 +171,12 @@ struct WorldStorage
   /// endpoint ordering. This scene-level filter is applied after broad-phase
   /// candidate generation and before narrow-phase contact generation.
   IgnoredCollisionPairSet ignoredCollisionPairs;
+
+  /// Baked dense-index Model artifact for simulation-mode steady-state paths.
+  BakedWorldModel bakedModel;
 };
+
+[[nodiscard]] DART_SIMULATION_API const BakedWorldModel&
+ensureBakedWorldModelCurrent(const World& world);
 
 } // namespace dart::simulation::detail

--- a/dart/simulation/multibody/link.cpp
+++ b/dart/simulation/multibody/link.cpp
@@ -201,6 +201,7 @@ void Link::setMass(double mass)
   dart::simulation::detail::registryOf(*getWorld())
       .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.mass = mass;
+  getWorld()->markModelChanged();
 }
 
 //==============================================================================
@@ -222,6 +223,7 @@ void Link::setInertia(const Eigen::Matrix3d& inertia)
   dart::simulation::detail::registryOf(*getWorld())
       .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.inertia = inertia;
+  getWorld()->markModelChanged();
 }
 
 //==============================================================================
@@ -243,6 +245,7 @@ void Link::setCenterOfMass(const Eigen::Vector3d& centerOfMass)
   dart::simulation::detail::registryOf(*getWorld())
       .get<comps::LinkModel>(detail::toRegistryEntity(getEntity()))
       .mass.localCenterOfMass = centerOfMass;
+  getWorld()->markModelChanged();
 }
 
 //==============================================================================

--- a/dart/simulation/world.cpp
+++ b/dart/simulation/world.cpp
@@ -3464,9 +3464,46 @@ detail::WorldStorage::WorldStorage(common::MemoryAllocator& allocator)
     differentiableInverseDynamicsScratch(allocator),
     differentiableDynamicsTermsScratch(allocator),
     ignoredCollisionPairs(
-        std::less<CollisionPairKey>{}, CollisionPairAllocator{allocator})
+        std::less<CollisionPairKey>{}, CollisionPairAllocator{allocator}),
+    bakedModel(allocator)
 {
   // Empty.
+}
+
+//==============================================================================
+detail::BakedWorldModel::BakedWorldModel(common::MemoryAllocator& allocator)
+  : rigidBodyEntities(EntityAllocator{allocator}),
+    dynamicRigidBodyEntities(EntityAllocator{allocator}),
+    rigidBodyIsDynamic(ByteAllocator{allocator}),
+    rigidBodyInverseMass(ScalarAllocator{allocator}),
+    rigidBodyInertia(ScalarAllocator{allocator}),
+    multibodies(MultibodyAllocator{allocator}),
+    multibodyLinkEntities(EntityAllocator{allocator}),
+    multibodyJointEntities(EntityAllocator{allocator}),
+    multibodyLinkDofOffsets(IndexAllocator{allocator}),
+    multibodyLinkDofs(IndexAllocator{allocator}),
+    multibodyLinkMass(ScalarAllocator{allocator}),
+    multibodyLinkInertia(ScalarAllocator{allocator})
+{
+  // Empty.
+}
+
+//==============================================================================
+void detail::BakedWorldModel::clear() noexcept
+{
+  valid = false;
+  rigidBodyEntities.clear();
+  dynamicRigidBodyEntities.clear();
+  rigidBodyIsDynamic.clear();
+  rigidBodyInverseMass.clear();
+  rigidBodyInertia.clear();
+  multibodies.clear();
+  multibodyLinkEntities.clear();
+  multibodyJointEntities.clear();
+  multibodyLinkDofOffsets.clear();
+  multibodyLinkDofs.clear();
+  multibodyLinkMass.clear();
+  multibodyLinkInertia.clear();
 }
 
 //==============================================================================
@@ -3491,6 +3528,112 @@ detail::WorldRegistry& detail::registryOf(World& world)
 const detail::WorldRegistry& detail::registryOf(const World& world)
 {
   return detail::storageOf(world).registry;
+}
+
+//==============================================================================
+const detail::BakedWorldModel& detail::ensureBakedWorldModelCurrent(
+    const World& world)
+{
+  auto& storage = const_cast<detail::WorldStorage&>(detail::storageOf(world));
+  auto& model = storage.bakedModel;
+  if (model.valid) {
+    return model;
+  }
+
+  auto& registry = storage.registry;
+  model.clear();
+
+  auto rigidBodyView = registry.view<
+      comps::RigidBodyTag,
+      comps::Transform,
+      comps::Velocity,
+      comps::MassProperties,
+      comps::Force>();
+  model.rigidBodyEntities.reserve(rigidBodyView.size_hint());
+  model.dynamicRigidBodyEntities.reserve(rigidBodyView.size_hint());
+  model.rigidBodyIsDynamic.reserve(rigidBodyView.size_hint());
+  model.rigidBodyInverseMass.reserve(rigidBodyView.size_hint());
+  model.rigidBodyInertia.reserve(9 * rigidBodyView.size_hint());
+  for (const auto entity : rigidBodyView) {
+    model.rigidBodyEntities.push_back(entity);
+  }
+  std::ranges::sort(model.rigidBodyEntities, [](auto lhs, auto rhs) {
+    return entt::to_integral(lhs) < entt::to_integral(rhs);
+  });
+  for (const auto entity : model.rigidBodyEntities) {
+    const bool dynamic = !registry.all_of<comps::StaticBodyTag>(entity);
+    model.rigidBodyIsDynamic.push_back(dynamic ? 1u : 0u);
+    if (dynamic) {
+      model.dynamicRigidBodyEntities.push_back(entity);
+    }
+
+    const auto& mass = registry.get<comps::MassProperties>(entity);
+    const double inverse
+        = (mass.mass > 0.0 && std::isfinite(mass.mass)) ? 1.0 / mass.mass : 0.0;
+    model.rigidBodyInverseMass.push_back(inverse);
+    for (int row = 0; row < 3; ++row) {
+      for (int col = 0; col < 3; ++col) {
+        model.rigidBodyInertia.push_back(mass.inertia(row, col));
+      }
+    }
+  }
+
+  auto multibodyView = registry.view<comps::MultibodyStructure>();
+  std::vector<entt::entity, detail::BakedWorldModel::EntityAllocator>
+      multibodyEntities(model.rigidBodyEntities.get_allocator());
+  for (const auto entity : multibodyView) {
+    multibodyEntities.push_back(entity);
+  }
+  std::ranges::sort(multibodyEntities, [](auto lhs, auto rhs) {
+    return entt::to_integral(lhs) < entt::to_integral(rhs);
+  });
+
+  std::size_t multibodyDofOffset = 0;
+  for (const auto entity : multibodyEntities) {
+    const auto& structure = registry.get<comps::MultibodyStructure>(entity);
+    detail::BakedMultibodyModel baked;
+    baked.entity = entity;
+    baked.linkOffset = model.multibodyLinkEntities.size();
+    baked.linkCount = structure.links.size();
+    baked.jointOffset = model.multibodyJointEntities.size();
+    baked.jointCount = structure.joints.size();
+    baked.dofOffset = multibodyDofOffset;
+
+    model.multibodyLinkEntities.insert(
+        model.multibodyLinkEntities.end(),
+        structure.links.begin(),
+        structure.links.end());
+    model.multibodyJointEntities.insert(
+        model.multibodyJointEntities.end(),
+        structure.joints.begin(),
+        structure.joints.end());
+
+    std::size_t localDofOffset = 0;
+    for (const auto linkEntity : structure.links) {
+      const auto& link = registry.get<comps::LinkModel>(linkEntity);
+      std::size_t linkDofs = 0;
+      if (link.parentJoint != entt::null) {
+        linkDofs = registry.get<comps::JointModel>(link.parentJoint).getDOF();
+      }
+      model.multibodyLinkDofOffsets.push_back(localDofOffset);
+      model.multibodyLinkDofs.push_back(linkDofs);
+      localDofOffset += linkDofs;
+
+      model.multibodyLinkMass.push_back(link.mass.mass);
+      for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+          model.multibodyLinkInertia.push_back(link.mass.inertia(row, col));
+        }
+      }
+    }
+    baked.dofCount = localDofOffset;
+    multibodyDofOffset += baked.dofCount;
+    model.multibodies.push_back(baked);
+  }
+
+  ++model.rigidBodyModelBuildCount;
+  model.valid = true;
+  return model;
 }
 
 //==============================================================================
@@ -3580,6 +3723,17 @@ void World::ensureDesignMode() const
 void World::markFrameTopologyChanged() noexcept
 {
   ++m_frameTopologyRevision;
+  if (m_storage != nullptr) {
+    m_storage->bakedModel.valid = false;
+  }
+}
+
+//==============================================================================
+void World::markModelChanged() noexcept
+{
+  if (m_storage != nullptr) {
+    m_storage->bakedModel.valid = false;
+  }
 }
 
 //==============================================================================
@@ -3702,6 +3856,7 @@ void World::reserveRegistryStorageForSimulation()
 void World::prepareStepPipelineCacheForCurrentConfiguration()
 {
   reserveRegistryStorageForSimulation();
+  (void)detail::ensureBakedWorldModelCurrent(*this);
   auto& cache = *m_stepPipelineCache;
   cache.hasAdvanceableRigidBodies = hasAdvanceableRigidBodyStructures(*this);
   cache.hasMultibodyStructure = hasMultibodyStructures(*this);
@@ -5996,50 +6151,12 @@ std::size_t World::getNumDifferentiableParameters() const noexcept
   return m_storage->differentiableParameters.size();
 }
 
-namespace {
-
-using DynamicRigidBodyEntityAllocator = common::StlAllocator<entt::entity>;
-using DynamicRigidBodyEntityVector
-    = std::vector<entt::entity, DynamicRigidBodyEntityAllocator>;
-
-DynamicRigidBodyEntityAllocator makeDynamicRigidBodyEntityAllocator(
-    const detail::WorldStorage& storage)
-{
-  return DynamicRigidBodyEntityAllocator{storage.memoryAllocator};
-}
-
-// Collect dynamic (non-static) rigid bodies in registry iteration order. This
-// is the same view and order the translational contact Jacobian uses, so the
-// state/control vectors line up with getStepDerivatives()'s [q; q̇] layout.
-DynamicRigidBodyEntityVector collectDynamicRigidBodies(
-    const auto& registry, DynamicRigidBodyEntityAllocator allocator)
-{
-  DynamicRigidBodyEntityVector bodies{allocator};
-  auto view = registry.template view<
-      comps::RigidBodyTag,
-      comps::Transform,
-      comps::Velocity,
-      comps::MassProperties,
-      comps::Force>();
-  for (const auto entity : view) {
-    if (registry.template all_of<comps::StaticBodyTag>(entity)) {
-      continue;
-    }
-    bodies.push_back(entity);
-  }
-  return bodies;
-}
-
-} // namespace
-
 //==============================================================================
 std::size_t World::getNumDofs() const
 {
   return 3
-         * collectDynamicRigidBodies(
-               m_storage->registry,
-               makeDynamicRigidBodyEntityAllocator(*m_storage))
-               .size();
+         * detail::ensureBakedWorldModelCurrent(*this)
+               .dynamicRigidBodyEntities.size();
 }
 
 //==============================================================================
@@ -6051,8 +6168,8 @@ std::size_t World::getNumEfforts() const
 //==============================================================================
 Eigen::VectorXd World::getStateVector() const
 {
-  const auto bodies = collectDynamicRigidBodies(
-      m_storage->registry, makeDynamicRigidBodyEntityAllocator(*m_storage));
+  const auto& bodies
+      = detail::ensureBakedWorldModelCurrent(*this).dynamicRigidBodyEntities;
   const Eigen::Index dofs = 3 * static_cast<Eigen::Index>(bodies.size());
   Eigen::VectorXd state(2 * dofs);
   for (std::size_t k = 0; k < bodies.size(); ++k) {
@@ -6069,8 +6186,8 @@ Eigen::VectorXd World::getStateVector() const
 //==============================================================================
 void World::setStateVector(const Eigen::VectorXd& state)
 {
-  const auto bodies = collectDynamicRigidBodies(
-      m_storage->registry, makeDynamicRigidBodyEntityAllocator(*m_storage));
+  const auto& bodies
+      = detail::ensureBakedWorldModelCurrent(*this).dynamicRigidBodyEntities;
   const Eigen::Index dofs = 3 * static_cast<Eigen::Index>(bodies.size());
   DART_SIMULATION_THROW_T_IF(
       state.size() != 2 * dofs,
@@ -6090,8 +6207,8 @@ void World::setStateVector(const Eigen::VectorXd& state)
 //==============================================================================
 Eigen::VectorXd World::getControlVector() const
 {
-  const auto bodies = collectDynamicRigidBodies(
-      m_storage->registry, makeDynamicRigidBodyEntityAllocator(*m_storage));
+  const auto& bodies
+      = detail::ensureBakedWorldModelCurrent(*this).dynamicRigidBodyEntities;
   const Eigen::Index dofs = 3 * static_cast<Eigen::Index>(bodies.size());
   Eigen::VectorXd control(dofs);
   for (std::size_t k = 0; k < bodies.size(); ++k) {
@@ -6105,8 +6222,8 @@ Eigen::VectorXd World::getControlVector() const
 //==============================================================================
 void World::setControlVector(const Eigen::VectorXd& control)
 {
-  const auto bodies = collectDynamicRigidBodies(
-      m_storage->registry, makeDynamicRigidBodyEntityAllocator(*m_storage));
+  const auto& bodies
+      = detail::ensureBakedWorldModelCurrent(*this).dynamicRigidBodyEntities;
   const Eigen::Index dofs = 3 * static_cast<Eigen::Index>(bodies.size());
   DART_SIMULATION_THROW_T_IF(
       control.size() != dofs,
@@ -7973,6 +8090,7 @@ void World::loadBinary(std::istream& input)
   }
 
   resetCountersFromRegistry();
+  m_storage->bakedModel.valid = false;
 
   if (m_simulationMode) {
     updateKinematics();

--- a/dart/simulation/world.hpp
+++ b/dart/simulation/world.hpp
@@ -782,9 +782,9 @@ public:
   /// state/control interface.
   ///
   /// First slice: the translational rigid-body reduction. `ndof = 3 * (number
-  /// of dynamic, non-static rigid bodies)`, matching the `[q; q̇]` layout of the
-  /// contact-aware step Jacobian. The full state vector therefore has size
-  /// `2 * ndof` and the control vector has size `ndof`.
+  /// of dynamic, non-static rigid bodies)`, using the baked dense rigid-body
+  /// index order created at the simulation boundary. The full state vector
+  /// therefore has size `2 * ndof` and the control vector has size `ndof`.
   [[nodiscard]] std::size_t getNumDofs() const;
 
   /// Number of control (effort) coordinates. Equal to `getNumDofs()`: the
@@ -795,8 +795,8 @@ public:
   /// The current state vector `x = [q; q̇]`, size `2 * getNumDofs()`.
   ///
   /// `q` is the stacked translational position and `q̇` the stacked linear
-  /// velocity of the dynamic (non-static) rigid bodies in registration order,
-  /// matching the layout of `getStepDerivatives()`.
+  /// velocity of the dynamic (non-static) rigid bodies in baked dense-index
+  /// order, matching the layout of `getStepDerivatives()`.
   [[nodiscard]] Eigen::VectorXd getStateVector() const;
 
   /// Overwrite the state vector `x = [q; q̇]` (size `2 * getNumDofs()`).
@@ -806,8 +806,8 @@ public:
   void setStateVector(const Eigen::VectorXd& state);
 
   /// The current control vector `u = τ`, size `getNumEfforts()`: the applied
-  /// force on each dynamic rigid body, three components per body, in
-  /// registration order.
+  /// force on each dynamic rigid body, three components per body, in baked
+  /// dense-index order.
   [[nodiscard]] Eigen::VectorXd getControlVector() const;
 
   /// Overwrite the control vector `u = τ` (size `getNumEfforts()`).
@@ -1136,6 +1136,7 @@ private:
       const CollisionQueryOptions& options,
       bool includeShapeContactDetails = true);
   void markFrameTopologyChanged() noexcept;
+  void markModelChanged() noexcept;
   [[nodiscard]] std::uint64_t getFrameTopologyRevision() const noexcept;
   void reserveRegistryStorageForSimulation();
   void prepareStepPipelineCacheForCurrentConfiguration();

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -701,7 +701,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
 
 ### WS2 — Physical data architecture
 
-#### WP-091.20 Model/State/Control component split [claimed]
+#### WP-091.20 Model/State/Control component split [done — PR #3029, merged 2026-06-16]
 
 - Objective: the articulated and deformable component fusion is split so
   storage matches the documented Model/State/Control/Contacts contract (the
@@ -781,7 +781,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   deformable suites). All three slices (20a/20b/20c) of WP-091.20 are now
   landed.
 
-#### WP-091.21 Baked dense-index Model artifact
+#### WP-091.21 Baked dense-index Model artifact [claimed]
 
 - Objective: `enterSimulationMode` bakes an immutable per-domain dense index
   (body/link/dof offsets, creation-ordered) plus per-multibody model arrays,
@@ -797,6 +797,13 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   path (assert via allocation/profile test); golden trajectories unchanged.
 - Gates: `pixi run lint`, `pixi run build`, `pixi run test-unit`.
 - Dependencies: WP-091.20.
+- Evidence (implementation branch): `detail::BakedWorldModel` now caches
+  creation-ordered rigid-body and multibody indices plus rigid-body Model arrays
+  in `WorldStorage`; state/control vectors, rigid-body batch extraction, and
+  batched integration consume the baked identity instead of rebuilding from
+  registry views or comparing names. Local validation: `pixi run lint`,
+  `pixi run build`, focused `test_world` dense-index/batch filters, and
+  `pixi run test-unit` (163/163).
 
 #### WP-091.22 Frame arena: wire or delete [claimed]
 
@@ -1063,7 +1070,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   design note's implementation order and keeping backend/device vocabulary
   out of public APIs.
 
-#### WP-091.33a Batch semantics tests [claimed]
+#### WP-091.33a Batch semantics tests [done — PR #3042, merged 2026-06-17]
 
 - Objective: the supported rigid-body batch paths are locked to "identical to
   independent sequential Worlds" before the batch owner is promoted.

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -22,34 +22,19 @@ its own line so status updates remain git-history friendly.
 - Status: Active
 - Horizon: Now
 - Dimension: Algorithm extensibility
-- Next step: WP-091.1 (solver-identity recording and AVBD relabel) is
-  `[done]` (PR #2990, merged 2026-06-13) — the AVBD packet family has a shared
-  schema contract that machine-records resolved solver identity at schema
-  version 2, enforced for new packet files by `pixi run check-avbd-packets` in
-  both the `lint` and `check-lint` aggregates, and the six mirrored
-  contact-scene claim sites are relabeled; writer-script migration to emit the
-  new field is a recorded follow-up (see the packet Evidence bullet).
-  WP-091.2 (golden trajectories) is `[done]` (PR #2994, merged 2026-06-14) —
-  `test_world_default_step_golden` locks the default `World::step` over a
-  three-scene matrix with a two-oracle design (analytical closed-form/physical
-  invariants plus the committed-snapshot behavior lock), so the refactor-heavy
-  WS1+ packets now have behavior-lock evidence to diff against. WP-091.3
-  architecture-claim lint (PR #2999) cites a DART-owned test for every
-  ✅-available architecture-page claim and adds `check-architecture-page` to
-  enforce it. WP-091.5 plan-ID renumber resolved the collisions: the
-  Linear-Time Variational Integrator is now `PLAN-084` and the Performance
-  Dashboard `PLAN-092`, guarded by a `check_plan_id_uniqueness` docs-policy
-  check. The remaining WS0 packet is WP-091.4 legacy freeze, which stays
-  **blocked**: PLAN-042 Decision 5 (which DART 6 surfaces are
-  removed/quarantined/wrapped/promoted) has no recorded maintainer direction
-  yet, so it needs a maintainer decision before it can be executed. With WS0
-  otherwise closed, open WS1 with WP-091.10 (virtual finalize/prepare on the
-  stage contract). Packets are
-  orchestrator-authored per [`../ai/orchestration.md`](../ai/orchestration.md)
-  and picked up via `dart-execute-packet`; availability follows each packet's
-  own Dependencies line. The standing rule applies now: new solver-family
-  work routes through [`solver-family-intake.md`](solver-family-intake.md)
-  and does not bypass the contracts this plan is landing.
+- Next step: WP-091.20 (Model/State/Control split) is `[done]` via PR #3029,
+  and WP-091.33a (batch semantics tests) is `[done]` via PR #3042. The current
+  branch executes WP-091.21: bake creation-ordered dense per-domain indices and
+  reusable Model artifacts so state vectors and batch validation stop depending
+  on registry iteration order or name-string matching. WP-091.33b remains
+  blocked until WP-091.21 is accepted. The remaining WS0 packet is WP-091.4 legacy
+  freeze, which stays **blocked**: PLAN-042 Decision 5 has no recorded
+  maintainer direction. Packets are orchestrator-authored per
+  [`../ai/orchestration.md`](../ai/orchestration.md) and picked up via
+  `dart-execute-packet`; availability follows each packet's own Dependencies
+  line. The standing rule applies now: new solver-family work routes through
+  [`solver-family-intake.md`](solver-family-intake.md) and does not bypass the
+  contracts this plan is landing.
 - Gate: A packet is done only when its named acceptance evidence exists and
   its listed `pixi run ...` gates pass, with availability governed by the
   per-packet Dependencies lines; plan completion follows the acceptance

--- a/tests/unit/simulation/world/test_world.cpp
+++ b/tests/unit/simulation/world/test_world.cpp
@@ -4016,7 +4016,7 @@ TEST(World, SaveBinaryIgnoredCollisionPairFilterUsesWorldAllocator)
       world.getIgnoredCollisionPairCount());
 }
 
-TEST(World, NumDofsDynamicBodyCollectionUsesWorldAllocator)
+TEST(World, NumDofsBakesDenseIndexWithWorldAllocator)
 {
   namespace sx = dart::simulation;
 
@@ -4043,15 +4043,73 @@ TEST(World, NumDofsDynamicBodyCollectionUsesWorldAllocator)
 
   EXPECT_EQ(dofs, 3u * kDynamicBodyCount);
   EXPECT_EQ(heapCounter.allocationCount(), 0u)
-      << "dynamic-body collection scratch should allocate through the World "
-         "free allocator, not the global heap";
+      << "dense-index bake should allocate through the World free allocator, "
+         "not the global heap";
   EXPECT_EQ(heapCounter.allocationBytes(), 0u);
-  EXPECT_EQ(freeList.getAllocatedSize(), liveBytesBeforeQuery)
-      << "getNumDofs should release dynamic-body collection scratch before "
-         "returning";
+  EXPECT_GT(freeList.getAllocatedSize(), liveBytesBeforeQuery)
+      << "getNumDofs should retain the baked dense index for steady-state "
+         "reuse";
   EXPECT_GT(freeList.getPeakAllocatedSize(), peakBytesBeforeQuery)
-      << "getNumDofs should allocate dynamic-body collection scratch through "
-         "the World free allocator";
+      << "getNumDofs should allocate dense-index storage through the World "
+         "free allocator";
+
+  const auto liveBytesAfterBake = freeList.getAllocatedSize();
+  ScopedHeapAllocationCounter secondHeapCounter;
+  const auto secondDofs = world.getNumDofs();
+  secondHeapCounter.stop();
+
+  EXPECT_EQ(secondDofs, dofs);
+  EXPECT_EQ(secondHeapCounter.allocationCount(), 0u);
+  EXPECT_EQ(secondHeapCounter.allocationBytes(), 0u);
+  EXPECT_EQ(freeList.getAllocatedSize(), liveBytesAfterBake)
+      << "A current dense-index artifact should be reused without growing the "
+         "World allocator";
+}
+
+TEST(World, StateAndControlVectorsUseBakedDenseIndexOrder)
+{
+  namespace sx = dart::simulation;
+
+  sx::World world;
+  sx::RigidBodyOptions firstOptions;
+  firstOptions.position = Eigen::Vector3d(1.0, 2.0, 3.0);
+  firstOptions.linearVelocity = Eigen::Vector3d(0.1, 0.2, 0.3);
+  auto first = world.addRigidBody("z_created_first", firstOptions);
+  first.setForce(Eigen::Vector3d(4.0, 5.0, 6.0));
+
+  sx::RigidBodyOptions secondOptions;
+  secondOptions.position = Eigen::Vector3d(7.0, 8.0, 9.0);
+  secondOptions.linearVelocity = Eigen::Vector3d(0.7, 0.8, 0.9);
+  auto second = world.addRigidBody("a_created_second", secondOptions);
+  second.setForce(Eigen::Vector3d(10.0, 11.0, 12.0));
+
+  sx::RigidBodyOptions staticOptions;
+  staticOptions.isStatic = true;
+  world.addRigidBody("m_static", staticOptions);
+
+  world.enterSimulationMode();
+  const auto& baked = sx::detail::storageOf(world).bakedModel;
+  ASSERT_TRUE(baked.valid);
+  ASSERT_EQ(baked.dynamicRigidBodyEntities.size(), 2u);
+  EXPECT_EQ(
+      baked.dynamicRigidBodyEntities[0],
+      sx::detail::toRegistryEntity(first.getEntity()));
+  EXPECT_EQ(
+      baked.dynamicRigidBodyEntities[1],
+      sx::detail::toRegistryEntity(second.getEntity()));
+
+  const Eigen::VectorXd state = world.getStateVector();
+  ASSERT_EQ(state.size(), 12);
+  EXPECT_TRUE(state.segment<3>(0).isApprox(firstOptions.position));
+  EXPECT_TRUE(state.segment<3>(3).isApprox(secondOptions.position));
+  EXPECT_TRUE(state.segment<3>(6).isApprox(firstOptions.linearVelocity));
+  EXPECT_TRUE(state.segment<3>(9).isApprox(secondOptions.linearVelocity));
+
+  const Eigen::VectorXd control = world.getControlVector();
+  ASSERT_EQ(control.size(), 6);
+  EXPECT_TRUE(control.segment<3>(0).isApprox(Eigen::Vector3d(4.0, 5.0, 6.0)));
+  EXPECT_TRUE(
+      control.segment<3>(3).isApprox(Eigen::Vector3d(10.0, 11.0, 12.0)));
 }
 
 #ifdef DART_HAS_DIFF
@@ -4639,13 +4697,47 @@ TEST(World, BatchedRigidBodyIntegrationStageScratchUsesProvidedAllocator)
 
     stage.execute(world, executor);
 
-    EXPECT_GE(freeList.getAllocationCount(), allocationsAfterStage + 15u)
+    EXPECT_GE(freeList.getAllocationCount(), allocationsAfterStage + 13u)
         << "allocator-aware batched rigid integration scratch should reserve "
-           "state, initial-state, model, force, torque, entity, frame-order, "
-           "and visit-state vectors from the provided free allocator";
+           "state, initial-state, force, torque, entity, frame-order, and "
+           "visit-state vectors from the provided free allocator";
   }
 
   EXPECT_EQ(freeList.getAllocationCount(), allocationsBeforeStage);
+}
+
+TEST(World, BatchedRigidBodyIntegrationStageReusesBakedModel)
+{
+  namespace common = dart::common;
+  namespace sx = dart::simulation;
+
+  sx::World world;
+  for (int i = 0; i < 3; ++i) {
+    sx::RigidBodyOptions options;
+    options.mass = 1.0 + i;
+    options.position = Eigen::Vector3d(i, 0.0, 0.0);
+    auto body
+        = world.addRigidBody("baked_model_body_" + std::to_string(i), options);
+    body.setForce(Eigen::Vector3d(0.1, 0.2, 0.3));
+  }
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.enterSimulationMode();
+
+  const auto& baked = sx::detail::storageOf(world).bakedModel;
+  ASSERT_TRUE(baked.valid);
+  const auto buildCountAfterBake = baked.rigidBodyModelBuildCount;
+
+  common::MemoryManager memoryManager;
+  sx::compute::SequentialExecutor executor;
+  sx::compute::BatchedRigidBodyIntegrationStage stage(&memoryManager);
+  stage.execute(world, executor);
+  stage.execute(world, executor);
+
+  EXPECT_EQ(
+      sx::detail::storageOf(world).bakedModel.rigidBodyModelBuildCount,
+      buildCountAfterBake)
+      << "steady-state batched integration should consume the baked Model "
+         "instead of rebuilding model arrays per execute";
 }
 
 TEST(World, RigidBodyContactScratchPayloadUsesWorldAllocator)
@@ -21608,44 +21700,59 @@ TEST(World, ApplyRigidBodyStateBatchValidatesBeforeMutating)
   EXPECT_EQ(beforePosition, afterPosition);
 }
 
-// Test that the multi-world batch rejects worlds whose rigid bodies do not
-// share the same ordered identity (same count but different bodies/order),
-// which would otherwise silently permute state between bodies.
-TEST(World, MultiWorldBatchRejectsMismatchedBodyIdentity)
+// Test that the multi-world batch validates the baked dense-index Model
+// identity rather than body names. Names are facade labels; homogeneous batch
+// identity comes from the baked ordered Model.
+TEST(World, MultiWorldBatchUsesDenseIndexModelIdentity)
 {
   namespace sx = dart::simulation;
   namespace compute = dart::simulation::compute;
 
-  auto addTwo = [](sx::World& world, const std::string& prefix) {
+  auto addTwo = [](sx::World& world, const std::string& prefix, double mass0) {
     for (int i = 0; i < 2; ++i) {
       sx::RigidBodyOptions options;
+      options.mass = mass0 + i;
       options.position = Eigen::Vector3d(i, 0.0, 0.0);
       world.addRigidBody(prefix + std::to_string(i), options);
     }
   };
 
-  // Same body count, different names => different ordered identity.
   sx::World named0;
   sx::World named1;
-  addTwo(named0, "a");
-  addTwo(named1, "b");
-  const std::vector<const sx::World*> mixed{&named0, &named1};
+  addTwo(named0, "a", 1.0);
+  addTwo(named1, "b", 1.0);
+  const std::vector<const sx::World*> renamed{&named0, &named1};
+  EXPECT_NO_THROW({ (void)compute::extractRigidBodyStateBatch(renamed); });
+
+  // Same body count but different Model => different dense-index identity.
+  sx::World differentModel;
+  addTwo(differentModel, "a", 10.0);
+  const std::vector<const sx::World*> mixed{&named0, &differentModel};
   EXPECT_THROW(
       { (void)compute::extractRigidBodyStateBatch(mixed); },
+      sx::InvalidArgumentException);
+
+  sx::World differentStaticMask;
+  addTwo(differentStaticMask, "a", 1.0);
+  differentStaticMask.getRigidBody("a1")->setStatic(true);
+  const std::vector<const sx::World*> staticMismatch{
+      &named0, &differentStaticMask};
+  EXPECT_THROW(
+      { (void)compute::extractRigidBodyStateBatch(staticMismatch); },
       sx::InvalidArgumentException);
 
   // A valid batch (consistent identity) applied to targets whose identities
   // disagree is rejected before any mutation.
   sx::World src0;
   sx::World src1;
-  addTwo(src0, "a");
-  addTwo(src1, "a");
+  addTwo(src0, "a", 1.0);
+  addTwo(src1, "a", 1.0);
   const std::vector<const sx::World*> sources{&src0, &src1};
   const auto batch = compute::extractRigidBodyStateBatch(sources);
 
   sx::World target0;
-  addTwo(target0, "a");
-  const std::vector<sx::World*> targets{&target0, &named1};
+  addTwo(target0, "a", 1.0);
+  const std::vector<sx::World*> targets{&target0, &differentModel};
   EXPECT_THROW(
       compute::applyRigidBodyStateBatch(targets, batch),
       sx::InvalidArgumentException);
@@ -21669,9 +21776,10 @@ TEST(World, BatchValidationFailuresReportLaneIndex)
     }
   };
 
-  auto addTwo = [](sx::World& world, const std::string& prefix) {
+  auto addTwo = [](sx::World& world, const std::string& prefix, double mass0) {
     for (int i = 0; i < 2; ++i) {
       sx::RigidBodyOptions options;
+      options.mass = mass0 + i;
       options.position = Eigen::Vector3d(i, 0.0, 0.0);
       world.addRigidBody(prefix + std::to_string(i), options);
     }
@@ -21679,14 +21787,14 @@ TEST(World, BatchValidationFailuresReportLaneIndex)
 
   sx::World source0;
   sx::World source1;
-  addTwo(source0, "body_");
-  addTwo(source1, "body_");
+  addTwo(source0, "body_", 1.0);
+  addTwo(source1, "body_", 1.0);
 
   const std::vector<const sx::World*> validSources{&source0, &source1};
   const auto batch = compute::extractRigidBodyStateBatch(validSources);
 
   sx::World mismatchedIdentity;
-  addTwo(mismatchedIdentity, "other_");
+  addTwo(mismatchedIdentity, "body_", 10.0);
   const std::vector<const sx::World*> mismatchedSources{
       &source0, &mismatchedIdentity};
   expectLaneOne(
@@ -21694,8 +21802,8 @@ TEST(World, BatchValidationFailuresReportLaneIndex)
 
   sx::World target0;
   sx::World target1;
-  addTwo(target0, "body_");
-  addTwo(target1, "other_");
+  addTwo(target0, "body_", 1.0);
+  addTwo(target1, "body_", 10.0);
   const std::vector<sx::World*> mismatchedTargets{&target0, &target1};
   expectLaneOne(
       [&] { compute::applyRigidBodyStateBatch(mismatchedTargets, batch); });
@@ -21778,7 +21886,7 @@ TEST(World, StepWorldsBatchedMatchesIndependentLaneReferences)
     const double seed = static_cast<double>(lane + 1u);
     for (int i = 0; i < 3; ++i) {
       sx::RigidBodyOptions options;
-      options.mass = seed + 0.5 * (i + 1);
+      options.mass = 1.0 + 0.5 * (i + 1);
       options.position
           = Eigen::Vector3d(seed + 0.1 * i, -0.25 * seed + 0.2 * i, 0.05 * i);
       options.linearVelocity = Eigen::Vector3d(
@@ -21790,7 +21898,7 @@ TEST(World, StepWorldsBatchedMatchesIndependentLaneReferences)
           Eigen::Vector3d(0.1 * seed, -0.05 * (i + 1), 0.02 * seed * (i + 1)));
     }
     world.setGravity(Eigen::Vector3d::Zero());
-    world.setTimeStep(0.02 + 0.005 * seed);
+    world.setTimeStep(0.025);
     world.enterSimulationMode();
   };
 
@@ -21936,10 +22044,8 @@ TEST(World, RigidBodyModelBatchIntegration)
   EXPECT_EQ(model.worldCount, 1u);
   EXPECT_EQ(model.bodyCount, 2u);
   ASSERT_EQ(model.inverseMass.size(), 2u);
-  // EnTT view order is not insertion order, so check the set, not positions.
-  EXPECT_TRUE(
-      (model.inverseMass[0] == 0.5 && model.inverseMass[1] == 0.25)
-      || (model.inverseMass[0] == 0.25 && model.inverseMass[1] == 0.5));
+  EXPECT_DOUBLE_EQ(model.inverseMass[0], 0.5);
+  EXPECT_DOUBLE_EQ(model.inverseMass[1], 0.25);
 
   const std::vector<double> force = {0.0, 0.0, 4.0, 0.0, 0.0, 8.0};
   const double dt = 0.5;
@@ -21953,8 +22059,8 @@ TEST(World, RigidBodyModelBatchIntegration)
 
   EXPECT_EQ(viaModel.linearVelocity, viaVector.linearVelocity);
   EXPECT_EQ(viaModel.position, viaVector.position);
-  // Per body, in extraction order: z-velocity == force.z * inverseMass * dt
-  // (initial velocity is zero), independent of the view iteration order.
+  // Per body, in baked dense-index order: z-velocity == force.z * inverseMass
+  // * dt (initial velocity is zero).
   for (std::size_t i = 0; i < model.bodyCount; ++i) {
     EXPECT_DOUBLE_EQ(
         viaModel.linearVelocity[3 * i + 2],


### PR DESCRIPTION
## Summary

- Bakes a World-owned dense-index Model artifact for rigid-body and multibody ordering.
- Routes state/control vectors, rigid-body batch extraction/application, and batched rigid integration through that baked identity.
- Reconciles PLAN-091 status for merged PRs #3029 and #3042, and records WP-091.21 validation evidence.

## Motivation / Problem

WP-091.21 depends on the Model/State/Control component split from #3029 and the batch semantics locks from #3042. The current state and batch paths still rebuilt ordered rigid-body model data from registry views and validated multi-world batches by body names, leaving ordering and model identity coupled to facade labels and per-call EnTT iteration.

## Changes / Key Changes

- Adds `detail::BakedWorldModel` to `WorldStorage`, with creation-ordered rigid-body indices, dynamic/static mask, rigid-body inverse mass/inertia arrays, and multibody link/joint/DOF offsets.
- Invalidates the baked artifact on topology/model changes and prepares it at simulation-mode boundaries.
- Reuses the baked artifact in `World` state/control vectors, rigid-body state/model batch helpers, contact Jacobian state ordering, and `BatchedRigidBodyIntegrationStage`.
- Replaces name-based multi-world batch validation with dense-index Model identity checks.
- Adds regression coverage for allocator-backed bake reuse, dense-index state/control order, model reuse in batched integration, and model/static-mask batch identity validation.

## Testing

- `pixi run build`
- `build/default/cpp/Release/bin/test_world --gtest_filter='World.NumDofsBakesDenseIndexWithWorldAllocator:World.StateAndControlVectorsUseBakedDenseIndexOrder:World.BatchedRigidBodyIntegrationStageScratchUsesProvidedAllocator:World.BatchedRigidBodyIntegrationStageReusesBakedModel:World.RigidBodyStateBatchMultiWorld:World.MultiWorldBatchUsesDenseIndexModelIdentity:World.BatchValidationFailuresReportLaneIndex:World.RigidBodyModelBatchIntegration:World.RigidBodyStateBatchSingleLaneMatchesWorldStepReference:World.StepWorldsBatchedMatchesIndependentLaneReferences'`
- `pixi run test-unit`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Builds on #3029 and #3042.
- PLAN-091 WP-091.21.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.17.1 for `release-6.17`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
