### PR TITLE
Discover lockfile workflow release branch

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -14,8 +14,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  discover-base-branches:
+    name: Maintenance | Discover lockfile bases
+    runs-on: ubuntu-latest
+    outputs:
+      bases: ${{ steps.branches.outputs.bases }}
+    steps:
+      - name: Discover latest DART 6 release branch
+        id: branches
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_branch=$(
+            git ls-remote --heads "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" "release-6.*" |
+              awk '{ sub("refs/heads/", "", $2); print $2 }' |
+              sort -V |
+              tail -n 1
+          )
+
+          if [ -z "${release_branch}" ]; then
+            echo "No release-6.* branch found" >&2
+            exit 1
+          fi
+
+          printf 'bases=["main","%s"]\n' "${release_branch}" >> "${GITHUB_OUTPUT}"
+
   pixi-update:
     name: Maintenance | Update pixi.lock (${{ matrix.base }})
+    needs: discover-base-branches
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.base }}
       cancel-in-progress: false
@@ -23,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base: [main, release-6.17]
+        base: ${{ fromJSON(needs.discover-base-branches.outputs.bases) }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Discover the latest `release-6.*` branch at runtime for the lockfile update workflow instead of hard-coding one release branch.

## Motivation / Problem

- The scheduled `Update Lock Files` workflow is failing because its matrix still checks out retired `release-6.17`.
- Hard-coding the active DART 6 release branch means the workflow needs another manual edit every time a new `release-6.*` branch becomes active.

## Changes / Key Changes

- Add a discovery job that lists remote `release-6.*` branches, sorts them by version, and emits a JSON matrix.
- Feed the existing lockfile update job from that discovered matrix so it runs for `main` and the latest DART 6 release branch.

## Testing

- `GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=dartsim/dart bash -lc 'set -euo pipefail; release_branch=$(git ls-remote --heads "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" "release-6.*" | awk '\''{ sub("refs/heads/", "", $2); print $2 }'\'' | sort -V | tail -n 1); if [ -z "${release_branch}" ]; then echo "No release-6.* branch found" >&2; exit 1; fi; printf '\''bases=["main","%s"]\n'\'' "${release_branch}"'`
- `pixi run check-lint-yaml`
- `pixi run lint`
- `git diff --check`

## Breaking Changes

- [x] None
- N/A: CI maintenance workflow only.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required: N/A, CI workflow maintenance only
- [x] Add unit tests for new functionality: N/A, workflow-only change
- [x] Document new methods and classes: N/A, no API/docs surface
- [x] Add Python bindings (dartpy) if applicable: N/A, no Python API
