### PR TITLE
Backport WorldConfig + collision-detector selection to release-6.20 (#2168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,17 @@
 
 * Simulation
 
+  * Added `dart::simulation::WorldConfig`, the `CollisionDetectorType` enum,
+    `World::setCollisionDetector(CollisionDetectorType)` /
+    `World::setCollisionDetector(CollisionDetectorPtr)` /
+    `World::getCollisionDetector()`, and corresponding dartpy bindings so users
+    can switch collision detectors (FCL, Bullet, ODE, DART) without reaching
+    into the constraint solver internals. The additions are opt-in: the default
+    `World` construction path keeps the existing default detector (FCL with
+    `PRIMITIVE` shapes) unchanged, and the pre-existing
+    `ConstraintSolver::setCollisionDetector(...)` API is untouched:
+    [#2168](https://github.com/dartsim/dart/pull/2168)
+
   * Harden contact handling against invalid geometry, fixing a crash reported
     through gz-physics. `BoxShape`, `CylinderShape`, `CapsuleShape`,
     `EllipsoidShape`, `ConeShape`, and `PyramidShape` now reject non-finite

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -38,11 +38,15 @@
 
 #include "dart/simulation/World.hpp"
 
+#include "dart/collision/CollisionDetector.hpp"
 #include "dart/collision/CollisionFilter.hpp"
 #include "dart/collision/CollisionGroup.hpp"
+#include "dart/collision/fcl/FCLCollisionDetector.hpp"
 #include "dart/common/Console.hpp"
+#include "dart/common/Logging.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/common/Profile.hpp"
+#include "dart/common/String.hpp"
 #include "dart/constraint/BoxedLcpConstraintSolver.hpp"
 #include "dart/constraint/ConstrainedGroup.hpp"
 #include "dart/dynamics/DegreeOfFreedom.hpp"
@@ -64,6 +68,87 @@
 
 namespace dart {
 namespace simulation {
+
+namespace {
+
+using dart::collision::CollisionDetector;
+using dart::collision::CollisionDetectorPtr;
+
+std::string toCollisionDetectorKey(CollisionDetectorType type)
+{
+  switch (type) {
+    case CollisionDetectorType::Dart:
+      return "dart";
+    case CollisionDetectorType::Fcl:
+      return "fcl";
+    case CollisionDetectorType::Bullet:
+      return "bullet";
+    case CollisionDetectorType::Ode:
+      return "ode";
+  }
+
+  DART_FATAL(
+      "Encountered unsupported CollisionDetectorType value: {}.",
+      static_cast<int>(type));
+  return "fcl";
+}
+
+CollisionDetectorPtr tryCreateCollisionDetector(const std::string& requestedKey)
+{
+  if (requestedKey.empty())
+    return nullptr;
+
+  auto key = common::toLower(requestedKey);
+
+  auto* factory = CollisionDetector::getFactory();
+  DART_ASSERT(factory);
+  if (!factory->canCreate(key))
+    return nullptr;
+
+  auto detector = factory->create(key);
+  if (!detector) {
+    DART_WARN(
+        "Failed to create collision detector '{}' even though the factory "
+        "reported it was available.",
+        key);
+  }
+
+  return detector;
+}
+
+CollisionDetectorPtr tryCreateCollisionDetector(CollisionDetectorType type)
+{
+  return tryCreateCollisionDetector(toCollisionDetectorKey(type));
+}
+
+// Resolves a collision detector for a World constructed from a WorldConfig.
+//
+// Returns nullptr when the requested detector is the default 'fcl' backend so
+// the World keeps the constraint solver's existing default detector untouched.
+// This keeps the default World construction path byte-for-byte equivalent to
+// the pre-WorldConfig behavior (FCL with PRIMITIVE shapes), which downstream
+// consumers such as gz-physics rely on. Only an explicitly non-default request
+// triggers a detector swap.
+CollisionDetectorPtr resolveCollisionDetector(const WorldConfig& config)
+{
+  const auto requestedType = config.collisionDetector;
+
+  // Default request: leave the constraint solver's default detector in place.
+  if (requestedType == CollisionDetectorType::Fcl)
+    return nullptr;
+
+  const auto requestedKey = toCollisionDetectorKey(requestedType);
+  if (auto detector = tryCreateCollisionDetector(requestedType))
+    return detector;
+
+  DART_WARN(
+      "WorldConfig requested collision detector '{}', but it is not "
+      "available. Keeping the world's default collision detector.",
+      requestedKey);
+  return nullptr;
+}
+
+} // namespace
 
 //==============================================================================
 static bool hasNonzeroGeneralizedVelocity(const dynamics::Skeleton& skel)
@@ -276,10 +361,19 @@ std::shared_ptr<World> World::create(const std::string& name)
 }
 
 //==============================================================================
-World::World(const std::string& _name)
-  : mName(_name),
-    mNameMgrForSkeletons("World::Skeleton | " + _name, "skeleton"),
-    mNameMgrForSimpleFrames("World::SimpleFrame | " + _name, "frame"),
+std::shared_ptr<World> World::create(const WorldConfig& config)
+{
+  return std::make_shared<World>(config);
+}
+
+//==============================================================================
+World::World(const std::string& _name) : World(WorldConfig(_name)) {}
+
+//==============================================================================
+World::World(const WorldConfig& config)
+  : mName(config.name),
+    mNameMgrForSkeletons("World::Skeleton | " + config.name, "skeleton"),
+    mNameMgrForSimpleFrames("World::SimpleFrame | " + config.name, "frame"),
     mGravity(0.0, 0.0, -9.81),
     mTimeStep(0.001),
     mTime(0.0),
@@ -291,6 +385,12 @@ World::World(const std::string& _name)
 
   auto solver = std::make_unique<constraint::BoxedLcpConstraintSolver>();
   setConstraintSolver(std::move(solver));
+
+  // Only swap the collision detector when a non-default backend is requested.
+  // The default 'fcl' request resolves to nullptr so the constraint solver's
+  // default detector (FCL with PRIMITIVE shapes) is preserved unchanged.
+  if (auto detector = resolveCollisionDetector(config))
+    setCollisionDetector(detector);
 }
 
 //==============================================================================
@@ -316,8 +416,9 @@ WorldPtr World::clone() const
   worldClone->setNumSimulationThreads(mNumSimulationThreads);
 
   auto cd = getConstraintSolver()->getCollisionDetector();
-  worldClone->getConstraintSolver()->setCollisionDetector(
-      cd->cloneWithoutCollisionObjects());
+  if (cd) {
+    worldClone->setCollisionDetector(cd->cloneWithoutCollisionObjects());
+  }
 
   // Clone and add each Skeleton
   for (std::size_t i = 0; i < mSkeletons.size(); ++i) {
@@ -1717,6 +1818,49 @@ bool World::checkCollision(
 const collision::CollisionResult& World::getLastCollisionResult() const
 {
   return mConstraintSolver->getLastCollisionResult();
+}
+
+//==============================================================================
+void World::setCollisionDetector(
+    const collision::CollisionDetectorPtr& collisionDetector)
+{
+  if (!collisionDetector) {
+    DART_WARN(
+        "Attempted to assign a null collision detector to world '{}'.", mName);
+    return;
+  }
+
+  mConstraintSolver->setCollisionDetector(collisionDetector);
+}
+
+//==============================================================================
+void World::setCollisionDetector(CollisionDetectorType collisionDetector)
+{
+  auto detector = tryCreateCollisionDetector(collisionDetector);
+  if (!detector) {
+    auto current = mConstraintSolver->getCollisionDetector();
+    DART_WARN(
+        "Collision detector '{}' is not available for world '{}'. Keeping the "
+        "current detector '{}'.",
+        toCollisionDetectorKey(collisionDetector),
+        mName,
+        current ? current->getType() : "unknown");
+    return;
+  }
+
+  setCollisionDetector(detector);
+}
+
+//==============================================================================
+collision::CollisionDetectorPtr World::getCollisionDetector()
+{
+  return mConstraintSolver->getCollisionDetector();
+}
+
+//==============================================================================
+collision::ConstCollisionDetectorPtr World::getCollisionDetector() const
+{
+  return mConstraintSolver->getCollisionDetector();
 }
 
 //==============================================================================

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -46,6 +46,7 @@
 #include <dart/constraint/SmartPointer.hpp>
 
 #include <dart/collision/CollisionOption.hpp>
+#include <dart/collision/SmartPointer.hpp>
 
 #include <dart/dynamics/SimpleFrame.hpp>
 #include <dart/dynamics/Skeleton.hpp>
@@ -59,6 +60,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace dart {
@@ -78,6 +80,28 @@ class CollisionResult;
 } // namespace collision
 
 namespace simulation {
+
+/// Available collision detector backends for a World.
+enum class CollisionDetectorType
+{
+  Dart,
+  Fcl,
+  Bullet,
+  Ode,
+};
+
+/// Configuration bundle used when constructing a World.
+struct WorldConfig final
+{
+  /// Friendly name for the world.
+  std::string name = "world";
+
+  /// Preferred collision detector for the world.
+  CollisionDetectorType collisionDetector = CollisionDetectorType::Fcl;
+
+  WorldConfig() = default;
+  explicit WorldConfig(std::string worldName) : name(std::move(worldName)) {}
+};
 
 DART_COMMON_DECLARE_SHARED_WEAK(World)
 
@@ -102,8 +126,14 @@ public:
   /// Creates a World
   static std::shared_ptr<World> create(const std::string& name = "world");
 
+  /// Creates a World using a configuration bundle.
+  static std::shared_ptr<World> create(const WorldConfig& config);
+
   /// Constructor
   World(const std::string& _name = "world");
+
+  /// Constructor with configuration bundle
+  explicit World(const WorldConfig& config);
 
   /// Destructor
   virtual ~World();
@@ -227,6 +257,19 @@ public:
   /// that this function does not return the collision checking result of
   /// World::checkCollision().
   const collision::CollisionResult& getLastCollisionResult() const;
+
+  /// Sets the collision detector used by the world's constraint solver.
+  void setCollisionDetector(
+      const collision::CollisionDetectorPtr& collisionDetector);
+
+  /// Sets the collision detector via a typed backend selection.
+  void setCollisionDetector(CollisionDetectorType collisionDetector);
+
+  /// Returns the collision detector used by the world.
+  collision::CollisionDetectorPtr getCollisionDetector();
+
+  /// Returns the collision detector used by the world (const).
+  collision::ConstCollisionDetectorPtr getCollisionDetector() const;
 
   //--------------------------------------------------------------------------
   // Simulation

--- a/python/dartpy/simulation/World.cpp
+++ b/python/dartpy/simulation/World.cpp
@@ -44,6 +44,14 @@ namespace python {
 
 void World(py::module& m)
 {
+  ::py::enum_<dart::simulation::CollisionDetectorType>(
+      m, "CollisionDetectorType")
+      .value("DART", dart::simulation::CollisionDetectorType::Dart)
+      .value("FCL", dart::simulation::CollisionDetectorType::Fcl)
+      .value("BULLET", dart::simulation::CollisionDetectorType::Bullet)
+      .value("ODE", dart::simulation::CollisionDetectorType::Ode)
+      .export_values();
+
   ::py::class_<
       dart::simulation::World,
       std::shared_ptr<dart::simulation::World>>(m, "World")
@@ -233,6 +241,26 @@ void World(py::module& m)
           +[](dart::simulation::World* self)
               -> const collision::CollisionResult& {
             return self->getLastCollisionResult();
+          })
+      .def(
+          "setCollisionDetector",
+          +[](dart::simulation::World* self,
+              const collision::CollisionDetectorPtr& detector) {
+            self->setCollisionDetector(detector);
+          },
+          ::py::arg("collisionDetector"))
+      .def(
+          "setCollisionDetector",
+          +[](dart::simulation::World* self,
+              dart::simulation::CollisionDetectorType type) {
+            self->setCollisionDetector(type);
+          },
+          ::py::arg("collisionDetectorType"))
+      .def(
+          "getCollisionDetector",
+          +[](dart::simulation::World* self)
+              -> dart::collision::CollisionDetectorPtr {
+            return self->getCollisionDetector();
           })
       .def(
           "reset",

--- a/tests/integration/test_World.cpp
+++ b/tests/integration/test_World.cpp
@@ -45,11 +45,14 @@
 #include <atomic>
 #include <chrono>
 #include <iostream>
+#include <string>
 #include <thread>
 #include <utility>
 #if HAVE_BULLET
   #include "dart/collision/bullet/bullet.hpp"
 #endif
+#include "dart/collision/dart/DARTCollisionDetector.hpp"
+#include "dart/collision/fcl/FCLCollisionDetector.hpp"
 #include "dart/constraint/BallJointConstraint.hpp"
 #include "dart/constraint/BoxedLcpConstraintSolver.hpp"
 #include "dart/constraint/DantzigBoxedLcpSolver.hpp"
@@ -60,6 +63,52 @@ using namespace dart;
 using namespace math;
 using namespace dynamics;
 using namespace simulation;
+
+namespace {
+
+class ScopedCollisionFactoryDisabler
+{
+public:
+  using Factory = collision::CollisionDetector::Factory;
+  using Creator = Factory::Creator;
+
+  ScopedCollisionFactoryDisabler(std::string key, Creator restorer)
+    : mFactory(collision::CollisionDetector::getFactory()),
+      mKey(std::move(key)),
+      mRestorer(std::move(restorer))
+  {
+    if (!mFactory || !mFactory->canCreate(mKey))
+      return;
+
+    mDisabled = true;
+    mFactory->unregisterCreator(mKey);
+  }
+
+  ScopedCollisionFactoryDisabler(const ScopedCollisionFactoryDisabler&)
+      = delete;
+  ScopedCollisionFactoryDisabler& operator=(
+      const ScopedCollisionFactoryDisabler&)
+      = delete;
+
+  ~ScopedCollisionFactoryDisabler()
+  {
+    if (mFactory && mDisabled && mRestorer)
+      mFactory->registerCreator(mKey, mRestorer);
+  }
+
+  bool wasDisabled() const
+  {
+    return mDisabled;
+  }
+
+private:
+  Factory* mFactory;
+  std::string mKey;
+  Creator mRestorer;
+  bool mDisabled{false};
+};
+
+} // namespace
 
 namespace {
 
@@ -384,11 +433,9 @@ TEST(World, ValidatingClones)
 
     // Set non default collision detector
 #if HAVE_BULLET
-    worlds.back()->getConstraintSolver()->setCollisionDetector(
-        collision::BulletCollisionDetector::create());
+    worlds.back()->setCollisionDetector(CollisionDetectorType::Bullet);
 #else
-    worlds.back()->getConstraintSolver()->setCollisionDetector(
-        collision::DARTCollisionDetector::create());
+    worlds.back()->setCollisionDetector(CollisionDetectorType::Dart);
 #endif
   }
 
@@ -399,9 +446,8 @@ TEST(World, ValidatingClones)
     for (std::size_t j = 1; j < 5; ++j) {
       clones.push_back(clones[j - 1]->clone());
 
-      auto originalCD = original->getConstraintSolver()->getCollisionDetector();
-      auto cloneCD
-          = clones.back()->getConstraintSolver()->getCollisionDetector();
+      auto originalCD = original->getCollisionDetector();
+      auto cloneCD = clones.back()->getCollisionDetector();
 
       std::string originalCDType = originalCD->getType();
       std::string cloneCDType = cloneCD->getType();
@@ -409,6 +455,130 @@ TEST(World, ValidatingClones)
       EXPECT_EQ(originalCDType, cloneCDType);
     }
   }
+}
+
+//==============================================================================
+TEST(World, SetCollisionDetectorByType)
+{
+  auto factory = collision::CollisionDetector::getFactory();
+  ASSERT_NE(factory, nullptr);
+
+  if (!factory->canCreate("dart"))
+    GTEST_SKIP() << "dart collision detector is not available in this build";
+
+  auto world = World::create();
+  world->setCollisionDetector(CollisionDetectorType::Dart);
+
+  ASSERT_TRUE(world->getCollisionDetector());
+  EXPECT_EQ(world->getCollisionDetector()->getType(), "dart");
+}
+
+//==============================================================================
+TEST(World, ConfiguresCollisionDetectorViaConfig)
+{
+  auto factory = collision::CollisionDetector::getFactory();
+  ASSERT_NE(factory, nullptr);
+
+  if (!factory->canCreate("dart"))
+    GTEST_SKIP() << "dart collision detector is not available in this build";
+
+  WorldConfig config;
+  config.name = "configured-world";
+  config.collisionDetector = CollisionDetectorType::Dart;
+  auto world = World::create(config);
+  ASSERT_TRUE(world->getCollisionDetector());
+  EXPECT_EQ(world->getCollisionDetector()->getType(), "dart");
+}
+
+//==============================================================================
+TEST(World, DefaultWorldUsesFclPrimitive)
+{
+  auto factory = collision::CollisionDetector::getFactory();
+  ASSERT_NE(factory, nullptr);
+
+  if (!factory->canCreate("fcl"))
+    GTEST_SKIP() << "fcl collision detector is not available in this build";
+
+  // The default World construction path must remain unchanged: it keeps the
+  // constraint solver's default FCL detector configured with PRIMITIVE shapes.
+  auto world = World::create();
+  auto fclDetector = std::dynamic_pointer_cast<collision::FCLCollisionDetector>(
+      world->getCollisionDetector());
+  ASSERT_TRUE(fclDetector);
+  EXPECT_EQ(
+      fclDetector->getPrimitiveShapeType(),
+      collision::FCLCollisionDetector::PRIMITIVE);
+}
+
+//==============================================================================
+TEST(World, TypedSetterToFclKeepsPrimitive)
+{
+  auto factory = collision::CollisionDetector::getFactory();
+  ASSERT_NE(factory, nullptr);
+
+  if (!factory->canCreate("fcl"))
+    GTEST_SKIP() << "fcl collision detector is not available in this build";
+
+  auto world = World::create();
+  world->setCollisionDetector(CollisionDetectorType::Dart);
+  world->setCollisionDetector(CollisionDetectorType::Fcl);
+
+  // The typed setter must produce a detector with the same default shape type
+  // as the rest of DART 6 (PRIMITIVE), not change the established default.
+  auto fclDetector = std::dynamic_pointer_cast<collision::FCLCollisionDetector>(
+      world->getCollisionDetector());
+  ASSERT_TRUE(fclDetector);
+  EXPECT_EQ(
+      fclDetector->getPrimitiveShapeType(),
+      collision::FCLCollisionDetector::PRIMITIVE);
+}
+
+//==============================================================================
+TEST(World, TypedSetterKeepsCurrentWhenDetectorUnavailable)
+{
+  ScopedCollisionFactoryDisabler disableDart(
+      collision::DARTCollisionDetector::getStaticType(),
+      []() -> collision::CollisionDetectorPtr {
+        return collision::DARTCollisionDetector::create();
+      });
+
+  if (!disableDart.wasDisabled())
+    GTEST_SKIP() << "dart collision detector is not registered in this build";
+
+  auto world = World::create();
+  auto original = world->getCollisionDetector();
+  ASSERT_TRUE(original);
+
+  world->setCollisionDetector(CollisionDetectorType::Dart);
+
+  auto current = world->getCollisionDetector();
+  ASSERT_TRUE(current);
+  EXPECT_EQ(current->getType(), original->getType());
+}
+
+//==============================================================================
+TEST(World, ConfigKeepsDefaultWhenPreferredDetectorUnavailable)
+{
+  ScopedCollisionFactoryDisabler disableDart(
+      collision::DARTCollisionDetector::getStaticType(),
+      []() -> collision::CollisionDetectorPtr {
+        return collision::DARTCollisionDetector::create();
+      });
+
+  if (!disableDart.wasDisabled())
+    GTEST_SKIP() << "dart collision detector is not registered in this build";
+
+  WorldConfig config;
+  config.name = "fallback-pref";
+  config.collisionDetector = CollisionDetectorType::Dart;
+
+  // When the preferred detector is unavailable, the World keeps the constraint
+  // solver's existing default detector (FCL), unchanged.
+  auto world = World::create(config);
+  ASSERT_TRUE(world->getCollisionDetector());
+  EXPECT_EQ(
+      world->getCollisionDetector()->getType(),
+      collision::FCLCollisionDetector::getStaticType());
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary
Additive backport of #2168 — adds `CollisionDetectorType` enum, `WorldConfig`, and `World::setCollisionDetector(CollisionDetectorType)` convenience overload on the classic World.

## gz backward-compat (additive / opt-in)
`ConstraintSolver` is **not touched** — the existing `setCollisionDetector(CollisionDetectorPtr)` path gz-physics uses is byte-for-byte intact. **Default World construction is unchanged**: unlike DART 7 (which forces FCL→MESH), this keeps DART 6's default FCL **PRIMITIVE** detector by making the default `Fcl` request a no-op swap (verified by `DefaultWorldUsesFclPrimitive`). Backend selection is purely opt-in via `WorldConfig`/the typed setter; an unavailable backend keeps the current detector. Full `test-gz` verification pending on the combined feature branch.

## Testing
- `test_World` 13/13 (incl. 6 new). dartpy binding compiles. (Env had only FCL registered, so the factory-unavailable fallback paths ran live.)

## DART 6 adaptations
- Preserves FCL PRIMITIVE default (dropped DART-7 MESH override); non-deprecated `ConstraintSolver` overloads; pybind11.

## Breaking Changes
- [x] None