### PR TITLE
Skip non-finite contacts and validate shape dimensions (DART 6 LTS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## DART 6
 
+### [DART 6.19.3 (TBD)](https://github.com/dartsim/dart/milestone/101?closed=1)
+
+* Simulation
+
+  * Harden contact handling against invalid geometry, fixing a crash reported
+    through gz-physics. `BoxShape`, `CylinderShape`, `CapsuleShape`,
+    `EllipsoidShape`, `ConeShape`, and `PyramidShape` now reject non-finite
+    (NaN/Inf) or non-positive dimensions like `SphereShape` already did, and
+    `ConstraintSolver` skips contacts whose point, normal, or penetration depth
+    is non-finite before contact-constraint creation. Together these stop an
+    invalid shape dimension (or a non-finite contact from a mesh or collision
+    backend) from crashing `ContactConstraint` on a `mSpatialNormalA` assertion
+    or corrupting the LCP solve with NaN/Inf:
+    [gazebosim/gz-physics#1010](https://github.com/gazebosim/gz-physics/issues/1010)
+
 ### [DART 6.19.2 (2026-06-19)](https://github.com/dartsim/dart/milestone/100?closed=1)
 
 DART 6.19.2 is a patch release on the DART 6 LTS line. It keeps automatic

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -58,6 +58,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include <cmath>
 #include <cstdint>
 
 namespace dart {
@@ -549,6 +550,22 @@ void ConstraintSolver::updateConstraints()
   // Create new contact constraints
   for (auto i = 0u; i < mCollisionResult.getNumContacts(); ++i) {
     auto& contact = mCollisionResult.getContact(i);
+
+    // Skip contacts with non-finite geometry. A collision shape with an invalid
+    // (infinite or NaN) dimension, a malformed mesh, or a third-party collision
+    // backend can report a contact whose point, normal, or penetration depth is
+    // not finite. Such a contact would otherwise inject NaN/Inf into the
+    // contact constraint Jacobians, corrupting the LCP solve in release builds
+    // and tripping an assertion in ContactConstraint in debug builds. See
+    // gz-physics issue #1010.
+    if (!contact.point.allFinite() || !contact.normal.allFinite()
+        || !std::isfinite(contact.penetrationDepth)) {
+      dtwarn << "[ConstraintSolver] Ignoring contact with non-finite geometry "
+             << "(point, normal, or penetration depth). This usually indicates "
+             << "a malformed collision mesh or a collision backend that "
+                "produced an invalid contact.\n";
+      continue;
+    }
 
     if (collision::Contact::isZeroNormal(contact.normal)) {
       // Skip this contact. This is because we assume that a contact with

--- a/dart/dynamics/BoxShape.cpp
+++ b/dart/dynamics/BoxShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/BoxShape.hpp"
 
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 
 #include <cmath>
@@ -40,11 +41,9 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-BoxShape::BoxShape(const Eigen::Vector3d& _size) : Shape(BOX), mSize(_size)
+BoxShape::BoxShape(const Eigen::Vector3d& _size) : Shape(BOX)
 {
-  DART_ASSERT(_size[0] > 0.0);
-  DART_ASSERT(_size[1] > 0.0);
-  DART_ASSERT(_size[2] > 0.0);
+  setSize(_size);
 }
 
 //==============================================================================
@@ -88,9 +87,16 @@ Eigen::Matrix3d BoxShape::computeInertia(
 //==============================================================================
 void BoxShape::setSize(const Eigen::Vector3d& _size)
 {
-  DART_ASSERT(_size[0] > 0.0);
-  DART_ASSERT(_size[1] > 0.0);
-  DART_ASSERT(_size[2] > 0.0);
+  if (!_size.allFinite() || (_size.array() <= 0.0).any()) {
+    DART_WARN(
+        "BoxShape::setSize: Invalid size '[{}, {}, {}]'. "
+        "Each size must be a positive finite value. Ignoring request.",
+        _size[0],
+        _size[1],
+        _size[2]);
+    return;
+  }
+
   mSize = _size;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/BoxShape.hpp
+++ b/dart/dynamics/BoxShape.hpp
@@ -81,7 +81,7 @@ protected:
 
 private:
   /// \brief Side lengths of the box
-  Eigen::Vector3d mSize;
+  Eigen::Vector3d mSize{Eigen::Vector3d::Ones()};
 };
 
 } // namespace dynamics

--- a/dart/dynamics/CapsuleShape.cpp
+++ b/dart/dynamics/CapsuleShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/CapsuleShape.hpp"
 
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
@@ -43,11 +44,10 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-CapsuleShape::CapsuleShape(double radius, double height)
-  : Shape(CAPSULE), mRadius(radius), mHeight(height)
+CapsuleShape::CapsuleShape(double radius, double height) : Shape(CAPSULE)
 {
-  DART_ASSERT(0.0 < radius);
-  DART_ASSERT(0.0 < height);
+  setRadius(radius);
+  setHeight(height);
 }
 
 //==============================================================================
@@ -72,7 +72,14 @@ double CapsuleShape::getRadius() const
 //==============================================================================
 void CapsuleShape::setRadius(double radius)
 {
-  DART_ASSERT(0.0 < radius);
+  if (!std::isfinite(radius) || radius <= 0.0) {
+    DART_WARN(
+        "CapsuleShape::setRadius: Invalid radius '{}'. "
+        "Radius must be a positive finite value. Ignoring request.",
+        radius);
+    return;
+  }
+
   mRadius = radius;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -89,7 +96,14 @@ double CapsuleShape::getHeight() const
 //==============================================================================
 void CapsuleShape::setHeight(double height)
 {
-  DART_ASSERT(0.0 < height);
+  if (!std::isfinite(height) || height <= 0.0) {
+    DART_WARN(
+        "CapsuleShape::setHeight: Invalid height '{}'. "
+        "Height must be a positive finite value. Ignoring request.",
+        height);
+    return;
+  }
+
   mHeight = height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/CapsuleShape.hpp
+++ b/dart/dynamics/CapsuleShape.hpp
@@ -93,10 +93,10 @@ protected:
 
 private:
   /// Radius of the capsule.
-  double mRadius;
+  double mRadius{1.0};
 
   /// Height of the cylindrical part.
-  double mHeight;
+  double mHeight{1.0};
 };
 
 } // namespace dynamics

--- a/dart/dynamics/ConeShape.cpp
+++ b/dart/dynamics/ConeShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/ConeShape.hpp"
 
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
@@ -43,11 +44,10 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-ConeShape::ConeShape(double radius, double height)
-  : Shape(CONE), mRadius(radius), mHeight(height)
+ConeShape::ConeShape(double radius, double height) : Shape(CONE)
 {
-  DART_ASSERT(0.0 < radius);
-  DART_ASSERT(0.0 < height);
+  setRadius(radius);
+  setHeight(height);
 }
 
 //==============================================================================
@@ -72,7 +72,14 @@ double ConeShape::getRadius() const
 //==============================================================================
 void ConeShape::setRadius(double radius)
 {
-  DART_ASSERT(0.0 < radius);
+  if (!std::isfinite(radius) || radius <= 0.0) {
+    DART_WARN(
+        "ConeShape::setRadius: Invalid radius '{}'. "
+        "Radius must be a positive finite value. Ignoring request.",
+        radius);
+    return;
+  }
+
   mRadius = radius;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -89,7 +96,14 @@ double ConeShape::getHeight() const
 //==============================================================================
 void ConeShape::setHeight(double height)
 {
-  DART_ASSERT(0.0 < height);
+  if (!std::isfinite(height) || height <= 0.0) {
+    DART_WARN(
+        "ConeShape::setHeight: Invalid height '{}'. "
+        "Height must be a positive finite value. Ignoring request.",
+        height);
+    return;
+  }
+
   mHeight = height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/ConeShape.hpp
+++ b/dart/dynamics/ConeShape.hpp
@@ -95,10 +95,10 @@ protected:
 
 private:
   /// Radius of the circular base.
-  double mRadius;
+  double mRadius{1.0};
 
   /// Height of the cylindrical part.
-  double mHeight;
+  double mHeight{1.0};
 };
 
 } // namespace dynamics

--- a/dart/dynamics/CylinderShape.cpp
+++ b/dart/dynamics/CylinderShape.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/dynamics/CylinderShape.hpp"
 
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
 
@@ -41,11 +42,10 @@ namespace dart {
 namespace dynamics {
 
 //==============================================================================
-CylinderShape::CylinderShape(double _radius, double _height)
-  : Shape(CYLINDER), mRadius(_radius), mHeight(_height)
+CylinderShape::CylinderShape(double _radius, double _height) : Shape(CYLINDER)
 {
-  DART_ASSERT(0.0 < _radius);
-  DART_ASSERT(0.0 < _height);
+  setRadius(_radius);
+  setHeight(_height);
 }
 
 //==============================================================================
@@ -70,7 +70,14 @@ double CylinderShape::getRadius() const
 //==============================================================================
 void CylinderShape::setRadius(double _radius)
 {
-  DART_ASSERT(0.0 < _radius);
+  if (!std::isfinite(_radius) || _radius <= 0.0) {
+    DART_WARN(
+        "CylinderShape::setRadius: Invalid radius '{}'. "
+        "Radius must be a positive finite value. Ignoring request.",
+        _radius);
+    return;
+  }
+
   mRadius = _radius;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -87,7 +94,14 @@ double CylinderShape::getHeight() const
 //==============================================================================
 void CylinderShape::setHeight(double _height)
 {
-  DART_ASSERT(0.0 < _height);
+  if (!std::isfinite(_height) || _height <= 0.0) {
+    DART_WARN(
+        "CylinderShape::setHeight: Invalid height '{}'. "
+        "Height must be a positive finite value. Ignoring request.",
+        _height);
+    return;
+  }
+
   mHeight = _height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/CylinderShape.hpp
+++ b/dart/dynamics/CylinderShape.hpp
@@ -84,10 +84,10 @@ protected:
 
 private:
   /// \brief
-  double mRadius;
+  double mRadius{1.0};
 
   /// \brief Height along z-axis.
-  double mHeight;
+  double mHeight{1.0};
 };
 
 } // namespace dynamics

--- a/dart/dynamics/EllipsoidShape.cpp
+++ b/dart/dynamics/EllipsoidShape.cpp
@@ -32,8 +32,11 @@
 
 #include "dart/dynamics/EllipsoidShape.hpp"
 
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/math/Helpers.hpp"
+
+#include <cmath>
 
 namespace dart {
 namespace dynamics {
@@ -79,9 +82,15 @@ const Eigen::Vector3d& EllipsoidShape::getSize() const
 //==============================================================================
 void EllipsoidShape::setDiameters(const Eigen::Vector3d& diameters)
 {
-  DART_ASSERT(diameters[0] > 0.0);
-  DART_ASSERT(diameters[1] > 0.0);
-  DART_ASSERT(diameters[2] > 0.0);
+  if (!diameters.allFinite() || (diameters.array() <= 0.0).any()) {
+    DART_WARN(
+        "EllipsoidShape::setDiameters: Invalid diameters '[{}, {}, {}]'. "
+        "Each diameter must be a positive finite value. Ignoring request.",
+        diameters[0],
+        diameters[1],
+        diameters[2]);
+    return;
+  }
 
   mDiameters = diameters;
 
@@ -100,12 +109,7 @@ const Eigen::Vector3d& EllipsoidShape::getDiameters() const
 //==============================================================================
 void EllipsoidShape::setRadii(const Eigen::Vector3d& radii)
 {
-  mDiameters = radii * 2.0;
-
-  mIsBoundingBoxDirty = true;
-  mIsVolumeDirty = true;
-
-  incrementVersion();
+  setDiameters(radii * 2.0);
 }
 
 //==============================================================================

--- a/dart/dynamics/EllipsoidShape.hpp
+++ b/dart/dynamics/EllipsoidShape.hpp
@@ -106,7 +106,7 @@ protected:
 
 private:
   /// \brief Diameters of this ellipsoid
-  Eigen::Vector3d mDiameters;
+  Eigen::Vector3d mDiameters{Eigen::Vector3d::Ones()};
 };
 
 } // namespace dynamics

--- a/dart/dynamics/PyramidShape.cpp
+++ b/dart/dynamics/PyramidShape.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/PyramidShape.hpp"
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
@@ -45,14 +46,11 @@ namespace dynamics {
 
 //==============================================================================
 PyramidShape::PyramidShape(double baseWidth, double baseDepth, double height)
-  : Shape(PYRAMID),
-    mBaseWidth(baseWidth),
-    mBaseDepth(baseDepth),
-    mHeight(height)
+  : Shape(PYRAMID)
 {
-  DART_ASSERT(0.0 < baseWidth);
-  DART_ASSERT(0.0 < baseDepth);
-  DART_ASSERT(0.0 < height);
+  setBaseWidth(baseWidth);
+  setBaseDepth(baseDepth);
+  setHeight(height);
 }
 
 //==============================================================================
@@ -77,7 +75,14 @@ double PyramidShape::getBaseWidth() const
 //==============================================================================
 void PyramidShape::setBaseWidth(double width)
 {
-  DART_ASSERT(0.0 < width);
+  if (!std::isfinite(width) || width <= 0.0) {
+    DART_WARN(
+        "PyramidShape::setBaseWidth: Invalid width '{}'. "
+        "Width must be a positive finite value. Ignoring request.",
+        width);
+    return;
+  }
+
   mBaseWidth = width;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -94,7 +99,14 @@ double PyramidShape::getBaseDepth() const
 //==============================================================================
 void PyramidShape::setBaseDepth(double depth)
 {
-  DART_ASSERT(0.0 < depth);
+  if (!std::isfinite(depth) || depth <= 0.0) {
+    DART_WARN(
+        "PyramidShape::setBaseDepth: Invalid depth '{}'. "
+        "Depth must be a positive finite value. Ignoring request.",
+        depth);
+    return;
+  }
+
   mBaseDepth = depth;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;
@@ -111,7 +123,14 @@ double PyramidShape::getHeight() const
 //==============================================================================
 void PyramidShape::setHeight(double height)
 {
-  DART_ASSERT(0.0 < height);
+  if (!std::isfinite(height) || height <= 0.0) {
+    DART_WARN(
+        "PyramidShape::setHeight: Invalid height '{}'. "
+        "Height must be a positive finite value. Ignoring request.",
+        height);
+    return;
+  }
+
   mHeight = height;
   mIsBoundingBoxDirty = true;
   mIsVolumeDirty = true;

--- a/dart/dynamics/PyramidShape.hpp
+++ b/dart/dynamics/PyramidShape.hpp
@@ -107,13 +107,13 @@ protected:
 
 private:
   /// Lateral length (algon X-axis) of the base.
-  double mBaseWidth;
+  double mBaseWidth{1.0};
 
   /// Longitudinal length (algon Y-axis) of the base.
-  double mBaseDepth;
+  double mBaseDepth{1.0};
 
   /// Perpendicular height from the base to the apex.
-  double mHeight;
+  double mHeight{1.0};
 };
 
 } // namespace dynamics

--- a/tests/unit/constraint/CMakeLists.txt
+++ b/tests/unit/constraint/CMakeLists.txt
@@ -1,4 +1,5 @@
 dart_add_test("unit" test_ContactSurface test_ContactSurface.cpp)
+dart_add_test("unit" test_NonFiniteContact test_NonFiniteContact.cpp)
 dart_add_test(
   "unit" test_CylindricalJointConstraint test_CylindricalJointConstraint.cpp
 )

--- a/tests/unit/constraint/test_NonFiniteContact.cpp
+++ b/tests/unit/constraint/test_NonFiniteContact.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2011-2024, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// \file test_NonFiniteContact.cpp
+/// \brief Regression test for gz-physics issue #1010:
+///        https://github.com/gazebosim/gz-physics/issues/1010
+///
+/// A contact with a non-finite (NaN/Inf) point, normal, or penetration depth
+/// used to propagate into ContactConstraint's spatial Jacobian, tripping
+/// `assert(!math::isNan(mSpatialNormalA))` in asserts-enabled builds and
+/// silently corrupting the LCP solve in release builds.
+///
+/// Primitive shapes now reject non-finite/non-positive dimensions, so a
+/// degenerate shape can no longer be the source. But the constraint solver must
+/// still defend itself against a non-finite contact coming from a source that
+/// shape validation cannot cover -- a malformed mesh/heightmap or a third-party
+/// collision backend. This test models that source with a collision detector
+/// that runs a normal sphere-sphere collision between two valid shapes and then
+/// corrupts the contact point to NaN, and verifies that
+/// ConstraintSolver::updateConstraints() drops the contact before contact
+/// constraint creation, leaving the solve crash-free and the state finite.
+
+#include "dart/collision/CollisionGroup.hpp"
+#include "dart/collision/CollisionOption.hpp"
+#include "dart/collision/CollisionResult.hpp"
+#include "dart/collision/dart/DARTCollisionDetector.hpp"
+#include "dart/constraint/BoxedLcpConstraintSolver.hpp"
+#include "dart/constraint/ContactSurface.hpp"
+#include "dart/dynamics/BodyNode.hpp"
+#include "dart/dynamics/FreeJoint.hpp"
+#include "dart/dynamics/ShapeNode.hpp"
+#include "dart/dynamics/Skeleton.hpp"
+#include "dart/dynamics/SphereShape.hpp"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include <cmath>
+
+using namespace dart;
+using namespace dart::dynamics;
+using namespace dart::constraint;
+
+namespace {
+
+/// A DART collision detector that performs a normal collision check and then
+/// corrupts the first reported contact point to NaN. This stands in for a
+/// malformed mesh or a third-party collision backend that emits a non-finite
+/// contact between otherwise valid collision objects -- the case the constraint
+/// solver must defend against now that primitive shapes validate their
+/// dimensions.
+class NonFiniteContactDetector : public collision::DARTCollisionDetector
+{
+public:
+  bool collide(
+      collision::CollisionGroup* group,
+      const collision::CollisionOption& option
+      = collision::CollisionOption(false, 1u, nullptr),
+      collision::CollisionResult* result = nullptr) override
+  {
+    const bool collided
+        = collision::DARTCollisionDetector::collide(group, option, result);
+    if (result != nullptr && result->getNumContacts() > 0u) {
+      result->getContact(0).point.x()
+          = std::numeric_limits<double>::quiet_NaN();
+    }
+    return collided;
+  }
+};
+
+/// Contact-surface handler that counts how many contacts reach contact
+/// constraint creation. ConstraintSolver only invokes the handler for contacts
+/// that survive the validity filters in updateConstraints(), so the count is
+/// exactly the number of contacts accepted into the solve.
+class CountingContactSurfaceHandler : public DefaultContactSurfaceHandler
+{
+public:
+  ContactConstraintPtr createConstraint(
+      collision::Contact& contact,
+      size_t numContactsOnCollisionObject,
+      double timeStep) const override
+  {
+    ++mNumContactsCreated;
+    return DefaultContactSurfaceHandler::createConstraint(
+        contact, numContactsOnCollisionObject, timeStep);
+  }
+
+  mutable int mNumContactsCreated = 0;
+};
+
+/// Creates a single-body skeleton with a FreeJoint at the given position.
+SkeletonPtr createBody(
+    const std::string& name,
+    const ShapePtr& shape,
+    const Eigen::Vector3d& position,
+    bool withDynamics)
+{
+  auto skeleton = Skeleton::create(name);
+  auto* body = skeleton->createJointAndBodyNodePair<FreeJoint>().second;
+
+  if (withDynamics)
+    body->createShapeNodeWith<CollisionAspect, DynamicsAspect>(shape);
+  else
+    body->createShapeNodeWith<CollisionAspect>(shape);
+
+  skeleton->setPositions(
+      (Eigen::Vector6d() << 0, 0, 0, position.x(), position.y(), position.z())
+          .finished());
+
+  return skeleton;
+}
+
+} // namespace
+
+//==============================================================================
+// A non-finite contact (here from a detector that emits a NaN contact point
+// between valid shapes) must be dropped before contact-constraint creation
+// instead of corrupting the solve.
+TEST(NonFiniteContact, NonFiniteContactIsSkipped)
+{
+  // Two valid, overlapping spheres.
+  auto baseBody = createBody(
+      "base",
+      std::make_shared<SphereShape>(1.0),
+      Eigen::Vector3d::Zero(),
+      /*withDynamics=*/false);
+  baseBody->setMobile(false);
+
+  auto fallingBody = createBody(
+      "falling_weight",
+      std::make_shared<SphereShape>(0.1),
+      Eigen::Vector3d(0.0, 0.0, 0.5),
+      /*withDynamics=*/true);
+
+  BoxedLcpConstraintSolver solver;
+  solver.setTimeStep(0.001);
+  solver.setCollisionDetector(std::make_shared<NonFiniteContactDetector>());
+  solver.addSkeleton(baseBody);
+  solver.addSkeleton(fallingBody);
+
+  auto handler = std::make_shared<CountingContactSurfaceHandler>();
+  solver.addContactSurfaceHandler(handler);
+
+  // Before the fix this aborts on an assertion (asserts-enabled builds) or runs
+  // the LCP solver on a NaN system (release builds).
+  ASSERT_NO_FATAL_FAILURE(solver.solve());
+
+  // Collision detection reports the overlap, and the contact it produces is
+  // non-finite: this is what the solver must defend against.
+  const auto& result = solver.getLastCollisionResult();
+  ASSERT_GT(result.getNumContacts(), 0u);
+  bool anyNonFinite = false;
+  for (std::size_t i = 0; i < result.getNumContacts(); ++i) {
+    const auto& contact = result.getContact(i);
+    if (!contact.point.allFinite() || !contact.normal.allFinite()
+        || !std::isfinite(contact.penetrationDepth)) {
+      anyNonFinite = true;
+    }
+  }
+  EXPECT_TRUE(anyNonFinite) << "Test setup no longer produces a non-finite "
+                               "contact";
+
+  // The non-finite contact must be filtered before contact-constraint creation.
+  EXPECT_EQ(handler->mNumContactsCreated, 0);
+
+  // And the solve must leave the simulation state finite.
+  EXPECT_TRUE(fallingBody->getPositions().allFinite());
+  EXPECT_TRUE(fallingBody->getVelocities().allFinite());
+  EXPECT_TRUE(baseBody->getVelocities().allFinite());
+}

--- a/tests/unit/dynamics/test_ShapeDimensionValidation.cpp
+++ b/tests/unit/dynamics/test_ShapeDimensionValidation.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/BoxShape.hpp>
+#include <dart/dynamics/CapsuleShape.hpp>
+#include <dart/dynamics/ConeShape.hpp>
+#include <dart/dynamics/CylinderShape.hpp>
+#include <dart/dynamics/EllipsoidShape.hpp>
+#include <dart/dynamics/PyramidShape.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <vector>
+
+#include <cmath>
+
+using namespace dart::dynamics;
+
+namespace {
+
+//==============================================================================
+// The set of invalid scalar dimensions every validated setter must reject.
+const std::vector<double>& invalidScalars()
+{
+  static const std::vector<double> values{
+      std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::infinity(),
+      -std::numeric_limits<double>::infinity(),
+      0.0,
+      -1.0};
+  return values;
+}
+
+} // namespace
+
+//==============================================================================
+TEST(ShapeDimensionValidation, BoxShapeRejectsInvalidSize)
+{
+  auto box = std::make_shared<BoxShape>(Eigen::Vector3d(1.0, 2.0, 3.0));
+  const Eigen::Vector3d original = box->getSize();
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+
+  for (const double bad : invalidScalars()) {
+    // Bad value in each component (one at a time) must be rejected.
+    box->setSize(Eigen::Vector3d(bad, 2.0, 3.0));
+    EXPECT_EQ(box->getSize(), original);
+
+    box->setSize(Eigen::Vector3d(1.0, bad, 3.0));
+    EXPECT_EQ(box->getSize(), original);
+
+    box->setSize(Eigen::Vector3d(1.0, 2.0, bad));
+    EXPECT_EQ(box->getSize(), original);
+  }
+
+  // Fully invalid vectors are rejected as well.
+  box->setSize(Eigen::Vector3d(nan, nan, nan));
+  EXPECT_EQ(box->getSize(), original);
+
+  box->setSize(Eigen::Vector3d(-inf, -inf, -inf));
+  EXPECT_EQ(box->getSize(), original);
+}
+
+//==============================================================================
+TEST(ShapeDimensionValidation, CylinderShapeRejectsInvalidRadiusAndHeight)
+{
+  auto cylinder = std::make_shared<CylinderShape>(1.0, 2.0);
+  const double originalRadius = cylinder->getRadius();
+  const double originalHeight = cylinder->getHeight();
+
+  for (const double bad : invalidScalars()) {
+    cylinder->setRadius(bad);
+    EXPECT_DOUBLE_EQ(cylinder->getRadius(), originalRadius);
+
+    cylinder->setHeight(bad);
+    EXPECT_DOUBLE_EQ(cylinder->getHeight(), originalHeight);
+  }
+}
+
+//==============================================================================
+TEST(ShapeDimensionValidation, CapsuleShapeRejectsInvalidRadiusAndHeight)
+{
+  auto capsule = std::make_shared<CapsuleShape>(1.0, 2.0);
+  const double originalRadius = capsule->getRadius();
+  const double originalHeight = capsule->getHeight();
+
+  for (const double bad : invalidScalars()) {
+    capsule->setRadius(bad);
+    EXPECT_DOUBLE_EQ(capsule->getRadius(), originalRadius);
+
+    capsule->setHeight(bad);
+    EXPECT_DOUBLE_EQ(capsule->getHeight(), originalHeight);
+  }
+}
+
+//==============================================================================
+TEST(ShapeDimensionValidation, EllipsoidShapeRejectsInvalidDiametersAndRadii)
+{
+  auto ellipsoid
+      = std::make_shared<EllipsoidShape>(Eigen::Vector3d(1.0, 2.0, 3.0));
+  const Eigen::Vector3d original = ellipsoid->getDiameters();
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+
+  for (const double bad : invalidScalars()) {
+    ellipsoid->setDiameters(Eigen::Vector3d(bad, 2.0, 3.0));
+    EXPECT_EQ(ellipsoid->getDiameters(), original);
+
+    ellipsoid->setDiameters(Eigen::Vector3d(1.0, bad, 3.0));
+    EXPECT_EQ(ellipsoid->getDiameters(), original);
+
+    ellipsoid->setDiameters(Eigen::Vector3d(1.0, 2.0, bad));
+    EXPECT_EQ(ellipsoid->getDiameters(), original);
+
+    // setRadii routes through setDiameters, so it must reject the same.
+    ellipsoid->setRadii(Eigen::Vector3d(bad, 1.0, 1.0));
+    EXPECT_EQ(ellipsoid->getDiameters(), original);
+  }
+
+  ellipsoid->setDiameters(Eigen::Vector3d(nan, nan, nan));
+  EXPECT_EQ(ellipsoid->getDiameters(), original);
+
+  ellipsoid->setDiameters(Eigen::Vector3d(-inf, -inf, -inf));
+  EXPECT_EQ(ellipsoid->getDiameters(), original);
+}
+
+//==============================================================================
+TEST(ShapeDimensionValidation, ConeShapeRejectsInvalidRadiusAndHeight)
+{
+  auto cone = std::make_shared<ConeShape>(1.0, 2.0);
+  const double originalRadius = cone->getRadius();
+  const double originalHeight = cone->getHeight();
+
+  for (const double bad : invalidScalars()) {
+    cone->setRadius(bad);
+    EXPECT_DOUBLE_EQ(cone->getRadius(), originalRadius);
+
+    cone->setHeight(bad);
+    EXPECT_DOUBLE_EQ(cone->getHeight(), originalHeight);
+  }
+}
+
+//==============================================================================
+TEST(ShapeDimensionValidation, PyramidShapeRejectsInvalidDimensions)
+{
+  auto pyramid = std::make_shared<PyramidShape>(1.0, 2.0, 3.0);
+  const double originalWidth = pyramid->getBaseWidth();
+  const double originalDepth = pyramid->getBaseDepth();
+  const double originalHeight = pyramid->getHeight();
+
+  for (const double bad : invalidScalars()) {
+    pyramid->setBaseWidth(bad);
+    EXPECT_DOUBLE_EQ(pyramid->getBaseWidth(), originalWidth);
+
+    pyramid->setBaseDepth(bad);
+    EXPECT_DOUBLE_EQ(pyramid->getBaseDepth(), originalDepth);
+
+    pyramid->setHeight(bad);
+    EXPECT_DOUBLE_EQ(pyramid->getHeight(), originalHeight);
+  }
+}


### PR DESCRIPTION
## Summary

DART 6 LTS backport of the fix for
[gazebosim/gz-physics#1010](https://github.com/gazebosim/gz-physics/issues/1010)
(DART 7 counterpart: dartsim/dart#3115). A collision shape with a non-finite
dimension produced a contact with a non-finite (NaN/Inf) point that crashed
`ContactConstraint` on the `mSpatialNormalA` assertion in asserts-enabled builds
and corrupted the LCP solve in release builds. Fixed with defense in depth:

1. **At the source** — `Box/Cylinder/Capsule/Ellipsoid/Cone/Pyramid` shapes now
   reject non-finite (NaN/Inf) or non-positive (`<= 0`) dimensions in their
   setters and constructors (warn + keep the previous valid value), matching the
   validation `SphereShape` already performed. This also protects inertia,
   bounding-box, and volume computations.
2. **At the solver (backstop)** — `ConstraintSolver::updateConstraints()` skips
   any contact whose point, normal, or penetration depth is non-finite, at the
   same chokepoint that already filters zero-normal, null-body, and
   negative-penetration contacts. This covers non-finite contacts from sources
   shape validation cannot reach: malformed meshes/heightmaps and third-party
   collision backends.

## Motivation / Problem

gz-physics links DART 6, and the report reproduced on DART 6.13.2. The native
`collideSphereSphere` computes `r / (r + r') = inf / inf = NaN` for an infinite
radius, yielding a NaN contact point that passes the existing validity filters.
`SphereShape` already rejected non-finite radii, but every other primitive
accepted invalid dimensions (`CylinderShape::setRadius` only used
`DART_ASSERT(0 < r)`, a no-op in release that does not catch `inf`), and
non-shape sources can produce non-finite contacts too.

## Changes / Key Changes

- `dart/dynamics/{Box,Cylinder,Capsule,Ellipsoid,Cone,Pyramid}Shape.{cpp,hpp}`:
  validate dimensions, route constructors through the validated setters, and
  give dimension members safe positive defaults.
- `ConstraintSolver::updateConstraints()`: skip contacts with non-finite point,
  normal, or penetration depth (`dtwarn`).
- Tests: `test_ShapeDimensionValidation` (NaN/Inf/non-positive rejection for all
  six shapes) and `test_NonFiniteContact` (injects a NaN contact point through a
  collision detector and asserts the contact never reaches constraint creation
  while the solve stays finite).

## Testing

- `pixi run lint`
- Built `dart` and ran `UNIT_dynamics_ShapeDimensionValidation` and
  `test_NonFiniteContact` — both pass (the latter fails without the fix).

## Breaking Changes

- [x] None (behavioral: invalid shape dimensions are now ignored with a warning
      instead of silently stored, consistent with the existing `SphereShape`).

## Related Issues / PRs (backports)

- Downstream report: gazebosim/gz-physics#1010
- DART 7 (`main`) counterpart: dartsim/dart#3115

---

#### Checklist

- [x] Milestone set (DART 6.19.3)
- [x] CHANGELOG.md updated
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes (N/A)
- [ ] Add Python bindings (dartpy) if applicable (N/A)
