### PR TITLE
Backport MeshShape TriMesh representation to DART 6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@
 
 * Dynamics
 
+  * Add TriMesh-backed `MeshShape` storage and material metadata while keeping
+    the legacy Assimp `aiScene` APIs available as deprecated DART 6
+    compatibility shims, and route mesh collision backends through the new
+    representation:
+    [#3145](https://github.com/dartsim/dart/pull/3145)
+
   * Fix `TranslationalJoint2D::copy(const TranslationalJoint2D*)` and
     `UniversalJoint::copy(const UniversalJoint*)` so they copy from the provided
     joint instead of self-copying, add the missing aligned allocation hook for

--- a/dart/collision/bullet/BulletCollisionDetector.cpp
+++ b/dart/collision/bullet/BulletCollisionDetector.cpp
@@ -56,6 +56,7 @@
 #include "dart/dynamics/ShapeFrame.hpp"
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
+#include "dart/math/TriMesh.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -90,8 +91,13 @@ void reportRayHits(
 std::unique_ptr<btCollisionShape> createBulletEllipsoidMesh(
     float sizeX, float sizeY, float sizeZ);
 
-std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
+[[maybe_unused]] std::unique_ptr<btCollisionShape>
+createBulletCollisionShapeFromAssimpScene(
     const Eigen::Vector3d& scale, const aiScene* scene);
+
+std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromTriMesh(
+    const Eigen::Vector3d& scale,
+    const std::shared_ptr<math::TriMesh<double>>& mesh);
 
 std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpMesh(
     const aiMesh* mesh);
@@ -101,6 +107,8 @@ std::unique_ptr<BulletCollisionShape> createBulletCollisionShapeFromHeightmap(
     const HeightmapShapeT* heightMap);
 
 bool isConvex(const aiMesh* mesh, float threshold = 0.001);
+
+bool isConvex(const math::TriMesh<double>& mesh, float threshold = 0.001);
 
 } // anonymous namespace
 
@@ -632,10 +640,10 @@ BulletCollisionDetector::createBulletCollisionShape(
         std::move(bulletCollisionShape));
   } else if (const auto shapeMesh = shape->as<MeshShape>()) {
     const auto scale = shapeMesh->getScale();
-    const auto mesh = shapeMesh->getMesh();
+    const auto mesh = shapeMesh->getTriMesh();
 
     auto bulletCollisionShape
-        = createBulletCollisionShapeFromAssimpScene(scale, mesh);
+        = createBulletCollisionShapeFromTriMesh(scale, mesh);
 
     return std::make_unique<BulletCollisionShape>(
         std::move(bulletCollisionShape));
@@ -957,7 +965,8 @@ std::unique_ptr<btCollisionShape> createBulletEllipsoidMesh(
 }
 
 //==============================================================================
-std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
+[[maybe_unused]] std::unique_ptr<btCollisionShape>
+createBulletCollisionShapeFromAssimpScene(
     const Eigen::Vector3d& scale, const aiScene* scene)
 {
   auto triMesh = new btTriangleMesh();
@@ -977,6 +986,41 @@ std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromAssimpScene(
   }
   const bool makeConvexMesh
       = scene->mNumMeshes == 1 && isConvex(scene->mMeshes[0]);
+  if (makeConvexMesh) {
+    auto convexMeshShape = std::make_unique<btConvexTriangleMeshShape>(triMesh);
+    convexMeshShape->setMargin(0.0f);
+    convexMeshShape->setUserPointer(triMesh);
+    return convexMeshShape;
+  } else {
+    auto gimpactMeshShape = std::make_unique<btGImpactMeshShape>(triMesh);
+    gimpactMeshShape->updateBound();
+    gimpactMeshShape->setUserPointer(triMesh);
+    return gimpactMeshShape;
+  }
+}
+
+//==============================================================================
+std::unique_ptr<btCollisionShape> createBulletCollisionShapeFromTriMesh(
+    const Eigen::Vector3d& scale,
+    const std::shared_ptr<math::TriMesh<double>>& mesh)
+{
+  if (!mesh)
+    return nullptr;
+
+  auto triMesh = new btTriangleMesh();
+
+  const auto& vertices = mesh->getVertices();
+  for (const auto& triangle : mesh->getTriangles()) {
+    btVector3 btVertices[3];
+    for (auto i = 0u; i < 3; ++i) {
+      const auto& vertex = vertices[triangle[i]];
+      btVertices[i] = btVector3(
+          vertex.x() * scale[0], vertex.y() * scale[1], vertex.z() * scale[2]);
+    }
+    triMesh->addTriangle(btVertices[0], btVertices[1], btVertices[2]);
+  }
+
+  const bool makeConvexMesh = isConvex(*mesh);
   if (makeConvexMesh) {
     auto convexMeshShape = std::make_unique<btConvexTriangleMeshShape>(triMesh);
     convexMeshShape->setMargin(0.0f);
@@ -1117,6 +1161,51 @@ bool isConvex(const aiMesh* mesh, float threshold)
       }
     }
   }
+  return true;
+}
+
+//==============================================================================
+bool isConvex(const math::TriMesh<double>& mesh, float threshold)
+{
+  const auto& points = mesh.getVertices();
+  const auto& triangles = mesh.getTriangles();
+
+  if (points.empty() || triangles.empty())
+    return false;
+
+  btVector3 vertices[3];
+  for (const auto& triangle : triangles) {
+    for (auto j = 0u; j < 3; ++j) {
+      const auto& vertex = points[triangle[j]];
+      vertices[j] = btVector3(vertex.x(), vertex.y(), vertex.z());
+    }
+
+    const btVector3& A = vertices[0];
+    const btVector3 B = vertices[1] - A;
+    const btVector3 C = vertices[2] - A;
+    const btVector3 normalRaw = B.cross(C);
+    const btScalar normalLengthSquared = normalRaw.length2();
+    if (normalLengthSquared <= btScalar(0.0))
+      continue;
+
+    const btVector3 normal = normalRaw / btSqrt(normalLengthSquared);
+    const float checkPoint = btVector3(
+                                 points[0].x() - A.x(),
+                                 points[0].y() - A.y(),
+                                 points[0].z() - A.z())
+                                 .dot(normal);
+
+    for (const auto& point : points) {
+      const float distance
+          = btVector3(point.x() - A.x(), point.y() - A.y(), point.z() - A.z())
+                .dot(normal);
+      if ((std::abs(checkPoint) > threshold) && (std::abs(distance) > threshold)
+          && (checkPoint * distance < 0.0f)) {
+        return false;
+      }
+    }
+  }
+
   return true;
 }
 

--- a/dart/collision/fcl/FCLCollisionDetector.cpp
+++ b/dart/collision/fcl/FCLCollisionDetector.cpp
@@ -54,6 +54,7 @@
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
 #include "dart/dynamics/VoxelGridShape.hpp"
+#include "dart/math/TriMesh.hpp"
 
 #include <assimp/scene.h>
 
@@ -628,6 +629,33 @@ template <class BV>
 
 //==============================================================================
 template <class BV>
