### PR TITLE
Backport ShapeNode inertia coverage to release-6.20 (#2170)

### DIFF
--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -37,6 +37,7 @@
 
 #include <dart/dynamics/EndEffector.hpp>
 #include <dart/dynamics/Frame.hpp>
+#include <dart/dynamics/Inertia.hpp>
 #include <dart/dynamics/Marker.hpp>
 #include <dart/dynamics/Node.hpp>
 #include <dart/dynamics/SmartPointer.hpp>
@@ -53,6 +54,7 @@
 #include <Eigen/Dense>
 #include <Eigen/StdVector>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -213,6 +215,12 @@ public:
 
   /// Get the inertia data for this BodyNode
   const Inertia& getInertia() const;
+
+  /// Sum transformed inertias of all ShapeNodes using the provided mass
+  /// provider. The callable should return an optional mass for each ShapeNode.
+  template <typename MassProvider>
+  std::optional<Inertia> computeInertiaFromShapeNodes(
+      MassProvider&& massProvider) const;
 
   /// Return the articulated body inertia
   const math::Inertia& getArticulatedInertia() const;

--- a/dart/dynamics/Inertia.cpp
+++ b/dart/dynamics/Inertia.cpp
@@ -252,6 +252,22 @@ const Eigen::Matrix6d& Inertia::getSpatialTensor() const
 }
 
 //==============================================================================
+Inertia Inertia::transformed(const Eigen::Isometry3d& transform) const
+{
+  const Eigen::Matrix6d adjoint = math::getAdTMatrix(transform.inverse());
+  return Inertia(adjoint.transpose() * getSpatialTensor() * adjoint);
+}
+
+//==============================================================================
+Inertia& Inertia::transform(const Eigen::Isometry3d& transform)
+{
+  const Eigen::Matrix6d adjoint = math::getAdTMatrix(transform.inverse());
+  mSpatialTensor = adjoint.transpose() * mSpatialTensor * adjoint;
+  computeParameters();
+  return *this;
+}
+
+//==============================================================================
 bool Inertia::verifyMoment(
     const Eigen::Matrix3d& _moment, bool _printWarnings, double _tolerance)
 {

--- a/dart/dynamics/Inertia.hpp
+++ b/dart/dynamics/Inertia.hpp
@@ -128,6 +128,15 @@ public:
   /// Get the spatial inertia tensor
   const Eigen::Matrix6d& getSpatialTensor() const;
 
+  /// Return a copy of this inertia expressed in the frame reached by applying
+  /// @f$transform@f$ to the current frame. The transform should be the
+  /// relative transform from the current frame to the target frame.
+  Inertia transformed(const Eigen::Isometry3d& transform) const;
+
+  /// Transform this inertia in place using the provided current-to-target
+  /// transform.
+  Inertia& transform(const Eigen::Isometry3d& transform);
+
   /// Returns true iff _moment is a physically valid moment of inertia
   static bool verifyMoment(
       const Eigen::Matrix3d& _moment,

--- a/dart/dynamics/ShapeNode.cpp
+++ b/dart/dynamics/ShapeNode.cpp
@@ -33,6 +33,7 @@
 #include "dart/dynamics/ShapeNode.hpp"
 
 #include "dart/dynamics/BodyNode.hpp"
+#include "dart/math/Geometry.hpp"
 
 namespace dart {
 namespace dynamics {
@@ -133,6 +134,25 @@ Eigen::Vector3d ShapeNode::getRelativeTranslation() const
 Eigen::Vector3d ShapeNode::getOffset() const
 {
   return getRelativeTranslation();
+}
+
+//==============================================================================
+Inertia ShapeNode::computeTransformedInertia(double mass) const
+{
+  DART_ASSERT(getShape() != nullptr);
+
+  const Eigen::Matrix3d localMoment = getShape()->computeInertia(mass);
+  const Inertia local(mass, Eigen::Vector3d::Zero(), localMoment);
+  const math::Inertia transformedSpatial = math::transformInertia(
+      getRelativeTransform().inverse(), local.getSpatialTensor());
+
+  return Inertia(transformedSpatial);
+}
+
+//==============================================================================
+Inertia ShapeNode::computeTransformedInertiaFromDensity(double density) const
+{
+  return computeTransformedInertia(density * getShape()->getVolume());
 }
 
 //==============================================================================

--- a/dart/dynamics/ShapeNode.hpp
+++ b/dart/dynamics/ShapeNode.hpp
@@ -33,6 +33,7 @@
 #ifndef DART_DYNAMICS_SHAPENODE_HPP_
 #define DART_DYNAMICS_SHAPENODE_HPP_
 
+#include <dart/dynamics/Inertia.hpp>
 #include <dart/dynamics/detail/ShapeNode.hpp>
 
 #include <dart/common/Signal.hpp>
@@ -104,6 +105,12 @@ public:
 
   /// Same as getRelativeTranslation()
   Eigen::Vector3d getOffset() const;
+
+  /// Compute the inertia of this Shape expressed in the parent body frame.
+  dynamics::Inertia computeTransformedInertia(double mass) const;
+
+  /// Same as computeTransformedInertia but accepts density.
+  dynamics::Inertia computeTransformedInertiaFromDensity(double density) const;
 
   // Documentation inherited
   ShapeNode* asShapeNode() override;

--- a/dart/dynamics/detail/BodyNode.hpp
+++ b/dart/dynamics/detail/BodyNode.hpp
@@ -338,6 +338,34 @@ void BodyNode::eachShapeNodeWith(Func func)
   }
 }
 
+//==============================================================================
+template <typename MassProvider>
+std::optional<Inertia> BodyNode::computeInertiaFromShapeNodes(
+    MassProvider&& massProvider) const
+{
+  Eigen::Matrix6d total = Eigen::Matrix6d::Zero();
+  bool used = false;
+
+  for (auto i = 0u; i < getNumShapeNodes(); ++i) {
+    const ShapeNode* shapeNode = getShapeNode(i);
+    auto maybeMass = massProvider(shapeNode);
+    if (!maybeMass.has_value())
+      continue;
+    const double mass = *maybeMass;
+    if (mass <= 0.0)
+      continue;
+
+    const Inertia transformed = shapeNode->computeTransformedInertia(mass);
+    total += transformed.getSpatialTensor();
+    used = true;
+  }
+
+  if (!used)
+    return std::nullopt;
+
+  return Inertia(total);
+}
+
 } // namespace dynamics
 } // namespace dart
 

--- a/dart/utils/SkelParser.cpp
+++ b/dart/utils/SkelParser.cpp
@@ -68,6 +68,7 @@
 #include "dart/dynamics/TranslationalJoint2D.hpp"
 #include "dart/dynamics/UniversalJoint.hpp"
 #include "dart/dynamics/WeldJoint.hpp"
+#include "dart/math/Geometry.hpp"
 #include "dart/utils/CompositeResourceRetriever.hpp"
 #include "dart/utils/DartResourceRetriever.hpp"
 #include "dart/utils/XmlHelpers.hpp"
@@ -76,8 +77,11 @@
 #include <Eigen/StdVector>
 
 #include <algorithm>
+#include <optional>
+#include <unordered_map>
 #include <vector>
 
+#include <cmath>
 #include <cstddef>
 
 namespace dart {
@@ -128,6 +132,75 @@ using IndexToJoint = std::map<std::size_t, std::string>;
 
 // first: Child BodyNode name | second: Order that Joint appears in file
 using JointToIndex = std::map<std::string, std::size_t>;
+
+bool isSoftMeshShape(const dynamics::Shape* shape)
+{
+  return shape && shape->getType() == dynamics::SoftMeshShape::getStaticType();
+}
+
+std::vector<dynamics::ShapeNode*> collectRigidShapeNodes(
+    dynamics::BodyNode* bodyNode)
+{
+  std::vector<dynamics::ShapeNode*> shapes;
+  const auto count = bodyNode->getNumShapeNodes();
+  shapes.reserve(count);
+
+  for (auto i = 0u; i < count; ++i) {
+    auto* shapeNode = bodyNode->getShapeNode(i);
+    if (shapeNode == nullptr || isSoftMeshShape(shapeNode->getShape().get()))
+      continue;
+    shapes.push_back(shapeNode);
+  }
+
+  return shapes;
+}
+
+bool setInertiaFromShapeNodes(dynamics::BodyNode* bodyNode)
+{
+  const double bodyMass = bodyNode->getMass();
+  if (bodyMass <= 0.0)
+    return false;
+
+  const auto shapeNodes = collectRigidShapeNodes(bodyNode);
+  if (shapeNodes.empty())
+    return false;
+
+  std::unordered_map<const dynamics::ShapeNode*, double> weights;
+  double totalWeight = 0.0;
+
+  for (const auto* shapeNode : shapeNodes) {
+    double weight = shapeNode->getShape()->getVolume();
+    if (!std::isfinite(weight) || weight <= 0.0)
+      weight = 1.0;
+    weights[shapeNode] = weight;
+    totalWeight += weight;
+  }
+
+  if (totalWeight <= 0.0)
+    totalWeight = static_cast<double>(weights.size());
+
+  const auto composite = bodyNode->computeInertiaFromShapeNodes(
+      [&](const dynamics::ShapeNode* shapeNode) -> std::optional<double> {
+        const auto it = weights.find(shapeNode);
+        if (it == weights.end())
+          return std::nullopt;
+        return bodyMass * (it->second / totalWeight);
+      });
+
+  if (!composite.has_value())
+    return false;
+
+  Eigen::Matrix3d moment = composite->getMoment();
+  const Eigen::Vector3d desiredCom = bodyNode->getInertia().getLocalCOM();
+  const Eigen::Vector3d delta = composite->getLocalCOM() - desiredCom;
+  if (!delta.isZero(1e-12))
+    moment = math::parallelAxisTheorem(moment, delta, bodyMass);
+
+  auto inertia = bodyNode->getInertia();
+  inertia.setMoment(moment);
+  bodyNode->setInertia(inertia);
+  return true;
+}
 
 simulation::WorldPtr readWorld(
     tinyxml2::XMLElement* _worldElement,
@@ -609,27 +682,8 @@ void readAspects(
     if (hasElement(bodyElement, "inertia")) {
       tinyxml2::XMLElement* inertiaElement = getElement(bodyElement, "inertia");
 
-      if (!hasElement(inertiaElement, "moment_of_inertia")) {
-        bodyNode->eachShapeNode(
-            [bodyNode](dynamics::ShapeNode* shapeNode) -> bool {
-              const auto& shapeType = shapeNode->getShape()->getType();
-              if (dynamics::SoftMeshShape::getStaticType() == shapeType)
-                return true;
-
-              auto mass = bodyNode->getMass();
-              const Eigen::Matrix3d Ic
-                  = shapeNode->getShape()->computeInertia(mass);
-              auto inertia = bodyNode->getInertia();
-              inertia.setMoment(Ic);
-              bodyNode->setInertia(inertia);
-
-              // TODO(JS): We use the inertia of the first non-soft mesh shape
-              // in a body for the body's inertia when not specified. We might
-              // want to use the summation of all the shapes' inertia instead.
-
-              return false;
-            });
-      }
+      if (!hasElement(inertiaElement, "moment_of_inertia"))
+        setInertiaFromShapeNodes(bodyNode);
     }
   }
 }

--- a/dart/utils/VskParser.cpp
+++ b/dart/utils/VskParser.cpp
@@ -33,11 +33,13 @@
 #include "dart/utils/VskParser.hpp"
 
 #include "dart/common/Macros.hpp"
+#include "dart/math/Geometry.hpp"
 
 // Standard Library
 #include <Eigen/Dense>
 
 #include <map>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 
@@ -905,28 +907,38 @@ void generateShapes(const dynamics::SkeletonPtr& skel, VskData& vskData)
   for (std::size_t i = 0; i < skel->getNumBodyNodes(); ++i) {
     dynamics::BodyNode* bodyNode = skel->getBodyNode(i);
 
+    const auto composite = bodyNode->computeInertiaFromShapeNodes(
+        [&](const dynamics::ShapeNode* shapeNode) -> std::optional<double> {
+          const auto shape = shapeNode->getShape();
+          if (!shape)
+            return std::nullopt;
+          const double mass = density * shape->getVolume();
+          if (mass <= 0.0)
+            return std::nullopt;
+          return mass;
+        });
+
+    Eigen::Matrix6d spatial = Eigen::Matrix6d::Zero();
     double totalMass = 0.0;
-    Eigen::Matrix3d totalMoi = Eigen::Matrix3d::Zero();
-    auto numShapeNodes = bodyNode->getNumNodes<dynamics::ShapeNode>();
-
-    for (auto j = 0u; j < numShapeNodes; ++j) {
-      auto shapeNode = bodyNode->getNode<dynamics::ShapeNode>(j);
-      auto shape = shapeNode->getShape();
-      const double mass = density * shape->getVolume();
-      const Eigen::Isometry3d& localTf = shapeNode->getRelativeTransform();
-      const Eigen::Matrix3d moi = shape->computeInertia(mass);
-
-      totalMass += mass;
-      totalMoi += math::parallelAxisTheorem(moi, localTf.translation(), mass);
-      // TODO(JS): We should take the orientation of the inertia into account,
-      // but Inertia class doens't support it for now. See #234.
+    if (composite.has_value()) {
+      spatial = composite->getSpatialTensor();
+      totalMass = composite->getMass();
     }
 
-    if (bodyNode->getMass() > 1e-5) {
+    if (bodyNode->getMass() > 1e-5 && totalMass > 0.0) {
       const double givenMass = bodyNode->getMass();
       const double ratio = givenMass / totalMass;
+      spatial *= ratio;
       totalMass = givenMass;
-      totalMoi *= ratio;
+    }
+
+    Eigen::Matrix3d totalMoi = Eigen::Matrix3d::Zero();
+    if (totalMass > 0.0) {
+      const dynamics::Inertia combined(spatial);
+      totalMoi = combined.getMoment();
+      const Eigen::Vector3d com = combined.getLocalCOM();
+      if (!com.isZero(1e-12))
+        totalMoi = math::parallelAxisTheorem(totalMoi, com, totalMass);
     }
 
     if (totalMass <= 0.0 || totalMoi.diagonal().norm() <= 0.0) {

--- a/python/dartpy/dynamics/Inertia.cpp
+++ b/python/dartpy/dynamics/Inertia.cpp
@@ -106,6 +106,21 @@ void Inertia(py::module& m)
           },
           ::py::return_value_policy::reference_internal)
       .def(
+          "transformed",
+          +[](const dart::dynamics::Inertia* self,
+              const Eigen::Isometry3d& transform) {
+            return self->transformed(transform);
+          },
+          ::py::arg("transform"))
+      .def(
+          "transform",
+          +[](dart::dynamics::Inertia* self,
+              const Eigen::Isometry3d& transform) -> dart::dynamics::Inertia& {
+            return self->transform(transform);
+          },
+          ::py::arg("transform"),
+          ::py::return_value_policy::reference_internal)
+      .def(
           "verify",
           +[](const dart::dynamics::Inertia* self,
               bool printWarnings,

--- a/python/dartpy/dynamics/ShapeNode.cpp
+++ b/python/dartpy/dynamics/ShapeNode.cpp
@@ -109,7 +109,21 @@ void ShapeNode(py::module& m)
           "getOffset",
           +[](const dart::dynamics::ShapeNode* self) -> Eigen::Vector3d {
             return self->getOffset();
-          });
+          })
+      .def(
+          "computeTransformedInertia",
+          +[](const dart::dynamics::ShapeNode* self,
+              double mass) -> dart::dynamics::Inertia {
+            return self->computeTransformedInertia(mass);
+          },
+          ::py::arg("mass"))
+      .def(
+          "computeTransformedInertiaFromDensity",
+          +[](const dart::dynamics::ShapeNode* self,
+              double density) -> dart::dynamics::Inertia {
+            return self->computeTransformedInertiaFromDensity(density);
+          },
+          ::py::arg("density"));
 }
 
 } // namespace python

