### PR TITLE
Add DART-native capsule primitive contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@
     deferring collision-result lookup-set construction until queried:
     [#3056](https://github.com/dartsim/dart/issues/3056)
 
+  * Add DART-native capsule contacts against spheres, boxes, cylinders, planes,
+    and other capsules, with primitive-pair regression coverage and capsule
+    benchmark scenes for comparing native and external collision backends:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
   * Add dependency-free primitive plane contacts and broadphase pruning to the
     DART collision backend for sphere, box, cylinder, and plane workloads,
     improving the original 3003-body issue scene while preserving close

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -35,6 +35,7 @@
 #include "dart/collision/CollisionObject.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/BoxShape.hpp"
+#include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
@@ -2061,7 +2062,724 @@ int collideSupportMappedShapes(
   return 1;
 }
 
+void addDartContact(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const Eigen::Vector3d& point,
+    Eigen::Vector3d normal,
+    double penetration,
+    CollisionResult& result)
+{
+  if (normal.squaredNorm() < 1e-12)
+    normal = Eigen::Vector3d::UnitZ();
+  else
+    normal.normalize();
+
+  Contact contact;
+  contact.collisionObject1 = o1;
+  contact.collisionObject2 = o2;
+  contact.point = point;
+  contact.normal = normal;
+  contact.penetrationDepth = penetration;
+  result.addContact(contact);
+}
+
+Eigen::Vector3d closestPointOnSegment(
+    const Eigen::Vector3d& point,
+    const Eigen::Vector3d& segmentStart,
+    const Eigen::Vector3d& segmentEnd)
+{
+  const Eigen::Vector3d segment = segmentEnd - segmentStart;
+  const double segmentLengthSq = segment.squaredNorm();
+
+  if (segmentLengthSq < 1e-10)
+    return segmentStart;
+
+  const double t = std::clamp(
+      (point - segmentStart).dot(segment) / segmentLengthSq, 0.0, 1.0);
+  return segmentStart + segment * t;
+}
+
+struct SegmentClosestPointResult
+{
+  Eigen::Vector3d point1;
+  Eigen::Vector3d point2;
+  double distSquared;
+};
+
+SegmentClosestPointResult closestPointsBetweenSegments(
+    const Eigen::Vector3d& p1,
+    const Eigen::Vector3d& q1,
+    const Eigen::Vector3d& p2,
+    const Eigen::Vector3d& q2)
+{
+  const Eigen::Vector3d d1 = q1 - p1;
+  const Eigen::Vector3d d2 = q2 - p2;
+  const Eigen::Vector3d r = p1 - p2;
+
+  const double a = d1.squaredNorm();
+  const double e = d2.squaredNorm();
+  const double f = d2.dot(r);
+
+  double s = 0.0;
+  double t = 0.0;
+
+  constexpr double epsilon = 1e-10;
+  if (a <= epsilon && e <= epsilon) {
+    s = t = 0.0;
+  } else if (a <= epsilon) {
+    s = 0.0;
+    t = std::clamp(f / e, 0.0, 1.0);
+  } else {
+    const double c = d1.dot(r);
+    if (e <= epsilon) {
+      t = 0.0;
+      s = std::clamp(-c / a, 0.0, 1.0);
+    } else {
+      const double b = d1.dot(d2);
+      const double denom = a * e - b * b;
+
+      if (denom != 0.0)
+        s = std::clamp((b * f - c * e) / denom, 0.0, 1.0);
+      else
+        s = 0.0;
+
+      t = (b * s + f) / e;
+
+      if (t < 0.0) {
+        t = 0.0;
+        s = std::clamp(-c / a, 0.0, 1.0);
+      } else if (t > 1.0) {
+        t = 1.0;
+        s = std::clamp((b - c) / a, 0.0, 1.0);
+      }
+    }
+  }
+
+  SegmentClosestPointResult result;
+  result.point1 = p1 + d1 * s;
+  result.point2 = p2 + d2 * t;
+  result.distSquared = (result.point1 - result.point2).squaredNorm();
+  return result;
+}
+
+Eigen::Vector3d closestPointOnBox(
+    const Eigen::Vector3d& point, const Eigen::Vector3d& halfExtents)
+{
+  return Eigen::Vector3d(
+      std::clamp(point.x(), -halfExtents.x(), halfExtents.x()),
+      std::clamp(point.y(), -halfExtents.y(), halfExtents.y()),
+      std::clamp(point.z(), -halfExtents.z(), halfExtents.z()));
+}
+
+Eigen::Vector3d closestPointOnSegmentInBoxSpace(
+    const Eigen::Vector3d& segmentStart,
+    const Eigen::Vector3d& segmentEnd,
+    const Eigen::Vector3d& halfExtents,
+    Eigen::Vector3d& closestOnSegment)
+{
+  const Eigen::Vector3d segment = segmentEnd - segmentStart;
+  const double segmentLengthSq = segment.squaredNorm();
+
+  if (segmentLengthSq < 1e-10) {
+    closestOnSegment = segmentStart;
+    return closestPointOnBox(segmentStart, halfExtents);
+  }
+
+  double bestDistSq = std::numeric_limits<double>::max();
+  double bestInteriorMargin = -std::numeric_limits<double>::infinity();
+  Eigen::Vector3d bestOnBox = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestOnSegment = segmentStart;
+
+  auto computeInteriorMargin = [&](const Eigen::Vector3d& point) {
+    double margin = std::numeric_limits<double>::infinity();
+    for (int axis = 0; axis < 3; ++axis) {
+      const double axisMargin = halfExtents[axis] - std::abs(point[axis]);
+      if (axisMargin < 0.0)
+        return -std::numeric_limits<double>::infinity();
+      margin = std::min(margin, axisMargin);
+    }
+    return margin;
+  };
+
+  auto testCandidate = [&](double t) {
+    const Eigen::Vector3d pointOnSegment = segmentStart + segment * t;
+    const Eigen::Vector3d pointOnBox
+        = closestPointOnBox(pointOnSegment, halfExtents);
+    const double distSq = (pointOnSegment - pointOnBox).squaredNorm();
+    const double interiorMargin = computeInteriorMargin(pointOnSegment);
+
+    if (distSq < bestDistSq - 1e-18
+        || (std::abs(distSq - bestDistSq) <= 1e-18
+            && interiorMargin > bestInteriorMargin)) {
+      bestDistSq = distSq;
+      bestInteriorMargin = interiorMargin;
+      bestOnBox = pointOnBox;
+      bestOnSegment = pointOnSegment;
+    }
+  };
+
+  std::array<double, 8> breakpoints{};
+  std::size_t numBreakpoints = 0;
+  breakpoints[numBreakpoints++] = 0.0;
+  breakpoints[numBreakpoints++] = 1.0;
+
+  constexpr double kAxisEps = 1e-12;
+  for (int axis = 0; axis < 3; ++axis) {
+    if (std::abs(segment[axis]) <= kAxisEps)
+      continue;
+
+    for (const double face : {-halfExtents[axis], halfExtents[axis]}) {
+      const double t = (face - segmentStart[axis]) / segment[axis];
+      if (t > 0.0 && t < 1.0)
+        breakpoints[numBreakpoints++] = t;
+    }
+  }
+
+  std::sort(breakpoints.begin(), breakpoints.begin() + numBreakpoints);
+
+  std::array<double, 8> uniqueBreakpoints{};
+  std::size_t numUniqueBreakpoints = 0;
+  for (std::size_t i = 0; i < numBreakpoints; ++i) {
+    if (numUniqueBreakpoints == 0
+        || std::abs(
+               breakpoints[i] - uniqueBreakpoints[numUniqueBreakpoints - 1])
+               > kAxisEps) {
+      uniqueBreakpoints[numUniqueBreakpoints++] = breakpoints[i];
+      testCandidate(breakpoints[i]);
+    }
+  }
+
+  for (std::size_t i = 0; i + 1 < numUniqueBreakpoints; ++i) {
+    const double lo = uniqueBreakpoints[i];
+    const double hi = uniqueBreakpoints[i + 1];
+    if (hi - lo <= kAxisEps)
+      continue;
+
+    const double mid = 0.5 * (lo + hi);
+    double numerator = 0.0;
+    double denominator = 0.0;
+    for (int axis = 0; axis < 3; ++axis) {
+      const double coord = segmentStart[axis] + segment[axis] * mid;
+      double face = 0.0;
+      if (coord < -halfExtents[axis])
+        face = -halfExtents[axis];
+      else if (coord > halfExtents[axis])
+        face = halfExtents[axis];
+      else
+        continue;
+
+      numerator += segment[axis] * (face - segmentStart[axis]);
+      denominator += segment[axis] * segment[axis];
+    }
+
+    if (denominator > kAxisEps)
+      testCandidate(std::clamp(numerator / denominator, lo, hi));
+    else
+      testCandidate(mid);
+  }
+
+  closestOnSegment = bestOnSegment;
+  return bestOnBox;
+}
+
+int collideCapsuleSphereImpl(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    double capsuleRadius,
+    double halfHeight,
+    const Eigen::Isometry3d& capsuleTransform,
+    double sphereRadius,
+    const Eigen::Isometry3d& sphereTransform,
+    bool flipNormal,
+    CollisionResult& result)
+{
+  const Eigen::Vector3d localTop(0.0, 0.0, halfHeight);
+  const Eigen::Vector3d localBottom(0.0, 0.0, -halfHeight);
+  const Eigen::Vector3d top = capsuleTransform * localTop;
+  const Eigen::Vector3d bottom = capsuleTransform * localBottom;
+  const Eigen::Vector3d sphereCenter = sphereTransform.translation();
+
+  const Eigen::Vector3d closestOnCapsule
+      = closestPointOnSegment(sphereCenter, bottom, top);
+  const Eigen::Vector3d diff = sphereCenter - closestOnCapsule;
+  const double distSquared = diff.squaredNorm();
+  const double sumRadii = capsuleRadius + sphereRadius;
+
+  if (distSquared > sumRadii * sumRadii)
+    return 0;
+
+  const double dist = std::sqrt(distSquared);
+  const double penetration = sumRadii - dist;
+  Eigen::Vector3d rawNormal;
+  if (dist < 1e-10)
+    rawNormal = Eigen::Vector3d::UnitZ();
+  else
+    rawNormal = -diff / dist;
+  Eigen::Vector3d normal = rawNormal;
+  if (flipNormal)
+    normal = -normal;
+
+  const Eigen::Vector3d contactPoint
+      = closestOnCapsule + (-rawNormal) * (capsuleRadius - penetration * 0.5);
+
+  addDartContact(o1, o2, contactPoint, normal, penetration, result);
+  return 1;
+}
+
+int collideCapsulesImpl(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    double radius1,
+    double halfHeight1,
+    const Eigen::Isometry3d& transform1,
+    double radius2,
+    double halfHeight2,
+    const Eigen::Isometry3d& transform2,
+    CollisionResult& result)
+{
+  const Eigen::Vector3d localTop1(0.0, 0.0, halfHeight1);
+  const Eigen::Vector3d localBottom1(0.0, 0.0, -halfHeight1);
+  const Eigen::Vector3d localTop2(0.0, 0.0, halfHeight2);
+  const Eigen::Vector3d localBottom2(0.0, 0.0, -halfHeight2);
+
+  const Eigen::Vector3d top1 = transform1 * localTop1;
+  const Eigen::Vector3d bottom1 = transform1 * localBottom1;
+  const Eigen::Vector3d top2 = transform2 * localTop2;
+  const Eigen::Vector3d bottom2 = transform2 * localBottom2;
+
+  auto closest = closestPointsBetweenSegments(bottom1, top1, bottom2, top2);
+
+  const double sumRadii = radius1 + radius2;
+  if (closest.distSquared > sumRadii * sumRadii)
+    return 0;
+
+  const double dist = std::sqrt(closest.distSquared);
+  const double penetration = sumRadii - dist;
+  Eigen::Vector3d normal;
+  if (dist < 1e-10)
+    normal = Eigen::Vector3d::UnitZ();
+  else
+    normal = (closest.point1 - closest.point2) / dist;
+  const Eigen::Vector3d contactPoint
+      = closest.point2 + normal * (radius2 - penetration * 0.5);
+
+  addDartContact(o1, o2, contactPoint, normal, penetration, result);
+  return 1;
+}
+
+int collideCapsuleBoxImpl(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    double capsuleRadius,
+    double halfHeight,
+    const Eigen::Isometry3d& capsuleTransform,
+    const Eigen::Vector3d& boxSize,
+    const Eigen::Isometry3d& boxTransform,
+    bool flipNormal,
+    CollisionResult& result)
+{
+  const Eigen::Vector3d halfExtents = 0.5 * boxSize;
+  const Eigen::Vector3d localTop(0.0, 0.0, halfHeight);
+  const Eigen::Vector3d localBottom(0.0, 0.0, -halfHeight);
+  const Eigen::Vector3d worldTop = capsuleTransform * localTop;
+  const Eigen::Vector3d worldBottom = capsuleTransform * localBottom;
+
+  const Eigen::Isometry3d boxInverse = boxTransform.inverse();
+  const Eigen::Vector3d boxTop = boxInverse * worldTop;
+  const Eigen::Vector3d boxBottom = boxInverse * worldBottom;
+
+  Eigen::Vector3d closestOnSegment;
+  closestPointOnSegmentInBoxSpace(
+      boxBottom, boxTop, halfExtents, closestOnSegment);
+
+  std::array<Eigen::Vector3d, 3> contactPoints;
+  std::array<Eigen::Vector3d, 3> contactNormals;
+  std::size_t numContacts = 0;
+
+  auto addContactForAxisPoint = [&](const Eigen::Vector3d& axisPointLocal) {
+    const Eigen::Vector3d pointOnBoxLocal
+        = closestPointOnBox(axisPointLocal, halfExtents);
+    const Eigen::Vector3d diff = axisPointLocal - pointOnBoxLocal;
+    const double distSquared = diff.squaredNorm();
+
+    if (distSquared > capsuleRadius * capsuleRadius)
+      return false;
+
+    const double dist = std::sqrt(distSquared);
+
+    Eigen::Vector3d normalLocal;
+    Eigen::Vector3d contactOnBoxLocal = pointOnBoxLocal;
+    double penetration = capsuleRadius - dist;
+    if (dist < 1e-10) {
+      const Eigen::Vector3d absAxisPoint = axisPointLocal.cwiseAbs();
+      const Eigen::Vector3d distToFace = halfExtents - absAxisPoint;
+      int minAxis = 0;
+      if (distToFace.y() < distToFace.x())
+        minAxis = 1;
+      if (distToFace.z() < distToFace[minAxis])
+        minAxis = 2;
+      normalLocal = Eigen::Vector3d::Zero();
+      normalLocal[minAxis] = (axisPointLocal[minAxis] >= 0.0) ? 1.0 : -1.0;
+      contactOnBoxLocal[minAxis] = normalLocal[minAxis] > 0.0
+                                       ? halfExtents[minAxis]
+                                       : -halfExtents[minAxis];
+      penetration = capsuleRadius + distToFace[minAxis];
+    } else {
+      normalLocal = diff / dist;
+    }
+
+    const Eigen::Vector3d normalWorld = boxTransform.rotation() * normalLocal;
+    Eigen::Vector3d contactNormal = -normalWorld;
+    if (flipNormal)
+      contactNormal = -contactNormal;
+
+    const Eigen::Vector3d contactPoint
+        = boxTransform * contactOnBoxLocal + normalWorld * (penetration * 0.5);
+
+    for (std::size_t i = 0; i < numContacts; ++i) {
+      if ((contactPoints[i] - contactPoint).squaredNorm() < 1e-12
+          && contactNormals[i].dot(contactNormal) > 0.999) {
+        return false;
+      }
+    }
+
+    addDartContact(o1, o2, contactPoint, contactNormal, penetration, result);
+    contactPoints[numContacts] = contactPoint;
+    contactNormals[numContacts] = contactNormal;
+    ++numContacts;
+    return true;
+  };
+
+  bool hit = addContactForAxisPoint(closestOnSegment);
+  hit = addContactForAxisPoint(boxBottom) || hit;
+  hit = addContactForAxisPoint(boxTop) || hit;
+  return hit ? static_cast<int>(numContacts) : 0;
+}
+
+int collidePlaneCapsuleImpl(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const Eigen::Vector3d& planeNormal,
+    double planeOffset,
+    const Eigen::Isometry3d& planeTransform,
+    double capsuleRadius,
+    double halfHeight,
+    const Eigen::Isometry3d& capsuleTransform,
+    bool flipNormal,
+    CollisionResult& result)
+{
+  const Eigen::Vector3d worldNormal = planeTransform.linear() * planeNormal;
+  const Eigen::Vector3d planePoint
+      = planeTransform.translation() + worldNormal * planeOffset;
+
+  const Eigen::Vector3d localTop(0.0, 0.0, halfHeight);
+  const Eigen::Vector3d localBottom(0.0, 0.0, -halfHeight);
+  const Eigen::Vector3d worldTop = capsuleTransform * localTop;
+  const Eigen::Vector3d worldBottom = capsuleTransform * localBottom;
+
+  const double distTop = worldNormal.dot(worldTop - planePoint);
+  const double distBottom = worldNormal.dot(worldBottom - planePoint);
+
+  const Eigen::Vector3d* closestEndpoint = &worldBottom;
+  double minDist = distBottom;
+  if (distTop < distBottom) {
+    closestEndpoint = &worldTop;
+    minDist = distTop;
+  }
+
+  if (minDist > capsuleRadius)
+    return 0;
+
+  const double penetration = capsuleRadius - minDist;
+  const Eigen::Vector3d contactPoint
+      = *closestEndpoint - worldNormal * (minDist - penetration * 0.5);
+
+  Eigen::Vector3d normal = worldNormal;
+  if (flipNormal)
+    normal = -normal;
+
+  addDartContact(o1, o2, contactPoint, normal, penetration, result);
+  return 1;
+}
+
+int collideCylinderCapsuleImpl(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    double cylRadius,
+    double cylHalfHeight,
+    const Eigen::Isometry3d& cylinderTransform,
+    double capRadius,
+    double capHalfHeight,
+    const Eigen::Isometry3d& capsuleTransform,
+    bool flipNormal,
+    CollisionResult& result)
+{
+  const Eigen::Vector3d capAxis = capsuleTransform.linear().col(2);
+  const Eigen::Vector3d capCenter = capsuleTransform.translation();
+  const Eigen::Vector3d capTop = capCenter + capAxis * capHalfHeight;
+  const Eigen::Vector3d capBot = capCenter - capAxis * capHalfHeight;
+
+  const Eigen::Isometry3d cylInv = cylinderTransform.inverse();
+  const Eigen::Vector3d capTopLocal = cylInv * capTop;
+  const Eigen::Vector3d capBotLocal = cylInv * capBot;
+
+  double bestPenetration = -std::numeric_limits<double>::max();
+  Eigen::Vector3d bestCylPoint = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestCapPoint = Eigen::Vector3d::Zero();
+  bool foundCollision = false;
+
+  auto checkCapsuleEndpoint = [&](const Eigen::Vector3d& capEndLocal) {
+    const double lateralDistSq
+        = capEndLocal.x() * capEndLocal.x() + capEndLocal.y() * capEndLocal.y();
+    const double lateralDist = std::sqrt(lateralDistSq);
+
+    Eigen::Vector3d closestOnCyl;
+    if (std::abs(capEndLocal.z()) <= cylHalfHeight) {
+      if (lateralDist <= cylRadius) {
+        const double lateralPen = cylRadius - lateralDist;
+        const double axialPen = cylHalfHeight - std::abs(capEndLocal.z());
+        if (lateralPen < axialPen && lateralDist > 1e-10) {
+          closestOnCyl = Eigen::Vector3d(
+              capEndLocal.x() * cylRadius / lateralDist,
+              capEndLocal.y() * cylRadius / lateralDist,
+              capEndLocal.z());
+        } else {
+          const double cappedZ
+              = capEndLocal.z() > 0.0 ? cylHalfHeight : -cylHalfHeight;
+          closestOnCyl
+              = Eigen::Vector3d(capEndLocal.x(), capEndLocal.y(), cappedZ);
+        }
+      } else {
+        closestOnCyl = Eigen::Vector3d(
+            capEndLocal.x() * cylRadius / lateralDist,
+            capEndLocal.y() * cylRadius / lateralDist,
+            capEndLocal.z());
+      }
+    } else {
+      const double cappedZ
+          = std::clamp(capEndLocal.z(), -cylHalfHeight, cylHalfHeight);
+      if (lateralDist <= cylRadius) {
+        closestOnCyl
+            = Eigen::Vector3d(capEndLocal.x(), capEndLocal.y(), cappedZ);
+      } else {
+        closestOnCyl = Eigen::Vector3d(
+            capEndLocal.x() * cylRadius / lateralDist,
+            capEndLocal.y() * cylRadius / lateralDist,
+            cappedZ);
+      }
+    }
+
+    const double dist = (capEndLocal - closestOnCyl).norm();
+    const double penetration = capRadius - dist;
+    if (penetration > 0.0 && penetration > bestPenetration) {
+      bestPenetration = penetration;
+      bestCylPoint = closestOnCyl;
+      bestCapPoint = capEndLocal;
+      foundCollision = true;
+    }
+  };
+
+  checkCapsuleEndpoint(capTopLocal);
+  checkCapsuleEndpoint(capBotLocal);
+
+  if (!foundCollision)
+    return 0;
+
+  Eigen::Vector3d normalLocal = bestCapPoint - bestCylPoint;
+  if (normalLocal.squaredNorm() < 1e-10)
+    normalLocal = Eigen::Vector3d::UnitZ();
+  else
+    normalLocal.normalize();
+
+  const Eigen::Vector3d normalWorld = cylinderTransform.linear() * normalLocal;
+  const Eigen::Vector3d contactWorld = cylinderTransform * bestCylPoint
+                                       + normalWorld * (bestPenetration * 0.5);
+
+  Eigen::Vector3d contactNormal = -normalWorld;
+  if (flipNormal)
+    contactNormal = -contactNormal;
+
+  addDartContact(o1, o2, contactWorld, contactNormal, bestPenetration, result);
+  return 1;
+}
+
 } // namespace