+::fcl::BVHModel<BV>* createMesh(
+    float _scaleX,
+    float _scaleY,
+    float _scaleZ,
+    const math::TriMesh<double>* _mesh)
+{
+  DART_ASSERT(_mesh);
+  ::fcl::BVHModel<BV>* model = new ::fcl::BVHModel<BV>;
+  model->beginModel();
+
+  const auto& vertices = _mesh->getVertices();
+  for (const auto& triangle : _mesh->getTriangles()) {
+    fcl::Vector3 fclVertices[3];
+    for (std::size_t i = 0; i < 3; ++i) {
+      const Eigen::Vector3d& vertex = vertices[triangle[i]];
+      fclVertices[i] = fcl::Vector3(
+          vertex.x() * _scaleX, vertex.y() * _scaleY, vertex.z() * _scaleZ);
+    }
+    model->addTriangle(fclVertices[0], fclVertices[1], fclVertices[2]);
+  }
+
+  model->endModel();
+  return model;
+}
+
+//==============================================================================
+template <class BV>
 ::fcl::BVHModel<BV>* createSoftMesh(const aiMesh* _mesh)
 {
   // Create FCL mesh from Assimp mesh
@@ -1115,9 +1143,9 @@ FCLCollisionDetector::createFCLCollisionGeometry(
 
     auto shapeMesh = static_cast<const MeshShape*>(shape.get());
     const Eigen::Vector3d& scale = shapeMesh->getScale();
-    auto aiScene = shapeMesh->getMesh();
+    auto triMesh = shapeMesh->getTriMesh();
 
-    geom = createMesh<fcl::OBBRSS>(scale[0], scale[1], scale[2], aiScene);
+    geom = createMesh<fcl::OBBRSS>(scale[0], scale[1], scale[2], triMesh.get());
   } else if (SoftMeshShape::getStaticType() == shapeType) {
     DART_ASSERT(dynamic_cast<const SoftMeshShape*>(shape.get()));
 

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -324,9 +324,9 @@ detail::OdeGeom* createOdeGeom(
     geom = new detail::OdePlane(collObj, normal, offset);
   } else if (const auto shapeMesh = shape->as<MeshShape>()) {
     const Eigen::Vector3d& scale = shapeMesh->getScale();
-    auto aiScene = shapeMesh->getMesh();
+    auto triMesh = shapeMesh->getTriMesh();
 
-    geom = new detail::OdeMesh(collObj, aiScene, scale);
+    geom = new detail::OdeMesh(collObj, triMesh.get(), scale);
   } else if (const auto heightMap = shape->as<HeightmapShapef>()) {
     geom = new detail::OdeHeightmapf(collObj, heightMap);
   } else if (const auto heightMap = shape->as<HeightmapShaped>()) {

--- a/dart/collision/ode/detail/OdeMesh.cpp
+++ b/dart/collision/ode/detail/OdeMesh.cpp
@@ -67,6 +67,31 @@ OdeMesh::OdeMesh(
 }
 
 //==============================================================================
+OdeMesh::OdeMesh(
+    const OdeCollisionObject* parent,
+    const math::TriMesh<double>* mesh,
+    const Eigen::Vector3d& scale)
+  : OdeGeom(parent), mOdeTriMeshDataId(nullptr)
+{
+  fillArrays(mesh, scale);
+
+  if (!mOdeTriMeshDataId)
+    mOdeTriMeshDataId = dGeomTriMeshDataCreate();
+
+  dGeomTriMeshDataBuildDouble1(
+      mOdeTriMeshDataId,
+      mVertices.data(),
+      3 * sizeof(double),
+      static_cast<int>(mVertices.size() / 3),
+      mIndices.data(),
+      static_cast<int>(mIndices.size()),
+      3 * sizeof(int),
+      mNormals.data());
+
+  mGeomId = dCreateTriMesh(0, mOdeTriMeshDataId, nullptr, nullptr, nullptr);
+}
+
+//==============================================================================
 OdeMesh::~OdeMesh()
 {
   dGeomDestroy(mGeomId);
@@ -130,6 +155,47 @@ void OdeMesh::fillArrays(const aiScene* scene, const Eigen::Vector3d& scale)
     }
 
     offset += mesh->mNumVertices;
+  }
+}
+
+//==============================================================================
+void OdeMesh::fillArrays(
+    const math::TriMesh<double>* mesh, const Eigen::Vector3d& scale)
+{
+  mVertices.clear();
+  mNormals.clear();
+  mIndices.clear();
+
+  if (!mesh)
+    return;
+
+  const auto& vertices = mesh->getVertices();
+  const auto& normals = mesh->getVertexNormals();
+  const auto& triangles = mesh->getTriangles();
+  const bool hasNormals = normals.size() == vertices.size();
+
+  mVertices.resize(vertices.size() * 3);
+  mNormals.resize(vertices.size() * 3);
+  mIndices.resize(triangles.size() * 3);
+
+  std::size_t vertexIndex = 0;
+  for (std::size_t i = 0; i < vertices.size(); ++i) {
+    const Eigen::Vector3d scaled = vertices[i].cwiseProduct(scale);
+    mVertices[vertexIndex] = scaled.x();
+    mNormals[vertexIndex++] = hasNormals ? normals[i].x() : 0.0;
+
+    mVertices[vertexIndex] = scaled.y();
+    mNormals[vertexIndex++] = hasNormals ? normals[i].y() : 0.0;
+
+    mVertices[vertexIndex] = scaled.z();
+    mNormals[vertexIndex++] = hasNormals ? normals[i].z() : 0.0;
+  }
+
+  std::size_t indexIndex = 0;
+  for (const auto& triangle : triangles) {
+    mIndices[indexIndex++] = static_cast<int>(triangle[0]);
+    mIndices[indexIndex++] = static_cast<int>(triangle[1]);
+    mIndices[indexIndex++] = static_cast<int>(triangle[2]);
   }
 }
 

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -242,10 +242,7 @@ void ArrowShape::configureArrow(
     for (std::size_t j = 0; j < 4; ++j)
       node->mTransformation[i][j] = tf(i, j);
 
-  mIsBoundingBoxDirty = true;
-  mIsVolumeDirty = true;
-
-  incrementVersion();
+  notifyLegacyMeshChanged();
 }
 
 //==============================================================================
@@ -258,7 +255,7 @@ ShapePtr ArrowShape::clone() const
   new_shape->mHead = mHead;
   new_shape->mProperties = mProperties;
 
-  new_shape->mMesh = new_scene;
+  new_shape->setLegacyMesh(new_scene, MeshOwnership::Copied);
   new_shape->mMeshUri = mMeshUri;
   new_shape->mMeshPath = mMeshPath;
   new_shape->mResourceRetriever = mResourceRetriever;
@@ -396,7 +393,7 @@ void ArrowShape::instantiate(std::size_t resolution)
     face->mIndices[2] = 2 * resolution;
   }
 
-  mMesh = scene;
+  setLegacyMesh(scene, MeshOwnership::Manual);
 
   // setColor(mColor);
   // TODO(JS)

--- a/dart/dynamics/ArrowShape.cpp
+++ b/dart/dynamics/ArrowShape.cpp
@@ -55,7 +55,10 @@ ArrowShape::Properties::Properties(
 }
 
 //==============================================================================
-ArrowShape::ArrowShape() : MeshShape(Eigen::Vector3d::Ones(), nullptr) {}
+ArrowShape::ArrowShape()
+  : MeshShape(Eigen::Vector3d::Ones(), std::shared_ptr<math::TriMesh<double>>())
+{
+}
 
 //==============================================================================
 ArrowShape::ArrowShape(
@@ -64,7 +67,8 @@ ArrowShape::ArrowShape(
     const Properties& _properties,
     const Eigen::Vector4d& _color,
     std::size_t _resolution)
-  : MeshShape(Eigen::Vector3d::Ones(), nullptr),
+  : MeshShape(
+      Eigen::Vector3d::Ones(), std::shared_ptr<math::TriMesh<double>>()),
     mTail(_tail),
     mHead(_head),
     mProperties(_properties)

--- a/dart/dynamics/MeshMaterial.hpp
+++ b/dart/dynamics/MeshMaterial.hpp
@@ -30,66 +30,30 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef DART_COLLISION_ODE_DETAIL_ODEMESH_HPP_
-#define DART_COLLISION_ODE_DETAIL_ODEMESH_HPP_
+#ifndef DART_DYNAMICS_MESHMATERIAL_HPP_
+#define DART_DYNAMICS_MESHMATERIAL_HPP_
 
-#include <dart/collision/ode/detail/OdeGeom.hpp>
+#include <Eigen/Core>
 
-#include <dart/math/TriMesh.hpp>
-
-#include <assimp/scene.h>
-#include <ode/ode.h>
+#include <string>
+#include <vector>
 
 namespace dart {
-namespace collision {
-namespace detail {
+namespace dynamics {
 
-class OdeMesh : public OdeGeom
+/// Simple material representation for mesh rendering.
+struct MeshMaterial
 {
-public:
-  /// Constructor
-  OdeMesh(
-      const OdeCollisionObject* parent,
-      const aiScene* scene,
-      const Eigen::Vector3d& scale = Eigen::Vector3d::Ones());
+  Eigen::Vector4f ambient{0.2f, 0.2f, 0.2f, 1.0f};
+  Eigen::Vector4f diffuse{0.8f, 0.8f, 0.8f, 1.0f};
+  Eigen::Vector4f specular{0.0f, 0.0f, 0.0f, 1.0f};
+  Eigen::Vector4f emissive{0.0f, 0.0f, 0.0f, 1.0f};
 
-  /// Constructor
-  OdeMesh(
-      const OdeCollisionObject* parent,
-      const math::TriMesh<double>* mesh,
-      const Eigen::Vector3d& scale = Eigen::Vector3d::Ones());
-
-  /// Destructor
-  virtual ~OdeMesh();
-
-  // Documentation inherited
-  void updateEngineData() override;
-
-private:
-  void fillArrays(
-      const aiScene* scene,
-      const Eigen::Vector3d& scale = Eigen::Vector3d::Ones());
-
-  void fillArrays(
-      const math::TriMesh<double>* mesh,
-      const Eigen::Vector3d& scale = Eigen::Vector3d::Ones());
-
-private:
-  /// Array of vertex values.
-  std::vector<double> mVertices;
-
-  /// Array of normals values.
-  std::vector<double> mNormals;
-
-  /// Array of index values.
-  std::vector<int> mIndices;
-
-  /// ODE trimesh data.
-  dTriMeshDataID mOdeTriMeshDataId;
+  float shininess{0.0f};
+  std::vector<std::string> textureImagePaths;
 };
 
-} // namespace detail
-} // namespace collision
+} // namespace dynamics
 } // namespace dart
 
-#endif // DART_COLLISION_ODE_DETAIL_ODEMESH_HPP_
+#endif // DART_DYNAMICS_MESHMATERIAL_HPP_

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -233,6 +233,41 @@ void MeshShape::releaseMesh()
 }
 
 //==============================================================================
