### PR TITLE
Fix py-demos compiler cache launchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,9 @@ compatibility remains on the active DART 6 LTS branch._
 - Moved local development and CI toward Pixi-owned tasks, tiered verification,
   load-aware parallelism, generated docs checks, CMake formatting, and
   reproducible benchmark/dashboard commands.
+- Kept Pixi `py-demos` builds on host compiler caching while preventing stale
+  CUDA launcher metadata from wrapping `nvcc`, so default and CUDA demo
+  workflows rebuild predictably.
 - Added AI-native docs, synced Claude/OpenCode/Codex workflow adapters, planning
   dashboards, and a changelog guide so future release notes stay curated for
   humans. ([#2446](https://github.com/dartsim/dart/pull/2446),

--- a/cmake/compiler_cache.cmake
+++ b/cmake/compiler_cache.cmake
@@ -88,17 +88,26 @@ function(dart_configure_compiler_cache)
     return()
   endif()
 
+  set(_dart_cuda_compiler_launcher_preconfigured OFF)
+  if(DEFINED CMAKE_CUDA_COMPILER_LAUNCHER)
+    set(_dart_cuda_compiler_launcher_preconfigured ON)
+  endif()
+
   if(CMAKE_C_COMPILER_LAUNCHER OR CMAKE_CXX_COMPILER_LAUNCHER)
+    if(CMAKE_CUDA_COMPILER AND NOT _dart_cuda_compiler_launcher_preconfigured)
+      set(
+        CMAKE_CUDA_COMPILER_LAUNCHER
+        ""
+        CACHE STRING
+        "CUDA compiler launcher used for caching"
+        FORCE
+      )
+    endif()
     message(
       STATUS
       "Compiler cache already configured (C: ${CMAKE_C_COMPILER_LAUNCHER} | CXX: ${CMAKE_CXX_COMPILER_LAUNCHER})"
     )
     return()
-  endif()
-
-  set(_dart_cuda_compiler_launcher_preconfigured OFF)
-  if(DEFINED CMAKE_CUDA_COMPILER_LAUNCHER)
-    set(_dart_cuda_compiler_launcher_preconfigured ON)
   endif()
 
   _dart_collect_compiler_cache_candidates(_dart_cache_candidates)
@@ -124,7 +133,7 @@ function(dart_configure_compiler_cache)
       if(CMAKE_CUDA_COMPILER AND NOT _dart_cuda_compiler_launcher_preconfigured)
         set(
           CMAKE_CUDA_COMPILER_LAUNCHER
-          "${_cache_executable}"
+          ""
           CACHE STRING
           "CUDA compiler launcher used for caching"
           FORCE

--- a/pixi.toml
+++ b/pixi.toml
@@ -914,19 +914,23 @@ if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ]; then
     cached_cxx_compiler=
     cached_cuda_compiler=
     cached_cuda_host_compiler=
+    cached_cuda_compiler_launcher=
     while IFS='=' read -r cache_key cache_value; do
       case "${cache_key}" in
         CMAKE_C_COMPILER:*) cached_c_compiler=${cache_value} ;;
         CMAKE_CXX_COMPILER:*) cached_cxx_compiler=${cache_value} ;;
         CMAKE_CUDA_COMPILER:*) cached_cuda_compiler=${cache_value} ;;
         CMAKE_CUDA_HOST_COMPILER:*) cached_cuda_host_compiler=${cache_value} ;;
+        CMAKE_CUDA_COMPILER_LAUNCHER:*) cached_cuda_compiler_launcher=${cache_value} ;;
       esac
     done < "${CMAKE_CACHE}"
     if [ "${cached_c_compiler}" != "${DART_CUDA_HOST_CC_VALUE}" ] \
       || [ "${cached_cxx_compiler}" != "${DART_CUDA_HOST_CXX_VALUE}" ] \
       || [ "${cached_cuda_compiler}" != "${CONDA_PREFIX}/bin/nvcc" ] \
       || { [ -n "${cached_cuda_host_compiler}" ] \
-        && [ "${cached_cuda_host_compiler}" != "${DART_CUDA_HOST_CXX_VALUE}" ]; }; then
+        && [ "${cached_cuda_host_compiler}" != "${DART_CUDA_HOST_CXX_VALUE}" ]; } \
+      || { [ -z "${CMAKE_CUDA_COMPILER_LAUNCHER:-}" ] \
+        && [ -n "${cached_cuda_compiler_launcher}" ]; }; then
       echo "CMake compiler cache changed for ${CMAKE_BUILD_DIR}; resetting cache metadata."
       rm -f "${CMAKE_CACHE}"
       rm -rf "${CMAKE_BUILD_DIR}/CMakeFiles"

--- a/python/tests/unit/test_pixi_cuda_py_demos_task.py
+++ b/python/tests/unit/test_pixi_cuda_py_demos_task.py
@@ -1,4 +1,4 @@
-"""Regression checks for the CUDA py-demos Pixi build path."""
+"""Regression checks for the default and CUDA py-demos Pixi build paths."""
 
 from __future__ import annotations
 
@@ -42,11 +42,14 @@ def test_config_py_resets_stale_cuda_compiler_cache_before_cmake() -> None:
     assert "CMAKE_CXX_COMPILER:*)" in script
     assert "CMAKE_CUDA_COMPILER:*)" in script
     assert "CMAKE_CUDA_HOST_COMPILER:*)" in script
+    assert "CMAKE_CUDA_COMPILER_LAUNCHER:*)" in script
+    assert '[ -z "${CMAKE_CUDA_COMPILER_LAUNCHER:-}" ]' in script
+    assert '[ -n "${cached_cuda_compiler_launcher}" ]' in script
     assert 'rm -f "${CMAKE_CACHE}"' in script
     assert 'rm -rf "${CMAKE_BUILD_DIR}/CMakeFiles"' in script
 
 
