### PR TITLE
Cache DART native collision shape metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@
 
 * Collision
 
+  * Speed up the DART-native collision backend by caching collision-object
+    shape metadata and local bounds, refreshing the cache only when the
+    associated `ShapeFrame` geometry version changes:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
   * Speed up active DART-native contact-heavy scenes by replacing global
     contact-point duplicate scans with reusable indexed contact aggregation and
     deferring collision-result lookup-set construction until queried:

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -33,6 +33,7 @@
 #include "dart/collision/dart/DARTCollide.hpp"
 
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/collision/dart/DARTCollisionObject.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
@@ -47,6 +48,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <string>
 
 #include <cmath>
 
@@ -3319,38 +3321,41 @@ int collidePlaneCylinder(
 }
 
 //==============================================================================
-int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
+namespace {
+
+int collideShapes(
+    CollisionObject* o1,
+    CollisionObject* o2,
+    const dynamics::Shape* shape1,
+    const dynamics::Shape* shape2,
+    const std::string& shapeType1,
+    const std::string& shapeType2,
+    CollisionResult& result)
 {
   // TODO(JS): We could make the contact point computation as optional for
   // the case that we want only binary check.
 
-  const auto& shape1 = o1->getShape();
-  const auto& shape2 = o2->getShape();
-
-  const auto& shapeType1 = shape1->getType();
-  const auto& shapeType2 = shape2->getType();
+  if (!shape1 || !shape2)
+    return false;
 
   const Eigen::Isometry3d& T1 = o1->getTransform();
   const Eigen::Isometry3d& T2 = o2->getTransform();
 
   if (dynamics::SphereShape::getStaticType() == shapeType1) {
-    const auto* sphere0
-        = static_cast<const dynamics::SphereShape*>(shape1.get());
+    const auto* sphere0 = static_cast<const dynamics::SphereShape*>(shape1);
 
     if (dynamics::SphereShape::getStaticType() == shapeType2) {
-      const auto* sphere1
-          = static_cast<const dynamics::SphereShape*>(shape2.get());
+      const auto* sphere1 = static_cast<const dynamics::SphereShape*>(shape2);
 
       return collideSphereSphere(
           o1, o2, sphere0->getRadius(), T1, sphere1->getRadius(), T2, result);
     } else if (dynamics::BoxShape::getStaticType() == shapeType2) {
-      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2.get());
+      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2);
 
       return collideSphereBox(
           o1, o2, sphere0->getRadius(), T1, box1->getSize(), T2, result);
     } else if (dynamics::PlaneShape::getStaticType() == shapeType2) {
-      const auto* plane1
-          = static_cast<const dynamics::PlaneShape*>(shape2.get());
+      const auto* plane1 = static_cast<const dynamics::PlaneShape*>(shape2);
 
       return collideSpherePlane(
           o1,
@@ -3363,7 +3368,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::CylinderShape::getStaticType() == shapeType2) {
       const auto* cylinder1
-          = static_cast<const dynamics::CylinderShape*>(shape2.get());
+          = static_cast<const dynamics::CylinderShape*>(shape2);
 
       return collideSphereCylinder(
           o1,
@@ -3375,8 +3380,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
-      const auto* capsule1
-          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+      const auto* capsule1 = static_cast<const dynamics::CapsuleShape*>(shape2);
 
       return collideSphereCapsule(
           o1,
@@ -3389,7 +3393,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
-          = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
+          = static_cast<const dynamics::EllipsoidShape*>(shape2);
 
       return collideSphereSphere(
           o1,
@@ -3401,22 +3405,20 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     }
   } else if (dynamics::BoxShape::getStaticType() == shapeType1) {
-    const auto* box0 = static_cast<const dynamics::BoxShape*>(shape1.get());
+    const auto* box0 = static_cast<const dynamics::BoxShape*>(shape1);
 
     if (dynamics::SphereShape::getStaticType() == shapeType2) {
-      const auto* sphere1
-          = static_cast<const dynamics::SphereShape*>(shape2.get());
+      const auto* sphere1 = static_cast<const dynamics::SphereShape*>(shape2);
 
       return collideBoxSphere(
           o1, o2, box0->getSize(), T1, sphere1->getRadius(), T2, result);
     } else if (dynamics::BoxShape::getStaticType() == shapeType2) {
-      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2.get());
+      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2);
 
       return collideBoxBox(
           o1, o2, box0->getSize(), T1, box1->getSize(), T2, result);
     } else if (dynamics::PlaneShape::getStaticType() == shapeType2) {
-      const auto* plane1
-          = static_cast<const dynamics::PlaneShape*>(shape2.get());
+      const auto* plane1 = static_cast<const dynamics::PlaneShape*>(shape2);
 
       return collideBoxPlane(
           o1,
@@ -3429,7 +3431,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::CylinderShape::getStaticType() == shapeType2) {
       const auto* cylinder1
-          = static_cast<const dynamics::CylinderShape*>(shape2.get());
+          = static_cast<const dynamics::CylinderShape*>(shape2);
 
       return collideBoxCylinder(
           o1,
@@ -3441,8 +3443,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
-      const auto* capsule1
-          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+      const auto* capsule1 = static_cast<const dynamics::CapsuleShape*>(shape2);
 
       return collideBoxCapsule(
           o1,
@@ -3455,18 +3456,17 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
-          = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
+          = static_cast<const dynamics::EllipsoidShape*>(shape2);
 
       return collideBoxSphere(
           o1, o2, box0->getSize(), T1, ellipsoid1->getRadii()[0], T2, result);
     }
   } else if (dynamics::EllipsoidShape::getStaticType() == shapeType1) {
     const auto* ellipsoid0
-        = static_cast<const dynamics::EllipsoidShape*>(shape1.get());
+        = static_cast<const dynamics::EllipsoidShape*>(shape1);
 
     if (dynamics::SphereShape::getStaticType() == shapeType2) {
-      const auto* sphere1
-          = static_cast<const dynamics::SphereShape*>(shape2.get());
+      const auto* sphere1 = static_cast<const dynamics::SphereShape*>(shape2);
 
       return collideSphereSphere(
           o1,
@@ -3477,13 +3477,13 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::BoxShape::getStaticType() == shapeType2) {
-      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2.get());
+      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2);
 
       return collideSphereBox(
           o1, o2, ellipsoid0->getRadii()[0], T1, box1->getSize(), T2, result);
     } else if (dynamics::CylinderShape::getStaticType() == shapeType2) {
       const auto* cylinder1
-          = static_cast<const dynamics::CylinderShape*>(shape2.get());
+          = static_cast<const dynamics::CylinderShape*>(shape2);
 
       if (ellipsoid0->isSphere()) {
         return collideSphereCylinder(
@@ -3497,8 +3497,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
             result);
       }
     } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
-      const auto* capsule1
-          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+      const auto* capsule1 = static_cast<const dynamics::CapsuleShape*>(shape2);
 
       if (ellipsoid0->isSphere()) {
         return collideSphereCapsule(
@@ -3512,8 +3511,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
             result);
       }
     } else if (dynamics::PlaneShape::getStaticType() == shapeType2) {
-      const auto* plane1
-          = static_cast<const dynamics::PlaneShape*>(shape2.get());
+      const auto* plane1 = static_cast<const dynamics::PlaneShape*>(shape2);
 
       if (ellipsoid0->isSphere()) {
         return collideSpherePlane(
@@ -3528,7 +3526,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
       }
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
-          = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
+          = static_cast<const dynamics::EllipsoidShape*>(shape2);
 
       return collideSphereSphere(
           o1,
@@ -3540,12 +3538,10 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     }
   } else if (dynamics::CylinderShape::getStaticType() == shapeType1) {
-    const auto* cylinder0
-        = static_cast<const dynamics::CylinderShape*>(shape1.get());
+    const auto* cylinder0 = static_cast<const dynamics::CylinderShape*>(shape1);
 
     if (dynamics::SphereShape::getStaticType() == shapeType2) {
-      const auto* sphere1
-          = static_cast<const dynamics::SphereShape*>(shape2.get());
+      const auto* sphere1 = static_cast<const dynamics::SphereShape*>(shape2);
 
       return collideCylinderSphere(
           o1,
@@ -3558,7 +3554,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
-          = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
+          = static_cast<const dynamics::EllipsoidShape*>(shape2);
 
       if (ellipsoid1->isSphere()) {
         return collideCylinderSphere(
@@ -3572,7 +3568,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
             result);
       }
     } else if (dynamics::BoxShape::getStaticType() == shapeType2) {
-      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2.get());
+      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2);
 
       return collideCylinderBox(
           o1,
@@ -3585,7 +3581,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::CylinderShape::getStaticType() == shapeType2) {
       const auto* cylinder1
-          = static_cast<const dynamics::CylinderShape*>(shape2.get());
+          = static_cast<const dynamics::CylinderShape*>(shape2);
 
       return collideCylinderCylinder(
           o1,
@@ -3598,8 +3594,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::PlaneShape::getStaticType() == shapeType2) {
-      const auto* plane1
-          = static_cast<const dynamics::PlaneShape*>(shape2.get());
+      const auto* plane1 = static_cast<const dynamics::PlaneShape*>(shape2);
 
       return collideCylinderPlane(
           o1,
@@ -3612,8 +3607,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
-      const auto* capsule1
-          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+      const auto* capsule1 = static_cast<const dynamics::CapsuleShape*>(shape2);
 
       return collideCylinderCapsule(
           o1,
@@ -3627,12 +3621,10 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     }
   } else if (dynamics::CapsuleShape::getStaticType() == shapeType1) {
-    const auto* capsule0
-        = static_cast<const dynamics::CapsuleShape*>(shape1.get());
+    const auto* capsule0 = static_cast<const dynamics::CapsuleShape*>(shape1);
 
     if (dynamics::SphereShape::getStaticType() == shapeType2) {
-      const auto* sphere1
-          = static_cast<const dynamics::SphereShape*>(shape2.get());
+      const auto* sphere1 = static_cast<const dynamics::SphereShape*>(shape2);
 
       return collideCapsuleSphere(
           o1,
@@ -3645,7 +3637,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
-          = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
+          = static_cast<const dynamics::EllipsoidShape*>(shape2);
 
       if (ellipsoid1->isSphere()) {
         return collideCapsuleSphere(
@@ -3659,7 +3651,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
             result);
       }
     } else if (dynamics::BoxShape::getStaticType() == shapeType2) {
-      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2.get());
+      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2);
 
       return collideCapsuleBox(
           o1,
@@ -3672,7 +3664,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::CylinderShape::getStaticType() == shapeType2) {
       const auto* cylinder1
-          = static_cast<const dynamics::CylinderShape*>(shape2.get());
+          = static_cast<const dynamics::CylinderShape*>(shape2);
 
       return collideCapsuleCylinder(
           o1,
@@ -3685,8 +3677,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
-      const auto* capsule1
-          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+      const auto* capsule1 = static_cast<const dynamics::CapsuleShape*>(shape2);
 
       return collideCapsuleCapsule(
           o1,
@@ -3699,8 +3690,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::PlaneShape::getStaticType() == shapeType2) {
-      const auto* plane1
-          = static_cast<const dynamics::PlaneShape*>(shape2.get());
+      const auto* plane1 = static_cast<const dynamics::PlaneShape*>(shape2);
 
       return collideCapsulePlane(
           o1,
@@ -3714,11 +3704,10 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     }
   } else if (dynamics::PlaneShape::getStaticType() == shapeType1) {
-    const auto* plane0 = static_cast<const dynamics::PlaneShape*>(shape1.get());
+    const auto* plane0 = static_cast<const dynamics::PlaneShape*>(shape1);
 
     if (dynamics::SphereShape::getStaticType() == shapeType2) {
-      const auto* sphere1
-          = static_cast<const dynamics::SphereShape*>(shape2.get());
+      const auto* sphere1 = static_cast<const dynamics::SphereShape*>(shape2);
 
       return collidePlaneSphere(
           o1,
@@ -3730,7 +3719,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::BoxShape::getStaticType() == shapeType2) {
-      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2.get());
+      const auto* box1 = static_cast<const dynamics::BoxShape*>(shape2);
 
       return collidePlaneBox(
           o1,
@@ -3743,7 +3732,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::CylinderShape::getStaticType() == shapeType2) {
       const auto* cylinder1
-          = static_cast<const dynamics::CylinderShape*>(shape2.get());
+          = static_cast<const dynamics::CylinderShape*>(shape2);
 
       return collidePlaneCylinder(
           o1,
@@ -3756,8 +3745,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           T2,
           result);
     } else if (dynamics::CapsuleShape::getStaticType() == shapeType2) {
-      const auto* capsule1
-          = static_cast<const dynamics::CapsuleShape*>(shape2.get());
+      const auto* capsule1 = static_cast<const dynamics::CapsuleShape*>(shape2);
 
       return collidePlaneCapsule(
           o1,
@@ -3771,7 +3759,7 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
           result);
     } else if (dynamics::EllipsoidShape::getStaticType() == shapeType2) {
       const auto* ellipsoid1
-          = static_cast<const dynamics::EllipsoidShape*>(shape2.get());
+          = static_cast<const dynamics::EllipsoidShape*>(shape2);
 
       if (ellipsoid1->isSphere()) {
         return collidePlaneSphere(
@@ -3788,10 +3776,42 @@ int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
   }
 
   dterr << "[DARTCollisionDetector] Attempting to check for an "
-        << "unsupported shape pair: [" << shape1->getType() << "] - ["
-        << shape2->getType() << "]. Returning false.\n";
+        << "unsupported shape pair: [" << shapeType1 << "] - [" << shapeType2
+        << "]. Returning false.\n";
 
   return false;
+}
+
+} // namespace
+
+//==============================================================================
+int collide(
+    DARTCollisionObject* o1, DARTCollisionObject* o2, CollisionResult& result)
+{
+  return collideShapes(
+      o1,
+      o2,
+      o1->getCachedShape(),
+      o2->getCachedShape(),
+      o1->getCachedShapeType(),
+      o2->getCachedShapeType(),
+      result);
+}
+
+//==============================================================================
+int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result)
+{
+  const auto shape1 = o1->getShape();
+  const auto shape2 = o2->getShape();
+
+  return collideShapes(
+      o1,
+      o2,
+      shape1.get(),
+      shape2.get(),
+      shape1 ? shape1->getType() : std::string(),
+      shape2 ? shape2->getType() : std::string(),
+      result);
 }
 
 } // namespace collision

--- a/dart/collision/dart/DARTCollide.hpp
+++ b/dart/collision/dart/DARTCollide.hpp
@@ -42,7 +42,12 @@
 namespace dart {
 namespace collision {
 
+class DARTCollisionObject;
+
 int collide(CollisionObject* o1, CollisionObject* o2, CollisionResult& result);
+
+int collide(
+    DARTCollisionObject* o1, DARTCollisionObject* o2, CollisionResult& result);
 
 int collideBoxBox(
     CollisionObject* o1,

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -283,6 +283,7 @@ bool DARTCollisionDetector::collide(
     return false;
 
   auto casted = static_cast<DARTCollisionGroup*>(group);
+  casted->updateEngineData();
   const auto& objects = casted->mCollisionObjects;
 
   if (objects.empty())
@@ -406,6 +407,9 @@ bool DARTCollisionDetector::collide(
 
   auto casted1 = static_cast<DARTCollisionGroup*>(group1);
   auto casted2 = static_cast<DARTCollisionGroup*>(group2);
+
+  casted1->updateEngineData();
+  casted2->updateEngineData();
 
   const auto& objects1 = casted1->mCollisionObjects;
   const auto& objects2 = casted2->mCollisionObjects;
@@ -947,7 +951,10 @@ bool checkPair(
   pairResult.clear();
 
   // Perform narrow-phase detection
-  collide(o1, o2, pairResult);
+  collide(
+      static_cast<DARTCollisionObject*>(o1),
+      static_cast<DARTCollisionObject*>(o2),
+      pairResult);
 
   // Early return for binary check
   if (!result)
@@ -1031,8 +1038,7 @@ bool isPlaneShape(const CollisionObject* object)
   if (!object)
     return false;
 
-  const auto& shape = object->getShape();
-  return shape && shape->getType() == dynamics::PlaneShape::getStaticType();
+  return static_cast<const DARTCollisionObject*>(object)->isCachedPlaneShape();
 }
 
 //==============================================================================
@@ -1045,18 +1051,16 @@ BroadphaseEntry makeBroadphaseEntry(CollisionObject* object)
   if (!object || entry.plane)
     return entry;
 
-  const auto& shape = object->getShape();
-  if (!shape)
+  const auto* dartObject = static_cast<const DARTCollisionObject*>(object);
+  if (!dartObject->getCachedShape())
     return entry;
 
-  const auto& localBox = shape->getBoundingBox();
+  const auto& localMin = dartObject->getCachedLocalBoundsMin();
+  const auto& localMax = dartObject->getCachedLocalBoundsMax();
+  if (!dartObject->hasFiniteCachedLocalBounds())
+    return entry;
+
   const auto& transform = object->getTransform();
-  const auto& localMin = localBox.getMin();
-  const auto& localMax = localBox.getMax();
-
-  if (!localMin.allFinite() || !localMax.allFinite())
-    return entry;
-
   entry.min = Eigen::Vector3d::Constant(std::numeric_limits<double>::max());
   entry.max = Eigen::Vector3d::Constant(-std::numeric_limits<double>::max());
 

--- a/dart/collision/dart/DARTCollisionObject.cpp
+++ b/dart/collision/dart/DARTCollisionObject.cpp
@@ -32,6 +32,11 @@
 
 #include "dart/collision/dart/DARTCollisionObject.hpp"
 
+#include "dart/dynamics/PlaneShape.hpp"
+#include "dart/dynamics/Shape.hpp"
+#include "dart/dynamics/ShapeFrame.hpp"
+#include "dart/math/Geometry.hpp"
+
 namespace dart {
 namespace collision {
 
@@ -41,13 +46,77 @@ DARTCollisionObject::DARTCollisionObject(
     const dynamics::ShapeFrame* shapeFrame)
   : CollisionObject(collisionDetector, shapeFrame)
 {
-  // Do nothing
+  refreshShapeCache();
+}
+
+//==============================================================================
+const dynamics::Shape* DARTCollisionObject::getCachedShape() const
+{
+  return mCachedShape.get();
+}
+
+//==============================================================================
+const std::string& DARTCollisionObject::getCachedShapeType() const
+{
+  static const std::string empty;
+  return mCachedShapeType ? *mCachedShapeType : empty;
+}
+
+//==============================================================================
+const Eigen::Vector3d& DARTCollisionObject::getCachedLocalBoundsMin() const
+{
+  return mCachedLocalBoundsMin;
+}
+
+//==============================================================================
+const Eigen::Vector3d& DARTCollisionObject::getCachedLocalBoundsMax() const
+{
+  return mCachedLocalBoundsMax;
+}
+
+//==============================================================================
+bool DARTCollisionObject::hasFiniteCachedLocalBounds() const
+{
+  return mHasFiniteCachedLocalBounds;
+}
+
+//==============================================================================
+bool DARTCollisionObject::isCachedPlaneShape() const
+{
+  return mIsCachedPlaneShape;
+}
+
+//==============================================================================
+void DARTCollisionObject::refreshShapeCache()
+{
+  const auto shapeFrameVersion = mShapeFrame ? mShapeFrame->getVersion() : 0u;
+  if (mCachedShapeFrameVersion == shapeFrameVersion)
+    return;
+
+  mCachedShapeFrameVersion = shapeFrameVersion;
+  mCachedShape = mShapeFrame ? mShapeFrame->getShape() : nullptr;
+  mCachedShapeType = mCachedShape ? &mCachedShape->getType() : nullptr;
+  mCachedLocalBoundsMin.setZero();
+  mCachedLocalBoundsMax.setZero();
+  mHasFiniteCachedLocalBounds = false;
+  mIsCachedPlaneShape
+      = mCachedShapeType
+        && *mCachedShapeType == dynamics::PlaneShape::getStaticType();
+
+  if (!mCachedShape || mIsCachedPlaneShape)
+    return;
+
+  const auto& localBox = mCachedShape->getBoundingBox();
+  mCachedLocalBoundsMin = localBox.getMin();
+  mCachedLocalBoundsMax = localBox.getMax();
+  mHasFiniteCachedLocalBounds
+      = mCachedLocalBoundsMin.allFinite() && mCachedLocalBoundsMax.allFinite();
 }
 
 //==============================================================================
 void DARTCollisionObject::updateEngineData()
 {
-  // Do nothing
+  refreshShapeCache();
 }
 
 } // namespace collision

--- a/dart/collision/dart/DARTCollisionObject.hpp
+++ b/dart/collision/dart/DARTCollisionObject.hpp
@@ -35,7 +35,14 @@
 
 #include <dart/collision/CollisionObject.hpp>
 
+#include <dart/dynamics/SmartPointer.hpp>
+
 #include <Eigen/Dense>
+
+#include <limits>
+#include <string>
+
+#include <cstddef>
 
 namespace dart {
 namespace collision {
@@ -53,8 +60,33 @@ protected:
       CollisionDetector* collisionDetector,
       const dynamics::ShapeFrame* shapeFrame);
 
+public:
+  const dynamics::Shape* getCachedShape() const;
+
+  const std::string& getCachedShapeType() const;
+
+  const Eigen::Vector3d& getCachedLocalBoundsMin() const;
+
+  const Eigen::Vector3d& getCachedLocalBoundsMax() const;
+
+  bool hasFiniteCachedLocalBounds() const;
+
+  bool isCachedPlaneShape() const;
+
+protected:
   // Documentation inherited
   void updateEngineData() override;
+
+private:
+  void refreshShapeCache();
+
+  dynamics::ConstShapePtr mCachedShape;
+  const std::string* mCachedShapeType{nullptr};
+  std::size_t mCachedShapeFrameVersion{std::numeric_limits<std::size_t>::max()};
+  Eigen::Vector3d mCachedLocalBoundsMin{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d mCachedLocalBoundsMax{Eigen::Vector3d::Zero()};
+  bool mHasFiniteCachedLocalBounds{false};
+  bool mIsCachedPlaneShape{false};
 };
 
 } // namespace collision

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -2,60 +2,55 @@
 
 ## Current Snapshot
 
-Bottom line: #3125 is merged, and the current slice is
-`perf/dart6-native-capsule-collision`, based on `origin/release-6.20`. This
-slice ports the DART 7 native capsule primitive contacts into the DART 6 native
-collision backend for capsule/sphere, capsule/box, capsule/cylinder,
-capsule/plane, and capsule/capsule pairs. The long-term target remains DART 7
-native-collision feature, test, and benchmark parity inside DART 6.20's
-dependency-free `dart/collision/dart/` backend, with FCL, Bullet, and ODE kept
-as comparison and regression dependencies once native coverage is complete.
+Bottom line: #3126 is merged and cleaned up locally. The current follow-up is
+`perf/dart6-native-shape-cache`, based on `origin/release-6.20`. This is a
+small DART-native hot-path slice: cache each DART collision object's shape
+pointer, type string, plane flag, and local bounding box, refresh that cache
+only when the `ShapeFrame` version changes, and use the cached data in
+broadphase and narrowphase dispatch. The goal is conservative data locality and
+shared-pointer churn reduction without changing contacts or solver behavior.
 
-Correctness guardrails for this slice:
+The original issue scene remains the primary active benchmark:
+`/tmp/3k_shapes.sdf`, with `3003` mobile sphere/box/cylinder bodies plus the
+static ground plane from the issue report. Command shape:
+`pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 300 --warmup 0
+--checkpoint 0 --quiet --collision <engine> --sdf-plane-shapes --world-threads
+16 --max-contacts 12000 --disable-deactivation`.
 
-- `test_Collision` now exercises DART-native capsule/capsule and capsule pairs
-  against sphere, box, cylinder, plane, and a rotated capsule/sphere case.
-- `contact_benchmark --generate-capsules` consumes final state hashes and now
-  defaults to the DART-native detector. It rejects the DART 6 FCL backend for
-  generated capsule scenes because that backend currently falls back to dummy
-  spheres for `CapsuleShape`, which is not an apples-to-apples comparison.
-- The original issue scene remains unchanged: `/tmp/3k_shapes.sdf` still has
-  `3003` mobile sphere/box/cylinder bodies plus the static ground plane from
-  the issue report.
-
-Current capsule-only active comparison, all with DART 6 dynamics, constraints,
-and solver; only collision detection changes. Command shape:
-`pixi run ex contact_benchmark -- --generate-capsules 120 --steps 3000
---warmup 0 --checkpoint 0 --quiet --world-threads 16 --max-contacts 1000
---disable-deactivation --collision <engine>`.
-
-| Engine | RTF | Final state |
-| --- | ---: | --- |
-| DART native | `1.06574` | finite, hash `0xb1abe373933000a3`, contacts `120`, pairs `120` |
-| ODE | `0.839581` | finite, hash `0xdad6992e61e05f66`, contacts `120`, pairs `120` |
-| Bullet | `0.745414` | finite, hash `0x494452692dc448e`, contacts `120`, pairs `120` |
-| FCL primitive | not comparable | DART 6 FCL maps capsules to fallback spheres; the legacy run hit contact cap `1000` with max penetration `65.45`, so the benchmark now rejects this combination |
-
-The default sleeping capsule run is intentionally not the active collision
-comparison, but it verifies that the new capsule contacts integrate with the
-resting fast path: DART native RTF `121.389`, finite state hash
-`0x80e1d697f42d28d7`, final resting `120 / 120`, final contacts `0`.
-
-Original issue-scene no-regression evidence, same final-state consumption:
+Current active original-scene evidence, all with DART 6 dynamics, constraints,
+and solver; only collision detection changes:
 
 | Run | RTF | Final state |
 | --- | ---: | --- |
-| #3125 DART native active baseline | `0.0536378` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
-| Current DART native active | `0.0497787` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
-| #3125 DART native default sleeping baseline | `1.88616` | finite, hash `0x131b6af79a44ff90`, resting `3003 / 3003`, contacts `0` |
-| Current DART native default sleeping | `1.88637` | finite, hash `0x131b6af79a44ff90`, resting `3003 / 3003`, contacts `0` |
+| #3126 DART native active baseline | `0.0545488` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
+| Current DART native active | `0.0573693` | finite, hash `0x6b50e84cd691f6e2`, contacts `5005`, pairs `3003` |
+| #3126 Bullet active comparison | `0.0636858` | finite, hash `0x1b1e6f3c78c0e01e`, contacts `5005`, pairs `3003` |
 
-The active original-scene RTF moved within run-to-run noise while preserving the
-exact DART-native final hash and contact counts. The new performance win is on
-the newly supported capsule primitive path: previous DART native did not
-support these contacts, while the current path is real-time on the active
-120-capsule floor-contact workload and beats the available Bullet and ODE
-comparison backends on the same DART 6 physics pipeline.
+No-rebuild repeats of the current DART-native path were RTF `0.0583932`,
+`0.0582933`, and `0.0575822`, all with the same DART-native final hash and
+contact counts. The measured improvement is real but modest: about `5-7%` on
+the active exact issue scene, still behind the Bullet collision backend for
+this workload. The profiler moved the inclusive `collide` scope from the
+recorded #3126 baseline `1.982 s` to `1.839 s` over 300 steps, while
+`updateConstraints` moved from `2.930 s` to `2.745 s`. The remaining active
+hotspots are collision itself, contact-constraint construction, and constrained
+group solving.
+
+Correctness guardrails for this slice:
+
+- The benchmark consumes the final state and preserves the exact DART-native
+  final hash, contact count, and contact-pair count on the original issue scene.
+- `test_Collision` adds a DART-native shape-geometry mutation case where a box
+  is resized after the collision group is created; the cached local bounds must
+  refresh from the `ShapeFrame` version for the second collision query to see
+  the new overlap.
+- `test_Collision` still passes after the cache and DART-specific narrowphase
+  overload changes.
+
+The current slice is worth a small PR if kept narrowly scoped, but it is not the
+major win. The north-star path remains importing/porting the DART 7 native
+collision feature set into DART 6.20's dependency-free
+`dart/collision/dart/` backend with equal or better coverage and benchmarks.
 
 The previous managed PR, #3071 `perf/dart6-parallel-islands`, landed as the
 parallel-stepping follow-up after #3111 and #3112 added the core
@@ -108,13 +103,14 @@ Native-collision follow-up: continue porting DART 7 native algorithms into
 DART 6.20's `dart/collision/dart/` path in dependency-free slices. The merged
 native slices added finite-shape broadphase filtering, plane/sphere/box/cylinder
 contacts, per-thread scratch reuse, and faster active contact aggregation in
-the existing DART backend. The active follow-up adds DART-native capsule
-primitive contacts and confirms the original issue scene did not regress. The
-next native slices should keep mining DART 7 for missing shape support,
-distance/CCD/raycast coverage, and manifold behavior while preserving
+the existing DART backend. The most recent merged native follow-up added
+DART-native capsule primitive contacts and confirmed the original issue scene
+did not regress. The active follow-up is a smaller cached-shape metadata slice.
+The next larger native slices should keep mining DART 7 for missing shape
+support, distance/CCD/raycast coverage, and manifold behavior while preserving
 gz-physics-facing API compatibility.
 
-- Current active branch: `perf/dart6-native-capsule-collision`, based on
+- Current active branch: `perf/dart6-native-shape-cache`, based on
   `origin/release-6.20`.
 - Exact issue scene used for the current evidence: `/tmp/3k_shapes.sdf`,
   3003 mobile sphere/box/cylinder bodies plus the static ground plane from the

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -468,6 +468,36 @@ TEST_F(Collision, SimpleFrames)
 }
 
 //==============================================================================
+TEST_F(Collision, DARTCollisionDetectorRefreshesChangedShapeGeometry)
+{
+  auto cd = DARTCollisionDetector::create();
+  auto simpleFrame1 = SimpleFrame::createShared(Frame::World());
+  auto simpleFrame2 = SimpleFrame::createShared(Frame::World());
+
+  auto shape1 = std::make_shared<BoxShape>(Eigen::Vector3d::Ones());
+  auto shape2 = std::make_shared<BoxShape>(Eigen::Vector3d::Ones());
+  simpleFrame1->setShape(shape1);
+  simpleFrame2->setShape(shape2);
+
+  simpleFrame1->setTranslation(Eigen::Vector3d::Zero());
+  simpleFrame2->setTranslation(Eigen::Vector3d(1.2, 0.0, 0.0));
+
+  auto group = cd->createCollisionGroup(simpleFrame1.get(), simpleFrame2.get());
+
+  collision::CollisionOption option;
+  option.enableContact = true;
+
+  collision::CollisionResult result;
+  EXPECT_FALSE(group->collide(option, &result));
+  EXPECT_EQ(0u, result.getNumContacts());
+
+  shape2->setSize(Eigen::Vector3d(1.6, 1.0, 1.0));
+
+  EXPECT_TRUE(group->collide(option, &result));
+  EXPECT_GT(result.getNumContacts(), 0u);
+}
+
+//==============================================================================
 void testSphereSphere(
     const std::shared_ptr<CollisionDetector>& cd, double tol = 1e-12)
 {


### PR DESCRIPTION
## Summary

- Cache DART-native collision shape metadata and local bounds with `ShapeFrame` version invalidation, preserving mutable shape correctness.
- Route DART-native broadphase and narrowphase through the cached metadata without changing the public API, solver behavior, or contact semantics.
- Record issue #3056 performance evidence for this focused DART 6.20 optimization slice: modest active-scene speedup, with the DART-native backend still behind the current Bullet comparison on the original-scale workload.

## Motivation / Problem

Issue #3056's active path is still collision-heavy after #3126. The DART-native detector repeatedly recovers shape/type/bounds data and generic collision-object state in the hot path even when the geometry is unchanged across frames. This PR keeps the change conservative for DART 6.20 and gz-physics compatibility: improve data locality and avoid redundant work, while keeping the existing API surface and contact results intact.

## Changes / Key Changes

- Add a versioned metadata cache to `DARTCollisionObject` for shape pointer, type string, local bounding box, finite-bound state, and plane state.
- Refresh DART-native collision group engine data before collision queries so cached geometry tracks shape-frame changes.
- Use cached local bounds in DART-native broadphase overlap checks.
- Add a DART-object narrowphase overload so the hot path avoids repeated generic object recovery.
- Add a regression test that changes box geometry after collision-object creation and verifies the DART-native detector refreshes cached bounds correctly.
- Update the issue #3056 dev-task note and changelog entry.

## Before / After

Workload: original-scale generated 3-lane issue #3056 scene from `/tmp/3k_shapes.sdf`, active simulation, sleeping disabled, 300 measured steps, 0 warmup, DART-native collision, plane shapes enabled, 16 world threads, max contacts 12000.

| Build | RTF | Contacts | Contact pairs | Final hash |
| --- | ---: | ---: | ---: | --- |
| #3126 DART-native active baseline | 0.0545488 | 5005 | 3003 | `0x6b50e84cd691f6e2` |
| This PR | 0.0573693 | 5005 | 3003 | `0x6b50e84cd691f6e2` |
| #3126 Bullet active comparison | 0.0636858 | 5005 | 3003 | `0x1b1e6f3c78c0e01e` |

Current no-rebuild repeats were `0.0583932`, `0.0582933`, and `0.0575822` RTF with the same DART-native final hash/contact counts. The text profiler also moved the DART-native active scene's `collide` time from the recorded #3126 baseline `1.982 s` to `1.839 s`, and `updateConstraints` from `2.930 s` to `2.745 s`.

This is a small but measurable hot-path cleanup, not the final #3056 win. The next larger step remains DART 7 native-collision feature parity and performance work.

## Testing

- `pixi run lint`
- `pixi run build`
- `ctest --test-dir build/default/cpp/Release -R '^test_Collision$' --output-on-failure`
- `pixi run test` (100/100 tests passed)
- `git diff --check`
- `pixi run ex contact_benchmark -- /tmp/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --disable-deactivation`
  - RTF `0.0573693`, wall `5.22927 s`, contacts `5005`, contact pairs `3003`, final hash `0x6b50e84cd691f6e2`, finite true, frame delta `300/300`.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Part of #3056.
- Builds on #3126.

---

#### Checklist

- [x] Milestone set (`DART 6.20.0` for `release-6.20`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no public API added
- [x] Add Python bindings (dartpy) if applicable: N/A, no Python API change
