### PR TITLE
Backport Inertia frame-change helpers to release-6.20 (#2153)

### DIFF
--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -252,6 +252,22 @@ const Eigen::Matrix6d& Inertia::getSpatialTensor() const
 }
 
 //==============================================================================
+Inertia Inertia::transformed(const Eigen::Isometry3d& transform) const
+{
+  const Eigen::Matrix6d adjoint = math::getAdTMatrix(transform.inverse());
+  return Inertia(adjoint.transpose() * getSpatialTensor() * adjoint);
+}
+
+//==============================================================================
+Inertia& Inertia::transform(const Eigen::Isometry3d& transform)
+{
+  const Eigen::Matrix6d adjoint = math::getAdTMatrix(transform.inverse());
+  mSpatialTensor = adjoint.transpose() * mSpatialTensor * adjoint;
+  computeParameters();
+  return *this;
+}
+
+//==============================================================================
 bool Inertia::verifyMoment(
     const Eigen::Matrix3d& _moment, bool _printWarnings, double _tolerance)
 {

--- a/dart/dynamics/Inertia.hpp
+++ b/dart/dynamics/Inertia.hpp
@@ -128,6 +128,15 @@ public:
   /// Get the spatial inertia tensor
   const Eigen::Matrix6d& getSpatialTensor() const;
 
+  /// Return a copy of this inertia expressed in the frame reached by applying
+  /// @f$transform@f$ to the current frame. The transform should be the
+  /// relative transform from the current frame to the target frame.
+  Inertia transformed(const Eigen::Isometry3d& transform) const;
+
+  /// Transform this inertia in place using the provided current-to-target
+  /// transform.
+  Inertia& transform(const Eigen::Isometry3d& transform);
+
   /// Returns true iff _moment is a physically valid moment of inertia
   static bool verifyMoment(
       const Eigen::Matrix3d& _moment,

--- a/python/dartpy/dynamics/Inertia.cpp
+++ b/python/dartpy/dynamics/Inertia.cpp
@@ -106,6 +106,21 @@ void Inertia(py::module& m)
           },
           ::py::return_value_policy::reference_internal)
       .def(
+          "transformed",
+          +[](const dart::dynamics::Inertia* self,
+              const Eigen::Isometry3d& transform) {
+            return self->transformed(transform);
+          },
+          ::py::arg("transform"))
+      .def(
+          "transform",
+          +[](dart::dynamics::Inertia* self,
+              const Eigen::Isometry3d& transform) -> dart::dynamics::Inertia& {
+            return self->transform(transform);
+          },
+          ::py::arg("transform"),
+          ::py::return_value_policy::reference_internal)
+      .def(
           "verify",
           +[](const dart::dynamics::Inertia* self,
               bool printWarnings,

--- a/tests/unit/dynamics/test_Inertia.cpp
+++ b/tests/unit/dynamics/test_Inertia.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/Inertia.hpp>
+
+#include <dart/math/Geometry.hpp>
+#include <dart/math/Random.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace dart;
+
+//==============================================================================
+TEST(Inertia, Transformations)
+{
+  const int numIter = 25;
+  const double tol = 1e-9;
+
+  for (int i = 0; i < numIter; ++i) {
+    const auto mass = math::Random::uniform<double>(0.1, 10.0);
+    const auto com = math::Random::uniform<Eigen::Vector3d>(-1.0, 1.0);
+    const auto moment
+        = Eigen::Matrix3d::Identity() * math::Random::uniform<double>(0.1, 2.0);
+    dynamics::Inertia inertia(mass, com, moment);
+
+    Eigen::Vector3d axis = math::Random::uniform<Eigen::Vector3d>(-1.0, 1.0);
+    if (axis.norm() < 1e-6)
+      axis = Eigen::Vector3d::UnitX();
+    axis.normalize();
+    const double angle = math::Random::uniform<double>(-3.14, 3.14);
+    Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
+    T.linear() = Eigen::AngleAxisd(angle, axis).toRotationMatrix();
+    T.translation() = math::Random::uniform<Eigen::Vector3d>(-0.5, 0.5);
+
+    const dynamics::Inertia transformed = inertia.transformed(T);
+    dynamics::Inertia inPlace = inertia;
+    dynamics::Inertia& inPlaceRef = inPlace.transform(T);
+    EXPECT_EQ(&inPlaceRef, &inPlace);
+
+    const Eigen::Matrix6d adjoint = math::getAdTMatrix(T.inverse());
+    const Eigen::Matrix6d expected
+        = adjoint.transpose() * inertia.getSpatialTensor() * adjoint;
+    EXPECT_TRUE(expected.isApprox(transformed.getSpatialTensor(), tol));
+    EXPECT_TRUE(expected.isApprox(inPlace.getSpatialTensor(), tol));
+    EXPECT_NEAR(transformed.getMass(), inertia.getMass(), tol);
+    EXPECT_NEAR(inPlace.getMass(), inertia.getMass(), tol);
+
+    const Eigen::Vector3d expectedCom
+        = T.linear() * inertia.getLocalCOM() + T.translation();
+    EXPECT_TRUE(transformed.getLocalCOM().isApprox(expectedCom, tol));
+    EXPECT_TRUE(inPlace.getLocalCOM().isApprox(expectedCom, tol));
+
+    const dynamics::Inertia identityTransformed
+        = inertia.transformed(Eigen::Isometry3d::Identity());
+    EXPECT_TRUE(identityTransformed.getSpatialTensor().isApprox(
+        inertia.getSpatialTensor(), tol));
+  }
+}


### PR DESCRIPTION
## Summary
Additive backport of #2153 — adds `Inertia::transformed(const Eigen::Isometry3d&) const` and `Inertia& transform(const Eigen::Isometry3d&)` frame-change helpers (+ pybind11 bindings). Maintainer-decision feature port for DART 6.20.

## gz backward-compat
Purely **additive** — two brand-new methods + bindings + one new unit test; zero existing `Inertia` declarations/definitions/layout changed, so gz-physics/gz-sim API, behavior, and performance are unaffected. Verified collectively with the other additive wave-1 backports via `pixi run -e gazebo test-gz` (gz-physics + gz-sim).

## Testing
- `UNIT_dynamics_Inertia` (Inertia.Transformations, 25 randomized iters): PASS. dartpy compiles/links; Python smoke OK.

## Breaking Changes
- [x] None