### PR TITLE
Convert live SKEL fixtures to SDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Articulated Body Algorithm for accurate, stable motion dynamics.
 - **Research-grade dynamics** — Featherstone algorithms, generalized coordinates, and direct access to dynamics quantities
 - **Easy to start** — Python and C++ packages through common package managers, plus reproducible source builds with pixi
 - **Extensible foundations** — Math, native collision, constraints, model loading, benchmarks, and tests that support new algorithms and baseline comparisons
-- **Unified model loading** — Load URDF, SDF, MJCF, and SKEL models through a single API
+- **Unified model loading** — Load URDF, SDF, and MJCF models through a single API
 - **Scalable compute roadmap** — Cross-platform CPU support today, with roadmap work for multi-core, SIMD, and accelerator backends
 - **Battle-tested ecosystem** — Powers [Gazebo](https://gazebosim.org), research labs, and production systems worldwide, with best-effort support for production use
 

--- a/dart/io/AGENTS.md
+++ b/dart/io/AGENTS.md
@@ -4,22 +4,23 @@ Agent guidelines for the IO/parsing module.
 
 ## Overview
 
-Unified model loading API for URDF, SDF, MJCF, and SKEL formats.
+Unified model loading API for URDF, SDF, and MJCF formats.
 
 ## Supported Formats
 
-| Format | Function                   | Notes             |
-| ------ | -------------------------- | ----------------- |
-| URDF   | `dart::io::readSkeleton()` | ROS standard      |
-| SDF    | `dart::io::readSkeleton()` | Gazebo format     |
-| MJCF   | `dart::io::readSkeleton()` | MuJoCo format     |
-| SKEL   | `dart::io::readSkeleton()` | DART legacy (XML) |
+| Format | Function                   | Notes         |
+| ------ | -------------------------- | ------------- |
+| URDF   | `dart::io::readSkeleton()` | ROS standard  |
+| SDF    | `dart::io::readSkeleton()` | Gazebo format |
+| MJCF   | `dart::io::readSkeleton()` | MuJoCo format |
 
 ## Key Concepts
 
 - **Unified API**: `dart::io::readSkeleton(path, options)` auto-detects format
 - **ReadOptions**: Package directories, resource retrieval callbacks
 - **Package resolution**: `package://` URIs for ROS compatibility
+- **SKEL removal**: DART 7 is removing legacy SKEL support; use `release-6.*`
+  when parity evidence requires old SKEL behavior.
 
 ## Code Patterns
 
@@ -36,7 +37,6 @@ Located in `dart/utils/`:
 - `urdf/UrdfParser.hpp` - URDF parsing
 - `sdf/SdfParser.hpp` - SDF parsing
 - `mjcf/MjcfParser.hpp` - MJCF parsing
-- `skel/SkelParser.hpp` - SKEL parsing
 
 ## Testing
 

--- a/dart/io/read.hpp
+++ b/dart/io/read.hpp
@@ -55,7 +55,7 @@ enum class ModelFormat
   /// Infer from URI (extension / XML root element).
   Auto = 0,
 
-  /// DART native XML format (.skel).
+  /// Legacy DART XML format (.skel), planned for removal before DART 7.
   Skel,
 
   /// SDF format (.sdf / .world).

--- a/dart/utils/dart_resource_retriever.hpp
+++ b/dart/utils/dart_resource_retriever.hpp
@@ -49,8 +49,8 @@ namespace utils {
 ///
 /// Example of a sample data URI:
 /// @code
-/// "dart://sample/skel/shapes.skel"
-///                \______________/
+/// "dart://sample/sdf/test/shapes.sdf"
+///                \_________________/
 ///                       |
 ///            file path with respect to
 ///            the sample data directory

--- a/data/sdf/test/cube.sdf
+++ b/data/sdf/test/cube.sdf
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <model name="box skeleton">
+    <link name="box">
+      <pose>0 0.125 0 1 2 3</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>1</mass>
+      </inertial>
+      <visual name="visual 1">
+        <geometry>
+          <box>
+            <size>0.2 0.2 0.2</size>
+          </box>
+        </geometry>
+      </visual>
+      <collision name="collision 1">
+        <geometry>
+          <box>
+            <size>0.2 0.2 0.2</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/data/sdf/test/shapes.sdf
+++ b/data/sdf/test/shapes.sdf
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <model name="box skeleton">
+    <link name="box">
+      <pose>-0.6 0 0 1 2 3</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>1</mass>
+      </inertial>
+      <visual name="visual 1">
+        <geometry>
+          <box>
+            <size>0.1 0.05 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <collision name="collision 1">
+        <geometry>
+          <box>
+            <size>0.1 0.05 0.1</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/data/sdf/test/single_pendulum.sdf
+++ b/data/sdf/test/single_pendulum.sdf
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <model name="single_pendulum">
+    <link name="link 1">
+      <pose>0.1 0 0 0 0 0</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>5</mass>
+        <inertia>
+          <ixx>1</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>2</iyy>
+          <iyz>0</iyz>
+          <izz>3</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual 1">
+        <geometry>
+          <box>
+            <size>0.1 0.2 0.3</size>
+          </box>
+        </geometry>
+      </visual>
+      <collision name="collision 1">
+        <geometry>
+          <box>
+            <size>0.1 0.2 0.3</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+    <joint name="joint 1" type="revolute">
+      <pose>-0.1 0 0 0 0 0</pose>
+      <parent>world</parent>
+      <child>link 1</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <dynamics>
+          <damping>10</damping>
+        </dynamics>
+      </axis>
+    </joint>
+  </model>
+</sdf>

--- a/data/sdf/test/test_shapes.sdf
+++ b/data/sdf/test/test_shapes.sdf
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <model name="ground skeleton">
+    <static>true</static>
+    <link name="ground">
+      <pose>0 -0.375 0 0 0 0</pose>
+      <visual name="visual 1">
+        <pose>0 -0.005 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>10 0.01 10</size>
+          </box>
+        </geometry>
+      </visual>
+      <collision name="collision 1">
+        <pose>0 -0.005 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>10 0.01 10</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/docs/dev_tasks/skel_format_evolution/README.md
+++ b/docs/dev_tasks/skel_format_evolution/README.md
@@ -2,47 +2,53 @@
 
 ## Current Status
 
-- [ ] Phase 0: Capture strategic decision + prototype reference (this PR)
-- [ ] Phase 1: SKEL deprecation. Add a runtime deprecation warning to
-      `dart::utils::SkelParser`, update tutorials and onboarding to point at
-      URDF / SDF / MJCF, and remove SKEL examples that have a URDF/SDF twin
-- [ ] Phase 2: YAML front-ends for URDF and SDF (not for SKEL). Decide on a
-      YAML parser (rapidyaml is the prototype's pick) and add the front-ends
-      behind `dart::io::ModelFormat::UrdfYaml` and `SdfYaml`, mirroring the
-      existing format dispatch
-- [ ] Phase 3: USD support. Coordinate with
+- [x] Phase 0: Capture strategic decision + prototype reference.
+- [x] Phase 1: Convert live SKEL fixtures used by examples, tests, and
+      benchmarks to SDF. This branch adds SDF replacements for the referenced
+      `single_pendulum`, `cube`, `shapes`, and `test_shapes` fixtures, moves
+      tests and resource retriever coverage off `dart://sample/skel`, and
+      verifies examples/tutorials/python examples/benchmarks have no SKEL file
+      loads.
+- [ ] Phase 2: Remove SKEL from DART 7 `main`: parser implementation,
+      `dart::io` format inference and dispatch, bindings/stubs, parser-specific
+      tests, `data/skel`, and user-facing DART 7 docs.
+- [ ] Phase 3: Optional YAML model/scene format. Decide whether YAML should be
+      a new DART-owned scene format or a front-end over URDF/SDF semantics; do
+      not implement SKEL syntax in YAML.
+- [ ] Phase 4: USD support. Coordinate with
       [`usd_scene_loader/`](../usd_scene_loader/) so SKEL evolution and USD
       adoption share design pressure on the unified `dart::io` front door
-- [ ] Phase 4: Export writers for URDF, SDF, and YAML so DART can round-trip
+- [ ] Phase 5: Export writers for URDF, SDF, and YAML so DART can round-trip
       a scene back to portable text
 
 ## Goal
 
 Close out [issue #496](https://github.com/dartsim/dart/issues/496) (2015
 proposal to convert SKEL XML to YAML) with a decision _not_ to YAML-ify SKEL,
-and instead invest the same engineering budget into deprecating SKEL,
-enhancing URDF and SDF, adopting USD, and adding format-export so DART scenes
-can leave the engine in the same standards-track formats they came in.
+and instead remove SKEL before the DART 7 release. Invest the same engineering
+budget into verified fixture migration, URDF/SDF/MJCF coverage, optional new
+YAML design, USD adoption, and format-export so DART scenes can leave the
+engine in portable formats.
 
 ## Non-Goals
 
 - Re-implementing SKEL as YAML. Issue #496's literal proposal is rejected;
   the rationale is in _Key Decisions_ below.
-- Forcing existing SKEL users off the format on a hard deadline. Read-only
-  SKEL parsing stays until DART 8 removes deprecated DART 6 / 7 APIs.
-- Building DART-specific YAML schemas that diverge from the URDF and SDF
-  semantics. YAML front-ends are alternate syntax over the same models.
+- Keeping SKEL support in DART 7 for compatibility. Legacy users should stay on
+  a `release-6.*` branch until their assets are migrated.
+- Building a YAML schema before deciding its maintenance, export, and
+  interchange contracts. YAML remains optional and must not be SKEL-in-YAML.
 
 ## Key Decisions
 
-- **SKEL is legacy, not evolving**. The format is verbose, string-based, and
-  has no installed-base outside DART. Industry has converged on URDF (ROS)
-  and SDF (Gazebo); MuJoCo and Drake have YAML alternatives over those same
-  models, not over a fork-specific schema.
-- **YAML belongs on URDF and SDF, not on SKEL**. A YAML front-end over
-  `urdfdom` and `libsdformat` reuses the canonical models and authoring
-  ecosystems. A SKEL-only YAML schema would create a third format DART has
-  to maintain.
+- **SKEL is legacy and should leave DART 7**. The format is verbose,
+  string-based, and has no installed-base outside DART. Industry has converged
+  on URDF (ROS), SDF (Gazebo), and MJCF (MuJoCo); DART 7 should not carry a
+  DART-only XML format forward.
+- **YAML is optional, but not SKEL YAML**. A YAML front-end over `urdfdom` and
+  `libsdformat` reuses canonical models and authoring ecosystems. A new
+  DART-owned YAML scene format may still be worth evaluating, but it must be a
+  clean DART 7 format with explicit semantics, tests, and export strategy.
 - **USD is the medium-term scene format**. Pixar / NVIDIA convergence makes
   USD the most likely cross-engine scene format. Loader work is tracked
   separately under [`usd_scene_loader/`](../usd_scene_loader/); SKEL
@@ -80,17 +86,28 @@ phase up.
 
 ## Immediate Next Steps
 
-1. Land this dev-task folder.
-2. When Phase 1 starts, fork a feature branch off `main`, run the
-   deprecation warning + tutorial update as a single small PR, and remove
-   the SKEL example files that have URDF / SDF twins.
+1. Finish this Phase 1 conversion branch: run the focused IO/simulation/resource
+   tests, docs policy, and lint.
+2. Start Phase 2 on a follow-up branch: remove `SkelParser`, `.skel`
+   inference/dispatch, parser-specific tests, bindings/stubs, and `data/skel`.
+3. After SKEL removal is mechanically under control, decide whether Phase 3 is
+   a YAML front-end over existing formats or a new DART-owned scene format.
+4. Keep Phase 4 USD work coordinated with
+   [`usd_scene_loader/`](../usd_scene_loader/) rather than duplicating that
+   loader surface here.
 
 ## Verification Gates
 
-- Phase 1: `pixi run lint`, `pixi run test-py` (parser warnings) and
-  `pixi run check-docs-policy` (tutorial references stay accurate).
-- Phase 2: focused tests under `tests/integration/io/` for the YAML
-  front-ends, parity with the XML originals.
-- Phase 3: see `usd_scene_loader/` gates.
-- Phase 4: round-trip tests that load a scene from each format and write it
+- Phase 1: focused IO/simulation/resource retriever tests for the converted SDF
+  fixtures; `rg` checks proving examples/tests/benchmarks no longer reference
+  `dart://sample/skel` or `data/skel`; `pixi run check-docs-policy`;
+  `pixi run lint`.
+- Phase 2: focused tests proving `.skel` no longer dispatches through
+  `dart::io`, parser-specific SKEL tests are removed, and the source tree no
+  longer ships DART 7 sample SKEL assets.
+- Phase 3: focused parser tests for any accepted YAML design, including parity
+  with the canonical format it maps to or explicit tests for a new DART-owned
+  schema.
+- Phase 4: see `usd_scene_loader/` gates.
+- Phase 5: round-trip tests that load a scene from each format and write it
   back, comparing the re-parsed models.

--- a/docs/dev_tasks/skel_format_evolution/README.md
+++ b/docs/dev_tasks/skel_format_evolution/README.md
@@ -11,7 +11,9 @@
       loads.
 - [ ] Phase 2: Remove SKEL from DART 7 `main`: parser implementation,
       `dart::io` format inference and dispatch, bindings/stubs, parser-specific
-      tests, `data/skel`, and user-facing DART 7 docs.
+      tests, `.skel` sample fixtures, and user-facing DART 7 docs. Preserve or
+      relocate non-SKEL mesh assets such as `data/skel/kima/*.dae` before
+      deleting any parent directory.
 - [ ] Phase 3: Optional YAML model/scene format. Decide whether YAML should be
       a new DART-owned scene format or a front-end over URDF/SDF semantics; do
       not implement SKEL syntax in YAML.
@@ -89,7 +91,9 @@ phase up.
 1. Finish this Phase 1 conversion branch: run the focused IO/simulation/resource
    tests, docs policy, and lint.
 2. Start Phase 2 on a follow-up branch: remove `SkelParser`, `.skel`
-   inference/dispatch, parser-specific tests, bindings/stubs, and `data/skel`.
+   inference/dispatch, parser-specific tests, bindings/stubs, and `.skel`
+   sample fixtures. Preserve or move non-SKEL mesh assets such as
+   `data/skel/kima/*.dae` before deleting any parent directory.
 3. After SKEL removal is mechanically under control, decide whether Phase 3 is
    a YAML front-end over existing formats or a new DART-owned scene format.
 4. Keep Phase 4 USD work coordinated with
@@ -104,7 +108,9 @@ phase up.
   `pixi run lint`.
 - Phase 2: focused tests proving `.skel` no longer dispatches through
   `dart::io`, parser-specific SKEL tests are removed, and the source tree no
-  longer ships DART 7 sample SKEL assets.
+  longer ships DART 7 sample `.skel` assets. Existing non-SKEL mesh tests that
+  load `data/skel/kima/*.dae` must keep passing, either from their current path
+  or after an explicit fixture relocation.
 - Phase 3: focused parser tests for any accepted YAML design, including parity
   with the canonical format it maps to or explicit tests for a new DART-owned
   schema.

--- a/docs/dev_tasks/skel_format_evolution/RESUME.md
+++ b/docs/dev_tasks/skel_format_evolution/RESUME.md
@@ -1,31 +1,51 @@
 # Resume: SKEL Format Evolution
 
+## Current Resume Checkpoint
+
+Phase 1 is implemented locally on `feature/remove-skel-dart7`: all SKEL files
+that were referenced by examples, tests, or benchmarks have SDF replacements and
+the live test/resource-retriever references have moved off `dart://sample/skel`.
+The converted fixtures are:
+
+- `data/skel/test/single_pendulum.skel` -> `data/sdf/test/single_pendulum.sdf`
+- `data/skel/cube.skel` -> `data/sdf/test/cube.sdf`
+- `data/skel/shapes.skel` -> `data/sdf/test/shapes.sdf`
+- `data/skel/test/test_shapes.skel` -> `data/sdf/test/test_shapes.sdf`
+
+The only remaining `.skel` strings under tests are parser-specific temporary
+paths in `tests/integration/io/test_skel_parser.cpp`; remove those with the
+parser in Phase 2.
+
 ## Last Session Summary
 
 Captured the strategic decision to close out
 [issue #496](https://github.com/dartsim/dart/issues/496) by _not_ converting
-SKEL to YAML, and to invest instead in SKEL deprecation, URDF / SDF YAML
-front-ends, USD adoption (via [`usd_scene_loader/`](../usd_scene_loader/)),
-and export writers. The retired `feature/skel_yaml` branch carried a
-1,991-line draft plan; that draft is preserved by SHA so the verbose phase
-docs can seed each phase as it picks up.
+SKEL to YAML, and to remove SKEL before the DART 7 release. Optional YAML work
+should be a new DART 7 format decision or a front-end over existing URDF/SDF
+semantics, not SKEL syntax in YAML. USD adoption remains tracked via
+[`usd_scene_loader/`](../usd_scene_loader/), and export writers remain part of
+the longer-term round-trip story. The retired `feature/skel_yaml` branch carried
+a 1,991-line draft plan; that draft is preserved by SHA so useful phase details
+can be recovered without adopting the old SKEL YAML direction.
 
 ## Current Branch
 
-`main` — no implementation work after the prototype plan.
+`feature/remove-skel-dart7` — local Phase 1 fixture conversion, not pushed.
 
 ## Immediate Next Step
 
-Pick Phase 1 (SKEL deprecation). Open a focused PR that adds a runtime
-deprecation warning to `dart::utils::SkelParser`, updates tutorials and
-onboarding to point at URDF / SDF / MJCF, and removes SKEL examples that
-have a URDF / SDF twin.
+Run the remaining Phase 1 gates if they have not already passed in the current
+session: focused IO read tests, `UNIT_simulation_world_SkeletonLoader`, resource
+retriever tests, `pixi run check-docs-policy`, and `pixi run lint`. After this
+conversion branch lands, pick Phase 2: remove `SkelParser`, `.skel`
+inference/dispatch, SKEL tests, bindings/stubs, and `data/skel`.
 
 ## Context That Would Be Lost
 
 - The 2015 issue #496 proposed converting SKEL XML to YAML. That proposal is
   rejected here; the rationale lives in `README.md` under _Key Decisions_.
-- YAML belongs on URDF and SDF (third-party canonical models), not on SKEL.
+- YAML, if added, must be a new DART 7 format decision or a front-end over
+  third-party canonical formats, not SKEL syntax in YAML.
 - USD work is tracked separately under
   [`usd_scene_loader/`](../usd_scene_loader/) — do not duplicate.
 - Export is part of the work, not a follow-up: round-trip enables save /
@@ -34,12 +54,11 @@ have a URDF / SDF twin.
 ## How to Resume
 
 ```bash
-git checkout main
-git pull --ff-only origin main
-git checkout -b feature/skel-deprecation-phase1
+git checkout feature/remove-skel-dart7
 
 # Inspect the prototype plan (while reflog still holds it):
 git show 1dd83e31586:docs/dev_tasks/skel_format/phase-01-deprecation.md
 ```
 
-Then translate the prototype's Phase 1 plan into a deprecation-warning PR.
+Then run the remaining verification gates and prepare the follow-up Phase 2
+removal branch.

--- a/docs/dev_tasks/skel_format_evolution/RESUME.md
+++ b/docs/dev_tasks/skel_format_evolution/RESUME.md
@@ -38,7 +38,10 @@ Run the remaining Phase 1 gates if they have not already passed in the current
 session: focused IO read tests, `UNIT_simulation_world_SkeletonLoader`, resource
 retriever tests, `pixi run check-docs-policy`, and `pixi run lint`. After this
 conversion branch lands, pick Phase 2: remove `SkelParser`, `.skel`
-inference/dispatch, SKEL tests, bindings/stubs, and `data/skel`.
+inference/dispatch, SKEL tests, bindings/stubs, and `.skel` sample fixtures.
+Do not delete the whole `data/skel` tree without first preserving or relocating
+non-SKEL mesh assets such as `data/skel/kima/*.dae`, which are still loaded by
+live mesh tests.
 
 ## Context That Would Be Lost
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -120,7 +120,7 @@ DART addresses the need for:
 - **ImGui Integration**: Private Dear ImGui overlays for controls and diagnostics
 - **Python Bindings**: Complete API coverage via nanobind with NumPy integration
 - **Optimization Helpers**: Core repo ships gradient-descent + IK primitives; the heavy-duty solver suite (IPOPT, NLopt, pagmo, SNOPT) now lives in [dart-optimization](https://github.com/dartsim/dart-optimization)
-- **File Format Support**: URDF, SDF, SKEL, MJCF for robot model loading (SKEL is legacy XML-only; prefer URDF/SDF/MJCF for new work)
+- **File Format Support**: URDF, SDF, and MJCF for robot model loading
 - **Cross-Platform**: Linux, macOS (Intel/ARM), Windows
 
 > Related projects: motion-planning helpers now reside in [dart-planning](https://github.com/dartsim/dart-planning) and the advanced optimizer suite lives in [dart-optimization](https://github.com/dartsim/dart-optimization). This repository focuses on the simulation core plus lightweight gradient-descent utilities.
@@ -490,7 +490,7 @@ drawing expressed as DART values instead of renderer types.
 **Key Modules**:
 
 - `dartpy` (top-level) - Core classes/functions (math, dynamics, collision, simulation, constraint, optimizer) exposed in snake_case
-- `dartpy.io` - File parsers (URDF, SDF, SKEL, MJCF) [alias for legacy `utils`]
+- `dartpy.io` - File parsers (URDF, SDF, MJCF) [alias for legacy `utils`]
 - `dartpy.gui` - Filament-backed GUI descriptors and helpers
 - Legacy `dartpy`/`math`/`dynamics`/`collision`/`simulation`/`constraint`/`optimizer`/`utils` remain importable while DART 7 clean-break gates are being closed, but emit `DeprecationWarning` and should not be part of the DART 7 public contract.
 
@@ -1096,12 +1096,11 @@ world->addSkeleton(robot);
 
 // SDF
 auto model = dart::io::readSkeleton("path/to/model.sdf");
-
-// SKEL (DART native format)
-auto legacy = dart::io::readSkeleton("path/to/skel.skel");
 ```
 
-> **Note:** SKEL stays as a legacy XML format for backward compatibility. There is no plan to redesign it (e.g., YAML); use URDF, SDF, or MJCF for new models.
+> **Note:** DART 7 is removing legacy SKEL support instead of redesigning it as
+> YAML. Migrate existing SKEL assets to URDF, SDF, or MJCF; use a `release-6.*`
+> branch when compatibility with old SKEL assets is required.
 
 ### Pattern 6: Debug Draws And Capture
 
@@ -1163,7 +1162,7 @@ with:
 ✅ **Interactive 3D visualization** through the Filament + GLFW3 + Dear ImGui GUI
 ✅ **Multiple collision backends** (FCL, Bullet, ODE)
 ✅ **Python integration** for ML/research workflows
-✅ **Extensive file format support** (URDF, SDF, MJCF, SKEL)
+✅ **Extensive file format support** (URDF, SDF, MJCF)
 ✅ **Cross-platform** with reproducible builds via pixi
 
 The codebase demonstrates clear layering, design patterns, and extensibility.

--- a/docs/onboarding/io-parsing.md
+++ b/docs/onboarding/io-parsing.md
@@ -26,8 +26,9 @@ This unified API and documentation were introduced while addressing issue #604
 component APIs. The DART 7 surface keeps a single, consistent skeleton-loading
 front door (`dart::io`) without introducing new nested namespaces, while keeping
 parser-specific customization available via `dart::utils::*` parsers where
-needed. Unit coverage for the promoted options lives in
-`tests/unit/io/test_Read.cpp`.
+needed. DART 7 is retiring SKEL rather than redesigning it as YAML; migrate
+legacy SKEL assets to URDF, SDF, or MJCF. Unit coverage for the promoted options
+lives in `tests/unit/io/test_Read.cpp`.
 
 ## Scope and design decision
 
@@ -135,4 +136,5 @@ Otherwise, prefer using the underlying parser API directly.
 
 The consolidated API is primarily for **C++** (`dart::io`). However, the Python bindings
 (`dartpy`) also expose parsers under `dart.io` (e.g. `dart.io.UrdfParser`). The legacy
-`dart.utils.*` parsers are deprecated and should be avoided in new code.
+`dart.utils.*` parsers are deprecated and should be avoided in new code. Treat
+SKEL as a DART 6 compatibility format while DART 7 removal work finishes.

--- a/docs/readthedocs/topics/skel-file-format.md
+++ b/docs/readthedocs/topics/skel-file-format.md
@@ -1,25 +1,24 @@
-# SKEL File Format
+# Legacy SKEL File Format
 
-SKEL is DART's native XML format for describing worlds, skeletons, robots, and
+SKEL is DART's legacy XML format for describing worlds, skeletons, robots, and
 environments. Its structure is based on [SDFormat](http://sdformat.org/) with a
 few DART-specific extensions.
 
-DART can also load URDF, SDFormat, and MJCF files — prefer those when you need to
-interchange models with other tools. SKEL is convenient when you want a compact,
-DART-focused scene or want to exercise DART-specific options directly.
+DART 7 is removing SKEL support instead of redesigning SKEL as YAML. Use URDF,
+SDFormat, or MJCF for new models, and migrate existing SKEL assets before
+depending on DART 7. Use a `release-6.*` branch when you need compatibility with
+old SKEL assets.
 
-## Loading a SKEL file
+## Legacy loading (DART 6 / migration only)
 
-On `main`, the promoted DART 7 front door reads a single model as a `Skeleton`.
-Bundled sample files are addressable with the `dart://sample/...` URI scheme; you
-can also pass an ordinary file path. Whole-world SKEL loading through the old
-public DART 6 API remains available on `release-6.*` branches for parity work.
+On DART 6, `dart::io::readSkeleton` could load a SKEL file from a file path.
+Whole-world SKEL loading through the old public DART 6 API remains available on
+`release-6.*` branches for parity work.
 
 ```cpp
-#include <dart/io/read.hpp>
+#include <dart/io/Read.hpp>
 
-auto skeleton = dart::io::readSkeleton(
-    dart::common::Uri("dart://sample/skel/cubes.skel"));
+auto skeleton = dart::io::readSkeleton("path/to/legacy.skel");
 ```
 
 ## Document structure
@@ -128,8 +127,8 @@ A single free-floating box falling under gravity:
 
 ## More examples and the authoritative schema
 
-DART ships dozens of sample `.skel` files under
-[`data/skel/`](https://github.com/dartsim/dart/tree/main/data/skel); they are the
-best reference for real-world usage. For the exact set of recognized elements and
-attributes, the parser source is authoritative:
-[`dart/utils/skel_parser.cpp`](https://github.com/dartsim/dart/blob/main/dart/utils/skel_parser.cpp).
+Historical DART revisions and `release-6.*` branches include sample `.skel`
+files under `data/skel/`; treat them as migration references rather than
+templates for new models. For the exact set of recognized elements and
+attributes, the legacy parser source is authoritative:
+`dart/utils/skel_parser.cpp`.

--- a/python/tests/unit/simulation/test_world.py
+++ b/python/tests/unit/simulation/test_world.py
@@ -5682,7 +5682,7 @@ def test_simulation_add_skeleton_loads_uri():
 
     world = sx.World()
     multibody = sx.add_skeleton(
-        world, "dart://sample/skel/test/single_pendulum.skel", options
+        world, "dart://sample/sdf/test/single_pendulum.sdf", options
     )
 
     assert multibody.name == "single_pendulum"
@@ -5710,7 +5710,7 @@ def test_simulation_add_skeleton_uri_accepts_read_options():
     read_options = sx.ReadOptions()
     assert read_options.format == sx.ModelFormat.AUTO
     assert read_options.sdf_default_root_joint_type == sx.RootJointType.FLOATING
-    read_options.format = sx.ModelFormat.SKEL
+    read_options.format = sx.ModelFormat.SDF
     read_options.sdf_default_root_joint_type = sx.RootJointType.FIXED
     read_options.add_package_directory("unused", "/tmp")
 
@@ -5720,7 +5720,7 @@ def test_simulation_add_skeleton_uri_accepts_read_options():
     world = sx.World()
     multibody = sx.add_skeleton(
         world,
-        "dart://sample/skel/test/single_pendulum.skel",
+        "dart://sample/sdf/test/single_pendulum.sdf",
         read_options,
         load_options,
     )
@@ -5729,11 +5729,11 @@ def test_simulation_add_skeleton_uri_accepts_read_options():
     assert multibody.get_link("py_read_options_anchor_link 1") is not None
 
     wrong_format = sx.ReadOptions()
-    wrong_format.format = sx.ModelFormat.SDF
+    wrong_format.format = sx.ModelFormat.URDF
     with pytest.raises(Exception, match="Failed to read Skeleton"):
         sx.add_skeleton(
             sx.World(),
-            "dart://sample/skel/test/single_pendulum.skel",
+            "dart://sample/sdf/test/single_pendulum.sdf",
             wrong_format,
         )
 

--- a/python/tests/unit/simulation/test_world.py
+++ b/python/tests/unit/simulation/test_world.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gc
 import importlib
 import math
+import os
 from pathlib import Path
 
 import dartpy as dart
@@ -25,13 +26,35 @@ def _simulation():
     return module
 
 
+def _dart_build_config_header():
+    candidates = []
+    runtime_dir = os.environ.get("DARTPY_RUNTIME_DIR")
+    if runtime_dir:
+        candidates.append(Path(runtime_dir).resolve())
+    if dart.__file__:
+        candidates.append(Path(dart.__file__).resolve().parent)
+
+    for path in candidates:
+        for parent in (path, *path.parents):
+            config_header = parent / "dart" / "config.hpp"
+            if config_header.exists():
+                return config_header
+    return None
+
+
+def _dart_build_has_sdf_support():
+    config_header = _dart_build_config_header()
+    if config_header is None:
+        return True
+    return "#define DART_HAVE_SDFORMAT 0" not in config_header.read_text(
+        encoding="utf-8"
+    )
+
+
 def _add_sdf_fixture_skeleton_or_skip(sx, world, *args):
-    try:
-        return sx.add_skeleton(world, SDF_PENDULUM_URI, *args)
-    except Exception as exc:
-        if "Failed to read Skeleton from URI" in str(exc):
-            pytest.skip("DART SDF support is disabled")
-        raise
+    if not _dart_build_has_sdf_support():
+        pytest.skip("DART SDF support is disabled")
+    return sx.add_skeleton(world, SDF_PENDULUM_URI, *args)
 
 
 def _translation_transform(x: float, y: float, z: float):

--- a/python/tests/unit/simulation/test_world.py
+++ b/python/tests/unit/simulation/test_world.py
@@ -10,6 +10,9 @@ import numpy as np
 import pytest
 
 
+SDF_PENDULUM_URI = "dart://sample/sdf/test/single_pendulum.sdf"
+
+
 def _simulation():
     try:
         module = importlib.import_module("dartpy")
@@ -20,6 +23,15 @@ def _simulation():
     if not hasattr(module, "World"):
         raise AssertionError("dartpy imported but did not expose World")
     return module
+
+
+def _add_sdf_fixture_skeleton_or_skip(sx, world, *args):
+    try:
+        return sx.add_skeleton(world, SDF_PENDULUM_URI, *args)
+    except Exception as exc:
+        if "Failed to read Skeleton from URI" in str(exc):
+            pytest.skip("DART SDF support is disabled")
+        raise
 
 
 def _translation_transform(x: float, y: float, z: float):
@@ -5681,9 +5693,7 @@ def test_simulation_add_skeleton_loads_uri():
     options.root_anchor_prefix = "py_uri_anchor_"
 
     world = sx.World()
-    multibody = sx.add_skeleton(
-        world, "dart://sample/sdf/test/single_pendulum.sdf", options
-    )
+    multibody = _add_sdf_fixture_skeleton_or_skip(sx, world, options)
 
     assert multibody.name == "single_pendulum"
     assert multibody.num_links == 2
@@ -5718,9 +5728,9 @@ def test_simulation_add_skeleton_uri_accepts_read_options():
     load_options.root_anchor_prefix = "py_read_options_anchor_"
 
     world = sx.World()
-    multibody = sx.add_skeleton(
+    multibody = _add_sdf_fixture_skeleton_or_skip(
+        sx,
         world,
-        "dart://sample/sdf/test/single_pendulum.sdf",
         read_options,
         load_options,
     )
@@ -5731,11 +5741,7 @@ def test_simulation_add_skeleton_uri_accepts_read_options():
     wrong_format = sx.ReadOptions()
     wrong_format.format = sx.ModelFormat.URDF
     with pytest.raises(Exception, match="Failed to read Skeleton"):
-        sx.add_skeleton(
-            sx.World(),
-            "dart://sample/sdf/test/single_pendulum.sdf",
-            wrong_format,
-        )
+        sx.add_skeleton(sx.World(), SDF_PENDULUM_URI, wrong_format)
 
 
 def test_simulation_api_does_not_expose_add_world_bridge():

--- a/python/tests/unit/utils/test_urdf_parser.py
+++ b/python/tests/unit/utils/test_urdf_parser.py
@@ -8,9 +8,9 @@ from tests.util import get_asset_path
 
 
 def test_parse_skeleton_non_existing_path_returns_null():
-    assert os.path.isfile(get_asset_path("skel/cubes.skel")) is True
+    assert os.path.isfile(get_asset_path("urdf/test/primitive_geometry.urdf")) is True
     parser = DartLoader()
-    assert parser.parse_skeleton(get_asset_path("skel/test/does_not_exist.urdf")) is None
+    assert parser.parse_skeleton(get_asset_path("urdf/test/does_not_exist.urdf")) is None
 
 
 def test_parse_skeleton_invalid_urdf_returns_null():

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -36,7 +36,6 @@ pixi run test-py       # Python tests only
 - `data/urdf/` - Sample URDF models
 - `data/sdf/` - Sample SDF models
 - `data/mjcf/` - Sample MJCF models
-- `data/skel/` - Sample SKEL models
 
 ## See Also
 

--- a/tests/integration/io/test_read.cpp
+++ b/tests/integration/io/test_read.cpp
@@ -34,14 +34,21 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <string_view>
+
 using namespace dart;
 
 //==============================================================================
-TEST(Read, AutoDetectsSkelSkeleton)
+TEST(Read, AutoDetectsConvertedSinglePendulumSdfSkeleton)
 {
   const auto skeleton
-      = io::readSkeleton("dart://sample/skel/test/single_pendulum.skel");
+      = io::readSkeleton("dart://sample/sdf/test/single_pendulum.sdf");
+#if DART_HAS_SDFORMAT
   EXPECT_NE(skeleton, nullptr);
+#else
+  EXPECT_EQ(skeleton, nullptr);
+#endif
 }
 
 //==============================================================================
@@ -57,6 +64,31 @@ TEST(Read, AutoDetectsSdfSkeleton)
 }
 
 //==============================================================================
+TEST(Read, ConvertedSkelFixturesLoadAsSdf)
+{
+#if DART_HAS_SDFORMAT
+  struct Fixture
+  {
+    std::string_view uri;
+    std::string_view expectedName;
+  };
+
+  constexpr std::array fixtures = {
+      Fixture{"dart://sample/sdf/test/single_pendulum.sdf", "single_pendulum"},
+      Fixture{"dart://sample/sdf/test/cube.sdf", "box skeleton"},
+      Fixture{"dart://sample/sdf/test/shapes.sdf", "box skeleton"},
+      Fixture{"dart://sample/sdf/test/test_shapes.sdf", "ground skeleton"},
+  };
+
+  for (const auto& fixture : fixtures) {
+    const auto skeleton = io::readSkeleton(fixture.uri);
+    ASSERT_NE(skeleton, nullptr) << fixture.uri;
+    EXPECT_EQ(skeleton->getName(), fixture.expectedName) << fixture.uri;
+  }
+#endif
+}
+
+//==============================================================================
 TEST(Read, MjcfDoesNotExposeDirectSkeletonLoading)
 {
   const auto skeleton = io::readSkeleton("dart://sample/mjcf/openai/ant.xml");
@@ -67,10 +99,14 @@ TEST(Read, MjcfDoesNotExposeDirectSkeletonLoading)
 TEST(Read, ExplicitFormatOverridesAuto)
 {
   io::ReadOptions options;
-  options.format = io::ModelFormat::Skel;
-  const auto skeleton = io::readSkeleton(
-      "dart://sample/skel/test/single_pendulum.skel", options);
+  options.format = io::ModelFormat::Sdf;
+  const auto skeleton
+      = io::readSkeleton("dart://sample/sdf/test/single_pendulum.sdf", options);
+#if DART_HAS_SDFORMAT
   EXPECT_NE(skeleton, nullptr);
+#else
+  EXPECT_EQ(skeleton, nullptr);
+#endif
 }
 
 //==============================================================================

--- a/tests/integration/io/test_urdf_parser.cpp
+++ b/tests/integration/io/test_urdf_parser.cpp
@@ -207,7 +207,7 @@ TEST(UrdfParser, parseSkeleton_NonExistantPathReturnsNull)
   UrdfParser parser;
   EXPECT_EQ(
       nullptr,
-      parser.parseSkeleton("dart://sample/skel/test/does_not_exist.urdf"));
+      parser.parseSkeleton("dart://sample/urdf/test/does_not_exist.urdf"));
 }
 
 //==============================================================================

--- a/tests/integration/utils/test_dart_resource_retriever.cpp
+++ b/tests/integration/utils/test_dart_resource_retriever.cpp
@@ -115,21 +115,21 @@ TEST(DartResourceRetriever, ExistsAndGetFilePathAndRetrieve)
   EXPECT_FALSE(retriever->exists("unknown://sample/test"));
   EXPECT_FALSE(retriever->exists("dart://unknown/test"));
   EXPECT_FALSE(retriever->exists("dart://sample/does/not/exist"));
-  EXPECT_TRUE(retriever->exists("dart://sample/skel/shapes.skel"));
+  EXPECT_TRUE(retriever->exists("dart://sample/sdf/test/shapes.sdf"));
 
   EXPECT_EQ(retriever->getFilePath("unknown://test"), "");
   EXPECT_EQ(retriever->getFilePath("unknown://sample/test"), "");
   EXPECT_EQ(retriever->getFilePath("dart://unknown/test"), "");
   EXPECT_EQ(retriever->getFilePath("dart://sample/does/not/exist"), "");
   EXPECT_EQ(
-      retriever->getFilePath("dart://sample/skel/shapes.skel"),
-      dart::config::dataPath("skel/shapes.skel"));
+      retriever->getFilePath("dart://sample/sdf/test/shapes.sdf"),
+      dart::config::dataPath("sdf/test/shapes.sdf"));
 
   EXPECT_EQ(nullptr, retriever->retrieve("unknown://test"));
   EXPECT_EQ(nullptr, retriever->retrieve("unknown://sample/test"));
   EXPECT_EQ(nullptr, retriever->retrieve("dart://unknown/test"));
   EXPECT_EQ(nullptr, retriever->retrieve("dart://sample/does/not/exist"));
-  EXPECT_NE(nullptr, retriever->retrieve("dart://sample/skel/shapes.skel"));
+  EXPECT_NE(nullptr, retriever->retrieve("dart://sample/sdf/test/shapes.sdf"));
 }
 
 //==============================================================================

--- a/tests/integration/utils/test_local_resource_retriever.cpp
+++ b/tests/integration/utils/test_local_resource_retriever.cpp
@@ -94,13 +94,13 @@ TEST(LocalResourceRetriever, exists_PathDoesNotExist_ReturnsFalse)
 TEST(LocalResourceRetriever, exists_FileUriDoesExists_ReturnsTrue)
 {
   LocalResourceRetriever retriever;
-  EXPECT_TRUE(retriever.exists(fileUri("skel/cube.skel")));
+  EXPECT_TRUE(retriever.exists(fileUri("sdf/test/cube.sdf")));
 }
 
 TEST(LocalResourceRetriever, exists_PathDoesExists_ReturnsTrue)
 {
   LocalResourceRetriever retriever;
-  EXPECT_TRUE(retriever.exists(localPath("skel/cube.skel")));
+  EXPECT_TRUE(retriever.exists(localPath("sdf/test/cube.sdf")));
 }
 
 TEST(LocalResourceRetriever, getFilePath_UnsupportedUri_ReturnsEmptyString)
@@ -125,16 +125,16 @@ TEST(LocalResourceRetriever, getFilePath_FileUriDoesExists_ReturnsPath)
 {
   LocalResourceRetriever retriever;
   EXPECT_EQ(
-      retriever.getFilePath(fileUri("skel/cube.skel")),
-      localPathString("skel/cube.skel"));
+      retriever.getFilePath(fileUri("sdf/test/cube.sdf")),
+      localPathString("sdf/test/cube.sdf"));
 }
 
 TEST(LocalResourceRetriever, getFilePath_PathDoesExists_ReturnsPath)
 {
   LocalResourceRetriever retriever;
   EXPECT_EQ(
-      retriever.getFilePath(localPath("skel/cube.skel")),
-      localPathString("skel/cube.skel"));
+      retriever.getFilePath(localPath("sdf/test/cube.sdf")),
+      localPathString("sdf/test/cube.sdf"));
 }
 
 TEST(LocalResourceRetriever, retrieve_UnsupportedUri_ReturnsNull)

--- a/tests/unit/io/test_read.cpp
+++ b/tests/unit/io/test_read.cpp
@@ -140,13 +140,18 @@ io::ReadOptions optionsWithContent(std::string content)
 } // namespace
 
 //==============================================================================
-TEST(ReadUnit, ReadsSkelSkeletonFromWorldFile)
+TEST(ReadUnit, ReadsConvertedSinglePendulumSdfFixture)
 {
+#if DART_HAS_SDFORMAT
   io::ReadOptions options;
-  options.format = io::ModelFormat::Skel;
-  const auto skeleton = io::readSkeleton(
-      "dart://sample/skel/test/single_pendulum.skel", options);
-  EXPECT_NE(skeleton, nullptr);
+  options.format = io::ModelFormat::Sdf;
+  const auto skeleton
+      = io::readSkeleton("dart://sample/sdf/test/single_pendulum.sdf", options);
+  ASSERT_NE(skeleton, nullptr);
+  EXPECT_EQ(skeleton->getName(), "single_pendulum");
+  EXPECT_NE(skeleton->getBodyNode("link 1"), nullptr);
+  EXPECT_NE(skeleton->getJoint("joint 1"), nullptr);
+#endif
 }
 
 //==============================================================================
@@ -209,7 +214,7 @@ TEST(ReadUnit, ReturnsNullForInvalidAmbiguousXmlContent)
 
   const std::array cases
       = {InvalidXmlCase{"empty", ""},
-         InvalidXmlCase{"invalid", "<skel>"},
+         InvalidXmlCase{"invalid", "<sdf>"},
          InvalidXmlCase{"rootless", "<?xml version=\"1.0\"?>"},
          InvalidXmlCase{"unknown_root", "<unknown />"}};
 
@@ -222,13 +227,23 @@ TEST(ReadUnit, ReturnsNullForInvalidAmbiguousXmlContent)
 }
 
 //==============================================================================
-TEST(ReadUnit, InfersSkelXmlRootBeforeReturningNullForEmptyWorld)
+TEST(ReadUnit, InfersSdfXmlRootForAmbiguousXmlUri)
 {
+#if DART_HAS_SDFORMAT
   const auto options = optionsWithContent(
-      "<skel version=\"1.0\"><world name=\"empty_world\" /></skel>");
-  const common::Uri uri("memory://empty_skel.xml");
+      R"(<sdf version="1.7">
+           <model name="memory_sdf">
+             <link name="link">
+               <inertial><mass>1.0</mass></inertial>
+             </link>
+           </model>
+         </sdf>)");
+  const common::Uri uri("memory://single_pendulum.xml");
 
-  EXPECT_EQ(io::readSkeleton(uri, options), nullptr);
+  const auto skeleton = io::readSkeleton(uri, options);
+  ASSERT_NE(skeleton, nullptr);
+  EXPECT_EQ(skeleton->getName(), "memory_sdf");
+#endif
 }
 
 //==============================================================================
