### PR TITLE
Skip injected allocation gate under coverage

### DIFF
--- a/tests/unit/simulation/world/test_world.cpp
+++ b/tests/unit/simulation/world/test_world.cpp
@@ -10370,9 +10370,15 @@ void expectInjectedPostBakeAllocationRejectedByGlobalHeapGate()
 
 TEST(World, FirstPostBakeGlobalHeapGateFailsOnInjectedAllocation)
 {
+#if defined(DART_CODECOV)
+  GTEST_SKIP()
+      << "The injected allocation gate depends on the global heap counter, "
+         "which is disabled under coverage instrumentation.";
+#else
   EXPECT_NONFATAL_FAILURE(
       expectInjectedPostBakeAllocationRejectedByGlobalHeapGate(),
       "global heap bytes allocated during first post-bake steps");
+#endif
 }
 
 TEST(World, IpcSemiImplicitMultibodyStepUsesForwardDynamicsStage)


### PR DESCRIPTION
## Summary
- Skip the injected global-heap gate self-test when `DART_CODECOV` disables the heap counter.

## Motivation / Problem
- `CI Linux` Coverage (Debug) failed on `origin/main` because `ScopedHeapAllocationCounter` intentionally reports zero under coverage instrumentation, so the injected-allocation self-test expected a non-fatal failure that cannot occur in that build.

## Changes / Key Changes
- Guard `World.FirstPostBakeGlobalHeapGateFailsOnInjectedAllocation` with a `DART_CODECOV` skip.
- Keep the non-coverage `EXPECT_NONFATAL_FAILURE` path unchanged so normal Debug/Release builds still prove the gate catches injected allocations.

## Testing
- `pixi run config-coverage`
- `pixi run cmake --build build/default/cpp/Debug --parallel "$JOBS" --target test_world`
- `pixi run bash -lc 'build/default/cpp/Debug/bin/test_world --gtest_filter=World.FirstPostBakeGlobalHeapGateFailsOnInjectedAllocation --gtest_also_run_disabled_tests'`
- `pixi run lint`
- `pixi run build`

CI observation:
- `CI Linux` run 27735859121 failed in Coverage (Debug), job 82065679719, at `World.FirstPostBakeGlobalHeapGateFailsOnInjectedAllocation`.
- The old `CI CUDA` run is queued on `ubuntu-latest-gpu`; current repo runner inventory showed no runner advertising that label, so no code failure log is available.

## Breaking Changes
- [x] None
- No public API or behavior changes.

## Related Issues / PRs (backports)
- Backport: N/A; `release-6.19` does not contain `tests/unit/simulation/world/test_world.cpp` / this DART 7 coverage test path.
- Related issues: None.

---
#### Checklist
- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required: N/A, internal CI/test gate only
- [x] Add unit tests for new functionality: N/A, test harness fix for existing coverage gate
- [x] Document new methods and classes: N/A
- [x] Add Python bindings (dartpy) if applicable: N/A