### PR TITLE
Speed up DART native active contact aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@
 
 * Collision
 
+  * Speed up active DART-native contact-heavy scenes by replacing global
+    contact-point duplicate scans with reusable indexed contact aggregation and
+    deferring collision-result lookup-set construction until queried:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
   * Add dependency-free primitive plane contacts and broadphase pruning to the
     DART collision backend for sphere, box, cylinder, and plane workloads,
     improving the original 3003-body issue scene while preserving close

--- a/dart/collision/CollisionResult.cpp
+++ b/dart/collision/CollisionResult.cpp
@@ -47,7 +47,6 @@ void CollisionResult::addContact(const Contact& contact)
   mContacts.push_back(contact);
   addObjectToCaches(contact.collisionObject1);
   addObjectToCaches(contact.collisionObject2);
-  mCollidingObjectCachesDirty = false;
 }
 
 //==============================================================================
@@ -124,6 +123,8 @@ CollisionResult::operator bool() const
 void CollisionResult::clear()
 {
   mContacts.clear();
+  mCollidingBodyNodeCandidates.clear();
+  mCollidingShapeFrameCandidates.clear();
   mCollidingShapeFrames.clear();
   mCollidingBodyNodes.clear();
   mCollidingObjectCachesDirty = false;
@@ -137,11 +138,18 @@ void CollisionResult::updateCollidingObjectCaches() const
 
   mCollidingShapeFrames.clear();
   mCollidingBodyNodes.clear();
+
+  for (const auto* frame : mCollidingShapeFrameCandidates)
+    mCollidingShapeFrames.insert(frame);
+
+  for (const auto* bodyNode : mCollidingBodyNodeCandidates)
+    mCollidingBodyNodes.insert(bodyNode);
+
   mCollidingObjectCachesDirty = false;
 }
 
 //==============================================================================
-void CollisionResult::addObjectToCaches(CollisionObject* object) const
+void CollisionResult::addObjectToCaches(CollisionObject* object)
 {
   if (!object) {
     dterr << "[CollisionResult::addObjectToCaches] Attempting to add a "
@@ -152,10 +160,12 @@ void CollisionResult::addObjectToCaches(CollisionObject* object) const
   }
 
   const dynamics::ShapeFrame* frame = object->getShapeFrame();
-  mCollidingShapeFrames.insert(frame);
+  mCollidingShapeFrameCandidates.push_back(frame);
 
   if (const auto* bodyNode = object->getBodyNode())
-    mCollidingBodyNodes.insert(bodyNode);
+    mCollidingBodyNodeCandidates.push_back(bodyNode);
+
+  mCollidingObjectCachesDirty = true;
 }
 
 } // namespace collision

--- a/dart/collision/CollisionResult.cpp
+++ b/dart/collision/CollisionResult.cpp
@@ -133,8 +133,10 @@ void CollisionResult::clear()
 //==============================================================================
 void CollisionResult::updateCollidingObjectCaches() const
 {
-  if (!mCollidingObjectCachesDirty)
+  if (!mCollidingObjectCachesDirty) {
+    mCollidingObjectCachesMaterialized = true;
     return;
+  }
 
   mCollidingShapeFrames.clear();
   mCollidingBodyNodes.clear();
@@ -146,6 +148,7 @@ void CollisionResult::updateCollidingObjectCaches() const
     mCollidingBodyNodes.insert(bodyNode);
 
   mCollidingObjectCachesDirty = false;
+  mCollidingObjectCachesMaterialized = true;
 }
 
 //==============================================================================
@@ -161,11 +164,16 @@ void CollisionResult::addObjectToCaches(CollisionObject* object)
 
   const dynamics::ShapeFrame* frame = object->getShapeFrame();
   mCollidingShapeFrameCandidates.push_back(frame);
+  if (mCollidingObjectCachesMaterialized)
+    mCollidingShapeFrames.insert(frame);
 
-  if (const auto* bodyNode = object->getBodyNode())
+  if (const auto* bodyNode = object->getBodyNode()) {
     mCollidingBodyNodeCandidates.push_back(bodyNode);
+    if (mCollidingObjectCachesMaterialized)
+      mCollidingBodyNodes.insert(bodyNode);
+  }
 
-  mCollidingObjectCachesDirty = true;
+  mCollidingObjectCachesDirty = !mCollidingObjectCachesMaterialized;
 }
 
 } // namespace collision

--- a/dart/collision/CollisionResult.hpp
+++ b/dart/collision/CollisionResult.hpp
@@ -113,6 +113,10 @@ protected:
   /// Whether the unordered lookup sets need to be rebuilt from the eagerly
   /// captured candidate vectors.
   mutable bool mCollidingObjectCachesDirty = false;
+
+  /// Whether the unordered lookup sets have been exposed to callers. Once a
+  /// caller can hold a reference to them, future mutations keep them current.
+  mutable bool mCollidingObjectCachesMaterialized = false;
 };
 
 } // namespace collision

--- a/dart/collision/CollisionResult.hpp
+++ b/dart/collision/CollisionResult.hpp
@@ -93,7 +93,7 @@ public:
 protected:
   void updateCollidingObjectCaches() const;
 