@@ -251,19 +266,25 @@ TEST(ReadUnit, TryReadSkeletonReturnsErrorForInvalidPath)
 //==============================================================================
 TEST(ReadUnit, TryReadSkeletonReturnsOkForValidFile)
 {
+#if DART_HAS_SDFORMAT
   const auto result
-      = io::tryReadSkeleton("dart://sample/skel/test/single_pendulum.skel");
+      = io::tryReadSkeleton("dart://sample/sdf/test/single_pendulum.sdf");
   EXPECT_TRUE(result.isOk());
   EXPECT_FALSE(result.isErr());
   EXPECT_NE(result.value(), nullptr);
+#endif
 }
 
 //==============================================================================
-TEST(ReadUnit, InfersFormatFromSkelExtension)
+TEST(ReadUnit, InfersFormatFromSdfExtension)
 {
   const auto skeleton
-      = io::readSkeleton("dart://sample/skel/test/single_pendulum.skel");
+      = io::readSkeleton("dart://sample/sdf/test/single_pendulum.sdf");
+#if DART_HAS_SDFORMAT
   EXPECT_NE(skeleton, nullptr);
+#else
+  EXPECT_EQ(skeleton, nullptr);
+#endif
 }
 
 //==============================================================================
@@ -287,14 +308,16 @@ TEST(ReadUnit, InfersFormatFromMjcfExtension)
 }
 
 //==============================================================================
