### PR TITLE
Harden py-demos selection and capture workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Exposed the rigid-body Python demo's contact-solver method in its live panel
   and capture metadata, giving py-demos a direct SI versus boxed-LCP inspection
   path for the DART 6 contact baseline, including scriptable capture-state
-  overrides for reproducible A/B packets.
+  overrides and labeled capture artifacts for reproducible A/B packets.
 - Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
   gestures in `py-demos` skip degenerate primitives instead of tripping
   Filament's empty-AABB precondition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,8 +211,9 @@ compatibility remains on the active DART 6 LTS branch._
 - Exposed the rigid-body Python demo's contact-solver method in its live panel
   and capture metadata, giving py-demos a direct SI versus boxed-LCP inspection
   path for the DART 6 contact baseline, including scriptable capture-state
-  overrides, labeled capture artifacts for reproducible A/B packets, and a
-  dedicated AVBD rigid-constraint showcase packet for M1 visual review.
+  overrides, labeled capture artifacts, a dedicated SI/boxed-LCP contact
+  baseline packet, and a dedicated AVBD rigid-constraint showcase packet for M1
+  visual review.
 - Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
   gestures in `py-demos` skip degenerate primitives instead of tripping
   Filament's empty-AABB precondition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,9 @@ compatibility remains on the active DART 6 LTS branch._
 - Exposed the rigid-body Python demo's contact-solver method in its live panel
   and capture metadata, giving py-demos a direct SI versus boxed-LCP inspection
   path for the DART 6 contact baseline.
+- Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
+  gestures in `py-demos` skip degenerate primitives instead of tripping
+  Filament's empty-AABB precondition.
 
 #### Gazebo Integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,8 @@ compatibility remains on the active DART 6 LTS branch._
 - Exposed the rigid-body Python demo's contact-solver method in its live panel
   and capture metadata, giving py-demos a direct SI versus boxed-LCP inspection
   path for the DART 6 contact baseline, including scriptable capture-state
