### PR TITLE
Backport per-DoF actuator type API to release-6.20 (#2222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,15 @@
 
 * Dynamics
 
+  * Add an opt-in per-DoF actuator type API to `Joint`
+    (`setActuatorType(index, type)`, `setActuatorTypes(vector)`,
+    `getActuatorType(index)`, `getActuatorTypes()`, `hasActuatorType()`) so
+    individual DoFs of a multi-DoF joint can be set to `MIMIC` while the rest
+    keep the joint-wide type. The existing joint-wide
+    `setActuatorType(ActuatorType)` / `getActuatorType()` API and its default
+    behavior are unchanged:
+    [#2222](https://github.com/dartsim/dart/pull/2222)
+
   * Add TriMesh-backed `MeshShape` storage and material metadata while keeping
     the legacy Assimp `aiScene` APIs available as deprecated DART 6
     compatibility shims, and route mesh collision backends through the new

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -725,8 +725,8 @@ bool ConstraintSolver::canJointCreateAutomaticConstraint(
     return false;
 
   return joint->hasCoulombFriction() || joint->areLimitsEnforced()
-         || joint->getActuatorType() == dynamics::Joint::SERVO
-         || (joint->getActuatorType() == dynamics::Joint::MIMIC
+         || joint->hasActuatorType(dynamics::Joint::SERVO)
+         || (joint->hasActuatorType(dynamics::Joint::MIMIC)
              && joint->getMimicJoint());
 }
 
@@ -1152,14 +1152,35 @@ void ConstraintSolver::updateConstraints()
       }
 
       if (joint->areLimitsEnforced()
-          || joint->getActuatorType() == dynamics::Joint::SERVO) {
+          || joint->hasActuatorType(dynamics::Joint::SERVO)) {
         mJointConstraints.push_back(std::make_shared<JointConstraint>(joint));
       }
 
-      if (joint->getActuatorType() == dynamics::Joint::MIMIC
-          && joint->getMimicJoint()) {
-        mMimicMotorConstraints.push_back(std::make_shared<MimicMotorConstraint>(
-            joint, joint->getMimicDofProperties()));
+      if (joint->hasActuatorType(dynamics::Joint::MIMIC)) {
+        auto mimicProps = joint->getMimicDofProperties();
+        const auto dofCount = joint->getNumDofs();
+        bool hasValidMimicDof = false;
+        for (std::size_t dofIndex = 0;
+             dofIndex < dofCount && dofIndex < mimicProps.size();
+             ++dofIndex) {
+          if (joint->getActuatorType(dofIndex) == dynamics::Joint::MIMIC) {
+            if (mimicProps[dofIndex].mReferenceJoint != nullptr) {
+              hasValidMimicDof = true;
+            } else {
+              DART_WARN(
+                  "Joint '{}' DoF {} is set to MIMIC without a reference; "
+                  "mimic constraint will be skipped.",
+                  joint->getName(),
+                  dofIndex);
+            }
+          }
+        }
+
+        if (hasValidMimicDof) {
+          mMimicMotorConstraints.push_back(
+              std::make_shared<MimicMotorConstraint>(
+                  joint, joint->getMimicDofProperties()));
+        }
       }
     }
   }

--- a/dart/constraint/JointConstraint.cpp
+++ b/dart/constraint/JointConstraint.cpp
@@ -322,7 +322,8 @@ void JointConstraint::update()
         continue;
       }
 
-      const bool isServo = mJoint->getActuatorType() == dynamics::Joint::SERVO;
+      const bool isServo = mJoint->getActuatorType(static_cast<std::size_t>(i))
+                           == dynamics::Joint::SERVO;
       const double servoCommand
           = isServo ? mJoint->getCommand(static_cast<std::size_t>(i)) : 0.0;
       const bool atLowerLimit
@@ -410,7 +411,8 @@ void JointConstraint::update()
     }
 
     // Servo motor constraint check
