### PR TITLE
Preserve contact wrench cache when sleeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### [DART 6.19.1 (TBD)](https://github.com/dartsim/dart/milestone/98?closed=1)
 
+* Simulation
+
+  * Preserve the last solved contact body-force cache when an island first
+    transitions into automatic deactivation, so joint transmitted-wrench
+    queries continue to include contact forces while the island is asleep:
+    [gazebosim/gz-physics#1007](https://github.com/gazebosim/gz-physics/issues/1007)
+
 * Tests
 
   * Loosen the `Issue1184` resting-accuracy regression tolerance from `1e-3` to

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -811,16 +811,17 @@ void ConstraintSolver::buildConstrainedGroups()
           = mGroupResting[it->second] && skeleton->isSleepCandidate();
     }
 
-    // Pass 2: stamp the island-atomic freeze flag and the island index. A
-    // grouped skeleton freezes iff its whole island rests; an ungrouped
-    // skeleton is never frozen by the solver (isolated bodies are cheap and
-    // handled by World::step directly). The island index is exposed for
-    // visualization/diagnostics (e.g. coloring islands in a viewer).
+    // Pass 2: stamp the island index and keep only already-frozen islands
+    // frozen. A newly eligible island must run one final contact solve before
+    // it freezes so observable force caches (e.g. transmitted wrench queries)
+    // keep the last solved constraint forces instead of an unconstrained
+    // forward-dynamics value.
     for (const auto& skeleton : mSkeletons) {
       const auto root = ConstraintBase::getRootSkeleton(skeleton);
       const auto it = rootToGroup.find(root.get());
       const bool grouped = (it != rootToGroup.end());
-      skeleton->setResting(grouped && mGroupResting[it->second]);
+      const bool groupCanRest = grouped && mGroupResting[it->second];
+      skeleton->setResting(groupCanRest && skeleton->isResting());
       skeleton->setIslandIndex(grouped ? static_cast<int>(it->second) : -1);
     }
   }
@@ -837,13 +838,51 @@ void ConstraintSolver::solveConstrainedGroups()
 {
   DART_PROFILE_SCOPED;
 
+  static thread_local std::vector<char> groupAlreadyResting;
+  groupAlreadyResting.assign(mConstrainedGroups.size(), 1);
+  static thread_local std::vector<char> groupSolvedToRest;
+  groupSolvedToRest.assign(mConstrainedGroups.size(), 0);
+
+  if (mDeactivationActive) {
+    for (const auto& skeleton : mSkeletons) {
+      const int island = skeleton->getIslandIndex();
+      if (island < 0)
+        continue;
+
+      const auto groupIndex = static_cast<std::size_t>(island);
+      if (groupIndex >= groupAlreadyResting.size())
+        continue;
+
+      if (!skeleton->isResting())
+        groupAlreadyResting[groupIndex] = 0;
+    }
+  }
+
   for (std::size_t i = 0; i < mConstrainedGroups.size(); ++i) {
-    // Skip islands in which every skeleton is resting. With the feature off no
-    // skeleton is resting, so every entry is false and nothing is skipped.
-    if (i < mGroupResting.size() && mGroupResting[i])
+    const bool groupCanRest = i < mGroupResting.size() && mGroupResting[i];
+
+    // Skip only islands that were already frozen at the start of this solve. A
+    // newly eligible island still needs one final solve to refresh the contact
+    // impulse and body-force caches before it is frozen for subsequent steps.
+    if (groupCanRest && groupAlreadyResting[i])
       continue;
 
     solveConstrainedGroup(mConstrainedGroups[i]);
+
+    if (groupCanRest)
+      groupSolvedToRest[i] = 1;
+  }
+
+  for (const auto& skeleton : mSkeletons) {
+    const int island = skeleton->getIslandIndex();
+    if (island < 0)
+      continue;
+
+    const auto groupIndex = static_cast<std::size_t>(island);
+    if (groupIndex < groupSolvedToRest.size()
+        && groupSolvedToRest[groupIndex]) {
+      skeleton->setResting(true);
+    }
   }
 }
 

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -238,18 +238,28 @@ void World::step(bool _resetCommand)
     if (!skel->isMobile())
       continue;
 
+    bool preservingFinalSleepSolve = false;
+
     // A resting skeleton skips both the impulse-based forward dynamics and the
     // position integration. The only exception is when an impulse was applied
     // to it this step: that means a moving body contacted this island (the
     // solver united them so the group was not all-resting and was solved),
     // delivering an impulse. Such a skeleton must wake and be processed
-    // normally so the impulse is applied and the position is advanced.
+    // normally so the impulse is applied and the position is advanced. A
+    // newly sleep-eligible contact island also receives one final solved
+    // impulse before freezing so transmitted-wrench/body-force queries keep
+    // the last solved contact forces; that path processes the impulse but
+    // preserves the resting state.
     if (deactivationEnabled && skel->isResting()) {
       if (skel->isImpulseApplied()) {
-        skel->setResting(false);
-        skel->setSleepCandidate(false);
-        if (!disturbedThisStep.empty())
-          disturbedThisStep[i] = true;
+        if (skel->isSleepCandidate()) {
+          preservingFinalSleepSolve = true;
+        } else {
+          skel->setResting(false);
+          skel->setSleepCandidate(false);
+          if (!disturbedThisStep.empty())
+            disturbedThisStep[i] = true;
+        }
       } else {
         continue;
       }
@@ -261,6 +271,10 @@ void World::step(bool _resetCommand)
     }
 
     skel->integratePositions(mTimeStep);