-TEST(ReadUnit, SkelWorldWithMultipleSkeletonsReturnsFirst)
+TEST(ReadUnit, ReadsConvertedTestShapesSdfFixture)
 {
+#if DART_HAS_SDFORMAT
   io::ReadOptions options;
-  options.format = io::ModelFormat::Skel;
+  options.format = io::ModelFormat::Sdf;
   const auto skeleton
-      = io::readSkeleton("dart://sample/skel/test/test_shapes.skel", options);
+      = io::readSkeleton("dart://sample/sdf/test/test_shapes.sdf", options);
   ASSERT_NE(skeleton, nullptr);
   EXPECT_EQ(skeleton->getName(), "ground skeleton");
+#endif
 }
 
 //==============================================================================
@@ -324,7 +347,7 @@ TEST(ReadUnit, PassesExplicitRetrieverThrough)
   auto retriever = std::make_shared<common::LocalResourceRetriever>();
   io::ReadOptions options;
   options.resourceRetriever = retriever;
-  options.format = io::ModelFormat::Skel;
-  const auto skeleton = io::readSkeleton("/nonexistent/robot.skel", options);
+  options.format = io::ModelFormat::Sdf;
+  const auto skeleton = io::readSkeleton("/nonexistent/robot.sdf", options);
   EXPECT_EQ(skeleton, nullptr);
 }

