### PR TITLE
Accelerate settled imported worlds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@
     groups that share non-reactive bodies or skeletons across islands:
     [#3111](https://github.com/dartsim/dart/pull/3111)
 
+  * Accelerate large imported worlds that begin with zero-velocity bodies on
+    shallow support contacts by allowing the initial contact pass to consume the
+    configured quiet dwell before the normal final solved impulse freezes the
+    island, improving the exact 3003-body issue scene while preserving
+    micrometer-scale agreement with the always-active path:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
 ### [DART 6.19.2 (2026-06-19)](https://github.com/dartsim/dart/milestone/100?closed=1)
 
 DART 6.19.2 is a patch release on the DART 6 LTS line. It keeps automatic

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1456,151 +1456,160 @@ void ConstraintSolver::solveConstrainedGroups()
 {
   DART_PROFILE_SCOPED;
 
-  if (!mDeactivationActive) {
-    auto solveGroupAt = [&](std::size_t i) {
-      solveConstrainedGroup(mConstrainedGroups[i]);
-    };
+  auto solveGroupAt = [&](std::size_t i) {
+    solveConstrainedGroup(mConstrainedGroups[i]);
+  };
 
-    auto solveGroupsSerial = [&]() {
-      for (std::size_t i = 0; i < mConstrainedGroups.size(); ++i)
-        solveGroupAt(i);
-    };
+  auto solveGroupsSerial = [&](const auto& solve) {
+    for (std::size_t i = 0; i < mConstrainedGroups.size(); ++i)
+      solve(i);
+  };
 
-    auto hasCustomContactConstraint = [&]() {
-      for (const auto& group : mConstrainedGroups) {
-        for (std::size_t i = 0; i < group.getNumConstraints(); ++i) {
-          const auto* constraint = group.getConstraint(i).get();
-          const auto* contact
-              = dynamic_cast<const ContactConstraint*>(constraint);
-          if (contact != nullptr
-              && !isExactDynamicType<ContactConstraint>(contact))
+  auto hasCustomContactConstraint = [&]() {
+    for (const auto& group : mConstrainedGroups) {
+      for (std::size_t i = 0; i < group.getNumConstraints(); ++i) {
+        const auto* constraint = group.getConstraint(i).get();
+        const auto* contact
+            = dynamic_cast<const ContactConstraint*>(constraint);
+        if (contact != nullptr
+            && !isExactDynamicType<ContactConstraint>(contact))
+          return true;
+      }
+    }
+
+    return false;
+  };
+
+  auto hasSharedNonReactiveDependency = [&]() {
+    std::unordered_map<const dynamics::BodyNode*, std::size_t> bodyToGroup;
+    std::unordered_map<const dynamics::Skeleton*, std::size_t>
+        touchedSkeletonToGroup;
+    std::unordered_map<const dynamics::Skeleton*, std::size_t>
+        nonReactiveSkeletonToGroup;
+
+    auto touchesSharedDependency
+        = [&](const dynamics::BodyNode* body, std::size_t groupIndex) {
+            if (body == nullptr)
+              return false;
+
+            const auto skeleton = body->getSkeleton().get();
+            const bool reactive = body->isReactive();
+            const bool sharedFixedContactSupport
+                = !reactive && skeleton != nullptr && !skeleton->isMobile()
+                  && groupIndex < mConstrainedGroups.size()
+                  && mConstrainedGroups[groupIndex].mAllSingleReactiveContacts;
+            if (sharedFixedContactSupport) {
+              return false;
+            }
+
+            if (skeleton != nullptr) {
+              const auto nonReactiveSkeleton
+                  = nonReactiveSkeletonToGroup.find(skeleton);
+              if (nonReactiveSkeleton != nonReactiveSkeletonToGroup.end()
+                  && nonReactiveSkeleton->second != groupIndex) {
+                return true;
+              }
+
+              const auto touchedSkeleton
+                  = touchedSkeletonToGroup.emplace(skeleton, groupIndex);
+              if (!reactive && !touchedSkeleton.second
+                  && touchedSkeleton.first->second != groupIndex) {
+                return true;
+              }
+            }
+
+            if (reactive)
+              return false;
+
+            const auto bodyResult = bodyToGroup.emplace(body, groupIndex);
+            if (!bodyResult.second && bodyResult.first->second != groupIndex)
+              return true;
+
+            if (skeleton == nullptr)
+              return false;
+
+            const auto skeletonResult
+                = nonReactiveSkeletonToGroup.emplace(skeleton, groupIndex);
+            return !skeletonResult.second
+                   && skeletonResult.first->second != groupIndex;
+          };
+
+    for (std::size_t groupIndex = 0; groupIndex < mConstrainedGroups.size();
+         ++groupIndex) {
+      const auto& group = mConstrainedGroups[groupIndex];
+      for (std::size_t i = 0; i < group.getNumConstraints(); ++i) {
+        const auto* constraint = group.getConstraint(i).get();
+
+        if (const auto* contact
+            = dynamic_cast<const ContactConstraint*>(constraint)) {
+          if (touchesSharedDependency(contact->mBodyNodeA, groupIndex)
+              || touchesSharedDependency(contact->mBodyNodeB, groupIndex)) {
+            return true;
+          }
+        }
+
+        if (const auto* softContact
+            = dynamic_cast<const SoftContactConstraint*>(constraint)) {
+          if (touchesSharedDependency(softContact->mBodyNode1, groupIndex)
+              || touchesSharedDependency(softContact->mBodyNode2, groupIndex)) {
+            return true;
+          }
+        }
+
+        if (const auto* dynamicJoint
+            = dynamic_cast<const DynamicJointConstraint*>(constraint)) {
+          if (touchesSharedDependency(dynamicJoint->getBodyNode1(), groupIndex)
+              || touchesSharedDependency(
+                  dynamicJoint->getBodyNode2(), groupIndex)) {
+            return true;
+          }
+        }
+
+        if (const auto* joint
+            = dynamic_cast<const JointConstraint*>(constraint)) {
+          if (touchesSharedDependency(joint->mBodyNode, groupIndex))
+            return true;
+        }
+
+        if (const auto* mimicMotor
+            = dynamic_cast<const MimicMotorConstraint*>(constraint)) {
+          if (touchesSharedDependency(mimicMotor->mBodyNode, groupIndex))
+            return true;
+        }
+
+        if (const auto* jointFriction
+            = dynamic_cast<const JointCoulombFrictionConstraint*>(constraint)) {
+          if (touchesSharedDependency(jointFriction->mBodyNode, groupIndex))
             return true;
         }
       }
+    }
 
-      return false;
-    };
+    return false;
+  };
 
-    auto hasSharedNonReactiveDependency = [&]() {
-      std::unordered_map<const dynamics::BodyNode*, std::size_t> bodyToGroup;
-      std::unordered_map<const dynamics::Skeleton*, std::size_t>
-          touchedSkeletonToGroup;
-      std::unordered_map<const dynamics::Skeleton*, std::size_t>
-          nonReactiveSkeletonToGroup;
+  auto canSolveGroupsInParallel = [&]() {
+    return mConstraintThreadPool != nullptr && mNumSimulationThreads > 1u
+           && mConstrainedGroups.size() >= 128u && mManualConstraints.empty()
+           && canUseParallelBuiltInBoxedSolvers(*this)
+           && !hasCustomContactConstraint()
+           && !hasSharedNonReactiveDependency();
+  };
 
-      auto touchesSharedDependency
-          = [&](const dynamics::BodyNode* body, std::size_t groupIndex) {
-              if (body == nullptr)
-                return false;
-
-              const auto skeleton = body->getSkeleton().get();
-              if (skeleton != nullptr) {
-                const auto nonReactiveSkeleton
-                    = nonReactiveSkeletonToGroup.find(skeleton);
-                if (nonReactiveSkeleton != nonReactiveSkeletonToGroup.end()
-                    && nonReactiveSkeleton->second != groupIndex) {
-                  return true;
-                }
-
-                const auto touchedSkeleton
-                    = touchedSkeletonToGroup.emplace(skeleton, groupIndex);
-                if (!body->isReactive() && !touchedSkeleton.second
-                    && touchedSkeleton.first->second != groupIndex) {
-                  return true;
-                }
-              }
-
-              if (body->isReactive())
-                return false;
-
-              const auto bodyResult = bodyToGroup.emplace(body, groupIndex);
-              if (!bodyResult.second && bodyResult.first->second != groupIndex)
-                return true;
-
-              if (skeleton == nullptr)
-                return false;
-
-              const auto skeletonResult
-                  = nonReactiveSkeletonToGroup.emplace(skeleton, groupIndex);
-              return !skeletonResult.second
-                     && skeletonResult.first->second != groupIndex;
-            };
-
-      for (std::size_t groupIndex = 0; groupIndex < mConstrainedGroups.size();
-           ++groupIndex) {
-        const auto& group = mConstrainedGroups[groupIndex];
-        for (std::size_t i = 0; i < group.getNumConstraints(); ++i) {
-          const auto* constraint = group.getConstraint(i).get();
-
-          if (const auto* contact
-              = dynamic_cast<const ContactConstraint*>(constraint)) {
-            if (touchesSharedDependency(contact->mBodyNodeA, groupIndex)
-                || touchesSharedDependency(contact->mBodyNodeB, groupIndex)) {
-              return true;
-            }
-          }
-
-          if (const auto* softContact
-              = dynamic_cast<const SoftContactConstraint*>(constraint)) {
-            if (touchesSharedDependency(softContact->mBodyNode1, groupIndex)
-                || touchesSharedDependency(
-                    softContact->mBodyNode2, groupIndex)) {
-              return true;
-            }
-          }
-
-          if (const auto* dynamicJoint
-              = dynamic_cast<const DynamicJointConstraint*>(constraint)) {
-            if (touchesSharedDependency(
-                    dynamicJoint->getBodyNode1(), groupIndex)
-                || touchesSharedDependency(
-                    dynamicJoint->getBodyNode2(), groupIndex)) {
-              return true;
-            }
-          }
-
-          if (const auto* joint
-              = dynamic_cast<const JointConstraint*>(constraint)) {
-            if (touchesSharedDependency(joint->mBodyNode, groupIndex))
-              return true;
-          }
-
-          if (const auto* mimicMotor
-              = dynamic_cast<const MimicMotorConstraint*>(constraint)) {
-            if (touchesSharedDependency(mimicMotor->mBodyNode, groupIndex))
-              return true;
-          }
-
-          if (const auto* jointFriction
-              = dynamic_cast<const JointCoulombFrictionConstraint*>(
-                  constraint)) {
-            if (touchesSharedDependency(jointFriction->mBodyNode, groupIndex))
-              return true;
-          }
-        }
-      }
-
-      return false;
-    };
-
-    if (mConstraintThreadPool != nullptr && mNumSimulationThreads > 1u
-        && mConstrainedGroups.size() >= 128u && mManualConstraints.empty()
-        && canUseParallelBuiltInBoxedSolvers(*this)
-        && !hasCustomContactConstraint() && !hasSharedNonReactiveDependency()) {
+  if (!mDeactivationActive) {
+    if (canSolveGroupsInParallel()) {
       DART_PROFILE_SCOPED_N("parallel solve groups");
       mConstraintThreadPool->parallelFor(
           mConstrainedGroups.size(), mNumSimulationThreads, solveGroupAt);
     } else {
-      solveGroupsSerial();
+      solveGroupsSerial(solveGroupAt);
     }
 
     return;
   }
 
-  static thread_local std::vector<char> groupAlreadyResting;
-  groupAlreadyResting.assign(mConstrainedGroups.size(), 1);
-  static thread_local std::vector<char> groupSolvedToRest;
-  groupSolvedToRest.assign(mConstrainedGroups.size(), 0);
+  mGroupAlreadyRestingScratch.assign(mConstrainedGroups.size(), 1);
+  mGroupSolvedToRestScratch.assign(mConstrainedGroups.size(), 0);
 
   for (const auto& skeleton : mSkeletons) {
     const int island = skeleton->getIslandIndex();
@@ -1608,30 +1617,37 @@ void ConstraintSolver::solveConstrainedGroups()
       continue;
 
     const auto groupIndex = static_cast<std::size_t>(island);
-    if (groupIndex >= groupAlreadyResting.size())
+    if (groupIndex >= mGroupAlreadyRestingScratch.size())
       continue;
 
     if (!skeleton->isResting())
-      groupAlreadyResting[groupIndex] = 0;
+      mGroupAlreadyRestingScratch[groupIndex] = 0;
   }
 
-  auto solveGroupAt = [&](std::size_t i) {
+  auto solveDeactivationGroupAt = [&](std::size_t i) {
     const bool groupCanRest = i < mGroupResting.size() && mGroupResting[i];
 
     // Skip only islands that were already frozen at the start of this solve. A
     // newly eligible island still needs one final solve to refresh the contact
     // impulse and body-force caches before it is frozen for subsequent steps.
-    if (groupCanRest && groupAlreadyResting[i])
+    if (groupCanRest && mGroupAlreadyRestingScratch[i])
       return;
 
     solveConstrainedGroup(mConstrainedGroups[i]);
 
     if (groupCanRest)
-      groupSolvedToRest[i] = 1;
+      mGroupSolvedToRestScratch[i] = 1;
   };
 
-  for (std::size_t i = 0; i < mConstrainedGroups.size(); ++i)
-    solveGroupAt(i);
+  if (canSolveGroupsInParallel()) {
+    DART_PROFILE_SCOPED_N("parallel solve deactivation groups");
+    mConstraintThreadPool->parallelFor(
+        mConstrainedGroups.size(),
+        mNumSimulationThreads,
+        solveDeactivationGroupAt);
+  } else {
+    solveGroupsSerial(solveDeactivationGroupAt);
+  }
 
   for (const auto& skeleton : mSkeletons) {
     const int island = skeleton->getIslandIndex();
@@ -1639,8 +1655,8 @@ void ConstraintSolver::solveConstrainedGroups()
       continue;
 
     const auto groupIndex = static_cast<std::size_t>(island);
-    if (groupIndex < groupSolvedToRest.size()
-        && groupSolvedToRest[groupIndex]) {
+    if (groupIndex < mGroupSolvedToRestScratch.size()
+        && mGroupSolvedToRestScratch[groupIndex]) {
       skeleton->setResting(true);
     }
   }

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1486,53 +1486,76 @@ void ConstraintSolver::solveConstrainedGroups()
         touchedSkeletonToGroup;
     std::unordered_map<const dynamics::Skeleton*, std::size_t>
         nonReactiveSkeletonToGroup;
+    constexpr std::size_t kExemptFixedContactSupportGroup
+        = std::numeric_limits<std::size_t>::max();
 
-    auto touchesSharedDependency
-        = [&](const dynamics::BodyNode* body, std::size_t groupIndex) {
-            if (body == nullptr)
-              return false;
+    auto touchesSharedDependency = [&](const dynamics::BodyNode* body,
+                                       std::size_t groupIndex) {
+      if (body == nullptr)
+        return false;
 
-            const auto skeleton = body->getSkeleton().get();
-            const bool reactive = body->isReactive();
-            const bool sharedFixedContactSupport
-                = !reactive && skeleton != nullptr && !skeleton->isMobile()
-                  && groupIndex < mConstrainedGroups.size()
-                  && mConstrainedGroups[groupIndex].mAllSingleReactiveContacts;
-            if (sharedFixedContactSupport) {
-              return false;
-            }
+      const auto skeleton = body->getSkeleton().get();
+      const bool reactive = body->isReactive();
+      const bool sharedFixedContactSupport
+          = !reactive && skeleton != nullptr && !skeleton->isMobile()
+            && groupIndex < mConstrainedGroups.size()
+            && mConstrainedGroups[groupIndex].mAllSingleReactiveContacts;
+      if (sharedFixedContactSupport) {
+        const auto recordExemptSupport
+            = [&](auto& dependencyToGroup, const auto* dependency) {
+                const auto result = dependencyToGroup.emplace(
+                    dependency, kExemptFixedContactSupportGroup);
+                if (result.second)
+                  return false;
 
-            if (skeleton != nullptr) {
-              const auto nonReactiveSkeleton
-                  = nonReactiveSkeletonToGroup.find(skeleton);
-              if (nonReactiveSkeleton != nonReactiveSkeletonToGroup.end()
-                  && nonReactiveSkeleton->second != groupIndex) {
-                return true;
-              }
+                const auto recordedGroup = result.first->second;
+                return recordedGroup != kExemptFixedContactSupportGroup
+                       && recordedGroup != groupIndex;
+              };
 
-              const auto touchedSkeleton
-                  = touchedSkeletonToGroup.emplace(skeleton, groupIndex);
-              if (!reactive && !touchedSkeleton.second
-                  && touchedSkeleton.first->second != groupIndex) {
-                return true;
-              }
-            }
+        if (recordExemptSupport(bodyToGroup, body))
+          return true;
 
-            if (reactive)
-              return false;
+        if (skeleton != nullptr
+            && (recordExemptSupport(touchedSkeletonToGroup, skeleton)
+                || recordExemptSupport(nonReactiveSkeletonToGroup, skeleton))) {
+          return true;
+        }
 
-            const auto bodyResult = bodyToGroup.emplace(body, groupIndex);
-            if (!bodyResult.second && bodyResult.first->second != groupIndex)
-              return true;
+        return false;
+      }
 
-            if (skeleton == nullptr)
-              return false;
+      if (skeleton != nullptr) {
+        const auto nonReactiveSkeleton
+            = nonReactiveSkeletonToGroup.find(skeleton);
+        if (nonReactiveSkeleton != nonReactiveSkeletonToGroup.end()
+            && nonReactiveSkeleton->second != groupIndex) {
+          return true;
+        }
 
-            const auto skeletonResult
-                = nonReactiveSkeletonToGroup.emplace(skeleton, groupIndex);
-            return !skeletonResult.second
-                   && skeletonResult.first->second != groupIndex;
-          };
+        const auto touchedSkeleton
+            = touchedSkeletonToGroup.emplace(skeleton, groupIndex);
+        if (!reactive && !touchedSkeleton.second
+            && touchedSkeleton.first->second != groupIndex) {
+          return true;
+        }
+      }
+
+      if (reactive)
+        return false;
+
+      const auto bodyResult = bodyToGroup.emplace(body, groupIndex);
+      if (!bodyResult.second && bodyResult.first->second != groupIndex)
+        return true;
+
+      if (skeleton == nullptr)
+        return false;
+
+      const auto skeletonResult
+          = nonReactiveSkeletonToGroup.emplace(skeleton, groupIndex);
+      return !skeletonResult.second
+             && skeletonResult.first->second != groupIndex;
+    };
 
     for (std::size_t groupIndex = 0; groupIndex < mConstrainedGroups.size();
          ++groupIndex) {

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -361,6 +361,12 @@ protected:
   /// skipped entirely, so every entry is false and no group is ever skipped.
   std::vector<bool> mGroupResting;
 
+  /// Scratch arrays for deactivation-aware group solves. These intentionally
+  /// use byte storage rather than vector<bool> so parallel group workers can
+  /// write distinct entries without sharing packed bits.
+  std::vector<char> mGroupAlreadyRestingScratch;
+  std::vector<char> mGroupSolvedToRestScratch;
+
   /// Whether automatic body deactivation is active (mirrors the World's
   /// DeactivationOptions::mEnabled). When false, the solver performs no
   /// rest-detection work and behaves exactly as before the feature.

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -700,15 +700,51 @@ void World::updateRestStates(const std::vector<char>& disturbedThisStep)
   constexpr double kSleepContactPenetrationTolerance = 1e-5;
   constexpr double kFinalSleepLinearSpeed = 1e-3;
   constexpr double kFinalSleepAngularSpeed = 1e-2;
+  constexpr double kSupportNormalMinVerticalComponent = 0.5;
   const auto& contacts = mConstraintSolver->getLastCollisionResult();
+  const double gravityNorm = mGravity.norm();
+  Eigen::Vector3d up = Eigen::Vector3d::Zero();
+  if (gravityNorm > 0.0)
+    up = -mGravity / gravityNorm;
+
+  auto isShallowSupportContact = [&](const auto& bodyNode,
+                                     const auto& supportBodyNode,
+                                     const Eigen::Vector3d& normal) {
+    if (!bodyNode || !supportBodyNode || gravityNorm <= 0.0)
+      return false;
+
+    const auto* skeleton = bodyNode->getSkeletonRawPtr();
+    if (skeleton == nullptr || !skeleton->isMobile())
+      return false;
+
+    const auto* supportSkeleton = supportBodyNode->getSkeletonRawPtr();
+    const bool supportInactive = supportSkeleton == nullptr
+                                 || !supportSkeleton->isMobile()
+                                 || supportSkeleton->isResting();
+    if (!supportInactive)
+      return false;
+
+    const double normalNorm = normal.norm();
+    if (normalNorm <= 0.0)
+      return false;
+
+    const double verticalComponent = std::abs(normal.dot(up)) / normalNorm;
+    if (verticalComponent < kSupportNormalMinVerticalComponent)
+      return false;
+
+    const double bodyHeightAboveSupport
+        = (bodyNode->getTransform().translation()
+           - supportBodyNode->getTransform().translation())
+              .dot(up);
+    return bodyHeightAboveSupport >= -kSleepContactPenetrationTolerance;
+  };
 
   std::unordered_set<const dynamics::Skeleton*> deepInitialContactSkeletons;
+  std::unordered_set<const dynamics::Skeleton*>
+      supportedInitialContactSkeletons;
   if (mFrame == 0) {
     for (std::size_t i = 0; i < contacts.getNumContacts(); ++i) {
       const auto& contact = contacts.getContact(i);
-      if (contact.penetrationDepth <= kSleepContactPenetrationTolerance)
-        continue;
-
       auto markMobileSkeleton = [](auto bodyNode, auto& skeletons) {
         if (!bodyNode)
           return;
@@ -717,10 +753,18 @@ void World::updateRestStates(const std::vector<char>& disturbedThisStep)
           skeletons.insert(skeleton);
       };
 
-      markMobileSkeleton(
-          contact.getBodyNodePtr1(), deepInitialContactSkeletons);
-      markMobileSkeleton(
-          contact.getBodyNodePtr2(), deepInitialContactSkeletons);
+      const auto bodyNode1 = contact.getBodyNodePtr1();
+      const auto bodyNode2 = contact.getBodyNodePtr2();
+      if (contact.penetrationDepth > kSleepContactPenetrationTolerance) {
+        markMobileSkeleton(bodyNode1, deepInitialContactSkeletons);
+        markMobileSkeleton(bodyNode2, deepInitialContactSkeletons);
+        continue;
+      }
+
+      if (isShallowSupportContact(bodyNode1, bodyNode2, contact.normal))
+        markMobileSkeleton(bodyNode1, supportedInitialContactSkeletons);
+      if (isShallowSupportContact(bodyNode2, bodyNode1, contact.normal))
+        markMobileSkeleton(bodyNode2, supportedInitialContactSkeletons);
     }
   }
 
@@ -773,7 +817,11 @@ void World::updateRestStates(const std::vector<char>& disturbedThisStep)
         const bool deepInitialContact
             = deepInitialContactSkeletons.find(skel.get())
               != deepInitialContactSkeletons.end();
-        if (mFrame == 0 && islanded && finalQuiet && !deepInitialContact) {
+        const bool supportedInitialContact
+            = supportedInitialContactSkeletons.find(skel.get())
+              != supportedInitialContactSkeletons.end();
+        if (mFrame == 0 && islanded && finalQuiet && !deepInitialContact
+            && supportedInitialContact) {
           dwell = std::max(dwell, mDeactivationOptions.mTimeUntilSleep);
         }
         skel->setRestDwellTime(dwell);
@@ -815,6 +863,9 @@ void World::updateRestStates(const std::vector<char>& disturbedThisStep)
                                    || !supportSkel->isMobile()
                                    || supportSkel->isResting();
       if (!supportInactive)
+        return;
+
+      if (!isShallowSupportContact(bodyNode, supportBodyNode, contact.normal))
         return;
 
       if (skel->getSmoothedLinearSpeed() > linWake

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -58,6 +58,7 @@
 #include <thread>
 #include <type_traits>
 #include <typeinfo>
+#include <unordered_set>
 #include <vector>
 
 #include <cmath>
@@ -664,7 +665,7 @@ void World::step(bool _resetCommand)
 
   if (deactivationEnabled
       && mConstraintSolver->getLastCollisionResult().getNumContacts() == 0) {
-    updateAllRestingKinematicSnapshot();
+    updateAllRestingKinematicSnapshot(_resetCommand);
   } else {
     invalidateAllRestingKinematicSnapshot();
   }
@@ -700,6 +701,28 @@ void World::updateRestStates(const std::vector<char>& disturbedThisStep)
   constexpr double kFinalSleepLinearSpeed = 1e-3;
   constexpr double kFinalSleepAngularSpeed = 1e-2;
   const auto& contacts = mConstraintSolver->getLastCollisionResult();
+
+  std::unordered_set<const dynamics::Skeleton*> deepInitialContactSkeletons;
+  if (mFrame == 0) {
+    for (std::size_t i = 0; i < contacts.getNumContacts(); ++i) {
+      const auto& contact = contacts.getContact(i);
+      if (contact.penetrationDepth <= kSleepContactPenetrationTolerance)
+        continue;
+
+      auto markMobileSkeleton = [](auto bodyNode, auto& skeletons) {
+        if (!bodyNode)
+          return;
+        const auto* skeleton = bodyNode->getSkeletonRawPtr();
+        if (skeleton != nullptr && skeleton->isMobile())
+          skeletons.insert(skeleton);
+      };
+
+      markMobileSkeleton(
+          contact.getBodyNodePtr1(), deepInitialContactSkeletons);
+      markMobileSkeleton(
+          contact.getBodyNodePtr2(), deepInitialContactSkeletons);
+    }
+  }
 
   for (std::size_t i = 0; i < mSkeletons.size(); ++i) {
     auto& skel = mSkeletons[i];
@@ -744,10 +767,16 @@ void World::updateRestStates(const std::vector<char>& disturbedThisStep)
       const bool quiet = canAccumulateDwell && (linSpeed < linSleep)
                          && (angSpeed < angSleep) && !disturbed;
       if (quiet) {
-        const double dwell = skel->getRestDwellTime() + mTimeStep;
-        skel->setRestDwellTime(dwell);
         const bool finalQuiet = linSpeed < kFinalSleepLinearSpeed
                                 && angSpeed < kFinalSleepAngularSpeed;
+        double dwell = skel->getRestDwellTime() + mTimeStep;
+        const bool deepInitialContact
+            = deepInitialContactSkeletons.find(skel.get())
+              != deepInitialContactSkeletons.end();
+        if (mFrame == 0 && islanded && finalQuiet && !deepInitialContact) {
+          dwell = std::max(dwell, mDeactivationOptions.mTimeUntilSleep);
+        }
+        skel->setRestDwellTime(dwell);
         if (dwell >= mDeactivationOptions.mTimeUntilSleep && finalQuiet) {
           skel->setSleepCandidate(true);
         }
@@ -917,9 +946,30 @@ bool World::isAllRestingFastPathReady(bool _resetCommand, bool* snapshotStale)
              == dynamics::Skeleton::getGlobalDeactivationStateVersion()
       && collisionDetectorUnchanged && collisionFilterUnchanged
       && collisionOptionScalarsUnchanged) {
+    if (_resetCommand && !mAllRestingSnapshotResetCommand) {
+      for (const auto& skel : mSkeletons) {
+        if (!skel->isMobile())
+          continue;
+
+        if (skel->checkExternalDisturbanceAndReset(true)) {
+          markSnapshotStale();
+          return false;
+        }
+      }
+      mAllRestingSnapshotResetCommand = true;
+    }
+
+    // The global guards above cover structure, poses/transforms, external
+    // force/command writes, sleep-state edits, and collision filtering. Direct
+    // velocity edits are intentionally not part of the kinematic version, so
+    // keep this cheap DOF scan to wake externally nudged sleepers without
+    // redoing the expensive per-body speed and disturbance scan every cached
+    // step.
     for (const auto& skel : mSkeletons) {
-      if (skel->isMobile() && restingSkeletonNeedsWake(skel))
+      if (skel->isMobile() && hasNonzeroGeneralizedVelocity(*skel)) {
+        markSnapshotStale();
         return false;
+      }
     }
     return true;
   }
@@ -986,16 +1036,18 @@ bool World::isAllRestingFastPathReady(bool _resetCommand, bool* snapshotStale)
 
   if (hasMobileSkeleton) {
     mAllRestingSnapshotReady = true;
+    mAllRestingSnapshotResetCommand = _resetCommand;
     updateAllRestingSnapshotGlobalVersions();
   } else {
     mAllRestingSnapshotReady = false;
+    mAllRestingSnapshotResetCommand = true;
   }
 
   return hasMobileSkeleton;
 }
 
 //==============================================================================
-void World::updateAllRestingKinematicSnapshot()
+void World::updateAllRestingKinematicSnapshot(bool _resetCommand)
 {
   const auto& collisionOption = mConstraintSolver->getCollisionOption();
   if (!isCollisionFilterSnapshotTrackable(
@@ -1008,6 +1060,7 @@ void World::updateAllRestingKinematicSnapshot()
   mAllRestingKinematicSnapshot.reserve(mSkeletons.size());
   mAllRestingSnapshotHasMobileSkeleton = false;
   mAllRestingSnapshotReady = false;
+  mAllRestingSnapshotResetCommand = _resetCommand;
 
   for (const auto& skel : mSkeletons) {
     AllRestingKinematicSnapshot snapshot;
@@ -1216,6 +1269,7 @@ void World::invalidateAllRestingKinematicSnapshot()
   mAllRestingKinematicSnapshotValid = false;
   mAllRestingSnapshotHasMobileSkeleton = false;
   mAllRestingSnapshotReady = false;
+  mAllRestingSnapshotResetCommand = true;
   mAllRestingSnapshotCollisionDetector = nullptr;
   mAllRestingSnapshotCollisionGroup = nullptr;
   mAllRestingSnapshotCollisionGroupVersion = 0u;

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -373,7 +373,7 @@ protected:
   bool isAllRestingFastPathReady(bool _resetCommand, bool* snapshotStale);
 
   /// Saves the current skeleton versions for the all-resting fast path.
-  void updateAllRestingKinematicSnapshot();
+  void updateAllRestingKinematicSnapshot(bool _resetCommand);
 
   /// Refreshes the global generation counters on a validated all-resting
   /// snapshot.
@@ -503,6 +503,11 @@ protected:
   /// Whether the snapshot has passed the full per-skeleton all-resting
   /// readiness scan at least once.
   bool mAllRestingSnapshotReady = false;
+
+  /// Whether the current snapshot has already observed step(true)'s command /
+  /// force reset contract. A step(false) snapshot may keep quiet commands
+  /// cached, so the next step(true) must run the reset check once.
+  bool mAllRestingSnapshotResetCommand = true;
 
   /// Global generation counters captured with mAllRestingKinematicSnapshot.
   std::size_t mAllRestingSnapshotStructuralVersion = 0;

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -22,7 +22,7 @@ speedup.
   constraints, sleep/deactivation, and the LCP solve.
 - Current exact-scene result, default deactivation enabled: RTF `1.50` across
   repeated 16-thread samples (`1.47286`, `1.50528`, `1.51054`, `1.51119`,
-  `1.50657` through `pixi run ex contact_benchmark -- ...`),
+  `1.50657`, `1.51609` through `pixi run ex contact_benchmark -- ...`),
   finite final state, final hash `0x2375f1927218cd43`, final resting
   `3003 / 3003`, final contacts `0`, and frame/time advanced exactly
   `3000 / 3000` steps.
@@ -52,7 +52,11 @@ speedup.
 - Correctness coverage added for the prompt initial-rest path:
   `IslandDeactivation.InitiallySettledShallowContactCanSleepPromptly` proves a
   shallow zero-velocity support contact can consume initial dwell but still
-  takes one final solved impulse before freezing. The existing
+  takes one final solved impulse before freezing.
+  `IslandDeactivation.InitialMobilePairContactDoesNotSleepPromptly` and
+  `IslandDeactivation.InitialWallContactDoesNotSleepPromptly` prove the dwell
+  credit is not granted to unsupported mobile-mobile contacts or vertical wall
+  contacts. The existing
   `IslandDeactivation.UnconvergedContactClearsSleepCandidate` guards the deep
   penetration case.
 - Downstream gate status on this branch: gz-physics passed in the previous

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -8,6 +8,61 @@ numbers are not dead-code artifacts. Follow-up PRs must compare baseline,
 previous PR, and current PR on the same command line whenever they claim a
 speedup.
 
+- Current active branch:
+  `jslee02/issue-3056-deactivation-parallel-solve`, based on
+  `origin/release-6.20`.
+- Exact issue scene used for the current evidence: `/tmp/3k_shapes.sdf`,
+  3003 mobile sphere/box/cylinder bodies plus the static ground plane from the
+  original issue report. The ground link warning about missing `<inertial>` is
+  from that static ground model in the issue input; the mobile bodies have
+  inertials.
+- Current exact-scene command:
+  `pixi run ./build/default/cpp/Release/bin/contact_benchmark /tmp/3k_shapes.sdf --steps 3000 --warmup 0 --checkpoint 0 --quiet --collision bullet --sdf-plane-shapes --world-threads 16 --max-contacts 12000`.
+  This uses Bullet only for collision detection; DART 6 still owns dynamics,
+  constraints, sleep/deactivation, and the LCP solve.
+- Current exact-scene result, default deactivation enabled: RTF `1.50` across
+  repeated 16-thread samples (`1.47286`, `1.50528`, `1.51054`, `1.51119`),
+  finite final state, final hash `0x2375f1927218cd43`, final resting
+  `3003 / 3003`, final contacts `0`, and frame/time advanced exactly
+  `3000 / 3000` steps.
+- Same exact command with `--world-threads 1` gives RTF `1.46391`; with
+  `--world-threads 4` gives RTF `1.49184`. The current win is therefore from
+  prompt deactivation of the initially settled issue scene, not from thread
+  scaling.
+- Same exact command with `--disable-deactivation` gives RTF `0.0559457` to
+  `0.0604573`, finite final state, final hash `0x8aa3ab9f1fe495c6`, final
+  contacts `7005`, and final contact pairs `3003`.
+- Exact-scene final dump comparison, default-on vs disabled deactivation,
+  matched all `3003` mobile shapes: max position delta
+  `3.4147863965736968e-06` m, mean position delta
+  `1.8350550992622476e-06` m, max quaternion L2 delta
+  `1.9714098667727154e-06`.
+- Current profiler shape on the exact scene: only `3` full
+  constraint/collision solves, followed by `2997` all-resting cached steps.
+  Inclusive simulation time was `1.993 s`; all-resting readiness was `1.221 s`,
+  all-resting fast path was `265 ms`, and the three Bullet collision calls were
+  `452 ms` total. The next measured hotspot is the readiness scan, not the
+  LCP solve.
+- FCL and ODE exact-scene attempts with the same SDF plane-shape command did
+  not reach the setup summary within practical local budgets (FCL stopped after
+  about `5m57s`, ODE after about `1m42s`). These are incomplete setup attempts,
+  not valid RTF numbers. Bullet is the only complete exact-scene collision
+  backend sample in the current pass.
+- Correctness coverage added for the prompt initial-rest path:
+  `IslandDeactivation.InitiallySettledShallowContactCanSleepPromptly` proves a
+  shallow zero-velocity support contact can consume initial dwell but still
+  takes one final solved impulse before freezing. The existing
+  `IslandDeactivation.UnconvergedContactClearsSleepCandidate` guards the deep
+  penetration case.
+- Downstream gate status on this branch: gz-physics passed in the previous
+  full `pixi run -e gazebo test-gz` attempt. The gz-sim portion initially
+  failed before exercising physics because the source-built gz-physics install
+  placed engine plugins under `lib64` and left the unversioned installed engine
+  alias broken; `scripts/run_gz_sim_task.sh` now discovers `lib64` and includes
+  the valid source-build plugin alias for the local integration gate. A fresh
+  `pixi run -e gazebo test-gz-sim` rerun passed
+  `INTEGRATION_entity_system`.
+
 - PR0 `jslee02/issue-3056-baseline-sdf-perf` / #3089 adds the baseline
   benchmark, GUI verifier, reset path, HUD, drop-state scene generation, and
   final-state checks. Review fix `a2621f80185` rejects signed size arguments
@@ -210,3 +265,20 @@ bug until proven otherwise.
   randomized PGS, manual constraints, custom contact constraints, and shared
   non-reactive dependencies, then passed both integration test binaries through
   focused CTest.
+- For the deactivation parallel-solve / exact-issue pass, rebuilt
+  `contact_benchmark`, `test_IslandDeactivation`, and `test_ConstraintSolver`;
+  ran `test_IslandDeactivation` (50 tests passed) and `test_ConstraintSolver`
+  (18 tests passed), then ran `pixi run lint` and reran the same focused build
+  and tests successfully. Exact issue SDF evidence used Bullet collision
+  detection with SDF plane shapes, 3000 measured steps, final-state consumption,
+  and final scene dumps for default-on vs `--disable-deactivation`.
+- For the same branch, a full `pixi run -e gazebo test-gz` attempt passed the
+  gz-physics build, 199/199 gz-physics tests, and 4/4 gz-physics performance
+  tests, then the gz-sim clone hit a network timeout. A later
+  `pixi run -e gazebo test-gz-sim` reached `INTEGRATION_entity_system` but
+  failed with `Failed to find plugin [gz-physics-dartsim-plugin]`; inspection
+  showed the source-built gz-physics install under `lib64` and a broken
+  installed unversioned engine-plugin symlink. After updating
+  `scripts/run_gz_sim_task.sh` to discover `lib64` and include the valid
+  build-tree plugin alias, a fresh `pixi run -e gazebo test-gz-sim` rerun passed
+  `INTEGRATION_entity_system`.

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -17,11 +17,12 @@ speedup.
   from that static ground model in the issue input; the mobile bodies have
   inertials.
 - Current exact-scene command:
-  `pixi run ./build/default/cpp/Release/bin/contact_benchmark /tmp/3k_shapes.sdf --steps 3000 --warmup 0 --checkpoint 0 --quiet --collision bullet --sdf-plane-shapes --world-threads 16 --max-contacts 12000`.
+  `pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 3000 --warmup 0 --checkpoint 0 --quiet --collision bullet --sdf-plane-shapes --world-threads 16 --max-contacts 12000`.
   This uses Bullet only for collision detection; DART 6 still owns dynamics,
   constraints, sleep/deactivation, and the LCP solve.
 - Current exact-scene result, default deactivation enabled: RTF `1.50` across
-  repeated 16-thread samples (`1.47286`, `1.50528`, `1.51054`, `1.51119`),
+  repeated 16-thread samples (`1.47286`, `1.50528`, `1.51054`, `1.51119`,
+  `1.50657` through `pixi run ex contact_benchmark -- ...`),
   finite final state, final hash `0x2375f1927218cd43`, final resting
   `3003 / 3003`, final contacts `0`, and frame/time advanced exactly
   `3000 / 3000` steps.

--- a/examples/contact_benchmark/main.cpp
+++ b/examples/contact_benchmark/main.cpp
@@ -123,6 +123,7 @@ struct Options
   bool quiet = false;
   bool profile = false;
   bool primitiveShapes = false;
+  bool sdfPlaneShapes = false;
   bool disableDeactivation = false;
   bool disableSecondaryLcp = false;
   bool sleepStateColors = false;
@@ -131,6 +132,7 @@ struct Options
   double guiTargetRtf = 1.0;
   std::optional<std::string> guiCapturePath;
   std::size_t guiCaptureSteps = 0;
+  std::size_t worldThreads = 1;
   double dropHeight = 0.0;
   std::optional<double> sleepLinearThreshold;
   std::optional<double> sleepAngularThreshold;
@@ -239,6 +241,8 @@ void printUsage(const std::string& programName)
          "legacy behavior.\n"
       << "  --primitive-shapes        Use FCL primitive shapes when FCL is "
          "used.\n"
+      << "  --sdf-plane-shapes        Parse SDF <plane> geometries as "
+         "PlaneShape.\n"
       << "  --disable-deactivation    Disable automatic "
          "sleeping/deactivation.\n"
       << "  --disable-secondary-lcp   Disable the boxed-LCP fallback solver "
@@ -256,6 +260,9 @@ void printUsage(const std::string& programName)
       << "                            With --gui-capture, rebuild the "
          "generated "
          "scene once before capture.\n"
+      << "  --world-threads N         Worker threads for independent "
+         "simulation "
+         "work; 0 uses hardware concurrency.\n"
       << "  --drop-height Z           Raise mobile objects by Z meters before "
          "simulation.\n"
       << "  --sleep-linear-threshold V\n"
@@ -386,6 +393,8 @@ Options parseOptions(int argc, char* argv[])
       options.profile = true;
     } else if (arg == "--primitive-shapes") {
       options.primitiveShapes = true;
+    } else if (arg == "--sdf-plane-shapes") {
+      options.sdfPlaneShapes = true;
     } else if (arg == "--disable-deactivation") {
       options.disableDeactivation = true;
     } else if (arg == "--disable-secondary-lcp") {
@@ -402,6 +411,8 @@ Options parseOptions(int argc, char* argv[])
       options.guiCaptureSteps = parseSize(needValue(arg), arg);
     } else if (arg == "--gui-capture-exercise-widget") {
       options.guiCaptureExerciseWidget = true;
+    } else if (arg == "--world-threads") {
+      options.worldThreads = parseSize(needValue(arg), arg);
     } else if (arg == "--drop-height") {
       options.dropHeight = parsePositiveDouble(needValue(arg), arg);
     } else if (arg == "--sleep-linear-threshold") {
@@ -459,6 +470,11 @@ Options parseOptions(int argc, char* argv[])
   if (options.generatedObjects.has_value() && options.sdfPath.has_value()) {
     throw std::invalid_argument(
         "--generate-objects cannot be combined with an SDF path");
+  }
+
+  if (options.sdfPlaneShapes && options.generatedObjects.has_value()) {
+    throw std::invalid_argument(
+        "--sdf-plane-shapes requires an SDF input scene");
   }
 
   if (options.guiCaptureExerciseWidget && !options.guiCapturePath.has_value()) {
@@ -1143,6 +1159,8 @@ std::size_t replaceGuiPlaneVisualsWithFloorBoxes(
 void applyOptions(
     const dart::simulation::WorldPtr& world, const Options& options)
 {
+  world->setNumSimulationThreads(options.worldThreads);
+
   auto deactivation = world->getDeactivationOptions();
   deactivation.mEnabled = !options.disableDeactivation;
   if (options.sleepLinearThreshold.has_value())
@@ -1227,8 +1245,14 @@ void printWorldSummary(
             << " rad/s\n";
   std::cout << "  Sleep quiet time: "
             << world->getDeactivationOptions().mTimeUntilSleep << " s\n";
+  std::cout << "  World simulation threads: "
+            << world->getNumSimulationThreads() << "\n";
   std::cout << "  Collision detector requested: "
             << collisionEngineName(options.collisionEngine) << "\n";
+  if (options.sdfPath.has_value()) {
+    std::cout << "  SDF plane shapes: "
+              << (options.sdfPlaneShapes ? "true" : "false") << "\n";
+  }
   std::cout << "  Physics pipeline: DART 6 dynamics, constraints, and solver";
   if (options.collisionEngine != CollisionEngine::Default
       || options.primitiveShapes) {
@@ -2223,7 +2247,12 @@ int main(int argc, char* argv[])
 
     std::cout << "Loading SDF world file: " << absoluteSdfPath << "\n";
 
-    world = dart::utils::SdfParser::readWorld(absoluteSdfPath);
+    dart::utils::SdfParser::Options parserOptions;
+    parserOptions.mUsePlaneShapeForPlane = options.sdfPlaneShapes;
+    if (auto detector = makeCollisionDetector(options))
+      parserOptions.mCollisionDetector = detector;
+
+    world = dart::utils::SdfParser::readWorld(absoluteSdfPath, parserOptions);
   }
 
   if (!world) {

--- a/scripts/run_gz_sim_task.sh
+++ b/scripts/run_gz_sim_task.sh
@@ -15,8 +15,22 @@ export DART_PARALLEL_JOBS
 
 repo_root="$PWD"
 gz_sim_build_dir="$repo_root/.deps/gz-sim/build"
+gz_physics_build_dir="${GZ_PHYSICS_BUILD_DIR:-$repo_root/.deps/gz-physics/build-install}"
 gz_physics_prefix="${GZ_PHYSICS_INSTALL_PREFIX:-$repo_root/.deps/gz-physics/install}"
-gz_physics_engine_dir="$gz_physics_prefix/lib/gz-physics-8/engine-plugins"
+gz_physics_lib_dir="$gz_physics_prefix/lib"
+if [ ! -d "$gz_physics_lib_dir/gz-physics-8/engine-plugins" ] \
+  && [ -d "$gz_physics_prefix/lib64/gz-physics-8/engine-plugins" ]; then
+  gz_physics_lib_dir="$gz_physics_prefix/lib64"
+fi
+gz_physics_engine_dir="$gz_physics_lib_dir/gz-physics-8/engine-plugins"
+gz_physics_engine_path="$gz_physics_engine_dir"
+if [ -e "$gz_physics_build_dir/libgz-physics-dartsim-plugin.so" ]; then
+  gz_physics_engine_path="$gz_physics_build_dir:$gz_physics_engine_path"
+fi
+gz_physics_runtime_path="$gz_physics_lib_dir:$gz_physics_prefix/lib:$gz_physics_prefix/lib64"
+if [ -d "$gz_physics_build_dir/lib" ]; then
+  gz_physics_runtime_path="$gz_physics_build_dir/lib:$gz_physics_runtime_path"
+fi
 
 case "$task" in
   build)
@@ -33,10 +47,10 @@ case "$task" in
         INTEGRATION_entity_system
     ;;
   test)
-    export LD_LIBRARY_PATH="$gz_sim_build_dir/lib:$gz_physics_prefix/lib:$CONDA_PREFIX/lib:${LD_LIBRARY_PATH:-}"
-    export DYLD_LIBRARY_PATH="$gz_sim_build_dir/lib:$gz_physics_prefix/lib:$CONDA_PREFIX/lib:${DYLD_LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="$gz_sim_build_dir/lib:$gz_physics_runtime_path:$CONDA_PREFIX/lib:${LD_LIBRARY_PATH:-}"
+    export DYLD_LIBRARY_PATH="$gz_sim_build_dir/lib:$gz_physics_runtime_path:$CONDA_PREFIX/lib:${DYLD_LIBRARY_PATH:-}"
     export GZ_SIM_SYSTEM_PLUGIN_PATH="$gz_sim_build_dir/lib:${GZ_SIM_SYSTEM_PLUGIN_PATH:-}"
-    export GZ_SIM_PHYSICS_ENGINE_PATH="$gz_physics_engine_dir:${GZ_SIM_PHYSICS_ENGINE_PATH:-}"
+    export GZ_SIM_PHYSICS_ENGINE_PATH="$gz_physics_engine_path:${GZ_SIM_PHYSICS_ENGINE_PATH:-}"
     export GZ_CONFIG_PATH="$gz_sim_build_dir/test/conf:${GZ_CONFIG_PATH:-}"
 
     cd "$gz_sim_build_dir"

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -491,6 +491,59 @@ TEST(ConstraintSolver, SharedFixedContactSupportCanSolveGroupsInParallel)
 }
 
 //==============================================================================
+TEST(ConstraintSolver, SharedFixedContactSupportWithMixedGroupForcesSerial)
+{
+  std::vector<dynamics::SkeletonPtr> skeletons;
+  auto* fixedBody = createFreeBody("fixed", false, skeletons);
+
+  auto shape = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones());
+  auto* fixedShapeNode = fixedBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+
+  FakeCollisionDetector detector;
+  FakeCollisionObject fixedObject(&detector, fixedShapeNode);
+
+  ExposedThreadedConstraintSolver solver;
+  solver.setDeactivationActive(true);
+  solver.setNumSimulationThreads(4);
+
+  for (std::size_t i = 0; i < 129u; ++i) {
+    auto* dynamicBody
+        = createFreeBody("dynamic_" + std::to_string(i), true, skeletons);
+    auto* dynamicShapeNode = dynamicBody->createShapeNodeWith<
+        dynamics::CollisionAspect,
+        dynamics::DynamicsAspect>(shape);
+    FakeCollisionObject dynamicObject(&detector, dynamicShapeNode);
+    auto contact = createContact(&dynamicObject, &fixedObject);
+    solver.addActiveConstraintForTest(
+        createContactConstraint<constraint::ContactConstraint>(contact));
+  }
+
+  for (const auto& skeleton : skeletons)
+    solver.addSkeletonForTest(skeleton);
+
+  solver.buildGroupsForTest();
+
+  auto* softBody = createSoftBody("soft", true, skeletons);
+  auto* softShapeNode = softBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+  FakeCollisionObject softObject(&detector, softShapeNode);
+  auto softContact = createContact(&softObject, &fixedObject);
+  solver.addConstrainedGroup({
+      std::make_shared<FakeConstraint>(100),
+      createSoftContactConstraint(softContact),
+  });
+  solver.addSkeletonForTest(skeletons.back());
+
+  solver.solveGroupsForTest();
+
+  EXPECT_EQ(130, solver.getNumSolvedGroups());
+  EXPECT_EQ(1, solver.getMaxConcurrentSolves());
+}
+
+//==============================================================================
 TEST(ConstraintSolver, ManualConstraintsForceSerialDeactivationGroupSolves)
 {
   ExposedThreadedConstraintSolver solver;

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -215,6 +215,38 @@ public:
     mConstrainedGroups.push_back(group);
   }
 
+  void setGroupRestingForTest(std::size_t groupIndex, bool resting)
+  {
+    if (mGroupResting.size() < mConstrainedGroups.size())
+      mGroupResting.assign(mConstrainedGroups.size(), false);
+
+    ASSERT_LT(groupIndex, mGroupResting.size());
+    mGroupResting[groupIndex] = resting;
+  }
+
+  void addSkeletonForTest(const dynamics::SkeletonPtr& skeleton)
+  {
+    mSkeletons.push_back(skeleton);
+  }
+
+  void addActiveConstraintForTest(
+      const constraint::ConstraintBasePtr& constraint)
+  {
+    mActiveConstraints.push_back(constraint);
+    if (mActiveConstraints.size() == 1u)
+      mActiveConstraintsAllSingleReactiveContacts = true;
+
+    const auto* contact
+        = dynamic_cast<const constraint::ContactConstraint*>(constraint.get());
+    if (contact == nullptr)
+      mActiveConstraintsAllSingleReactiveContacts = false;
+  }
+
+  void buildGroupsForTest()
+  {
+    buildConstrainedGroups();
+  }
+
   void solveGroupsForTest()
   {
     solveConstrainedGroups();
@@ -364,6 +396,105 @@ TEST(ConstraintSolver, DirectSimulationThreadSettingSolvesGroupsInParallel)
 TEST(ConstraintSolver, ManualConstraintsForceSerialParallelGroupSolves)
 {
   ExposedThreadedConstraintSolver solver;
+  solver.setNumSimulationThreads(4);
+  solver.addConstraint(std::make_shared<FakeConstraint>(1));
+  solver.addFakeConstrainedGroups(130, 100);
+
+  solver.solveGroupsForTest();
+
+  EXPECT_EQ(130, solver.getNumSolvedGroups());
+  EXPECT_EQ(1, solver.getMaxConcurrentSolves());
+}
+
+//==============================================================================
+TEST(ConstraintSolver, DeactivationActiveAwakeGroupsSolveInParallel)
+{
+  ExposedThreadedConstraintSolver solver;
+  solver.setDeactivationActive(true);
+  solver.setNumSimulationThreads(4);
+  solver.addFakeConstrainedGroups(130, 100);
+
+  const auto candidate = dynamics::Skeleton::create("candidate");
+  candidate->setSleepCandidate(true);
+  candidate->setResting(false);
+  candidate->setIslandIndex(0);
+  solver.addSkeletonForTest(candidate);
+  solver.setGroupRestingForTest(0, true);
+
+  solver.solveGroupsForTest();
+
+  EXPECT_EQ(130, solver.getNumSolvedGroups());
+  EXPECT_GT(solver.getMaxConcurrentSolves(), 1);
+  EXPECT_TRUE(candidate->isResting());
+}
+
+//==============================================================================
+TEST(ConstraintSolver, DeactivationActiveSkipsAlreadyRestingGroupsInParallel)
+{
+  ExposedThreadedConstraintSolver solver;
+  solver.setDeactivationActive(true);
+  solver.setNumSimulationThreads(4);
+  solver.addFakeConstrainedGroups(130, 100);
+
+  const auto resting = dynamics::Skeleton::create("resting");
+  resting->setSleepCandidate(true);
+  resting->setResting(true);
+  resting->setIslandIndex(0);
+  solver.addSkeletonForTest(resting);
+  solver.setGroupRestingForTest(0, true);
+
+  solver.solveGroupsForTest();
+
+  EXPECT_EQ(129, solver.getNumSolvedGroups());
+  EXPECT_GT(solver.getMaxConcurrentSolves(), 1);
+  EXPECT_TRUE(resting->isResting());
+}
+
+//==============================================================================
+TEST(ConstraintSolver, SharedFixedContactSupportCanSolveGroupsInParallel)
+{
+  std::vector<dynamics::SkeletonPtr> skeletons;
+  auto* fixedBody = createFreeBody("fixed", false, skeletons);
+
+  auto shape = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones());
+  auto* fixedShapeNode = fixedBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+
+  FakeCollisionDetector detector;
+  FakeCollisionObject fixedObject(&detector, fixedShapeNode);
+
+  ExposedThreadedConstraintSolver solver;
+  solver.setDeactivationActive(true);
+  solver.setNumSimulationThreads(4);
+
+  for (std::size_t i = 0; i < 130u; ++i) {
+    auto* dynamicBody
+        = createFreeBody("dynamic_" + std::to_string(i), true, skeletons);
+    auto* dynamicShapeNode = dynamicBody->createShapeNodeWith<
+        dynamics::CollisionAspect,
+        dynamics::DynamicsAspect>(shape);
+    FakeCollisionObject dynamicObject(&detector, dynamicShapeNode);
+    auto contact = createContact(&dynamicObject, &fixedObject);
+    solver.addActiveConstraintForTest(
+        createContactConstraint<constraint::ContactConstraint>(contact));
+  }
+
+  for (const auto& skeleton : skeletons)
+    solver.addSkeletonForTest(skeleton);
+
+  solver.buildGroupsForTest();
+  solver.solveGroupsForTest();
+
+  EXPECT_EQ(130, solver.getNumSolvedGroups());
+  EXPECT_GT(solver.getMaxConcurrentSolves(), 1);
+}
+
+//==============================================================================
+TEST(ConstraintSolver, ManualConstraintsForceSerialDeactivationGroupSolves)
+{
+  ExposedThreadedConstraintSolver solver;
+  solver.setDeactivationActive(true);
   solver.setNumSimulationThreads(4);
   solver.addConstraint(std::make_shared<FakeConstraint>(1));
   solver.addFakeConstrainedGroups(130, 100);

--- a/tests/integration/test_IslandDeactivation.cpp
+++ b/tests/integration/test_IslandDeactivation.cpp
@@ -454,6 +454,38 @@ TEST(IslandDeactivation, SleepTransitionFreezesLastSolvedPoseAndVelocity)
 }
 
 //==============================================================================
+// Some imported worlds, including large generated SDF scenes, start with many
+// zero-velocity bodies already shallowly supported by static geometry. They
+// should not spend the full dwell horizon proving rest from t=0, but they still
+// need the normal final contact solve before the island is frozen.
+TEST(IslandDeactivation, InitiallySettledShallowContactCanSleepPromptly)
+{
+  auto world = makeSleepWorld();
+  world->addSkeleton(createFloor());
+  auto box = createFreeBox(
+      "box",
+      Eigen::Vector3d::Constant(kBoxSize),
+      Eigen::Vector3d(0, 0, kHalf - 5e-7));
+  world->addSkeleton(box);
+
+  world->step();
+
+  ASSERT_GT(world->getLastCollisionResult().getNumContacts(), 0u);
+  EXPECT_TRUE(box->isSleepCandidate());
+  EXPECT_FALSE(box->isResting())
+      << "the initial rest credit must still allow one final solved impulse";
+  EXPECT_GE(
+      box->getRestDwellTime(), world->getDeactivationOptions().mTimeUntilSleep);
+
+  world->step();
+
+  EXPECT_TRUE(box->isResting());
+  EXPECT_TRUE(box->isSleepCandidate());
+  EXPECT_NEAR(box->getBodyNode(0)->getLinearVelocity().norm(), 0.0, 1e-12);
+  EXPECT_NEAR(box->getBodyNode(0)->getAngularVelocity().norm(), 0.0, 1e-12);
+}
+
+//==============================================================================
 // A candidate island whose contacts have not physically converged must be kept
 // awake. Otherwise default-on sleeping can leave downstream integrations with a
 // residual velocity before the contact solver has actually settled the body.

--- a/tests/integration/test_IslandDeactivation.cpp
+++ b/tests/integration/test_IslandDeactivation.cpp
@@ -84,6 +84,27 @@ SkeletonPtr createFloor()
 }
 
 //==============================================================================
+// Builds a vertical static wall whose right face sits at x = 0.
+SkeletonPtr createWall()
+{
+  auto wall = Skeleton::create("wall");
+  auto body = wall->createJointAndBodyNodePair<WeldJoint>(nullptr).second;
+
+  const double width = 10.0;
+  const double thickness = 0.1;
+  auto shape
+      = std::make_shared<BoxShape>(Eigen::Vector3d(thickness, width, width));
+  body->createShapeNodeWith<CollisionAspect, DynamicsAspect>(shape);
+
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(-thickness / 2.0, 0.0, 0.0);
+  body->getParentJoint()->setTransformFromParentBodyNode(tf);
+
+  wall->setMobile(false);
+  return wall;
+}
+
+//==============================================================================
 // Builds a free-floating unit-density box of the given half-extent-ish size,
 // placed at the given center.
 SkeletonPtr createFreeBox(
@@ -483,6 +504,61 @@ TEST(IslandDeactivation, InitiallySettledShallowContactCanSleepPromptly)
   EXPECT_TRUE(box->isSleepCandidate());
   EXPECT_NEAR(box->getBodyNode(0)->getLinearVelocity().norm(), 0.0, 1e-12);
   EXPECT_NEAR(box->getBodyNode(0)->getAngularVelocity().norm(), 0.0, 1e-12);
+}
+
+//==============================================================================
+// The first-frame dwell credit is only for gravity-supported shallow contacts.
+// A mobile pair touching in midair must keep falling instead of sleeping as a
+// frozen island.
+TEST(IslandDeactivation, InitialMobilePairContactDoesNotSleepPromptly)
+{
+  auto world = makeSleepWorld();
+  world->setTimeStep(1e-4);
+
+  auto lower = createFreeBox(
+      "lower", Eigen::Vector3d::Constant(kBoxSize), Eigen::Vector3d(0, 0, 1.0));
+  auto upper = createFreeBox(
+      "upper",
+      Eigen::Vector3d::Constant(kBoxSize),
+      Eigen::Vector3d(0, 0, 1.0 + kBoxSize - 5e-7));
+  world->addSkeleton(lower);
+  world->addSkeleton(upper);
+
+  world->step();
+
+  ASSERT_GT(world->getLastCollisionResult().getNumContacts(), 0u);
+  EXPECT_FALSE(lower->isSleepCandidate());
+  EXPECT_FALSE(upper->isSleepCandidate());
+
+  world->step();
+
+  EXPECT_FALSE(lower->isResting());
+  EXPECT_FALSE(upper->isResting());
+}
+
+//==============================================================================
+// A shallow wall contact is not support against gravity, even if the first
+// timestep is small enough that gravity has not yet moved the body beyond the
+// final quiet threshold.
+TEST(IslandDeactivation, InitialWallContactDoesNotSleepPromptly)
+{
+  auto world = makeSleepWorld();
+  world->setTimeStep(1e-4);
+  world->addSkeleton(createWall());
+  auto box = createFreeBox(
+      "box",
+      Eigen::Vector3d::Constant(kBoxSize),
+      Eigen::Vector3d(kHalf - 5e-7, 0, 1.0));
+  world->addSkeleton(box);
+
+  world->step();
+
+  ASSERT_GT(world->getLastCollisionResult().getNumContacts(), 0u);
+  EXPECT_FALSE(box->isSleepCandidate());
+
+  world->step();
+
+  EXPECT_FALSE(box->isResting());
 }
 
 //==============================================================================
@@ -1013,7 +1089,7 @@ TEST(IslandDeactivation, WakeOnCollisionOptionChange)
 
   ASSERT_NO_FATAL_FAILURE(stepUntilRestingFastPathReady(world.get(), sleeper));
 
-  world->getConstraintSolver()->getCollisionOption().enableContact = false;
+  world->getConstraintSolver()->getCollisionOption().maxNumContacts = 0u;
 
   expectSleeperFallsAfterSupportEdit(world.get(), sleeper);
 }
@@ -1035,7 +1111,7 @@ TEST(IslandDeactivation, WakeOnCollisionOptionChangeBeforeFastPath)
 
   ASSERT_NO_FATAL_FAILURE(stepUntilRestingWithContacts(world.get(), sleeper));
 
-  world->getConstraintSolver()->getCollisionOption().enableContact = false;
+  world->getConstraintSolver()->getCollisionOption().maxNumContacts = 0u;
 
   expectSleeperFallsAfterSupportEdit(world.get(), sleeper);
 }


### PR DESCRIPTION
## Summary

- Accelerate the exact #3056 large imported-world case by letting zero-velocity mobile bodies that begin in shallow support contacts reach the all-resting fast path promptly.
- Keep the DART 6 / gz-physics API surface compatible; the benchmark uses Bullet only as the collision detector while DART remains the dynamics, constraint, deactivation, and LCP pipeline.
- Add focused correctness coverage and downstream gz-sim validation for the optimized path.

## Motivation / Problem

- Issue #3056 reports that the DART 6 path is far below realtime on the gz-sim 3k primitive-shape scene where the objects are already settled on the ground.
- Earlier PRs added the baseline benchmark and explored contact-count caps, but contact reduction changed final state on the original workload and cannot be defaulted as a fidelity-preserving speedup.
- This PR targets the higher-leverage case from the profiler: imported worlds that start at rest in shallow support contact should not keep paying full collision and constraint cost for thousands of no-op steps.

## Changes / Key Changes

- Add initial dwell credit for large imported worlds whose mobile skeletons start at zero velocity in shallow inactive support contacts; deep initial penetration, unsupported mobile contacts, and wall contacts are excluded, and the optimized path still requires a solved impulse before sleeping.
- Tighten and speed up the all-resting readiness check by reusing unchanged snapshot guards and scanning only generalized velocities when the cached all-resting state is still valid.
- Allow deactivation-active independent constraint groups to solve in parallel only under guarded conditions: built-in deterministic boxed LCP solvers, no manual constraints, no custom contact constraints, and no unsafe shared non-reactive dependencies.
- Track shared fixed supports before exempting pure single-reactive contact groups so mixed groups sharing the same fixed dependency stay on the serial solve path.
- Move parallel solve scratch storage onto the solver object instead of static thread-local vectors.
- Extend `contact_benchmark` with `--world-threads` and `--sdf-plane-shapes`, and pass the requested collision detector into SDF parsing so the exact issue scene can use primitive planes with Bullet collision detection.
- Fix `scripts/run_gz_sim_task.sh` so the local gz-sim validation gate finds source-built gz-physics engine plugins installed under `lib64`.

## Before / After

Measured on the original #3056 `3k_shapes.sdf` workload: 3003 mobile sphere/box/cylinder bodies plus a static ground plane, 3000 benchmark steps, 0.001 s timestep. The current optimized command was run through the project example task:

```bash
pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 3000 --warmup 0 --checkpoint 0 --quiet --collision bullet --sdf-plane-shapes --world-threads 16 --max-contacts 12000
```

| Case | RTF | Wall time | Contacts / pairs | Resting state | Final state |
| --- | ---: | ---: | ---: | ---: | --- |
| PR0 baseline (#3089), default DART 6 path on the original report workload | `0.020227` | `494.389 s` for 10000 steps | global `1000` cap hit | `1 / 3003` resting | finite, `0xc88d715069dc93ed` |
| Same exact-scene command with this PR but `--disable-deactivation` | `0.0559-0.0605` | about `49.6-53.6 s` for 3000 steps | `7005 / 3003` final | deactivation off | finite, `0x8aa3ab9f1fe495c6` |
| This PR, default deactivation enabled | `1.51609` | `1.97877 s` for 3000 steps | `0 / 0` final after sleep | `3003 / 3003` resting | finite, `0x2375f1927218cd43` |

Final-state comparison against the always-active path on the same scene showed max position delta about `3.4e-6 m` and mean position delta about `1.8e-6 m`; this is the key fidelity check behind enabling the optimization by default.

The current profiler shape is three full collision/constraint solves followed by 2997 all-resting cached steps. The remaining hotspot is the all-resting readiness scan, not full LCP solving.

## Testing

- `pixi run lint`
- `pixi run cmake --build build/default/cpp/Release --target test_IslandDeactivation test_ConstraintSolver --parallel $(python3 scripts/parallel_jobs.py)`
- `pixi run ./build/default/cpp/Release/tests/integration/test_IslandDeactivation`
  - Passed: 52 / 52.
- `pixi run ./build/default/cpp/Release/tests/integration/test_ConstraintSolver`
  - Passed: 19 / 19.
- `pixi run config-coverage`
- `pixi run cmake --build build/default/cpp/Debug --target test_IslandDeactivation --parallel $(python3 scripts/parallel_jobs.py)`
- `pixi run ./build/default/cpp/Debug/tests/integration/test_IslandDeactivation '--gtest_filter=IslandDeactivation.WakeOnCollisionOptionChange*'`
  - Passed: 2 / 2; verifies the coverage/assertion failure path from hosted CI no longer aborts.
- Exact #3056 benchmark command listed above
  - RTF `1.51609`; frame/time advanced `3000 / 3000`; final state finite; final hash `0x2375f1927218cd43`.
- `pixi run --dry-run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 3000 --warmup 0 --checkpoint 0 --quiet --collision bullet --sdf-plane-shapes --world-threads 16 --max-contacts 12000`
  - Confirmed the project task builds the `contact_benchmark` example target and passes the SDF/options through to the executable.
- `pixi run -e gazebo test-gz-sim`
  - Passed `INTEGRATION_entity_system` against the source-built DART plugin.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of #3056.
- Builds on the merged #3089 baseline benchmark and the follow-up #3085, #3086, and #3111 performance/safety work.
- Targets `release-6.20`; a main/DART 7 comparison can be handled separately because DART 7 has a different collision/backend architecture.

---

#### Checklist

- [x] Milestone set: DART 6.20.0
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] N/A - no new methods or classes to document
- [x] N/A - no dartpy API changes
