### PR TITLE
Packaging 6.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## DART 6
 
-### DART 6.19.2 (Unreleased)
+### [DART 6.19.2 (2026-06-19)](https://github.com/dartsim/dart/milestone/100?closed=1)
+
+DART 6.19.2 is a patch release on the DART 6 LTS line. It keeps automatic
+sleeping enabled while adding regression coverage for the gz-sim wheel-command
+path and extending Gazebo validation to cover the downstream gz-sim failure
+reported against DART 6.19.1.
 
 * Tests
 
@@ -11,6 +16,7 @@
     `ChangedWorldPoses` root-cause patch before running gz-sim's
     `INTEGRATION_entity_system` regression against the source-built DART 6
     plugin:
+    [#3068](https://github.com/dartsim/dart/pull/3068),
     [gazebosim/gz-sim#3697](https://github.com/gazebosim/gz-sim/issues/3697)
 
 ### [DART 6.19.1 (2026-06-17)](https://github.com/dartsim/dart/milestone/98?closed=1)

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.19.1</version>
+  <version>6.19.2</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.19.1"
+version = "6.19.2"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
## Summary

- Prepare DART 6.19.2 release packaging.
- Bump package metadata from 6.19.1 to 6.19.2.
- Date and link the DART 6.19.2 changelog section.

## Motivation / Problem

- PR #3068 has merged into `release-6.19`, completing the DART 6.19.2 milestone contents. This PR prepares the version metadata and release notes for publishing the patch release.

## Changes / Key Changes

- Updates `package.xml` to 6.19.2.
- Updates `pixi.toml` workspace version to 6.19.2.
- Finalizes the DART 6.19.2 changelog section with the release date, milestone link, release summary, and PR evidence.

## Testing

- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Release milestone: https://github.com/dartsim/dart/milestone/100
- Release content PR: https://github.com/dartsim/dart/pull/3068

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for release branches)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
