### PR TITLE
Keep profile allocation test on inline graph path

### DIFF
--- a/tests/unit/simulation/world/test_world_step_profiling.cpp
+++ b/tests/unit/simulation/world/test_world_step_profiling.cpp
@@ -533,6 +533,9 @@ TEST(WorldStepProfileIntegration, WarmedNestedGraphProfileDoesNotAllocate)
   }
 
   sx::compute::ParallelExecutor executor(2);
+  // Keep the no-allocation assertion focused on reusable profiling snapshots;
+  // Taskflow's scheduling future allocates on each non-inline run.
+  executor.setInlineThreshold(9);
 
   world.setStepProfilingEnabled(true);
   world.step(executor);


### PR DESCRIPTION
## Summary

- Keeps the warmed World step profile allocation regression test on the `ParallelExecutor` inline graph path so it measures reusable profiling snapshot storage, not Taskflow scheduler/future allocations.

## Motivation / Problem

- Local `pixi run test-all` failed in `WorldStepProfileIntegration.WarmedNestedGraphProfileDoesNotAllocate` after the frame-heavy fixture exercised the non-inline Taskflow path.
- The non-inline Taskflow `Executor::run()` path allocates per run outside DART's profile snapshot storage, so the zero-allocation assertion was testing scheduler internals rather than the profile reuse contract.

## Changes / Key Changes

- Sets the test executor inline threshold to cover the compact kinematics graph used by this fixture.
- Leaves the nested graph profile capture and capacity-stability assertions in place.

## Testing

- `DART_PARALLEL_JOBS=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run build-simulation-tests ON Release`
- `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 pixi run -- ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_world_step_profiling$'`
- `pixi run lint`

## Breaking Changes

- [x] None
- Test-only adjustment; no runtime API or behavior change.

## Related Issues / PRs (backports)

- Follow-up to the local verification failure seen after #3065 merged.
- Related to #3061's frame-heavy profiling fixture.
- Backport: N/A, DART 7 test-only follow-up.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required (N/A: test-only adjustment)
- [x] Add unit tests for new functionality (N/A: existing regression test adjusted)
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)
