### PR TITLE
Backport ARM64 joint copy and Icosphere fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@
     `addObjectToCaches` nullptr errors otherwise):
     [#3114](https://github.com/dartsim/dart/pull/3114)
 
+* Dynamics
+
+  * Fix `TranslationalJoint2D::copy(const TranslationalJoint2D*)` and
+    `UniversalJoint::copy(const UniversalJoint*)` so they copy from the provided
+    joint instead of self-copying, add the missing aligned allocation hook for
+    `TranslationalJoint2DUniqueProperties`, and avoid an ARM64/NEON crash in
+    `Icosphere::computeIcosahedron()` by keeping the triangle table local:
+    [#3130](https://github.com/dartsim/dart/pull/3130)
+
 * Simulation
 
   * Enable resting-world deactivation by default with wake-aware invalidation

--- a/dart/dynamics/TranslationalJoint2D.cpp
+++ b/dart/dynamics/TranslationalJoint2D.cpp
@@ -94,7 +94,7 @@ void TranslationalJoint2D::copy(const TranslationalJoint2D* otherJoint)
   if (nullptr == otherJoint)
     return;
 
-  copy(*this);
+  copy(*otherJoint);
 }
 
 //==============================================================================

--- a/dart/dynamics/UniversalJoint.cpp
+++ b/dart/dynamics/UniversalJoint.cpp
@@ -89,7 +89,7 @@ void UniversalJoint::copy(const UniversalJoint* _otherJoint)
   if (nullptr == _otherJoint)
     return;
 
-  copy(*this);
+  copy(*_otherJoint);
 }
 
 //==============================================================================

--- a/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
+++ b/dart/dynamics/detail/TranslationalJoint2DAspect.hpp
@@ -51,6 +51,9 @@ namespace detail {
 class TranslationalJoint2DUniqueProperties
 {
 public:
+  // To get byte-aligned Eigen vectors
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   /// Constructor for pre-defined plane types. Defaults to the XY plane if
   /// PlaneType::ARBITRARY is specified.
   explicit TranslationalJoint2DUniqueProperties(

--- a/dart/math/detail/Icosphere-impl.hpp
+++ b/dart/math/detail/Icosphere-impl.hpp
@@ -90,7 +90,8 @@ Icosphere<S>::computeIcosahedron(S radius)
          {z, -x, 0},
          {-z, -x, 0}};
 
-  static std::vector<Triangle> triangles
+  // Do NOT make static: causes SEGFAULT on ARM64/NEON (alignment issue).
+  const std::vector<Triangle> triangles
       = {{0, 4, 1},  {0, 9, 4},  {9, 5, 4},  {4, 5, 8},  {4, 8, 1},
          {8, 10, 1}, {8, 3, 10}, {5, 3, 8},  {5, 2, 3},  {2, 7, 3},
          {7, 10, 3}, {7, 6, 10}, {7, 11, 6}, {11, 0, 6}, {0, 1, 6},

--- a/docs/dev_tasks/dart6_backport_audit/README.md
+++ b/docs/dev_tasks/dart6_backport_audit/README.md
@@ -59,7 +59,7 @@ queue.
 
 | PR | Category | What | Lane status | Scope |
 | --- | --- | --- | --- | --- |
-| [#2509](https://github.com/dartsim/dart/pull/2509) | compat-critical bug | ARM64/NEON SEGFAULT (`Icosphere` static table) + self-copy bugs (`TranslationalJoint2D`/`UniversalJoint`) + missing `EIGEN_MAKE_ALIGNED_OPERATOR_NEW` | `main` only; **missing from `release-6.20`** | Backport (PascalCase); most urgent (crash class) |
+| [#2509](https://github.com/dartsim/dart/pull/2509) | compat-critical bug | ARM64/NEON SEGFAULT (`Icosphere` static table) + self-copy bugs (`TranslationalJoint2D`/`UniversalJoint`) + missing `EIGEN_MAKE_ALIGNED_OPERATOR_NEW` | Backported by [#3130](https://github.com/dartsim/dart/pull/3130) | Done when #3130 lands |
 | [#2339](https://github.com/dartsim/dart/pull/2339) | compat-critical bug | FCL primitive contact-normal normalization; default `mPrimitiveShapeType` MESH→PRIMITIVE | `main` only; **missing from `release-6.20`** | Backport; collision surface (gz gate) |
 | [#3115](https://github.com/dartsim/dart/pull/3115) / [#3117](https://github.com/dartsim/dart/pull/3117) | compat-critical bug | Skip non-finite contacts and validate shape dimensions | On `main` (#3115) **and** `release-6.19` (#3117 twin); **missing from `release-6.20`** | Forward-port the #3117 LTS twin; constraint surface (gz gate) |
 | [#2233](https://github.com/dartsim/dart/pull/2233) | compat-critical bug | URDF multidof joint limits + vector-form `GenericJoint` setters | `main` only; **missing from `release-6.20`** | Backport; parser surface (gz gate) |
@@ -283,11 +283,12 @@ Each backport PR carries its own gate, sized to the touched surface:
 
 ## Remaining work
 
-1. **Compat-critical backport queue** — port the seven compat-critical items
-   (#2509, #2339, #3115/#3117, #2233, #2271, #2285, #2247) in the order and with
-   the per-surface gates given in [`RESUME.md`](RESUME.md) section 1. #2509 is
-   most urgent (crash class); #3115/#3117 is a forward-port of the DART-6-shaped
-   #3117 twin. Run the gz gate on every collision/constraint/parser surface.
+1. **Compat-critical backport queue** — #2509 is carried by
+   [#3130](https://github.com/dartsim/dart/pull/3130). Port the remaining six
+   compat-critical items (#2339, #3115/#3117, #2233, #2271, #2285, #2247) in
+   the order and with the per-surface gates given in [`RESUME.md`](RESUME.md)
+   section 1. #3115/#3117 is a forward-port of the DART-6-shaped #3117 twin.
+   Run the gz gate on every collision/constraint/parser surface.
 2. **CI/tooling bumps** — selective action-version bumps to `release-6.20`
    workflows only where the workflow is shared with `main`; skip `main`-only
    actions.

--- a/docs/dev_tasks/dart6_backport_audit/RESUME.md
+++ b/docs/dev_tasks/dart6_backport_audit/RESUME.md
@@ -41,9 +41,10 @@ branch `backport/<pr>-to-release-6.20` off `origin/release-6.20`, milestone
 PascalCase `dart/utils/...`; main is snake_case `dart/io|...`; pybind11 not
 nanobind) — see the recipe in section 2.
 
-- [ ] **[#2509](https://github.com/dartsim/dart/pull/2509) — ARM64 SEGFAULT
+- [x] **[#2509](https://github.com/dartsim/dart/pull/2509) — ARM64 SEGFAULT
   (TranslationalJoint2D / Icosphere) + self-copy bugs** *(MOST URGENT — crash
   class)*
+  - Backported by [#3130](https://github.com/dartsim/dart/pull/3130).
   - Commit `25b77a15984`.
   - Three sub-fixes, DART 6 PascalCase paths:
     (1) `copy(*this)` -> `copy(*otherJoint…)` in

--- a/tests/unit/dynamics/test_Joints.cpp
+++ b/tests/unit/dynamics/test_Joints.cpp
@@ -100,3 +100,45 @@ TEST(Joints, SimulationSurvivesOverflowTransforms)
     EXPECT_NO_THROW(world->step());
   }
 }
+
+TEST(Joints, TranslationalJoint2DCopyPointerUsesSource)
+{
+  auto skel = Skeleton::create("translational_2d_copy");
+  auto [joint, body] = skel->createJointAndBodyNodePair<TranslationalJoint2D>();
+  (void)body;
+
+  joint->setXYPlane(false);
+  joint->copy(static_cast<const TranslationalJoint2D*>(nullptr));
+  joint->copy(joint);
+
+  auto [otherJoint, otherBody]
+      = skel->createJointAndBodyNodePair<TranslationalJoint2D>();
+  (void)otherBody;
+  otherJoint->setYZPlane(false);
+
+  joint->copy(otherJoint);
+  EXPECT_EQ(joint->getPlaneType(), TranslationalJoint2D::PlaneType::YZ);
+}
+
+TEST(Joints, UniversalJointCopyPointerUsesSource)
+{
+  auto skel = Skeleton::create("universal_copy");
+  auto [joint, body] = skel->createJointAndBodyNodePair<UniversalJoint>();
+  (void)body;
+
+  UniversalJoint::Properties props;
+  props.mAxis[0] = Eigen::Vector3d::UnitX();
+  props.mAxis[1] = Eigen::Vector3d::UnitZ();
+  joint->setProperties(props);
+
+  joint->copy(static_cast<const UniversalJoint*>(nullptr));
+  joint->copy(joint);
+
+  auto [otherJoint, otherBody]
+      = skel->createJointAndBodyNodePair<UniversalJoint>();
+  (void)otherBody;
+  otherJoint->setAxis1(Eigen::Vector3d::UnitY());
+
+  joint->copy(otherJoint);
+  EXPECT_TRUE(joint->getAxis1().isApprox(Eigen::Vector3d::UnitY()));
+}


### PR DESCRIPTION
## Summary

- Backports the DART 7 #2509 crash/copy fixes onto `release-6.20`.
- Fixes pointer-copy overloads for `TranslationalJoint2D` and `UniversalJoint`, and removes the ARM64-unsafe static Icosphere triangle table.

## Motivation / Problem

- `release-6.20` still had the #2509 bug class: joint pointer-copy overloads ignored their source argument, and `Icosphere::computeIcosahedron()` kept a static aligned container that can crash on macOS ARM64/NEON release builds.

## Changes / Key Changes

- `TranslationalJoint2D::copy(const TranslationalJoint2D*)` now copies from the provided joint.
- `UniversalJoint::copy(const UniversalJoint*)` now copies from the provided joint.
- `TranslationalJoint2DUniqueProperties` now has `EIGEN_MAKE_ALIGNED_OPERATOR_NEW`.
- `Icosphere::computeIcosahedron()` now uses a local const triangle vector instead of a static vector.
- Added DART 6 unit regression coverage for the joint pointer-copy overloads.
- Added the DART 6.20 changelog entry and marked #2509 as carried by this PR in the backport-audit task docs.

## Testing

- `pixi run build`
- `pixi run cmake --build build/default/cpp/Release -j --target UNIT_dynamics_Joints UNIT_math_Icosphere`
- `pixi run ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_dynamics_Joints|UNIT_math_Icosphere)$'`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Backports #2509 to `release-6.20`.
- Tracked by `docs/dev_tasks/dart6_backport_audit/`.

---

#### Checklist

- [x] Milestone set (DART 6.20.0 for `release-6.20`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no new public API
- [x] Add Python bindings (dartpy) if applicable: N/A, no binding changes
