### PR TITLE
Refresh north-star operating state

### DIFF
--- a/docs/dev_tasks/simbicon_locomotion/02-warm-start-branch-retirement.md
+++ b/docs/dev_tasks/simbicon_locomotion/02-warm-start-branch-retirement.md
@@ -1,17 +1,22 @@
 # Warm-Start Checkpoint Retirement
 
-This note extracts the durable state from
-`feature/dart7-unified-contact-warm-start` so that branch can be removed after
-the retirement note lands on `main` and the maintainer approves deletion.
+This note extracts the durable state from the retired
+`feature/dart7-unified-contact-warm-start` checkpoint branch. PR
+[#3047](https://github.com/dartsim/dart/pull/3047) landed this audit on `main`,
+and the local and remote checkpoint branches were deleted on 2026-06-17 after
+maintainer approval.
 
 ## Branch Audit
 
-- Local and remote branch: `feature/dart7-unified-contact-warm-start`.
+- Retired local and remote branch:
+  `feature/dart7-unified-contact-warm-start`.
 - Pull request: none found for this branch.
 - Relationship to `origin/main` at audit time: 37 commits behind and 295 commits
   ahead.
 - Diff size at audit time: hundreds of files, including broad DART 7 contact,
   multibody, actuator, solver, SIMBICON diagnostic, and planning edits.
+- Deletion evidence: after deletion, both local and remote ref checks returned
+  no refs for `feature/dart7-unified-contact-warm-start`.
 
 Do not merge or rebase this branch into `main`. Treat it as an old checkpoint,
 not as an integration branch. Any remaining useful code from it should be
@@ -62,13 +67,8 @@ ported wholesale. Use the maintained plans instead:
   and work-packet sequencing.
 - `docs/dev_tasks/rigid_body_dynamics_solver/` for active implementation state.
 
-## Removal Criteria
+## Removal Result
 
-`feature/dart7-unified-contact-warm-start` is removable after:
-
-1. This retirement note and the updated SIMBICON resume pointers land on
-   `main`.
-2. Any active agent handoff points at current `main`, PR #3043, and this note
-   instead of the checkpoint branch.
-3. The maintainer explicitly approves deleting the local and remote checkpoint
-   branch.
+`feature/dart7-unified-contact-warm-start` has been removed locally and from
+`origin`. Current SIMBICON handoff state points at `main`, PR #3043, and this
+note instead of the checkpoint branch.

--- a/docs/dev_tasks/simbicon_locomotion/README.md
+++ b/docs/dev_tasks/simbicon_locomotion/README.md
@@ -1,22 +1,21 @@
 # Python SIMBICON Locomotion — Dev Task
 
-## Latest Focus (2026-06-17, Warm-Start Checkpoint Retirement)
+## Latest Focus (2026-06-17, Late State-0 Stance Diagnostics)
 
-Branch: `docs/retire-warm-start-checkpoint`.
+Branch: `main` or a fresh branch from current `main`.
 
 PR [#3043](https://github.com/dartsim/dart/pull/3043) landed the reusable Atlas
 SIMBICON pose-window comparison utility on `main`, including per-foot
 transform translation, trace-vertical position, local z-axis tilt relative to
-the trace vertical axis, and stance/swing aliases. The large
-`feature/dart7-unified-contact-warm-start` branch is now a checkpoint only, not
-a branch to merge or resume from directly.
+the trace vertical axis, and stance/swing aliases. PR
+[#3047](https://github.com/dartsim/dart/pull/3047) landed the retirement audit
+for the old `feature/dart7-unified-contact-warm-start` checkpoint, and the
+local and remote checkpoint branches have been deleted.
 
-Immediate next step: land the retirement audit in
-[`02-warm-start-branch-retirement.md`](02-warm-start-branch-retirement.md), then
-run `scripts/compare_atlas_simbicon_pose_window.py` on the late state-`0` trace
-window from current `main`. Use the stance-foot tilt numbers together with
-support-row counts around steps `3970`, `4000`, `4070`, and `4100` before trying
-another stance-reaction or torso-reaction probe.
+Immediate next step: run `scripts/compare_atlas_simbicon_pose_window.py` on the
+late state-`0` trace window from current `main`. Use the stance-foot tilt
+numbers together with support-row counts around steps `3970`, `4000`, `4070`,
+and `4100` before trying another stance-reaction or torso-reaction probe.
 
 ## Current Status
 
@@ -27,6 +26,9 @@ another stance-reaction or torso-reaction probe.
 - [x] Pose-window comparison utility landed (PR #3043): use it from `main` for
       late state-`0` stance-foot pose/tilt comparisons instead of resuming the
       old warm-start checkpoint branch.
+- [x] Warm-start checkpoint retired (PR #3047 + branch deletion): the old
+      `feature/dart7-unified-contact-warm-start` branch is no longer a resume
+      surface.
 - [x] Diagnosed and partly fixed the dominant fall mode (gradual height sink)
       via stance-leg height regulation (`height_kp`); torso control completed as
       a true PD.
@@ -64,14 +66,10 @@ indefinitely under the shared SIMBICON controller — including together in the
 
 ## Immediate Next Steps
 
-1. Finish landing
-   [`02-warm-start-branch-retirement.md`](02-warm-start-branch-retirement.md) so
-   `feature/dart7-unified-contact-warm-start` can be removed after explicit
-   maintainer approval.
-2. Run the pose-window comparison utility on late state-`0` DART 6/DART 7 trace
+1. Run the pose-window comparison utility on late state-`0` DART 6/DART 7 trace
    JSONs for steps `3970`, `4000`, `4070`, and `4100`; compare stance-foot
    tilt, stance pose, support-row counts, and support patch location.
-3. Attack lateral balance structurally rather than by gain tuning — candidate
+2. Attack lateral balance structurally rather than by gain tuning — candidate
    approaches are enumerated in `01-diagnosis.md` ("Restart / next-attempt
    options"). Re-verify with the fall-step harness over ≥3000 steps per robot
    **and** the duo, not a short render.

--- a/docs/dev_tasks/simbicon_locomotion/RESUME.md
+++ b/docs/dev_tasks/simbicon_locomotion/RESUME.md
@@ -1,41 +1,40 @@
 # Resume: Python SIMBICON Locomotion
 
-## Current Resume Checkpoint (2026-06-17, Warm-Start Checkpoint Retirement)
+## Current Resume Checkpoint (2026-06-17, Late State-0 Stance Diagnostics)
 
-Current branch: `docs/retire-warm-start-checkpoint`.
+Current branch: `main` or a fresh branch from current `main`.
 
 PR [#3043](https://github.com/dartsim/dart/pull/3043) is merged on `main`; the
 small Atlas SIMBICON pose-window comparison utility no longer needs the old
-checkpoint branch. This branch documents the remaining durable evidence from
+checkpoint branch. PR [#3047](https://github.com/dartsim/dart/pull/3047)
+landed the remaining durable evidence from
 `feature/dart7-unified-contact-warm-start` in
-[`02-warm-start-branch-retirement.md`](02-warm-start-branch-retirement.md) so
-that checkpoint can be removed after this note lands and the maintainer
-explicitly approves deleting the local and remote branch.
+[`02-warm-start-branch-retirement.md`](02-warm-start-branch-retirement.md), and
+the local and remote checkpoint branches were deleted on 2026-06-17 after
+maintainer approval.
 
 Validation so far:
 
 - `pixi run python -m pytest python/tests/unit/test_compare_atlas_simbicon_pose_window.py -q`
 - `pixi run lint`
 
-Immediate next step: finish the docs-only retirement PR, then run
-`scripts/compare_atlas_simbicon_pose_window.py` against the late state-`0`
-DART 6/DART 7 trace JSONs from current `main`. Compare stance-foot local z-axis
-tilt with support-row counts around steps `3970`, `4000`, `4070`, and `4100`
-before trying another stance hip-roll or torso-reaction probe. Do not return to
-global native surface tolerance, seed-depth changes, reactive state-2 support
-hold clamps, or blunt swing `hpx`/`hpy` target clamps without new evidence.
+Immediate next step: run `scripts/compare_atlas_simbicon_pose_window.py`
+against the late state-`0` DART 6/DART 7 trace JSONs from current `main`.
+Compare stance-foot local z-axis tilt with support-row counts around steps
+`3970`, `4000`, `4070`, and `4100` before trying another stance hip-roll or
+torso-reaction probe. Do not return to global native surface tolerance,
+seed-depth changes, reactive state-2 support-hold clamps, or blunt swing
+`hpx`/`hpy` target clamps without new evidence.
 
 How to resume:
 
 ```bash
-git checkout docs/retire-warm-start-checkpoint
+git checkout main
+git pull --ff-only
 git status --short --branch
-pixi run lint
 ```
 
-Then open a docs-only PR for this retirement note. After that PR lands, ask the
-maintainer before deleting `feature/dart7-unified-contact-warm-start` locally
-and remotely.
+Then run the late state-`0` pose-window comparison from current `main`.
 
 The older resume notes below predate PR #3043 and this retirement audit. Keep
 them as SIMBICON task history, but do not treat their branch instructions as

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -783,7 +783,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   deformable suites). All three slices (20a/20b/20c) of WP-091.20 are now
   landed.
 
-#### WP-091.21 Baked dense-index Model artifact [claimed]
+#### WP-091.21 Baked dense-index Model artifact [done — PR #3044, merged 2026-06-17]
 
 - Objective: `enterSimulationMode` bakes an immutable per-domain dense index
   (body/link/dof offsets, creation-ordered) plus per-multibody model arrays,
@@ -799,7 +799,8 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   path (assert via allocation/profile test); golden trajectories unchanged.
 - Gates: `pixi run lint`, `pixi run build`, `pixi run test-unit`.
 - Dependencies: WP-091.20.
-- Evidence (implementation branch): `detail::BakedWorldModel` now caches
+- Evidence: PR [#3044](https://github.com/dartsim/dart/pull/3044) landed this
+  packet. `detail::BakedWorldModel` now caches
   creation-ordered rigid-body and multibody indices plus rigid-body Model arrays
   in `WorldStorage`; state/control vectors, rigid-body batch extraction, and
   batched integration consume the baked identity instead of rebuilding from

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -23,11 +23,12 @@ its own line so status updates remain git-history friendly.
 - Horizon: Now
 - Dimension: Algorithm extensibility
 - Next step: WP-091.20 (Model/State/Control split) is `[done]` via PR #3029,
-  and WP-091.33a (batch semantics tests) is `[done]` via PR #3042. The current
-  branch executes WP-091.21: bake creation-ordered dense per-domain indices and
-  reusable Model artifacts so state vectors and batch validation stop depending
-  on registry iteration order or name-string matching. WP-091.33b remains
-  blocked until WP-091.21 is accepted. The remaining WS0 packet is WP-091.4 legacy
+  WP-091.21 (baked dense-index Model artifact) is `[done]` via PR #3044, and
+  WP-091.33a (batch semantics tests) is `[done]` via PR #3042. WP-091.33b is
+  now the next unblocked packet, but the existing remote branch
+  `wp-091-33b-baked-rigid-model-state-owner` is stale relative to `main` and
+  mixes WP-091.33b/WP-091.33c work; reconcile or recreate it from current
+  `main` before opening a PR. The remaining WS0 packet is WP-091.4 legacy
   freeze, which stays **blocked**: PLAN-042 Decision 5 has no recorded
   maintainer direction. Packets are orchestrator-authored per
   [`../ai/orchestration.md`](../ai/orchestration.md) and picked up via


### PR DESCRIPTION
## Summary

- Refreshes the current north-star operating state after the warm-start checkpoint branch was retired and WP-091.21 landed.
- Keeps future agents on current `main` for SIMBICON and PLAN-091 follow-up work instead of stale branch instructions.

## Motivation / Problem

- PR #3047 landed the warm-start checkpoint retirement audit, and the old `feature/dart7-unified-contact-warm-start` branch has now been deleted locally and remotely.
- PR #3044 completed WP-091.21, but the dashboard still described WP-091.21 as the active packet and still treated WP-091.33b as blocked.

## Changes / Key Changes

- Record the warm-start checkpoint branch deletion in the SIMBICON retirement note.
- Update the SIMBICON README and RESUME handoff to make late state-0 stance diagnostics the next step from current `main`.
- Mark WP-091.21 done via PR #3044 and identify WP-091.33b as the next unblocked PLAN-091 packet.
- Note that the existing `wp-091-33b-baked-rigid-model-state-owner` branch is stale/mixed and should be reconciled or recreated before PR work.

## Testing

- `pixi run lint-md`
- `pixi run check-lint-md`
- `pixi run check-docs-policy`
- `pixi run check-lint-spell`
- `pixi run lint`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Related: #3043, #3044, #3047.
- Backports: None; docs-only DART 7 operating-state refresh.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required: N/A, internal plan/dev-task operating-state refresh only.
- [x] Add unit tests for new functionality: N/A, docs-only state refresh.
- [x] Document new methods and classes: N/A, no API changes.
- [x] Add Python bindings (dartpy) if applicable: N/A, no binding changes.
