### PR TITLE
Fix FCL null contact when contact generation is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@
     distances, shared-object refreshes, and collision-result cache lifetime:
     [#3085](https://github.com/dartsim/dart/pull/3085)
 
+  * Fix the FCL collision detector adding a default-constructed contact with
+    null collision objects when contact generation is disabled
+    (`CollisionOption::enableContact = false`) with more than one contact
+    requested, which aborted asserts-enabled builds (and logged repeated
+    `addObjectToCaches` nullptr errors otherwise):
+    [#3112](https://github.com/dartsim/dart/pull/3112)
+
 * Simulation
 
   * Enable resting-world deactivation by default with wake-aware invalidation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
     (`CollisionOption::enableContact = false`) with more than one contact
     requested, which aborted asserts-enabled builds (and logged repeated
     `addObjectToCaches` nullptr errors otherwise):
-    [#3112](https://github.com/dartsim/dart/pull/3112)
+    [#3114](https://github.com/dartsim/dart/pull/3114)
 
 * Simulation
 

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -1914,7 +1914,13 @@ void postProcessDART(
     }
 
     unfiltered.push_back(pair1);
-    unfiltered.push_back(pair2);
+    // pair2 is only populated inside the option.enableContact branch above
+    // (via pair2 = pair1 plus the mesh contact-point computation). When
+    // contact geometry is disabled it stays default-constructed with null
+    // collision objects, so adding it would trip the nullptr guard in
+    // CollisionResult::addObjectToCaches. Only emit it when it is valid.
+    if (option.enableContact)
+      unfiltered.push_back(pair2);
   }
 
   const auto tol = 1e-12;


### PR DESCRIPTION
## Summary

Fix an FCL collision-detector abort on `release-6.20` when contact generation
is disabled (`CollisionOption::enableContact = false`). This is the root cause of
the failing **coverage** and **Asserts enabled (no -DNDEBUG)** CI jobs, both of
which aborted in `IslandDeactivation.WakeOnCollisionOptionChange`.

## Motivation / Problem

`postProcessDART` builds two contact points (`pair1`/`pair2`) per FCL contact,
but `pair2` is only populated inside the `option.enableContact` branch (via
`pair2 = pair1` plus the mesh contact-point computation). When contact
generation is disabled with the default FCL detector (`primitiveShapeType ==
MESH`) and more than one contact requested (the constraint solver's default),
`pair2` stayed default-constructed with **null** collision objects and was still
added to the result, tripping the nullptr guard in
`CollisionResult::addObjectToCaches`:

```
CollisionResult.cpp:150: ... addObjectToCaches(...): Assertion `false' failed.
```

That aborts asserts-enabled/coverage builds; Release silently logged repeated
`addObjectToCaches` nullptr errors instead.

This is a latent defect dating back to #2850 (DART 6.17.0). It surfaced on
`release-6.20` once `IslandDeactivation.WakeOnCollisionOptionChange` (added in
#3086) became the first test to exercise `enableContact = false` on a contacting
box-box scene. DART 7 (`main`) rewrote the collision module and has no equivalent
`postProcessDART` path, so no `main` backport is required.

## Changes / Key Changes

- `dart/collision/fcl/FCLCollisionDetector.cpp`: only push `pair2` when it was
  actually populated (i.e. when `option.enableContact` is true). `pair1` already
  carries the valid collision objects with a zero normal, which the constraint
  solver skips, so binary "do they collide" detection keeps working without a
  spurious null-object contact.
- `CHANGELOG.md`: add a Collision entry under DART 6.20.0.

## Testing

- `IslandDeactivation.WakeOnCollisionOptionChange` and
  `...WakeOnCollisionOptionChangeBeforeFastPath` (previously aborting) now pass.
- Full `test_IslandDeactivation` (all 49 subtests) passes in an asserts-enabled
  build (`CMAKE_BUILD_TYPE=None`, no `-DNDEBUG`) — the exact configuration the CI
  job uses.
- clang-format clean on the changed file.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Surfaced by #3086; latent since #2850. No `main` backport (code path does not
  exist on DART 7).

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] `pixi run` formatting check passes on the change
- [x] Regression covered by the existing `IslandDeactivation` integration test