-  overrides and labeled capture artifacts for reproducible A/B packets.
+  overrides, labeled capture artifacts for reproducible A/B packets, and a
+  dedicated AVBD rigid-constraint showcase packet for M1 visual review.
 - Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
   gestures in `py-demos` skip degenerate primitives instead of tripping
   Filament's empty-AABB precondition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,7 +210,8 @@ compatibility remains on the active DART 6 LTS branch._
   ([#3043](https://github.com/dartsim/dart/pull/3043))
 - Exposed the rigid-body Python demo's contact-solver method in its live panel
   and capture metadata, giving py-demos a direct SI versus boxed-LCP inspection
-  path for the DART 6 contact baseline.
+  path for the DART 6 contact baseline, including scriptable capture-state
+  overrides for reproducible A/B packets.
 - Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
   gestures in `py-demos` skip degenerate primitives instead of tripping
   Filament's empty-AABB precondition.

--- a/dart/gui/debug.cpp
+++ b/dart/gui/debug.cpp
@@ -59,6 +59,8 @@
 namespace dart::gui {
 namespace {
 
+constexpr double kMinDebugLineLengthSquared = 1e-18;
+
 Eigen::Vector4d rgba(double red, double green, double blue, double alpha = 1.0)
 {
   return {red, green, blue, alpha};
@@ -71,6 +73,13 @@ void appendLine(
     const Eigen::Vector4d& color,
     std::string label = {})
 {
+  const Eigen::Vector3d segment = to - from;
+  const double lengthSquared = segment.squaredNorm();
+  if (!from.allFinite() || !to.allFinite() || !std::isfinite(lengthSquared)
+      || lengthSquared <= kMinDebugLineLengthSquared) {
+    return;
+  }
+
   DebugLineDescriptor line;
   line.from = from;
   line.to = to;

--- a/dart/gui/detail/renderable_factory.cpp
+++ b/dart/gui/detail/renderable_factory.cpp
@@ -88,6 +88,8 @@ namespace {
 
 constexpr int kDebugLineTubeSegments = 8;
 constexpr double kTwoPi = 6.2831853071795864769;
+constexpr double kMinDebugLineLength = 1e-9;
+constexpr double kMinDebugTriangleArea = 1e-12;
 constexpr float kDefaultDielectricMetallic = 0.0f;
 constexpr float kDefaultMatteRoughness = 0.82f;
 
@@ -538,17 +540,32 @@ std::uint32_t packColor(const Eigen::Vector4d& rgba)
   return red | (green << 8u) | (blue << 16u) | (alpha << 24u);
 }
 
-void appendThinDebugLine(
+bool isDrawableDebugLine(const DebugLineDescriptor& line)
+{
+  if (!line.from.allFinite() || !line.to.allFinite()) {
+    return false;
+  }
+
+  const double length = (line.to - line.from).norm();
+  return std::isfinite(length) && length >= kMinDebugLineLength;
+}
+
+bool appendThinDebugLine(
     std::vector<DebugVertex>& vertices,
     std::vector<std::uint32_t>& indices,
     const DebugLineDescriptor& line)
 {
+  if (!isDrawableDebugLine(line)) {
+    return false;
+  }
+
   const auto start = static_cast<std::uint32_t>(vertices.size());
   const std::uint32_t color = packColor(line.rgba);
   vertices.push_back({toFloat3(line.from), color});
   vertices.push_back({toFloat3(line.to), color});
   indices.push_back(start);
   indices.push_back(start + 1u);
+  return true;
 }
 
 bool appendThickDebugLine(
@@ -557,15 +574,12 @@ bool appendThickDebugLine(
     const DebugLineDescriptor& line)
 {
   if (line.thickness <= 0.0 || !std::isfinite(line.thickness)
-      || !line.from.allFinite() || !line.to.allFinite()) {
+      || !isDrawableDebugLine(line)) {
     return false;
   }
 
   const Eigen::Vector3d segment = line.to - line.from;
   const double length = segment.norm();
-  if (!std::isfinite(length) || length < 1e-9) {
-    return false;
-  }
 
   const Eigen::Vector3d direction = segment / length;
   const Eigen::Vector3d seed = std::abs(direction.z()) < 0.9
@@ -651,6 +665,12 @@ bool appendDebugTriangle(
 {
   if (!triangle.a.allFinite() || !triangle.b.allFinite()
       || !triangle.c.allFinite()) {
+    return false;
+  }
+  const Eigen::Vector3d normal
+      = (triangle.b - triangle.a).cross(triangle.c - triangle.a);
+  const double area = normal.norm() * 0.5;
+  if (!std::isfinite(area) || area <= kMinDebugTriangleArea) {
     return false;
   }
 

--- a/docs/dev_tasks/py_demos_framework/01-milestones.md
+++ b/docs/dev_tasks/py_demos_framework/01-milestones.md
@@ -154,9 +154,11 @@ So the M1 flagship is **two complementary showcases**, both reference-grade:
 
 **Current M1 scoping:** keep the completed M1 experience as complementary
 contact-policy / boxed-LCP and AVBD constraint-showcase packets for now. The
-dedicated AVBD packet is curated from the existing `avbd_*` scenes; a unified
-comparison scene remains a possible follow-up only if the two packets do not
-produce enough reviewer-facing visual evidence.
+dedicated contact-baseline packet captures the `rigid_body` Sequential Impulse
+and boxed-LCP variants with state/label metadata; the dedicated AVBD packet is
+curated from the existing `avbd_*` scenes. A unified comparison scene remains a
+possible follow-up only if the two packets do not produce enough
+reviewer-facing visual evidence.
 
 ---
 

--- a/docs/dev_tasks/py_demos_framework/01-milestones.md
+++ b/docs/dev_tasks/py_demos_framework/01-milestones.md
@@ -157,8 +157,11 @@ contact-policy / boxed-LCP and AVBD constraint-showcase packets for now. The
 dedicated contact-baseline packet captures the `rigid_body` Sequential Impulse
 and boxed-LCP variants with state/label metadata; the dedicated AVBD packet is
 curated from the existing `avbd_*` scenes. A unified comparison scene remains a
-possible follow-up only if the two packets do not produce enough
-reviewer-facing visual evidence.
+possible follow-up only if review asks for stronger single-scene visual
+evidence. The current full-packet pass is sufficient for the active PR:
+contact-baseline rows are solver-evidence-first through labels, restored state,
+solver identity, and metrics, while AVBD rows provide the visually distinct
+rigid-constraint showcase.
 
 ---
 

--- a/docs/dev_tasks/py_demos_framework/01-milestones.md
+++ b/docs/dev_tasks/py_demos_framework/01-milestones.md
@@ -152,9 +152,11 @@ So the M1 flagship is **two complementary showcases**, both reference-grade:
 2. **AVBD constraint showcase** — joints / motors / breakable constraints solved
    by AVBD (the modern differentiator), curated from the `avbd_*` scenes.
 
-**Remaining M1 scoping point for the task owner:** whether the completed M1
-experience should stay as complementary contact and AVBD scenes, or grow into a
-new unified comparison scene.
+**Current M1 scoping:** keep the completed M1 experience as complementary
+contact-policy / boxed-LCP and AVBD constraint-showcase packets for now. The
+dedicated AVBD packet is curated from the existing `avbd_*` scenes; a unified
+comparison scene remains a possible follow-up only if the two packets do not
+produce enough reviewer-facing visual evidence.
 
 ---
 

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -46,9 +46,11 @@ and replay metadata.
         metadata so Sequential Impulse and the DART 6-style boxed-LCP contact
         path can be inspected from the live demo. The panel also has one-click
         baseline presets for the default Sequential Impulse and boxed-LCP
-        contact paths. Realtime rigid workflow rows keep the rigid-body solver
-        fixed to the Sequential Impulse path; use `rigid_solver_compare` and the
-        explicit IPC shelf scenes for SI-vs-IPC visual inspection.
+        contact paths, plus a route into the side-by-side
+        `rigid_contact_solver_compare` row. Realtime rigid workflow rows keep
+        the rigid-body solver fixed to the Sequential Impulse path; use
+        `rigid_solver_compare` and the explicit IPC shelf scenes for SI-vs-IPC
+        visual inspection.
   - [x] Scriptable contact-policy capture: `py-demo-capture` can restore
         scene-owned replay state before launch via `--scene-state-json`, and
         `--capture-label` gives stateful A/B captures distinct artifact stems

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -49,6 +49,15 @@ and replay metadata.
         advertises the boxed-LCP baseline capture command. Verified in default
         and CUDA environments with manifests resolving
         `contact_solver_method=BOXED_LCP`.
+  - [x] AVBD rigid-constraint showcase packet: the dedicated
+        `--avbd-showcase-only` workflow packet now captures the curated
+        fixed-joint/contact, breakable-joint, spherical breakable-joint,
+        revolute-motor, and prismatic-motor AVBD rows as a complementary M1
+        packet. The manifest and review index label these rows as
+        `avbd_constraint_showcase` and keep the scope explicit: this is the
+        AVBD `sx` rigid-constraint track beside the World contact-policy /
+        boxed-LCP baseline, not a head-to-head solver enum comparison. Verified
+        with default and CUDA packet row captures.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 
@@ -92,8 +101,11 @@ repeatable operation.
    and boxed-LCP contacts when the PR needs reviewer-facing image/video
    artifacts; the scripted boxed-LCP command is now:
    `pixi run py-demo-capture -- --scene rigid_body --frames 180 --width 960 --height 540 --show-ui --scene-state-json '{"controls":{"contact_method_index":1}}' --capture-label boxed_lcp`.
-4. Curate the AVBD constraint showcase from the existing `avbd_*` scenes and
-   decide whether the final M1 experience remains two complementary scenes or
-   grows into one unified comparison scene.
+4. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence:
+   `pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --output-dir /tmp/dart_capture_rigid_avbd_showcase`.
+   M1 remains two complementary showcases for now: World contact-policy /
+   boxed-LCP baseline packets plus the AVBD `sx` rigid-constraint showcase.
+   Revisit a unified comparison scene only after those two packets have enough
+   reviewer-facing visual evidence.
 
 See `01-milestones.md` for the detailed milestone criteria and solver analysis.

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -44,9 +44,11 @@ and replay metadata.
         visual inspection.
   - [x] Scriptable contact-policy capture: `py-demo-capture` can restore
         scene-owned replay state before launch via `--scene-state-json`, and
-        the `rigid_body` workflow panel now advertises the boxed-LCP baseline
-        capture command. Verified in default and CUDA environments with
-        manifests resolving `contact_solver_method=BOXED_LCP`.
+        `--capture-label` gives stateful A/B captures distinct artifact stems
+        and default output directories. The `rigid_body` workflow panel now
+        advertises the boxed-LCP baseline capture command. Verified in default
+        and CUDA environments with manifests resolving
+        `contact_solver_method=BOXED_LCP`.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 
@@ -89,7 +91,7 @@ repeatable operation.
 3. Capture a longer visual A/B packet for `rigid_body` with Sequential Impulse
    and boxed-LCP contacts when the PR needs reviewer-facing image/video
    artifacts; the scripted boxed-LCP command is now:
-   `pixi run py-demo-capture -- --scene rigid_body --frames 180 --width 960 --height 540 --show-ui --scene-state-json '{"controls":{"contact_method_index":1}}'`.
+   `pixi run py-demo-capture -- --scene rigid_body --frames 180 --width 960 --height 540 --show-ui --scene-state-json '{"controls":{"contact_method_index":1}}' --capture-label boxed_lcp`.
 4. Curate the AVBD constraint showcase from the existing `avbd_*` scenes and
    decide whether the final M1 experience remains two complementary scenes or
    grows into one unified comparison scene.

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -30,6 +30,9 @@ and replay metadata.
         viewer (`py-demos-smoke --render`, `pixi run -e cuda py-demos-render-smoke`,
         `test_demos_render_smoke.py`). **155/155** render non-blank; blank-detector
         verified (rejects a uniform frame). Software-Mesa env applied for dev hosts.
+  - [x] Interactive selection/force-drag overlay hardening: a zero-motion
+        click/drag on `rigid_body` no longer feeds degenerate debug primitives
+        into Filament's AABB precondition path.
 - [ ] **M1 — Best domain + solver**: pick the flagship domain (rigid body) and
       solver, and make that path excellent end-to-end (visual + panels + replay + capture + docs). **In progress**.
   - [x] First contact-baseline increment: the flagship `rigid_body` scene
@@ -73,11 +76,14 @@ repeatable operation.
 
 ## Immediate Next Steps
 
-1. Verify the M1 contact-baseline increment with focused C++/dartpy tests,
+1. Keep the interactive selection repro in the validation set when touching
+   `dart::gui` debug overlays:
+   `pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2`.
+2. Verify the M1 contact-baseline increment with focused C++/dartpy tests,
    `python/tests/unit/test_py_demo_panels.py`, and the M0 smoke guards.
-2. Capture a visual A/B packet for `rigid_body` with Sequential Impulse and
+3. Capture a visual A/B packet for `rigid_body` with Sequential Impulse and
    boxed-LCP contacts so reviewers can inspect the DART 6 baseline behavior.
-3. Curate the AVBD constraint showcase from the existing `avbd_*` scenes and
+4. Curate the AVBD constraint showcase from the existing `avbd_*` scenes and
    decide whether the final M1 experience remains two complementary scenes or
    grows into one unified comparison scene.
 

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -33,6 +33,12 @@ and replay metadata.
   - [x] Interactive selection/force-drag overlay hardening: a zero-motion
         click/drag on `rigid_body` no longer feeds degenerate debug primitives
         into Filament's AABB precondition path.
+  - [x] Local full-catalog regression pass on PR #3084 local head `bd0b8e7`:
+        default `pixi run py-demos-smoke --json-out
+    /tmp/py_demos_smoke_default_pr3084_local.json` passed **155/155** in
+        `real 47.96s`; CUDA `pixi run -e cuda py-demos-smoke --json-out
+    /tmp/py_demos_smoke_cuda_pr3084_local.json` passed **155/155** in
+        `real 76.18s`.
 - [ ] **M1 — Best domain + solver**: pick the flagship domain (rigid body) and
       solver, and make that path excellent end-to-end (visual + panels + replay + capture + docs). **In progress**.
   - [x] First contact-baseline increment: the flagship `rigid_body` scene

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -35,9 +35,9 @@ and replay metadata.
         into Filament's AABB precondition path.
   - [x] Local full-catalog regression pass on PR #3084 local head `bd0b8e7`:
         default `pixi run py-demos-smoke --json-out
-    /tmp/py_demos_smoke_default_pr3084_local.json` passed **155/155** in
+/tmp/py_demos_smoke_default_pr3084_local.json` passed **155/155** in
         `real 47.96s`; CUDA `pixi run -e cuda py-demos-smoke --json-out
-    /tmp/py_demos_smoke_cuda_pr3084_local.json` passed **155/155** in
+/tmp/py_demos_smoke_cuda_pr3084_local.json` passed **155/155** in
         `real 76.18s`.
 - [ ] **M1 — Best domain + solver**: pick the flagship domain (rigid body) and
       solver, and make that path excellent end-to-end (visual + panels + replay + capture + docs). **In progress**.

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -42,6 +42,11 @@ and replay metadata.
         keep the rigid-body solver fixed to the Sequential Impulse path; use
         `rigid_solver_compare` and the explicit IPC shelf scenes for SI-vs-IPC
         visual inspection.
+  - [x] Scriptable contact-policy capture: `py-demo-capture` can restore
+        scene-owned replay state before launch via `--scene-state-json`, and
+        the `rigid_body` workflow panel now advertises the boxed-LCP baseline
+        capture command. Verified in default and CUDA environments with
+        manifests resolving `contact_solver_method=BOXED_LCP`.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 
@@ -81,8 +86,10 @@ repeatable operation.
    `pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2`.
 2. Verify the M1 contact-baseline increment with focused C++/dartpy tests,
    `python/tests/unit/test_py_demo_panels.py`, and the M0 smoke guards.
-3. Capture a visual A/B packet for `rigid_body` with Sequential Impulse and
-   boxed-LCP contacts so reviewers can inspect the DART 6 baseline behavior.
+3. Capture a longer visual A/B packet for `rigid_body` with Sequential Impulse
+   and boxed-LCP contacts when the PR needs reviewer-facing image/video
+   artifacts; the scripted boxed-LCP command is now:
+   `pixi run py-demo-capture -- --scene rigid_body --frames 180 --width 960 --height 540 --show-ui --scene-state-json '{"controls":{"contact_method_index":1}}'`.
 4. Curate the AVBD constraint showcase from the existing `avbd_*` scenes and
    decide whether the final M1 experience remains two complementary scenes or
    grows into one unified comparison scene.

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -46,8 +46,8 @@ and replay metadata.
         scene-owned replay state before launch via `--scene-state-json`, and
         `--capture-label` gives stateful A/B captures distinct artifact stems
         and default output directories. The `rigid_body` workflow panel now
-        advertises the boxed-LCP baseline capture command. Verified in default
-        and CUDA environments with manifests resolving
+        advertises both the boxed-LCP baseline live command and capture command.
+        Verified in default and CUDA environments with manifests resolving
         `contact_solver_method=BOXED_LCP`.
   - [x] Dedicated contact-baseline packet: the `--contact-baseline-only`
         workflow captures the `rigid_body` Sequential Impulse and boxed-LCP

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -49,6 +49,10 @@ and replay metadata.
         advertises the boxed-LCP baseline capture command. Verified in default
         and CUDA environments with manifests resolving
         `contact_solver_method=BOXED_LCP`.
+  - [x] Dedicated contact-baseline packet: the `--contact-baseline-only`
+        workflow captures the `rigid_body` Sequential Impulse and boxed-LCP
+        contact-policy variants as one review-indexed packet, with per-row
+        state/label metadata and rerun commands.
   - [x] AVBD rigid-constraint showcase packet: the dedicated
         `--avbd-showcase-only` workflow packet now captures the curated
         fixed-joint/contact, breakable-joint, spherical breakable-joint,
@@ -97,10 +101,9 @@ repeatable operation.
    `pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2`.
 2. Verify the M1 contact-baseline increment with focused C++/dartpy tests,
    `python/tests/unit/test_py_demo_panels.py`, and the M0 smoke guards.
-3. Capture a longer visual A/B packet for `rigid_body` with Sequential Impulse
-   and boxed-LCP contacts when the PR needs reviewer-facing image/video
-   artifacts; the scripted boxed-LCP command is now:
-   `pixi run py-demo-capture -- --scene rigid_body --frames 180 --width 960 --height 540 --show-ui --scene-state-json '{"controls":{"contact_method_index":1}}' --capture-label boxed_lcp`.
+3. Use the dedicated contact-baseline packet for reviewer-facing SI/boxed-LCP
+   evidence:
+   `pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --output-dir /tmp/dart_capture_rigid_contact_baseline`.
 4. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence:
    `pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --output-dir /tmp/dart_capture_rigid_avbd_showcase`.
    M1 remains two complementary showcases for now: World contact-policy /

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -55,8 +55,10 @@ and replay metadata.
         scene-owned replay state before launch via `--scene-state-json`, and
         `--capture-label` gives stateful A/B captures distinct artifact stems
         and default output directories. The `rigid_body` workflow panel now
-        advertises both the boxed-LCP baseline live command and capture command.
-        Verified in default and CUDA environments with manifests resolving
+        advertises both the boxed-LCP baseline live command and capture command,
+        and state overrides honor explicit `--scene`, `DART_DEMOS_SCENE`, and
+        the default `rigid_body` front-door selector. Verified in default and
+        CUDA environments with manifests resolving
         `contact_solver_method=BOXED_LCP`.
   - [x] Dedicated contact-baseline packet: the `--contact-baseline-only`
         workflow captures the `rigid_body` Sequential Impulse and boxed-LCP

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -62,6 +62,14 @@ and replay metadata.
         AVBD `sx` rigid-constraint track beside the World contact-policy /
         boxed-LCP baseline, not a head-to-head solver enum comparison. Verified
         with default and CUDA packet row captures.
+  - [x] Reviewer-facing visual packet pass: full contact-baseline and AVBD
+        showcase packets completed in both default and CUDA Pixi environments.
+        The AVBD rows are visually legible with docked diagnostics; the
+        contact-baseline rows are solver-evidence-first because SI and boxed-LCP
+        look similar in the docked view, so labels, restored state, solver
+        identity, and metrics in the review index are the key evidence. A
+        unified comparison scene is not required for the current PR evidence;
+        keep it as a follow-up only if review finds the two packets insufficient.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 
@@ -102,13 +110,14 @@ repeatable operation.
 2. Verify the M1 contact-baseline increment with focused C++/dartpy tests,
    `python/tests/unit/test_py_demo_panels.py`, and the M0 smoke guards.
 3. Use the dedicated contact-baseline packet for reviewer-facing SI/boxed-LCP
-   evidence:
+   evidence when refreshing artifacts:
    `pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --output-dir /tmp/dart_capture_rigid_contact_baseline`.
-4. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence:
+4. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence when
+   refreshing artifacts:
    `pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --output-dir /tmp/dart_capture_rigid_avbd_showcase`.
    M1 remains two complementary showcases for now: World contact-policy /
    boxed-LCP baseline packets plus the AVBD `sx` rigid-constraint showcase.
-   Revisit a unified comparison scene only after those two packets have enough
-   reviewer-facing visual evidence.
+   The full-packet pass produced enough current PR evidence; revisit a unified
+   comparison scene only if review asks for a stronger single-scene visual.
 
 See `01-milestones.md` for the detailed milestone criteria and solver analysis.

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -38,10 +38,11 @@ and replay metadata.
   - [x] First contact-baseline increment: the flagship `rigid_body` scene
         exposes `contact_solver_method` in its panel, replay state, and capture
         metadata so Sequential Impulse and the DART 6-style boxed-LCP contact
-        path can be inspected from the live demo. Realtime rigid workflow rows
-        keep the rigid-body solver fixed to the Sequential Impulse path; use
-        `rigid_solver_compare` and the explicit IPC shelf scenes for SI-vs-IPC
-        visual inspection.
+        path can be inspected from the live demo. The panel also has one-click
+        baseline presets for the default Sequential Impulse and boxed-LCP
+        contact paths. Realtime rigid workflow rows keep the rigid-body solver
+        fixed to the Sequential Impulse path; use `rigid_solver_compare` and the
+        explicit IPC shelf scenes for SI-vs-IPC visual inspection.
   - [x] Scriptable contact-policy capture: `py-demo-capture` can restore
         scene-owned replay state before launch via `--scene-state-json`, and
         `--capture-label` gives stateful A/B captures distinct artifact stems

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -37,6 +37,17 @@ workflow panel now advertises the boxed-LCP baseline capture command with
 output directories and artifact stems. Default/CUDA captures resolved
 `contact_solver_method=BOXED_LCP` in their manifests.
 
+The contact-baseline path is now also a first-class workflow packet:
+
+```bash
+pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only \
+  --output-dir /tmp/dart_capture_rigid_contact_baseline
+```
+
+It captures the `rigid_body` Sequential Impulse and boxed-LCP contact-policy
+variants as one review-indexed packet with per-row capture labels, state
+metadata, and row rerun commands.
+
 The current M1 slice curates the AVBD rigid-constraint showcase from the
 existing `avbd_*` scenes instead of creating a new unified scene. The dedicated
 packet command is:
@@ -56,17 +67,18 @@ row captures for `avbd_rigid_revolute_motor` completed with
 
 `fix/py-demos-selection-crash` - published as PR #3084. The PR includes the
 selection debug-overlay fix, scriptable capture-state restoration, labeled
-stateful captures, and the AVBD showcase packet.
+stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
+packet.
 
 ## Immediate Next Step
 
 **M1 is in progress.** Keep the scripted selection repro above in the validation
-set, use the labeled scripted capture-state path for rigid-body SI vs boxed-LCP
-visual packets, and use the dedicated AVBD showcase packet for the modern
-rigid-constraint track. The next useful slice is a reviewer-facing visual packet
-pass: capture full SI/boxed-LCP and AVBD packets, inspect screenshots/review
-indexes, then decide whether M1 needs a unified comparison scene or whether the
-two complementary packets are enough for review.
+set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
+visual evidence, and use the dedicated AVBD showcase packet for the modern
+rigid-constraint track. The next useful slice is a reviewer-facing visual
+packet pass: capture the full contact-baseline and AVBD packets, inspect
+screenshots/review indexes, then decide whether M1 needs a unified comparison
+scene or whether the two complementary packets are enough for review.
 
 Re-run any M0 guard:
 
@@ -123,4 +135,4 @@ ls build/cuda/cpp/Release-docking/python/dartpy/_dartpy*.so 2>/dev/null || echo 
 ```
 
 Then: run the py-demos panel/smoke guards, and proceed with reviewer-facing M1
-visual packet capture for the boxed-LCP contact baseline and AVBD showcase.
+visual packet capture for the contact baseline and AVBD showcase.

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -63,22 +63,50 @@ beside the World contact-policy / boxed-LCP baseline. Default and CUDA packet
 row captures for `avbd_rigid_revolute_motor` completed with
 `solver=avbd_rigid_joints` in the workflow manifests.
 
+The full reviewer-facing packet pass completed on PR #3084 head `fd8db58`:
+
+- Default contact-baseline packet:
+  `/tmp/dart_capture_rigid_contact_baseline_full_default_3084_fd8db58`
+  (`real 32.58s`).
+- CUDA contact-baseline packet:
+  `/tmp/dart_capture_rigid_contact_baseline_full_cuda_3084_fd8db58`
+  (`real 33.50s`).
+- Default AVBD showcase packet:
+  `/tmp/dart_capture_rigid_avbd_showcase_full_default_3084_fd8db58`
+  (`real 35.37s`).
+- CUDA AVBD showcase packet:
+  `/tmp/dart_capture_rigid_avbd_showcase_full_cuda_3084_fd8db58`
+  (`real 36.40s`).
+
+All four workflow manifests report `status=complete`; the review indexes report
+complete guidance, solver identity, and scene metrics with zero failed rows.
+Visual inspection found the AVBD rows readable as docked visual evidence. The
+contact-baseline screenshots are intentionally similar, so the review-index
+labels, scene-state metadata, `contact_solver_method` solver identity, and
+metrics are the distinguishing evidence. This is enough for the current PR
+evidence; a unified comparison scene is deferred unless review asks for a
+stronger single-scene visual.
+
+A follow-up local improvement makes packet review pages report their M1 phase
+maps for contact-baseline and AVBD-only packets instead of showing `phases 0`.
+
 ## Current Branch
 
 `fix/py-demos-selection-crash` - published as PR #3084. The PR includes the
 selection debug-overlay fix, scriptable capture-state restoration, labeled
 stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
-packet.
+packet. Local follow-up work may be ahead of the remote PR branch until the
+phase-map reporting fix is pushed.
 
 ## Immediate Next Step
 
 **M1 is in progress.** Keep the scripted selection repro above in the validation
 set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
-rigid-constraint track. The next useful slice is a reviewer-facing visual
-packet pass: capture the full contact-baseline and AVBD packets, inspect
-screenshots/review indexes, then decide whether M1 needs a unified comparison
-scene or whether the two complementary packets are enough for review.
+rigid-constraint track. The next useful slice is PR management: push the local
+phase-map reporting fix after explicit approval, refresh the PR body with the
+full-packet evidence if pushing, then watch CI/Codex review for actionable
+feedback.
 
 Re-run any M0 guard:
 
@@ -134,5 +162,6 @@ git status && git log -3 --oneline
 ls build/cuda/cpp/Release-docking/python/dartpy/_dartpy*.so 2>/dev/null || echo "needs build"
 ```
 
-Then: run the py-demos panel/smoke guards, and proceed with reviewer-facing M1
-visual packet capture for the contact baseline and AVBD showcase.
+Then: run the py-demos panel/smoke guards if changing runtime behavior; for the
+current reporting-only follow-up, focused capture tests plus `pixi run lint` are
+the relevant local gates before any approved push.

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -104,6 +104,14 @@ The next local UI follow-up adds an `Open contact comparison` button to the
 direct path from the baseline scene to the side-by-side Sequential
 Impulse/boxed-LCP comparison row.
 
+The fresh Codex review on PR #3084 head `e9ef404` found a valid state-override
+edge case: `DART_DEMOS_SCENE=rigid_body pixi run py-demos --
+--scene-state-json ...` rejected the override even though the environment
+variable selects a single supported scene. The local fix resolves the
+state-override target from explicit `--scene`, then `DART_DEMOS_SCENE`, then the
+injected default `rigid_body` scene, while still rejecting true multi-scene
+cycle runs.
+
 A broad local M0 regression recheck completed on PR #3084 local head `bd0b8e7`:
 default `pixi run py-demos-smoke --json-out
 /tmp/py_demos_smoke_default_pr3084_local.json` passed 155/155 scenes in
@@ -121,7 +129,8 @@ command, boxed-LCP workflow-panel UI, rigid-body contact preset, and
 full-catalog smoke evidence follow-ups. The PR body has been refreshed with the
 default and CUDA before/after launch timings plus the full-catalog smoke
 results. A local UI follow-up for the `rigid_body` contact-comparison route may
-be ahead of the remote PR branch until explicitly pushed.
+be ahead of the remote PR branch until explicitly pushed. A local follow-up also
+addresses the Codex `DART_DEMOS_SCENE` / `--scene-state-json` review finding.
 
 ## Immediate Next Step
 
@@ -130,8 +139,9 @@ set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
 rigid-constraint track. The next useful slice is PR management: watch hosted CI
 and the fresh Codex review request on PR #3084 for actionable feedback. If the
-local contact-comparison route is included in PR #3084, refresh the PR body and
-rerun/retrigger the same review loop after the approved push.
+local contact-comparison route and `DART_DEMOS_SCENE` state-override fix are
+included in PR #3084, refresh the PR body and rerun/retrigger the same review
+loop after the approved push.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -91,6 +91,9 @@ A follow-up local improvement makes packet review pages report their M1 phase
 maps for contact-baseline and AVBD-only packets instead of showing `phases 0`.
 It also preserves `scene_state_json` in each row's `open live` command, so the
 boxed-LCP contact-baseline row opens the same state that the capture used.
+The live rigid workflow panel now advertises the matching boxed-LCP `py-demos`
+command beside the boxed-LCP capture command, so the panel opens and captures
+the same stateful baseline.
 
 ## Current Branch
 
@@ -98,7 +101,8 @@ boxed-LCP contact-baseline row opens the same state that the capture used.
 selection debug-overlay fix, scriptable capture-state restoration, labeled
 stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
 packet. Local follow-up work may be ahead of the remote PR branch until the
-phase-map and stateful open-live command fixes are pushed.
+phase-map, stateful open-live command, and boxed-LCP workflow-panel UI fixes are
+pushed.
 
 ## Immediate Next Step
 
@@ -106,9 +110,9 @@ phase-map and stateful open-live command fixes are pushed.
 set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
 rigid-constraint track. The next useful slice is PR management: push the local
-phase-map/open-live command fixes after explicit approval, refresh the PR body
-with the full-packet evidence if pushing, then watch CI/Codex review for
-actionable feedback.
+phase-map/open-live command and workflow-panel UI fixes after explicit
+approval, refresh the PR body with the full-packet evidence if pushing, then
+watch CI/Codex review for actionable feedback.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -98,6 +98,13 @@ The `rigid_body` scene panel also has one-click Sequential Impulse and boxed-LCP
 baseline preset buttons that set the contact solver and reset the scene through
 the same replay/capture state path.
 
+A broad local M0 regression recheck completed on PR #3084 local head `bd0b8e7`:
+default `pixi run py-demos-smoke --json-out
+/tmp/py_demos_smoke_default_pr3084_local.json` passed 155/155 scenes in
+`real 47.96s`, and CUDA `pixi run -e cuda py-demos-smoke --json-out
+/tmp/py_demos_smoke_cuda_pr3084_local.json` passed 155/155 scenes in
+`real 76.18s`.
+
 ## Current Branch
 
 `fix/py-demos-selection-crash` - published as PR #3084. The PR includes the
@@ -105,7 +112,7 @@ selection debug-overlay fix, scriptable capture-state restoration, labeled
 stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
 packet. Local follow-up work may be ahead of the remote PR branch until the
 phase-map, stateful open-live command, boxed-LCP workflow-panel UI, and
-rigid-body contact preset fixes are pushed.
+rigid-body contact preset fixes plus full-catalog smoke evidence are pushed.
 
 ## Immediate Next Step
 
@@ -113,9 +120,10 @@ rigid-body contact preset fixes are pushed.
 set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
 rigid-constraint track. The next useful slice is PR management: push the local
-phase-map/open-live command, workflow-panel UI, and contact preset fixes after
-explicit approval, refresh the PR body with the full-packet evidence if pushing,
-then watch CI/Codex review for actionable feedback.
+phase-map/open-live command, workflow-panel UI, contact preset, and smoke
+evidence fixes after explicit approval, refresh the PR body with the full-packet
+and full-catalog smoke evidence if pushing, then watch CI/Codex review for
+actionable feedback.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -37,18 +37,37 @@ workflow panel now advertises the boxed-LCP baseline capture command with
 output directories and artifact stems. Default/CUDA captures resolved
 `contact_solver_method=BOXED_LCP` in their manifests.
 
+The current M1 slice curates the AVBD rigid-constraint showcase from the
+existing `avbd_*` scenes instead of creating a new unified scene. The dedicated
+packet command is:
+
+```bash
+pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only \
+  --output-dir /tmp/dart_capture_rigid_avbd_showcase
+```
+
+It captures fixed-joint/contact, breakable-joint, spherical breakable-joint,
+revolute-motor, and prismatic-motor AVBD rows as a complementary M1 showcase
+beside the World contact-policy / boxed-LCP baseline. Default and CUDA packet
+row captures for `avbd_rigid_revolute_motor` completed with
+`solver=avbd_rigid_joints` in the workflow manifests.
+
 ## Current Branch
 
-`fix/py-demos-selection-crash` - clean after two local follow-up commits:
+`fix/py-demos-selection-crash` - clean after three local follow-up commits:
 `Add scriptable py-demos capture state` and
-`Label py-demos stateful captures`. Neither commit has been pushed to PR #3084
-yet.
+`Label py-demos stateful captures`, followed by the AVBD showcase packet commit.
+These commits have not been pushed to PR #3084 yet.
 
 ## Immediate Next Step
 
 **M1 is in progress.** Keep the scripted selection repro above in the validation
 set, use the labeled scripted capture-state path for rigid-body SI vs boxed-LCP
-visual packets, then curate the AVBD constraint showcase.
+visual packets, and use the dedicated AVBD showcase packet for the modern
+rigid-constraint track. The next useful slice is a reviewer-facing visual packet
+pass: capture full SI/boxed-LCP and AVBD packets, inspect screenshots/review
+indexes, then decide whether M1 needs a unified comparison scene or whether the
+two complementary packets are enough for review.
 
 Re-run any M0 guard:
 
@@ -66,6 +85,9 @@ PYTHONPATH=build/cuda/cpp/Release-docking/python:python .pixi/envs/cuda/bin/pyth
 - First M1 increment: enhance the existing `rigid_body` scene before creating a
   new comparison scene. This keeps the baseline path visible in the flagship
   scene while AVBD showcase curation proceeds separately.
+- AVBD showcase curation: keep M1 as two complementary packets for now. The
+  AVBD packet is scoped to the existing `sx` rigid-constraint scenes and does
+  not claim solver-enum parity with the World contact-policy baseline.
 - Capture-state overrides belong to scenes that already expose
   `replay_restore_state`; unsupported scenes should fail clearly rather than
   silently pretending a panel state was applied.
@@ -95,12 +117,11 @@ PYTHONPATH=build/cuda/cpp/Release-docking/python:python .pixi/envs/cuda/bin/pyth
 ## How to Resume
 
 ```bash
-git checkout py-demos-framework
+git checkout fix/py-demos-selection-crash
 git status && git log -3 --oneline
 # Verify build state:
 ls build/cuda/cpp/Release-docking/python/dartpy/_dartpy*.so 2>/dev/null || echo "needs build"
 ```
 
-Then: run focused C++/dartpy verification for the writable contact solver
-method, run the py-demos panel/smoke guards, and proceed with the AVBD showcase
-curation or reviewer-facing M1 visual packet capture.
+Then: run the py-demos panel/smoke guards, and proceed with reviewer-facing M1
+visual packet capture for the boxed-LCP contact baseline and AVBD showcase.

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -32,15 +32,23 @@ against degenerate debug primitives.
 The next M1 slice added scriptable capture-state restoration:
 `py-demo-capture -- --scene-state-json '{"controls":{"contact_method_index":1}}'`
 restores scene-owned replay state before the viewer starts. The `rigid_body`
-workflow panel now advertises the boxed-LCP baseline capture command, and
-default/CUDA captures resolved `contact_solver_method=BOXED_LCP` in their
-manifests.
+workflow panel now advertises the boxed-LCP baseline capture command with
+`--capture-label boxed_lcp`, so stateful A/B captures use distinct default
+output directories and artifact stems. Default/CUDA captures resolved
+`contact_solver_method=BOXED_LCP` in their manifests.
+
+## Current Branch
+
+`fix/py-demos-selection-crash` - clean after two local follow-up commits:
+`Add scriptable py-demos capture state` and
+`Label py-demos stateful captures`. Neither commit has been pushed to PR #3084
+yet.
 
 ## Immediate Next Step
 
 **M1 is in progress.** Keep the scripted selection repro above in the validation
-set, use the scripted capture-state path for rigid-body SI vs boxed-LCP visual
-packets, then curate the AVBD constraint showcase.
+set, use the labeled scripted capture-state path for rigid-body SI vs boxed-LCP
+visual packets, then curate the AVBD constraint showcase.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -29,11 +29,18 @@ pixi run py-demos -- --scene rigid_body --headless --frames 4 \
 The fix hardens both debug-line generation and the Filament renderable factory
 against degenerate debug primitives.
 
+The next M1 slice added scriptable capture-state restoration:
+`py-demo-capture -- --scene-state-json '{"controls":{"contact_method_index":1}}'`
+restores scene-owned replay state before the viewer starts. The `rigid_body`
+workflow panel now advertises the boxed-LCP baseline capture command, and
+default/CUDA captures resolved `contact_solver_method=BOXED_LCP` in their
+manifests.
+
 ## Immediate Next Step
 
 **M1 is in progress.** Keep the scripted selection repro above in the validation
-set, verify the contact-baseline increment, then capture the rigid-body SI vs
-boxed-LCP visual evidence and curate the AVBD constraint showcase.
+set, use the scripted capture-state path for rigid-body SI vs boxed-LCP visual
+packets, then curate the AVBD constraint showcase.
 
 Re-run any M0 guard:
 
@@ -51,6 +58,9 @@ PYTHONPATH=build/cuda/cpp/Release-docking/python:python .pixi/envs/cuda/bin/pyth
 - First M1 increment: enhance the existing `rigid_body` scene before creating a
   new comparison scene. This keeps the baseline path visible in the flagship
   scene while AVBD showcase curation proceeds separately.
+- Capture-state overrides belong to scenes that already expose
+  `replay_restore_state`; unsupported scenes should fail clearly rather than
+  silently pretending a panel state was applied.
 - M0 triage: **quarantine to green** — non-runnable/planned scenes are marked
   skipped (tracked as deferred), not crashed and not force-fixed.
 - Sibling worktrees (`task_6` memory allocator, `task_7` WP-091 enum) keep
@@ -84,4 +94,5 @@ ls build/cuda/cpp/Release-docking/python/dartpy/_dartpy*.so 2>/dev/null || echo 
 ```
 
 Then: run focused C++/dartpy verification for the writable contact solver
-method, run the py-demos panel/smoke guards, and proceed with M1 visual capture.
+method, run the py-demos panel/smoke guards, and proceed with the AVBD showcase
+curation or reviewer-facing M1 visual packet capture.

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -15,11 +15,25 @@ testing found realtime workflow rows should stay on the Sequential Impulse
 rigid-body solver; SI-vs-IPC inspection belongs in `rigid_solver_compare` and
 explicit IPC shelf scenes.
 
+Interactive selection found one M0 gap: a click/force-drag with no cursor motion
+could enqueue a zero-length debug overlay segment, trip Filament's empty-AABB
+precondition, and then fail shutdown while destroying `dartDebugColor`.
+Reproducer:
+
+```bash
+pixi run py-demos -- --scene rigid_body --headless --frames 4 \
+  --width 640 --height 480 --screenshot /tmp/rigid_body.ppm \
+  --scripted-force-drag 1:sphere_0_visual:0,0,0:2
+```
+
+The fix hardens both debug-line generation and the Filament renderable factory
+against degenerate debug primitives.
+
 ## Immediate Next Step
 
-**M1 is in progress.** Verify the contact-baseline increment, then capture the
-rigid-body SI vs boxed-LCP visual evidence and curate the AVBD constraint
-showcase.
+**M1 is in progress.** Keep the scripted selection repro above in the validation
+set, verify the contact-baseline increment, then capture the rigid-body SI vs
+boxed-LCP visual evidence and curate the AVBD constraint showcase.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -110,20 +110,19 @@ default `pixi run py-demos-smoke --json-out
 `fix/py-demos-selection-crash` - published as PR #3084. The PR includes the
 selection debug-overlay fix, scriptable capture-state restoration, labeled
 stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
-packet. Local follow-up work may be ahead of the remote PR branch until the
-phase-map, stateful open-live command, boxed-LCP workflow-panel UI, and
-rigid-body contact preset fixes plus full-catalog smoke evidence are pushed.
+packet. The remote PR branch also includes the phase-map, stateful open-live
+command, boxed-LCP workflow-panel UI, rigid-body contact preset, and
+full-catalog smoke evidence follow-ups. The PR body has been refreshed with the
+default and CUDA before/after launch timings plus the full-catalog smoke
+results.
 
 ## Immediate Next Step
 
 **M1 is in progress.** Keep the scripted selection repro above in the validation
 set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
-rigid-constraint track. The next useful slice is PR management: push the local
-phase-map/open-live command, workflow-panel UI, contact preset, and smoke
-evidence fixes after explicit approval, refresh the PR body with the full-packet
-and full-catalog smoke evidence if pushing, then watch CI/Codex review for
-actionable feedback.
+rigid-constraint track. The next useful slice is PR management: watch hosted CI
+and the fresh Codex review request on PR #3084 for actionable feedback.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -94,6 +94,9 @@ boxed-LCP contact-baseline row opens the same state that the capture used.
 The live rigid workflow panel now advertises the matching boxed-LCP `py-demos`
 command beside the boxed-LCP capture command, so the panel opens and captures
 the same stateful baseline.
+The `rigid_body` scene panel also has one-click Sequential Impulse and boxed-LCP
+baseline preset buttons that set the contact solver and reset the scene through
+the same replay/capture state path.
 
 ## Current Branch
 
@@ -101,8 +104,8 @@ the same stateful baseline.
 selection debug-overlay fix, scriptable capture-state restoration, labeled
 stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
 packet. Local follow-up work may be ahead of the remote PR branch until the
-phase-map, stateful open-live command, and boxed-LCP workflow-panel UI fixes are
-pushed.
+phase-map, stateful open-live command, boxed-LCP workflow-panel UI, and
+rigid-body contact preset fixes are pushed.
 
 ## Immediate Next Step
 
@@ -110,9 +113,9 @@ pushed.
 set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
 rigid-constraint track. The next useful slice is PR management: push the local
-phase-map/open-live command and workflow-panel UI fixes after explicit
-approval, refresh the PR body with the full-packet evidence if pushing, then
-watch CI/Codex review for actionable feedback.
+phase-map/open-live command, workflow-panel UI, and contact preset fixes after
+explicit approval, refresh the PR body with the full-packet evidence if pushing,
+then watch CI/Codex review for actionable feedback.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -54,10 +54,9 @@ row captures for `avbd_rigid_revolute_motor` completed with
 
 ## Current Branch
 
-`fix/py-demos-selection-crash` - clean after three local follow-up commits:
-`Add scriptable py-demos capture state` and
-`Label py-demos stateful captures`, followed by the AVBD showcase packet commit.
-These commits have not been pushed to PR #3084 yet.
+`fix/py-demos-selection-crash` - published as PR #3084. The PR includes the
+selection debug-overlay fix, scriptable capture-state restoration, labeled
+stateful captures, and the AVBD showcase packet.
 
 ## Immediate Next Step
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -89,6 +89,8 @@ stronger single-scene visual.
 
 A follow-up local improvement makes packet review pages report their M1 phase
 maps for contact-baseline and AVBD-only packets instead of showing `phases 0`.
+It also preserves `scene_state_json` in each row's `open live` command, so the
+boxed-LCP contact-baseline row opens the same state that the capture used.
 
 ## Current Branch
 
@@ -96,7 +98,7 @@ maps for contact-baseline and AVBD-only packets instead of showing `phases 0`.
 selection debug-overlay fix, scriptable capture-state restoration, labeled
 stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
 packet. Local follow-up work may be ahead of the remote PR branch until the
-phase-map reporting fix is pushed.
+phase-map and stateful open-live command fixes are pushed.
 
 ## Immediate Next Step
 
@@ -104,9 +106,9 @@ phase-map reporting fix is pushed.
 set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
 rigid-constraint track. The next useful slice is PR management: push the local
-phase-map reporting fix after explicit approval, refresh the PR body with the
-full-packet evidence if pushing, then watch CI/Codex review for actionable
-feedback.
+phase-map/open-live command fixes after explicit approval, refresh the PR body
+with the full-packet evidence if pushing, then watch CI/Codex review for
+actionable feedback.
 
 Re-run any M0 guard:
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -98,6 +98,12 @@ The `rigid_body` scene panel also has one-click Sequential Impulse and boxed-LCP
 baseline preset buttons that set the contact solver and reset the scene through
 the same replay/capture state path.
 
+The next local UI follow-up adds an `Open contact comparison` button to the
+`rigid_body` front-door panel. It routes through the existing panel
+`request_scene_switch` hook to `rigid_contact_solver_compare`, giving users a
+direct path from the baseline scene to the side-by-side Sequential
+Impulse/boxed-LCP comparison row.
+
 A broad local M0 regression recheck completed on PR #3084 local head `bd0b8e7`:
 default `pixi run py-demos-smoke --json-out
 /tmp/py_demos_smoke_default_pr3084_local.json` passed 155/155 scenes in
@@ -114,7 +120,8 @@ packet. The remote PR branch also includes the phase-map, stateful open-live
 command, boxed-LCP workflow-panel UI, rigid-body contact preset, and
 full-catalog smoke evidence follow-ups. The PR body has been refreshed with the
 default and CUDA before/after launch timings plus the full-catalog smoke
-results.
+results. A local UI follow-up for the `rigid_body` contact-comparison route may
+be ahead of the remote PR branch until explicitly pushed.
 
 ## Immediate Next Step
 
@@ -122,7 +129,9 @@ results.
 set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
 visual evidence, and use the dedicated AVBD showcase packet for the modern
 rigid-constraint track. The next useful slice is PR management: watch hosted CI
-and the fresh Codex review request on PR #3084 for actionable feedback.
+and the fresh Codex review request on PR #3084 for actionable feedback. If the
+local contact-comparison route is included in PR #3084, refresh the PR body and
+rerun/retrigger the same review loop after the approved push.
 
 Re-run any M0 guard:
 

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -930,13 +930,14 @@ writes a top-level manifest that points at every per-scene manifest and a
 questions, try-first guidance, scope notes, live open commands, capture
 commands, workflow-row rerun commands, and metric summaries from one page: the
 in-viewer `Rigid Workflow` panel also shows the full numbered packet,
-current-row rerun, and extended related/IPC-shelf/packet commands.
+current-row rerun, AVBD showcase, and extended related/IPC-shelf/packet
+commands.
 Numbered rows carry their workflow phase and focus axis in the manifest and
-review card, while optional related, direct IPC shelf, and capture-first packet
-rows carry the same row-guidance fields in the manifest and review index, so
-extended packets remain readable without opening the live GUI. The same outputs
-also include a guidance-completeness audit and the exact top-level workflow
-command for the selected packet.
+review card, while the AVBD showcase and optional related, direct IPC shelf,
+and capture-first packet rows carry the same row-guidance fields in the
+manifest and review index, so non-numbered packets remain readable without
+opening the live GUI. The same outputs also include a guidance-completeness
+audit and the exact top-level workflow command for the selected packet.
 
 ```bash
 pixi run py-demo-capture -- --rigid-workflow --dry-run
@@ -988,6 +989,19 @@ pixi run py-demo-capture -- --rigid-workflow --include-related \
     --include-packets --output-dir /tmp/dart_capture_rigid_workflow_with_packets
 ```
 
+Use `--avbd-showcase-only` when the target is the curated AVBD
+rigid-constraint showcase rather than the numbered World rigid workflow. The
+packet captures the current fixed-joint/contact, breakable-joint, spherical
+breakable-joint, revolute-motor, and prismatic-motor AVBD rows as a
+complementary M1 showcase beside the World contact-policy and boxed-LCP
+baseline; it is not a head-to-head solver enum comparison.
+
+```bash
+pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --dry-run
+pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only \
+    --output-dir /tmp/dart_capture_rigid_avbd_showcase
+```
+
 Capture the direct Rigid IPC shelf routes with the docked UI visible:
 
 These commands are also included after the numbered rows, and after related
@@ -1008,21 +1022,22 @@ pixi run py-demo-capture -- --scene rigid_ipc_pile --frames 72 \
 For targeted reruns after a failed or manually inspected row, keep the same
 workflow packet but bound the row range. Row numbers stay absolute, so row 37
 still writes under `scenes/37_<scene>` when related evidence is included. With
-`--include-related --include-packets`, rows 49-50 are the two
+`--include-related --include-packets`, rows 44-45 are the two
 capture-first stack packets. If `--include-ipc-shelf` is also requested, those
-packet rows become 53-54.
+packet rows become 48-49.
 
 ```bash
 pixi run py-demo-capture -- --rigid-workflow \
     --workflow-start-row 15 --workflow-end-row 17 --dry-run
 pixi run py-demo-capture -- --rigid-workflow --include-related \
-    --include-packets --workflow-start-row 49 --workflow-end-row 50 \
+    --include-packets --workflow-start-row 44 --workflow-end-row 45 \
     --output-dir /tmp/dart_capture_rigid_workflow_packet_rerun
 ```
 
 For row-range packets, manifest fields such as `include_related`,
-`include_ipc_shelf`, and `include_packets` record the requested packet shape;
-`selected_include_related`, `selected_include_ipc_shelf`, and
+`include_avbd_showcase`, `include_ipc_shelf`, and `include_packets` record the
+requested packet shape; `selected_include_related`,
+`selected_include_avbd_showcase`, `selected_include_ipc_shelf`, and
 `selected_include_packets` record which optional groups are present in the
 selected row range. The generated `review_index.html` header mirrors this with
 row-span, requested-groups, and selected-groups badges.
@@ -1145,10 +1160,11 @@ differentiable contact-gradient routes use it for target/rest height, analytic
 versus complementarity-aware thrust/final-height/loss values, height and
 target-error gaps, pre-contact counts, identical forward-state evidence,
 analytic-freefall error, surrogate block magnitude, vertical sensitivity,
-fallback status, and compact history summaries. The AVBD related routes use it
-for fixed-joint contact offset/clearance/contact counts, spherical breakage
-anchor/orientation drift, and free-rigid revolute/prismatic motor tracking. The
-early numbered rigid workflow rows use it for body-mode flags, free-flight
+fallback status, and compact history summaries. The AVBD showcase routes use it
+for fixed-joint contact offset/clearance/contact counts, breakable fixed and
+spherical-joint state, anchor/orientation drift, and free-rigid
+revolute/prismatic motor tracking. The early numbered rigid workflow rows use
+it for body-mode flags, free-flight
 momentum/energy residuals, frame-transform residuals,
 force/torque accumulator response, point-load lever-arm response,
 time-step error ratios, restitution rebound, and pair-material mixing fields,
@@ -1195,6 +1211,14 @@ pixi run py-demo-capture -- --scene diff_drone_liftoff --frames 96 \
     --width 960 --height 540 --show-ui
 pixi run py-demo-capture -- --scene diff_pre_contact_surrogate --frames 24 \
     --width 960 --height 540 --show-ui
+```
+
+Capture every AVBD showcase route with the docked UI visible:
+
+These commands are also included in the dedicated AVBD packet by
+`py-demo-capture -- --rigid-workflow --avbd-showcase-only`.
+
+```bash
 pixi run py-demo-capture -- --scene avbd_rigid_fixed_joint_contact --frames 72 \
     --width 960 --height 540 --show-ui
 pixi run py-demo-capture -- --scene avbd_rigid_breakable_joint --frames 72 \

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -930,11 +930,12 @@ writes a top-level manifest that points at every per-scene manifest and a
 questions, try-first guidance, scope notes, live open commands, capture
 commands, workflow-row rerun commands, and metric summaries from one page: the
 in-viewer `Rigid Workflow` panel also shows the full numbered packet,
-current-row rerun, AVBD showcase, and extended related/IPC-shelf/packet
-commands.
+current-row rerun, contact-baseline, AVBD showcase, and extended
+related/IPC-shelf/packet commands.
 Numbered rows carry their workflow phase and focus axis in the manifest and
-review card, while the AVBD showcase and optional related, direct IPC shelf,
-and capture-first packet rows carry the same row-guidance fields in the
+review card, while the contact-baseline packet, AVBD showcase, and optional
+related, direct IPC shelf, and capture-first packet rows carry row-guidance
+fields in the
 manifest and review index, so non-numbered packets remain readable without
 opening the live GUI. The same outputs also include a guidance-completeness
 audit and the exact top-level workflow command for the selected packet.
@@ -987,6 +988,18 @@ shelf rows when those groups are requested:
 pixi run py-demo-capture -- --rigid-workflow --include-packets --dry-run
 pixi run py-demo-capture -- --rigid-workflow --include-related \
     --include-packets --output-dir /tmp/dart_capture_rigid_workflow_with_packets
+```
+
+Use `--contact-baseline-only` when the target is the M1 World contact-policy
+baseline. The packet captures the flagship `rigid_body` scene twice: the
+default Sequential Impulse contact path and the same scene restored with the
+boxed-LCP contact method before the first frame. Both rows keep stable capture
+labels and state metadata in the workflow manifest and review index.
+
+```bash
+pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --dry-run
+pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only \
+    --output-dir /tmp/dart_capture_rigid_contact_baseline
 ```
 
 Use `--avbd-showcase-only` when the target is the curated AVBD

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -78,6 +78,17 @@ pixi run py-demo-capture -- --scene rigid_solver_compare --frames 72 \
     --width 960 --height 540 --show-ui --video --fps 24
 ```
 
+Scene-owned replay state can also be restored before capture with
+`--scene-state-json`. This is useful for reproducible visual A/B packets where a
+panel control would otherwise need to be clicked manually. For example, capture
+the `rigid_body` baseline with the boxed-LCP contact method selected:
+
+```bash
+pixi run py-demo-capture -- --scene rigid_body --frames 180 \
+    --width 960 --height 540 --show-ui \
+    --scene-state-json '{"controls":{"contact_method_index":1}}'
+```
+
 The docked workspace has a top `Simulation` toolbar, a searchable `Demos`
 navigator, scene-specific panels on the right, bottom scene panels when a demo
 owns timeline controls, and a docked DART diagnostics panel. Use `Rebuild` to

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -80,13 +80,16 @@ pixi run py-demo-capture -- --scene rigid_solver_compare --frames 72 \
 
 Scene-owned replay state can also be restored before capture with
 `--scene-state-json`. This is useful for reproducible visual A/B packets where a
-panel control would otherwise need to be clicked manually. For example, capture
-the `rigid_body` baseline with the boxed-LCP contact method selected:
+panel control would otherwise need to be clicked manually. Add
+`--capture-label` to give the stateful capture a distinct default output
+directory and artifact stem. For example, capture the `rigid_body` baseline with
+the boxed-LCP contact method selected:
 
 ```bash
 pixi run py-demo-capture -- --scene rigid_body --frames 180 \
     --width 960 --height 540 --show-ui \
-    --scene-state-json '{"controls":{"contact_method_index":1}}'
+    --scene-state-json '{"controls":{"contact_method_index":1}}' \
+    --capture-label boxed_lcp
 ```
 
 The docked workspace has a top `Simulation` toolbar, a searchable `Demos`

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -943,6 +943,7 @@ def _rigid_workflow_viewer_command(scene_id: str, width: int, height: int) -> st
 
 def _rigid_workflow_packet_command(
     *,
+    contact_baseline_only: bool = False,
     avbd_showcase_only: bool = False,
     include_related: bool = False,
     include_ipc_shelf: bool = False,
@@ -955,6 +956,8 @@ def _rigid_workflow_packet_command(
     output_dir: str | None = None,
 ) -> str:
     command = "pixi run py-demo-capture -- --rigid-workflow"
+    if contact_baseline_only:
+        command = f"{command} --contact-baseline-only"
     if avbd_showcase_only:
         command = f"{command} --avbd-showcase-only"
     if include_related:
@@ -2567,6 +2570,15 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
             )
         )
         builder.item_tooltip("Capture all numbered rows and write review_index.html.")
+        builder.text(
+            _rigid_workflow_packet_command(
+                contact_baseline_only=True,
+                output_dir="/tmp/dart_capture_rigid_contact_baseline",
+            )
+        )
+        builder.item_tooltip(
+            "Capture the SI and boxed-LCP rigid_body contact-baseline packet."
+        )
         builder.text(
             _rigid_workflow_packet_command(
                 avbd_showcase_only=True,

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -937,8 +937,19 @@ def _rigid_workflow_capture_command(
     return command
 
 
-def _rigid_workflow_viewer_command(scene_id: str, width: int, height: int) -> str:
-    return f"pixi run py-demos -- --scene {scene_id} --width {width} --height {height}"
+def _rigid_workflow_viewer_command(
+    scene_id: str,
+    width: int,
+    height: int,
+    scene_state_json: str | None = None,
+) -> str:
+    command = (
+        f"pixi run py-demos -- --scene {scene_id} "
+        f"--width {width} --height {height}"
+    )
+    if scene_state_json is not None:
+        command = f"{command} --scene-state-json {shlex.quote(scene_state_json)}"
+    return command
 
 
 def _rigid_workflow_packet_command(
@@ -2547,6 +2558,18 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
         builder.item_tooltip("Run from the repository root to regenerate this row.")
         if guide.scene_id == "rigid_body":
             builder.text("Boxed-LCP baseline variant")
+            builder.text(
+                _rigid_workflow_viewer_command(
+                    guide.scene_id,
+                    guide.capture_width,
+                    guide.capture_height,
+                    scene_state_json=_RIGID_BODY_BOXED_LCP_STATE_JSON,
+                )
+            )
+            builder.item_tooltip(
+                "Open the rigid_body row live with the contact solver set to "
+                "Boxed LCP before the first frame."
+            )
             builder.text(
                 _rigid_workflow_capture_command(
                     guide.scene_id,

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -2849,11 +2849,33 @@ def _default_initial_scene_args(
 
     if scene_arg is not None:
         return []
-    if environ.get("DART_DEMOS_SCENE"):
+    if _environment_initial_scene_id(environ) is not None:
         return []
     if "--cycle-scenes" in argv:
         return []
     return ["--scene", DEFAULT_INITIAL_SCENE_ID]
+
+
+def _environment_initial_scene_id(environ: Mapping[str, str]) -> str | None:
+    value = environ.get("DART_DEMOS_SCENE", "").strip()
+    if not value:
+        return None
+    return _canonical_scene_id(value)
+
+
+def _scene_state_target_scene_id(
+    scene_arg: str | None,
+    default_initial_scene_args: list[str],
+    environ: Mapping[str, str],
+) -> str | None:
+    if scene_arg is not None:
+        return _canonical_scene_id(scene_arg)
+    environment_scene_id = _environment_initial_scene_id(environ)
+    if environment_scene_id is not None:
+        return environment_scene_id
+    if default_initial_scene_args:
+        return DEFAULT_INITIAL_SCENE_ID
+    return None
 
 
 def _make_gpu_panel(sx: Any) -> ScenePanel:
@@ -2959,16 +2981,16 @@ def run(argv: Iterable[str], scenes: list[PythonDemoScene]) -> int:
     scene_state_override = _parse_scene_state_json(known.scene_state_json)
     scene_state_scene_id: str | None = None
     if scene_state_override is not None:
-        if known.scene is not None:
-            scene_state_scene_id = _canonical_scene_id(known.scene)
-        elif default_initial_scene_args:
-            scene_state_scene_id = DEFAULT_INITIAL_SCENE_ID
-        else:
+        scene_state_scene_id = _scene_state_target_scene_id(
+            known.scene, default_initial_scene_args, os.environ
+        )
+        if scene_state_scene_id is None:
             raise SystemExit(
                 "--scene-state-json requires a single selected scene; pass "
                 "--scene or omit --cycle-scenes so the default rigid_body "
                 "scene is selected"
             )
+        _validate_scene(scene_state_scene_id, scenes)
 
     # Import dartpy.gui lazily so `--list` works even when the GUI
     # backend isn't built (e.g. on CI variants without filament).

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -943,6 +943,7 @@ def _rigid_workflow_viewer_command(scene_id: str, width: int, height: int) -> st
 
 def _rigid_workflow_packet_command(
     *,
+    avbd_showcase_only: bool = False,
     include_related: bool = False,
     include_ipc_shelf: bool = False,
     include_packets: bool = False,
@@ -954,6 +955,8 @@ def _rigid_workflow_packet_command(
     output_dir: str | None = None,
 ) -> str:
     command = "pixi run py-demo-capture -- --rigid-workflow"
+    if avbd_showcase_only:
+        command = f"{command} --avbd-showcase-only"
     if include_related:
         command = f"{command} --include-related"
     if include_ipc_shelf:
@@ -2564,6 +2567,15 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
             )
         )
         builder.item_tooltip("Capture all numbered rows and write review_index.html.")
+        builder.text(
+            _rigid_workflow_packet_command(
+                avbd_showcase_only=True,
+                output_dir="/tmp/dart_capture_rigid_avbd_showcase",
+            )
+        )
+        builder.item_tooltip(
+            "Capture the curated AVBD rigid-constraint showcase packet."
+        )
         builder.text(_rigid_workflow_row_packet_command(guide))
         builder.item_tooltip("Capture only this workflow row in a review packet.")
         builder.text(_rigid_workflow_row_video_packet_command(guide))

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -34,6 +34,7 @@ import math
 import os
 import re
 import signal
+import shlex
 import sys
 import threading
 import time
@@ -52,6 +53,8 @@ REPLAY_TIMELINE_INFO_KEY = "replay_timeline"
 REPLAY_WORLD_INFO_KEYS = ("sx_world", "physics_world")
 CAPTURE_METRICS_INFO_KEY = "capture_metrics"
 CAPTURE_METADATA_EVENT_NAME = "scene_capture_metadata"
+SCENE_STATE_OVERRIDE_INFO_KEY = "scene_state_override"
+_RIGID_BODY_BOXED_LCP_STATE_JSON = '{"controls":{"contact_method_index":1}}'
 CAPTURE_METRICS_EVENT_NAME = "scene_capture_metrics"
 _REPLAY_RATE_LABELS = (
     "1 frame/tick",
@@ -918,6 +921,7 @@ def _rigid_workflow_capture_command(
     width: int,
     height: int,
     show_ui: bool,
+    scene_state_json: str | None = None,
 ) -> str:
     command = (
         "pixi run py-demo-capture -- "
@@ -925,6 +929,8 @@ def _rigid_workflow_capture_command(
     )
     if show_ui:
         command = f"{command} --show-ui"
+    if scene_state_json is not None:
+        command = f"{command} --scene-state-json {shlex.quote(scene_state_json)}"
     return command
 
 
@@ -1968,10 +1974,51 @@ def _capture_metadata_mapping(setup: SceneSetup) -> dict[str, Any]:
     replay_timeline = _replay_timeline_capture_metadata(setup)
     if replay_timeline is not None:
         metadata[REPLAY_TIMELINE_INFO_KEY] = replay_timeline
+    scene_state_override = setup.info.get(SCENE_STATE_OVERRIDE_INFO_KEY)
+    if scene_state_override is not None:
+        metadata[SCENE_STATE_OVERRIDE_INFO_KEY] = scene_state_override
     skipped_reason = setup.info.get("shared_replay_skipped_reason")
     if isinstance(skipped_reason, str) and skipped_reason:
         metadata["shared_replay_skipped_reason"] = skipped_reason
     return metadata
+
+
+def _parse_scene_state_json(text: str) -> dict[str, Any] | None:
+    if not text:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"--scene-state-json must be a JSON object: {exc.msg}"
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise SystemExit("--scene-state-json must be a JSON object")
+    return dict(payload)
+
+
+def _apply_scene_state_override(
+    scene: PythonDemoScene, setup: SceneSetup, state: Mapping[str, Any] | None
+) -> SceneSetup:
+    if state is None:
+        return setup
+
+    restore = setup.info.get("replay_restore_state")
+    if not callable(restore):
+        raise RuntimeError(
+            f"Python demo scene '{scene.id}' does not support --scene-state-json"
+        )
+    state_copy = copy.deepcopy(dict(state))
+    try:
+        restore(state_copy)
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(
+            f"Python demo scene '{scene.id}' rejected --scene-state-json: {exc}"
+        ) from exc
+    setup.info[SCENE_STATE_OVERRIDE_INFO_KEY] = _capture_metrics_json_value(
+        state_copy
+    )
+    return setup
 
 
 def _append_capture_metadata_event(
@@ -2489,6 +2536,22 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
         builder.item_tooltip("Open this row live in py-demos for interactive debugging.")
         builder.text(guide.capture_command)
         builder.item_tooltip("Run from the repository root to regenerate this row.")
+        if guide.scene_id == "rigid_body":
+            builder.text("Boxed-LCP baseline variant")
+            builder.text(
+                _rigid_workflow_capture_command(
+                    guide.scene_id,
+                    guide.capture_frames,
+                    guide.capture_width,
+                    guide.capture_height,
+                    guide.capture_show_ui,
+                    scene_state_json=_RIGID_BODY_BOXED_LCP_STATE_JSON,
+                )
+            )
+            builder.item_tooltip(
+                "Capture the same baseline row with the contact solver set to "
+                "Boxed LCP before the first frame."
+            )
         builder.separator()
         builder.text("Review packet")
         builder.text(
@@ -2631,6 +2694,7 @@ def _make_world_factory(
     scene: PythonDemoScene,
     gpu_panel: ScenePanel | None = None,
     capture_metrics_event_log: str = "",
+    scene_state_override: Mapping[str, Any] | None = None,
 ) -> Callable[[], Any]:
     """Wrap scene.build() so dart.gui.run_demos can call it as a factory.
 
@@ -2641,6 +2705,7 @@ def _make_world_factory(
     def factory() -> Any:
         with _bounded_scene_build(scene.id):
             setup = scene.build()
+        setup = _apply_scene_state_override(scene, setup, scene_state_override)
         setup = _attach_replay_controls(scene, setup)
         _append_capture_metadata_event(capture_metrics_event_log, scene.id, setup)
         setup = _attach_capture_metrics_recording(
@@ -2710,16 +2775,17 @@ def _strip_runner_local_flags(argv: list[str]) -> list[str]:
 
     stripped: list[str] = []
     skip_next = False
+    flags_with_values = {"--capture-metrics-event-log", "--scene-state-json"}
     for arg in argv:
         if skip_next:
             skip_next = False
             continue
         if arg in {"--gpu", "--no-gpu"}:
             continue
-        if arg == "--capture-metrics-event-log":
+        if arg in flags_with_values:
             skip_next = True
             continue
-        if arg.startswith("--capture-metrics-event-log="):
+        if any(arg.startswith(f"{flag}=") for flag in flags_with_values):
             continue
         stripped.append(arg)
     return stripped
@@ -2826,6 +2892,7 @@ def run(argv: Iterable[str], scenes: list[PythonDemoScene]) -> int:
     parser.add_argument("--gpu", dest="gpu", action="store_true", default=None)
     parser.add_argument("--no-gpu", dest="gpu", action="store_false")
     parser.add_argument("--capture-metrics-event-log", default="")
+    parser.add_argument("--scene-state-json", default="")
     known, _passthrough = parser.parse_known_args(argv)
 
     if known.list:
@@ -2838,6 +2905,19 @@ def run(argv: Iterable[str], scenes: list[PythonDemoScene]) -> int:
     )
     if default_initial_scene_args:
         _validate_scene(DEFAULT_INITIAL_SCENE_ID, scenes)
+    scene_state_override = _parse_scene_state_json(known.scene_state_json)
+    scene_state_scene_id: str | None = None
+    if scene_state_override is not None:
+        if known.scene is not None:
+            scene_state_scene_id = _canonical_scene_id(known.scene)
+        elif default_initial_scene_args:
+            scene_state_scene_id = DEFAULT_INITIAL_SCENE_ID
+        else:
+            raise SystemExit(
+                "--scene-state-json requires a single selected scene; pass "
+                "--scene or omit --cycle-scenes so the default rigid_body "
+                "scene is selected"
+            )
 
     # Import dartpy.gui lazily so `--list` works even when the GUI
     # backend isn't built (e.g. on CI variants without filament).
@@ -2867,6 +2947,11 @@ def run(argv: Iterable[str], scenes: list[PythonDemoScene]) -> int:
                 scene,
                 gpu_panel,
                 capture_metrics_event_log=known.capture_metrics_event_log,
+                scene_state_override=(
+                    scene_state_override
+                    if scene.id == scene_state_scene_id
+                    else None
+                ),
             ),
         )
         for scene in scenes

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -922,6 +922,7 @@ def _rigid_workflow_capture_command(
     height: int,
     show_ui: bool,
     scene_state_json: str | None = None,
+    capture_label: str | None = None,
 ) -> str:
     command = (
         "pixi run py-demo-capture -- "
@@ -931,6 +932,8 @@ def _rigid_workflow_capture_command(
         command = f"{command} --show-ui"
     if scene_state_json is not None:
         command = f"{command} --scene-state-json {shlex.quote(scene_state_json)}"
+    if capture_label is not None:
+        command = f"{command} --capture-label {shlex.quote(capture_label)}"
     return command
 
 
@@ -2546,6 +2549,7 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
                     guide.capture_height,
                     guide.capture_show_ui,
                     scene_state_json=_RIGID_BODY_BOXED_LCP_STATE_JSON,
+                    capture_label="boxed_lcp",
                 )
             )
             builder.item_tooltip(

--- a/python/examples/demos/scenes/rigid_body.py
+++ b/python/examples/demos/scenes/rigid_body.py
@@ -39,6 +39,7 @@ _CONTACT_METHODS: tuple[tuple[str, sx.ContactSolverMethod], ...] = (
 )
 _CONTACT_METHOD_SEQUENTIAL_INDEX = 0
 _CONTACT_METHOD_BOXED_LCP_INDEX = 1
+_CONTACT_POLICY_COMPARE_SCENE_ID = "rigid_contact_solver_compare"
 
 
 def _visual_for(
@@ -367,6 +368,11 @@ class _RigidBodyBaseline:
         )
         self.reset(clear_replay=True)
 
+    def _request_contact_policy_compare(self, context: object) -> None:
+        request_scene_switch = getattr(context, "request_scene_switch", None)
+        if callable(request_scene_switch):
+            request_scene_switch(_CONTACT_POLICY_COMPARE_SCENE_ID)
+
     def build_panel(self, builder: object, context: object) -> None:
         changed_solver, solver_index = builder.select(
             "Solver", int(self.solver_index), [label for label, _solver in _SOLVERS]
@@ -402,6 +408,11 @@ class _RigidBodyBaseline:
         if builder.button("Boxed LCP"):
             self._set_contact_method_index(_CONTACT_METHOD_BOXED_LCP_INDEX)
         builder.item_tooltip("Reset to the DART 6-style boxed-LCP baseline.")
+        if builder.button("Open contact comparison"):
+            self._request_contact_policy_compare(context)
+        builder.item_tooltip(
+            "Open the side-by-side Sequential Impulse and boxed-LCP policy row."
+        )
         if builder.button("Reset baseline scene"):
             self.reset(clear_replay=True)
 

--- a/python/examples/demos/scenes/rigid_body.py
+++ b/python/examples/demos/scenes/rigid_body.py
@@ -37,6 +37,8 @@ _CONTACT_METHODS: tuple[tuple[str, sx.ContactSolverMethod], ...] = (
     ("Sequential impulse", sx.ContactSolverMethod.SEQUENTIAL_IMPULSE),
     ("Boxed LCP", sx.ContactSolverMethod.BOXED_LCP),
 )
+_CONTACT_METHOD_SEQUENTIAL_INDEX = 0
+_CONTACT_METHOD_BOXED_LCP_INDEX = 1
 
 
 def _visual_for(
@@ -355,6 +357,16 @@ class _RigidBodyBaseline:
         history.clear()
         history.extend(float(value) for value in values)
 
+    def _set_contact_method_index(self, index: int) -> None:
+        self.contact_method_index = max(
+            0,
+            min(
+                int(index),
+                len(_CONTACT_METHODS) - 1,
+            ),
+        )
+        self.reset(clear_replay=True)
+
     def build_panel(self, builder: object, context: object) -> None:
         changed_solver, solver_index = builder.select(
             "Solver", int(self.solver_index), [label for label, _solver in _SOLVERS]
@@ -375,14 +387,21 @@ class _RigidBodyBaseline:
             self.solver_index = int(solver_index)
             self.reset(clear_replay=True)
         if changed_contact_method:
-            self.contact_method_index = int(contact_method_index)
-            self.reset(clear_replay=True)
+            self._set_contact_method_index(contact_method_index)
         if changed_friction:
             self.friction = float(friction)
             self._apply_materials()
         if changed_restitution:
             self.restitution = float(restitution)
             self._apply_materials()
+        builder.text("Contact baseline preset")
+        if builder.button("Sequential impulse"):
+            self._set_contact_method_index(_CONTACT_METHOD_SEQUENTIAL_INDEX)
+        builder.item_tooltip("Reset to the default contact baseline.")
+        builder.same_line()
+        if builder.button("Boxed LCP"):
+            self._set_contact_method_index(_CONTACT_METHOD_BOXED_LCP_INDEX)
+        builder.item_tooltip("Reset to the DART 6-style boxed-LCP baseline.")
         if builder.button("Reset baseline scene"):
             self.reset(clear_replay=True)
 

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -694,16 +694,53 @@ def test_rigid_workflow_dry_run_can_capture_avbd_showcase_only(
         manifest["captures"][0]["workflow_label"]
         == "AVBD constraint showcase"
     )
+    assert (
+        manifest["captures"][0]["workflow_phase"]
+        == "M1 AVBD constraint showcase"
+    )
+    assert (
+        manifest["captures"][0]["focus_axis"]
+        == "AVBD rigid constraint track"
+    )
     assert "fixed joint coherent" in manifest["captures"][0]["user_question"]
     assert "boxed-LCP baseline" in manifest["captures"][0]["scope"]
     assert manifest["captures"][1]["workflow_label"] == "AVBD constraint showcase"
+    assert manifest["captures"][1]["workflow_phase"] == (
+        "M1 AVBD constraint showcase"
+    )
+    assert manifest["captures"][1]["focus_axis"] == "AVBD rigid constraint track"
     assert "slider motor" in manifest["captures"][1]["user_question"]
     assert "slider travel" in manifest["captures"][1]["inspect"]
     assert manifest["captures"][1]["manifest"].endswith(
         "scenes/02_avbd_rigid_prismatic_motor/manifest.json"
     )
+    assert manifest["workflow_phase_summary"] == [
+        {
+            "phase": "M1 AVBD constraint showcase",
+            "focus_axes": ["AVBD rigid constraint track"],
+            "captured_count": 0,
+            "failed_count": 0,
+            "planned_count": len(avbd_specs),
+            "row_count": len(avbd_specs),
+            "row_span": "1-2",
+            "rows": [1, 2],
+            "scenes": [
+                "avbd_rigid_fixed_joint_contact",
+                "avbd_rigid_prismatic_motor",
+            ],
+            "status_counts": {
+                "captured": 0,
+                "failed": 0,
+                "planned": len(avbd_specs),
+            },
+        }
+    ]
     review_html = pathlib.Path(manifest["artifacts"]["review_index"]).read_text()
     assert "AVBD constraint showcase" in review_html
+    assert "<strong>phases</strong> 1" in review_html
+    assert "Workflow Phase Map" in review_html
+    assert "M1 AVBD constraint showcase" in review_html
+    assert "AVBD rigid constraint track" in review_html
     assert "avbd showcase" in review_html
     assert "avbd_constraint_showcase" in review_html
     assert "fixed joint coherent" in review_html
@@ -784,14 +821,46 @@ def test_rigid_workflow_dry_run_can_capture_contact_baseline_only(
         f"{output}/reruns/02_rigid_body"
     )
     assert manifest["captures"][0]["workflow_label"] == "Contact baseline"
+    assert manifest["captures"][0]["workflow_phase"] == "M1 contact-policy baseline"
+    assert (
+        manifest["captures"][0]["focus_axis"]
+        == "Sequential Impulse vs boxed-LCP contact method"
+    )
     assert "Sequential Impulse contact path" in manifest["captures"][0]["user_question"]
     assert manifest["captures"][1]["workflow_label"] == "Contact baseline"
+    assert manifest["captures"][1]["workflow_phase"] == "M1 contact-policy baseline"
+    assert (
+        manifest["captures"][1]["focus_axis"]
+        == "Sequential Impulse vs boxed-LCP contact method"
+    )
     assert "boxed-LCP contact baseline" in manifest["captures"][1]["user_question"]
     assert "contact_solver_method=BOXED_LCP" in manifest["captures"][1][
         "healthy_signal"
     ]
+    assert manifest["workflow_phase_summary"] == [
+        {
+            "phase": "M1 contact-policy baseline",
+            "focus_axes": ["Sequential Impulse vs boxed-LCP contact method"],
+            "captured_count": 0,
+            "failed_count": 0,
+            "planned_count": 2,
+            "row_count": 2,
+            "row_span": "1-2",
+            "rows": [1, 2],
+            "scenes": ["rigid_body", "rigid_body"],
+            "status_counts": {
+                "captured": 0,
+                "failed": 0,
+                "planned": 2,
+            },
+        }
+    ]
     review_html = pathlib.Path(manifest["artifacts"]["review_index"]).read_text()
     assert "contact baseline" in review_html
+    assert "<strong>phases</strong> 1" in review_html
+    assert "Workflow Phase Map" in review_html
+    assert "M1 contact-policy baseline" in review_html
+    assert "Sequential Impulse vs boxed-LCP contact method" in review_html
     assert "--contact-baseline-only" in review_html
     assert "<dt>capture label</dt><dd>sequential_impulse</dd>" in review_html
     assert "<dt>capture label</dt><dd>boxed_lcp</dd>" in review_html

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -494,9 +494,11 @@ def test_rigid_workflow_dry_run_writes_capture_plan(
     assert rc == 0
     manifest = json.loads((output / "manifest.json").read_text())
     assert manifest["workflow"] == "rigid_visual_verification"
+    assert manifest["include_avbd_showcase"] is False
     assert manifest["include_related"] is False
     assert manifest["include_ipc_shelf"] is False
     assert manifest["include_packets"] is False
+    assert manifest["selected_include_avbd_showcase"] is False
     assert manifest["selected_include_related"] is False
     assert manifest["selected_include_ipc_shelf"] is False
     assert manifest["selected_include_packets"] is False
@@ -629,6 +631,84 @@ def test_rigid_workflow_dry_run_writes_capture_plan(
         review_html
     )
     assert "pixi run py-demo-capture -- --scene rigid_body" in review_html
+
+
+def test_rigid_workflow_dry_run_can_capture_avbd_showcase_only(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "rigid_avbd_showcase"
+    avbd_specs = (
+        ("avbd_rigid_fixed_joint_contact", 72, 960, 540, True),
+        ("avbd_rigid_prismatic_motor", 72, 960, 540, True),
+    )
+    monkeypatch.setattr(
+        capture_py_demo,
+        "RIGID_WORKFLOW_AVBD_SHOWCASE_CAPTURE_SPECS",
+        avbd_specs,
+    )
+
+    def fail_run(_argv: list[str]) -> int:
+        raise AssertionError("dry-run should not render scenes")
+
+    monkeypatch.setattr(capture_py_demo, "_run_scene_capture_from_argv", fail_run)
+
+    rc = capture_py_demo.main(
+        [
+            "--rigid-workflow",
+            "--avbd-showcase-only",
+            "--dry-run",
+            "--output-dir",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
+    manifest = json.loads((output / "manifest.json").read_text())
+    assert manifest["include_avbd_showcase"] is True
+    assert manifest["include_related"] is False
+    assert manifest["include_ipc_shelf"] is False
+    assert manifest["include_packets"] is False
+    assert manifest["selected_include_avbd_showcase"] is True
+    assert manifest["selected_include_related"] is False
+    assert manifest["selected_include_ipc_shelf"] is False
+    assert manifest["selected_include_packets"] is False
+    assert manifest["capture_count"] == len(avbd_specs)
+    assert manifest["workflow_total_count"] == len(avbd_specs)
+    assert manifest["workflow_row_start"] == 1
+    assert manifest["workflow_row_end"] == len(avbd_specs)
+    assert [capture["scene"] for capture in manifest["captures"]] == [
+        "avbd_rigid_fixed_joint_contact",
+        "avbd_rigid_prismatic_motor",
+    ]
+    assert [capture["workflow_group"] for capture in manifest["captures"]] == [
+        "avbd_constraint_showcase",
+        "avbd_constraint_showcase",
+    ]
+    assert (
+        manifest["captures"][0]["workflow_rerun_command"]
+        == "pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only "
+        "--workflow-start-row 1 --workflow-end-row 1 --output-dir "
+        f"{output}/reruns/01_avbd_rigid_fixed_joint_contact"
+    )
+    assert (
+        manifest["captures"][0]["workflow_label"]
+        == "AVBD constraint showcase"
+    )
+    assert "fixed joint coherent" in manifest["captures"][0]["user_question"]
+    assert "boxed-LCP baseline" in manifest["captures"][0]["scope"]
+    assert manifest["captures"][1]["workflow_label"] == "AVBD constraint showcase"
+    assert "slider motor" in manifest["captures"][1]["user_question"]
+    assert "slider travel" in manifest["captures"][1]["inspect"]
+    assert manifest["captures"][1]["manifest"].endswith(
+        "scenes/02_avbd_rigid_prismatic_motor/manifest.json"
+    )
+    review_html = pathlib.Path(manifest["artifacts"]["review_index"]).read_text()
+    assert "AVBD constraint showcase" in review_html
+    assert "avbd showcase" in review_html
+    assert "avbd_constraint_showcase" in review_html
+    assert "fixed joint coherent" in review_html
+    assert "slider motor" in review_html
+    assert "--avbd-showcase-only" in review_html
 
 
 def test_rigid_workflow_dry_run_can_include_related_evidence(
@@ -2970,6 +3050,10 @@ def test_rigid_workflow_scene_capture_runs_in_child_process(
     ("flag", "message"),
     (
         ("--include-related", "--include-related requires --rigid-workflow"),
+        (
+            "--avbd-showcase-only",
+            "--avbd-showcase-only requires --rigid-workflow",
+        ),
         ("--include-ipc-shelf", "--include-ipc-shelf requires --rigid-workflow"),
         ("--include-packets", "--include-packets requires --rigid-workflow"),
         (
@@ -2988,6 +3072,25 @@ def test_rigid_workflow_extra_groups_require_workflow(flag: str, message: str) -
         args.insert(1, "1")
     with pytest.raises(SystemExit, match=message):
         capture_py_demo.main(args)
+
+
+def test_rigid_workflow_avbd_showcase_rejects_other_groups(
+    tmp_path: pathlib.Path,
+) -> None:
+    with pytest.raises(
+        SystemExit,
+        match="--avbd-showcase-only cannot be combined with other workflow groups",
+    ):
+        capture_py_demo.main(
+            [
+                "--rigid-workflow",
+                "--avbd-showcase-only",
+                "--include-related",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -820,6 +820,11 @@ def test_rigid_workflow_dry_run_can_capture_contact_baseline_only(
         "--workflow-start-row 2 --workflow-end-row 2 --output-dir "
         f"{output}/reruns/02_rigid_body"
     )
+    assert "--scene-state-json" not in manifest["captures"][0]["viewer_command"]
+    assert (
+        "--scene-state-json '{\"controls\":{\"contact_method_index\":1}}'"
+        in manifest["captures"][1]["viewer_command"]
+    )
     assert manifest["captures"][0]["workflow_label"] == "Contact baseline"
     assert manifest["captures"][0]["workflow_phase"] == "M1 contact-policy baseline"
     assert (
@@ -865,6 +870,10 @@ def test_rigid_workflow_dry_run_can_capture_contact_baseline_only(
     assert "<dt>capture label</dt><dd>sequential_impulse</dd>" in review_html
     assert "<dt>capture label</dt><dd>boxed_lcp</dd>" in review_html
     assert "<dt>scene state</dt><dd>{&quot;controls&quot;" in review_html
+    assert (
+        "pixi run py-demos -- --scene rigid_body --width 960 --height 540 "
+        "--scene-state-json &#x27;{&quot;controls&quot;:"
+    ) in review_html
 
 
 def test_rigid_workflow_dry_run_can_include_related_evidence(

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -711,6 +711,93 @@ def test_rigid_workflow_dry_run_can_capture_avbd_showcase_only(
     assert "--avbd-showcase-only" in review_html
 
 
+def test_rigid_workflow_dry_run_can_capture_contact_baseline_only(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "rigid_contact_baseline"
+
+    def fail_run(_argv: list[str]) -> int:
+        raise AssertionError("dry-run should not render scenes")
+
+    monkeypatch.setattr(capture_py_demo, "_run_scene_capture_from_argv", fail_run)
+
+    rc = capture_py_demo.main(
+        [
+            "--rigid-workflow",
+            "--contact-baseline-only",
+            "--dry-run",
+            "--output-dir",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
+    manifest = json.loads((output / "manifest.json").read_text())
+    assert manifest["include_contact_baseline"] is True
+    assert manifest["include_avbd_showcase"] is False
+    assert manifest["include_related"] is False
+    assert manifest["include_ipc_shelf"] is False
+    assert manifest["include_packets"] is False
+    assert manifest["selected_include_contact_baseline"] is True
+    assert manifest["selected_include_avbd_showcase"] is False
+    assert manifest["selected_include_related"] is False
+    assert manifest["selected_include_ipc_shelf"] is False
+    assert manifest["selected_include_packets"] is False
+    assert manifest["capture_count"] == 2
+    assert manifest["workflow_total_count"] == 2
+    assert manifest["workflow_row_start"] == 1
+    assert manifest["workflow_row_end"] == 2
+    assert [capture["scene"] for capture in manifest["captures"]] == [
+        "rigid_body",
+        "rigid_body",
+    ]
+    assert [capture["workflow_group"] for capture in manifest["captures"]] == [
+        "contact_baseline",
+        "contact_baseline",
+    ]
+    assert [capture["capture_label"] for capture in manifest["captures"]] == [
+        "sequential_impulse",
+        "boxed_lcp",
+    ]
+    assert manifest["captures"][0]["scene_state_json"] == ""
+    assert (
+        manifest["captures"][1]["scene_state_json"]
+        == '{"controls":{"contact_method_index":1}}'
+    )
+    assert "--capture-label sequential_impulse" in manifest["captures"][0]["command"]
+    assert "--capture-label boxed_lcp" in manifest["captures"][1]["command"]
+    assert "--scene-state-json" not in manifest["captures"][0]["command"]
+    assert (
+        "--scene-state-json '{\"controls\":{\"contact_method_index\":1}}'"
+        in manifest["captures"][1]["command"]
+    )
+    assert (
+        manifest["captures"][0]["workflow_rerun_command"]
+        == "pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only "
+        "--workflow-start-row 1 --workflow-end-row 1 --output-dir "
+        f"{output}/reruns/01_rigid_body"
+    )
+    assert (
+        manifest["captures"][1]["workflow_rerun_command"]
+        == "pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only "
+        "--workflow-start-row 2 --workflow-end-row 2 --output-dir "
+        f"{output}/reruns/02_rigid_body"
+    )
+    assert manifest["captures"][0]["workflow_label"] == "Contact baseline"
+    assert "Sequential Impulse contact path" in manifest["captures"][0]["user_question"]
+    assert manifest["captures"][1]["workflow_label"] == "Contact baseline"
+    assert "boxed-LCP contact baseline" in manifest["captures"][1]["user_question"]
+    assert "contact_solver_method=BOXED_LCP" in manifest["captures"][1][
+        "healthy_signal"
+    ]
+    review_html = pathlib.Path(manifest["artifacts"]["review_index"]).read_text()
+    assert "contact baseline" in review_html
+    assert "--contact-baseline-only" in review_html
+    assert "<dt>capture label</dt><dd>sequential_impulse</dd>" in review_html
+    assert "<dt>capture label</dt><dd>boxed_lcp</dd>" in review_html
+    assert "<dt>scene state</dt><dd>{&quot;controls&quot;" in review_html
+
+
 def test_rigid_workflow_dry_run_can_include_related_evidence(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3051,6 +3138,10 @@ def test_rigid_workflow_scene_capture_runs_in_child_process(
     (
         ("--include-related", "--include-related requires --rigid-workflow"),
         (
+            "--contact-baseline-only",
+            "--contact-baseline-only requires --rigid-workflow",
+        ),
+        (
             "--avbd-showcase-only",
             "--avbd-showcase-only requires --rigid-workflow",
         ),
@@ -3072,6 +3163,44 @@ def test_rigid_workflow_extra_groups_require_workflow(flag: str, message: str) -
         args.insert(1, "1")
     with pytest.raises(SystemExit, match=message):
         capture_py_demo.main(args)
+
+
+def test_rigid_workflow_contact_baseline_rejects_other_groups(
+    tmp_path: pathlib.Path,
+) -> None:
+    with pytest.raises(
+        SystemExit,
+        match="--contact-baseline-only cannot be combined with other workflow groups",
+    ):
+        capture_py_demo.main(
+            [
+                "--rigid-workflow",
+                "--contact-baseline-only",
+                "--include-related",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+
+
+def test_rigid_workflow_contact_baseline_rejects_avbd_showcase(
+    tmp_path: pathlib.Path,
+) -> None:
+    with pytest.raises(
+        SystemExit,
+        match="--contact-baseline-only cannot be combined with --avbd-showcase-only",
+    ):
+        capture_py_demo.main(
+            [
+                "--rigid-workflow",
+                "--contact-baseline-only",
+                "--avbd-showcase-only",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
 
 
 def test_rigid_workflow_avbd_showcase_rejects_other_groups(

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -3052,6 +3052,57 @@ def test_visual_capture_default_scene_matches_py_demos_front_door() -> None:
     assert DEFAULT_INITIAL_SCENE_ID == "rigid_body"
 
 
+def test_visual_capture_label_uses_distinct_default_dir_and_artifacts(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_default_output_dir(scene: str) -> pathlib.Path:
+        return tmp_path / scene
+
+    def fake_run_demo(demo_args: list[str]) -> int:
+        screenshot = pathlib.Path(demo_args[demo_args.index("--screenshot") + 1])
+        frames = pathlib.Path(demo_args[demo_args.index("--out") + 1])
+        screenshot.parent.mkdir(parents=True, exist_ok=True)
+        frames.mkdir(parents=True, exist_ok=True)
+        _write_ppm(screenshot, bytes([255, 0, 0, 0, 255, 0]))
+        _write_ppm(frames / "frame_000001.ppm", bytes([255, 0, 0, 0, 255, 0]))
+        return 0
+
+    monkeypatch.setattr(capture_py_demo, "_default_output_dir", fake_default_output_dir)
+    monkeypatch.setattr(capture_py_demo, "_run_demo", fake_run_demo)
+
+    rc = capture_py_demo.main(
+        [
+            "--scene",
+            "rigid_body",
+            "--frames",
+            "1",
+            "--width",
+            "2",
+            "--height",
+            "1",
+            "--scene-state-json",
+            '{"controls":{"contact_method_index":1}}',
+            "--capture-label",
+            "boxed_lcp",
+        ]
+    )
+
+    assert rc == 0
+    output = tmp_path / "rigid_body_boxed_lcp"
+    assert (output / "rigid_body_boxed_lcp.png").is_file()
+    manifest = capture_py_demo.json.loads((output / "manifest.json").read_text())
+    assert manifest["capture_label"] == "boxed_lcp"
+    assert manifest["scene_state"] == {"controls": {"contact_method_index": 1}}
+    assert manifest["artifacts"]["screenshot"] == str(
+        output / "rigid_body_boxed_lcp.png"
+    )
+
+
+def test_visual_capture_label_requires_artifact_safe_text() -> None:
+    with pytest.raises(SystemExit):
+        capture_py_demo.parse_args(["--capture-label", "boxed lcp"])
+
+
 def test_visual_capture_rejects_noop_backend(tmp_path: pathlib.Path) -> None:
     args = argparse.Namespace(
         backend="noop",

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -31,6 +31,7 @@ from examples.demos.runner import (
     _rigid_workflow_row_video_packet_command,
     _rigid_workflow_viewer_command,
     _scene_build_timeout_ms,
+    _scene_state_target_scene_id,
     _workflow_matching_guides,
     _workflow_related_evidence_matches,
     _validate_scene,
@@ -753,6 +754,25 @@ def test_default_py_demos_launch_uses_rigid_body_front_door() -> None:
     )
     assert _default_initial_scene_args([], None, {"DART_DEMOS_SCENE": "boxes"}) == []
     assert _default_initial_scene_args(["--cycle-scenes"], None, {}) == []
+
+
+def test_scene_state_target_scene_id_honors_explicit_env_and_default_scene() -> None:
+    assert (
+        _scene_state_target_scene_id(
+            "rigid-body", [], {"DART_DEMOS_SCENE": "rigid_contact_solver_compare"}
+        )
+        == "rigid_body"
+    )
+    assert (
+        _scene_state_target_scene_id(
+            None, [], {"DART_DEMOS_SCENE": "rigid-contact-solver-compare"}
+        )
+        == "rigid_contact_solver_compare"
+    )
+    assert _scene_state_target_scene_id(None, ["--scene", "rigid_body"], {}) == (
+        "rigid_body"
+    )
+    assert _scene_state_target_scene_id(None, [], {}) is None
 
 
 def test_scene_build_timeout_follows_demo_startup_budget_by_default(

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3382,6 +3382,25 @@ def test_rigid_body_panel_contact_baseline_presets_reset_scene() -> None:
     assert len(controller._speed_history) == 1
 
 
+def test_rigid_body_panel_routes_to_contact_policy_comparison() -> None:
+    _require_simulation_symbols("World")
+
+    setup = rigid_body.build()
+    controller = setup.info["rigid_body_controller"]
+    context = _FakePanelContext()
+    builder = _ScriptedPanelBuilder(clicked_buttons={"Open contact comparison"})
+
+    setup.panels[0].build(builder, context)
+
+    assert "button:Open contact comparison" in builder.events
+    assert (
+        "tooltip:Open the side-by-side Sequential Impulse and boxed-LCP policy row."
+        in builder.events
+    )
+    assert context.scene_switch_requests == ["rigid_contact_solver_compare"]
+    assert controller.contact_method_index == 0
+
+
 def test_rigid_collision_query_options_panel_edits_capture_controls() -> None:
     _require_simulation_symbols("World", "CollisionQueryOptions")
 

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -15,13 +15,17 @@ from examples.demos.runner import (
     REPLAY_TIMELINE_INFO_KEY,
     RIGID_VISUAL_WORKFLOW_CAPTURE_SPECS,
     RIGID_VISUAL_WORKFLOW_GUIDES,
+    SCENE_STATE_OVERRIDE_INFO_KEY,
     ScenePanel,
     SceneSetup,
+    _apply_scene_state_override,
     _attach_replay_controls,
     _capture_metadata_mapping,
     _default_initial_scene_args,
     _has_world_replay_api,
     _make_world_factory,
+    _parse_scene_state_json,
+    _rigid_workflow_capture_command,
     _rigid_workflow_packet_command,
     _rigid_workflow_row_packet_command,
     _rigid_workflow_row_video_packet_command,
@@ -193,6 +197,45 @@ def test_make_world_factory_returns_debug_provider() -> None:
     result = _make_world_factory(scene)()
 
     assert result == (None, None, None, None, debug_provider)
+
+
+def test_scene_state_override_uses_replay_restore_hook() -> None:
+    restored: list[dict[str, object]] = []
+
+    def restore_state(state: dict[str, object]) -> None:
+        restored.append(state)
+
+    scene = PythonDemoScene(
+        id="stateful",
+        title="Stateful",
+        category="Tests",
+        summary="Accepts scriptable state.",
+        build=lambda: SceneSetup(),
+    )
+    setup = SceneSetup(info={"replay_restore_state": restore_state})
+    state = {"controls": {"contact_method_index": 1}}
+
+    _apply_scene_state_override(scene, setup, state)
+    state["controls"]["contact_method_index"] = 0
+
+    assert restored == [{"controls": {"contact_method_index": 1}}]
+    assert setup.info[SCENE_STATE_OVERRIDE_INFO_KEY] == {
+        "controls": {"contact_method_index": 1}
+    }
+    assert _capture_metadata_mapping(setup)[SCENE_STATE_OVERRIDE_INFO_KEY] == {
+        "controls": {"contact_method_index": 1}
+    }
+
+
+def test_parse_scene_state_json_requires_object() -> None:
+    assert _parse_scene_state_json('{"controls":{"contact_method_index":1}}') == {
+        "controls": {"contact_method_index": 1}
+    }
+    assert _parse_scene_state_json("") is None
+    with pytest.raises(SystemExit):
+        _parse_scene_state_json("[1, 2]")
+    with pytest.raises(SystemExit):
+        _parse_scene_state_json("{")
 
 
 def test_make_world_factory_injects_shared_replay_panel_for_world_scenes() -> None:
@@ -3503,6 +3546,23 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
         )
         assert f"text:{guide.capture_command}" in events
         assert "tooltip:Run from the repository root to regenerate this row." in events
+        if scene_id == "rigid_body":
+            assert "text:Boxed-LCP baseline variant" in events
+            assert (
+                "text:"
+                + _rigid_workflow_capture_command(
+                    guide.scene_id,
+                    guide.capture_frames,
+                    guide.capture_width,
+                    guide.capture_height,
+                    guide.capture_show_ui,
+                    scene_state_json='{"controls":{"contact_method_index":1}}',
+                )
+            ) in events
+            assert (
+                "tooltip:Capture the same baseline row with the contact solver "
+                "set to Boxed LCP before the first frame."
+            ) in events
         assert "text:Review packet" in events
         assert (
             "text:"

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3341,6 +3341,47 @@ def test_rigid_body_panel_edits_contact_solver_method() -> None:
     assert world.contact_solver_method == sx.ContactSolverMethod.BOXED_LCP
 
 
+def test_rigid_body_panel_contact_baseline_presets_reset_scene() -> None:
+    sx = _require_simulation_symbols("RigidBodySolver", "ContactSolverMethod", "World")
+
+    setup = rigid_body.build()
+    controller = setup.info["rigid_body_controller"]
+    world = setup.info["sx_world"]
+    assert setup.pre_step is not None
+
+    for _ in range(3):
+        setup.pre_step()
+    assert world.time > 0.0
+
+    boxed_builder = _ScriptedPanelBuilder(clicked_buttons={"Boxed LCP"})
+    setup.panels[0].build(boxed_builder, object())
+
+    assert "text:Contact baseline preset" in boxed_builder.events
+    assert "button:Sequential impulse" in boxed_builder.events
+    assert "button:Boxed LCP" in boxed_builder.events
+    assert "same_line" in boxed_builder.events
+    assert (
+        "tooltip:Reset to the DART 6-style boxed-LCP baseline."
+        in boxed_builder.events
+    )
+    assert controller.contact_method_index == 1
+    assert world.time == pytest.approx(0.0)
+    assert world.contact_solver_method == sx.ContactSolverMethod.BOXED_LCP
+    assert len(controller._speed_history) == 1
+
+    setup.pre_step()
+    assert world.time > 0.0
+
+    si_builder = _ScriptedPanelBuilder(clicked_buttons={"Sequential impulse"})
+    setup.panels[0].build(si_builder, object())
+
+    assert "tooltip:Reset to the default contact baseline." in si_builder.events
+    assert controller.contact_method_index == 0
+    assert world.time == pytest.approx(0.0)
+    assert world.contact_solver_method == sx.ContactSolverMethod.SEQUENTIAL_IMPULSE
+    assert len(controller._speed_history) == 1
+
+
 def test_rigid_collision_query_options_panel_edits_capture_controls() -> None:
     _require_simulation_symbols("World", "CollisionQueryOptions")
 

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3578,6 +3578,17 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
         assert (
             "text:"
             + _rigid_workflow_packet_command(
+                contact_baseline_only=True,
+                output_dir="/tmp/dart_capture_rigid_contact_baseline",
+            )
+        ) in events
+        assert (
+            "tooltip:Capture the SI and boxed-LCP rigid_body "
+            "contact-baseline packet."
+        ) in events
+        assert (
+            "text:"
+            + _rigid_workflow_packet_command(
                 avbd_showcase_only=True,
                 output_dir="/tmp/dart_capture_rigid_avbd_showcase",
             )

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3550,6 +3550,19 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
             assert "text:Boxed-LCP baseline variant" in events
             assert (
                 "text:"
+                + _rigid_workflow_viewer_command(
+                    guide.scene_id,
+                    guide.capture_width,
+                    guide.capture_height,
+                    scene_state_json='{"controls":{"contact_method_index":1}}',
+                )
+            ) in events
+            assert (
+                "tooltip:Open the rigid_body row live with the contact solver "
+                "set to Boxed LCP before the first frame."
+            ) in events
+            assert (
+                "text:"
                 + _rigid_workflow_capture_command(
                     guide.scene_id,
                     guide.capture_frames,

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3575,6 +3575,17 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
             "tooltip:Capture all numbered rows and write review_index.html."
             in events
         )
+        assert (
+            "text:"
+            + _rigid_workflow_packet_command(
+                avbd_showcase_only=True,
+                output_dir="/tmp/dart_capture_rigid_avbd_showcase",
+            )
+        ) in events
+        assert (
+            "tooltip:Capture the curated AVBD rigid-constraint showcase packet."
+            in events
+        )
         assert f"text:{_rigid_workflow_row_packet_command(guide)}" in events
         assert (
             "tooltip:Capture only this workflow row in a review packet."

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3557,6 +3557,7 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
                     guide.capture_height,
                     guide.capture_show_ui,
                     scene_state_json='{"controls":{"contact_method_index":1}}',
+                    capture_label="boxed_lcp",
                 )
             ) in events
             assert (

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -472,9 +472,14 @@ _RIGID_WORKFLOW_IPC_SHELF_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
     },
 }
 
+_RIGID_WORKFLOW_AVBD_PHASE = "M1 AVBD constraint showcase"
+_RIGID_WORKFLOW_AVBD_FOCUS_AXIS = "AVBD rigid constraint track"
+
 _RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
     "avbd_rigid_fixed_joint_contact": {
         "workflow_label": "AVBD constraint showcase",
+        "workflow_phase": _RIGID_WORKFLOW_AVBD_PHASE,
+        "focus_axis": _RIGID_WORKFLOW_AVBD_FOCUS_AXIS,
         "user_question": (
             "Can AVBD keep a fixed joint coherent while contact is active?"
         ),
@@ -500,6 +505,8 @@ _RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = 
     },
     "avbd_rigid_breakable_joint": {
         "workflow_label": "AVBD constraint showcase",
+        "workflow_phase": _RIGID_WORKFLOW_AVBD_PHASE,
+        "focus_axis": _RIGID_WORKFLOW_AVBD_FOCUS_AXIS,
         "user_question": (
             "Can AVBD show fixed-joint breakage and reset lifecycle evidence?"
         ),
@@ -524,6 +531,8 @@ _RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = 
     },
     "avbd_rigid_spherical_breakable_joint": {
         "workflow_label": "AVBD constraint showcase",
+        "workflow_phase": _RIGID_WORKFLOW_AVBD_PHASE,
+        "focus_axis": _RIGID_WORKFLOW_AVBD_FOCUS_AXIS,
         "user_question": (
             "Can AVBD show spherical anchor breakage while orientation stays free?"
         ),
@@ -549,6 +558,8 @@ _RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = 
     },
     "avbd_rigid_revolute_motor": {
         "workflow_label": "AVBD constraint showcase",
+        "workflow_phase": _RIGID_WORKFLOW_AVBD_PHASE,
+        "focus_axis": _RIGID_WORKFLOW_AVBD_FOCUS_AXIS,
         "user_question": (
             "Can AVBD drive a free-rigid hinge motor with finite diagnostics?"
         ),
@@ -574,6 +585,8 @@ _RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = 
     },
     "avbd_rigid_prismatic_motor": {
         "workflow_label": "AVBD constraint showcase",
+        "workflow_phase": _RIGID_WORKFLOW_AVBD_PHASE,
+        "focus_axis": _RIGID_WORKFLOW_AVBD_FOCUS_AXIS,
         "user_question": (
             "Can AVBD drive a free-rigid slider motor with finite diagnostics?"
         ),
@@ -2932,8 +2945,6 @@ def _workflow_phase_summary(
 ) -> list[dict[str, object]]:
     phases: dict[str, dict[str, object]] = {}
     for capture in captures:
-        if capture.get("workflow_group") != "numbered":
-            continue
         phase = capture.get("workflow_phase")
         if not isinstance(phase, str) or not phase:
             continue

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -1665,8 +1665,16 @@ def _public_command(argv: list[str]) -> str:
     return "pixi run py-demo-capture -- " + " ".join(shlex.quote(arg) for arg in argv)
 
 
-def _viewer_command(scene: str, width: int, height: int, backend: str = "") -> str:
+def _viewer_command(
+    scene: str,
+    width: int,
+    height: int,
+    backend: str = "",
+    scene_state_json: str = "",
+) -> str:
     argv = ["--scene", scene, "--width", str(width), "--height", str(height)]
+    if scene_state_json:
+        argv.extend(["--scene-state-json", scene_state_json])
     if backend:
         argv.extend(["--backend", backend])
     return "pixi run py-demos -- " + " ".join(shlex.quote(arg) for arg in argv)
@@ -1739,7 +1747,13 @@ def _workflow_plan_entries(
                 "workflow_rerun_command": _public_command(
                     _workflow_row_rerun_argv(args, order, scene, output_dir)
                 ),
-                "viewer_command": _viewer_command(scene, width, height, args.backend),
+                "viewer_command": _viewer_command(
+                    scene,
+                    width,
+                    height,
+                    args.backend,
+                    scene_state_json,
+                ),
                 "status": "planned",
             }
         )

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -656,6 +656,18 @@ def _assignment_dict(values: list[str], option_name: str) -> dict[str, str]:
     return assignments
 
 
+def _json_object(value: str, option_name: str) -> dict[str, object] | None:
+    if not value:
+        return None
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{option_name} expects a JSON object: {exc.msg}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"{option_name} expects a JSON object")
+    return payload
+
+
 def _run_demo_with_env(demo_args: list[str], scene_env: dict[str, str]) -> int:
     previous: dict[str, str | None] = {key: os.environ.get(key) for key in scene_env}
     try:
@@ -927,6 +939,9 @@ def build_demo_args(
         demo_args.append("--show-ui")
     if args.backend:
         demo_args.extend(["--backend", args.backend])
+    scene_state_json = getattr(args, "scene_state_json", "")
+    if scene_state_json:
+        demo_args.extend(["--scene-state-json", scene_state_json])
     capture_metrics_event_log = getattr(args, "capture_metrics_event_log", None)
     if capture_metrics_event_log:
         demo_args.extend(
@@ -1087,6 +1102,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--backend", default="")
     parser.add_argument("--allow-noop", action="store_true")
     parser.add_argument("--show-ui", action="store_true")
+    parser.add_argument(
+        "--scene-state-json",
+        default="",
+        help=(
+            "Restore a JSON scene state before rendering the selected scene. "
+            "Scenes opt in by exposing replay_restore_state."
+        ),
+    )
     parser.add_argument("--video", action="store_true")
     parser.add_argument("--fps", type=int, default=24)
     parser.add_argument("--output-dir", type=pathlib.Path)
@@ -3244,6 +3267,8 @@ def _validate_rigid_workflow_args(args: argparse.Namespace) -> None:
         raise SystemExit(
             "--rigid-workflow cannot be combined with scripted switch or force drag"
         )
+    if args.scene_state_json:
+        raise SystemExit("--rigid-workflow cannot be combined with --scene-state-json")
 
 
 def _run_rigid_workflow(args: argparse.Namespace) -> int:
@@ -3399,6 +3424,7 @@ def main(argv: list[str] | None = None) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     scene_env = _assignment_dict(args.env, "--env")
     metadata = _assignment_dict(args.metadata, "--metadata")
+    scene_state = _json_object(args.scene_state_json, "--scene-state-json")
     capture_stem = _capture_stem(args)
     screenshot_ppm = output_dir / f"{capture_stem}.ppm"
     screenshot_png = output_dir / f"{capture_stem}.png"
@@ -3474,6 +3500,7 @@ def main(argv: list[str] | None = None) -> int:
         "scene_metadata": None,
         "show_ui": args.show_ui,
         "metadata": metadata,
+        "scene_state": scene_state,
         "scene_environment": scene_env,
         "ui_ready": None,
         "visual_evidence": visual_evidence,

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -256,7 +256,35 @@ def _default_output_dir(scene: str) -> pathlib.Path:
     return pathlib.Path(tempfile.gettempdir()) / "dart_py_demo_capture" / safe
 
 
-RIGID_WORKFLOW_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], ...] = (
+WorkflowCaptureSpec = (
+    tuple[str, int, int, int, bool] | tuple[str, int, int, int, bool, str, str | None]
+)
+
+
+def _workflow_spec_fields(
+    spec: WorkflowCaptureSpec,
+) -> tuple[str, int, int, int, bool, str, str | None]:
+    if len(spec) not in (5, 7):
+        raise ValueError(f"expected 5- or 7-field workflow spec, got {len(spec)}")
+    scene, frames, width, height, show_ui = spec[:5]
+    scene_state_json = str(spec[5]) if len(spec) == 7 else ""
+    capture_label = spec[6] if len(spec) == 7 else None
+    if capture_label is not None:
+        capture_label = str(capture_label)
+    return (
+        str(scene),
+        int(frames),
+        int(width),
+        int(height),
+        bool(show_ui),
+        scene_state_json,
+        capture_label,
+    )
+
+
+_RIGID_BODY_BOXED_LCP_STATE_JSON = '{"controls":{"contact_method_index":1}}'
+
+RIGID_WORKFLOW_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("rigid_body", 180, 960, 540, True),
     ("rigid_body_modes", 72, 960, 540, True),
     ("rigid_free_flight", 96, 960, 540, True),
@@ -296,7 +324,7 @@ RIGID_WORKFLOW_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], ...] = (
 )
 
 
-RIGID_WORKFLOW_RELATED_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], ...] = (
+RIGID_WORKFLOW_RELATED_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("deactivation_sleeping", 72, 960, 540, True),
     ("floating_base", 72, 960, 540, True),
     ("articulated", 72, 960, 540, True),
@@ -307,9 +335,21 @@ RIGID_WORKFLOW_RELATED_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], ...
 )
 
 
-RIGID_WORKFLOW_AVBD_SHOWCASE_CAPTURE_SPECS: tuple[
-    tuple[str, int, int, int, bool], ...
-] = (
+RIGID_WORKFLOW_CONTACT_BASELINE_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
+    ("rigid_body", 180, 960, 540, True, "", "sequential_impulse"),
+    (
+        "rigid_body",
+        180,
+        960,
+        540,
+        True,
+        _RIGID_BODY_BOXED_LCP_STATE_JSON,
+        "boxed_lcp",
+    ),
+)
+
+
+RIGID_WORKFLOW_AVBD_SHOWCASE_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("avbd_rigid_fixed_joint_contact", 72, 960, 540, True),
     ("avbd_rigid_breakable_joint", 72, 960, 540, True),
     ("avbd_rigid_spherical_breakable_joint", 72, 960, 540, True),
@@ -318,7 +358,7 @@ RIGID_WORKFLOW_AVBD_SHOWCASE_CAPTURE_SPECS: tuple[
 )
 
 
-RIGID_WORKFLOW_IPC_SHELF_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], ...] = (
+RIGID_WORKFLOW_IPC_SHELF_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("rigid_ipc", 72, 960, 540, True),
     ("rigid_ipc_slide", 72, 960, 540, True),
     ("rigid_ipc_incline", 72, 960, 540, True),
@@ -326,7 +366,7 @@ RIGID_WORKFLOW_IPC_SHELF_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], .
 )
 
 
-RIGID_WORKFLOW_PACKET_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], ...] = (
+RIGID_WORKFLOW_PACKET_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("rigid_ipc_stack_packet", 24, 960, 540, True),
     ("rigid_ipc_heavy_stack_packet", 12, 960, 540, True),
 )
@@ -559,6 +599,65 @@ _RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = 
     },
 }
 
+_RIGID_WORKFLOW_CONTACT_BASELINE_GUIDANCE_BY_LABEL: dict[str, dict[str, object]] = {
+    "sequential_impulse": {
+        "workflow_label": "Contact baseline",
+        "workflow_phase": "M1 contact-policy baseline",
+        "focus_axis": "Sequential Impulse vs boxed-LCP contact method",
+        "user_question": (
+            "What does the flagship rigid_body scene show with the default "
+            "Sequential Impulse contact path?"
+        ),
+        "try_first": (
+            "Use this row as the live DART 7 contact-policy baseline before "
+            "inspecting the boxed-LCP variant."
+        ),
+        "inspect": [
+            "contact solver method",
+            "contact count",
+            "body motion",
+            "controls",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "The scene renders with docked diagnostics and reports the default "
+            "Sequential Impulse contact method."
+        ),
+        "scope": (
+            "World rigid-body contact-policy baseline for M1; complementary to "
+            "the AVBD rigid-constraint showcase."
+        ),
+    },
+    "boxed_lcp": {
+        "workflow_label": "Contact baseline",
+        "workflow_phase": "M1 contact-policy baseline",
+        "focus_axis": "Sequential Impulse vs boxed-LCP contact method",
+        "user_question": (
+            "How does the same rigid_body scene behave with the DART 6-style "
+            "boxed-LCP contact baseline selected before launch?"
+        ),
+        "try_first": (
+            "Use this row when reviewer evidence needs the known-good boxed-LCP "
+            "contact baseline without manual panel setup."
+        ),
+        "inspect": [
+            "contact solver method",
+            "capture state",
+            "contact count",
+            "body motion",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "The manifest resolves contact_solver_method=BOXED_LCP and keeps "
+            "the docked visual evidence distinct from the SI row."
+        ),
+        "scope": (
+            "World contact-policy baseline using boxed-LCP contacts; not an "
+            "AVBD solver-enum or rigid-body solver-family comparison."
+        ),
+    },
+}
+
 _RIGID_WORKFLOW_PACKET_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
     "rigid_ipc_stack_packet": {
         "workflow_label": "Capture-first packet",
@@ -627,31 +726,27 @@ _RIGID_WORKFLOW_PACKET_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
 }
 
 
-def rigid_workflow_capture_specs() -> tuple[tuple[str, int, int, int, bool], ...]:
+def rigid_workflow_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
     return RIGID_WORKFLOW_CAPTURE_SPECS
 
 
-def rigid_workflow_related_capture_specs() -> (
-    tuple[tuple[str, int, int, int, bool], ...]
-):
+def rigid_workflow_related_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
     return RIGID_WORKFLOW_RELATED_CAPTURE_SPECS
 
 
-def rigid_workflow_avbd_showcase_capture_specs() -> (
-    tuple[tuple[str, int, int, int, bool], ...]
-):
+def rigid_workflow_contact_baseline_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
+    return RIGID_WORKFLOW_CONTACT_BASELINE_CAPTURE_SPECS
+
+
+def rigid_workflow_avbd_showcase_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
     return RIGID_WORKFLOW_AVBD_SHOWCASE_CAPTURE_SPECS
 
 
-def rigid_workflow_ipc_shelf_capture_specs() -> (
-    tuple[tuple[str, int, int, int, bool], ...]
-):
+def rigid_workflow_ipc_shelf_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
     return RIGID_WORKFLOW_IPC_SHELF_CAPTURE_SPECS
 
 
-def rigid_workflow_packet_capture_specs() -> (
-    tuple[tuple[str, int, int, int, bool], ...]
-):
+def rigid_workflow_packet_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
     return RIGID_WORKFLOW_PACKET_CAPTURE_SPECS
 
 
@@ -1227,6 +1322,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--contact-baseline-only",
+        action="store_true",
+        help=(
+            "With --rigid-workflow, capture only the SI versus boxed-LCP "
+            "rigid_body contact-baseline packet."
+        ),
+    )
+    parser.add_argument(
         "--include-ipc-shelf",
         action="store_true",
         help=(
@@ -1364,6 +1467,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def _workflow_output_dir(args: argparse.Namespace) -> pathlib.Path:
     if args.output_dir:
         return args.output_dir
+    if getattr(args, "contact_baseline_only", False):
+        return _default_output_dir("rigid_contact_baseline")
     if getattr(args, "avbd_showcase_only", False):
         return _default_output_dir("rigid_avbd_showcase")
     return _default_output_dir("rigid_workflow")
@@ -1377,7 +1482,9 @@ def _workflow_scene_output_dir(
 
 def _workflow_capture_specs(
     args: argparse.Namespace,
-) -> tuple[tuple[str, int, int, int, bool], ...]:
+) -> tuple[WorkflowCaptureSpec, ...]:
+    if getattr(args, "contact_baseline_only", False):
+        return rigid_workflow_contact_baseline_capture_specs()
     if getattr(args, "avbd_showcase_only", False):
         return rigid_workflow_avbd_showcase_capture_specs()
     specs = list(rigid_workflow_capture_specs())
@@ -1394,6 +1501,7 @@ def _workflow_requested_include_flags(
     args: argparse.Namespace,
 ) -> dict[str, bool]:
     return {
+        "include_contact_baseline": bool(getattr(args, "contact_baseline_only", False)),
         "include_avbd_showcase": bool(getattr(args, "avbd_showcase_only", False)),
         "include_related": bool(getattr(args, "include_related", False)),
         "include_ipc_shelf": bool(getattr(args, "include_ipc_shelf", False)),
@@ -1424,10 +1532,12 @@ def _workflow_row_bounds(args: argparse.Namespace, total_count: int) -> tuple[in
 def _workflow_scene_argv(
     args: argparse.Namespace,
     order: int,
-    spec: tuple[str, int, int, int, bool],
+    spec: WorkflowCaptureSpec,
     output_dir: pathlib.Path,
 ) -> list[str]:
-    scene, frames, width, height, show_ui = spec
+    scene, frames, width, height, show_ui, scene_state_json, capture_label = (
+        _workflow_spec_fields(spec)
+    )
     scene_output = _workflow_scene_output_dir(output_dir, order, scene)
     scene_argv = [
         "--scene",
@@ -1443,6 +1553,10 @@ def _workflow_scene_argv(
     ]
     if show_ui:
         scene_argv.append("--show-ui")
+    if scene_state_json:
+        scene_argv.extend(["--scene-state-json", scene_state_json])
+    if capture_label:
+        scene_argv.extend(["--capture-label", capture_label])
     if args.backend:
         scene_argv.extend(["--backend", args.backend])
     if args.allow_noop:
@@ -1465,6 +1579,8 @@ def _workflow_row_rerun_argv(
     output_dir: pathlib.Path,
 ) -> list[str]:
     rerun_argv = ["--rigid-workflow"]
+    if getattr(args, "contact_baseline_only", False):
+        rerun_argv.append("--contact-baseline-only")
     if getattr(args, "avbd_showcase_only", False):
         rerun_argv.append("--avbd-showcase-only")
     if getattr(args, "include_related", False):
@@ -1502,6 +1618,8 @@ def _workflow_command_argv(
     args: argparse.Namespace, output_dir: pathlib.Path
 ) -> list[str]:
     workflow_argv = ["--rigid-workflow"]
+    if getattr(args, "contact_baseline_only", False):
+        workflow_argv.append("--contact-baseline-only")
     if getattr(args, "avbd_showcase_only", False):
         workflow_argv.append("--avbd-showcase-only")
     if getattr(args, "include_related", False):
@@ -1546,16 +1664,25 @@ def _workflow_plan_entries(
 ) -> list[dict[str, object]]:
     entries: list[dict[str, object]] = []
     specs = _workflow_capture_specs(args)
+    contact_baseline_only = bool(getattr(args, "contact_baseline_only", False))
     avbd_showcase_only = bool(getattr(args, "avbd_showcase_only", False))
-    numbered_count = 0 if avbd_showcase_only else len(rigid_workflow_capture_specs())
+    numbered_count = (
+        0
+        if contact_baseline_only or avbd_showcase_only
+        else len(rigid_workflow_capture_specs())
+    )
     related_count = (
         len(rigid_workflow_related_capture_specs())
-        if not avbd_showcase_only and getattr(args, "include_related", False)
+        if not contact_baseline_only
+        and not avbd_showcase_only
+        and getattr(args, "include_related", False)
         else 0
     )
     ipc_shelf_count = (
         len(rigid_workflow_ipc_shelf_capture_specs())
-        if not avbd_showcase_only and getattr(args, "include_ipc_shelf", False)
+        if not contact_baseline_only
+        and not avbd_showcase_only
+        and getattr(args, "include_ipc_shelf", False)
         else 0
     )
     count = len(specs)
@@ -1564,10 +1691,14 @@ def _workflow_plan_entries(
     for order, spec in enumerate(specs, start=1):
         if order < start_row or order > end_row:
             continue
-        scene, frames, width, height, show_ui = spec
+        scene, frames, width, height, show_ui, scene_state_json, capture_label = (
+            _workflow_spec_fields(spec)
+        )
         scene_output = _workflow_scene_output_dir(output_dir, order, scene)
         argv = _workflow_scene_argv(args, order, spec, output_dir)
-        if avbd_showcase_only:
+        if contact_baseline_only:
+            workflow_group = "contact_baseline"
+        elif avbd_showcase_only:
             workflow_group = "avbd_constraint_showcase"
         elif order <= numbered_count:
             workflow_group = "numbered"
@@ -1587,6 +1718,8 @@ def _workflow_plan_entries(
                 "width": width,
                 "height": height,
                 "show_ui": show_ui,
+                "scene_state_json": scene_state_json,
+                "capture_label": capture_label,
                 "output_dir": str(scene_output),
                 "manifest": str(scene_output / "manifest.json"),
                 "command": _public_command(argv),
@@ -1598,6 +1731,12 @@ def _workflow_plan_entries(
             }
         )
         entries[-1].update(guidance_by_scene.get(scene, {}))
+        if contact_baseline_only and capture_label:
+            entries[-1].update(
+                _RIGID_WORKFLOW_CONTACT_BASELINE_GUIDANCE_BY_LABEL.get(
+                    capture_label, {}
+                )
+            )
     return entries
 
 
@@ -2234,6 +2373,7 @@ def _workflow_metric_highlights(metrics: dict[str, object]) -> list[str]:
 
 _WORKFLOW_GROUP_LABELS = {
     "numbered": "numbered",
+    "contact_baseline": "contact baseline",
     "avbd_constraint_showcase": "avbd showcase",
     "related_evidence": "related",
     "rigid_ipc_shelf": "ipc shelf",
@@ -2273,6 +2413,8 @@ def _workflow_requested_group_labels(
 ) -> str:
     if requested_include_flags is None:
         return fallback
+    if requested_include_flags.get("include_contact_baseline", False):
+        return "contact baseline"
     if requested_include_flags.get("include_avbd_showcase", False):
         return "avbd showcase"
     labels = ["numbered"]
@@ -2631,6 +2773,12 @@ def _workflow_review_card(capture: dict[str, object], output_dir: pathlib.Path) 
         ),
         _workflow_detail("ui", "docked" if capture.get("show_ui") else "headless"),
     ]
+    capture_label = capture.get("capture_label")
+    if isinstance(capture_label, str) and capture_label:
+        details.append(_workflow_detail("capture label", capture_label))
+    scene_state_json = capture.get("scene_state_json")
+    if isinstance(scene_state_json, str) and scene_state_json:
+        details.append(_workflow_detail("scene state", scene_state_json))
     workflow_label = capture.get("workflow_label")
     if isinstance(workflow_label, str) and workflow_label:
         details.insert(0, _workflow_detail("role", workflow_label))
@@ -3348,6 +3496,9 @@ def _write_workflow_manifest(
     )
     completed = sum(1 for capture in captures if capture.get("status") == "captured")
     failed = sum(1 for capture in captures if capture.get("status") == "failed")
+    selected_include_contact_baseline = any(
+        capture.get("workflow_group") == "contact_baseline" for capture in captures
+    )
     selected_include_avbd_showcase = any(
         capture.get("workflow_group") == "avbd_constraint_showcase"
         for capture in captures
@@ -3362,6 +3513,7 @@ def _write_workflow_manifest(
         capture.get("workflow_group") == "capture_first_packet" for capture in captures
     )
     requested_include_flags = requested_include_flags or {
+        "include_contact_baseline": selected_include_contact_baseline,
         "include_avbd_showcase": selected_include_avbd_showcase,
         "include_related": selected_include_related,
         "include_ipc_shelf": selected_include_ipc_shelf,
@@ -3406,10 +3558,18 @@ def _write_workflow_manifest(
         {
             "schema_version": 1,
             "workflow": "rigid_visual_verification",
-            "include_avbd_showcase": requested_include_flags["include_avbd_showcase"],
-            "include_related": requested_include_flags["include_related"],
-            "include_ipc_shelf": requested_include_flags["include_ipc_shelf"],
-            "include_packets": requested_include_flags["include_packets"],
+            "include_contact_baseline": requested_include_flags.get(
+                "include_contact_baseline", False
+            ),
+            "include_avbd_showcase": requested_include_flags.get(
+                "include_avbd_showcase", False
+            ),
+            "include_related": requested_include_flags.get("include_related", False),
+            "include_ipc_shelf": requested_include_flags.get(
+                "include_ipc_shelf", False
+            ),
+            "include_packets": requested_include_flags.get("include_packets", False),
+            "selected_include_contact_baseline": selected_include_contact_baseline,
             "selected_include_avbd_showcase": selected_include_avbd_showcase,
             "selected_include_related": selected_include_related,
             "selected_include_ipc_shelf": selected_include_ipc_shelf,
@@ -3481,6 +3641,19 @@ def _validate_rigid_workflow_args(args: argparse.Namespace) -> None:
         raise SystemExit("--rigid-workflow cannot be combined with --scene-state-json")
     if args.capture_label:
         raise SystemExit("--rigid-workflow cannot be combined with --capture-label")
+    exclusive_packets = int(bool(args.contact_baseline_only)) + int(
+        bool(args.avbd_showcase_only)
+    )
+    if exclusive_packets > 1:
+        raise SystemExit(
+            "--contact-baseline-only cannot be combined with --avbd-showcase-only"
+        )
+    if args.contact_baseline_only and (
+        args.include_related or args.include_ipc_shelf or args.include_packets
+    ):
+        raise SystemExit(
+            "--contact-baseline-only cannot be combined with other workflow groups"
+        )
     if args.avbd_showcase_only and (
         args.include_related or args.include_ipc_shelf or args.include_packets
     ):
@@ -3592,6 +3765,8 @@ def _run_rigid_workflow(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     _apply_stable_linux_render_env()
     args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.contact_baseline_only and not args.rigid_workflow:
+        raise SystemExit("--contact-baseline-only requires --rigid-workflow")
     if args.avbd_showcase_only and not args.rigid_workflow:
         raise SystemExit("--avbd-showcase-only requires --rigid-workflow")
     if args.include_related and not args.rigid_workflow:

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -594,18 +594,47 @@ def _safe_stem(value: str) -> str:
     return safe or "scene"
 
 
+def _parse_capture_label(text: str) -> str:
+    if not text:
+        raise argparse.ArgumentTypeError("expected non-empty capture label")
+    safe = _safe_stem(text)
+    if safe != text:
+        raise argparse.ArgumentTypeError(
+            "expected capture label using only letters, digits, '-' or '_'"
+        )
+    return text
+
+
 def _capture_stem(args: argparse.Namespace) -> str:
+    scene_stem = _safe_stem(args.scene)
     switch_scene = getattr(args, "switch_scene", "")
     if switch_scene:
-        return f"{_safe_stem(args.scene)}_to_{_safe_stem(switch_scene)}"
-    force_drag_target = getattr(args, "force_drag_target", "")
-    if force_drag_target:
-        return f"{_safe_stem(args.scene)}_force_{_safe_stem(force_drag_target)}"
-    force_drag_pixel = getattr(args, "force_drag_pixel", None)
-    if force_drag_pixel is not None:
+        stem = f"{scene_stem}_to_{_safe_stem(switch_scene)}"
+    elif force_drag_target := getattr(args, "force_drag_target", ""):
+        stem = f"{scene_stem}_force_{_safe_stem(force_drag_target)}"
+    elif (force_drag_pixel := getattr(args, "force_drag_pixel", None)) is not None:
         x, y = force_drag_pixel
-        return f"{_safe_stem(args.scene)}_force_pixel_{x:g}_{y:g}"
-    return _safe_stem(args.scene)
+        stem = f"{scene_stem}_force_pixel_{x:g}_{y:g}"
+    else:
+        stem = scene_stem
+
+    capture_label = getattr(args, "capture_label", "")
+    if capture_label:
+        stem = f"{stem}_{capture_label}"
+    return stem
+
+
+def _single_capture_output_dir(args: argparse.Namespace) -> pathlib.Path:
+    if args.output_dir is not None:
+        return args.output_dir
+    if args.capture_label:
+        return _default_output_dir(f"{args.scene}_{args.capture_label}")
+    return _default_output_dir(args.scene)
+
+
+def _capture_label(args: argparse.Namespace) -> str | None:
+    label = getattr(args, "capture_label", "")
+    return label or None
 
 
 def _parse_vector3(text: str) -> tuple[float, float, float]:
@@ -1108,6 +1137,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help=(
             "Restore a JSON scene state before rendering the selected scene. "
             "Scenes opt in by exposing replay_restore_state."
+        ),
+    )
+    parser.add_argument(
+        "--capture-label",
+        default=None,
+        type=_parse_capture_label,
+        help=(
+            "Append a stable label to single-capture artifact names and, when "
+            "--output-dir is omitted, use a label-specific default directory."
         ),
     )
     parser.add_argument("--video", action="store_true")
@@ -3269,6 +3307,8 @@ def _validate_rigid_workflow_args(args: argparse.Namespace) -> None:
         )
     if args.scene_state_json:
         raise SystemExit("--rigid-workflow cannot be combined with --scene-state-json")
+    if args.capture_label:
+        raise SystemExit("--rigid-workflow cannot be combined with --capture-label")
 
 
 def _run_rigid_workflow(args: argparse.Namespace) -> int:
@@ -3420,7 +3460,7 @@ def main(argv: list[str] | None = None) -> int:
             "--frames must be greater than --force-drag-frame + --force-drag-frames"
         )
 
-    output_dir = args.output_dir or _default_output_dir(args.scene)
+    output_dir = _single_capture_output_dir(args)
     output_dir.mkdir(parents=True, exist_ok=True)
     scene_env = _assignment_dict(args.env, "--env")
     metadata = _assignment_dict(args.metadata, "--metadata")
@@ -3500,6 +3540,7 @@ def main(argv: list[str] | None = None) -> int:
         "scene_metadata": None,
         "show_ui": args.show_ui,
         "metadata": metadata,
+        "capture_label": _capture_label(args),
         "scene_state": scene_state,
         "scene_environment": scene_env,
         "ui_ready": None,

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -304,6 +304,12 @@ RIGID_WORKFLOW_RELATED_CAPTURE_SPECS: tuple[tuple[str, int, int, int, bool], ...
     ("rigid_ipc_edge_drop", 72, 960, 540, True),
     ("diff_drone_liftoff", 96, 960, 540, True),
     ("diff_pre_contact_surrogate", 24, 960, 540, True),
+)
+
+
+RIGID_WORKFLOW_AVBD_SHOWCASE_CAPTURE_SPECS: tuple[
+    tuple[str, int, int, int, bool], ...
+] = (
     ("avbd_rigid_fixed_joint_contact", 72, 960, 540, True),
     ("avbd_rigid_breakable_joint", 72, 960, 540, True),
     ("avbd_rigid_spherical_breakable_joint", 72, 960, 540, True),
@@ -426,6 +432,133 @@ _RIGID_WORKFLOW_IPC_SHELF_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
     },
 }
 
+_RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
+    "avbd_rigid_fixed_joint_contact": {
+        "workflow_label": "AVBD constraint showcase",
+        "user_question": (
+            "Can AVBD keep a fixed joint coherent while contact is active?"
+        ),
+        "try_first": (
+            "Use this showcase packet when M1 needs modern AVBD rigid-constraint "
+            "evidence beside the World contact baseline."
+        ),
+        "inspect": [
+            "joint error",
+            "contact count",
+            "payload height",
+            "constraint status",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "The fixed relation stays finite while contact remains visible."
+        ),
+        "scope": (
+            "AVBD sx rigid-constraint showcase; complementary to the World "
+            "contact-policy and boxed-LCP baseline, not a head-to-head solver "
+            "enum comparison."
+        ),
+    },
+    "avbd_rigid_breakable_joint": {
+        "workflow_label": "AVBD constraint showcase",
+        "user_question": (
+            "Can AVBD show fixed-joint breakage and reset lifecycle evidence?"
+        ),
+        "try_first": (
+            "Use this row for the fixed break/reset lifecycle before treating "
+            "AVBD as a broader rigid-body default."
+        ),
+        "inspect": [
+            "break threshold",
+            "broken state",
+            "connector color",
+            "payload release",
+            "reset behavior",
+        ],
+        "healthy_signal": (
+            "Breakage, visual connector state, and payload release agree."
+        ),
+        "scope": (
+            "AVBD fixed-joint breakage row; not sequential-impulse, IPC, or "
+            "boxed-LCP parity evidence."
+        ),
+    },
+    "avbd_rigid_spherical_breakable_joint": {
+        "workflow_label": "AVBD constraint showcase",
+        "user_question": (
+            "Can AVBD show spherical anchor breakage while orientation stays free?"
+        ),
+        "try_first": (
+            "Use this row after fixed breakage when the constraint question is "
+            "positional anchoring with free orientation."
+        ),
+        "inspect": [
+            "anchor error",
+            "break threshold",
+            "broken state",
+            "orientation freedom",
+            "reset behavior",
+        ],
+        "healthy_signal": (
+            "Anchor break/reset state is visible while free orientation is not "
+            "over-constrained."
+        ),
+        "scope": (
+            "AVBD spherical breakage row; not a World multibody joint API "
+            "comparison."
+        ),
+    },
+    "avbd_rigid_revolute_motor": {
+        "workflow_label": "AVBD constraint showcase",
+        "user_question": (
+            "Can AVBD drive a free-rigid hinge motor with finite diagnostics?"
+        ),
+        "try_first": (
+            "Use this row for AVBD angular motor behavior before comparing "
+            "World multibody motor/limit rows."
+        ),
+        "inspect": [
+            "hinge angle",
+            "target speed",
+            "measured speed",
+            "constraint error",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "Hinge motion follows the command while constraint error and timing "
+            "stay finite."
+        ),
+        "scope": (
+            "AVBD free-rigid revolute motor row; not a World multibody motor "
+            "or limit comparison."
+        ),
+    },
+    "avbd_rigid_prismatic_motor": {
+        "workflow_label": "AVBD constraint showcase",
+        "user_question": (
+            "Can AVBD drive a free-rigid slider motor with finite diagnostics?"
+        ),
+        "try_first": (
+            "Use this row for AVBD translational motor behavior before "
+            "comparing World multibody motor/limit rows."
+        ),
+        "inspect": [
+            "slider travel",
+            "target speed",
+            "measured speed",
+            "constraint error",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "Slider travel follows the command while constraint error and "
+            "timing stay finite."
+        ),
+        "scope": (
+            "AVBD free-rigid prismatic motor row; not a World multibody motor "
+            "or limit comparison."
+        ),
+    },
+}
+
 _RIGID_WORKFLOW_PACKET_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
     "rigid_ipc_stack_packet": {
         "workflow_label": "Capture-first packet",
@@ -502,6 +635,12 @@ def rigid_workflow_related_capture_specs() -> (
     tuple[tuple[str, int, int, int, bool], ...]
 ):
     return RIGID_WORKFLOW_RELATED_CAPTURE_SPECS
+
+
+def rigid_workflow_avbd_showcase_capture_specs() -> (
+    tuple[tuple[str, int, int, int, bool], ...]
+):
+    return RIGID_WORKFLOW_AVBD_SHOWCASE_CAPTURE_SPECS
 
 
 def rigid_workflow_ipc_shelf_capture_specs() -> (
@@ -584,6 +723,7 @@ def _rigid_workflow_guidance_by_scene() -> dict[str, dict[str, object]]:
                     "related_source_label": source_label,
                     "related_shelf": entry.shelf,
                 }
+    guidance.update(_RIGID_WORKFLOW_AVBD_SHOWCASE_GUIDANCE_BY_SCENE)
     guidance.update(_RIGID_WORKFLOW_IPC_SHELF_GUIDANCE_BY_SCENE)
     guidance.update(_RIGID_WORKFLOW_PACKET_GUIDANCE_BY_SCENE)
     return guidance
@@ -1079,6 +1219,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--avbd-showcase-only",
+        action="store_true",
+        help=(
+            "With --rigid-workflow, capture only the curated AVBD rigid-constraint "
+            "showcase packet."
+        ),
+    )
+    parser.add_argument(
         "--include-ipc-shelf",
         action="store_true",
         help=(
@@ -1214,7 +1362,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def _workflow_output_dir(args: argparse.Namespace) -> pathlib.Path:
-    return args.output_dir or _default_output_dir("rigid_workflow")
+    if args.output_dir:
+        return args.output_dir
+    if getattr(args, "avbd_showcase_only", False):
+        return _default_output_dir("rigid_avbd_showcase")
+    return _default_output_dir("rigid_workflow")
 
 
 def _workflow_scene_output_dir(
@@ -1226,6 +1378,8 @@ def _workflow_scene_output_dir(
 def _workflow_capture_specs(
     args: argparse.Namespace,
 ) -> tuple[tuple[str, int, int, int, bool], ...]:
+    if getattr(args, "avbd_showcase_only", False):
+        return rigid_workflow_avbd_showcase_capture_specs()
     specs = list(rigid_workflow_capture_specs())
     if getattr(args, "include_related", False):
         specs.extend(rigid_workflow_related_capture_specs())
@@ -1240,6 +1394,7 @@ def _workflow_requested_include_flags(
     args: argparse.Namespace,
 ) -> dict[str, bool]:
     return {
+        "include_avbd_showcase": bool(getattr(args, "avbd_showcase_only", False)),
         "include_related": bool(getattr(args, "include_related", False)),
         "include_ipc_shelf": bool(getattr(args, "include_ipc_shelf", False)),
         "include_packets": bool(getattr(args, "include_packets", False)),
@@ -1310,6 +1465,8 @@ def _workflow_row_rerun_argv(
     output_dir: pathlib.Path,
 ) -> list[str]:
     rerun_argv = ["--rigid-workflow"]
+    if getattr(args, "avbd_showcase_only", False):
+        rerun_argv.append("--avbd-showcase-only")
     if getattr(args, "include_related", False):
         rerun_argv.append("--include-related")
     if getattr(args, "include_ipc_shelf", False):
@@ -1345,6 +1502,8 @@ def _workflow_command_argv(
     args: argparse.Namespace, output_dir: pathlib.Path
 ) -> list[str]:
     workflow_argv = ["--rigid-workflow"]
+    if getattr(args, "avbd_showcase_only", False):
+        workflow_argv.append("--avbd-showcase-only")
     if getattr(args, "include_related", False):
         workflow_argv.append("--include-related")
     if getattr(args, "include_ipc_shelf", False):
@@ -1387,15 +1546,16 @@ def _workflow_plan_entries(
 ) -> list[dict[str, object]]:
     entries: list[dict[str, object]] = []
     specs = _workflow_capture_specs(args)
-    numbered_count = len(rigid_workflow_capture_specs())
+    avbd_showcase_only = bool(getattr(args, "avbd_showcase_only", False))
+    numbered_count = 0 if avbd_showcase_only else len(rigid_workflow_capture_specs())
     related_count = (
         len(rigid_workflow_related_capture_specs())
-        if getattr(args, "include_related", False)
+        if not avbd_showcase_only and getattr(args, "include_related", False)
         else 0
     )
     ipc_shelf_count = (
         len(rigid_workflow_ipc_shelf_capture_specs())
-        if getattr(args, "include_ipc_shelf", False)
+        if not avbd_showcase_only and getattr(args, "include_ipc_shelf", False)
         else 0
     )
     count = len(specs)
@@ -1407,7 +1567,9 @@ def _workflow_plan_entries(
         scene, frames, width, height, show_ui = spec
         scene_output = _workflow_scene_output_dir(output_dir, order, scene)
         argv = _workflow_scene_argv(args, order, spec, output_dir)
-        if order <= numbered_count:
+        if avbd_showcase_only:
+            workflow_group = "avbd_constraint_showcase"
+        elif order <= numbered_count:
             workflow_group = "numbered"
         elif order <= numbered_count + related_count:
             workflow_group = "related_evidence"
@@ -2072,6 +2234,7 @@ def _workflow_metric_highlights(metrics: dict[str, object]) -> list[str]:
 
 _WORKFLOW_GROUP_LABELS = {
     "numbered": "numbered",
+    "avbd_constraint_showcase": "avbd showcase",
     "related_evidence": "related",
     "rigid_ipc_shelf": "ipc shelf",
     "capture_first_packet": "packets",
@@ -2110,6 +2273,8 @@ def _workflow_requested_group_labels(
 ) -> str:
     if requested_include_flags is None:
         return fallback
+    if requested_include_flags.get("include_avbd_showcase", False):
+        return "avbd showcase"
     labels = ["numbered"]
     if requested_include_flags.get("include_related", False):
         labels.append("related")
@@ -3183,6 +3348,10 @@ def _write_workflow_manifest(
     )
     completed = sum(1 for capture in captures if capture.get("status") == "captured")
     failed = sum(1 for capture in captures if capture.get("status") == "failed")
+    selected_include_avbd_showcase = any(
+        capture.get("workflow_group") == "avbd_constraint_showcase"
+        for capture in captures
+    )
     selected_include_related = any(
         capture.get("workflow_group") == "related_evidence" for capture in captures
     )
@@ -3193,6 +3362,7 @@ def _write_workflow_manifest(
         capture.get("workflow_group") == "capture_first_packet" for capture in captures
     )
     requested_include_flags = requested_include_flags or {
+        "include_avbd_showcase": selected_include_avbd_showcase,
         "include_related": selected_include_related,
         "include_ipc_shelf": selected_include_ipc_shelf,
         "include_packets": selected_include_packets,
@@ -3236,9 +3406,11 @@ def _write_workflow_manifest(
         {
             "schema_version": 1,
             "workflow": "rigid_visual_verification",
+            "include_avbd_showcase": requested_include_flags["include_avbd_showcase"],
             "include_related": requested_include_flags["include_related"],
             "include_ipc_shelf": requested_include_flags["include_ipc_shelf"],
             "include_packets": requested_include_flags["include_packets"],
+            "selected_include_avbd_showcase": selected_include_avbd_showcase,
             "selected_include_related": selected_include_related,
             "selected_include_ipc_shelf": selected_include_ipc_shelf,
             "selected_include_packets": selected_include_packets,
@@ -3309,6 +3481,12 @@ def _validate_rigid_workflow_args(args: argparse.Namespace) -> None:
         raise SystemExit("--rigid-workflow cannot be combined with --scene-state-json")
     if args.capture_label:
         raise SystemExit("--rigid-workflow cannot be combined with --capture-label")
+    if args.avbd_showcase_only and (
+        args.include_related or args.include_ipc_shelf or args.include_packets
+    ):
+        raise SystemExit(
+            "--avbd-showcase-only cannot be combined with other workflow groups"
+        )
 
 
 def _run_rigid_workflow(args: argparse.Namespace) -> int:
@@ -3414,6 +3592,8 @@ def _run_rigid_workflow(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     _apply_stable_linux_render_env()
     args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.avbd_showcase_only and not args.rigid_workflow:
+        raise SystemExit("--avbd-showcase-only requires --rigid-workflow")
     if args.include_related and not args.rigid_workflow:
         raise SystemExit("--include-related requires --rigid-workflow")
     if args.include_ipc_shelf and not args.rigid_workflow:

--- a/tests/unit/gui/test_gui_debug_visuals.cpp
+++ b/tests/unit/gui/test_gui_debug_visuals.cpp
@@ -65,6 +65,16 @@ using dart::dynamics::BoxShape;
 using dart::dynamics::FreeJoint;
 using dart::dynamics::Skeleton;
 
+void expectFiniteNonZeroLines(
+    const std::vector<dart::gui::DebugLineDescriptor>& lines)
+{
+  for (const auto& line : lines) {
+    EXPECT_TRUE(line.from.allFinite()) << line.label;
+    EXPECT_TRUE(line.to.allFinite()) << line.label;
+    EXPECT_GT((line.to - line.from).norm(), 1e-12) << line.label;
+  }
+}
+
 TEST(GuiDebugVisuals, JointAxisDebugLinesFollowRevoluteAxis)
 {
   auto skeleton = Skeleton::create("joint_axis");
@@ -105,6 +115,30 @@ TEST(GuiDebugVisuals, VelocityDebugLinesRespectOptions)
   // Zero velocity produces no arrow even when the option is on.
   pair.first->setVelocities(Eigen::VectorXd::Zero(6));
   EXPECT_TRUE(dart::gui::makeVelocityDebugLines(*body, options).empty());
+}
+
+TEST(GuiDebugVisuals, SelectionDebugLinesSkipFlatBoundsDegenerateEdges)
+{
+  dart::gui::RenderableDescriptor descriptor;
+  descriptor.material.visible = true;
+  descriptor.geometry.hasLocalBounds = true;
+  descriptor.geometry.localBoundsMin = Eigen::Vector3d(-1.0, -2.0, 0.0);
+  descriptor.geometry.localBoundsMax = Eigen::Vector3d(1.0, 2.0, 0.0);
+
+  const auto lines = dart::gui::makeSelectionDebugLines(descriptor);
+  ASSERT_FALSE(lines.empty());
+  expectFiniteNonZeroLines(lines);
+}
+
+TEST(GuiDebugVisuals, SelectionDebugLinesSkipZeroVolumeBounds)
+{
+  dart::gui::RenderableDescriptor descriptor;
+  descriptor.material.visible = true;
+  descriptor.geometry.hasLocalBounds = true;
+  descriptor.geometry.localBoundsMin = Eigen::Vector3d::Ones();
+  descriptor.geometry.localBoundsMax = Eigen::Vector3d::Ones();
+
+  EXPECT_TRUE(dart::gui::makeSelectionDebugLines(descriptor).empty());
 }
 
 TEST(GuiDebugVisuals, PerShapePbrOverridesFlowThroughDescriptor)


### PR DESCRIPTION
## Summary

- Hardens `py-demos --scene rigid_body` selection/force-drag debug overlays so zero-motion clicks no longer crash either the default or CUDA Pixi demo path.
- Adds repeatable capture workflows for the flagship rigid-body SI versus boxed-LCP contact baseline and the curated AVBD rigid-constraint showcase.
- Adds live workflow controls for switching the rigid-body contact baseline, including boxed-LCP state restoration from generated commands and a direct route to the SI/boxed-LCP comparison scene.
- Honors explicit, environment-selected, and default `rigid_body` scene-state overrides for both `pixi run py-demos` and `pixi run -e cuda py-demos`.
- Updates the py-demos docs, M1 task handoff, unit tests, and DART 7 changelog for the new capture workflow surface.

## Motivation / Problem

After #3082 fixed the `py-demos` launcher/build path, both `pixi run py-demos` and `pixi run -e cuda py-demos` reached a runtime crash when a click/force-drag produced degenerate debug overlay geometry. The same M1 py-demos workflow also needed a reproducible way to capture the DART 6-style boxed-LCP contact baseline, the default Sequential Impulse comparison row, and the AVBD rigid-constraint showcase without relying on manual panel setup.

## Changes / Key Changes

- Skip zero-length generated debug lines at the `dart::gui` helper layer.
- Validate externally supplied debug lines and triangles in the Filament renderable factory before allocating GPU resources.
- Add GUI unit coverage for flat and zero-volume selection bounds.
- Add `py-demo-capture -- --scene-state-json ...` plus `--capture-label ...`, and expose stateful capture/open-live commands from the `rigid_body` workflow panel.
- Add `py-demo-capture -- --rigid-workflow --contact-baseline-only` for the two-row SI versus boxed-LCP `rigid_body` contact-baseline packet.
- Add one-click Sequential Impulse and boxed-LCP presets to the `rigid_body` scene panel, plus an `Open contact comparison` route to the dedicated side-by-side comparison scene.
- Add `py-demo-capture -- --rigid-workflow --avbd-showcase-only` for fixed-joint/contact, breakable-joint, spherical breakable-joint, revolute-motor, and prismatic-motor AVBD rows.
- Apply `--scene-state-json` to the resolved scene selected by explicit `--scene`, `DART_DEMOS_SCENE`, or the default injected `rigid_body` scene.
- Update `python/examples/demos/README.md`, `docs/dev_tasks/py_demos_framework/*`, and the DART 7 changelog.

## Before / After

Baseline is `dc9a8b1` (`main` after #3082). Current pushed head is `2fdc71e`, which also merges current `origin/main` (`c4682aa`). Times are `/usr/bin/time -p` `real` elapsed for the full Pixi task; before rows fail after the listed elapsed time, after rows pass. This is a launch-path stability check, not a throughput benchmark.

| Command | Before | After |
| --- | --- | --- |
| `/usr/bin/time -p pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` | Failed in `real 2.31s` with `AABB can't be empty` and the `dartDebugColor` teardown error. | Passed in `real 1.90s` on `11e9696`; passed again after merging current `main` in `real 1.99s` on `2fdc71e`. |
| `/usr/bin/time -p pixi run -e cuda py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_rigid_body_cuda.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` | Failed in `real 3.26s` with the same empty-AABB and `dartDebugColor` teardown error. | Passed in `real 2.23s` on `11e9696`; passed again after merging current `main` in `real 2.31s` on `2fdc71e`, with CUDA reported ON. |

Additional capture and smoke evidence:

- The dedicated contact-baseline packet dry-run planned the two `rigid_body` rows, `sequential_impulse` and `boxed_lcp`, in `real 1.52s`.
- The boxed-LCP contact-baseline row passed in default (`real 17.08s`) and CUDA (`real 17.36s`) workflow captures; both manifests resolved `contact_solver_method=BOXED_LCP`, and the CUDA output reported `GPU deformable solve (CUDA) ON [auto]`.
- AVBD showcase row 4 (`avbd_rigid_revolute_motor`) passed in both default (`real 8.05s`) and CUDA (`real 8.64s`) workflow captures with `solver=avbd_rigid_joints` in the manifests.
- Full-catalog py-demos smoke passed in both environments on current pushed head `2fdc71e`: default `pixi run py-demos-smoke --json-out /tmp/py_demos_smoke_default_pr3084_2fdc71e.json` passed 155/155 in `real 50.02s`; CUDA `pixi run -e cuda py-demos-smoke --json-out /tmp/py_demos_smoke_cuda_pr3084_2fdc71e.json` passed 155/155 in `real 79.57s`.

## Testing

- `pixi run cmake --build build/default/cpp/Release-docking --target UNIT_gui_DebugVisuals`
- `pixi run ctest --test-dir build/default/cpp/Release-docking --output-on-failure -R '^UNIT_gui_DebugVisuals$'`
- `PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python -m pytest python/tests/unit/test_capture_py_demo.py -q` (`85 passed`)
- `PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python -m pytest python/tests/unit/test_py_demo_panels.py -q` (`163 passed, 7 skipped`; later `165 passed, 7 skipped` after the follow-up scene-state and route coverage)
- `/usr/bin/time -p pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_rigid_body_after_pr3084_11e9696.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 1.90s`)
- `/usr/bin/time -p pixi run -e cuda py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_rigid_body_cuda_after_pr3084_11e9696.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 2.23s`)
- `/usr/bin/time -p pixi run py-demos -- --scene rigid_body --width 960 --height 540 --scene-state-json '{"controls":{"contact_method_index":1}}'` (`real 1.86s`)
- `/usr/bin/time -p pixi run -e cuda py-demos -- --scene rigid_body --width 960 --height 540 --scene-state-json '{"controls":{"contact_method_index":1}}'` (`real 2.30s`, CUDA ON)
- `/usr/bin/time -p env DART_DEMOS_SCENE=rigid_body pixi run py-demos -- --scene-state-json '{"controls":{"contact_method_index":1}}' --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_env_scene_state_default.ppm` (`real 2.13s`)
- `/usr/bin/time -p env DART_DEMOS_SCENE=rigid_body pixi run -e cuda py-demos -- --scene-state-json '{"controls":{"contact_method_index":1}}' --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_env_scene_state_cuda.ppm` (`real 2.53s`, CUDA ON)
- `/usr/bin/time -p pixi run py-demo-capture -- --scene rigid_body --frames 180 --width 960 --height 540 --show-ui --scene-state-json '{"controls":{"contact_method_index":1}}' --capture-label boxed_lcp`
- `/usr/bin/time -p pixi run -e cuda py-demo-capture -- --scene rigid_body --frames 180 --width 960 --height 540 --show-ui --scene-state-json '{"controls":{"contact_method_index":1}}' --capture-label boxed_lcp`
- `/usr/bin/time -p pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --dry-run --output-dir /tmp/dart_capture_rigid_contact_baseline_plan_3084` (`real 1.52s`)
- `/usr/bin/time -p pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --workflow-start-row 2 --workflow-end-row 2 --output-dir /tmp/dart_capture_rigid_contact_baseline_boxed_default_3084` (`real 17.08s`)
- `/usr/bin/time -p pixi run -e cuda py-demo-capture -- --rigid-workflow --contact-baseline-only --workflow-start-row 2 --workflow-end-row 2 --output-dir /tmp/dart_capture_rigid_contact_baseline_boxed_cuda_3084` (`real 17.36s`)
- `/usr/bin/time -p pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --dry-run --output-dir /tmp/dart_capture_rigid_avbd_showcase_plan_3084`
- `/usr/bin/time -p pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --workflow-start-row 4 --workflow-end-row 4 --output-dir /tmp/dart_capture_rigid_avbd_showcase_revolute_default_3084`
- `/usr/bin/time -p pixi run -e cuda py-demo-capture -- --rigid-workflow --avbd-showcase-only --workflow-start-row 4 --workflow-end-row 4 --output-dir /tmp/dart_capture_rigid_avbd_showcase_revolute_cuda_3084`
- `pixi run lint` after merging current `origin/main`
- `/usr/bin/time -p pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_rigid_body_after_merge_push.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 1.99s` on `2fdc71e`)
- `/usr/bin/time -p pixi run -e cuda py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/dart_py_demos_rigid_body_after_merge_push_cuda.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 2.31s`, CUDA ON, on `2fdc71e`)
- `/usr/bin/time -p pixi run py-demos-smoke --json-out /tmp/py_demos_smoke_default_pr3084_2fdc71e.json` (`PASS 155/155 FAIL 0`, `real 50.02s` on `2fdc71e`)
- `/usr/bin/time -p pixi run -e cuda py-demos-smoke --json-out /tmp/py_demos_smoke_cuda_pr3084_2fdc71e.json` (`PASS 155/155 FAIL 0`, `real 79.57s` on `2fdc71e`)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows #3082 for the `py-demos` launch/build path.
- No DART 6 backport: this is in the DART 7 Filament/`py-demos` stack.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A - no new methods/classes)
- [x] Add Python bindings (dartpy) if applicable (N/A - no binding changes)