+
+int collideCapsuleSphere(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const double& capsule_rad,
+    const double& half_height,
+    const Eigen::Isometry3d& T0,
+    const double& sphere_rad,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collideCapsuleSphereImpl(
+      o1, o2, capsule_rad, half_height, T0, sphere_rad, T1, false, result);
+}
+
+int collideSphereCapsule(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const double& sphere_rad,
+    const Eigen::Isometry3d& T0,
+    const double& capsule_rad,
+    const double& half_height,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collideCapsuleSphereImpl(
+      o1, o2, capsule_rad, half_height, T1, sphere_rad, T0, true, result);
+}
+
+int collideCapsuleCapsule(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const double& capsule_rad1,
+    const double& half_height1,
+    const Eigen::Isometry3d& T0,
+    const double& capsule_rad2,
+    const double& half_height2,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collideCapsulesImpl(
+      o1,
+      o2,
+      capsule_rad1,
+      half_height1,
+      T0,
+      capsule_rad2,
+      half_height2,
+      T1,
+      result);
+}
+
+int collideCapsuleBox(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const double& capsule_rad,
+    const double& half_height,
+    const Eigen::Isometry3d& T0,
+    const Eigen::Vector3d& size1,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collideCapsuleBoxImpl(
+      o1, o2, capsule_rad, half_height, T0, size1, T1, true, result);
+}
+
+int collideBoxCapsule(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const Eigen::Vector3d& size0,
+    const Eigen::Isometry3d& T0,
+    const double& capsule_rad,
+    const double& half_height,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collideCapsuleBoxImpl(
+      o1, o2, capsule_rad, half_height, T1, size0, T0, false, result);
+}
+
+int collideCapsulePlane(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const double& capsule_rad,
+    const double& half_height,
+    const Eigen::Isometry3d& T0,
+    const Eigen::Vector3d& plane_normal,
+    const double& plane_offset,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collidePlaneCapsuleImpl(
+      o1,
+      o2,
+      plane_normal,
+      plane_offset,
+      T1,
+      capsule_rad,
+      half_height,
+      T0,
+      false,
+      result);
+}
+
+int collidePlaneCapsule(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const Eigen::Vector3d& plane_normal,
+    const double& plane_offset,
+    const Eigen::Isometry3d& T0,
+    const double& capsule_rad,
+    const double& half_height,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collidePlaneCapsuleImpl(
+      o1,
+      o2,
+      plane_normal,
+      plane_offset,
+      T0,
+      capsule_rad,
+      half_height,
+      T1,
+      true,
+      result);
+}
+
+int collideCapsuleCylinder(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const double& capsule_rad,
+    const double& capsule_half_height,
+    const Eigen::Isometry3d& T0,
+    const double& cyl_rad,
+    const double& cyl_half_height,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collideCylinderCapsuleImpl(
+      o1,
+      o2,
+      cyl_rad,
+      cyl_half_height,
+      T1,
+      capsule_rad,
+      capsule_half_height,
+      T0,
+      true,
+      result);
+}
+
+int collideCylinderCapsule(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const double& cyl_rad,
+    const double& cyl_half_height,
+    const Eigen::Isometry3d& T0,
+    const double& capsule_rad,
+    const double& capsule_half_height,
+    const Eigen::Isometry3d& T1,
+    CollisionResult& result)
+{
+  return collideCylinderCapsuleImpl(
+      o1,
+      o2,
+      cyl_rad,
+      cyl_half_height,
+      T0,
+      capsule_rad,
+      capsule_half_height,
+      T1,
+      false,
+      result);
+}
 
 int collideBoxCylinder(
     CollisionObject* o1,
@@ -2501,6 +3219,19 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           0.5 * cylinder1->getHeight(),
           T2,
           result);
