### PR TITLE
Add DART 7 User Guide and clarify DART 6 vs DART 7 on the docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,11 @@ compatibility remains on the active DART 6 LTS branch._
 - Hardened `dart::gui` debug overlays so zero-motion selection and force-drag
   gestures in `py-demos` skip degenerate primitives instead of tripping
   Filament's empty-AABB precondition.
+- Added a DART 7 **User Guide** to the documentation site — a Python-first walk
+  from "Hello, DART" through the World, rigid bodies, articulated systems,
+  contacts, solvers, and visualization — and a site-wide version notice (plus a
+  README callout) that distinguishes the in-development DART 7 docs from the
+  stable DART 6 LTS site.
 
 #### Gazebo Integration
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ foundations for users who need more than a black-box simulator. DART uses
 generalized coordinates for articulated rigid body systems and Featherstone's
 Articulated Body Algorithm for accurate, stable motion dynamics.
 
+> [!IMPORTANT]
+> **Which DART is this?** This `main` branch tracks **DART 7**, an in-progress
+> redesign that is **not yet recommended for production use**. Its documentation
+> is the [`latest`](https://dart.readthedocs.io/en/latest/) site.
+>
+> For a stable release, use **DART 6 LTS**:
+> [documentation](https://dart.readthedocs.io/en/stable/) ·
+> [`release-6.19` branch](https://github.com/dartsim/dart/tree/release-6.19).
+
 <p align="center">
   <img src="docs/assets/unitree_g1_demo.gif" width="720" alt="Unitree G1 humanoid demo" />
 </p>
@@ -71,10 +80,10 @@ for current source-checkout examples; DART 6 C++ snippets remain on the
 
 The quick-start snippets above target the current `main` branch and DART 7 API.
 Until DART 7 package artifacts are published, package managers resolve the
-latest published DART 6 artifacts instead. During the 6.17 rollout, some indexes
-may still serve 6.16.x until their packages finish publishing; use the file-free
-package smoke checks below for the installed package version, or use the source
-checkout path for the DART 7 quick starts.
+latest published DART 6 artifacts instead, and different indexes may briefly
+serve different DART 6 patch releases until their packages finish publishing.
+Use the file-free package smoke checks below for the installed package version,
+or use the source checkout path for the DART 7 quick starts.
 
 ### Python (Recommended)
 
@@ -163,8 +172,9 @@ search terms, and capture commands are in the
 
 #### Branches
 
-- `main` — Active development targeting DART 7
-- `release-6.17` — Maintenance branch for DART 6 (critical fixes only)
+- `main` — Active development targeting DART 7 (not yet production-ready)
+- `release-6.19` — Maintenance branch for DART 6 LTS (critical fixes only); see
+  the [DART 6 documentation](https://dart.readthedocs.io/en/stable/)
 
 ## Citation
 

--- a/docs/onboarding/dart7-docs-migration.md
+++ b/docs/onboarding/dart7-docs-migration.md
@@ -1,0 +1,54 @@
+# DART 7 Documentation Migration Plan
+
+The published `latest` documentation is built from `main` and is meant to
+document **DART 7**. DART 7 is an in-progress redesign, so some pages still carry
+**DART 6** content that has not been rewritten for the DART 7 API yet.
+
+This plan tracks those pages so the legacy content is **clearly marked but not
+lost**, and so nothing is forgotten when DART 7 grows the capability needed to
+port a page. It is the counterpart to the per-page notices on the site.
+
+## How this works
+
+- Every page in `latest` whose content is still DART 6 carries a **legacy
+  notice** at the top. The reusable RST notice lives in
+  [`docs/readthedocs/_includes/legacy_dart6.rst`](../readthedocs/_includes/legacy_dart6.rst)
+  (included via `.. include:: /_includes/legacy_dart6.rst`); Markdown pages use
+  an equivalent inline admonition.
+- Each notice links back to this plan, and this plan lists every notice. That
+  closed loop means the legacy content stays visible and accountable instead of
+  being deleted and forgotten.
+- **When you port a page to DART 7**: rewrite the content against the current
+  `dart.World` facade, remove the legacy notice (delete the `.. include::` line
+  or the inline admonition), and update the page's row below to `Ported`. When
+  the last row is ported, delete this file and the `_includes/legacy_dart6.rst`
+  fragment.
+
+Principle: prefer **same-or-better DART 7 coverage** over deletion. Only drop a
+page outright when the underlying capability is intentionally removed from DART 7
+(for example, the SKEL format).
+
+## Status
+
+Legend: **Legacy** = DART 6 content, notice shown · **Partial** = some DART 7,
+some legacy · **Ported** = fully DART 7, notice removed.
+
+| Page                                   | Status           | What is still DART 6                                                                                                        | DART 7 blocker                                                                                                           | Action when unblocked                                                                                                                                     |
+| -------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `shared/inverse_kinematics/index.rst`  | Legacy           | Entire modular IK framework (`InverseKinematics`, `EndEffector`, `createIK`/`getIK`/`solveAndApply`, `SimpleFrame` targets) | DART 7 facade exposes no IK framework yet                                                                                | Write a DART 7 IK user-guide page, then rewrite or redirect                                                                                               |
+| `shared/inverse_kinematics/ikfast.rst` | Legacy           | `SharedLibraryIkFast` analytic IK plugged into `InverseKinematics`                                                          | No facade IK hook for analytic solvers                                                                                   | Rewrite once DART 7 exposes analytic IK                                                                                                                   |
+| `dartpy/user_guide/examples.rst`       | Legacy           | camelCase `addSkeleton`/`getPositions`/`parseSkeleton`/`getSimFrames` hello-world                                           | None — superseded                                                                                                        | Already linked to the DART 7 {doc}`hello_dart </user_guide/getting_started/hello_dart>`; retire this page once the User Guide fully covers loading models |
+| `topics/control-theory.md`             | Partial          | PD/inverse-dynamics code uses the DART 6 Skeleton API; the math is version-neutral                                          | No facade generalized-state/actuator API (`get_positions`/`set_forces`, `ActuatorType`, mass/Coriolis/gravity accessors) | Update code blocks when the facade control API lands                                                                                                      |
+| `topics/control-gain-tuning.md`        | Partial          | DOF error/state reads (`getPositionDifferences`, etc.); math is version-neutral                                             | No facade generalized-state API                                                                                          | Update code blocks when available                                                                                                                         |
+| `topics/numerical-methods.md`          | Partial          | Custom-integrator loop and `getConstraintSolver()` sections                                                                 | No documented facade custom-integrator path; solver selection now uses `RigidBodySolver`/`ContactSolverMethod`           | Rewrite the integrator/solver-settings sections for the DART 7 facade                                                                                     |
+| `topics/simulation-stability.md`       | Partial          | Controller-gotchas and compliance-over-gains rely on DART 6 actuator/DOF-spring APIs                                        | No facade actuator/per-DOF spring-damping API                                                                            | Update those sections when available                                                                                                                      |
+| `topics/skel-file-format.md`           | Legacy (removed) | `dart::io::readSkeleton` SKEL loading                                                                                       | SKEL is intentionally removed from DART 7                                                                                | No port; keep as clearly-labeled historical reference (or relocate out of `latest`)                                                                       |
+| `overview.rst`                         | Partial          | Feature bullets for modular IK, whole-body IK, IkFast, and soft body nodes                                                  | Those subsystems are not in the DART 7 facade yet                                                                        | Remove the targeted note and update the bullets as each subsystem lands                                                                                   |
+
+## Pages reviewed and kept as-is (DART 7-current or version-neutral)
+
+`index.rst`, `gallery.rst`, `architecture.md`, `papers.md`,
+`community/*`, `topics/index.rst`, `tutorials/index.rst`,
+`dartpy/user_guide/installation.rst`, `dart/user_guide/installation.rst`,
+`dart/user_guide/api_boundaries.rst`, `dart/user_guide/migration_guide.rst`, and
+the new `user_guide/**` pages.

--- a/docs/readthedocs/README.md
+++ b/docs/readthedocs/README.md
@@ -70,4 +70,9 @@ Use `pixi run docs-clean` to remove generated documentation outputs.
   include shims under `dartpy/api/modules/`.
 - Keep developer and maintainer workflow docs under `docs/onboarding/` unless
   they are intentionally published as user-facing RTD pages.
+- This site documents DART 7. Pages that still carry **DART 6** content show a
+  legacy notice (`.. include:: /_includes/legacy_dart6.rst` for RST, or an inline
+  admonition for Markdown) and are tracked in
+  [`docs/onboarding/dart7-docs-migration.md`](../onboarding/dart7-docs-migration.md).
+  When you port a page to DART 7, remove its notice and update that plan.
 - Verify with `pixi run docs-build` for published-site changes when feasible.

--- a/docs/readthedocs/_includes/legacy_dart6.rst
+++ b/docs/readthedocs/_includes/legacy_dart6.rst
@@ -1,0 +1,11 @@
+.. admonition:: DART 6 content — DART 7 update pending
+   :class: caution
+
+   This page still documents the **DART 6** API and has not yet been rewritten
+   for DART 7. The underlying concepts carry over, but the DART 7 API differs and
+   some of this functionality is not available in the DART 7 facade yet. For
+   DART 7 material that is ready today, start with the :doc:`/user_guide/index`.
+   For the authoritative, currently-supported version of this page, use the
+   `DART 6 documentation <https://dart.readthedocs.io/en/stable/>`_. Porting is
+   tracked in the `documentation migration plan
+   <https://github.com/dartsim/dart/blob/main/docs/onboarding/dart7-docs-migration.md>`_.

--- a/docs/readthedocs/_static/css/custom.css
+++ b/docs/readthedocs/_static/css/custom.css
@@ -1,0 +1,198 @@
+/* DART documentation — site-local styling.
+ *
+ * Two concerns live here:
+ *   1. The DART 7 / DART 6 version notice banner shown on every page of the
+ *      "latest" (DART 7) build. The template lives in
+ *      ``_templates/layout.html``; this file owns its appearance.
+ *   2. The DART 7 User Guide landing-page card grid. The markup lives in
+ *      ``user_guide/index.md`` as a small block of HTML; this file owns its
+ *      look so the guide reads as a guided walkthrough rather than a bare
+ *      table of contents.
+ *
+ * Colors derive from the DART logo (warm amber + slate) so the site keeps its
+ * own identity instead of mirroring any other project's documentation theme.
+ */
+
+:root {
+  --dart-amber: #e8821e;
+  --dart-amber-soft: #fbe6d2;
+  --dart-amber-line: #f3c48a;
+  --dart-slate: #2b3440;
+  --dart-slate-soft: #5a6675;
+  --dart-ink: #1f2730;
+  --dart-card-bg: #ffffff;
+  --dart-card-border: #e4e8ee;
+}
+
+/* --------------------------------------------------------------------------
+ * Version notice banner (DART 7 vs DART 6 LTS)
+ * ------------------------------------------------------------------------ */
+
+.dart-version-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 0 0 1.5rem 0;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--dart-amber-line);
+  border-left: 4px solid var(--dart-amber);
+  border-radius: 6px;
+  background: var(--dart-amber-soft);
+  color: var(--dart-ink);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.dart-version-banner__badge {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: var(--dart-amber);
+  color: #ffffff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.dart-version-banner__text {
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+
+.dart-version-banner a {
+  color: #b5610a;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.dart-version-banner a:hover {
+  color: #8f4c06;
+}
+
+/* --------------------------------------------------------------------------
+ * User Guide landing-page card grid
+ * ------------------------------------------------------------------------ */
+
+.ug-hero {
+  margin: 0 0 1.75rem 0;
+  padding: 1.4rem 1.5rem;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--dart-slate) 0%, #3b4858 100%);
+  color: #f4f6f8;
+}
+
+.ug-hero__kicker {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dart-amber-line);
+}
+
+.ug-hero h2,
+.ug-hero p:first-of-type {
+  margin-top: 0;
+}
+
+.ug-hero p {
+  margin-bottom: 0;
+  color: #d6dce3;
+  font-size: 0.98rem;
+}
+
+.ug-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15.5rem, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 2rem 0;
+}
+
+.ug-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 1.1rem 1.15rem 1.2rem;
+  border: 1px solid #e4e8ee;
+  border-radius: 9px;
+  background: var(--dart-card-bg);
+  overflow: hidden;
+  transition: transform 0.12s ease, box-shadow 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.ug-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: var(--dart-amber);
+}
+
+.ug-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 22px rgba(43, 52, 64, 0.12);
+  border-color: var(--dart-amber-line);
+}
+
+.ug-card__step {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dart-amber);
+}
+
+.ug-card__title {
+  margin: 0.3rem 0 0.4rem 0;
+  font-size: 1.08rem;
+  font-weight: 700;
+  color: var(--dart-slate);
+}
+
+.ug-card__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.ug-card__title a:hover {
+  color: var(--dart-amber);
+}
+
+.ug-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--dart-slate-soft);
+}
+
+.ug-card__links {
+  margin-top: 0.7rem;
+  font-size: 0.86rem;
+}
+
+.ug-card__links a {
+  font-weight: 600;
+}
+
+/* Make the whole card clickable when it wraps a single primary link. */
+.ug-card--linked a.ug-card__cover {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  text-indent: -9999px;
+}
+
+@media (max-width: 480px) {
+  .ug-card-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/readthedocs/_templates/layout.html
+++ b/docs/readthedocs/_templates/layout.html
@@ -1,0 +1,24 @@
+{# Extend the Read the Docs theme to show a site-wide DART 7 / DART 6 notice.
+
+   This template only exists on ``main`` (the DART 7 line), so Read the Docs
+   renders the banner on the "latest" build but not on the ``release-6.*`` tag
+   builds that produce the DART 6 LTS documentation. That keeps the message
+   accurate per version without any runtime version sniffing.
+
+   The banner markup is intentionally small; its appearance lives in
+   ``_static/css/custom.css`` (``.dart-version-banner``). #}
+{% extends "!layout.html" %}
+
+{% block document %}
+  <div class="dart-version-banner" role="note" aria-label="DART version notice">
+    <span class="dart-version-banner__badge">DART&nbsp;7 · in development</span>
+    <span class="dart-version-banner__text">
+      You are reading the documentation for <strong>DART&nbsp;7</strong>, an
+      in-progress redesign that is <strong>not yet recommended for production
+      use</strong>. Looking for the current stable release? See the
+      <a href="https://dart.readthedocs.io/en/stable/">DART&nbsp;6 LTS
+      documentation</a>.
+    </span>
+  </div>
+  {{ super() }}
+{% endblock %}

--- a/docs/readthedocs/conf.py
+++ b/docs/readthedocs/conf.py
@@ -563,6 +563,9 @@ html_theme_options = {
 }
 html_extra_path = ["_generated"]
 
+# Site-local stylesheet: version-notice banner and User Guide card grid.
+html_css_files = ["css/custom.css"]
+
 # Setting for multi language
 source_encoding = "utf-8"
 locale_dirs = ["locales/"]

--- a/docs/readthedocs/conf.py
+++ b/docs/readthedocs/conf.py
@@ -548,6 +548,8 @@ exclude_patterns = [
     "Thumbs.db",
     ".DS_Store",
     "README.md",
+    # Reusable RST fragments pulled in via ``.. include::``; not standalone docs.
+    "_includes",
 ]
 
 

--- a/docs/readthedocs/dartpy/user_guide/examples.rst
+++ b/docs/readthedocs/dartpy/user_guide/examples.rst
@@ -1,6 +1,13 @@
 Examples
 ========
 
+.. include:: /_includes/legacy_dart6.rst
+
+.. note::
+
+   For a DART 7 "Hello, World" simulation using the current API, see
+   :doc:`/user_guide/getting_started/hello_dart`.
+
 Once you have installed dartpy using pip install -U dartpy, you can run the following "Hello World" example to simulate a 6-DOF robot using DART.
 
 .. note::

--- a/docs/readthedocs/index.rst
+++ b/docs/readthedocs/index.rst
@@ -6,6 +6,16 @@
 Welcome to DART documentation!
 ==============================
 
+.. admonition:: You are reading the DART 7 documentation
+   :class: important
+
+   This site documents **DART 7**, an in-progress redesign that is **not yet
+   recommended for production use**. If you need a stable release, use
+   **DART 6 LTS**: see the `DART 6 documentation
+   <https://dart.readthedocs.io/en/stable/>`_ and the `release-6.19 branch
+   <https://github.com/dartsim/dart/tree/release-6.19>`_. New to DART 7? Start
+   with the :doc:`user_guide/index`.
+
 Introduction
 ------------
 
@@ -139,6 +149,13 @@ If you use DART in an academic publication, please consider citing this
    Architecture <architecture>
    gallery
    papers
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: User Guide
+
+   User Guide <user_guide/index>
 
 .. toctree::
    :maxdepth: 2

--- a/docs/readthedocs/overview.rst
+++ b/docs/readthedocs/overview.rst
@@ -26,6 +26,15 @@ In summary, DART supports robotics, animation, machine-learning research, and be
 Features
 --------
 
+.. note::
+
+   Some capabilities listed below are not yet available in the DART 7 facade and
+   remain **DART 6** features — notably the modular inverse-kinematics framework,
+   analytic IkFast integration, and soft body nodes. See the `documentation
+   migration plan
+   <https://github.com/dartsim/dart/blob/main/docs/onboarding/dart7-docs-migration.md>`_
+   for porting status.
+
 General
 ~~~~~~~
 

--- a/docs/readthedocs/shared/inverse_kinematics/ikfast.rst
+++ b/docs/readthedocs/shared/inverse_kinematics/ikfast.rst
@@ -1,6 +1,8 @@
 IkFast Support and Integration
 ==============================
 
+.. include:: /_includes/legacy_dart6.rst
+
 IkFast is the analytic inverse kinematics generator that ships with
 `OpenRAVE <https://github.com/rdiankov/openrave>`_. DART exposes the generated
 solutions through :class:`dart::dynamics::SharedLibraryIkFast` so that an IKFast

--- a/docs/readthedocs/shared/inverse_kinematics/index.rst
+++ b/docs/readthedocs/shared/inverse_kinematics/index.rst
@@ -1,6 +1,8 @@
 Inverse Kinematics
 ===================
 
+.. include:: /_includes/legacy_dart6.rst
+
 DART ships with a modular inverse kinematics (IK) framework that works the same
 way across C++ and dartpy. Every end effector can own an
 :class:`dart::dynamics::InverseKinematics` instance that exposes:

--- a/docs/readthedocs/topics/control-gain-tuning.md
+++ b/docs/readthedocs/topics/control-gain-tuning.md
@@ -1,5 +1,14 @@
 # Control Gain Tuning (Discrete-Time)
 
+```{admonition} DART 6 code — DART 7 update pending
+:class: caution
+
+The concepts on this page are version-independent, but the **code examples use
+the DART 6 API** and have not yet been updated for DART 7. For DART 7 material
+that is ready today, see the {doc}`User Guide </user_guide/index>`. Porting is
+tracked in the [documentation migration plan](https://github.com/dartsim/dart/blob/main/docs/onboarding/dart7-docs-migration.md).
+```
+
 ## Why discrete time matters
 
 Most controller equations are derived in continuous time, but simulation runs

--- a/docs/readthedocs/topics/control-theory.md
+++ b/docs/readthedocs/topics/control-theory.md
@@ -1,5 +1,14 @@
 # Control Theory Primer
 
+```{admonition} DART 6 code — DART 7 update pending
+:class: caution
+
+The concepts on this page are version-independent, but the **code examples use
+the DART 6 API** and have not yet been updated for DART 7. For DART 7 material
+that is ready today, see the {doc}`User Guide </user_guide/index>`. Porting is
+tracked in the [documentation migration plan](https://github.com/dartsim/dart/blob/main/docs/onboarding/dart7-docs-migration.md).
+```
+
 ## Why this exists
 
 DART makes it easy to _simulate_ articulated rigid bodies, but it does not pick

--- a/docs/readthedocs/topics/numerical-methods.md
+++ b/docs/readthedocs/topics/numerical-methods.md
@@ -1,5 +1,14 @@
 # Numerical Methods Primer
 
+```{admonition} DART 6 code — DART 7 update pending
+:class: caution
+
+The concepts on this page are version-independent, but the **code examples use
+the DART 6 API** and have not yet been updated for DART 7. For DART 7 material
+that is ready today, see the {doc}`User Guide </user_guide/index>`. Porting is
+tracked in the [documentation migration plan](https://github.com/dartsim/dart/blob/main/docs/onboarding/dart7-docs-migration.md).
+```
+
 ## Why this exists
 
 If a simulation “explodes”, jitters, or drifts, the root cause is often

--- a/docs/readthedocs/topics/simulation-stability.md
+++ b/docs/readthedocs/topics/simulation-stability.md
@@ -1,5 +1,14 @@
 # Simulation Stability Checklist
 
+```{admonition} DART 6 code — DART 7 update pending
+:class: caution
+
+The concepts on this page are version-independent, but the **code examples use
+the DART 6 API** and have not yet been updated for DART 7. For DART 7 material
+that is ready today, see the {doc}`User Guide </user_guide/index>`. Porting is
+tracked in the [documentation migration plan](https://github.com/dartsim/dart/blob/main/docs/onboarding/dart7-docs-migration.md).
+```
+
 ## Symptoms and common causes
 
 When a simulation looks “wrong”, it is often a numerical stability problem.

--- a/docs/readthedocs/topics/skel-file-format.md
+++ b/docs/readthedocs/topics/skel-file-format.md
@@ -1,5 +1,14 @@
 # Legacy SKEL File Format
 
+```{admonition} DART 6 feature — removed in DART 7
+:class: caution
+
+SKEL is a **DART 6** format. DART 7 removes SKEL support, so the loader shown
+here is not part of the DART 7 API. Use URDF, SDFormat, or MJCF for new models,
+or a `release-6.*` branch when you need SKEL. Status is tracked in the
+[documentation migration plan](https://github.com/dartsim/dart/blob/main/docs/onboarding/dart7-docs-migration.md).
+```
+
 SKEL is DART's legacy XML format for describing worlds, skeletons, robots, and
 environments. Its structure is based on [SDFormat](http://sdformat.org/) with a
 few DART-specific extensions.

--- a/docs/readthedocs/user_guide/concepts/articulated_systems.md
+++ b/docs/readthedocs/user_guide/concepts/articulated_systems.md
@@ -1,0 +1,110 @@
+# Articulated systems
+
+A robot arm, a leg, a pendulum chain — these are **articulated systems**: rigid
+links connected by joints. In DART 7 you build one as a `Multibody`: a tree of
+**links** joined by **joints**, owned by the world.
+
+## Building a multibody
+
+Add a multibody to the world, then add links. The first link is the root; every
+later link names its `parent` and the `JointSpec` that connects it. A
+`JointSpec` describes the joint's type, axis, and where it sits relative to the
+parent:
+
+```python
+import dartpy as dart
+import numpy as np
+
+def translation(x, y, z):
+    t = np.eye(4)
+    t[:3, 3] = (x, y, z)
+    return t
+
+world = dart.World()
+robot = world.add_multibody("arm")
+
+# Root link.
+base = robot.add_link("base")
+
+# Upper arm on a revolute (hinge) shoulder, one metre out from the base.
+upper = robot.add_link(
+    "upper_arm",
+    parent=base,
+    joint=dart.JointSpec(
+        name="shoulder",
+        type=dart.JointType.REVOLUTE,
+        axis=(0.0, 1.0, 0.0),
+        transform_from_parent=translation(1.0, 0.0, 0.0),
+    ),
+)
+upper.mass = 2.0
+upper.inertia = ((0.10, 0.0, 0.0), (0.0, 0.20, 0.0), (0.0, 0.0, 0.30))
+
+# Forearm on a 2-axis universal wrist.
+fore = robot.add_link(
+    "forearm",
+    parent=upper,
+    joint=dart.JointSpec(
+        name="wrist",
+        type=dart.JointType.UNIVERSAL,
+        axis=(0.0, 0.0, 1.0),
+        axis2=(0.0, 1.0, 0.0),
+        transform_from_parent=translation(1.0, 0.0, 0.0),
+    ),
+)
+fore.mass = 1.0
+fore.inertia = ((0.05, 0.0, 0.0), (0.0, 0.05, 0.0), (0.0, 0.0, 0.05))
+
+world.enter_simulation_mode()
+```
+
+This arm has three degrees of freedom: a 1-DOF revolute shoulder plus a 2-DOF
+universal wrist. `robot.num_dofs` reports the total generalized-coordinate count
+for the tree.
+
+## Links
+
+A **link** is a rigid body inside the multibody tree. It carries inertial
+properties and acts as a frame you can query:
+
+```python
+upper.mass                      # link mass
+upper.inertia                   # 3x3 inertia tensor
+upper.translation               # world-frame position of the link
+upper.parent_joint              # the joint connecting it to its parent
+```
+
+## Joints
+
+A **joint** defines how a link can move relative to its parent. You reach a
+joint through its child link's `parent_joint`, then read or write its
+generalized state:
+
+```python
+shoulder = upper.parent_joint
+shoulder.position               # generalized position(s)
+shoulder.velocity               # generalized velocity(ies)
+shoulder.damping_coefficient    # viscous damping
+```
+
+Common joint types include `REVOLUTE` (a hinge, 1 DOF), `UNIVERSAL` (2 DOF), and
+others selected through `dart.JointType`. The `axis` (and `axis2` for two-axis
+joints) sets the direction of motion, and `transform_from_parent` places the
+joint frame relative to the parent link.
+
+## Trees and closed loops
+
+A `Multibody` is a **tree**: each link has exactly one parent joint, which keeps
+articulated dynamics fast and well-conditioned. Mechanisms with closed loops —
+four-bar linkages, parallel arms — are modeled by adding explicit **loop
+closures** on top of the tree rather than by forcing a second parent. Loop
+closure is an advanced, still-maturing area of the DART 7 API; for now, build the
+tree and consult the
+[simulation API design notes](https://github.com/dartsim/dart/blob/main/docs/design/simulation_cpp_api.md)
+for the current state of closed-chain support.
+
+## Next
+
+Bodies now move and collide. The next section explains how DART finds and
+resolves those collisions: {doc}`collisions & contacts
+<../interaction/collisions_and_contacts>`.

--- a/docs/readthedocs/user_guide/concepts/rigid_bodies.md
+++ b/docs/readthedocs/user_guide/concepts/rigid_bodies.md
@@ -1,0 +1,95 @@
+# Rigid bodies & shapes
+
+A **rigid body** is a single solid object: a falling box, a ball, a table, a
+floor. It is the simplest thing you can simulate in DART and the building block
+for everything else. This page covers how to create rigid bodies, give them
+shape, and read and write their state.
+
+## Creating a rigid body
+
+Describe the body with a `RigidBodyOptions` value object, then add it to the
+world by name. `add_rigid_body` returns a **handle** you keep to interact with
+the body later:
+
+```python
+import dartpy as dart
+import numpy as np
+
+opts = dart.RigidBodyOptions()
+opts.mass = 2.0
+opts.position = np.array([0.0, 0.0, 1.5])           # initial world position
+opts.linear_velocity = np.array([1.0, 0.0, 0.0])    # initial linear velocity
+opts.angular_velocity = np.array([0.0, 2.0, 0.0])   # initial spin
+
+box = world.add_rigid_body("falling_box", opts)
+```
+
+Names are unique within a world, so `"falling_box"` both identifies the body and
+lets you look it up later.
+
+### Static bodies
+
+A body marked **static** has effectively infinite mass and never moves. Ground
+planes, walls, and fixtures are static:
+
+```python
+ground_opts = dart.RigidBodyOptions()
+ground_opts.is_static = True
+ground_opts.position = np.array([0.0, 0.0, 0.0])
+ground = world.add_rigid_body("ground", ground_opts)
+```
+
+## Giving a body a collision shape
+
+A body with no shape has mass and motion but cannot touch anything. Attach a
+**collision shape** so it participates in contact. The shape factories take
+their natural parameters — boxes take **half extents**, spheres take a radius:
+
+```python
+ground.set_collision_shape(dart.CollisionShape.box(np.array([2.0, 2.0, 0.05])))
+box.set_collision_shape(dart.CollisionShape.sphere(0.2))
+```
+
+Half extents mean the ground box above spans 4 m × 4 m × 0.1 m. Collision shapes
+are what {doc}`collision detection <../interaction/collisions_and_contacts>`
+tests against.
+
+## Reading and writing state
+
+After each `world.step()`, a body's state is fresh. The handle exposes its pose
+and motion in the world frame:
+
+```python
+box.transform          # 4x4 homogeneous transform
+box.translation        # xyz position
+box.linear_velocity    # world-frame linear velocity
+box.angular_velocity   # world-frame angular velocity
+box.kinetic_energy     # scalar kinetic energy
+```
+
+You can also set these directly — for example, to reset a body to a known state
+before a new rollout:
+
+```python
+box.linear_velocity = np.array([0.0, 0.0, 0.0])
+box.angular_velocity = np.array([0.0, 0.0, 0.0])
+```
+
+## Surface material
+
+Friction and restitution (bounciness) control how a body behaves on contact.
+Tune them per body to get sliding, sticking, or bouncing:
+
+```python
+box.friction = 0.85       # higher = grippier
+box.restitution = 0.2     # higher = bouncier (0 = no bounce)
+```
+
+A low-friction, low-restitution body slides and settles; a high-restitution body
+rebounds. These pair with the contact solver described in
+{doc}`../interaction/solvers`.
+
+## Next
+
+One body is a start. Connect several with joints and you have a robot — see
+{doc}`articulated systems <articulated_systems>`.

--- a/docs/readthedocs/user_guide/concepts/world.md
+++ b/docs/readthedocs/user_guide/concepts/world.md
@@ -1,0 +1,96 @@
+# The World
+
+`dart.World` is the heart of DART 7. A single `World` object owns your scene's
+topology (bodies, multibodies, and the connections between them), the simulation
+clock, gravity, and the step pipeline that advances physics. Almost everything
+you do in DART starts from a world.
+
+## Creating a world
+
+You can create a world with defaults and configure it later, or pass options up
+front:
+
+```python
+import dartpy as dart
+
+# Defaults
+world = dart.World()
+
+# Configured at construction
+world = dart.World(
+    time_step=1.0 / 1000.0,
+    rigid_body_solver=dart.RigidBodySolver.SEQUENTIAL_IMPULSE,
+    contact_solver_method=dart.ContactSolverMethod.SEQUENTIAL_IMPULSE,
+)
+```
+
+Solver choices are covered in {doc}`../interaction/solvers`.
+
+## Two modes: design, then simulate
+
+A DART world has two phases, and keeping them separate is what makes stepping
+fast and predictable:
+
+- **Design mode** (the default after construction) is where you _build_ the
+  scene: add rigid bodies, add multibodies, attach shapes, and set initial
+  state.
+- **Simulation mode** is where you _run_ it. Calling `enter_simulation_mode()`
+  finalizes the topology so DART can allocate runtime state once, up front.
+
+```python
+# --- design mode: build the scene ---
+ground = world.add_rigid_body("ground", ground_opts)
+robot = world.add_multibody("arm")
+# ...
+
+# --- switch to simulation mode, then step ---
+world.enter_simulation_mode()
+world.step()
+```
+
+`world.step()` will enter simulation mode for you on the first call, so the
+explicit call is mainly there when you want deterministic allocation or to catch
+topology errors at a known point. After finalization, restructuring the scene
+requires an explicit reset or rebuild rather than ad-hoc edits — this is what
+lets the per-step path stay allocation-free.
+
+## What a step does
+
+`world.step()` runs a **content-aware pipeline**: it executes only the stages
+your scene needs. A scene of free rigid bodies runs rigid-body integration and
+contact resolution; add an articulated robot and the multibody dynamics stage
+joins in; the pipeline finishes with a kinematics refresh so every transform you
+read afterwards is current. You select _capabilities and policies_ (which solver,
+which contact method) rather than wiring stages together by hand.
+
+## Kinematics without dynamics
+
+Sometimes you only need to update where things are — for motion planning,
+collision queries, playback, or visualization — without integrating forces. Set
+the poses you care about and refresh the frames:
+
+```python
+world.enter_simulation_mode()
+# ... set joint or body positions ...
+world.update_kinematics()     # refresh transforms; no force integration
+```
+
+This reuses the _same_ world, bodies, and frames as full physics, so you never
+have to maintain a separate "kinematics-only" copy of your scene.
+
+## Inspecting the world
+
+A world exposes simple lookups and counters for the objects it owns, plus the
+clock you read in the loop:
+
+```python
+world.time            # current simulated time (seconds)
+world.time_step       # integration interval
+world.collide()       # run collision detection now; returns the contacts
+```
+
+## Next
+
+With the world understood, the next two pages cover the things you put inside it:
+{doc}`rigid bodies <rigid_bodies>` and {doc}`articulated systems
+<articulated_systems>`.

--- a/docs/readthedocs/user_guide/getting_started/hello_dart.md
+++ b/docs/readthedocs/user_guide/getting_started/hello_dart.md
@@ -14,10 +14,12 @@ import numpy as np
 world = dart.World(time_step=1.0 / 1000.0)
 world.gravity = np.array([0.0, 0.0, -9.81])
 
-# 2. Add a static ground plate. CollisionShape.box takes *half* extents,
-#    so this is a 4 m x 4 m x 0.1 m slab centered at the origin.
+# 2. Add a static ground plate. CollisionShape.box takes *half* extents, so this
+#    is a 4 m x 4 m x 0.1 m slab; placing its center at z = -0.05 puts the top
+#    surface at z = 0.
 ground_opts = dart.RigidBodyOptions()
 ground_opts.is_static = True
+ground_opts.position = np.array([0.0, 0.0, -0.05])
 ground = world.add_rigid_body("ground", ground_opts)
 ground.set_collision_shape(dart.CollisionShape.box(np.array([2.0, 2.0, 0.05])))
 

--- a/docs/readthedocs/user_guide/getting_started/hello_dart.md
+++ b/docs/readthedocs/user_guide/getting_started/hello_dart.md
@@ -1,0 +1,86 @@
+# Hello, DART
+
+Let's write the smallest useful DART program: drop a box onto the ground and
+watch it fall. Every DART simulation follows the same three beats — **build a
+world, lock it, step it** — and this example shows all three.
+
+## The full program
+
+```python
+import dartpy as dart
+import numpy as np
+
+# 1. Create a world. The time step is the physics integration interval.
+world = dart.World(time_step=1.0 / 1000.0)
+world.gravity = np.array([0.0, 0.0, -9.81])
+
+# 2. Add a static ground plate. CollisionShape.box takes *half* extents,
+#    so this is a 4 m x 4 m x 0.1 m slab centered at the origin.
+ground_opts = dart.RigidBodyOptions()
+ground_opts.is_static = True
+ground = world.add_rigid_body("ground", ground_opts)
+ground.set_collision_shape(dart.CollisionShape.box(np.array([2.0, 2.0, 0.05])))
+
+# 3. Add a 1 kg box one metre above the ground.
+box_opts = dart.RigidBodyOptions()
+box_opts.mass = 1.0
+box_opts.position = np.array([0.0, 0.0, 1.0])
+box = world.add_rigid_body("box", box_opts)
+box.set_collision_shape(dart.CollisionShape.box(np.array([0.1, 0.1, 0.1])))
+
+# 4. Lock the topology, then advance the simulation.
+world.enter_simulation_mode()
+for step in range(1000):
+    world.step()
+    if step % 100 == 0:
+        height = float(box.translation[2])
+        print(f"t = {world.time:5.3f} s   box height = {height:6.4f} m")
+```
+
+Running it prints the box falling and settling on the ground:
+
+```text
+t = 0.000 s   box height = 1.0000 m
+t = 0.100 s   box height = 0.9519 m
+t = 0.200 s   box height = 0.8076 m
+t = 0.300 s   box height = 0.5670 m
+t = 0.400 s   box height = 0.2303 m
+t = 0.500 s   box height = 0.1000 m
+...
+```
+
+(The exact numbers depend on your DART version and solver settings; the shape of
+the motion — accelerate, then rest on the ground — is what matters.)
+
+## What each step does
+
+1. **Build a world.** {doc}`dart.World <../concepts/world>` is the single object
+   that owns everything: bodies, time, gravity, and the step pipeline. The
+   `time_step` is how much simulated time each `step()` advances.
+
+2. **Add bodies.** A `RigidBodyOptions` value object carries the initial state
+   (mass, pose, velocity, whether the body is static). `add_rigid_body` returns
+   a handle you keep to read or change the body later. A _static_ body never
+   moves — perfect for ground and walls. Giving a body a **collision shape**
+   lets it take part in contact.
+
+3. **Lock the topology.** `enter_simulation_mode()` finalizes the scene so DART
+   can allocate runtime state. After this point you step rather than restructure;
+   see {doc}`../concepts/world` for the design-mode / simulation-mode split.
+
+4. **Step.** Each `world.step()` integrates the physics forward by one
+   `time_step` and refreshes every body's state. Reading `box.translation`
+   afterwards returns the fresh world-frame position.
+
+## Things to try
+
+- Change `box_opts.position` to start the box off-center and watch it topple as
+  it lands.
+- Give the box an initial spin with `box_opts.angular_velocity =
+np.array([0.0, 4.0, 0.0])`.
+- Add a second box with a different name and mass, then print both heights.
+
+## Next
+
+You have a running simulation. Next, look more closely at the loop that drives
+it in {doc}`simulation_loop`.

--- a/docs/readthedocs/user_guide/getting_started/installation.md
+++ b/docs/readthedocs/user_guide/getting_started/installation.md
@@ -1,0 +1,76 @@
+# Install DART
+
+DART 7 is **Python-first**: the quickest way to start is the `dartpy` package.
+Building from source gives you the newest DART 7 surface and the interactive
+viewer.
+
+```{admonition} Pre-release packages
+:class: note
+
+DART 7 artifacts are published as pre-releases while the API stabilizes. Until a
+final DART 7 release is tagged, package managers may still resolve the latest
+DART 6 artifacts unless you opt into the pre-release. When in doubt, build from
+source for the examples in this guide.
+```
+
+## Python package
+
+Use your preferred package manager to add `dartpy` to an environment:
+
+```bash
+uv add dartpy                 # uv (recommended for Python-first projects)
+pip install dartpy --pre      # PyPI wheels; --pre opts into DART 7 pre-releases
+pixi add dartpy               # Pixi environment
+conda install -c conda-forge dartpy
+```
+
+Verify the install by creating a tiny world in code — this does not need any
+sample data files:
+
+```python
+import dartpy as dart
+
+world = dart.World()
+world.add_rigid_body("box", dart.RigidBodyOptions())
+world.enter_simulation_mode()
+world.step()
+print(f"Stepped one frame to t = {world.time:.4f} s")
+```
+
+If that prints without error, you are ready for {doc}`hello_dart`.
+
+## Build from source
+
+A source checkout tracks the `main` branch and gives you the full DART 7 API
+plus the interactive demos. DART uses [pixi](https://pixi.sh) to provide a
+reproducible toolchain:
+
+```bash
+git clone https://github.com/dartsim/dart.git
+cd dart
+pixi install            # fetch the toolchain and dependencies
+pixi run build          # build C++ and the dartpy bindings
+```
+
+Run a headless smoke check to confirm the build works:
+
+```bash
+pixi run py-demos -- --scene rigid_body --headless --frames 1
+```
+
+To use your source build from a plain Python interpreter, point `PYTHONPATH` at
+the built bindings (the exact path is printed at the end of `pixi run build`),
+for example:
+
+```bash
+PYTHONPATH=build/default/cpp/Release/python python your_script.py
+```
+
+For more detail on supported platforms and wheels, see the
+{doc}`Python installation reference </dartpy/user_guide/installation>`. For
+build troubleshooting, see the developer
+[building guide](https://github.com/dartsim/dart/blob/main/docs/onboarding/building.md).
+
+## Next
+
+You have DART installed — now run your first simulation in {doc}`hello_dart`.

--- a/docs/readthedocs/user_guide/getting_started/installation.md
+++ b/docs/readthedocs/user_guide/getting_started/installation.md
@@ -1,28 +1,31 @@
 # Install DART
 
-DART 7 is **Python-first**: the quickest way to start is the `dartpy` package.
-Building from source gives you the newest DART 7 surface and the interactive
-viewer.
+DART 7 is **Python-first**, but because it is still in development its `dartpy`
+packages are pre-releases. The two reliable ways to get the DART 7 API used
+throughout this guide are PyPI pre-release wheels and a source build.
 
-```{admonition} Pre-release packages
-:class: note
+```{admonition} Default channels still install DART 6
+:class: important
 
-DART 7 artifacts are published as pre-releases while the API stabilizes. Until a
-final DART 7 release is tagged, package managers may still resolve the latest
-DART 6 artifacts unless you opt into the pre-release. When in doubt, build from
-source for the examples in this guide.
+Plain `uv add dartpy`, `pixi add dartpy`, and `conda install dartpy` resolve the
+**stable DART 6** line, which uses a different API — `dart.World()` and
+`add_rigid_body` from this guide do not exist there. Install DART 7 explicitly
+with one of the options below, or build from source.
 ```
 
-## Python package
+## Python package (pre-release)
 
-Use your preferred package manager to add `dartpy` to an environment:
+DART 7 wheels are published as pre-releases on PyPI (currently Linux x86_64 /
+CPython 3.14). Opt into pre-releases so you get DART 7 rather than DART 6:
 
 ```bash
-uv add dartpy                 # uv (recommended for Python-first projects)
-pip install dartpy --pre      # PyPI wheels; --pre opts into DART 7 pre-releases
-pixi add dartpy               # Pixi environment
-conda install -c conda-forge dartpy
+pip install --pre dartpy           # pip (PyPI)
+uv add dartpy --prerelease allow    # uv (PyPI)
 ```
+
+The default `pixi add dartpy` and `conda install -c conda-forge dartpy` channels
+currently track the stable **DART 6** line; use them for DART 6, or build from
+source (below) for the DART 7 examples in this guide.
 
 Verify the install by creating a tiny world in code — this does not need any
 sample data files:

--- a/docs/readthedocs/user_guide/getting_started/simulation_loop.md
+++ b/docs/readthedocs/user_guide/getting_started/simulation_loop.md
@@ -1,0 +1,78 @@
+# The simulation loop
+
+Every DART program is a loop around `world.step()`. This page explains what a
+step is, how time and gravity work, and how to read results back out.
+
+## Time steps
+
+A `World` advances in fixed increments called the **time step**. Set it when you
+create the world, or change it later through the `time_step` property:
+
+```python
+import dartpy as dart
+
+world = dart.World(time_step=1.0 / 1000.0)   # 1 ms per step
+print(world.time_step)                       # -> 0.001
+```
+
+Each call to `world.step()` advances simulated time by exactly one time step and
+updates `world.time`:
+
+```python
+world.enter_simulation_mode()
+for _ in range(500):
+    world.step()
+print(f"simulated {world.time:.3f} seconds")   # -> 0.500 seconds
+```
+
+Smaller time steps are more accurate and more stable but cost more per second of
+simulated time. A common starting point is `1/1000` s for contact-rich scenes
+and `1/240`–`1/120` s for lighter ones. To advance a fixed amount of wall-clock
+behavior, choose the time step first, then loop the right number of steps.
+
+## Gravity
+
+Gravity is a world-level vector in metres per second squared. DART pulls along
+**−Z** by default; set it explicitly when you want a different magnitude or
+direction:
+
+```python
+import numpy as np
+
+world.gravity = np.array([0.0, 0.0, -9.81])   # Earth, −Z is "down"
+world.gravity = np.array([0.0, 0.0, -1.62])   # the Moon
+world.gravity = np.array([0.0, 0.0, 0.0])     # free space
+```
+
+## Reading state during the loop
+
+After each step, body and joint state is fresh, so you can read it directly.
+Handles returned by `add_rigid_body` expose the body's current pose and motion:
+
+```python
+world.enter_simulation_mode()
+for step in range(1000):
+    world.step()
+    position = np.asarray(box.translation)        # world-frame xyz
+    velocity = np.asarray(box.linear_velocity)    # world-frame linear velocity
+    if step % 100 == 0:
+        speed = float(np.linalg.norm(velocity))
+        print(f"t={world.time:5.3f}  z={position[2]:.3f}  speed={speed:.3f}")
+```
+
+This is also where a controller belongs: read state at the top of the loop,
+compute a command, apply it, then step. Keeping _read → decide → act → step_ in
+that order makes the loop deterministic and easy to test.
+
+## A note on determinism
+
+`world.step()` is **synchronous and deterministic**: when it returns, the step
+is complete and every output it produced is fresh. The same world, built the
+same way and stepped the same number of times, produces the same result. That
+predictability is deliberate — it keeps simulations reproducible for research,
+testing, and controller development.
+
+## Next
+
+You now know the loop. The next section looks at the central object it revolves
+around: {doc}`the World <../concepts/world>`.

--- a/docs/readthedocs/user_guide/index.md
+++ b/docs/readthedocs/user_guide/index.md
@@ -1,0 +1,123 @@
+# User Guide
+
+```{raw} html
+<div class="ug-hero">
+  <span class="ug-hero__kicker">DART 7 · Python-first</span>
+  <h2 style="color:#ffffff;border:0;margin-top:0;">Build a simulation, step by step</h2>
+  <p>
+    This guide takes you from a one-file "hello, DART" simulation to building
+    articulated robots, tuning contact, and visualizing results. Pages are
+    ordered to be read start to finish, but each stands on its own once you know
+    the basics.
+  </p>
+</div>
+```
+
+DART 7 is the in-progress redesign of the Dynamic Animation and Robotics
+Toolkit. It keeps DART's transparent, research-grade dynamics while exposing a
+smaller, Python-first API built around a single `World` object. This guide uses
+that API throughout.
+
+```{admonition} DART 7 is under active development
+:class: warning
+
+The DART 7 API shown here is still evolving and is **not yet recommended for
+production**. Names and behavior can change between releases. For production
+work, use [DART 6 LTS](https://dart.readthedocs.io/en/stable/). If something in
+this guide does not match your build, please
+[open an issue](https://github.com/dartsim/dart/issues).
+```
+
+## Where to start
+
+```{raw} html
+<div class="ug-card-grid">
+  <div class="ug-card">
+    <span class="ug-card__step">Start here</span>
+    <div class="ug-card__title"><a href="getting_started/installation.html">Install DART</a></div>
+    <p>Add <code>dartpy</code> to a Python environment, or build from source for the newest DART 7 surface.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">First steps</span>
+    <div class="ug-card__title"><a href="getting_started/hello_dart.html">Hello, DART</a></div>
+    <p>Drop a box onto the ground in a dozen lines and read back its motion.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">First steps</span>
+    <div class="ug-card__title"><a href="getting_started/simulation_loop.html">The simulation loop</a></div>
+    <p>Time steps, gravity, and what actually happens on each <code>world.step()</code>.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">Core concepts</span>
+    <div class="ug-card__title"><a href="concepts/world.html">The World</a></div>
+    <p>The single entry point that owns bodies, time, and the step pipeline.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">Core concepts</span>
+    <div class="ug-card__title"><a href="concepts/rigid_bodies.html">Rigid bodies &amp; shapes</a></div>
+    <p>Mass, pose, collision shapes, and surface material for single bodies.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">Core concepts</span>
+    <div class="ug-card__title"><a href="concepts/articulated_systems.html">Articulated systems</a></div>
+    <p>Build multibodies from links and joints — the heart of robot modeling.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">Going further</span>
+    <div class="ug-card__title"><a href="interaction/collisions_and_contacts.html">Collisions &amp; contacts</a></div>
+    <p>How DART finds contacts and resolves them so bodies don't interpenetrate.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">Going further</span>
+    <div class="ug-card__title"><a href="interaction/solvers.html">Choosing solvers</a></div>
+    <p>Pick the integration and contact methods that fit your accuracy and speed needs.</p>
+  </div>
+  <div class="ug-card">
+    <span class="ug-card__step">Going further</span>
+    <div class="ug-card__title"><a href="visualization.html">Visualization</a></div>
+    <p>See your scene in the interactive viewer and capture frames headlessly.</p>
+  </div>
+</div>
+```
+
+## How this guide is organized
+
+- **Getting started** — installation, your first simulation, and the loop that
+  drives every DART program.
+- **Core concepts** — the `World`, rigid bodies, and articulated systems you
+  compose into a scene.
+- **Going further** — collisions and contacts, solver choices, and
+  visualization.
+- **{doc}`Next steps <next_steps>`** — deeper topics, runnable examples, and API
+  references.
+
+```{toctree}
+:hidden:
+:caption: Getting started
+:maxdepth: 1
+
+getting_started/installation
+getting_started/hello_dart
+getting_started/simulation_loop
+```
+
+```{toctree}
+:hidden:
+:caption: Core concepts
+:maxdepth: 1
+
+concepts/world
+concepts/rigid_bodies
+concepts/articulated_systems
+```
+
+```{toctree}
+:hidden:
+:caption: Going further
+:maxdepth: 1
+
+interaction/collisions_and_contacts
+interaction/solvers
+visualization
+next_steps
+```

--- a/docs/readthedocs/user_guide/interaction/collisions_and_contacts.md
+++ b/docs/readthedocs/user_guide/interaction/collisions_and_contacts.md
@@ -1,0 +1,71 @@
+# Collisions & contacts
+
+When two shapes overlap, DART generates **contacts** and the contact solver
+resolves them so bodies push apart instead of passing through each other. This
+page explains how collision works and how to query it.
+
+## Shapes make contact possible
+
+Only bodies with a **collision shape** take part in contact. A body with mass but
+no shape still moves under gravity and forces, but nothing can touch it. Attach a
+shape when you want a body to collide:
+
+```python
+import dartpy as dart
+import numpy as np
+
+ground.set_collision_shape(dart.CollisionShape.box(np.array([2.0, 2.0, 0.05])))
+ball.set_collision_shape(dart.CollisionShape.sphere(0.15))
+```
+
+Box shapes take **half extents**; spheres take a radius. Keep collision shapes as
+simple as your scene allows — primitive shapes are faster and more robust than
+dense meshes.
+
+## How contact is resolved during a step
+
+On each `world.step()`, DART:
+
+1. **Detects** overlapping shape pairs (collision detection).
+2. **Generates** contact points with positions and normals.
+3. **Solves** for contact impulses that prevent interpenetration and apply
+   friction, then integrates the result.
+
+Because the whole sequence happens inside `step()`, you normally don't manage it
+by hand — you set up shapes and materials, and the world does the rest.
+
+## Querying contacts yourself
+
+You can run collision detection on demand — useful for diagnostics, sensors, or
+motion-planning checks — with `world.collide()`, which returns the current
+contacts:
+
+```python
+contacts = world.collide()
+print(f"{len(contacts)} contact(s) this frame")
+```
+
+This is a **query**: it reports contacts without integrating impulses or
+advancing time, so it pairs naturally with the kinematics-only workflow from
+{doc}`../concepts/world`.
+
+## Friction and restitution
+
+Each body's surface material shapes the contact response. **Friction** resists
+sliding; **restitution** controls bounce. They are properties of the bodies in
+contact:
+
+```python
+ball.friction = 0.4
+ball.restitution = 0.6     # a lively bounce
+ground.friction = 0.9
+```
+
+DART combines the materials of the two bodies in a contact to decide the net
+behavior, so a bouncy ball on a grippy floor still bounces but does not slide
+away.
+
+## Next
+
+Contact behavior also depends on _which solver_ runs it. Pick the right one in
+{doc}`choosing solvers <solvers>`.

--- a/docs/readthedocs/user_guide/interaction/solvers.md
+++ b/docs/readthedocs/user_guide/interaction/solvers.md
@@ -1,0 +1,80 @@
+# Choosing solvers
+
+DART solves two related problems each step: how to **integrate** body motion and
+how to **resolve contact**. DART 7 lets you choose the method for each so you can
+trade accuracy against speed for your scene. You select methods by _capability_,
+not by naming an internal backend.
+
+## Setting solver methods
+
+Choose methods when you create the world:
+
+```python
+import dartpy as dart
+
+world = dart.World(
+    time_step=1.0 / 1000.0,
+    rigid_body_solver=dart.RigidBodySolver.SEQUENTIAL_IMPULSE,
+    contact_solver_method=dart.ContactSolverMethod.SEQUENTIAL_IMPULSE,
+)
+```
+
+The same choices are available as world properties, so you can switch between
+runs:
+
+```python
+world.rigid_body_solver = dart.RigidBodySolver.SEQUENTIAL_IMPULSE
+world.contact_solver_method = dart.ContactSolverMethod.BOXED_LCP
+```
+
+## Contact solver methods
+
+Two contact methods are useful to know:
+
+- **Sequential impulse** (`ContactSolverMethod.SEQUENTIAL_IMPULSE`) iterates over
+  contacts applying impulses. It is fast and robust for real-time, contact-rich
+  scenes — a good default.
+- **Boxed LCP** (`ContactSolverMethod.BOXED_LCP`) formulates contact as a linear
+  complementarity problem. It is the more traditional DART formulation and a
+  useful reference when comparing results.
+
+If you are unsure, start with sequential impulse and switch to boxed LCP when you
+want to cross-check behavior.
+
+## Thinking in capabilities
+
+DART describes solvers by what they _do_ rather than by an engine name. When you
+reach for more advanced behavior, you are really choosing along axes like these:
+
+| Capability         | Example choices                                         |
+| ------------------ | ------------------------------------------------------- |
+| Integration family | semi-implicit Euler, implicit Euler, variational        |
+| Constraint solve   | projected Gauss-Seidel / sequential impulse, direct LCP |
+| Coordinates        | generalized (articulated), maximal (free rigid bodies)  |
+| Supported features | contacts, joints, friction, closed chains               |
+
+This vocabulary is stable even as implementations improve underneath, which means
+the method you request keeps working while DART gets faster.
+
+```{admonition} A developing area
+:class: note
+
+The exact set of solver and contact methods is still expanding in DART 7. The
+[`rigid_solver_compare` and `rigid_contact_solver_compare` demos](https://github.com/dartsim/dart/tree/main/python/examples/demos)
+are the best way to *see* the differences between methods side by side. Treat the
+enum values above as the current, stable starting set rather than the final list.
+```
+
+## See the differences
+
+Run the comparison demos from a source checkout to watch methods diverge on the
+same scene:
+
+```bash
+pixi run py-demos -- --scene rigid_solver_compare
+pixi run py-demos -- --scene rigid_contact_solver_compare
+```
+
+## Next
+
+To watch any of this happen, open the {doc}`viewer <../visualization>`.

--- a/docs/readthedocs/user_guide/next_steps.md
+++ b/docs/readthedocs/user_guide/next_steps.md
@@ -1,0 +1,54 @@
+# Next steps
+
+You can now build a world, populate it with rigid bodies and articulated
+systems, resolve contact, choose solvers, and visualize the result. Here is where
+to go to deepen each thread.
+
+## Go deeper on the concepts
+
+- **{doc}`Key Topics </topics/index>`** — concept overviews and deep dives,
+  including control theory, numerical methods, simulation stability, and inverse
+  kinematics.
+- **{doc}`Architecture </architecture>`** — how DART 7 supports multiple physics
+  domains, solver methods, and compute backends in one step pipeline.
+
+## Learn from runnable examples
+
+The demo scenes are working DART 7 programs you can read, run, and modify:
+
+- [Demo scene sources](https://github.com/dartsim/dart/tree/main/python/examples/demos/scenes)
+  — rigid bodies, articulated arms, solver comparisons, and more.
+- [Python examples](https://github.com/dartsim/dart/tree/main/python/examples)
+  — the broader example tree.
+
+Run any scene with `pixi run py-demos -- --scene <id>` (use `--list` to see them
+all).
+
+## Reference
+
+- **{doc}`Python API reference </dartpy/python_api_reference>`** — the full
+  `dartpy` surface.
+- **{doc}`C++ API reference </dart/cpp_api_reference>`** — for C++ users; note the
+  DART 7 C++ facade is still being finalized.
+- **[Simulation API design notes](https://github.com/dartsim/dart/blob/main/docs/design/simulation_cpp_api.md)**
+  — the rationale and current state of the DART 7 `World` API, including areas
+  (like closed-chain loop closures) that are still maturing.
+
+## Get help and follow along
+
+- **Questions and discussion:**
+  [GitHub Discussions](https://github.com/dartsim/dart/discussions).
+- **Bugs and documentation fixes:**
+  [GitHub Issues](https://github.com/dartsim/dart/issues) — DART 7 is under active
+  development, so reports of anything that does not match these pages are
+  especially welcome.
+- **Stable release:** if you need production-ready DART today, use
+  [DART 6 LTS](https://dart.readthedocs.io/en/stable/).
+
+```{admonition} Help shape the guide
+:class: tip
+
+This user guide grows alongside DART 7. If a topic you need is missing — sensors,
+deformable bodies, differentiable simulation, batched worlds — open an issue so
+it can be prioritized.
+```

--- a/docs/readthedocs/user_guide/visualization.md
+++ b/docs/readthedocs/user_guide/visualization.md
@@ -1,0 +1,60 @@
+# Visualization
+
+Numbers in a loop are great for tests; for everything else you want to _see_ the
+simulation. DART 7 ships an interactive viewer and a curated set of demo scenes,
+and it can render frames headlessly for screenshots and CI.
+
+## Run the interactive demos
+
+From a source checkout, the demo runner opens scenes in the viewer:
+
+```bash
+pixi run py-demos                                   # open the default scene
+pixi run py-demos -- --scene rigid_body             # pick a scene by id
+pixi run py-demos -- --list                         # list every scene
+```
+
+Each scene builds a real `World`, steps it live, and draws the result, with
+on-screen panels for tweaking parameters. Browsing the
+[scene sources](https://github.com/dartsim/dart/tree/main/python/examples/demos/scenes)
+is one of the fastest ways to learn idiomatic DART 7 — they use exactly the API
+this guide describes.
+
+## Render headlessly
+
+For screenshots, documentation, or automated checks, render without opening a
+window:
+
+```bash
+# One headless frame — a quick smoke check.
+pixi run py-demos -- --scene rigid_body --headless --frames 1
+
+# Capture a PNG (the helper rejects blank frames and prints the artifact path).
+pixi run py-demo-capture -- --scene rigid_body --frames 2 --width 640 --height 360
+```
+
+Headless rendering uses the same render path as the interactive viewer, so a
+capture is faithful evidence of what the scene looks like.
+
+## The standalone viewer
+
+DART also provides a standalone viewer application for source builds:
+
+```bash
+pixi run dartsim
+```
+
+## How visuals relate to physics
+
+DART keeps **physics** and **visuals** as separate concerns: the world owns the
+dynamics, and the viewer reads each body's world transform to draw it. That
+separation is why a headless physics-only script (like {doc}`Hello, DART
+<getting_started/hello_dart>`) needs no graphics at all, while the same world can
+be handed to the viewer when you want to watch it. You can always inspect a body
+visually and verify it numerically with `body.translation` — the two agree
+because they read the same state.
+
+## Next
+
+Ready to go deeper? See {doc}`next_steps` for advanced topics, runnable examples,
+and the API reference.


### PR DESCRIPTION
## Summary

- Make the `latest` documentation coherently document **DART 7**: clearly
  distinguish it from the stable **DART 6 LTS** release, add a guided,
  Python-first **User Guide**, and mark (rather than delete) the pages that still
  carry DART 6 content so nothing misleads readers and nothing is lost.

## Motivation / Problem

The `latest` docs (built from `main`) describe DART 7, which is still under
active development, but the site gave readers no cue to use DART 6 LTS for
production and offered no guided path into the new DART 7 API. Several pages also
still presented **DART 6** APIs (inverse kinematics, IkFast, the camelCase dartpy
example, the control/numerics primers' code, the SKEL format) under the DART 7
site with no signal that they predate DART 7.

## Changes / Key Changes

**DART 6 vs DART 7 distinction**

- Site-wide version banner on every `latest` page (`_templates/layout.html`);
  template lives only on `main`, so it shows on DART 7 builds, not DART 6 tags.
- In-content landing-page note (survives PDF/epub where the banner cannot reach).
- README "Which DART is this?" callout; fixed stale `release-6.17` → `release-6.19`.

**DART 7 User Guide** (`docs/readthedocs/user_guide/`)

- New "User Guide" nav section with a card-grid landing page and grouped sidebar,
  walking from *Hello, DART* through World → rigid bodies → articulated systems →
  collisions & contacts → solvers → visualization → next steps.
- Examples use the real DART 7 snake_case API, grounded in the `py-demos` scenes.

**Mark legacy DART 6 content (don't delete it)**

- Reusable legacy notice (`_includes/legacy_dart6.rst`) applied to the
  fully-DART-6 pages (inverse kinematics, IkFast, the dartpy example); tailored
  inline admonitions for the Markdown concept primers (concepts valid, code is
  DART 6) and the removed SKEL format; a targeted note on `overview.rst` for the
  IK/soft-body feature bullets only.
- `docs/onboarding/dart7-docs-migration.md` tracks each legacy page, its DART 7
  blocker, and the action to port it. Every notice links to it, so legacy content
  stays visible and is removed only when genuinely ported.

## Testing

- `pixi run docs-build` — build succeeded; all User Guide pages and legacy
  notices render; no warnings related to these changes.
- `pixi run lint` — No problems found.
- User Guide API symbols verified against `python/stubs/dartpy/*.pyi` and the
  `py-demos` scenes; legacy/version classification of every `latest` page checked
  against the actual DART 7 facade surface.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None
