### PR TITLE
Import release branch AI workflows

### DIFF
--- a/.claude/commands/dart-analyze.md
+++ b/.claude/commands/dart-analyze.md
@@ -1,0 +1,46 @@
+---
+description: analyze repository evidence without editing
+agent: build
+---
+
+Analyze repository evidence without editing: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/ai/principles.md
+@docs/ai/workflows.md
+@docs/ai/verification.md
+@docs/onboarding/ai-tools.md
+
+## Workflow
+
+1. Restate the question and the read-only boundary. Do not edit files, stage
+   changes, or perform GitHub, CI, branch, or review-thread mutations.
+2. Inspect local state enough to avoid misreading user work:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   ```
+3. Build an evidence set from repository files, tests, docs, generated
+   artifacts, and command output. Load task-specific docs from `AGENTS.md` when
+   the question names a subsystem.
+4. Separate direct evidence from inference and unknowns. Do not present an
+   inference as a fact, and do not turn a read-only answer into an
+   implementation plan.
+5. Rank explanations, risks, or options by confidence when multiple readings
+   are plausible. Use concrete file and line references for material claims.
+6. If current external documentation or standards are needed for correctness,
+   gather source-backed evidence and label date/version context explicitly.
+7. Stop when the synthesis answers the question with enough evidence, or report
+   the exact proof source that is unavailable.
+
+## Output
+
+Report:
+
+- the question answered and the scope inspected;
+- ranked synthesis with confidence;
+- evidence, inference, and unknowns as separate sections;
+- any discriminating read-only probe that would reduce remaining uncertainty;
+- confirmation that no local edits or external mutations were performed.

--- a/.claude/commands/dart-backport-pr.md
+++ b/.claude/commands/dart-backport-pr.md
@@ -1,0 +1,41 @@
+---
+description: backport a merged main PR to a release branch
+agent: build
+---
+
+Backport PR or commits: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/release-management.md
+
+## Workflow
+
+1. Verify the source PR or commit is merged to `main`:
+   ```bash
+   gh pr view <SOURCE_PR> --json state,mergedAt,baseRefName,mergeCommit
+   ```
+2. Check whether an equivalent change already exists on the release branch:
+   ```bash
+   git fetch origin <RELEASE_BRANCH> main
+   git cherry -v --abbrev=40 origin/<RELEASE_BRANCH> origin/main | grep <COMMIT_HASH>
+   ```
+3. Create a release branch from the release target:
+   ```bash
+   git switch --no-track -C backport/<SOURCE_PR>-to-<RELEASE_BRANCH> origin/<RELEASE_BRANCH>
+   ```
+4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
+5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.
+6. Run `pixi run lint` and the smallest relevant release-branch checks.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, open the PR against the release branch with milestone
+   matching that release branch and use the PR template.
+
+## Output
+
+- Backport PR URL
+- Source PR/commit
+- Conflicts resolved, if any
+- Checks run and CI status

--- a/.claude/commands/dart-backport-pr.md
+++ b/.claude/commands/dart-backport-pr.md
@@ -22,9 +22,15 @@ Backport PR or commits: $ARGUMENTS
    git fetch origin <RELEASE_BRANCH> main
    git cherry -v --abbrev=40 origin/<RELEASE_BRANCH> origin/main | grep <COMMIT_HASH>
    ```
-3. Create a release branch from the release target:
+3. Create a release branch from the release target without resetting an
+   existing local branch:
    ```bash
-   git switch --no-track -C backport/<SOURCE_PR>-to-<RELEASE_BRANCH> origin/<RELEASE_BRANCH>
+   BRANCH=backport/<SOURCE_PR>-to-<RELEASE_BRANCH>
+   if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+     git switch "$BRANCH"
+   else
+     git switch --no-track -c "$BRANCH" origin/<RELEASE_BRANCH>
+   fi
    ```
 4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
 5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.

--- a/.claude/commands/dart-branch-cleanup.md
+++ b/.claude/commands/dart-branch-cleanup.md
@@ -1,0 +1,82 @@
+---
+description: analyze or clean stale repository branches
+agent: build
+---
+
+Analyze or clean branches: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/contributing.md
+
+## Modes
+
+- `analyze`: inspect only, no deletions
+- `action`: prepare follow-up, or delete only after ownership/safety are clear
+  and the maintainer/user gives explicit approval for each local or remote
+  branch deletion
+
+Default to `analyze` if the requested mode is ambiguous.
+
+## Workflow
+
+1. `git fetch --all --no-prune`
+2. List stale remote-tracking refs without deleting them:
+   ```bash
+   git remote prune origin --dry-run
+   ```
+   If `origin` uses SSH and port 22 is unavailable, keep the check read-only
+   and use a temporary HTTPS rewrite instead of changing repository config:
+   ```bash
+   git -c url.https://github.com/.insteadOf=git@github.com: \
+     fetch --all --no-prune
+   git -c url.https://github.com/.insteadOf=git@github.com: \
+     remote prune origin --dry-run
+   ```
+   To confirm that a remote PR branch was deleted without updating refs, query
+   GitHub directly over HTTPS:
+   ```bash
+   git ls-remote --heads https://github.com/dartsim/dart.git <BRANCH>
+   ```
+3. Determine the target/base branch from the PR or task, usually
+   `origin/release-6.20` for this release lane.
+4. For each branch:
+   ```bash
+   git rev-list --left-right --count <TARGET>...<BRANCH>
+   git log --oneline <TARGET>..<BRANCH>
+   git diff --stat <TARGET>..<BRANCH>
+   git cherry -v <TARGET> <BRANCH>
+   ```
+5. Before any explicitly approved local branch deletion, check whether the
+   branch is checked out by a linked worktree:
+   ```bash
+   git worktree list --porcelain
+   git -C <WORKTREE> status --short --branch
+   ```
+   Dirty linked worktrees must not be removed, detached, or reset during branch
+   cleanup. Only after explicit maintainer/user approval, switch that worktree
+   to a preservation branch at the same commit to free the obsolete branch name
+   before deleting the merged branch.
+6. The command `git branch --merged` may not prove ancestry for PR branches
+   that landed through a squash or merge commit. Use the merged PR state plus
+   an empty tree diff or equivalent `git cherry -v` output as the deletion
+   signal; if the history relationship is unclear, keep the branch.
+7. Classify recommendations only; deleting a candidate requires explicit
+   maintainer/user approval:
+   - `ahead=0`: safe deletion candidate
+   - equivalent commits already landed: deletion candidate
+   - small, current, useful diff: keep or rebase into PR
+   - large or unclear diff: document follow-up before action
+8. Ask for explicit maintainer/user approval before pruning refs or deleting any
+   local or remote branch, even when ownership, branch purpose, and remote
+   impact look clear.
+
+## Output
+
+- Branch summary with ahead/behind count and last commit date
+- Useful commits or risks
+- Recommendation: delete, keep, rebase, or needs follow-up
+- Actions taken after explicit maintainer/user approval, if action mode was
+  explicitly requested

--- a/.claude/commands/dart-docs-update.md
+++ b/.claude/commands/dart-docs-update.md
@@ -1,0 +1,31 @@
+---
+description: update documentation without code changes
+agent: build
+---
+
+Update documentation: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/README.md
+@docs/ai/principles.md
+@docs/ai/verification.md
+@docs/onboarding/ai-tools.md
+@docs/onboarding/changelog.md
+
+## Workflow
+
+1. Create a branch from the target branch, for example:
+   `git switch --no-track -c docs/<topic> origin/release-6.20`
+2. Edit docs and AI workflow sources only:
+   - Regular docs: `docs/**`, `README.md`, `AGENTS.md`, `CONTRIBUTING.md`
+   - AI source files: `.claude/commands/**`, `.claude/skills/**`
+3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
+4. Update indexes and cross-references that point to changed docs
+5. Use `docs/ai/verification.md` to select the docs-only or AI docs/adapters
+   gate set, then run `pixi run lint` before committing
+6. Record the `CHANGELOG.md` decision using `docs/onboarding/changelog.md`.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, push with the same local and remote topic-branch name, use
+   `.github/PULL_REQUEST_TEMPLATE.md`, and set the proper milestone.

--- a/.claude/commands/dart-downstream-fix.md
+++ b/.claude/commands/dart-downstream-fix.md
@@ -1,0 +1,50 @@
+---
+description: fix a DART bug reported through gz-physics or Gazebo
+agent: build
+---
+
+Fix downstream-reported DART issue: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ci-cd.md
+
+## When To Use
+
+Use for downstream issues in gz-physics, Gazebo, or gz-sim that trace back to DART behavior: crashes, assertions, NaN/Inf propagation, missing validation, or DART performance regressions.
+
+## Workflow
+
+1. Read the downstream issue, logs, stack traces, and reproduction steps.
+2. Identify the DART API, component, and invalid usage pattern involved.
+3. Search for related validation and recovery patterns in DART.
+4. Plan the smallest fix and the regression test location.
+5. Decide whether the bug applies to the active release line. For applicable
+   bug fixes, implement on the active DART 6 LTS branch first, then cherry-pick
+   or reapply to `main` for DART 7:
+   - branch:
+     `fix/<downstream-project>-<issue-number>-<brief-description>-6-lts`
+   - add a regression test that reproduces the downstream symptom
+   - keep the fix minimal; no unrelated refactors
+6. Run `pixi run lint` and relevant tests; use `pixi run test-all` when
+   feasible, and run `pixi run -e gazebo test-gz` when Gazebo/gz-physics
+   compatibility could be affected.
+7. Ask for explicit maintainer/user approval before pushing or creating PRs.
+   After approval, create the release-branch PR with the branch-matching DART
+   6.x patch milestone and reference the downstream issue.
+8. Create the matching `main` PR with milestone `DART 7.0`; adapt API
+   differences if needed.
+
+## Release-Line Differences
+
+- DART 7 commonly uses `DART_WARN()` and `<dart/All.hpp>`.
+- DART 6 LTS may use `dtwarn << ...`, `<dart/dart.hpp>`, and older test CMake patterns.
+
+## Output
+
+- Root cause and fix summary
+- Main PR URL and release PR URL, if applicable
+- Tests run and CI status
+- Link back to the downstream issue

--- a/.claude/commands/dart-fix-ci.md
+++ b/.claude/commands/dart-fix-ci.md
@@ -1,0 +1,42 @@
+---
+description: debug and fix failing CI checks
+agent: build
+---
+
+Fix CI failure: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+
+## Workflow
+
+1. Identify failing checks: `gh pr checks <PR_NUMBER>` or `gh run view <RUN_ID>`.
+2. Inspect the first real failure:
+   ```bash
+   gh run view <RUN_ID> --log-failed
+   gh run view <RUN_ID> --job <JOB_ID> --log
+   ```
+3. If a job is still in progress, wait for logs instead of guessing.
+4. Reproduce locally with the smallest relevant command:
+   - formatting: `pixi run lint`
+   - tests: `pixi run test`, `pixi run test-py`, or another existing
+     focused `pixi run ...` test task
+   - coverage: add targeted tests for uncovered changed lines
+5. Fix the root cause with minimal scope.
+6. If the failure is infrastructure-only, ask for explicit maintainer/user
+   approval before rerunning the failed job or running:
+   ```bash
+   gh run rerun <RUN_ID> --failed
+   ```
+7. Ask for explicit maintainer/user approval before pushing, CI re-triggers, or
+   other GitHub mutations; after approval, push and watch CI until the PR is
+   green.
+
+## Output
+
+- Root cause
+- Fix or rerun action
+- Commands run
+- Current CI status

--- a/.claude/commands/dart-manage-pr.md
+++ b/.claude/commands/dart-manage-pr.md
@@ -151,10 +151,10 @@ gh pr checks <PR_NUMBER>
    - Confirm review requirements are satisfied and local validation matches the
      intended transition.
    - If the PR is draft, mark it ready after explicit approval once Codex is
-     clean and local validation passed on the current head: default
-     `pixi run test-all`, plus the Gazebo gate when package or downstream
-     compatibility could be affected. Hosted CI may still be pending for the
-     ready-for-review transition.
+     clean and local validation passed on the current head: `pixi run test-all`
+     for build coverage, `pixi run test`/`pixi run test-py` for affected
+     C++/Python behavior, plus the Gazebo gate when package or downstream
+     compatibility could be affected. Hosted CI may still be pending.
    - Confirm required hosted checks are passing before merge.
    - Do not merge unless explicitly asked or the workflow clearly includes merge.
    - PR comments, review re-triggers, thread resolution, reviewer requests,

--- a/.claude/commands/dart-manage-pr.md
+++ b/.claude/commands/dart-manage-pr.md
@@ -1,0 +1,196 @@
+---
+description: manage an open DART pull request through CI, review, and cleanup
+agent: build
+---
+
+Manage an open DART pull request after explicit maintainer/user approval for
+mutations: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/ai-tools.md
+
+## Invocation Contract
+
+When the user says `manage <PR>` or `continue managing <PR>` without limiting
+the request to status-only, treat that as approval to run the full PR-management
+loop to the next terminal state:
+
+- required policy metadata checked and corrected when stale;
+- CI monitored until green, failed, or blocked;
+- merge conflicts reproduced and resolved locally;
+- review comments addressed, pushed, resolved, and re-reviewed when appropriate;
+- PR body/testing evidence refreshed when it no longer matches the branch.
+
+This explicit approval covers routine PR-maintenance mutations needed for that
+loop: additive fix commits and pushes, PR description/metadata corrections,
+resolving already-addressed review threads, rerunning failed CI jobs, and
+requesting a fresh AI review after follow-up fixes. It does **not** cover
+merging the PR into the target branch, force-pushes, branch deletion, PR
+closure, base-branch changes, or human reviewer requests; ask separately for
+those.
+
+Do not call the PR managed just because checks are green. Continue until the PR
+is mergeable with required checks complete and addressed review threads are
+resolved, or until a concrete blocker remains.
+
+## Identify the PR
+
+Use the PR number or URL from `$ARGUMENTS`. If none is provided, infer the PR
+from the current branch:
+
+```bash
+gh pr view --json number,url,headRefName,baseRefName
+```
+
+Then inspect the full state:
+
+```bash
+gh pr view <PR_NUMBER> --json number,title,state,isDraft,baseRefName,headRefName,mergeStateStatus,milestone,url,reviewDecision,statusCheckRollup
+gh pr checks <PR_NUMBER>
+```
+
+## Workflow
+
+1. Confirm scope and policy:
+   - Check that the base branch, milestone, title, and PR template are correct.
+   - For bug fixes, verify the required DART 6 LTS + `main` dual-PR flow.
+   - Confirm the PR body's testing/status section matches the current head and
+     does not point reviewers to deleted dev-task evidence as still pending.
+   - Confirm the PR body is readable and follows template order: Summary,
+     Motivation / Problem, Changes / Key Changes, optional Before / After,
+     Testing, Breaking Changes, and Related Issues / PRs. Keep Summary first as
+     the skimmable user/downstream outcome; if problem context must lead, fold
+     it into Summary and keep the fuller why in Motivation. Mechanics belong in
+     Changes unless they explain user-visible risk.
+   - When the PR has meaningful user-facing API, workflow, behavior, or
+     performance impact, confirm the body has a concise Before / After section
+     that compares the relevant old and new surfaces. For performance claims,
+     ensure the baseline is explicit: CPU path, parent commit, `main`, or prior
+     implementation, plus workload, metric, and important limitations. Each
+     row should be phrased as a user-visible before/after, with backend details
+     used only as supporting context.
+   - For visual PR evidence, ensure transient screenshots, headless renders,
+     GIFs, and videos are hosted as GitHub PR/issue Markdown attachments
+     (`https://github.com/user-attachments/assets/...`) rather than committed to
+     the branch. If evidence files were committed only for the PR description,
+     remove them and replace the PR body entry with a GitHub attachment URL. If
+     the current tooling cannot upload an attachment, ask a maintainer to upload
+     the local artifact through the PR editor instead of keeping it under
+     `docs/assets/`.
+   - Inspect local state before editing:
+     ```bash
+     git status --short --branch
+     git diff --stat
+     git diff --check
+     ```
+2. Monitor CI:
+   ```bash
+   gh pr checks <PR_NUMBER> --watch --interval 30 --fail-fast
+   ```
+   If checks are still queued or running, report the current jobs and keep
+   watching unless the user asked only for status.
+   Also poll mergeability:
+   ```bash
+   gh pr view <PR_NUMBER> --json mergeStateStatus,headRefOid,isDraft,reviewDecision
+   ```
+   If GitHub reports conflicts, fetch the target branch and resolve them before
+   treating green checks as sufficient.
+3. Fix failures:
+   - Inspect the newest failed run or job, not an older cancelled run.
+   - Use the `dart-fix-ci` workflow for non-trivial CI debugging.
+   - Reproduce locally with the relevant `pixi run ...` task or focused test.
+   - Before committing fixes, run `pixi run lint`; also run build or tests when
+     code or behavior changed.
+   - Commit only intended files. Push only after explicit maintainer/user
+     approval, then continue monitoring the PR.
+   - For already-published PRs, prefer additive follow-up commits so reviewers
+     can inspect each update. Amend or force-push only after explicit
+     maintainer/user approval and only when the user explicitly requests it or
+     when there is a clear reason such as removing sensitive content or
+     repairing broken branch history.
+   - Before every push, first merge the latest base branch into the PR branch
+     (on every push, not just the first) so each pushed/CI-tested state reflects
+     the current target base branch and conflicts surface early:
+     ```bash
+     git fetch origin <base-branch>
+     git merge --no-ff origin/<base-branch>  # never rebase a published PR branch
+     # rebuild + retest if the merge touched code
+     git push                                 # after explicit approval
+     ```
+     The local base merge is a routine pre-push step; the push itself still
+     requires explicit maintainer/user approval. Do not rebase a published PR
+     branch by default because it invalidates existing CI runs and makes PR
+     review/comment history harder to follow. Rebase or force-push only when the
+     maintainer explicitly requests it.
+4. Address reviews:
+   - Use the `dart-review-pr` workflow for substantive review feedback.
+   - Never reply to AI-generated review comments from bot users such as
+     `chatgpt-codex-connector[bot]`, `github-code-quality[bot]`,
+     `github-actions[bot]`, or `copilot[bot]`.
+   - When a draft PR is first published, request Codex review with a top-level
+     `@codex review` once explicit maintainer/user approval covers PR comments;
+     it can run while the PR remains draft. If Codex already shows an activity
+     signal or submitted review, do not post a duplicate trigger.
+   - Apply AI-review fixes silently. After explicit maintainer/user approval
+     and after the branch is ready, push, resolve reviewed and addressed
+     threads, and request a fresh AI review only when the approved follow-up
+     push addressed Codex review comments, or when the first trigger has a
+     concrete timeout/blocker:
+     ```bash
+     gh pr comment <PR_NUMBER> --body "@codex review"
+     ```
+   - For human reviewers, reply only when a response is useful after a fix or
+     when a question needs clarification.
+   - After posting `@codex review`, keep monitoring until a submitted review,
+     a visible activity signal, or a concrete timeout/blocker is observed.
+5. Mark ready or merge only when appropriate:
+   - Confirm review requirements are satisfied and local validation matches the
+     intended transition.
+   - If the PR is draft, mark it ready after explicit approval once Codex is
+     clean and local validation passed on the current head: default
+     `pixi run test-all`, plus the Gazebo gate when package or downstream
+     compatibility could be affected. Hosted CI may still be pending for the
+     ready-for-review transition.
+   - Confirm required hosted checks are passing before merge.
+   - Do not merge unless explicitly asked or the workflow clearly includes merge.
+   - PR comments, review re-triggers, thread resolution, reviewer requests,
+     ready-for-review transitions, merges, and branch deletion are external
+     mutations and require explicit maintainer/user approval.
+   - Confirm the merge method from repository settings or the user. Recent DART
+     PRs usually use single-parent PR-title commits, so prefer squash/rebase
+     over merge commits unless the repository settings or user request differ.
+   - Use the current head SHA when merging so a moved branch cannot be merged
+     accidentally.
+6. Clean up after merge:
+   - Confirm the PR merged and identify the head branch before deleting.
+   - After explicit maintainer/user approval, prefer merge-time deletion with
+     the approved merge method and head SHA:
+     ```bash
+     gh pr merge <PR_NUMBER> --squash --match-head-commit <HEAD_SHA> --delete-branch
+     ```
+     Use `--rebase` or `--merge` instead of `--squash` when requested.
+   - After explicit maintainer/user approval, otherwise delete only the PR
+     branch after confirming it has landed:
+     ```bash
+     git push origin --delete <HEAD_BRANCH>
+     git switch <BASE_BRANCH>
+     git pull --ff-only
+     git branch -D <HEAD_BRANCH>
+     ```
+     Use force-delete locally only after explicit maintainer/user approval and
+     after confirming the PR branch has landed; squash and rebase merges do not
+     preserve the branch tip in target-branch ancestry.
+
+## Output
+
+Report:
+
+- PR number, URL, base, head, draft state, milestone, and merge status.
+- CI summary: passing, failing, pending, or skipped checks.
+- Review summary and whether `@codex review` was triggered.
+- Commits pushed, merge action, and branch cleanup action.
+- Remaining blockers or next action.

--- a/.claude/commands/dart-mechanical-refactor.md
+++ b/.claude/commands/dart-mechanical-refactor.md
@@ -1,0 +1,38 @@
+---
+description: perform a behavior-preserving mechanical refactor
+agent: build
+---
+
+Perform mechanical refactor: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@CONTRIBUTING.md
+@docs/onboarding/code-style.md
+
+## Workflow
+
+1. Define the exact transformation and scope before editing.
+2. Create a topic branch from the target branch, for example
+   `git switch --no-track -c refactor/<topic> origin/release-6.20`.
+3. Prefer scriptable or automated edits when the transformation is repetitive.
+4. Keep behavior unchanged; do not mix in feature work or cleanup outside scope.
+5. If reorganizing files, update CMake, pixi tasks, generated indexes, and docs.
+6. Run focused checks first, then broader checks according to risk:
+   - `pixi run lint`
+   - `pixi run build`
+   - `pixi run test`
+   - `pixi run test-all` when feasible
+   - `pixi run -e gazebo test-gz` when package, collision, constraint, or
+     downstream Gazebo/gz-physics compatibility could be affected
+7. Ask for explicit maintainer/user approval before pushing or opening a PR.
+   After approval, open a PR with a clear scope statement and no
+   behavior-change claim unless tested.
+
+## Output
+
+- Transformation summary
+- Files or areas changed
+- Verification run
+- Any residual risk

--- a/.claude/commands/dart-new-task.md
+++ b/.claude/commands/dart-new-task.md
@@ -1,0 +1,61 @@
+---
+description: start a feature, bugfix, refactor, docs, build, or test task
+agent: build
+---
+
+Start a new task in DART: $ARGUMENTS
+
+## Required Reading
+
+Read these files first:
+@AGENTS.md
+@docs/onboarding/building.md
+@docs/onboarding/contributing.md
+@docs/onboarding/code-style.md
+@docs/dev_tasks/README.md
+@docs/ai/sessions.md
+@docs/ai/principles.md
+@docs/ai/verification.md
+
+## Workflow
+
+1. **Understand the task** - Parse: goal, constraints, type (feature|bugfix|refactor|docs)
+2. **Assess scope** - Multi-phase or multi-session? Create
+   `docs/dev_tasks/<task>/` (see `docs/dev_tasks/README.md` for criteria).
+   For multi-session, design-heavy, public API, solver/paper, release, or
+   cross-module work, fill the dev-task specification intake before editing:
+   value, scope, assumptions, traceability, non-goals, acceptance evidence,
+   gates, and open decisions. If consequential ambiguity would change public
+   API, release compatibility, numerical correctness, benchmark claims, or
+   roadmap scope, record an owner-local `Decision needed` block instead of
+   silently choosing.
+3. **Setup** - Choose the target branch before creating a topic branch. For
+   DART 6.20 maintenance, dependency-minimization, docs, and compatibility
+   work, branch from `origin/release-6.20` without tracking the release ref:
+   `git switch --no-track -c <type>/<topic> origin/release-6.20`. Bug fixes
+   that also apply to DART 7 still need a separate `main` PR after the release
+   branch fix.
+4. **Implement** - Keep commits focused, follow code style
+5. **Verify** - Run `pixi run lint` before committing, then run the focused
+   release-branch gate for the touched surface. Use `pixi run test-all` when
+   feasible, and `pixi run -e gazebo test-gz` for package, collision,
+   constraint, or downstream Gazebo/gz-physics compatibility work.
+6. **PR** - After explicit maintainer/user approval, push with the same local
+   and remote topic-branch name:
+   `branch=$(git branch --show-current); git push -u origin "HEAD:${branch}"`.
+   Then create the draft PR against `<target-branch>` with the branch-matching
+   DART 6.x patch milestone and `.github/PULL_REQUEST_TEMPLATE.md`.
+7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, first
+   promote durable dashboards, evidence matrices, API inventories, migration
+   maps, or long-lived decisions into release/onboarding/AI docs.
+   Then remove the dev-task folder completely (include the deletion in this PR,
+   not after merge).
+
+## Type-Specific
+
+- **Bugfix**: Requires PRs to BOTH the active DART 6 LTS branch AND `main`
+- **Refactor**: No behavior changes
+- **Feature**: Add tests + docs
+- **DART 7 solver or architecture work**: Do that on `main`, not on the DART
+  6.20 support branch. Use this release branch only for compatible maintenance,
+  dependency minimization, CI, docs, and backports.

--- a/.claude/commands/dart-pr.md
+++ b/.claude/commands/dart-pr.md
@@ -1,0 +1,179 @@
+---
+description: create a branch, commit, push, and open a DART pull request
+agent: build
+---
+
+Prepare or open a DART pull request after explicit maintainer/user approval:
+$ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ai-tools.md
+@docs/onboarding/changelog.md
+@.github/PULL_REQUEST_TEMPLATE.md
+
+## Recent PR Patterns
+
+When the expected PR style is unclear, inspect recently merged PRs before
+drafting the title or body:
+
+```bash
+gh pr list --repo dartsim/dart --state merged --base <target-branch> --limit 10 \
+  --json number,title,body,mergedAt
+```
+
+Use these practices:
+
+- Keep titles plain, scoped, and outcome-focused. Do not add agent prefixes.
+- Fill the PR template in DART's default order: Summary, Motivation / Problem,
+  Changes / Key Changes, optional Before / After, Testing, Breaking Changes,
+  and Related Issues / PRs. Keep Summary first because reviewers need the
+  skimmable outcome before the rationale. If the motivation is necessary to
+  understand the outcome, make the first Summary sentence problem-oriented,
+  then put the fuller why in Motivation / Problem rather than moving Motivation
+  above Summary.
+- Write the opening Summary and Motivation from the perspective of a user or
+  downstream maintainer who is not already familiar with the implementation:
+  lead with what changes for them, what stays compatible, how they would opt in
+  or migrate, and why the evidence matters. Keep implementation details in
+  Changes unless they explain a user-visible outcome or risk.
+- When the change has meaningful user-facing API, workflow, behavior, or
+  performance impact, add a concise `## Before / After` section before
+  Testing. Use a small table or bullets that cover only relevant dimensions
+  such as public API, commands/workflows, behavior, migration, and performance
+  baseline. Phrase each row as a user-visible before/after, then name the
+  implementation mechanism only as supporting context. For performance claims,
+  name the baseline explicitly: CPU path, parent commit, `main`, or prior
+  implementation, plus workload, metric, and important limitations.
+- In Testing, list exact commands, targets, or test names that ran.
+- For CI, performance, or infrastructure work, include evidence such as CI run
+  observations, timing, reruns, benchmark output, or why a skipped check is
+  expected.
+- For rendering, model, mesh, texture, GUI, or visual-example changes, include
+  a before/after visual comparison when practical:
+  - Prefer an existing headless example path such as `--headless`,
+    `--frames`, `--width`, `--height`, and `--screenshot` over manual
+    screenshots.
+  - Capture the before image from the base branch or by temporarily restoring
+    the replaced sample/assets, then capture the after image from the final
+    branch with the same camera, dimensions, frame count, and renderer.
+  - Inspect the images yourself and include the commands plus any environment
+    variables such as software rendering flags in the PR body.
+  - Upload transient comparison images, GIFs, and videos through the GitHub
+    PR/issue Markdown attachment flow so the PR body contains GitHub-hosted
+    `https://github.com/user-attachments/assets/...` URLs that render inline.
+    Do not commit screenshots, headless renders, GIFs, or screencast videos
+    solely as PR evidence. Commit visual files only when they are durable
+    documentation, fixtures, or source assets that should live in the
+    repository.
+  - The official GitHub attachment flow is the web PR/issue editor drag/drop or
+    file picker. `gh pr edit`, `gh pr comment`, and the public REST API do not
+    provide a supported generic attachment upload command; any command or action
+    that edits or comments on a PR still requires explicit maintainer/user
+    approval. Use a maintainer-approved upload helper only when it produces
+    GitHub attachment URLs without committing files to the branch; helpers that
+    mimic the web upload may require a browser session cookie and must not be
+    used unless the maintainer has explicitly approved that credential handling.
+  - If the current tool cannot upload PR attachments, keep the local artifact
+    paths in the working note, ask a maintainer to upload them through the PR
+    editor, and then update the PR body with the returned GitHub attachment
+    URL after explicit maintainer/user approval. Do not fall back to committing
+    transient evidence into `docs/assets/`.
+  - If no headless path exists, either add a narrowly scoped capture mode when
+    it fits the example or document why visual comparison is not practical.
+- Mark non-applicable checklist items as "N/A" with a short reason.
+- Mention related PRs, issues, backports, and follow-ups explicitly, including
+  "None" when there is no related work.
+
+## Workflow
+
+1. Inspect scope:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   ```
+2. Exclude unrelated dirty files unless the user explicitly includes them.
+3. Choose the target branch and milestone:
+
+   | Target                          | Milestone                      |
+   | ------------------------------- | ------------------------------ |
+   | `main`                          | `DART 7.0`                     |
+   | Active DART 6 LTS `release-6.*` | Branch-matching DART 6.x patch |
+
+4. For bug fixes, use the dual-PR flow: fix the active DART 6 LTS branch first,
+   then cherry-pick or reapply to `main`.
+5. Before every commit, run:
+   ```bash
+   pixi run lint
+   ```
+   Also run `pixi run build` for C++ or Python changes and focused tests for
+   behavior changes.
+6. Create or update a topic branch when needed:
+   ```bash
+   git switch --no-track -c <type>/<topic> origin/<target-branch>
+   ```
+7. Commit only intended files with a plain descriptive commit title.
+8. Ask for explicit maintainer/user approval before pushing or opening the draft
+   PR. Never push directly to `release-*`. If approved:
+   ```bash
+   branch=$(git branch --show-current)
+   git push -u origin "HEAD:${branch}"
+   gh pr create --draft --base <target-branch> --milestone "<milestone>" \
+     --title "<plain title>" --body-file <filled-template-file>
+   ```
+   For fast feedback on a draft PR, also request Codex review after publication
+   when approval covers PR comments:
+   ```bash
+   gh pr comment <PR_NUMBER> --body "@codex review"
+   ```
+   If Codex already shows an activity signal or submitted review, do not post a
+   duplicate trigger.
+9. After a PR is published, prefer additive follow-up commits for updates so
+   reviewers can inspect each review round. Amend or force-push only after
+   explicit maintainer/user approval and only when the user explicitly requests
+   it or when there is a clear reason such as removing sensitive content or
+   repairing broken branch history.
+10. Before every push to a published PR branch, first merge the latest base
+    branch into it (on every push, not just the first) so each pushed/CI-tested
+    state reflects the current target base branch and conflicts surface early:
+    ```bash
+    git fetch origin <target-branch>
+    git merge --no-ff origin/<target-branch>  # never rebase a published PR branch
+    # rebuild + retest if the merge touched code
+    git push                                   # after explicit approval
+    ```
+    The local base merge is a routine pre-push step; the push itself still
+    requires explicit maintainer/user approval. Do not rebase a published PR
+    branch by default because it invalidates existing CI runs and makes PR
+    review/comment history harder to follow. Rebase or force-push only when the
+    maintainer explicitly requests it.
+11. Use `docs/onboarding/changelog.md` for the changelog decision. If
+    `CHANGELOG.md` needs the PR number, keep the follow-up changelog commit
+    local until explicit maintainer/user approval is given for the additional
+    push or PR update.
+12. Monitor CI:
+    ```bash
+    gh pr checks <PR_NUMBER>
+    ```
+
+## AI Review Comments
+
+Never reply to AI-generated review comments from bot users such as
+`chatgpt-codex-connector[bot]`, `github-code-quality[bot]`,
+`github-actions[bot]`, or `copilot[bot]`.
+When a draft PR is first published, a top-level `@codex review` is the preferred
+fast path once explicit maintainer/user approval covers PR comments; it can run
+while the PR remains draft. Make fixes silently. Push and ask for a new AI review
+with `@codex review` only after explicit maintainer/user approval and only when
+the approved follow-up push addressed Codex review comments, or when the first
+trigger has a concrete timeout/blocker.
+
+After Codex returns no actionable issues and local validation passes on the
+current head (default `pixi run test-all`, plus the Gazebo gate when package or
+downstream compatibility could be affected), a draft PR is ready to mark ready
+for human review after explicit approval even if hosted CI is still pending. Do
+not merge until branch protection and required checks pass unless a maintainer
+explicitly approves a policy bypass.

--- a/.claude/commands/dart-pr.md
+++ b/.claude/commands/dart-pr.md
@@ -172,8 +172,10 @@ the approved follow-up push addressed Codex review comments, or when the first
 trigger has a concrete timeout/blocker.
 
 After Codex returns no actionable issues and local validation passes on the
-current head (default `pixi run test-all`, plus the Gazebo gate when package or
-downstream compatibility could be affected), a draft PR is ready to mark ready
-for human review after explicit approval even if hosted CI is still pending. Do
-not merge until branch protection and required checks pass unless a maintainer
-explicitly approves a policy bypass.
+current head (`pixi run test-all` for build coverage, `pixi run test` when C++
+runtime behavior could be affected, `pixi run test-py` when Python behavior
+could be affected, plus the Gazebo gate when package or downstream compatibility
+could be affected), a draft PR is ready to mark ready for human review after
+explicit approval even if hosted CI is still pending. Do not merge until branch
+protection and required checks pass unless a maintainer explicitly approves a
+policy bypass.

--- a/.claude/commands/dart-release-ci-fix.md
+++ b/.claude/commands/dart-release-ci-fix.md
@@ -19,10 +19,16 @@ Fix release-branch CI: $ARGUMENTS
    gh run view <RUN_ID> --job <JOB_ID> --log
    ```
 2. Check whether an equivalent fix already exists on `main`.
-3. If continuing an existing PR, fetch and checkout that branch. Otherwise branch from the release branch:
+3. If continuing an existing PR, fetch and checkout that branch. Otherwise
+   branch from the release branch without resetting an existing local branch:
    ```bash
    git fetch origin <RELEASE_BRANCH>
-   git switch --no-track -C fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   BRANCH=fix/<issue>-<release-branch>
+   if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+     git switch "$BRANCH"
+   else
+     git switch --no-track -c "$BRANCH" origin/<RELEASE_BRANCH>
+   fi
    ```
 4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
 5. Explain why the failure was not caught earlier and whether workflow coverage should change.

--- a/.claude/commands/dart-release-ci-fix.md
+++ b/.claude/commands/dart-release-ci-fix.md
@@ -1,0 +1,41 @@
+---
+description: debug and fix CI failures on a release branch
+agent: build
+---
+
+Fix release-branch CI: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/release-management.md
+
+## Workflow
+
+1. Inspect the failing run:
+   ```bash
+   gh run view <RUN_ID> --log-failed
+   gh run view <RUN_ID> --job <JOB_ID> --log
+   ```
+2. Check whether an equivalent fix already exists on `main`.
+3. If continuing an existing PR, fetch and checkout that branch. Otherwise branch from the release branch:
+   ```bash
+   git fetch origin <RELEASE_BRANCH>
+   git switch --no-track -C fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   ```
+4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
+5. Explain why the failure was not caught earlier and whether workflow coverage should change.
+6. Run `pixi run lint` and release-relevant build/tests.
+7. Ask for explicit maintainer/user approval before pushing, creating, or
+   updating the release-branch PR; after approval, use the current release
+   milestone and PR template.
+8. Monitor CI until green.
+
+## Output
+
+- Root cause
+- Fix summary
+- PR URL
+- CI status
+- Prevention recommendation, if any

--- a/.claude/commands/dart-resume.md
+++ b/.claude/commands/dart-resume.md
@@ -1,0 +1,76 @@
+---
+description: continue work from a previous session
+agent: build
+---
+
+Resume unfinished work: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/dev_tasks/README.md
+@docs/ai/sessions.md
+@docs/ai/verification.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/contributing.md
+
+## Step 1: Recon (no changes)
+
+```bash
+git rev-parse --show-toplevel
+git status -sb && git branch -vv && git log -10 --oneline --decorate
+git diff --stat && git stash list
+gh pr list --head "$(git branch --show-current)"
+gh pr status
+```
+
+## Step 2: Reconstruct
+
+Infer the task from branch name, commits, diffs, issue/PR description, and any
+`docs/dev_tasks/<task>/` state. If the goal is still unclear after recon, stop
+and ask.
+
+## Step 3: Continue
+
+- Propose a 3-6 step plan before editing.
+- Continue with minimal scope and preserve existing user changes.
+- For active solver/paper implementations, keep the plan or dev-task resume
+  surface explicit about the completed slice, the next missing paper-parity
+  gap, and why focused green tests are not a full paper-completion claim.
+- If the task is being completed, run a completion audit before finalizing:
+  identify the exact `docs/dev_tasks/<task>/` folder, inspect it for remaining
+  plans/evidence/decisions, promote any durable dashboard, evidence matrix, API
+  inventory, migration map, long-lived decision, or deferred-but-real work into
+  release/onboarding/AI docs, update any durable status surface when the task
+  changes roadmap state, then remove the dev-task folder
+  completely in the completing change.
+- If remaining work is real but blocked by a substantial design decision,
+  maintainer direction, external dependency, or scope boundary that should not
+  be resolved in the current session, ask the human before retiring the folder
+  unless prior maintainer direction is already recorded. Record the parked or
+  blocked work in the durable owner doc before deletion.
+- Do not call a dev task complete while `docs/dev_tasks/<task>/` still exists.
+  If implementation is done but the folder remains, the remaining work is the
+  durable-doc promotion plus folder cleanup.
+- Run `pixi run lint` before committing.
+- Run relevant tests; use `pixi run test-all` before done when feasible, and
+  `pixi run -e gazebo test-gz` when package or downstream Gazebo/gz-physics
+  compatibility could be affected.
+- Push with the same local and remote topic-branch name only after explicit
+  maintainer/user approval:
+  `branch=$(git branch --show-current); git push -u origin "HEAD:${branch}"`.
+- For already-published PRs, prefer additive follow-up commits. Amend or
+  force-push only after explicit maintainer/user approval and only when the user
+  explicitly requests it or when there is a clear reason such as removing
+  sensitive content or repairing broken branch history.
+- If an already-published PR needs the latest target branch, use explicit
+  maintainer/user approval to update that published branch by merging the
+  target branch and pushing normally. Do not rebase published PR branches by
+  default because that invalidates existing CI runs and makes PR review/comment
+  history harder to follow. Rebase or force-push only when the maintainer
+  explicitly requests it.
+
+## Safety
+
+No destructive git commands (`reset --hard`, dropping stashes, deleting branches)
+without explicit maintainer/user approval.

--- a/.claude/commands/dart-review-pr.md
+++ b/.claude/commands/dart-review-pr.md
@@ -1,0 +1,82 @@
+---
+description: review a PR or address review feedback
+agent: build
+---
+
+Review or respond to PR: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/code-style.md
+@docs/onboarding/ai-tools.md (for AI-generated review handling)
+
+## To Review
+
+```bash
+gh pr view $1 && gh pr diff $1
+```
+
+Check: code style, tests, docs, focused commits
+
+## To Address Feedback
+
+```bash
+gh pr view $1 --comments
+```
+
+Apply minimal fixes locally and verify. Do not push, comment, resolve threads,
+or re-trigger review without explicit maintainer/user approval for that
+external mutation.
+
+For published PRs, prefer a new follow-up commit for review fixes so reviewers
+can inspect what changed since the previous round. Amend or force-push only
+after explicit maintainer/user approval and only when the user explicitly
+requests it or when there is a clear reason such as removing sensitive content
+or repairing broken branch history.
+
+Before every push, first merge the latest base branch into the PR branch (on
+every push, not just the first) so each pushed/CI-tested state reflects current
+target base branch and conflicts surface early: `git fetch origin <base>` then
+`git merge --no-ff origin/<base>`, rebuild/retest if the merge touched code, then
+push. The local base merge is a routine pre-push step; the push itself still
+requires explicit maintainer/user approval. Do not rebase a published PR branch
+by default because it invalidates existing CI runs and makes PR review/comment
+history harder to follow. Rebase or force-push only when the maintainer
+explicitly requests it.
+
+If the push is rejected because the remote PR head moved, fetch and compare the
+remote head before retrying. If it already contains an equivalent review fix,
+validate that head and follow `docs/onboarding/ai-tools.md` instead of pushing a
+duplicate commit.
+
+## Automated Reviews (Codex, Code Quality, Copilot, etc.)
+
+When a draft PR is first published, request the first Codex review with a
+top-level `@codex review` once explicit maintainer/user approval covers PR
+comments; it can run while the PR remains draft. If Codex already shows an
+activity signal or submitted review, do not post a duplicate trigger.
+
+1. Make the local fix silently (no reply)
+2. Run the relevant local gates, including `pixi run lint` before any commit
+3. Ask for explicit maintainer/user approval before push, thread resolution,
+   PR comment, or review re-trigger
+4. If approved, push the fix silently
+5. If approved, resolve only reviewed and addressed thread IDs via GraphQL (see
+   ai-tools.md)
+6. After the approved push, if the fixes addressed Codex review comments, ask
+   for explicit maintainer/user approval for the PR comment, then re-trigger:
+   `gh pr comment $1 --body "@codex review"`
+7. Also handle `github-code-quality[bot]` review comments with the same
+   no-inline-reply loop. Fix valid findings locally and push silently after
+   approval; do not re-trigger Codex solely for non-Codex bot findings unless
+   Codex comments were also addressed.
+8. Monitor CI: `gh pr checks $1`
+9. Check for new review, repeat until no actionable comments remain
+10. For draft PRs, mark ready after explicit approval once Codex is clean and
+    local validation passes on the current head: default `pixi run test-all`,
+    plus the Gazebo gate when package or downstream compatibility could be
+    affected; merge still waits for required hosted checks unless a maintainer
+    explicitly approves a policy bypass
+
+Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/.claude/commands/dart-review-pr.md
+++ b/.claude/commands/dart-review-pr.md
@@ -74,9 +74,11 @@ activity signal or submitted review, do not post a duplicate trigger.
 8. Monitor CI: `gh pr checks $1`
 9. Check for new review, repeat until no actionable comments remain
 10. For draft PRs, mark ready after explicit approval once Codex is clean and
-    local validation passes on the current head: default `pixi run test-all`,
-    plus the Gazebo gate when package or downstream compatibility could be
-    affected; merge still waits for required hosted checks unless a maintainer
-    explicitly approves a policy bypass
+    local validation passes on the current head: `pixi run test-all` for
+    build coverage, `pixi run test` when C++ runtime behavior could be
+    affected, `pixi run test-py` when Python behavior could be affected, plus
+    the Gazebo gate when package or downstream compatibility could be affected;
+    merge still waits for required hosted checks unless a maintainer explicitly
+    approves a policy bypass
 
 Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/.claude/skills/dart-build/SKILL.md
+++ b/.claude/skills/dart-build/SKILL.md
@@ -13,7 +13,7 @@ Load this skill when working with DART's build system.
 pixi run config       # Configure CMake
 pixi run build        # Build
 pixi run test         # Run tests