+void MeshShape::setLegacyMesh(const aiScene* mesh, MeshOwnership ownership)
+{
+  if (mesh == mMesh.get()) {
+    notifyLegacyMeshChanged();
+    return;
+  }
+
+  const bool meshIsCached = mesh && mesh == mCachedAiScene;
+  const MeshOwnership effectiveOwnership
+      = meshIsCached ? MeshOwnership::Imported : ownership;
+
+  if (mCachedAiScene) {
+    if (meshIsCached)
+      mCachedAiScene = nullptr;
+    else
+      aiReleaseImport(mCachedAiScene);
+  }
+
+  releaseMesh();
+  mMesh.set(mesh, effectiveOwnership);
+  notifyLegacyMeshChanged();
+}
+
+//==============================================================================
+void MeshShape::notifyLegacyMeshChanged()
+{
+  mTriMesh = convertAssimpMesh(mMesh.get(), &mSubMeshRanges);
+  extractMaterialsFromScene(mMesh.get());
+
+  mIsBoundingBoxDirty = true;
+  mIsVolumeDirty = true;
+  incrementVersion();
+}
+
+//==============================================================================
 std::shared_ptr<const aiScene> MeshShape::makeMeshHandle(
     const aiScene* mesh, MeshOwnership ownership)
 {
@@ -262,7 +297,7 @@ std::shared_ptr<const aiScene> MeshShape::makeMeshHandle(
 //==============================================================================
 MeshShape::MeshHandle& MeshShape::MeshHandle::operator=(const aiScene* mesh)
 {
-  set(mesh, MeshOwnership::Manual);
+  set(mesh, MeshOwnership::None);
   return *this;
 }
 

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -838,6 +838,17 @@ ShapePtr MeshShape::clone() const
     clonedTriMesh = std::make_shared<math::TriMesh<double>>(*triMesh);
 
   auto new_shape = std::make_shared<MeshShape>(mScale, clonedTriMesh, mMeshUri);
+  const aiScene* legacyScene = mMesh ? mMesh.get() : mCachedAiScene;
+  if (legacyScene) {
+    aiScene* copiedScene = nullptr;
+    aiCopyScene(legacyScene, &copiedScene);
+    if (copiedScene) {
+      new_shape->setLegacyMesh(copiedScene, MeshOwnership::Copied);
+      if (clonedTriMesh)
+        new_shape->mTriMesh = clonedTriMesh;
+    }
+  }
+
   new_shape->mMeshPath = mMeshPath;
   new_shape->mResourceRetriever = mResourceRetriever;
   new_shape->mDisplayList = mDisplayList;

--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/MeshShape.hpp"
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Deprecated.hpp"
 #include "dart/common/LocalResourceRetriever.hpp"
 #include "dart/common/Uri.hpp"
 #include "dart/config.hpp"
@@ -43,11 +44,16 @@
 #include <assimp/cexport.h>
 #include <assimp/cimport.h>
 #include <assimp/config.h>
+#include <assimp/material.h>
 #include <assimp/postprocess.h>
 
 #include <algorithm>
+#include <iomanip>
 #include <limits>
+#include <locale>
+#include <sstream>
 #include <string>
+#include <utility>
 
 #if !(ASSIMP_AISCENE_CTOR_DTOR_DEFINED)
 // We define our own constructor and destructor for aiScene, because it seems to
@@ -138,46 +144,185 @@ namespace dynamics {
 MeshShape::MeshShape(
     const Eigen::Vector3d& scale,
     const aiScene* mesh,
-    const common::Uri& path,
-    common::ResourceRetrieverPtr resourceRetriever)
+    const common::Uri& uri,
+    common::ResourceRetrieverPtr resourceRetriever,
+    MeshOwnership ownership)
   : Shape(MESH),
-    mMesh(nullptr),
-    mMeshOwnership(MeshOwnership::None),
+    mTriMesh(nullptr),
+    mCachedAiScene(nullptr),
     mDisplayList(0),
+    mScale(scale),
     mColorMode(MATERIAL_COLOR),
     mAlphaMode(BLEND),
     mColorIndex(0)
 {
-  setMesh(mesh, path, std::move(resourceRetriever));
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  setMesh(mesh, ownership, uri, std::move(resourceRetriever));
+  DART_SUPPRESS_DEPRECATED_END
+  setScale(scale);
+}
+
+//==============================================================================
+MeshShape::MeshShape(
+    const Eigen::Vector3d& scale,
+    std::shared_ptr<math::TriMesh<double>> mesh,
+    const common::Uri& uri)
+  : MeshShape(scale, std::move(mesh), uri, nullptr)
+{
+}
+
+//==============================================================================
+MeshShape::MeshShape(
+    const Eigen::Vector3d& scale,
+    std::shared_ptr<math::TriMesh<double>> mesh,
+    const common::Uri& uri,
+    common::ResourceRetrieverPtr resourceRetriever)
+  : Shape(MESH),
+    mTriMesh(std::move(mesh)),
+    mCachedAiScene(nullptr),
+    mMeshUri(uri),
+    mResourceRetriever(std::move(resourceRetriever)),
+    mDisplayList(0),
+    mScale(scale),
+    mColorMode(MATERIAL_COLOR),
+    mAlphaMode(BLEND),
+    mColorIndex(0)
+{
+  if (mResourceRetriever)
+    mMeshPath = mResourceRetriever->getFilePath(uri);
+
+  setScale(scale);
+}
+
+//==============================================================================
+MeshShape::MeshShape(
+    const Eigen::Vector3d& scale,
+    std::shared_ptr<const aiScene> mesh,
+    const common::Uri& uri,
+    common::ResourceRetrieverPtr resourceRetriever)
+  : Shape(MESH),
+    mTriMesh(nullptr),
+    mCachedAiScene(nullptr),
+    mDisplayList(0),
+    mScale(scale),
+    mColorMode(MATERIAL_COLOR),
+    mAlphaMode(BLEND),
+    mColorIndex(0)
+{
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  setMesh(std::move(mesh), uri, std::move(resourceRetriever));
+  DART_SUPPRESS_DEPRECATED_END
   setScale(scale);
 }
 
 //==============================================================================
 MeshShape::~MeshShape()
 {
+  if (mCachedAiScene) {
+    aiReleaseImport(mCachedAiScene);
+    mCachedAiScene = nullptr;
+  }
+
   releaseMesh();
 }
 
 //==============================================================================
 void MeshShape::releaseMesh()
 {
-  if (!mMesh)
-    return;
+  mMesh.reset();
+}
 
-  switch (mMeshOwnership) {
+//==============================================================================
+std::shared_ptr<const aiScene> MeshShape::makeMeshHandle(
+    const aiScene* mesh, MeshOwnership ownership)
+{
+  if (!mesh)
+    return nullptr;
+
+  switch (ownership) {
     case MeshOwnership::Imported:
-      aiReleaseImport(const_cast<aiScene*>(mMesh));
-      break;
+      return std::shared_ptr<const aiScene>(mesh, [](const aiScene* scene) {
+        aiReleaseImport(const_cast<aiScene*>(scene));
+      });
     case MeshOwnership::Copied:
-      aiFreeScene(const_cast<aiScene*>(mMesh));
-      break;
+      return std::shared_ptr<const aiScene>(mesh, [](const aiScene* scene) {
+        aiFreeScene(const_cast<aiScene*>(scene));
+      });
+    case MeshOwnership::Manual:
+      return std::shared_ptr<const aiScene>(mesh, [](const aiScene* scene) {
+        delete const_cast<aiScene*>(scene);
+      });
+    case MeshOwnership::Custom:
     case MeshOwnership::None:
     default:
-      break;
+      return std::shared_ptr<const aiScene>(mesh, [](const aiScene*) {});
   }
+}
 
-  mMesh = nullptr;
+//==============================================================================
+MeshShape::MeshHandle& MeshShape::MeshHandle::operator=(const aiScene* mesh)
+{
+  set(mesh, MeshOwnership::Manual);
+  return *this;
+}
+
+//==============================================================================
+MeshShape::MeshHandle& MeshShape::MeshHandle::operator=(
+    std::shared_ptr<const aiScene> mesh)
+{
+  set(std::move(mesh));
+  return *this;
+}
+
+//==============================================================================
+const aiScene* MeshShape::MeshHandle::get() const
+{
+  return mMesh.get();
+}
+
+//==============================================================================
+const aiScene* MeshShape::MeshHandle::operator->() const
+{
+  return mMesh.get();
+}
+
+//==============================================================================
+MeshShape::MeshHandle::operator bool() const
+{
+  return static_cast<bool>(mMesh);
+}
+
+//==============================================================================
+void MeshShape::MeshHandle::reset()
+{
+  mMesh.reset();
   mMeshOwnership = MeshOwnership::None;
+}
+
+//==============================================================================
+MeshShape::MeshOwnership MeshShape::MeshHandle::getOwnership() const
+{
+  return mMeshOwnership;
+}
+
+//==============================================================================
+const std::shared_ptr<const aiScene>& MeshShape::MeshHandle::getShared() const
+{
+  return mMesh;
+}
+
+//==============================================================================
+void MeshShape::MeshHandle::set(const aiScene* mesh, MeshOwnership ownership)
+{
+  mMesh = MeshShape::makeMeshHandle(mesh, ownership);
+  mMeshOwnership = mesh ? ownership : MeshOwnership::None;
+}
+
+//==============================================================================
+void MeshShape::MeshHandle::set(std::shared_ptr<const aiScene> mesh)
+{
+  mMesh = std::move(mesh);
+  mMeshOwnership = mMesh ? MeshOwnership::Custom : MeshOwnership::None;
 }
 
 //==============================================================================
@@ -196,7 +341,174 @@ const std::string& MeshShape::getStaticType()
 //==============================================================================
 const aiScene* MeshShape::getMesh() const
 {
-  return mMesh;
+  if (mMesh)
+    return mMesh.get();
+
+  if (!mCachedAiScene)
+    mCachedAiScene = convertToAssimpMesh();
+
+  return mCachedAiScene;
+}
+
+//==============================================================================
+std::shared_ptr<math::TriMesh<double>> MeshShape::getTriMesh() const
+{
+  if (!mTriMesh) {
+    const aiScene* scene = nullptr;
+    if (mMesh)
+      scene = mMesh.get();
+    else if (mCachedAiScene)
+      scene = mCachedAiScene;
+
+    if (scene) {
+      auto* self = const_cast<MeshShape*>(this);
+      self->mTriMesh = convertAssimpMesh(scene, &self->mSubMeshRanges);
+      self->extractMaterialsFromScene(scene);
+    }
+  }
+
+  return mTriMesh;
+}
+
+//==============================================================================
+std::shared_ptr<math::TriMesh<double>> MeshShape::convertAssimpMesh(
+    const aiScene* scene)
+{
+  return convertAssimpMesh(scene, nullptr);
+}
+
+//==============================================================================
+std::shared_ptr<math::TriMesh<double>> MeshShape::convertAssimpMesh(
+    const aiScene* scene, std::vector<SubMeshRange>* subMeshes)
+{
+  if (!scene)
+    return nullptr;
+
+  auto triMesh = std::make_shared<math::TriMesh<double>>();
+  if (subMeshes)
+    subMeshes->clear();
+
+  std::size_t totalVertices = 0;
+  std::size_t totalFaces = 0;
+  for (auto i = 0u; i < scene->mNumMeshes; ++i) {
+    const aiMesh* mesh = scene->mMeshes[i];
+    if (!mesh)
+      continue;
+
+    totalVertices += mesh->mNumVertices;
+    totalFaces += mesh->mNumFaces;
+  }
+
+  triMesh->reserveVertices(totalVertices);
+  triMesh->reserveTriangles(totalFaces);
+  triMesh->reserveVertexNormals(totalVertices);
+
+  for (auto meshIndex = 0u; meshIndex < scene->mNumMeshes; ++meshIndex) {
+    const aiMesh* mesh = scene->mMeshes[meshIndex];
+    if (!mesh)
+      continue;
+
+    const std::size_t vertexOffset = triMesh->getVertices().size();
+    const std::size_t triangleOffset = triMesh->getTriangles().size();
+    std::size_t triangleCount = 0;
+
+    for (auto i = 0u; i < mesh->mNumVertices; ++i) {
+      const aiVector3D& vertex = mesh->mVertices[i];
+      triMesh->addVertex(vertex.x, vertex.y, vertex.z);
+    }
+
+    for (auto i = 0u; i < mesh->mNumFaces; ++i) {
+      const aiFace& face = mesh->mFaces[i];
+      if (face.mNumIndices != 3)
+        continue;
+
+      triMesh->addTriangle(
+          face.mIndices[0] + vertexOffset,
+          face.mIndices[1] + vertexOffset,
+          face.mIndices[2] + vertexOffset);
+      ++triangleCount;
+    }
+
+    if (mesh->mNormals) {
+      for (auto i = 0u; i < mesh->mNumVertices; ++i) {
+        const aiVector3D& normal = mesh->mNormals[i];
+        triMesh->addVertexNormal(normal.x, normal.y, normal.z);
+      }
+    }
+
+    if (subMeshes) {
+      SubMeshRange range;
+      range.vertexOffset = vertexOffset;
+      range.vertexCount = mesh->mNumVertices;
+      range.triangleOffset = triangleOffset;
+      range.triangleCount = triangleCount;
+      range.materialIndex = mesh->mMaterialIndex;
+      subMeshes->push_back(range);
+    }
+  }
+
+  if (triMesh->hasTriangles()
+      && triMesh->getVertexNormals().size() != triMesh->getVertices().size()) {
+    triMesh->computeVertexNormals();
+  }
+
+  return triMesh;
+}
+
+//==============================================================================
+const aiScene* MeshShape::convertToAssimpMesh() const
+{
+  if (!mTriMesh || !mTriMesh->hasTriangles())
+    return nullptr;
+
+  std::ostringstream stream;
+  stream.imbue(std::locale::classic());
+  stream << std::setprecision(std::numeric_limits<double>::max_digits10);
+
+  const auto& vertices = mTriMesh->getVertices();
+  for (const auto& vertex : vertices) {
+    stream << "v " << vertex.x() << ' ' << vertex.y() << ' ' << vertex.z()
+           << '\n';
+  }
+
+  const auto& normals = mTriMesh->getVertexNormals();
+  const bool hasNormals = normals.size() == vertices.size();
+  if (hasNormals) {
+    for (const auto& normal : normals) {
+      stream << "vn " << normal.x() << ' ' << normal.y() << ' ' << normal.z()
+             << '\n';
+    }
+  }
+
+  for (const auto& triangle : mTriMesh->getTriangles()) {
+    const std::size_t i0 = static_cast<std::size_t>(triangle.x()) + 1;
+    const std::size_t i1 = static_cast<std::size_t>(triangle.y()) + 1;
+    const std::size_t i2 = static_cast<std::size_t>(triangle.z()) + 1;
+
+    if (hasNormals) {
+      stream << "f " << i0 << "//" << i0 << ' ' << i1 << "//" << i1 << ' ' << i2
+             << "//" << i2 << '\n';
+    } else {
+      stream << "f " << i0 << ' ' << i1 << ' ' << i2 << '\n';
+    }
+  }
+
+  const std::string obj = stream.str();
+  const unsigned int flags = aiProcess_Triangulate
+                             | aiProcess_JoinIdenticalVertices
+                             | aiProcess_SortByPType | aiProcess_OptimizeMeshes
+                             | aiProcess_GenNormals;
+
+  const aiScene* scene = aiImportFileFromMemory(
+      obj.data(), static_cast<unsigned int>(obj.size()), flags, "obj");
+
+  if (!scene) {
+    dtwarn << "[MeshShape::convertToAssimpMesh] Failed to import TriMesh via "
+              "Assimp: "
+           << aiGetErrorString() << "\n";
+  }
+
+  return scene;
 }
 
 //==============================================================================
@@ -235,7 +547,13 @@ void MeshShape::setMesh(
     const std::string& path,
     common::ResourceRetrieverPtr resourceRetriever)
 {
-  setMesh(mesh, common::Uri(path), std::move(resourceRetriever));
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  setMesh(
+      mesh,
+      MeshOwnership::Imported,
+      common::Uri(path),
+      std::move(resourceRetriever));
+  DART_SUPPRESS_DEPRECATED_END
 }
 
 //==============================================================================
@@ -244,45 +562,87 @@ void MeshShape::setMesh(
     const common::Uri& uri,
     common::ResourceRetrieverPtr resourceRetriever)
 {
-  const bool meshChanged = (mesh != mMesh);
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  setMesh(mesh, MeshOwnership::Imported, uri, std::move(resourceRetriever));
+  DART_SUPPRESS_DEPRECATED_END
+}
 
-  if (meshChanged) {
-    // Only release/replace the underlying mesh when the pointer actually
-    // changes, so reusing the same aiScene* for a metadata-only update does not
-    // free the mesh we are about to keep.
-    releaseMesh();
+//==============================================================================
+void MeshShape::setMesh(
+    const aiScene* mesh,
+    MeshOwnership ownership,
+    const common::Uri& uri,
+    common::ResourceRetrieverPtr resourceRetriever)
+{
+  const bool sameMesh
+      = mesh == mMesh.get() && ownership == mMesh.getOwnership();
+  const bool sameMetadata = mMeshUri.toString() == uri.toString()
+                            && mResourceRetriever == resourceRetriever;
+  if (sameMesh && sameMetadata)
+    return;
 
-    mMesh = mesh;
-    mMeshOwnership = mesh ? MeshOwnership::Imported : MeshOwnership::None;
-  }
+  if (!sameMesh) {
+    const bool meshIsCached = mesh && mesh == mCachedAiScene;
+    const MeshOwnership effectiveOwnership
+        = meshIsCached ? MeshOwnership::Imported : ownership;
 
-  if (!mMesh) {
-    if (meshChanged) {
-      mMeshUri.clear();
-      mMeshPath.clear();
-      mResourceRetriever = nullptr;
-      incrementVersion();
+    if (mCachedAiScene) {
+      if (meshIsCached)
+        mCachedAiScene = nullptr;
+      else
+        aiReleaseImport(mCachedAiScene);
     }
-    return;
+
+    releaseMesh();
+    mMesh.set(mesh, effectiveOwnership);
+    mTriMesh = convertAssimpMesh(mMesh.get(), &mSubMeshRanges);
+    extractMaterialsFromScene(mMesh.get());
   }
-
-  std::string newMeshPath
-      = resourceRetriever ? resourceRetriever->getFilePath(uri) : std::string();
-
-  // Refresh the metadata even when the mesh pointer is reused, so a
-  // metadata-only update (same aiScene*, different uri/retriever) is not lost;
-  // skip the work (and the version bump) only when nothing actually changed.
-  const bool metadataChanged
-      = meshChanged || mMeshUri.toString() != uri.toString()
-        || mMeshPath != newMeshPath || mResourceRetriever != resourceRetriever;
-
-  if (!metadataChanged)
-    return;
 
   mMeshUri = uri;
-  mMeshPath = std::move(newMeshPath);
+  mMeshPath
+      = resourceRetriever ? resourceRetriever->getFilePath(uri) : std::string();
   mResourceRetriever = std::move(resourceRetriever);
 
+  mIsBoundingBoxDirty = true;
+  mIsVolumeDirty = true;
+  incrementVersion();
+}
+
+//==============================================================================
+void MeshShape::setMesh(
+    std::shared_ptr<const aiScene> mesh,
+    const common::Uri& uri,
+    common::ResourceRetrieverPtr resourceRetriever)
+{
+  const bool sameMesh = mesh && mesh.get() == mMesh.get()
+                        && mMesh.getOwnership() == MeshOwnership::Custom;
+  const bool sameMetadata = mMeshUri.toString() == uri.toString()
+                            && mResourceRetriever == resourceRetriever;
+  if (sameMesh && sameMetadata)
+    return;
+
+  if (!sameMesh) {
+    if (mCachedAiScene) {
+      if (mesh && mesh.get() == mCachedAiScene)
+        mCachedAiScene = nullptr;
+      else
+        aiReleaseImport(mCachedAiScene);
+    }
+
+    releaseMesh();
+    mMesh.set(std::move(mesh));
+    mTriMesh = convertAssimpMesh(mMesh.get(), &mSubMeshRanges);
+    extractMaterialsFromScene(mMesh.get());
+  }
+
+  mMeshUri = uri;
+  mMeshPath
+      = resourceRetriever ? resourceRetriever->getFilePath(uri) : std::string();
+  mResourceRetriever = std::move(resourceRetriever);
+
+  mIsBoundingBoxDirty = true;
+  mIsVolumeDirty = true;
   incrementVersion();
 }
 
@@ -357,6 +717,78 @@ void MeshShape::setDisplayList(int index)
 }
 
 //==============================================================================
+const std::vector<MeshMaterial>& MeshShape::getMaterials() const
+{
+  return mMaterials;
+}
+
+//==============================================================================
+std::size_t MeshShape::getNumMaterials() const
+{
+  return mMaterials.size();
+}
+
+//==============================================================================
+const MeshMaterial* MeshShape::getMaterial(std::size_t index) const
+{
+  if (index < mMaterials.size())
+    return &mMaterials[index];
+
+  return nullptr;
+}
+
+//==============================================================================
+void MeshShape::extractMaterialsFromScene(const aiScene* scene)
+{
+  mMaterials.clear();
+  if (!scene || scene->mNumMaterials == 0)
+    return;
+
+  mMaterials.reserve(scene->mNumMaterials);
+  for (auto i = 0u; i < scene->mNumMaterials; ++i) {
+    aiMaterial* aiMat = scene->mMaterials[i];
+    if (!aiMat)
+      continue;
+
+    MeshMaterial material;
+
+    aiColor4D color;
+    if (aiGetMaterialColor(aiMat, AI_MATKEY_COLOR_AMBIENT, &color)
+        == AI_SUCCESS) {
+      material.ambient = Eigen::Vector4f(color.r, color.g, color.b, color.a);
+    }
+    if (aiGetMaterialColor(aiMat, AI_MATKEY_COLOR_DIFFUSE, &color)
+        == AI_SUCCESS) {
+      material.diffuse = Eigen::Vector4f(color.r, color.g, color.b, color.a);
+    }
+    if (aiGetMaterialColor(aiMat, AI_MATKEY_COLOR_SPECULAR, &color)
+        == AI_SUCCESS) {
+      material.specular = Eigen::Vector4f(color.r, color.g, color.b, color.a);
+    }
+    if (aiGetMaterialColor(aiMat, AI_MATKEY_COLOR_EMISSIVE, &color)
+        == AI_SUCCESS) {
+      material.emissive = Eigen::Vector4f(color.r, color.g, color.b, color.a);
+    }
+
+    unsigned int maxValue = 1;
+    float shininess = 0.0f;
+    if (aiGetMaterialFloatArray(
+            aiMat, AI_MATKEY_SHININESS, &shininess, &maxValue)
+        == AI_SUCCESS) {
+      material.shininess = shininess;
+    }
+
+    aiString texturePath;
+    if (aiMat->GetTexture(aiTextureType_DIFFUSE, 0, &texturePath)
+        == AI_SUCCESS) {
+      material.textureImagePaths.emplace_back(texturePath.C_Str());
+    }
+
+    mMaterials.emplace_back(std::move(material));
+  }
+}
+
+//==============================================================================
 Eigen::Matrix3d MeshShape::computeInertia(double _mass) const
 {
   // Use bounding box to represent the mesh
@@ -366,16 +798,19 @@ Eigen::Matrix3d MeshShape::computeInertia(double _mass) const
 //==============================================================================
 ShapePtr MeshShape::clone() const
 {
-  aiScene* new_scene = cloneMesh();
+  std::shared_ptr<math::TriMesh<double>> clonedTriMesh;
+  if (const auto triMesh = getTriMesh())
+    clonedTriMesh = std::make_shared<math::TriMesh<double>>(*triMesh);
 
-  auto new_shape = std::make_shared<MeshShape>(
-      mScale, new_scene, mMeshUri, mResourceRetriever);
-  new_shape->mMeshOwnership = MeshOwnership::Copied;
+  auto new_shape = std::make_shared<MeshShape>(mScale, clonedTriMesh, mMeshUri);
   new_shape->mMeshPath = mMeshPath;
+  new_shape->mResourceRetriever = mResourceRetriever;
   new_shape->mDisplayList = mDisplayList;
   new_shape->mColorMode = mColorMode;
   new_shape->mAlphaMode = mAlphaMode;
   new_shape->mColorIndex = mColorIndex;
+  new_shape->mMaterials = mMaterials;
+  new_shape->mSubMeshRanges = mSubMeshRanges;
 
   return new_shape;
 }
@@ -383,7 +818,8 @@ ShapePtr MeshShape::clone() const
 //==============================================================================
 void MeshShape::updateBoundingBox() const
 {
-  if (!mMesh) {
+  const auto triMesh = getTriMesh();
+  if (!triMesh || triMesh->getVertices().empty()) {
     mBoundingBox.setMin(Eigen::Vector3d::Zero());
     mBoundingBox.setMax(Eigen::Vector3d::Zero());
     mIsBoundingBoxDirty = false;
@@ -394,13 +830,10 @@ void MeshShape::updateBoundingBox() const
       = Eigen::Vector3d::Constant(std::numeric_limits<double>::infinity());
   Eigen::Vector3d maxPoint = -minPoint;
 
-  for (unsigned i = 0u; i < mMesh->mNumMeshes; i++) {
-    for (unsigned j = 0u; j < mMesh->mMeshes[i]->mNumVertices; j++) {
-      const auto& vertex = mMesh->mMeshes[i]->mVertices[j];
-      const Eigen::Vector3d eigenVertex(vertex.x, vertex.y, vertex.z);
-      minPoint = minPoint.cwiseMin(eigenVertex.cwiseProduct(mScale));
-      maxPoint = maxPoint.cwiseMax(eigenVertex.cwiseProduct(mScale));
-    }
+  for (const auto& vertex : triMesh->getVertices()) {
+    const Eigen::Vector3d scaledVertex = vertex.cwiseProduct(mScale);
+    minPoint = minPoint.cwiseMin(scaledVertex);
+    maxPoint = maxPoint.cwiseMax(scaledVertex);
   }
 
   mBoundingBox.setMin(minPoint);
@@ -420,11 +853,14 @@ void MeshShape::updateVolume() const
 //==============================================================================
 aiScene* MeshShape::cloneMesh() const
 {
-  if (!mMesh)
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  const aiScene* scene = getMesh();
+  DART_SUPPRESS_DEPRECATED_END
+  if (!scene)
     return nullptr;
 
   aiScene* new_scene = nullptr;
-  aiCopyScene(mMesh, &new_scene);
+  aiCopyScene(scene, &new_scene);
   return new_scene;
 }
 
@@ -526,14 +962,20 @@ const aiScene* MeshShape::loadMesh(
 const aiScene* MeshShape::loadMesh(
     const common::Uri& uri, const common::ResourceRetrieverPtr& retriever)
 {
-  return loadMesh(uri.toString(), retriever);
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  const aiScene* scene = loadMesh(uri.toString(), retriever);
+  DART_SUPPRESS_DEPRECATED_END
+  return scene;
 }
 
 //==============================================================================
 const aiScene* MeshShape::loadMesh(const std::string& filePath)
 {
   const auto retriever = std::make_shared<common::LocalResourceRetriever>();
-  return loadMesh("file://" + filePath, retriever);
+  DART_SUPPRESS_DEPRECATED_BEGIN
+  const aiScene* scene = loadMesh("file://" + filePath, retriever);
+  DART_SUPPRESS_DEPRECATED_END
+  return scene;
 }
 
 } // namespace dynamics

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -314,6 +314,12 @@ protected:
 
   void releaseMesh();
 
+  /// Replaces the legacy Assimp mesh while preserving cache invariants.
+  void setLegacyMesh(const aiScene* mesh, MeshOwnership ownership);
+
+  /// Rebuilds TriMesh/material caches after in-place Assimp mesh updates.
+  void notifyLegacyMeshChanged();
+
   MeshHandle mMesh;
 
   /// Converts aiScene to TriMesh for internal use.

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -33,13 +33,18 @@
 #ifndef DART_DYNAMICS_MESHSHAPE_HPP_
 #define DART_DYNAMICS_MESHSHAPE_HPP_
 
+#include <dart/dynamics/MeshMaterial.hpp>
 #include <dart/dynamics/Shape.hpp>
+
+#include <dart/math/TriMesh.hpp>
 
 #include <dart/common/ResourceRetriever.hpp>
 
 #include <assimp/scene.h>
 
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace dart {
 namespace dynamics {
@@ -47,6 +52,15 @@ namespace dynamics {
 class MeshShape : public Shape
 {
 public:
+  enum class MeshOwnership
+  {
+    None,
+    Imported, // from aiImportFile* family; free with aiReleaseImport
+    Copied,   // from aiCopyScene; free with aiFreeScene
+    Manual,   // from manual new aiScene; free with delete
+    Custom    // managed externally via shared_ptr deleter
+  };
+
   enum ColorMode
   {
     MATERIAL_COLOR = 0, ///< Use the colors specified by the Mesh's material
@@ -77,10 +91,34 @@ public:
     SHAPE_ALPHA
   };
 
-  /// Constructor.
+  /// Constructor using TriMesh.
+  MeshShape(
+      const Eigen::Vector3d& scale,
+      std::shared_ptr<math::TriMesh<double>> mesh,
+      const common::Uri& uri = "");
+
+  /// Constructor using TriMesh with a resource retriever.
+  MeshShape(
+      const Eigen::Vector3d& scale,
+      std::shared_ptr<math::TriMesh<double>> mesh,
+      const common::Uri& uri,
+      common::ResourceRetrieverPtr resourceRetriever);
+
+  /// Constructor using aiScene.
+  [[deprecated("Use TriMesh-based APIs; Assimp APIs will be removed in DART 8.")]]
   MeshShape(
       const Eigen::Vector3d& scale,
       const aiScene* mesh,
+      const common::Uri& uri = "",
+      common::ResourceRetrieverPtr resourceRetriever = nullptr,
+      MeshOwnership ownership = MeshOwnership::Imported);
+
+  /// Constructor that accepts a shared_ptr so callers can provide a custom
+  /// deleter for aiScene.
+  [[deprecated("Use TriMesh-based APIs; Assimp APIs will be removed in DART 8.")]]
+  MeshShape(
+      const Eigen::Vector3d& scale,
+      std::shared_ptr<const aiScene> mesh,
       const common::Uri& uri = "",
       common::ResourceRetrieverPtr resourceRetriever = nullptr);
 
@@ -93,7 +131,14 @@ public:
   /// Returns shape type for this class
   static const std::string& getStaticType();
 
-  const aiScene* getMesh() const;
+  /// Returns the TriMesh representation of this mesh.
+  std::shared_ptr<math::TriMesh<double>> getTriMesh() const;
+
+  /// Returns the aiScene representation of this mesh.
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART "
+      "8.")]] const aiScene*
+  getMesh() const;
 
   /// Updates positions of the vertices or the elements. By default, this does
   /// nothing; you must extend the MeshShape class and implement your own
@@ -101,14 +146,35 @@ public:
   /// rendering
   virtual void update();
 
-  void setMesh(
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART 8.")]] void
+  setMesh(
       const aiScene* mesh,
       const std::string& path = "",
       common::ResourceRetrieverPtr resourceRetriever = nullptr);
 
-  void setMesh(
+  /// Sets the mesh pointer with explicit ownership semantics.
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART 8.")]] void
+  setMesh(
+      const aiScene* mesh,
+      MeshOwnership ownership,
+      const common::Uri& path,
+      common::ResourceRetrieverPtr resourceRetriever = nullptr);
+
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART 8.")]] void
+  setMesh(
       const aiScene* mesh,
       const common::Uri& path,
+      common::ResourceRetrieverPtr resourceRetriever = nullptr);
+
+  /// Sets the mesh using a shared_ptr so callers can provide a custom deleter.
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART 8.")]] void
+  setMesh(
+      std::shared_ptr<const aiScene> mesh,
+      const common::Uri& path = "",
       common::ResourceRetrieverPtr resourceRetriever = nullptr);
 
   /// Returns URI to the mesh as std::string; an empty string if unavailable.
@@ -169,12 +235,30 @@ public:
 
   void setDisplayList(int index);
 
-  static const aiScene* loadMesh(const std::string& filePath);
+  /// Returns materials extracted from the mesh.
+  const std::vector<MeshMaterial>& getMaterials() const;
 
-  static const aiScene* loadMesh(
+  /// Returns the number of materials in this mesh.
+  std::size_t getNumMaterials() const;
+
+  /// Returns a specific material by index, or nullptr when out of bounds.
+  const MeshMaterial* getMaterial(std::size_t index) const;
+
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART "
+      "8.")]] static const aiScene*
+  loadMesh(const std::string& filePath);
+
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART "
+      "8.")]] static const aiScene*
+  loadMesh(
       const std::string& _uri, const common::ResourceRetrieverPtr& retriever);
 
-  static const aiScene* loadMesh(
+  [[deprecated(
+      "Use TriMesh-based APIs; Assimp APIs will be removed in DART "
+      "8.")]] static const aiScene*
+  loadMesh(
       const common::Uri& uri, const common::ResourceRetrieverPtr& retriever);
 
   // Documentation inherited.
@@ -184,6 +268,42 @@ public:
   virtual ShapePtr clone() const override;
 
 protected:
+  class MeshHandle
+  {
+  public:
+    MeshHandle() = default;
+
+    MeshHandle& operator=(const aiScene* mesh);
+    MeshHandle& operator=(std::shared_ptr<const aiScene> mesh);
+
+    const aiScene* get() const;
+    const aiScene* operator->() const;
+    explicit operator bool() const;
+
+    void reset();
+    MeshOwnership getOwnership() const;
+    const std::shared_ptr<const aiScene>& getShared() const;
+
+    void set(const aiScene* mesh, MeshOwnership ownership);
+    void set(std::shared_ptr<const aiScene> mesh);
+
+  private:
+    std::shared_ptr<const aiScene> mMesh;
+    MeshOwnership mMeshOwnership{MeshOwnership::None};
+  };
+
+  struct SubMeshRange
+  {
+    std::size_t vertexOffset{0};
+    std::size_t vertexCount{0};
+    std::size_t triangleOffset{0};
+    std::size_t triangleCount{0};
+    unsigned int materialIndex{0};
+  };
+
+  static std::shared_ptr<const aiScene> makeMeshHandle(
+      const aiScene* mesh, MeshOwnership ownership);
+
   // Documentation inherited.
   void updateBoundingBox() const override;
 
@@ -192,17 +312,29 @@ protected:
 
   aiScene* cloneMesh() const;
 
-  enum class MeshOwnership
-  {
-    None,
-    Imported, // from aiImportFile* family; free with aiReleaseImport
-    Copied    // from aiCopyScene; free with aiFreeScene
-  };
-
   void releaseMesh();
 
-  const aiScene* mMesh;
-  MeshOwnership mMeshOwnership{MeshOwnership::None};
+  MeshHandle mMesh;
+
+  /// Converts aiScene to TriMesh for internal use.
+  static std::shared_ptr<math::TriMesh<double>> convertAssimpMesh(
+      const aiScene* scene);
+  static std::shared_ptr<math::TriMesh<double>> convertAssimpMesh(
+      const aiScene* scene, std::vector<SubMeshRange>* subMeshes);
+
+  /// Converts TriMesh back to aiScene for backward compatibility.
+  const aiScene* convertToAssimpMesh() const;
+
+  void extractMaterialsFromScene(const aiScene* scene);
+
+  /// TriMesh representation.
+  std::shared_ptr<math::TriMesh<double>> mTriMesh;
+
+  /// Submesh ranges extracted from Assimp.
+  std::vector<SubMeshRange> mSubMeshRanges;
+
+  /// Cached aiScene for backward compatibility.
+  mutable const aiScene* mCachedAiScene;
 
   /// URI the mesh, if available).
   common::Uri mMeshUri;
@@ -212,6 +344,9 @@ protected:
 
   /// Optional method of loading resources by URI.
   common::ResourceRetrieverPtr mResourceRetriever;
+
+  /// Materials extracted from the mesh.
+  std::vector<MeshMaterial> mMaterials;
 
   /// OpenGL DisplayList id for rendering
   int mDisplayList;

--- a/dart/gui/osg/InteractiveFrame.cpp
+++ b/dart/gui/osg/InteractiveFrame.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/InteractiveFrame.hpp"
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Deprecated.hpp"
 #include "dart/dynamics/ArrowShape.hpp"
 #include "dart/dynamics/LineSegmentShape.hpp"
 #include "dart/dynamics/MeshShape.hpp"
@@ -443,8 +444,10 @@ void InteractiveFrame::createStandardVisualizationShapes(
     scene->mMeshes[0] = mesh;
     scene->mRootNode = node;
 
+    DART_SUPPRESS_DEPRECATED_BEGIN
     std::shared_ptr<dart::dynamics::MeshShape> shape(
         new dart::dynamics::MeshShape(Eigen::Vector3d::Ones(), scene));
+    DART_SUPPRESS_DEPRECATED_END
     shape->setColorMode(dart::dynamics::MeshShape::COLOR_INDEX);
 
     Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
@@ -527,8 +530,10 @@ void InteractiveFrame::createStandardVisualizationShapes(
     scene->mMeshes[0] = mesh;
     scene->mRootNode = node;
 
+    DART_SUPPRESS_DEPRECATED_BEGIN
     std::shared_ptr<dart::dynamics::MeshShape> shape(
         new dart::dynamics::MeshShape(Eigen::Vector3d::Ones(), scene));
+    DART_SUPPRESS_DEPRECATED_END
     shape->setColorMode(dart::dynamics::MeshShape::COLOR_INDEX);
 
     Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/gui/osg/render/MeshShapeNode.hpp"
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Deprecated.hpp"
 #include "dart/common/Filesystem.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/MeshShape.hpp"
@@ -229,7 +230,9 @@ bool checkSpecularSanity(const aiColor4D& c)
 //==============================================================================
 void MeshShapeNode::extractData(bool firstTime)
 {
+  DART_SUPPRESS_DEPRECATED_BEGIN
   const aiScene* scene = mMeshShape->getMesh();
+  DART_SUPPRESS_DEPRECATED_END
   const aiNode* root = scene->mRootNode;
 
   if (firstTime) // extract material properties
@@ -522,7 +525,9 @@ void MeshShapeGeode::extractData(bool)
 {
   clearChildUtilizationFlags();
 
+  DART_SUPPRESS_DEPRECATED_BEGIN
   const aiScene* scene = mMeshShape->getMesh();
+  DART_SUPPRESS_DEPRECATED_END
   for (std::size_t i = 0; i < mAiNode->mNumMeshes; ++i) {
     aiMesh* mesh = scene->mMeshes[mAiNode->mMeshes[i]];
 

--- a/dart/math/Mesh.hpp
+++ b/dart/math/Mesh.hpp
@@ -65,8 +65,14 @@ public:
   /// Returns the vertices of the mesh.
   const Vertices& getVertices() const;
 
+  /// Returns the vertices of the mesh.
+  Vertices& getVertices();
+
   /// Returns the vertex normals of the mesh.
   const Normals& getVertexNormals() const;
+
+  /// Returns the vertex normals of the mesh.
+  Normals& getVertexNormals();
 
   /// Clears all the vertices and vertex normals.
   virtual void clear();

--- a/dart/math/TriMesh.hpp
+++ b/dart/math/TriMesh.hpp
@@ -64,6 +64,33 @@ public:
   /// Sets vertices and triangles.
   void setTriangles(const Vertices& vertices, const Triangles& triangles);
 
+  /// Reserves space for vertices.
+  void reserveVertices(std::size_t n);
+
+  /// Adds a vertex to the mesh.
+  void addVertex(S x, S y, S z);
+
+  /// Adds a vertex to the mesh.
+  void addVertex(const Vector3& vertex);
+
+  /// Reserves space for triangles.
+  void reserveTriangles(std::size_t n);
+
+  /// Adds a triangle to the mesh.
+  void addTriangle(Index idx0, Index idx1, Index idx2);
+
+  /// Adds a triangle to the mesh.
+  void addTriangle(const Triangle& triangle);
+
+  /// Reserves space for vertex normals.
+  void reserveVertexNormals(std::size_t n);
+
+  /// Adds a vertex normal to the mesh.
+  void addVertexNormal(S x, S y, S z);
+
+  /// Adds a vertex normal to the mesh.
+  void addVertexNormal(const Vector3& normal);
+
   /// Computes vertex normals.
   void computeVertexNormals();
 

--- a/dart/math/detail/Mesh-impl.hpp
+++ b/dart/math/detail/Mesh-impl.hpp
@@ -68,7 +68,21 @@ const typename Mesh<S>::Vertices& Mesh<S>::getVertices() const
 
 //==============================================================================
 template <typename S>
+typename Mesh<S>::Vertices& Mesh<S>::getVertices()
+{
+  return this->mVertices;
+}
+
+//==============================================================================
+template <typename S>
 const typename Mesh<S>::Normals& Mesh<S>::getVertexNormals() const
+{
+  return this->mVertexNormals;
+}
+
+//==============================================================================
+template <typename S>
+typename Mesh<S>::Normals& Mesh<S>::getVertexNormals()
 {
   return this->mVertexNormals;
 }

--- a/dart/math/detail/TriMesh-impl.hpp
+++ b/dart/math/detail/TriMesh-impl.hpp
@@ -61,6 +61,69 @@ void TriMesh<S>::setTriangles(
 
 //==============================================================================
 template <typename S>
+void TriMesh<S>::reserveVertices(std::size_t n)
+{
+  this->mVertices.reserve(n);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::addVertex(S x, S y, S z)
+{
+  this->mVertices.emplace_back(x, y, z);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::addVertex(const Vector3& vertex)
+{
+  this->mVertices.push_back(vertex);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::reserveTriangles(std::size_t n)
+{
+  mTriangles.reserve(n);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::addTriangle(Index idx0, Index idx1, Index idx2)
+{
+  mTriangles.emplace_back(idx0, idx1, idx2);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::addTriangle(const Triangle& triangle)
+{
+  mTriangles.push_back(triangle);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::reserveVertexNormals(std::size_t n)
+{
+  this->mVertexNormals.reserve(n);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::addVertexNormal(S x, S y, S z)
+{
+  this->mVertexNormals.emplace_back(x, y, z);
+}
+
+//==============================================================================
+template <typename S>
+void TriMesh<S>::addVertexNormal(const Vector3& normal)
+{
+  this->mVertexNormals.push_back(normal);
+}
+
+//==============================================================================
+template <typename S>
 void TriMesh<S>::computeVertexNormals()
 {
   computeTriangleNormals();

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -36,6 +36,7 @@
 #include "dart/collision/dart/DARTCollisionDetector.hpp"
 #include "dart/collision/fcl/FCLCollisionDetector.hpp"
 #include "dart/common/Console.hpp"
+#include "dart/common/Deprecated.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/config.hpp"
 #include "dart/constraint/ConstraintSolver.hpp"
@@ -1310,10 +1311,14 @@ dynamics::ShapePtr readShape(
 
     const common::Uri meshUri
         = common::Uri::createFromRelativeUri(baseUri, filename);
+    DART_SUPPRESS_DEPRECATED_BEGIN
     const aiScene* model = dynamics::MeshShape::loadMesh(meshUri, retriever);
+    DART_SUPPRESS_DEPRECATED_END
     if (model) {
+      DART_SUPPRESS_DEPRECATED_BEGIN
       newShape = std::make_shared<dynamics::MeshShape>(
           scale, model, meshUri, retriever);
+      DART_SUPPRESS_DEPRECATED_END
     } else {
       dterr << "Fail to load model[" << filename << "]." << std::endl;
     }

--- a/dart/utils/mjcf/detail/Mesh.cpp
+++ b/dart/utils/mjcf/detail/Mesh.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/mjcf/detail/Mesh.hpp"
 
+#include "dart/common/Deprecated.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/utils/XmlHelpers.hpp"
 #include "dart/utils/mjcf/detail/Utils.hpp"
@@ -114,13 +115,17 @@ Errors Mesh::postprocess(const Compiler& /*compiler*/)
 //==============================================================================
 dynamics::MeshShapePtr Mesh::createMeshShape() const
 {
+  DART_SUPPRESS_DEPRECATED_BEGIN
   const aiScene* model = dynamics::MeshShape::loadMesh(mMeshUri, mRetriever);
+  DART_SUPPRESS_DEPRECATED_END
   if (model == nullptr) {
     return nullptr;
   }
 
+  DART_SUPPRESS_DEPRECATED_BEGIN
   auto shape = std::make_shared<dynamics::MeshShape>(
       mScale, model, mMeshUri, mRetriever);
+  DART_SUPPRESS_DEPRECATED_END
   shape->setColorMode(dynamics::MeshShape::ColorMode::MATERIAL_COLOR);
   return shape;
 }

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -33,6 +33,7 @@
 #include "dart/utils/sdf/SdfParser.hpp"
 
 #include "dart/common/Console.hpp"
+#include "dart/common/Deprecated.hpp"
 #include "dart/common/LocalResourceRetriever.hpp"
 #include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
@@ -1014,12 +1015,16 @@ dynamics::ShapePtr readShape(
                                 : Eigen::Vector3d::Ones();
 
     const std::string meshUri = common::Uri::getRelativeUri(baseUri, uri);
+    DART_SUPPRESS_DEPRECATED_BEGIN
     const aiScene* model = dynamics::MeshShape::loadMesh(meshUri, _retriever);
+    DART_SUPPRESS_DEPRECATED_END
 
-    if (model)
+    if (model) {
+      DART_SUPPRESS_DEPRECATED_BEGIN
       newShape = std::make_shared<dynamics::MeshShape>(
           scale, model, meshUri, _retriever);
-    else {
+      DART_SUPPRESS_DEPRECATED_END
+    } else {
       dtwarn << "[SdfParser::readShape] Failed to load mesh model [" << meshUri
              << "].\n";
       return nullptr;

--- a/dart/utils/urdf/DartLoader.cpp
+++ b/dart/utils/urdf/DartLoader.cpp
@@ -32,6 +32,7 @@
 
 #include "dart/utils/urdf/DartLoader.hpp"
 
+#include "dart/common/Deprecated.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/BoxShape.hpp"
@@ -778,14 +779,18 @@ dynamics::ShapePtr DartLoader::createShape(
 
       // Load the mesh.
       const std::string resolvedUri = absoluteUri.toString();
+      DART_SUPPRESS_DEPRECATED_BEGIN
       const aiScene* scene
           = dynamics::MeshShape::loadMesh(resolvedUri, _resourceRetriever);
+      DART_SUPPRESS_DEPRECATED_END
       if (!scene)
         return nullptr;
 
       const Eigen::Vector3d scale(mesh->scale.x, mesh->scale.y, mesh->scale.z);
+      DART_SUPPRESS_DEPRECATED_BEGIN
       shape = std::make_shared<dynamics::MeshShape>(
           scale, scene, resolvedUri, _resourceRetriever);
+      DART_SUPPRESS_DEPRECATED_END
       break;
     }
     default:

--- a/examples/point_cloud/main.cpp
+++ b/examples/point_cloud/main.cpp
@@ -37,6 +37,8 @@
 #include <dart/utils/urdf/urdf.hpp>
 #include <dart/utils/utils.hpp>
 
+#include <dart/common/Deprecated.hpp>
+
 #include <dart/dart.hpp>
 
 #include <iostream>
@@ -204,7 +206,9 @@ protected:
         continue;
       auto mesh = std::static_pointer_cast<dynamics::MeshShape>(shape);
 
+      DART_SUPPRESS_DEPRECATED_BEGIN
       auto assimpScene = mesh->getMesh();
+      DART_SUPPRESS_DEPRECATED_END
       DART_ASSERT(assimpScene);
 
       if (assimpScene->mNumMeshes < 1)

--- a/python/dartpy/dynamics/Shape.cpp
+++ b/python/dartpy/dynamics/Shape.cpp
@@ -33,6 +33,8 @@
 #include "eigen_geometry_pybind.h"
 #include "eigen_pybind.h"
 
+#include <dart/common/Deprecated.hpp>
+
 #include <dart/dart.hpp>
 
 #include <pybind11/pybind11.h>
@@ -42,6 +44,8 @@ namespace py = pybind11;
 
 namespace dart {
 namespace python {
+
+DART_SUPPRESS_DEPRECATED_BEGIN
 
 void Shape(py::module& m)
 {
@@ -1275,3 +1279,5 @@ void Shape(py::module& m)
 
 } // namespace python
 } // namespace dart
+
+DART_SUPPRESS_DEPRECATED_END

--- a/tests/regression/test_Issue1234.cpp
+++ b/tests/regression/test_Issue1234.cpp
@@ -47,6 +47,8 @@
 #include <dart/dynamics/Skeleton.hpp>
 #include <dart/dynamics/WeldJoint.hpp>
 
+#include <dart/common/Deprecated.hpp>
+
 #include <TestHelpers.hpp>
 #include <gtest/gtest.h>
 
@@ -91,11 +93,13 @@ void runIssue1234Test(
     std::function<dart::collision::CollisionDetectorPtr()> detectorFactory)
 {
   const std::string meshUri = "dart://sample/obj/BoxSmall.obj";
+  DART_SUPPRESS_DEPRECATED_BEGIN
   const auto aiscene = dart::dynamics::MeshShape::loadMesh(
       meshUri, dart::utils::DartResourceRetriever::create());
   ASSERT_TRUE(aiscene);
   const auto mesh = std::make_shared<dart::dynamics::MeshShape>(
       100.0 * Eigen::Vector3d::Ones(), aiscene, meshUri);
+  DART_SUPPRESS_DEPRECATED_END
 
   const auto bb = mesh->getBoundingBox();
   for (int i = 0; i < 3; ++i) {

--- a/tests/unit/dynamics/test_MeshShape.cpp
+++ b/tests/unit/dynamics/test_MeshShape.cpp
@@ -2,6 +2,7 @@
 #include "dart/common/LocalResourceRetriever.hpp"
 #include "dart/common/Uri.hpp"
 #include "dart/config.hpp"
+#include "dart/dynamics/ArrowShape.hpp"
 #include "dart/dynamics/AssimpInputResourceAdaptor.hpp"
 #include "dart/dynamics/MeshShape.hpp"
 
@@ -10,7 +11,9 @@
 #include <assimp/postprocess.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -138,6 +141,15 @@ double readColladaUnitScale(const std::string& path)
   }
 }
 
+double maxVertexZ(const math::TriMesh<double>& mesh)
+{
+  double maxZ = -std::numeric_limits<double>::infinity();
+  for (const auto& vertex : mesh.getVertices())
+    maxZ = std::max(maxZ, vertex.z());
+
+  return maxZ;
+}
+
 } // namespace
 
 TEST(MeshShapeTest, TriMeshConstructorUpdatesBoundsAndAssimpBridge)
@@ -226,6 +238,26 @@ TEST(MeshShapeTest, ReusingMeshPointerRefreshesMetadata)
   EXPECT_EQ(mesh->getMesh(), scene);
   EXPECT_EQ(mesh->getMeshUri(), otherUri);
   EXPECT_EQ(mesh->getMeshPath(), retriever->getFilePath(common::Uri(otherUri)));
+}
+
+TEST(MeshShapeTest, ArrowShapeRefreshesTriMeshAfterPositionUpdates)
+{
+  dynamics::ArrowShape arrow(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitZ());
+
+  const auto originalMesh = arrow.getTriMesh();
+  ASSERT_NE(originalMesh, nullptr);
+  const double originalMaxZ = maxVertexZ(*originalMesh);
+
+  arrow.setPositions(Eigen::Vector3d::Zero(), 2.0 * Eigen::Vector3d::UnitZ());
+
+  const auto updatedMesh = arrow.getTriMesh();
+  ASSERT_NE(updatedMesh, nullptr);
+  EXPECT_NE(updatedMesh, originalMesh);
+  EXPECT_GT(maxVertexZ(*updatedMesh), originalMaxZ * 1.5);
+
+  auto clone = std::dynamic_pointer_cast<dynamics::ArrowShape>(arrow.clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_GT(clone->getBoundingBox().computeFullExtents().z(), 1.5);
 }
 
 TEST(MeshShapeTest, ColladaUnitMetadataApplied)

--- a/tests/unit/dynamics/test_MeshShape.cpp
+++ b/tests/unit/dynamics/test_MeshShape.cpp
@@ -1,3 +1,4 @@
+#include "dart/common/Deprecated.hpp"
 #include "dart/common/LocalResourceRetriever.hpp"
 #include "dart/common/Uri.hpp"
 #include "dart/config.hpp"
@@ -14,6 +15,8 @@
 #include <string>
 
 using namespace dart;
+
+DART_SUPPRESS_DEPRECATED_BEGIN
 
 namespace {
 
@@ -136,6 +139,33 @@ double readColladaUnitScale(const std::string& path)
 }
 
 } // namespace
+
+TEST(MeshShapeTest, TriMeshConstructorUpdatesBoundsAndAssimpBridge)
+{
+  auto triMesh = std::make_shared<math::TriMesh<double>>();
+  triMesh->reserveVertices(3);
+  triMesh->addVertex(0.0, 0.0, 0.0);
+  triMesh->addVertex(2.0, 0.0, 0.0);
+  triMesh->addVertex(0.0, 3.0, 4.0);
+  triMesh->addTriangle(0, 1, 2);
+  triMesh->computeVertexNormals();
+
+  dynamics::MeshShape shape(Eigen::Vector3d(2.0, 3.0, 4.0), triMesh);
+  EXPECT_EQ(shape.getTriMesh(), triMesh);
+  EXPECT_TRUE(shape.getBoundingBox().computeFullExtents().isApprox(
+      Eigen::Vector3d(4.0, 9.0, 16.0), 1e-12));
+
+  const aiScene* scene = shape.getMesh();
+  ASSERT_NE(scene, nullptr);
+  ASSERT_GT(scene->mNumMeshes, 0u);
+  EXPECT_EQ(shape.getMesh(), scene);
+
+  auto clone = std::dynamic_pointer_cast<dynamics::MeshShape>(shape.clone());
+  ASSERT_NE(clone, nullptr);
+  EXPECT_NE(clone->getTriMesh(), triMesh);
+  EXPECT_TRUE(clone->getBoundingBox().computeFullExtents().isApprox(
+      shape.getBoundingBox().computeFullExtents(), 1e-12));
+}
 
 TEST(MeshShapeTest, CloneCreatesIndependentScene)
 {
@@ -263,3 +293,5 @@ TEST(MeshShapeTest, ColladaUriWithoutExtensionStillLoads)
       << "aliasExtents=" << aliasExtents.transpose()
       << ", canonicalExtents=" << canonicalExtents.transpose();
 }
+
+DART_SUPPRESS_DEPRECATED_END

--- a/tests/unit/dynamics/test_MeshShape.cpp
+++ b/tests/unit/dynamics/test_MeshShape.cpp
@@ -8,6 +8,7 @@
 
 #include <assimp/cimport.h>
 #include <assimp/config.h>
+#include <assimp/material.h>
 #include <assimp/postprocess.h>
 #include <gtest/gtest.h>
 
@@ -181,7 +182,7 @@ TEST(MeshShapeTest, TriMeshConstructorUpdatesBoundsAndAssimpBridge)
 
 TEST(MeshShapeTest, CloneCreatesIndependentScene)
 {
-  const std::string filePath = DART_DATA_LOCAL_PATH "skel/kima/l-foot.dae";
+  const std::string filePath = DART_DATA_LOCAL_PATH "sdf/atlas/r_scap.dae";
   const std::string fileUri = common::Uri::createFromPath(filePath).toString();
   ASSERT_FALSE(fileUri.empty());
 
@@ -197,9 +198,25 @@ TEST(MeshShapeTest, CloneCreatesIndependentScene)
   auto cloned
       = std::dynamic_pointer_cast<dynamics::MeshShape>(original->clone());
   ASSERT_NE(cloned, nullptr);
-  EXPECT_NE(original->getMesh(), cloned->getMesh());
+  const aiScene* clonedScene = cloned->getMesh();
+  ASSERT_NE(clonedScene, nullptr);
+  EXPECT_NE(original->getMesh(), clonedScene);
   EXPECT_TRUE(cloned->getBoundingBox().computeFullExtents().isApprox(
       originalExtents, 1e-12));
+
+  ASSERT_GT(scene->mNumMaterials, 0u);
+  ASSERT_GT(clonedScene->mNumMaterials, 0u);
+  aiString originalTexture;
+  aiString clonedTexture;
+  ASSERT_EQ(
+      scene->mMaterials[0]->GetTexture(
+          aiTextureType_DIFFUSE, 0, &originalTexture),
+      AI_SUCCESS);
+  ASSERT_EQ(
+      clonedScene->mMaterials[0]->GetTexture(
+          aiTextureType_DIFFUSE, 0, &clonedTexture),
+      AI_SUCCESS);
+  EXPECT_STREQ(originalTexture.C_Str(), clonedTexture.C_Str());
 
   cloned->setScale(Eigen::Vector3d::Constant(2.0));
   EXPECT_TRUE(cloned->getBoundingBox().computeFullExtents().isApprox(


### PR DESCRIPTION
## Summary

- Backports the MeshShape TriMesh representation from #2325 to `release-6.20` while preserving the DART 6 Assimp-based compatibility APIs.
- Routes FCL, ODE, Bullet, OSG, parser, example, and dartpy compatibility call sites through the new representation or explicit deprecation suppression where legacy `aiScene` access remains required.

## Motivation / Problem

- `release-6.20` still needs the MeshShape/TriMesh compatibility slice so downstream users can move toward Assimp-free mesh storage without breaking existing DART 6 callers.
- The source branch diverged substantially from `main`, so this is a manual release-compatible backport rather than a clean cherry-pick of #2325.

## Changes / Key Changes

- Adds mutable TriMesh builder helpers and a lightweight `MeshMaterial` record used by `MeshShape`.
- Adds TriMesh constructors, `getTriMesh()`, cached `getMesh()` bridging, explicit `aiScene` ownership handling, material extraction, and deprecated legacy Assimp constructors/accessors for DART 6 compatibility.
- Updates FCL, ODE, and Bullet mesh collision construction to consume `MeshShape::getTriMesh()`.
- Keeps OSG rendering, parsers, examples, tests, and dartpy source-compatible with explicit deprecated-API suppression at internal compatibility call sites.
- Adds unit coverage for the TriMesh constructor, bounding box scaling, clone behavior, and lazy Assimp bridge.

## Testing

- `pixi run lint`
- `pixi run cmake --build build/default/cpp/Release -j --target dart-gui-osg dartpy point_cloud test_Issue1234 UNIT_dynamics_MeshShape UNIT_math_TriMesh test_Collision`
- `pixi run ctest --test-dir build/default/cpp/Release --output-on-failure -R 'UNIT_dynamics_MeshShape|UNIT_math_TriMesh|test_Collision$|test_Issue1234'`
- `LD_LIBRARY_PATH=build/default/cpp/Release/lib:.pixi/envs/cuda/lib PYTHONPATH=build/default/cpp/Release/python pixi run python -c "import dartpy; print(dartpy.__file__); print(hasattr(dartpy.dynamics, 'MeshShape'))"`
- `pixi run -e gazebo test-gz`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Backports #2325

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable