### PR TITLE
Ignore .omo agent draft directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ compile_flags.txt
 
 # AI tool local state
 .omc/
+.omo/
 .omx/
 .sisyphus/
 


### PR DESCRIPTION
## Summary

Add `.omo/` to `.gitignore` so local AI-agent draft/plan/notepad artifacts are not accidentally committed.

## Motivation / Problem

`.gitignore` already ignores other AI tool local-state directories (`.omc/`, `.omx/`, `.sisyphus/`, plus the allowlisted `.claude/`/`.codex/`/`.opencode/` trees) but not `.omo/`. Agent sessions write drafts/plans/notepads under `.omo/`, which currently show up as untracked.

## Changes / Key Changes

- Add `.omo/` to the "AI tool local state" block in `.gitignore`.

## Testing

- `git check-ignore -v .omo` confirms the directory is now ignored; no tracked files are affected (`git ls-files .omo` is empty).

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None