-pixi run test-all     # Full validation (lint + build + tests)
+pixi run test-all     # Build all CMake targets
 pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
 pixi run lint         # Format code
 ```

--- a/.claude/skills/dart-build/SKILL.md
+++ b/.claude/skills/dart-build/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: dart-build
+description: "DART Build: CMake, pixi, dependencies, and build troubleshooting"
+---
+
+# DART Build System
+
+Load this skill when working with DART's build system.
+
+## Quick Commands
+
+```bash
+pixi run config       # Configure CMake
+pixi run build        # Build
+pixi run test         # Run tests
+pixi run test-all     # Full validation (lint + build + tests)
+pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
+pixi run lint         # Format code
+```
+
+## Full Documentation
+
+For complete build instructions, read: `docs/onboarding/building.md`
+
+For build system internals (CMake, dependencies): `docs/onboarding/build-system.md`
+
+## Common Issues
+
+| Issue              | Solution                                   |
+| ------------------ | ------------------------------------------ |
+| CMake not found    | `pixi install`                             |
+| Missing dependency | Check `pixi.toml`                          |
+| Build failure      | `pixi run config` then `pixi run build` |
+| Linking error      | Check CMakeLists.txt in relevant module    |
+
+## Release Branch Notes
+
+- This DART 6.20 support branch prioritizes compatibility with installed
+  headers, package exports, and downstream Gazebo/gz-physics behavior.
+- For package, collision, constraint, or dependency changes that could affect
+  downstream users, run the Gazebo gate when practical:
+  `pixi run -e gazebo test-gz`.
+
+## Pixi Lockfiles
+
+- Do not edit `pixi.lock` by hand. Change dependency constraints in
+  `pixi.toml`, then run a Pixi command such as `pixi install` to let Pixi
+  regenerate the lockfile.
+- If `pixi.lock` changes format or has broad solver churn, keep the generated
+  output and call it out in the PR rather than attempting to splice lockfile
+  entries manually.
+
+## GUI Visual Checks
+
+- For GUI rendering changes, use existing examples or tests on this release
+  branch and inspect any captured artifacts yourself; do not rely only on
+  command success.
+
+## Key Files
+
+- `pixi.toml` - Package management
+- `CMakeLists.txt` - Build configuration
+- `cmake/` - CMake modules

--- a/.claude/skills/dart-ci/SKILL.md
+++ b/.claude/skills/dart-ci/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: dart-ci
+description: "DART CI: GitHub Actions, cache debugging, and platform-specific failures"
+---
+
+# DART CI/CD Troubleshooting
+
+Load this skill when debugging CI failures or working with GitHub Actions.
+
+## Quick Commands
+
+```bash
+# Monitor PR checks
+gh pr checks <PR_NUMBER>
+gh pr checks <PR_NUMBER> --watch --interval 30 --fail-fast
+
+# View run details
+gh run list --branch <BRANCH> -e pull_request -L 20
+gh run watch <RUN_ID> --interval 30
+gh run view <RUN_ID> --json status,conclusion,url
+
+# Debug failures
+gh run view <RUN_ID> --job <JOB_ID> --log-failed
+gh run view <RUN_ID> --json jobs --jq '.jobs[] | {name, databaseId}'
+
+# Rerun failed jobs only after explicit maintainer/user approval
+gh run rerun <RUN_ID> --failed
+gh run rerun <RUN_ID> --job <DATABASE_ID>
+```
+
+## Full Documentation
+
+For complete CI/CD guide: `docs/onboarding/ci-cd.md`
+
+## Common Failure Modes
+
+| Failure Type         | Solution                                                 |
+| -------------------- | -------------------------------------------------------- |
+| Formatting fails     | `pixi run lint`; push only after approval                |
+| Codecov patch fails  | Add tests for uncovered lines                            |
+| FreeBSD RTTI fails   | Use type enums + `static_cast` instead of `dynamic_cast` |
+| macOS ARM64 SEGFAULT | Replace `alloca()`/VLAs with `std::vector<T>`            |
+| RTD build fails      | Use defensive `.get(key, default)` patterns              |
+| gz-physics fails     | Reproduce with `pixi run -e gazebo test-gz`              |
+
+## Workflow Architecture
+
+| Workflow            | Purpose                 | Platforms  |
+| ------------------- | ----------------------- | ---------- |
+| `ci_lint.yml`       | Formatting              | Ubuntu     |
+| `ci_ubuntu.yml`     | Build + test + coverage | Ubuntu     |
+| `ci_macos.yml`      | Build + test            | macOS      |
+| `ci_windows.yml`    | Build + test            | Windows    |
+| `ci_freebsd.yml`    | Build + test (VM)       | FreeBSD    |
+| `ci_gz_physics.yml` | Gazebo integration      | Ubuntu     |
+
+## Downstream Compatibility Policy
+
+Package, exported-target, collision, constraint, and dependency changes can
+affect Gazebo/gz-physics even when local unit tests pass. Reproduce those
+failures with the Gazebo Pixi environment when practical:
+`pixi run -e gazebo test-gz`.
+
+## Fast Iteration Loop
+
+1. Identify failing step from job logs
+2. Reproduce locally with same build toggles
+3. Fix the smallest failing test
+4. Push only after explicit maintainer/user approval, then monitor:
+   `gh run watch <RUN_ID>`
+
+## Caching
+
+- sccache/ccache reduces build time 50-70%
+- Check cache hit rates in workflow logs
+- Force cache bust by changing cache key if needed
+
+## Expected CI Times
+
+| Platform | Cached    | Uncached  |
+| -------- | --------- | --------- |
+| Ubuntu   | 20-30 min | 45-60 min |
+| macOS    | 15-25 min | 30-45 min |
+| Windows  | 15-20 min | 25-35 min |

--- a/.claude/skills/dart-contribute/SKILL.md
+++ b/.claude/skills/dart-contribute/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: dart-contribute
+description: "DART Contribute: branching, PRs, review workflow, and dual-PR bugfixes"
+---
+
+# DART Contribution Workflow
+
+Load this skill when contributing code to DART.
+
+## Full Documentation
+
+For complete guide: `docs/onboarding/contributing.md`
+
+For code style: `docs/onboarding/code-style.md`
+
+## Branch Naming
+
+- `feature/<topic>` - New features
+- `fix/<topic>` - Bug fixes
+- `refactor/<topic>` - Refactoring
+- `docs/<topic>` - Documentation
+
+## PR Workflow
+
+```bash
+# DART 6.20 maintenance work starts from the release branch without tracking it
+git fetch origin release-6.20
+git switch --no-track -c <type>/<topic> origin/release-6.20
+
+# Bug fixes that apply to the current release line start from the active DART 6 LTS branch
+DART6_LTS_BRANCH=$(git branch -r --list 'origin/release-6.*' | sed 's|.*/||' | sort -V | tail -1)
+git switch --no-track -c "fix/<topic>-${DART6_LTS_BRANCH#release-}" "origin/$DART6_LTS_BRANCH"
+
+# Make changes, then
+pixi run lint
+pixi run test-all
+# For package, collision, constraint, dependency, or downstream compatibility changes
+pixi run -e gazebo test-gz
+
+# After explicit maintainer/user approval, push and create PR
+branch=$(git branch --show-current)
+git push -u origin "HEAD:${branch}"
+gh pr create --draft --base <target-branch> --milestone "<milestone>"
+```
+
+Use the branch-matching DART 6.x patch milestone for release-branch PRs. Use
+`--base main --milestone "DART 7.0"` only for the separate DART 7 companion PR
+when a bug fix also applies to `main`.
+
+Rule of thumb: run `pixi run lint` before committing so auto-fixes are included.
+
+Use `.github/PULL_REQUEST_TEMPLATE.md` and keep DART's default order: Summary, Motivation / Problem, Changes / Key Changes, optional Before / After, Testing, Breaking Changes, and Related Issues / PRs. Keep Summary first as the reviewer skim target. If the motivation is necessary to understand the outcome, make the first Summary sentence problem-oriented, then put the fuller why in Motivation / Problem rather than moving Motivation above Summary.
+
+Write PR descriptions for a user or downstream maintainer who is not already familiar with the implementation. Lead Summary and Motivation with what changes for them, what stays compatible, how they opt in or migrate, and why the evidence matters; keep implementation mechanics in Changes unless they explain user-visible risk.
+
+When a PR has meaningful user-facing API, workflow, behavior, or performance impact, add a concise Before / After section. Cover only relevant dimensions, phrase rows as user-visible before/after outcomes, and for performance claims name the baseline explicitly: CPU path, parent commit, `main`, or prior implementation, plus workload, metric, and important limitations.
+
+Use plain descriptive commit messages and PR titles. Do not prefix them with agent tags such as `[codex]`, `[claude]`, or `[opencode]`.
+
+For already-published PRs, keep history inspectable with additive commits. If
+the PR branch needs the latest target branch, use explicit maintainer/user
+approval to update that published branch by merging the target branch and
+pushing normally. Do not rebase published PR branches by default because that
+invalidates existing CI runs and makes PR review/comment history harder to
+follow. Rebase or force-push only when the maintainer explicitly requests it.
+
+## Milestones (Required)
+
+Always set a milestone when creating PRs after explicit maintainer/user
+approval:
+
+| Target Branch                          | Milestone                      |
+| -------------------------------------- | ------------------------------ |
+| `main`                                 | `DART 7.0` (or next major)     |
+| Active DART 6 LTS `release-6.*` branch | Branch-matching DART 6.x patch |
+
+```bash
+# After explicit maintainer/user approval, set milestone on existing PR
+gh pr edit <PR#> --milestone "DART 7.0"
+
+# List available milestones
+gh api repos/dartsim/dart/milestones --jq '.[] | .title'
+```
+
+## CRITICAL: Bug Fix Dual-PR
+
+Bug fixes require PRs to **BOTH** release lines:
+
+1. **Active DART 6 LTS `release-6.*` branch** - Current DART 6 maintenance line
+2. **`main`** - Next release
+
+Steps:
+
+1. Fix on the active DART 6 LTS branch first
+2. Cherry-pick to `main`
+3. After explicit maintainer/user approval, create separate PRs for each
+
+## CHANGELOG (After Approved PR Exists)
+
+Use `docs/onboarding/changelog.md` as the source of truth. After the approved PR
+exists, check if `CHANGELOG.md` needs updating:
+
+| Change Type                      | Update CHANGELOG?                    |
+| -------------------------------- | ------------------------------------ |
+| Bug fixes                        | ✅ Yes                               |
+| New features                     | ✅ Yes                               |
+| Breaking changes                 | ✅ Yes (in Breaking Changes section) |
+| Documentation improvements       | ✅ Yes (in Tooling and Docs)         |
+| CI/tooling changes               | ✅ Yes (in Tooling and Docs)         |
+| Refactoring (no behavior change) | ⚠️ Maybe (if significant)            |
+| Dependency bumps                 | ⚠️ Maybe (if user-facing)            |
+| Typo fixes                       | ❌ No                                |
+
+Format: `- Reader-visible outcome. ([#PR](https://github.com/dartsim/dart/pull/PR))`
+
+Keep entries concise. If details need more than a few wrapped lines, move the
+details to the owner doc, plan, or migration note and link that document.
+Do not add one bullet per PR when several PRs ship one reader-visible outcome;
+merge them into one human-readable release-note entry.
+
+```bash
+# Example entry in CHANGELOG.md under appropriate section:
+- Added AI-native documentation with AGENTS.md and module-specific guides. ([#2446](https://github.com/dartsim/dart/pull/2446))
+```
+
+## Code Review
+
+- Address all feedback
+- Keep changes minimal
+- Update tests if behavior changed
+- Run full validation, then ask for explicit maintainer/user approval before
+  pushing fixes
+
+## CI Loop
+
+```bash
+gh run watch <RUN_ID> --interval 30
+```
+
+Fix failures until green.

--- a/.claude/skills/dart-io/SKILL.md
+++ b/.claude/skills/dart-io/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: dart-io
+description: "DART IO: URDF, SDF, MJCF, SKEL parsers, and dart::io loading"
+---
+
+# DART Model Loading (`dart::io`)
+
+Load this skill when working with robot model files or parsers.
+
+## Quick Start
+
+```cpp
+#include <dart/io/Read.hpp>
+
+// Format auto-detection
+auto skel = dart::io::readSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+```
+
+## Full Documentation
+
+For complete I/O guide: `docs/onboarding/io-parsing.md`
+
+For module-specific details: `dart/io/AGENTS.md`
+
+## Supported Formats
+
+| Format | Extension        | Use Case      |
+| ------ | ---------------- | ------------- |
+| URDF   | `.urdf`          | ROS robots    |
+| SDF    | `.sdf`, `.world` | Gazebo models |
+| MJCF   | `.xml`           | MuJoCo models |
+| SKEL   | `.skel`          | Legacy DART   |
+
+## Common Patterns
+
+```cpp
+// URDF with package resolution
+dart::io::ReadOptions options;
+options.addPackageDirectory("my_robot", "/path/to/my_robot");
+auto skel = dart::io::readSkeleton("package://my_robot/urdf/robot.urdf", options);
+
+// Force specific format
+options.format = dart::io::ModelFormat::Sdf;
+```
+
+## Key Files
+
+- API: `dart/io/Read.hpp`
+- Tests: `tests/unit/io/test_Read.cpp`

--- a/.claude/skills/dart-io/SKILL.md
+++ b/.claude/skills/dart-io/SKILL.md
@@ -1,26 +1,27 @@
 ---
 name: dart-io
-description: "DART IO: URDF, SDF, MJCF, SKEL parsers, and dart::io loading"
+description: "DART IO: URDF, SDF, MJCF, SKEL parsers, and dart::utils loading"
 ---
 
-# DART Model Loading (`dart::io`)
+# DART Model Loading (`dart::utils`)
 
 Load this skill when working with robot model files or parsers.
 
 ## Quick Start
 
 ```cpp
-#include <dart/io/Read.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
 
-// Format auto-detection
-auto skel = dart::io::readSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+dart::utils::DartLoader loader;
+auto skel = loader.parseSkeleton(
+    "dart://sample/urdf/KR5/KR5 sixx R650.urdf");
 ```
 
 ## Full Documentation
 
 For complete I/O guide: `docs/onboarding/io-parsing.md`
 
-For module-specific details: `dart/io/AGENTS.md`
+For repository-specific guidance: `AGENTS.md`
 
 ## Supported Formats
 
@@ -34,16 +35,21 @@ For module-specific details: `dart/io/AGENTS.md`
 ## Common Patterns
 
 ```cpp
+#include <dart/utils/sdf/SdfParser.hpp>
+
 // URDF with package resolution
-dart::io::ReadOptions options;
-options.addPackageDirectory("my_robot", "/path/to/my_robot");
-auto skel = dart::io::readSkeleton("package://my_robot/urdf/robot.urdf", options);
+dart::utils::DartLoader loader;
+loader.addPackageDirectory("my_robot", "/path/to/my_robot");
+auto skel = loader.parseSkeleton("package://my_robot/urdf/robot.urdf");
 
 // Force specific format
-options.format = dart::io::ModelFormat::Sdf;
+auto world = dart::utils::SdfParser::readWorld("dart://sample/sdf/world.sdf");
 ```
 
 ## Key Files
 
-- API: `dart/io/Read.hpp`
-- Tests: `tests/unit/io/test_Read.cpp`
+- URDF API: `dart/utils/urdf/DartLoader.hpp`
+- SDF API: `dart/utils/sdf/SdfParser.hpp`
+- SKEL API: `dart/utils/SkelParser.hpp`
+- Tests: `tests/integration/test_DartLoader.cpp`,
+  `tests/integration/test_SdfParser.cpp`, `tests/integration/test_SkelParser.cpp`

--- a/.claude/skills/dart-python/SKILL.md
+++ b/.claude/skills/dart-python/SKILL.md
@@ -12,9 +12,10 @@ Load this skill when working with Python bindings or dartpy.
 ```python
 import dartpy as dart
 
-world = dart.World()
-skel = dart.io.read_skeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
-world.add_skeleton(skel)
+world = dart.simulation.World()
+loader = dart.utils.DartLoader()
+skel = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
+world.addSkeleton(skel)
 
 for _ in range(100):
     world.step()
@@ -31,7 +32,6 @@ For module-specific details: `python/AGENTS.md`
 ```bash
 pixi run build-py-dev    # Build for development
 pixi run test-py         # Run Python tests
-pixi run generate-stubs  # Generate type stubs
 ```
 
 ## Wheel Building
@@ -42,7 +42,8 @@ release-branch wheel tasks in the same PR that introduces them.
 
 ## Key Patterns
 
-- **snake_case** preferred (camelCase emits DeprecationWarning)
+- Follow the existing DART 6 camelCase binding names used in `python/examples`
+  and `python/tests`.
 - NumPy arrays auto-convert to Eigen types
 - GUI requires `DART_BUILD_GUI=ON`
 
@@ -50,4 +51,3 @@ release-branch wheel tasks in the same PR that introduces them.
 
 - Package config: `pyproject.toml`
 - Build system: `python/dartpy/CMakeLists.txt`
-- Type stubs: `python/stubs/dartpy/`

--- a/.claude/skills/dart-python/SKILL.md
+++ b/.claude/skills/dart-python/SKILL.md
@@ -25,7 +25,7 @@ for _ in range(100):
 
 For complete Python bindings guide: `docs/onboarding/python-bindings.md`
 
-For module-specific details: `python/AGENTS.md`
+For current examples and test patterns: `python/examples/` and `python/tests/`
 
 ## Quick Commands
 

--- a/.claude/skills/dart-python/SKILL.md
+++ b/.claude/skills/dart-python/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: dart-python
+description: "DART Python: dartpy bindings, nanobind, wheels, and API patterns"
+---
+
+# DART Python Bindings (dartpy)
+
+Load this skill when working with Python bindings or dartpy.
+
+## Quick Start
+
+```python
+import dartpy as dart
+
+world = dart.World()
+skel = dart.io.read_skeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
+world.add_skeleton(skel)
+
+for _ in range(100):
+    world.step()
+```
+
+## Full Documentation
+
+For complete Python bindings guide: `docs/onboarding/python-bindings.md`
+
+For module-specific details: `python/AGENTS.md`
+
+## Quick Commands
+
+```bash
+pixi run build-py-dev    # Build for development
+pixi run test-py         # Run Python tests
+pixi run generate-stubs  # Generate type stubs
+```
+
+## Wheel Building
+
+```bash
+pixi run -e py314-wheel wheel-build
+pixi run -e py314-wheel wheel-repair  # Linux only
+pixi run -e py314-wheel wheel-test
+```
+
+## Key Patterns
+
+- **snake_case** preferred (camelCase emits DeprecationWarning)
+- NumPy arrays auto-convert to Eigen types
+- GUI requires `DART_BUILD_GUI=ON`
+
+## Key Files
+
+- Package config: `pyproject.toml`
+- Build system: `python/dartpy/CMakeLists.txt`
+- Type stubs: `python/stubs/dartpy/`

--- a/.claude/skills/dart-python/SKILL.md
+++ b/.claude/skills/dart-python/SKILL.md
@@ -36,11 +36,9 @@ pixi run generate-stubs  # Generate type stubs
 
 ## Wheel Building
 
-```bash
-pixi run -e py314-wheel wheel-build
-pixi run -e py314-wheel wheel-repair  # Linux only
-pixi run -e py314-wheel wheel-test
-```
+This release branch does not define local Pixi wheel tasks. Before changing
+wheel packaging, inspect the current CI/package workflow and add or document
+release-branch wheel tasks in the same PR that introduces them.
 
 ## Key Patterns
 

--- a/.claude/skills/dart-test/SKILL.md
+++ b/.claude/skills/dart-test/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: dart-test
+description: "DART Test: unit tests, integration tests, CI validation, and debugging"
+---
+
+# DART Testing
+
+Load this skill when writing or debugging tests.
+
+## Quick Commands
+
+```bash
+pixi run test         # Quick test run
+pixi run test-py      # Python tests
+pixi run test-all     # Full validation
+pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
+```
+
+## Full Documentation
+
+For complete testing guide: `docs/onboarding/testing.md`
+
+For CI/CD troubleshooting: `docs/onboarding/ci-cd.md`
+
+## Test Organization
+
+- Unit tests: `tests/unit/`
+- Integration tests: `tests/integration/`
+- Regression tests: Near the code they test
+
+## Writing Tests
+
+1. Follow existing patterns in the test directory
+2. Use GoogleTest framework
+3. Name tests descriptively: `TEST(ClassName, MethodName_Condition_ExpectedResult)`
+
+## CI Validation
+
+Before submitting PR:
+
+```bash
+pixi run lint         # Must pass
+pixi run test-all     # Must pass
+pixi run -e gazebo test-gz # Must pass when Gazebo/gz-physics compatibility could be affected
+```
+
+## Debugging Test Failures
+
+```bash
+# Run the smallest existing Pixi test task that covers the failure
+pixi run test
+
+# Get CI logs
+gh run view <RUN_ID> --log-failed
+```
+
+## Gotchas
+
+- `pixi run build` builds libraries only, NOT every test binary. If you run
+  `ctest` directly, build the relevant test target first; `pixi run build-tests`
+  builds the release-branch test targets.
+- `pixi run test-all` is the default full release-branch gate.
+- For package, collision, constraint, or dependency changes that could affect
+  downstream users, run `pixi run -e gazebo test-gz` when practical.

--- a/.claude/skills/dart-test/SKILL.md
+++ b/.claude/skills/dart-test/SKILL.md
@@ -12,7 +12,7 @@ Load this skill when writing or debugging tests.
 ```bash
 pixi run test         # Quick test run
 pixi run test-py      # Python tests
-pixi run test-all     # Full validation
+pixi run test-all     # Build all CMake targets
 pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
 ```
 
@@ -40,7 +40,7 @@ Before submitting PR:
 
 ```bash
 pixi run lint         # Must pass
-pixi run test-all     # Must pass
+pixi run test-all     # Must pass when all CMake targets should build
 pixi run -e gazebo test-gz # Must pass when Gazebo/gz-physics compatibility could be affected
 ```
 
@@ -59,6 +59,8 @@ gh run view <RUN_ID> --log-failed
 - `pixi run build` builds libraries only, NOT every test binary. If you run
   `ctest` directly, build the relevant test target first; `pixi run build-tests`
   builds the release-branch test targets.
-- `pixi run test-all` is the default full release-branch gate.
+- `pixi run test-all` builds all CMake targets on this branch. Pair it with
+  `pixi run lint`, `pixi run test`, and `pixi run test-py` when those gates are
+  required for the touched surface.
 - For package, collision, constraint, or dependency changes that could affect
   downstream users, run `pixi run -e gazebo test-gz` when practical.

--- a/.codex/skills/dart-analyze/SKILL.md
+++ b/.codex/skills/dart-analyze/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: dart-analyze
+description: "DART Analyze: analyze repository evidence without editing"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-analyze.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-analyze
+
+Use this skill in Codex to run the DART `dart-analyze` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-analyze <arguments>`
+- Codex: `$dart-analyze <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Analyze repository evidence without editing: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/ai/principles.md
+@docs/ai/workflows.md
+@docs/ai/verification.md
+@docs/onboarding/ai-tools.md
+
+## Workflow
+
+1. Restate the question and the read-only boundary. Do not edit files, stage
+   changes, or perform GitHub, CI, branch, or review-thread mutations.
+2. Inspect local state enough to avoid misreading user work:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   ```
+3. Build an evidence set from repository files, tests, docs, generated
+   artifacts, and command output. Load task-specific docs from `AGENTS.md` when
+   the question names a subsystem.
+4. Separate direct evidence from inference and unknowns. Do not present an
+   inference as a fact, and do not turn a read-only answer into an
+   implementation plan.
+5. Rank explanations, risks, or options by confidence when multiple readings
+   are plausible. Use concrete file and line references for material claims.
+6. If current external documentation or standards are needed for correctness,
+   gather source-backed evidence and label date/version context explicitly.
+7. Stop when the synthesis answers the question with enough evidence, or report
+   the exact proof source that is unavailable.
+
+## Output
+
+Report:
+
+- the question answered and the scope inspected;
+- ranked synthesis with confidence;
+- evidence, inference, and unknowns as separate sections;
+- any discriminating read-only probe that would reduce remaining uncertainty;
+- confirmation that no local edits or external mutations were performed.

--- a/.codex/skills/dart-backport-pr/SKILL.md
+++ b/.codex/skills/dart-backport-pr/SKILL.md
@@ -43,9 +43,15 @@ Backport PR or commits: $ARGUMENTS
    git fetch origin <RELEASE_BRANCH> main
    git cherry -v --abbrev=40 origin/<RELEASE_BRANCH> origin/main | grep <COMMIT_HASH>
    ```
-3. Create a release branch from the release target:
+3. Create a release branch from the release target without resetting an
+   existing local branch:
    ```bash
-   git switch --no-track -C backport/<SOURCE_PR>-to-<RELEASE_BRANCH> origin/<RELEASE_BRANCH>
+   BRANCH=backport/<SOURCE_PR>-to-<RELEASE_BRANCH>
+   if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+     git switch "$BRANCH"
+   else
+     git switch --no-track -c "$BRANCH" origin/<RELEASE_BRANCH>
+   fi
    ```
 4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
 5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.

--- a/.codex/skills/dart-backport-pr/SKILL.md
+++ b/.codex/skills/dart-backport-pr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: dart-backport-pr
+description: "DART Backport PR: backport a merged main PR to a release branch"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-backport-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-backport-pr
+
+Use this skill in Codex to run the DART `dart-backport-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-backport-pr <arguments>`
+- Codex: `$dart-backport-pr <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Backport PR or commits: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/release-management.md
+
+## Workflow
+
+1. Verify the source PR or commit is merged to `main`:
+   ```bash
+   gh pr view <SOURCE_PR> --json state,mergedAt,baseRefName,mergeCommit
+   ```
+2. Check whether an equivalent change already exists on the release branch:
+   ```bash
+   git fetch origin <RELEASE_BRANCH> main
+   git cherry -v --abbrev=40 origin/<RELEASE_BRANCH> origin/main | grep <COMMIT_HASH>
+   ```
+3. Create a release branch from the release target:
+   ```bash
+   git switch --no-track -C backport/<SOURCE_PR>-to-<RELEASE_BRANCH> origin/<RELEASE_BRANCH>
+   ```
+4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
+5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.
+6. Run `pixi run lint` and the smallest relevant release-branch checks.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, open the PR against the release branch with milestone
+   matching that release branch and use the PR template.
+
+## Output
+
+- Backport PR URL
+- Source PR/commit
+- Conflicts resolved, if any
+- Checks run and CI status

--- a/.codex/skills/dart-branch-cleanup/SKILL.md
+++ b/.codex/skills/dart-branch-cleanup/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: dart-branch-cleanup
+description: "DART Branch Cleanup: analyze or clean stale repository branches"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-branch-cleanup.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-branch-cleanup
+
+Use this skill in Codex to run the DART `dart-branch-cleanup` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-branch-cleanup <arguments>`
+- Codex: `$dart-branch-cleanup <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Analyze or clean branches: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/contributing.md
+
+## Modes
+
+- `analyze`: inspect only, no deletions
+- `action`: prepare follow-up, or delete only after ownership/safety are clear
+  and the maintainer/user gives explicit approval for each local or remote
+  branch deletion
+
+Default to `analyze` if the requested mode is ambiguous.
+
+## Workflow
+
+1. `git fetch --all --no-prune`
+2. List stale remote-tracking refs without deleting them:
+   ```bash
+   git remote prune origin --dry-run
+   ```
+   If `origin` uses SSH and port 22 is unavailable, keep the check read-only
+   and use a temporary HTTPS rewrite instead of changing repository config:
+   ```bash
+   git -c url.https://github.com/.insteadOf=git@github.com: \
+     fetch --all --no-prune
+   git -c url.https://github.com/.insteadOf=git@github.com: \
+     remote prune origin --dry-run
+   ```
+   To confirm that a remote PR branch was deleted without updating refs, query
+   GitHub directly over HTTPS:
+   ```bash
+   git ls-remote --heads https://github.com/dartsim/dart.git <BRANCH>
+   ```
+3. Determine the target/base branch from the PR or task, usually
+   `origin/release-6.20` for this release lane.
+4. For each branch:
+   ```bash
+   git rev-list --left-right --count <TARGET>...<BRANCH>
+   git log --oneline <TARGET>..<BRANCH>
+   git diff --stat <TARGET>..<BRANCH>
+   git cherry -v <TARGET> <BRANCH>
+   ```
+5. Before any explicitly approved local branch deletion, check whether the
+   branch is checked out by a linked worktree:
+   ```bash
+   git worktree list --porcelain
+   git -C <WORKTREE> status --short --branch
+   ```
+   Dirty linked worktrees must not be removed, detached, or reset during branch
+   cleanup. Only after explicit maintainer/user approval, switch that worktree
+   to a preservation branch at the same commit to free the obsolete branch name
+   before deleting the merged branch.
+6. The command `git branch --merged` may not prove ancestry for PR branches
+   that landed through a squash or merge commit. Use the merged PR state plus
+   an empty tree diff or equivalent `git cherry -v` output as the deletion
+   signal; if the history relationship is unclear, keep the branch.
+7. Classify recommendations only; deleting a candidate requires explicit
+   maintainer/user approval:
+   - `ahead=0`: safe deletion candidate
+   - equivalent commits already landed: deletion candidate
+   - small, current, useful diff: keep or rebase into PR
+   - large or unclear diff: document follow-up before action
+8. Ask for explicit maintainer/user approval before pruning refs or deleting any
+   local or remote branch, even when ownership, branch purpose, and remote
+   impact look clear.
+
+## Output
+
+- Branch summary with ahead/behind count and last commit date
+- Useful commits or risks
+- Recommendation: delete, keep, rebase, or needs follow-up
+- Actions taken after explicit maintainer/user approval, if action mode was
+  explicitly requested

--- a/.codex/skills/dart-build/SKILL.md
+++ b/.codex/skills/dart-build/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: dart-build
+description: "DART Build: CMake, pixi, dependencies, and build troubleshooting"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/skills/dart-build/SKILL.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# DART Build System
+
+Load this skill when working with DART's build system.
+
+## Quick Commands
+
+```bash
+pixi run config       # Configure CMake
+pixi run build        # Build
+pixi run test         # Run tests
+pixi run test-all     # Full validation (lint + build + tests)
+pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
+pixi run lint         # Format code
+```
+
+## Full Documentation
+
+For complete build instructions, read: `docs/onboarding/building.md`
+
+For build system internals (CMake, dependencies): `docs/onboarding/build-system.md`
+
+## Common Issues
+
+| Issue              | Solution                                   |
+| ------------------ | ------------------------------------------ |
+| CMake not found    | `pixi install`                             |
+| Missing dependency | Check `pixi.toml`                          |
+| Build failure      | `pixi run config` then `pixi run build` |
+| Linking error      | Check CMakeLists.txt in relevant module    |
+
+## Release Branch Notes
+
+- This DART 6.20 support branch prioritizes compatibility with installed
+  headers, package exports, and downstream Gazebo/gz-physics behavior.
+- For package, collision, constraint, or dependency changes that could affect
+  downstream users, run the Gazebo gate when practical:
+  `pixi run -e gazebo test-gz`.
+
+## Pixi Lockfiles
+
+- Do not edit `pixi.lock` by hand. Change dependency constraints in
+  `pixi.toml`, then run a Pixi command such as `pixi install` to let Pixi
+  regenerate the lockfile.
+- If `pixi.lock` changes format or has broad solver churn, keep the generated
+  output and call it out in the PR rather than attempting to splice lockfile
+  entries manually.
+
+## GUI Visual Checks
+
+- For GUI rendering changes, use existing examples or tests on this release
+  branch and inspect any captured artifacts yourself; do not rely only on
+  command success.
+
+## Key Files
+
+- `pixi.toml` - Package management
+- `CMakeLists.txt` - Build configuration
+- `cmake/` - CMake modules

--- a/.codex/skills/dart-build/SKILL.md
+++ b/.codex/skills/dart-build/SKILL.md
@@ -17,7 +17,7 @@ Load this skill when working with DART's build system.
 pixi run config       # Configure CMake
 pixi run build        # Build
 pixi run test         # Run tests
-pixi run test-all     # Full validation (lint + build + tests)
+pixi run test-all     # Build all CMake targets
 pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
 pixi run lint         # Format code
 ```

--- a/.codex/skills/dart-ci/SKILL.md
+++ b/.codex/skills/dart-ci/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: dart-ci
+description: "DART CI: GitHub Actions, cache debugging, and platform-specific failures"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/skills/dart-ci/SKILL.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# DART CI/CD Troubleshooting
+
+Load this skill when debugging CI failures or working with GitHub Actions.
+
+## Quick Commands
+
+```bash
+# Monitor PR checks
+gh pr checks <PR_NUMBER>
+gh pr checks <PR_NUMBER> --watch --interval 30 --fail-fast
+
+# View run details
+gh run list --branch <BRANCH> -e pull_request -L 20
+gh run watch <RUN_ID> --interval 30
+gh run view <RUN_ID> --json status,conclusion,url
+
+# Debug failures
+gh run view <RUN_ID> --job <JOB_ID> --log-failed
+gh run view <RUN_ID> --json jobs --jq '.jobs[] | {name, databaseId}'
+
+# Rerun failed jobs only after explicit maintainer/user approval
+gh run rerun <RUN_ID> --failed
+gh run rerun <RUN_ID> --job <DATABASE_ID>
+```
+
+## Full Documentation
+
+For complete CI/CD guide: `docs/onboarding/ci-cd.md`
+
+## Common Failure Modes
+
+| Failure Type         | Solution                                                 |
+| -------------------- | -------------------------------------------------------- |
+| Formatting fails     | `pixi run lint`; push only after approval                |
+| Codecov patch fails  | Add tests for uncovered lines                            |
+| FreeBSD RTTI fails   | Use type enums + `static_cast` instead of `dynamic_cast` |
+| macOS ARM64 SEGFAULT | Replace `alloca()`/VLAs with `std::vector<T>`            |
+| RTD build fails      | Use defensive `.get(key, default)` patterns              |
+| gz-physics fails     | Reproduce with `pixi run -e gazebo test-gz`              |
+
+## Workflow Architecture
+
+| Workflow            | Purpose                 | Platforms  |
+| ------------------- | ----------------------- | ---------- |
+| `ci_lint.yml`       | Formatting              | Ubuntu     |
+| `ci_ubuntu.yml`     | Build + test + coverage | Ubuntu     |
+| `ci_macos.yml`      | Build + test            | macOS      |
+| `ci_windows.yml`    | Build + test            | Windows    |
+| `ci_freebsd.yml`    | Build + test (VM)       | FreeBSD    |
+| `ci_gz_physics.yml` | Gazebo integration      | Ubuntu     |
+
+## Downstream Compatibility Policy
+
+Package, exported-target, collision, constraint, and dependency changes can
+affect Gazebo/gz-physics even when local unit tests pass. Reproduce those
+failures with the Gazebo Pixi environment when practical:
+`pixi run -e gazebo test-gz`.
+
+## Fast Iteration Loop
+
+1. Identify failing step from job logs
+2. Reproduce locally with same build toggles
+3. Fix the smallest failing test
+4. Push only after explicit maintainer/user approval, then monitor:
+   `gh run watch <RUN_ID>`
+
+## Caching
+
+- sccache/ccache reduces build time 50-70%
+- Check cache hit rates in workflow logs
+- Force cache bust by changing cache key if needed
+
+## Expected CI Times
+
+| Platform | Cached    | Uncached  |
+| -------- | --------- | --------- |
+| Ubuntu   | 20-30 min | 45-60 min |
+| macOS    | 15-25 min | 30-45 min |
+| Windows  | 15-20 min | 25-35 min |

--- a/.codex/skills/dart-contribute/SKILL.md
+++ b/.codex/skills/dart-contribute/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: dart-contribute
+description: "DART Contribute: branching, PRs, review workflow, and dual-PR bugfixes"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/skills/dart-contribute/SKILL.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# DART Contribution Workflow
+
+Load this skill when contributing code to DART.
+
+## Full Documentation
+
+For complete guide: `docs/onboarding/contributing.md`
+
+For code style: `docs/onboarding/code-style.md`
+
+## Branch Naming
+
+- `feature/<topic>` - New features
+- `fix/<topic>` - Bug fixes
+- `refactor/<topic>` - Refactoring
+- `docs/<topic>` - Documentation
+
+## PR Workflow
+
+```bash
+# DART 6.20 maintenance work starts from the release branch without tracking it
+git fetch origin release-6.20
+git switch --no-track -c <type>/<topic> origin/release-6.20
+
+# Bug fixes that apply to the current release line start from the active DART 6 LTS branch
+DART6_LTS_BRANCH=$(git branch -r --list 'origin/release-6.*' | sed 's|.*/||' | sort -V | tail -1)
+git switch --no-track -c "fix/<topic>-${DART6_LTS_BRANCH#release-}" "origin/$DART6_LTS_BRANCH"
+
+# Make changes, then
+pixi run lint
+pixi run test-all
+# For package, collision, constraint, dependency, or downstream compatibility changes
+pixi run -e gazebo test-gz
+
+# After explicit maintainer/user approval, push and create PR
+branch=$(git branch --show-current)
+git push -u origin "HEAD:${branch}"
+gh pr create --draft --base <target-branch> --milestone "<milestone>"
+```
+
+Use the branch-matching DART 6.x patch milestone for release-branch PRs. Use
+`--base main --milestone "DART 7.0"` only for the separate DART 7 companion PR
+when a bug fix also applies to `main`.
+
+Rule of thumb: run `pixi run lint` before committing so auto-fixes are included.
+
+Use `.github/PULL_REQUEST_TEMPLATE.md` and keep DART's default order: Summary, Motivation / Problem, Changes / Key Changes, optional Before / After, Testing, Breaking Changes, and Related Issues / PRs. Keep Summary first as the reviewer skim target. If the motivation is necessary to understand the outcome, make the first Summary sentence problem-oriented, then put the fuller why in Motivation / Problem rather than moving Motivation above Summary.
+
+Write PR descriptions for a user or downstream maintainer who is not already familiar with the implementation. Lead Summary and Motivation with what changes for them, what stays compatible, how they opt in or migrate, and why the evidence matters; keep implementation mechanics in Changes unless they explain user-visible risk.
+
+When a PR has meaningful user-facing API, workflow, behavior, or performance impact, add a concise Before / After section. Cover only relevant dimensions, phrase rows as user-visible before/after outcomes, and for performance claims name the baseline explicitly: CPU path, parent commit, `main`, or prior implementation, plus workload, metric, and important limitations.
+
+Use plain descriptive commit messages and PR titles. Do not prefix them with agent tags such as `[codex]`, `[claude]`, or `[opencode]`.
+
+For already-published PRs, keep history inspectable with additive commits. If
+the PR branch needs the latest target branch, use explicit maintainer/user
+approval to update that published branch by merging the target branch and
+pushing normally. Do not rebase published PR branches by default because that
+invalidates existing CI runs and makes PR review/comment history harder to
+follow. Rebase or force-push only when the maintainer explicitly requests it.
+
+## Milestones (Required)
+
+Always set a milestone when creating PRs after explicit maintainer/user
+approval:
+
+| Target Branch                          | Milestone                      |
+| -------------------------------------- | ------------------------------ |
+| `main`                                 | `DART 7.0` (or next major)     |
+| Active DART 6 LTS `release-6.*` branch | Branch-matching DART 6.x patch |
+
+```bash
+# After explicit maintainer/user approval, set milestone on existing PR
+gh pr edit <PR#> --milestone "DART 7.0"
+
+# List available milestones
+gh api repos/dartsim/dart/milestones --jq '.[] | .title'
+```
+
+## CRITICAL: Bug Fix Dual-PR
+
+Bug fixes require PRs to **BOTH** release lines:
+
+1. **Active DART 6 LTS `release-6.*` branch** - Current DART 6 maintenance line
+2. **`main`** - Next release
+
+Steps:
+
+1. Fix on the active DART 6 LTS branch first
+2. Cherry-pick to `main`
+3. After explicit maintainer/user approval, create separate PRs for each
+
+## CHANGELOG (After Approved PR Exists)
+
+Use `docs/onboarding/changelog.md` as the source of truth. After the approved PR
+exists, check if `CHANGELOG.md` needs updating:
+
+| Change Type                      | Update CHANGELOG?                    |
+| -------------------------------- | ------------------------------------ |
+| Bug fixes                        | ✅ Yes                               |
+| New features                     | ✅ Yes                               |
+| Breaking changes                 | ✅ Yes (in Breaking Changes section) |
+| Documentation improvements       | ✅ Yes (in Tooling and Docs)         |
+| CI/tooling changes               | ✅ Yes (in Tooling and Docs)         |
+| Refactoring (no behavior change) | ⚠️ Maybe (if significant)            |
+| Dependency bumps                 | ⚠️ Maybe (if user-facing)            |
+| Typo fixes                       | ❌ No                                |
+
+Format: `- Reader-visible outcome. ([#PR](https://github.com/dartsim/dart/pull/PR))`
+
+Keep entries concise. If details need more than a few wrapped lines, move the
+details to the owner doc, plan, or migration note and link that document.
+Do not add one bullet per PR when several PRs ship one reader-visible outcome;
+merge them into one human-readable release-note entry.
+
+```bash
+# Example entry in CHANGELOG.md under appropriate section:
+- Added AI-native documentation with AGENTS.md and module-specific guides. ([#2446](https://github.com/dartsim/dart/pull/2446))
+```
+
+## Code Review
+
+- Address all feedback
+- Keep changes minimal
+- Update tests if behavior changed
+- Run full validation, then ask for explicit maintainer/user approval before
+  pushing fixes
+
+## CI Loop
+
+```bash
+gh run watch <RUN_ID> --interval 30
+```
+
+Fix failures until green.

--- a/.codex/skills/dart-docs-update/SKILL.md
+++ b/.codex/skills/dart-docs-update/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: dart-docs-update
+description: "DART Docs Update: update documentation without code changes"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-docs-update.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-docs-update
+
+Use this skill in Codex to run the DART `dart-docs-update` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-docs-update <arguments>`
+- Codex: `$dart-docs-update <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Update documentation: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/README.md
+@docs/ai/principles.md
+@docs/ai/verification.md
+@docs/onboarding/ai-tools.md
+@docs/onboarding/changelog.md
+
+## Workflow
+
+1. Create a branch from the target branch, for example:
+   `git switch --no-track -c docs/<topic> origin/release-6.20`
+2. Edit docs and AI workflow sources only:
+   - Regular docs: `docs/**`, `README.md`, `AGENTS.md`, `CONTRIBUTING.md`
+   - AI source files: `.claude/commands/**`, `.claude/skills/**`
+3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
+4. Update indexes and cross-references that point to changed docs
+5. Use `docs/ai/verification.md` to select the docs-only or AI docs/adapters
+   gate set, then run `pixi run lint` before committing
+6. Record the `CHANGELOG.md` decision using `docs/onboarding/changelog.md`.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, push with the same local and remote topic-branch name, use
+   `.github/PULL_REQUEST_TEMPLATE.md`, and set the proper milestone.

--- a/.codex/skills/dart-downstream-fix/SKILL.md
+++ b/.codex/skills/dart-downstream-fix/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: dart-downstream-fix
+description: "DART Downstream Fix: fix a DART bug reported through gz-physics or Gazebo"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-downstream-fix.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-downstream-fix
+
+Use this skill in Codex to run the DART `dart-downstream-fix` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-downstream-fix <arguments>`
+- Codex: `$dart-downstream-fix <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Fix downstream-reported DART issue: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ci-cd.md
+
+## When To Use
+
+Use for downstream issues in gz-physics, Gazebo, or gz-sim that trace back to DART behavior: crashes, assertions, NaN/Inf propagation, missing validation, or DART performance regressions.
+
+## Workflow
+
+1. Read the downstream issue, logs, stack traces, and reproduction steps.
+2. Identify the DART API, component, and invalid usage pattern involved.
+3. Search for related validation and recovery patterns in DART.
+4. Plan the smallest fix and the regression test location.
+5. Decide whether the bug applies to the active release line. For applicable
+   bug fixes, implement on the active DART 6 LTS branch first, then cherry-pick
+   or reapply to `main` for DART 7:
+   - branch:
+     `fix/<downstream-project>-<issue-number>-<brief-description>-6-lts`
+   - add a regression test that reproduces the downstream symptom
+   - keep the fix minimal; no unrelated refactors
+6. Run `pixi run lint` and relevant tests; use `pixi run test-all` when
+   feasible, and run `pixi run -e gazebo test-gz` when Gazebo/gz-physics
+   compatibility could be affected.
+7. Ask for explicit maintainer/user approval before pushing or creating PRs.
+   After approval, create the release-branch PR with the branch-matching DART
+   6.x patch milestone and reference the downstream issue.
+8. Create the matching `main` PR with milestone `DART 7.0`; adapt API
+   differences if needed.
+
+## Release-Line Differences
+
+- DART 7 commonly uses `DART_WARN()` and `<dart/All.hpp>`.
+- DART 6 LTS may use `dtwarn << ...`, `<dart/dart.hpp>`, and older test CMake patterns.
+
+## Output
+
+- Root cause and fix summary
+- Main PR URL and release PR URL, if applicable
+- Tests run and CI status
+- Link back to the downstream issue

--- a/.codex/skills/dart-fix-ci/SKILL.md
+++ b/.codex/skills/dart-fix-ci/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: dart-fix-ci
+description: "DART Fix CI: debug and fix failing CI checks"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-fix-ci.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-fix-ci
+
+Use this skill in Codex to run the DART `dart-fix-ci` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-fix-ci <arguments>`
+- Codex: `$dart-fix-ci <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Fix CI failure: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+
+## Workflow
+
+1. Identify failing checks: `gh pr checks <PR_NUMBER>` or `gh run view <RUN_ID>`.
+2. Inspect the first real failure:
+   ```bash
+   gh run view <RUN_ID> --log-failed
+   gh run view <RUN_ID> --job <JOB_ID> --log
+   ```
+3. If a job is still in progress, wait for logs instead of guessing.
+4. Reproduce locally with the smallest relevant command:
+   - formatting: `pixi run lint`
+   - tests: `pixi run test`, `pixi run test-py`, or another existing
+     focused `pixi run ...` test task
+   - coverage: add targeted tests for uncovered changed lines
+5. Fix the root cause with minimal scope.
+6. If the failure is infrastructure-only, ask for explicit maintainer/user
+   approval before rerunning the failed job or running:
+   ```bash
+   gh run rerun <RUN_ID> --failed
+   ```
+7. Ask for explicit maintainer/user approval before pushing, CI re-triggers, or
+   other GitHub mutations; after approval, push and watch CI until the PR is
+   green.
+
+## Output
+
+- Root cause
+- Fix or rerun action
+- Commands run
+- Current CI status

--- a/.codex/skills/dart-io/SKILL.md
+++ b/.codex/skills/dart-io/SKILL.md
@@ -1,30 +1,31 @@
 ---
 name: dart-io
-description: "DART IO: URDF, SDF, MJCF, SKEL parsers, and dart::io loading"
+description: "DART IO: URDF, SDF, MJCF, SKEL parsers, and dart::utils loading"
 ---
 <!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
 <!-- Source: .claude/skills/dart-io/SKILL.md -->
 <!-- Sync script: scripts/sync_ai_commands.py -->
 <!-- Run `pixi run sync-ai-commands` to update -->
 
-# DART Model Loading (`dart::io`)
+# DART Model Loading (`dart::utils`)
 
 Load this skill when working with robot model files or parsers.
 
 ## Quick Start
 
 ```cpp
-#include <dart/io/Read.hpp>
+#include <dart/utils/urdf/DartLoader.hpp>
 
-// Format auto-detection
-auto skel = dart::io::readSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+dart::utils::DartLoader loader;
+auto skel = loader.parseSkeleton(
+    "dart://sample/urdf/KR5/KR5 sixx R650.urdf");
 ```
 
 ## Full Documentation
 
 For complete I/O guide: `docs/onboarding/io-parsing.md`
 
-For module-specific details: `dart/io/AGENTS.md`
+For repository-specific guidance: `AGENTS.md`
 
 ## Supported Formats
 
@@ -38,16 +39,21 @@ For module-specific details: `dart/io/AGENTS.md`
 ## Common Patterns
 
 ```cpp
+#include <dart/utils/sdf/SdfParser.hpp>
+
 // URDF with package resolution
-dart::io::ReadOptions options;
-options.addPackageDirectory("my_robot", "/path/to/my_robot");
-auto skel = dart::io::readSkeleton("package://my_robot/urdf/robot.urdf", options);
+dart::utils::DartLoader loader;
+loader.addPackageDirectory("my_robot", "/path/to/my_robot");
+auto skel = loader.parseSkeleton("package://my_robot/urdf/robot.urdf");
 
 // Force specific format
-options.format = dart::io::ModelFormat::Sdf;
+auto world = dart::utils::SdfParser::readWorld("dart://sample/sdf/world.sdf");
 ```
 
 ## Key Files
 
-- API: `dart/io/Read.hpp`
-- Tests: `tests/unit/io/test_Read.cpp`
+- URDF API: `dart/utils/urdf/DartLoader.hpp`
+- SDF API: `dart/utils/sdf/SdfParser.hpp`
+- SKEL API: `dart/utils/SkelParser.hpp`
+- Tests: `tests/integration/test_DartLoader.cpp`,
+  `tests/integration/test_SdfParser.cpp`, `tests/integration/test_SkelParser.cpp`

--- a/.codex/skills/dart-io/SKILL.md
+++ b/.codex/skills/dart-io/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: dart-io
+description: "DART IO: URDF, SDF, MJCF, SKEL parsers, and dart::io loading"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/skills/dart-io/SKILL.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# DART Model Loading (`dart::io`)
+
+Load this skill when working with robot model files or parsers.
+
+## Quick Start
+
+```cpp
+#include <dart/io/Read.hpp>
+
+// Format auto-detection
+auto skel = dart::io::readSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf");
+```
+
+## Full Documentation
+
+For complete I/O guide: `docs/onboarding/io-parsing.md`
+
+For module-specific details: `dart/io/AGENTS.md`
+
+## Supported Formats
+
+| Format | Extension        | Use Case      |
+| ------ | ---------------- | ------------- |
+| URDF   | `.urdf`          | ROS robots    |
+| SDF    | `.sdf`, `.world` | Gazebo models |
+| MJCF   | `.xml`           | MuJoCo models |
+| SKEL   | `.skel`          | Legacy DART   |
+
+## Common Patterns
+
+```cpp
+// URDF with package resolution
+dart::io::ReadOptions options;
+options.addPackageDirectory("my_robot", "/path/to/my_robot");
+auto skel = dart::io::readSkeleton("package://my_robot/urdf/robot.urdf", options);
+
+// Force specific format
+options.format = dart::io::ModelFormat::Sdf;
+```
+
+## Key Files
+
+- API: `dart/io/Read.hpp`
+- Tests: `tests/unit/io/test_Read.cpp`

--- a/.codex/skills/dart-manage-pr/SKILL.md
+++ b/.codex/skills/dart-manage-pr/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: dart-manage-pr
+description: "DART Manage PR: manage an open DART pull request through CI, review, and cleanup"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-manage-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-manage-pr
+
+Use this skill in Codex to run the DART `dart-manage-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-manage-pr <arguments>`
+- Codex: `$dart-manage-pr <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Manage an open DART pull request after explicit maintainer/user approval for
+mutations: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/ai-tools.md
+
+## Invocation Contract
+
+When the user says `manage <PR>` or `continue managing <PR>` without limiting
+the request to status-only, treat that as approval to run the full PR-management
+loop to the next terminal state:
+
+- required policy metadata checked and corrected when stale;
+- CI monitored until green, failed, or blocked;
+- merge conflicts reproduced and resolved locally;
+- review comments addressed, pushed, resolved, and re-reviewed when appropriate;
+- PR body/testing evidence refreshed when it no longer matches the branch.
+
+This explicit approval covers routine PR-maintenance mutations needed for that
+loop: additive fix commits and pushes, PR description/metadata corrections,
+resolving already-addressed review threads, rerunning failed CI jobs, and
+requesting a fresh AI review after follow-up fixes. It does **not** cover
+merging the PR into the target branch, force-pushes, branch deletion, PR
+closure, base-branch changes, or human reviewer requests; ask separately for
+those.
+
+Do not call the PR managed just because checks are green. Continue until the PR
+is mergeable with required checks complete and addressed review threads are
+resolved, or until a concrete blocker remains.
+
+## Identify the PR
+
+Use the PR number or URL from `$ARGUMENTS`. If none is provided, infer the PR
+from the current branch:
+
+```bash
+gh pr view --json number,url,headRefName,baseRefName
+```
+
+Then inspect the full state:
+
+```bash
+gh pr view <PR_NUMBER> --json number,title,state,isDraft,baseRefName,headRefName,mergeStateStatus,milestone,url,reviewDecision,statusCheckRollup
+gh pr checks <PR_NUMBER>
+```
+
+## Workflow
+
+1. Confirm scope and policy:
+   - Check that the base branch, milestone, title, and PR template are correct.
+   - For bug fixes, verify the required DART 6 LTS + `main` dual-PR flow.
+   - Confirm the PR body's testing/status section matches the current head and
+     does not point reviewers to deleted dev-task evidence as still pending.
+   - Confirm the PR body is readable and follows template order: Summary,
+     Motivation / Problem, Changes / Key Changes, optional Before / After,
+     Testing, Breaking Changes, and Related Issues / PRs. Keep Summary first as
+     the skimmable user/downstream outcome; if problem context must lead, fold
+     it into Summary and keep the fuller why in Motivation. Mechanics belong in
+     Changes unless they explain user-visible risk.
+   - When the PR has meaningful user-facing API, workflow, behavior, or
+     performance impact, confirm the body has a concise Before / After section
+     that compares the relevant old and new surfaces. For performance claims,
+     ensure the baseline is explicit: CPU path, parent commit, `main`, or prior
+     implementation, plus workload, metric, and important limitations. Each
+     row should be phrased as a user-visible before/after, with backend details
+     used only as supporting context.
+   - For visual PR evidence, ensure transient screenshots, headless renders,
+     GIFs, and videos are hosted as GitHub PR/issue Markdown attachments
+     (`https://github.com/user-attachments/assets/...`) rather than committed to
+     the branch. If evidence files were committed only for the PR description,
+     remove them and replace the PR body entry with a GitHub attachment URL. If
+     the current tooling cannot upload an attachment, ask a maintainer to upload
+     the local artifact through the PR editor instead of keeping it under
+     `docs/assets/`.
+   - Inspect local state before editing:
+     ```bash
+     git status --short --branch
+     git diff --stat
+     git diff --check
+     ```
+2. Monitor CI:
+   ```bash
+   gh pr checks <PR_NUMBER> --watch --interval 30 --fail-fast
+   ```
+   If checks are still queued or running, report the current jobs and keep
+   watching unless the user asked only for status.
+   Also poll mergeability:
+   ```bash
+   gh pr view <PR_NUMBER> --json mergeStateStatus,headRefOid,isDraft,reviewDecision
+   ```
+   If GitHub reports conflicts, fetch the target branch and resolve them before
+   treating green checks as sufficient.
+3. Fix failures:
+   - Inspect the newest failed run or job, not an older cancelled run.
+   - Use the `dart-fix-ci` workflow for non-trivial CI debugging.
+   - Reproduce locally with the relevant `pixi run ...` task or focused test.
+   - Before committing fixes, run `pixi run lint`; also run build or tests when
+     code or behavior changed.
+   - Commit only intended files. Push only after explicit maintainer/user
+     approval, then continue monitoring the PR.
+   - For already-published PRs, prefer additive follow-up commits so reviewers
+     can inspect each update. Amend or force-push only after explicit
+     maintainer/user approval and only when the user explicitly requests it or
+     when there is a clear reason such as removing sensitive content or
+     repairing broken branch history.
+   - Before every push, first merge the latest base branch into the PR branch
+     (on every push, not just the first) so each pushed/CI-tested state reflects
+     the current target base branch and conflicts surface early:
+     ```bash
+     git fetch origin <base-branch>
+     git merge --no-ff origin/<base-branch>  # never rebase a published PR branch
+     # rebuild + retest if the merge touched code
+     git push                                 # after explicit approval
+     ```
+     The local base merge is a routine pre-push step; the push itself still
+     requires explicit maintainer/user approval. Do not rebase a published PR
+     branch by default because it invalidates existing CI runs and makes PR
+     review/comment history harder to follow. Rebase or force-push only when the
+     maintainer explicitly requests it.
+4. Address reviews:
+   - Use the `dart-review-pr` workflow for substantive review feedback.
+   - Never reply to AI-generated review comments from bot users such as
+     `chatgpt-codex-connector[bot]`, `github-code-quality[bot]`,
+     `github-actions[bot]`, or `copilot[bot]`.
+   - When a draft PR is first published, request Codex review with a top-level
+     `@codex review` once explicit maintainer/user approval covers PR comments;
+     it can run while the PR remains draft. If Codex already shows an activity
+     signal or submitted review, do not post a duplicate trigger.
+   - Apply AI-review fixes silently. After explicit maintainer/user approval
+     and after the branch is ready, push, resolve reviewed and addressed
+     threads, and request a fresh AI review only when the approved follow-up
+     push addressed Codex review comments, or when the first trigger has a
+     concrete timeout/blocker:
+     ```bash
+     gh pr comment <PR_NUMBER> --body "@codex review"
+     ```
+   - For human reviewers, reply only when a response is useful after a fix or
+     when a question needs clarification.
+   - After posting `@codex review`, keep monitoring until a submitted review,
+     a visible activity signal, or a concrete timeout/blocker is observed.
+5. Mark ready or merge only when appropriate:
+   - Confirm review requirements are satisfied and local validation matches the
+     intended transition.
+   - If the PR is draft, mark it ready after explicit approval once Codex is
+     clean and local validation passed on the current head: default
+     `pixi run test-all`, plus the Gazebo gate when package or downstream
+     compatibility could be affected. Hosted CI may still be pending for the
+     ready-for-review transition.
+   - Confirm required hosted checks are passing before merge.
+   - Do not merge unless explicitly asked or the workflow clearly includes merge.
+   - PR comments, review re-triggers, thread resolution, reviewer requests,
+     ready-for-review transitions, merges, and branch deletion are external
+     mutations and require explicit maintainer/user approval.
+   - Confirm the merge method from repository settings or the user. Recent DART
+     PRs usually use single-parent PR-title commits, so prefer squash/rebase
+     over merge commits unless the repository settings or user request differ.
+   - Use the current head SHA when merging so a moved branch cannot be merged
+     accidentally.
+6. Clean up after merge:
+   - Confirm the PR merged and identify the head branch before deleting.
+   - After explicit maintainer/user approval, prefer merge-time deletion with
+     the approved merge method and head SHA:
+     ```bash
+     gh pr merge <PR_NUMBER> --squash --match-head-commit <HEAD_SHA> --delete-branch
+     ```
+     Use `--rebase` or `--merge` instead of `--squash` when requested.
+   - After explicit maintainer/user approval, otherwise delete only the PR
+     branch after confirming it has landed:
+     ```bash
+     git push origin --delete <HEAD_BRANCH>
+     git switch <BASE_BRANCH>
+     git pull --ff-only
+     git branch -D <HEAD_BRANCH>
+     ```
+     Use force-delete locally only after explicit maintainer/user approval and
+     after confirming the PR branch has landed; squash and rebase merges do not
+     preserve the branch tip in target-branch ancestry.
+
+## Output
+
+Report:
+
+- PR number, URL, base, head, draft state, milestone, and merge status.
+- CI summary: passing, failing, pending, or skipped checks.
+- Review summary and whether `@codex review` was triggered.
+- Commits pushed, merge action, and branch cleanup action.
+- Remaining blockers or next action.

--- a/.codex/skills/dart-manage-pr/SKILL.md
+++ b/.codex/skills/dart-manage-pr/SKILL.md
@@ -172,10 +172,10 @@ gh pr checks <PR_NUMBER>
    - Confirm review requirements are satisfied and local validation matches the
      intended transition.
    - If the PR is draft, mark it ready after explicit approval once Codex is
-     clean and local validation passed on the current head: default
-     `pixi run test-all`, plus the Gazebo gate when package or downstream
-     compatibility could be affected. Hosted CI may still be pending for the
-     ready-for-review transition.
+     clean and local validation passed on the current head: `pixi run test-all`
+     for build coverage, `pixi run test`/`pixi run test-py` for affected
+     C++/Python behavior, plus the Gazebo gate when package or downstream
+     compatibility could be affected. Hosted CI may still be pending.
    - Confirm required hosted checks are passing before merge.
    - Do not merge unless explicitly asked or the workflow clearly includes merge.
    - PR comments, review re-triggers, thread resolution, reviewer requests,

--- a/.codex/skills/dart-mechanical-refactor/SKILL.md
+++ b/.codex/skills/dart-mechanical-refactor/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: dart-mechanical-refactor
+description: "DART Mechanical Refactor: perform a behavior-preserving mechanical refactor"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-mechanical-refactor.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-mechanical-refactor
+
+Use this skill in Codex to run the DART `dart-mechanical-refactor` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-mechanical-refactor <arguments>`
+- Codex: `$dart-mechanical-refactor <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Perform mechanical refactor: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@CONTRIBUTING.md
+@docs/onboarding/code-style.md
+
+## Workflow
+
+1. Define the exact transformation and scope before editing.
+2. Create a topic branch from the target branch, for example
+   `git switch --no-track -c refactor/<topic> origin/release-6.20`.
+3. Prefer scriptable or automated edits when the transformation is repetitive.
+4. Keep behavior unchanged; do not mix in feature work or cleanup outside scope.
+5. If reorganizing files, update CMake, pixi tasks, generated indexes, and docs.
+6. Run focused checks first, then broader checks according to risk:
+   - `pixi run lint`
+   - `pixi run build`
+   - `pixi run test`
+   - `pixi run test-all` when feasible
+   - `pixi run -e gazebo test-gz` when package, collision, constraint, or
+     downstream Gazebo/gz-physics compatibility could be affected
+7. Ask for explicit maintainer/user approval before pushing or opening a PR.
+   After approval, open a PR with a clear scope statement and no
+   behavior-change claim unless tested.
+
+## Output
+
+- Transformation summary
+- Files or areas changed
+- Verification run
+- Any residual risk

--- a/.codex/skills/dart-new-task/SKILL.md
+++ b/.codex/skills/dart-new-task/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: dart-new-task
+description: "DART New Task: start a feature, bugfix, refactor, docs, build, or test task"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-new-task.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-new-task
+
+Use this skill in Codex to run the DART `dart-new-task` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-new-task <arguments>`
+- Codex: `$dart-new-task <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Start a new task in DART: $ARGUMENTS
+
+## Required Reading
+
+Read these files first:
+@AGENTS.md
+@docs/onboarding/building.md
+@docs/onboarding/contributing.md
+@docs/onboarding/code-style.md
+@docs/dev_tasks/README.md
+@docs/ai/sessions.md
+@docs/ai/principles.md
+@docs/ai/verification.md
+
+## Workflow
+
+1. **Understand the task** - Parse: goal, constraints, type (feature|bugfix|refactor|docs)
+2. **Assess scope** - Multi-phase or multi-session? Create
+   `docs/dev_tasks/<task>/` (see `docs/dev_tasks/README.md` for criteria).
+   For multi-session, design-heavy, public API, solver/paper, release, or
+   cross-module work, fill the dev-task specification intake before editing:
+   value, scope, assumptions, traceability, non-goals, acceptance evidence,
+   gates, and open decisions. If consequential ambiguity would change public
+   API, release compatibility, numerical correctness, benchmark claims, or
+   roadmap scope, record an owner-local `Decision needed` block instead of
+   silently choosing.
+3. **Setup** - Choose the target branch before creating a topic branch. For
+   DART 6.20 maintenance, dependency-minimization, docs, and compatibility
+   work, branch from `origin/release-6.20` without tracking the release ref:
+   `git switch --no-track -c <type>/<topic> origin/release-6.20`. Bug fixes
+   that also apply to DART 7 still need a separate `main` PR after the release
+   branch fix.
+4. **Implement** - Keep commits focused, follow code style
+5. **Verify** - Run `pixi run lint` before committing, then run the focused
+   release-branch gate for the touched surface. Use `pixi run test-all` when
+   feasible, and `pixi run -e gazebo test-gz` for package, collision,
+   constraint, or downstream Gazebo/gz-physics compatibility work.
+6. **PR** - After explicit maintainer/user approval, push with the same local
+   and remote topic-branch name:
+   `branch=$(git branch --show-current); git push -u origin "HEAD:${branch}"`.
+   Then create the draft PR against `<target-branch>` with the branch-matching
+   DART 6.x patch milestone and `.github/PULL_REQUEST_TEMPLATE.md`.
+7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, first
+   promote durable dashboards, evidence matrices, API inventories, migration
+   maps, or long-lived decisions into release/onboarding/AI docs.
+   Then remove the dev-task folder completely (include the deletion in this PR,
+   not after merge).
+
+## Type-Specific
+
+- **Bugfix**: Requires PRs to BOTH the active DART 6 LTS branch AND `main`
+- **Refactor**: No behavior changes
+- **Feature**: Add tests + docs
+- **DART 7 solver or architecture work**: Do that on `main`, not on the DART
+  6.20 support branch. Use this release branch only for compatible maintenance,
+  dependency minimization, CI, docs, and backports.

--- a/.codex/skills/dart-pr/SKILL.md
+++ b/.codex/skills/dart-pr/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: dart-pr
+description: "DART PR: create a branch, commit, push, and open a DART pull request"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-pr
+
+Use this skill in Codex to run the DART `dart-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-pr <arguments>`
+- Codex: `$dart-pr <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Prepare or open a DART pull request after explicit maintainer/user approval:
+$ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ai-tools.md
+@docs/onboarding/changelog.md
+@.github/PULL_REQUEST_TEMPLATE.md
+
+## Recent PR Patterns
+
+When the expected PR style is unclear, inspect recently merged PRs before
+drafting the title or body:
+
+```bash
+gh pr list --repo dartsim/dart --state merged --base <target-branch> --limit 10 \
+  --json number,title,body,mergedAt
+```
+
+Use these practices:
+
+- Keep titles plain, scoped, and outcome-focused. Do not add agent prefixes.
+- Fill the PR template in DART's default order: Summary, Motivation / Problem,
+  Changes / Key Changes, optional Before / After, Testing, Breaking Changes,
+  and Related Issues / PRs. Keep Summary first because reviewers need the
+  skimmable outcome before the rationale. If the motivation is necessary to
+  understand the outcome, make the first Summary sentence problem-oriented,
+  then put the fuller why in Motivation / Problem rather than moving Motivation
+  above Summary.
+- Write the opening Summary and Motivation from the perspective of a user or
+  downstream maintainer who is not already familiar with the implementation:
+  lead with what changes for them, what stays compatible, how they would opt in
+  or migrate, and why the evidence matters. Keep implementation details in
+  Changes unless they explain a user-visible outcome or risk.
+- When the change has meaningful user-facing API, workflow, behavior, or
+  performance impact, add a concise `## Before / After` section before
+  Testing. Use a small table or bullets that cover only relevant dimensions
+  such as public API, commands/workflows, behavior, migration, and performance
+  baseline. Phrase each row as a user-visible before/after, then name the
+  implementation mechanism only as supporting context. For performance claims,
+  name the baseline explicitly: CPU path, parent commit, `main`, or prior
+  implementation, plus workload, metric, and important limitations.
+- In Testing, list exact commands, targets, or test names that ran.
+- For CI, performance, or infrastructure work, include evidence such as CI run
+  observations, timing, reruns, benchmark output, or why a skipped check is
+  expected.
+- For rendering, model, mesh, texture, GUI, or visual-example changes, include
+  a before/after visual comparison when practical:
+  - Prefer an existing headless example path such as `--headless`,
+    `--frames`, `--width`, `--height`, and `--screenshot` over manual
+    screenshots.
+  - Capture the before image from the base branch or by temporarily restoring
+    the replaced sample/assets, then capture the after image from the final
+    branch with the same camera, dimensions, frame count, and renderer.
+  - Inspect the images yourself and include the commands plus any environment
+    variables such as software rendering flags in the PR body.
+  - Upload transient comparison images, GIFs, and videos through the GitHub
+    PR/issue Markdown attachment flow so the PR body contains GitHub-hosted
+    `https://github.com/user-attachments/assets/...` URLs that render inline.
+    Do not commit screenshots, headless renders, GIFs, or screencast videos
+    solely as PR evidence. Commit visual files only when they are durable
+    documentation, fixtures, or source assets that should live in the
+    repository.
+  - The official GitHub attachment flow is the web PR/issue editor drag/drop or
+    file picker. `gh pr edit`, `gh pr comment`, and the public REST API do not
+    provide a supported generic attachment upload command; any command or action
+    that edits or comments on a PR still requires explicit maintainer/user
+    approval. Use a maintainer-approved upload helper only when it produces
+    GitHub attachment URLs without committing files to the branch; helpers that
+    mimic the web upload may require a browser session cookie and must not be
+    used unless the maintainer has explicitly approved that credential handling.
+  - If the current tool cannot upload PR attachments, keep the local artifact
+    paths in the working note, ask a maintainer to upload them through the PR
+    editor, and then update the PR body with the returned GitHub attachment
+    URL after explicit maintainer/user approval. Do not fall back to committing
+    transient evidence into `docs/assets/`.
+  - If no headless path exists, either add a narrowly scoped capture mode when
+    it fits the example or document why visual comparison is not practical.
+- Mark non-applicable checklist items as "N/A" with a short reason.
+- Mention related PRs, issues, backports, and follow-ups explicitly, including
+  "None" when there is no related work.
+
+## Workflow
+
+1. Inspect scope:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   ```
+2. Exclude unrelated dirty files unless the user explicitly includes them.
+3. Choose the target branch and milestone:
+
+   | Target                          | Milestone                      |
+   | ------------------------------- | ------------------------------ |
+   | `main`                          | `DART 7.0`                     |
+   | Active DART 6 LTS `release-6.*` | Branch-matching DART 6.x patch |
+
+4. For bug fixes, use the dual-PR flow: fix the active DART 6 LTS branch first,
+   then cherry-pick or reapply to `main`.
+5. Before every commit, run:
+   ```bash
+   pixi run lint
+   ```
+   Also run `pixi run build` for C++ or Python changes and focused tests for
+   behavior changes.
+6. Create or update a topic branch when needed:
+   ```bash
+   git switch --no-track -c <type>/<topic> origin/<target-branch>
+   ```
+7. Commit only intended files with a plain descriptive commit title.
+8. Ask for explicit maintainer/user approval before pushing or opening the draft
+   PR. Never push directly to `release-*`. If approved:
+   ```bash
+   branch=$(git branch --show-current)
+   git push -u origin "HEAD:${branch}"
+   gh pr create --draft --base <target-branch> --milestone "<milestone>" \
+     --title "<plain title>" --body-file <filled-template-file>
+   ```
+   For fast feedback on a draft PR, also request Codex review after publication
+   when approval covers PR comments:
+   ```bash
+   gh pr comment <PR_NUMBER> --body "@codex review"
+   ```
+   If Codex already shows an activity signal or submitted review, do not post a
+   duplicate trigger.
+9. After a PR is published, prefer additive follow-up commits for updates so
+   reviewers can inspect each review round. Amend or force-push only after
+   explicit maintainer/user approval and only when the user explicitly requests
+   it or when there is a clear reason such as removing sensitive content or
+   repairing broken branch history.
+10. Before every push to a published PR branch, first merge the latest base
+    branch into it (on every push, not just the first) so each pushed/CI-tested
+    state reflects the current target base branch and conflicts surface early:
+    ```bash
+    git fetch origin <target-branch>
+    git merge --no-ff origin/<target-branch>  # never rebase a published PR branch
+    # rebuild + retest if the merge touched code
+    git push                                   # after explicit approval
+    ```
+    The local base merge is a routine pre-push step; the push itself still
+    requires explicit maintainer/user approval. Do not rebase a published PR
+    branch by default because it invalidates existing CI runs and makes PR
+    review/comment history harder to follow. Rebase or force-push only when the
+    maintainer explicitly requests it.
+11. Use `docs/onboarding/changelog.md` for the changelog decision. If
+    `CHANGELOG.md` needs the PR number, keep the follow-up changelog commit
+    local until explicit maintainer/user approval is given for the additional
+    push or PR update.
+12. Monitor CI:
+    ```bash
+    gh pr checks <PR_NUMBER>
+    ```
+
+## AI Review Comments
+
+Never reply to AI-generated review comments from bot users such as
+`chatgpt-codex-connector[bot]`, `github-code-quality[bot]`,
+`github-actions[bot]`, or `copilot[bot]`.
+When a draft PR is first published, a top-level `@codex review` is the preferred
+fast path once explicit maintainer/user approval covers PR comments; it can run
+while the PR remains draft. Make fixes silently. Push and ask for a new AI review
+with `@codex review` only after explicit maintainer/user approval and only when
+the approved follow-up push addressed Codex review comments, or when the first
+trigger has a concrete timeout/blocker.
+
+After Codex returns no actionable issues and local validation passes on the
+current head (default `pixi run test-all`, plus the Gazebo gate when package or
+downstream compatibility could be affected), a draft PR is ready to mark ready
+for human review after explicit approval even if hosted CI is still pending. Do
+not merge until branch protection and required checks pass unless a maintainer
+explicitly approves a policy bypass.

--- a/.codex/skills/dart-pr/SKILL.md
+++ b/.codex/skills/dart-pr/SKILL.md
@@ -193,8 +193,10 @@ the approved follow-up push addressed Codex review comments, or when the first
 trigger has a concrete timeout/blocker.
 
 After Codex returns no actionable issues and local validation passes on the
-current head (default `pixi run test-all`, plus the Gazebo gate when package or
-downstream compatibility could be affected), a draft PR is ready to mark ready
-for human review after explicit approval even if hosted CI is still pending. Do
-not merge until branch protection and required checks pass unless a maintainer
-explicitly approves a policy bypass.
+current head (`pixi run test-all` for build coverage, `pixi run test` when C++
+runtime behavior could be affected, `pixi run test-py` when Python behavior
+could be affected, plus the Gazebo gate when package or downstream compatibility
+could be affected), a draft PR is ready to mark ready for human review after
+explicit approval even if hosted CI is still pending. Do not merge until branch
+protection and required checks pass unless a maintainer explicitly approves a
+policy bypass.

--- a/.codex/skills/dart-python/SKILL.md
+++ b/.codex/skills/dart-python/SKILL.md
@@ -16,9 +16,10 @@ Load this skill when working with Python bindings or dartpy.
 ```python
 import dartpy as dart
 
-world = dart.World()
-skel = dart.io.read_skeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
-world.add_skeleton(skel)
+world = dart.simulation.World()
+loader = dart.utils.DartLoader()
+skel = loader.parseSkeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
+world.addSkeleton(skel)
 
 for _ in range(100):
     world.step()
@@ -35,7 +36,6 @@ For module-specific details: `python/AGENTS.md`
 ```bash
 pixi run build-py-dev    # Build for development
 pixi run test-py         # Run Python tests
-pixi run generate-stubs  # Generate type stubs
 ```
 
 ## Wheel Building
@@ -46,7 +46,8 @@ release-branch wheel tasks in the same PR that introduces them.
 
 ## Key Patterns
 
-- **snake_case** preferred (camelCase emits DeprecationWarning)
+- Follow the existing DART 6 camelCase binding names used in `python/examples`
+  and `python/tests`.
 - NumPy arrays auto-convert to Eigen types
 - GUI requires `DART_BUILD_GUI=ON`
 
@@ -54,4 +55,3 @@ release-branch wheel tasks in the same PR that introduces them.
 
 - Package config: `pyproject.toml`
 - Build system: `python/dartpy/CMakeLists.txt`
-- Type stubs: `python/stubs/dartpy/`

--- a/.codex/skills/dart-python/SKILL.md
+++ b/.codex/skills/dart-python/SKILL.md
@@ -40,11 +40,9 @@ pixi run generate-stubs  # Generate type stubs
 
 ## Wheel Building
 
-```bash
-pixi run -e py314-wheel wheel-build
-pixi run -e py314-wheel wheel-repair  # Linux only
-pixi run -e py314-wheel wheel-test
-```
+This release branch does not define local Pixi wheel tasks. Before changing
+wheel packaging, inspect the current CI/package workflow and add or document
+release-branch wheel tasks in the same PR that introduces them.
 
 ## Key Patterns
 

--- a/.codex/skills/dart-python/SKILL.md
+++ b/.codex/skills/dart-python/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: dart-python
+description: "DART Python: dartpy bindings, nanobind, wheels, and API patterns"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/skills/dart-python/SKILL.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# DART Python Bindings (dartpy)
+
+Load this skill when working with Python bindings or dartpy.
+
+## Quick Start
+
+```python
+import dartpy as dart
+
+world = dart.World()
+skel = dart.io.read_skeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
+world.add_skeleton(skel)
+
+for _ in range(100):
+    world.step()
+```
+
+## Full Documentation
+
+For complete Python bindings guide: `docs/onboarding/python-bindings.md`
+
+For module-specific details: `python/AGENTS.md`
+
+## Quick Commands
+
+```bash
+pixi run build-py-dev    # Build for development
+pixi run test-py         # Run Python tests
+pixi run generate-stubs  # Generate type stubs
+```
+
+## Wheel Building
+
+```bash
+pixi run -e py314-wheel wheel-build
+pixi run -e py314-wheel wheel-repair  # Linux only
+pixi run -e py314-wheel wheel-test
+```
+
+## Key Patterns
+
+- **snake_case** preferred (camelCase emits DeprecationWarning)
+- NumPy arrays auto-convert to Eigen types
+- GUI requires `DART_BUILD_GUI=ON`
+
+## Key Files
+
+- Package config: `pyproject.toml`
+- Build system: `python/dartpy/CMakeLists.txt`
+- Type stubs: `python/stubs/dartpy/`

--- a/.codex/skills/dart-python/SKILL.md
+++ b/.codex/skills/dart-python/SKILL.md
@@ -29,7 +29,7 @@ for _ in range(100):
 
 For complete Python bindings guide: `docs/onboarding/python-bindings.md`
 
-For module-specific details: `python/AGENTS.md`
+For current examples and test patterns: `python/examples/` and `python/tests/`
 
 ## Quick Commands
 

--- a/.codex/skills/dart-release-ci-fix/SKILL.md
+++ b/.codex/skills/dart-release-ci-fix/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: dart-release-ci-fix
+description: "DART Release CI Fix: debug and fix CI failures on a release branch"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-release-ci-fix.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-release-ci-fix
+
+Use this skill in Codex to run the DART `dart-release-ci-fix` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-release-ci-fix <arguments>`
+- Codex: `$dart-release-ci-fix <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Fix release-branch CI: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/release-management.md
+
+## Workflow
+
+1. Inspect the failing run:
+   ```bash
+   gh run view <RUN_ID> --log-failed
+   gh run view <RUN_ID> --job <JOB_ID> --log
+   ```
+2. Check whether an equivalent fix already exists on `main`.
+3. If continuing an existing PR, fetch and checkout that branch. Otherwise branch from the release branch:
+   ```bash
+   git fetch origin <RELEASE_BRANCH>
+   git switch --no-track -C fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   ```
+4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
+5. Explain why the failure was not caught earlier and whether workflow coverage should change.
+6. Run `pixi run lint` and release-relevant build/tests.
+7. Ask for explicit maintainer/user approval before pushing, creating, or
+   updating the release-branch PR; after approval, use the current release
+   milestone and PR template.
+8. Monitor CI until green.
+
+## Output
+
+- Root cause
+- Fix summary
+- PR URL
+- CI status
+- Prevention recommendation, if any

--- a/.codex/skills/dart-release-ci-fix/SKILL.md
+++ b/.codex/skills/dart-release-ci-fix/SKILL.md
@@ -40,10 +40,16 @@ Fix release-branch CI: $ARGUMENTS
    gh run view <RUN_ID> --job <JOB_ID> --log
    ```
 2. Check whether an equivalent fix already exists on `main`.
-3. If continuing an existing PR, fetch and checkout that branch. Otherwise branch from the release branch:
+3. If continuing an existing PR, fetch and checkout that branch. Otherwise
+   branch from the release branch without resetting an existing local branch:
    ```bash
    git fetch origin <RELEASE_BRANCH>
-   git switch --no-track -C fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   BRANCH=fix/<issue>-<release-branch>
+   if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+     git switch "$BRANCH"
+   else
+     git switch --no-track -c "$BRANCH" origin/<RELEASE_BRANCH>
+   fi
    ```
 4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
 5. Explain why the failure was not caught earlier and whether workflow coverage should change.

--- a/.codex/skills/dart-resume/SKILL.md
+++ b/.codex/skills/dart-resume/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: dart-resume
+description: "DART Resume: continue work from a previous session"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-resume.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-resume
+
+Use this skill in Codex to run the DART `dart-resume` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-resume <arguments>`
+- Codex: `$dart-resume <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Resume unfinished work: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/dev_tasks/README.md
+@docs/ai/sessions.md
+@docs/ai/verification.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/contributing.md
+
+## Step 1: Recon (no changes)
+
+```bash
+git rev-parse --show-toplevel
+git status -sb && git branch -vv && git log -10 --oneline --decorate
+git diff --stat && git stash list
+gh pr list --head "$(git branch --show-current)"
+gh pr status
+```
+
+## Step 2: Reconstruct
+
+Infer the task from branch name, commits, diffs, issue/PR description, and any
+`docs/dev_tasks/<task>/` state. If the goal is still unclear after recon, stop
+and ask.
+
+## Step 3: Continue
+
+- Propose a 3-6 step plan before editing.
+- Continue with minimal scope and preserve existing user changes.
+- For active solver/paper implementations, keep the plan or dev-task resume
+  surface explicit about the completed slice, the next missing paper-parity
+  gap, and why focused green tests are not a full paper-completion claim.
+- If the task is being completed, run a completion audit before finalizing:
+  identify the exact `docs/dev_tasks/<task>/` folder, inspect it for remaining
+  plans/evidence/decisions, promote any durable dashboard, evidence matrix, API
+  inventory, migration map, long-lived decision, or deferred-but-real work into
+  release/onboarding/AI docs, update any durable status surface when the task
+  changes roadmap state, then remove the dev-task folder
+  completely in the completing change.
+- If remaining work is real but blocked by a substantial design decision,
+  maintainer direction, external dependency, or scope boundary that should not
+  be resolved in the current session, ask the human before retiring the folder
+  unless prior maintainer direction is already recorded. Record the parked or
+  blocked work in the durable owner doc before deletion.
+- Do not call a dev task complete while `docs/dev_tasks/<task>/` still exists.
+  If implementation is done but the folder remains, the remaining work is the
+  durable-doc promotion plus folder cleanup.
+- Run `pixi run lint` before committing.
+- Run relevant tests; use `pixi run test-all` before done when feasible, and
+  `pixi run -e gazebo test-gz` when package or downstream Gazebo/gz-physics
+  compatibility could be affected.
+- Push with the same local and remote topic-branch name only after explicit
+  maintainer/user approval:
+  `branch=$(git branch --show-current); git push -u origin "HEAD:${branch}"`.
+- For already-published PRs, prefer additive follow-up commits. Amend or
+  force-push only after explicit maintainer/user approval and only when the user
+  explicitly requests it or when there is a clear reason such as removing
+  sensitive content or repairing broken branch history.
+- If an already-published PR needs the latest target branch, use explicit
+  maintainer/user approval to update that published branch by merging the
+  target branch and pushing normally. Do not rebase published PR branches by
+  default because that invalidates existing CI runs and makes PR review/comment
+  history harder to follow. Rebase or force-push only when the maintainer
+  explicitly requests it.
+
+## Safety
+
+No destructive git commands (`reset --hard`, dropping stashes, deleting branches)
+without explicit maintainer/user approval.

--- a/.codex/skills/dart-review-pr/SKILL.md
+++ b/.codex/skills/dart-review-pr/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: dart-review-pr
+description: "DART Review PR: review a PR or address review feedback"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-review-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# dart-review-pr
+
+Use this skill in Codex to run the DART `dart-review-pr` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/dart-review-pr <arguments>`
+- Codex: `$dart-review-pr <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+Review or respond to PR: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/code-style.md
+@docs/onboarding/ai-tools.md (for AI-generated review handling)
+
+## To Review
+
+```bash
+gh pr view $1 && gh pr diff $1
+```
+
+Check: code style, tests, docs, focused commits
+
+## To Address Feedback
+
+```bash
+gh pr view $1 --comments
+```
+
+Apply minimal fixes locally and verify. Do not push, comment, resolve threads,
+or re-trigger review without explicit maintainer/user approval for that
+external mutation.
+
+For published PRs, prefer a new follow-up commit for review fixes so reviewers
+can inspect what changed since the previous round. Amend or force-push only
+after explicit maintainer/user approval and only when the user explicitly
+requests it or when there is a clear reason such as removing sensitive content
+or repairing broken branch history.
+
+Before every push, first merge the latest base branch into the PR branch (on
+every push, not just the first) so each pushed/CI-tested state reflects current
+target base branch and conflicts surface early: `git fetch origin <base>` then
+`git merge --no-ff origin/<base>`, rebuild/retest if the merge touched code, then
+push. The local base merge is a routine pre-push step; the push itself still
+requires explicit maintainer/user approval. Do not rebase a published PR branch
+by default because it invalidates existing CI runs and makes PR review/comment
+history harder to follow. Rebase or force-push only when the maintainer
+explicitly requests it.
+
+If the push is rejected because the remote PR head moved, fetch and compare the
+remote head before retrying. If it already contains an equivalent review fix,
+validate that head and follow `docs/onboarding/ai-tools.md` instead of pushing a
+duplicate commit.
+
+## Automated Reviews (Codex, Code Quality, Copilot, etc.)
+
+When a draft PR is first published, request the first Codex review with a
+top-level `@codex review` once explicit maintainer/user approval covers PR
+comments; it can run while the PR remains draft. If Codex already shows an
+activity signal or submitted review, do not post a duplicate trigger.
+
+1. Make the local fix silently (no reply)
+2. Run the relevant local gates, including `pixi run lint` before any commit
+3. Ask for explicit maintainer/user approval before push, thread resolution,
+   PR comment, or review re-trigger
+4. If approved, push the fix silently
+5. If approved, resolve only reviewed and addressed thread IDs via GraphQL (see
+   ai-tools.md)
+6. After the approved push, if the fixes addressed Codex review comments, ask
+   for explicit maintainer/user approval for the PR comment, then re-trigger:
+   `gh pr comment $1 --body "@codex review"`
+7. Also handle `github-code-quality[bot]` review comments with the same
+   no-inline-reply loop. Fix valid findings locally and push silently after
+   approval; do not re-trigger Codex solely for non-Codex bot findings unless
+   Codex comments were also addressed.
+8. Monitor CI: `gh pr checks $1`
+9. Check for new review, repeat until no actionable comments remain
+10. For draft PRs, mark ready after explicit approval once Codex is clean and
+    local validation passes on the current head: default `pixi run test-all`,
+    plus the Gazebo gate when package or downstream compatibility could be
+    affected; merge still waits for required hosted checks unless a maintainer
+    explicitly approves a policy bypass
+
+Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/.codex/skills/dart-review-pr/SKILL.md
+++ b/.codex/skills/dart-review-pr/SKILL.md
@@ -95,9 +95,11 @@ activity signal or submitted review, do not post a duplicate trigger.
 8. Monitor CI: `gh pr checks $1`
 9. Check for new review, repeat until no actionable comments remain
 10. For draft PRs, mark ready after explicit approval once Codex is clean and
-    local validation passes on the current head: default `pixi run test-all`,
-    plus the Gazebo gate when package or downstream compatibility could be
-    affected; merge still waits for required hosted checks unless a maintainer
-    explicitly approves a policy bypass
+    local validation passes on the current head: `pixi run test-all` for
+    build coverage, `pixi run test` when C++ runtime behavior could be
+    affected, `pixi run test-py` when Python behavior could be affected, plus
+    the Gazebo gate when package or downstream compatibility could be affected;
+    merge still waits for required hosted checks unless a maintainer explicitly
+    approves a policy bypass
 
 Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/.codex/skills/dart-test/SKILL.md
+++ b/.codex/skills/dart-test/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: dart-test
+description: "DART Test: unit tests, integration tests, CI validation, and debugging"
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/skills/dart-test/SKILL.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+# DART Testing
+
+Load this skill when writing or debugging tests.
+
+## Quick Commands
+
+```bash
+pixi run test         # Quick test run
+pixi run test-py      # Python tests
+pixi run test-all     # Full validation
+pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
+```
+
+## Full Documentation
+
+For complete testing guide: `docs/onboarding/testing.md`
+
+For CI/CD troubleshooting: `docs/onboarding/ci-cd.md`
+
+## Test Organization
+
+- Unit tests: `tests/unit/`
+- Integration tests: `tests/integration/`
+- Regression tests: Near the code they test
+
+## Writing Tests
+
+1. Follow existing patterns in the test directory
+2. Use GoogleTest framework
+3. Name tests descriptively: `TEST(ClassName, MethodName_Condition_ExpectedResult)`
+
+## CI Validation
+
+Before submitting PR:
+
+```bash
+pixi run lint         # Must pass
+pixi run test-all     # Must pass
+pixi run -e gazebo test-gz # Must pass when Gazebo/gz-physics compatibility could be affected
+```
+
+## Debugging Test Failures
+
+```bash
+# Run the smallest existing Pixi test task that covers the failure
+pixi run test
+
+# Get CI logs
+gh run view <RUN_ID> --log-failed
+```
+
+## Gotchas
+
+- `pixi run build` builds libraries only, NOT every test binary. If you run
+  `ctest` directly, build the relevant test target first; `pixi run build-tests`
+  builds the release-branch test targets.
+- `pixi run test-all` is the default full release-branch gate.
+- For package, collision, constraint, or dependency changes that could affect
+  downstream users, run `pixi run -e gazebo test-gz` when practical.

--- a/.codex/skills/dart-test/SKILL.md
+++ b/.codex/skills/dart-test/SKILL.md
@@ -16,7 +16,7 @@ Load this skill when writing or debugging tests.
 ```bash
 pixi run test         # Quick test run
 pixi run test-py      # Python tests
-pixi run test-all     # Full validation
+pixi run test-all     # Build all CMake targets
 pixi run -e gazebo test-gz # Gazebo/gz-physics compatibility gate
 ```
 
@@ -44,7 +44,7 @@ Before submitting PR:
 
 ```bash
 pixi run lint         # Must pass
-pixi run test-all     # Must pass
+pixi run test-all     # Must pass when all CMake targets should build
 pixi run -e gazebo test-gz # Must pass when Gazebo/gz-physics compatibility could be affected
 ```
 
@@ -63,6 +63,8 @@ gh run view <RUN_ID> --log-failed
 - `pixi run build` builds libraries only, NOT every test binary. If you run
   `ctest` directly, build the relevant test target first; `pixi run build-tests`
   builds the release-branch test targets.
-- `pixi run test-all` is the default full release-branch gate.
+- `pixi run test-all` builds all CMake targets on this branch. Pair it with
+  `pixi run lint`, `pixi run test`, and `pixi run test-py` when those gates are
+  required for the touched surface.
 - For package, collision, constraint, or dependency changes that could affect
   downstream users, run `pixi run -e gazebo test-gz` when practical.

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ compile_flags.txt
 !.opencode/command/**/*.md
 !.opencode/AGENTS.md
 
+!.codex/
 .codex/*
 !.codex/skills/
 !.codex/skills/**/

--- a/.opencode/command/dart-analyze.md
+++ b/.opencode/command/dart-analyze.md
@@ -1,0 +1,50 @@
+---
+description: analyze repository evidence without editing
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-analyze.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Analyze repository evidence without editing: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/ai/principles.md
+@docs/ai/workflows.md
+@docs/ai/verification.md
+@docs/onboarding/ai-tools.md
+
+## Workflow
+
+1. Restate the question and the read-only boundary. Do not edit files, stage
+   changes, or perform GitHub, CI, branch, or review-thread mutations.
+2. Inspect local state enough to avoid misreading user work:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   ```
+3. Build an evidence set from repository files, tests, docs, generated
+   artifacts, and command output. Load task-specific docs from `AGENTS.md` when
+   the question names a subsystem.
+4. Separate direct evidence from inference and unknowns. Do not present an
+   inference as a fact, and do not turn a read-only answer into an
+   implementation plan.
+5. Rank explanations, risks, or options by confidence when multiple readings
+   are plausible. Use concrete file and line references for material claims.
+6. If current external documentation or standards are needed for correctness,
+   gather source-backed evidence and label date/version context explicitly.
+7. Stop when the synthesis answers the question with enough evidence, or report
+   the exact proof source that is unavailable.
+
+## Output
+
+Report:
+
+- the question answered and the scope inspected;
+- ranked synthesis with confidence;
+- evidence, inference, and unknowns as separate sections;
+- any discriminating read-only probe that would reduce remaining uncertainty;
+- confirmation that no local edits or external mutations were performed.

--- a/.opencode/command/dart-backport-pr.md
+++ b/.opencode/command/dart-backport-pr.md
@@ -1,0 +1,45 @@
+---
+description: backport a merged main PR to a release branch
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-backport-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Backport PR or commits: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/release-management.md
+
+## Workflow
+
+1. Verify the source PR or commit is merged to `main`:
+   ```bash
+   gh pr view <SOURCE_PR> --json state,mergedAt,baseRefName,mergeCommit
+   ```
+2. Check whether an equivalent change already exists on the release branch:
+   ```bash
+   git fetch origin <RELEASE_BRANCH> main
+   git cherry -v --abbrev=40 origin/<RELEASE_BRANCH> origin/main | grep <COMMIT_HASH>
+   ```
+3. Create a release branch from the release target:
+   ```bash
+   git switch --no-track -C backport/<SOURCE_PR>-to-<RELEASE_BRANCH> origin/<RELEASE_BRANCH>
+   ```
+4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
+5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.
+6. Run `pixi run lint` and the smallest relevant release-branch checks.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, open the PR against the release branch with milestone
+   matching that release branch and use the PR template.
+
+## Output
+
+- Backport PR URL
+- Source PR/commit
+- Conflicts resolved, if any
+- Checks run and CI status

--- a/.opencode/command/dart-backport-pr.md
+++ b/.opencode/command/dart-backport-pr.md
@@ -26,9 +26,15 @@ Backport PR or commits: $ARGUMENTS
    git fetch origin <RELEASE_BRANCH> main
    git cherry -v --abbrev=40 origin/<RELEASE_BRANCH> origin/main | grep <COMMIT_HASH>
    ```
-3. Create a release branch from the release target:
+3. Create a release branch from the release target without resetting an
+   existing local branch:
    ```bash
-   git switch --no-track -C backport/<SOURCE_PR>-to-<RELEASE_BRANCH> origin/<RELEASE_BRANCH>
+   BRANCH=backport/<SOURCE_PR>-to-<RELEASE_BRANCH>
+   if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+     git switch "$BRANCH"
+   else
+     git switch --no-track -c "$BRANCH" origin/<RELEASE_BRANCH>
+   fi
    ```
 4. Cherry-pick with provenance: `git cherry-pick -x <COMMIT_HASH>`.
 5. Resolve conflicts minimally; stop and ask if conflicts are broad or change behavior.

--- a/.opencode/command/dart-branch-cleanup.md
+++ b/.opencode/command/dart-branch-cleanup.md
@@ -1,0 +1,86 @@
+---
+description: analyze or clean stale repository branches
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-branch-cleanup.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Analyze or clean branches: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/contributing.md
+
+## Modes
+
+- `analyze`: inspect only, no deletions
+- `action`: prepare follow-up, or delete only after ownership/safety are clear
+  and the maintainer/user gives explicit approval for each local or remote
+  branch deletion
+
+Default to `analyze` if the requested mode is ambiguous.
+
+## Workflow
+
+1. `git fetch --all --no-prune`
+2. List stale remote-tracking refs without deleting them:
+   ```bash
+   git remote prune origin --dry-run
+   ```
+   If `origin` uses SSH and port 22 is unavailable, keep the check read-only
+   and use a temporary HTTPS rewrite instead of changing repository config:
+   ```bash
+   git -c url.https://github.com/.insteadOf=git@github.com: \
+     fetch --all --no-prune
+   git -c url.https://github.com/.insteadOf=git@github.com: \
+     remote prune origin --dry-run
+   ```
+   To confirm that a remote PR branch was deleted without updating refs, query
+   GitHub directly over HTTPS:
+   ```bash
+   git ls-remote --heads https://github.com/dartsim/dart.git <BRANCH>
+   ```
+3. Determine the target/base branch from the PR or task, usually
+   `origin/release-6.20` for this release lane.
+4. For each branch:
+   ```bash
+   git rev-list --left-right --count <TARGET>...<BRANCH>
+   git log --oneline <TARGET>..<BRANCH>
+   git diff --stat <TARGET>..<BRANCH>
+   git cherry -v <TARGET> <BRANCH>
+   ```
+5. Before any explicitly approved local branch deletion, check whether the
+   branch is checked out by a linked worktree:
+   ```bash
+   git worktree list --porcelain
+   git -C <WORKTREE> status --short --branch
+   ```
+   Dirty linked worktrees must not be removed, detached, or reset during branch
+   cleanup. Only after explicit maintainer/user approval, switch that worktree
+   to a preservation branch at the same commit to free the obsolete branch name
+   before deleting the merged branch.
+6. The command `git branch --merged` may not prove ancestry for PR branches
+   that landed through a squash or merge commit. Use the merged PR state plus
+   an empty tree diff or equivalent `git cherry -v` output as the deletion
+   signal; if the history relationship is unclear, keep the branch.
+7. Classify recommendations only; deleting a candidate requires explicit
+   maintainer/user approval:
+   - `ahead=0`: safe deletion candidate
+   - equivalent commits already landed: deletion candidate
+   - small, current, useful diff: keep or rebase into PR
+   - large or unclear diff: document follow-up before action
+8. Ask for explicit maintainer/user approval before pruning refs or deleting any
+   local or remote branch, even when ownership, branch purpose, and remote
+   impact look clear.
+
+## Output
+
+- Branch summary with ahead/behind count and last commit date
+- Useful commits or risks
+- Recommendation: delete, keep, rebase, or needs follow-up
+- Actions taken after explicit maintainer/user approval, if action mode was
+  explicitly requested

--- a/.opencode/command/dart-docs-update.md
+++ b/.opencode/command/dart-docs-update.md
@@ -1,0 +1,35 @@
+---
+description: update documentation without code changes
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-docs-update.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Update documentation: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/README.md
+@docs/ai/principles.md
+@docs/ai/verification.md
+@docs/onboarding/ai-tools.md
+@docs/onboarding/changelog.md
+
+## Workflow
+
+1. Create a branch from the target branch, for example:
+   `git switch --no-track -c docs/<topic> origin/release-6.20`
+2. Edit docs and AI workflow sources only:
+   - Regular docs: `docs/**`, `README.md`, `AGENTS.md`, `CONTRIBUTING.md`
+   - AI source files: `.claude/commands/**`, `.claude/skills/**`
+3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
+4. Update indexes and cross-references that point to changed docs
+5. Use `docs/ai/verification.md` to select the docs-only or AI docs/adapters
+   gate set, then run `pixi run lint` before committing
+6. Record the `CHANGELOG.md` decision using `docs/onboarding/changelog.md`.
+7. Ask for explicit maintainer/user approval before pushing or opening the PR.
+   After approval, push with the same local and remote topic-branch name, use
+   `.github/PULL_REQUEST_TEMPLATE.md`, and set the proper milestone.

--- a/.opencode/command/dart-downstream-fix.md
+++ b/.opencode/command/dart-downstream-fix.md
@@ -1,0 +1,54 @@
+---
+description: fix a DART bug reported through gz-physics or Gazebo
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-downstream-fix.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Fix downstream-reported DART issue: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ci-cd.md
+
+## When To Use
+
+Use for downstream issues in gz-physics, Gazebo, or gz-sim that trace back to DART behavior: crashes, assertions, NaN/Inf propagation, missing validation, or DART performance regressions.
+
+## Workflow
+
+1. Read the downstream issue, logs, stack traces, and reproduction steps.
+2. Identify the DART API, component, and invalid usage pattern involved.
+3. Search for related validation and recovery patterns in DART.
+4. Plan the smallest fix and the regression test location.
+5. Decide whether the bug applies to the active release line. For applicable
+   bug fixes, implement on the active DART 6 LTS branch first, then cherry-pick
+   or reapply to `main` for DART 7:
+   - branch:
+     `fix/<downstream-project>-<issue-number>-<brief-description>-6-lts`
+   - add a regression test that reproduces the downstream symptom
+   - keep the fix minimal; no unrelated refactors
+6. Run `pixi run lint` and relevant tests; use `pixi run test-all` when
+   feasible, and run `pixi run -e gazebo test-gz` when Gazebo/gz-physics
+   compatibility could be affected.
+7. Ask for explicit maintainer/user approval before pushing or creating PRs.
+   After approval, create the release-branch PR with the branch-matching DART
+   6.x patch milestone and reference the downstream issue.
+8. Create the matching `main` PR with milestone `DART 7.0`; adapt API
+   differences if needed.
+
+## Release-Line Differences
+
+- DART 7 commonly uses `DART_WARN()` and `<dart/All.hpp>`.
+- DART 6 LTS may use `dtwarn << ...`, `<dart/dart.hpp>`, and older test CMake patterns.
+
+## Output
+
+- Root cause and fix summary
+- Main PR URL and release PR URL, if applicable
+- Tests run and CI status
+- Link back to the downstream issue

--- a/.opencode/command/dart-fix-ci.md
+++ b/.opencode/command/dart-fix-ci.md
@@ -1,0 +1,46 @@
+---
+description: debug and fix failing CI checks
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-fix-ci.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Fix CI failure: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+
+## Workflow
+
+1. Identify failing checks: `gh pr checks <PR_NUMBER>` or `gh run view <RUN_ID>`.
+2. Inspect the first real failure:
+   ```bash
+   gh run view <RUN_ID> --log-failed
+   gh run view <RUN_ID> --job <JOB_ID> --log
+   ```
+3. If a job is still in progress, wait for logs instead of guessing.
+4. Reproduce locally with the smallest relevant command:
+   - formatting: `pixi run lint`
+   - tests: `pixi run test`, `pixi run test-py`, or another existing
+     focused `pixi run ...` test task
+   - coverage: add targeted tests for uncovered changed lines
+5. Fix the root cause with minimal scope.
+6. If the failure is infrastructure-only, ask for explicit maintainer/user
+   approval before rerunning the failed job or running:
+   ```bash
+   gh run rerun <RUN_ID> --failed
+   ```
+7. Ask for explicit maintainer/user approval before pushing, CI re-triggers, or
+   other GitHub mutations; after approval, push and watch CI until the PR is
+   green.
+
+## Output
+
+- Root cause
+- Fix or rerun action
+- Commands run
+- Current CI status

--- a/.opencode/command/dart-manage-pr.md
+++ b/.opencode/command/dart-manage-pr.md
@@ -155,10 +155,10 @@ gh pr checks <PR_NUMBER>
    - Confirm review requirements are satisfied and local validation matches the
      intended transition.
    - If the PR is draft, mark it ready after explicit approval once Codex is
-     clean and local validation passed on the current head: default
-     `pixi run test-all`, plus the Gazebo gate when package or downstream
-     compatibility could be affected. Hosted CI may still be pending for the
-     ready-for-review transition.
+     clean and local validation passed on the current head: `pixi run test-all`
+     for build coverage, `pixi run test`/`pixi run test-py` for affected
+     C++/Python behavior, plus the Gazebo gate when package or downstream
+     compatibility could be affected. Hosted CI may still be pending.
    - Confirm required hosted checks are passing before merge.
    - Do not merge unless explicitly asked or the workflow clearly includes merge.
    - PR comments, review re-triggers, thread resolution, reviewer requests,

--- a/.opencode/command/dart-manage-pr.md
+++ b/.opencode/command/dart-manage-pr.md
@@ -1,0 +1,200 @@
+---
+description: manage an open DART pull request through CI, review, and cleanup
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-manage-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Manage an open DART pull request after explicit maintainer/user approval for
+mutations: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/ai-tools.md
+
+## Invocation Contract
+
+When the user says `manage <PR>` or `continue managing <PR>` without limiting
+the request to status-only, treat that as approval to run the full PR-management
+loop to the next terminal state:
+
+- required policy metadata checked and corrected when stale;
+- CI monitored until green, failed, or blocked;
+- merge conflicts reproduced and resolved locally;
+- review comments addressed, pushed, resolved, and re-reviewed when appropriate;
+- PR body/testing evidence refreshed when it no longer matches the branch.
+
+This explicit approval covers routine PR-maintenance mutations needed for that
+loop: additive fix commits and pushes, PR description/metadata corrections,
+resolving already-addressed review threads, rerunning failed CI jobs, and
+requesting a fresh AI review after follow-up fixes. It does **not** cover
+merging the PR into the target branch, force-pushes, branch deletion, PR
+closure, base-branch changes, or human reviewer requests; ask separately for
+those.
+
+Do not call the PR managed just because checks are green. Continue until the PR
+is mergeable with required checks complete and addressed review threads are
+resolved, or until a concrete blocker remains.
+
+## Identify the PR
+
+Use the PR number or URL from `$ARGUMENTS`. If none is provided, infer the PR
+from the current branch:
+
+```bash
+gh pr view --json number,url,headRefName,baseRefName
+```
+
+Then inspect the full state:
+
+```bash
+gh pr view <PR_NUMBER> --json number,title,state,isDraft,baseRefName,headRefName,mergeStateStatus,milestone,url,reviewDecision,statusCheckRollup
+gh pr checks <PR_NUMBER>
+```
+
+## Workflow
+
+1. Confirm scope and policy:
+   - Check that the base branch, milestone, title, and PR template are correct.
+   - For bug fixes, verify the required DART 6 LTS + `main` dual-PR flow.
+   - Confirm the PR body's testing/status section matches the current head and
+     does not point reviewers to deleted dev-task evidence as still pending.
+   - Confirm the PR body is readable and follows template order: Summary,
+     Motivation / Problem, Changes / Key Changes, optional Before / After,
+     Testing, Breaking Changes, and Related Issues / PRs. Keep Summary first as
+     the skimmable user/downstream outcome; if problem context must lead, fold
+     it into Summary and keep the fuller why in Motivation. Mechanics belong in
+     Changes unless they explain user-visible risk.
+   - When the PR has meaningful user-facing API, workflow, behavior, or
+     performance impact, confirm the body has a concise Before / After section
+     that compares the relevant old and new surfaces. For performance claims,
+     ensure the baseline is explicit: CPU path, parent commit, `main`, or prior
+     implementation, plus workload, metric, and important limitations. Each
+     row should be phrased as a user-visible before/after, with backend details
+     used only as supporting context.
+   - For visual PR evidence, ensure transient screenshots, headless renders,
+     GIFs, and videos are hosted as GitHub PR/issue Markdown attachments
+     (`https://github.com/user-attachments/assets/...`) rather than committed to
+     the branch. If evidence files were committed only for the PR description,
+     remove them and replace the PR body entry with a GitHub attachment URL. If
+     the current tooling cannot upload an attachment, ask a maintainer to upload
+     the local artifact through the PR editor instead of keeping it under
+     `docs/assets/`.
+   - Inspect local state before editing:
+     ```bash
+     git status --short --branch
+     git diff --stat
+     git diff --check
+     ```
+2. Monitor CI:
+   ```bash
+   gh pr checks <PR_NUMBER> --watch --interval 30 --fail-fast
+   ```
+   If checks are still queued or running, report the current jobs and keep
+   watching unless the user asked only for status.
+   Also poll mergeability:
+   ```bash
+   gh pr view <PR_NUMBER> --json mergeStateStatus,headRefOid,isDraft,reviewDecision
+   ```
+   If GitHub reports conflicts, fetch the target branch and resolve them before
+   treating green checks as sufficient.
+3. Fix failures:
+   - Inspect the newest failed run or job, not an older cancelled run.
+   - Use the `dart-fix-ci` workflow for non-trivial CI debugging.
+   - Reproduce locally with the relevant `pixi run ...` task or focused test.
+   - Before committing fixes, run `pixi run lint`; also run build or tests when
+     code or behavior changed.
+   - Commit only intended files. Push only after explicit maintainer/user
+     approval, then continue monitoring the PR.
+   - For already-published PRs, prefer additive follow-up commits so reviewers
+     can inspect each update. Amend or force-push only after explicit
+     maintainer/user approval and only when the user explicitly requests it or
+     when there is a clear reason such as removing sensitive content or
+     repairing broken branch history.
+   - Before every push, first merge the latest base branch into the PR branch
+     (on every push, not just the first) so each pushed/CI-tested state reflects
+     the current target base branch and conflicts surface early:
+     ```bash
+     git fetch origin <base-branch>
+     git merge --no-ff origin/<base-branch>  # never rebase a published PR branch
+     # rebuild + retest if the merge touched code
+     git push                                 # after explicit approval
+     ```
+     The local base merge is a routine pre-push step; the push itself still
+     requires explicit maintainer/user approval. Do not rebase a published PR
+     branch by default because it invalidates existing CI runs and makes PR
+     review/comment history harder to follow. Rebase or force-push only when the
+     maintainer explicitly requests it.
+4. Address reviews:
+   - Use the `dart-review-pr` workflow for substantive review feedback.
+   - Never reply to AI-generated review comments from bot users such as
+     `chatgpt-codex-connector[bot]`, `github-code-quality[bot]`,
+     `github-actions[bot]`, or `copilot[bot]`.
+   - When a draft PR is first published, request Codex review with a top-level
+     `@codex review` once explicit maintainer/user approval covers PR comments;
+     it can run while the PR remains draft. If Codex already shows an activity
+     signal or submitted review, do not post a duplicate trigger.
+   - Apply AI-review fixes silently. After explicit maintainer/user approval
+     and after the branch is ready, push, resolve reviewed and addressed
+     threads, and request a fresh AI review only when the approved follow-up
+     push addressed Codex review comments, or when the first trigger has a
+     concrete timeout/blocker:
+     ```bash
+     gh pr comment <PR_NUMBER> --body "@codex review"
+     ```
+   - For human reviewers, reply only when a response is useful after a fix or
+     when a question needs clarification.
+   - After posting `@codex review`, keep monitoring until a submitted review,
+     a visible activity signal, or a concrete timeout/blocker is observed.
+5. Mark ready or merge only when appropriate:
+   - Confirm review requirements are satisfied and local validation matches the
+     intended transition.
+   - If the PR is draft, mark it ready after explicit approval once Codex is
+     clean and local validation passed on the current head: default
+     `pixi run test-all`, plus the Gazebo gate when package or downstream
+     compatibility could be affected. Hosted CI may still be pending for the
+     ready-for-review transition.
+   - Confirm required hosted checks are passing before merge.
+   - Do not merge unless explicitly asked or the workflow clearly includes merge.
+   - PR comments, review re-triggers, thread resolution, reviewer requests,
+     ready-for-review transitions, merges, and branch deletion are external
+     mutations and require explicit maintainer/user approval.
+   - Confirm the merge method from repository settings or the user. Recent DART
+     PRs usually use single-parent PR-title commits, so prefer squash/rebase
+     over merge commits unless the repository settings or user request differ.
+   - Use the current head SHA when merging so a moved branch cannot be merged
+     accidentally.
+6. Clean up after merge:
+   - Confirm the PR merged and identify the head branch before deleting.
+   - After explicit maintainer/user approval, prefer merge-time deletion with
+     the approved merge method and head SHA:
+     ```bash
+     gh pr merge <PR_NUMBER> --squash --match-head-commit <HEAD_SHA> --delete-branch
+     ```
+     Use `--rebase` or `--merge` instead of `--squash` when requested.
+   - After explicit maintainer/user approval, otherwise delete only the PR
+     branch after confirming it has landed:
+     ```bash
+     git push origin --delete <HEAD_BRANCH>
+     git switch <BASE_BRANCH>
+     git pull --ff-only
+     git branch -D <HEAD_BRANCH>
+     ```
+     Use force-delete locally only after explicit maintainer/user approval and
+     after confirming the PR branch has landed; squash and rebase merges do not
+     preserve the branch tip in target-branch ancestry.
+
+## Output
+
+Report:
+
+- PR number, URL, base, head, draft state, milestone, and merge status.
+- CI summary: passing, failing, pending, or skipped checks.
+- Review summary and whether `@codex review` was triggered.
+- Commits pushed, merge action, and branch cleanup action.
+- Remaining blockers or next action.

--- a/.opencode/command/dart-mechanical-refactor.md
+++ b/.opencode/command/dart-mechanical-refactor.md
@@ -1,0 +1,42 @@
+---
+description: perform a behavior-preserving mechanical refactor
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-mechanical-refactor.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Perform mechanical refactor: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@CONTRIBUTING.md
+@docs/onboarding/code-style.md
+
+## Workflow
+
+1. Define the exact transformation and scope before editing.
+2. Create a topic branch from the target branch, for example
+   `git switch --no-track -c refactor/<topic> origin/release-6.20`.
+3. Prefer scriptable or automated edits when the transformation is repetitive.
+4. Keep behavior unchanged; do not mix in feature work or cleanup outside scope.
+5. If reorganizing files, update CMake, pixi tasks, generated indexes, and docs.
+6. Run focused checks first, then broader checks according to risk:
+   - `pixi run lint`
+   - `pixi run build`
+   - `pixi run test`
+   - `pixi run test-all` when feasible
+   - `pixi run -e gazebo test-gz` when package, collision, constraint, or
+     downstream Gazebo/gz-physics compatibility could be affected
+7. Ask for explicit maintainer/user approval before pushing or opening a PR.
+   After approval, open a PR with a clear scope statement and no
+   behavior-change claim unless tested.
+
+## Output
+
+- Transformation summary
+- Files or areas changed
+- Verification run
+- Any residual risk

--- a/.opencode/command/dart-new-task.md
+++ b/.opencode/command/dart-new-task.md
@@ -1,0 +1,65 @@
+---
+description: start a feature, bugfix, refactor, docs, build, or test task
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-new-task.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Start a new task in DART: $ARGUMENTS
+
+## Required Reading
+
+Read these files first:
+@AGENTS.md
+@docs/onboarding/building.md
+@docs/onboarding/contributing.md
+@docs/onboarding/code-style.md
+@docs/dev_tasks/README.md
+@docs/ai/sessions.md
+@docs/ai/principles.md
+@docs/ai/verification.md
+
+## Workflow
+
+1. **Understand the task** - Parse: goal, constraints, type (feature|bugfix|refactor|docs)
+2. **Assess scope** - Multi-phase or multi-session? Create
+   `docs/dev_tasks/<task>/` (see `docs/dev_tasks/README.md` for criteria).
+   For multi-session, design-heavy, public API, solver/paper, release, or
+   cross-module work, fill the dev-task specification intake before editing:
+   value, scope, assumptions, traceability, non-goals, acceptance evidence,
+   gates, and open decisions. If consequential ambiguity would change public
+   API, release compatibility, numerical correctness, benchmark claims, or
+   roadmap scope, record an owner-local `Decision needed` block instead of
+   silently choosing.
+3. **Setup** - Choose the target branch before creating a topic branch. For
+   DART 6.20 maintenance, dependency-minimization, docs, and compatibility
+   work, branch from `origin/release-6.20` without tracking the release ref:
+   `git switch --no-track -c <type>/<topic> origin/release-6.20`. Bug fixes
+   that also apply to DART 7 still need a separate `main` PR after the release
+   branch fix.
+4. **Implement** - Keep commits focused, follow code style
+5. **Verify** - Run `pixi run lint` before committing, then run the focused
+   release-branch gate for the touched surface. Use `pixi run test-all` when
+   feasible, and `pixi run -e gazebo test-gz` for package, collision,
+   constraint, or downstream Gazebo/gz-physics compatibility work.
+6. **PR** - After explicit maintainer/user approval, push with the same local
+   and remote topic-branch name:
+   `branch=$(git branch --show-current); git push -u origin "HEAD:${branch}"`.
+   Then create the draft PR against `<target-branch>` with the branch-matching
+   DART 6.x patch milestone and `.github/PULL_REQUEST_TEMPLATE.md`.
+7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, first
+   promote durable dashboards, evidence matrices, API inventories, migration
+   maps, or long-lived decisions into release/onboarding/AI docs.
+   Then remove the dev-task folder completely (include the deletion in this PR,
+   not after merge).
+
+## Type-Specific
+
+- **Bugfix**: Requires PRs to BOTH the active DART 6 LTS branch AND `main`
+- **Refactor**: No behavior changes
+- **Feature**: Add tests + docs
+- **DART 7 solver or architecture work**: Do that on `main`, not on the DART
+  6.20 support branch. Use this release branch only for compatible maintenance,
+  dependency minimization, CI, docs, and backports.

--- a/.opencode/command/dart-pr.md
+++ b/.opencode/command/dart-pr.md
@@ -176,8 +176,10 @@ the approved follow-up push addressed Codex review comments, or when the first
 trigger has a concrete timeout/blocker.
 
 After Codex returns no actionable issues and local validation passes on the
-current head (default `pixi run test-all`, plus the Gazebo gate when package or
-downstream compatibility could be affected), a draft PR is ready to mark ready
-for human review after explicit approval even if hosted CI is still pending. Do
-not merge until branch protection and required checks pass unless a maintainer
-explicitly approves a policy bypass.
+current head (`pixi run test-all` for build coverage, `pixi run test` when C++
+runtime behavior could be affected, `pixi run test-py` when Python behavior
+could be affected, plus the Gazebo gate when package or downstream compatibility
+could be affected), a draft PR is ready to mark ready for human review after
+explicit approval even if hosted CI is still pending. Do not merge until branch
+protection and required checks pass unless a maintainer explicitly approves a
+policy bypass.

--- a/.opencode/command/dart-pr.md
+++ b/.opencode/command/dart-pr.md
@@ -1,0 +1,183 @@
+---
+description: create a branch, commit, push, and open a DART pull request
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Prepare or open a DART pull request after explicit maintainer/user approval:
+$ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/contributing.md
+@docs/onboarding/ai-tools.md
+@docs/onboarding/changelog.md
+@.github/PULL_REQUEST_TEMPLATE.md
+
+## Recent PR Patterns
+
+When the expected PR style is unclear, inspect recently merged PRs before
+drafting the title or body:
+
+```bash
+gh pr list --repo dartsim/dart --state merged --base <target-branch> --limit 10 \
+  --json number,title,body,mergedAt
+```
+
+Use these practices:
+
+- Keep titles plain, scoped, and outcome-focused. Do not add agent prefixes.
+- Fill the PR template in DART's default order: Summary, Motivation / Problem,
+  Changes / Key Changes, optional Before / After, Testing, Breaking Changes,
+  and Related Issues / PRs. Keep Summary first because reviewers need the
+  skimmable outcome before the rationale. If the motivation is necessary to
+  understand the outcome, make the first Summary sentence problem-oriented,
+  then put the fuller why in Motivation / Problem rather than moving Motivation
+  above Summary.
+- Write the opening Summary and Motivation from the perspective of a user or
+  downstream maintainer who is not already familiar with the implementation:
+  lead with what changes for them, what stays compatible, how they would opt in
+  or migrate, and why the evidence matters. Keep implementation details in
+  Changes unless they explain a user-visible outcome or risk.
+- When the change has meaningful user-facing API, workflow, behavior, or
+  performance impact, add a concise `## Before / After` section before
+  Testing. Use a small table or bullets that cover only relevant dimensions
+  such as public API, commands/workflows, behavior, migration, and performance
+  baseline. Phrase each row as a user-visible before/after, then name the
+  implementation mechanism only as supporting context. For performance claims,
+  name the baseline explicitly: CPU path, parent commit, `main`, or prior
+  implementation, plus workload, metric, and important limitations.
+- In Testing, list exact commands, targets, or test names that ran.
+- For CI, performance, or infrastructure work, include evidence such as CI run
+  observations, timing, reruns, benchmark output, or why a skipped check is
+  expected.
+- For rendering, model, mesh, texture, GUI, or visual-example changes, include
+  a before/after visual comparison when practical:
+  - Prefer an existing headless example path such as `--headless`,
+    `--frames`, `--width`, `--height`, and `--screenshot` over manual
+    screenshots.
+  - Capture the before image from the base branch or by temporarily restoring
+    the replaced sample/assets, then capture the after image from the final
+    branch with the same camera, dimensions, frame count, and renderer.
+  - Inspect the images yourself and include the commands plus any environment
+    variables such as software rendering flags in the PR body.
+  - Upload transient comparison images, GIFs, and videos through the GitHub
+    PR/issue Markdown attachment flow so the PR body contains GitHub-hosted
+    `https://github.com/user-attachments/assets/...` URLs that render inline.
+    Do not commit screenshots, headless renders, GIFs, or screencast videos
+    solely as PR evidence. Commit visual files only when they are durable
+    documentation, fixtures, or source assets that should live in the
+    repository.
+  - The official GitHub attachment flow is the web PR/issue editor drag/drop or
+    file picker. `gh pr edit`, `gh pr comment`, and the public REST API do not
+    provide a supported generic attachment upload command; any command or action
+    that edits or comments on a PR still requires explicit maintainer/user
+    approval. Use a maintainer-approved upload helper only when it produces
+    GitHub attachment URLs without committing files to the branch; helpers that
+    mimic the web upload may require a browser session cookie and must not be
+    used unless the maintainer has explicitly approved that credential handling.
+  - If the current tool cannot upload PR attachments, keep the local artifact
+    paths in the working note, ask a maintainer to upload them through the PR
+    editor, and then update the PR body with the returned GitHub attachment
+    URL after explicit maintainer/user approval. Do not fall back to committing
+    transient evidence into `docs/assets/`.
+  - If no headless path exists, either add a narrowly scoped capture mode when
+    it fits the example or document why visual comparison is not practical.
+- Mark non-applicable checklist items as "N/A" with a short reason.
+- Mention related PRs, issues, backports, and follow-ups explicitly, including
+  "None" when there is no related work.
+
+## Workflow
+
+1. Inspect scope:
+   ```bash
+   git status --short --branch
+   git diff --stat
+   git diff --check
+   ```
+2. Exclude unrelated dirty files unless the user explicitly includes them.
+3. Choose the target branch and milestone:
+
+   | Target                          | Milestone                      |
+   | ------------------------------- | ------------------------------ |
+   | `main`                          | `DART 7.0`                     |
+   | Active DART 6 LTS `release-6.*` | Branch-matching DART 6.x patch |
+
+4. For bug fixes, use the dual-PR flow: fix the active DART 6 LTS branch first,
+   then cherry-pick or reapply to `main`.
+5. Before every commit, run:
+   ```bash
+   pixi run lint
+   ```
+   Also run `pixi run build` for C++ or Python changes and focused tests for
+   behavior changes.
+6. Create or update a topic branch when needed:
+   ```bash
+   git switch --no-track -c <type>/<topic> origin/<target-branch>
+   ```
+7. Commit only intended files with a plain descriptive commit title.
+8. Ask for explicit maintainer/user approval before pushing or opening the draft
+   PR. Never push directly to `release-*`. If approved:
+   ```bash
+   branch=$(git branch --show-current)
+   git push -u origin "HEAD:${branch}"
+   gh pr create --draft --base <target-branch> --milestone "<milestone>" \
+     --title "<plain title>" --body-file <filled-template-file>
+   ```
+   For fast feedback on a draft PR, also request Codex review after publication
+   when approval covers PR comments:
+   ```bash
+   gh pr comment <PR_NUMBER> --body "@codex review"
+   ```
+   If Codex already shows an activity signal or submitted review, do not post a
+   duplicate trigger.
+9. After a PR is published, prefer additive follow-up commits for updates so
+   reviewers can inspect each review round. Amend or force-push only after
+   explicit maintainer/user approval and only when the user explicitly requests
+   it or when there is a clear reason such as removing sensitive content or
+   repairing broken branch history.
+10. Before every push to a published PR branch, first merge the latest base
+    branch into it (on every push, not just the first) so each pushed/CI-tested
+    state reflects the current target base branch and conflicts surface early:
+    ```bash
+    git fetch origin <target-branch>
+    git merge --no-ff origin/<target-branch>  # never rebase a published PR branch
+    # rebuild + retest if the merge touched code
+    git push                                   # after explicit approval
+    ```
+    The local base merge is a routine pre-push step; the push itself still
+    requires explicit maintainer/user approval. Do not rebase a published PR
+    branch by default because it invalidates existing CI runs and makes PR
+    review/comment history harder to follow. Rebase or force-push only when the
+    maintainer explicitly requests it.
+11. Use `docs/onboarding/changelog.md` for the changelog decision. If
+    `CHANGELOG.md` needs the PR number, keep the follow-up changelog commit
+    local until explicit maintainer/user approval is given for the additional
+    push or PR update.
+12. Monitor CI:
+    ```bash
+    gh pr checks <PR_NUMBER>
+    ```
+
+## AI Review Comments
+
+Never reply to AI-generated review comments from bot users such as
+`chatgpt-codex-connector[bot]`, `github-code-quality[bot]`,
+`github-actions[bot]`, or `copilot[bot]`.
+When a draft PR is first published, a top-level `@codex review` is the preferred
+fast path once explicit maintainer/user approval covers PR comments; it can run
+while the PR remains draft. Make fixes silently. Push and ask for a new AI review
+with `@codex review` only after explicit maintainer/user approval and only when
+the approved follow-up push addressed Codex review comments, or when the first
+trigger has a concrete timeout/blocker.
+
+After Codex returns no actionable issues and local validation passes on the
+current head (default `pixi run test-all`, plus the Gazebo gate when package or
+downstream compatibility could be affected), a draft PR is ready to mark ready
+for human review after explicit approval even if hosted CI is still pending. Do
+not merge until branch protection and required checks pass unless a maintainer
+explicitly approves a policy bypass.

--- a/.opencode/command/dart-release-ci-fix.md
+++ b/.opencode/command/dart-release-ci-fix.md
@@ -23,10 +23,16 @@ Fix release-branch CI: $ARGUMENTS
    gh run view <RUN_ID> --job <JOB_ID> --log
    ```
 2. Check whether an equivalent fix already exists on `main`.
-3. If continuing an existing PR, fetch and checkout that branch. Otherwise branch from the release branch:
+3. If continuing an existing PR, fetch and checkout that branch. Otherwise
+   branch from the release branch without resetting an existing local branch:
    ```bash
    git fetch origin <RELEASE_BRANCH>
-   git switch --no-track -C fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   BRANCH=fix/<issue>-<release-branch>
+   if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+     git switch "$BRANCH"
+   else
+     git switch --no-track -c "$BRANCH" origin/<RELEASE_BRANCH>
+   fi
    ```
 4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
 5. Explain why the failure was not caught earlier and whether workflow coverage should change.

--- a/.opencode/command/dart-release-ci-fix.md
+++ b/.opencode/command/dart-release-ci-fix.md
@@ -1,0 +1,45 @@
+---
+description: debug and fix CI failures on a release branch
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-release-ci-fix.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Fix release-branch CI: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/release-management.md
+
+## Workflow
+
+1. Inspect the failing run:
+   ```bash
+   gh run view <RUN_ID> --log-failed
+   gh run view <RUN_ID> --job <JOB_ID> --log
+   ```
+2. Check whether an equivalent fix already exists on `main`.
+3. If continuing an existing PR, fetch and checkout that branch. Otherwise branch from the release branch:
+   ```bash
+   git fetch origin <RELEASE_BRANCH>
+   git switch --no-track -C fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   ```
+4. Prefer cherry-picking a proven `main` fix. If a new fix is required, keep it release-scoped and minimal.
+5. Explain why the failure was not caught earlier and whether workflow coverage should change.
+6. Run `pixi run lint` and release-relevant build/tests.
+7. Ask for explicit maintainer/user approval before pushing, creating, or
+   updating the release-branch PR; after approval, use the current release
+   milestone and PR template.
+8. Monitor CI until green.
+
+## Output
+
+- Root cause
+- Fix summary
+- PR URL
+- CI status
+- Prevention recommendation, if any

--- a/.opencode/command/dart-resume.md
+++ b/.opencode/command/dart-resume.md
@@ -1,0 +1,80 @@
+---
+description: continue work from a previous session
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-resume.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Resume unfinished work: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/dev_tasks/README.md
+@docs/ai/sessions.md
+@docs/ai/verification.md
+@docs/onboarding/ci-cd.md
+@docs/onboarding/contributing.md
+
+## Step 1: Recon (no changes)
+
+```bash
+git rev-parse --show-toplevel
+git status -sb && git branch -vv && git log -10 --oneline --decorate
+git diff --stat && git stash list
+gh pr list --head "$(git branch --show-current)"
+gh pr status
+```
+
+## Step 2: Reconstruct
+
+Infer the task from branch name, commits, diffs, issue/PR description, and any
+`docs/dev_tasks/<task>/` state. If the goal is still unclear after recon, stop
+and ask.
+
+## Step 3: Continue
+
+- Propose a 3-6 step plan before editing.
+- Continue with minimal scope and preserve existing user changes.
+- For active solver/paper implementations, keep the plan or dev-task resume
+  surface explicit about the completed slice, the next missing paper-parity
+  gap, and why focused green tests are not a full paper-completion claim.
+- If the task is being completed, run a completion audit before finalizing:
+  identify the exact `docs/dev_tasks/<task>/` folder, inspect it for remaining
+  plans/evidence/decisions, promote any durable dashboard, evidence matrix, API
+  inventory, migration map, long-lived decision, or deferred-but-real work into
+  release/onboarding/AI docs, update any durable status surface when the task
+  changes roadmap state, then remove the dev-task folder
+  completely in the completing change.
+- If remaining work is real but blocked by a substantial design decision,
+  maintainer direction, external dependency, or scope boundary that should not
+  be resolved in the current session, ask the human before retiring the folder
+  unless prior maintainer direction is already recorded. Record the parked or
+  blocked work in the durable owner doc before deletion.
+- Do not call a dev task complete while `docs/dev_tasks/<task>/` still exists.
+  If implementation is done but the folder remains, the remaining work is the
+  durable-doc promotion plus folder cleanup.
+- Run `pixi run lint` before committing.
+- Run relevant tests; use `pixi run test-all` before done when feasible, and
+  `pixi run -e gazebo test-gz` when package or downstream Gazebo/gz-physics
+  compatibility could be affected.
+- Push with the same local and remote topic-branch name only after explicit
+  maintainer/user approval:
+  `branch=$(git branch --show-current); git push -u origin "HEAD:${branch}"`.
+- For already-published PRs, prefer additive follow-up commits. Amend or
+  force-push only after explicit maintainer/user approval and only when the user
+  explicitly requests it or when there is a clear reason such as removing
+  sensitive content or repairing broken branch history.
+- If an already-published PR needs the latest target branch, use explicit
+  maintainer/user approval to update that published branch by merging the
+  target branch and pushing normally. Do not rebase published PR branches by
+  default because that invalidates existing CI runs and makes PR review/comment
+  history harder to follow. Rebase or force-push only when the maintainer
+  explicitly requests it.
+
+## Safety
+
+No destructive git commands (`reset --hard`, dropping stashes, deleting branches)
+without explicit maintainer/user approval.

--- a/.opencode/command/dart-review-pr.md
+++ b/.opencode/command/dart-review-pr.md
@@ -78,9 +78,11 @@ activity signal or submitted review, do not post a duplicate trigger.
 8. Monitor CI: `gh pr checks $1`
 9. Check for new review, repeat until no actionable comments remain
 10. For draft PRs, mark ready after explicit approval once Codex is clean and
-    local validation passes on the current head: default `pixi run test-all`,
-    plus the Gazebo gate when package or downstream compatibility could be
-    affected; merge still waits for required hosted checks unless a maintainer
-    explicitly approves a policy bypass
+    local validation passes on the current head: `pixi run test-all` for
+    build coverage, `pixi run test` when C++ runtime behavior could be
+    affected, `pixi run test-py` when Python behavior could be affected, plus
+    the Gazebo gate when package or downstream compatibility could be affected;
+    merge still waits for required hosted checks unless a maintainer explicitly
+    approves a policy bypass
 
 Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/.opencode/command/dart-review-pr.md
+++ b/.opencode/command/dart-review-pr.md
@@ -1,0 +1,86 @@
+---
+description: review a PR or address review feedback
+agent: build
+---
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: .claude/commands/dart-review-pr.md -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+Review or respond to PR: $ARGUMENTS
+
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/code-style.md
+@docs/onboarding/ai-tools.md (for AI-generated review handling)
+
+## To Review
+
+```bash
+gh pr view $1 && gh pr diff $1
+```
+
+Check: code style, tests, docs, focused commits
+
+## To Address Feedback
+
+```bash
+gh pr view $1 --comments
+```
+
+Apply minimal fixes locally and verify. Do not push, comment, resolve threads,
+or re-trigger review without explicit maintainer/user approval for that
+external mutation.
+
+For published PRs, prefer a new follow-up commit for review fixes so reviewers
+can inspect what changed since the previous round. Amend or force-push only
+after explicit maintainer/user approval and only when the user explicitly
+requests it or when there is a clear reason such as removing sensitive content
+or repairing broken branch history.
+
+Before every push, first merge the latest base branch into the PR branch (on
+every push, not just the first) so each pushed/CI-tested state reflects current
+target base branch and conflicts surface early: `git fetch origin <base>` then
+`git merge --no-ff origin/<base>`, rebuild/retest if the merge touched code, then
+push. The local base merge is a routine pre-push step; the push itself still
+requires explicit maintainer/user approval. Do not rebase a published PR branch
+by default because it invalidates existing CI runs and makes PR review/comment
+history harder to follow. Rebase or force-push only when the maintainer
+explicitly requests it.
+
+If the push is rejected because the remote PR head moved, fetch and compare the
+remote head before retrying. If it already contains an equivalent review fix,
+validate that head and follow `docs/onboarding/ai-tools.md` instead of pushing a
+duplicate commit.
+
+## Automated Reviews (Codex, Code Quality, Copilot, etc.)
+
+When a draft PR is first published, request the first Codex review with a
+top-level `@codex review` once explicit maintainer/user approval covers PR
+comments; it can run while the PR remains draft. If Codex already shows an
+activity signal or submitted review, do not post a duplicate trigger.
+
+1. Make the local fix silently (no reply)
+2. Run the relevant local gates, including `pixi run lint` before any commit
+3. Ask for explicit maintainer/user approval before push, thread resolution,
+   PR comment, or review re-trigger
+4. If approved, push the fix silently
+5. If approved, resolve only reviewed and addressed thread IDs via GraphQL (see
+   ai-tools.md)
+6. After the approved push, if the fixes addressed Codex review comments, ask
+   for explicit maintainer/user approval for the PR comment, then re-trigger:
+   `gh pr comment $1 --body "@codex review"`
+7. Also handle `github-code-quality[bot]` review comments with the same
+   no-inline-reply loop. Fix valid findings locally and push silently after
+   approval; do not re-trigger Codex solely for non-Codex bot findings unless
+   Codex comments were also addressed.
+8. Monitor CI: `gh pr checks $1`
+9. Check for new review, repeat until no actionable comments remain
+10. For draft PRs, mark ready after explicit approval once Codex is clean and
+    local validation passes on the current head: default `pixi run test-all`,
+    plus the Gazebo gate when package or downstream compatibility could be
+    affected; merge still waits for required hosted checks unless a maintainer
+    explicitly approves a policy bypass
+
+Full iterative loop: `docs/onboarding/ai-tools.md` § "Autonomous Review-Fix-Monitor Loop"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ This file provides conventions and tips for agents working in this repository.  
 - Prefer [`rg`](https://github.com/BurntSushi/ripgrep) for searching the code base.
 - Keep commits focused and run the relevant checks before committing.
 - Follow the style guide in `CONTRIBUTING.md` (two‑space indent, camelCase functions, PascalCase classes, no cuddled braces).
+- For DART 6.20 work, branch from `origin/release-6.20` with a topic branch,
+  never by committing directly on `release-*`.
+- Do not let a local topic branch track `origin/release-*`. Use
+  `git switch --no-track -c <type>/<topic> origin/release-6.20`.
+- Push topic branches with the same local and remote branch name:
+  `branch=$(git branch --show-current); git push -u origin "HEAD:${branch}"`.
 
 ## Building for Codex
 These steps configure and compile DART from source in the Codex environment.
@@ -23,12 +29,13 @@ These steps configure and compile DART from source in the Codex environment.
    ```
 3. Build the Python bindings (`dartpy`):
    ```bash
-   pixi run build-dartpy
+   pixi run build-py-dev
    ```
 4. Run the test suites:
    ```bash
    pixi run test        # C++ tests
-   pixi run test-dartpy # Python tests
+   pixi run test-py     # Python tests
+   pixi run test-all    # Lint + build + tests
    ```
 
 If `pixi` is unavailable, install it from [https://pixi.sh](https://pixi.sh) and ensure the toolchain dependencies in `pixi.toml` are met.  The build system uses CMake and Ninja under the hood, so you can fall back to manual CMake builds if necessary.
@@ -37,3 +44,12 @@ If `pixi` is unavailable, install it from [https://pixi.sh](https://pixi.sh) and
 - Documentation lives in `docs/` and `tutorials/`.
 - Examples demonstrating API usage can be found in `examples/`.
 
+## AI Workflows
+
+Release-branch AI workflow guidance lives in `docs/ai/README.md`,
+`docs/ai/principles.md`, and `docs/ai/workflows.md`.
+
+Editable sources live in `.claude/commands/` and `.claude/skills/`. Generated
+Codex and OpenCode entrypoints live in `.codex/skills/` and
+`.opencode/command/`; do not hand-edit generated files. Run
+`pixi run check-ai-commands` to verify parity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ These steps configure and compile DART from source in the Codex environment.
    ```bash
    pixi run test        # C++ tests
    pixi run test-py     # Python tests
-   pixi run test-all    # Lint + build + tests
+   pixi run test-all    # Build all default targets; run lint/tests separately
    ```
 
 If `pixi` is unavailable, install it from [https://pixi.sh](https://pixi.sh) and ensure the toolchain dependencies in `pixi.toml` are met.  The build system uses CMake and Ninja under the hood, so you can fall back to manual CMake builds if necessary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# DART Documentation
+
+This release branch keeps public user documentation under `docs/readthedocs/`
+and agent/developer workflow guidance under the folders below.
+
+- [`ai/README.md`](ai/README.md): AI workflow entrypoint for DART 6.20 work.
+- [`dev_tasks/README.md`](dev_tasks/README.md): multi-session task tracking.
+- [`onboarding/`](onboarding/): build, test, CI, contribution, and release
+  workflow references for maintainers and agents.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,20 @@
+# DART 6.20 AI Workflows
+
+This directory contains the release-branch AI workflow map used by Codex,
+Claude Code, and OpenCode. It is intentionally smaller than the DART 7 `main`
+workflow surface and focuses on the workflows needed to maintain the DART 6 LTS
+line.
+
+Start with:
+
+- [`principles.md`](principles.md)
+- [`workflows.md`](workflows.md)
+- [`verification.md`](verification.md)
+- [`sessions.md`](sessions.md)
+- [`components.md`](components.md)
+- [`capabilities.json`](capabilities.json)
+
+Editable workflow sources live in `.claude/commands/` and `.claude/skills/`.
+Generated Codex and OpenCode surfaces live in `.codex/skills/` and
+`.opencode/command/`. Run `python scripts/sync_ai_commands.py --check` to
+verify parity.

--- a/docs/ai/capabilities.json
+++ b/docs/ai/capabilities.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": 1,
+  "owner": "docs/ai/capabilities.json owns machine-readable capability status, category, and gate profile. docs/ai/workflows.md owns human-readable public paths and gate details.",
+  "workflows": [
+    {
+      "name": "dart-analyze",
+      "category": "analysis",
+      "status": "active",
+      "gate_profile": "read-only"
+    },
+    {
+      "name": "dart-new-task",
+      "category": "task-lifecycle",
+      "status": "active",
+      "gate_profile": "task-specific"
+    },
+    {
+      "name": "dart-resume",
+      "category": "task-lifecycle",
+      "status": "active",
+      "gate_profile": "state-check"
+    },
+    {
+      "name": "dart-fix-ci",
+      "category": "ci",
+      "status": "active",
+      "gate_profile": "reproduction"
+    },
+    {
+      "name": "dart-review-pr",
+      "category": "review",
+      "status": "active",
+      "gate_profile": "read-only"
+    },
+    {
+      "name": "dart-pr",
+      "category": "pr",
+      "status": "active",
+      "gate_profile": "pr-ready"
+    },
+    {
+      "name": "dart-manage-pr",
+      "category": "pr",
+      "status": "active",
+      "gate_profile": "approval-boundary"
+    },
+    {
+      "name": "dart-docs-update",
+      "category": "docs",
+      "status": "active",
+      "gate_profile": "docs-ai"
+    },
+    {
+      "name": "dart-mechanical-refactor",
+      "category": "refactor",
+      "status": "active",
+      "gate_profile": "code-gate"
+    },
+    {
+      "name": "dart-downstream-fix",
+      "category": "issue-work",
+      "status": "active",
+      "gate_profile": "code-gate"
+    },
+    {
+      "name": "dart-release-ci-fix",
+      "category": "release",
+      "status": "active",
+      "gate_profile": "reproduction"
+    },
+    {
+      "name": "dart-backport-pr",
+      "category": "release",
+      "status": "active",
+      "gate_profile": "release-gate"
+    },
+    {
+      "name": "dart-branch-cleanup",
+      "category": "git",
+      "status": "active",
+      "gate_profile": "read-only"
+    }
+  ],
+  "domain_skills": [
+    {
+      "name": "dart-build",
+      "category": "build",
+      "status": "active",
+      "gate_profile": "command"
+    },
+    {
+      "name": "dart-ci",
+      "category": "ci",
+      "status": "active",
+      "gate_profile": "reference"
+    },
+    {
+      "name": "dart-contribute",
+      "category": "contribution",
+      "status": "active",
+      "gate_profile": "reference"
+    },
+    {
+      "name": "dart-test",
+      "category": "test",
+      "status": "active",
+      "gate_profile": "command"
+    },
+    {
+      "name": "dart-python",
+      "category": "python",
+      "status": "active",
+      "gate_profile": "reference"
+    },
+    {
+      "name": "dart-io",
+      "category": "io",
+      "status": "active",
+      "gate_profile": "reference"
+    }
+  ]
+}

--- a/docs/ai/components.md
+++ b/docs/ai/components.md
@@ -1,0 +1,14 @@
+# AI Components
+
+The DART 6.20 release branch uses a small cross-agent workflow surface:
+
+- `.claude/commands/`: editable workflow command sources.
+- `.claude/skills/`: editable domain-skill sources.
+- `.opencode/command/`: generated OpenCode command files.
+- `.codex/skills/`: generated Codex workflow and domain skills.
+- `scripts/sync_ai_commands.py`: sync and validation tool.
+- `docs/ai/capabilities.json`: machine-readable workflow inventory.
+- `docs/ai/workflows.md`: human-readable workflow map and gates.
+
+Use `.claude/` as the editable source. Do not hand-edit generated `.codex/` or
+`.opencode/` files; rerun the sync script instead.

--- a/docs/ai/north-star.md
+++ b/docs/ai/north-star.md
@@ -1,0 +1,16 @@
+# Release Branch North Star
+
+For DART 6.20, the north star is a stable compatibility branch with a smaller
+dependency footprint, preserved downstream Gazebo/gz-physics behavior, and
+clear maintenance workflow support.
+
+Near-term AI-assisted work should prioritize:
+
+- one-dependency or one-vendored-tree cleanup PRs;
+- compatibility evidence for package components and installed headers;
+- release-branch CI and Gazebo gates;
+- clean handoffs through `docs/dev_tasks/`.
+
+Do not use DART 7 clean-break assumptions as proof that a DART 6.20 removal is
+safe. Use DART 7 only as reference evidence and then prove the release-branch
+compatibility surface directly.

--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -1,0 +1,33 @@
+# AI Principles
+
+These principles apply to AI-assisted work on the DART 6.20 support branch.
+
+## Evidence First
+
+- Inspect the current branch, worktree, and relevant source files before
+  editing.
+- Treat live GitHub state and current command output as authoritative.
+- Do not rely on stale branch notes when a current checkout or PR can be
+  inspected.
+
+## Compatibility First
+
+- DART 6.20 is a compatibility support lane. Preserve existing public headers,
+  package components, and downstream Gazebo/gz-physics behavior unless a
+  maintainer explicitly accepts a breaking change.
+- Bug fixes that apply to both DART 6 and DART 7 should follow the dual-PR
+  policy in `docs/onboarding/contributing.md`.
+
+## Approval Boundaries
+
+- GitHub mutations, pushes, PR creation or updates, branch deletion, CI reruns,
+  and review-thread mutations require explicit maintainer/user approval.
+- Never reply to AI-generated review comments. Make local fixes silently and
+  request a fresh review only after an approved push.
+
+## Scope Control
+
+- Keep PRs focused. For dependency minimization, prefer one dependency or one
+  `dart/external` tree per PR unless a shared mechanical step is required.
+- Use `docs/dev_tasks/<task>/` for multi-session state. Promote durable facts to
+  onboarding, release, or compatibility docs before retiring a task folder.

--- a/docs/ai/sessions.md
+++ b/docs/ai/sessions.md
@@ -1,0 +1,14 @@
+# Session State
+
+Use `docs/dev_tasks/<task>/` for multi-session implementation work.
+
+Each active task should keep:
+
+- `README.md` for scope, evidence, decisions, and remaining work.
+- `RESUME.md` when another session needs exact next steps.
+- `HANDOFF.md` only when the task is being transferred across agents or
+  worktrees.
+
+Keep these notes current with branch name, PR number, exact validation commands,
+known blockers, and next action. Do not treat a dev-task note as durable
+documentation after the work completes; promote durable content first.

--- a/docs/ai/verification.md
+++ b/docs/ai/verification.md
@@ -13,7 +13,7 @@ surface affects shared behavior.
   default-solver changes that can affect Gazebo/gz-physics, run the Gazebo gate:
 
   ```bash
-  N=${DART_SAFE_JOBS:-$(python scripts/parallel_jobs.py)}
+  N=${DART_SAFE_JOBS:-$(python3 scripts/parallel_jobs.py)}
   DART_PARALLEL_JOBS=$N CTEST_PARALLEL_LEVEL=$N pixi run -e gazebo test-gz
   ```
 

--- a/docs/ai/verification.md
+++ b/docs/ai/verification.md
@@ -1,0 +1,38 @@
+# Verification Guide
+
+Use the narrowest gate that proves the change, then broaden when the touched
+surface affects shared behavior.
+
+## Baseline Checks
+
+- Always inspect `git status --short --branch`.
+- Before every commit, run `pixi run lint`.
+- For C++ or Python code changes, run `pixi run build` and the focused tests for
+  the touched module.
+- For package, exported target, installed-header, collision, constraint, or
+  default-solver changes that can affect Gazebo/gz-physics, run the Gazebo gate:
+
+  ```bash
+  N=${DART_SAFE_JOBS:-$(python scripts/parallel_jobs.py)}
+  DART_PARALLEL_JOBS=$N CTEST_PARALLEL_LEVEL=$N pixi run -e gazebo test-gz
+  ```
+
+## Docs And Workflow Changes
+
+- For AI workflow changes, run:
+
+  ```bash
+  pixi run sync-ai-commands
+  pixi run check-ai-commands
+  pixi run lint
+  ```
+
+- For ordinary docs-only changes on this release branch, run `pixi run lint`.
+  If the docs affect Read the Docs pages, run `pixi run docs-build` when
+  practical.
+
+## Completion Audit
+
+Before calling work complete, verify every explicit requirement against current
+evidence: files, command output, tests, PR state, and downstream gates where
+applicable. If evidence is indirect or missing, keep working.

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -1,0 +1,38 @@
+# AI Workflow Map
+
+DART 6.20 exposes a release-branch subset of the DART AI workflows across
+supported AI tools.
+
+- Claude Code and OpenCode use `/dart-*` commands.
+- Codex uses generated `$dart-*` skills from `.codex/skills/`.
+- `.claude/commands/` and `.claude/skills/` are the editable source.
+- `.opencode/command/` and `.codex/skills/` are generated.
+
+## User-Invoked Workflows
+
+| Capability | Codex | Claude/OpenCode | Required docs and public path | Minimum gate or exception |
+| --- | --- | --- | --- | --- |
+| `dart-analyze` | `$dart-analyze` | `/dart-analyze` | `docs/ai/principles.md`, `docs/ai/workflows.md`, `docs/ai/verification.md`, `docs/onboarding/ai-tools.md` | Read-only analysis; no local mutation gate beyond inspected evidence |
+| `dart-new-task` | `$dart-new-task` | `/dart-new-task` | `docs/onboarding/building.md`, `docs/onboarding/contributing.md`, `docs/onboarding/code-style.md`, `docs/dev_tasks/README.md`, `docs/ai/sessions.md`, `docs/ai/principles.md`, `docs/ai/verification.md` | Use target-specific gates and task-specific gates from `docs/ai/verification.md`; external mutations require explicit approval |
+| `dart-resume` | `$dart-resume` | `/dart-resume` | `docs/dev_tasks/README.md`, `docs/ai/sessions.md`, `docs/ai/verification.md`, `docs/onboarding/ci-cd.md`, `docs/onboarding/contributing.md` | Start with `git status --short --branch`; external mutations require explicit approval |
+| `dart-fix-ci` | `$dart-fix-ci` | `/dart-fix-ci` | `docs/onboarding/ci-cd.md` | Use local reproduction when possible; external mutations require explicit approval |
+| `dart-review-pr` | `$dart-review-pr` | `/dart-review-pr` | `docs/onboarding/code-style.md`, `docs/onboarding/ai-tools.md` | Read-only findings unless explicit approval allows mutations |
+| `dart-pr` | `$dart-pr` | `/dart-pr` | `docs/onboarding/contributing.md`, `docs/onboarding/ai-tools.md`, `docs/onboarding/changelog.md`, `.github/PULL_REQUEST_TEMPLATE.md` | `pixi run lint`, target-specific gates, milestone and changelog decision; push and PR creation require explicit approval |
+| `dart-manage-pr` | `$dart-manage-pr` | `/dart-manage-pr` | `docs/onboarding/contributing.md`, `docs/onboarding/ci-cd.md`, `docs/onboarding/ai-tools.md` | Status-only is read-only; push, PR updates, reruns, comments, and review mutations require explicit approval |
+| `dart-docs-update` | `$dart-docs-update` | `/dart-docs-update` | `docs/README.md`, `docs/ai/principles.md`, `docs/ai/verification.md`, `docs/onboarding/ai-tools.md`, `docs/onboarding/changelog.md` | Use Relevant docs/AI checks from `docs/ai/verification.md`; external mutations require explicit approval |
+| `dart-mechanical-refactor` | `$dart-mechanical-refactor` | `/dart-mechanical-refactor` | `CONTRIBUTING.md`, `docs/onboarding/code-style.md` | `pixi run lint` plus focused build/test proving behavior preservation; external mutations require explicit approval |
+| `dart-downstream-fix` | `$dart-downstream-fix` | `/dart-downstream-fix` | `docs/onboarding/contributing.md`, `docs/onboarding/ci-cd.md` | `pixi run lint`, focused build/test, and regression test when applicable; external mutations require explicit approval |
+| `dart-release-ci-fix` | `$dart-release-ci-fix` | `/dart-release-ci-fix` | `docs/onboarding/ci-cd.md`, `docs/onboarding/release-management.md` | Use local reproduction when possible; external mutations require explicit approval |
+| `dart-backport-pr` | `$dart-backport-pr` | `/dart-backport-pr` | `docs/onboarding/contributing.md`, `docs/onboarding/release-management.md` | Use release-target focused tests plus `pixi run lint`; external mutations require explicit approval |
+| `dart-branch-cleanup` | `$dart-branch-cleanup` | `/dart-branch-cleanup` | `docs/onboarding/ci-cd.md`, `docs/onboarding/contributing.md` | Read-only analysis unless explicit approval allows branch deletion |
+
+## Domain Skills
+
+| Capability | Codex | Manual public path |
+| --- | --- | --- |
+| `dart-build` | `$dart-build` | `docs/onboarding/building.md`, `docs/onboarding/build-system.md`, `pixi run build` |
+| `dart-ci` | `$dart-ci` | `docs/onboarding/ci-cd.md` |
+| `dart-contribute` | `$dart-contribute` | `docs/onboarding/contributing.md`, `CONTRIBUTING.md` |
+| `dart-test` | `$dart-test` | `docs/onboarding/testing.md`, `pixi run test`, `pixi run test-py` |
+| `dart-python` | `$dart-python` | `docs/onboarding/python-bindings.md`, `python/AGENTS.md` |
+| `dart-io` | `$dart-io` | `docs/onboarding/io-parsing.md`, `dart/io/AGENTS.md` |

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -34,5 +34,5 @@ supported AI tools.
 | `dart-ci` | `$dart-ci` | `docs/onboarding/ci-cd.md` |
 | `dart-contribute` | `$dart-contribute` | `docs/onboarding/contributing.md`, `CONTRIBUTING.md` |
 | `dart-test` | `$dart-test` | `docs/onboarding/testing.md`, `pixi run test`, `pixi run test-py` |
-| `dart-python` | `$dart-python` | `docs/onboarding/python-bindings.md`, `python/AGENTS.md` |
-| `dart-io` | `$dart-io` | `docs/onboarding/io-parsing.md`, `dart/io/AGENTS.md` |
+| `dart-python` | `$dart-python` | `docs/onboarding/python-bindings.md`, `python/examples/`, `python/tests/` |
+| `dart-io` | `$dart-io` | `docs/onboarding/io-parsing.md`, `dart/utils/`, `tests/integration/test_DartLoader.cpp` |

--- a/docs/dev_tasks/README.md
+++ b/docs/dev_tasks/README.md
@@ -1,0 +1,19 @@
+# Development Task Tracking
+
+Use `docs/dev_tasks/<task>/` for multi-session DART 6.20 work that needs
+handoff state, sequencing, or evidence beyond a single commit.
+
+Create a task folder when work is multi-phase, spans more than one session, or
+has compatibility gates that future agents must preserve.
+
+Recommended files:
+
+- `README.md`: scope, current evidence, decisions, validation, and remaining
+  work.
+- `RESUME.md`: exact next steps for a later session.
+- `HANDOFF.md`: optional transfer note when handing work to another agent or
+  worktree.
+
+Before completing a task, move durable facts to the right owner: release docs,
+onboarding docs, changelog, compatibility notes, or source comments. Do not
+leave important decisions only in a temporary task folder.

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -7,9 +7,11 @@ This task is for the DART 6.20 support lane.
 - Implementation branch:
   `plan/dart6-dependency-minimization-6.20`, based on
   `origin/release-6.20`.
-- DART 7 reference checkout: `/home/js/dev/dartsim/dart/main`, on `main`.
-- Do not use the `task_2` worktree on `main` for this task. Use the separate
-  main checkout, or remote refs, only as comparison evidence.
+- DART 7 reference: use `origin/main` directly, or create a local worktree from
+  `origin/main` for comparisons. Do not rely on a developer-specific checkout
+  path.
+- Do not use the `task_2` worktree on `main` for this task. Use a separate main
+  worktree, or remote refs, only as comparison evidence.
 
 Evidence was collected on 2026-06-19 after fetching `origin/main`,
 `origin/release-6.20`, and `origin/release-6.19`.

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -234,7 +234,7 @@ Select gates by touched surface:
   surfaces that can affect gz-physics:
 
   ```bash
-  N=${DART_SAFE_JOBS:-$(python scripts/parallel_jobs.py)}
+  N=${DART_SAFE_JOBS:-$(python3 scripts/parallel_jobs.py)}
   DART_PARALLEL_JOBS=$N CTEST_PARALLEL_LEVEL=$N pixi run -e gazebo test-gz
   ```
 

--- a/docs/onboarding/ai-tools.md
+++ b/docs/onboarding/ai-tools.md
@@ -1,0 +1,55 @@
+# AI Tooling And Review Rules
+
+This release branch supports Claude Code, OpenCode, and Codex workflow
+entrypoints generated from `.claude/` sources.
+
+## Source And Generated Files
+
+- Edit workflow commands in `.claude/commands/`.
+- Edit domain skills in `.claude/skills/`.
+- Do not hand-edit `.codex/skills/` or `.opencode/command/`; run
+  `pixi run sync-ai-commands` instead.
+- Check parity with `pixi run check-ai-commands`.
+
+## Approval Boundaries
+
+The following actions require explicit maintainer/user approval:
+
+- pushing commits;
+- opening, editing, marking ready, or merging PRs;
+- posting PR or issue comments;
+- rerunning CI;
+- resolving review threads;
+- deleting local or remote branches after explicit maintainer/user approval.
+
+## AI Review Comments
+
+Never reply to AI-generated review comments from bot users such as
+`chatgpt-codex-connector[bot]`, `github-code-quality[bot]`,
+`github-actions[bot]`, or `copilot[bot]`.
+
+Make fixes silently. After an approved follow-up push, request a new top-level
+review only when explicit approval covers the PR comment.
+
+## PR Branches
+
+Before every approved push to a published PR branch, fetch and merge the latest
+target base branch into the topic branch. Use merge, not rebase, unless a
+maintainer explicitly requests history rewriting.
+
+Never push directly to `release-*` branches. Create a topic branch from the
+release base without tracking the release ref:
+
+```bash
+git fetch origin release-6.20
+git switch --no-track -c <type>/<topic> origin/release-6.20
+```
+
+After explicit maintainer/user approval, push the topic branch with the same
+local and remote branch name:
+
+```bash
+branch=$(git branch --show-current)
+# Requires explicit maintainer/user approval.
+git push -u origin "HEAD:${branch}"
+```

--- a/docs/onboarding/build-system.md
+++ b/docs/onboarding/build-system.md
@@ -1,0 +1,15 @@
+# Build System Notes
+
+DART 6.20 uses CMake through Pixi tasks. Dependency cleanup must preserve
+exported CMake package behavior unless a maintainer explicitly accepts a
+compatibility break.
+
+Important checks:
+
+- `pixi run config`
+- `pixi run build`
+- `pixi run test`
+- `pixi run -e gazebo test-gz` for Gazebo/gz-physics compatibility surfaces
+
+When moving optional dependencies out of the default environment, verify both
+dependency-present and dependency-absent configure paths where practical.

--- a/docs/onboarding/building.md
+++ b/docs/onboarding/building.md
@@ -1,0 +1,16 @@
+# Building DART 6.20
+
+Use Pixi tasks from the repository root.
+
+```bash
+pixi run config
+pixi run build
+pixi run build-py-dev
+```
+
+`pixi run config` configures the default CMake build under `build/`.
+`pixi run build` builds the C++ libraries. `pixi run build-py-dev` builds the
+Python bindings in the development tree.
+
+For package or dependency changes, validate both the default configure/build
+path and any feature environment affected by the change.

--- a/docs/onboarding/changelog.md
+++ b/docs/onboarding/changelog.md
@@ -1,0 +1,10 @@
+# Changelog Guidance
+
+Update `CHANGELOG.md` when a PR adds user-visible features, fixes bugs, changes
+dependencies, changes public behavior, or introduces a breaking change.
+
+Docs-only planning, generated workflow sync, and ignore-file hygiene usually do
+not need a changelog entry unless they change a public contributor workflow.
+
+When a changelog entry needs a PR number, create the PR first, then add the
+entry in a follow-up commit after explicit approval for the additional push.

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -1,0 +1,19 @@
+# CI And Release-Branch Checks
+
+Use GitHub Actions as the hosted source of truth after a PR is opened. Locally,
+run the smallest gate that proves the touched surface, then broaden when shared
+runtime, package, or downstream behavior changes.
+
+Useful commands:
+
+```bash
+pixi run lint
+pixi run build
+pixi run test
+pixi run test-py
+pixi run -e gazebo test-gz
+```
+
+For failing CI, inspect the exact run and job logs before changing code. Prefer
+reproducing locally, but document when a hosted-platform failure cannot be
+reproduced on the current machine.

--- a/docs/onboarding/code-style.md
+++ b/docs/onboarding/code-style.md
@@ -1,0 +1,10 @@
+# Code Style
+
+Follow the existing style in nearby files.
+
+- Use two-space indentation in C++.
+- Use project naming conventions already present in the touched module.
+- Keep includes minimal and ordered consistently with neighboring files.
+- Prefer small, behavior-preserving commits for mechanical changes.
+
+Run `pixi run lint` before committing.

--- a/docs/onboarding/contributing.md
+++ b/docs/onboarding/contributing.md
@@ -7,8 +7,8 @@ git fetch origin release-6.20
 git switch --no-track -c <type>/<topic> origin/release-6.20
 ```
 
-Do not push directly to `release-*`. Push topic branches with matching local and
-remote names:
+Do not push directly to `release-*`. After explicit maintainer or user approval,
+push topic branches with matching local and remote names:
 
 ```bash
 branch=$(git branch --show-current)

--- a/docs/onboarding/contributing.md
+++ b/docs/onboarding/contributing.md
@@ -1,0 +1,37 @@
+# Contributing On The DART 6.20 Branch
+
+Keep changes focused and branch from the target release branch:
+
+```bash
+git fetch origin release-6.20
+git switch --no-track -c <type>/<topic> origin/release-6.20
+```
+
+Do not push directly to `release-*`. Push topic branches with matching local and
+remote names:
+
+```bash
+branch=$(git branch --show-current)
+git push -u origin "HEAD:${branch}"
+```
+
+Before every commit, run:
+
+```bash
+pixi run lint
+```
+
+For C++ or Python changes, also run `pixi run build` and focused tests. For
+Gazebo/gz-physics compatibility surfaces, run:
+
+```bash
+N=${DART_SAFE_JOBS:-$(python scripts/parallel_jobs.py)}
+DART_PARALLEL_JOBS=$N CTEST_PARALLEL_LEVEL=$N pixi run -e gazebo test-gz
+```
+
+Bug fixes that apply to both DART 6 and DART 7 need both a release-branch PR
+and a `main` PR. Dependency-minimization work on DART 6.20 must preserve
+installed headers, package components, and downstream behavior unless a
+maintainer explicitly approves a breaking change.
+
+Use the branch-matching DART 6.x milestone for release-branch PRs.

--- a/docs/onboarding/contributing.md
+++ b/docs/onboarding/contributing.md
@@ -25,7 +25,7 @@ For C++ or Python changes, also run `pixi run build` and focused tests. For
 Gazebo/gz-physics compatibility surfaces, run:
 
 ```bash
-N=${DART_SAFE_JOBS:-$(python scripts/parallel_jobs.py)}
+N=${DART_SAFE_JOBS:-$(python3 scripts/parallel_jobs.py)}
 DART_PARALLEL_JOBS=$N CTEST_PARALLEL_LEVEL=$N pixi run -e gazebo test-gz
 ```
 

--- a/docs/onboarding/io-parsing.md
+++ b/docs/onboarding/io-parsing.md
@@ -1,0 +1,8 @@
+# IO And Model Loading
+
+Model loading and parser changes can affect downstream users and Gazebo
+compatibility. For dependency cleanup, treat parser dependencies and installed
+headers as compatibility surfaces.
+
+Run focused IO tests when touching parser code, model-loading dependencies, or
+package metadata used by IO components.

--- a/docs/onboarding/python-bindings.md
+++ b/docs/onboarding/python-bindings.md
@@ -1,0 +1,11 @@
+# Python Bindings
+
+DART Python bindings are built through the Pixi/CMake workflow.
+
+```bash
+pixi run build-py-dev
+pixi run test-py
+```
+
+Run Python tests when dependency, package, or target changes can alter dartpy
+imports, linked components, or installed package behavior.

--- a/docs/onboarding/release-management.md
+++ b/docs/onboarding/release-management.md
@@ -1,0 +1,12 @@
+# Release Management
+
+DART 6.20 work targets `release-6.20` and the branch-matching DART 6.x
+milestone.
+
+Release-branch PRs should:
+
+- preserve DART 6 compatibility unless explicitly approved otherwise;
+- document package and dependency changes clearly;
+- run Gazebo/gz-physics gates when downstream behavior can be affected;
+- keep changelog and version metadata changes separate from unrelated cleanup
+  when possible.

--- a/docs/onboarding/testing.md
+++ b/docs/onboarding/testing.md
@@ -1,0 +1,17 @@
+# Testing
+
+Use Pixi tasks from the repository root.
+
+```bash
+pixi run test
+pixi run test-py
+pixi run test-all
+```
+
+`pixi run test` runs the C++ test suite after building tests. `pixi run test-py`
+runs the Python binding tests. `pixi run test-all` is the broad default gate for
+the release branch.
+
+For dependency minimization, run focused tests for the touched component and
+then broaden when the dependency affects shared package, collision, constraint,
+or GUI behavior.

--- a/pixi.toml
+++ b/pixi.toml
@@ -94,6 +94,13 @@ check-lint-py = { cmd = """
 
 check-lint = { depends-on = ["check-lint-cpp", "check-lint-py"] }
 
+sync-ai-commands = { cmd = ["python", "scripts/sync_ai_commands.py"] }
+check-ai-commands = { cmd = [
+    "python",
+    "scripts/sync_ai_commands.py",
+    "--check",
+] }
+
 build = { cmd = """
     cmake \
         --build build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \

--- a/pixi.toml
+++ b/pixi.toml
@@ -94,12 +94,8 @@ check-lint-py = { cmd = """
 
 check-lint = { depends-on = ["check-lint-cpp", "check-lint-py"] }
 
-sync-ai-commands = { cmd = ["python", "scripts/sync_ai_commands.py"] }
-check-ai-commands = { cmd = [
-    "python",
-    "scripts/sync_ai_commands.py",
-    "--check",
-] }
+sync-ai-commands = { cmd = "python scripts/sync_ai_commands.py" }
+check-ai-commands = { cmd = "python scripts/sync_ai_commands.py --check" }
 
 build = { cmd = """
     cmake \

--- a/scripts/parallel_jobs.py
+++ b/scripts/parallel_jobs.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Single source of truth for DART build/test parallelism.
+
+Two knobs are exported:
+
+* ``compute_parallel_jobs()``: how many compile/link jobs to launch.
+* ``compute_load_limit()``: the OS load ceiling for load-aware scheduling.
+
+Both honor environment overrides and an optional host-local
+``~/.dart-dev/parallelism.env`` file (``KEY=VALUE`` lines) so every clone on a
+workstation can share one policy. Environment variables always win over the
+file. See ``docs/ai/verification.md`` for the release-branch gate commands that
+call this helper.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_DART_DEV_ENV_LOADED = False
+
+
+def _running_under_ci() -> bool:
+    return bool(os.getenv("GITHUB_ACTIONS") or os.getenv("CI"))
+
+
+def load_dart_dev_env() -> None:
+    """Merge ``~/.dart-dev/parallelism.env`` into the environment once.
+
+    Existing environment variables are never overwritten, so an explicit
+    ``DART_PARALLEL_JOBS=...`` on the command line still wins. CI never reads
+    the file, keeping automated runs hermetic.
+    """
+    global _DART_DEV_ENV_LOADED
+    if _DART_DEV_ENV_LOADED or _running_under_ci():
+        return
+    _DART_DEV_ENV_LOADED = True
+
+    env_file = Path.home() / ".dart-dev" / "parallelism.env"
+    try:
+        lines = env_file.read_text(encoding="utf-8").splitlines()
+    except (OSError, ValueError):
+        return
+
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            os.environ.setdefault(key, value)
+
+
+def _env_int(name: str) -> int | None:
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return None
+
+
+def compute_parallel_jobs() -> int:
+    """Return the compile/link job count for build and test commands."""
+    load_dart_dev_env()
+
+    override = _env_int("DART_PARALLEL_JOBS")
+    if override and override > 0:
+        return override
+
+    cpus = os.cpu_count() or 1
+
+    # CI runners advertise high CPU counts, but spawning that many build jobs
+    # frequently exhausts process slots. Cap automated runs aggressively.
+    if os.getenv("GITHUB_ACTIONS"):
+        return min(16, cpus)
+
+    if cpus <= 8:
+        jobs = cpus
+    else:
+        jobs = max(1, (cpus * 3) // 4)
+
+    # Avoid exhausting process limits on large self-hosted machines.
+    return min(jobs, 32)
+
+
+def compute_load_limit() -> int | None:
+    """Return the OS load ceiling for ninja ``-l`` and ctest ``--test-load``.
+
+    Returns ``None`` when load-aware scheduling should be disabled, so callers
+    add no flag and preserve historical CI behavior.
+    """
+    load_dart_dev_env()
+
+    raw = os.environ.get("DART_BUILD_LOAD_LIMIT")
+    if raw is not None:
+        token = raw.strip().lower()
+        if token in {"0", "off", "none", "false", ""}:
+            return None
+        try:
+            value = int(token)
+            return value if value > 0 else None
+        except ValueError:
+            return None
+
+    if _running_under_ci():
+        return None
+
+    return (os.cpu_count() or 1) + 2
+
+
+def ninja_load_args() -> list[str]:
+    """Return native-tool passthrough args for ninja's load limit."""
+    limit = compute_load_limit()
+    return ["-l", str(limit)] if limit else []
+
+
+def main() -> int:
+    print(compute_parallel_jobs())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_ai_commands.py
+++ b/scripts/sync_ai_commands.py
@@ -1,0 +1,1517 @@
+#!/usr/bin/env python3
+"""Sync AI commands and skills across tool directories.
+
+Different AI coding tools read from different directories:
+- Claude Code: .claude/commands/, .claude/skills/
+- OpenCode: .opencode/command/
+- Codex: .codex/skills/ (domain skills plus command-derived workflow skills)
+
+This script keeps them in sync using .claude/ as the current editable source
+for workflow commands and domain skills.
+It also verifies that every supported agent has the same effective DART
+capability set, even when tools expose workflows through different UI concepts
+(commands vs skills).
+
+Usage:
+    python scripts/sync_ai_commands.py          # Sync and report
+    python scripts/sync_ai_commands.py --check  # Check only (CI mode)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+CODEX_NAME_LIMIT = 100
+CODEX_DESC_LIMIT = 500
+MAX_SKILL_LINES = 500
+MAX_COMMAND_LINES = 200
+CAPABILITY_SCHEMA_VERSION = 1
+CAPABILITY_STATUS_VALUES = {"active", "deprecated", "parked", "proposed"}
+CAPABILITY_WORKFLOW_GATE_PROFILE_VALUES = {
+    "approval-boundary",
+    "code-gate",
+    "docs-ai",
+    "draft-only",
+    "maintainer-only",
+    "pr-ready",
+    "read-only",
+    "release-gate",
+    "reproduction",
+    "routed",
+    "state-check",
+    "task-specific",
+}
+CAPABILITY_DOMAIN_GATE_PROFILE_VALUES = {"command", "reference"}
+CAPABILITY_WORKFLOW_GATE_PROFILE_MARKERS = {
+    "approval-boundary": ("explicit approval",),
+    "code-gate": ("`pixi run lint`", "focused build/test", "regression test"),
+    "docs-ai": ("docs/AI checks", "docs/ai/verification.md", "principle audit"),
+    "draft-only": ("draft text",),
+    "maintainer-only": ("Maintainer-only",),
+    "pr-ready": ("CHANGELOG", "milestone"),
+    "read-only": ("Read-only", "read-only"),
+    "release-gate": ("release verification", "release-target", "release gates"),
+    "reproduction": ("local reproduction", "reproduction command"),
+    "routed": ("task-specific gates",),
+    "state-check": ("`git status --short --branch`",),
+    "task-specific": ("task-specific gates",),
+}
+
+# Header added to auto-generated files
+AUTO_GEN_HEADER = """\
+<!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
+<!-- Source: {source_path} -->
+<!-- Sync script: scripts/sync_ai_commands.py -->
+<!-- Run `pixi run sync-ai-commands` to update -->
+
+"""
+
+
+def get_repo_root() -> Path:
+    return Path(__file__).parent.parent
+
+
+def display_path(path: Path) -> str:
+    """Return a repo-relative path when possible, otherwise a readable path."""
+    try:
+        return str(path.relative_to(get_repo_root()))
+    except ValueError:
+        return str(path)
+
+
+def parse_skill_frontmatter(content: str) -> dict[str, str]:
+    """Extract name and description from YAML frontmatter."""
+    return parse_frontmatter(content, ["name", "description"])
+
+
+def parse_command_frontmatter(content: str) -> dict[str, str]:
+    """Extract supported metadata from command YAML frontmatter."""
+    return parse_frontmatter(content, ["description", "argument-hint"])
+
+
+def parse_frontmatter(content: str, keys: list[str]) -> dict[str, str]:
+    """Extract selected single-line fields from YAML frontmatter."""
+    match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return {}
+
+    frontmatter = match.group(1)
+    result = {}
+
+    for key in keys:
+        pattern = rf"^{key}:\s*(.+)$"
+        m = re.search(pattern, frontmatter, re.MULTILINE)
+        if m:
+            result[key] = normalize_frontmatter_value(m.group(1).strip())
+
+    return result
+
+
+def normalize_frontmatter_value(value: str) -> str:
+    """Normalize the single-line YAML scalars used in our frontmatter."""
+    if len(value) < 2:
+        return value
+    if value[0] == '"' and value[-1] == '"':
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value[1:-1]
+    if value[0] == "'" and value[-1] == "'":
+        return value[1:-1].replace("''", "'")
+    return value
+
+
+def validate_frontmatter_yaml_scalars(content: str, path_label: str) -> list[str]:
+    """Catch YAML-invalid unquoted scalar patterns in frontmatter."""
+    match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return []
+
+    errors = []
+    frontmatter = match.group(1)
+
+    for line_number, line in enumerate(frontmatter.splitlines(), start=2):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not m:
+            continue
+
+        key = m.group(1)
+        value = m.group(2).strip()
+        if not value or value[0] in {'"', "'", "|", ">"}:
+            continue
+
+        if ": " in value:
+            errors.append(
+                f"{path_label}:{line_number}: frontmatter field `{key}` contains "
+                "`: ` and must be quoted for strict YAML parsers"
+            )
+
+    return errors
+
+
+def strip_frontmatter(content: str) -> str:
+    """Remove YAML frontmatter from a Markdown document."""
+    match = re.match(r"^---\s*\n.*?\n---\s*\n?", content, re.DOTALL)
+    if not match:
+        return content
+    return content[match.end() :]
+
+
+def skill_display_name(skill_name: str) -> str:
+    """Convert a skill id into the display name used by Codex."""
+    acronyms = {"dart": "DART", "ci": "CI", "io": "IO", "pr": "PR"}
+    return " ".join(acronyms.get(part, part.title()) for part in skill_name.split("-"))
+
+
+def sentence_case(text: str) -> str:
+    """Lowercase only the first character for compact skill descriptions."""
+    if not text:
+        return text
+    return text[0].lower() + text[1:]
+
+
+def validate_codex_skill(skill_path: Path) -> list[str]:
+    """Validate skill meets Codex format requirements. Returns list of warnings."""
+    warnings = []
+    content = skill_path.read_text()
+    meta = parse_skill_frontmatter(content)
+
+    name = meta.get("name", "")
+    desc = meta.get("description", "")
+
+    if len(name) > CODEX_NAME_LIMIT:
+        warnings.append(
+            f"name exceeds Codex limit ({len(name)} > {CODEX_NAME_LIMIT} chars)"
+        )
+    if "\n" in name:
+        warnings.append("name contains newline (Codex requires single line)")
+    if len(desc) > CODEX_DESC_LIMIT:
+        warnings.append(
+            f"description exceeds Codex limit ({len(desc)} > {CODEX_DESC_LIMIT} chars)"
+        )
+    if "\n" in desc:
+        warnings.append("description contains newline (Codex requires single line)")
+
+    return warnings
+
+
+def list_command_names(command_dir: Path) -> set[str]:
+    """Return command names from a flat command directory."""
+    if not command_dir.exists():
+        return set()
+    return {path.stem for path in command_dir.glob("*.md")}
+
+
+def list_skill_names(skill_dir: Path) -> tuple[set[str], list[str]]:
+    """Return declared skill names and frontmatter/folder consistency errors."""
+    if not skill_dir.exists():
+        return set(), []
+
+    names: set[str] = set()
+    errors: list[str] = []
+
+    for skill_path in sorted(skill_dir.glob("*/SKILL.md")):
+        folder_name = skill_path.parent.name
+        rel_path = display_path(skill_path)
+        meta = parse_skill_frontmatter(skill_path.read_text())
+        declared_name = meta.get("name", "")
+
+        if not declared_name:
+            errors.append(f"{rel_path}: missing required frontmatter field `name`")
+            continue
+        if declared_name != folder_name:
+            errors.append(
+                f"{rel_path}: folder name `{folder_name}` does not match "
+                f"declared skill name `{declared_name}`"
+            )
+        if declared_name in names:
+            errors.append(
+                f"{rel_path}: duplicate declared skill name `{declared_name}`"
+            )
+
+        names.add(declared_name)
+
+    return names, errors
+
+
+def print_skill_name_errors(label: str, errors: list[str]) -> None:
+    """Print skill name validation errors with an agent/tool label."""
+    for error in errors:
+        print(f"  SKILL ERROR: {label}: {error}")
+
+
+def format_names(names: set[str]) -> str:
+    """Format a set of names for readable mismatch output."""
+    if not names:
+        return "(none)"
+    return ", ".join(sorted(names))
+
+
+def check_capability_parity(repo_root: Path) -> bool:
+    """Verify supported agents expose the same effective DART capabilities."""
+    claude_commands = list_command_names(repo_root / ".claude" / "commands")
+    opencode_commands = list_command_names(repo_root / ".opencode" / "command")
+    shared_skills, shared_skill_errors = list_skill_names(
+        repo_root / ".claude" / "skills"
+    )
+    codex_skills, codex_skill_errors = list_skill_names(repo_root / ".codex" / "skills")
+
+    expected = claude_commands | shared_skills
+    agent_sets = {
+        "Claude Code": claude_commands | shared_skills,
+        "OpenCode": opencode_commands | shared_skills,
+        "Codex": codex_skills,
+    }
+
+    ok = True
+
+    if shared_skill_errors:
+        ok = False
+        print_skill_name_errors(".claude/skills", shared_skill_errors)
+    if codex_skill_errors:
+        ok = False
+        print_skill_name_errors(".codex/skills", codex_skill_errors)
+
+    if claude_commands & shared_skills:
+        ok = False
+        print(
+            "  COLLISION: commands and skills share names: "
+            f"{format_names(claude_commands & shared_skills)}"
+        )
+
+    for agent, capabilities in agent_sets.items():
+        missing = expected - capabilities
+        extra = capabilities - expected
+        if missing or extra:
+            ok = False
+            print(f"  MISMATCH: {agent}")
+            if missing:
+                print(f"    missing: {format_names(missing)}")
+            if extra:
+                print(f"    extra:   {format_names(extra)}")
+
+    if ok:
+        print(f"  OK: {len(expected)} shared capabilities: {format_names(expected)}")
+
+    return ok
+
+
+def validate_style_and_budget(repo_root: Path) -> bool:
+    """Validate concise, consistent command and skill metadata across agents."""
+    errors: list[str] = []
+
+    skill_dirs = [
+        (".claude/skills", repo_root / ".claude" / "skills"),
+        (".codex/skills", repo_root / ".codex" / "skills"),
+    ]
+    command_dirs = [
+        (".claude/commands", repo_root / ".claude" / "commands"),
+        (".opencode/command", repo_root / ".opencode" / "command"),
+    ]
+
+    for label, skill_dir in skill_dirs:
+        for skill_path in sorted(skill_dir.glob("*/SKILL.md")):
+            content = skill_path.read_text()
+            meta = parse_skill_frontmatter(content)
+            name = meta.get("name", "")
+            desc = meta.get("description", "")
+            path_label = display_path(skill_path)
+
+            errors.extend(validate_frontmatter_yaml_scalars(content, path_label))
+
+            if not desc:
+                errors.append(f"{path_label}: missing required description")
+            elif name and not desc.startswith(f"{skill_display_name(name)}: "):
+                errors.append(
+                    f"{path_label}: description should start with "
+                    f"`{skill_display_name(name)}: `"
+                )
+
+            line_count = len(content.splitlines())
+            if line_count > MAX_SKILL_LINES:
+                errors.append(
+                    f"{path_label}: {line_count} lines exceeds "
+                    f"{MAX_SKILL_LINES}-line skill budget"
+                )
+
+            if label == ".codex/skills":
+                for warning in validate_codex_skill(skill_path):
+                    errors.append(f"{path_label}: {warning}")
+
+    for label, command_dir in command_dirs:
+        for command_path in sorted(command_dir.glob("*.md")):
+            content = command_path.read_text()
+            meta = parse_command_frontmatter(content)
+            desc = meta.get("description", "")
+            path_label = display_path(command_path)
+
+            errors.extend(validate_frontmatter_yaml_scalars(content, path_label))
+
+            if not desc:
+                errors.append(f"{path_label}: missing required description")
+            elif desc[0].isupper():
+                errors.append(
+                    f"{path_label}: description should be a lowercase sentence "
+                    "fragment; Codex adds the display name"
+                )
+            elif desc.endswith("."):
+                errors.append(f"{path_label}: description should not end with a period")
+
+            line_count = len(content.splitlines())
+            if line_count > MAX_COMMAND_LINES:
+                errors.append(
+                    f"{path_label}: {line_count} lines exceeds "
+                    f"{MAX_COMMAND_LINES}-line command budget"
+                )
+
+    if errors:
+        for error in errors:
+            print(f"  STYLE ERROR: {error}")
+        return False
+
+    print(
+        "  OK: skill descriptions use display-name prefixes; command descriptions "
+        "stay concise; files are within context budgets"
+    )
+    return True
+
+
+def parse_workflow_rows(workflow_content: str) -> dict[str, list[str]]:
+    """Extract user-invoked workflow table rows keyed by capability name."""
+    rows: dict[str, list[str]] = {}
+    in_user_table = False
+
+    for line in workflow_content.splitlines():
+        if line.startswith("## User-Invoked Workflows"):
+            in_user_table = True
+            continue
+        if in_user_table and line.startswith("## "):
+            break
+        if not in_user_table or not line.startswith("| `dart-"):
+            continue
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 5:
+            continue
+        match = re.fullmatch(r"`(dart-[a-z0-9-]+)`", cells[0])
+        if match:
+            rows[match.group(1)] = cells
+
+    return rows
+
+
+def parse_domain_skill_rows(workflow_content: str) -> dict[str, list[str]]:
+    """Extract domain skill table rows keyed by capability name."""
+    rows: dict[str, list[str]] = {}
+    in_domain_table = False
+
+    for line in workflow_content.splitlines():
+        if line.startswith("## Domain Skills"):
+            in_domain_table = True
+            continue
+        if in_domain_table and line.startswith("## "):
+            break
+        if not in_domain_table or not line.startswith("| `dart-"):
+            continue
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        match = re.fullmatch(r"`(dart-[a-z0-9-]+)`", cells[0])
+        if match:
+            rows[match.group(1)] = cells
+
+    return rows
+
+
+def extract_required_reading_from_content(content: str) -> list[str]:
+    """Extract @file entries from a command Required Reading section."""
+    readings: list[str] = []
+    in_required_reading = False
+
+    for line in content.splitlines():
+        if line.startswith("## Required Reading"):
+            in_required_reading = True
+            continue
+        if in_required_reading and line.startswith("## "):
+            break
+        if not in_required_reading:
+            continue
+
+        match = re.match(r"@([^\s]+)", line.strip())
+        if match:
+            readings.append(match.group(1))
+
+    return readings
+
+
+def extract_required_reading(command_path: Path) -> list[str]:
+    """Extract @file entries from a command's Required Reading section."""
+    return extract_required_reading_from_content(command_path.read_text())
+
+
+def required_reading_path_errors(repo_root: Path, command_path: Path) -> list[str]:
+    """Return errors for @file required-reading entries that do not exist."""
+    errors: list[str] = []
+    for required in extract_required_reading(command_path):
+        required_path = repo_root / required
+        if not required_path.exists():
+            errors.append(
+                f"{display_path(command_path)}: required reading `{required}` "
+                "does not exist"
+            )
+    return errors
+
+
+def missing_required_reading_errors(
+    workflow_path_label: str,
+    name: str,
+    public_path: str,
+    required_reading: list[str],
+) -> list[str]:
+    """Return workflow row errors for required reading not in public path."""
+    return [
+        f"{workflow_path_label}: `{name}` missing required reading `{required}`"
+        for required in required_reading
+        if required != "AGENTS.md" and required not in public_path
+    ]
+
+
+def has_gate_evidence(gate_cell: str) -> bool:
+    """Return whether a workflow gate cell names a local gate or exception."""
+    accepted_markers = [
+        "pixi run",
+        "git status",
+        "local reproduction",
+        "focused build/test",
+        "focused tests",
+        "target-specific gates",
+        "release-target focused tests",
+        "regression test",
+        "CI/review green",
+        "CI is green",
+        "Read-only",
+        "read-only",
+        "No local gate",
+        "Maintainer-only",
+        "release verification",
+        "Relevant docs/AI checks",
+    ]
+    return any(marker in gate_cell for marker in accepted_markers)
+
+
+def _validate_capability_entries(
+    section: str, entries: object, expected_names: set[str]
+) -> tuple[dict[str, str], list[str]]:
+    """Validate one capability manifest section and return declared profiles."""
+    errors: list[str] = []
+    declared_profiles: dict[str, str] = {}
+
+    if not isinstance(entries, list):
+        return declared_profiles, [
+            f"docs/ai/capabilities.json: `{section}` must be a list"
+        ]
+
+    allowed_gate_profiles = (
+        CAPABILITY_DOMAIN_GATE_PROFILE_VALUES
+        if section == "domain_skills"
+        else CAPABILITY_WORKFLOW_GATE_PROFILE_VALUES
+    )
+
+    for index, entry in enumerate(entries, start=1):
+        label = f"docs/ai/capabilities.json:{section}[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{label}: entry must be an object")
+            continue
+
+        name = entry.get("name")
+        category = entry.get("category")
+        status = entry.get("status")
+        gate_profile = entry.get("gate_profile")
+
+        if not isinstance(name, str) or not name:
+            errors.append(f"{label}: missing string `name`")
+            continue
+        if not re.fullmatch(r"dart-[a-z0-9-]+", name):
+            errors.append(f"{label}: invalid capability name `{name}`")
+        if name in declared_profiles:
+            errors.append(f"{label}: duplicate capability `{name}`")
+        declared_profiles[name] = gate_profile if isinstance(gate_profile, str) else ""
+
+        if not isinstance(category, str) or not re.fullmatch(
+            r"[a-z][a-z0-9-]*", category or ""
+        ):
+            errors.append(f"{label}: missing or invalid `category`")
+        if status not in CAPABILITY_STATUS_VALUES:
+            errors.append(
+                f"{label}: status must be one of "
+                f"{format_names(CAPABILITY_STATUS_VALUES)}"
+            )
+        if gate_profile not in allowed_gate_profiles:
+            errors.append(
+                f"{label}: gate_profile must be one of "
+                f"{format_names(allowed_gate_profiles)}"
+            )
+
+    declared_names = set(declared_profiles)
+    missing = expected_names - declared_names
+    extra = declared_names - expected_names
+    if missing:
+        errors.append(
+            f"docs/ai/capabilities.json: `{section}` missing "
+            f"{format_names(missing)}"
+        )
+    if extra:
+        errors.append(
+            f"docs/ai/capabilities.json: `{section}` has unknown "
+            f"{format_names(extra)}"
+        )
+
+    return declared_profiles, errors
+
+
+def validate_capability_manifest(
+    repo_root: Path,
+    command_names: set[str],
+    skill_names: set[str],
+    workflow_rows: dict[str, list[str]],
+    domain_skill_rows: dict[str, list[str]],
+) -> list[str]:
+    """Validate the machine-readable AI capability manifest."""
+    manifest_path = repo_root / "docs" / "ai" / "capabilities.json"
+    if not manifest_path.exists():
+        return [f"{display_path(manifest_path)}: missing capability manifest"]
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as error:
+        return [f"{display_path(manifest_path)}:{error.lineno}: invalid JSON"]
+
+    errors: list[str] = []
+    if not isinstance(manifest, dict):
+        return [f"{display_path(manifest_path)}: manifest must be an object"]
+    if manifest.get("schema_version") != CAPABILITY_SCHEMA_VERSION:
+        errors.append(
+            f"{display_path(manifest_path)}: schema_version must be "
+            f"{CAPABILITY_SCHEMA_VERSION}"
+        )
+
+    workflow_profiles, workflow_errors = _validate_capability_entries(
+        "workflows", manifest.get("workflows"), command_names
+    )
+    skill_profiles, skill_errors = _validate_capability_entries(
+        "domain_skills", manifest.get("domain_skills"), skill_names
+    )
+    errors.extend(workflow_errors)
+    errors.extend(skill_errors)
+
+    for name in sorted(workflow_profiles):
+        cells = workflow_rows.get(name)
+        if not cells:
+            errors.append(
+                f"{display_path(manifest_path)}: workflow `{name}` lacks "
+                "docs/ai/workflows.md row"
+            )
+            continue
+        if not cells[3] or cells[3] == "-":
+            errors.append(
+                f"{display_path(manifest_path)}: workflow `{name}` lacks public path"
+            )
+        if not cells[4] or not has_gate_evidence(cells[4]):
+            errors.append(
+                f"{display_path(manifest_path)}: workflow `{name}` lacks gate evidence"
+            )
+        profile_markers = CAPABILITY_WORKFLOW_GATE_PROFILE_MARKERS.get(
+            workflow_profiles[name]
+        )
+        if profile_markers and not any(
+            marker in cells[4] for marker in profile_markers
+        ):
+            errors.append(
+                f"{display_path(manifest_path)}: workflow `{name}` gate evidence "
+                f"does not match `{workflow_profiles[name]}` profile"
+            )
+
+    for name in sorted(skill_profiles):
+        cells = domain_skill_rows.get(name)
+        if not cells:
+            errors.append(
+                f"{display_path(manifest_path)}: domain skill `{name}` lacks "
+                "docs/ai/workflows.md row"
+            )
+            continue
+        public_path = cells[2] if len(cells) > 2 else ""
+        if not public_path or public_path == "-":
+            errors.append(
+                f"{display_path(manifest_path)}: domain skill `{name}` lacks "
+                "required docs/command path"
+            )
+        elif not any(
+            marker in public_path for marker in ("docs/", "CONTRIBUTING.md", "pixi run")
+        ):
+            errors.append(
+                f"{display_path(manifest_path)}: domain skill `{name}` lacks "
+                "usable docs/command path"
+            )
+
+    return errors
+
+
+def validate_approval_boundary(repo_root: Path) -> list[str]:
+    """Check GitHub/remote mutation commands explicitly require approval."""
+    errors: list[str] = []
+    mutation_pattern_strings = [
+        r"\bgit push\b",
+        r"\bgh pr create\b",
+        r"\bgh pr comment\b",
+        r"\bgh pr edit\b",
+        r"\bgh pr merge\b",
+        r"\bgh pr ready\b",
+        r"\bgh pr review\b",
+        r"\bgh issue comment\b",
+        r"\bgh issue close\b",
+        r"\bgh issue edit\b",
+        r"\bgh run rerun\b",
+        r"\bgh pr update-branch\b",
+        r"\bgh api\b(?!\s+graphql\b)[^\n;|&]*(?:(?:--method(?:=|\s+)|-X\s*)"
+        + r"(?:POST|PATCH|PUT|DELETE)\b|(?:--field|-f)\s+\w+=)",
+        r"\bgh api graphql\b[^\n;|&]*\bmutation\b",
+        r"^\s*mutation(?:\s+\w+)?\s*\{",
+        r"\bgit fetch\b[^\n;|&]*(?:--prune\b|-[A-Za-z]*p[A-Za-z]*\b)",
+        r"\bgit remote update\b[^\n;|&]*(?:--prune\b|-[A-Za-z]*p[A-Za-z]*\b)",
+        r"\bgit remote prune\b",
+        r"\bgit branch\b[^\n;|&]*(?:-[A-Za-z]*[dD][A-Za-z]*\b|--delete\b)",
+        r"\bresolveReviewThread\b",
+        r"--delete-branch\b",
+        r"\borigin --delete\b",
+        r"^\s*(?:\d+\.\s*)?(?:[-*]\s*)?(?:if approved,\s*)?push\b",
+        r"\bpush(?:ing)? (?:the )?(?:fix(?:es)?|change|changes|commit|commits|branch)\b",
+        r"\bpush(?:ing)? and (?:ask|create|creating|monitor|open|opening|watch)\b",
+        r"\bpush(?:ing)?, (?:comment|resolve|re-trigger|retrigger)\b",
+        r"\bpush(?:es|ing)?\b.{0,120}\b(?:PRs?|pull requests?)\b",
+        r"\b(?:create|creating|open|opening)\b.{0,80}\b(?:PRs?|pull requests?)\b",
+        r"\bcreate or update (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\bcreate/update (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\bupdate (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\bupdating (?:a |the )?.{0,120}(?:PRs?|pull requests?)\b",
+        r"\b(?:PRs?|pull requests?) update\b",
+        r"\bset(?:ting)? (?:the )?.{0,120}milestones?\b",
+        r"\brerun(?:ning)? (?:the )?(?:failed )?(?:CI|check|job|jobs|workflow)\b",
+        r"\bmerg(?:e|ing) (?:the )?(?:PR|pull request)\b",
+        r"\bresolv(?:e|ing) (?:only )?(?:the )?(?:addressed |reviewed |reviewed and addressed |reviewed, addressed )?(?:review )?(?:thread IDs?|threads?|conversations?)\b",
+        r"\bdelet(?:e|ing)\b.{0,80}\bbranch(?:es)?\b",
+        r"\bbranch(?:es)? (?:is |are )?(?:a )?deletion candidate(?:s)?\b",
+        r"\bdeletion candidate(?:s)?\b",
+        r"\bprun(?:e|ing)\b.{0,80}\brefs?\b",
+        r"\bforce-delete locally\b",
+    ]
+    mutation_pattern = re.compile(
+        "|".join(f"(?:{pattern})" for pattern in mutation_pattern_strings), re.I
+    )
+    mutation_examples = {
+        "Open a PR with the release milestone": "uppercase PR opening prose",
+        "opening the release-branch PR": "gerund PR opening prose",
+        "After approval, push the fix": "non-line-initial push prose",
+        "pushing fixes to the PR": "gerund push prose",
+        "pushes to PRs": "plural push/PR prose",
+        "open a pull request": "pull request opening prose",
+        "update the pull request": "pull request update prose",
+        "open a DART pull request": "qualified pull request opening prose",
+        "Create release packaging PR": "qualified PR opening prose",
+        "gh pr update-branch": "PR update-branch command",
+        "gh api --method POST repos/dartsim/dart/issues/1/comments": "mutating gh api command",
+        "gh api --method=PATCH repos/dartsim/dart/issues/1": "mutating gh api equals method command",
+        "gh api -X DELETE repos/dartsim/dart/git/refs/heads/tmp": "mutating gh api short method command",
+        "gh api -XPOST repos/dartsim/dart/issues": "mutating gh api attached short method command",
+        "gh api repos/dartsim/dart/issues/1/comments -f body=x": "implicit mutating gh api field command",
+        'gh api graphql -f query="mutation { foo }"': "mutating gh api graphql command",
+        "mutation { resolveReviewThread": "GraphQL mutation block",
+        "git fetch --all --prune": "fetch prune command",
+        "git fetch origin --prune": "fetch remote prune command",
+        "git fetch origin -p": "fetch remote short prune command",
+        "git fetch -p": "fetch short prune command",
+        "git remote update --prune": "remote update prune command",
+        "git remote update origin --prune": "remote update remote prune command",
+        "git remote update -p": "remote update short prune command",
+        "git remote prune origin": "remote prune command",
+        "pruning refs": "pruning refs prose",
+        "Deleting stale branches": "branch deletion prose",
+        "delete any branch": "any branch deletion prose",
+        "deleting any local or remote branch": "local-or-remote branch deletion prose",
+        "git branch -D <HEAD_BRANCH>": "local branch deletion command",
+        "git branch -df <HEAD_BRANCH>": "combined branch force-delete command",
+        "git branch -rd origin/foo": "combined remote branch delete command",
+        "git branch --delete --force <HEAD_BRANCH>": "long-form branch deletion command",
+        "Branch is a deletion candidate": "branch deletion candidate prose",
+        "resolve the thread": "singular thread resolution prose",
+        "resolve only reviewed and addressed thread IDs": "reviewed thread ID resolution prose",
+        "update the PR after editing": "PR update prose",
+        "PR update after changelog edit": "noun PR update prose",
+        "After opening the PR, merge PR": "compound PR mutation prose",
+        "Rerunning failed jobs": "gerund CI rerun prose",
+        "Merging PR after checks pass": "gerund merge prose",
+        "Resolving addressed threads via GraphQL": "gerund thread-resolution prose",
+    }
+    for example, label in mutation_examples.items():
+        if not mutation_pattern.search(example):
+            errors.append(f"internal mutation pattern self-check failed: {label}")
+
+    approval_pattern = re.compile(r"explicit\s+(?:maintainer/user\s+)?approval", re.I)
+
+    def build_scan_text(lines: list[str], index: int, in_fence: bool) -> str:
+        """Join a Markdown paragraph or wrapped list item for prose scanning."""
+        current = lines[index]
+        current_stripped = current.strip()
+        if not current_stripped:
+            return ""
+
+        parts = [current_stripped]
+        current_indent = len(current) - len(current.lstrip())
+        current_is_list = bool(re.match(r"(?:[-*]|\d+\.)\s", current_stripped))
+        current_is_block = current_stripped.startswith(("#", "|", "```", "---"))
+
+        if current_is_block or in_fence:
+            return current_stripped
+
+        for next_line in lines[index + 1 : index + 5]:
+            next_stripped = next_line.strip()
+            if not next_stripped or next_stripped.startswith(("#", "|", "```", "---")):
+                break
+
+            next_indent = len(next_line) - len(next_line.lstrip())
+            next_is_list = bool(re.match(r"(?:[-*]|\d+\.)\s", next_stripped))
+            if current_is_list:
+                if next_indent <= current_indent:
+                    break
+            elif next_is_list:
+                break
+
+            parts.append(next_stripped)
+
+        return " ".join(parts)
+
+    def strip_safe_prune_commands(scan_text: str) -> str:
+        """Remove explicitly safe prune inspection commands before scanning."""
+        scan_text = re.sub(
+            r"\bgit fetch\b[^\n;|&]*--no-prune\b",
+            "",
+            scan_text,
+            flags=re.I,
+        )
+        scan_text = re.sub(
+            r"\bgit remote prune\b[^\n;|&]*--dry-run\b",
+            "",
+            scan_text,
+            flags=re.I,
+        )
+        return scan_text
+
+    def scan_lines(label: str, lines: list[str]) -> None:
+        frontmatter_end = 0
+        if lines and lines[0].strip() == "---":
+            for line_index, frontmatter_line in enumerate(lines[1:], start=1):
+                if frontmatter_line.strip() == "---":
+                    frontmatter_end = line_index + 1
+                    break
+
+        in_fence = False
+        for index, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_fence = not in_fence
+                continue
+            if index < frontmatter_end:
+                continue
+            if re.search(r"\bwhy resolve after\b", line, re.I):
+                continue
+            scan_text = strip_safe_prune_commands(
+                build_scan_text(lines, index, in_fence).replace("$ARGUMENTS", "")
+            )
+            if not mutation_pattern.search(scan_text):
+                continue
+
+            start = max(0, index - 6)
+            end = min(len(lines), index + 8)
+            context = "\n".join(lines[start:end])
+            if approval_pattern.search(context):
+                continue
+
+            errors.append(
+                f"{label}:{index + 1}: mutation command lacks "
+                "nearby explicit approval boundary"
+            )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["Push changes: $ARGUMENTS"],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: same-line "
+            "$ARGUMENTS hid mutation prose"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines("internal approval-boundary self-check", ["git fetch --all --prune"])
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: fetch prune command "
+            "was not detected"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines("internal approval-boundary self-check", ["git remote prune origin"])
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: remote prune command "
+            "was not detected"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines("internal approval-boundary self-check", ["git fetch --all --no-prune"])
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: --no-prune command "
+            "was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        [
+            "```bash",
+            "git fetch origin <RELEASE_BRANCH>",
+            "git checkout -B release/<NEW_VERSION>-version-bump origin/<RELEASE_BRANCH>",
+            "```",
+        ],
+    )
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: fenced safe fetch "
+            "was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["git fetch --all --no-prune && git push"],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: --no-prune hid "
+            "compound mutation"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["git remote prune origin --dry-run"],
+    )
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: prune dry-run command "
+            "was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["git remote prune origin --dry-run; gh pr merge"],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: prune dry-run hid "
+            "compound mutation"
+        )
+    else:
+        del errors[before_self_check:]
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        ["gh api graphql -f query='", "  query { repository { id } }"],
+    )
+    if len(errors) != before_self_check:
+        del errors[before_self_check:]
+        errors.append(
+            "internal approval-boundary self-check failed: read-only GraphQL "
+            "query was flagged"
+        )
+
+    before_self_check = len(errors)
+    scan_lines(
+        "internal approval-boundary self-check",
+        [
+            "- `action`: delete only after ownership is clear",
+            "  and the branch deletion is requested",
+        ],
+    )
+    if len(errors) == before_self_check:
+        errors.append(
+            "internal approval-boundary self-check failed: wrapped branch "
+            "deletion prose was not detected"
+        )
+    else:
+        del errors[before_self_check:]
+
+    scan_paths = [
+        *sorted((repo_root / ".claude" / "commands").glob("*.md")),
+        *sorted((repo_root / ".claude" / "skills").glob("*/SKILL.md")),
+        *sorted((repo_root / "docs" / "ai").glob("*.md")),
+        repo_root / "docs" / "onboarding" / "ai-tools.md",
+    ]
+
+    for path in scan_paths:
+        scan_lines(display_path(path), path.read_text().splitlines())
+
+    for command_path in sorted((repo_root / ".claude" / "commands").glob("*.md")):
+        rendered_wrapper = render_codex_command_skill(command_path).split(
+            "\n## Command Body\n", 1
+        )[0]
+        scan_lines(
+            f"generated Codex wrapper for {command_path.stem}",
+            rendered_wrapper.splitlines(),
+        )
+
+    ai_tools = repo_root / "docs" / "onboarding" / "ai-tools.md"
+    if ai_tools.exists() and re.search(
+        r"resolve (?:all|every) unresolved thread", ai_tools.read_text(), re.I
+    ):
+        errors.append(
+            f"{display_path(ai_tools)}: bulk review-thread resolution is forbidden"
+        )
+
+    return errors
+
+
+def validate_ai_docs(repo_root: Path) -> bool:
+    """Validate the checked AI-native docs that index generated capabilities."""
+    errors: list[str] = []
+    docs_dir = repo_root / "docs" / "ai"
+    required_files = [
+        docs_dir / "README.md",
+        docs_dir / "principles.md",
+        docs_dir / "north-star.md",
+        docs_dir / "workflows.md",
+        docs_dir / "verification.md",
+        docs_dir / "sessions.md",
+        docs_dir / "components.md",
+        docs_dir / "capabilities.json",
+    ]
+
+    for path in required_files:
+        if not path.exists():
+            errors.append(f"{display_path(path)}: missing required AI doc")
+
+    agents_content = (repo_root / "AGENTS.md").read_text()
+    docs_readme_content = (repo_root / "docs" / "README.md").read_text()
+    if "docs/ai/README.md" not in agents_content:
+        errors.append("AGENTS.md: missing docs/ai/README.md pointer")
+    if "docs/ai/principles.md" not in agents_content:
+        errors.append("AGENTS.md: missing docs/ai/principles.md pointer")
+    if "ai/README.md" not in docs_readme_content:
+        errors.append("docs/README.md: missing ai/README.md index link")
+
+    workflows_path = docs_dir / "workflows.md"
+    if workflows_path.exists():
+        workflow_content = workflows_path.read_text()
+        command_names = list_command_names(repo_root / ".claude" / "commands")
+        skill_names, skill_errors = list_skill_names(repo_root / ".claude" / "skills")
+        errors.extend(skill_errors)
+        expected = command_names | skill_names
+        workflow_rows = parse_workflow_rows(workflow_content)
+        domain_skill_rows = parse_domain_skill_rows(workflow_content)
+
+        if has_gate_evidence("explicit approval before push"):
+            errors.append(
+                "internal workflow gate self-check failed: approval-only gate accepted"
+            )
+
+        fake_required = extract_required_reading_from_content("""
+## Required Reading
+
+@AGENTS.md
+@docs/onboarding/required.md (inline note)
+@docs/onboarding/extra.md
+
+## Workflow
+""")
+        fake_missing = missing_required_reading_errors(
+            "docs/ai/workflows.md",
+            "dart-fake",
+            "docs/onboarding/required.md",
+            fake_required,
+        )
+        if len(fake_missing) != 1 or "docs/onboarding/extra.md" not in fake_missing[0]:
+            errors.append(
+                "internal workflow docs self-check failed: missing required "
+                "reading was not detected"
+            )
+
+        for name in sorted(expected):
+            if f"`{name}`" not in workflow_content:
+                errors.append(
+                    f"{display_path(workflows_path)}: missing capability `{name}`"
+                )
+
+        for name in sorted(command_names):
+            command_path = repo_root / ".claude" / "commands" / f"{name}.md"
+            cells = workflow_rows.get(name)
+            if not cells:
+                errors.append(
+                    f"{display_path(workflows_path)}: missing workflow row `{name}`"
+                )
+                continue
+            public_path = cells[3]
+            gate = cells[4]
+            if not public_path or public_path == "-":
+                errors.append(
+                    f"{display_path(workflows_path)}: `{name}` missing public path"
+                )
+            if not gate or not has_gate_evidence(gate):
+                errors.append(
+                    f"{display_path(workflows_path)}: `{name}` missing gate evidence"
+                )
+
+            errors.extend(required_reading_path_errors(repo_root, command_path))
+            errors.extend(
+                missing_required_reading_errors(
+                    display_path(workflows_path),
+                    name,
+                    public_path,
+                    extract_required_reading(command_path),
+                )
+            )
+
+        for name in sorted(skill_names):
+            if name not in domain_skill_rows:
+                errors.append(
+                    f"{display_path(workflows_path)}: missing domain skill row `{name}`"
+                )
+
+        errors.extend(
+            validate_capability_manifest(
+                repo_root,
+                command_names,
+                skill_names,
+                workflow_rows,
+                domain_skill_rows,
+            )
+        )
+
+        approval_workflows = {
+            "dart-backport-pr",
+            "dart-branch-cleanup",
+            "dart-close-issue",
+            "dart-docs-update",
+            "dart-downstream-fix",
+            "dart-fix-ci",
+            "dart-fix-issue",
+            "dart-manage-pr",
+            "dart-merge-pr",
+            "dart-mechanical-refactor",
+            "dart-new-task",
+            "dart-next",
+            "dart-pr",
+            "dart-release-ci-fix",
+            "dart-release-merge-main",
+            "dart-release-packaging",
+            "dart-resume",
+            "dart-review-pr",
+            "dart-triage-issue",
+        }
+        for name in sorted(approval_workflows & command_names):
+            cells = workflow_rows.get(name)
+            row_text = " ".join(cells) if cells else ""
+            if cells and not ("explicit" in row_text and "approval" in row_text):
+                errors.append(
+                    f"{display_path(workflows_path)}: `{name}` missing approval gate"
+                )
+
+        documented = set(re.findall(r"`(dart-[a-z0-9-]+)`", workflow_content))
+        extra = documented - expected
+        for name in sorted(extra):
+            errors.append(
+                f"{display_path(workflows_path)}: unknown capability `{name}`"
+            )
+
+        if "docs/ai/workflows.md" not in agents_content:
+            errors.append("AGENTS.md: missing docs/ai/workflows.md catalog pointer")
+        if ".claude/commands/" not in agents_content:
+            errors.append("AGENTS.md: missing .claude/commands/ source pointer")
+        if ".codex/skills/" not in agents_content:
+            errors.append("AGENTS.md: missing .codex/skills/ generated pointer")
+
+    errors.extend(validate_approval_boundary(repo_root))
+
+    private_pattern = re.compile(r"(?:/home/|/Users/|~/|fbsource|arvr/libraries)")
+    for path in docs_dir.glob("*.md"):
+        for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+            if private_pattern.search(line):
+                errors.append(
+                    f"{display_path(path)}:{line_number}: private path reference"
+                )
+
+    if errors:
+        for error in errors:
+            print(f"  AI DOC ERROR: {error}")
+        return False
+
+    print("  OK: docs/ai entrypoint, workflow index, and public paths are valid")
+    return True
+
+
+def has_auto_gen_header(content: str) -> bool:
+    """Check if content has the auto-generated header."""
+    return "<!-- AUTO-GENERATED FILE" in content
+
+
+def strip_auto_gen_header(content: str) -> str:
+    """Remove auto-generated header from content for comparison."""
+    lines = content.split("\n")
+    result_lines = []
+    in_header = False
+
+    for line in lines:
+        if line.startswith("<!-- AUTO-GENERATED FILE"):
+            in_header = True
+            continue
+        if in_header:
+            if line.startswith("<!--"):
+                continue
+            in_header = False
+        result_lines.append(line)
+
+    return "\n".join(result_lines)
+
+
+def add_auto_gen_header(content: str, source_path: str) -> str:
+    """Add auto-generated header after YAML frontmatter (if present) to preserve tool parsing."""
+    header = AUTO_GEN_HEADER.format(source_path=source_path).rstrip("\n")
+
+    if content.startswith("---"):
+        lines = content.split("\n")
+        for i, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                frontmatter = "\n".join(lines[: i + 1])
+                rest = "\n".join(lines[i + 1 :])
+                return frontmatter + "\n" + header + "\n" + rest
+    return header + "\n\n" + content
+
+
+def sync_flat_files(
+    source_dir: Path,
+    target_dir: Path,
+    pattern: str,
+    label: str,
+    check_only: bool = False,
+) -> tuple[bool, int, int, int]:
+    """Sync flat files from source to target directory.
+
+    Returns:
+        Tuple of (all_synced, synced_count, skipped_count, orphan_count)
+    """
+    if not source_dir.exists():
+        print(f"Source directory not found: {source_dir}")
+        return False, -1, 0, 0
+
+    if not check_only:
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+    source_files = sorted(source_dir.glob(pattern))
+    all_synced = True
+    synced_count = 0
+    skipped_count = 0
+
+    for source_file in source_files:
+        target_file = target_dir / source_file.name
+        source_content = source_file.read_text()
+        source_rel_path = source_file.relative_to(get_repo_root())
+
+        if target_file.exists():
+            target_content = target_file.read_text()
+            target_content_stripped = strip_auto_gen_header(target_content)
+            if source_content == target_content_stripped and has_auto_gen_header(
+                target_content
+            ):
+                skipped_count += 1
+                continue
+
+        all_synced = False
+
+        if check_only:
+            status = "MISMATCH" if target_file.exists() else "MISSING"
+            print(f"  {status}: {source_file.name}")
+        else:
+            content_with_header = add_auto_gen_header(
+                source_content, str(source_rel_path)
+            )
+            target_file.write_text(content_with_header)
+            print(f"  SYNCED:   {source_file.name}")
+            synced_count += 1
+
+    # Check for orphaned files
+    if target_dir.exists():
+        target_files = set(f.name for f in target_dir.glob(pattern))
+        source_names = set(f.name for f in source_files)
+        orphaned = target_files - source_names
+
+        for orphan in sorted(orphaned):
+            all_synced = False
+            orphan_path = target_dir / orphan
+            if check_only:
+                print(f"  ORPHAN:   {orphan}")
+            else:
+                orphan_path.unlink()
+                print(f"  REMOVED:  {orphan}")
+    else:
+        orphaned = set()
+
+    return all_synced, synced_count, skipped_count, len(orphaned)
+
+
+def render_codex_command_skill(command_path: Path) -> str:
+    """Render a Claude/OpenCode command as a Codex skill."""
+    command_name = command_path.stem
+    command_content = command_path.read_text()
+    meta = parse_command_frontmatter(command_content)
+    description = meta.get("description", f"Run the {command_name} workflow")
+    command_body = strip_frontmatter(command_content).strip()
+
+    skill_description = (
+        f"{skill_display_name(command_name)}: {sentence_case(description)}"
+    )
+
+    return f"""\
+---
+name: {command_name}
+description: {json.dumps(skill_description)}
+---
+
+# {command_name}
+
+Use this skill in Codex to run the DART `{command_name}` workflow. The editable
+workflow source currently lives in `.claude/commands/`, and this generated
+Codex skill is a first-class Codex entrypoint.
+
+## Invocation
+
+- Claude Code/OpenCode: `/{command_name} <arguments>`
+- Codex: `${command_name} <arguments>`
+
+Treat the text after the skill name as `$ARGUMENTS`. When the workflow
+references `$1`, `$2`, etc., map those to the positional values supplied by the
+user.
+
+## Command Body
+
+{command_body}
+"""
+
+
+def sync_codex_skills(
+    skill_source_dir: Path,
+    command_source_dir: Path,
+    target_dir: Path,
+    check_only: bool = False,
+) -> tuple[bool, int, int, int]:
+    """Sync explicit skills plus command-derived workflow skills to Codex."""
+    if not skill_source_dir.exists():
+        print(f"Source directory not found: {skill_source_dir}")
+        return False, -1, 0, 0
+    if not command_source_dir.exists():
+        print(f"Source directory not found: {command_source_dir}")
+        return False, -1, 0, 0
+
+    if not check_only:
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+    source_skill_names_set, source_skill_errors = list_skill_names(skill_source_dir)
+    if source_skill_errors:
+        for error in source_skill_errors:
+            print(f"  ERROR:    {error}")
+        return False, -1, 0, 0
+
+    source_skill_names = sorted(source_skill_names_set)
+    source_command_files = sorted(command_source_dir.glob("*.md"))
+    source_command_names = [f.stem for f in source_command_files]
+
+    collisions = sorted(set(source_skill_names) & set(source_command_names))
+    if collisions:
+        for name in collisions:
+            print(
+                "  ERROR:    "
+                f"{name} exists as both .claude/skills and .claude/commands"
+            )
+        return False, -1, 0, 0
+
+    expected_names = set(source_skill_names) | set(source_command_names)
+    all_synced = True
+    synced_count = 0
+    skipped_count = 0
+
+    items: list[tuple[str, Path, str]] = []
+
+    for skill_name in source_skill_names:
+        source_skill = skill_source_dir / skill_name / "SKILL.md"
+        source_content = source_skill.read_text()
+
+        warnings = validate_codex_skill(source_skill)
+        for warning in warnings:
+            print(f"  WARNING:  {skill_name}: {warning}")
+
+        items.append((skill_name, source_skill, source_content))
+
+    for command_file in source_command_files:
+        items.append(
+            (command_file.stem, command_file, render_codex_command_skill(command_file))
+        )
+
+    for skill_name, source_path, content in items:
+        target_skill_dir = target_dir / skill_name
+        target_skill = target_skill_dir / "SKILL.md"
+        source_rel_path = source_path.relative_to(get_repo_root())
+
+        if target_skill.exists():
+            target_content = target_skill.read_text()
+            target_content_stripped = strip_auto_gen_header(target_content)
+            if content == target_content_stripped and has_auto_gen_header(
+                target_content
+            ):
+                skipped_count += 1
+                continue
+
+        all_synced = False
+
+        if check_only:
+            status = "MISMATCH" if target_skill.exists() else "MISSING"
+            print(f"  {status}: {skill_name}/SKILL.md")
+        else:
+            target_skill_dir.mkdir(parents=True, exist_ok=True)
+            content_with_header = add_auto_gen_header(content, str(source_rel_path))
+            target_skill.write_text(content_with_header)
+            print(f"  SYNCED:   {skill_name}/SKILL.md")
+            synced_count += 1
+
+    if target_dir.exists():
+        target_skills = set(d.parent.name for d in target_dir.glob("*/SKILL.md"))
+        orphaned = target_skills - expected_names
+
+        for orphan in sorted(orphaned):
+            all_synced = False
+            orphan_path = target_dir / orphan
+            if check_only:
+                print(f"  ORPHAN:   {orphan}/")
+            else:
+                shutil.rmtree(orphan_path)
+                print(f"  REMOVED:  {orphan}/")
+    else:
+        orphaned = set()
+
+    return all_synced, synced_count, skipped_count, len(orphaned)
+
+
+def sync_all(check_only: bool = False) -> bool:
+    """Sync all AI tool directories.
+
+    Args:
+        check_only: If True, only check if files match (don't modify).
+
+    Returns:
+        True if all files are in sync, False otherwise.
+    """
+    repo_root = get_repo_root()
+    all_synced = True
+
+    # 1. Sync commands: .claude/commands/ -> .opencode/command/
+    print("Commands (.claude/commands/ -> .opencode/command/):")
+    synced, s, k, o = sync_flat_files(
+        repo_root / ".claude" / "commands",
+        repo_root / ".opencode" / "command",
+        "*.md",
+        "commands",
+        check_only,
+    )
+    if s < 0 or (check_only and not synced):
+        all_synced = False
+    if not check_only:
+        print(f"  Total: {s} synced, {k} unchanged, {o} orphans removed")
+    print()
+
+    print("Skills + command workflows (.claude/ -> .codex/skills/):")
+    synced, s, k, o = sync_codex_skills(
+        repo_root / ".claude" / "skills",
+        repo_root / ".claude" / "commands",
+        repo_root / ".codex" / "skills",
+        check_only=check_only,
+    )
+    if s < 0 or (check_only and not synced):
+        all_synced = False
+    if not check_only:
+        print(f"  Total: {s} synced, {k} unchanged, {o} orphans removed")
+    print()
+
+    print("Effective capability parity (Claude Code, OpenCode, Codex):")
+    if not check_capability_parity(repo_root):
+        all_synced = False
+    print()
+
+    print("Skill and command style:")
+    if not validate_style_and_budget(repo_root):
+        all_synced = False
+    print()
+
+    print("AI docs:")
+    if not validate_ai_docs(repo_root):
+        all_synced = False
+    print()
+
+    # Summary
+    if check_only:
+        if all_synced:
+            print("✓ All AI tool files are in sync")
+        else:
+            print("✗ Files are out of sync. Run: pixi run sync-ai-commands")
+
+    return all_synced
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Sync AI commands and skills across tool directories"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check if files are in sync without modifying (for CI)",
+    )
+    args = parser.parse_args()
+
+    success = sync_all(check_only=args.check)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Import the release-branch AI workflow surface for Claude Code, OpenCode, and Codex on `release-6.20`.
- Add release-specific onboarding and AI guidance that keeps DART 6.20 work on topic branches based on `origin/release-6.20`.
- Add generated command/skill sync checks, a checked-in parallel job helper for documented gates, and allow generated `.codex` skill files through the repository ignore rules.