-    if (mJoint->getActuatorType() == dynamics::Joint::SERVO) {
+    if (mJoint->getActuatorType(static_cast<std::size_t>(i))
+        == dynamics::Joint::SERVO) {
       double desired_velocity = mJoint->getCommand(static_cast<std::size_t>(i));
 
       // Clip to velocity limits (when valid) and position-derived limits

--- a/dart/constraint/MimicMotorConstraint.cpp
+++ b/dart/constraint/MimicMotorConstraint.cpp
@@ -163,6 +163,12 @@ void MimicMotorConstraint::update()
   for (std::size_t i = 0; i < dof; ++i) {
     const auto& mimicProp = mMimicProps[i];
 
+    if (mJoint->getActuatorType(i) != dynamics::Joint::MIMIC
+        || mimicProp.mReferenceJoint == nullptr) {
+      mActive[i] = false;
+      continue;
+    }
+
     double timeStep = mJoint->getSkeleton()->getTimeStep();
     double velLower = mJoint->getVelocityLowerLimit(i);
     double velUpper = mJoint->getVelocityUpperLimit(i);
@@ -329,11 +335,14 @@ dynamics::SkeletonPtr MimicMotorConstraint::getRootSkeleton() const
 //==============================================================================
 bool MimicMotorConstraint::isActive() const
 {
-  // Since we are not allowed to set the joint actuator type per each
-  // DegreeOfFreedom, we just check if the whole joint is SERVO actuator.
-  if (mJoint->getActuatorType() == dynamics::Joint::MIMIC)
-    return true;
-
+  const std::size_t dof = mJoint->getNumDofs();
+  for (std::size_t i = 0; i < dof; ++i) {
+    if (mJoint->getActuatorType(i) == dynamics::Joint::MIMIC
+        && i < mMimicProps.size()
+        && mMimicProps[i].mReferenceJoint != nullptr) {
+      return true;
+    }
+  }
   return false;
 }
 

--- a/dart/dynamics/Joint.cpp
+++ b/dart/dynamics/Joint.cpp
@@ -134,6 +134,8 @@ void Joint::setAspectProperties(const AspectProperties& properties)
   setTransformFromChildBodyNode(properties.mT_ChildBodyToJoint);
   setLimitEnforcement(properties.mIsPositionLimitEnforced);
   setActuatorType(properties.mActuatorType);
+  for (const auto& [index, actuatorType] : properties.mActuatorTypes)
+    setActuatorType(index, actuatorType);
   setMimicJointDofs(properties.mMimicDofProps);
 }
 
@@ -203,10 +205,136 @@ const std::string& Joint::getName() const
 //==============================================================================
 void Joint::setActuatorType(Joint::ActuatorType _actuatorType)
 {
-  if (mAspectProperties.mActuatorType == _actuatorType)
+  if (mAspectProperties.mActuatorType == _actuatorType
+      && mAspectProperties.mActuatorTypes.empty())
     return;
 
   mAspectProperties.mActuatorType = _actuatorType;
+  mAspectProperties.mActuatorTypes.clear();
+  notifyAutomaticConstraintPropertiesUpdated();
+  resetCommands();
+}
+
+//==============================================================================
+void Joint::setActuatorType(std::size_t index, ActuatorType actuatorType)
+{
+  if (index >= getNumDofs()) {
+    DART_ERROR(
+        "Attempted to set actuator type for invalid index {} on Joint [{}] "
+        "with {} DoFs.",
+        index,
+        getName(),
+        getNumDofs());
+    return;
+  }
+
+  const bool defaultDynamic
+      = isDynamicActuatorType(mAspectProperties.mActuatorType);
+  const bool requestedDynamic = isDynamicActuatorType(actuatorType);
+  if (requestedDynamic != defaultDynamic) {
+    DART_ERROR(
+        "Cannot assign actuator type {} to DoF {} of Joint [{}] because it "
+        "does not match the dynamic/kinematic classification of the "
+        "joint-wide actuator type {}.",
+        static_cast<int>(actuatorType),
+        index,
+        getName(),
+        static_cast<int>(mAspectProperties.mActuatorType));
+    return;
+  }
+
+  if (actuatorType != mAspectProperties.mActuatorType
+      && actuatorType != Joint::MIMIC) {
+    DART_ERROR(
+        "Only per-DoF overrides to Joint::MIMIC are supported. Requested "
+        "actuator type {} for DoF {} on Joint [{}].",
+        static_cast<int>(actuatorType),
+        index,
+        getName());
+    return;
+  }
+
+  auto& overrides = mAspectProperties.mActuatorTypes;
+
+  if (actuatorType == mAspectProperties.mActuatorType) {
+    const auto it = overrides.find(index);
+    if (it == overrides.end())
+      return;
+
+    overrides.erase(it);
+    notifyAutomaticConstraintPropertiesUpdated();
+    resetCommands();
+    return;
+  }
+
+  const auto it = overrides.find(index);
+  if (it != overrides.end() && it->second == actuatorType)
+    return;
+
+  overrides[index] = actuatorType;
+  notifyAutomaticConstraintPropertiesUpdated();
+  resetCommands();
+}
+
+//==============================================================================
+void Joint::setActuatorTypes(const std::vector<ActuatorType>& actuatorTypes)
+{
+  if (actuatorTypes.size() != getNumDofs()) {
+    DART_ERROR(
+        "Actuator type vector size ({}) does not match the number of DoFs ({}) "
+        "for Joint [{}].",
+        actuatorTypes.size(),
+        getNumDofs(),
+        getName());
+    return;
+  }
+
+  if (actuatorTypes.empty()) {
+    if (!mAspectProperties.mActuatorTypes.empty()) {
+      mAspectProperties.mActuatorTypes.clear();
+      notifyAutomaticConstraintPropertiesUpdated();
+      resetCommands();
+    }
+    return;
+  }
+
+  ActuatorType newDefault = actuatorTypes.front();
+  std::map<std::size_t, ActuatorType> newOverrides;
+  const bool newDefaultDynamic = isDynamicActuatorType(newDefault);
+
+  for (std::size_t i = 1; i < actuatorTypes.size(); ++i) {
+    const auto type = actuatorTypes[i];
+    if (isDynamicActuatorType(type) != newDefaultDynamic) {
+      DART_ERROR(
+          "Actuator type {} for DoF {} of Joint [{}] does not match the "
+          "dynamic/kinematic classification of the joint-wide actuator type "
+          "{}.",
+          static_cast<int>(type),
+          i,
+          getName(),
+          static_cast<int>(newDefault));
+      return;
+    }
+    if (type != newDefault) {
+      if (type != Joint::MIMIC) {
+        DART_ERROR(
+            "Only per-DoF overrides to Joint::MIMIC are supported. Requested "
+            "actuator type {} for DoF {} on Joint [{}].",
+            static_cast<int>(type),
+            i,
+            getName());
+        return;
+      }
+      newOverrides.emplace(i, type);
+    }
+  }
+
+  if (mAspectProperties.mActuatorType == newDefault
+      && mAspectProperties.mActuatorTypes == newOverrides)
+    return;
+
+  mAspectProperties.mActuatorType = newDefault;
+  mAspectProperties.mActuatorTypes = std::move(newOverrides);
   notifyAutomaticConstraintPropertiesUpdated();
   resetCommands();
 }
@@ -215,6 +343,92 @@ void Joint::setActuatorType(Joint::ActuatorType _actuatorType)
 Joint::ActuatorType Joint::getActuatorType() const
 {
   return mAspectProperties.mActuatorType;
+}
+
+//==============================================================================
+Joint::ActuatorType Joint::getActuatorType(std::size_t index) const
+{
+  if (index >= getNumDofs()) {
+    DART_ERROR(
+        "Requested actuator type for invalid index {} on Joint [{}] with {} "
+        "DoFs.",
+        index,
+        getName(),
+        getNumDofs());
+    return mAspectProperties.mActuatorType;
+  }
+
+  const auto it = mAspectProperties.mActuatorTypes.find(index);
+  if (it != mAspectProperties.mActuatorTypes.end())
+    return it->second;
+
+  return mAspectProperties.mActuatorType;
+}
+
+//==============================================================================
+std::vector<Joint::ActuatorType> Joint::getActuatorTypes() const
+{
+  const auto numDofs = getNumDofs();
+  std::vector<ActuatorType> actuatorTypes(
+      numDofs, mAspectProperties.mActuatorType);
+
+  for (const auto& [index, type] : mAspectProperties.mActuatorTypes) {
+    if (index < numDofs)
+      actuatorTypes[index] = type;
+  }
+
+  return actuatorTypes;
+}
+
+//==============================================================================
+bool Joint::hasActuatorType(ActuatorType actuatorType) const
+{
+  const auto numDofs = getNumDofs();
+  for (std::size_t i = 0; i < numDofs; ++i) {
+    if (getActuatorType(i) == actuatorType)
+      return true;
+  }
+  return false;
+}
+
+//==============================================================================
+bool Joint::isKinematicActuatorType(ActuatorType actuatorType)
+{
+  switch (actuatorType) {
+    case ACCELERATION:
+    case VELOCITY:
+    case LOCKED:
+      return true;
+    case FORCE:
+    case PASSIVE:
+    case SERVO:
+    case MIMIC:
+      return false;
+    default:
+      DART_ERROR(
+          "Unsupported actuator type: {}.", static_cast<int>(actuatorType));
+      return false;
+  }
+}
+
+//==============================================================================
+bool Joint::isDynamicActuatorType(ActuatorType actuatorType)
+{
+  switch (actuatorType) {
+    case FORCE:
+    case PASSIVE:
+    case SERVO:
+    case MIMIC:
+      return true;
+    case ACCELERATION:
+    case VELOCITY:
+    case LOCKED:
+      return false;
+    default:
+      DART_ERROR(
+          "Unsupported actuator type: {}.", static_cast<int>(actuatorType));
+      return false;
+  }
 }
 
 //==============================================================================
@@ -287,21 +501,16 @@ const std::vector<MimicDofProperties>& Joint::getMimicDofProperties() const
 //==============================================================================
 bool Joint::isKinematic() const
 {
-  switch (mAspectProperties.mActuatorType) {
-    case FORCE:
-    case PASSIVE:
-    case SERVO:
-    case MIMIC:
+  const auto numDofs = getNumDofs();
+  if (numDofs == 0)
+    return isKinematicActuatorType(mAspectProperties.mActuatorType);
+
+  for (std::size_t i = 0; i < numDofs; ++i) {
+    if (!isKinematicActuatorType(getActuatorType(i)))
       return false;
-    case ACCELERATION:
-    case VELOCITY:
-    case LOCKED:
-      return true;
-    default: {
-      dterr << "Unsupported actuator type." << std::endl;
-      return false;
-    }
   }
+
+  return true;
 }
 
 //==============================================================================

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -45,6 +45,7 @@
 #include <dart/common/Subject.hpp>
 #include <dart/common/VersionCounter.hpp>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -137,10 +138,43 @@ public:
 
   /// Set actuator type. Switching types clears any cached commands so stale
   /// inputs do not leak across actuator modes.
+  ///
+  /// This is the joint-wide actuator type. Calling it also clears any per-DoF
+  /// overrides previously set via setActuatorType(index, ...), restoring the
+  /// uniform joint-wide behavior.
   void setActuatorType(ActuatorType _actuatorType);
+
+  /// Set the actuator type for a specific DoF.
+  ///
+  /// Per-DoF overrides are additive on top of the joint-wide actuator type and
+  /// are currently restricted to overriding individual DoFs to Joint::MIMIC
+  /// (so a multi-DoF joint can have some DoFs follow a reference joint while
+  /// the others keep the joint-wide type). The requested type must share the
+  /// dynamic/kinematic classification of the joint-wide type.
+  void setActuatorType(std::size_t index, ActuatorType actuatorType);
+
+  /// Set actuator types for each DoF. The first entry is used as the joint-wide
+  /// actuator type, and each subsequent entry overrides the joint-wide type
+  /// when it differs.
+  void setActuatorTypes(const std::vector<ActuatorType>& actuatorTypes);
 
   /// Get actuator type
   ActuatorType getActuatorType() const;
+
+  /// Gets the actuator type of the specified DoF.
+  ActuatorType getActuatorType(std::size_t index) const;
+
+  /// Returns the actuator type of each DoF.
+  std::vector<ActuatorType> getActuatorTypes() const;
+
+  /// Returns true if any DoF uses the specified actuator type.
+  bool hasActuatorType(ActuatorType actuatorType) const;
+
+  /// Returns true if the provided actuator type is considered kinematic.
+  static bool isKinematicActuatorType(ActuatorType actuatorType);
+
+  /// Returns true if the provided actuator type is considered dynamic.
+  static bool isDynamicActuatorType(ActuatorType actuatorType);
 
   /// Set the mimic joint with a single reference joint and the same multiplier
   /// and offset for all dependent joint's DoFs.

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -538,18 +538,28 @@ SkeletonPtr Skeleton::cloneSkeleton(const std::string& cloneName) const
   // Fix mimic joint references
   for (std::size_t i = 0; i < getNumJoints(); ++i) {
     Joint* joint = skelClone->getJoint(i);
-    if (joint->getActuatorType() == Joint::MIMIC) {
-      const Joint* mimicJoint
-          = skelClone->getJoint(joint->getMimicJoint()->getName());
-      if (mimicJoint) {
-        joint->setMimicJoint(
-            mimicJoint, joint->getMimicMultiplier(), joint->getMimicOffset());
-      } else {
+    const auto& mimicProps = joint->getMimicDofProperties();
+    const std::size_t dofCount
+        = std::min(joint->getNumDofs(), mimicProps.size());
+    for (std::size_t dofIndex = 0; dofIndex < dofCount; ++dofIndex) {
+      const auto* sourceJoint = mimicProps[dofIndex].mReferenceJoint;
+      if (sourceJoint == nullptr
+          || joint->getActuatorType(dofIndex) != Joint::MIMIC)
+        continue;
+
+      const Joint* clonedReference
+          = skelClone->getJoint(sourceJoint->getName());
+      if (clonedReference == nullptr) {
         dterr << "[Skeleton::clone] Failed to clone mimic joint successfully: "
-              << "Unable to find the mimic joint ["
-              << joint->getMimicJoint()->getName()
-              << "] in the cloned Skeleton. Please report this as a bug!\n";
+              << "Unable to find the mimic joint [" << sourceJoint->getName()
+              << "] for DoF " << dofIndex
+              << " in the cloned Skeleton. Please report this as a bug!\n";
+        continue;
       }
+
+      auto updatedProp = mimicProps[dofIndex];
+      updatedProp.mReferenceJoint = clonedReference;
+      joint->setMimicJointDof(dofIndex, updatedProp);
     }
   }
 

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -391,7 +391,7 @@ void GenericJoint<ConfigSpaceT>::setCommand(size_t index, double command)
     return;
   }
 
-  switch (Joint::mAspectProperties.mActuatorType) {
+  switch (this->getActuatorType(index)) {
     case Joint::FORCE:
       this->mAspectState.mCommands[index] = math::clip(
           command,
@@ -470,60 +470,10 @@ void GenericJoint<ConfigSpaceT>::setCommands(const Eigen::VectorXd& commands)
     return;
   }
 
-  switch (Joint::mAspectProperties.mActuatorType) {
-    case Joint::FORCE:
-      this->mAspectState.mCommands = math::clip(
-          commands,
-          Base::mAspectProperties.mForceLowerLimits,
-          Base::mAspectProperties.mForceUpperLimits);
-      break;
-    case Joint::PASSIVE:
-      if (!commands.isZero()) {
-        dtwarn << "[GenericJoint::setCommands] Attempting to set a non-zero ("
-               << commands.transpose() << ") command for a PASSIVE joint ["
-               << this->getName() << "].\n";
-      }
-      this->mAspectState.mCommands.setZero();
-      break;
-    case Joint::SERVO:
-      this->mAspectState.mCommands = math::clip(
-          commands,
-          Base::mAspectProperties.mVelocityLowerLimits,
-          Base::mAspectProperties.mVelocityUpperLimits);
-      break;
-    case Joint::MIMIC:
-      if (!commands.isZero()) {
-        dtwarn << "[GenericJoint::setCommands] Attempting to set a non-zero ("
-               << commands.transpose() << ") command for a MIMIC joint ["
-               << this->getName() << "].\n";
-      }
-      this->mAspectState.mCommands.setZero();
-      break;
-    case Joint::ACCELERATION:
-      this->mAspectState.mCommands = math::clip(
-          commands,
-          Base::mAspectProperties.mAccelerationLowerLimits,
-          Base::mAspectProperties.mAccelerationUpperLimits);
-      break;
-    case Joint::VELOCITY:
-      this->mAspectState.mCommands = math::clip(
-          commands,
-          Base::mAspectProperties.mVelocityLowerLimits,
-          Base::mAspectProperties.mVelocityUpperLimits);
-      // TODO: This possibly makes the acceleration to exceed the limits.
-      break;
-    case Joint::LOCKED:
-      if (!commands.isZero()) {
-        dtwarn << "[GenericJoint::setCommands] Attempting to set a non-zero ("
-               << commands.transpose() << ") command for a LOCKED joint ["
-               << this->getName() << "].\n";
-      }
-      this->mAspectState.mCommands.setZero();
-      break;
-    default:
-      DART_ASSERT(false);
-      break;
-  }
+  // Dispatch per DoF so that joints with mixed (per-DoF) actuator types apply
+  // the correct clamping/zeroing rules for each DoF.
+  for (std::size_t i = 0; i < getNumDofs(); ++i)
+    setCommand(i, commands[static_cast<Eigen::Index>(i)]);
 
   this->notifyExternalDisturbanceUpdated();
 }
@@ -848,7 +798,7 @@ void GenericJoint<ConfigSpaceT>::setVelocity(size_t index, double velocity)
   this->mAspectState.mVelocities[index] = velocity;
   this->notifyVelocityUpdated();
 
-  if (Joint::mAspectProperties.mActuatorType == Joint::VELOCITY)
+  if (this->getActuatorType(index) == Joint::VELOCITY)
     this->mAspectState.mCommands[index] = this->getVelocitiesStatic()[index];
 }
 
@@ -876,8 +826,10 @@ void GenericJoint<ConfigSpaceT>::setVelocities(
 
   setVelocitiesStatic(velocities);
 
-  if (Joint::mAspectProperties.mActuatorType == Joint::VELOCITY)
-    this->mAspectState.mCommands = this->getVelocitiesStatic();
+  for (std::size_t i = 0; i < getNumDofs(); ++i) {
+    if (this->getActuatorType(i) == Joint::VELOCITY)
+      this->mAspectState.mCommands[i] = this->getVelocitiesStatic()[i];
+  }
 }
 
 //==============================================================================
@@ -1065,7 +1017,7 @@ void GenericJoint<ConfigSpaceT>::setAcceleration(
   this->mAspectState.mAccelerations[index] = acceleration;
   this->notifyAccelerationUpdated();
 
-  if (Joint::mAspectProperties.mActuatorType == Joint::ACCELERATION) {
+  if (this->getActuatorType(index) == Joint::ACCELERATION) {
     const double command = this->getAccelerationsStatic()[index];
     if (this->mAspectState.mCommands[index] != command) {
       this->mAspectState.mCommands[index] = command;
@@ -1098,13 +1050,18 @@ void GenericJoint<ConfigSpaceT>::setAccelerations(
 
   setAccelerationsStatic(accelerations);
 
-  if (Joint::mAspectProperties.mActuatorType == Joint::ACCELERATION) {
-    const auto& commands = this->getAccelerationsStatic();
-    if (this->mAspectState.mCommands != commands) {
-      this->mAspectState.mCommands = commands;
-      this->notifyExternalDisturbanceUpdated();
+  bool commandChanged = false;
+  for (std::size_t i = 0; i < getNumDofs(); ++i) {
+    if (this->getActuatorType(i) == Joint::ACCELERATION) {
+      const double command = this->getAccelerationsStatic()[i];
+      if (this->mAspectState.mCommands[i] != command) {
+        this->mAspectState.mCommands[i] = command;
+        commandChanged = true;
+      }
     }
   }
+  if (commandChanged)
+    this->notifyExternalDisturbanceUpdated();
 }
 
 //==============================================================================
@@ -1221,7 +1178,7 @@ void GenericJoint<ConfigSpaceT>::setForce(size_t index, double force)
 
   this->mAspectState.mForces[index] = force;
 
-  if (Joint::mAspectProperties.mActuatorType == Joint::FORCE)
+  if (this->getActuatorType(index) == Joint::FORCE)
     this->mAspectState.mCommands[index] = this->mAspectState.mForces[index];
 
   this->notifyExternalDisturbanceUpdated();
@@ -1250,8 +1207,10 @@ void GenericJoint<ConfigSpaceT>::setForces(const Eigen::VectorXd& forces)
 
   this->mAspectState.mForces = forces;
 
-  if (Joint::mAspectProperties.mActuatorType == Joint::FORCE)
-    this->mAspectState.mCommands = this->mAspectState.mForces;
+  for (std::size_t i = 0; i < getNumDofs(); ++i) {
+    if (this->getActuatorType(i) == Joint::FORCE)
+      this->mAspectState.mCommands[i] = this->mAspectState.mForces[i];
+  }
 
   this->notifyExternalDisturbanceUpdated();
 }
@@ -1357,8 +1316,10 @@ void GenericJoint<ConfigSpaceT>::resetForces()
 {
   this->mAspectState.mForces.setZero();
 
-  if (Joint::mAspectProperties.mActuatorType == Joint::FORCE)
-    this->mAspectState.mCommands = this->mAspectState.mForces;
+  for (std::size_t i = 0; i < getNumDofs(); ++i) {
+    if (this->getActuatorType(i) == Joint::FORCE)
+      this->mAspectState.mCommands[i] = this->mAspectState.mForces[i];
+  }
 
   this->notifyExternalDisturbanceUpdated();
 }

--- a/dart/dynamics/detail/JointAspect.hpp
+++ b/dart/dynamics/detail/JointAspect.hpp
@@ -38,7 +38,10 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <map>
 #include <vector>
+
+#include <cstddef>
 
 namespace dart {
 namespace dynamics {
@@ -130,6 +133,10 @@ struct JointProperties
 
   /// Actuator type
   ActuatorType mActuatorType;
+
+  /// Actuator types for specific DoFs that override the joint-wide actuator
+  /// type.
+  std::map<std::size_t, ActuatorType> mActuatorTypes;
 
   /// Vector of MimicDofProperties for each dependent DoF in the joint.
   std::vector<MimicDofProperties> mMimicDofProps;

--- a/python/dartpy/dynamics/Joint.cpp
+++ b/python/dartpy/dynamics/Joint.cpp
@@ -35,6 +35,7 @@
 #include <eigen_geometry_pybind.h>
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -247,6 +248,43 @@ void Joint(py::module& m)
               -> dart::dynamics::Joint::ActuatorType {
             return self->getActuatorType();
           })
+      .def(
+          "setActuatorTypeForDof",
+          +[](dart::dynamics::Joint* self,
+              std::size_t index,
+              dart::dynamics::Joint::ActuatorType actuatorType) -> void {
+            self->setActuatorType(index, actuatorType);
+          },
+          ::py::arg("index"),
+          ::py::arg("actuatorType"))
+      .def(
+          "setActuatorTypes",
+          +[](dart::dynamics::Joint* self,
+              const std::vector<dart::dynamics::Joint::ActuatorType>&
+                  actuatorTypes) -> void {
+            self->setActuatorTypes(actuatorTypes);
+          },
+          ::py::arg("actuatorTypes"))
+      .def(
+          "getActuatorTypeForDof",
+          +[](const dart::dynamics::Joint* self,
+              std::size_t index) -> dart::dynamics::Joint::ActuatorType {
+            return self->getActuatorType(index);
+          },
+          ::py::arg("index"))
+      .def(
+          "getActuatorTypes",
+          +[](const dart::dynamics::Joint* self)
+              -> std::vector<dart::dynamics::Joint::ActuatorType> {
+            return self->getActuatorTypes();
+          })
+      .def(
+          "hasActuatorType",
+          +[](const dart::dynamics::Joint* self,
+              dart::dynamics::Joint::ActuatorType actuatorType) -> bool {
+            return self->hasActuatorType(actuatorType);
+          },
+          ::py::arg("actuatorType"))
       .def(
           "isKinematic",
           +[](const dart::dynamics::Joint* self) -> bool {

--- a/tests/integration/test_Joints.cpp
+++ b/tests/integration/test_Joints.cpp
@@ -37,6 +37,7 @@
 #include "dart/dynamics/EulerJoint.hpp"
 #include "dart/dynamics/FreeJoint.hpp"
 #include "dart/dynamics/InverseKinematics.hpp"
+#include "dart/dynamics/MimicDofProperties.hpp"
 #include "dart/dynamics/PlanarJoint.hpp"
 #include "dart/dynamics/PrismaticJoint.hpp"
 #include "dart/dynamics/RevoluteJoint.hpp"
@@ -1224,6 +1225,124 @@ TEST_F(JOINTS, MIMIC_JOINT_UNBOUNDED_LIMITS_STAY_FINITE)
   const double finalError
       = std::abs(reference->getPosition(0) - follower->getPosition(0));
   EXPECT_LT(finalError, initialError);
+}
+
+//==============================================================================
+TEST_F(JOINTS, PARTIAL_MIMIC_JOINT)
+{
+  using namespace dart::math::suffixes;
+
+  auto world = simulation::World::create();
+  world->setGravity(Eigen::Vector3d::Zero());
+  world->setTimeStep(1e-3);
+
+  auto skeleton = Skeleton::create("partial_mimic");
+  auto leaderPair = skeleton->createJointAndBodyNodePair<RevoluteJoint>();
+  auto leaderJoint = leaderPair.first;
+  auto followerPair
+      = skeleton->createJointAndBodyNodePair<UniversalJoint>(leaderPair.second);
+  auto followerJoint = followerPair.first;
+
+  leaderPair.second->setMass(1.0);
+  followerPair.second->setMass(1.0);
+
+  const double forceLimit = 1e5;
+  std::array<Joint*, 2> joints = {leaderJoint, followerJoint};
+  for (Joint* joint : joints) {
+    for (std::size_t i = 0; i < joint->getNumDofs(); ++i) {
+      joint->setDampingCoefficient(i, 0.0);
+      joint->setSpringStiffness(i, 0.0);
+      joint->setCoulombFriction(i, 0.0);
+      joint->setForceLowerLimit(i, -forceLimit);
+      joint->setForceUpperLimit(i, forceLimit);
+      joint->setVelocityLowerLimit(i, -forceLimit);
+      joint->setVelocityUpperLimit(i, forceLimit);
+    }
+  }
+
+  leaderJoint->setActuatorType(Joint::SERVO);
+  followerJoint->setActuatorType(Joint::SERVO);
+
+  MimicDofProperties mimicProps;
+  mimicProps.mReferenceJoint = leaderJoint;
+  mimicProps.mReferenceDofIndex = 0;
+  mimicProps.mMultiplier = 1.0;
+  mimicProps.mOffset = 0.0;
+  followerJoint->setMimicJointDof(1, mimicProps);
+  followerJoint->setActuatorType(1, Joint::MIMIC);
+
+  // The joint-wide getter/default path must remain SERVO (gz-physics
+  // compatibility), while only DoF 1 is overridden to MIMIC.
+  EXPECT_EQ(followerJoint->getActuatorType(), Joint::SERVO);
+  EXPECT_EQ(followerJoint->getActuatorType(0), Joint::SERVO);
+  EXPECT_EQ(followerJoint->getActuatorType(1), Joint::MIMIC);
+  EXPECT_TRUE(followerJoint->hasActuatorType(Joint::MIMIC));
+  EXPECT_TRUE(followerJoint->hasActuatorType(Joint::SERVO));
+
+  world->addSkeleton(skeleton);
+
+#if DART_BUILD_MODE_DEBUG
+  const std::size_t numSteps = 400;
+#else
+  const std::size_t numSteps = 2000;
+#endif
+  const double followerCommand = 0.25;
+  const double tolVel = 1e-3;
+  const double tolPos = 5e-3;
+
+  for (std::size_t i = 0; i < numSteps; ++i) {
+    const double leaderCommand = std::sin(world->getTime());
+
+    leaderJoint->setCommand(0, leaderCommand);
+    followerJoint->setCommand(0, followerCommand);
+
+    world->step();
+
+    EXPECT_NEAR(leaderJoint->getVelocity(0), leaderCommand, tolVel);
+    EXPECT_NEAR(followerJoint->getVelocity(0), followerCommand, tolVel);
+
+    if (i > numSteps / 5) {
+      EXPECT_NEAR(
+          followerJoint->getPosition(1), leaderJoint->getPosition(0), tolPos);
+    }
+  }
+}
+
+//==============================================================================
+TEST_F(JOINTS, PARTIAL_MIMIC_JOINT_WIDE_PATH_UNCHANGED)
+{
+  // Verify that the joint-wide actuator API is byte-for-byte unaffected by the
+  // per-DoF additions: setting the joint-wide type maps uniformly to every DoF
+  // and clears any per-DoF overrides, preserving the pre-existing semantics
+  // that gz-physics/Gazebo rely on.
+  auto skeleton = Skeleton::create("joint_wide");
+  auto pair = skeleton->createJointAndBodyNodePair<UniversalJoint>();
+  auto* joint = pair.first;
+
+  // Default joint-wide type applies to all DoFs.
+  EXPECT_EQ(joint->getActuatorType(0), joint->getActuatorType());
+  EXPECT_EQ(joint->getActuatorType(1), joint->getActuatorType());
+
+  joint->setActuatorType(Joint::SERVO);
+  EXPECT_EQ(joint->getActuatorType(), Joint::SERVO);
+  EXPECT_EQ(joint->getActuatorType(0), Joint::SERVO);
+  EXPECT_EQ(joint->getActuatorType(1), Joint::SERVO);
+  EXPECT_FALSE(joint->hasActuatorType(Joint::MIMIC));
+
+  // Add a per-DoF override, then re-apply the joint-wide setter; the override
+  // must be cleared so behavior matches the legacy joint-wide-only API.
+  MimicDofProperties mimicProps;
+  mimicProps.mReferenceJoint = joint;
+  mimicProps.mReferenceDofIndex = 0;
+  joint->setMimicJointDof(1, mimicProps);
+  joint->setActuatorType(1, Joint::MIMIC);
+  EXPECT_EQ(joint->getActuatorType(1), Joint::MIMIC);
+
+  joint->setActuatorType(Joint::FORCE);
+  EXPECT_EQ(joint->getActuatorType(), Joint::FORCE);
+  EXPECT_EQ(joint->getActuatorType(0), Joint::FORCE);
+  EXPECT_EQ(joint->getActuatorType(1), Joint::FORCE);
+  EXPECT_FALSE(joint->hasActuatorType(Joint::MIMIC));
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary
Additive backport of #2222 — per-DoF actuator type API (`setActuatorType(index,type)`, `setActuatorTypes(vector)`, `getActuatorType(index)`, `hasActuatorType()`) alongside the existing joint-wide API, so individual DoFs of a multi-DoF joint can be MIMIC/SERVO/etc.

## gz backward-compat (additive / opt-in)
The per-DoF map **defaults to the joint-wide `mActuatorType`**; the no-arg `getActuatorType()` / `setActuatorType(ActuatorType)` keep exact semantics; a joint that never touches the per-DoF API behaves identically. Verified by the added `PARTIAL_MIMIC_JOINT_WIDE_PATH_UNCHANGED` guard test + 3 pre-existing mimic tests. gz-physics (joint-wide actuator types only) is byte-for-byte unaffected. The coupler-constraint path (absent on 6.20) was deliberately omitted. Full `pixi run -e gazebo test-gz` verification pending on the combined feature branch.

## Testing
- `test_Joints` 27/27, `test_GenericJoints` 8/8, `test_ConstraintSolver` 20/20, `test_JointForceTorque` 3/3. dartpy builds + smoke OK.

## DART 6 adaptations
- `std::span` → `const std::vector<ActuatorType>&`; nanobind → pybind11.

## Breaking Changes
- [x] None