### PR TITLE
Use C++23 literal operator spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
     an explicit system ImGui opt-in path:
     [#3081](https://github.com/dartsim/dart/pull/3081)
 
+  * Update the math user-defined literal declarations to the C++23 spelling
+    accepted by newer AppleClang warning-as-error builds.
+
 * Collision
 
   * Speed up the DART-native collision backend by caching collision-object

--- a/dart/math/Helpers.hpp
+++ b/dart/math/Helpers.hpp
@@ -325,39 +325,39 @@ inline Eigen::VectorXd randomVectorXd(std::size_t size, double limit)
 namespace suffixes {
 
 //==============================================================================
-constexpr double operator"" _pi(long double x)
+constexpr double operator""_pi(long double x)
 {
   return x * constants<double>::pi();
 }
 
 //==============================================================================
-constexpr double operator"" _pi(unsigned long long int x)
+constexpr double operator""_pi(unsigned long long int x)
 {
-  return operator"" _pi(static_cast<long double>(x));
+  return operator""_pi(static_cast<long double>(x));
 }
 
 //==============================================================================
-constexpr double operator"" _rad(long double angle)
+constexpr double operator""_rad(long double angle)
 {
   return angle;
 }
 
 //==============================================================================
-constexpr double operator"" _rad(unsigned long long int angle)
+constexpr double operator""_rad(unsigned long long int angle)
 {
-  return operator"" _rad(static_cast<long double>(angle));
+  return operator""_rad(static_cast<long double>(angle));
 }
 
 //==============================================================================
-constexpr double operator"" _deg(long double angle)
+constexpr double operator""_deg(long double angle)
 {
   return toRadian(angle);
 }
 
 //==============================================================================
-constexpr double operator"" _deg(unsigned long long int angle)
+constexpr double operator""_deg(unsigned long long int angle)
 {
-  return operator"" _deg(static_cast<long double>(angle));
+  return operator""_deg(static_cast<long double>(angle));
 }
 
 } // namespace suffixes


### PR DESCRIPTION
## Summary

- Updates DART 6 math user-defined literal declarations to the C++23 spelling with no whitespace between `operator""` and the suffix.
- Matches the spelling already used on `main` after the header rename.
- Refreshes the branch onto the latest `release-6.20` after the ARM64 joint/Icosphere backport landed.

## Motivation / Problem

Newer AppleClang treats whitespace before user-defined literal suffixes as deprecated, and DART CI builds with warnings as errors. The release branch still used the older spelling in `dart/math/Helpers.hpp`, which breaks macOS arm64 builds before unrelated PR code is compiled.

## Changes / Key Changes

- Changes `_pi`, `_rad`, and `_deg` literal operator declarations and forwarding calls to `operator""_suffix` spelling.
- Adds a DART 6.20 changelog entry for the build compatibility fix.

## Testing

- `pixi run lint`
- `pixi run build`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Unblocks release-6.20 macOS CI for the active issue #3056 performance stack.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality: N/A, spelling-only build compatibility fix
- [x] Document new methods and classes: N/A
- [x] Add Python bindings (dartpy) if applicable: N/A