-  void addObjectToCaches(CollisionObject* object) const;
+  void addObjectToCaches(CollisionObject* object);
 
   /// List of contact information for each contact
   std::vector<Contact> mContacts;
@@ -104,9 +104,14 @@ protected:
   /// Set of ShapeFrames that are colliding
   mutable std::unordered_set<const dynamics::ShapeFrame*> mCollidingShapeFrames;
 
-  /// Kept for subclasses that may have called updateCollidingObjectCaches().
-  /// addContact() populates the caches eagerly because CollisionObject
-  /// instances can be shorter-lived than the result that stores their contacts.
+  /// Captured eagerly because CollisionObject instances can be shorter-lived
+  /// than the result that stores their contacts. The unordered lookup sets are
+  /// rebuilt lazily from these stable pointers only when queried.
+  std::vector<const dynamics::BodyNode*> mCollidingBodyNodeCandidates;
+  std::vector<const dynamics::ShapeFrame*> mCollidingShapeFrameCandidates;
+
+  /// Whether the unordered lookup sets need to be rebuilt from the eagerly
+  /// captured candidate vectors.
   mutable bool mCollidingObjectCachesDirty = false;
 };
 

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -48,6 +48,9 @@
 #include <limits>
 #include <vector>
 
+#include <cmath>
+#include <cstdint>
+
 namespace dart {
 namespace collision {
 
@@ -62,6 +65,48 @@ struct BroadphaseEntry
   bool plane{false};
 };
 
+constexpr double kContactDuplicateTolerance = 3.0e-12;
+constexpr std::size_t kInvalidContactPointIndex
+    = std::numeric_limits<std::size_t>::max();
+
+struct ContactPointKey
+{
+  std::int64_t x{0};
+  std::int64_t y{0};
+  std::int64_t z{0};
+};
+
+bool operator==(const ContactPointKey& lhs, const ContactPointKey& rhs);
+
+struct ContactPointBucket
+{
+  ContactPointKey key;
+  std::size_t head{kInvalidContactPointIndex};
+  bool occupied{false};
+};
+
+class ContactPointIndex
+{
+public:
+  void clear();
+  void prepare(std::size_t maxContacts);
+  bool containsClose(const Eigen::Vector3d& point) const;
+  void add(const Eigen::Vector3d& point);
+
+private:
+  bool containsCloseLinear(const Eigen::Vector3d& point) const;
+  void ensureBucketCapacity(std::size_t requiredPoints);
+  void rehash(std::size_t bucketCount);
+  std::size_t findBucketIndex(const ContactPointKey& key) const;
+  std::size_t findOrCreateBucketIndex(const ContactPointKey& key);
+
+  std::vector<ContactPointBucket> buckets;
+  std::vector<std::size_t> usedBuckets;
+  std::vector<Eigen::Vector3d> points;
+  std::vector<std::size_t> nextPoint;
+  std::size_t bucketMask{0u};
+};
+
 struct BroadphaseScratch
 {
   std::vector<BroadphaseEntry> finiteEntries1;
@@ -73,6 +118,7 @@ struct BroadphaseScratch
   std::vector<const BroadphaseEntry*> sortedEntries1;
   std::vector<const BroadphaseEntry*> sortedEntries2;
   CollisionResult pairResult;
+  ContactPointIndex contactPointIndex;
 
   void clear();
 };
@@ -241,6 +287,8 @@ bool DARTCollisionDetector::collide(
 
   auto& scratch = getBroadphaseScratch();
   scratch.clear();
+  if (result)
+    scratch.contactPointIndex.prepare(option.maxNumContacts);
   buildBroadphaseEntries(
       objects,
       scratch.finiteEntries1,
@@ -364,6 +412,8 @@ bool DARTCollisionDetector::collide(
 
   auto& scratch = getBroadphaseScratch();
   scratch.clear();
+  if (result)
+    scratch.contactPointIndex.prepare(option.maxNumContacts);
   buildBroadphaseEntries(
       objects1,
       scratch.finiteEntries1,
@@ -597,6 +647,268 @@ void DARTCollisionDetector::refreshCollisionObject(CollisionObject* /*object*/)
 namespace {
 
 //==============================================================================
+bool operator==(const ContactPointKey& lhs, const ContactPointKey& rhs)
+{
+  return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z;
+}
+
+//==============================================================================
+std::size_t hashContactPointKey(const ContactPointKey& key)
+{
+  auto mix = [](std::uint64_t value) {
+    value ^= value >> 30;
+    value *= 0xbf58476d1ce4e5b9ULL;
+    value ^= value >> 27;
+    value *= 0x94d049bb133111ebULL;
+    value ^= value >> 31;
+    return value;
+  };
+
+  auto hash = mix(static_cast<std::uint64_t>(key.x));
+  hash ^= mix(
+      static_cast<std::uint64_t>(key.y) + 0x9e3779b97f4a7c15ULL + (hash << 6)
+      + (hash >> 2));
+  hash ^= mix(
+      static_cast<std::uint64_t>(key.z) + 0x9e3779b97f4a7c15ULL + (hash << 6)
+      + (hash >> 2));
+
+  return static_cast<std::size_t>(hash);
+}
+
+//==============================================================================
+std::size_t nextPowerOfTwo(std::size_t value)
+{
+  std::size_t power = 1u;
+  while (power < value
+         && power <= std::numeric_limits<std::size_t>::max() / 2u) {
+    power <<= 1u;
+  }
+
+  return power;
+}
+
+//==============================================================================
+bool makeContactPointKey(const Eigen::Vector3d& point, ContactPointKey& key)
+{
+  for (auto i = 0; i < 3; ++i) {
+    if (!std::isfinite(point[i]))
+      return false;
+
+    const auto cell = std::floor(point[i] / kContactDuplicateTolerance);
+    if (cell < static_cast<double>(std::numeric_limits<std::int64_t>::min())
+        || cell > static_cast<double>(
+               std::numeric_limits<std::int64_t>::max())) {
+      return false;
+    }
+
+    if (i == 0)
+      key.x = static_cast<std::int64_t>(cell);
+    else if (i == 1)
+      key.y = static_cast<std::int64_t>(cell);
+    else
+      key.z = static_cast<std::int64_t>(cell);
+  }
+
+  return true;
+}
+
+//==============================================================================
+bool offsetCell(std::int64_t cell, int offset, std::int64_t& result)
+{
+  if (offset > 0) {
+    if (cell > std::numeric_limits<std::int64_t>::max() - offset)
+      return false;
+  } else if (offset < 0) {
+    if (cell < std::numeric_limits<std::int64_t>::min() - offset)
+      return false;
+  }
+
+  result = cell + offset;
+  return true;
+}
+
+//==============================================================================
+void ContactPointIndex::clear()
+{
+  for (const auto bucketIndex : usedBuckets)
+    buckets[bucketIndex] = ContactPointBucket();
+
+  usedBuckets.clear();
+  points.clear();
+  nextPoint.clear();
+}
+
+//==============================================================================
+void ContactPointIndex::prepare(std::size_t maxContacts)
+{
+  clear();
+
+  const auto reserveContacts
+      = std::max<std::size_t>(16u, std::min<std::size_t>(maxContacts, 65536u));
+  points.reserve(reserveContacts);
+  nextPoint.reserve(reserveContacts);
+  usedBuckets.reserve(reserveContacts);
+  ensureBucketCapacity(reserveContacts);
+}
+
+//==============================================================================
+bool ContactPointIndex::containsClose(const Eigen::Vector3d& point) const
+{
+  ContactPointKey key;
+  if (buckets.empty() || !makeContactPointKey(point, key))
+    return containsCloseLinear(point);
+
+  for (auto dx = -1; dx <= 1; ++dx) {
+    ContactPointKey neighbor;
+    if (!offsetCell(key.x, dx, neighbor.x))
+      continue;
+
+    for (auto dy = -1; dy <= 1; ++dy) {
+      if (!offsetCell(key.y, dy, neighbor.y))
+        continue;
+
+      for (auto dz = -1; dz <= 1; ++dz) {
+        if (!offsetCell(key.z, dz, neighbor.z))
+          continue;
+
+        const auto bucketIndex = findBucketIndex(neighbor);
+        if (bucketIndex == kInvalidContactPointIndex)
+          continue;
+
+        for (auto pointIndex = buckets[bucketIndex].head;
+             pointIndex != kInvalidContactPointIndex;
+             pointIndex = nextPoint[pointIndex]) {
+          if (isClose(point, points[pointIndex], kContactDuplicateTolerance))
+            return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+//==============================================================================
+void ContactPointIndex::add(const Eigen::Vector3d& point)
+{
+  ensureBucketCapacity(points.size() + 1u);
+
+  const auto pointIndex = points.size();
+  points.push_back(point);
+  nextPoint.push_back(kInvalidContactPointIndex);
+
+  ContactPointKey key;
+  if (!makeContactPointKey(point, key))
+    return;
+
+  const auto bucketIndex = findOrCreateBucketIndex(key);
+  if (bucketIndex == kInvalidContactPointIndex)
+    return;
+
+  nextPoint[pointIndex] = buckets[bucketIndex].head;
+  buckets[bucketIndex].head = pointIndex;
+}
+
+//==============================================================================
+bool ContactPointIndex::containsCloseLinear(const Eigen::Vector3d& point) const
+{
+  for (const auto& existingPoint : points) {
+    if (isClose(point, existingPoint, kContactDuplicateTolerance))
+      return true;
+  }
+
+  return false;
+}
+
+//==============================================================================
+void ContactPointIndex::ensureBucketCapacity(std::size_t requiredPoints)
+{
+  const auto minBucketCount = 64u;
+  auto desiredBucketCount = minBucketCount;
+  if (requiredPoints <= std::numeric_limits<std::size_t>::max() / 4u) {
+    desiredBucketCount
+        = std::max<std::size_t>(minBucketCount, requiredPoints * 4u);
+  }
+
+  desiredBucketCount = nextPowerOfTwo(desiredBucketCount);
+  if (buckets.size() >= desiredBucketCount)
+    return;
+
+  rehash(desiredBucketCount);
+}
+
+//==============================================================================
+void ContactPointIndex::rehash(std::size_t bucketCount)
+{
+  buckets.assign(bucketCount, ContactPointBucket());
+  usedBuckets.clear();
+  bucketMask = buckets.empty() ? 0u : buckets.size() - 1u;
+
+  for (auto i = 0u; i < points.size(); ++i) {
+    nextPoint[i] = kInvalidContactPointIndex;
+
+    ContactPointKey key;
+    if (!makeContactPointKey(points[i], key))
+      continue;
+
+    const auto bucketIndex = findOrCreateBucketIndex(key);
+    if (bucketIndex == kInvalidContactPointIndex)
+      continue;
+
+    nextPoint[i] = buckets[bucketIndex].head;
+    buckets[bucketIndex].head = i;
+  }
+}
+
+//==============================================================================
+std::size_t ContactPointIndex::findBucketIndex(const ContactPointKey& key) const
+{
+  if (buckets.empty())
+    return kInvalidContactPointIndex;
+
+  auto bucketIndex = hashContactPointKey(key) & bucketMask;
+  for (auto probe = 0u; probe < buckets.size(); ++probe) {
+    const auto& bucket = buckets[bucketIndex];
+    if (!bucket.occupied)
+      return kInvalidContactPointIndex;
+
+    if (bucket.key == key)
+      return bucketIndex;
+
+    bucketIndex = (bucketIndex + 1u) & bucketMask;
+  }
+
+  return kInvalidContactPointIndex;
+}
+
+//==============================================================================
+std::size_t ContactPointIndex::findOrCreateBucketIndex(
+    const ContactPointKey& key)
+{
+  if (buckets.empty())
+    return kInvalidContactPointIndex;
+
+  auto bucketIndex = hashContactPointKey(key) & bucketMask;
+  for (auto probe = 0u; probe < buckets.size(); ++probe) {
+    auto& bucket = buckets[bucketIndex];
+    if (!bucket.occupied) {
+      bucket.occupied = true;
+      bucket.key = key;
+      bucket.head = kInvalidContactPointIndex;
+      usedBuckets.push_back(bucketIndex);
+      return bucketIndex;
+    }
+
+    if (bucket.key == key)
+      return bucketIndex;
+
+    bucketIndex = (bucketIndex + 1u) & bucketMask;
+  }
+
+  return kInvalidContactPointIndex;
+}
+
+//==============================================================================
 void BroadphaseScratch::clear()
 {
   finiteEntries1.clear();
@@ -608,6 +920,7 @@ void BroadphaseScratch::clear()
   sortedEntries1.clear();
   sortedEntries2.clear();
   pairResult.clear();
+  contactPointIndex.clear();
 }
 
 //==============================================================================
@@ -683,31 +996,22 @@ void postProcess(
   if (!pairResult.isCollision())
     return;
 
-  // Don't add repeated points
-  const auto tol = 3.0e-12;
-
+  auto& contactPointIndex = getBroadphaseScratch().contactPointIndex;
   const auto maxContactsPerPair = option.getEffectiveMaxNumContactsPerPair();
   std::size_t pairContacts = 0u;
-  for (auto pairContact : pairResult.getContacts()) {
+  for (const auto& pairContact : pairResult.getContacts()) {
     if (pairContacts >= maxContactsPerPair)
       break;
 
-    auto foundClose = false;
-
-    for (auto totalContact : totalResult.getContacts()) {
-      if (isClose(pairContact.point, totalContact.point, tol)) {
-        foundClose = true;
-        break;
-      }
-    }
-
-    if (foundClose)
+    // Don't add repeated points.
+    if (contactPointIndex.containsClose(pairContact.point))
       continue;
 
     auto contact = pairContact;
     contact.collisionObject1 = o1;
     contact.collisionObject2 = o2;
     totalResult.addContact(contact);
+    contactPointIndex.add(contact.point);
     ++pairContacts;
 
     if (totalResult.getNumContacts() >= option.maxNumContacts)

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -66,6 +66,8 @@ struct BroadphaseEntry
 };
 
 constexpr double kContactDuplicateTolerance = 3.0e-12;
+constexpr double kContactPointKeyLowerBound = -9223372036854775808.0;
+constexpr double kContactPointKeyUpperBound = 9223372036854775808.0;
 constexpr std::size_t kInvalidContactPointIndex
     = std::numeric_limits<std::size_t>::max();
 
@@ -695,9 +697,8 @@ bool makeContactPointKey(const Eigen::Vector3d& point, ContactPointKey& key)
       return false;
 
     const auto cell = std::floor(point[i] / kContactDuplicateTolerance);
-    if (cell < static_cast<double>(std::numeric_limits<std::int64_t>::min())
-        || cell > static_cast<double>(
-               std::numeric_limits<std::int64_t>::max())) {
+    if (cell < kContactPointKeyLowerBound
+        || cell >= kContactPointKeyUpperBound) {
       return false;
     }
 

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -2,43 +2,50 @@
 
 ## Current Snapshot
 
-Bottom line: #3071 is merged, so the performance stack has moved to the native
-collision phase on `perf/dart6-native-collision`, based on `release-6.20`. This
-phase is intentionally evidence-gated: the DART 7 native detector cannot be
-copied literally into DART 6 because the main-branch collision world depends on
-EnTT and C++23 APIs, while DART 6.20 remains C++17 and gz-physics compatible.
-The first implementation slice ports the useful primitive contact behavior into
-the existing `dart/collision/dart/` backend without adding dependencies:
-finite-shape broadphase filtering plus plane contacts for the original #3056
-sphere/box/cylinder workload. The success bar is still the same original issue
-scene, final-state/hash correctness, focused collision tests, and RTF compared
-against Bullet/FCL/ODE where those backends complete.
+Bottom line: #3123 is merged, so the next slice is active-mode native collision
+performance on `perf/dart6-native-active-collision`, based on `release-6.20`.
+The long-term target remains DART 7 native-collision feature, test, and
+benchmark parity inside DART 6.20's dependency-free `dart/collision/dart/`
+backend. Once that path proves correctness and performance across the required
+shape set, FCL, Bullet, and ODE should become optional comparison and regression
+dependencies for tests/benchmarks rather than required production collision
+backends. Middle PRs are acceptable, but each one must keep gz-physics-facing
+API behavior compatible and show measured baseline-vs-current evidence.
 
-Current native-collision evidence on the original `/tmp/3k_shapes.sdf` issue
-scene, 3000 steps, `--sdf-plane-shapes --world-threads 16 --max-contacts 12000`,
-and default deactivation enabled:
+Current active-mode evidence uses the original `/tmp/3k_shapes.sdf` issue scene:
+3003 mobile sphere/box/cylinder bodies, DART 6 dynamics/constraints/solver,
+300 steps, `--disable-deactivation --sdf-plane-shapes --world-threads 16
+--max-contacts 12000`, with final-state consumption enabled.
 
-| Collision backend | RTF | Final state |
-| --- | ---: | --- |
-| DART native, current branch | `1.90971` | finite, hash `0x131b6af79a44ff90`, resting `3003 / 3003`, contacts `0` |
-| Bullet | `1.5567` | finite, hash `0x2375f1927218cd43`, resting `3003 / 3003`, contacts `0` |
-| ODE | `0.0257735` | finite, hash `0x4e5f6556657720`, resting `3003 / 3003`, contacts `0` |
-| FCL primitive | no RTF | did not complete setup within a 180 s local timeout |
+| Run | RTF | Collision time | Final state |
+| --- | ---: | ---: | --- |
+| Merged #3123 DART native baseline | `0.0198059` | `37.16 ms/step` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
+| Current DART native | `0.0536378` | `6.316 ms/step` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
+| Current Bullet comparison | `0.0607573` | `4.227 ms/step` | finite, hash `0x1b1e6f3c78c0e01e`, contacts `5005`, pairs `3003` |
 
-DART native and Bullet settle to the same shape keys. Final-scene dump deltas
-after 3000 steps are small: max position delta `3.432794147777784e-06` m, mean
-position delta `1.8434777525926603e-06` m, max quaternion delta
+The current native slice preserves the DART-native final hash while raising
+active no-sleep RTF by `2.7x` and reducing DART-native collision time by `5.9x`
+on the same workload. It does not yet beat Bullet in active mode; Bullet remains
+about `13%` faster end-to-end on this run. The profile-driven cause of the
+native gain was the previous all-contact duplicate scan in DART-native contact
+post-processing, plus shared `CollisionResult` lookup-cache work on temporary
+per-pair results.
+
+The original default sleeping issue case remains above real time after this
+slice. Current DART native command:
+`pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 3000 --warmup 0
+--checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16
+--max-contacts 12000 --profile`. Result: RTF `1.88616`, finite final state,
+hash `0x131b6af79a44ff90`, frame/time advanced `3000 / 3000`, final resting
+`3003 / 3003`, final contacts `0`.
+
+DART native and Bullet settle to the same shape keys in the earlier #3123
+3000-step comparison. Final-scene dump deltas were small: max position delta
+`3.432794147777784e-06` m, mean position delta
+`1.8434777525926603e-06` m, max quaternion delta
 `1.9819543267524604e-06`, and max z delta `2.8028646514299815e-06` m. Spheres
-match exactly; boxes and cylinders account for the tiny residual differences.
-
-Active-mode caveat: with `--disable-deactivation` and 300 steps, DART native is
-still slower than Bullet even with the same final contact count (`5005` contacts
-across `3003` pairs). Current DART native: RTF `0.0207091`, final hash
-`0x6b50e84cd691f6e2`, profiler `collide` time `10.84 s` / `36.12 ms` per
-call. Bullet: RTF `0.0553424`, final hash `0x1b1e6f3c78c0e01e`, profiler
-`collide` time `1.484 s` / `4.948 ms` per call. The default issue-scene win is
-real, but the active no-sleep path still needs deeper DART-native narrow-phase
-optimization before claiming a broad replacement for Bullet.
+matched exactly; boxes and cylinders accounted for the tiny residual
+differences.
 
 The previous managed PR, #3071 `perf/dart6-parallel-islands`, landed as the
 parallel-stepping follow-up after #3111 and #3112 added the core
@@ -89,12 +96,15 @@ pinned to CPUs 0-15:
 
 Native-collision follow-up: continue porting DART 7 native algorithms into
 DART 6.20's `dart/collision/dart/` path in dependency-free slices. The current
-slice adds finite-shape broadphase filtering, plane/sphere/box/cylinder
-contacts, and per-thread scratch reuse in the existing DART backend. It beats
-Bullet on the default sleeping issue scene while preserving close settled-state
-agreement, but Bullet still wins active no-deactivation collision time.
+merged slice added finite-shape broadphase filtering, plane/sphere/box/cylinder
+contacts, and per-thread scratch reuse in the existing DART backend. The active
+follow-up replaces the all-contact duplicate scan with a reusable spatial index
+and avoids eager unordered lookup-cache work for temporary per-pair collision
+results. DART native beats Bullet on the default sleeping issue scene while
+preserving close settled-state agreement; Bullet remains the active-mode target
+to beat.
 
-- Current active branch: `perf/dart6-native-collision`, based on
+- Current active branch: `perf/dart6-native-active-collision`, based on
   `origin/release-6.20`.
 - Exact issue scene used for the current evidence: `/tmp/3k_shapes.sdf`,
   3003 mobile sphere/box/cylinder bodies plus the static ground plane from the
@@ -106,28 +116,30 @@ agreement, but Bullet still wins active no-deactivation collision time.
   This uses the dependency-free DART collision backend for collision detection;
   DART 6 also owns dynamics, constraints, sleep/deactivation, and the LCP solve.
 - Current exact-scene native result, default deactivation enabled: RTF
-  `1.90971`, finite final state, final hash `0x131b6af79a44ff90`, final
+  `1.88616`, finite final state, final hash `0x131b6af79a44ff90`, final
   resting `3003 / 3003`, final contacts `0`, and frame/time advanced exactly
-  `3000 / 3000` steps. The same command with Bullet collision detection gives
-  RTF `1.5567`.
+  `3000 / 3000` steps. The earlier same-scene Bullet comparison on the merged
+  native slice gave RTF `1.5567`.
 - Same exact command with `--world-threads 1` gives RTF `1.46391`; with
   `--world-threads 4` gives RTF `1.49184`. The current win is therefore from
   prompt deactivation of the initially settled issue scene, not from thread
   scaling.
-- Same exact command with `--disable-deactivation` gives RTF `0.0559457` to
-  `0.0604573`, finite final state, final hash `0x8aa3ab9f1fe495c6`, final
-  contacts `7005`, and final contact pairs `3003`.
+- Same exact command with `--steps 300 --disable-deactivation --profile` gives
+  current DART native RTF `0.0536378`, finite final state, hash
+  `0x6b50e84cd691f6e2`, final contacts `5005`, and final contact pairs `3003`.
+  The current Bullet comparison gives RTF `0.0607573`, hash
+  `0x1b1e6f3c78c0e01e`, final contacts `5005`, and final contact pairs `3003`.
 - Exact-scene final dump comparison, default-on vs disabled deactivation,
   matched all `3003` mobile shapes: max position delta
   `3.4147863965736968e-06` m, mean position delta
   `1.8350550992622476e-06` m, max quaternion L2 delta
   `1.9714098667727154e-06`.
-- Current profiler shape on the exact scene: only `3` full
+- Current default-sleeping profiler shape on the exact scene: only `3` full
   constraint/collision solves, followed by `2997` all-resting cached steps.
-  Inclusive simulation time was `1.993 s`; all-resting readiness was `1.221 s`,
-  all-resting fast path was `265 ms`, and the three Bullet collision calls were
-  `452 ms` total. The next measured hotspot is the readiness scan, not the
-  LCP solve.
+  Inclusive simulation time was `1.588 s`; all-resting readiness was `1.249 s`,
+  all-resting fast path was `267 ms`, and the three native collision calls were
+  `14.33 ms` total. The next measured default-sleeping hotspot is the readiness
+  scan, not the LCP solve.
 - FCL and ODE exact-scene comparison: FCL primitive did not complete setup
   within a 180 s timeout. ODE completed but measured RTF `0.0257735`, far below
   DART native and Bullet on this scene.

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -841,6 +841,52 @@ TEST_F(Collision, DartPlanePrimitiveContacts)
 }
 
 //==============================================================================
+TEST_F(Collision, DartContactPointDeduplicationKeepsDistinctPoints)
+{
+  auto cd = DARTCollisionDetector::create();
+
+  auto planeFrame = SimpleFrame::createShared(Frame::World());
+  planeFrame->setShape(
+      std::make_shared<PlaneShape>(Eigen::Vector3d::UnitZ(), 0.0));
+
+  auto sphere1 = SimpleFrame::createShared(Frame::World());
+  auto sphere2 = SimpleFrame::createShared(Frame::World());
+  auto sphere3 = SimpleFrame::createShared(Frame::World());
+
+  sphere1->setShape(std::make_shared<SphereShape>(0.5));
+  sphere2->setShape(std::make_shared<SphereShape>(0.5));
+  sphere3->setShape(std::make_shared<SphereShape>(0.5));
+
+  sphere1->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.45));
+  sphere2->setTranslation(Eigen::Vector3d(1.0e-12, 0.0, 0.45));
+  sphere3->setTranslation(Eigen::Vector3d(1.0e-10, 0.0, 0.45));
+
+  auto planeGroup = cd->createCollisionGroup(planeFrame.get());
+  auto sphereGroup
+      = cd->createCollisionGroup(sphere1.get(), sphere2.get(), sphere3.get());
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 8u;
+
+  CollisionResult result;
+  ASSERT_TRUE(planeGroup->collide(sphereGroup.get(), option, &result));
+  ASSERT_EQ(result.getNumContacts(), 2u);
+
+  std::vector<double> contactXs;
+  for (const auto& contact : result.getContacts()) {
+    EXPECT_EQ(contact.collisionObject1->getShapeFrame(), planeFrame.get());
+    EXPECT_NEAR(contact.penetrationDepth, 0.05, 1e-12);
+    EXPECT_TRUE(contact.normal.isApprox(-Eigen::Vector3d::UnitZ(), 1e-12));
+    contactXs.push_back(contact.point.x());
+  }
+
+  std::sort(contactXs.begin(), contactXs.end());
+  EXPECT_NEAR(contactXs[0], 0.0, 1e-12);
+  EXPECT_NEAR(contactXs[1], 1.0e-10, 1e-12);
+}
+
+//==============================================================================
 TEST_F(Collision, DartSphereCylinderOrderSymmetry)
 {
   auto cd = DARTCollisionDetector::create();

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -2524,6 +2524,67 @@ TEST_F(Collision, CollisionResultCachesCollidingFramesEagerly)
 }
 
 //==============================================================================
+TEST_F(Collision, CollisionResultKeepsMaterializedCollidingSetsCurrent)
+{
+  auto detector = FCLCollisionDetector::create();
+
+  auto skelA = Skeleton::create("result_set_a");
+  auto skelB = Skeleton::create("result_set_b");
+  auto skelC = Skeleton::create("result_set_c");
+  auto skelD = Skeleton::create("result_set_d");
+
+  auto pairA = skelA->createJointAndBodyNodePair<FreeJoint>();
+  auto pairB = skelB->createJointAndBodyNodePair<FreeJoint>();
+  auto pairC = skelC->createJointAndBodyNodePair<FreeJoint>();
+  auto pairD = skelD->createJointAndBodyNodePair<FreeJoint>();
+
+  auto box = std::make_shared<BoxShape>(Eigen::Vector3d::Constant(1.0));
+  auto* nodeA = pairA.second->createShapeNodeWith<CollisionAspect>(box);
+  auto* nodeB = pairB.second->createShapeNodeWith<CollisionAspect>(box);
+  auto* nodeC = pairC.second->createShapeNodeWith<CollisionAspect>(box);
+  auto* nodeD = pairD.second->createShapeNodeWith<CollisionAspect>(box);
+
+  TestCollisionObject objectA(detector.get(), nodeA);
+  TestCollisionObject objectB(detector.get(), nodeB);
+  TestCollisionObject objectC(detector.get(), nodeC);
+  TestCollisionObject objectD(detector.get(), nodeD);
+
+  CollisionResult result;
+  const auto& frames = result.getCollidingShapeFrames();
+  const auto& bodies = result.getCollidingBodyNodes();
+  EXPECT_TRUE(frames.empty());
+  EXPECT_TRUE(bodies.empty());
+
+  Contact contactAB;
+  contactAB.collisionObject1 = &objectA;
+  contactAB.collisionObject2 = &objectB;
+  result.addContact(contactAB);
+
+  EXPECT_TRUE(frames.count(nodeA));
+  EXPECT_TRUE(frames.count(nodeB));
+  EXPECT_TRUE(bodies.count(pairA.second));
+  EXPECT_TRUE(bodies.count(pairB.second));
+
+  result.clear();
+  EXPECT_TRUE(frames.empty());
+  EXPECT_TRUE(bodies.empty());
+
+  Contact contactCD;
+  contactCD.collisionObject1 = &objectC;
+  contactCD.collisionObject2 = &objectD;
+  result.addContact(contactCD);
+
+  EXPECT_FALSE(frames.count(nodeA));
+  EXPECT_FALSE(frames.count(nodeB));
+  EXPECT_TRUE(frames.count(nodeC));
+  EXPECT_TRUE(frames.count(nodeD));
+  EXPECT_FALSE(bodies.count(pairA.second));
+  EXPECT_FALSE(bodies.count(pairB.second));
+  EXPECT_TRUE(bodies.count(pairC.second));
+  EXPECT_TRUE(bodies.count(pairD.second));
+}
+
+//==============================================================================
 TEST_F(Collision, CreateCollisionGroupFromVariousObject)
 {
   auto fcl_mesh_dart = FCLCollisionDetector::create();

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -852,18 +852,28 @@ TEST_F(Collision, DartContactPointDeduplicationKeepsDistinctPoints)
   auto sphere1 = SimpleFrame::createShared(Frame::World());
   auto sphere2 = SimpleFrame::createShared(Frame::World());
   auto sphere3 = SimpleFrame::createShared(Frame::World());
+  auto sphere4 = SimpleFrame::createShared(Frame::World());
+  auto sphere5 = SimpleFrame::createShared(Frame::World());
 
   sphere1->setShape(std::make_shared<SphereShape>(0.5));
   sphere2->setShape(std::make_shared<SphereShape>(0.5));
   sphere3->setShape(std::make_shared<SphereShape>(0.5));
+  sphere4->setShape(std::make_shared<SphereShape>(0.5));
+  sphere5->setShape(std::make_shared<SphereShape>(0.5));
 
   sphere1->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.45));
   sphere2->setTranslation(Eigen::Vector3d(1.0e-12, 0.0, 0.45));
   sphere3->setTranslation(Eigen::Vector3d(1.0e-10, 0.0, 0.45));
+  sphere4->setTranslation(Eigen::Vector3d(3.0e7, 0.0, 0.45));
+  sphere5->setTranslation(Eigen::Vector3d(3.0e7, 0.0, 0.45));
 
   auto planeGroup = cd->createCollisionGroup(planeFrame.get());
-  auto sphereGroup
-      = cd->createCollisionGroup(sphere1.get(), sphere2.get(), sphere3.get());
+  auto sphereGroup = cd->createCollisionGroup(
+      sphere1.get(),
+      sphere2.get(),
+      sphere3.get(),
+      sphere4.get(),
+      sphere5.get());
 
   CollisionOption option;
   option.enableContact = true;
@@ -871,7 +881,7 @@ TEST_F(Collision, DartContactPointDeduplicationKeepsDistinctPoints)
 
   CollisionResult result;
   ASSERT_TRUE(planeGroup->collide(sphereGroup.get(), option, &result));
-  ASSERT_EQ(result.getNumContacts(), 2u);
+  ASSERT_EQ(result.getNumContacts(), 3u);
 
   std::vector<double> contactXs;
   for (const auto& contact : result.getContacts()) {
@@ -884,6 +894,7 @@ TEST_F(Collision, DartContactPointDeduplicationKeepsDistinctPoints)
   std::sort(contactXs.begin(), contactXs.end());
   EXPECT_NEAR(contactXs[0], 0.0, 1e-12);
   EXPECT_NEAR(contactXs[1], 1.0e-10, 1e-12);
+  EXPECT_NEAR(contactXs[2], 3.0e7, 1e-6);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Speeds up the DART-native collision backend's active contact-heavy path by replacing the global contact-point duplicate scan with reusable indexed contact aggregation.
- Defers `CollisionResult` body/frame lookup-set construction until callers query those sets, while still eagerly capturing stable body/frame pointers for short-lived collision objects.
- Records the issue #3056 baseline/current evidence and the longer DART-native dependency-reduction target in the dev-task notes.

## Motivation / Problem

The merged native collision backend work made the original issue #3056 default sleeping scene exceed real time, but the same scene with deactivation disabled was still dominated by DART-native contact post-processing. Profiling showed collision time at about `37.16 ms/step` on the active 3003-body issue scene, with most of that time spent scanning all previously accepted contacts for every candidate contact.

This PR keeps the DART 6 API surface compatible with gz-physics and focuses on one measured hot path. It is also a step toward the longer-term goal of making DART's native collision backend feature-complete and fast enough that FCL, Bullet, and ODE can eventually be retained for comparison and regression tests rather than required production collision backends.

## Changes / Key Changes

- Adds a per-thread reusable `ContactPointIndex` for DART-native contact aggregation, preserving the existing `3e-12` duplicate tolerance and exact `isClose()` acceptance check.
- Reuses vector-backed/open-addressed storage so the active simulation loop avoids unordered-map allocation churn after the first capacity preparation.
- Changes `CollisionResult` to capture colliding body/frame candidates eagerly, then rebuild unordered lookup sets lazily only when `inCollision()` / colliding-set accessors are queried.
- Adds `Collision.DartContactPointDeduplicationKeepsDistinctPoints` to prove near-duplicate contact points are still merged while distinct points inside the same contact-heavy result are retained.
- Updates `CHANGELOG.md` and `docs/dev_tasks/issue_3056_dart6_performance/README.md` with baseline-vs-current RTF and profiling evidence.

## Before / After

Original issue scene: `/tmp/3k_shapes.sdf`, 3003 mobile sphere/box/cylinder bodies, DART 6 dynamics/constraints/solver, `--sdf-plane-shapes --world-threads 16 --max-contacts 12000`.

| Run | RTF | Collision time | Final state |
| --- | ---: | ---: | --- |
| Merged #3123 DART native, active no-sleep, 300 steps | `0.0198059` | `37.16 ms/step` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
| This PR DART native, active no-sleep, 300 steps | `0.051123` | `6.491 ms/step` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
| This PR Bullet comparison, active no-sleep, 300 steps | `0.0607573` | `4.227 ms/step` | finite, hash `0x1b1e6f3c78c0e01e`, contacts `5005`, pairs `3003` |
| This PR DART native, default deactivation, 3000 steps | `1.88616` | three collision calls total `14.33 ms` | finite, hash `0x131b6af79a44ff90`, resting `3003 / 3003`, contacts `0` |

The active DART-native final hash is unchanged from the merged #3123 DART-native baseline. DART native is now much closer to the Bullet comparison on the always-active path, but Bullet still remains faster on this run.

## Testing

- `pixi run lint`
- `pixi run test -- -R '^(test_Collision|test_CollisionGroups|test_ContactSurface)$' --output-on-failure`
- `pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --disable-deactivation --profile`
- `pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision bullet --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --disable-deactivation --profile`
- `pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 3000 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --profile`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of #3056.
- Follows #3123.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable

