### PR TITLE
Add coverage tests for DART 6.20 backport gaps (#3134, #3136)

### DIFF
--- a/tests/integration/test_DartLoader.cpp
+++ b/tests/integration/test_DartLoader.cpp
@@ -515,6 +515,166 @@ TEST(DartLoader, parseFloatingJointLimits)
 }
 
 //==============================================================================
+TEST(DartLoader, parseFloatingJointLowerLimitOnly)
+{
+  // Only a lower bound (lower > 0) is provided. The upper bound stays unbounded
+  // (+inf) and the rest/initial position collapses to the one-sided lower
+  // bound.
+  // clang-format off
+  const std::string urdfStr = R"(
+    <robot name="floating_example">
+      <link name="base"/>
+      <link name="child"/>
+      <joint name="floating_joint" type="floating">
+        <parent link="base"/>
+        <child link="child"/>
+        <limit lower="0.3" velocity="1.1" effort="2.2"/>
+      </joint>
+    </robot>
+  )";
+  // clang-format on
+
+  DartLoader loader;
+  auto robot = loader.parseSkeletonString(urdfStr, "");
+  ASSERT_TRUE(robot);
+
+  auto* joint
+      = dynamic_cast<dynamics::FreeJoint*>(robot->getJoint("floating_joint"));
+  ASSERT_TRUE(joint);
+
+  const Eigen::VectorXd lower
+      = Eigen::VectorXd::Constant(joint->getNumDofs(), 0.3);
+
+  EXPECT_TRUE(joint->getPositionLowerLimits().isApprox(lower));
+  for (auto i = 0u; i < joint->getNumDofs(); ++i) {
+    EXPECT_DOUBLE_EQ(
+        joint->getPositionUpperLimit(i), dart::math::constantsd::inf());
+  }
+  EXPECT_TRUE(joint->getRestPositions().isApprox(lower));
+  EXPECT_TRUE(joint->getInitialPositions().isApprox(lower));
+}
+
+//==============================================================================
+TEST(DartLoader, parseFloatingJointUpperLimitOnly)
+{
+  // Only an upper bound (upper < 0) is provided. The lower bound stays
+  // unbounded (-inf) and the rest/initial position collapses to the one-sided
+  // upper bound.
+  // clang-format off
+  const std::string urdfStr = R"(
+    <robot name="floating_example">
+      <link name="base"/>
+      <link name="child"/>
+      <joint name="floating_joint" type="floating">
+        <parent link="base"/>
+        <child link="child"/>
+        <limit upper="-0.3" velocity="1.1" effort="2.2"/>
+      </joint>
+    </robot>
+  )";
+  // clang-format on
+
+  DartLoader loader;
+  auto robot = loader.parseSkeletonString(urdfStr, "");
+  ASSERT_TRUE(robot);
+
+  auto* joint
+      = dynamic_cast<dynamics::FreeJoint*>(robot->getJoint("floating_joint"));
+  ASSERT_TRUE(joint);
+
+  const Eigen::VectorXd upper
+      = Eigen::VectorXd::Constant(joint->getNumDofs(), -0.3);
+
+  EXPECT_TRUE(joint->getPositionUpperLimits().isApprox(upper));
+  for (auto i = 0u; i < joint->getNumDofs(); ++i) {
+    EXPECT_DOUBLE_EQ(
+        joint->getPositionLowerLimit(i), -dart::math::constantsd::inf());
+  }
+  EXPECT_TRUE(joint->getRestPositions().isApprox(upper));
+  EXPECT_TRUE(joint->getInitialPositions().isApprox(upper));
+}
+
+//==============================================================================
+TEST(DartLoader, parsePlanarJointLowerLimitOnly)
+{
+  // Planar-joint counterpart of parseFloatingJointLowerLimitOnly: only a lower
+  // bound (lower > 0) is provided.
+  // clang-format off
+  const std::string urdfStr = R"(
+    <robot name="planar_example">
+      <link name="base"/>
+      <link name="tip"/>
+      <joint name="planar_joint" type="planar">
+        <parent link="base"/>
+        <child link="tip"/>
+        <limit lower="0.3" velocity="2.5" effort="3.5"/>
+        <axis xyz="0 0 1"/>
+      </joint>
+    </robot>
+  )";
+  // clang-format on
+
+  DartLoader loader;
+  auto robot = loader.parseSkeletonString(urdfStr, "");
+  ASSERT_TRUE(robot);
+
+  auto* joint
+      = dynamic_cast<dynamics::PlanarJoint*>(robot->getJoint("planar_joint"));
+  ASSERT_TRUE(joint);
+
+  const Eigen::VectorXd lower
+      = Eigen::VectorXd::Constant(joint->getNumDofs(), 0.3);
+
+  EXPECT_TRUE(joint->getPositionLowerLimits().isApprox(lower));
+  for (auto i = 0u; i < joint->getNumDofs(); ++i) {
+    EXPECT_DOUBLE_EQ(
+        joint->getPositionUpperLimit(i), dart::math::constantsd::inf());
+  }
+  EXPECT_TRUE(joint->getRestPositions().isApprox(lower));
+  EXPECT_TRUE(joint->getInitialPositions().isApprox(lower));
+}
+
+//==============================================================================
+TEST(DartLoader, parsePlanarJointUpperLimitOnly)
+{
+  // Planar-joint counterpart of parseFloatingJointUpperLimitOnly: only an upper
+  // bound (upper < 0) is provided.
+  // clang-format off
+  const std::string urdfStr = R"(
+    <robot name="planar_example">
+      <link name="base"/>
+      <link name="tip"/>
+      <joint name="planar_joint" type="planar">
+        <parent link="base"/>
+        <child link="tip"/>
+        <limit upper="-0.3" velocity="2.5" effort="3.5"/>
+        <axis xyz="0 0 1"/>
+      </joint>
+    </robot>
+  )";
+  // clang-format on
+
+  DartLoader loader;
+  auto robot = loader.parseSkeletonString(urdfStr, "");
+  ASSERT_TRUE(robot);
+
+  auto* joint
+      = dynamic_cast<dynamics::PlanarJoint*>(robot->getJoint("planar_joint"));
+  ASSERT_TRUE(joint);
+
+  const Eigen::VectorXd upper
+      = Eigen::VectorXd::Constant(joint->getNumDofs(), -0.3);
+
+  EXPECT_TRUE(joint->getPositionUpperLimits().isApprox(upper));
+  for (auto i = 0u; i < joint->getNumDofs(); ++i) {
+    EXPECT_DOUBLE_EQ(
+        joint->getPositionLowerLimit(i), -dart::math::constantsd::inf());
+  }
+  EXPECT_TRUE(joint->getRestPositions().isApprox(upper));
+  EXPECT_TRUE(joint->getInitialPositions().isApprox(upper));
+}
+
+//==============================================================================
 TEST(DartLoader, parseFloatingJointEffortVelocityOnlyKeepsPositionUnbounded)
 {
   // clang-format off

--- a/tests/unit/math/test_Helpers.cpp
+++ b/tests/unit/math/test_Helpers.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/math/Constants.hpp"
+#include "dart/math/Helpers.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace dart;
+using namespace dart::math::suffixes;
+
+//==============================================================================
+TEST(Helpers, AngleLiteralOperatorsFloat)
+{
+  // The floating-point (long double) overloads of the user-defined literal
+  // operators.
+  EXPECT_DOUBLE_EQ(1.0_pi, math::constantsd::pi());
+  EXPECT_DOUBLE_EQ(0.5_pi, math::constantsd::pi() / 2.0);
+  EXPECT_DOUBLE_EQ(2.0_pi, 2.0 * math::constantsd::pi());
+
+  EXPECT_DOUBLE_EQ(1.5_rad, 1.5);
+  EXPECT_DOUBLE_EQ(0.0_rad, 0.0);
+
+  EXPECT_DOUBLE_EQ(90.0_deg, math::constantsd::pi() / 2.0);
+  EXPECT_DOUBLE_EQ(180.0_deg, math::constantsd::pi());
+  EXPECT_DOUBLE_EQ(0.0_deg, 0.0);
+}
+
+//==============================================================================
+TEST(Helpers, AngleLiteralOperatorsInteger)
+{
+  // The integer (unsigned long long int) overloads of the user-defined literal
+  // operators. These forward to the long double overloads, so the results must
+  // match the floating-point equivalents exactly.
+  EXPECT_DOUBLE_EQ(0_pi, 0.0);
+  EXPECT_DOUBLE_EQ(1_pi, math::constantsd::pi());
+  EXPECT_DOUBLE_EQ(2_pi, 2.0 * math::constantsd::pi());
+  EXPECT_DOUBLE_EQ(1_pi, 1.0_pi);
+
+  EXPECT_DOUBLE_EQ(0_rad, 0.0);
+  EXPECT_DOUBLE_EQ(2_rad, 2.0);
+  EXPECT_DOUBLE_EQ(2_rad, 2.0_rad);
+
+  EXPECT_DOUBLE_EQ(0_deg, 0.0);
+  EXPECT_DOUBLE_EQ(90_deg, math::constantsd::pi() / 2.0);
+  EXPECT_DOUBLE_EQ(180_deg, math::constantsd::pi());
+  EXPECT_DOUBLE_EQ(360_deg, 2.0 * math::constantsd::pi());
+  EXPECT_DOUBLE_EQ(90_deg, 90.0_deg);
+}


### PR DESCRIPTION
## Summary

- Close the codecov patch-coverage gaps left by the recently-merged DART 6.20
  backports #3134 (URDF multidof limits) and #3136 (Bullet phantom contacts).
  Test-only; no production code changes.

## Changes / Key Changes

- **`tests/unit/math/test_Helpers.cpp`** (new) — covers the `unsigned long long`
  overloads of the `_pi` / `_rad` / `_deg` angle literal operators
  (`dart/math/Helpers.hpp`), the recurring uncovered lines codecov flagged on
  **both #3134 and #3136**. Existing tests only exercised the floating-point
  overloads (`90.0_deg`); the integer overloads (`90_deg`, `1_pi`, `2_rad`) had
  no runtime coverage. Asserted via runtime `EXPECT_DOUBLE_EQ`.
- **`tests/integration/test_DartLoader.cpp`** — adds floating/planar joint tests
  for **lower-only** and **upper-only** `<limit>` shapes
  (`parseFloatingJointLowerLimitOnly`, `parseFloatingJointUpperLimitOnly`,
  `parsePlanarJointLowerLimitOnly`, `parsePlanarJointUpperLimitOnly`), covering
  the one-sided initial/rest-position derivation branches in `DartLoader.cpp`
  (~lines 720-723 / 789-792) that the existing average-branch test
  (`parseFloatingJointLimits`) left uncovered (#3134). The unbounded side is
  asserted to remain ±inf.

## Testing

- `pixi run cmake --build build/default/cpp/Release --target UNIT_math_Helpers test_DartLoader`
  builds clean.
- `Helpers.*` 2/2 pass; `DartLoader.*` 31/31 pass (27 pre-existing + 4 new), no
  regressions.
- Note: the `GenericJoint` vector-setter `DIM_MISMATCH` branches flagged by
  codecov are `DART_ASSERT(false)` programmer-error paths (abort under asserts),
  so they are not meaningfully unit-testable and are intentionally not covered.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Coverage follow-up for #3134 and #3136.

---

#### Checklist

- [x] Milestone set (DART 6.20.0 for `release-6.20`)
- [x] CHANGELOG.md updated if required — N/A (test-only)
- [x] Add unit tests for new functionality — this PR *is* the tests
- [x] Document new methods and classes — N/A
- [x] Add Python bindings (dartpy) if applicable — N/A
