### PR TITLE
Add rigid body py-demos material workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,12 +208,12 @@ compatibility remains on the active DART 6 LTS branch._
 - Added and tuned Atlas/G1/Hubo puppet and SIMBICON Python demos, including a
   reusable pose-window comparison utility for locomotion evidence.
   ([#3043](https://github.com/dartsim/dart/pull/3043))
-- Exposed the rigid-body Python demo's contact-solver method in its live panel
-  and capture metadata, giving py-demos a direct SI versus boxed-LCP inspection
-  path for the DART 6 contact baseline, including scriptable capture-state
-  overrides, labeled capture artifacts, a dedicated SI/boxed-LCP contact
-  baseline packet, and a dedicated AVBD rigid-constraint showcase packet for M1
-  visual review.
+- Exposed the rigid-body Python demo's contact-solver method and material
+  presets in its live panel and capture metadata, giving py-demos direct SI
+  versus boxed-LCP and friction/restitution inspection paths, including
+  scriptable capture-state overrides, labeled capture artifacts, a dedicated
+  SI/boxed-LCP contact-baseline packet, a material-example packet, and a
+  dedicated AVBD rigid-constraint showcase packet for M1 visual review.
 - Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
   gestures in `py-demos` skip degenerate primitives instead of tripping
   Filament's empty-AABB precondition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,12 +208,13 @@ compatibility remains on the active DART 6 LTS branch._
 - Added and tuned Atlas/G1/Hubo puppet and SIMBICON Python demos, including a
   reusable pose-window comparison utility for locomotion evidence.
   ([#3043](https://github.com/dartsim/dart/pull/3043))
-- Exposed the rigid-body Python demo's contact-solver method and material
-  presets in its live panel and capture metadata, giving py-demos direct SI
-  versus boxed-LCP and friction/restitution inspection paths, including
-  scriptable capture-state overrides, labeled capture artifacts, a dedicated
-  SI/boxed-LCP contact-baseline packet, a material-example packet, and a
-  dedicated AVBD rigid-constraint showcase packet for M1 visual review.
+- Exposed the rigid-body Python demo's fixed rigid-solver context,
+  contact-solver method, and material presets in its live panel and capture
+  metadata, giving py-demos direct SI versus boxed-LCP and
+  friction/restitution inspection paths, including scriptable capture-state
+  overrides, labeled capture artifacts, a dedicated SI/boxed-LCP
+  contact-baseline packet, a material-example packet, and a dedicated AVBD
+  rigid-constraint showcase packet for M1 visual review.
 - Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
   gestures in `py-demos` skip degenerate primitives instead of tripping
   Filament's empty-AABB precondition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Exposed the rigid-body Python demo's fixed rigid-solver context,
   contact-solver method, and material presets in its live panel and capture
   metadata, giving py-demos direct SI versus boxed-LCP and
-  friction/restitution inspection paths, including scriptable capture-state
+  named material-preset inspection paths, including scriptable capture-state
   overrides, labeled capture artifacts, a dedicated SI/boxed-LCP
   contact-baseline packet, a material-example packet, and a dedicated AVBD
   rigid-constraint showcase packet for M1 visual review.

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -93,6 +93,15 @@ and replay metadata.
         workflow captures the `rigid_body` Default, Slide, and Bounce
         friction/restitution variants as one review-indexed packet with
         state/label metadata and rerun commands.
+  - [x] Reviewer-facing material packet pass: full material-example packets
+        completed in both default and CUDA Pixi environments on local head
+        `2b887338002`. The default packet
+        `/tmp/dart_capture_rigid_material_examples_full_default_2b887338002`
+        completed in `real 63.16s`; the CUDA packet
+        `/tmp/dart_capture_rigid_material_examples_full_cuda_2b887338002`
+        completed in `real 94.86s`. Both manifests report `status=complete`,
+        three captured material rows, complete guidance, solver identity, and
+        scene metrics.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -90,8 +90,9 @@ and replay metadata.
         one-click Default, Slide, and Bounce material presets that reset the scene
         and flow through the same friction/restitution replay and capture
         controls as the manual sliders. The panel also reports the active
-        material preset or custom friction/restitution state and routes directly
-        to the dedicated material-mixing row for deeper inspection.
+        material preset or custom friction/restitution state, preserves that
+        label in replay/capture metrics, and routes directly to the dedicated
+        material-mixing row for deeper inspection.
   - [x] Front-door AVBD bridge: the flagship `rigid_body` panel now links
         directly to `avbd_rigid_fixed_joint_contact`, giving the baseline World
         contact/material scene a live path into the curated AVBD rigid-constraint
@@ -108,7 +109,7 @@ and replay metadata.
         `/tmp/dart_capture_rigid_material_examples_full_cuda_2b887338002`
         completed in `real 94.86s`. Both manifests report `status=complete`,
         three captured material rows, complete guidance, solver identity, and
-        scene metrics.
+        material scene metrics.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -33,6 +33,10 @@ and replay metadata.
   - [x] Interactive selection/force-drag overlay hardening: a zero-motion
         click/drag on `rigid_body` no longer feeds degenerate debug primitives
         into Filament's AABB precondition path.
+  - [x] Selection crash regression guard: the real-viewer integration suite now
+        runs the original zero-motion `rigid_body` scripted force-drag path and
+        requires a valid headless screenshot, so the exact crash path is covered
+        beyond manual PR evidence.
   - [x] Local full-catalog regression pass on PR #3084 local head `bd0b8e7`:
         default `pixi run py-demos-smoke --json-out
 /tmp/py_demos_smoke_default_pr3084_local.json` passed **155/155** in
@@ -116,7 +120,9 @@ repeatable operation.
 ## Immediate Next Steps
 
 1. Keep the interactive selection repro in the validation set when touching
-   `dart::gui` debug overlays:
+   `dart::gui` debug overlays. The focused regression test is
+   `python/tests/integration/test_demos_cycle.py::test_rigid_body_scripted_selection_force_drag_is_stable`;
+   the direct manual command remains:
    `pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2`.
 2. Verify the M1 contact-baseline increment with focused C++/dartpy tests,
    `python/tests/unit/test_py_demo_panels.py`, and the M0 smoke guards.

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -91,6 +91,10 @@ and replay metadata.
         controls as the manual sliders. The panel also reports the active
         material preset or custom friction/restitution state and routes directly
         to the dedicated material-mixing row for deeper inspection.
+  - [x] Front-door AVBD bridge: the flagship `rigid_body` panel now links
+        directly to `avbd_rigid_fixed_joint_contact`, giving the baseline World
+        contact/material scene a live path into the curated AVBD rigid-constraint
+        showcase without pretending the two tracks are one solver enum.
   - [x] Dedicated material-example packet: the `--material-examples-only`
         workflow captures the `rigid_body` Default, Slide, and Bounce
         friction/restitution variants as one review-indexed packet with

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -89,6 +89,10 @@ and replay metadata.
         one-click Default, Slide, and Bounce material presets that reset the scene
         and flow through the same friction/restitution replay and capture
         controls as the manual sliders.
+  - [x] Dedicated material-example packet: the `--material-examples-only`
+        workflow captures the `rigid_body` Default, Slide, and Bounce
+        friction/restitution variants as one review-indexed packet with
+        state/label metadata and rerun commands.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 
@@ -133,10 +137,13 @@ repeatable operation.
 3. Keep the `rigid_body` material example presets covered by
    `python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene`
    when touching the flagship panel or material controls.
-4. Use the dedicated contact-baseline packet for reviewer-facing SI/boxed-LCP
+4. Use the dedicated material-example packet for reviewer-facing
+   friction/restitution examples when refreshing artifacts:
+   `pixi run py-demo-capture -- --rigid-workflow --material-examples-only --output-dir /tmp/dart_capture_rigid_material_examples`.
+5. Use the dedicated contact-baseline packet for reviewer-facing SI/boxed-LCP
    evidence when refreshing artifacts:
    `pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --output-dir /tmp/dart_capture_rigid_contact_baseline`.
-5. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence when
+6. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence when
    refreshing artifacts:
    `pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --output-dir /tmp/dart_capture_rigid_avbd_showcase`.
    M1 remains two complementary showcases for now: World contact-policy /

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -52,7 +52,8 @@ and replay metadata.
         baseline presets for the default Sequential Impulse and boxed-LCP
         contact paths, plus a route into the side-by-side
         `rigid_contact_solver_compare` row. Realtime rigid workflow rows keep
-        the rigid-body solver fixed to the Sequential Impulse path; use
+        the rigid-body solver fixed to the Sequential Impulse path and present
+        that as fixed panel context instead of a one-option selector; use
         `rigid_solver_compare` and the explicit IPC shelf scenes for SI-vs-IPC
         visual inspection.
   - [x] Scriptable contact-policy capture: `py-demo-capture` can restore

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -85,6 +85,10 @@ and replay metadata.
         identity, and metrics in the review index are the key evidence. A
         unified comparison scene is not required for the current PR evidence;
         keep it as a follow-up only if review finds the two packets insufficient.
+  - [x] Front-door material examples: the flagship `rigid_body` panel now has
+        one-click Default, Slide, and Bounce material presets that reset the scene
+        and flow through the same friction/restitution replay and capture
+        controls as the manual sliders.
 - [ ] **Beyond M1**: repeat M1 outward — expand solvers and domains
       incrementally, each with sufficient testing and verification.
 
@@ -126,10 +130,13 @@ repeatable operation.
    `pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2`.
 2. Verify the M1 contact-baseline increment with focused C++/dartpy tests,
    `python/tests/unit/test_py_demo_panels.py`, and the M0 smoke guards.
-3. Use the dedicated contact-baseline packet for reviewer-facing SI/boxed-LCP
+3. Keep the `rigid_body` material example presets covered by
+   `python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene`
+   when touching the flagship panel or material controls.
+4. Use the dedicated contact-baseline packet for reviewer-facing SI/boxed-LCP
    evidence when refreshing artifacts:
    `pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --output-dir /tmp/dart_capture_rigid_contact_baseline`.
-4. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence when
+5. Use the dedicated AVBD showcase packet for reviewer-facing M1 evidence when
    refreshing artifacts:
    `pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --output-dir /tmp/dart_capture_rigid_avbd_showcase`.
    M1 remains two complementary showcases for now: World contact-policy /

--- a/docs/dev_tasks/py_demos_framework/README.md
+++ b/docs/dev_tasks/py_demos_framework/README.md
@@ -88,7 +88,9 @@ and replay metadata.
   - [x] Front-door material examples: the flagship `rigid_body` panel now has
         one-click Default, Slide, and Bounce material presets that reset the scene
         and flow through the same friction/restitution replay and capture
-        controls as the manual sliders.
+        controls as the manual sliders. The panel also reports the active
+        material preset or custom friction/restitution state and routes directly
+        to the dedicated material-mixing row for deeper inspection.
   - [x] Dedicated material-example packet: the `--material-examples-only`
         workflow captures the `rigid_body` Default, Slide, and Bounce
         friction/restitution variants as one review-indexed packet with

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -130,11 +130,17 @@ presets that set friction/restitution and reset through the existing replay and
 capture state path, giving reviewers quick rigid-body material cases without
 leaving the flagship scene.
 
+The latest local increment promotes those material examples into the workflow
+capture helper: `py-demo-capture -- --rigid-workflow --material-examples-only`
+captures the Default, Slide, and Bounce `rigid_body` variants as a
+review-indexed packet with state metadata, capture labels, rerun commands, and
+the same workflow guidance fields used by the contact-baseline and AVBD packets.
+
 ## Current Branch
 
 `fix/py-demos-selection-regression-guard` - branched from current `main` after
 the #3084 merge. It currently contains the scripted-selection integration guard
-plus the small `rigid_body` material-example preset increment. Keep any
+plus the `rigid_body` material-example preset and packet increments. Keep any
 remaining edits narrow, keep the dev-task handoff current, and validate the
 exact default/CUDA py-demos front doors before publishing a follow-up PR.
 
@@ -159,6 +165,18 @@ PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
   -m pytest \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene \
   -q
+```
+
+For the material-example workflow packet increment, also run:
+
+```bash
+PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
+  -m pytest \
+  python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_can_capture_material_examples_only \
+  python/tests/unit/test_py_demo_panels.py::test_rigid_workflow_panel_renders_guidance_for_numbered_rows \
+  -q
+pixi run py-demo-capture -- --rigid-workflow --material-examples-only \
+  --dry-run --output-dir /tmp/dart_capture_rigid_material_examples_dry_run
 ```
 
 After this follow-up, continue M1 by using the dedicated contact-baseline packet

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -155,14 +155,20 @@ active material preset (or `Custom`) beside the live friction/restitution values
 and adds an `Open material mixing` route to `rigid_material_mixing`, matching
 the existing contact-comparison route pattern.
 
+The next local M1 bridge adds an `Open AVBD showcase` route from the same
+`rigid_body` front-door panel to `avbd_rigid_fixed_joint_contact`. This keeps
+the AVBD rigid-constraint track discoverable from the flagship baseline scene
+while preserving the documented distinction between World contact-policy rows
+and the separate AVBD `sx` constraint showcase.
+
 ## Current Branch
 
 `fix/py-demos-selection-regression-guard` - branched from current `main` after
 the #3084 merge. It currently contains the scripted-selection integration guard
 plus the `rigid_body` material-example preset, packet, full-packet evidence, and
-material-route UI increments. Keep any remaining edits narrow, keep the dev-task
-handoff current, and validate the exact default/CUDA py-demos front doors before
-publishing a follow-up PR.
+material/AVBD-route UI increments. Keep any remaining edits narrow, keep the
+dev-task handoff current, and validate the exact default/CUDA py-demos front
+doors before publishing a follow-up PR.
 
 ## Immediate Next Step
 
@@ -186,6 +192,7 @@ PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_status_tracks_custom_sliders \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_routes_to_material_mixing \
+  python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_routes_to_avbd_showcase \
   -q
 ```
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -161,14 +161,19 @@ the AVBD rigid-constraint track discoverable from the flagship baseline scene
 while preserving the documented distinction between World contact-policy rows
 and the separate AVBD `sx` constraint showcase.
 
+The latest UI cleanup removes the one-option `Solver` dropdown from the
+`rigid_body` front-door panel. The panel now displays the Sequential Impulse
+rigid solver as fixed baseline context and points users to
+`rigid_solver_compare` for real SI-vs-IPC inspection.
+
 ## Current Branch
 
 `fix/py-demos-selection-regression-guard` - branched from current `main` after
 the #3084 merge. It currently contains the scripted-selection integration guard
 plus the `rigid_body` material-example preset, packet, full-packet evidence, and
-material/AVBD-route UI increments. Keep any remaining edits narrow, keep the
-dev-task handoff current, and validate the exact default/CUDA py-demos front
-doors before publishing a follow-up PR.
+material/AVBD-route/fixed-solver-context UI increments. Keep any remaining edits
+narrow, keep the dev-task handoff current, and validate the exact default/CUDA
+py-demos front doors before publishing a follow-up PR.
 
 ## Immediate Next Step
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -155,6 +155,11 @@ active material preset (or `Custom`) beside the live friction/restitution values
 and adds an `Open material mixing` route to `rigid_material_mixing`, matching
 the existing contact-comparison route pattern.
 
+The newest material-evidence slice also records the active material preset name
+in `rigid_body` capture metrics and replay state, and replay restore accepts a
+`material_preset` control name so packet rows can preserve the same
+Default/Slide/Bounce/Custom label shown in the live panel.
+
 The next local M1 bridge adds an `Open AVBD showcase` route from the same
 `rigid_body` front-door panel to `avbd_rigid_fixed_joint_contact`. This keeps
 the AVBD rigid-constraint track discoverable from the flagship baseline scene
@@ -171,9 +176,10 @@ rigid solver as fixed baseline context and points users to
 `fix/py-demos-selection-regression-guard` - branched from current `main` after
 the #3084 merge. It currently contains the scripted-selection integration guard
 plus the `rigid_body` material-example preset, packet, full-packet evidence, and
-material/AVBD-route/fixed-solver-context UI increments. Keep any remaining edits
-narrow, keep the dev-task handoff current, and validate the exact default/CUDA
-py-demos front doors before publishing a follow-up PR.
+material/AVBD-route/fixed-solver-context UI increments, plus material-preset
+labels in replay/capture metrics. Keep any remaining edits narrow, keep the
+dev-task handoff current, and validate the exact default/CUDA py-demos front
+doors before publishing a follow-up PR.
 
 ## Immediate Next Step
 
@@ -196,8 +202,10 @@ PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
   -m pytest \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_status_tracks_custom_sliders \
+  python/tests/unit/test_py_demo_panels.py::test_rigid_body_replay_restore_accepts_material_preset_name \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_routes_to_material_mixing \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_routes_to_avbd_showcase \
+  python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_latest_signals_include_material_preset \
   -q
 ```
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -150,6 +150,11 @@ Both workflow manifests report `status=complete`, three captured
 `bounce_material`), complete guidance, solver identity, scene metrics, and
 friction/restitution state metadata for the Slide and Bounce variants.
 
+The current local follow-up now uses named `material_preset` replay state for
+the Slide and Bounce material-example packet rows instead of raw
+friction/restitution JSON, so the packet commands exercise the same
+user-facing restore path that capture metrics report.
+
 The latest local UI slice makes the `rigid_body` front-door panel report the
 active material preset (or `Custom`) beside the live friction/restitution values
 and adds an `Open material mixing` route to `rigid_material_mixing`, matching

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -124,12 +124,19 @@ branch adds a durable real-viewer regression guard for the original
 zero-motion `rigid_body` scripted force-drag crash path, so the crash is covered
 by pytest instead of relying only on manual PR evidence.
 
+The same follow-up branch also advances the M1 `rigid_body` front door with
+one-click material examples. The panel now has Default, Slide, and Bounce
+presets that set friction/restitution and reset through the existing replay and
+capture state path, giving reviewers quick rigid-body material cases without
+leaving the flagship scene.
+
 ## Current Branch
 
 `fix/py-demos-selection-regression-guard` - branched from current `main` after
-the #3084 merge. This branch should stay narrow: add the scripted-selection
-integration guard, keep the dev-task handoff current, and validate the exact
-default/CUDA py-demos front doors before publishing a follow-up PR.
+the #3084 merge. It currently contains the scripted-selection integration guard
+plus the small `rigid_body` material-example preset increment. Keep any
+remaining edits narrow, keep the dev-task handoff current, and validate the
+exact default/CUDA py-demos front doors before publishing a follow-up PR.
 
 ## Immediate Next Step
 
@@ -144,6 +151,15 @@ PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
 Then keep the direct default and CUDA front-door commands in the validation set:
 `pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2`
 and the matching `pixi run -e cuda py-demos` command.
+
+For the material-preset panel increment, also run:
+
+```bash
+PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
+  -m pytest \
+  python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene \
+  -q
+```
 
 After this follow-up, continue M1 by using the dedicated contact-baseline packet
 for rigid-body SI vs boxed-LCP visual evidence and the dedicated AVBD showcase

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -119,29 +119,35 @@ default `pixi run py-demos-smoke --json-out
 /tmp/py_demos_smoke_cuda_pr3084_local.json` passed 155/155 scenes in
 `real 76.18s`.
 
+PR #3084 merged to `main` as `0e6dcd0` on 2026-06-19. The current follow-up
+branch adds a durable real-viewer regression guard for the original
+zero-motion `rigid_body` scripted force-drag crash path, so the crash is covered
+by pytest instead of relying only on manual PR evidence.
+
 ## Current Branch
 
-`fix/py-demos-selection-crash` - published as PR #3084. The PR includes the
-selection debug-overlay fix, scriptable capture-state restoration, labeled
-stateful captures, the dedicated contact-baseline packet, and the AVBD showcase
-packet. The remote PR branch also includes the phase-map, stateful open-live
-command, boxed-LCP workflow-panel UI, rigid-body contact preset, and
-full-catalog smoke evidence follow-ups. The PR body has been refreshed with the
-default and CUDA before/after launch timings plus the full-catalog smoke
-results. A local UI follow-up for the `rigid_body` contact-comparison route may
-be ahead of the remote PR branch until explicitly pushed. A local follow-up also
-addresses the Codex `DART_DEMOS_SCENE` / `--scene-state-json` review finding.
+`fix/py-demos-selection-regression-guard` - branched from current `main` after
+the #3084 merge. This branch should stay narrow: add the scripted-selection
+integration guard, keep the dev-task handoff current, and validate the exact
+default/CUDA py-demos front doors before publishing a follow-up PR.
 
 ## Immediate Next Step
 
-**M1 is in progress.** Keep the scripted selection repro above in the validation
-set, use the dedicated contact-baseline packet for rigid-body SI vs boxed-LCP
-visual evidence, and use the dedicated AVBD showcase packet for the modern
-rigid-constraint track. The next useful slice is PR management: watch hosted CI
-and the fresh Codex review request on PR #3084 for actionable feedback. If the
-local contact-comparison route and `DART_DEMOS_SCENE` state-override fix are
-included in PR #3084, refresh the PR body and rerun/retrigger the same review
-loop after the approved push.
+**M1 is in progress.** For this branch, run the focused regression test:
+
+```bash
+PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
+  -m pytest \
+  python/tests/integration/test_demos_cycle.py::test_rigid_body_scripted_selection_force_drag_is_stable -q
+```
+
+Then keep the direct default and CUDA front-door commands in the validation set:
+`pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2`
+and the matching `pixi run -e cuda py-demos` command.
+
+After this follow-up, continue M1 by using the dedicated contact-baseline packet
+for rigid-body SI vs boxed-LCP visual evidence and the dedicated AVBD showcase
+packet for the modern rigid-constraint track.
 
 Re-run any M0 guard:
 
@@ -191,12 +197,12 @@ PYTHONPATH=build/cuda/cpp/Release-docking/python:python .pixi/envs/cuda/bin/pyth
 ## How to Resume
 
 ```bash
-git checkout fix/py-demos-selection-crash
+git checkout fix/py-demos-selection-regression-guard
 git status && git log -3 --oneline
 # Verify build state:
 ls build/cuda/cpp/Release-docking/python/dartpy/_dartpy*.so 2>/dev/null || echo "needs build"
 ```
 
-Then: run the py-demos panel/smoke guards if changing runtime behavior; for the
-current reporting-only follow-up, focused capture tests plus `pixi run lint` are
-the relevant local gates before any approved push.
+Then: run the focused scripted-selection regression guard, the default/CUDA
+manual front-door checks, and `pixi run lint` before any commit or approved
+push.

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -150,14 +150,19 @@ Both workflow manifests report `status=complete`, three captured
 `bounce_material`), complete guidance, solver identity, scene metrics, and
 friction/restitution state metadata for the Slide and Bounce variants.
 
+The latest local UI slice makes the `rigid_body` front-door panel report the
+active material preset (or `Custom`) beside the live friction/restitution values
+and adds an `Open material mixing` route to `rigid_material_mixing`, matching
+the existing contact-comparison route pattern.
+
 ## Current Branch
 
 `fix/py-demos-selection-regression-guard` - branched from current `main` after
 the #3084 merge. It currently contains the scripted-selection integration guard
-plus the `rigid_body` material-example preset, packet, and full-packet evidence
-increments. Keep any remaining edits narrow, keep the dev-task handoff current,
-and validate the exact default/CUDA py-demos front doors before publishing a
-follow-up PR.
+plus the `rigid_body` material-example preset, packet, full-packet evidence, and
+material-route UI increments. Keep any remaining edits narrow, keep the dev-task
+handoff current, and validate the exact default/CUDA py-demos front doors before
+publishing a follow-up PR.
 
 ## Immediate Next Step
 
@@ -179,6 +184,8 @@ For the material-preset panel increment, also run:
 PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python \
   -m pytest \
   python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene \
+  python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_status_tracks_custom_sliders \
+  python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_routes_to_material_mixing \
   -q
 ```
 

--- a/docs/dev_tasks/py_demos_framework/RESUME.md
+++ b/docs/dev_tasks/py_demos_framework/RESUME.md
@@ -136,13 +136,28 @@ captures the Default, Slide, and Bounce `rigid_body` variants as a
 review-indexed packet with state metadata, capture labels, rerun commands, and
 the same workflow guidance fields used by the contact-baseline and AVBD packets.
 
+The full material-example packet pass completed on local head `2b887338002`:
+
+- Default material-example packet:
+  `/tmp/dart_capture_rigid_material_examples_full_default_2b887338002`
+  (`real 63.16s`).
+- CUDA material-example packet:
+  `/tmp/dart_capture_rigid_material_examples_full_cuda_2b887338002`
+  (`real 94.86s`).
+
+Both workflow manifests report `status=complete`, three captured
+`material_examples` rows (`default_material`, `slide_material`,
+`bounce_material`), complete guidance, solver identity, scene metrics, and
+friction/restitution state metadata for the Slide and Bounce variants.
+
 ## Current Branch
 
 `fix/py-demos-selection-regression-guard` - branched from current `main` after
 the #3084 merge. It currently contains the scripted-selection integration guard
-plus the `rigid_body` material-example preset and packet increments. Keep any
-remaining edits narrow, keep the dev-task handoff current, and validate the
-exact default/CUDA py-demos front doors before publishing a follow-up PR.
+plus the `rigid_body` material-example preset, packet, and full-packet evidence
+increments. Keep any remaining edits narrow, keep the dev-task handoff current,
+and validate the exact default/CUDA py-demos front doors before publishing a
+follow-up PR.
 
 ## Immediate Next Step
 

--- a/docs/plans/103-examples-strategy/rigid-body-visual-verification.md
+++ b/docs/plans/103-examples-strategy/rigid-body-visual-verification.md
@@ -453,6 +453,16 @@ pixi run py-demo-capture -- --rigid-workflow --include-packets --dry-run
 pixi run py-demo-capture -- --rigid-workflow --include-related --include-packets --output-dir /tmp/dart_capture_rigid_workflow_with_packets
 ```
 
+Use `--material-examples-only` when the target is the M1 `rigid_body`
+front-door material examples. The packet captures Default, Slide, and Bounce
+variants of the same scene, preserving friction/restitution state and capture
+labels in the manifest and review index.
+
+```bash
+pixi run py-demo-capture -- --rigid-workflow --material-examples-only --dry-run
+pixi run py-demo-capture -- --rigid-workflow --material-examples-only --output-dir /tmp/dart_capture_rigid_material_examples
+```
+
 Capture the direct Rigid IPC shelf routes with the docked UI visible:
 
 These commands are also included after the numbered rows, and after related

--- a/docs/plans/103-examples-strategy/rigid-body-visual-verification.md
+++ b/docs/plans/103-examples-strategy/rigid-body-visual-verification.md
@@ -1295,9 +1295,10 @@ shelf, packets`, selected groups `related, ipc shelf, packets`, guidance
 - Latest baseline-hardening follow-up:
   `PYTHONPATH=build/default/cpp/Release/python:build/default/cpp/Release/python/dartpy:python pixi run python -m pytest python/tests/integration/test_demos_cycle.py::test_rigid_body_baseline_reports_restartable_first_run_diagnostics python/tests/integration/test_demos_cycle.py::test_rigid_body_modes_compare_dynamic_static_kinematic_semantics python/tests/integration/test_demos_cycle.py::test_rigid_frame_hierarchy_tracks_body_fixed_frame python/tests/integration/test_demos_cycle.py::test_rigid_joint_breakage_marks_and_resets_breakage python/tests/integration/test_demos_cycle.py::test_rigid_verifier_replay_snapshots_restore_controls python/tests/integration/test_demos_cycle.py::test_world_scenes_use_solver_focused_categories python/tests/integration/test_demos_cycle.py::test_world_rigid_visual_verification_scenes_are_ordered python/tests/integration/test_demos_cycle.py::test_rigid_visual_workflow_viewer_titles_are_numbered python/tests/integration/test_demos_cycle.py::test_rigid_visual_workflow_docs_use_current_navigator_count python/tests/integration/test_demos_cycle.py::test_rigid_visual_verification_sidecar_matches_registry_order python/tests/integration/test_demos_cycle.py::test_rigid_visual_verification_readme_matches_sidecar_order python/tests/integration/test_demos_cycle.py::test_rigid_visual_verification_capture_commands_match_workflow python/tests/unit/test_py_demo_panels.py::test_high_value_world_scenes_expose_custom_panels python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_resets_baseline_scene python/tests/unit/test_py_demo_panels.py::test_rigid_joint_breakage_panel_resets_lifecycle -q`
   reported `15 passed`. It upgrades the default `rigid_body` first-run scene with
-  selectable solver/material controls, explicit reset, force drag, contact,
-  energy, height, speed, step-timing, and replay-control diagnostics while keeping
-  focused edge cases in later rows. The docked visual smoke command for
+  fixed Sequential Impulse solver context, material/contact controls, explicit
+  reset, force drag, contact, energy, height, speed, step-timing, and
+  replay-control diagnostics while keeping focused edge cases in later rows. The
+  docked visual smoke command for
   `rigid_body` wrote a nonblank 960x540 screenshot plus 23 PNG frames with final
   contacts at 0. `pixi run lint` passed and bounded `pixi run build` reported
   `ninja: no work to do`.

--- a/docs/plans/103-examples-strategy/rigid-body-visual-verification.md
+++ b/docs/plans/103-examples-strategy/rigid-body-visual-verification.md
@@ -455,7 +455,7 @@ pixi run py-demo-capture -- --rigid-workflow --include-related --include-packets
 
 Use `--material-examples-only` when the target is the M1 `rigid_body`
 front-door material examples. The packet captures Default, Slide, and Bounce
-variants of the same scene, preserving friction/restitution state and capture
+variants of the same scene, preserving named material-preset state and capture
 labels in the manifest and review index.
 
 ```bash

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -351,10 +351,10 @@ solver comparisons.
 
 The **`rigid_body`** scene is the default front door for DART 7 rigid-body
 `World` dynamics. It keeps the first run simple: falling spheres and a box,
-static ground, live replay, viewport force drag, fixed-solver context, material
-controls, an
-explicit reset path, and a compact panel for baseline speed, height, energy,
-contact, and step-timing state. Use the focused rows below when a material,
+static ground, live replay, viewport force drag, fixed-solver context, named
+material presets, an explicit reset path, and a compact panel for baseline
+speed, height, energy, contact, material, and step-timing state. Use the
+focused rows below when a material,
 contact-query, solver, executor, friction, stacking, manipulation, body-mode,
 kinematic, external-load, point-load, time-step, or joint behavior needs deeper
 inspection.
@@ -1006,7 +1006,8 @@ pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only \
 Use `--material-examples-only` when the target is the M1 `rigid_body`
 front-door material examples. The packet captures Default, Slide, and Bounce
 variants of the same scene, preserving friction/restitution state and capture
-labels in the manifest and review index.
+labels in the manifest and review index, plus the resolved material-preset name
+in the latest scene metrics.
 
 ```bash
 pixi run py-demo-capture -- --rigid-workflow --material-examples-only --dry-run

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -1005,7 +1005,7 @@ pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only \
 
 Use `--material-examples-only` when the target is the M1 `rigid_body`
 front-door material examples. The packet captures Default, Slide, and Bounce
-variants of the same scene, preserving friction/restitution state and capture
+variants of the same scene, preserving named material-preset state and capture
 labels in the manifest and review index, plus the resolved material-preset name
 in the latest scene metrics.
 

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -930,15 +930,15 @@ writes a top-level manifest that points at every per-scene manifest and a
 questions, try-first guidance, scope notes, live open commands, capture
 commands, workflow-row rerun commands, and metric summaries from one page: the
 in-viewer `Rigid Workflow` panel also shows the full numbered packet,
-current-row rerun, contact-baseline, AVBD showcase, and extended
-related/IPC-shelf/packet commands.
+current-row rerun, contact-baseline, material-example, AVBD showcase, and
+extended related/IPC-shelf/packet commands.
 Numbered rows carry their workflow phase and focus axis in the manifest and
-review card, while the contact-baseline packet, AVBD showcase, and optional
-related, direct IPC shelf, and capture-first packet rows carry row-guidance
-fields in the
-manifest and review index, so non-numbered packets remain readable without
-opening the live GUI. The same outputs also include a guidance-completeness
-audit and the exact top-level workflow command for the selected packet.
+review card, while the contact-baseline packet, material-example packet, AVBD
+showcase, and optional related, direct IPC shelf, and capture-first packet rows
+carry row-guidance fields in the manifest and review index, so non-numbered
+packets remain readable without opening the live GUI. The same outputs also
+include a guidance-completeness audit and the exact top-level workflow command
+for the selected packet.
 
 ```bash
 pixi run py-demo-capture -- --rigid-workflow --dry-run
@@ -1000,6 +1000,17 @@ labels and state metadata in the workflow manifest and review index.
 pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --dry-run
 pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only \
     --output-dir /tmp/dart_capture_rigid_contact_baseline
+```
+
+Use `--material-examples-only` when the target is the M1 `rigid_body`
+front-door material examples. The packet captures Default, Slide, and Bounce
+variants of the same scene, preserving friction/restitution state and capture
+labels in the manifest and review index.
+
+```bash
+pixi run py-demo-capture -- --rigid-workflow --material-examples-only --dry-run
+pixi run py-demo-capture -- --rigid-workflow --material-examples-only \
+    --output-dir /tmp/dart_capture_rigid_material_examples
 ```
 
 Use `--avbd-showcase-only` when the target is the curated AVBD

--- a/python/examples/demos/README.md
+++ b/python/examples/demos/README.md
@@ -351,7 +351,8 @@ solver comparisons.
 
 The **`rigid_body`** scene is the default front door for DART 7 rigid-body
 `World` dynamics. It keeps the first run simple: falling spheres and a box,
-static ground, live replay, viewport force drag, solver/material controls, an
+static ground, live replay, viewport force drag, fixed-solver context, material
+controls, an
 explicit reset path, and a compact panel for baseline speed, height, energy,
 contact, and step-timing state. Use the focused rows below when a material,
 contact-query, solver, executor, friction, stacking, manipulation, body-mode,

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -192,7 +192,10 @@ _RIGID_VISUAL_WORKFLOW_GUIDE_TEXT: Mapping[
 ] = {
     "rigid_body": (
         "What is the baseline DART 7 World rigid-body path?",
-        ("Solver/material controls", "Contacts, energy, step timing"),
+        (
+            "Fixed Sequential Impulse solver context",
+            "Material/contact controls, energy, step timing",
+        ),
         "Baseline front door; focused edge cases stay in the specialized verifier rows.",
     ),
     "rigid_body_modes": (
@@ -380,7 +383,7 @@ _RIGID_VISUAL_WORKFLOW_GUIDE_TEXT: Mapping[
 
 _RIGID_VISUAL_WORKFLOW_CHECKLIST_TEXT: Mapping[str, tuple[str, str]] = {
     "rigid_body": (
-        "Try solver/material controls, then reset the baseline.",
+        "Try material/contact controls, then reset the fixed Sequential Impulse baseline.",
         "Healthy: contacts settle while energy, speed, and step timing remain bounded.",
     ),
     "rigid_body_modes": (

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -55,6 +55,12 @@ CAPTURE_METRICS_INFO_KEY = "capture_metrics"
 CAPTURE_METADATA_EVENT_NAME = "scene_capture_metadata"
 SCENE_STATE_OVERRIDE_INFO_KEY = "scene_state_override"
 _RIGID_BODY_BOXED_LCP_STATE_JSON = '{"controls":{"contact_method_index":1}}'
+_RIGID_BODY_SLIDE_MATERIAL_STATE_JSON = (
+    '{"controls":{"friction":0.08,"restitution":0.02}}'
+)
+_RIGID_BODY_BOUNCE_MATERIAL_STATE_JSON = (
+    '{"controls":{"friction":0.45,"restitution":0.65}}'
+)
 CAPTURE_METRICS_EVENT_NAME = "scene_capture_metrics"
 _REPLAY_RATE_LABELS = (
     "1 frame/tick",
@@ -956,6 +962,7 @@ def _rigid_workflow_packet_command(
     *,
     contact_baseline_only: bool = False,
     avbd_showcase_only: bool = False,
+    material_examples_only: bool = False,
     include_related: bool = False,
     include_ipc_shelf: bool = False,
     include_packets: bool = False,
@@ -971,6 +978,8 @@ def _rigid_workflow_packet_command(
         command = f"{command} --contact-baseline-only"
     if avbd_showcase_only:
         command = f"{command} --avbd-showcase-only"
+    if material_examples_only:
+        command = f"{command} --material-examples-only"
     if include_related:
         command = f"{command} --include-related"
     if include_ipc_shelf:
@@ -2585,6 +2594,38 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
                 "Capture the same baseline row with the contact solver set to "
                 "Boxed LCP before the first frame."
             )
+            builder.text("Material example variants")
+            for label, state_json, capture_label in (
+                ("Slide", _RIGID_BODY_SLIDE_MATERIAL_STATE_JSON, "slide_material"),
+                ("Bounce", _RIGID_BODY_BOUNCE_MATERIAL_STATE_JSON, "bounce_material"),
+            ):
+                builder.text(
+                    _rigid_workflow_viewer_command(
+                        guide.scene_id,
+                        guide.capture_width,
+                        guide.capture_height,
+                        scene_state_json=state_json,
+                    )
+                )
+                builder.item_tooltip(
+                    f"Open the rigid_body row live with the {label} material "
+                    "example restored before the first frame."
+                )
+                builder.text(
+                    _rigid_workflow_capture_command(
+                        guide.scene_id,
+                        guide.capture_frames,
+                        guide.capture_width,
+                        guide.capture_height,
+                        guide.capture_show_ui,
+                        scene_state_json=state_json,
+                        capture_label=capture_label,
+                    )
+                )
+                builder.item_tooltip(
+                    f"Capture the {label} material example with restored "
+                    "friction/restitution controls."
+                )
         builder.separator()
         builder.text("Review packet")
         builder.text(
@@ -2601,6 +2642,15 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
         )
         builder.item_tooltip(
             "Capture the SI and boxed-LCP rigid_body contact-baseline packet."
+        )
+        builder.text(
+            _rigid_workflow_packet_command(
+                material_examples_only=True,
+                output_dir="/tmp/dart_capture_rigid_material_examples",
+            )
+        )
+        builder.item_tooltip(
+            "Capture the Default, Slide, and Bounce rigid_body material-example packet."
         )
         builder.text(
             _rigid_workflow_packet_command(

--- a/python/examples/demos/runner.py
+++ b/python/examples/demos/runner.py
@@ -56,10 +56,10 @@ CAPTURE_METADATA_EVENT_NAME = "scene_capture_metadata"
 SCENE_STATE_OVERRIDE_INFO_KEY = "scene_state_override"
 _RIGID_BODY_BOXED_LCP_STATE_JSON = '{"controls":{"contact_method_index":1}}'
 _RIGID_BODY_SLIDE_MATERIAL_STATE_JSON = (
-    '{"controls":{"friction":0.08,"restitution":0.02}}'
+    '{"controls":{"material_preset":"Slide"}}'
 )
 _RIGID_BODY_BOUNCE_MATERIAL_STATE_JSON = (
-    '{"controls":{"friction":0.45,"restitution":0.65}}'
+    '{"controls":{"material_preset":"Bounce"}}'
 )
 CAPTURE_METRICS_EVENT_NAME = "scene_capture_metrics"
 _REPLAY_RATE_LABELS = (
@@ -2623,8 +2623,8 @@ def _make_rigid_workflow_panel(scene: PythonDemoScene) -> ScenePanel | None:
                     )
                 )
                 builder.item_tooltip(
-                    f"Capture the {label} material example with restored "
-                    "friction/restitution controls."
+                    f"Capture the {label} material example with the named "
+                    "material preset restored."
                 )
         builder.separator()
         builder.text("Review packet")

--- a/python/examples/demos/scenes/rigid_body.py
+++ b/python/examples/demos/scenes/rigid_body.py
@@ -429,8 +429,9 @@ class _RigidBodyBaseline:
             request_scene_switch(_AVBD_SHOWCASE_SCENE_ID)
 
     def build_panel(self, builder: object, context: object) -> None:
-        changed_solver, solver_index = builder.select(
-            "Solver", int(self.solver_index), [label for label, _solver in _SOLVERS]
+        builder.text(f"rigid solver: {self._solver_label()} (fixed baseline)")
+        builder.item_tooltip(
+            "Use Rigid Solver Compare for SI-vs-IPC rigid-body solver inspection."
         )
         changed_contact_method, contact_method_index = builder.select(
             "Contact solver",
@@ -444,9 +445,6 @@ class _RigidBodyBaseline:
             "Restitution", float(self.restitution), 0.0, 0.8
         )
 
-        if changed_solver:
-            self.solver_index = int(solver_index)
-            self.reset(clear_replay=True)
         if changed_contact_method:
             self._set_contact_method_index(contact_method_index)
         if changed_friction:

--- a/python/examples/demos/scenes/rigid_body.py
+++ b/python/examples/demos/scenes/rigid_body.py
@@ -41,6 +41,7 @@ _CONTACT_METHOD_SEQUENTIAL_INDEX = 0
 _CONTACT_METHOD_BOXED_LCP_INDEX = 1
 _CONTACT_POLICY_COMPARE_SCENE_ID = "rigid_contact_solver_compare"
 _MATERIAL_MIXING_SCENE_ID = "rigid_material_mixing"
+_AVBD_SHOWCASE_SCENE_ID = "avbd_rigid_fixed_joint_contact"
 
 
 def _visual_for(
@@ -422,6 +423,11 @@ class _RigidBodyBaseline:
         if callable(request_scene_switch):
             request_scene_switch(_MATERIAL_MIXING_SCENE_ID)
 
+    def _request_avbd_showcase(self, context: object) -> None:
+        request_scene_switch = getattr(context, "request_scene_switch", None)
+        if callable(request_scene_switch):
+            request_scene_switch(_AVBD_SHOWCASE_SCENE_ID)
+
     def build_panel(self, builder: object, context: object) -> None:
         changed_solver, solver_index = builder.select(
             "Solver", int(self.solver_index), [label for label, _solver in _SOLVERS]
@@ -477,6 +483,11 @@ class _RigidBodyBaseline:
             self._request_contact_policy_compare(context)
         builder.item_tooltip(
             "Open the side-by-side Sequential Impulse and boxed-LCP policy row."
+        )
+        if builder.button("Open AVBD showcase"):
+            self._request_avbd_showcase(context)
+        builder.item_tooltip(
+            "Open the curated AVBD fixed-joint/contact rigid-constraint row."
         )
         if builder.button("Reset baseline scene"):
             self.reset(clear_replay=True)

--- a/python/examples/demos/scenes/rigid_body.py
+++ b/python/examples/demos/scenes/rigid_body.py
@@ -40,6 +40,7 @@ _CONTACT_METHODS: tuple[tuple[str, sx.ContactSolverMethod], ...] = (
 _CONTACT_METHOD_SEQUENTIAL_INDEX = 0
 _CONTACT_METHOD_BOXED_LCP_INDEX = 1
 _CONTACT_POLICY_COMPARE_SCENE_ID = "rigid_contact_solver_compare"
+_MATERIAL_MIXING_SCENE_ID = "rigid_material_mixing"
 
 
 def _visual_for(
@@ -403,10 +404,23 @@ class _RigidBodyBaseline:
         self.restitution = float(preset.restitution)
         self.reset(clear_replay=True)
 
+    def _active_material_label(self) -> str:
+        for preset in _MATERIAL_PRESETS:
+            if np.isclose(self.friction, preset.friction) and np.isclose(
+                self.restitution, preset.restitution
+            ):
+                return preset.label
+        return "Custom"
+
     def _request_contact_policy_compare(self, context: object) -> None:
         request_scene_switch = getattr(context, "request_scene_switch", None)
         if callable(request_scene_switch):
             request_scene_switch(_CONTACT_POLICY_COMPARE_SCENE_ID)
+
+    def _request_material_mixing(self, context: object) -> None:
+        request_scene_switch = getattr(context, "request_scene_switch", None)
+        if callable(request_scene_switch):
+            request_scene_switch(_MATERIAL_MIXING_SCENE_ID)
 
     def build_panel(self, builder: object, context: object) -> None:
         changed_solver, solver_index = builder.select(
@@ -450,6 +464,15 @@ class _RigidBodyBaseline:
             if builder.button(preset.label):
                 self._apply_material_preset(preset)
             builder.item_tooltip(preset.tooltip)
+        builder.text(
+            f"active material: {self._active_material_label()} | "
+            f"friction {self.friction:.2f} | restitution {self.restitution:.2f}"
+        )
+        if builder.button("Open material mixing"):
+            self._request_material_mixing(context)
+        builder.item_tooltip(
+            "Open the dedicated friction/restitution material-combine row."
+        )
         if builder.button("Open contact comparison"):
             self._request_contact_policy_compare(context)
         builder.item_tooltip(

--- a/python/examples/demos/scenes/rigid_body.py
+++ b/python/examples/demos/scenes/rigid_body.py
@@ -60,6 +60,36 @@ class _InitialBodyState:
     angular_velocity: np.ndarray
 
 
+@dataclass(frozen=True)
+class _MaterialPreset:
+    label: str
+    friction: float
+    restitution: float
+    tooltip: str
+
+
+_MATERIAL_PRESETS: tuple[_MaterialPreset, ...] = (
+    _MaterialPreset(
+        "Default",
+        _DEFAULT_FRICTION,
+        _DEFAULT_RESTITUTION,
+        "Reset to the default high-friction falling-stack material.",
+    ),
+    _MaterialPreset(
+        "Slide",
+        0.08,
+        0.02,
+        "Reset with low friction and low bounce for sliding contact inspection.",
+    ),
+    _MaterialPreset(
+        "Bounce",
+        0.45,
+        0.65,
+        "Reset with moderate friction and high restitution for rebound inspection.",
+    ),
+)
+
+
 class _RigidBodyBaseline:
     def __init__(self) -> None:
         self.solver_index = 0
@@ -368,6 +398,11 @@ class _RigidBodyBaseline:
         )
         self.reset(clear_replay=True)
 
+    def _apply_material_preset(self, preset: _MaterialPreset) -> None:
+        self.friction = float(preset.friction)
+        self.restitution = float(preset.restitution)
+        self.reset(clear_replay=True)
+
     def _request_contact_policy_compare(self, context: object) -> None:
         request_scene_switch = getattr(context, "request_scene_switch", None)
         if callable(request_scene_switch):
@@ -408,6 +443,13 @@ class _RigidBodyBaseline:
         if builder.button("Boxed LCP"):
             self._set_contact_method_index(_CONTACT_METHOD_BOXED_LCP_INDEX)
         builder.item_tooltip("Reset to the DART 6-style boxed-LCP baseline.")
+        builder.text("Material examples")
+        for index, preset in enumerate(_MATERIAL_PRESETS):
+            if index > 0:
+                builder.same_line()
+            if builder.button(preset.label):
+                self._apply_material_preset(preset)
+            builder.item_tooltip(preset.tooltip)
         if builder.button("Open contact comparison"):
             self._request_contact_policy_compare(context)
         builder.item_tooltip(

--- a/python/examples/demos/scenes/rigid_body.py
+++ b/python/examples/demos/scenes/rigid_body.py
@@ -248,6 +248,7 @@ class _RigidBodyBaseline:
             "step_ms": step_ms,
             "solver": self._solver_label(),
             "contact_solver": self._contact_method_label(),
+            "material_preset": self._active_material_label(),
             "executor": "World.step default",
         }
 
@@ -298,6 +299,9 @@ class _RigidBodyBaseline:
     def capture_metrics(self) -> dict[str, Any]:
         if not self._last_metrics:
             self._record_metrics()
+        material_preset = self._active_material_label()
+        metrics = dict(self._last_metrics)
+        metrics["material_preset"] = material_preset
         speed_values = list(self._speed_history)
         height_values = list(self._min_height_history)
         energy_values = list(self._energy_history)
@@ -307,6 +311,7 @@ class _RigidBodyBaseline:
             "row": "rigid_body",
             "solver": self._solver_label(),
             "contact_solver": self._contact_method_label(),
+            "material_preset": material_preset,
             "executor": "World.step default",
             "solver_enum": self._solver().name,
             "contact_solver_method": self._contact_method().name,
@@ -325,8 +330,9 @@ class _RigidBodyBaseline:
                 "restitution": float(self.restitution),
                 "solver_index": float(self.solver_index),
                 "contact_method_index": float(self.contact_method_index),
+                "material_preset": material_preset,
             },
-            "metrics": dict(self._last_metrics),
+            "metrics": metrics,
             "history": {
                 "samples": float(len(speed_values)),
                 "max_speed": max(speed_values, default=0.0),
@@ -344,6 +350,7 @@ class _RigidBodyBaseline:
                 "contact_method_index": int(self.contact_method_index),
                 "friction": float(self.friction),
                 "restitution": float(self.restitution),
+                "material_preset": self._active_material_label(),
             },
             "speed_history": list(self._speed_history),
             "min_height_history": list(self._min_height_history),
@@ -369,6 +376,21 @@ class _RigidBodyBaseline:
                 len(_CONTACT_METHODS) - 1,
             ),
         )
+        material_preset = controls.get("material_preset")
+        if (
+            isinstance(material_preset, str)
+            and (
+                "friction" not in controls
+                or "restitution" not in controls
+            )
+        ):
+            for preset in _MATERIAL_PRESETS:
+                if preset.label == material_preset:
+                    if "friction" not in controls:
+                        self.friction = float(preset.friction)
+                    if "restitution" not in controls:
+                        self.restitution = float(preset.restitution)
+                    break
         self.friction = float(controls.get("friction", self.friction))
         self.restitution = float(controls.get("restitution", self.restitution))
         self.world.rigid_body_solver = self._solver()

--- a/python/tests/integration/test_demos_cycle.py
+++ b/python/tests/integration/test_demos_cycle.py
@@ -12396,6 +12396,40 @@ def test_runner_screenshot_writes_ppm(tmp_path: pathlib.Path) -> None:
         assert len(data) > 1024, f"PPM too small: {len(data)} bytes"
 
 
+def test_rigid_body_scripted_selection_force_drag_is_stable(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Regression coverage for zero-motion selection/force-drag debug overlays."""
+
+    if not _gui_run_demos_available():
+        pytest.skip("dartpy.gui.run_demos unavailable (GUI not built)")
+
+    out = tmp_path / "rigid_body_force_drag.ppm"
+    rc = run(
+        [
+            "--scene",
+            "rigid_body",
+            "--headless",
+            "--frames",
+            "4",
+            "--width",
+            "640",
+            "--height",
+            "480",
+            "--screenshot",
+            str(out),
+            "--scripted-force-drag",
+            "1:sphere_0_visual:0,0,0:2",
+        ],
+        make_demo_scenes(),
+    )
+
+    assert rc == 0
+    data = out.read_bytes()
+    assert data.startswith(b"P6"), f"not a PPM: {data[:8]!r}"
+    assert len(data) > 1024, f"PPM too small: {len(data)} bytes"
+
+
 def test_show_ui_uses_docked_workspace_regions(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -191,7 +191,10 @@ def test_visual_capture_manifest_records_image_evidence(
         "workflow_phase": "1. Foundations: state, frames, and loads",
         "focus_axis": "DART 7 World rigid-body baseline",
         "try_first": "Start here before moving to specialized rows.",
-        "inspect": ["Solver/material controls", "Contacts, energy, step timing"],
+        "inspect": [
+            "Fixed Sequential Impulse solver context",
+            "Material/contact controls, energy, step timing",
+        ],
         "healthy_signal": "Contacts settle and energy remains bounded.",
         "scope": "Baseline front door; focused edge cases stay specialized.",
     }
@@ -581,7 +584,14 @@ def test_rigid_workflow_dry_run_writes_capture_plan(
         manifest["captures"][0]["user_question"]
         == "What is the baseline DART 7 World rigid-body path?"
     )
-    assert "Solver/material controls" in manifest["captures"][0]["inspect"]
+    assert (
+        "Fixed Sequential Impulse solver context"
+        in manifest["captures"][0]["inspect"]
+    )
+    assert (
+        "Material/contact controls, energy, step timing"
+        in manifest["captures"][0]["inspect"]
+    )
     assert manifest["captures"][1]["workflow_label"] == "Solver family"
     assert manifest["captures"][1]["workflow_phase"] == "4. Solver decision path"
     assert manifest["captures"][1]["focus_axis"] == "rigid-body solver family"

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -1952,6 +1952,22 @@ def test_rigid_workflow_latest_signals_prioritize_baseline_values() -> None:
     )
 
 
+def test_rigid_workflow_latest_signals_include_material_preset() -> None:
+    highlights = capture_py_demo._workflow_metric_highlights(
+        {
+            "baseline_max_speed": 2.1,
+            "dynamic_body_count": 5,
+            "material_preset": "Bounce",
+            "solver": "Sequential impulse",
+        }
+    )
+
+    assert "material preset: Bounce" in highlights
+    assert highlights.index("dynamic body count: 5") < highlights.index(
+        "material preset: Bounce"
+    )
+
+
 def test_rigid_workflow_latest_signals_prioritize_free_flight_values() -> None:
     highlights = capture_py_demo._workflow_metric_highlights(
         {

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -876,6 +876,126 @@ def test_rigid_workflow_dry_run_can_capture_contact_baseline_only(
     ) in review_html
 
 
+def test_rigid_workflow_dry_run_can_capture_material_examples_only(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "rigid_material_examples"
+
+    def fail_run(_argv: list[str]) -> int:
+        raise AssertionError("dry-run should not render scenes")
+
+    monkeypatch.setattr(capture_py_demo, "_run_scene_capture_from_argv", fail_run)
+
+    rc = capture_py_demo.main(
+        [
+            "--rigid-workflow",
+            "--material-examples-only",
+            "--dry-run",
+            "--output-dir",
+            str(output),
+        ]
+    )
+
+    assert rc == 0
+    manifest = json.loads((output / "manifest.json").read_text())
+    assert manifest["include_material_examples"] is True
+    assert manifest["include_contact_baseline"] is False
+    assert manifest["include_avbd_showcase"] is False
+    assert manifest["include_related"] is False
+    assert manifest["include_ipc_shelf"] is False
+    assert manifest["include_packets"] is False
+    assert manifest["selected_include_material_examples"] is True
+    assert manifest["selected_include_contact_baseline"] is False
+    assert manifest["selected_include_avbd_showcase"] is False
+    assert manifest["selected_include_related"] is False
+    assert manifest["selected_include_ipc_shelf"] is False
+    assert manifest["selected_include_packets"] is False
+    assert manifest["capture_count"] == 3
+    assert manifest["workflow_total_count"] == 3
+    assert manifest["workflow_row_start"] == 1
+    assert manifest["workflow_row_end"] == 3
+    assert [capture["scene"] for capture in manifest["captures"]] == [
+        "rigid_body",
+        "rigid_body",
+        "rigid_body",
+    ]
+    assert [capture["workflow_group"] for capture in manifest["captures"]] == [
+        "material_examples",
+        "material_examples",
+        "material_examples",
+    ]
+    assert [capture["capture_label"] for capture in manifest["captures"]] == [
+        "default_material",
+        "slide_material",
+        "bounce_material",
+    ]
+    assert manifest["captures"][0]["scene_state_json"] == ""
+    assert (
+        manifest["captures"][1]["scene_state_json"]
+        == '{"controls":{"friction":0.08,"restitution":0.02}}'
+    )
+    assert (
+        manifest["captures"][2]["scene_state_json"]
+        == '{"controls":{"friction":0.45,"restitution":0.65}}'
+    )
+    assert "--capture-label default_material" in manifest["captures"][0]["command"]
+    assert "--capture-label slide_material" in manifest["captures"][1]["command"]
+    assert "--capture-label bounce_material" in manifest["captures"][2]["command"]
+    assert "--scene-state-json" not in manifest["captures"][0]["command"]
+    assert (
+        "--scene-state-json '{\"controls\":{\"friction\":0.08,\"restitution\":0.02}}'"
+        in manifest["captures"][1]["command"]
+    )
+    assert (
+        "--scene-state-json '{\"controls\":{\"friction\":0.45,\"restitution\":0.65}}'"
+        in manifest["captures"][2]["viewer_command"]
+    )
+    assert (
+        manifest["captures"][0]["workflow_rerun_command"]
+        == "pixi run py-demo-capture -- --rigid-workflow --material-examples-only "
+        "--workflow-start-row 1 --workflow-end-row 1 --output-dir "
+        f"{output}/reruns/01_rigid_body"
+    )
+    assert manifest["captures"][0]["workflow_label"] == "Material example"
+    assert manifest["captures"][0]["workflow_phase"] == "M1 material examples"
+    assert (
+        manifest["captures"][0]["focus_axis"]
+        == "rigid_body friction/restitution presets"
+    )
+    assert "default high-friction" in manifest["captures"][0]["user_question"]
+    assert "sliding contact controls" in manifest["captures"][1]["try_first"]
+    assert "friction=0.45" in manifest["captures"][2]["healthy_signal"]
+    assert manifest["workflow_phase_summary"] == [
+        {
+            "phase": "M1 material examples",
+            "focus_axes": ["rigid_body friction/restitution presets"],
+            "captured_count": 0,
+            "failed_count": 0,
+            "planned_count": 3,
+            "row_count": 3,
+            "row_span": "1-3",
+            "rows": [1, 2, 3],
+            "scenes": ["rigid_body", "rigid_body", "rigid_body"],
+            "status_counts": {
+                "captured": 0,
+                "failed": 0,
+                "planned": 3,
+            },
+        }
+    ]
+    review_html = pathlib.Path(manifest["artifacts"]["review_index"]).read_text()
+    assert "material examples" in review_html
+    assert "<strong>phases</strong> 1" in review_html
+    assert "Workflow Phase Map" in review_html
+    assert "M1 material examples" in review_html
+    assert "rigid_body friction/restitution presets" in review_html
+    assert "--material-examples-only" in review_html
+    assert "<dt>capture label</dt><dd>default_material</dd>" in review_html
+    assert "<dt>capture label</dt><dd>slide_material</dd>" in review_html
+    assert "<dt>capture label</dt><dd>bounce_material</dd>" in review_html
+    assert "<dt>scene state</dt><dd>{&quot;controls&quot;" in review_html
+
+
 def test_rigid_workflow_dry_run_can_include_related_evidence(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3223,6 +3343,10 @@ def test_rigid_workflow_scene_capture_runs_in_child_process(
             "--avbd-showcase-only",
             "--avbd-showcase-only requires --rigid-workflow",
         ),
+        (
+            "--material-examples-only",
+            "--material-examples-only requires --rigid-workflow",
+        ),
         ("--include-ipc-shelf", "--include-ipc-shelf requires --rigid-workflow"),
         ("--include-packets", "--include-packets requires --rigid-workflow"),
         (
@@ -3273,6 +3397,44 @@ def test_rigid_workflow_contact_baseline_rejects_avbd_showcase(
             [
                 "--rigid-workflow",
                 "--contact-baseline-only",
+                "--avbd-showcase-only",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+
+
+def test_rigid_workflow_material_examples_rejects_other_groups(
+    tmp_path: pathlib.Path,
+) -> None:
+    with pytest.raises(
+        SystemExit,
+        match="--material-examples-only cannot be combined with other workflow groups",
+    ):
+        capture_py_demo.main(
+            [
+                "--rigid-workflow",
+                "--material-examples-only",
+                "--include-related",
+                "--dry-run",
+                "--output-dir",
+                str(tmp_path),
+            ]
+        )
+
+
+def test_rigid_workflow_material_examples_rejects_other_packets(
+    tmp_path: pathlib.Path,
+) -> None:
+    with pytest.raises(
+        SystemExit,
+        match="--material-examples-only cannot be combined with other workflow packets",
+    ):
+        capture_py_demo.main(
+            [
+                "--rigid-workflow",
+                "--material-examples-only",
                 "--avbd-showcase-only",
                 "--dry-run",
                 "--output-dir",

--- a/python/tests/unit/test_capture_py_demo.py
+++ b/python/tests/unit/test_capture_py_demo.py
@@ -932,22 +932,22 @@ def test_rigid_workflow_dry_run_can_capture_material_examples_only(
     assert manifest["captures"][0]["scene_state_json"] == ""
     assert (
         manifest["captures"][1]["scene_state_json"]
-        == '{"controls":{"friction":0.08,"restitution":0.02}}'
+        == '{"controls":{"material_preset":"Slide"}}'
     )
     assert (
         manifest["captures"][2]["scene_state_json"]
-        == '{"controls":{"friction":0.45,"restitution":0.65}}'
+        == '{"controls":{"material_preset":"Bounce"}}'
     )
     assert "--capture-label default_material" in manifest["captures"][0]["command"]
     assert "--capture-label slide_material" in manifest["captures"][1]["command"]
     assert "--capture-label bounce_material" in manifest["captures"][2]["command"]
     assert "--scene-state-json" not in manifest["captures"][0]["command"]
     assert (
-        "--scene-state-json '{\"controls\":{\"friction\":0.08,\"restitution\":0.02}}'"
+        "--scene-state-json '{\"controls\":{\"material_preset\":\"Slide\"}}'"
         in manifest["captures"][1]["command"]
     )
     assert (
-        "--scene-state-json '{\"controls\":{\"friction\":0.45,\"restitution\":0.65}}'"
+        "--scene-state-json '{\"controls\":{\"material_preset\":\"Bounce\"}}'"
         in manifest["captures"][2]["viewer_command"]
     )
     assert (
@@ -964,7 +964,7 @@ def test_rigid_workflow_dry_run_can_capture_material_examples_only(
     )
     assert "default high-friction" in manifest["captures"][0]["user_question"]
     assert "sliding contact controls" in manifest["captures"][1]["try_first"]
-    assert "friction=0.45" in manifest["captures"][2]["healthy_signal"]
+    assert "material_preset=Bounce" in manifest["captures"][2]["healthy_signal"]
     assert manifest["workflow_phase_summary"] == [
         {
             "phase": "M1 material examples",

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3702,6 +3702,61 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
                 "tooltip:Capture the same baseline row with the contact solver "
                 "set to Boxed LCP before the first frame."
             ) in events
+            assert "text:Material example variants" in events
+            assert (
+                "text:"
+                + _rigid_workflow_viewer_command(
+                    guide.scene_id,
+                    guide.capture_width,
+                    guide.capture_height,
+                    scene_state_json='{"controls":{"friction":0.08,"restitution":0.02}}',
+                )
+            ) in events
+            assert (
+                "tooltip:Open the rigid_body row live with the Slide material "
+                "example restored before the first frame."
+            ) in events
+            assert (
+                "text:"
+                + _rigid_workflow_capture_command(
+                    guide.scene_id,
+                    guide.capture_frames,
+                    guide.capture_width,
+                    guide.capture_height,
+                    guide.capture_show_ui,
+                    scene_state_json='{"controls":{"friction":0.08,"restitution":0.02}}',
+                    capture_label="slide_material",
+                )
+            ) in events
+            assert (
+                "tooltip:Capture the Slide material example with restored "
+                "friction/restitution controls."
+            ) in events
+            assert (
+                "text:"
+                + _rigid_workflow_viewer_command(
+                    guide.scene_id,
+                    guide.capture_width,
+                    guide.capture_height,
+                    scene_state_json='{"controls":{"friction":0.45,"restitution":0.65}}',
+                )
+            ) in events
+            assert (
+                "text:"
+                + _rigid_workflow_capture_command(
+                    guide.scene_id,
+                    guide.capture_frames,
+                    guide.capture_width,
+                    guide.capture_height,
+                    guide.capture_show_ui,
+                    scene_state_json='{"controls":{"friction":0.45,"restitution":0.65}}',
+                    capture_label="bounce_material",
+                )
+            ) in events
+            assert (
+                "tooltip:Capture the Bounce material example with restored "
+                "friction/restitution controls."
+            ) in events
         assert "text:Review packet" in events
         assert (
             "text:"
@@ -3723,6 +3778,17 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
         assert (
             "tooltip:Capture the SI and boxed-LCP rigid_body "
             "contact-baseline packet."
+        ) in events
+        assert (
+            "text:"
+            + _rigid_workflow_packet_command(
+                material_examples_only=True,
+                output_dir="/tmp/dart_capture_rigid_material_examples",
+            )
+        ) in events
+        assert (
+            "tooltip:Capture the Default, Slide, and Bounce rigid_body "
+            "material-example packet."
         ) in events
         assert (
             "text:"

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3809,7 +3809,7 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
                     guide.scene_id,
                     guide.capture_width,
                     guide.capture_height,
-                    scene_state_json='{"controls":{"friction":0.08,"restitution":0.02}}',
+                    scene_state_json='{"controls":{"material_preset":"Slide"}}',
                 )
             ) in events
             assert (
@@ -3824,13 +3824,13 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
                     guide.capture_width,
                     guide.capture_height,
                     guide.capture_show_ui,
-                    scene_state_json='{"controls":{"friction":0.08,"restitution":0.02}}',
+                    scene_state_json='{"controls":{"material_preset":"Slide"}}',
                     capture_label="slide_material",
                 )
             ) in events
             assert (
-                "tooltip:Capture the Slide material example with restored "
-                "friction/restitution controls."
+                "tooltip:Capture the Slide material example with the named "
+                "material preset restored."
             ) in events
             assert (
                 "text:"
@@ -3838,7 +3838,7 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
                     guide.scene_id,
                     guide.capture_width,
                     guide.capture_height,
-                    scene_state_json='{"controls":{"friction":0.45,"restitution":0.65}}',
+                    scene_state_json='{"controls":{"material_preset":"Bounce"}}',
                 )
             ) in events
             assert (
@@ -3849,13 +3849,13 @@ def test_rigid_workflow_panel_renders_guidance_for_numbered_rows() -> None:
                     guide.capture_width,
                     guide.capture_height,
                     guide.capture_show_ui,
-                    scene_state_json='{"controls":{"friction":0.45,"restitution":0.65}}',
+                    scene_state_json='{"controls":{"material_preset":"Bounce"}}',
                     capture_label="bounce_material",
                 )
             ) in events
             assert (
-                "tooltip:Capture the Bounce material example with restored "
-                "friction/restitution controls."
+                "tooltip:Capture the Bounce material example with the named "
+                "material preset restored."
             ) in events
         assert "text:Review packet" in events
         assert (

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3402,6 +3402,51 @@ def test_rigid_body_panel_contact_baseline_presets_reset_scene() -> None:
     assert len(controller._speed_history) == 1
 
 
+@pytest.mark.parametrize("preset", rigid_body._MATERIAL_PRESETS)
+def test_rigid_body_panel_material_example_presets_reset_scene(
+    preset: rigid_body._MaterialPreset,
+) -> None:
+    _require_simulation_symbols("RigidBodySolver", "World")
+
+    setup = rigid_body.build()
+    controller = setup.info["rigid_body_controller"]
+    world = setup.info["sx_world"]
+    assert setup.pre_step is not None
+
+    for _ in range(3):
+        setup.pre_step()
+    assert world.time > 0.0
+
+    builder = _ScriptedPanelBuilder(clicked_buttons={preset.label})
+    setup.panels[0].build(builder, object())
+
+    assert "text:Material examples" in builder.events
+    assert all(
+        f"button:{candidate.label}" in builder.events
+        for candidate in rigid_body._MATERIAL_PRESETS
+    )
+    assert f"tooltip:{preset.tooltip}" in builder.events
+    assert controller.friction == pytest.approx(preset.friction)
+    assert controller.restitution == pytest.approx(preset.restitution)
+    assert world.time == pytest.approx(0.0)
+    assert controller.ground.friction == pytest.approx(preset.friction)
+    assert all(
+        body.friction == pytest.approx(preset.friction)
+        for body in controller.dynamic_bodies
+    )
+    assert all(
+        body.restitution == pytest.approx(preset.restitution)
+        for body in controller.dynamic_bodies
+    )
+    assert len(controller._speed_history) == 1
+
+    capture_metrics = setup.info[CAPTURE_METRICS_INFO_KEY]()
+    assert capture_metrics["controls"]["friction"] == pytest.approx(preset.friction)
+    assert capture_metrics["controls"]["restitution"] == pytest.approx(
+        preset.restitution
+    )
+
+
 def test_rigid_body_panel_routes_to_contact_policy_comparison() -> None:
     _require_simulation_symbols("World")
 

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3426,6 +3426,10 @@ def test_rigid_body_panel_material_example_presets_reset_scene(
         for candidate in rigid_body._MATERIAL_PRESETS
     )
     assert f"tooltip:{preset.tooltip}" in builder.events
+    assert (
+        f"text:active material: {preset.label} | friction {preset.friction:.2f} "
+        f"| restitution {preset.restitution:.2f}"
+    ) in builder.events
     assert controller.friction == pytest.approx(preset.friction)
     assert controller.restitution == pytest.approx(preset.restitution)
     assert world.time == pytest.approx(0.0)
@@ -3445,6 +3449,56 @@ def test_rigid_body_panel_material_example_presets_reset_scene(
     assert capture_metrics["controls"]["restitution"] == pytest.approx(
         preset.restitution
     )
+
+
+def test_rigid_body_panel_material_status_tracks_custom_sliders() -> None:
+    _require_simulation_symbols("RigidBodySolver", "World")
+
+    setup = rigid_body.build()
+    controller = setup.info["rigid_body_controller"]
+    builder = _ScriptedPanelBuilder(
+        slider_values={
+            "Friction": 0.33,
+            "Restitution": 0.44,
+        }
+    )
+
+    setup.panels[0].build(builder, object())
+
+    assert "text:active material: Custom | friction 0.33 | restitution 0.44" in (
+        builder.events
+    )
+    assert controller.friction == pytest.approx(0.33)
+    assert controller.restitution == pytest.approx(0.44)
+    assert controller.ground.friction == pytest.approx(0.33)
+    assert all(
+        body.friction == pytest.approx(0.33) for body in controller.dynamic_bodies
+    )
+    assert all(
+        body.restitution == pytest.approx(0.44)
+        for body in controller.dynamic_bodies
+    )
+
+    capture_metrics = setup.info[CAPTURE_METRICS_INFO_KEY]()
+    assert capture_metrics["controls"]["friction"] == pytest.approx(0.33)
+    assert capture_metrics["controls"]["restitution"] == pytest.approx(0.44)
+
+
+def test_rigid_body_panel_routes_to_material_mixing() -> None:
+    _require_simulation_symbols("World")
+
+    setup = rigid_body.build()
+    context = _FakePanelContext()
+    builder = _ScriptedPanelBuilder(clicked_buttons={"Open material mixing"})
+
+    setup.panels[0].build(builder, context)
+
+    assert "button:Open material mixing" in builder.events
+    assert (
+        "tooltip:Open the dedicated friction/restitution material-combine row."
+        in builder.events
+    )
+    assert context.scene_switch_requests == ["rigid_material_mixing"]
 
 
 def test_rigid_body_panel_routes_to_contact_policy_comparison() -> None:

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3450,10 +3450,16 @@ def test_rigid_body_panel_material_example_presets_reset_scene(
     assert len(controller._speed_history) == 1
 
     capture_metrics = setup.info[CAPTURE_METRICS_INFO_KEY]()
+    assert capture_metrics["material_preset"] == preset.label
     assert capture_metrics["controls"]["friction"] == pytest.approx(preset.friction)
     assert capture_metrics["controls"]["restitution"] == pytest.approx(
         preset.restitution
     )
+    assert capture_metrics["controls"]["material_preset"] == preset.label
+    assert capture_metrics["metrics"]["material_preset"] == preset.label
+
+    replay_state = controller.capture_replay_state()
+    assert replay_state["controls"]["material_preset"] == preset.label
 
 
 def test_rigid_body_panel_material_status_tracks_custom_sliders() -> None:
@@ -3485,8 +3491,26 @@ def test_rigid_body_panel_material_status_tracks_custom_sliders() -> None:
     )
 
     capture_metrics = setup.info[CAPTURE_METRICS_INFO_KEY]()
+    assert capture_metrics["material_preset"] == "Custom"
     assert capture_metrics["controls"]["friction"] == pytest.approx(0.33)
     assert capture_metrics["controls"]["restitution"] == pytest.approx(0.44)
+    assert capture_metrics["controls"]["material_preset"] == "Custom"
+    assert capture_metrics["metrics"]["material_preset"] == "Custom"
+
+
+def test_rigid_body_replay_restore_accepts_material_preset_name() -> None:
+    _require_simulation_symbols("RigidBodySolver", "World")
+
+    setup = rigid_body.build()
+    controller = setup.info["rigid_body_controller"]
+
+    controller.restore_replay_state({"controls": {"material_preset": "Bounce"}})
+
+    assert controller.friction == pytest.approx(0.45)
+    assert controller.restitution == pytest.approx(0.65)
+    capture_metrics = setup.info[CAPTURE_METRICS_INFO_KEY]()
+    assert capture_metrics["material_preset"] == "Bounce"
+    assert capture_metrics["controls"]["material_preset"] == "Bounce"
 
 
 def test_rigid_body_panel_routes_to_material_mixing() -> None:

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3335,7 +3335,12 @@ def test_rigid_body_panel_edits_contact_solver_method() -> None:
     builder = _ScriptedPanelBuilder(select_values={"Contact solver": target_method})
     setup.panels[0].build(builder, object())
 
-    assert builder.events[0] == "select:Solver:0:Sequential impulse"
+    assert builder.events[0] == "text:rigid solver: Sequential impulse (fixed baseline)"
+    assert (
+        "tooltip:Use Rigid Solver Compare for SI-vs-IPC rigid-body solver inspection."
+        in builder.events
+    )
+    assert not any(event.startswith("select:Solver:") for event in builder.events)
     assert any(event.startswith("select:Contact solver:") for event in builder.events)
     assert controller.contact_method_index == target_method
     assert world.time == pytest.approx(0.0)

--- a/python/tests/unit/test_py_demo_panels.py
+++ b/python/tests/unit/test_py_demo_panels.py
@@ -3520,6 +3520,23 @@ def test_rigid_body_panel_routes_to_contact_policy_comparison() -> None:
     assert controller.contact_method_index == 0
 
 
+def test_rigid_body_panel_routes_to_avbd_showcase() -> None:
+    _require_simulation_symbols("World")
+
+    setup = rigid_body.build()
+    context = _FakePanelContext()
+    builder = _ScriptedPanelBuilder(clicked_buttons={"Open AVBD showcase"})
+
+    setup.panels[0].build(builder, context)
+
+    assert "button:Open AVBD showcase" in builder.events
+    assert (
+        "tooltip:Open the curated AVBD fixed-joint/contact rigid-constraint row."
+        in builder.events
+    )
+    assert context.scene_switch_requests == ["avbd_rigid_fixed_joint_contact"]
+
+
 def test_rigid_collision_query_options_panel_edits_capture_controls() -> None:
     _require_simulation_symbols("World", "CollisionQueryOptions")
 

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -283,12 +283,8 @@ def _workflow_spec_fields(
 
 
 _RIGID_BODY_BOXED_LCP_STATE_JSON = '{"controls":{"contact_method_index":1}}'
-_RIGID_BODY_SLIDE_MATERIAL_STATE_JSON = (
-    '{"controls":{"friction":0.08,"restitution":0.02}}'
-)
-_RIGID_BODY_BOUNCE_MATERIAL_STATE_JSON = (
-    '{"controls":{"friction":0.45,"restitution":0.65}}'
-)
+_RIGID_BODY_SLIDE_MATERIAL_STATE_JSON = '{"controls":{"material_preset":"Slide"}}'
+_RIGID_BODY_BOUNCE_MATERIAL_STATE_JSON = '{"controls":{"material_preset":"Bounce"}}'
 
 RIGID_WORKFLOW_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("rigid_body", 180, 960, 540, True),
@@ -754,8 +750,8 @@ _RIGID_WORKFLOW_MATERIAL_EXAMPLES_GUIDANCE_BY_LABEL: dict[str, dict[str, object]
             "step timing",
         ],
         "healthy_signal": (
-            "The manifest preserves friction=0.08 and restitution=0.02 in the "
-            "scene-state metadata and capture metrics."
+            "The manifest preserves material_preset=Slide in scene-state "
+            "metadata and capture metrics."
         ),
         "scope": (
             "Low-friction material example on the World rigid_body scene; not "
@@ -782,8 +778,8 @@ _RIGID_WORKFLOW_MATERIAL_EXAMPLES_GUIDANCE_BY_LABEL: dict[str, dict[str, object]
             "step timing",
         ],
         "healthy_signal": (
-            "The manifest preserves friction=0.45 and restitution=0.65 in the "
-            "scene-state metadata and capture metrics."
+            "The manifest preserves material_preset=Bounce in scene-state "
+            "metadata and capture metrics."
         ),
         "scope": (
             "Bouncy material example on the World rigid_body scene; not a "

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -2088,6 +2088,7 @@ _WORKFLOW_METRIC_HIGHLIGHT_KEYS = (
     "baseline_scene_contact_count",
     "baseline_step_ms",
     "dynamic_body_count",
+    "material_preset",
     "drift_position_error",
     "drift_momentum_drift",
     "drift_speed",

--- a/scripts/capture_py_demo.py
+++ b/scripts/capture_py_demo.py
@@ -283,6 +283,12 @@ def _workflow_spec_fields(
 
 
 _RIGID_BODY_BOXED_LCP_STATE_JSON = '{"controls":{"contact_method_index":1}}'
+_RIGID_BODY_SLIDE_MATERIAL_STATE_JSON = (
+    '{"controls":{"friction":0.08,"restitution":0.02}}'
+)
+_RIGID_BODY_BOUNCE_MATERIAL_STATE_JSON = (
+    '{"controls":{"friction":0.45,"restitution":0.65}}'
+)
 
 RIGID_WORKFLOW_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
     ("rigid_body", 180, 960, 540, True),
@@ -345,6 +351,29 @@ RIGID_WORKFLOW_CONTACT_BASELINE_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] =
         True,
         _RIGID_BODY_BOXED_LCP_STATE_JSON,
         "boxed_lcp",
+    ),
+)
+
+
+RIGID_WORKFLOW_MATERIAL_EXAMPLE_CAPTURE_SPECS: tuple[WorkflowCaptureSpec, ...] = (
+    ("rigid_body", 180, 960, 540, True, "", "default_material"),
+    (
+        "rigid_body",
+        180,
+        960,
+        540,
+        True,
+        _RIGID_BODY_SLIDE_MATERIAL_STATE_JSON,
+        "slide_material",
+    ),
+    (
+        "rigid_body",
+        180,
+        960,
+        540,
+        True,
+        _RIGID_BODY_BOUNCE_MATERIAL_STATE_JSON,
+        "bounce_material",
     ),
 )
 
@@ -671,6 +700,93 @@ _RIGID_WORKFLOW_CONTACT_BASELINE_GUIDANCE_BY_LABEL: dict[str, dict[str, object]]
     },
 }
 
+_RIGID_WORKFLOW_MATERIAL_EXAMPLES_GUIDANCE_BY_LABEL: dict[str, dict[str, object]] = {
+    "default_material": {
+        "workflow_label": "Material example",
+        "workflow_phase": "M1 material examples",
+        "focus_axis": "rigid_body friction/restitution presets",
+        "user_question": (
+            "What does the flagship rigid_body scene show with the default "
+            "high-friction falling-stack material?"
+        ),
+        "try_first": (
+            "Use this row as the material-example baseline before inspecting "
+            "the Slide and Bounce variants."
+        ),
+        "inspect": [
+            "friction control",
+            "restitution control",
+            "body motion",
+            "contact count",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "The manifest records the default material controls and the scene "
+            "renders with docked diagnostics."
+        ),
+        "scope": (
+            "World rigid-body material example for M1; not a solver-family or "
+            "contact-policy comparison."
+        ),
+    },
+    "slide_material": {
+        "workflow_label": "Material example",
+        "workflow_phase": "M1 material examples",
+        "focus_axis": "rigid_body friction/restitution presets",
+        "user_question": (
+            "How does the flagship rigid_body scene behave with a low-friction, "
+            "low-bounce material preset restored before launch?"
+        ),
+        "try_first": (
+            "Use this row when reviewer evidence needs the same scene with "
+            "sliding contact controls applied reproducibly."
+        ),
+        "inspect": [
+            "friction control",
+            "restitution control",
+            "body motion",
+            "contact count",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "The manifest preserves friction=0.08 and restitution=0.02 in the "
+            "scene-state metadata and capture metrics."
+        ),
+        "scope": (
+            "Low-friction material example on the World rigid_body scene; not "
+            "an analytic stick/slip threshold proof."
+        ),
+    },
+    "bounce_material": {
+        "workflow_label": "Material example",
+        "workflow_phase": "M1 material examples",
+        "focus_axis": "rigid_body friction/restitution presets",
+        "user_question": (
+            "How does the flagship rigid_body scene behave with a bouncy "
+            "material preset restored before launch?"
+        ),
+        "try_first": (
+            "Use this row when reviewer evidence needs the same scene with "
+            "higher restitution applied reproducibly."
+        ),
+        "inspect": [
+            "friction control",
+            "restitution control",
+            "body motion",
+            "contact count",
+            "step timing",
+        ],
+        "healthy_signal": (
+            "The manifest preserves friction=0.45 and restitution=0.65 in the "
+            "scene-state metadata and capture metrics."
+        ),
+        "scope": (
+            "Bouncy material example on the World rigid_body scene; not a "
+            "complete restitution ladder or energy-conservation claim."
+        ),
+    },
+}
+
 _RIGID_WORKFLOW_PACKET_GUIDANCE_BY_SCENE: dict[str, dict[str, object]] = {
     "rigid_ipc_stack_packet": {
         "workflow_label": "Capture-first packet",
@@ -749,6 +865,10 @@ def rigid_workflow_related_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
 
 def rigid_workflow_contact_baseline_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
     return RIGID_WORKFLOW_CONTACT_BASELINE_CAPTURE_SPECS
+
+
+def rigid_workflow_material_example_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
+    return RIGID_WORKFLOW_MATERIAL_EXAMPLE_CAPTURE_SPECS
 
 
 def rigid_workflow_avbd_showcase_capture_specs() -> tuple[WorkflowCaptureSpec, ...]:
@@ -1343,6 +1463,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--material-examples-only",
+        action="store_true",
+        help=(
+            "With --rigid-workflow, capture only the Default, Slide, and Bounce "
+            "rigid_body material-example packet."
+        ),
+    )
+    parser.add_argument(
         "--include-ipc-shelf",
         action="store_true",
         help=(
@@ -1482,6 +1610,8 @@ def _workflow_output_dir(args: argparse.Namespace) -> pathlib.Path:
         return args.output_dir
     if getattr(args, "contact_baseline_only", False):
         return _default_output_dir("rigid_contact_baseline")
+    if getattr(args, "material_examples_only", False):
+        return _default_output_dir("rigid_material_examples")
     if getattr(args, "avbd_showcase_only", False):
         return _default_output_dir("rigid_avbd_showcase")
     return _default_output_dir("rigid_workflow")
@@ -1498,6 +1628,8 @@ def _workflow_capture_specs(
 ) -> tuple[WorkflowCaptureSpec, ...]:
     if getattr(args, "contact_baseline_only", False):
         return rigid_workflow_contact_baseline_capture_specs()
+    if getattr(args, "material_examples_only", False):
+        return rigid_workflow_material_example_capture_specs()
     if getattr(args, "avbd_showcase_only", False):
         return rigid_workflow_avbd_showcase_capture_specs()
     specs = list(rigid_workflow_capture_specs())
@@ -1515,6 +1647,9 @@ def _workflow_requested_include_flags(
 ) -> dict[str, bool]:
     return {
         "include_contact_baseline": bool(getattr(args, "contact_baseline_only", False)),
+        "include_material_examples": bool(
+            getattr(args, "material_examples_only", False)
+        ),
         "include_avbd_showcase": bool(getattr(args, "avbd_showcase_only", False)),
         "include_related": bool(getattr(args, "include_related", False)),
         "include_ipc_shelf": bool(getattr(args, "include_ipc_shelf", False)),
@@ -1594,6 +1729,8 @@ def _workflow_row_rerun_argv(
     rerun_argv = ["--rigid-workflow"]
     if getattr(args, "contact_baseline_only", False):
         rerun_argv.append("--contact-baseline-only")
+    if getattr(args, "material_examples_only", False):
+        rerun_argv.append("--material-examples-only")
     if getattr(args, "avbd_showcase_only", False):
         rerun_argv.append("--avbd-showcase-only")
     if getattr(args, "include_related", False):
@@ -1633,6 +1770,8 @@ def _workflow_command_argv(
     workflow_argv = ["--rigid-workflow"]
     if getattr(args, "contact_baseline_only", False):
         workflow_argv.append("--contact-baseline-only")
+    if getattr(args, "material_examples_only", False):
+        workflow_argv.append("--material-examples-only")
     if getattr(args, "avbd_showcase_only", False):
         workflow_argv.append("--avbd-showcase-only")
     if getattr(args, "include_related", False):
@@ -1686,15 +1825,17 @@ def _workflow_plan_entries(
     entries: list[dict[str, object]] = []
     specs = _workflow_capture_specs(args)
     contact_baseline_only = bool(getattr(args, "contact_baseline_only", False))
+    material_examples_only = bool(getattr(args, "material_examples_only", False))
     avbd_showcase_only = bool(getattr(args, "avbd_showcase_only", False))
     numbered_count = (
         0
-        if contact_baseline_only or avbd_showcase_only
+        if contact_baseline_only or material_examples_only or avbd_showcase_only
         else len(rigid_workflow_capture_specs())
     )
     related_count = (
         len(rigid_workflow_related_capture_specs())
         if not contact_baseline_only
+        and not material_examples_only
         and not avbd_showcase_only
         and getattr(args, "include_related", False)
         else 0
@@ -1702,6 +1843,7 @@ def _workflow_plan_entries(
     ipc_shelf_count = (
         len(rigid_workflow_ipc_shelf_capture_specs())
         if not contact_baseline_only
+        and not material_examples_only
         and not avbd_showcase_only
         and getattr(args, "include_ipc_shelf", False)
         else 0
@@ -1719,6 +1861,8 @@ def _workflow_plan_entries(
         argv = _workflow_scene_argv(args, order, spec, output_dir)
         if contact_baseline_only:
             workflow_group = "contact_baseline"
+        elif material_examples_only:
+            workflow_group = "material_examples"
         elif avbd_showcase_only:
             workflow_group = "avbd_constraint_showcase"
         elif order <= numbered_count:
@@ -1761,6 +1905,12 @@ def _workflow_plan_entries(
         if contact_baseline_only and capture_label:
             entries[-1].update(
                 _RIGID_WORKFLOW_CONTACT_BASELINE_GUIDANCE_BY_LABEL.get(
+                    capture_label, {}
+                )
+            )
+        if material_examples_only and capture_label:
+            entries[-1].update(
+                _RIGID_WORKFLOW_MATERIAL_EXAMPLES_GUIDANCE_BY_LABEL.get(
                     capture_label, {}
                 )
             )
@@ -2401,6 +2551,7 @@ def _workflow_metric_highlights(metrics: dict[str, object]) -> list[str]:
 _WORKFLOW_GROUP_LABELS = {
     "numbered": "numbered",
     "contact_baseline": "contact baseline",
+    "material_examples": "material examples",
     "avbd_constraint_showcase": "avbd showcase",
     "related_evidence": "related",
     "rigid_ipc_shelf": "ipc shelf",
@@ -2442,6 +2593,8 @@ def _workflow_requested_group_labels(
         return fallback
     if requested_include_flags.get("include_contact_baseline", False):
         return "contact baseline"
+    if requested_include_flags.get("include_material_examples", False):
+        return "material examples"
     if requested_include_flags.get("include_avbd_showcase", False):
         return "avbd showcase"
     labels = ["numbered"]
@@ -3524,6 +3677,9 @@ def _write_workflow_manifest(
     selected_include_contact_baseline = any(
         capture.get("workflow_group") == "contact_baseline" for capture in captures
     )
+    selected_include_material_examples = any(
+        capture.get("workflow_group") == "material_examples" for capture in captures
+    )
     selected_include_avbd_showcase = any(
         capture.get("workflow_group") == "avbd_constraint_showcase"
         for capture in captures
@@ -3539,6 +3695,7 @@ def _write_workflow_manifest(
     )
     requested_include_flags = requested_include_flags or {
         "include_contact_baseline": selected_include_contact_baseline,
+        "include_material_examples": selected_include_material_examples,
         "include_avbd_showcase": selected_include_avbd_showcase,
         "include_related": selected_include_related,
         "include_ipc_shelf": selected_include_ipc_shelf,
@@ -3586,6 +3743,9 @@ def _write_workflow_manifest(
             "include_contact_baseline": requested_include_flags.get(
                 "include_contact_baseline", False
             ),
+            "include_material_examples": requested_include_flags.get(
+                "include_material_examples", False
+            ),
             "include_avbd_showcase": requested_include_flags.get(
                 "include_avbd_showcase", False
             ),
@@ -3595,6 +3755,7 @@ def _write_workflow_manifest(
             ),
             "include_packets": requested_include_flags.get("include_packets", False),
             "selected_include_contact_baseline": selected_include_contact_baseline,
+            "selected_include_material_examples": selected_include_material_examples,
             "selected_include_avbd_showcase": selected_include_avbd_showcase,
             "selected_include_related": selected_include_related,
             "selected_include_ipc_shelf": selected_include_ipc_shelf,
@@ -3666,18 +3827,30 @@ def _validate_rigid_workflow_args(args: argparse.Namespace) -> None:
         raise SystemExit("--rigid-workflow cannot be combined with --scene-state-json")
     if args.capture_label:
         raise SystemExit("--rigid-workflow cannot be combined with --capture-label")
-    exclusive_packets = int(bool(args.contact_baseline_only)) + int(
-        bool(args.avbd_showcase_only)
+    exclusive_packets = (
+        int(bool(args.contact_baseline_only))
+        + int(bool(args.material_examples_only))
+        + int(bool(args.avbd_showcase_only))
     )
     if exclusive_packets > 1:
+        if args.contact_baseline_only and args.avbd_showcase_only:
+            raise SystemExit(
+                "--contact-baseline-only cannot be combined with --avbd-showcase-only"
+            )
         raise SystemExit(
-            "--contact-baseline-only cannot be combined with --avbd-showcase-only"
+            "--material-examples-only cannot be combined with other workflow packets"
         )
     if args.contact_baseline_only and (
         args.include_related or args.include_ipc_shelf or args.include_packets
     ):
         raise SystemExit(
             "--contact-baseline-only cannot be combined with other workflow groups"
+        )
+    if args.material_examples_only and (
+        args.include_related or args.include_ipc_shelf or args.include_packets
+    ):
+        raise SystemExit(
+            "--material-examples-only cannot be combined with other workflow groups"
         )
     if args.avbd_showcase_only and (
         args.include_related or args.include_ipc_shelf or args.include_packets
@@ -3792,6 +3965,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     if args.contact_baseline_only and not args.rigid_workflow:
         raise SystemExit("--contact-baseline-only requires --rigid-workflow")
+    if args.material_examples_only and not args.rigid_workflow:
+        raise SystemExit("--material-examples-only requires --rigid-workflow")
     if args.avbd_showcase_only and not args.rigid_workflow:
         raise SystemExit("--avbd-showcase-only requires --rigid-workflow")
     if args.include_related and not args.rigid_workflow:


### PR DESCRIPTION
## Summary

- Adds durable `py-demos` regression coverage for the original `rigid_body` scripted selection/force-drag crash path, then extends the flagship rigid-body front door with material examples, packet capture support, clearer fixed-solver context, and M1 navigation routes.
- Gives reviewers and developers one-click Default, Slide, and Bounce material presets, active material/custom status, material-preset labels in replay/capture evidence, direct routes into material mixing and the curated AVBD fixed-joint/contact showcase, and removes the misleading one-option rigid solver selector.

## Motivation / Problem

- The original `pixi run py-demos` repro could crash in the real Filament viewer before producing a usable screenshot, so the crash path needed a persistent integration guard rather than only manual evidence.
- The M1 rigid-body demo path now needs reviewer-facing material examples that work in both the default and CUDA Pixi environments, with capture manifests that preserve friction/restitution state, preset labels, and latest-signal evidence.
- M1 also frames AVBD as the modern rigid-constraint track beside the World contact-policy baseline, so the flagship `rigid_body` scene should offer a live route into that existing showcase without conflating the two solver surfaces.
- The flagship scene intentionally keeps its realtime rigid-body solver fixed to Sequential Impulse, so the panel should present that as context rather than as a selectable one-option dropdown.

## Changes / Key Changes

- Adds a real-viewer pytest guard for the zero-motion scripted force-drag path on `rigid_body`.
- Adds Default, Slide, and Bounce material presets to the `rigid_body` panel and reflects the active preset or `Custom` friction/restitution state in the panel.
- Records the active material preset name in `rigid_body` capture metrics and replay state; replay restore can now accept a `material_preset` control name.
- Emits material example packet state with named `material_preset` controls so capture/replay exercises the same user-facing panel state as manual review.
- Replaces the one-option `Solver` dropdown with fixed Sequential Impulse context and a tooltip pointing SI-vs-IPC users to `rigid_solver_compare`.
- Updates the runner-owned Rigid Workflow guide and capture-manifest strings so reviewers see fixed-solver context plus material/contact controls, not stale solver-control guidance.
- Adds `Open material mixing` routing from the `rigid_body` panel to `rigid_material_mixing`.
- Adds `Open AVBD showcase` routing from the `rigid_body` panel to `avbd_rigid_fixed_joint_contact`.
- Adds `py-demo-capture -- --rigid-workflow --material-examples-only` for Default/Slide/Bounce packet captures, with row state, labels, rerun commands, and review-index metadata.
- Updates the py-demos dev-task, changelog, and examples/verification docs for the material workflow, fixed solver context, preset-label evidence, and AVBD front-door bridge.

## Before / After

| Path | Before | After |
| --- | --- | --- |
| Default `pixi run py-demos` scripted `rigid_body` force-drag repro | Failed before completion with Filament empty-AABB / `dartDebugColor` teardown errors. | Passes and writes `/tmp/rigid_body_selection_current_default_ce16c839.ppm`; latest current-head run completed on `ce16c839de9` in `real 133.96s` including the rebuild after merging current `main` (warm predecessor run: `93e1156b4e0`, `real 4.02s`). |
| CUDA `pixi run -e cuda py-demos` scripted `rigid_body` force-drag repro | Same crash path had no durable regression guard under the CUDA front door. | Passes with GPU deformable solve enabled and writes `/tmp/rigid_body_selection_current_cuda_ce16c839.ppm`; latest current-head run completed on `ce16c839de9` in `real 190.34s` including the CUDA rebuild after merging current `main` (warm predecessor run: `93e1156b4e0`, `real 2.58s`). |
| Material example review packet | Reviewers had to set friction/restitution manually or use unrelated rows; capture metrics exposed coefficients but not the panel's user-facing preset label. | `--material-examples-only` captures Default, Slide, and Bounce rows; packets completed on head `93e1156b4e0` in default `real 48.36s` and CUDA `real 49.06s`, and the latest head `ce16c839de9` keeps the rows on named `material_preset` scene state while fixing the guide text. |
| Rigid-body workflow guidance | The Rigid Workflow panel and capture manifests still pointed reviewers at solver controls that no longer exist on the fixed-baseline `rigid_body` panel. | The workflow guide now names fixed Sequential Impulse context plus material/contact controls, and tests lock those manifest strings. |
| Rigid-body solver context | The flagship `rigid_body` panel showed a one-option `Solver` dropdown even though SI-vs-IPC inspection belongs in `rigid_solver_compare`. | The panel now displays `rigid solver: Sequential impulse (fixed baseline)` and points users to the solver-comparison row. |
| Rigid-body M1 navigation | The baseline scene linked to contact/material inspection but not the AVBD rigid-constraint track. | `rigid_body` now routes directly to `avbd_rigid_fixed_joint_contact`, keeping AVBD discoverable while preserving the World-vs-AVBD track distinction. |

## Testing

Latest pushed head `ce16c839de9` after merging current `main`:

- `/usr/bin/time -p pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body_selection_current_default_ce16c839.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 133.96`; includes rebuild after the main merge)
- `/usr/bin/time -p pixi run -e cuda py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body_selection_current_cuda_ce16c839.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 190.34`; includes CUDA rebuild after the main merge)
- `/usr/bin/time -p pixi run py-demos-smoke --json-out /tmp/py_demos_smoke_default_3090_ce16c839.json` (`PASS 155/155`, `real 50.46`)
- `/usr/bin/time -p pixi run -e cuda py-demos-smoke --json-out /tmp/py_demos_smoke_cuda_3090_ce16c839.json` (`PASS 155/155`, `real 79.31`)

Previous pushed head `acb3621cf1c` focused review-fix evidence:

- `pixi run lint` (`real 30.99`)
- `/usr/bin/time -p env PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python -m pytest python/tests/unit/test_capture_py_demo.py::test_visual_capture_manifest_records_image_evidence python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_writes_capture_plan python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_can_capture_material_examples_only python/tests/unit/test_py_demo_panels.py::test_rigid_workflow_panel_renders_guidance_for_numbered_rows -q` (`4 passed`, `real 0.74`)
- `/usr/bin/time -p env PYTHONPATH=build/cuda/cpp/Release-docking/python:python pixi run -e cuda python -m pytest python/tests/unit/test_capture_py_demo.py::test_visual_capture_manifest_records_image_evidence python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_writes_capture_plan python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_can_capture_material_examples_only python/tests/unit/test_py_demo_panels.py::test_rigid_workflow_panel_renders_guidance_for_numbered_rows -q` (`4 passed`, `real 0.61`)
- `rg -n "Solver/material controls|solver/material controls|Try solver/material controls|selectable solver/material controls" python docs -g '!docs/readthedocs/_generated/**'` (no matches)

Feature/runtime evidence from predecessor head `93e1156b4e0`:

- `pixi run build`
- `env PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python -m pytest python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_can_capture_material_examples_only python/tests/unit/test_py_demo_panels.py::test_rigid_workflow_panel_renders_guidance_for_numbered_rows python/tests/unit/test_py_demo_panels.py::test_rigid_body_replay_restore_accepts_material_preset_name -q` (`3 passed`, `real 0.48`)
- `env PYTHONPATH=build/cuda/cpp/Release-docking/python:python pixi run -e cuda python -m pytest python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_can_capture_material_examples_only python/tests/unit/test_py_demo_panels.py::test_rigid_workflow_panel_renders_guidance_for_numbered_rows python/tests/unit/test_py_demo_panels.py::test_rigid_body_replay_restore_accepts_material_preset_name -q` (`3 passed`, `real 0.48`)
- `pixi run py-demo-capture -- --rigid-workflow --material-examples-only --dry-run --output-dir /tmp/dart_capture_rigid_material_examples_named_preset_dry_run_post_lint` (emits `{"controls":{"material_preset":"Slide"}}` and `{"controls":{"material_preset":"Bounce"}}` rows, `real 1.58`)
- `/usr/bin/time -p pixi run py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body_selection_local_head_default.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 4.02`)
- `/usr/bin/time -p pixi run -e cuda py-demos -- --scene rigid_body --headless --frames 4 --width 640 --height 480 --screenshot /tmp/rigid_body_selection_local_head_cuda.ppm --scripted-force-drag 1:sphere_0_visual:0,0,0:2` (`real 2.58`)
- `/usr/bin/time -p pixi run py-demos-smoke --json-out /tmp/py_demos_smoke_default_3090_93e1156.json` (`PASS 155/155`, `real 51.69`)
- `/usr/bin/time -p pixi run -e cuda py-demos-smoke --json-out /tmp/py_demos_smoke_cuda_3090_93e1156.json` (`PASS 155/155`, `real 76.67`)
- `/usr/bin/time -p pixi run py-demo-capture -- --rigid-workflow --material-examples-only --output-dir /tmp/dart_capture_rigid_material_examples_current_default_3090_93e1156` (`status=complete`, `3/3`, `real 48.36`)
- `/usr/bin/time -p pixi run -e cuda py-demo-capture -- --rigid-workflow --material-examples-only --output-dir /tmp/dart_capture_rigid_material_examples_current_cuda_3090_93e1156` (`status=complete`, `3/3`, `real 49.06`)

Earlier branch evidence before the final named-preset packet-state follow-up:

- `PYTHONPATH=build/default/cpp/Release-docking/python:python pixi run python -m pytest python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_status_tracks_custom_sliders python/tests/unit/test_py_demo_panels.py::test_rigid_body_replay_restore_accepts_material_preset_name python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_latest_signals_include_material_preset python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_can_capture_material_examples_only -q` (`7 passed`)
- `PYTHONPATH=build/cuda/cpp/Release-docking/python:python pixi run -e cuda python -m pytest python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_example_presets_reset_scene python/tests/unit/test_py_demo_panels.py::test_rigid_body_panel_material_status_tracks_custom_sliders python/tests/unit/test_py_demo_panels.py::test_rigid_body_replay_restore_accepts_material_preset_name python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_latest_signals_include_material_preset python/tests/unit/test_capture_py_demo.py::test_rigid_workflow_dry_run_can_capture_material_examples_only -q` (`7 passed`)
- `/usr/bin/time -p pixi run py-demos-render-smoke --json-out /tmp/py_demos_render_smoke_default_3090_023afe2.json` (`PASS 155/155`, `real 137.25`)
- `/usr/bin/time -p pixi run -e cuda py-demos-render-smoke --json-out /tmp/py_demos_render_smoke_cuda_3090_023afe2.json` (`PASS 155/155`, `real 154.89`)
- `/usr/bin/time -p pixi run py-demo-capture -- --rigid-workflow --contact-baseline-only --output-dir /tmp/dart_capture_rigid_contact_baseline_current_default_3090_023afe2` (`status=complete`, `2/2`, `real 35.94`)
- `/usr/bin/time -p pixi run -e cuda py-demo-capture -- --rigid-workflow --contact-baseline-only --output-dir /tmp/dart_capture_rigid_contact_baseline_current_cuda_3090_023afe2` (`status=complete`, `2/2`, `real 36.14`)
- `/usr/bin/time -p pixi run py-demo-capture -- --rigid-workflow --avbd-showcase-only --output-dir /tmp/dart_capture_rigid_avbd_showcase_current_default_3090_023afe2` (`status=complete`, `5/5`, `real 38.46`)
- `/usr/bin/time -p pixi run -e cuda py-demo-capture -- --rigid-workflow --avbd-showcase-only --output-dir /tmp/dart_capture_rigid_avbd_showcase_current_cuda_3090_023afe2` (`status=complete`, `5/5`, `real 39.58`)
- Focused default pytest including `test_rigid_body_scripted_selection_force_drag_is_stable` completed with `9 passed`.

## Breaking Changes

- [x] None
- No public API or command removal.

## Related Issues / PRs (backports)

- Builds on #3084, which merged the py-demos selection/capture hardening base.
- Builds on #3082 for the CUDA `py-demos` compiler-cache launch path.
- Includes the current `main` base through #3091.
- Backport: N/A; this targets the DART 7 `py-demos` workflow on `main`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: no new public methods/classes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no binding changes)