--- a/tests/unit/simulation/world/test_skeleton_loader.cpp
+++ b/tests/unit/simulation/world/test_skeleton_loader.cpp
@@ -569,6 +569,7 @@ TEST(SkeletonLoader, LoadedPendulumAdvancesOneStep)
 
 TEST(SkeletonLoader, LoadsSkeletonFromUri)
 {
+#if DART_HAS_SDFORMAT
   sx::World world;
   sx::io::SkeletonLoadOptions options;
   options.rootAnchorPrefix = "uri_anchor_";
@@ -591,6 +592,9 @@ TEST(SkeletonLoader, LoadsSkeletonFromUri)
   EXPECT_EQ(joint.getType(), sx::JointType::Revolute);
   EXPECT_TRUE(joint.getAxis().isApprox(Eigen::Vector3d::UnitZ()));
   expectBoxCollisionShape(*link, Eigen::Vector3d(0.05, 0.1, 0.15));
+#else
+  GTEST_SKIP() << "SDF support is disabled";
+#endif
 }
 
 TEST(SkeletonLoader, TranslatesMultipleSkeletonsIntoWorld)
@@ -683,6 +687,7 @@ TEST(SkeletonLoader, RejectsInvalidBodyInertiaBeforeCreatingMultibody)
 
 TEST(SkeletonLoader, LoadsUriWithReadOptions)
 {
+#if DART_HAS_SDFORMAT
   const dart::common::Uri uri("dart://sample/sdf/test/single_pendulum.sdf");
 
   dart::io::ReadOptions readOptions;
@@ -704,6 +709,9 @@ TEST(SkeletonLoader, LoadsUriWithReadOptions)
   EXPECT_THROW(
       sx::io::addSkeleton(rejectedWorld, uri, wrongFormat),
       sx::InvalidArgumentException);
+#else
+  GTEST_SKIP() << "SDF support is disabled";
+#endif
 }
 
 TEST(SkeletonLoader, TranslatesMeshCollisionShape)