--- a/tests/unit/dynamics/test_Inertia.cpp
+++ b/tests/unit/dynamics/test_Inertia.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/Inertia.hpp>
+
+#include <dart/math/Geometry.hpp>
+#include <dart/math/Random.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace dart;
+
+//==============================================================================
+TEST(Inertia, Transformations)
+{
+  const int numIter = 25;
+  const double tol = 1e-9;
+
+  for (int i = 0; i < numIter; ++i) {
+    const auto mass = math::Random::uniform<double>(0.1, 10.0);
+    const auto com = math::Random::uniform<Eigen::Vector3d>(-1.0, 1.0);
+    const auto moment
+        = Eigen::Matrix3d::Identity() * math::Random::uniform<double>(0.1, 2.0);
+    dynamics::Inertia inertia(mass, com, moment);
+
+    Eigen::Vector3d axis = math::Random::uniform<Eigen::Vector3d>(-1.0, 1.0);
+    if (axis.norm() < 1e-6)
+      axis = Eigen::Vector3d::UnitX();
+    axis.normalize();
+    const double angle = math::Random::uniform<double>(-3.14, 3.14);
+    Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
+    T.linear() = Eigen::AngleAxisd(angle, axis).toRotationMatrix();
+    T.translation() = math::Random::uniform<Eigen::Vector3d>(-0.5, 0.5);
+
+    const dynamics::Inertia transformed = inertia.transformed(T);
+    dynamics::Inertia inPlace = inertia;
+    dynamics::Inertia& inPlaceRef = inPlace.transform(T);
+    EXPECT_EQ(&inPlaceRef, &inPlace);
+
+    const Eigen::Matrix6d adjoint = math::getAdTMatrix(T.inverse());
+    const Eigen::Matrix6d expected
+        = adjoint.transpose() * inertia.getSpatialTensor() * adjoint;
+    EXPECT_TRUE(expected.isApprox(transformed.getSpatialTensor(), tol));
+    EXPECT_TRUE(expected.isApprox(inPlace.getSpatialTensor(), tol));
+    EXPECT_NEAR(transformed.getMass(), inertia.getMass(), tol);
+    EXPECT_NEAR(inPlace.getMass(), inertia.getMass(), tol);
+
+    const Eigen::Vector3d expectedCom
+        = T.linear() * inertia.getLocalCOM() + T.translation();
+    EXPECT_TRUE(transformed.getLocalCOM().isApprox(expectedCom, tol));
+    EXPECT_TRUE(inPlace.getLocalCOM().isApprox(expectedCom, tol));
+
+    const dynamics::Inertia identityTransformed
+        = inertia.transformed(Eigen::Isometry3d::Identity());
+    EXPECT_TRUE(identityTransformed.getSpatialTensor().isApprox(
+        inertia.getSpatialTensor(), tol));
+  }
+}

