### PR TITLE
Packaging 6.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## DART 6
 
-### [DART 6.19.1 (TBD)](https://github.com/dartsim/dart/milestone/98?closed=1)
+### [DART 6.19.1 (2026-06-17)](https://github.com/dartsim/dart/milestone/98?closed=1)
 
 * Simulation
 
   * Preserve the last solved contact body-force cache when an island first
     transitions into automatic deactivation, so joint transmitted-wrench
     queries continue to include contact forces while the island is asleep:
+    [#3051](https://github.com/dartsim/dart/pull/3051),
     [gazebosim/gz-physics#1007](https://github.com/gazebosim/gz-physics/issues/1007)
 
 * Tests
@@ -16,7 +17,13 @@
   * Build and run the pinned gz-physics test suite in the DART 6 Gazebo CI gate
     instead of only checking that the plugin links, and add macOS x64/arm64
     coverage so downstream Homebrew regressions are caught before release:
+    [#3050](https://github.com/dartsim/dart/pull/3050),
     [gazebosim/gz-physics#1007](https://github.com/gazebosim/gz-physics/issues/1007)
+
+  * Cover the sleep-transition wrench-cache regression paths, including the
+    final contact impulse before sleep, non-candidate wakeup, and stale
+    constraint-island index handling:
+    [#3055](https://github.com/dartsim/dart/pull/3055)
 
   * Loosen the `Issue1184` resting-accuracy regression tolerance from `1e-3` to
     `2e-3` so it is not flipped by micrometer-scale cross-platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@
     [#3051](https://github.com/dartsim/dart/pull/3051),
     [gazebosim/gz-physics#1007](https://github.com/gazebosim/gz-physics/issues/1007)
 
+* Performance
+
+  * Speed up the articulated-body forward-dynamics hot path by caching the
+    owning `Skeleton` pointer in `BodyNode` and avoiding fixed-size to dynamic
+    Eigen temporaries in `math::isNan` and `math::isInf`, improving the
+    `BM_Dynamics` benchmark by about 18% while preserving bit-exact results:
+    [#3028](https://github.com/dartsim/dart/pull/3028)
+
+  * Remove per-pivot heap allocations in `ContactConstraint` by evaluating
+    spatial-normal matrix-vector products directly into the solver buffers,
+    reducing contact-heavy `boxes` per-step heap allocations by about 58% and
+    improving wall-clock time by about 6% with bit-exact results:
+    [#3033](https://github.com/dartsim/dart/pull/3033)
+
+  * Avoid heap temporaries in `BodyNode` force-aggregation routines by writing
+    Jacobian-transpose products directly into Skeleton tree-cache segments:
+    [#3037](https://github.com/dartsim/dart/pull/3037)
+
+  * Reduce remaining contact-heavy per-step heap allocations by scanning
+    external disturbances per DOF and storing contact spatial normals inline,
+    cutting `boxes` heap allocations by about 38% on top of the earlier
+    allocation reductions while preserving bit-exact finite-state results:
+    [#3040](https://github.com/dartsim/dart/pull/3040)
+
 * Tests
 
   * Build and run the pinned gz-physics test suite in the DART 6 Gazebo CI gate

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.19.0</version>
+  <version>6.19.1</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.19.0"
+version = "6.19.1"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
## Summary

- Prepare DART 6.19.1 release packaging.

## Motivation / Problem

- Publish a DART 6.19 patch release containing the sleeping contact wrench-cache fix, downstream gz-physics CI/test coverage, and the bit-exact performance/allocation improvements that landed on `release-6.19` after `v6.19.0`.

## Changes / Key Changes

- Bump `package.xml` and `pixi.toml` from `6.19.0` to `6.19.1`.
- Date the DART 6.19.1 changelog section.
- Link all merged DART 6.19.1 release PRs in the changelog entries.
- Keep included PRs assigned to the `DART 6.19.1` milestone.

## Testing

- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- #3028
- #3031
- #3033
- #3037
- #3040
- #3050
- #3051
- #3055
- https://github.com/gazebosim/gz-physics/issues/1007

---

#### Checklist

- [x] Milestone set to `DART 6.19.1`
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality (N/A: packaging-only)
- [x] Document new methods and classes (N/A: packaging-only)
- [x] Add Python bindings (dartpy) if applicable (N/A: packaging-only)