+    } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
+      const auto* capsule1
+          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+
+      return collideSphereCapsule(
+          o1,
+          o2,
+          sphere0->getRadius(),
+          T1,
+          capsule1->getRadius(),
+          0.5 * capsule1->getHeight(),
+          T2,
+          result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
           = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
@@ -2554,6 +3285,19 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           0.5 * cylinder1->getHeight(),
           T2,
           result);
+    } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
+      const auto* capsule1
+          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+
+      return collideBoxCapsule(
+          o1,
+          o2,
+          box0->getSize(),
+          T1,
+          capsule1->getRadius(),
+          0.5 * capsule1->getHeight(),
+          T2,
+          result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
           = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
@@ -2594,6 +3338,21 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
             T1,
             cylinder1->getRadius(),
             0.5 * cylinder1->getHeight(),
+            T2,
+            result);
+      }
+    } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
+      const auto* capsule1
+          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+
+      if (ellipsoid0->isSphere()) {
+        return collideSphereCapsule(
+            o1,
+            o2,
+            ellipsoid0->getRadii()[0],
+            T1,
+            capsule1->getRadius(),
+            0.5 * capsule1->getHeight(),
             T2,
             result);
       }
@@ -2697,6 +3456,107 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           plane1->getOffset(),
           T2,
           result);
