### PR TITLE
fix(simulation): eliminate per-step heap allocations in boxed-LCP fallback contact assembly

### DIFF
--- a/dart/simulation/compute/rigid_body_constraint.cpp
+++ b/dart/simulation/compute/rigid_body_constraint.cpp
@@ -320,33 +320,30 @@ void assembleRigidBodyContactProblemInto(
   }
 
   const std::size_t n = problem.constraints.size();
-  if (!options.populateSystem && !options.populateJacobian) {
-    // No dense system requested: release any stale buffers so the members keep
-    // their documented "no system" post-condition. resize(0, ...) is a no-op
-    // when already empty, so the common populateSystem=false callers stay
-    // allocation-free across repeated same-shape steps.
-    problem.delassus.resize(0, 0);
-    problem.rhs.resize(0);
-    problem.lo.resize(0);
-    problem.hi.resize(0);
-    problem.findex.resize(0);
-    problem.jacobian.resize(0, 0);
-    return;
-  }
-
   const auto size
       = static_cast<Eigen::Index>(n * RigidBodyContactProblem::kRowsPerContact);
+
+  // Each optional output is handled independently: cleared when its flag is
+  // disabled (so a caller that reuses the problem and toggles only one flag can
+  // never observe stale shape/content from a previous assembly), and resized in
+  // place when enabled (so a stable contact shape reuses the existing buffers --
+  // Eigen reallocates only when the requested size differs). resize(0, ...) is a
+  // no-op when already empty, so repeated same-shape steps stay malloc-free.
   if (options.populateSystem) {
-    // Resize in place so a stable contact shape reuses the existing buffers
-    // (Eigen reallocates only when the requested size differs). The Delassus
-    // block is fully overwritten below, but it is zeroed in place to preserve
-    // the previous Eigen::MatrixXd::Zero(size, size) initialization exactly.
+    // The Delassus block is fully overwritten below, but it is zeroed in place
+    // to preserve the previous Eigen::MatrixXd::Zero(size, size) init exactly.
     problem.delassus.resize(size, size);
     problem.delassus.setZero();
     problem.rhs.resize(size);
     problem.lo.resize(size);
     problem.hi.resize(size);
     problem.findex.resize(size);
+  } else {
+    problem.delassus.resize(0, 0);
+    problem.rhs.resize(0);
+    problem.lo.resize(0);
+    problem.hi.resize(0);
+    problem.findex.resize(0);
   }
   if (options.populateJacobian) {
     // The Jacobian rows are accumulated with +=, so it must be zeroed; resize
@@ -354,6 +351,12 @@ void assembleRigidBodyContactProblemInto(
     problem.jacobian.resize(
         size, static_cast<Eigen::Index>(6 * problem.dynamicBodies.size()));
     problem.jacobian.setZero();
+  } else {
+    problem.jacobian.resize(0, 0);
+  }
+
+  if (!options.populateSystem && !options.populateJacobian) {
+    return;
   }
 
   for (std::size_t i = 0; i < n; ++i) {

--- a/dart/simulation/compute/rigid_body_constraint.cpp
+++ b/dart/simulation/compute/rigid_body_constraint.cpp
@@ -326,9 +326,10 @@ void assembleRigidBodyContactProblemInto(
   // Each optional output is handled independently: cleared when its flag is
   // disabled (so a caller that reuses the problem and toggles only one flag can
   // never observe stale shape/content from a previous assembly), and resized in
-  // place when enabled (so a stable contact shape reuses the existing buffers --
-  // Eigen reallocates only when the requested size differs). resize(0, ...) is a
-  // no-op when already empty, so repeated same-shape steps stay malloc-free.
+  // place when enabled (so a stable contact shape reuses the existing buffers
+  // -- Eigen reallocates only when the requested size differs). resize(0, ...)
+  // is a no-op when already empty, so repeated same-shape steps stay
+  // malloc-free.
   if (options.populateSystem) {
     // The Delassus block is fully overwritten below, but it is zeroed in place
     // to preserve the previous Eigen::MatrixXd::Zero(size, size) init exactly.

--- a/dart/simulation/compute/rigid_body_constraint.cpp
+++ b/dart/simulation/compute/rigid_body_constraint.cpp
@@ -197,12 +197,6 @@ void assembleRigidBodyContactProblemInto(
 {
   problem.constraints.clear();
   problem.dynamicBodies.clear();
-  problem.delassus.resize(0, 0);
-  problem.rhs.resize(0);
-  problem.lo.resize(0);
-  problem.hi.resize(0);
-  problem.findex.resize(0);
-  problem.jacobian.resize(0, 0);
 
   std::size_t rigidContactCount = 0;
   for (const auto& contact : contacts) {
@@ -327,21 +321,39 @@ void assembleRigidBodyContactProblemInto(
 
   const std::size_t n = problem.constraints.size();
   if (!options.populateSystem && !options.populateJacobian) {
+    // No dense system requested: release any stale buffers so the members keep
+    // their documented "no system" post-condition. resize(0, ...) is a no-op
+    // when already empty, so the common populateSystem=false callers stay
+    // allocation-free across repeated same-shape steps.
+    problem.delassus.resize(0, 0);
+    problem.rhs.resize(0);
+    problem.lo.resize(0);
+    problem.hi.resize(0);
+    problem.findex.resize(0);
+    problem.jacobian.resize(0, 0);
     return;
   }
 
   const auto size
       = static_cast<Eigen::Index>(n * RigidBodyContactProblem::kRowsPerContact);
   if (options.populateSystem) {
-    problem.delassus = Eigen::MatrixXd::Zero(size, size);
+    // Resize in place so a stable contact shape reuses the existing buffers
+    // (Eigen reallocates only when the requested size differs). The Delassus
+    // block is fully overwritten below, but it is zeroed in place to preserve
+    // the previous Eigen::MatrixXd::Zero(size, size) initialization exactly.
+    problem.delassus.resize(size, size);
+    problem.delassus.setZero();
     problem.rhs.resize(size);
     problem.lo.resize(size);
     problem.hi.resize(size);
     problem.findex.resize(size);
   }
   if (options.populateJacobian) {
-    problem.jacobian = Eigen::MatrixXd::Zero(
+    // The Jacobian rows are accumulated with +=, so it must be zeroed; resize
+    // in place first to keep a stable shape on the allocator-backed buffer.
+    problem.jacobian.resize(
         size, static_cast<Eigen::Index>(6 * problem.dynamicBodies.size()));
+    problem.jacobian.setZero();
   }
 
   for (std::size_t i = 0; i < n; ++i) {


### PR DESCRIPTION
## Problem
`World.BakedBoxedLcpFallbackContactStepsDoNotMallocOnHeap` (ctest `test_world_raw_malloc`) regressed: the boxed-LCP fallback contact path did **20 real heap allocations per step** (expected 0), violating the no-malloc guarantee hardened under WP-122/PLAN-091. The other no-malloc paths (RigidIpc, default, variational, velocity-actuated) were already clean.

## Root cause (located via `malloc` backtraces, not assumption)
All 20 allocations came from one site: **`assembleRigidBodyContactProblemInto`** (`dart/simulation/compute/rigid_body_constraint.cpp`), on the real BoxedLcp hot path (`UnifiedConstraintStage::execute → assembleProblemIntoScratch`). It unconditionally `resize(0,0)`'d the **persistent, already-primed** `scratch.rigidProblem` Eigen members at the top of the function, then rebuilt them with `Eigen::MatrixXd::Zero(size, size)` — freeing and reallocating the delassus/rhs/lo/hi/findex buffers every step, even though `UnifiedConstraintStage::prepare()` had primed them at `enterSimulationMode()` precisely for reuse. Larger "mixed fallback" systems → larger reallocations → the 20 mallocs.

## Fix (behavior-preserving — memory sourcing only)
- Drop the unconditional top-of-function `resize(0,…)` that freed the primed buffers.
- The no-system early-return resizes the members to 0 there (preserves the documented "no system" post-condition).
- The populate path uses in-place `resize(size, size)` + `setZero()`, so Eigen reuses the existing allocation when the contact shape is unchanged. The Delassus block is still fully overwritten and the Jacobian still zeroed before its `+=` accumulation — **identical numerics**.

## Before / after
- Before: 20 allocations → **FAIL**.
- After: **0 allocations** → `test_world_raw_malloc` passes.

## Validation
- Full Release `-L simulation` suite: **79/79 pass, 0 failed** (incl. golden/parity/regression: `test_world_default_step_golden`, `test_world_contact_parity`, `test_world_dart7_regression`) — no numerical/behavioral regression.
- Compiles clean in Debug and Release.

_Single-file change (`rigid_body_constraint.cpp`, +20/−8). Found while verifying the dartpy split (#3094); it was the lone pre-existing failure in `test-all`._