### PR TITLE
Backport mimic motor constraint robustness to release-6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@
     ERP-scaled position correction, clamped force-mixing and ERP parameters,
     and finite fallback force and velocity limits for joints with unbounded
     limits:
-    [#2247](https://github.com/dartsim/dart/pull/2247)
+    [#3137](https://github.com/dartsim/dart/pull/3137)
 
   * Expose the opt-in simulation thread controls to dartpy via
     `World.setNumSimulationThreads()` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@
     groups that share non-reactive bodies or skeletons across islands:
     [#3111](https://github.com/dartsim/dart/pull/3111)
 
+  * Make mimic motor constraints robust for Gazebo mimic repros by using
+    ERP-scaled position correction, clamped force-mixing and ERP parameters,
+    and finite fallback force and velocity limits for joints with unbounded
+    limits:
+    [#2247](https://github.com/dartsim/dart/pull/2247)
+
   * Expose the opt-in simulation thread controls to dartpy via
     `World.setNumSimulationThreads()` and
     `ConstraintSolver.setNumSimulationThreads()`, and add a Pixi task for the

--- a/dart/constraint/MimicMotorConstraint.cpp
+++ b/dart/constraint/MimicMotorConstraint.cpp
@@ -33,6 +33,7 @@
 #include "dart/constraint/MimicMotorConstraint.hpp"
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
@@ -41,12 +42,22 @@
 
 #include <iostream>
 
-#define DART_CFM 1e-9
+#include <cmath>
+
+namespace {
+
+constexpr inline double kConstraintForceMixing = 1e-6;
+constexpr inline double kDefaultForceLimit = 800.0;
+constexpr inline double kDefaultVelocityLimit = 50.0;
+constexpr inline double kDefaultErp = 0.4;
+
+} // namespace
 
 namespace dart {
 namespace constraint {
 
-double MimicMotorConstraint::mConstraintForceMixing = DART_CFM;
+double MimicMotorConstraint::mConstraintForceMixing = kConstraintForceMixing;
+double MimicMotorConstraint::mErrorReductionParameter = kDefaultErp;
 
 //==============================================================================
 MimicMotorConstraint::MimicMotorConstraint(
@@ -99,22 +110,47 @@ const std::string& MimicMotorConstraint::getStaticType()
 //==============================================================================
 void MimicMotorConstraint::setConstraintForceMixing(double cfm)
 {
-  // Clamp constraint force mixing parameter if it is out of the range
-  if (cfm < 1e-9) {
-    dtwarn << "[MimicMotorConstraint::setConstraintForceMixing] "
-           << "Constraint force mixing parameter[" << cfm
-           << "] is lower than 1e-9. "
-           << "It is set to 1e-9.\n";
-    mConstraintForceMixing = 1e-9;
+  double clamped = cfm;
+  if (clamped < 1e-9) {
+    DART_WARN(
+        "Constraint force mixing parameter[{}] is lower than 1e-9. It is set "
+        "to 1e-9.",
+        cfm);
+    clamped = 1e-9;
   }
 
-  mConstraintForceMixing = cfm;
+  mConstraintForceMixing = clamped;
 }
 
 //==============================================================================
 double MimicMotorConstraint::getConstraintForceMixing()
 {
   return mConstraintForceMixing;
+}
+
+//==============================================================================
+void MimicMotorConstraint::setErrorReductionParameter(double erp)
+{
+  double clamped = erp;
+  if (clamped < 0.0) {
+    DART_WARN(
+        "Error reduction parameter [{}] is lower than 0.0. It is set to 0.0.",
+        erp);
+    clamped = 0.0;
+  } else if (clamped > 1.0) {
+    DART_WARN(
+        "Error reduction parameter [{}] is greater than 1.0. It is set to 1.0.",
+        erp);
+    clamped = 1.0;
+  }
+
+  mErrorReductionParameter = clamped;
+}
+
+//==============================================================================
+double MimicMotorConstraint::getErrorReductionParameter()
+{
+  return mErrorReductionParameter;
 }
 
 //==============================================================================
@@ -128,21 +164,34 @@ void MimicMotorConstraint::update()
     const auto& mimicProp = mMimicProps[i];
 
     double timeStep = mJoint->getSkeleton()->getTimeStep();
+    double velLower = mJoint->getVelocityLowerLimit(i);
+    double velUpper = mJoint->getVelocityUpperLimit(i);
+    if (!std::isfinite(velLower))
+      velLower = -kDefaultVelocityLimit;
+    if (!std::isfinite(velUpper))
+      velUpper = kDefaultVelocityLimit;
+
     double qError
         = mimicProp.mReferenceJoint->getPosition(mimicProp.mReferenceDofIndex)
               * mimicProp.mMultiplier
           + mimicProp.mOffset - mJoint->getPosition(i);
-    double desiredVelocity = math::clip(
-        qError / timeStep,
-        mJoint->getVelocityLowerLimit(i),
-        mJoint->getVelocityUpperLimit(i));
+    const double erp = mErrorReductionParameter;
+    double desiredVelocity
+        = math::clip((erp * qError) / timeStep, velLower, velUpper);
 
     mNegativeVelocityError[i] = desiredVelocity - mJoint->getVelocity(i);
 
     if (mNegativeVelocityError[i] != 0.0) {
       // Note that we are computing impulse not force
-      mUpperBound[i] = mJoint->getForceUpperLimit(i) * timeStep;
-      mLowerBound[i] = mJoint->getForceLowerLimit(i) * timeStep;
+      double upper = mJoint->getForceUpperLimit(i);
+      double lower = mJoint->getForceLowerLimit(i);
+      if (!std::isfinite(upper))
+        upper = kDefaultForceLimit;
+      if (!std::isfinite(lower))
+        lower = -kDefaultForceLimit;
+
+      mUpperBound[i] = upper * timeStep;
+      mLowerBound[i] = lower * timeStep;
 
       if (mActive[i]) {
         ++(mLifeTime[i]);

--- a/dart/constraint/MimicMotorConstraint.hpp
+++ b/dart/constraint/MimicMotorConstraint.hpp
@@ -80,6 +80,12 @@ public:
   /// Get global constraint force mixing parameter
   static double getConstraintForceMixing();
 
+  /// Set global error reduction parameter applied to mimic motors.
+  static void setErrorReductionParameter(double erp);
+
+  /// Get global error reduction parameter applied to mimic motors.
+  static double getErrorReductionParameter();
+
   //----------------------------------------------------------------------------
   // Friendship
   //----------------------------------------------------------------------------
@@ -153,9 +159,12 @@ private:
   double mLowerBound[6];
 
   /// Global constraint force mixing parameter in the range of [1e-9, 1]. The
-  /// default is 1e-5
+  /// default is 1e-6
   /// \sa http://www.ode.org/ode-latest-userguide.html#sec_3_8_0
   static double mConstraintForceMixing;
+
+  /// Global error reduction parameter that scales mimic motor position error.
+  static double mErrorReductionParameter;
 };
 
 } // namespace constraint

--- a/dart/math/Helpers.hpp
+++ b/dart/math/Helpers.hpp
@@ -325,39 +325,39 @@ inline Eigen::VectorXd randomVectorXd(std::size_t size, double limit)
 namespace suffixes {
 
 //==============================================================================
-constexpr double operator"" _pi(long double x)
+constexpr double operator""_pi(long double x)
 {
   return x * constants<double>::pi();
 }
 
 //==============================================================================
-constexpr double operator"" _pi(unsigned long long int x)
+constexpr double operator""_pi(unsigned long long int x)
 {
-  return operator"" _pi(static_cast<long double>(x));
+  return operator""_pi(static_cast<long double>(x));
 }
 
 //==============================================================================
-constexpr double operator"" _rad(long double angle)
+constexpr double operator""_rad(long double angle)
 {
   return angle;
 }
 
 //==============================================================================
-constexpr double operator"" _rad(unsigned long long int angle)
+constexpr double operator""_rad(unsigned long long int angle)
 {
-  return operator"" _rad(static_cast<long double>(angle));
+  return operator""_rad(static_cast<long double>(angle));
 }
 
 //==============================================================================
-constexpr double operator"" _deg(long double angle)
+constexpr double operator""_deg(long double angle)
 {
   return toRadian(angle);
 }
 
 //==============================================================================
-constexpr double operator"" _deg(unsigned long long int angle)
+constexpr double operator""_deg(unsigned long long int angle)
 {
-  return operator"" _deg(static_cast<long double>(angle));
+  return operator""_deg(static_cast<long double>(angle));
 }
 
 } // namespace suffixes

--- a/tests/integration/test_Joints.cpp
+++ b/tests/integration/test_Joints.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "TestHelpers.hpp"
+#include "dart/constraint/MimicMotorConstraint.hpp"
 #include "dart/dynamics/BallJoint.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/EulerJoint.hpp"
@@ -54,6 +55,8 @@
 
 #include <array>
 #include <iostream>
+
+#include <cmath>
 
 using namespace dart;
 using namespace dart::math;
@@ -1056,7 +1059,7 @@ void testMimicJoint()
 
   double timestep = 1e-3;
   double tol = 1e-9;
-  double tolPos = 1e-3;
+  double tolPos = 3e-3;
   double sufficient_force = 1e+5;
 
   // World
@@ -1138,6 +1141,89 @@ void testMimicJoint()
 TEST_F(JOINTS, MIMIC_JOINT)
 {
   testMimicJoint();
+}
+
+//==============================================================================
+TEST_F(JOINTS, MIMIC_MOTOR_CONSTRAINT_PARAMETERS)
+{
+  using dart::constraint::MimicMotorConstraint;
+
+  MimicMotorConstraint::setConstraintForceMixing(0.0);
+  EXPECT_DOUBLE_EQ(1e-9, MimicMotorConstraint::getConstraintForceMixing());
+
+  MimicMotorConstraint::setConstraintForceMixing(1e-4);
+  EXPECT_DOUBLE_EQ(1e-4, MimicMotorConstraint::getConstraintForceMixing());
+
+  MimicMotorConstraint::setErrorReductionParameter(-0.5);
+  EXPECT_DOUBLE_EQ(0.0, MimicMotorConstraint::getErrorReductionParameter());
+
+  MimicMotorConstraint::setErrorReductionParameter(1.5);
+  EXPECT_DOUBLE_EQ(1.0, MimicMotorConstraint::getErrorReductionParameter());
+
+  MimicMotorConstraint::setErrorReductionParameter(0.25);
+  EXPECT_DOUBLE_EQ(0.25, MimicMotorConstraint::getErrorReductionParameter());
+
+  MimicMotorConstraint::setConstraintForceMixing(1e-6);
+  MimicMotorConstraint::setErrorReductionParameter(0.4);
+}
+
+//==============================================================================
+TEST_F(JOINTS, MIMIC_JOINT_UNBOUNDED_LIMITS_STAY_FINITE)
+{
+  using dart::constraint::MimicMotorConstraint;
+  using namespace dart::math::suffixes;
+
+  MimicMotorConstraint::setConstraintForceMixing(1e-6);
+  MimicMotorConstraint::setErrorReductionParameter(0.4);
+
+  simulation::WorldPtr world = simulation::World::create();
+  ASSERT_NE(nullptr, world);
+  world->setGravity(Eigen::Vector3d::Zero());
+  world->setTimeStep(1e-3);
+
+  const Vector3d dim(1, 1, 1);
+  const Vector3d offset(0, 0, 2);
+  SkeletonPtr pendulum = createNLinkPendulum(2, dim, DOF_ROLL, offset);
+  ASSERT_NE(nullptr, pendulum);
+  pendulum->disableSelfCollisionCheck();
+
+  for (std::size_t i = 0; i < pendulum->getNumBodyNodes(); ++i) {
+    auto* bodyNode = pendulum->getBodyNode(i);
+    bodyNode->removeAllShapeNodesWith<CollisionAspect>();
+  }
+
+  auto* reference = pendulum->getJoint(0);
+  auto* follower = pendulum->getJoint(1);
+  ASSERT_NE(nullptr, reference);
+  ASSERT_NE(nullptr, follower);
+
+  reference->setPosition(0, 45.0_deg);
+  reference->setActuatorType(Joint::PASSIVE);
+  reference->setDampingCoefficient(0, 0.0);
+  reference->setSpringStiffness(0, 0.0);
+
+  follower->setPosition(0, -45.0_deg);
+  follower->setActuatorType(Joint::MIMIC);
+  follower->setMimicJoint(reference, 1.0, 0.0);
+  follower->setDampingCoefficient(0, 0.0);
+  follower->setSpringStiffness(0, 0.0);
+
+  const double initialError
+      = std::abs(reference->getPosition(0) - follower->getPosition(0));
+
+  world->addSkeleton(pendulum);
+
+  for (int i = 0; i < 100; ++i) {
+    world->step();
+    EXPECT_TRUE(std::isfinite(reference->getPosition(0)));
+    EXPECT_TRUE(std::isfinite(follower->getPosition(0)));
+    EXPECT_TRUE(std::isfinite(reference->getVelocity(0)));
+    EXPECT_TRUE(std::isfinite(follower->getVelocity(0)));
+  }
+
+  const double finalError
+      = std::abs(reference->getPosition(0) - follower->getPosition(0));
+  EXPECT_LT(finalError, initialError);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Backports the mimic motor constraint robustness fix from #2247 to `release-6.20`.

## Motivation / Problem

- Mimic motor constraints could become unstable for Gazebo mimic scenarios when joints expose unbounded force or velocity limits.
- The source fix also clamps the global force-mixing and ERP parameters and applies ERP-scaled position correction.

## Changes / Key Changes

- Adds finite fallback force and velocity limits in `MimicMotorConstraint` when joint limits are unbounded.
- Adds clamped mimic motor ERP accessors and fixes force-mixing clamping.
- Updates mimic joint regression coverage and the DART 6.20 changelog.
- Modernizes math literal operator spelling so macOS arm64 AppleClang 21 CI does not fail `-Wdeprecated-literal-operator` under `-Werror`.

## Testing

- `pixi run build`
- `pixi run cmake --build build/default/cpp/Release -j --target test_Joints`
- `pixi run ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_Joints$'`
- `DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run -e gazebo test-gz`
- `pixi run lint`
- `pixi run build` after the AppleClang literal-operator follow-up

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Backport of #2247

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)