--- a/tests/unit/simulation/world/test_skeleton_loader.cpp
+++ b/tests/unit/simulation/world/test_skeleton_loader.cpp
@@ -575,7 +575,7 @@ TEST(SkeletonLoader, LoadsSkeletonFromUri)
 
   const sx::Multibody multibody = sx::io::addSkeleton(
       world,
-      dart::common::Uri("dart://sample/skel/test/single_pendulum.skel"),
+      dart::common::Uri("dart://sample/sdf/test/single_pendulum.sdf"),
       options);
 
   EXPECT_EQ(multibody.getName(), "single_pendulum");
@@ -683,10 +683,10 @@ TEST(SkeletonLoader, RejectsInvalidBodyInertiaBeforeCreatingMultibody)
 
 TEST(SkeletonLoader, LoadsUriWithReadOptions)
 {
-  const dart::common::Uri uri("dart://sample/skel/test/single_pendulum.skel");
+  const dart::common::Uri uri("dart://sample/sdf/test/single_pendulum.sdf");
 
   dart::io::ReadOptions readOptions;
-  readOptions.format = dart::io::ModelFormat::Skel;
+  readOptions.format = dart::io::ModelFormat::Sdf;
 
   sx::io::SkeletonLoadOptions loadOptions;
   loadOptions.rootAnchorPrefix = "read_options_anchor_";
@@ -698,7 +698,7 @@ TEST(SkeletonLoader, LoadsUriWithReadOptions)
   EXPECT_TRUE(multibody.getLink("read_options_anchor_link 1").has_value());
 
   dart::io::ReadOptions wrongFormat;
-  wrongFormat.format = dart::io::ModelFormat::Sdf;
+  wrongFormat.format = dart::io::ModelFormat::Urdf;
 
   sx::World rejectedWorld;
   EXPECT_THROW(
@@ -764,7 +764,8 @@ TEST(SkeletonLoader, RejectsUnreadableUri)
   sx::World world;
   EXPECT_THROW(
       sx::io::addSkeleton(
-          world, dart::common::Uri("dart://sample/skel/does_not_exist.skel")),
+          world,
+          dart::common::Uri("dart://sample/sdf/test/does_not_exist.sdf")),
       sx::InvalidArgumentException);
 }
 