## Motivation / Problem

- The DART 6.20 dependency-minimization sequence needs reusable PR, review, CI, and release-branch workflow guidance before opening a series of focused cleanup PRs.
- The imported guidance must not point release-branch agents at `main`, set local topic branches to track `origin/release-6.20`, push directly to `release-*` branches, or document commands that fail on this checkout.

## Changes / Key Changes

- Adds editable `.claude/commands/` and `.claude/skills/` sources plus generated `.opencode/command/` and `.codex/skills/` entrypoints.
- Adds `scripts/sync_ai_commands.py` with `pixi run sync-ai-commands` and `pixi run check-ai-commands` tasks.
- Adds `scripts/parallel_jobs.py` so Gazebo verification snippets use a checked-in helper.
- Adds release-focused docs under `docs/ai/`, `docs/onboarding/`, and `docs/dev_tasks/README.md`.
- Updates `AGENTS.md` and `docs/onboarding/ai-tools.md` to require same-name topic-branch pushes and to avoid direct `release-*` pushes.
- Updates `.gitignore` so tracked generated `.codex/skills/**/SKILL.md` files are not hidden by broader ignore rules.

## Testing

- `pixi run sync-ai-commands && pixi run check-ai-commands`
- `pixi run check-ai-commands`
- `N=${DART_SAFE_JOBS:-$(python3 scripts/parallel_jobs.py)}; printf '%s\n' "$N"`
- `pixi run lint`
- `git diff --check`
- `git diff --cached --check`

## Breaking Changes

- [x] None
- N/A: contributor workflow import only; no public API or runtime behavior changes.

## Related Issues / PRs (backports)

- Follows #3074.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required: N/A per `docs/onboarding/changelog.md` for workflow-sync and ignore-file hygiene without public runtime behavior changes
- [x] Add unit tests for new functionality: N/A, docs/tooling import; covered by sync/check/lint gates
- [x] Document new methods and classes: N/A, no API changes
- [x] Add Python bindings (dartpy) if applicable: N/A, no binding changes
