### PR TITLE
PLAN-091: Close architecture hardening metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@ compatibility remains on the active DART 6 LTS branch._
   vectors, with scoped C++/dartpy rigid-body vector accessors for the previous
   rigid-only translational slice.
   ([#3077](https://github.com/dartsim/dart/pull/3077))
+- Expanded `World::computeStepMetrics()` so DART 7 metrics include cached
+  rigid-contact counts, penetration, solver iterations/residuals, and
+  world-frame multibody momentum while remaining a read-only query.
 - Fixed retained rigid-IPC solver scratch reuse so lagged-friction objective
   assembly keeps the active barrier Hessian while adding friction and dynamics
   terms.

--- a/dart/simulation/compute/rigid_body_constraint.cpp
+++ b/dart/simulation/compute/rigid_body_constraint.cpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <optional>
 
 #include <cmath>
 
@@ -73,6 +74,52 @@ std::array<ContactEnd, 2> endsOf(const RigidBodyContactConstraint& c)
 const Eigen::Vector3d& directionOf(const RigidBodyContactConstraint& c, int row)
 {
   return row == 0 ? c.normal : (row == 1 ? c.tangent1 : c.tangent2);
+}
+
+//==============================================================================
+Eigen::Index contactRowIndex(
+    RigidBodyContactRowLayout layout,
+    std::size_t contactIndex,
+    int row,
+    std::size_t contactCount)
+{
+  const Eigen::Index i = static_cast<Eigen::Index>(contactIndex);
+  switch (layout) {
+    case RigidBodyContactRowLayout::ContactMajor:
+      return i * RigidBodyContactProblem::kRowsPerContact + row;
+    case RigidBodyContactRowLayout::NormalThenTangents:
+      if (row == 0) {
+        return i;
+      }
+      return static_cast<Eigen::Index>(contactCount) + 2 * i + (row - 1);
+  }
+  return i * RigidBodyContactProblem::kRowsPerContact + row;
+}
+
+//==============================================================================
+std::optional<std::size_t> dynamicBodyColumn(
+    const std::vector<entt::entity, RigidBodyContactProblem::EntityAllocator>&
+        dynamicBodies,
+    entt::entity entity)
+{
+  const auto it = std::find(dynamicBodies.begin(), dynamicBodies.end(), entity);
+  if (it == dynamicBodies.end()) {
+    return std::nullopt;
+  }
+  return static_cast<std::size_t>(std::distance(dynamicBodies.begin(), it));
+}
+
+//==============================================================================
+void registerDynamicBody(
+    std::vector<entt::entity, RigidBodyContactProblem::EntityAllocator>&
+        dynamicBodies,
+    entt::entity entity,
+    bool isStatic)
+{
+  if (isStatic || dynamicBodyColumn(dynamicBodies, entity).has_value()) {
+    return;
+  }
+  dynamicBodies.push_back(entity);
 }
 
 //==============================================================================
@@ -116,8 +163,18 @@ Eigen::Vector3d computeRigidBodyContactPointVelocity(
 RigidBodyContactProblem assembleRigidBodyContactProblem(
     const detail::WorldRegistry& registry, std::span<const Contact> contacts)
 {
+  return assembleRigidBodyContactProblem(
+      registry, contacts, RigidBodyContactAssemblyOptions{});
+}
+
+//==============================================================================
+RigidBodyContactProblem assembleRigidBodyContactProblem(
+    const detail::WorldRegistry& registry,
+    std::span<const Contact> contacts,
+    const RigidBodyContactAssemblyOptions& options)
+{
   RigidBodyContactProblem problem;
-  assembleRigidBodyContactProblemInto(problem, registry, contacts);
+  assembleRigidBodyContactProblemInto(problem, registry, contacts, options);
   return problem;
 }
 
@@ -127,7 +184,25 @@ void assembleRigidBodyContactProblemInto(
     const detail::WorldRegistry& registry,
     std::span<const Contact> contacts)
 {
+  assembleRigidBodyContactProblemInto(
+      problem, registry, contacts, RigidBodyContactAssemblyOptions{});
+}
+
+//==============================================================================
+void assembleRigidBodyContactProblemInto(
+    RigidBodyContactProblem& problem,
+    const detail::WorldRegistry& registry,
+    std::span<const Contact> contacts,
+    const RigidBodyContactAssemblyOptions& options)
+{
   problem.constraints.clear();
+  problem.dynamicBodies.clear();
+  problem.delassus.resize(0, 0);
+  problem.rhs.resize(0);
+  problem.lo.resize(0);
+  problem.hi.resize(0);
+  problem.findex.resize(0);
+  problem.jacobian.resize(0, 0);
 
   std::size_t rigidContactCount = 0;
   for (const auto& contact : contacts) {
@@ -194,7 +269,7 @@ void assembleRigidBodyContactProblemInto(
 
     // Restitution target from the pre-solve approach velocity. Combine the two
     // materials by taking the larger bounce.
-    const double restitution = std::max(
+    constraint.restitution = std::max(
         detail::restitutionOf(registry, entityA),
         detail::restitutionOf(registry, entityB));
     const auto& velocityA = registry.get<comps::Velocity>(entityA);
@@ -208,8 +283,9 @@ void assembleRigidBodyContactProblemInto(
     constexpr double restitutionThreshold
         = detail::kRigidContactRestitutionThreshold;
     constraint.restitutionVelocity
-        = (restitution > 0.0 && initialApproach < -restitutionThreshold)
-              ? -restitution * initialApproach
+        = (constraint.restitution > 0.0
+           && initialApproach < -restitutionThreshold)
+              ? -constraint.restitution * initialApproach
               : 0.0;
 
     // Two tangent directions spanning the contact plane, plus their effective
@@ -230,24 +306,48 @@ void assembleRigidBodyContactProblemInto(
     constraint.friction = std::sqrt(
         detail::frictionOf(registry, entityA)
         * detail::frictionOf(registry, entityB));
+    constraint.normalVelocityBias = constraint.restitutionVelocity;
+    if (options.includeBaumgarteBias && options.timeStep > 0.0
+        && initialApproach > detail::kRigidContactBaumgarteApproachThreshold
+        && !registry.all_of<comps::KinematicBodyTag>(entityA)
+        && !registry.all_of<comps::KinematicBodyTag>(entityB)) {
+      const double penetration = std::max(
+          0.0, contact.depth - detail::kRigidContactPositionAllowance);
+      const double baumgarteVelocity
+          = detail::kRigidContactPositionCorrectionFactor * penetration
+            / options.timeStep;
+      constraint.normalVelocityBias
+          = std::max(constraint.normalVelocityBias, baumgarteVelocity);
+    }
 
     problem.constraints.push_back(constraint);
+    registerDynamicBody(problem.dynamicBodies, entityA, constraint.staticA);
+    registerDynamicBody(problem.dynamicBodies, entityB, constraint.staticB);
   }
 
   const std::size_t n = problem.constraints.size();
+  if (!options.populateSystem && !options.populateJacobian) {
+    return;
+  }
+
   const auto size
       = static_cast<Eigen::Index>(n * RigidBodyContactProblem::kRowsPerContact);
-  problem.delassus = Eigen::MatrixXd::Zero(size, size);
-  problem.rhs.resize(size);
-  problem.lo.resize(size);
-  problem.hi.resize(size);
-  problem.findex.resize(size);
+  if (options.populateSystem) {
+    problem.delassus = Eigen::MatrixXd::Zero(size, size);
+    problem.rhs.resize(size);
+    problem.lo.resize(size);
+    problem.hi.resize(size);
+    problem.findex.resize(size);
+  }
+  if (options.populateJacobian) {
+    problem.jacobian = Eigen::MatrixXd::Zero(
+        size, static_cast<Eigen::Index>(6 * problem.dynamicBodies.size()));
+  }
 
   for (std::size_t i = 0; i < n; ++i) {
     const auto& ci = problem.constraints[i];
     const auto endsI = endsOf(ci);
-    const Eigen::Index normalRow = static_cast<Eigen::Index>(i)
-                                   * RigidBodyContactProblem::kRowsPerContact;
+    const Eigen::Index normalRow = contactRowIndex(options.rowLayout, i, 0, n);
 
     // Relative contact velocity before any impulse is applied this step.
     const auto& velocityA = registry.get<comps::Velocity>(ci.bodyA);
@@ -258,35 +358,81 @@ void assembleRigidBodyContactProblemInto(
               velocityA, ci.armA, ci.staticA);
 
     // Normal row: drive the approach velocity to the restitution target.
-    problem.rhs[normalRow]
-        = ci.restitutionVelocity - relativeVelocity.dot(ci.normal);
-    problem.lo[normalRow] = 0.0;
-    problem.hi[normalRow] = std::numeric_limits<double>::infinity();
-    problem.findex[normalRow] = -1;
+    if (options.populateSystem) {
+      problem.rhs[normalRow]
+          = ci.normalVelocityBias - relativeVelocity.dot(ci.normal);
+      problem.lo[normalRow] = 0.0;
+      problem.hi[normalRow] = std::numeric_limits<double>::infinity();
+      problem.findex[normalRow] = -1;
+    }
 
     // Friction rows: drive each tangential velocity to zero, bounded by the
     // Coulomb cone. `hi` carries the friction coefficient mu; the solver scales
     // it by the solved normal impulse referenced through `findex`.
     for (int t = 1; t < RigidBodyContactProblem::kRowsPerContact; ++t) {
-      const Eigen::Index row = normalRow + t;
-      problem.rhs[row] = -relativeVelocity.dot(directionOf(ci, t));
-      problem.lo[row] = -ci.friction;
-      problem.hi[row] = ci.friction;
-      problem.findex[row] = static_cast<int>(normalRow);
+      if (options.populateSystem) {
+        const Eigen::Index row = contactRowIndex(options.rowLayout, i, t, n);
+        problem.rhs[row] = -relativeVelocity.dot(directionOf(ci, t));
+        problem.lo[row] = -ci.friction;
+        problem.hi[row] = ci.friction;
+        problem.findex[row] = static_cast<int>(normalRow);
+      }
     }
 
-    // Fill the 3x3 Delassus block of contact i against every contact j.
-    for (std::size_t j = 0; j < n; ++j) {
-      const auto& cj = problem.constraints[j];
-      const auto endsJ = endsOf(cj);
-      const Eigen::Index columnBase
-          = static_cast<Eigen::Index>(j)
-            * RigidBodyContactProblem::kRowsPerContact;
-      for (int a = 0; a < RigidBodyContactProblem::kRowsPerContact; ++a) {
-        for (int b = 0; b < RigidBodyContactProblem::kRowsPerContact; ++b) {
-          problem.delassus(normalRow + a, columnBase + b) = delassusEntry(
-              endsI, directionOf(ci, a), endsJ, directionOf(cj, b));
+    if (options.populateJacobian) {
+      const auto fillJacobianRow = [&](Eigen::Index row,
+                                       const Eigen::Vector3d& direction) {
+        if (!ci.staticB) {
+          const auto column
+              = dynamicBodyColumn(problem.dynamicBodies, ci.bodyB);
+          if (column.has_value()) {
+            const Eigen::Index base = static_cast<Eigen::Index>(6 * *column);
+            problem.jacobian.block<1, 3>(row, base) += direction.transpose();
+            problem.jacobian.block<1, 3>(row, base + 3)
+                += ci.armB.cross(direction).transpose();
+          }
         }
+        if (!ci.staticA) {
+          const auto column
+              = dynamicBodyColumn(problem.dynamicBodies, ci.bodyA);
+          if (column.has_value()) {
+            const Eigen::Index base = static_cast<Eigen::Index>(6 * *column);
+            problem.jacobian.block<1, 3>(row, base) -= direction.transpose();
+            problem.jacobian.block<1, 3>(row, base + 3)
+                -= ci.armA.cross(direction).transpose();
+          }
+        }
+      };
+      for (int a = 0; a < RigidBodyContactProblem::kRowsPerContact; ++a) {
+        fillJacobianRow(
+            contactRowIndex(options.rowLayout, i, a, n), directionOf(ci, a));
+      }
+    }
+
+    if (options.populateSystem) {
+      // Fill the 3x3 Delassus block of contact i against every contact j.
+      for (std::size_t j = 0; j < n; ++j) {
+        const auto& cj = problem.constraints[j];
+        const auto endsJ = endsOf(cj);
+        for (int a = 0; a < RigidBodyContactProblem::kRowsPerContact; ++a) {
+          const Eigen::Index row = contactRowIndex(options.rowLayout, i, a, n);
+          for (int b = 0; b < RigidBodyContactProblem::kRowsPerContact; ++b) {
+            const Eigen::Index col
+                = contactRowIndex(options.rowLayout, j, b, n);
+            problem.delassus(row, col) = delassusEntry(
+                endsI, directionOf(ci, a), endsJ, directionOf(cj, b));
+          }
+        }
+      }
+    }
+  }
+
+  if (options.populateSystem && options.regularizeFrictionRows) {
+    for (std::size_t i = 0; i < n; ++i) {
+      for (int t = 1; t < RigidBodyContactProblem::kRowsPerContact; ++t) {
+        const Eigen::Index row = contactRowIndex(options.rowLayout, i, t, n);
+        problem.delassus(row, row)
+            += problem.delassus(row, row) * detail::kRigidContactFrictionCfm;
       }
     }
   }

--- a/dart/simulation/compute/rigid_body_constraint.hpp
+++ b/dart/simulation/compute/rigid_body_constraint.hpp
@@ -67,7 +67,9 @@ struct RigidBodyContactConstraint
   Eigen::Matrix3d invInertiaB = Eigen::Matrix3d::Zero();
   double effectiveMass = 0.0;
   double depth = 0.0;
+  double restitution = 0.0;
   double restitutionVelocity = 0.0;
+  double normalVelocityBias = 0.0;
   double normalImpulse = 0.0;
   Eigen::Vector3d tangent1 = Eigen::Vector3d::UnitX();
   Eigen::Vector3d tangent2 = Eigen::Vector3d::UnitY();
@@ -78,47 +80,84 @@ struct RigidBodyContactConstraint
   double friction = 1.0;
 };
 
-/// Fully assembled rigid-body contact-space boxed-LCP.
+enum class RigidBodyContactRowLayout
+{
+  /// Rows are grouped by contact: normal, tangent 1, tangent 2.
+  ContactMajor,
+  /// All normal rows first, then each contact's two tangent rows.
+  NormalThenTangents,
+};
+
+struct RigidBodyContactAssemblyOptions
+{
+  bool populateSystem = true;
+  bool populateJacobian = false;
+  RigidBodyContactRowLayout rowLayout = RigidBodyContactRowLayout::ContactMajor;
+  bool includeBaumgarteBias = false;
+  bool regularizeFrictionRows = false;
+  double timeStep = 0.0;
+};
+
+/// Canonical rigid-body contact problem.
+///
+/// The accepted contacts and dynamic-body order are always populated. Dense
+/// system rows and Jacobian rows are optional because some callers consume only
+/// the precomputed per-contact constraints.
 struct RigidBodyContactProblem
 {
   static constexpr int kRowsPerContact = 3;
 
   using ConstraintAllocator = common::StlAllocator<RigidBodyContactConstraint>;
+  using EntityAllocator = common::StlAllocator<entt::entity>;
 
   RigidBodyContactProblem() = default;
 
   explicit RigidBodyContactProblem(common::MemoryAllocator& allocator)
-    : constraints(ConstraintAllocator{allocator})
+    : constraints(ConstraintAllocator{allocator}),
+      dynamicBodies(EntityAllocator{allocator})
   {
   }
 
   std::vector<RigidBodyContactConstraint, ConstraintAllocator> constraints;
+  std::vector<entt::entity, EntityAllocator> dynamicBodies;
   Eigen::MatrixXd delassus;
   Eigen::VectorXd rhs;
   Eigen::VectorXd lo;
   Eigen::VectorXd hi;
   Eigen::VectorXi findex;
+  Eigen::MatrixXd jacobian;
 };
 
 /// Velocity of a rigid body's contact point in world coordinates.
 DART_SIMULATION_API Eigen::Vector3d computeRigidBodyContactPointVelocity(
     const comps::Velocity& velocity, const Eigen::Vector3d& arm, bool isStatic);
 
-/// Assemble the rigid-body-only boxed-LCP contact problem.
+/// Assemble the rigid-body-only contact problem.
 ///
 /// Contacts involving multibody links are ignored here; they are handled by
 /// articulated contact stages until the unified constraint stage lands. The
-/// output row order is exactly three rows per accepted rigid contact: normal,
+/// default output row order is three rows per accepted rigid contact: normal,
 /// first tangent, second tangent.
 DART_SIMULATION_API RigidBodyContactProblem assembleRigidBodyContactProblem(
     const detail::WorldRegistry& registry, std::span<const Contact> contacts);
 
-/// Assemble the rigid-body-only boxed-LCP contact problem into caller-owned
+DART_SIMULATION_API RigidBodyContactProblem assembleRigidBodyContactProblem(
+    const detail::WorldRegistry& registry,
+    std::span<const Contact> contacts,
+    const RigidBodyContactAssemblyOptions& options);
+
+/// Assemble the rigid-body-only contact problem into caller-owned
 /// storage, reusing any existing vector/Eigen capacity for same-shape solves.
 DART_SIMULATION_API void assembleRigidBodyContactProblemInto(
     RigidBodyContactProblem& problem,
     const detail::WorldRegistry& registry,
     std::span<const Contact> contacts);
+
+DART_SIMULATION_API void assembleRigidBodyContactProblemInto(
+    RigidBodyContactProblem& problem,
+    const detail::WorldRegistry& registry,
+    std::span<const Contact> contacts,
+    const RigidBodyContactAssemblyOptions& options);
 
 /// Apply one world-space contact impulse to both rigid-body ends.
 DART_SIMULATION_API void applyRigidBodyContactImpulse(

--- a/dart/simulation/compute/rigid_body_contact_stage.cpp
+++ b/dart/simulation/compute/rigid_body_contact_stage.cpp
@@ -40,6 +40,7 @@
 #include "dart/simulation/compute/compute_executor.hpp"
 #include "dart/simulation/compute/detail/stage_scratch.hpp"
 #include "dart/simulation/compute/detail/world_step_stages.hpp"
+#include "dart/simulation/compute/rigid_body_constraint.hpp"
 #include "dart/simulation/detail/entity_conversion.hpp"
 #include "dart/simulation/detail/rigid_avbd/rigid_world_contact.hpp"
 #include "dart/simulation/detail/rigid_contact/boxed_lcp_contact.hpp"
@@ -127,25 +128,49 @@ std::optional<comps::RigidAvbdContactConfig> rigidAvbdContactStageConfig(
 
   return merged;
 }
-bool hasContactNormalAngularTerm(const Eigen::Vector3d& normalArmCross)
-{
-  return normalArmCross.x() != 0.0 || normalArmCross.y() != 0.0
-         || normalArmCross.z() != 0.0;
-}
-
-//==============================================================================
-bool needsContactInverseInertia(
-    const Eigen::Vector3d& normalArmCross, const double friction)
-{
-  return friction > 0.0 || hasContactNormalAngularTerm(normalArmCross);
-}
-
-//==============================================================================
 struct RigidContactCandidate
 {
   entt::entity entity = entt::null;
   bool prescribedResponse = false;
 };
+
+//==============================================================================
+void recordRigidContactEnvelopeMetrics(
+    World& world,
+    const detail::WorldRegistry& registry,
+    std::span<const Contact> contacts)
+{
+  auto& metrics = detail::storageOf(world).lastStepDiagnostics;
+  for (const auto& contact : contacts) {
+    const auto entityA = detail::toRegistryEntity(contact.bodyA.getEntity());
+    const auto entityB = detail::toRegistryEntity(contact.bodyB.getEntity());
+    if (!registry.all_of<comps::RigidBodyTag>(entityA)
+        || !registry.all_of<comps::RigidBodyTag>(entityB)) {
+      continue;
+    }
+    const bool staticA
+        = detail::hasPrescribedRigidBodyContactResponse(registry, entityA);
+    const bool staticB
+        = detail::hasPrescribedRigidBodyContactResponse(registry, entityB);
+    if (staticA && staticB) {
+      continue;
+    }
+    ++metrics.activeContactCount;
+    metrics.maxPenetrationDepth
+        = std::max(metrics.maxPenetrationDepth, std::max(0.0, contact.depth));
+  }
+}
+
+//==============================================================================
+void recordSolverDiagnostics(
+    World& world, std::size_t iterations, double residual = 0.0)
+{
+  auto& metrics = detail::storageOf(world).lastStepDiagnostics;
+  metrics.lastStepIterations += iterations;
+  if (std::isfinite(residual)) {
+    metrics.lastStepResidual = std::max(metrics.lastStepResidual, residual);
+  }
+}
 
 //==============================================================================
 detail::WorldStorage::CollisionPairKey makeCollisionPairKey(
@@ -378,53 +403,14 @@ struct RigidBodyContactStage::AvbdScratch
 //==============================================================================
 struct RigidBodyContactStage::ContactScratch
 {
-  struct NormalConstraint
-  {
-    entt::entity bodyA;
-    entt::entity bodyB;
-    comps::Velocity* velocityA;
-    comps::Velocity* velocityB;
-    Eigen::Vector3d normal;
-    Eigen::Vector3d armA;
-    Eigen::Vector3d armB;
-    bool staticA;
-    bool staticB;
-    double invMassA;
-    double invMassB;
-    Eigen::Matrix3d invInertiaA;
-    Eigen::Matrix3d invInertiaB;
-    bool hasNormalAngularA;
-    bool hasNormalAngularB;
-    double effectiveMass;
-    double inverseEffectiveMass;
-    double depth;
-    double restitutionVelocity;
-    double normalImpulse;
-    Eigen::Vector3d normalArmCrossA;
-    Eigen::Vector3d normalArmCrossB;
-    Eigen::Vector3d normalLinearDeltaA;
-    Eigen::Vector3d normalLinearDeltaB;
-    Eigen::Vector3d normalAngularDeltaA;
-    Eigen::Vector3d normalAngularDeltaB;
-    Eigen::Vector3d tangent1;
-    Eigen::Vector3d tangent2;
-    double tangentMass1;
-    double tangentMass2;
-    double tangentImpulse1;
-    double tangentImpulse2;
-    double friction;
-  };
-
-  using ConstraintAllocator = common::StlAllocator<NormalConstraint>;
-
   ContactScratch() = default;
 
   explicit ContactScratch(common::MemoryAllocator& allocator)
-    : constraints(ConstraintAllocator{allocator})
+    : problem(allocator)
   {
   }
 
-  std::vector<NormalConstraint, ConstraintAllocator> constraints;
+  RigidBodyContactProblem problem;
 };
 
 //==============================================================================
@@ -509,7 +495,7 @@ void RigidBodyContactStage::prepare(World& world)
         createContactScratch(m_memoryManager),
         ContactScratchDeleter{m_memoryManager});
   }
-  auto& constraints = m_contactScratch->constraints;
+  auto& constraints = m_contactScratch->problem.constraints;
   constraints.clear();
 
   const auto& registry = dart::simulation::detail::registryOf(world);
@@ -675,6 +661,7 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
       return false;
     }
 
+    recordSolverDiagnostics(world, solveResult.stats.iterations);
     const dvbd::AvbdRigidWorldContactApplyResult projection
         = dvbd::applyAvbdRigidWorldContactVelocityProjection(
             registry, scratch.snapshot, timeStep);
@@ -703,6 +690,7 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
     deactivationContacts = world.filterContactsForDeactivation(contacts);
     contacts = deactivationContacts;
   }
+  recordRigidContactEnvelopeMetrics(world, registry, contacts);
   if (contacts.empty()) {
     if (projectAvbdRigidPointJoints()) {
       return;
@@ -811,6 +799,7 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
           || solveResult.jointLinearRows != 0u
           || solveResult.jointAngularRows != 0u || solveResult.motorRows != 0u
           || solveResult.distanceSpringRows != 0u) {
+        recordSolverDiagnostics(world, solveResult.stats.iterations);
         const dvbd::AvbdRigidWorldContactApplyResult projection
             = dvbd::applyAvbdRigidWorldContactVelocityProjection(
                 registry, scratch.snapshot, timeStep);
@@ -843,241 +832,49 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
     return;
   }
 
-  const auto contactPointVelocity = [](const comps::Velocity& velocity,
-                                       const Eigen::Vector3d& arm,
-                                       bool isStatic) -> Eigen::Vector3d {
-    if (isStatic) {
-      return Eigen::Vector3d::Zero();
-    }
-    return velocity.linear + velocity.angular.cross(arm);
-  };
-  const auto normalPointVelocity = [](const comps::Velocity& velocity,
-                                      const Eigen::Vector3d& normal,
-                                      const Eigen::Vector3d& normalArmCross,
-                                      bool hasNormalAngular,
-                                      bool isStatic) -> double {
-    if (isStatic) {
-      return 0.0;
-    }
-    double result = velocity.linear.dot(normal);
-    if (hasNormalAngular) {
-      result += velocity.angular.dot(normalArmCross);
-    }
-    return result;
-  };
-
   if (m_contactScratch == nullptr) {
     m_contactScratch = ContactScratchPtr(
         createContactScratch(m_memoryManager),
         ContactScratchDeleter{m_memoryManager});
   }
-  auto& constraints = m_contactScratch->constraints;
-  constraints.clear();
-  constraints.reserve(contacts.size());
-  bool hasFrictionConstraints = false;
-  for (const auto& contact : contacts) {
-    const auto entityA = detail::toRegistryEntity(contact.bodyA.getEntity());
-    const auto entityB = detail::toRegistryEntity(contact.bodyB.getEntity());
-
-    // This sequential-impulse solver handles rigid-body pairs only; contacts
-    // involving multibody links are resolved by the articulated contact solve.
-    if (!registry.all_of<comps::RigidBodyTag>(entityA)
-        || !registry.all_of<comps::RigidBodyTag>(entityB)) {
-      continue;
-    }
-
-    const auto& transformA = registry.get<comps::Transform>(entityA);
-    const auto& transformB = registry.get<comps::Transform>(entityB);
-    const auto& massA = registry.get<comps::MassProperties>(entityA);
-    const auto& massB = registry.get<comps::MassProperties>(entityB);
-
-    const bool staticA
-        = detail::hasPrescribedRigidBodyContactResponse(registry, entityA);
-    const bool staticB
-        = detail::hasPrescribedRigidBodyContactResponse(registry, entityB);
-
-    ContactScratch::NormalConstraint constraint;
-    constraint.bodyA = entityA;
-    constraint.bodyB = entityB;
-    constraint.normal = contact.normal;
-    constraint.depth = contact.depth;
-    constraint.staticA = staticA;
-    constraint.staticB = staticB;
-    constraint.armA = Eigen::Vector3d::Zero();
-    if (!staticA) {
-      constraint.armA = contact.point - transformA.position;
-    }
-    constraint.armB = Eigen::Vector3d::Zero();
-    if (!staticB) {
-      constraint.armB = contact.point - transformB.position;
-    }
-    constraint.invMassA = staticA ? 0.0 : detail::inverseMassOf(massA);
-    constraint.invMassB = staticB ? 0.0 : detail::inverseMassOf(massB);
-    const double frictionProduct = detail::frictionOf(registry, entityA)
-                                   * detail::frictionOf(registry, entityB);
-    constraint.friction
-        = frictionProduct == 0.0 ? 0.0 : std::sqrt(frictionProduct);
-
-    constraint.normalArmCrossA = staticA
-                                     ? Eigen::Vector3d::Zero()
-                                     : constraint.armA.cross(constraint.normal);
-    constraint.normalArmCrossB = staticB
-                                     ? Eigen::Vector3d::Zero()
-                                     : constraint.armB.cross(constraint.normal);
-    constraint.hasNormalAngularA
-        = !staticA && hasContactNormalAngularTerm(constraint.normalArmCrossA);
-    constraint.hasNormalAngularB
-        = !staticB && hasContactNormalAngularTerm(constraint.normalArmCrossB);
-    const bool needsInverseInertiaA
-        = !staticA
-          && needsContactInverseInertia(
-              constraint.normalArmCrossA, constraint.friction);
-    const bool needsInverseInertiaB
-        = !staticB
-          && needsContactInverseInertia(
-              constraint.normalArmCrossB, constraint.friction);
-    constraint.invInertiaA
-        = needsInverseInertiaA
-              ? detail::inverseWorldInertiaOf(massA, transformA)
-              : Eigen::Matrix3d::Zero();
-    constraint.invInertiaB
-        = needsInverseInertiaB
-              ? detail::inverseWorldInertiaOf(massB, transformB)
-              : Eigen::Matrix3d::Zero();
-    constraint.normalLinearDeltaA = -constraint.invMassA * constraint.normal;
-    constraint.normalLinearDeltaB = constraint.invMassB * constraint.normal;
-    constraint.normalAngularDeltaA = Eigen::Vector3d::Zero();
-    if (constraint.hasNormalAngularA) {
-      constraint.normalAngularDeltaA
-          = -constraint.invInertiaA * constraint.normalArmCrossA;
-    }
-    constraint.normalAngularDeltaB = Eigen::Vector3d::Zero();
-    if (constraint.hasNormalAngularB) {
-      constraint.normalAngularDeltaB
-          = constraint.invInertiaB * constraint.normalArmCrossB;
-    }
-    const double angular
-        = (constraint.hasNormalAngularA
-               ? constraint.normalArmCrossA.dot(
-                     constraint.invInertiaA * constraint.normalArmCrossA)
-               : 0.0)
-          + (constraint.hasNormalAngularB
-                 ? constraint.normalArmCrossB.dot(
-                       constraint.invInertiaB * constraint.normalArmCrossB)
-                 : 0.0);
-    constraint.effectiveMass
-        = constraint.invMassA + constraint.invMassB + angular;
-    if (constraint.effectiveMass <= 0.0) {
-      continue; // Both bodies are static.
-    }
-    constraint.inverseEffectiveMass = 1.0 / constraint.effectiveMass;
-
-    // Restitution target from the pre-solve approach velocity (the impact
-    // speed). Combine the two materials by taking the larger bounce.
-    const double restitution = std::max(
-        detail::restitutionOf(registry, entityA),
-        detail::restitutionOf(registry, entityB));
-    auto& velocityA = registry.get<comps::Velocity>(entityA);
-    auto& velocityB = registry.get<comps::Velocity>(entityB);
-    constraint.velocityA = &velocityA;
-    constraint.velocityB = &velocityB;
-    const double initialApproach = normalPointVelocity(
-                                       velocityB,
-                                       constraint.normal,
-                                       constraint.normalArmCrossB,
-                                       constraint.hasNormalAngularB,
-                                       constraint.staticB)
-                                   - normalPointVelocity(
-                                       velocityA,
-                                       constraint.normal,
-                                       constraint.normalArmCrossA,
-                                       constraint.hasNormalAngularA,
-                                       constraint.staticA);
-    constexpr double restitutionThreshold
-        = detail::kRigidContactRestitutionThreshold;
-    constraint.restitutionVelocity
-        = (restitution > 0.0 && initialApproach < -restitutionThreshold)
-              ? -restitution * initialApproach
-              : 0.0;
-    constraint.normalImpulse = 0.0;
-
-    constraint.tangentImpulse1 = 0.0;
-    constraint.tangentImpulse2 = 0.0;
-    if (constraint.friction > 0.0) {
-      // Two tangent directions spanning the contact plane, plus their effective
-      // masses, for a friction-pyramid (box) Coulomb model.
-      constraint.tangent1 = constraint.normal.unitOrthogonal();
-      constraint.tangent2 = constraint.normal.cross(constraint.tangent1);
-      const auto tangentMass = [&](const Eigen::Vector3d& tangent) {
-        double result = constraint.invMassA + constraint.invMassB;
-        if (!constraint.staticA) {
-          const Eigen::Vector3d crossTangentA = constraint.armA.cross(tangent);
-          result += tangent.dot(
-              (constraint.invInertiaA * crossTangentA).cross(constraint.armA));
-        }
-        if (!constraint.staticB) {
-          const Eigen::Vector3d crossTangentB = constraint.armB.cross(tangent);
-          result += tangent.dot(
-              (constraint.invInertiaB * crossTangentB).cross(constraint.armB));
-        }
-        return result;
-      };
-      constraint.tangentMass1 = tangentMass(constraint.tangent1);
-      constraint.tangentMass2 = tangentMass(constraint.tangent2);
-      hasFrictionConstraints = true;
-    } else {
-      constraint.tangent1 = Eigen::Vector3d::Zero();
-      constraint.tangent2 = Eigen::Vector3d::Zero();
-      constraint.tangentMass1 = 0.0;
-      constraint.tangentMass2 = 0.0;
-    }
-
-    constraints.push_back(constraint);
+  RigidBodyContactAssemblyOptions assemblyOptions;
+  assemblyOptions.populateSystem = false;
+  assembleRigidBodyContactProblemInto(
+      m_contactScratch->problem, registry, contacts, assemblyOptions);
+  auto& constraints = m_contactScratch->problem.constraints;
+  const bool hasFrictionConstraints = std::any_of(
+      constraints.begin(), constraints.end(), [](const auto& constraint) {
+        return constraint.friction > 0.0;
+      });
+  if (!constraints.empty()) {
+    recordSolverDiagnostics(world, m_iterations);
   }
 
   // Sequential impulses (Gauss-Seidel) drive each contact's normal approach
   // velocity to its restitution target. The accumulated normal impulse is
   // clamped non-negative so contacts only push, never pull.
-  const auto solveNormalImpulse =
-      [&](ContactScratch::NormalConstraint& constraint) {
-        auto& velocityA = *constraint.velocityA;
-        auto& velocityB = *constraint.velocityB;
+  const auto solveNormalImpulse = [&](RigidBodyContactConstraint& constraint) {
+    const auto& velocityA = registry.get<comps::Velocity>(constraint.bodyA);
+    const auto& velocityB = registry.get<comps::Velocity>(constraint.bodyB);
+    const double approach
+        = (computeRigidBodyContactPointVelocity(
+               velocityB, constraint.armB, constraint.staticB)
+           - computeRigidBodyContactPointVelocity(
+               velocityA, constraint.armA, constraint.staticA))
+              .dot(constraint.normal);
 
-        const double approach = normalPointVelocity(
-                                    velocityB,
-                                    constraint.normal,
-                                    constraint.normalArmCrossB,
-                                    constraint.hasNormalAngularB,
-                                    constraint.staticB)
-                                - normalPointVelocity(
-                                    velocityA,
-                                    constraint.normal,
-                                    constraint.normalArmCrossA,
-                                    constraint.hasNormalAngularA,
-                                    constraint.staticA);
+    double lambda = -(approach - constraint.restitutionVelocity)
+                    / constraint.effectiveMass;
+    const double clamped = std::max(constraint.normalImpulse + lambda, 0.0);
+    lambda = clamped - constraint.normalImpulse;
+    constraint.normalImpulse = clamped;
 
-        double lambda = -(approach - constraint.restitutionVelocity)
-                        * constraint.inverseEffectiveMass;
-        const double clamped = std::max(constraint.normalImpulse + lambda, 0.0);
-        lambda = clamped - constraint.normalImpulse;
-        constraint.normalImpulse = clamped;
-
-        if (lambda == 0.0) {
-          return;
-        }
-        if (!constraint.staticA) {
-          velocityA.linear += lambda * constraint.normalLinearDeltaA;
-          if (constraint.hasNormalAngularA) {
-            velocityA.angular += lambda * constraint.normalAngularDeltaA;
-          }
-        }
-        if (!constraint.staticB) {
-          velocityB.linear += lambda * constraint.normalLinearDeltaB;
-          if (constraint.hasNormalAngularB) {
-            velocityB.angular += lambda * constraint.normalAngularDeltaB;
-          }
-        }
-      };
+    if (lambda == 0.0) {
+      return;
+    }
+    applyRigidBodyContactImpulse(
+        registry, constraint, lambda * constraint.normal);
+  };
 
   if (!hasFrictionConstraints) {
     for (std::size_t iteration = 0; iteration < m_iterations; ++iteration) {
@@ -1093,8 +890,6 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
         // Coulomb friction along each tangent, clamped to the friction pyramid
         // bounded by the accumulated normal impulse.
         if (constraint.friction > 0.0) {
-          auto& velocityA = *constraint.velocityA;
-          auto& velocityB = *constraint.velocityB;
           const double frictionLimit
               = constraint.friction * constraint.normalImpulse;
           const auto solveFriction = [&](const Eigen::Vector3d& tangent,
@@ -1103,10 +898,14 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
             if (tangentMass <= 0.0 || frictionLimit <= 0.0) {
               return;
             }
+            const auto& velocityA
+                = registry.get<comps::Velocity>(constraint.bodyA);
+            const auto& velocityB
+                = registry.get<comps::Velocity>(constraint.bodyB);
             const Eigen::Vector3d tangentVelocity
-                = contactPointVelocity(
+                = computeRigidBodyContactPointVelocity(
                       velocityB, constraint.armB, constraint.staticB)
-                  - contactPointVelocity(
+                  - computeRigidBodyContactPointVelocity(
                       velocityA, constraint.armA, constraint.staticA);
             double tangentLambda = -tangentVelocity.dot(tangent) / tangentMass;
             const double clampedTangent = std::clamp(
@@ -1119,18 +918,8 @@ void RigidBodyContactStage::execute(World& world, ComputeExecutor& /*executor*/)
 
             const Eigen::Vector3d tangentImpulseVector
                 = tangentLambda * tangent;
-            if (!constraint.staticB) {
-              velocityB.linear += constraint.invMassB * tangentImpulseVector;
-              velocityB.angular
-                  += constraint.invInertiaB
-                     * constraint.armB.cross(tangentImpulseVector);
-            }
-            if (!constraint.staticA) {
-              velocityA.linear -= constraint.invMassA * tangentImpulseVector;
-              velocityA.angular
-                  -= constraint.invInertiaA
-                     * constraint.armA.cross(tangentImpulseVector);
-            }
+            applyRigidBodyContactImpulse(
+                registry, constraint, tangentImpulseVector);
           };
           solveFriction(
               constraint.tangent1,

--- a/dart/simulation/compute/variational_integration.cpp
+++ b/dart/simulation/compute/variational_integration.cpp
@@ -25,6 +25,7 @@
 #include "dart/simulation/detail/rigid_avbd/rigid_world_contact.hpp"
 #include "dart/simulation/detail/variational/discrete_mechanics_math.hpp"
 #include "dart/simulation/detail/world_registry_access.hpp"
+#include "dart/simulation/detail/world_storage.hpp"
 #include "dart/simulation/world.hpp"
 
 #include <Eigen/Cholesky>
@@ -4217,14 +4218,30 @@ MultibodyMechanicalEnergyTerms computeMultibodyMechanicalEnergyTerms(
   // Mirrors computeMultibodyMechanicalEnergy's per-link terms exactly (same
   // VarTree forward-kinematics world transforms), so terms.kinetic +
   // terms.potential equals that function's mechanical-energy return value.
+  // Momentum uses the same body-frame spatial velocities, rotated once into the
+  // world frame and accumulated about the world origin.
   for (std::size_t i = 0; i < tree.links.size(); ++i) {
     const auto& link = tree.links[i];
     const Vector6& spatialVelocity = stepScratch.currentSpatialVelocities[i];
     terms.kinetic += 0.5 * spatialVelocity.dot(link.inertia * spatialVelocity);
     const auto& linkComp = registry.get<comps::LinkModel>(structure.links[i]);
-    const Eigen::Vector3d comWorld
-        = link.worldTransform * linkComp.mass.localCenterOfMass;
+    const Eigen::Matrix3d rotation = link.worldTransform.linear();
+    const Eigen::Vector3d comLocal = linkComp.mass.localCenterOfMass;
+    const Eigen::Vector3d comWorld = link.worldTransform * comLocal;
     terms.potential -= linkComp.mass.mass * gravity.dot(comWorld);
+
+    const Eigen::Vector3d angularWorld
+        = rotation * spatialVelocity.template head<3>();
+    const Eigen::Vector3d originLinearWorld
+        = rotation * spatialVelocity.template tail<3>();
+    const Eigen::Vector3d comLinearWorld
+        = originLinearWorld + angularWorld.cross(rotation * comLocal);
+    const Eigen::Vector3d linearMomentum = linkComp.mass.mass * comLinearWorld;
+    const Eigen::Matrix3d worldInertia
+        = rotation * linkComp.mass.inertia * rotation.transpose();
+    terms.linearMomentum += linearMomentum;
+    terms.angularMomentum
+        += comWorld.cross(linearMomentum) + worldInertia * angularWorld;
   }
   return terms;
 }
@@ -4689,7 +4706,7 @@ void MultibodyVariationalIntegrationStage::execute(
         }
       }
     }
-    integrateMultibodyVariationalImpl(
+    const VariationalSolveReport report = integrateMultibodyVariationalImpl(
         registry,
         structure,
         gravity,
@@ -4710,6 +4727,12 @@ void MultibodyVariationalIntegrationStage::execute(
         &scratch.inverseDynamics,
         &scratch.projection,
         &scratch.anderson);
+    auto& metrics = detail::storageOf(world).lastStepDiagnostics;
+    metrics.lastStepIterations += report.iterations;
+    if (std::isfinite(report.residualNorm)) {
+      metrics.lastStepResidual
+          = std::max(metrics.lastStepResidual, report.residualNorm);
+    }
     if (compliantScratch != nullptr && !compliantScratch->constraints.empty()) {
       updateVariationalCompliantLoopConstraintRows(
           registry, structure, scratch.tree, *compliantScratch);

--- a/dart/simulation/compute/variational_integration.hpp
+++ b/dart/simulation/compute/variational_integration.hpp
@@ -737,17 +737,19 @@ DART_SIMULATION_API VariationalSolveReport integrateMultibodyVariational(
     MultibodyVariationalTreeScratch& treeScratch,
     VariationalStepScratch& stepScratch);
 
-/// The kinetic/potential split of a multibody's mechanical energy, computed
-/// from the same forward-kinematics world transforms as
+/// The energy/momentum split of a multibody, computed from the same
+/// forward-kinematics world transforms and link-frame spatial velocities as
 /// `computeMultibodyMechanicalEnergy` (so `kinetic + potential` equals it). Use
-/// this for a physical per-domain energy split: deriving the split from the
-/// stored `comps::LinkState::worldTransform` cache is unreliable (it is not
-/// always refreshed for the current configuration), which is why the metrics
-/// layer routes through this helper instead.
+/// this for physical per-domain metrics: deriving the split from the stored
+/// `comps::LinkState::worldTransform` cache is unreliable (it is not always
+/// refreshed for the current configuration), which is why the metrics layer
+/// routes through this helper instead.
 struct MultibodyMechanicalEnergyTerms
 {
   double kinetic = 0.0;
   double potential = 0.0;
+  Eigen::Vector3d linearMomentum = Eigen::Vector3d::Zero();
+  Eigen::Vector3d angularMomentum = Eigen::Vector3d::Zero();
 };
 
 [[nodiscard]] DART_SIMULATION_API MultibodyMechanicalEnergyTerms

--- a/dart/simulation/compute/world_step_profile.hpp
+++ b/dart/simulation/compute/world_step_profile.hpp
@@ -241,26 +241,27 @@ struct DART_SIMULATION_API StepMetrics
   /// Total angular momentum about the world origin (world frame).
   Eigen::Vector3d angularMomentum = Eigen::Vector3d::Zero();
 
-  /// Number of active rigid contacts at the current state.
+  /// Number of active rigid contacts processed by the last mutating rigid
+  /// contact stage.
   ///
-  /// Populating this requires a narrow-phase contact pass, which mutates the
-  /// World's collision-query cache and so cannot run from the read-only
-  /// `computeStepMetrics()` query. This foundational WP-091.24 slice therefore
-  /// leaves it at 0; a later slice adds an explicit contact-metrics path.
+  /// `computeStepMetrics()` is a read-only query and does not run narrow phase
+  /// itself; this is the cached value from `World::step()` (0 before any
+  /// contact stage has run, or when the active stage reported no rigid-rigid
+  /// contacts).
   std::size_t activeContactCount = 0;
 
-  /// Maximum penetration depth over active rigid contacts (meters). Left at 0
-  /// for the same read-only reason as `activeContactCount`.
+  /// Maximum penetration depth over active rigid contacts processed by the last
+  /// mutating rigid contact stage (meters). Cached for the same reason as
+  /// `activeContactCount`.
   double maxPenetrationDepth = 0.0;
 
-  /// RIQN/solver iterations performed on the last step, when the active solver
-  /// exposes it; 0 otherwise. The default step profile records per-stage timing
-  /// only, so this is 0 until a later slice threads solver-iteration data
-  /// through the profile rather than inventing a value here.
+  /// Solver iterations performed by the stages that expose an iteration count
+  /// during the last `World::step()`. Direct solves and stages without a public
+  /// iteration count contribute 0.
   std::size_t lastStepIterations = 0;
 
-  /// Final solver residual norm on the last step, when available; 0 otherwise
-  /// (same provenance caveat as `lastStepIterations`).
+  /// Maximum final solver residual norm reported by stages during the last
+  /// `World::step()`. Stages without a comparable residual contribute 0.
   double lastStepResidual = 0.0;
 };
 

--- a/dart/simulation/detail/contact_jacobians.cpp
+++ b/dart/simulation/detail/contact_jacobians.cpp
@@ -37,6 +37,7 @@
 #include "dart/simulation/comps/contact_material.hpp"
 #include "dart/simulation/comps/dynamics.hpp"
 #include "dart/simulation/comps/rigid_body.hpp"
+#include "dart/simulation/compute/rigid_body_constraint.hpp"
 #include "dart/simulation/detail/entity_conversion.hpp"
 #include "dart/simulation/detail/rigid_contact/rigid_contact_assembly.hpp"
 
@@ -343,43 +344,27 @@ ContactScene buildScene(
     registerBody(entity, false);
   }
 
-  for (const auto& contact : contacts) {
-    const auto entityA = detail::toRegistryEntity(contact.bodyA.getEntity());
-    const auto entityB = detail::toRegistryEntity(contact.bodyB.getEntity());
-
-    // Rigid-body pairs only (parity with solveBoxedLcpContacts).
-    if (!registry.all_of<comps::RigidBodyTag>(entityA)
-        || !registry.all_of<comps::RigidBodyTag>(entityB)) {
-      continue;
-    }
-    const bool prescribedA
-        = hasPrescribedRigidBodyContactResponse(registry, entityA);
-    const bool prescribedB
-        = hasPrescribedRigidBodyContactResponse(registry, entityB);
-    if (prescribedA && prescribedB) {
-      continue;
-    }
-
-    const auto& transformA = registry.get<comps::Transform>(entityA);
-    const auto& transformB = registry.get<comps::Transform>(entityB);
-
+  compute::RigidBodyContactProblem rigidContacts(allocator);
+  compute::RigidBodyContactAssemblyOptions assemblyOptions;
+  assemblyOptions.populateSystem = false;
+  compute::assembleRigidBodyContactProblemInto(
+      rigidContacts, registry, contacts, assemblyOptions);
+  for (const auto& constraint : rigidContacts.constraints) {
     FrozenContact frozen;
-    frozen.bodyA = entityA;
-    frozen.bodyB = entityB;
-    frozen.prescribedA = prescribedA;
-    frozen.prescribedB = prescribedB;
-    frozen.normal = contact.normal;
-    frozen.tangent1 = contact.normal.unitOrthogonal();
-    frozen.tangent2 = contact.normal.cross(frozen.tangent1);
-    frozen.armA = contact.point - transformA.position;
-    frozen.armB = contact.point - transformB.position;
-    frozen.restitution = std::max(
-        restitutionOf(registry, entityA), restitutionOf(registry, entityB));
-    frozen.friction = std::sqrt(
-        frictionOf(registry, entityA) * frictionOf(registry, entityB));
+    frozen.bodyA = constraint.bodyA;
+    frozen.bodyB = constraint.bodyB;
+    frozen.prescribedA = constraint.staticA;
+    frozen.prescribedB = constraint.staticB;
+    frozen.normal = constraint.normal;
+    frozen.tangent1 = constraint.tangent1;
+    frozen.tangent2 = constraint.tangent2;
+    frozen.armA = constraint.armA;
+    frozen.armB = constraint.armB;
+    frozen.restitution = constraint.restitution;
+    frozen.friction = constraint.friction;
 
-    registerBody(entityA, prescribedA);
-    registerBody(entityB, prescribedB);
+    registerBody(constraint.bodyA, constraint.staticA);
+    registerBody(constraint.bodyB, constraint.staticB);
     scene.contacts.push_back(frozen);
   }
 

--- a/dart/simulation/detail/rigid_contact/boxed_lcp_contact.cpp
+++ b/dart/simulation/detail/rigid_contact/boxed_lcp_contact.cpp
@@ -50,9 +50,9 @@
 #include <Eigen/Geometry>
 #include <entt/entt.hpp>
 
+#include <algorithm>
 #include <limits>
 #include <span>
-#include <unordered_map>
 #include <vector>
 
 #include <cmath>
@@ -63,8 +63,8 @@ namespace dart::simulation::detail {
 void BoxedLcpContactScratch::reserve(
     std::size_t contactCapacity, std::size_t bodyCapacity)
 {
-  normals.reserve(contactCapacity);
-  bodyColumn.reserve(bodyCapacity);
+  problem.constraints.reserve(contactCapacity);
+  problem.dynamicBodies.reserve(bodyCapacity);
 
   const Eigen::Index rows = static_cast<Eigen::Index>(3u * contactCapacity);
   const Eigen::Index dofs = static_cast<Eigen::Index>(6u * bodyCapacity);
@@ -119,8 +119,14 @@ void BoxedLcpContactScratch::reserve(
 //==============================================================================
 void BoxedLcpContactScratch::clearProblem()
 {
-  normals.clear();
-  bodyColumn.clear();
+  problem.constraints.clear();
+  problem.dynamicBodies.clear();
+  problem.delassus.resize(0, 0);
+  problem.rhs.resize(0);
+  problem.lo.resize(0);
+  problem.hi.resize(0);
+  problem.findex.resize(0);
+  problem.jacobian.resize(0, 0);
   systemA.clear();
   systemB.clear();
   systemLo.clear();
@@ -149,12 +155,17 @@ void reserveBoxedLcpContactScratch(
     return;
   }
 
-  scratch.normals.reserve(contacts.size());
-  scratch.bodyColumn.clear();
-  scratch.bodyColumn.reserve(2u * contacts.size());
+  scratch.problem.constraints.reserve(contacts.size());
+  scratch.problem.dynamicBodies.clear();
+  scratch.problem.dynamicBodies.reserve(2u * contacts.size());
   const auto registerBody = [&](entt::entity entity, bool isStatic) {
-    if (!isStatic) {
-      scratch.bodyColumn.emplace(entity, scratch.bodyColumn.size());
+    if (isStatic) {
+      return;
+    }
+    auto& dynamicBodies = scratch.problem.dynamicBodies;
+    if (std::find(dynamicBodies.begin(), dynamicBodies.end(), entity)
+        == dynamicBodies.end()) {
+      dynamicBodies.push_back(entity);
     }
   };
 
@@ -180,8 +191,8 @@ void reserveBoxedLcpContactScratch(
     registerBody(entityB, staticB);
   }
 
-  scratch.reserve(activeContacts, scratch.bodyColumn.size());
-  scratch.bodyColumn.clear();
+  scratch.reserve(activeContacts, scratch.problem.dynamicBodies.size());
+  scratch.problem.dynamicBodies.clear();
 }
 
 //==============================================================================
@@ -211,122 +222,30 @@ BoxedLcpContactSnapshot& solveBoxedLcpContactsImpl(
     return scratch.snapshot;
   }
 
-  // Velocity-level bias combines restitution with a Baumgarte-style
-  // penetration recovery for slow resting contacts. High-speed inelastic
-  // impacts stay restitution-only so penetration bias does not inject extra
-  // rebound velocity. The positional projection step still removes any
-  // residual penetration after the impulse solve; the slow-contact velocity
-  // bias prevents taller coupled stacks from accumulating downward drift
-  // between projections.
-  constexpr double restitutionThreshold = kRigidContactRestitutionThreshold;
-  constexpr double penetrationSlop = 1e-4;
-  constexpr double baumgarteFactor = 0.2;
-  constexpr double baumgarteApproachThreshold = -0.25;
+  compute::RigidBodyContactAssemblyOptions assemblyOptions;
+  assemblyOptions.populateSystem = false;
+  assemblyOptions.includeBaumgarteBias = true;
+  assemblyOptions.timeStep = timeStep;
+  compute::assembleRigidBodyContactProblemInto(
+      scratch.problem, registry, contacts, assemblyOptions);
 
-  // Collect rigid-body/rigid-body normal contacts and the dynamic bodies they
-  // touch. Each dynamic body owns a 6-column block in J ([v; ω]).
-  auto& normals = scratch.normals;
-  auto& bodyColumn = scratch.bodyColumn;
-  normals.clear();
-  normals.reserve(contacts.size());
-  bodyColumn.clear();
-  bodyColumn.reserve(2u * contacts.size());
-
-  const auto registerBody = [&](entt::entity entity, bool isStatic) {
-    if (isStatic) {
-      return;
-    }
-    bodyColumn.emplace(entity, bodyColumn.size());
-  };
-
-  for (const auto& contact : contacts) {
-    const auto entityA = detail::toRegistryEntity(contact.bodyA.getEntity());
-    const auto entityB = detail::toRegistryEntity(contact.bodyB.getEntity());
-
-    // Rigid-body pairs only; articulated-link contacts are out of scope for
-    // this slice (handled by the multibody solve).
-    if (!registry.all_of<comps::RigidBodyTag>(entityA)
-        || !registry.all_of<comps::RigidBodyTag>(entityB)) {
-      continue;
-    }
-
-    const bool kinematicA = registry.all_of<comps::KinematicBodyTag>(entityA);
-    const bool kinematicB = registry.all_of<comps::KinematicBodyTag>(entityB);
-    const bool staticA
-        = hasPrescribedRigidBodyContactResponse(registry, entityA);
-    const bool staticB
-        = hasPrescribedRigidBodyContactResponse(registry, entityB);
-    if (staticA && staticB) {
-      continue;
-    }
-
-    const auto& transformA = registry.get<comps::Transform>(entityA);
-    const auto& transformB = registry.get<comps::Transform>(entityB);
-
-    BoxedLcpContactNormal normal;
-    normal.bodyA = entityA;
-    normal.bodyB = entityB;
-    normal.staticA = staticA;
-    normal.staticB = staticB;
-    normal.normal = contact.normal;
-    // Orthonormal tangent basis spanning the contact plane, matching the
-    // sequential-impulse stage's convention so the box Coulomb model is shared.
-    normal.tangent1 = contact.normal.unitOrthogonal();
-    normal.tangent2 = contact.normal.cross(normal.tangent1);
-    normal.friction = std::sqrt(
-        frictionOf(registry, entityA) * frictionOf(registry, entityB));
-    normal.armA = contact.point - transformA.position;
-    normal.armB = contact.point - transformB.position;
-
-    // Restitution target from the pre-solve approach velocity, combining the
-    // two materials by the larger bounce (parity with the existing stage).
-    const auto& velocityA = registry.get<comps::Velocity>(entityA);
-    const auto& velocityB = registry.get<comps::Velocity>(entityB);
-    Eigen::Vector3d pointVelocityA = Eigen::Vector3d::Zero();
-    if (!staticA) {
-      pointVelocityA = velocityA.linear + velocityA.angular.cross(normal.armA);
-    }
-    Eigen::Vector3d pointVelocityB = Eigen::Vector3d::Zero();
-    if (!staticB) {
-      pointVelocityB = velocityB.linear + velocityB.angular.cross(normal.armB);
-    }
-    const double approach
-        = (pointVelocityB - pointVelocityA).dot(normal.normal);
-
-    const double restitution = std::max(
-        restitutionOf(registry, entityA), restitutionOf(registry, entityB));
-    const double restitutionVelocity
-        = (restitution > 0.0 && approach < -restitutionThreshold)
-              ? -restitution * approach
-              : 0.0;
-    // Kinematic bodies follow the sequential-impulse compatibility path here:
-    // their prescribed motion is ignored by the LCP contact solve, and initial
-    // penetration does not inject a velocity-level push from the kinematic
-    // body.
-    const double baumgarteVelocity
-        = (timeStep > 0.0 && !kinematicA && !kinematicB
-           && approach > baumgarteApproachThreshold)
-              ? baumgarteFactor * std::max(0.0, contact.depth - penetrationSlop)
-                    / timeStep
-              : 0.0;
-
-    normal.bias = std::max(restitutionVelocity, baumgarteVelocity);
-
-    registerBody(entityA, staticA);
-    registerBody(entityB, staticB);
-    normals.push_back(normal);
-  }
-
-  const Eigen::Index n = static_cast<Eigen::Index>(normals.size());
+  auto& constraints = scratch.problem.constraints;
+  const auto& dynamicBodies = scratch.problem.dynamicBodies;
+  const Eigen::Index n = static_cast<Eigen::Index>(constraints.size());
   if (n == 0) {
     scratch.clearProblem();
     return scratch.snapshot;
   }
 
-  const std::size_t bodyCount = bodyColumn.size();
+  const std::size_t bodyCount = dynamicBodies.size();
   const Eigen::Index dofs = static_cast<Eigen::Index>(6 * bodyCount);
-  scratch.reserve(normals.size(), bodyCount);
+  scratch.reserve(constraints.size(), bodyCount);
   auto& snapshot = scratch.snapshot;
+  const auto bodyColumn = [&](entt::entity entity) {
+    const auto it
+        = std::find(dynamicBodies.begin(), dynamicBodies.end(), entity);
+    return static_cast<Eigen::Index>(std::distance(dynamicBodies.begin(), it));
+  };
 
   // Stacked inverse mass operator M⁻¹ (block-diagonal, 6 dofs per body) and the
   // free velocity v_free at solve time.
@@ -337,7 +256,8 @@ BoxedLcpContactSnapshot& solveBoxedLcpContactsImpl(
   Eigen::Map<Eigen::VectorXd> vFree(scratch.vFree.data(), dofs);
   Minv.setZero();
   vFree.setZero();
-  for (const auto& [entity, column] : bodyColumn) {
+  for (std::size_t column = 0; column < dynamicBodies.size(); ++column) {
+    const auto entity = dynamicBodies[column];
     const auto& mass = registry.get<comps::MassProperties>(entity);
     const auto& transform = registry.get<comps::Transform>(entity);
     const auto& velocity = registry.get<comps::Velocity>(entity);
@@ -368,26 +288,26 @@ BoxedLcpContactSnapshot& solveBoxedLcpContactsImpl(
   Eigen::Map<Eigen::MatrixXd> J(scratch.systemJ.data(), rows, dofs);
   J.setZero();
   const auto fillRow = [&](Eigen::Index row,
-                           const BoxedLcpContactNormal& contact,
+                           const compute::RigidBodyContactConstraint& contact,
                            const Eigen::Vector3d& direction) {
     if (!contact.staticB) {
       const Eigen::Index base
-          = static_cast<Eigen::Index>(6 * bodyColumn.at(contact.bodyB));
+          = static_cast<Eigen::Index>(6 * bodyColumn(contact.bodyB));
       J.block<1, 3>(row, base) += direction.transpose();
       J.block<1, 3>(row, base + 3) += contact.armB.cross(direction).transpose();
     }
     if (!contact.staticA) {
       const Eigen::Index base
-          = static_cast<Eigen::Index>(6 * bodyColumn.at(contact.bodyA));
+          = static_cast<Eigen::Index>(6 * bodyColumn(contact.bodyA));
       J.block<1, 3>(row, base) -= direction.transpose();
       J.block<1, 3>(row, base + 3) -= contact.armA.cross(direction).transpose();
     }
   };
   for (Eigen::Index i = 0; i < n; ++i) {
-    const auto& normal = normals[static_cast<std::size_t>(i)];
-    fillRow(i, normal, normal.normal);
-    fillRow(n + 2 * i, normal, normal.tangent1);
-    fillRow(n + 2 * i + 1, normal, normal.tangent2);
+    const auto& constraint = constraints[static_cast<std::size_t>(i)];
+    fillRow(i, constraint, constraint.normal);
+    fillRow(n + 2 * i, constraint, constraint.tangent1);
+    fillRow(n + 2 * i + 1, constraint, constraint.tangent2);
   }
 
   // Delassus system: A = J M⁻¹ Jᵀ.
@@ -411,7 +331,7 @@ BoxedLcpContactSnapshot& solveBoxedLcpContactsImpl(
   b.noalias() = J * vFree;
   b = -b;
   for (Eigen::Index i = 0; i < n; ++i) {
-    b[i] += normals[static_cast<std::size_t>(i)].bias;
+    b[i] += constraints[static_cast<std::size_t>(i)].normalVelocityBias;
   }
 
   // Constraint-force-mixing regularization on the FRICTION-row diagonal,
@@ -440,7 +360,7 @@ BoxedLcpContactSnapshot& solveBoxedLcpContactsImpl(
   hi.setConstant(std::numeric_limits<double>::infinity());
   findex.setConstant(-1);
   for (Eigen::Index i = 0; i < n; ++i) {
-    const double mu = normals[static_cast<std::size_t>(i)].friction;
+    const double mu = constraints[static_cast<std::size_t>(i)].friction;
     for (Eigen::Index t = 0; t < 2; ++t) {
       const Eigen::Index row = n + 2 * i + t;
       lo[row] = -mu;
@@ -497,7 +417,8 @@ BoxedLcpContactSnapshot& solveBoxedLcpContactsImpl(
   Eigen::Map<Eigen::VectorXd> deltaV(scratch.deltaV.data(), dofs);
   jtImpulse.noalias() = J.transpose() * f;
   deltaV.noalias() = Minv * jtImpulse;
-  for (const auto& [entity, column] : bodyColumn) {
+  for (std::size_t column = 0; column < dynamicBodies.size(); ++column) {
+    const auto entity = dynamicBodies[column];
     const Eigen::Index base = static_cast<Eigen::Index>(6 * column);
     auto& velocity = registry.get<comps::Velocity>(entity);
     velocity.linear += deltaV.segment<3>(base);

--- a/dart/simulation/detail/rigid_contact/boxed_lcp_contact.hpp
+++ b/dart/simulation/detail/rigid_contact/boxed_lcp_contact.hpp
@@ -47,6 +47,7 @@
 // entry point is marked DART_SIMULATION_API so a test/diff layer can link it
 // across the experimental .so (DART applies strict symbol visibility).
 
+#include <dart/simulation/compute/rigid_body_constraint.hpp>
 #include <dart/simulation/detail/world_registry_types.hpp>
 #include <dart/simulation/export.hpp>
 #include <dart/simulation/fwd.hpp>
@@ -61,7 +62,6 @@
 #include <entt/fwd.hpp>
 
 #include <span>
-#include <unordered_map>
 #include <vector>
 
 #include <cstddef>
@@ -123,49 +123,17 @@ struct DART_SIMULATION_API BoxedLcpContactSnapshot
   }
 };
 
-// Per-contact constraint, mirroring the sequential-impulse stage so the two
-// paths assemble the same physics: a normal row plus two tangential friction
-// rows spanning the contact plane (box Coulomb model).
-struct BoxedLcpContactNormal
-{
-  entt::entity bodyA{entt::null};
-  entt::entity bodyB{entt::null};
-  bool staticA = false;
-  bool staticB = false;
-  Eigen::Vector3d normal = Eigen::Vector3d::UnitZ();
-  Eigen::Vector3d tangent1 = Eigen::Vector3d::UnitX();
-  Eigen::Vector3d tangent2 = Eigen::Vector3d::UnitY();
-  Eigen::Vector3d armA = Eigen::Vector3d::Zero();
-  Eigen::Vector3d armB = Eigen::Vector3d::Zero();
-  double bias = 0.0; // Baumgarte/restitution bias as a target normal velocity.
-  double friction = 0.0; // Combined Coulomb friction coefficient mu.
-};
-
 struct DART_SIMULATION_API BoxedLcpContactScratch
 {
-  using NormalAllocator = dart::common::StlAllocator<BoxedLcpContactNormal>;
   using DoubleAllocator = dart::common::StlAllocator<double>;
   using IntAllocator = dart::common::StlAllocator<int>;
   using DoubleVector = std::vector<double, DoubleAllocator>;
   using IntVector = std::vector<int, IntAllocator>;
-  using BodyColumnPair = std::pair<const entt::entity, std::size_t>;
-  using BodyColumnAllocator = dart::common::StlAllocator<BodyColumnPair>;
-  using BodyColumnMap = std::unordered_map<
-      entt::entity,
-      std::size_t,
-      std::hash<entt::entity>,
-      std::equal_to<entt::entity>,
-      BodyColumnAllocator>;
 
   BoxedLcpContactScratch() = default;
 
   explicit BoxedLcpContactScratch(dart::common::MemoryAllocator& allocator)
-    : normals(NormalAllocator{allocator}),
-      bodyColumn(
-          0u,
-          std::hash<entt::entity>{},
-          std::equal_to<entt::entity>{},
-          BodyColumnAllocator{allocator}),
+    : problem(allocator),
       systemA(DoubleAllocator{allocator}),
       systemB(DoubleAllocator{allocator}),
       systemLo(DoubleAllocator{allocator}),
@@ -185,8 +153,7 @@ struct DART_SIMULATION_API BoxedLcpContactScratch
   void reserve(std::size_t contactCapacity, std::size_t bodyCapacity);
   void clearProblem();
 
-  std::vector<BoxedLcpContactNormal, NormalAllocator> normals;
-  BodyColumnMap bodyColumn;
+  compute::RigidBodyContactProblem problem;
   BoxedLcpContactSnapshot snapshot;
   DoubleVector systemA;
   DoubleVector systemB;

--- a/dart/simulation/detail/rigid_contact/rigid_contact_assembly.hpp
+++ b/dart/simulation/detail/rigid_contact/rigid_contact_assembly.hpp
@@ -68,6 +68,10 @@ inline constexpr double kRigidContactPositionAllowance = 1e-4;
 /// Fraction of penetration beyond the allowance removed by position projection.
 inline constexpr double kRigidContactPositionCorrectionFactor = 0.2;
 
+/// Slow-contact velocity threshold above which Baumgarte penetration bias is
+/// allowed to assist the boxed-LCP solve (m/s).
+inline constexpr double kRigidContactBaumgarteApproachThreshold = -0.25;
+
 /// Reciprocal of a finite, positive body mass; zero for static/degenerate mass.
 inline double inverseMassOf(const comps::MassProperties& mass)
 {

--- a/dart/simulation/detail/world_storage.hpp
+++ b/dart/simulation/detail/world_storage.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <dart/simulation/compute/multibody_dynamics.hpp>
+#include <dart/simulation/compute/world_step_profile.hpp>
 #include <dart/simulation/detail/smooth_jacobians.hpp>
 #include <dart/simulation/detail/world_registry_types.hpp>
 #include <dart/simulation/diff/physical_parameter.hpp>
@@ -177,6 +178,11 @@ struct WorldStorage
   /// differentiable step allocation-free, but callers still need `step()` to
   /// populate a semantically valid derivative snapshot.
   bool stepDerivativesValid = false;
+
+  /// Last-step contact and solver diagnostics populated by mutating step
+  /// stages. `World::computeStepMetrics()` folds these into its read-only
+  /// physical snapshot without running a narrow-phase query itself.
+  compute::StepMetrics lastStepDiagnostics;
 
   /// Persistent pair-level collision-query exclusions, stored with canonical
   /// endpoint ordering. This scene-level filter is applied after broad-phase

--- a/dart/simulation/world.cpp
+++ b/dart/simulation/world.cpp
@@ -6475,6 +6475,7 @@ bool World::tryStepCleanNoWorkDefaultPipeline()
   m_memoryDiagnostics.frameScratchOverflowCount = 0;
   m_memoryDiagnostics.frameScratchOverflowBytes = 0;
   m_lastDeformableSolverDiagnostics = {};
+  m_storage->lastStepDiagnostics = {};
   m_time += m_timeStep;
   ++m_frame;
   if (m_replay && m_replay->recordingEnabled) {
@@ -6640,6 +6641,7 @@ void World::stepPipelineOnce(
   }
 
   resetFrameScratchForStep();
+  m_storage->lastStepDiagnostics = {};
   prepareDeactivationForStep();
 
   // Differentiable opt-in: record the analytic contact-free step Jacobians at
@@ -6944,15 +6946,13 @@ compute::StepMetrics World::computeStepMetrics() const
         += transform.position.cross(linear) + worldInertia * velocity.angular;
   }
 
-  // Multibodies: link world-frame velocities are not stored (they are derived
-  // from the joint degrees of freedom by forward kinematics), so both the
-  // kinetic and potential terms are taken from the variational integrator's own
-  // energy helper, which evaluates them on the VarTree's forward-kinematics
-  // world transforms. This makes the per-domain split physical -- an earlier
-  // version derived potential from the stored comps::LinkState::worldTransform
-  // cache, whose gauge did not match the helper (yielding negative kinetic
-  // energy at rest). World-frame multibody-link momentum aggregation still
-  // needs the link Jacobian and is deferred to a later WP-091.24 slice.
+  // Multibodies: link world-frame velocities are derived from the joint degrees
+  // of freedom by forward kinematics, so energy and momentum are taken from the
+  // variational integrator's helper. It evaluates them on the VarTree's
+  // forward-kinematics world transforms and link-frame spatial velocities. This
+  // keeps the per-domain split physical -- an earlier version derived potential
+  // from the stored comps::LinkState::worldTransform cache, whose gauge did not
+  // match the helper (yielding negative kinetic energy at rest).
   const auto structureView = registry.view<comps::MultibodyStructure>();
   for (const auto structureEntity : structureView) {
     const auto& structure
@@ -6962,7 +6962,17 @@ compute::StepMetrics World::computeStepMetrics() const
         registry, structure, gravity);
     metrics.kineticEnergy += terms.kinetic;
     metrics.potentialEnergy += terms.potential;
+    metrics.linearMomentum += terms.linearMomentum;
+    metrics.angularMomentum += terms.angularMomentum;
   }
+
+  metrics.activeContactCount
+      = m_storage->lastStepDiagnostics.activeContactCount;
+  metrics.maxPenetrationDepth
+      = m_storage->lastStepDiagnostics.maxPenetrationDepth;
+  metrics.lastStepIterations
+      = m_storage->lastStepDiagnostics.lastStepIterations;
+  metrics.lastStepResidual = m_storage->lastStepDiagnostics.lastStepResidual;
 
   metrics.totalEnergy = metrics.kineticEnergy + metrics.potentialEnergy;
   return metrics;

--- a/docs/plans/091-architecture-hardening.md
+++ b/docs/plans/091-architecture-hardening.md
@@ -632,15 +632,22 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   projection helper and the sequential path call the same projection helper
   instead of keeping duplicate loops. Behavior-preserving cleanup only; the
   four assembler layouts still remain distinct.
-  **Slice B (remaining):** converge the four contact-problem _assemblers_ (the
-  canonical `RigidBodyContactProblem` producer, the boxed-LCP assembly, the
-  differentiable-capture rebuild, and the sequential-impulse scratch in
-  `world_step_stage.cpp`) onto one producer, single-source the remaining
-  positional-correction constants in `world_step_stage.cpp`, and hand the
-  populated snapshot to the
-  differentiable capture instead of rebuilding it — the higher-risk
-  physics-convergence work this slice deliberately leaves for a focused
-  follow-up (which also needs the diff build unbroken).
+  **Slice B (closeout packet):** the four rigid contact assemblers now route
+  through the canonical `compute::RigidBodyContactProblem` producer. The
+  producer records per-contact restitution/material data, dynamic-body ordering,
+  optional Baumgarte velocity bias, optional friction-row regularization, and
+  either contact-major or normal-then-tangents row layouts; callers can request
+  only canonical constraints, only the dense system, or both. Sequential impulse
+  consumes those canonical constraints directly instead of rebuilding local
+  normal rows; boxed-LCP builds its normal-first allocator-backed snapshot from
+  the same constraints while preserving the public/fixture row order; and
+  `detail/contact_jacobians.cpp` freezes differentiable contacts from the same
+  canonical producer rather than reclassifying endpoints itself. The remaining
+  Baumgarte approach-threshold constant is single-sourced beside the other
+  rigid-contact constants. Focused validation: `pixi run build`,
+  `test_rigid_body_constraint`, `test_boxed_lcp_contact`, and
+  `test_unified_constraint` pass, including new row-layout/Jacobian and
+  Baumgarte-bias unit coverage.
 
 #### WP-091.14 Family-neutral joint model [done — PR #3003, merged 2026-06-14]
 
@@ -1009,7 +1016,7 @@ hasSubstitution()`. Python surface matches: nanobind exposes
   integration families are genuinely distinct paths (final energy −18.2298 vs
   −18.2052). `test_cross_family_corpus` 1/1, golden 3/3, lint +
   `check-api-boundaries` green; pure-additive (no library change).
-  **Standalone harness + packet slice (pending acceptance in PR #3083):**
+  **Standalone harness + packet slice (landed via PR #3083):**
   `tests/benchmark/simulation/bm_plan091_cross_family_corpus.cpp`
   runs the same registered cross-family row set as a standalone Google
   Benchmark target,
@@ -1026,10 +1033,27 @@ tests/test_benchmark_packet_utils.py -q` green; actual benchmark packet smoke:
 scripts/write_plan091_cross_family_metrics_packet.py --benchmark-json
 .benchmark_results/plan091/cross_family_metrics_benchmark.json --output
 .benchmark_results/plan091/cross_family_metrics_packet.json` accepted them.
-  **Remaining:** contact/iteration metric population (needs a non-const
-  narrow-phase pass), world-frame multibody-link momentum aggregation, and a
-  corpus-wide order-of-convergence sweep (the current convergence seed covers
-  one scene).
+  **Metrics closeout packet:** `WorldStorage` now caches last-step diagnostics
+  from mutating stages so `World::computeStepMetrics()` stays read-only while
+  still reporting contact and solver fields. The rigid contact stage records
+  active rigid-rigid contact count, maximum penetration depth, and the exposed
+  sequential/AVBD iteration budget; the variational multibody stage records
+  RIQN iterations plus final residual norm; direct solvers and stages without a
+  comparable public residual still contribute 0 by contract. The multibody
+  energy helper now also returns world-frame linear and angular momentum by
+  rotating link-frame spatial velocities and COM inertia terms from the same
+  VarTree state used for energy, so `StepMetrics` reports full rigid +
+  multibody momentum without touching link-cache gauges. Validation adds
+  `World.ComputeStepMetricsReportsCachedContactDiagnostics`,
+  `World.ComputeStepMetricsReportsMultibodyMomentum`, and
+  `CrossFamilyCorpus.SmoothMultibodyScenesConvergeUnderTimeStepRefinement`;
+  focused gates: `pixi run build`,
+  `test_world --gtest_filter='World.ComputeStepMetrics*'`, and ctest over
+  `test_rigid_body_constraint`, `test_boxed_lcp_contact`,
+  `test_unified_constraint`, `test_cross_family_metrics`, and
+  `test_cross_family_corpus` pass. **Remaining:** none for WP-091.24; boxed-LCP
+  direct solves intentionally continue to report 0 iterations/residual because
+  they do not expose iterative convergence data.
   NOTE: independent of this
   slice, the branch carries one **pre-existing** red test
   (`World.BakedDynamicRigidIpcStepsDoNotGrowWorldBaseAllocator`, an exact

--- a/docs/plans/dashboard.md
+++ b/docs/plans/dashboard.md
@@ -28,17 +28,18 @@ its own line so status updates remain git-history friendly.
   WP-091.33a via PR #3042; WP-091.21 via PR #3044; WP-091.31, WP-091.33b, and
   WP-091.33c via PR #3052; WP-091.32 via PR #3058; WP-091.33d plus WP-091.34
   via PR #3061; WP-091.15 via PR #3067; WP-091.40 via PR #3077; and
-  WP-091.41 through WP-091.44 via PR #3072. The remaining WS0 packet is
+  WP-091.41 through WP-091.44 via PR #3072; and the WP-091.24 standalone
+  harness/packet slice, bounded WP-091.13 shared-helper cleanup, and
+  WP-091.33e packet-reporting checker via PR #3083. The remaining WS0 packet is
   WP-091.4 legacy freeze, which stays **blocked**: PLAN-042 Decision 5 has no
   recorded maintainer direction.
-  WP-091.13 and WP-091.24 still have partial landed evidence under
-  `[claimed]` headings, so they require orchestrator release or split
-  follow-up packets before executor pickup; PR #3083 adds the WP-091.24
-  standalone cross-family metrics harness/packet slice plus a bounded
-  WP-091.13 shared-helper/projection-constant cleanup while leaving the risky
-  contact/iteration and multibody-momentum metric semantics explicit.
-  WP-091.33e is claimed in PR #3083 for the batched precision/transfer
-  packet-reporting checker.
+  WP-091.13 and WP-091.24 now have closeout evidence under their `[claimed]`
+  headings: one canonical rigid-contact assembly producer feeds sequential
+  impulse, boxed-LCP, and differentiable capture, while `StepMetrics` now folds
+  cached contact/iteration diagnostics, variational residuals, multibody
+  momentum, and a smooth-corpus convergence sweep. After this closeout packet,
+  the only PLAN-091 item without executable closure remains the blocked
+  WP-091.4 decision.
   Packets are orchestrator-authored per
   [`../ai/orchestration.md`](../ai/orchestration.md) and picked up via
   `dart-execute-packet`; availability follows each packet's own Dependencies

--- a/tests/unit/simulation/compute/test_cross_family_corpus.cpp
+++ b/tests/unit/simulation/compute/test_cross_family_corpus.cpp
@@ -487,6 +487,63 @@ CorpusRow runCaseFamily(const SceneCase& c, const std::string& family)
   return row;
 }
 
+std::string multibodyNameForScene(const SceneCase& c)
+{
+  if (c.id == "pendulum_1link") {
+    return "pend1";
+  }
+  if (c.id == "pendulum_2link") {
+    return "pend2";
+  }
+  return {};
+}
+
+Eigen::VectorXd jointPositionVector(sx::World& world, const SceneCase& c)
+{
+  const std::string robotName = multibodyNameForScene(c);
+  auto robot = world.getMultibody(robotName);
+  if (!robot.has_value()) {
+    return {};
+  }
+
+  Eigen::Index dofs = 0;
+  for (auto joint : robot->getJoints()) {
+    dofs += joint.getDOFCount();
+  }
+
+  Eigen::VectorXd q(dofs);
+  Eigen::Index offset = 0;
+  for (auto joint : robot->getJoints()) {
+    const Eigen::VectorXd segment = joint.getPosition();
+    q.segment(offset, segment.size()) = segment;
+    offset += segment.size();
+  }
+  return q;
+}
+
+Eigen::VectorXd rollSmoothCaseJointPositions(
+    const SceneCase& c, const std::string& family, double dt, double totalTime)
+{
+  sx::World world;
+  world.setMultibodyOptions(
+      {.integrationFamily
+       = (family == "variational integrator")
+             ? sx::MultibodyIntegrationFamily::Variational
+             : sx::MultibodyIntegrationFamily::SemiImplicit});
+  c.build(world);
+  world.setTimeStep(dt);
+  world.enterSimulationMode();
+  if (c.postEnter) {
+    c.postEnter(world);
+  }
+
+  const int steps = static_cast<int>(std::lround(totalTime / dt));
+  for (int k = 0; k < steps; ++k) {
+    world.step();
+  }
+  return jointPositionVector(world, c);
+}
+
 //==============================================================================
 // The harness test: iterate the corpus, run every family of every case from one
 // loop, log the rows, and assert finiteness + invariant + cross-family
@@ -660,6 +717,51 @@ TEST(CrossFamilyCorpus, AllScenesRunUnderEveryFamily)
   // Echo the table to stdout too, so the comparison is visible without parsing
   // the gtest XML property -- the rows ARE the deliverable of this harness.
   std::cout << "\n[cross-family corpus rows]\n" << table.str() << std::endl;
+}
+
+TEST(CrossFamilyCorpus, SmoothMultibodyScenesConvergeUnderTimeStepRefinement)
+{
+  const std::vector<SceneCase> corpus = makeCorpus();
+  ASSERT_FALSE(corpus.empty());
+
+  // Contact rows are deliberately excluded from this convergence sweep: impact
+  // activation is nonsmooth, so halving dt can move event timing rather than
+  // expose the integration order. The smooth multibody corpus rows have the
+  // same initial condition under every family and a continuous state
+  // trajectory, so self-convergence against a dt/4 reference is a meaningful
+  // gate.
+  constexpr double kTotalTime = 0.2;
+  constexpr double kCoarseDt = 2.0e-3;
+  constexpr double kMediumDt = 1.0e-3;
+  constexpr double kFineDt = 5.0e-4;
+
+  int checkedRows = 0;
+  for (const SceneCase& c : corpus) {
+    if (c.axis != FamilyAxis::MultibodyIntegration) {
+      continue;
+    }
+    for (const std::string& family : c.families) {
+      const Eigen::VectorXd coarse
+          = rollSmoothCaseJointPositions(c, family, kCoarseDt, kTotalTime);
+      const Eigen::VectorXd medium
+          = rollSmoothCaseJointPositions(c, family, kMediumDt, kTotalTime);
+      const Eigen::VectorXd fine
+          = rollSmoothCaseJointPositions(c, family, kFineDt, kTotalTime);
+      ASSERT_EQ(coarse.size(), medium.size()) << c.id << ":" << family;
+      ASSERT_EQ(medium.size(), fine.size()) << c.id << ":" << family;
+      ASSERT_GT(fine.size(), 0) << c.id << ":" << family;
+
+      const double coarseError = (coarse - fine).norm();
+      const double mediumError = (medium - fine).norm();
+      ASSERT_GT(coarseError, 1e-10) << c.id << ":" << family;
+      EXPECT_LT(mediumError, 0.8 * coarseError)
+          << c.id << ":" << family << " coarse=" << coarseError
+          << " medium=" << mediumError;
+      ++checkedRows;
+    }
+  }
+
+  EXPECT_GE(checkedRows, 4);
 }
 
 } // namespace

--- a/tests/unit/simulation/compute/test_rigid_body_constraint.cpp
+++ b/tests/unit/simulation/compute/test_rigid_body_constraint.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <span>
 #include <vector>
 
 #include <cmath>
@@ -228,4 +229,114 @@ TEST(RigidBodyConstraint, TreatsKinematicBodiesAsPrescribed)
       kinematic.getAngularVelocity().isApprox(kinematicAngularBefore, 1e-12));
   EXPECT_TRUE(dynamic.getLinearVelocity().isApprox(
       dynamicLinearBefore + Eigen::Vector3d(0.0, 0.0, 0.25), 1e-12));
+}
+
+//==============================================================================
+TEST(RigidBodyConstraint, SupportsNormalFirstRowsAndJacobian)
+{
+  namespace sx = dart::simulation;
+
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+
+  sx::RigidBodyOptions groundOptions;
+  groundOptions.isStatic = true;
+  groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+  auto ground = world.addRigidBody("ground", groundOptions);
+
+  sx::RigidBodyOptions lowerOptions;
+  lowerOptions.position = Eigen::Vector3d(0.0, 0.0, 0.5);
+  auto lower = world.addRigidBody("lower", lowerOptions);
+
+  sx::RigidBodyOptions upperOptions;
+  upperOptions.position = Eigen::Vector3d(0.0, 0.0, 1.5);
+  auto upper = world.addRigidBody("upper", upperOptions);
+
+  std::vector<sx::Contact> contacts;
+  sx::Contact groundLower;
+  groundLower.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+  groundLower.bodyB = sx::CollisionBody(lower.getEntity(), &world);
+  groundLower.point = Eigen::Vector3d(0.0, 0.0, 0.0);
+  groundLower.normal = Eigen::Vector3d::UnitZ();
+  groundLower.depth = 0.02;
+  contacts.push_back(groundLower);
+
+  sx::Contact lowerUpper;
+  lowerUpper.bodyA = sx::CollisionBody(lower.getEntity(), &world);
+  lowerUpper.bodyB = sx::CollisionBody(upper.getEntity(), &world);
+  lowerUpper.point = Eigen::Vector3d(0.0, 0.0, 1.0);
+  lowerUpper.normal = Eigen::Vector3d::UnitZ();
+  lowerUpper.depth = 0.03;
+  contacts.push_back(lowerUpper);
+
+  sx::compute::RigidBodyContactAssemblyOptions options;
+  options.rowLayout
+      = sx::compute::RigidBodyContactRowLayout::NormalThenTangents;
+  options.populateJacobian = true;
+  options.regularizeFrictionRows = true;
+  const auto problem = sx::compute::assembleRigidBodyContactProblem(
+      dart::simulation::detail::registryOf(world), contacts, options);
+
+  ASSERT_EQ(problem.constraints.size(), 2u);
+  ASSERT_EQ(problem.dynamicBodies.size(), 2u);
+  ASSERT_EQ(problem.delassus.rows(), 6);
+  ASSERT_EQ(problem.jacobian.rows(), 6);
+  ASSERT_EQ(problem.jacobian.cols(), 12);
+
+  EXPECT_EQ(problem.findex[0], -1);
+  EXPECT_EQ(problem.findex[1], -1);
+  EXPECT_EQ(problem.findex[2], 0);
+  EXPECT_EQ(problem.findex[3], 0);
+  EXPECT_EQ(problem.findex[4], 1);
+  EXPECT_EQ(problem.findex[5], 1);
+
+  const Eigen::RowVector3d zRow(0.0, 0.0, 1.0);
+  EXPECT_TRUE((problem.jacobian.block<1, 3>(0, 0).isApprox(zRow)));
+  EXPECT_TRUE((problem.jacobian.block<1, 3>(1, 0).isApprox(-zRow)));
+  EXPECT_TRUE((problem.jacobian.block<1, 3>(1, 6).isApprox(zRow)));
+
+  sx::compute::RigidBodyContactAssemblyOptions unregularized = options;
+  unregularized.regularizeFrictionRows = false;
+  const auto reference = sx::compute::assembleRigidBodyContactProblem(
+      dart::simulation::detail::registryOf(world), contacts, unregularized);
+  EXPECT_GT(problem.delassus(2, 2), reference.delassus(2, 2));
+  EXPECT_GT(problem.delassus(5, 5), reference.delassus(5, 5));
+}
+
+//==============================================================================
+TEST(RigidBodyConstraint, AppliesBaumgarteVelocityBiasWhenRequested)
+{
+  namespace sx = dart::simulation;
+
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+
+  sx::RigidBodyOptions groundOptions;
+  groundOptions.isStatic = true;
+  groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+  auto ground = world.addRigidBody("ground", groundOptions);
+
+  sx::RigidBodyOptions bodyOptions;
+  bodyOptions.position = Eigen::Vector3d(0.0, 0.0, 0.5);
+  auto body = world.addRigidBody("body", bodyOptions);
+
+  sx::Contact contact;
+  contact.bodyA = sx::CollisionBody(ground.getEntity(), &world);
+  contact.bodyB = sx::CollisionBody(body.getEntity(), &world);
+  contact.point = Eigen::Vector3d::Zero();
+  contact.normal = Eigen::Vector3d::UnitZ();
+  contact.depth = 0.03;
+
+  sx::compute::RigidBodyContactAssemblyOptions options;
+  options.includeBaumgarteBias = true;
+  options.timeStep = 0.01;
+  const auto problem = sx::compute::assembleRigidBodyContactProblem(
+      dart::simulation::detail::registryOf(world),
+      std::span<const sx::Contact>(&contact, 1),
+      options);
+
+  ASSERT_EQ(problem.constraints.size(), 1u);
+  constexpr double kExpectedBias = 0.2 * (0.03 - 1e-4) / 0.01;
+  EXPECT_NEAR(problem.constraints[0].normalVelocityBias, kExpectedBias, 1e-12);
+  EXPECT_NEAR(problem.rhs[0], kExpectedBias, 1e-12);
 }

--- a/tests/unit/simulation/world/test_world.cpp
+++ b/tests/unit/simulation/world/test_world.cpp
@@ -24953,6 +24953,79 @@ TEST(World, ComputeStepMetricsConservesLinearMomentumThroughCollision)
   EXPECT_LE(after.kineticEnergy, initial.kineticEnergy + 1e-9);
 }
 
+TEST(World, ComputeStepMetricsReportsCachedContactDiagnostics)
+{
+  namespace sx = dart::simulation;
+
+  sx::WorldOptions options;
+  options.contactSolverMethod = sx::ContactSolverMethod::SequentialImpulse;
+  sx::World world(options);
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(1e-3);
+
+  sx::RigidBodyOptions groundOptions;
+  groundOptions.isStatic = true;
+  groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+  auto ground = world.addRigidBody("ground", groundOptions);
+  ground.setCollisionShape(
+      sx::CollisionShape::makeBox(Eigen::Vector3d(5.0, 5.0, 0.5)));
+
+  sx::RigidBodyOptions sphereOptions;
+  sphereOptions.position = Eigen::Vector3d(0.0, 0.0, 0.45);
+  auto sphere = world.addRigidBody("sphere", sphereOptions);
+  sphere.setCollisionShape(sx::CollisionShape::makeSphere(0.5));
+
+  world.enterSimulationMode();
+  const sx::compute::StepMetrics before = world.computeStepMetrics();
+  EXPECT_EQ(before.activeContactCount, 0u);
+  EXPECT_DOUBLE_EQ(before.maxPenetrationDepth, 0.0);
+  EXPECT_EQ(before.lastStepIterations, 0u);
+
+  world.step();
+
+  const sx::compute::StepMetrics after = world.computeStepMetrics();
+  EXPECT_GE(after.activeContactCount, 1u);
+  EXPECT_GT(after.maxPenetrationDepth, 1e-3);
+  EXPECT_GT(after.lastStepIterations, 0u);
+  EXPECT_DOUBLE_EQ(after.lastStepResidual, 0.0);
+
+  const sx::compute::StepMetrics repeated = world.computeStepMetrics();
+  EXPECT_EQ(repeated.activeContactCount, after.activeContactCount);
+  EXPECT_DOUBLE_EQ(repeated.maxPenetrationDepth, after.maxPenetrationDepth);
+  EXPECT_EQ(repeated.lastStepIterations, after.lastStepIterations);
+  EXPECT_DOUBLE_EQ(repeated.lastStepResidual, after.lastStepResidual);
+}
+
+TEST(World, ComputeStepMetricsReportsMultibodyMomentum)
+{
+  namespace sx = dart::simulation;
+
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+
+  auto robot = world.addMultibody("slider");
+  auto base = robot.addLink("base");
+  sx::JointSpec spec;
+  spec.name = "slide";
+  spec.type = sx::JointType::Prismatic;
+  spec.axis = Eigen::Vector3d::UnitX();
+  auto link = robot.addLink("link", base, spec);
+  link.setMass(2.0);
+  link.setInertia(Eigen::Vector3d(0.1, 0.1, 0.1).asDiagonal());
+
+  world.enterSimulationMode();
+  auto joint = link.getParentJoint();
+  joint.setVelocity(Eigen::VectorXd::Constant(1, 0.7));
+  world.updateKinematics();
+
+  const sx::compute::StepMetrics metrics = world.computeStepMetrics();
+
+  EXPECT_NEAR(metrics.kineticEnergy, 0.5 * 2.0 * 0.7 * 0.7, 1e-12);
+  EXPECT_TRUE(metrics.linearMomentum.isApprox(
+      Eigen::Vector3d(2.0 * 0.7, 0.0, 0.0), 1e-12));
+  EXPECT_TRUE(metrics.angularMomentum.isApprox(Eigen::Vector3d::Zero(), 1e-12));
+}
+
 TEST(World, ComputeStepMetricsPotentialEnergyConvergesWithTimeStep)
 {
   namespace sx = dart::simulation;


### PR DESCRIPTION
## Summary

- Closes the remaining executable WP-091.13/WP-091.24 work in one PR: canonical rigid contact assembly now feeds sequential impulse, boxed-LCP, and differentiable capture.
- Expands `World::computeStepMetrics()` with cached contact diagnostics, solver iteration/residual fields, and world-frame multibody momentum while preserving the read-only query contract.
- Updates WP-091 plan/dashboard evidence and DART 7 changelog for the closeout state.

## Motivation / Problem

WP-091 still had two partial architecture-hardening packets after #3083: contact assembly was shared only at the helper level, and `StepMetrics` still left contact/iteration fields plus multibody momentum as deferred zeros. This keeps that remaining work consolidated instead of opening more packet PRs.

## Changes / Key Changes

- Added `RigidBodyContactAssemblyOptions` so the canonical contact producer can emit constraint-only, dense-system, Jacobian, contact-major, or normal-first layouts from the same contact classification.
- Reworked sequential impulse, boxed-LCP, and differentiable contact freezing to consume canonical `RigidBodyContactProblem` data.
- Cached last-step rigid contact count, penetration, sequential/AVBD iteration counts, and variational iterations/residuals for `computeStepMetrics()`.
- Extended multibody mechanical terms with world-frame linear/angular momentum from VarTree spatial velocities.
- Added focused unit coverage for row layout/Jacobian assembly, Baumgarte bias, contact diagnostics, multibody momentum, and smooth corpus self-convergence.

## Testing

- `pixi run lint`
- `pixi run build`
- `build/default/cpp/Release/bin/test_world --gtest_filter='World.ComputeStepMetrics*'`
- `ctest --test-dir build/default/cpp/Release -j "$JOBS" -R "test_rigid_body_constraint|test_boxed_lcp_contact|test_unified_constraint|test_cross_family_metrics|test_cross_family_corpus" --output-on-failure`
- `pixi run test-unit`
- `pixi run check-dart7-promotion-surface`
- `pixi run python -m pytest tests/test_plan091_cross_family_metrics_packet.py tests/test_benchmark_packet_utils.py -q`
- `pixi run bm --target bm_plan091_cross_family_corpus -- --benchmark_min_time=1x --benchmark_repetitions=1 --benchmark_out=.benchmark_results/plan091/cross_family_metrics_benchmark.json --benchmark_out_format=json`
- `pixi run python scripts/write_plan091_cross_family_metrics_packet.py --benchmark-json .benchmark_results/plan091/cross_family_metrics_benchmark.json --output .benchmark_results/plan091/cross_family_metrics_packet.json`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows #3083
- PLAN-091 WP-091.13 / WP-091.24 closeout on `main`; no DART 6 backport.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable: N/A, no Python surface change