### PR TITLE
Cover sleep-transition wrench cache paths

### DIFF
--- a/tests/integration/test_IslandDeactivation.cpp
+++ b/tests/integration/test_IslandDeactivation.cpp
@@ -56,6 +56,18 @@ using namespace dart::simulation;
 
 namespace {
 
+class ExposedConstraintSolver final : public constraint::ConstraintSolver
+{
+public:
+  void solveGroupsForTest()
+  {
+    solveConstrainedGroups();
+  }
+
+protected:
+  void solveConstrainedGroup(constraint::ConstrainedGroup&) override {}
+};
+
 //==============================================================================
 // Builds a thin static floor (immobile) centered so its top surface sits at
 // z = 0.
@@ -227,6 +239,79 @@ TEST(IslandDeactivation, SleepingPreservesContactBodyForce)
 
   EXPECT_GT(bodyForce.tail<3>().norm(), 1.0)
       << "sleep transition discarded the solved contact force";
+}
+
+//==============================================================================
+// A contact island that is already resting but carries the final solved impulse
+// must process that impulse without waking. This covers the path that preserves
+// the contact-force cache for transmitted-wrench queries while freezing the
+// island for subsequent steps.
+TEST(IslandDeactivation, FinalSleepImpulseKeepsBodyFrozen)
+{
+  auto world = makeSleepWorld();
+  world->addSkeleton(createFloor());
+  auto arm = createPinnedContactArm("arm");
+  world->addSkeleton(arm);
+
+  // Establish the contact island, then force the exact post-solver state used
+  // for the final sleep solve: resting, sleep-candidate, and carrying an
+  // impulse.
+  world->step();
+  arm->setSleepCandidate(true);
+  arm->setResting(true);
+  arm->setImpulseApplied(true);
+  arm->setVelocities(
+      Eigen::VectorXd::Ones(static_cast<int>(arm->getNumDofs())));
+
+  world->step();
+
+  EXPECT_TRUE(arm->isResting());
+  EXPECT_TRUE(arm->isSleepCandidate());
+  EXPECT_FALSE(arm->isImpulseApplied());
+  EXPECT_TRUE(arm->getVelocities().isZero(1e-12));
+}
+
+//==============================================================================
+// If a resting body receives an impulse while it is not still a sleep
+// candidate, it must wake and process the impulse normally.
+TEST(IslandDeactivation, NonCandidateImpulseWakesRestingBody)
+{
+  auto world = makeSleepWorld();
+  world->setGravity(Eigen::Vector3d::Zero());
+
+  auto box = createFreeBox(
+      "box", Eigen::Vector3d::Constant(kBoxSize), Eigen::Vector3d::Zero());
+  world->addSkeleton(box);
+
+  box->setResting(true);
+  box->setSleepCandidate(false);
+  box->setImpulseApplied(true);
+
+  world->step();
+
+  EXPECT_FALSE(box->isResting());
+  EXPECT_FALSE(box->isSleepCandidate());
+  EXPECT_FALSE(box->isImpulseApplied());
+}
+
+//==============================================================================
+// The solver may see stale diagnostic island indices when
+// solveConstrainedGroups is exercised directly without rebuilding groups. It
+// should ignore them instead of indexing into an empty group vector.
+TEST(IslandDeactivation, SolverIgnoresStaleIslandIndexWithoutGroups)
+{
+  ExposedConstraintSolver solver;
+  auto box = createFreeBox(
+      "box", Eigen::Vector3d::Constant(kBoxSize), Eigen::Vector3d::Zero());
+
+  solver.addSkeleton(box);
+  solver.setDeactivationActive(true);
+  box->setIslandIndex(0);
+  box->setResting(true);
+
+  solver.solveGroupsForTest();
+
+  EXPECT_TRUE(box->isResting());
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Add focused island-deactivation tests for the final sleep impulse path that preserves cached contact forces.
- Add coverage for the non-candidate impulse wake path and a defensive stale-island-index solver path.

## Motivation / Problem

- Follow-up to #3051 to address Codecov patch coverage feedback on the sleep-transition wrench-cache fix.

## Changes / Key Changes

- Covers the final solved impulse path used before a newly resting contact island freezes.
- Covers the resting-but-not-sleep-candidate impulse path to keep wake behavior documented.
- Exposes `solveConstrainedGroups()` through a test-only solver fixture to exercise stale island index handling.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --target test_IslandDeactivation --parallel "$JOBS"`
- `build/default/cpp/Release/tests/integration/test_IslandDeactivation --gtest_filter='IslandDeactivation.*'`
- `pixi run build`
- `pixi run test`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3051
- Built on #3050

---

#### Checklist

- [x] Milestone set (DART 6.19.1)
- [x] CHANGELOG.md updated if required (not required: test-only coverage follow-up)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