+
+    if (preservingFinalSleepSolve && skel->getNumDofs() > 0)
+      skel->setVelocities(
+          Eigen::VectorXd::Zero(static_cast<int>(skel->getNumDofs())));
 
     if (_resetCommand) {
       skel->clearInternalForces();

--- a/tests/integration/test_IslandDeactivation.cpp
+++ b/tests/integration/test_IslandDeactivation.cpp
@@ -110,6 +110,36 @@ SkeletonPtr createFreeBox(
 }
 
 //==============================================================================
+// Builds a one-link articulated body with a revolute root joint and a box link
+// whose bottom face rests on the floor. Unlike a single free body, this exposes
+// the solved contact load through BodyNode::getBodyForce(), matching the joint
+// transmitted-wrench path used by downstream adapters.
+SkeletonPtr createPinnedContactArm(const std::string& name)
+{
+  auto skel = Skeleton::create(name);
+
+  RevoluteJoint::Properties jointProps;
+  jointProps.mName = name + "_joint";
+  jointProps.mAxis = Eigen::Vector3d::UnitY();
+  jointProps.mT_ParentBodyToJoint.translation()
+      = Eigen::Vector3d(0, 0, 0.999999);
+  jointProps.mT_ChildBodyToJoint.translation() = Eigen::Vector3d(0, 0, 0.5);
+
+  BodyNode::Properties bodyProps(
+      BodyNode::AspectProperties(std::string(name + "_body")));
+  bodyProps.mInertia.setMass(1.0);
+
+  auto* body = skel->createJointAndBodyNodePair<RevoluteJoint>(
+                       nullptr, jointProps, bodyProps)
+                   .second;
+
+  auto shape = std::make_shared<BoxShape>(Eigen::Vector3d(0.2, 0.2, 1.0));
+  body->createShapeNodeWith<CollisionAspect, DynamicsAspect>(shape);
+
+  return skel;
+}
+
+//==============================================================================
 // Steps the world until the predicate is satisfied or maxSteps is exceeded.
 // Returns the number of steps taken (== maxSteps if never satisfied).
 template <typename Predicate>
@@ -173,6 +203,30 @@ TEST(IslandDeactivation, SettlesThenSleeps)
     EXPECT_TRUE(box->getPositions().isApprox(frozenPos, 1e-12))
         << "frozen box drifted at step " << i;
   }
+}
+
+//==============================================================================
+// A skeleton that is put to sleep must preserve the last solved contact wrench
+// in its BodyNode force cache. Downstream adapters expose this through joint
+// transmitted-wrench APIs, so the transition into sleep must not overwrite the
+// value with an unconstrained forward-dynamics pass.
+TEST(IslandDeactivation, SleepingPreservesContactBodyForce)
+{
+  auto world = makeSleepWorld();
+  world->addSkeleton(createFloor());
+  auto arm = createPinnedContactArm("arm");
+  world->addSkeleton(arm);
+
+  const std::size_t stepsToSleep
+      = stepUntil(world.get(), 5000, [&]() { return arm->isResting(); });
+  ASSERT_LT(stepsToSleep, 5000u) << "arm never went to sleep";
+  ASSERT_TRUE(arm->isResting());
+
+  const auto* body = arm->getBodyNode(0);
+  const Eigen::Vector6d bodyForce = body->getBodyForce();
+
+  EXPECT_GT(bodyForce.tail<3>().norm(), 1.0)
+      << "sleep transition discarded the solved contact force";
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Preserve the last solved contact body-force cache when a contact island first enters automatic deactivation.
- Keep joint transmitted-wrench queries including contact forces while the island is asleep, fixing the DART-side behavior behind gazebosim/gz-physics#1007.

## Motivation / Problem

- On `release-6.19`, a contact island can become sleep-eligible before the constraint solve refreshes observable contact-force caches for the frozen state.
- `World::step()` then runs an unconstrained forward-dynamics pass during the sleep transition, and downstream gz-physics observes a transmitted wrench without the solved contact contribution.

## Changes / Key Changes

- Keep newly sleep-eligible islands awake for one final contact solve, then mark them resting after the solve completes.
- Continue skipping islands that were already resting at the start of the solve.
- Preserve the final sleep-transition impulse path in `World::step()` without waking a legitimately sleep-eligible island.
- Add an island-deactivation regression that verifies a pinned articulated body preserves a nonzero solved contact body force after entering sleep.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test` passed 97/97 C++ tests, including `test_IslandDeactivation`.
- Targeted downstream check passed after installing this branch into the Gazebo Pixi environment: `COMMON_TEST_joint_transmitted_wrench_features_dartsim`.
- Full local gz-physics suite passed after the fix: `ctest --output-on-failure --parallel 4 -E PERFORMANCE_` passed 199/199 and `ctest --output-on-failure --parallel 1 -R PERFORMANCE_` passed 4/4.
- Hosted fixed-CI verification passed on a temporary branch containing this fix plus companion CI PR #3050: `CI gz-physics / ubuntu-latest` at https://github.com/dartsim/dart/actions/runs/27678961208/job/81861226868 ran `test-gz`, passed `COMMON_TEST_joint_transmitted_wrench_features_dartsim`, and reported `100% tests passed, 0 tests failed out of 199` plus `100% tests passed, 0 tests failed out of 4` performance tests.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes gazebosim/gz-physics#1007.
- Companion CI coverage PR: #3050.

---

#### Checklist

- [x] Milestone set (`DART 6.19.1` for `release-6.19`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no public API change
- [x] Add Python bindings (dartpy) if applicable: N/A