-def test_config_py_keeps_host_compiler_cache_for_cuda_py_demos() -> None:
+def test_config_py_keeps_compiler_cache_for_default_and_cuda_py_demos() -> None:
     script = _task_script("config-py")
 
     disable_assignment = script.index(
@@ -67,9 +70,12 @@ def test_cmake_compiler_cache_respects_empty_cuda_launcher() -> None:
     script = CMAKE_COMPILER_CACHE.read_text(encoding="utf-8")
 
     preconfigured_check = script.index("DEFINED CMAKE_CUDA_COMPILER_LAUNCHER")
-    cuda_launcher_set = script.index("CMAKE_CUDA_COMPILER_LAUNCHER\n          ")
-    assert preconfigured_check < cuda_launcher_set
+    cuda_launcher_clear = script.index(
+        'CMAKE_CUDA_COMPILER_LAUNCHER\n          ""'
+    )
+    assert preconfigured_check < cuda_launcher_clear
     assert "NOT _dart_cuda_compiler_launcher_preconfigured" in script
+    assert 'CMAKE_CUDA_COMPILER_LAUNCHER\n          "${_cache_executable}"' not in script
 
 
 def test_py_demos_depends_on_docking_dartpy_build() -> None:


### PR DESCRIPTION
## Summary

- Keep Pixi `py-demos` builds using host C/C++ compiler caching in both default and CUDA environments while preventing automatic `sccache` wrapping of `nvcc`.
- Reset stale CUDA launcher metadata before CUDA `config-py` reconfigures, so `pixi run -e cuda py-demos` recovers from older `CMAKE_CUDA_COMPILER_LAUNCHER=sccache` caches.

## Motivation / Problem

`pixi run -e cuda py-demos -- --list` could inherit stale CUDA compiler-launcher cache state and invoke `sccache ... nvcc`. On this workstation, the pre-fix run failed after 5:20.76 with `fatbinary fatal: Could not open input file 'barrier_friction_kernel_cuda.ptx'` during a 337-step CUDA dartpy build.

The fix keeps the useful host compiler cache for default `pixi run py-demos` and CUDA host C/C++ rebuilds, but leaves CUDA compilation itself on direct `nvcc` unless a user explicitly preconfigures a CUDA launcher.

## Changes / Key Changes

- Update `cmake/compiler_cache.cmake` so automatic cache selection sets C/CXX launchers but leaves `CMAKE_CUDA_COMPILER_LAUNCHER` empty unless it was explicitly preconfigured.
- Update Pixi `config-py` CUDA cache validation to delete stale CMake metadata when the build cache still records a CUDA launcher that the current environment no longer requests.
- Add regression coverage for default and CUDA `py-demos` build paths, including stale CUDA launcher reset behavior and preserving host compiler caching.
- Update `CHANGELOG.md` for the DART 7 developer-tooling workflow change.

## Before / After Timing

| Command | Before | After |
| --- | --- | --- |
| `pixi run py-demos -- --list` | Parent-commit warm no-op: passed in 0:02.61. | Final branch warm no-op: passed in 0:02.62. Default C/CXX launchers remain `sccache`. |
| `pixi run -e cuda py-demos -- --list` | Failed after 5:20.76 with `sccache ... nvcc` and missing generated PTX. | First recovery run passed in 4:20.73 after completing 124 remaining build steps; final-base rebuild passed in 1:35.24; final warm no-op passed in 0:02.88. |
| `pixi run -e cuda py-demos -- --scene rigid_body --headless --frames 1` | Not separately measured before; covered by the same stale CUDA launcher failure mode. | Final warm smoke passed in 0:02.82 with `ninja: no work to do` and CUDA GPU deformable solve enabled. |

Final launcher state checked after the fix:

- Default `build/default/cpp/Release-docking`: C and CXX launchers are `sccache`.
- CUDA `build/cuda/cpp/Release-docking`: C and CXX launchers are `sccache`; CUDA launcher is empty.
- CUDA compile command for `barrier_friction_kernel_cuda.cu.o` starts with direct `nvcc`, not `sccache`.

## Testing

- `pixi run lint`
- `pixi run python -m pytest python/tests/unit/test_pixi_cuda_py_demos_task.py`
- `git diff --check`
- `/usr/bin/time -f 'elapsed=%E user=%U sys=%S maxrss=%MKB' pixi run py-demos -- --list >/tmp/dart-py-demos-default-list-postbase-warm.txt`
- `/usr/bin/time -f 'elapsed=%E user=%U sys=%S maxrss=%MKB' pixi run -e cuda py-demos -- --list >/tmp/dart-py-demos-cuda-list-postbase-warm.txt`
- `/usr/bin/time -f 'elapsed=%E user=%U sys=%S maxrss=%MKB' pixi run -e cuda py-demos -- --scene rigid_body --headless --frames 1 >/tmp/dart-py-demos-cuda-headless-postbase.txt`
- `rg -n 'CMAKE_(C|CXX|CUDA)_COMPILER_LAUNCHER' build/default/cpp/Release-docking/CMakeCache.txt build/cuda/cpp/Release-docking/CMakeCache.txt`
- `pixi run -e cuda ninja -C build/cuda/cpp/Release-docking -t commands dart/simulation/CMakeFiles/dart-simulation-cuda.dir/compute/cuda/barrier_friction_kernel_cuda.cu.o | head -1`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None. This is DART 7/Pixi demo workflow tooling on `main`; no DART 6 backport planned.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes - N/A, no new API
- [x] Add Python bindings (dartpy) if applicable - N/A, no binding change
