### PR TITLE
Make Debug CI mold install optional

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -501,8 +501,28 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
-          packages: libgl1-mesa-dev libglu1-mesa-dev xvfb mold
+          packages: libgl1-mesa-dev libglu1-mesa-dev xvfb
           version: 3
+
+      - name: Install mold when available
+        run: |
+          if command -v mold >/dev/null 2>&1; then
+            mold --version
+            exit 0
+          fi
+
+          # Self-hosted ubuntu-latest runners may not expose the mold apt
+          # package. Keep mold as an opportunistic Debug dartpy link
+          # accelerator and let CMake fall back when it is unavailable.
+          if sudo apt-get update && apt-cache show mold >/dev/null 2>&1; then
+            if sudo apt-get install -y --no-install-recommends mold; then
+              mold --version
+            else
+              echo "::notice::Unable to install mold; Debug dartpy will use the default linker."
+            fi
+          else
+            echo "::notice::mold is unavailable on this runner; Debug dartpy will use the default linker."
+          fi
 
       - name: Configure environment for compiler cache
         uses: ./.github/actions/configure-compiler-cache


### PR DESCRIPTION
## Summary

- Makes the Ubuntu Debug Tests `mold` linker install best-effort so self-hosted `ubuntu-latest` runners without an apt `mold` package do not fail before configure, build, or test.

## Motivation / Problem

- Post-merge CI for #3048 failed in `CI Linux / Debug Tests` on self-hosted runner `dartsim-mark13-5` before any DART build or test ran.
- The failing step was `Install system dependencies`; the cached apt package action exited because the runner could not locate the `mold` package.
- `mold` is only an accelerator for the Debug dartpy link path. CMake already falls back cleanly when `DART_USE_MOLD` is requested but `mold` is not on `PATH`.

## Changes / Key Changes

- Removes `mold` from the required cached apt package list in the Ubuntu Debug Tests job.
- Adds a best-effort `Install mold when available` shell step that uses an existing `mold`, installs it when apt exposes it, or emits a notice and lets CMake use the default linker.
- Keeps the Debug dartpy smoke path and `DART_USE_MOLD_OVERRIDE=ON`; only the package-install failure is made non-blocking.

## Testing

- `pixi run python -c "import yaml; yaml.safe_load(open('.github/workflows/ci_ubuntu.yml')); print('valid')"`
- `git diff --check`
- `pixi run lint`
- CI evidence: https://github.com/dartsim/dart/actions/runs/27726705365/job/82024961447 failed in `Install system dependencies` with `N: Unable to locate package mold` on `dartsim-mark13-5`, before any configure, build, or test step.

## Breaking Changes

- [x] None
- CI workflow maintenance only.

## Related Issues / PRs (backports)

- Follow-up to #3048.
- Backports: None; post-merge `main` CI workflow hardening only.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required: N/A, CI workflow maintenance only.
- [x] Add unit tests for new functionality: N/A, workflow-only CI hardening.
- [x] Document new methods and classes: N/A, no API changes.
- [x] Add Python bindings (dartpy) if applicable: N/A.