### PR DESCRIPTION
## Summary

- Converts the SKEL fixtures that are still used by examples, tests, benchmarks, and Python tests into SDF fixtures so the DART 7 SKEL removal can proceed without losing coverage.
- Keeps runtime SKEL support intact in this PR; the follow-up removal slice owns deleting the parser, dispatch, bindings, stubs, parser tests, and data/skel.

## Motivation / Problem

- DART 7 should remove legacy SKEL support before release rather than redesigning SKEL as YAML. The first safe step is to move live coverage and sample-resource references away from data/skel while preserving the scenarios those tests exercise.

## Changes / Key Changes

- Added SDF replacements for the referenced single_pendulum, cube, shapes, and test_shapes SKEL fixtures under data/sdf/test/.
- Updated C++ IO, simulation skeleton-loader, resource-retriever, and URDF negative-path tests to use the converted SDF or URDF assets.
- Updated Python simulation and URDF tests to avoid SKEL sample paths; remaining Python SKEL mentions are parser/stub-specific follow-up work.
- Guarded SDF-backed URI-loader tests so no-sdformat builds skip that coverage instead of failing when SDF parsing is intentionally disabled.
- Updated onboarding, readthedocs, module guidance, and the skel_format_evolution dev task to describe SKEL as a DART 6 compatibility format and track DART 7 removal.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Live test/resource fixtures | Several tests loaded dart://sample/skel or data/skel assets. | Live C++/Python tests, examples, tutorials, and benchmarks no longer reference dart://sample/skel or data/skel. |
| SKEL removal plan | Docs still described deprecated/legacy SKEL support as retained. | Docs and dev-task notes point to removal before DART 7, with YAML left as a separate optional format decision. |
| Runtime support | SKEL parser and dispatch still exist. | Still exists; parser/API removal is intentionally left for the next slice. |