--- a/tests/unit/dynamics/test_ShapeNodeInertia.cpp
+++ b/tests/unit/dynamics/test_ShapeNodeInertia.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011-2025, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "GTestUtils.hpp"
+
+#include <dart/dynamics/BodyNode.hpp>
+#include <dart/dynamics/BoxShape.hpp>
+#include <dart/dynamics/ShapeNode.hpp>
+#include <dart/dynamics/Skeleton.hpp>
+#include <dart/dynamics/WeldJoint.hpp>
+
+#include <dart/math/Constants.hpp>
+#include <dart/math/Geometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+using namespace dart;
+using namespace dart::dynamics;
+
+namespace {
+
+SkeletonPtr makeSkeleton()
+{
+  auto skel = Skeleton::create();
+  skel->createJointAndBodyNodePair<WeldJoint>(nullptr);
+  return skel;
+}
+
+} // namespace
+
+//==============================================================================
+TEST(ShapeNodeInertia, AppliesRelativeTransform)
+{
+  const auto skel = makeSkeleton();
+  auto* body = skel->getBodyNode(0);
+  const auto shape = std::make_shared<BoxShape>(Eigen::Vector3d(0.2, 0.1, 0.3));
+  auto* node = body->createShapeNodeWith<VisualAspect>(shape);
+
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(0.5, -0.2, 0.1);
+  tf.linear() = Eigen::AngleAxisd(
+                    math::constantsd::pi() / 4.0, Eigen::Vector3d::UnitZ())
+                    .toRotationMatrix();
+  node->setRelativeTransform(tf);
+
+  const double mass = 3.0;
+  const Inertia inertia = node->computeTransformedInertia(mass);
+
+  const Eigen::Matrix3d localMoment = shape->computeInertia(mass);
+  const Eigen::Matrix3d expectedMoment
+      = tf.linear() * localMoment * tf.linear().transpose();
+
+  EXPECT_VECTOR_DOUBLE_EQ(tf.translation(), inertia.getLocalCOM());
+  EXPECT_MATRIX_DOUBLE_EQ(expectedMoment, inertia.getMoment());
+}
+
+//==============================================================================
+TEST(ShapeNodeInertia, BodyNodeAggregationMatchesManualSum)
+{
+  const auto skel = makeSkeleton();
+  auto* body = skel->getBodyNode(0);
+
+  const auto shapeA
+      = std::make_shared<BoxShape>(Eigen::Vector3d(0.1, 0.2, 0.3));
+  const auto shapeB
+      = std::make_shared<BoxShape>(Eigen::Vector3d(0.15, 0.25, 0.05));
+
+  auto* nodeA = body->createShapeNodeWith<VisualAspect>(shapeA);
+  auto* nodeB = body->createShapeNodeWith<VisualAspect>(shapeB);
+
+  Eigen::Isometry3d tfA = Eigen::Isometry3d::Identity();
+  tfA.translation() = Eigen::Vector3d(0.1, 0.0, 0.05);
+  nodeA->setRelativeTransform(tfA);
+
+  Eigen::Isometry3d tfB = Eigen::Isometry3d::Identity();
+  tfB.translation() = Eigen::Vector3d(-0.05, 0.02, -0.03);
+  tfB.linear() = Eigen::AngleAxisd(
+                     math::constantsd::pi() / 3.0, Eigen::Vector3d::UnitY())
+                     .toRotationMatrix();
+  nodeB->setRelativeTransform(tfB);
+
+  const double massA = 2.0;
+  const double massB = 4.0;
+
+  const auto combined = body->computeInertiaFromShapeNodes(
+      [&](const ShapeNode* node) -> std::optional<double> {
+        if (node == nodeA)
+          return massA;
+        if (node == nodeB)
+          return massB;
+        return std::nullopt;
+      });
+  ASSERT_TRUE(combined.has_value());
+
+  const Eigen::Matrix6d expectedSpatial
+      = nodeA->computeTransformedInertia(massA).getSpatialTensor()
+        + nodeB->computeTransformedInertia(massB).getSpatialTensor();
+
+  EXPECT_MATRIX_DOUBLE_EQ(expectedSpatial, combined->getSpatialTensor());
+}


### PR DESCRIPTION
Backports #2170 (Improve ShapeNode inertia coverage) to `release-6.20`.

**Backward compatibility:** additive / opt-in only — no change to the default API, behavior, or performance of the path gz-physics / gz-sim rely on. The volume-weighted shape-node inertia aggregation only runs when `<inertia>` omits `<moment_of_inertia>` (previously a single-shape inference), so explicit inertias are unaffected.

**Local verification (CI is gridlocked, so verified locally):**
- `pixi run test-all` — full C++ + Python suite green.
- `pixi run -e gazebo test-gz` — gz-physics 199 + 4 perf + gz-sim `INTEGRATION_entity_system` green on the cumulative release-6.20 state.

Adapted to the DART-6 layout (PascalCase headers, pybind11, `dart/utils`). Depends on `Inertia::transformed()` (#2153, already merged). Port notes: `docs/dev_tasks/dart6_backport_audit`.