### PR TITLE
PLAN-091: Add remaining architecture hardening evidence

### DIFF
--- a/dart/simulation/compute/rigid_body_contact_stage.cpp
+++ b/dart/simulation/compute/rigid_body_contact_stage.cpp
@@ -52,7 +52,6 @@
 #include <dart/common/memory_manager.hpp>
 #include <dart/common/stl_allocator.hpp>
 
-#include <Eigen/Cholesky>
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 #include <entt/entt.hpp>
@@ -71,18 +70,6 @@ namespace dart::simulation::compute {
 namespace dvbd = dart::simulation::detail::deformable_vbd;
 
 namespace {
-
-Eigen::Quaterniond normalizeOrIdentity(const Eigen::Quaterniond& orientation)
-{
-  const auto norm = orientation.norm();
-  if (norm <= 0.0 || !std::isfinite(norm)) {
-    return Eigen::Quaterniond::Identity();
-  }
-
-  auto normalized = orientation;
-  normalized.coeffs() /= norm;
-  return normalized;
-}
 
 const comps::RigidAvbdContactConfig* enabledRigidAvbdContactConfig(
     const detail::WorldRegistry& registry, entt::entity entity)
@@ -140,31 +127,6 @@ std::optional<comps::RigidAvbdContactConfig> rigidAvbdContactStageConfig(
 
   return merged;
 }
-double inverseMass(const comps::MassProperties& mass)
-{
-  return (mass.mass > 0.0 && std::isfinite(mass.mass)) ? 1.0 / mass.mass : 0.0;
-}
-
-//==============================================================================
-Eigen::Matrix3d inverseWorldInertia(
-    const comps::MassProperties& mass, const comps::Transform& transform)
-{
-  if (!(mass.mass > 0.0) || !std::isfinite(mass.mass)) {
-    return Eigen::Matrix3d::Zero();
-  }
-
-  const Eigen::Matrix3d rotation
-      = normalizeOrIdentity(transform.orientation).toRotationMatrix();
-  const Eigen::Matrix3d worldInertia
-      = rotation * mass.inertia * rotation.transpose();
-  Eigen::LDLT<Eigen::Matrix3d> solver(worldInertia);
-  if (solver.info() != Eigen::Success || !solver.isPositive()) {
-    return Eigen::Matrix3d::Zero();
-  }
-  return solver.solve(Eigen::Matrix3d::Identity());
-}
-
-//==============================================================================
 bool hasContactNormalAngularTerm(const Eigen::Vector3d& normalArmCross)
 {
   return normalArmCross.x() != 0.0 || normalArmCross.y() != 0.0
@@ -176,32 +138,6 @@ bool needsContactInverseInertia(
     const Eigen::Vector3d& normalArmCross, const double friction)
 {
   return friction > 0.0 || hasContactNormalAngularTerm(normalArmCross);
-}
-
-//==============================================================================
-double restitutionOf(const comps::ContactMaterial* material)
-{
-  if (material != nullptr) {
-    return material->restitution;
-  }
-  return 0.0;
-}
-
-//==============================================================================
-double frictionOf(const comps::ContactMaterial* material)
-{
-  if (material != nullptr) {
-    return material->friction;
-  }
-  return 1.0;
-}
-
-//==============================================================================
-bool hasPrescribedRigidBodyContactResponse(
-    const detail::WorldRegistry& registry, entt::entity entity)
-{
-  return registry.all_of<comps::StaticBodyTag>(entity)
-         || registry.all_of<comps::KinematicBodyTag>(entity);
 }
 
 //==============================================================================
@@ -257,7 +193,7 @@ bool shouldSkipRigidBodyContactQuery(const World& world)
     }
 
     const bool prescribedResponse
-        = hasPrescribedRigidBodyContactResponse(registry, entity);
+        = detail::hasPrescribedRigidBodyContactResponse(registry, entity);
     if (!prescribedResponse) {
       if (!hasIgnoredCollisionPairs) {
         return false;
@@ -308,8 +244,9 @@ void resolveRigidBodyContactPositions(
     std::span<const Contact> contacts,
     double /*timeStep*/)
 {
-  constexpr double allowance = 1e-4;
-  constexpr double correctionFactor = 0.2;
+  constexpr double allowance = detail::kRigidContactPositionAllowance;
+  constexpr double correctionFactor
+      = detail::kRigidContactPositionCorrectionFactor;
   for (const auto& contact : contacts) {
     const auto entityA = detail::toRegistryEntity(contact.bodyA.getEntity());
     const auto entityB = detail::toRegistryEntity(contact.bodyB.getEntity());
@@ -324,15 +261,17 @@ void resolveRigidBodyContactPositions(
     }
 
     const bool staticA
-        = hasPrescribedRigidBodyContactResponse(registry, entityA);
+        = detail::hasPrescribedRigidBodyContactResponse(registry, entityA);
     const bool staticB
-        = hasPrescribedRigidBodyContactResponse(registry, entityB);
+        = detail::hasPrescribedRigidBodyContactResponse(registry, entityB);
     const double invMassA
         = staticA ? 0.0
-                  : inverseMass(registry.get<comps::MassProperties>(entityA));
+                  : detail::inverseMassOf(
+                        registry.get<comps::MassProperties>(entityA));
     const double invMassB
         = staticB ? 0.0
-                  : inverseMass(registry.get<comps::MassProperties>(entityB));
+                  : detail::inverseMassOf(
+                        registry.get<comps::MassProperties>(entityB));
     const double totalInverseMass = invMassA + invMassB;
     if (totalInverseMass <= 0.0) {
       continue;
@@ -443,8 +382,6 @@ struct RigidBodyContactStage::ContactScratch
   {
     entt::entity bodyA;
     entt::entity bodyB;
-    comps::Transform* transformA;
-    comps::Transform* transformB;
     comps::Velocity* velocityA;
     comps::Velocity* velocityB;
     Eigen::Vector3d normal;
@@ -949,21 +886,19 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
       continue;
     }
 
-    auto& transformA = registry.get<comps::Transform>(entityA);
-    auto& transformB = registry.get<comps::Transform>(entityB);
+    const auto& transformA = registry.get<comps::Transform>(entityA);
+    const auto& transformB = registry.get<comps::Transform>(entityB);
     const auto& massA = registry.get<comps::MassProperties>(entityA);
     const auto& massB = registry.get<comps::MassProperties>(entityB);
 
     const bool staticA
-        = hasPrescribedRigidBodyContactResponse(registry, entityA);
+        = detail::hasPrescribedRigidBodyContactResponse(registry, entityA);
     const bool staticB
-        = hasPrescribedRigidBodyContactResponse(registry, entityB);
+        = detail::hasPrescribedRigidBodyContactResponse(registry, entityB);
 
     ContactScratch::NormalConstraint constraint;
     constraint.bodyA = entityA;
     constraint.bodyB = entityB;
-    constraint.transformA = &transformA;
-    constraint.transformB = &transformB;
     constraint.normal = contact.normal;
     constraint.depth = contact.depth;
     constraint.staticA = staticA;
@@ -976,12 +911,10 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
     if (!staticB) {
       constraint.armB = contact.point - transformB.position;
     }
-    constraint.invMassA = staticA ? 0.0 : inverseMass(massA);
-    constraint.invMassB = staticB ? 0.0 : inverseMass(massB);
-    const auto* materialA = registry.try_get<comps::ContactMaterial>(entityA);
-    const auto* materialB = registry.try_get<comps::ContactMaterial>(entityB);
-    const double frictionProduct
-        = frictionOf(materialA) * frictionOf(materialB);
+    constraint.invMassA = staticA ? 0.0 : detail::inverseMassOf(massA);
+    constraint.invMassB = staticB ? 0.0 : detail::inverseMassOf(massB);
+    const double frictionProduct = detail::frictionOf(registry, entityA)
+                                   * detail::frictionOf(registry, entityB);
     constraint.friction
         = frictionProduct == 0.0 ? 0.0 : std::sqrt(frictionProduct);
 
@@ -1003,12 +936,14 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
         = !staticB
           && needsContactInverseInertia(
               constraint.normalArmCrossB, constraint.friction);
-    constraint.invInertiaA = needsInverseInertiaA
-                                 ? inverseWorldInertia(massA, transformA)
-                                 : Eigen::Matrix3d::Zero();
-    constraint.invInertiaB = needsInverseInertiaB
-                                 ? inverseWorldInertia(massB, transformB)
-                                 : Eigen::Matrix3d::Zero();
+    constraint.invInertiaA
+        = needsInverseInertiaA
+              ? detail::inverseWorldInertiaOf(massA, transformA)
+              : Eigen::Matrix3d::Zero();
+    constraint.invInertiaB
+        = needsInverseInertiaB
+              ? detail::inverseWorldInertiaOf(massB, transformB)
+              : Eigen::Matrix3d::Zero();
     constraint.normalLinearDeltaA = -constraint.invMassA * constraint.normal;
     constraint.normalLinearDeltaB = constraint.invMassB * constraint.normal;
     constraint.normalAngularDeltaA = Eigen::Vector3d::Zero();
@@ -1039,8 +974,9 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
 
     // Restitution target from the pre-solve approach velocity (the impact
     // speed). Combine the two materials by taking the larger bounce.
-    const double restitution
-        = std::max(restitutionOf(materialA), restitutionOf(materialB));
+    const double restitution = std::max(
+        detail::restitutionOf(registry, entityA),
+        detail::restitutionOf(registry, entityB));
     auto& velocityA = registry.get<comps::Velocity>(entityA);
     auto& velocityB = registry.get<comps::Velocity>(entityB);
     constraint.velocityA = &velocityA;
@@ -1209,31 +1145,7 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
     }
   }
 
-  // Positional correction (projection) removes residual penetration beyond a
-  // small allowance without injecting velocity, so resting stacks do not sink.
-  constexpr double allowance = 1e-4;
-  constexpr double correctionFactor = 0.2;
-  for (const auto& constraint : constraints) {
-    const double penetration = constraint.depth - allowance;
-    if (penetration <= 0.0) {
-      continue;
-    }
-
-    const double totalInverseMass = constraint.invMassA + constraint.invMassB;
-    if (totalInverseMass <= 0.0) {
-      continue;
-    }
-
-    const Eigen::Vector3d correction
-        = (correctionFactor * penetration / totalInverseMass)
-          * constraint.normal;
-    if (!constraint.staticA) {
-      constraint.transformA->position -= constraint.invMassA * correction;
-    }
-    if (!constraint.staticB) {
-      constraint.transformB->position += constraint.invMassB * correction;
-    }
-  }
+  resolveRigidBodyContactPositions(registry, contacts, world.getTimeStep());
 }
 
 //==============================================================================

--- a/dart/simulation/detail/rigid_contact/rigid_contact_assembly.hpp
+++ b/dart/simulation/detail/rigid_contact/rigid_contact_assembly.hpp
@@ -62,6 +62,12 @@ inline constexpr double kRigidContactRestitutionThreshold = 1e-3;
 /// differentiable capture mirrors it to match the forward boxed-LCP step.
 inline constexpr double kRigidContactFrictionCfm = 1e-5;
 
+/// Penetration depth below this allowance is left unprojected (meters).
+inline constexpr double kRigidContactPositionAllowance = 1e-4;
+
+/// Fraction of penetration beyond the allowance removed by position projection.
+inline constexpr double kRigidContactPositionCorrectionFactor = 0.2;
+
 /// Reciprocal of a finite, positive body mass; zero for static/degenerate mass.
 inline double inverseMassOf(const comps::MassProperties& mass)
 {

--- a/docs/design/batched_world_device_residency.md
+++ b/docs/design/batched_world_device_residency.md
@@ -128,6 +128,11 @@ Policy:
   precision control is needed, expose a backend-neutral policy value.
 - Claims about speedups must report whether transfer time is included and must
   compare against the double reference or explain the accepted tolerance.
+- Batched benchmark packets must record the resolved backend, resolved
+  precision, whether transfer time is included, lane count, step count, and the
+  resolved execution shape for every representative batched row. The Phase 5
+  CUDA packet checker enforces these fields for new batched evidence rows so a
+  timing result cannot be separated from its precision or transfer policy.
 
 ## Current Seeds
 

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -999,8 +999,8 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   integration families are genuinely distinct paths (final energy −18.2298 vs
   −18.2052). `test_cross_family_corpus` 1/1, golden 3/3, lint +
   `check-api-boundaries` green; pure-additive (no library change).
-  **Standalone harness + packet slice (implemented in the one-PR remaining
-  branch):** `tests/benchmark/simulation/bm_plan091_cross_family_corpus.cpp`
+  **Standalone harness + packet slice (pending acceptance in PR #3083):**
+  `tests/benchmark/simulation/bm_plan091_cross_family_corpus.cpp`
   runs the same registered cross-family row set as a standalone Google
   Benchmark target,
   `docs/plans/091-architecture-hardening/cross-family-metrics-corpus.json`
@@ -1307,9 +1307,9 @@ scripts/write_plan091_cross_family_metrics_packet.py --benchmark-json
   is included and what double-reference tolerance applies.
 - Gates: `pixi run lint`, `pixi run check-docs-policy`, packet checker tests.
 - Dependencies: WP-091.24, WP-091.33a.
-- Evidence (pending acceptance in the one-PR remaining branch): batched packet
-  rows now carry the resolved backend, precision, transfer-inclusion flag, lane
-  count, step count, and resolved execution shape through shared
+- Evidence (pending acceptance in PR #3083): batched packet rows now carry the
+  resolved backend, precision, transfer-inclusion flag, lane count, step count,
+  and resolved execution shape through shared
   `benchmark_packet_utils.batched_benchmark_row_schema_errors(...)`;
   `scripts/check_phase5_gpu_packet.py` rejects missing fields on the Phase 5
   CUDA representative CPU/GPU rows; `scripts/write_phase5_cuda_packet.py`

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -998,12 +998,28 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   `pendulum_2link` (integration axis); the 2-link case confirms the two
   integration families are genuinely distinct paths (final energy −18.2298 vs
   −18.2052). `test_cross_family_corpus` 1/1, golden 3/3, lint +
-  `check-api-boundaries` green; pure-additive (no library change). **Remaining:**
-  a standalone harness binary + manifest-driven packet writer (replacing the
-  per-scene script fleet) and the cross-family dashboard row set,
-  contact/iteration metric population (needs a non-const narrow-phase pass),
-  world-frame multibody-link momentum aggregation, and a corpus-wide
-  order-of-convergence sweep (this seeds it for one scene).
+  `check-api-boundaries` green; pure-additive (no library change).
+  **Standalone harness + packet slice (implemented in the one-PR remaining
+  branch):** `tests/benchmark/simulation/bm_plan091_cross_family_corpus.cpp`
+  runs the same registered cross-family row set as a standalone Google
+  Benchmark target,
+  `docs/plans/091-architecture-hardening/cross-family-metrics-corpus.json`
+  records the manifest of scene/family/invariant rows, and
+  `scripts/write_plan091_cross_family_metrics_packet.py` validates the
+  benchmark JSON into an evidence packet tagged with scene ID, resolved solver
+  identity, and public `World::computeStepMetrics()` counters. Focused
+  validation: `pixi run python -m pytest
+tests/test_plan091_cross_family_metrics_packet.py
+tests/test_benchmark_packet_utils.py -q` green; actual benchmark packet smoke:
+  `pixi run bm --target bm_plan091_cross_family_corpus -- ...` emitted all 8
+  rows and `pixi run python
+scripts/write_plan091_cross_family_metrics_packet.py --benchmark-json
+.benchmark_results/plan091/cross_family_metrics_benchmark.json --output
+.benchmark_results/plan091/cross_family_metrics_packet.json` accepted them.
+  **Remaining:** contact/iteration metric population (needs a non-const
+  narrow-phase pass), world-frame multibody-link momentum aggregation, and a
+  corpus-wide order-of-convergence sweep (the current convergence seed covers
+  one scene).
   NOTE: independent of this
   slice, the branch carries one **pre-existing** red test
   (`World.BakedDynamicRigidIpcStepsDoNotGrowWorldBaseAllocator`, an exact
@@ -1276,7 +1292,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   row `BM_CudaResidentRigidBodyStateBatchLinearRollout/4/256/1`) passed.
   Accepted by maintainer merge of PR #3061.
 
-#### WP-091.33e Precision and packet reporting
+#### WP-091.33e Precision and packet reporting [claimed]
 
 - Objective: batched benchmark and diagnostic packets report backend,
   precision, transfer inclusion, lane count, and resolved execution shape.
@@ -1291,6 +1307,17 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   is included and what double-reference tolerance applies.
 - Gates: `pixi run lint`, `pixi run check-docs-policy`, packet checker tests.
 - Dependencies: WP-091.24, WP-091.33a.
+- Evidence (pending acceptance in the one-PR remaining branch): batched packet
+  rows now carry the resolved backend, precision, transfer-inclusion flag, lane
+  count, step count, and resolved execution shape through shared
+  `benchmark_packet_utils.batched_benchmark_row_schema_errors(...)`;
+  `scripts/check_phase5_gpu_packet.py` rejects missing fields on the Phase 5
+  CUDA representative CPU/GPU rows; `scripts/write_phase5_cuda_packet.py`
+  annotates those rows from the resolved workload shape; and
+  `docs/design/batched_world_device_residency.md` records the policy that
+  timing claims cannot be separated from precision or transfer accounting.
+  Focused validation: `pixi run python -m pytest
+tests/test_benchmark_packet_utils.py -q` green.
 
 #### WP-091.34 Graph granularity policy [done — PR #3061, merged 2026-06-18]
 
@@ -1319,7 +1346,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
 
 ### WS4 — Facade and public API
 
-#### WP-091.40 Reserve general state-vector semantics [claimed]
+#### WP-091.40 Reserve general state-vector semantics [done — PR #3077, merged 2026-06-19]
 
 - Objective: the general names (`getNumDofs`, `getStateVector`,
   `getControlVector`) stop carrying a translational-rigid-only slice; the

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -622,6 +622,16 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   `kRigidContactRestitutionThreshold`, so the restitution threshold is now
   defined once across all four contact paths (golden 3/3, contact parity 5/5,
   boxed-LCP 122/122 unchanged).
+  **Safe shared-helper cleanup (pending acceptance in PR #3083):** the remaining
+  sequential-impulse local copies of the shared rigid-contact helper seam
+  (`inverseMassOf`, `inverseWorldInertiaOf`, material accessors, and prescribed
+  response classification) now route through
+  `detail/rigid_contact/rigid_contact_assembly.hpp`. The two positional
+  projection constants (`1e-4` allowance, `0.2` correction factor) now live next
+  to the rigid-contact constants in that shared header, and both the standalone
+  projection helper and the sequential path call the same projection helper
+  instead of keeping duplicate loops. Behavior-preserving cleanup only; the
+  four assembler layouts still remain distinct.
   **Slice B (remaining):** converge the four contact-problem _assemblers_ (the
   canonical `RigidBodyContactProblem` producer, the boxed-LCP assembly, the
   differentiable-capture rebuild, and the sequential-impulse scratch in

--- a/docs/plans/091-architecture-hardening/cross-family-metrics-corpus.json
+++ b/docs/plans/091-architecture-hardening/cross-family-metrics-corpus.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "packet_name": "plan091_cross_family_metrics_packet",
+  "rows": [
+    {
+      "row_id": "rigid_head_on__sequential_impulse",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/rigid_head_on_sequential_impulse",
+      "scene_id": "rigid_head_on",
+      "family_axis": "rigid-contact",
+      "resolved_solver_identity": "rigid-contact:sequential-impulse",
+      "invariant": "conserves-linear-momentum"
+    },
+    {
+      "row_id": "rigid_head_on__boxed_lcp",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/rigid_head_on_boxed_lcp",
+      "scene_id": "rigid_head_on",
+      "family_axis": "rigid-contact",
+      "resolved_solver_identity": "rigid-contact:boxed-lcp",
+      "invariant": "conserves-linear-momentum"
+    },
+    {
+      "row_id": "sphere_drop__sequential_impulse",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/sphere_drop_sequential_impulse",
+      "scene_id": "sphere_drop",
+      "family_axis": "rigid-contact",
+      "resolved_solver_identity": "rigid-contact:sequential-impulse",
+      "invariant": "settles-on-static-support"
+    },
+    {
+      "row_id": "sphere_drop__boxed_lcp",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/sphere_drop_boxed_lcp",
+      "scene_id": "sphere_drop",
+      "family_axis": "rigid-contact",
+      "resolved_solver_identity": "rigid-contact:boxed-lcp",
+      "invariant": "settles-on-static-support"
+    },
+    {
+      "row_id": "pendulum_1link__semi_implicit",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/pendulum_1link_semi_implicit",
+      "scene_id": "pendulum_1link",
+      "family_axis": "multibody-integration",
+      "resolved_solver_identity": "multibody:semi-implicit",
+      "invariant": "conserves-total-energy"
+    },
+    {
+      "row_id": "pendulum_1link__variational",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/pendulum_1link_variational",
+      "scene_id": "pendulum_1link",
+      "family_axis": "multibody-integration",
+      "resolved_solver_identity": "multibody:variational",
+      "invariant": "conserves-total-energy"
+    },
+    {
+      "row_id": "pendulum_2link__semi_implicit",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/pendulum_2link_semi_implicit",
+      "scene_id": "pendulum_2link",
+      "family_axis": "multibody-integration",
+      "resolved_solver_identity": "multibody:semi-implicit",
+      "invariant": "conserves-total-energy"
+    },
+    {
+      "row_id": "pendulum_2link__variational",
+      "benchmark": "BM_Plan091CrossFamilyCorpus/pendulum_2link_variational",
+      "scene_id": "pendulum_2link",
+      "family_axis": "multibody-integration",
+      "resolved_solver_identity": "multibody:variational",
+      "invariant": "conserves-total-energy"
+    }
+  ]
+}

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -34,7 +34,8 @@ its own line so status updates remain git-history friendly.
   WP-091.13 and WP-091.24 still have partial landed evidence under
   `[claimed]` headings, so they require orchestrator release or split
   follow-up packets before executor pickup; PR #3083 adds the WP-091.24
-  standalone cross-family metrics harness/packet slice while leaving the risky
+  standalone cross-family metrics harness/packet slice plus a bounded
+  WP-091.13 shared-helper/projection-constant cleanup while leaving the risky
   contact/iteration and multibody-momentum metric semantics explicit.
   WP-091.33e is claimed in PR #3083 for the batched precision/transfer
   packet-reporting checker.

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -33,11 +33,11 @@ its own line so status updates remain git-history friendly.
   recorded maintainer direction.
   WP-091.13 and WP-091.24 still have partial landed evidence under
   `[claimed]` headings, so they require orchestrator release or split
-  follow-up packets before executor pickup; the one-PR remaining branch adds
-  the WP-091.24 standalone cross-family metrics harness/packet slice while
-  leaving the risky contact/iteration and multibody-momentum metric semantics
-  explicit. WP-091.33e is claimed on the same remaining branch for the batched
-  precision/transfer packet-reporting checker.
+  follow-up packets before executor pickup; PR #3083 adds the WP-091.24
+  standalone cross-family metrics harness/packet slice while leaving the risky
+  contact/iteration and multibody-momentum metric semantics explicit.
+  WP-091.33e is claimed in PR #3083 for the batched precision/transfer
+  packet-reporting checker.
   Packets are orchestrator-authored per
   [`../ai/orchestration.md`](../ai/orchestration.md) and picked up via
   `dart-execute-packet`; availability follows each packet's own Dependencies

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -27,14 +27,17 @@ its own line so status updates remain git-history friendly.
   PR #3020; WP-091.20, WP-091.22, WP-091.30, and WP-091.33 via PR #3029;
   WP-091.33a via PR #3042; WP-091.21 via PR #3044; WP-091.31, WP-091.33b, and
   WP-091.33c via PR #3052; WP-091.32 via PR #3058; WP-091.33d plus WP-091.34
-  via PR #3061; WP-091.15 via PR #3067; and WP-091.41 through WP-091.44 via
-  PR #3072. The remaining WS0 packet is WP-091.4 legacy freeze, which stays
-  **blocked**: PLAN-042 Decision 5 has no recorded maintainer direction.
+  via PR #3061; WP-091.15 via PR #3067; WP-091.40 via PR #3077; and
+  WP-091.41 through WP-091.44 via PR #3072. The remaining WS0 packet is
+  WP-091.4 legacy freeze, which stays **blocked**: PLAN-042 Decision 5 has no
+  recorded maintainer direction.
   WP-091.13 and WP-091.24 still have partial landed evidence under
   `[claimed]` headings, so they require orchestrator release or split
-  follow-up packets before executor pickup. WP-091.33e waits on WP-091.24.
-  WP-091.40 is claimed on the final WS4 branch after recording the scoped
-  rigid-body naming decision in the packet.
+  follow-up packets before executor pickup; the one-PR remaining branch adds
+  the WP-091.24 standalone cross-family metrics harness/packet slice while
+  leaving the risky contact/iteration and multibody-momentum metric semantics
+  explicit. WP-091.33e is claimed on the same remaining branch for the batched
+  precision/transfer packet-reporting checker.
   Packets are orchestrator-authored per
   [`../ai/orchestration.md`](../ai/orchestration.md) and picked up via
   `dart-execute-packet`; availability follows each packet's own Dependencies

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -1035,15 +1035,15 @@ pixi run py-demo-capture -- --scene rigid_ipc_pile --frames 72 \
 For targeted reruns after a failed or manually inspected row, keep the same
 workflow packet but bound the row range. Row numbers stay absolute, so row 37
 still writes under `scenes/37_<scene>` when related evidence is included. With
-`--include-related --include-packets`, rows 44-45 are the two
+`--include-related --include-packets`, rows 49-50 are the two
 capture-first stack packets. If `--include-ipc-shelf` is also requested, those
-packet rows become 48-49.
+packet rows become 53-54.
 
 ```bash
 pixi run py-demo-capture -- --rigid-workflow \
     --workflow-start-row 15 --workflow-end-row 17 --dry-run
 pixi run py-demo-capture -- --rigid-workflow --include-related \
-    --include-packets --workflow-start-row 44 --workflow-end-row 45 \
+    --include-packets --workflow-start-row 49 --workflow-end-row 50 \
     --output-dir /tmp/dart_capture_rigid_workflow_packet_rerun
 ```
 
@@ -1223,6 +1223,16 @@ pixi run py-demo-capture -- --scene rigid_ipc_edge_drop --frames 72 \
 pixi run py-demo-capture -- --scene diff_drone_liftoff --frames 96 \
     --width 960 --height 540 --show-ui
 pixi run py-demo-capture -- --scene diff_pre_contact_surrogate --frames 24 \
+    --width 960 --height 540 --show-ui
+pixi run py-demo-capture -- --scene avbd_rigid_fixed_joint_contact --frames 72 \
+    --width 960 --height 540 --show-ui
+pixi run py-demo-capture -- --scene avbd_rigid_breakable_joint --frames 72 \
+    --width 960 --height 540 --show-ui
+pixi run py-demo-capture -- --scene avbd_rigid_spherical_breakable_joint \
+    --frames 72 --width 960 --height 540 --show-ui
+pixi run py-demo-capture -- --scene avbd_rigid_revolute_motor --frames 72 \
+    --width 960 --height 540 --show-ui
+pixi run py-demo-capture -- --scene avbd_rigid_prismatic_motor --frames 72 \
     --width 960 --height 540 --show-ui
 ```
 

--- a/python/tests/unit/test_check_phase5_gpu_packet.py
+++ b/python/tests/unit/test_check_phase5_gpu_packet.py
@@ -22,7 +22,15 @@ def _load_module():
     return module
 
 
-def _median_row(name, real_time):
+def _median_row(
+    name,
+    real_time,
+    *,
+    backend="cpu",
+    includes_transfer_time=False,
+    lane_count=4096,
+    step_count=100,
+):
     return {
         "name": f"{name}_median",
         "run_name": f"{name}_median",
@@ -30,6 +38,12 @@ def _median_row(name, real_time):
         "aggregate_name": "median",
         "real_time": real_time,
         "time_unit": "ms",
+        "backend": backend,
+        "precision": "double-reference",
+        "includes_transfer_time": includes_transfer_time,
+        "lane_count": lane_count,
+        "resolved_execution_shape": "homogeneous-batch",
+        "step_count": step_count,
     }
 
 
@@ -50,8 +64,15 @@ def _packet(*, cpu_ms=100.0, gpu_ms=70.0, max_error=1e-12, world_count=4096):
             _median_row(
                 f"BM_Phase5RigidBodyBatchCpuBaseline/{world_count}/128/100",
                 cpu_ms,
+                lane_count=world_count,
             ),
-            _median_row(f"BM_Phase5RigidBodyBatchGpu/{world_count}/128/100", gpu_ms),
+            _median_row(
+                f"BM_Phase5RigidBodyBatchGpu/{world_count}/128/100",
+                gpu_ms,
+                backend="cuda",
+                includes_transfer_time=True,
+                lane_count=world_count,
+            ),
         ],
     }
 

--- a/python/tests/unit/test_check_phase5_gpu_packet.py
+++ b/python/tests/unit/test_check_phase5_gpu_packet.py
@@ -147,6 +147,26 @@ def test_validate_packet_rejects_non_median_rows():
         module.validate_packet(packet)
 
 
+def test_validate_packet_rejects_unannotated_representative_raw_row():
+    module = _load_module()
+    packet = _packet()
+    packet["benchmarks"].insert(
+        0,
+        {
+            "name": f"{CPU_ROW}/repeats:3",
+            "run_name": f"{CPU_ROW}/repeats:3",
+            "real_time": 100.0,
+            "time_unit": "ms",
+        },
+    )
+
+    with pytest.raises(
+        module.Phase5PacketError,
+        match="backend must be a non-empty string",
+    ):
+        module.validate_packet(packet)
+
+
 def test_validate_packet_rejects_small_world_count():
     module = _load_module()
 

--- a/scripts/benchmark_packet_utils.py
+++ b/scripts/benchmark_packet_utils.py
@@ -34,7 +34,7 @@ def benchmark_timing_ns(row: Mapping[str, Any]) -> float:
         return math.nan
     try:
         return timing_to_ns(float(value), str(row.get("time_unit", "ns")))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):  # fmt: skip
         return math.nan
 
 

--- a/scripts/benchmark_packet_utils.py
+++ b/scripts/benchmark_packet_utils.py
@@ -116,3 +116,42 @@ def benchmark_packet_timing_schema_errors(
                 f"must be finite and non-negative"
             )
     return errors
+
+
+def batched_benchmark_row_schema_errors(
+    row: Mapping[str, Any], packet_name: str
+) -> list[str]:
+    """Return schema errors for a PLAN-091 batched benchmark packet row."""
+
+    errors: list[str] = []
+    backend = row.get("backend")
+    if not isinstance(backend, str) or not backend:
+        errors.append(f"{packet_name}.backend must be a non-empty string")
+
+    precision = row.get("precision")
+    if not isinstance(precision, str) or not precision:
+        errors.append(f"{packet_name}.precision must be a non-empty string")
+
+    includes_transfer_time = row.get("includes_transfer_time")
+    if not isinstance(includes_transfer_time, bool):
+        errors.append(f"{packet_name}.includes_transfer_time must be a boolean")
+
+    lane_count = row.get("lane_count")
+    if not isinstance(lane_count, int) or isinstance(lane_count, bool):
+        errors.append(f"{packet_name}.lane_count must be an integer")
+    elif lane_count <= 0:
+        errors.append(f"{packet_name}.lane_count must be positive")
+
+    execution_shape = row.get("resolved_execution_shape")
+    if not isinstance(execution_shape, str) or not execution_shape:
+        errors.append(
+            f"{packet_name}.resolved_execution_shape must be a non-empty string"
+        )
+
+    step_count = row.get("step_count")
+    if not isinstance(step_count, int) or isinstance(step_count, bool):
+        errors.append(f"{packet_name}.step_count must be an integer")
+    elif step_count <= 0:
+        errors.append(f"{packet_name}.step_count must be positive")
+
+    return errors

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -332,6 +332,11 @@ RIGID_WORKFLOW_RELATED_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("rigid_ipc_edge_drop", 72, 960, 540, True),
     ("diff_drone_liftoff", 96, 960, 540, True),
     ("diff_pre_contact_surrogate", 24, 960, 540, True),
+    ("avbd_rigid_fixed_joint_contact", 72, 960, 540, True),
+    ("avbd_rigid_breakable_joint", 72, 960, 540, True),
+    ("avbd_rigid_spherical_breakable_joint", 72, 960, 540, True),
+    ("avbd_rigid_revolute_motor", 72, 960, 540, True),
+    ("avbd_rigid_prismatic_motor", 72, 960, 540, True),
 )
 
 

--- a/scripts/check_phase5_gpu_packet.py
+++ b/scripts/check_phase5_gpu_packet.py
@@ -311,6 +311,20 @@ def _median_rows_by_name(rows: list) -> dict[str, dict]:
     return median_rows
 
 
+def _representative_rows_by_name(
+    rows: list,
+    names: tuple[str, str],
+) -> dict[str, list[dict]]:
+    representative_rows = {name: [] for name in names}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = canonical_benchmark_name(benchmark_row_name(row))
+        if name in representative_rows:
+            representative_rows[name].append(row)
+    return representative_rows
+
+
 def validate_packet(
     data: dict,
     *,
@@ -345,42 +359,48 @@ def validate_packet(
     if missing:
         raise Phase5PacketError("missing median benchmark rows: " + ", ".join(missing))
 
+    representative_rows = _representative_rows_by_name(rows, (cpu_name, gpu_name))
     timings: dict[str, float] = {}
-    for name, expected_backend in ((cpu_name, "cpu"), (gpu_name, "cuda")):
-        row = median_rows[name]
-        errors = batched_benchmark_row_schema_errors(
-            row, f"phase5_gpu_packet.benchmarks[{name}]"
-        )
-        if errors:
-            raise Phase5PacketError(errors[0])
-        if row["backend"] != expected_backend:
-            raise Phase5PacketError(
-                f"phase5_gpu_packet.benchmarks[{name}].backend must be "
-                f"{expected_backend!r}"
+    expected_rows = (
+        (cpu_name, "cpu", False),
+        (gpu_name, "cuda", True),
+    )
+    for name, expected_backend, expected_transfer_time in expected_rows:
+        for row in representative_rows[name]:
+            errors = batched_benchmark_row_schema_errors(
+                row, f"phase5_gpu_packet.benchmarks[{name}]"
             )
-        if row["lane_count"] != world_count:
-            raise Phase5PacketError(
-                f"phase5_gpu_packet.benchmarks[{name}].lane_count must match "
-                "phase5_gpu_packet.world_count"
-            )
-        if row["step_count"] != actual_step_count:
-            raise Phase5PacketError(
-                f"phase5_gpu_packet.benchmarks[{name}].step_count must match "
-                "phase5_gpu_packet.step_count"
-            )
-        timing = benchmark_timing_ns(row)
+            if errors:
+                raise Phase5PacketError(errors[0])
+            if row["backend"] != expected_backend:
+                raise Phase5PacketError(
+                    f"phase5_gpu_packet.benchmarks[{name}].backend must be "
+                    f"{expected_backend!r}"
+                )
+            if row["includes_transfer_time"] is not expected_transfer_time:
+                raise Phase5PacketError(
+                    f"phase5_gpu_packet.benchmarks[{name}].includes_transfer_time "
+                    f"must be {expected_transfer_time!r}"
+                )
+            if row["lane_count"] != world_count:
+                raise Phase5PacketError(
+                    f"phase5_gpu_packet.benchmarks[{name}].lane_count must match "
+                    "phase5_gpu_packet.world_count"
+                )
+            if row["step_count"] != actual_step_count:
+                raise Phase5PacketError(
+                    f"phase5_gpu_packet.benchmarks[{name}].step_count must match "
+                    "phase5_gpu_packet.step_count"
+                )
+
+        median_row = median_rows[name]
+        timing = benchmark_timing_ns(median_row)
         if not math.isfinite(timing) or timing <= 0.0:
             raise Phase5PacketError(
                 f"phase5_gpu_packet.benchmarks[{name}] median timing must be "
                 "finite and positive"
             )
         timings[name] = timing
-    gpu_row = median_rows[gpu_name]
-    if not gpu_row["includes_transfer_time"]:
-        raise Phase5PacketError(
-            f"phase5_gpu_packet.benchmarks[{gpu_name}].includes_transfer_time "
-            "must be true for the full GPU workload"
-        )
 
     cpu_ns = timings[cpu_name]
     gpu_ns = timings[gpu_name]

--- a/scripts/check_phase5_gpu_packet.py
+++ b/scripts/check_phase5_gpu_packet.py
@@ -37,7 +37,10 @@ import sys
 from pathlib import Path
 
 from benchmark_packet_utils import (
+    batched_benchmark_row_schema_errors,
     benchmark_packet_timing_schema_errors,
+    benchmark_row_name,
+    canonical_benchmark_name,
     median_timing_by_name,
 )
 
@@ -203,6 +206,12 @@ def make_packet_template(
                 "aggregate_name": "median",
                 "real_time": None,
                 "time_unit": "ms",
+                "backend": "cpu",
+                "precision": "double-reference",
+                "includes_transfer_time": False,
+                "lane_count": world_count,
+                "resolved_execution_shape": "homogeneous-batch",
+                "step_count": step_count,
             },
             {
                 "name": gpu_name,
@@ -211,6 +220,12 @@ def make_packet_template(
                 "aggregate_name": "median",
                 "real_time": None,
                 "time_unit": "ms",
+                "backend": "cuda",
+                "precision": "double-reference",
+                "includes_transfer_time": True,
+                "lane_count": world_count,
+                "resolved_execution_shape": "homogeneous-batch",
+                "step_count": step_count,
             },
         ],
     }
@@ -274,6 +289,17 @@ def _validate_metadata(
     return world_count, actual_body_count, actual_step_count, max_error
 
 
+def _find_median_row(rows: list, canonical_name: str) -> dict | None:
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get("aggregate_name") != "median":
+            continue
+        if canonical_benchmark_name(benchmark_row_name(row)) == canonical_name:
+            return row
+    return None
+
+
 def validate_packet(
     data: dict,
     *,
@@ -307,6 +333,32 @@ def validate_packet(
     missing = [name for name in (cpu_name, gpu_name) if name not in timings]
     if missing:
         raise Phase5PacketError("missing median benchmark rows: " + ", ".join(missing))
+
+    for name in (cpu_name, gpu_name):
+        row = _find_median_row(rows, name)
+        if row is None:
+            raise Phase5PacketError(f"missing median benchmark row: {name}")
+        errors = batched_benchmark_row_schema_errors(
+            row, f"phase5_gpu_packet.benchmarks[{name}]"
+        )
+        if errors:
+            raise Phase5PacketError(errors[0])
+        if row["lane_count"] != world_count:
+            raise Phase5PacketError(
+                f"phase5_gpu_packet.benchmarks[{name}].lane_count must match "
+                "phase5_gpu_packet.world_count"
+            )
+        if row["step_count"] != actual_step_count:
+            raise Phase5PacketError(
+                f"phase5_gpu_packet.benchmarks[{name}].step_count must match "
+                "phase5_gpu_packet.step_count"
+            )
+    gpu_row = _find_median_row(rows, gpu_name)
+    if not gpu_row["includes_transfer_time"]:
+        raise Phase5PacketError(
+            f"phase5_gpu_packet.benchmarks[{gpu_name}].includes_transfer_time "
+            "must be true for the full GPU workload"
+        )
 
     cpu_ns = timings[cpu_name]
     gpu_ns = timings[gpu_name]

--- a/scripts/check_phase5_gpu_packet.py
+++ b/scripts/check_phase5_gpu_packet.py
@@ -334,7 +334,7 @@ def validate_packet(
     if missing:
         raise Phase5PacketError("missing median benchmark rows: " + ", ".join(missing))
 
-    for name in (cpu_name, gpu_name):
+    for name, expected_backend in ((cpu_name, "cpu"), (gpu_name, "cuda")):
         row = _find_median_row(rows, name)
         if row is None:
             raise Phase5PacketError(f"missing median benchmark row: {name}")
@@ -343,6 +343,11 @@ def validate_packet(
         )
         if errors:
             raise Phase5PacketError(errors[0])
+        if row["backend"] != expected_backend:
+            raise Phase5PacketError(
+                f"phase5_gpu_packet.benchmarks[{name}].backend must be "
+                f"{expected_backend!r}"
+            )
         if row["lane_count"] != world_count:
             raise Phase5PacketError(
                 f"phase5_gpu_packet.benchmarks[{name}].lane_count must match "

--- a/scripts/check_phase5_gpu_packet.py
+++ b/scripts/check_phase5_gpu_packet.py
@@ -40,8 +40,8 @@ from benchmark_packet_utils import (
     batched_benchmark_row_schema_errors,
     benchmark_packet_timing_schema_errors,
     benchmark_row_name,
+    benchmark_timing_ns,
     canonical_benchmark_name,
-    median_timing_by_name,
 )
 
 DEFAULT_CPU_PREFIX = "BM_Phase5RigidBodyBatchCpuBaseline"
@@ -289,15 +289,26 @@ def _validate_metadata(
     return world_count, actual_body_count, actual_step_count, max_error
 
 
-def _find_median_row(rows: list, canonical_name: str) -> dict | None:
+def _median_rows_by_name(rows: list) -> dict[str, dict]:
+    median_rows: dict[str, dict] = {}
+    duplicates: set[str] = set()
     for row in rows:
         if not isinstance(row, dict):
             continue
         if row.get("aggregate_name") != "median":
             continue
-        if canonical_benchmark_name(benchmark_row_name(row)) == canonical_name:
-            return row
-    return None
+        name = canonical_benchmark_name(benchmark_row_name(row))
+        if not name:
+            continue
+        if name in median_rows:
+            duplicates.add(name)
+            continue
+        median_rows[name] = row
+    if duplicates:
+        raise Phase5PacketError(
+            "duplicate median benchmark rows: " + ", ".join(sorted(duplicates))
+        )
+    return median_rows
 
 
 def validate_packet(
@@ -329,15 +340,14 @@ def validate_packet(
 
     cpu_name = f"{cpu_prefix}/{world_count}/{actual_body_count}/{actual_step_count}"
     gpu_name = f"{gpu_prefix}/{world_count}/{actual_body_count}/{actual_step_count}"
-    timings = median_timing_by_name(rows)
-    missing = [name for name in (cpu_name, gpu_name) if name not in timings]
+    median_rows = _median_rows_by_name(rows)
+    missing = [name for name in (cpu_name, gpu_name) if name not in median_rows]
     if missing:
         raise Phase5PacketError("missing median benchmark rows: " + ", ".join(missing))
 
+    timings: dict[str, float] = {}
     for name, expected_backend in ((cpu_name, "cpu"), (gpu_name, "cuda")):
-        row = _find_median_row(rows, name)
-        if row is None:
-            raise Phase5PacketError(f"missing median benchmark row: {name}")
+        row = median_rows[name]
         errors = batched_benchmark_row_schema_errors(
             row, f"phase5_gpu_packet.benchmarks[{name}]"
         )
@@ -358,7 +368,14 @@ def validate_packet(
                 f"phase5_gpu_packet.benchmarks[{name}].step_count must match "
                 "phase5_gpu_packet.step_count"
             )
-    gpu_row = _find_median_row(rows, gpu_name)
+        timing = benchmark_timing_ns(row)
+        if not math.isfinite(timing) or timing <= 0.0:
+            raise Phase5PacketError(
+                f"phase5_gpu_packet.benchmarks[{name}] median timing must be "
+                "finite and positive"
+            )
+        timings[name] = timing
+    gpu_row = median_rows[gpu_name]
     if not gpu_row["includes_transfer_time"]:
         raise Phase5PacketError(
             f"phase5_gpu_packet.benchmarks[{gpu_name}].includes_transfer_time "

--- a/scripts/write_phase5_cuda_packet.py
+++ b/scripts/write_phase5_cuda_packet.py
@@ -182,6 +182,69 @@ def extract_max_final_state_abs_error(
     )
 
 
+def _annotate_batched_row(
+    row: dict,
+    *,
+    backend: str,
+    includes_transfer_time: bool,
+    world_count: int,
+    step_count: int,
+) -> dict:
+    annotated = dict(row)
+    annotated.update(
+        {
+            "backend": backend,
+            "precision": "double-reference",
+            "includes_transfer_time": includes_transfer_time,
+            "lane_count": world_count,
+            "resolved_execution_shape": "homogeneous-batch",
+            "step_count": step_count,
+        }
+    )
+    return annotated
+
+
+def annotate_representative_rows(
+    rows: list[dict],
+    args: argparse.Namespace,
+) -> list[dict]:
+    cpu_target = (
+        f"{args.cpu_prefix}/{args.world_count}/{args.body_count}/{args.step_count}"
+    )
+    gpu_target = (
+        f"{args.gpu_prefix}/{args.world_count}/{args.body_count}/{args.step_count}"
+    )
+    annotated_rows: list[dict] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            annotated_rows.append(row)
+            continue
+        name = _canonical_name(_row_name(row))
+        if row.get("aggregate_name") == "median" and name == cpu_target:
+            annotated_rows.append(
+                _annotate_batched_row(
+                    row,
+                    backend="cpu",
+                    includes_transfer_time=False,
+                    world_count=args.world_count,
+                    step_count=args.step_count,
+                )
+            )
+        elif row.get("aggregate_name") == "median" and name == gpu_target:
+            annotated_rows.append(
+                _annotate_batched_row(
+                    row,
+                    backend="cuda",
+                    includes_transfer_time=args.includes_transfer_setup_compute_readback,
+                    world_count=args.world_count,
+                    step_count=args.step_count,
+                )
+            )
+        else:
+            annotated_rows.append(dict(row))
+    return annotated_rows
+
+
 def make_packet(data: dict, args: argparse.Namespace) -> dict:
     rows = data["benchmarks"]
     max_error = extract_max_final_state_abs_error(
@@ -209,7 +272,7 @@ def make_packet(data: dict, args: argparse.Namespace) -> dict:
             ),
             "phase5_benchmark_contract_passed": (args.phase5_benchmark_contract_passed),
         },
-        "benchmarks": rows,
+        "benchmarks": annotate_representative_rows(rows, args),
     }
 
 

--- a/scripts/write_phase5_cuda_packet.py
+++ b/scripts/write_phase5_cuda_packet.py
@@ -220,7 +220,7 @@ def annotate_representative_rows(
             annotated_rows.append(row)
             continue
         name = _canonical_name(_row_name(row))
-        if row.get("aggregate_name") == "median" and name == cpu_target:
+        if name == cpu_target:
             annotated_rows.append(
                 _annotate_batched_row(
                     row,
@@ -230,7 +230,7 @@ def annotate_representative_rows(
                     step_count=args.step_count,
                 )
             )
-        elif row.get("aggregate_name") == "median" and name == gpu_target:
+        elif name == gpu_target:
             annotated_rows.append(
                 _annotate_batched_row(
                     row,

--- a/scripts/write_plan091_cross_family_metrics_packet.py
+++ b/scripts/write_plan091_cross_family_metrics_packet.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Write a PLAN-091 cross-family metrics packet from benchmark JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from benchmark_packet_utils import (  # noqa: E402
+    benchmark_row_name,
+    benchmark_timing_field_errors,
+    canonical_benchmark_name,
+)
+
+DEFAULT_MANIFEST = Path(
+    "docs/plans/091-architecture-hardening/cross-family-metrics-corpus.json"
+)
+DEFAULT_OUTPUT = Path(".benchmark_results/plan091/cross_family_metrics_packet.json")
+PACKET_KEY = "plan091_cross_family_metrics_packet"
+
+REQUIRED_METRIC_COUNTERS = (
+    "step_count",
+    "kinetic_energy",
+    "potential_energy",
+    "total_energy",
+    "linear_momentum_x",
+    "linear_momentum_y",
+    "linear_momentum_z",
+    "angular_momentum_x",
+    "angular_momentum_y",
+    "angular_momentum_z",
+    "active_contact_count",
+    "max_penetration_depth",
+    "last_step_iterations",
+    "last_step_residual",
+)
+
+
+class Plan091CrossFamilyPacketError(RuntimeError):
+    pass
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--benchmark-json",
+        type=Path,
+        required=True,
+        help="Google Benchmark JSON from bm_plan091_cross_family_corpus.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help=f"Expected corpus manifest (default: {DEFAULT_MANIFEST}).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output packet JSON path (default: {DEFAULT_OUTPUT}).",
+    )
+    return parser.parse_args(list(argv))
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        data = json.load(stream)
+    if not isinstance(data, dict):
+        raise Plan091CrossFamilyPacketError(f"{path} root must be a JSON object")
+    return data
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    manifest = _load_json(path)
+    rows = manifest.get("rows")
+    if not isinstance(rows, list) or not rows:
+        raise Plan091CrossFamilyPacketError(f"{path} has no manifest rows")
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise Plan091CrossFamilyPacketError(
+                f"{path}.rows[{index}] must be an object"
+            )
+        for field in (
+            "row_id",
+            "benchmark",
+            "scene_id",
+            "family_axis",
+            "resolved_solver_identity",
+            "invariant",
+        ):
+            if not isinstance(row.get(field), str) or not row[field]:
+                raise Plan091CrossFamilyPacketError(
+                    f"{path}.rows[{index}].{field} must be a non-empty string"
+                )
+    return manifest
+
+
+def _finite_number(row: Mapping[str, Any], field: str) -> float | None:
+    value = row.get(field)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    value = float(value)
+    return value if math.isfinite(value) else None
+
+
+def _metric_counters(row: Mapping[str, Any], name: str) -> dict[str, float]:
+    counters: dict[str, float] = {}
+    missing: list[str] = []
+    for field in REQUIRED_METRIC_COUNTERS:
+        value = _finite_number(row, field)
+        if value is None:
+            missing.append(field)
+        else:
+            counters[field] = value
+    if missing:
+        raise Plan091CrossFamilyPacketError(
+            f"{name} is missing finite StepMetrics counters: " + ", ".join(missing)
+        )
+    if counters["step_count"] <= 0:
+        raise Plan091CrossFamilyPacketError(f"{name}.step_count must be positive")
+    if counters["active_contact_count"] < 0:
+        raise Plan091CrossFamilyPacketError(
+            f"{name}.active_contact_count must be non-negative"
+        )
+    if counters["max_penetration_depth"] < 0.0:
+        raise Plan091CrossFamilyPacketError(
+            f"{name}.max_penetration_depth must be non-negative"
+        )
+    if counters["last_step_iterations"] < 0:
+        raise Plan091CrossFamilyPacketError(
+            f"{name}.last_step_iterations must be non-negative"
+        )
+    if counters["last_step_residual"] < 0.0:
+        raise Plan091CrossFamilyPacketError(
+            f"{name}.last_step_residual must be non-negative"
+        )
+    return counters
+
+
+def _rows_by_canonical_name(rows: list[Any]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        aggregate_name = row.get("aggregate_name")
+        if aggregate_name not in {None, "median"}:
+            continue
+        name = canonical_benchmark_name(benchmark_row_name(row))
+        if not name:
+            continue
+        if aggregate_name == "median" or name not in result:
+            result[name] = row
+    return result
+
+
+def make_packet(
+    benchmark_data: dict[str, Any], manifest: dict[str, Any]
+) -> dict[str, Any]:
+    rows = benchmark_data.get("benchmarks")
+    if not isinstance(rows, list):
+        raise Plan091CrossFamilyPacketError(
+            "benchmark JSON is missing a benchmark row list"
+        )
+
+    by_name = _rows_by_canonical_name(rows)
+    packet_rows: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for manifest_row in manifest["rows"]:
+        benchmark_name = manifest_row["benchmark"]
+        benchmark_row = by_name.get(benchmark_name)
+        if benchmark_row is None:
+            errors.append(f"missing benchmark row: {benchmark_name}")
+            continue
+        errors.extend(benchmark_timing_field_errors(benchmark_row, benchmark_name))
+        counters = _metric_counters(benchmark_row, benchmark_name)
+        packet_rows.append(
+            {
+                "row_id": manifest_row["row_id"],
+                "scene_id": manifest_row["scene_id"],
+                "family_axis": manifest_row["family_axis"],
+                "resolved_solver_identity": manifest_row["resolved_solver_identity"],
+                "invariant": manifest_row["invariant"],
+                "benchmark": benchmark_name,
+                "metrics": counters,
+            }
+        )
+
+    if errors:
+        raise Plan091CrossFamilyPacketError("\n".join(errors))
+
+    return {
+        PACKET_KEY: {
+            "schema_version": int(manifest.get("schema_version", 1)),
+            "metric_source": "dart::simulation::World::computeStepMetrics",
+            "row_count": len(packet_rows),
+            "rows": packet_rows,
+        },
+        "benchmarks": rows,
+    }
+
+
+def write_packet(path: Path, packet: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(packet, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    try:
+        packet = make_packet(
+            _load_json(args.benchmark_json), load_manifest(args.manifest)
+        )
+    except Plan091CrossFamilyPacketError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    write_packet(args.output, packet)
+    print(
+        "Wrote PLAN-091 cross-family metrics packet: "
+        f"{args.output} ({packet[PACKET_KEY]['row_count']} rows)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/benchmark/simulation/CMakeLists.txt
+++ b/tests/benchmark/simulation/CMakeLists.txt
@@ -70,6 +70,11 @@ if(DART_SIMULATION_BUILD_BENCHMARKS)
   )
 
   dart_add_simulation_benchmark(
+    bm_plan091_cross_family_corpus
+    ${CMAKE_CURRENT_SOURCE_DIR}/bm_plan091_cross_family_corpus.cpp
+  )
+
+  dart_add_simulation_benchmark(
     bm_vbd_vertex_block_kernel
     ${CMAKE_CURRENT_SOURCE_DIR}/bm_vbd_vertex_block_kernel.cpp
   )

--- a/tests/benchmark/simulation/bm_plan091_cross_family_corpus.cpp
+++ b/tests/benchmark/simulation/bm_plan091_cross_family_corpus.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the "BSD-style" License
+ */
+
+#include <dart/simulation/body/collision_shape.hpp>
+#include <dart/simulation/body/rigid_body.hpp>
+#include <dart/simulation/body/rigid_body_options.hpp>
+#include <dart/simulation/compute/world_step_profile.hpp>
+#include <dart/simulation/multibody/multibody.hpp>
+#include <dart/simulation/multibody/multibody_options.hpp>
+#include <dart/simulation/world.hpp>
+#include <dart/simulation/world_options.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <benchmark/benchmark.h>
+
+#include <cmath>
+#include <cstddef>
+
+namespace sx = dart::simulation;
+namespace sxc = dart::simulation::compute;
+
+namespace {
+
+// The benchmark is the standalone packet-producing counterpart to
+// `test_cross_family_corpus.cpp`: each row runs one scene under one resolved
+// solver family and emits the public StepMetrics counters that the packet
+// writer validates.
+enum class SceneId
+{
+  RigidHeadOn,
+  SphereDrop,
+  Pendulum1Link,
+  Pendulum2Link,
+};
+
+enum class FamilyId
+{
+  SequentialImpulse,
+  BoxedLcp,
+  SemiImplicit,
+  Variational,
+};
+
+struct Scenario
+{
+  SceneId scene;
+  FamilyId family;
+  int steps;
+};
+
+bool isFinite(const sxc::StepMetrics& metrics)
+{
+  return std::isfinite(metrics.kineticEnergy)
+         && std::isfinite(metrics.potentialEnergy)
+         && std::isfinite(metrics.totalEnergy)
+         && metrics.linearMomentum.allFinite()
+         && metrics.angularMomentum.allFinite()
+         && std::isfinite(metrics.maxPenetrationDepth)
+         && std::isfinite(metrics.lastStepResidual);
+}
+
+void buildRigidHeadOn(sx::World& world)
+{
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(1e-3);
+
+  sx::RigidBodyOptions a;
+  a.mass = 1.0;
+  a.inertia = 0.1 * Eigen::Matrix3d::Identity();
+  a.position = Eigen::Vector3d(-1.2, 0.0, 0.0);
+  a.linearVelocity = Eigen::Vector3d(1.5, 0.0, 0.0);
+  auto bodyA = world.addRigidBody("headon_a", a);
+  bodyA.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
+
+  sx::RigidBodyOptions b;
+  b.mass = 2.0;
+  b.inertia = 0.1 * Eigen::Matrix3d::Identity();
+  b.position = Eigen::Vector3d(1.2, 0.0, 0.0);
+  b.linearVelocity = Eigen::Vector3d(-0.5, 0.0, 0.0);
+  auto bodyB = world.addRigidBody("headon_b", b);
+  bodyB.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
+}
+
+void buildSphereDrop(sx::World& world)
+{
+  world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world.setTimeStep(5e-3);
+
+  sx::RigidBodyOptions groundOptions;
+  groundOptions.isStatic = true;
+  groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+  auto ground = world.addRigidBody("drop_ground", groundOptions);
+  ground.setCollisionShape(
+      sx::CollisionShape::makeBox(Eigen::Vector3d(5.0, 5.0, 0.5)));
+  ground.setFriction(0.0);
+
+  sx::RigidBodyOptions sphereOptions;
+  sphereOptions.position = Eigen::Vector3d(0.0, 0.0, 1.0);
+  auto sphere = world.addRigidBody("drop_sphere", sphereOptions);
+  sphere.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
+  sphere.setFriction(0.0);
+}
+
+void buildPendulum1(sx::World& world)
+{
+  world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world.setTimeStep(1e-3);
+
+  auto robot = world.addMultibody("pend1");
+  auto base = robot.addLink("base");
+  Eigen::Isometry3d offset = Eigen::Isometry3d::Identity();
+  offset.translation() = Eigen::Vector3d(1.0, 0.0, 0.0);
+  sx::JointSpec spec;
+  spec.name = "hinge";
+  spec.type = sx::JointType::Revolute;
+  spec.axis = Eigen::Vector3d::UnitY();
+  spec.transformFromParent = offset;
+  auto bob = robot.addLink("bob", base, spec);
+  bob.setMass(1.0);
+  bob.setInertia(Eigen::Vector3d(0.05, 0.05, 0.05).asDiagonal());
+}
+
+void buildPendulum2(sx::World& world)
+{
+  world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+  world.setTimeStep(1e-3);
+
+  auto robot = world.addMultibody("pend2");
+  auto base = robot.addLink("base");
+  const auto offset = [](double x) {
+    Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+    transform.translation() = Eigen::Vector3d(x, 0.0, 0.0);
+    return transform;
+  };
+
+  sx::JointSpec spec1;
+  spec1.name = "j1";
+  spec1.type = sx::JointType::Revolute;
+  spec1.axis = Eigen::Vector3d::UnitY();
+  spec1.transformFromParent = offset(0.7);
+  auto link1 = robot.addLink("link1", base, spec1);
+  link1.setMass(1.5);
+  link1.setInertia(Eigen::Vector3d(0.05, 0.08, 0.05).asDiagonal());
+
+  sx::JointSpec spec2;
+  spec2.name = "j2";
+  spec2.type = sx::JointType::Revolute;
+  spec2.axis = Eigen::Vector3d::UnitY();
+  spec2.transformFromParent = offset(0.6);
+  auto link2 = robot.addLink("link2", link1, spec2);
+  link2.setMass(1.0);
+  link2.setInertia(Eigen::Vector3d(0.04, 0.06, 0.04).asDiagonal());
+}
+
+void releaseAllJoints(sx::World& world, const char* robotName, double angle)
+{
+  auto robot = world.getMultibody(robotName).value();
+  for (auto joint : robot.getJoints()) {
+    if (joint.getDOFCount() > 0) {
+      joint.setPosition(Eigen::VectorXd::Constant(joint.getDOFCount(), angle));
+    }
+  }
+  world.updateKinematics();
+}
+
+void buildScene(sx::World& world, SceneId scene)
+{
+  switch (scene) {
+    case SceneId::RigidHeadOn:
+      buildRigidHeadOn(world);
+      return;
+    case SceneId::SphereDrop:
+      buildSphereDrop(world);
+      return;
+    case SceneId::Pendulum1Link:
+      buildPendulum1(world);
+      return;
+    case SceneId::Pendulum2Link:
+      buildPendulum2(world);
+      return;
+  }
+}
+
+void configureWorld(sx::World& world, FamilyId family)
+{
+  if (family == FamilyId::SemiImplicit) {
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::SemiImplicit});
+  } else if (family == FamilyId::Variational) {
+    world.setMultibodyOptions(
+        {.integrationFamily = sx::MultibodyIntegrationFamily::Variational});
+  }
+}
+
+sx::WorldOptions makeWorldOptions(FamilyId family)
+{
+  sx::WorldOptions options;
+  if (family == FamilyId::BoxedLcp) {
+    options.contactSolverMethod = sx::ContactSolverMethod::BoxedLcp;
+  } else if (family == FamilyId::SequentialImpulse) {
+    options.contactSolverMethod = sx::ContactSolverMethod::SequentialImpulse;
+  }
+  return options;
+}
+
+void postEnter(sx::World& world, SceneId scene)
+{
+  if (scene == SceneId::Pendulum1Link) {
+    releaseAllJoints(world, "pend1", 1.0);
+  } else if (scene == SceneId::Pendulum2Link) {
+    releaseAllJoints(world, "pend2", 0.8);
+  }
+}
+
+sxc::StepMetrics runScenario(const Scenario& scenario)
+{
+  sx::World world(makeWorldOptions(scenario.family));
+  configureWorld(world, scenario.family);
+  buildScene(world, scenario.scene);
+  world.enterSimulationMode();
+  postEnter(world, scenario.scene);
+
+  for (int step = 0; step < scenario.steps; ++step) {
+    world.step();
+  }
+  return world.computeStepMetrics();
+}
+
+void recordMetrics(
+    benchmark::State& state,
+    const Scenario& scenario,
+    const sxc::StepMetrics& m)
+{
+  state.counters["step_count"] = static_cast<double>(scenario.steps);
+  state.counters["kinetic_energy"] = m.kineticEnergy;
+  state.counters["potential_energy"] = m.potentialEnergy;
+  state.counters["total_energy"] = m.totalEnergy;
+  state.counters["linear_momentum_x"] = m.linearMomentum.x();
+  state.counters["linear_momentum_y"] = m.linearMomentum.y();
+  state.counters["linear_momentum_z"] = m.linearMomentum.z();
+  state.counters["angular_momentum_x"] = m.angularMomentum.x();
+  state.counters["angular_momentum_y"] = m.angularMomentum.y();
+  state.counters["angular_momentum_z"] = m.angularMomentum.z();
+  state.counters["active_contact_count"]
+      = static_cast<double>(m.activeContactCount);
+  state.counters["max_penetration_depth"] = m.maxPenetrationDepth;
+  state.counters["last_step_iterations"]
+      = static_cast<double>(m.lastStepIterations);
+  state.counters["last_step_residual"] = m.lastStepResidual;
+}
+
+void BM_Plan091CrossFamilyCorpus(
+    benchmark::State& state, const Scenario& scenario)
+{
+  sxc::StepMetrics metrics;
+  for (auto _ : state) {
+    metrics = runScenario(scenario);
+    if (!isFinite(metrics)) {
+      state.SkipWithError("non-finite StepMetrics");
+      break;
+    }
+    benchmark::DoNotOptimize(metrics.totalEnergy);
+  }
+  recordMetrics(state, scenario, metrics);
+  state.SetItemsProcessed(
+      static_cast<int64_t>(state.iterations())
+      * static_cast<int64_t>(scenario.steps));
+}
+
+} // namespace
+
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    rigid_head_on_sequential_impulse,
+    Scenario{SceneId::RigidHeadOn, FamilyId::SequentialImpulse, 1500});
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    rigid_head_on_boxed_lcp,
+    Scenario{SceneId::RigidHeadOn, FamilyId::BoxedLcp, 1500});
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    sphere_drop_sequential_impulse,
+    Scenario{SceneId::SphereDrop, FamilyId::SequentialImpulse, 600});
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    sphere_drop_boxed_lcp,
+    Scenario{SceneId::SphereDrop, FamilyId::BoxedLcp, 600});
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    pendulum_1link_semi_implicit,
+    Scenario{SceneId::Pendulum1Link, FamilyId::SemiImplicit, 20000});
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    pendulum_1link_variational,
+    Scenario{SceneId::Pendulum1Link, FamilyId::Variational, 20000});
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    pendulum_2link_semi_implicit,
+    Scenario{SceneId::Pendulum2Link, FamilyId::SemiImplicit, 8000});
+BENCHMARK_CAPTURE(
+    BM_Plan091CrossFamilyCorpus,
+    pendulum_2link_variational,
+    Scenario{SceneId::Pendulum2Link, FamilyId::Variational, 8000});
+
+BENCHMARK_MAIN();

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -292,6 +292,40 @@ def test_phase5_packet_validator_rejects_missing_batched_row_metadata():
         raise AssertionError("expected missing batched-row metadata to fail")
 
 
+def test_phase5_packet_validator_rejects_unannotated_representative_raw_rows():
+    phase5 = load_script_module("check_phase5_gpu_packet")
+    data = phase5.make_packet_template()
+    metadata = data["phase5_gpu_packet"]
+    metadata["includes_transfer_setup_compute_readback"] = True
+    metadata["max_final_state_abs_error"] = 1e-12
+    for key in phase5.REQUIRED_EVIDENCE_FLAGS:
+        metadata[key] = True
+    cpu_row, gpu_row = data["benchmarks"]
+    cpu_row["real_time"] = 4.0
+    cpu_row["cpu_time"] = 4.0
+    gpu_row["real_time"] = 2.0
+    gpu_row["cpu_time"] = 2.0
+    data["benchmarks"].insert(
+        0,
+        {
+            "run_name": "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100/repeats:3",
+            "cpu_time": 4.1,
+            "real_time": 4.1,
+            "time_unit": "ms",
+        },
+    )
+
+    try:
+        phase5.validate_packet(data)
+    except phase5.Phase5PacketError as exc:
+        assert (
+            "phase5_gpu_packet.benchmarks[BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100].backend"
+            in str(exc)
+        )
+    else:
+        raise AssertionError("expected unannotated representative raw row to fail")
+
+
 def test_phase5_cuda_packet_writer_annotates_representative_batched_rows():
     writer = load_script_module("write_phase5_cuda_packet")
 

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -109,7 +109,99 @@ def test_benchmark_packet_timing_schema_rejects_bad_fields():
     ]
 
 
+def test_batched_benchmark_row_schema_accepts_required_reporting_fields():
+    utils = load_script_module("benchmark_packet_utils")
+
+    errors = utils.batched_benchmark_row_schema_errors(
+        {
+            "backend": "cuda-resident",
+            "precision": "float64-reference",
+            "includes_transfer_time": False,
+            "lane_count": 4,
+            "resolved_execution_shape": "homogeneous-batch",
+            "step_count": 100,
+        },
+        "plan091_batched_packet.rows[0]",
+    )
+
+    assert errors == []
+
+
+def test_batched_benchmark_row_schema_rejects_missing_reporting_fields():
+    utils = load_script_module("benchmark_packet_utils")
+
+    errors = utils.batched_benchmark_row_schema_errors(
+        {
+            "backend": "",
+            "precision": None,
+            "includes_transfer_time": "no",
+            "lane_count": 0,
+            "resolved_execution_shape": "",
+            "step_count": True,
+        },
+        "plan091_batched_packet.rows[0]",
+    )
+
+    assert errors == [
+        "plan091_batched_packet.rows[0].backend must be a non-empty string",
+        "plan091_batched_packet.rows[0].precision must be a non-empty string",
+        "plan091_batched_packet.rows[0].includes_transfer_time must be a boolean",
+        "plan091_batched_packet.rows[0].lane_count must be positive",
+        "plan091_batched_packet.rows[0].resolved_execution_shape must be a non-empty string",
+        "plan091_batched_packet.rows[0].step_count must be an integer",
+    ]
+
+
 def test_phase5_packet_validator_uses_shared_canonical_rows():
+    phase5 = load_script_module("check_phase5_gpu_packet")
+    data = phase5.make_packet_template()
+    metadata = data["phase5_gpu_packet"]
+    metadata["includes_transfer_setup_compute_readback"] = True
+    metadata["max_final_state_abs_error"] = 1e-12
+    for key in phase5.REQUIRED_EVIDENCE_FLAGS:
+        metadata[key] = True
+    cpu_row = aggregate_row(
+        "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100/repeats:3_median",
+        "median",
+        4.0,
+        time_unit="ms",
+    )
+    cpu_row.update(
+        {
+            "backend": "cpu",
+            "precision": "double-reference",
+            "includes_transfer_time": False,
+            "lane_count": 4096,
+            "resolved_execution_shape": "homogeneous-batch",
+            "step_count": 100,
+        }
+    )
+    gpu_row = aggregate_row(
+        "BM_Phase5RigidBodyBatchGpu/4096/128/100/repeats:3_median",
+        "median",
+        2.0,
+        time_unit="ms",
+    )
+    gpu_row.update(
+        {
+            "backend": "cuda",
+            "precision": "double-reference",
+            "includes_transfer_time": True,
+            "lane_count": 4096,
+            "resolved_execution_shape": "homogeneous-batch",
+            "step_count": 100,
+        }
+    )
+    data["benchmarks"] = [cpu_row, gpu_row]
+
+    summary = phase5.validate_packet(data)
+
+    assert summary["cpu_median_ns"] == 4_000_000.0
+    assert summary["gpu_median_ns"] == 2_000_000.0
+    assert summary["speedup"] == 2.0
+
+
+def test_phase5_packet_validator_rejects_missing_batched_row_metadata():
     phase5 = load_script_module("check_phase5_gpu_packet")
     data = phase5.make_packet_template()
     metadata = data["phase5_gpu_packet"]
@@ -119,33 +211,104 @@ def test_phase5_packet_validator_uses_shared_canonical_rows():
         metadata[key] = True
     data["benchmarks"] = [
         aggregate_row(
-            "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100/repeats:3_median",
+            "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100_median",
             "median",
             4.0,
             time_unit="ms",
         ),
         aggregate_row(
-            "BM_Phase5RigidBodyBatchGpu/4096/128/100/repeats:3_median",
+            "BM_Phase5RigidBodyBatchGpu/4096/128/100_median",
             "median",
             2.0,
             time_unit="ms",
         ),
     ]
 
-    summary = phase5.validate_packet(data)
+    try:
+        phase5.validate_packet(data)
+    except phase5.Phase5PacketError as exc:
+        assert (
+            "phase5_gpu_packet.benchmarks[BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100].backend"
+            in str(exc)
+        )
+    else:
+        raise AssertionError("expected missing batched-row metadata to fail")
 
-    assert summary["cpu_median_ns"] == 4_000_000.0
-    assert summary["gpu_median_ns"] == 2_000_000.0
-    assert summary["speedup"] == 2.0
+
+def test_phase5_cuda_packet_writer_annotates_representative_batched_rows():
+    writer = load_script_module("write_phase5_cuda_packet")
+
+    class Args:
+        cpu_prefix = "BM_Phase5RigidBodyBatchCpuBaseline"
+        gpu_prefix = "BM_Phase5RigidBodyBatchGpu"
+        world_count = 4096
+        body_count = 128
+        step_count = 100
+        includes_transfer_setup_compute_readback = True
+        gpu_build_import_gate_passed = True
+        compute_backend_boundaries_passed = True
+        no_gpu_runtime_dependencies_passed = True
+        phase5_benchmark_contract_passed = True
+
+    rows = [
+        aggregate_row(
+            "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100_median",
+            "median",
+            4.0,
+            time_unit="ms",
+        ),
+        aggregate_row(
+            "BM_Phase5RigidBodyBatchGpu/4096/128/100_median",
+            "median",
+            2.0,
+            time_unit="ms",
+        )
+        | {"max_final_state_abs_error": 1e-12},
+    ]
+
+    packet = writer.make_packet({"benchmarks": rows}, Args())
+
+    cpu_row, gpu_row = packet["benchmarks"]
+    assert cpu_row["backend"] == "cpu"
+    assert cpu_row["includes_transfer_time"] is False
+    assert gpu_row["backend"] == "cuda"
+    assert gpu_row["precision"] == "double-reference"
+    assert gpu_row["includes_transfer_time"] is True
+    assert gpu_row["lane_count"] == 4096
+    assert gpu_row["resolved_execution_shape"] == "homogeneous-batch"
 
 
 def test_abd_packet_validator_uses_shared_row_validation(tmp_path, capsys):
     abd = load_script_module("check_abd_comparison_packet")
+    rows = [
+        aggregate_row(f"{name}_median", "median", 1.0)
+        for name in sorted(abd.EXPECTED_BENCHMARKS)
+    ]
+    for row in rows:
+        if row["run_name"] == f"{abd.MICRO_SOLVE_BENCHMARK}_median":
+            row.update(
+                {
+                    "row_abd_alg_affine_body": 1.0,
+                    "paper_scale": 0.0,
+                    "affine_dynamic_body_count": 1.0,
+                    "static_triangle_body_count": 1.0,
+                    "point_triangle_pair_count": 1.0,
+                    "valid_solve": 1.0,
+                    "converged": 1.0,
+                    "barrier_active": 1.0,
+                    "solver_iterations": 8.0,
+                    "initial_objective": 2.0,
+                    "final_objective": 1.0,
+                    "objective_decrease": 1.0,
+                    "initial_gradient_norm": 3.0,
+                    "final_gradient_norm": 0.5,
+                    "initial_squared_distance": 0.01,
+                    "final_squared_distance": 0.02,
+                    "squared_activation_distance": 0.1,
+                }
+            )
     packet = {
-        "benchmarks": [
-            aggregate_row(f"{name}_median", "median", 1.0)
-            for name in sorted(abd.EXPECTED_BENCHMARKS)
-        ]
+        "benchmarks": rows,
     }
     path = tmp_path / "abd_packet.json"
     path.write_text(json.dumps(packet), encoding="utf-8")

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -228,6 +228,36 @@ def test_phase5_packet_validator_rejects_swapped_backend_labels():
         raise AssertionError("expected swapped backend labels to fail")
 
 
+def test_phase5_packet_validator_rejects_duplicate_median_rows():
+    phase5 = load_script_module("check_phase5_gpu_packet")
+    data = phase5.make_packet_template()
+    metadata = data["phase5_gpu_packet"]
+    metadata["includes_transfer_setup_compute_readback"] = True
+    metadata["max_final_state_abs_error"] = 1e-12
+    for key in phase5.REQUIRED_EVIDENCE_FLAGS:
+        metadata[key] = True
+    cpu_row, gpu_row = data["benchmarks"]
+    cpu_row["real_time"] = 4.0
+    cpu_row["cpu_time"] = 4.0
+    gpu_row["real_time"] = 2.0
+    gpu_row["cpu_time"] = 2.0
+    data["benchmarks"].append(
+        aggregate_row(
+            "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100/repeats:3_median",
+            "median",
+            3.0,
+            time_unit="ms",
+        )
+    )
+
+    try:
+        phase5.validate_packet(data)
+    except phase5.Phase5PacketError as exc:
+        assert "duplicate median benchmark rows" in str(exc)
+    else:
+        raise AssertionError("expected duplicate median rows to fail")
+
+
 def test_phase5_packet_validator_rejects_missing_batched_row_metadata():
     phase5 = load_script_module("check_phase5_gpu_packet")
     data = phase5.make_packet_template()

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -251,12 +251,24 @@ def test_phase5_cuda_packet_writer_annotates_representative_batched_rows():
         phase5_benchmark_contract_passed = True
 
     rows = [
+        {
+            "run_name": "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100/repeats:3",
+            "cpu_time": 4.1,
+            "real_time": 4.1,
+            "time_unit": "ms",
+        },
         aggregate_row(
             "BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100_median",
             "median",
             4.0,
             time_unit="ms",
         ),
+        {
+            "run_name": "BM_Phase5RigidBodyBatchGpu/4096/128/100/repeats:3",
+            "cpu_time": 2.1,
+            "real_time": 2.1,
+            "time_unit": "ms",
+        },
         aggregate_row(
             "BM_Phase5RigidBodyBatchGpu/4096/128/100_median",
             "median",
@@ -264,18 +276,22 @@ def test_phase5_cuda_packet_writer_annotates_representative_batched_rows():
             time_unit="ms",
         )
         | {"max_final_state_abs_error": 1e-12},
+        aggregate_row("BM_Unrelated/1_median", "median", 8.0, time_unit="ms"),
     ]
 
     packet = writer.make_packet({"benchmarks": rows}, Args())
 
-    cpu_row, gpu_row = packet["benchmarks"]
+    cpu_raw, cpu_row, gpu_raw, gpu_row, unrelated = packet["benchmarks"]
+    assert cpu_raw["backend"] == "cpu"
     assert cpu_row["backend"] == "cpu"
     assert cpu_row["includes_transfer_time"] is False
+    assert gpu_raw["backend"] == "cuda"
     assert gpu_row["backend"] == "cuda"
     assert gpu_row["precision"] == "double-reference"
     assert gpu_row["includes_transfer_time"] is True
     assert gpu_row["lane_count"] == 4096
     assert gpu_row["resolved_execution_shape"] == "homogeneous-batch"
+    assert "backend" not in unrelated
 
 
 def test_abd_packet_validator_uses_shared_row_validation(tmp_path, capsys):

--- a/tests/test_benchmark_packet_utils.py
+++ b/tests/test_benchmark_packet_utils.py
@@ -201,6 +201,33 @@ def test_phase5_packet_validator_uses_shared_canonical_rows():
     assert summary["speedup"] == 2.0
 
 
+def test_phase5_packet_validator_rejects_swapped_backend_labels():
+    phase5 = load_script_module("check_phase5_gpu_packet")
+    data = phase5.make_packet_template()
+    metadata = data["phase5_gpu_packet"]
+    metadata["includes_transfer_setup_compute_readback"] = True
+    metadata["max_final_state_abs_error"] = 1e-12
+    for key in phase5.REQUIRED_EVIDENCE_FLAGS:
+        metadata[key] = True
+    cpu_row, gpu_row = data["benchmarks"]
+    cpu_row["backend"] = "cuda"
+    gpu_row["backend"] = "cpu"
+    cpu_row["real_time"] = 4.0
+    cpu_row["cpu_time"] = 4.0
+    gpu_row["real_time"] = 2.0
+    gpu_row["cpu_time"] = 2.0
+
+    try:
+        phase5.validate_packet(data)
+    except phase5.Phase5PacketError as exc:
+        assert (
+            "phase5_gpu_packet.benchmarks[BM_Phase5RigidBodyBatchCpuBaseline/4096/128/100].backend must be 'cpu'"
+            in str(exc)
+        )
+    else:
+        raise AssertionError("expected swapped backend labels to fail")
+
+
 def test_phase5_packet_validator_rejects_missing_batched_row_metadata():
     phase5 = load_script_module("check_phase5_gpu_packet")
     data = phase5.make_packet_template()

--- a/tests/test_plan091_cross_family_metrics_packet.py
+++ b/tests/test_plan091_cross_family_metrics_packet.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "write_plan091_cross_family_metrics_packet.py"
+MANIFEST = (
+    ROOT
+    / "docs"
+    / "plans"
+    / "091-architecture-hardening"
+    / "cross-family-metrics-corpus.json"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "write_plan091_cross_family_metrics_packet",
+        SCRIPT,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _benchmark_row(name: str) -> dict[str, object]:
+    return {
+        "name": f"{name}_median",
+        "run_name": f"{name}_median",
+        "aggregate_name": "median",
+        "real_time": 1.0,
+        "cpu_time": 1.0,
+        "time_unit": "ms",
+        "step_count": 32,
+        "kinetic_energy": 1.0,
+        "potential_energy": -0.5,
+        "total_energy": 0.5,
+        "linear_momentum_x": 0.1,
+        "linear_momentum_y": 0.0,
+        "linear_momentum_z": 0.0,
+        "angular_momentum_x": 0.0,
+        "angular_momentum_y": 0.2,
+        "angular_momentum_z": 0.0,
+        "active_contact_count": 0,
+        "max_penetration_depth": 0.0,
+        "last_step_iterations": 0,
+        "last_step_residual": 0.0,
+    }
+
+
+def _benchmark_data(manifest: dict[str, object]) -> dict[str, object]:
+    rows = manifest["rows"]
+    assert isinstance(rows, list)
+    return {"benchmarks": [_benchmark_row(row["benchmark"]) for row in rows]}
+
+
+def test_plan091_cross_family_packet_accepts_manifest_rows():
+    module = _load_module()
+    manifest = module.load_manifest(MANIFEST)
+
+    packet = module.make_packet(_benchmark_data(manifest), manifest)
+
+    metadata = packet[module.PACKET_KEY]
+    assert metadata["metric_source"] == "dart::simulation::World::computeStepMetrics"
+    assert metadata["row_count"] == len(manifest["rows"])
+    first = metadata["rows"][0]
+    assert first["scene_id"] == "rigid_head_on"
+    assert first["resolved_solver_identity"] == "rigid-contact:sequential-impulse"
+    assert first["metrics"]["total_energy"] == 0.5
+
+
+def test_plan091_cross_family_packet_rejects_missing_row():
+    module = _load_module()
+    manifest = module.load_manifest(MANIFEST)
+    data = _benchmark_data(manifest)
+    data["benchmarks"].pop()
+
+    with pytest.raises(module.Plan091CrossFamilyPacketError, match="missing"):
+        module.make_packet(data, manifest)
+
+
+def test_plan091_cross_family_packet_prefers_median_over_raw_rows():
+    module = _load_module()
+    manifest = module.load_manifest(MANIFEST)
+    data = _benchmark_data(manifest)
+    first_name = manifest["rows"][0]["benchmark"]
+
+    median_row = data["benchmarks"][0]
+    median_row["total_energy"] = 0.5
+    raw_row = _benchmark_row(first_name)
+    raw_row["name"] = first_name
+    raw_row["run_name"] = first_name
+    raw_row.pop("aggregate_name")
+    raw_row["total_energy"] = 99.0
+    data["benchmarks"].append(raw_row)
+
+    packet = module.make_packet(data, manifest)
+
+    first = packet[module.PACKET_KEY]["rows"][0]
+    assert first["metrics"]["total_energy"] == 0.5
+
+
+def test_plan091_cross_family_packet_rejects_missing_metric_counter():
+    module = _load_module()
+    manifest = module.load_manifest(MANIFEST)
+    data = _benchmark_data(manifest)
+    data["benchmarks"][0].pop("linear_momentum_x")
+
+    with pytest.raises(
+        module.Plan091CrossFamilyPacketError,
+        match="linear_momentum_x",
+    ):
+        module.make_packet(data, manifest)


### PR DESCRIPTION
## Summary

- Adds the WP-091.24 cross-family metrics harness, manifest, and packet writer around the existing public `World::computeStepMetrics()` counters.
- Adds the WP-091.33e batched packet reporting schema for backend, precision, transfer inclusion, lane count, step count, and resolved execution shape.
- Adds the bounded WP-091.13 rigid-contact cleanup by sharing positional projection constants and routing the sequential path through the existing shared helper seam.
- Updates PLAN-091/dashboard state after PR #3077 and records the remaining metric-semantics and full assembler-convergence work explicitly.

## Motivation / Problem

- WP-091 still needed a consolidated evidence PR after PR #3077 landed. This keeps the safe remaining packet work and a behavior-preserving contact cleanup in one branch while avoiding risky semantic changes to contact/iteration metrics, multibody momentum aggregation, or full contact assembler convergence.

## Changes / Key Changes

- Adds `bm_plan091_cross_family_corpus`, an 8-row Google Benchmark target covering rigid contact solver and multibody integration families.
- Adds a manifest-driven PLAN-091 cross-family metrics packet writer and tests.
- Adds shared batched benchmark row validation and wires Phase 5 CUDA packet templates/writer/checker to require backend/precision/transfer/lane/shape metadata.
- Shares rigid-contact position projection constants in `rigid_contact_assembly.hpp`, removes duplicated sequential-impulse helper copies, and reuses the standalone projection helper after the impulse solve.
- Documents batched packet policy and records current WP-091 status in the plan/dashboard.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit`
- `pixi run python -m pytest tests/test_plan091_cross_family_metrics_packet.py tests/test_benchmark_packet_utils.py -q`
- `pixi run python scripts/check_phase5_gpu_packet.py --input .benchmark_results/plan091/phase5_gpu_packet_valid.json`
- `pixi run bm --target bm_plan091_cross_family_corpus -- --benchmark_min_time=0.001s --benchmark_repetitions=1 --benchmark_report_aggregates_only=true --benchmark_out=.benchmark_results/plan091/cross_family_metrics_benchmark.json --benchmark_out_format=json`
- `pixi run python scripts/write_plan091_cross_family_metrics_packet.py --benchmark-json .benchmark_results/plan091/cross_family_metrics_benchmark.json --output .benchmark_results/plan091/cross_family_metrics_packet.json`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows PR #3077.
- PLAN-091 architecture hardening: WP-091.13, WP-091.24, and WP-091.33e.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