+    } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
+      const auto* capsule1
+          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+
+      return collideCylinderCapsule(
+          o1,
+          o2,
+          cylinder0->getRadius(),
+          0.5 * cylinder0->getHeight(),
+          T1,
+          capsule1->getRadius(),
+          0.5 * capsule1->getHeight(),
+          T2,
+          result);
+    }
+  } else if (dynamics::CapsuleShape::getStaticType() == shapeType1) {
+    const auto* capsule0
+        = static_cast<const dynamics::CapsuleShape*>(shape1.get());
+
+    if (dynamics::SphereShape::getStaticType() == shapeType2) {
+      const auto* sphere1
+          = static_cast<const dynamics::SphereShape*>(shape2.get());
+
+      return collideCapsuleSphere(
+          o1,
+          o2,
+          capsule0->getRadius(),
+          0.5 * capsule0->getHeight(),
+          T1,
+          sphere1->getRadius(),
+          T2,
+          result);
+    } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
+      const auto* ellipsoid1
+          = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
+
+      if (ellipsoid1->isSphere()) {
+        return collideCapsuleSphere(
+            o1,
+            o2,
+            capsule0->getRadius(),
+            0.5 * capsule0->getHeight(),
+            T1,
+            ellipsoid1->getRadii()[0],
+            T2,
+            result);
+      }
+    } else if (dynamics::BoxShape::getStaticType() == shapeType2) {
+      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2.get());
+
+      return collideCapsuleBox(
+          o1,
+          o2,
+          capsule0->getRadius(),
+          0.5 * capsule0->getHeight(),
+          T1,
+          box1->getSize(),
+          T2,
+          result);
+    } else if (dynamics::CylinderShape::getStaticType() == shapeType2) {
+      const auto* cylinder1
+          = static_cast<const dynamics::CylinderShape*>(shape2.get());
+
+      return collideCapsuleCylinder(
+          o1,
+          o2,
+          capsule0->getRadius(),
+          0.5 * capsule0->getHeight(),
+          T1,
+          cylinder1->getRadius(),
+          0.5 * cylinder1->getHeight(),
+          T2,
+          result);
+    } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
+      const auto* capsule1
+          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+
+      return collideCapsuleCapsule(
+          o1,
+          o2,
+          capsule0->getRadius(),
+          0.5 * capsule0->getHeight(),
+          T1,
+          capsule1->getRadius(),
+          0.5 * capsule1->getHeight(),
+          T2,
+          result);
+    } else if (dynamics::PlaneShape::getStaticType() == shapeType2) {
+      const auto* plane1
+          = static_cast<const dynamics::PlaneShape*>(shape2.get());
+
+      return collideCapsulePlane(
+          o1,
+          o2,
+          capsule0->getRadius(),
+          0.5 * capsule0->getHeight(),
+          T1,
+          plane1->getNormal(),
+          plane1->getOffset(),
+          T2,
+          result);
     }
   } else if (dynamics::PlaneShape::getStaticType() == shapeType1) {
     const auto* plane0 = static_cast<const dynamics::PlaneShape*>(shape1.get());
@@ -2738,6 +3598,20 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T1,
           cylinder1->getRadius(),
           0.5 * cylinder1->getHeight(),
+          T2,
+          result);
+    } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
+      const auto* capsule1
+          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+
+      return collidePlaneCapsule(
+          o1,
+          o2,
+          plane0->getNormal(),
+          plane0->getOffset(),
+          T1,
+          capsule1->getRadius(),
+          0.5 * capsule1->getHeight(),
           T2,
           result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <limits>
 #include <memory>
 
@@ -2163,6 +2164,40 @@ SegmentClosestPointResult closestPointsBetweenSegments(
   return result;
 }
 
+Eigen::Vector3d chooseCapsuleCapsuleFallbackNormal(
+    const CollisionObject* o1,
+    const CollisionObject* o2,
+    const Eigen::Isometry3d& transform1,
+    const Eigen::Isometry3d& transform2)
+{
+  constexpr double epsilon = 1e-10;
+
+  const Eigen::Vector3d centerDelta
+      = transform1.translation() - transform2.translation();
+  if (centerDelta.squaredNorm() > epsilon * epsilon)
+    return centerDelta.normalized();
+
+  const Eigen::Vector3d axis1 = transform1.linear().col(2).normalized();
+  const Eigen::Vector3d axis2 = transform2.linear().col(2).normalized();
+  const Eigen::Vector3d axisCross = axis1.cross(axis2);
+  if (axisCross.squaredNorm() > epsilon * epsilon)
+    return axisCross.normalized();
+
+  const Eigen::Vector3d reference = std::abs(axis1.x()) < 0.9
+                                        ? Eigen::Vector3d::UnitX()
+                                        : Eigen::Vector3d::UnitY();
+  Eigen::Vector3d normal = axis1.cross(reference);
+  if (normal.squaredNorm() <= epsilon * epsilon)
+    normal = Eigen::Vector3d::UnitZ();
+  else
+    normal.normalize();
+
+  if (std::less<const CollisionObject*>()(o2, o1))
+    normal = -normal;
+
+  return normal;
+}
+
 Eigen::Vector3d closestPointOnBox(
     const Eigen::Vector3d& point, const Eigen::Vector3d& halfExtents)
 {
@@ -2358,7 +2393,7 @@ int collideCapsulesImpl(
   const double penetration = sumRadii - dist;
   Eigen::Vector3d normal;
   if (dist < 1e-10)
-    normal = Eigen::Vector3d::UnitZ();
+    normal = chooseCapsuleCapsuleFallbackNormal(o1, o2, transform1, transform2);
   else
     normal = (closest.point1 - closest.point2) / dist;
   const Eigen::Vector3d contactPoint

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -2525,82 +2525,122 @@ int collideCylinderCapsuleImpl(
   const Eigen::Vector3d capBotLocal = cylInv * capBot;
 
   double bestPenetration = -std::numeric_limits<double>::max();
-  Eigen::Vector3d bestCylPoint = Eigen::Vector3d::Zero();
-  Eigen::Vector3d bestCapPoint = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestContactPoint = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestNormal = Eigen::Vector3d::Zero();
   bool foundCollision = false;
 
-  auto checkCapsuleEndpoint = [&](const Eigen::Vector3d& capEndLocal) {
-    const double lateralDistSq
-        = capEndLocal.x() * capEndLocal.x() + capEndLocal.y() * capEndLocal.y();
-    const double lateralDist = std::sqrt(lateralDistSq);
+  auto recordCandidate = [&](const Eigen::Vector3d& point,
+                             const Eigen::Vector3d& normal,
+                             double penetration) {
+    if (penetration < 0.0 || penetration <= bestPenetration)
+      return;
 
-    Eigen::Vector3d closestOnCyl;
-    if (std::abs(capEndLocal.z()) <= cylHalfHeight) {
-      if (lateralDist <= cylRadius) {
-        const double lateralPen = cylRadius - lateralDist;
-        const double axialPen = cylHalfHeight - std::abs(capEndLocal.z());
-        if (lateralPen < axialPen && lateralDist > 1e-10) {
-          closestOnCyl = Eigen::Vector3d(
-              capEndLocal.x() * cylRadius / lateralDist,
-              capEndLocal.y() * cylRadius / lateralDist,
-              capEndLocal.z());
-        } else {
-          const double cappedZ
-              = capEndLocal.z() > 0.0 ? cylHalfHeight : -cylHalfHeight;
-          closestOnCyl
-              = Eigen::Vector3d(capEndLocal.x(), capEndLocal.y(), cappedZ);
-        }
+    bestPenetration = penetration;
+    bestContactPoint = point;
+    bestNormal = normal;
+    foundCollision = true;
+  };
+
+  auto checkCapsuleEndpoint = [&](const Eigen::Vector3d& center) {
+    const double radialDist
+        = std::sqrt(center.x() * center.x() + center.y() * center.y());
+    const Eigen::Vector3d radialDir
+        = getCylinderRadialDirection(center, radialDist);
+    const double sidePenetration = cylRadius + capRadius - radialDist;
+    const double absZ = std::abs(center.z());
+
+    if (radialDist <= cylRadius && absZ <= cylHalfHeight + capRadius) {
+      const double capSign = center.z() >= 0.0 ? 1.0 : -1.0;
+      const double capPenetration
+          = cylHalfHeight + capRadius - capSign * center.z();
+
+      if (absZ <= cylHalfHeight && sidePenetration <= capPenetration) {
+        Eigen::Vector3d point = radialDir * (cylRadius - 0.5 * sidePenetration);
+        point.z() = center.z();
+        recordCandidate(point, -radialDir, sidePenetration);
       } else {
-        closestOnCyl = Eigen::Vector3d(
-            capEndLocal.x() * cylRadius / lateralDist,
-            capEndLocal.y() * cylRadius / lateralDist,
-            capEndLocal.z());
+        const Eigen::Vector3d normal(0.0, 0.0, -capSign);
+        const Eigen::Vector3d point(
+            center.x(),
+            center.y(),
+            capSign * (cylHalfHeight - 0.5 * capPenetration));
+        recordCandidate(point, normal, capPenetration);
       }
+    } else if (sidePenetration >= 0.0) {
+      if (absZ > cylHalfHeight) {
+        Eigen::Vector3d point = radialDir * cylRadius;
+        point.z() = math::sign(center.z()) * cylHalfHeight;
+
+        const Eigen::Vector3d normal = point - center;
+        const double edgePenetration = capRadius - normal.norm();
+        recordCandidate(point, normal, edgePenetration);
+      } else {
+        Eigen::Vector3d point = radialDir * (cylRadius - 0.5 * sidePenetration);
+        point.z() = center.z();
+        recordCandidate(point, -radialDir, sidePenetration);
+      }
+    }
+  };
+
+  auto checkCapsuleSegment = [&]() {
+    const Eigen::Vector3d axisBottom(0.0, 0.0, -cylHalfHeight);
+    const Eigen::Vector3d axisTop(0.0, 0.0, cylHalfHeight);
+    const auto closest = closestPointsBetweenSegments(
+        capBotLocal, capTopLocal, axisBottom, axisTop);
+
+    if (std::abs(closest.point1.z()) > cylHalfHeight)
+      return;
+
+    Eigen::Vector3d radial = closest.point1 - closest.point2;
+    radial.z() = 0.0;
+    double radialDist = radial.norm();
+    if (radialDist > cylRadius + capRadius)
+      return;
+
+    const double closestRadialDist = radialDist;
+    if (radialDist < 1e-10) {
+      const Eigen::Vector3d segment = capTopLocal - capBotLocal;
+      radial = Eigen::Vector3d::UnitZ().cross(segment);
+      radial.z() = 0.0;
+      radialDist = radial.norm();
+      if (radialDist < 1e-10)
+        radial = Eigen::Vector3d::UnitX();
+      else
+        radial /= radialDist;
     } else {
-      const double cappedZ
-          = std::clamp(capEndLocal.z(), -cylHalfHeight, cylHalfHeight);
-      if (lateralDist <= cylRadius) {
-        closestOnCyl
-            = Eigen::Vector3d(capEndLocal.x(), capEndLocal.y(), cappedZ);
-      } else {
-        closestOnCyl = Eigen::Vector3d(
-            capEndLocal.x() * cylRadius / lateralDist,
-            capEndLocal.y() * cylRadius / lateralDist,
-            cappedZ);
-      }
+      radial /= radialDist;
     }
 
-    const double dist = (capEndLocal - closestOnCyl).norm();
-    const double penetration = capRadius - dist;
-    if (penetration > 0.0 && penetration > bestPenetration) {
-      bestPenetration = penetration;
-      bestCylPoint = closestOnCyl;
-      bestCapPoint = capEndLocal;
-      foundCollision = true;
-    }
+    const double penetration = cylRadius + capRadius - closestRadialDist;
+    Eigen::Vector3d point = radial * (cylRadius - 0.5 * penetration);
+    point.z() = std::clamp(closest.point1.z(), -cylHalfHeight, cylHalfHeight);
+    recordCandidate(point, -radial, penetration);
   };
 
   checkCapsuleEndpoint(capTopLocal);
   checkCapsuleEndpoint(capBotLocal);
+  checkCapsuleSegment();
 
   if (!foundCollision)
     return 0;
 
-  Eigen::Vector3d normalLocal = bestCapPoint - bestCylPoint;
-  if (normalLocal.squaredNorm() < 1e-10)
-    normalLocal = Eigen::Vector3d::UnitZ();
-  else
-    normalLocal.normalize();
+  if (bestNormal.squaredNorm() < 1e-10) {
+    bestNormal = Eigen::Vector3d::UnitZ();
+  } else {
+    bestNormal.normalize();
+  }
 
-  const Eigen::Vector3d normalWorld = cylinderTransform.linear() * normalLocal;
-  const Eigen::Vector3d contactWorld = cylinderTransform * bestCylPoint
-                                       + normalWorld * (bestPenetration * 0.5);
-
-  Eigen::Vector3d contactNormal = -normalWorld;
+  Eigen::Vector3d contactNormal = cylinderTransform.linear() * bestNormal;
   if (flipNormal)
     contactNormal = -contactNormal;
 
-  addDartContact(o1, o2, contactWorld, contactNormal, bestPenetration, result);
+  addDartContact(
+      o1,
+      o2,
+      cylinderTransform * bestContactPoint,
+      contactNormal,
+      bestPenetration,
+      result);
   return 1;
 }
 

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -2582,6 +2582,79 @@ int collideCylinderCapsuleImpl(
     }
   };
 
+  auto checkCapsuleCap = [&](double capZ) {
+    const Eigen::Vector3d segment = capTopLocal - capBotLocal;
+
+    auto evaluateAt = [&](double t) {
+      t = std::clamp(t, 0.0, 1.0);
+      const Eigen::Vector3d pointOnSegment = capBotLocal + segment * t;
+      const double radialDist = std::sqrt(
+          pointOnSegment.x() * pointOnSegment.x()
+          + pointOnSegment.y() * pointOnSegment.y());
+
+      Eigen::Vector3d pointOnCap;
+      if (radialDist <= cylRadius || radialDist < 1e-10) {
+        pointOnCap
+            = Eigen::Vector3d(pointOnSegment.x(), pointOnSegment.y(), capZ);
+      } else {
+        pointOnCap = Eigen::Vector3d(
+            pointOnSegment.x() * cylRadius / radialDist,
+            pointOnSegment.y() * cylRadius / radialDist,
+            capZ);
+      }
+
+      Eigen::Vector3d normal = pointOnCap - pointOnSegment;
+      const double distance = normal.norm();
+      const double penetration = capRadius - distance;
+      if (penetration < 0.0)
+        return;
+
+      if (distance < 1e-10) {
+        normal = Eigen::Vector3d(0.0, 0.0, capZ >= 0.0 ? -1.0 : 1.0);
+      } else {
+        normal /= distance;
+      }
+
+      recordCandidate(
+          pointOnCap + normal * (0.5 * penetration), normal, penetration);
+    };
+
+    auto distanceSquaredAt = [&](double t) {
+      t = std::clamp(t, 0.0, 1.0);
+      const Eigen::Vector3d pointOnSegment = capBotLocal + segment * t;
+      const double radialDist = std::sqrt(
+          pointOnSegment.x() * pointOnSegment.x()
+          + pointOnSegment.y() * pointOnSegment.y());
+      const double radialExcess = std::max(0.0, radialDist - cylRadius);
+      const double axialDistance = pointOnSegment.z() - capZ;
+      return radialExcess * radialExcess + axialDistance * axialDistance;
+    };
+
+    double lo = 0.0;
+    double hi = 1.0;
+    for (int i = 0; i < 24; ++i) {
+      const double m1 = lo + (hi - lo) / 3.0;
+      const double m2 = hi - (hi - lo) / 3.0;
+      if (distanceSquaredAt(m1) < distanceSquaredAt(m2))
+        hi = m2;
+      else
+        lo = m1;
+    }
+
+    evaluateAt(0.0);
+    evaluateAt(1.0);
+    evaluateAt(0.5 * (lo + hi));
+
+    if (std::abs(segment.z()) > 1e-10)
+      evaluateAt((capZ - capBotLocal.z()) / segment.z());
+
+    const Eigen::Vector2d start2d(capBotLocal.x(), capBotLocal.y());
+    const Eigen::Vector2d segment2d(segment.x(), segment.y());
+    const double segment2dLengthSq = segment2d.squaredNorm();
+    if (segment2dLengthSq > 1e-10)
+      evaluateAt(-start2d.dot(segment2d) / segment2dLengthSq);
+  };
+
   auto checkCapsuleSegment = [&]() {
     const Eigen::Vector3d axisBottom(0.0, 0.0, -cylHalfHeight);
     const Eigen::Vector3d axisTop(0.0, 0.0, cylHalfHeight);
@@ -2619,6 +2692,8 @@ int collideCylinderCapsuleImpl(
 
   checkCapsuleEndpoint(capTopLocal);
   checkCapsuleEndpoint(capBotLocal);
+  checkCapsuleCap(cylHalfHeight);
+  checkCapsuleCap(-cylHalfHeight);
   checkCapsuleSegment();
 
   if (!foundCollision)

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -2481,11 +2481,16 @@ int collidePlaneCapsuleImpl(
   const double distTop = worldNormal.dot(worldTop - planePoint);
   const double distBottom = worldNormal.dot(worldBottom - planePoint);
 
-  const Eigen::Vector3d* closestEndpoint = &worldBottom;
+  Eigen::Vector3d closestPointOnAxis = worldBottom;
   double minDist = distBottom;
-  if (distTop < distBottom) {
-    closestEndpoint = &worldTop;
+  const double distanceTolerance
+      = 1e-12 * std::max({1.0, std::abs(distTop), std::abs(distBottom)});
+  if (distTop < distBottom - distanceTolerance) {
+    closestPointOnAxis = worldTop;
     minDist = distTop;
+  } else if (std::abs(distTop - distBottom) <= distanceTolerance) {
+    closestPointOnAxis = 0.5 * (worldTop + worldBottom);
+    minDist = 0.5 * (distTop + distBottom);
   }
 
   if (minDist > capsuleRadius)
@@ -2493,7 +2498,7 @@ int collidePlaneCapsuleImpl(
 
   const double penetration = capsuleRadius - minDist;
   const Eigen::Vector3d contactPoint
-      = *closestEndpoint - worldNormal * (minDist - penetration * 0.5);
+      = closestPointOnAxis - worldNormal * (minDist - penetration * 0.5);
 
   Eigen::Vector3d normal = worldNormal;
   if (flipNormal)

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -38,6 +38,7 @@
 #include "dart/collision/dart/DARTCollisionGroup.hpp"
 #include "dart/collision/dart/DARTCollisionObject.hpp"
 #include "dart/dynamics/BoxShape.hpp"
+#include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/EllipsoidShape.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
@@ -613,6 +614,9 @@ void warnUnsupportedShapeType(const dynamics::ShapeFrame* shapeFrame)
   if (shapeType == dynamics::CylinderShape::getStaticType())
     return;
 
+  if (shapeType == dynamics::CapsuleShape::getStaticType())
+    return;
+
   if (shapeType == dynamics::EllipsoidShape::getStaticType()) {
     const auto& ellipsoid
         = std::static_pointer_cast<const dynamics::EllipsoidShape>(shape);
@@ -624,8 +628,9 @@ void warnUnsupportedShapeType(const dynamics::ShapeFrame* shapeFrame)
   dterr << "[DARTCollisionDetector] Attempting to create shape type ["
         << shapeType << "] that is not supported "
         << "by DARTCollisionDetector. Currently, only SphereShape, BoxShape, "
-        << "CylinderShape, PlaneShape, and EllipsoidShape (only when all the "
-        << "radii are equal) are supported. This shape will always get "
+        << "CylinderShape, CapsuleShape, PlaneShape, and EllipsoidShape (only "
+        << "when all the radii are equal) are supported. This shape will "
+           "always get "
         << "penetrated by other "
         << "objects.\n";
 }

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -2,50 +2,60 @@
 
 ## Current Snapshot
 
-Bottom line: #3123 is merged, so the next slice is active-mode native collision
-performance on `perf/dart6-native-active-collision`, based on `release-6.20`.
-The long-term target remains DART 7 native-collision feature, test, and
-benchmark parity inside DART 6.20's dependency-free `dart/collision/dart/`
-backend. Once that path proves correctness and performance across the required
-shape set, FCL, Bullet, and ODE should become optional comparison and regression
-dependencies for tests/benchmarks rather than required production collision
-backends. Middle PRs are acceptable, but each one must keep gz-physics-facing
-API behavior compatible and show measured baseline-vs-current evidence.
+Bottom line: #3125 is merged, and the current slice is
+`perf/dart6-native-capsule-collision`, based on `origin/release-6.20`. This
+slice ports the DART 7 native capsule primitive contacts into the DART 6 native
+collision backend for capsule/sphere, capsule/box, capsule/cylinder,
+capsule/plane, and capsule/capsule pairs. The long-term target remains DART 7
+native-collision feature, test, and benchmark parity inside DART 6.20's
+dependency-free `dart/collision/dart/` backend, with FCL, Bullet, and ODE kept
+as comparison and regression dependencies once native coverage is complete.
 
-Current active-mode evidence uses the original `/tmp/3k_shapes.sdf` issue scene:
-3003 mobile sphere/box/cylinder bodies, DART 6 dynamics/constraints/solver,
-300 steps, `--disable-deactivation --sdf-plane-shapes --world-threads 16
---max-contacts 12000`, with final-state consumption enabled.
+Correctness guardrails for this slice:
 
-| Run | RTF | Collision time | Final state |
-| --- | ---: | ---: | --- |
-| Merged #3123 DART native baseline | `0.0198059` | `37.16 ms/step` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
-| Current DART native | `0.0536378` | `6.316 ms/step` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
-| Current Bullet comparison | `0.0607573` | `4.227 ms/step` | finite, hash `0x1b1e6f3c78c0e01e`, contacts `5005`, pairs `3003` |
+- `test_Collision` now exercises DART-native capsule/capsule and capsule pairs
+  against sphere, box, cylinder, plane, and a rotated capsule/sphere case.
+- `contact_benchmark --generate-capsules` consumes final state hashes and now
+  defaults to the DART-native detector. It rejects the DART 6 FCL backend for
+  generated capsule scenes because that backend currently falls back to dummy
+  spheres for `CapsuleShape`, which is not an apples-to-apples comparison.
+- The original issue scene remains unchanged: `/tmp/3k_shapes.sdf` still has
+  `3003` mobile sphere/box/cylinder bodies plus the static ground plane from
+  the issue report.
 
-The current native slice preserves the DART-native final hash while raising
-active no-sleep RTF by `2.7x` and reducing DART-native collision time by `5.9x`
-on the same workload. It does not yet beat Bullet in active mode; Bullet remains
-about `13%` faster end-to-end on this run. The profile-driven cause of the
-native gain was the previous all-contact duplicate scan in DART-native contact
-post-processing, plus shared `CollisionResult` lookup-cache work on temporary
-per-pair results.
+Current capsule-only active comparison, all with DART 6 dynamics, constraints,
+and solver; only collision detection changes. Command shape:
+`pixi run ex contact_benchmark -- --generate-capsules 120 --steps 3000
+--warmup 0 --checkpoint 0 --quiet --world-threads 16 --max-contacts 1000
+--disable-deactivation --collision <engine>`.
 
-The original default sleeping issue case remains above real time after this
-slice. Current DART native command:
-`pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 3000 --warmup 0
---checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16
---max-contacts 12000 --profile`. Result: RTF `1.88616`, finite final state,
-hash `0x131b6af79a44ff90`, frame/time advanced `3000 / 3000`, final resting
-`3003 / 3003`, final contacts `0`.
+| Engine | RTF | Final state |
+| --- | ---: | --- |
+| DART native | `1.06574` | finite, hash `0xb1abe373933000a3`, contacts `120`, pairs `120` |
+| ODE | `0.839581` | finite, hash `0xdad6992e61e05f66`, contacts `120`, pairs `120` |
+| Bullet | `0.745414` | finite, hash `0x494452692dc448e`, contacts `120`, pairs `120` |
+| FCL primitive | not comparable | DART 6 FCL maps capsules to fallback spheres; the legacy run hit contact cap `1000` with max penetration `65.45`, so the benchmark now rejects this combination |
 
-DART native and Bullet settle to the same shape keys in the earlier #3123
-3000-step comparison. Final-scene dump deltas were small: max position delta
-`3.432794147777784e-06` m, mean position delta
-`1.8434777525926603e-06` m, max quaternion delta
-`1.9819543267524604e-06`, and max z delta `2.8028646514299815e-06` m. Spheres
-matched exactly; boxes and cylinders accounted for the tiny residual
-differences.
+The default sleeping capsule run is intentionally not the active collision
+comparison, but it verifies that the new capsule contacts integrate with the
+resting fast path: DART native RTF `121.389`, finite state hash
+`0x80e1d697f42d28d7`, final resting `120 / 120`, final contacts `0`.
+
+Original issue-scene no-regression evidence, same final-state consumption:
+
+| Run | RTF | Final state |
+| --- | ---: | --- |
+| #3125 DART native active baseline | `0.0536378` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
+| Current DART native active | `0.0497787` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
+| #3125 DART native default sleeping baseline | `1.88616` | finite, hash `0x131b6af79a44ff90`, resting `3003 / 3003`, contacts `0` |
+| Current DART native default sleeping | `1.88637` | finite, hash `0x131b6af79a44ff90`, resting `3003 / 3003`, contacts `0` |
+
+The active original-scene RTF moved within run-to-run noise while preserving the
+exact DART-native final hash and contact counts. The new performance win is on
+the newly supported capsule primitive path: previous DART native did not
+support these contacts, while the current path is real-time on the active
+120-capsule floor-contact workload and beats the available Bullet and ODE
+comparison backends on the same DART 6 physics pipeline.
 
 The previous managed PR, #3071 `perf/dart6-parallel-islands`, landed as the
 parallel-stepping follow-up after #3111 and #3112 added the core
@@ -95,16 +105,16 @@ pinned to CPUs 0-15:
   should present this caveat instead of implying unlimited CPU scaling.
 
 Native-collision follow-up: continue porting DART 7 native algorithms into
-DART 6.20's `dart/collision/dart/` path in dependency-free slices. The current
-merged slice added finite-shape broadphase filtering, plane/sphere/box/cylinder
-contacts, and per-thread scratch reuse in the existing DART backend. The active
-follow-up replaces the all-contact duplicate scan with a reusable spatial index
-and avoids eager unordered lookup-cache work for temporary per-pair collision
-results. DART native beats Bullet on the default sleeping issue scene while
-preserving close settled-state agreement; Bullet remains the active-mode target
-to beat.
+DART 6.20's `dart/collision/dart/` path in dependency-free slices. The merged
+native slices added finite-shape broadphase filtering, plane/sphere/box/cylinder
+contacts, per-thread scratch reuse, and faster active contact aggregation in
+the existing DART backend. The active follow-up adds DART-native capsule
+primitive contacts and confirms the original issue scene did not regress. The
+next native slices should keep mining DART 7 for missing shape support,
+distance/CCD/raycast coverage, and manifold behavior while preserving
+gz-physics-facing API compatibility.
 
-- Current active branch: `perf/dart6-native-active-collision`, based on
+- Current active branch: `perf/dart6-native-capsule-collision`, based on
   `origin/release-6.20`.
 - Exact issue scene used for the current evidence: `/tmp/3k_shapes.sdf`,
   3003 mobile sphere/box/cylinder bodies plus the static ground plane from the

--- a/examples/contact_benchmark/main.cpp
+++ b/examples/contact_benchmark/main.cpp
@@ -369,6 +369,22 @@ BoxedLcpSolverKind parseBoxedLcpSolver(const std::string& value)
   throw std::invalid_argument("Invalid --lcp-solver value: " + value);
 }
 
+void normalizeGeneratedCapsuleCollisionOptions(Options& options)
+{
+  if (!options.generateCapsules)
+    return;
+
+  if (options.collisionEngine == CollisionEngine::Default)
+    options.collisionEngine = CollisionEngine::Dart;
+
+  if (options.collisionEngine == CollisionEngine::Fcl
+      || options.primitiveShapes) {
+    throw std::invalid_argument(
+        "--generate-capsules cannot use the DART 6 FCL backend because FCL "
+        "capsule geometry is not wired through this backend");
+  }
+}
+
 Options parseOptions(int argc, char* argv[])
 {
   Options options;
@@ -485,18 +501,7 @@ Options parseOptions(int argc, char* argv[])
         "--sdf-plane-shapes requires an SDF input scene");
   }
 
-  if (options.generateCapsules
-      && options.collisionEngine == CollisionEngine::Default) {
-    options.collisionEngine = CollisionEngine::Dart;
-  }
-
-  if (options.generateCapsules
-      && (options.collisionEngine == CollisionEngine::Fcl
-          || options.primitiveShapes)) {
-    throw std::invalid_argument(
-        "--generate-capsules cannot use the DART 6 FCL backend because FCL "
-        "capsule geometry is not wired through this backend");
-  }
+  normalizeGeneratedCapsuleCollisionOptions(options);
 
   if (options.guiCaptureExerciseWidget && !options.guiCapturePath.has_value()) {
     throw std::invalid_argument(
@@ -1830,7 +1835,7 @@ private:
     return options;
   }
 
-  bool replaceGeneratedScene(const Options& options, std::string* error)
+  bool replaceGeneratedScene(Options options, std::string* error)
   {
     if (!mViewer || !mNode || !mEventHandler) {
       if (error)
@@ -1839,6 +1844,7 @@ private:
     }
 
     try {
+      normalizeGeneratedCapsuleCollisionOptions(options);
       auto newWorld = createGeneratedWorld(options);
       applyOptions(newWorld, options);
       if (options.dropHeight > 0.0)

--- a/examples/contact_benchmark/main.cpp
+++ b/examples/contact_benchmark/main.cpp
@@ -50,6 +50,7 @@
 #include <dart/collision/ode/OdeCollisionDetector.hpp>
 
 #include <dart/dynamics/BoxShape.hpp>
+#include <dart/dynamics/CapsuleShape.hpp>
 #include <dart/dynamics/CylinderShape.hpp>
 #include <dart/dynamics/EllipsoidShape.hpp>
 #include <dart/dynamics/FreeJoint.hpp>
@@ -138,6 +139,7 @@ struct Options
   std::optional<double> sleepAngularThreshold;
   std::optional<double> sleepTimeUntilSleep;
   std::optional<std::size_t> generatedObjects;
+  bool generateCapsules = false;
   double generatedSpacing = kDefaultGeneratedSpacing;
   std::optional<std::string> dumpFinalScenePath;
   std::optional<std::size_t> maxContacts;
@@ -274,6 +276,8 @@ void printUsage(const std::string& programName)
       << "  --sleep-time T            Override quiet dwell time before sleep.\n"
       << "  --generate-objects N      Generate an in-memory 3-lane "
          "sphere/box/cylinder scene instead of loading SDF.\n"
+      << "  --generate-capsules N     Generate an in-memory capsule-only "
+         "scene instead of loading SDF.\n"
       << "  --generated-spacing X     Center spacing for generated objects; "
          "default 1.1 m.\n"
       << "  --dump-final-scene PATH   Write final collision geometry JSONL "
@@ -423,6 +427,10 @@ Options parseOptions(int argc, char* argv[])
       options.sleepTimeUntilSleep = parsePositiveDouble(needValue(arg), arg);
     } else if (arg == "--generate-objects" || arg == "--num-objects") {
       options.generatedObjects = parseSize(needValue(arg), arg);
+      options.generateCapsules = false;
+    } else if (arg == "--generate-capsules") {
+      options.generatedObjects = parseSize(needValue(arg), arg);
+      options.generateCapsules = true;
     } else if (arg == "--generated-spacing") {
       options.generatedSpacing = parsePositiveDouble(needValue(arg), arg);
     } else if (arg == "--dump-final-scene") {
@@ -464,17 +472,30 @@ Options parseOptions(int argc, char* argv[])
   }
 
   if (options.generatedObjects.has_value() && *options.generatedObjects == 0) {
-    throw std::invalid_argument("--generate-objects must be positive");
+    throw std::invalid_argument("Generated object count must be positive");
   }
 
   if (options.generatedObjects.has_value() && options.sdfPath.has_value()) {
     throw std::invalid_argument(
-        "--generate-objects cannot be combined with an SDF path");
+        "Generated scenes cannot be combined with an SDF path");
   }
 
   if (options.sdfPlaneShapes && options.generatedObjects.has_value()) {
     throw std::invalid_argument(
         "--sdf-plane-shapes requires an SDF input scene");
+  }
+
+  if (options.generateCapsules
+      && options.collisionEngine == CollisionEngine::Default) {
+    options.collisionEngine = CollisionEngine::Dart;
+  }
+
+  if (options.generateCapsules
+      && (options.collisionEngine == CollisionEngine::Fcl
+          || options.primitiveShapes)) {
+    throw std::invalid_argument(
+        "--generate-capsules cannot use the DART 6 FCL backend because FCL "
+        "capsule geometry is not wired through this backend");
   }
 
   if (options.guiCaptureExerciseWidget && !options.guiCapturePath.has_value()) {
@@ -546,8 +567,16 @@ void setShapeInertia(
   body->setInertia(inertia);
 }
 
-GeneratedShapeSpec makeGeneratedShape(std::size_t index)
+GeneratedShapeSpec makeGeneratedShape(std::size_t index, bool capsulesOnly)
 {
+  if (capsulesOnly) {
+    return {
+        std::make_shared<dart::dynamics::CapsuleShape>(0.5, 1.0),
+        1.0,
+        Eigen::Vector4d(0.65, 0.15, 1.0, 1.0),
+        "capsule"};
+  }
+
   switch (index % 3u) {
     case 0u:
       return {
@@ -574,17 +603,20 @@ GeneratedShapeSpec makeGeneratedShape(std::size_t index)
 dart::simulation::WorldPtr createGeneratedWorld(const Options& options)
 {
   const std::size_t numObjects = *options.generatedObjects;
-  constexpr std::size_t kLanes = 3u;
+  const std::size_t lanes = options.generateCapsules ? 1u : 3u;
 
-  auto world = dart::simulation::World::create("generated_3lane_shapes");
+  auto world = dart::simulation::World::create(
+      options.generateCapsules ? "generated_capsules"
+                               : "generated_3lane_shapes");
   world->setTimeStep(0.001);
   if (auto detector = makeCollisionDetector(options))
     world->getConstraintSolver()->setCollisionDetector(detector);
 
-  const std::size_t rows = (numObjects + kLanes - 1u) / kLanes;
+  const std::size_t rows = (numObjects + lanes - 1u) / lanes;
   const double floorLength = std::max(
       10.0, (static_cast<double>(rows) + 2.0) * options.generatedSpacing);
-  const double floorWidth = std::max(10.0, 4.0 * options.generatedSpacing);
+  const double floorWidth = std::max(
+      10.0, static_cast<double>(lanes + 1u) * options.generatedSpacing);
   const double floorCenterX = rows > 0 ? 0.5 * static_cast<double>(rows - 1u)
                                              * options.generatedSpacing
                                        : 0.0;
@@ -609,9 +641,9 @@ dart::simulation::WorldPtr createGeneratedWorld(const Options& options)
   world->addSkeleton(ground);
 
   for (std::size_t i = 0; i < numObjects; ++i) {
-    const std::size_t row = i / kLanes;
-    const std::size_t lane = i % kLanes;
-    const auto spec = makeGeneratedShape(lane);
+    const std::size_t row = i / lanes;
+    const std::size_t lane = i % lanes;
+    const auto spec = makeGeneratedShape(lane, options.generateCapsules);
 
     auto skeleton = dart::dynamics::Skeleton::create(
         std::string(spec.namePrefix) + "_" + std::to_string(i));
@@ -628,7 +660,8 @@ dart::simulation::WorldPtr createGeneratedWorld(const Options& options)
     Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
     transform.translation() = Eigen::Vector3d(
         static_cast<double>(row) * options.generatedSpacing,
-        (static_cast<double>(lane) - 1.0) * options.generatedSpacing,
+        (static_cast<double>(lane) - 0.5 * static_cast<double>(lanes - 1u))
+            * options.generatedSpacing,
         spec.centerHeight);
     dart::dynamics::FreeJoint::setTransformOf(body, transform);
 
@@ -873,6 +906,9 @@ void writeShapeParameters(std::ostream& out, const dart::dynamics::Shape* shape)
     writeVector(out, box->getSize());
   } else if (const auto* sphere = dynamic_cast<const SphereShape*>(shape)) {
     out << ",\"primitive\":\"sphere\",\"radius\":" << sphere->getRadius();
+  } else if (const auto* capsule = dynamic_cast<const CapsuleShape*>(shape)) {
+    out << ",\"primitive\":\"capsule\",\"radius\":" << capsule->getRadius()
+        << ",\"height\":" << capsule->getHeight();
   } else if (const auto* cylinder = dynamic_cast<const CylinderShape*>(shape)) {
     out << ",\"primitive\":\"cylinder\",\"radius\":" << cylinder->getRadius()
         << ",\"height\":" << cylinder->getHeight();
@@ -1264,6 +1300,10 @@ void printWorldSummary(
   if (options.generatedObjects.has_value()) {
     std::cout << "  Generated mobile objects: " << *options.generatedObjects
               << "\n";
+    std::cout << "  Generated scene: "
+              << (options.generateCapsules ? "capsule-only"
+                                           : "sphere/box/cylinder")
+              << "\n";
     std::cout << "  Generated object spacing: " << options.generatedSpacing
               << " m\n";
   }
@@ -1593,7 +1633,9 @@ private:
     out << "pipeline DART 6, collision detector "
         << collisionEngineName(mOptions.collisionEngine);
     if (mOptions.generatedObjects.has_value())
-      out << ", generated objects " << *mOptions.generatedObjects;
+      out << ", generated "
+          << (mOptions.generateCapsules ? "capsules " : "objects ")
+          << *mOptions.generatedObjects;
     if (mOptions.dropHeight > 0.0)
       out << ", drop height " << mOptions.dropHeight << " m";
     out << "\n";
@@ -2236,8 +2278,10 @@ int main(int argc, char* argv[])
 
   dart::simulation::WorldPtr world;
   if (options.generatedObjects.has_value()) {
-    std::cout << "Generating in-memory 3-lane shape world with "
-              << *options.generatedObjects << " mobile objects\n";
+    std::cout << "Generating in-memory "
+              << (options.generateCapsules ? "capsule-only" : "3-lane shape")
+              << " world with " << *options.generatedObjects
+              << " mobile objects\n";
     world = createGeneratedWorld(options);
   } else {
     std::filesystem::path p(*options.sdfPath);

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -1732,8 +1732,80 @@ TEST_F(Collision, testCapsuleCapsule)
   testCapsuleCapsule(bullet);
 #endif
 
-  // auto dart = DARTCollisionDetector::create();
-  // testCapsuleCapsule(dart);
+  auto dart = DARTCollisionDetector::create();
+  testCapsuleCapsule(dart);
+}
+
+//==============================================================================
+TEST_F(Collision, DartCapsulePrimitivePairs)
+{
+  auto cd = DARTCollisionDetector::create();
+
+  auto capsuleFrame = SimpleFrame::createShared(Frame::World());
+  auto sphereFrame = SimpleFrame::createShared(Frame::World());
+  auto boxFrame = SimpleFrame::createShared(Frame::World());
+  auto cylinderFrame = SimpleFrame::createShared(Frame::World());
+  auto capsule2Frame = SimpleFrame::createShared(Frame::World());
+  auto planeFrame = SimpleFrame::createShared(Frame::World());
+
+  capsuleFrame->setShape(std::make_shared<CapsuleShape>(0.25, 1.0));
+  sphereFrame->setShape(std::make_shared<SphereShape>(0.25));
+  boxFrame->setShape(
+      std::make_shared<BoxShape>(Eigen::Vector3d::Constant(0.4)));
+  cylinderFrame->setShape(std::make_shared<CylinderShape>(0.25, 1.0));
+  capsule2Frame->setShape(std::make_shared<CapsuleShape>(0.25, 1.0));
+  planeFrame->setShape(
+      std::make_shared<PlaneShape>(Eigen::Vector3d::UnitZ(), 0.0));
+
+  capsuleFrame->setTranslation(Eigen::Vector3d::Zero());
+  sphereFrame->setTranslation(Eigen::Vector3d(0.45, 0.0, 0.0));
+  boxFrame->setTranslation(Eigen::Vector3d(0.4, 0.0, 0.0));
+  cylinderFrame->setTranslation(Eigen::Vector3d(0.45, 0.0, 0.0));
+  capsule2Frame->setTranslation(Eigen::Vector3d(0.45, 0.0, 0.0));
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 8u;
+
+  auto expectContact = [&](const std::shared_ptr<SimpleFrame>& first,
+                           const std::shared_ptr<SimpleFrame>& second,
+                           const Eigen::Vector3d& expectedNormal,
+                           double expectedDepth) {
+    auto firstGroup = cd->createCollisionGroup(first.get());
+    auto secondGroup = cd->createCollisionGroup(second.get());
+
+    CollisionResult result;
+    ASSERT_TRUE(firstGroup->collide(secondGroup.get(), option, &result));
+    ASSERT_GE(result.getNumContacts(), 1u);
+
+    const auto& contact = result.getContact(0);
+    EXPECT_EQ(contact.collisionObject1->getShapeFrame(), first.get());
+    EXPECT_EQ(contact.collisionObject2->getShapeFrame(), second.get());
+    EXPECT_TRUE(contact.point.allFinite());
+    EXPECT_TRUE(contact.normal.isApprox(expectedNormal, 1e-12))
+        << contact.normal.transpose();
+    EXPECT_NEAR(contact.penetrationDepth, expectedDepth, 1e-12);
+  };
+
+  expectContact(capsuleFrame, sphereFrame, -Eigen::Vector3d::UnitX(), 0.05);
+  expectContact(sphereFrame, capsuleFrame, Eigen::Vector3d::UnitX(), 0.05);
+  expectContact(capsuleFrame, boxFrame, -Eigen::Vector3d::UnitX(), 0.05);
+  expectContact(boxFrame, capsuleFrame, Eigen::Vector3d::UnitX(), 0.05);
+  expectContact(capsuleFrame, cylinderFrame, -Eigen::Vector3d::UnitX(), 0.05);
+  expectContact(cylinderFrame, capsuleFrame, Eigen::Vector3d::UnitX(), 0.05);
+  expectContact(capsuleFrame, capsule2Frame, -Eigen::Vector3d::UnitX(), 0.05);
+
+  capsuleFrame->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.7));
+  expectContact(capsuleFrame, planeFrame, Eigen::Vector3d::UnitZ(), 0.05);
+  expectContact(planeFrame, capsuleFrame, -Eigen::Vector3d::UnitZ(), 0.05);
+
+  Eigen::Isometry3d horizontalCapsuleTf = Eigen::Isometry3d::Identity();
+  horizontalCapsuleTf.linear()
+      = Eigen::AngleAxisd(0.5 * constantsd::pi(), Eigen::Vector3d::UnitY())
+            .toRotationMatrix();
+  capsuleFrame->setTransform(horizontalCapsuleTf);
+  sphereFrame->setTranslation(Eigen::Vector3d(0.95, 0.0, 0.0));
+  expectContact(capsuleFrame, sphereFrame, -Eigen::Vector3d::UnitX(), 0.05);
 }
 
 //==============================================================================

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -1836,6 +1836,13 @@ TEST_F(Collision, DartCapsulePrimitivePairs)
   capsuleFrame->setTransform(horizontalCapsuleTf);
   expectContact(capsuleFrame, cylinderFrame, Eigen::Vector3d::UnitY(), 0.35);
   expectContact(cylinderFrame, capsuleFrame, -Eigen::Vector3d::UnitY(), 0.35);
+
+  cylinderFrame->setShape(std::make_shared<CylinderShape>(0.5, 1.0));
+  Eigen::Isometry3d horizontalCapsuleAboveCapTf = horizontalCapsuleTf;
+  horizontalCapsuleAboveCapTf.translation() = Eigen::Vector3d(0.0, 0.0, 0.55);
+  capsuleFrame->setTransform(horizontalCapsuleAboveCapTf);
+  expectContact(capsuleFrame, cylinderFrame, Eigen::Vector3d::UnitZ(), 0.05);
+  expectContact(cylinderFrame, capsuleFrame, -Eigen::Vector3d::UnitZ(), 0.05);
 }
 
 //==============================================================================

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -1767,10 +1767,11 @@ TEST_F(Collision, DartCapsulePrimitivePairs)
   option.enableContact = true;
   option.maxNumContacts = 8u;
 
-  auto expectContact = [&](const std::shared_ptr<SimpleFrame>& first,
-                           const std::shared_ptr<SimpleFrame>& second,
-                           const Eigen::Vector3d& expectedNormal,
-                           double expectedDepth) {
+  auto expectContactWithPoint = [&](const std::shared_ptr<SimpleFrame>& first,
+                                    const std::shared_ptr<SimpleFrame>& second,
+                                    const Eigen::Vector3d& expectedNormal,
+                                    double expectedDepth,
+                                    const Eigen::Vector3d* expectedPoint) {
     auto firstGroup = cd->createCollisionGroup(first.get());
     auto secondGroup = cd->createCollisionGroup(second.get());
 
@@ -1785,6 +1786,18 @@ TEST_F(Collision, DartCapsulePrimitivePairs)
     EXPECT_TRUE(contact.normal.isApprox(expectedNormal, 1e-12))
         << contact.normal.transpose();
     EXPECT_NEAR(contact.penetrationDepth, expectedDepth, 1e-12);
+    if (expectedPoint != nullptr) {
+      EXPECT_TRUE(contact.point.isApprox(*expectedPoint, 1e-12))
+          << contact.point.transpose();
+    }
+  };
+
+  auto expectContact = [&](const std::shared_ptr<SimpleFrame>& first,
+                           const std::shared_ptr<SimpleFrame>& second,
+                           const Eigen::Vector3d& expectedNormal,
+                           double expectedDepth) {
+    expectContactWithPoint(
+        first, second, expectedNormal, expectedDepth, nullptr);
   };
 
   auto expectPositiveContact = [&](const std::shared_ptr<SimpleFrame>& first,
@@ -1820,6 +1833,22 @@ TEST_F(Collision, DartCapsulePrimitivePairs)
   horizontalCapsuleTf.linear()
       = Eigen::AngleAxisd(0.5 * constantsd::pi(), Eigen::Vector3d::UnitY())
             .toRotationMatrix();
+  capsuleFrame->setTransform(horizontalCapsuleTf);
+  capsuleFrame->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.2));
+  const Eigen::Vector3d centeredPlaneContact(0.0, 0.0, 0.025);
+  expectContactWithPoint(
+      capsuleFrame,
+      planeFrame,
+      Eigen::Vector3d::UnitZ(),
+      0.05,
+      &centeredPlaneContact);
+  expectContactWithPoint(
+      planeFrame,
+      capsuleFrame,
+      -Eigen::Vector3d::UnitZ(),
+      0.05,
+      &centeredPlaneContact);
+
   capsuleFrame->setTransform(horizontalCapsuleTf);
   sphereFrame->setTranslation(Eigen::Vector3d(0.95, 0.0, 0.0));
   expectContact(capsuleFrame, sphereFrame, -Eigen::Vector3d::UnitX(), 0.05);

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -1825,6 +1825,11 @@ TEST_F(Collision, DartCapsulePrimitivePairs)
   expectContact(cylinderFrame, capsuleFrame, Eigen::Vector3d::UnitX(), 0.05);
   expectContact(capsuleFrame, capsule2Frame, -Eigen::Vector3d::UnitX(), 0.05);
 
+  capsuleFrame->setTranslation(Eigen::Vector3d::Zero());
+  capsule2Frame->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.2));
+  expectContact(capsuleFrame, capsule2Frame, -Eigen::Vector3d::UnitZ(), 0.5);
+  expectContact(capsule2Frame, capsuleFrame, Eigen::Vector3d::UnitZ(), 0.5);
+
   capsuleFrame->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.7));
   expectContact(capsuleFrame, planeFrame, Eigen::Vector3d::UnitZ(), 0.05);
   expectContact(planeFrame, capsuleFrame, -Eigen::Vector3d::UnitZ(), 0.05);

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -1787,6 +1787,23 @@ TEST_F(Collision, DartCapsulePrimitivePairs)
     EXPECT_NEAR(contact.penetrationDepth, expectedDepth, 1e-12);
   };
 
+  auto expectPositiveContact = [&](const std::shared_ptr<SimpleFrame>& first,
+                                   const std::shared_ptr<SimpleFrame>& second) {
+    auto firstGroup = cd->createCollisionGroup(first.get());
+    auto secondGroup = cd->createCollisionGroup(second.get());
+
+    CollisionResult result;
+    ASSERT_TRUE(firstGroup->collide(secondGroup.get(), option, &result));
+    ASSERT_GE(result.getNumContacts(), 1u);
+
+    const auto& contact = result.getContact(0);
+    EXPECT_EQ(contact.collisionObject1->getShapeFrame(), first.get());
+    EXPECT_EQ(contact.collisionObject2->getShapeFrame(), second.get());
+    EXPECT_TRUE(contact.point.allFinite());
+    EXPECT_TRUE(contact.normal.allFinite());
+    EXPECT_GT(contact.penetrationDepth, 0.0);
+  };
+
   expectContact(capsuleFrame, sphereFrame, -Eigen::Vector3d::UnitX(), 0.05);
   expectContact(sphereFrame, capsuleFrame, Eigen::Vector3d::UnitX(), 0.05);
   expectContact(capsuleFrame, boxFrame, -Eigen::Vector3d::UnitX(), 0.05);
@@ -1806,6 +1823,19 @@ TEST_F(Collision, DartCapsulePrimitivePairs)
   capsuleFrame->setTransform(horizontalCapsuleTf);
   sphereFrame->setTranslation(Eigen::Vector3d(0.95, 0.0, 0.0));
   expectContact(capsuleFrame, sphereFrame, -Eigen::Vector3d::UnitX(), 0.05);
+
+  capsuleFrame->setShape(std::make_shared<CapsuleShape>(0.1, 0.2));
+  cylinderFrame->setShape(std::make_shared<CylinderShape>(0.5, 1.0));
+  capsuleFrame->setTransform(Eigen::Isometry3d::Identity());
+  cylinderFrame->setTransform(Eigen::Isometry3d::Identity());
+  expectPositiveContact(capsuleFrame, cylinderFrame);
+  expectPositiveContact(cylinderFrame, capsuleFrame);
+
+  capsuleFrame->setShape(std::make_shared<CapsuleShape>(0.1, 2.0));
+  cylinderFrame->setShape(std::make_shared<CylinderShape>(0.25, 1.0));
+  capsuleFrame->setTransform(horizontalCapsuleTf);
+  expectContact(capsuleFrame, cylinderFrame, Eigen::Vector3d::UnitY(), 0.35);
+  expectContact(cylinderFrame, capsuleFrame, -Eigen::Vector3d::UnitY(), 0.35);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Add DART-native primitive contacts for `CapsuleShape` against spheres, boxes, cylinders, planes, and other capsules.
- Add capsule generated-scene coverage to `contact_benchmark` so native, Bullet, and ODE collision backends can be compared on a capsule workload without relying on mesh conversion.
- Record issue #3056 performance evidence for this slice in the dev-task tracker.

## Motivation / Problem

The DART 6 native collision backend still lacked capsule primitive narrowphase coverage, so capsule-heavy worlds had to use an external backend or fall back to unsupported/incorrect comparison paths. That leaves a gap for the issue #3056 direction of making the native backend competitive while preserving gz-physics-compatible DART 6 behavior.

This is a focused DART 7 native-collision backport slice for capsules. It keeps the rest of the DART 6 simulation pipeline unchanged and only changes the native collision detector's primitive-pair support.

## Changes / Key Changes

- Port capsule primitive-pair narrowphase helpers into `dart/collision/dart/` for capsule/sphere, capsule/box, capsule/cylinder, capsule/plane, and capsule/capsule.
- Mark `CapsuleShape` as supported by the DART collision detector instead of warning as unsupported.
- Extend collision tests to cover both object orderings, normals, depths, finite contact points, and a rotated capsule case.
- Add `--generate-capsules N` to `contact_benchmark` for repeatable capsule-ground workloads.
- Reject `--generate-capsules` with the DART 6 FCL primitive path because that backend currently maps capsules through an invalid fallback sphere path, which would produce misleading benchmark numbers.
- Update `CHANGELOG.md` and the issue #3056 dev-task evidence.

## Before / After

| Workload | Before | After |
| --- | --- | --- |
| DART native capsule primitive pairs | Unsupported by the native detector | Supported for sphere, box, cylinder, plane, and capsule pairings |
| Capsule benchmark comparison | No generated capsule workload; FCL fallback could look comparable while using invalid geometry | `--generate-capsules` produces a native capsule workload and rejects the invalid FCL primitive path |
| Active 120-capsule generated workload | No native capsule baseline | DART native RTF `1.06574`, ODE RTF `0.839581`, Bullet RTF `0.745414` |
| Original 3003-body issue scene | Parent #3125 default sleeping RTF `1.88616`, active RTF `0.0536378` | Current default sleeping RTF `1.88637`, active RTF `0.0497787`; hashes/contact counts unchanged for the measured modes |

Benchmark command shape for the capsule active workload:

```bash
pixi run ex contact_benchmark -- --generate-capsules 120 --steps 3000 --warmup 0 --checkpoint 0 --quiet --world-threads 16 --max-contacts 1000 --disable-deactivation --collision <engine>
```

Original issue scene checks used `/tmp/3k_shapes.sdf` with DART native collision, `--sdf-plane-shapes`, `--world-threads 16`, and `--max-contacts 12000`.

## Testing

- `pixi run lint`
- `pixi run build`
- `git diff --check`
- `pixi run test -- -R '^test_Collision$' --output-on-failure`
- `pixi run test -- -R '^test_CapsuleGroundContact$' --output-on-failure`
- `pixi run -e gazebo test-gz`
- `pixi run ex contact_benchmark -- --generate-capsules 1 --steps 1 --warmup 0 --checkpoint 0 --quiet`
- `pixi run ex contact_benchmark -- --generate-capsules 1 --steps 1 --warmup 0 --checkpoint 0 --quiet --collision fcl --primitive-shapes` exits with the intended validation error.
- Capsule active benchmark comparisons for DART native, Bullet, and ODE recorded in `docs/dev_tasks/issue_3056_dart6_performance/README.md`.
- Original issue #3056 scene default-sleeping and active no-sleep no-regression checks recorded in `docs/dev_tasks/issue_3056_dart6_performance/README.md`.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Related to #3056.
- Builds on #3125.
- DART 7 native-collision parity direction; this PR is the DART 6.20 release-branch slice.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no new public methods/classes
- [x] Add Python bindings (dartpy) if applicable: N/A, no new Python API