## Testing

- `pixi run cmake --build build/default/cpp/Release --target test_io_readNone INTEGRATION_io_Read test_skeleton_loader INTEGRATION_utils_LocalResourceRetriever INTEGRATION_utils_DartResourceRetriever INTEGRATION_io_UrdfParser --parallel "$JOBS"`
- `pixi run ctest --test-dir build/default/cpp/Release -j "$JOBS" --output-on-failure -R '^(test_io_readNone|INTEGRATION_io_Read|test_skeleton_loader|INTEGRATION_utils_LocalResourceRetriever|INTEGRATION_utils_DartResourceRetriever|INTEGRATION_io_UrdfParser)$'`
- Follow-up guard validation: `pixi run cmake --build build/default/cpp/Release --target test_skeleton_loader --parallel "$JOBS"`
- Follow-up guard validation: `pixi run ctest --test-dir build/default/cpp/Release -j "$JOBS" --output-on-failure -R '^test_skeleton_loader$'`
- `pixi run test-py` (1390 passed, 11 skipped)
- `pixi run lint`
- `pixi run check-docs-policy` (passes with evidence-date advisories in docs/ai/north-star.md)
- `git diff --check`
- `rg -n -F 'sample/skel' tests python/tests examples tutorials python/examples tests/benchmark` (no output)
- `rg -n -F 'data/skel' tests python/tests examples tutorials python/examples tests/benchmark` (no output)

## Breaking Changes

- [x] None in this PR. Runtime SKEL support is unchanged; the breaking removal is planned for a follow-up DART 7 slice.

## Related Issues / PRs (backports)

- Related: https://github.com/dartsim/dart/issues/496
- Backports: None; this is DART 7 removal-prep work for `main`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required. N/A: release-note-worthy runtime removal is intentionally deferred to the parser/API removal PR.
- [x] Add unit tests for new functionality. Updated existing unit/integration/Python coverage for converted fixtures.
- [x] Document new methods and classes. N/A: no new public methods/classes.
- [x] Add Python bindings (dartpy) if applicable. N/A: no new bindings; Python tests were updated.