### PR TITLE
Use built-in GitHub issue types in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ""
-labels: "type: bug"
+type: Bug
 assignees: ""
 ---
 
@@ -20,7 +20,9 @@ assignees: ""
 - Installation: [e.g., pixi, conda, apt, homebrew, vcpkg, source]
 - Compiler (if source): [e.g., GCC 13.2.0, Clang 18.0.0, MSVC 2026]
 
-> **Note:** Bug fixes are only accepted for `main` and `release-6.17`. If using 6.16 or older, please upgrade to 6.17.x first and verify the issue still exists.
+> **Note:** Bug fixes are only accepted for `main` and the latest maintained
+> DART 6 LTS release branch. If using an older DART 6 minor line, please
+> upgrade to the latest 6.x first and verify the issue still exists.
 
 **Expected vs Current Behavior:**
 Describe what you expected and what actually happens.

--- a/.github/ISSUE_TEMPLATE/build-test-failure.yml
+++ b/.github/ISSUE_TEMPLATE/build-test-failure.yml
@@ -1,8 +1,8 @@
 name: Build/Test Failure (Specific Platform)
 description: Report build or test failures on a specific OS/distro or packaging stack.
 title: "[Build/Test] <short summary>"
+type: Bug
 labels:
-  - "priority: low"
   - "status: help wanted"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ""
-labels: "type: feature request"
+type: Feature
 assignees: ""
 ---
 


### PR DESCRIPTION
## Summary

- Use GitHub built-in issue types in issue templates instead of DART's removed `type:*` labels.
- Stop auto-applying the old `priority: low` label to build/test failure reports; priority now belongs to the repo `Priority` issue field.
- Keep `status: help wanted` on community-supported build/test reports.

## Motivation / Problem

- GitHub now has first-class issue/PR types, and DART has issue fields for priority and effort, so duplicative labels should not be applied by templates.

## Changes / Key Changes

- Set `type: Bug` for bug report and build/test failure templates.
- Set `type: Feature` for the feature request template.
- Replace the stale hard-coded DART 6 LTS branch note with generic latest-maintained-DART-6 wording.
- Remove `priority: low` from the build/test failure template.

## Testing

- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Label cleanup: deleted `priority: low`, `priority: medium`, and `priority: high` from `dartsim/dart`; `type:*` labels were already removed.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required (not required: repository issue-template and label metadata only)
- [x] Add unit tests for new functionality (not applicable)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
