### PR TITLE
Backport coordinate charts for BallJoint and FreeJoint to release-6.20 (#2351)

### DIFF
--- a/dart/dynamics/BallJoint.cpp
+++ b/dart/dynamics/BallJoint.cpp
@@ -37,22 +37,35 @@
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
 
+#include <array>
 #include <string>
 
 namespace dart {
 namespace dynamics {
 
 //==============================================================================
-BallJoint::Properties::Properties(const Base::Properties& properties)
-  : Base::Properties(properties)
+BallJoint::~BallJoint()
 {
   // Do nothing
 }
 
 //==============================================================================
-BallJoint::~BallJoint()
+void BallJoint::setProperties(const Properties& properties)
 {
-  // Do nothing
+  Base::setProperties(static_cast<const Base::Properties&>(properties));
+  setProperties(static_cast<const UniqueProperties&>(properties));
+}
+
+//==============================================================================
+void BallJoint::setProperties(const UniqueProperties& properties)
+{
+  setAspectProperties(properties);
+}
+
+//==============================================================================
+void BallJoint::setAspectProperties(const AspectProperties& properties)
+{
+  setCoordinateChart(properties.mCoordinateChart);
 }
 
 //==============================================================================
@@ -78,20 +91,95 @@ bool BallJoint::isCyclic(std::size_t _index) const
 //==============================================================================
 BallJoint::Properties BallJoint::getBallJointProperties() const
 {
-  return getGenericJointProperties();
+  return BallJoint::Properties(
+      getGenericJointProperties(), getBallJointAspect()->getProperties());
+}
+
+//==============================================================================
+void BallJoint::copy(const BallJoint& otherJoint)
+{
+  if (this == &otherJoint)
+    return;
+
+  setProperties(otherJoint.getBallJointProperties());
+}
+
+//==============================================================================
+void BallJoint::copy(const BallJoint* otherJoint)
+{
+  if (nullptr == otherJoint)
+    return;
+
+  copy(*otherJoint);
+}
+
+//==============================================================================
+BallJoint& BallJoint::operator=(const BallJoint& otherJoint)
+{
+  copy(otherJoint);
+  return *this;
+}
+
+//==============================================================================
+void BallJoint::setCoordinateChart(CoordinateChart chart)
+{
+  if (mAspectProperties.mCoordinateChart == chart)
+    return;
+
+  const CoordinateChart previousChart = mAspectProperties.mCoordinateChart;
+  const Eigen::Matrix3d rotation
+      = convertToRotation(getPositionsStatic(), previousChart);
+
+  mAspectProperties.mCoordinateChart = chart;
+  updateDegreeOfFreedomNames();
+
+  setPositionsStatic(convertToPositions(rotation, chart));
+  updateRelativeJacobian(true);
+  Joint::incrementVersion();
+}
+
+//==============================================================================
+BallJoint::CoordinateChart BallJoint::getCoordinateChart() const
+{
+  return mAspectProperties.mCoordinateChart;
 }
 
 //==============================================================================
 Eigen::Isometry3d BallJoint::convertToTransform(
     const Eigen::Vector3d& _positions)
 {
-  return Eigen::Isometry3d(convertToRotation(_positions));
+  return convertToTransform(_positions, CoordinateChart::EXP_MAP);
+}
+
+//==============================================================================
+Eigen::Isometry3d BallJoint::convertToTransform(
+    const Eigen::Vector3d& _positions, CoordinateChart chart)
+{
+  return Eigen::Isometry3d(convertToRotation(_positions, chart));
 }
 
 //==============================================================================
 Eigen::Matrix3d BallJoint::convertToRotation(const Eigen::Vector3d& _positions)
 {
-  return math::expMapRot(_positions);
+  return convertToRotation(_positions, CoordinateChart::EXP_MAP);
+}
+
+//==============================================================================
+Eigen::Matrix3d BallJoint::convertToRotation(
+    const Eigen::Vector3d& _positions, CoordinateChart chart)
+{
+  switch (chart) {
+    case CoordinateChart::EXP_MAP:
+      return math::expMapRot(_positions);
+    case CoordinateChart::EULER_XYZ:
+      return math::eulerXYZToMatrix(_positions);
+    case CoordinateChart::EULER_ZYX:
+      return math::eulerZYXToMatrix(_positions);
+    default:
+      DART_ERROR(
+          "Invalid coordinate chart specified ({})", static_cast<int>(chart));
+      return Eigen::Matrix3d::Identity();
+  }
 }
 
 //==============================================================================
@@ -102,6 +190,7 @@ BallJoint::BallJoint(const Properties& properties)
 
   // Inherited Aspects must be created in the final joint class in reverse order
   // or else we get pure virtual function calls
+  createBallJointAspect(properties);
   createGenericJointAspect(properties);
   createJointAspect(properties);
 }
@@ -123,19 +212,19 @@ Eigen::Matrix<double, 6, 3> BallJoint::getRelativeJacobianStatic(
 Eigen::Vector3d BallJoint::getPositionDifferencesStatic(
     const Eigen::Vector3d& _q2, const Eigen::Vector3d& _q1) const
 {
-  const Eigen::Matrix3d R1 = convertToRotation(_q1);
-  const Eigen::Matrix3d R2 = convertToRotation(_q2);
+  const Eigen::Matrix3d R1 = convertToRotation(_q1, getCoordinateChart());
+  const Eigen::Matrix3d R2 = convertToRotation(_q2, getCoordinateChart());
 
-  return convertToPositions(R1.transpose() * R2);
+  return convertToPositions(R1.transpose() * R2, getCoordinateChart());
 }
 
 //==============================================================================
 void BallJoint::integratePositions(double _dt)
 {
-  Eigen::Matrix3d Rnext
-      = getR().linear() * convertToRotation(getVelocitiesStatic() * _dt);
+  const Eigen::Matrix3d Rnext
+      = getR().linear() * math::expMapRot(getVelocitiesStatic() * _dt);
 
-  setPositionsStatic(convertToPositions(Rnext));
+  setPositionsStatic(convertToPositions(Rnext, getCoordinateChart()));
 }
 
 //==============================================================================
@@ -162,27 +251,30 @@ void BallJoint::integratePositions(
   const Eigen::Vector3d q0Static = q0;
   const Eigen::Vector3d vStatic = v;
 
-  const Eigen::Matrix3d R0 = convertToRotation(q0Static);
-  const Eigen::Matrix3d Rnext = R0 * convertToRotation(vStatic * dt);
+  const Eigen::Matrix3d R0 = convertToRotation(q0Static, getCoordinateChart());
+  const Eigen::Matrix3d Rnext = R0 * math::expMapRot(vStatic * dt);
 
-  result = convertToPositions(Rnext);
+  result = convertToPositions(Rnext, getCoordinateChart());
 }
 
 //==============================================================================
 void BallJoint::updateDegreeOfFreedomNames()
 {
-  if (!mDofs[0]->isNamePreserved())
-    mDofs[0]->setName(Joint::mAspectProperties.mName + "_x", false);
-  if (!mDofs[1]->isNamePreserved())
-    mDofs[1]->setName(Joint::mAspectProperties.mName + "_y", false);
-  if (!mDofs[2]->isNamePreserved())
-    mDofs[2]->setName(Joint::mAspectProperties.mName + "_z", false);
+  std::array<std::string, 3> affixes{"_x", "_y", "_z"};
+
+  if (getCoordinateChart() == CoordinateChart::EULER_ZYX)
+    affixes = {"_z", "_y", "_x"};
+
+  for (std::size_t i = 0; i < affixes.size(); ++i) {
+    if (!mDofs[i]->isNamePreserved())
+      mDofs[i]->setName(Joint::mAspectProperties.mName + affixes[i], false);
+  }
 }
 
 //==============================================================================
 void BallJoint::updateRelativeTransform() const
 {
-  mR.linear() = convertToRotation(getPositionsStatic());
+  mR.linear() = convertToRotation(getPositionsStatic(), getCoordinateChart());
 
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mR
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();

--- a/dart/dynamics/BallJoint.hpp
+++ b/dart/dynamics/BallJoint.hpp
@@ -33,7 +33,9 @@
 #ifndef DART_DYNAMICS_BALLJOINT_HPP_
 #define DART_DYNAMICS_BALLJOINT_HPP_
 
-#include <dart/dynamics/GenericJoint.hpp>
+#include <dart/dynamics/detail/BallJointAspect.hpp>
+
+#include <dart/math/Geometry.hpp>
 
 #include <Eigen/Dense>
 
@@ -41,24 +43,29 @@ namespace dart {
 namespace dynamics {
 
 /// class BallJoint
-class BallJoint : public GenericJoint<math::SO3Space>
+class BallJoint : public detail::BallJointBase
 {
 public:
   friend class Skeleton;
 
-  using Base = GenericJoint<math::SO3Space>;
+  using CoordinateChart = detail::CoordinateChart;
+  using UniqueProperties = detail::BallJointUniqueProperties;
+  using Properties = detail::BallJointProperties;
+  using Base = detail::BallJointBase;
 
-  struct Properties : Base::Properties
-  {
-    DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(Properties)
-
-    Properties(const Base::Properties& properties = Base::Properties());
-
-    virtual ~Properties() = default;
-  };
+  DART_BAKE_SPECIALIZED_ASPECT_IRREGULAR(Aspect, BallJointAspect)
 
   /// Destructor
   virtual ~BallJoint();
+
+  /// Set the Properties of this BallJoint
+  void setProperties(const Properties& properties);
+
+  /// Set the Properties of this BallJoint
+  void setProperties(const UniqueProperties& properties);
+
+  /// Set the AspectProperties of this BallJoint
+  void setAspectProperties(const AspectProperties& properties);
 
   // Documentation inherited
   const std::string& getType() const override;
@@ -72,6 +79,26 @@ public:
   /// Get the Properties of this BallJoint
   Properties getBallJointProperties() const;
 
+  /// Copy the Properties of another BallJoint
+  void copy(const BallJoint& otherJoint);
+
+  /// Copy the Properties of another BallJoint
+  void copy(const BallJoint* otherJoint);
+
+  /// Same as copy(const BallJoint&)
+  BallJoint& operator=(const BallJoint& otherJoint);
+
+  /// Set the coordinate chart used for generalized positions.
+  ///
+  /// This affects how positions map to rotations. Generalized velocities
+  /// remain angular velocities.
+  ///
+  /// Preserves the current pose by reparameterizing existing positions.
+  void setCoordinateChart(CoordinateChart chart);
+
+  /// Get the coordinate chart used for generalized positions.
+  CoordinateChart getCoordinateChart() const;
+
   /// Convert a rotation into a 3D vector that can be used to set the positions
   /// of a BallJoint. The positions returned by this function will result in a
   /// relative transform of
@@ -81,15 +108,46 @@ public:
   template <typename RotationType>
   static Eigen::Vector3d convertToPositions(const RotationType& _rotation)
   {
-    return math::logMap(_rotation);
+    return convertToPositions(_rotation, CoordinateChart::EXP_MAP);
+  }
+
+  /// Convert a rotation into a 3D vector that can be used to set the positions
+  /// of a BallJoint using the specified coordinate chart.
+  template <typename RotationType>
+  static Eigen::Vector3d convertToPositions(
+      const RotationType& _rotation, CoordinateChart chart)
+  {
+    switch (chart) {
+      case CoordinateChart::EXP_MAP:
+        return math::logMap(_rotation);
+      case CoordinateChart::EULER_XYZ:
+        return math::matrixToEulerXYZ(_rotation);
+      case CoordinateChart::EULER_ZYX:
+        return math::matrixToEulerZYX(_rotation);
+      default:
+        DART_WARN(
+            "Unsupported coordinate chart ({}); returning zero vector",
+            static_cast<int>(chart));
+        return Eigen::Vector3d::Zero();
+    }
   }
 
   /// Convert a BallJoint-style position vector into a transform
   static Eigen::Isometry3d convertToTransform(
       const Eigen::Vector3d& _positions);
 
+  /// Convert a BallJoint-style position vector into a transform using the
+  /// specified coordinate chart.
+  static Eigen::Isometry3d convertToTransform(
+      const Eigen::Vector3d& _positions, CoordinateChart chart);
+
   /// Convert a BallJoint-style position vector into a rotation matrix
   static Eigen::Matrix3d convertToRotation(const Eigen::Vector3d& _positions);
+
+  /// Convert a BallJoint-style position vector into a rotation matrix using
+  /// the specified coordinate chart.
+  static Eigen::Matrix3d convertToRotation(
+      const Eigen::Vector3d& _positions, CoordinateChart chart);
 
   // Documentation inherited
   Eigen::Matrix<double, 6, 3> getRelativeJacobianStatic(

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -37,17 +37,11 @@
 #include "dart/math/Geometry.hpp"
 #include "dart/math/Helpers.hpp"
 
+#include <array>
 #include <string>
 
 namespace dart {
 namespace dynamics {
-
-//==============================================================================
-FreeJoint::Properties::Properties(const Base::Properties& properties)
-  : Base::Properties(properties)
-{
-  // Do nothing
-}
 
 //==============================================================================
 FreeJoint::~FreeJoint()
@@ -56,16 +50,108 @@ FreeJoint::~FreeJoint()
 }
 
 //==============================================================================
+void FreeJoint::setProperties(const Properties& properties)
+{
+  Base::setProperties(static_cast<const Base::Properties&>(properties));
+  setProperties(static_cast<const UniqueProperties&>(properties));
+}
+
+//==============================================================================
+void FreeJoint::setProperties(const UniqueProperties& properties)
+{
+  setAspectProperties(properties);
+}
+
+//==============================================================================
+void FreeJoint::setAspectProperties(const AspectProperties& properties)
+{
+  setCoordinateChart(properties.mCoordinateChart);
+}
+
+//==============================================================================
 FreeJoint::Properties FreeJoint::getFreeJointProperties() const
 {
-  return getGenericJointProperties();
+  return FreeJoint::Properties(
+      getGenericJointProperties(), getFreeJointAspect()->getProperties());
+}
+
+//==============================================================================
+void FreeJoint::copy(const FreeJoint& otherJoint)
+{
+  if (this == &otherJoint)
+    return;
+
+  setProperties(otherJoint.getFreeJointProperties());
+}
+
+//==============================================================================
+void FreeJoint::copy(const FreeJoint* otherJoint)
+{
+  if (nullptr == otherJoint)
+    return;
+
+  copy(*otherJoint);
+}
+
+//==============================================================================
+FreeJoint& FreeJoint::operator=(const FreeJoint& otherJoint)
+{
+  copy(otherJoint);
+  return *this;
+}
+
+//==============================================================================
+void FreeJoint::setCoordinateChart(CoordinateChart chart)
+{
+  if (mAspectProperties.mCoordinateChart == chart)
+    return;
+
+  const CoordinateChart previousChart = mAspectProperties.mCoordinateChart;
+  const Eigen::Isometry3d transform
+      = convertToTransform(getPositionsStatic(), previousChart);
+
+  mAspectProperties.mCoordinateChart = chart;
+  updateDegreeOfFreedomNames();
+
+  setPositionsStatic(convertToPositions(transform, chart));
+  updateRelativeJacobian(true);
+  Joint::incrementVersion();
+}
+
+//==============================================================================
+FreeJoint::CoordinateChart FreeJoint::getCoordinateChart() const
+{
+  return mAspectProperties.mCoordinateChart;
 }
 
 //==============================================================================
 Eigen::Vector6d FreeJoint::convertToPositions(const Eigen::Isometry3d& _tf)
 {
+  return convertToPositions(_tf, CoordinateChart::EXP_MAP);
+}
+
+//==============================================================================
+Eigen::Vector6d FreeJoint::convertToPositions(
+    const Eigen::Isometry3d& _tf, CoordinateChart chart)
+{
   Eigen::Vector6d x;
-  x.head<3>() = math::logMap(_tf.linear());
+  switch (chart) {
+    case CoordinateChart::EXP_MAP:
+      x.head<3>() = math::logMap(_tf.linear());
+      break;
+    case CoordinateChart::EULER_XYZ:
+      x.head<3>() = math::matrixToEulerXYZ(_tf.linear());
+      break;
+    case CoordinateChart::EULER_ZYX:
+      x.head<3>() = math::matrixToEulerZYX(_tf.linear());
+      break;
+    default:
+      DART_WARN(
+          "Unsupported coordinate chart ({}); returning zero rotation",
+          static_cast<int>(chart));
+      x.head<3>().setZero();
+      break;
+  }
   x.tail<3>() = _tf.translation();
   return x;
 }
@@ -74,8 +160,30 @@ Eigen::Vector6d FreeJoint::convertToPositions(const Eigen::Isometry3d& _tf)
 Eigen::Isometry3d FreeJoint::convertToTransform(
     const Eigen::Vector6d& _positions)
 {
+  return convertToTransform(_positions, CoordinateChart::EXP_MAP);
+}
+
+//==============================================================================
+Eigen::Isometry3d FreeJoint::convertToTransform(
+    const Eigen::Vector6d& _positions, CoordinateChart chart)
+{
   Eigen::Isometry3d tf(Eigen::Isometry3d::Identity());
-  tf.linear() = math::expMapRot(_positions.head<3>());
+  switch (chart) {
+    case CoordinateChart::EXP_MAP:
+      tf.linear() = math::expMapRot(_positions.head<3>());
+      break;
+    case CoordinateChart::EULER_XYZ:
+      tf.linear() = math::eulerXYZToMatrix(_positions.head<3>());
+      break;
+    case CoordinateChart::EULER_ZYX:
+      tf.linear() = math::eulerZYXToMatrix(_positions.head<3>());
+      break;
+    default:
+      DART_ERROR(
+          "Invalid coordinate chart specified ({})", static_cast<int>(chart));
+      tf.linear().setIdentity();
+      break;
+  }
   tf.translation() = _positions.tail<3>();
   return tf;
 }
@@ -185,7 +293,8 @@ void FreeJoint::setRelativeTransform(const Eigen::Isometry3d& newTransform)
 {
   setPositionsStatic(convertToPositions(
       Joint::mAspectProperties.mT_ParentBodyToJoint.inverse() * newTransform
-      * Joint::mAspectProperties.mT_ChildBodyToJoint));
+          * Joint::mAspectProperties.mT_ChildBodyToJoint,
+      getCoordinateChart()));
 }
 
 //==============================================================================
@@ -505,7 +614,8 @@ void FreeJoint::setAngularAcceleration(
 Eigen::Matrix6d FreeJoint::getRelativeJacobianStatic(
     const Eigen::Vector6d& positions) const
 {
-  const Eigen::Isometry3d Q = convertToTransform(positions);
+  const Eigen::Isometry3d Q
+      = convertToTransform(positions, getCoordinateChart());
   const Eigen::Isometry3d T
       = Joint::mAspectProperties.mT_ParentBodyToJoint * Q
         * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
@@ -524,15 +634,16 @@ Eigen::Matrix6d FreeJoint::getRelativeJacobianStatic(
 Eigen::Vector6d FreeJoint::getPositionDifferencesStatic(
     const Eigen::Vector6d& _q2, const Eigen::Vector6d& _q1) const
 {
-  const Eigen::Isometry3d Q1 = convertToTransform(_q1);
-  const Eigen::Isometry3d Q2 = convertToTransform(_q2);
+  const Eigen::Isometry3d Q1 = convertToTransform(_q1, getCoordinateChart());
+  const Eigen::Isometry3d Q2 = convertToTransform(_q2, getCoordinateChart());
 
   Eigen::Vector6d diff = Eigen::Vector6d::Zero();
 
-  const Eigen::Matrix3d rotation1 = Q1.linear();
-  const Eigen::Matrix3d rotationChange = rotation1.transpose() * Q2.linear();
-
-  diff.head<3>() = rotation1 * math::logMap(rotationChange);
+  const Eigen::Matrix3d rotationChange = Q2.linear() * Q1.linear().transpose();
+  Eigen::Isometry3d rotationOnly = Eigen::Isometry3d::Identity();
+  rotationOnly.linear() = rotationChange;
+  diff.head<3>()
+      = convertToPositions(rotationOnly, getCoordinateChart()).head<3>();
   diff.tail<3>() = Q2.translation() - Q1.translation();
 
   return diff;
@@ -546,6 +657,7 @@ FreeJoint::FreeJoint(const Properties& properties)
 
   // Inherited Aspects must be created in the final joint class in reverse order
   // or else we get pure virtual function calls
+  createFreeJointAspect(properties);
   createGenericJointAspect(properties);
   createJointAspect(properties);
 }
@@ -597,7 +709,7 @@ void FreeJoint::integratePositions(double _dt)
   const Eigen::Isometry3d nextQ
       = parentBodyToJoint.inverse() * nextRelativeTransform * childBodyToJoint;
 
-  setPositionsStatic(convertToPositions(nextQ));
+  setPositionsStatic(convertToPositions(nextQ, getCoordinateChart()));
 }
 
 //==============================================================================
@@ -629,7 +741,8 @@ void FreeJoint::integratePositions(
   const Eigen::Isometry3d& childBodyToJoint
       = Joint::mAspectProperties.mT_ChildBodyToJoint;
 
-  const Eigen::Isometry3d Q0 = convertToTransform(q0Static);
+  const Eigen::Isometry3d Q0
+      = convertToTransform(q0Static, getCoordinateChart());
   const Eigen::Isometry3d relativeTransform0
       = parentBodyToJoint * Q0 * childBodyToJoint.inverse();
 
@@ -646,7 +759,7 @@ void FreeJoint::integratePositions(
   const Eigen::Isometry3d Qnext
       = parentBodyToJoint.inverse() * nextRelativeTransform * childBodyToJoint;
 
-  result = convertToPositions(Qnext);
+  result = convertToPositions(Qnext, getCoordinateChart());
 }
 
 //==============================================================================
@@ -665,12 +778,16 @@ void FreeJoint::updateConstrainedTerms(double timeStep)
 //==============================================================================
 void FreeJoint::updateDegreeOfFreedomNames()
 {
-  if (!mDofs[0]->isNamePreserved())
-    mDofs[0]->setName(Joint::mAspectProperties.mName + "_rot_x", false);
-  if (!mDofs[1]->isNamePreserved())
-    mDofs[1]->setName(Joint::mAspectProperties.mName + "_rot_y", false);
-  if (!mDofs[2]->isNamePreserved())
-    mDofs[2]->setName(Joint::mAspectProperties.mName + "_rot_z", false);
+  std::array<std::string, 3> rotAffixes{"_rot_x", "_rot_y", "_rot_z"};
+
+  if (getCoordinateChart() == CoordinateChart::EULER_ZYX)
+    rotAffixes = {"_rot_z", "_rot_y", "_rot_x"};
+
+  for (std::size_t i = 0; i < rotAffixes.size(); ++i) {
+    if (!mDofs[i]->isNamePreserved())
+      mDofs[i]->setName(Joint::mAspectProperties.mName + rotAffixes[i], false);
+  }
+
   if (!mDofs[3]->isNamePreserved())
     mDofs[3]->setName(Joint::mAspectProperties.mName + "_pos_x", false);
   if (!mDofs[4]->isNamePreserved())
@@ -682,7 +799,7 @@ void FreeJoint::updateDegreeOfFreedomNames()
 //==============================================================================
 void FreeJoint::updateRelativeTransform() const
 {
-  mQ = convertToTransform(getPositionsStatic());
+  mQ = convertToTransform(getPositionsStatic(), getCoordinateChart());
 
   mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mQ
        * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();

--- a/dart/dynamics/FreeJoint.hpp
+++ b/dart/dynamics/FreeJoint.hpp
@@ -33,7 +33,7 @@
 #ifndef DART_DYNAMICS_FREEJOINT_HPP_
 #define DART_DYNAMICS_FREEJOINT_HPP_
 
-#include <dart/dynamics/GenericJoint.hpp>
+#include <dart/dynamics/detail/FreeJointAspect.hpp>
 
 #include <dart/common/Deprecated.hpp>
 
@@ -45,29 +45,43 @@ namespace dart {
 namespace dynamics {
 
 /// class FreeJoint
-class FreeJoint : public GenericJoint<math::SE3Space>
+class FreeJoint : public detail::FreeJointBase
 {
 public:
   friend class Skeleton;
 
-  using Base = GenericJoint<math::SE3Space>;
+  using CoordinateChart = detail::CoordinateChart;
+  using UniqueProperties = detail::FreeJointUniqueProperties;
+  using Properties = detail::FreeJointProperties;
+  using Base = detail::FreeJointBase;
 
-  struct Properties : Base::Properties
-  {
-    DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(Properties)
-
-    Properties(const Base::Properties& properties = Base::Properties());
-
-    virtual ~Properties() = default;
-  };
+  DART_BAKE_SPECIALIZED_ASPECT_IRREGULAR(Aspect, FreeJointAspect)
 
   FreeJoint(const FreeJoint&) = delete;
 
   /// Destructor
   virtual ~FreeJoint();
 
+  /// Set the Properties of this FreeJoint
+  void setProperties(const Properties& properties);
+
+  /// Set the Properties of this FreeJoint
+  void setProperties(const UniqueProperties& properties);
+
+  /// Set the AspectProperties of this FreeJoint
+  void setAspectProperties(const AspectProperties& properties);
+
   /// Get the Properties of this FreeJoint
   Properties getFreeJointProperties() const;
+
+  /// Copy the Properties of another FreeJoint
+  void copy(const FreeJoint& otherJoint);
+
+  /// Copy the Properties of another FreeJoint
+  void copy(const FreeJoint* otherJoint);
+
+  /// Same as copy(const FreeJoint&)
+  FreeJoint& operator=(const FreeJoint& otherJoint);
 
   // Documentation inherited
   const std::string& getType() const override;
@@ -78,6 +92,16 @@ public:
   // Documentation inherited
   bool isCyclic(std::size_t _index) const override;
 
+  /// Set the coordinate chart used for the rotational portion of generalized
+  /// positions. Generalized velocities remain spatial velocities.
+  ///
+  /// Preserves the current pose by reparameterizing existing positions.
+  void setCoordinateChart(CoordinateChart chart);
+
+  /// Get the coordinate chart used for the rotational portion of generalized
+  /// positions.
+  CoordinateChart getCoordinateChart() const;
+
   /// Convert a transform into a 6D vector that can be used to set the positions
   /// of a FreeJoint. The positions returned by this function will result in a
   /// relative transform of
@@ -86,9 +110,20 @@ public:
   /// the child BodyNode frames when applied to a FreeJoint.
   static Eigen::Vector6d convertToPositions(const Eigen::Isometry3d& _tf);
 
+  /// Convert a transform into a 6D vector that can be used to set the positions
+  /// of a FreeJoint using the specified coordinate chart for the rotational
+  /// portion.
+  static Eigen::Vector6d convertToPositions(
+      const Eigen::Isometry3d& _tf, CoordinateChart chart);
+
   /// Convert a FreeJoint-style 6D vector into a transform
   static Eigen::Isometry3d convertToTransform(
       const Eigen::Vector6d& _positions);
+
+  /// Convert a FreeJoint-style 6D vector into a transform using the specified
+  /// coordinate chart for the rotational portion.
+  static Eigen::Isometry3d convertToTransform(
+      const Eigen::Vector6d& _positions, CoordinateChart chart);
 
   /// If the given joint is a FreeJoint, then set the transform of the given
   /// Joint's child BodyNode so that its transform with respect to

--- a/dart/dynamics/detail/BallJointAspect.cpp
+++ b/dart/dynamics/detail/BallJointAspect.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/BallJoint.hpp"
+
+namespace dart {
+namespace dynamics {
+namespace detail {
+
+//==============================================================================
+BallJointUniqueProperties::BallJointUniqueProperties(CoordinateChart _chart)
+  : mCoordinateChart(_chart)
+{
+  // Do nothing
+}
+
+//==============================================================================
+BallJointProperties::BallJointProperties(
+    const GenericJoint<math::SO3Space>::Properties& genericProperties,
+    const BallJointUniqueProperties& ballJointProperties)
+  : GenericJoint<math::SO3Space>::Properties(genericProperties),
+    BallJointUniqueProperties(ballJointProperties)
+{
+  // Do nothing
+}
+
+} // namespace detail
+} // namespace dynamics
+} // namespace dart

--- a/dart/dynamics/detail/BallJointAspect.hpp
+++ b/dart/dynamics/detail/BallJointAspect.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_DETAIL_BALLJOINTASPECT_HPP_
+#define DART_DYNAMICS_DETAIL_BALLJOINTASPECT_HPP_
+
+#include <dart/dynamics/GenericJoint.hpp>
+#include <dart/dynamics/detail/JointCoordinateChart.hpp>
+
+namespace dart {
+namespace dynamics {
+
+class BallJoint;
+
+namespace detail {
+
+//==============================================================================
+struct BallJointUniqueProperties
+{
+  /// Coordinate chart for generalized positions.
+  CoordinateChart mCoordinateChart;
+
+  /// Constructor
+  BallJointUniqueProperties(CoordinateChart _chart = CoordinateChart::EXP_MAP);
+
+  virtual ~BallJointUniqueProperties() = default;
+};
+
+//==============================================================================
+struct BallJointProperties : GenericJoint<math::SO3Space>::Properties,
+                             BallJointUniqueProperties
+{
+  DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(BallJointProperties)
+
+  /// Composed constructor
+  BallJointProperties(
+      const GenericJoint<math::SO3Space>::Properties& genericJointProperties
+      = GenericJoint<math::SO3Space>::Properties(),
+      const BallJointUniqueProperties& ballJointProperties
+      = BallJointUniqueProperties());
+
+  virtual ~BallJointProperties() = default;
+};
+
+//==============================================================================
+using BallJointBase = common::EmbedPropertiesOnTopOf<
+    BallJoint,
+    BallJointUniqueProperties,
+    GenericJoint<math::SO3Space>>;
+
+} // namespace detail
+} // namespace dynamics
+} // namespace dart
+
+#endif // DART_DYNAMICS_DETAIL_BALLJOINTASPECT_HPP_

--- a/dart/dynamics/detail/FreeJointAspect.cpp
+++ b/dart/dynamics/detail/FreeJointAspect.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/FreeJoint.hpp"
+
+namespace dart {
+namespace dynamics {
+namespace detail {
+
+//==============================================================================
+FreeJointUniqueProperties::FreeJointUniqueProperties(CoordinateChart _chart)
+  : mCoordinateChart(_chart)
+{
+  // Do nothing
+}
+
+//==============================================================================
+FreeJointProperties::FreeJointProperties(
+    const GenericJoint<math::SE3Space>::Properties& genericProperties,
+    const FreeJointUniqueProperties& freeJointProperties)
+  : GenericJoint<math::SE3Space>::Properties(genericProperties),
+    FreeJointUniqueProperties(freeJointProperties)
+{
+  // Do nothing
+}
+
+} // namespace detail
+} // namespace dynamics
+} // namespace dart

--- a/dart/dynamics/detail/FreeJointAspect.hpp
+++ b/dart/dynamics/detail/FreeJointAspect.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_DETAIL_FREEJOINTASPECT_HPP_
+#define DART_DYNAMICS_DETAIL_FREEJOINTASPECT_HPP_
+
+#include <dart/dynamics/GenericJoint.hpp>
+#include <dart/dynamics/detail/JointCoordinateChart.hpp>
+
+namespace dart {
+namespace dynamics {
+
+class FreeJoint;
+
+namespace detail {
+
+//==============================================================================
+struct FreeJointUniqueProperties
+{
+  /// Coordinate chart for the rotational portion of generalized positions.
+  CoordinateChart mCoordinateChart;
+
+  /// Constructor
+  FreeJointUniqueProperties(CoordinateChart _chart = CoordinateChart::EXP_MAP);
+
+  virtual ~FreeJointUniqueProperties() = default;
+};
+
+//==============================================================================
+struct FreeJointProperties : GenericJoint<math::SE3Space>::Properties,
+                             FreeJointUniqueProperties
+{
+  DART_DEFINE_ALIGNED_SHARED_OBJECT_CREATOR(FreeJointProperties)
+
+  /// Composed constructor
+  FreeJointProperties(
+      const GenericJoint<math::SE3Space>::Properties& genericJointProperties
+      = GenericJoint<math::SE3Space>::Properties(),
+      const FreeJointUniqueProperties& freeJointProperties
+      = FreeJointUniqueProperties());
+
+  virtual ~FreeJointProperties() = default;
+};
+
+//==============================================================================
+using FreeJointBase = common::EmbedPropertiesOnTopOf<
+    FreeJoint,
+    FreeJointUniqueProperties,
+    GenericJoint<math::SE3Space>>;
+
+} // namespace detail
+} // namespace dynamics
+} // namespace dart
+
+#endif // DART_DYNAMICS_DETAIL_FREEJOINTASPECT_HPP_

--- a/dart/dynamics/detail/JointCoordinateChart.hpp
+++ b/dart/dynamics/detail/JointCoordinateChart.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_DYNAMICS_DETAIL_JOINTCOORDINATECHART_HPP_
+#define DART_DYNAMICS_DETAIL_JOINTCOORDINATECHART_HPP_
+
+namespace dart {
+namespace dynamics {
+namespace detail {
+
+enum class CoordinateChart : int
+{
+  EXP_MAP = 0,
+  EULER_XYZ = 1,
+  EULER_ZYX = 2
+};
+
+} // namespace detail
+} // namespace dynamics
+} // namespace dart
+
+#endif // DART_DYNAMICS_DETAIL_JOINTCOORDINATECHART_HPP_

--- a/tests/integration/test_Joints.cpp
+++ b/tests/integration/test_Joints.cpp
@@ -1490,6 +1490,84 @@ TEST_F(JOINTS, CONVENIENCE_FUNCTIONS)
 }
 
 //==============================================================================
+TEST_F(JOINTS, BallJointCoordinateChart)
+{
+  SkeletonPtr skel = Skeleton::create("ball_chart");
+
+  BallJoint::Properties ballProps;
+  ballProps.mCoordinateChart = BallJoint::CoordinateChart::EULER_XYZ;
+
+  auto [ballJoint, ballBody]
+      = skel->createJointAndBodyNodePair<BallJoint>(nullptr, ballProps);
+  (void)ballBody;
+
+  EXPECT_EQ(
+      ballJoint->getCoordinateChart(), BallJoint::CoordinateChart::EULER_XYZ);
+
+  const Eigen::Vector3d xyzAngles(0.2, -0.1, 0.3);
+  const Eigen::Matrix3d xyzRotation = math::eulerXYZToMatrix(xyzAngles);
+  const Eigen::Vector3d xyzPositions = BallJoint::convertToPositions(
+      xyzRotation, BallJoint::CoordinateChart::EULER_XYZ);
+  ballJoint->setPositions(xyzPositions);
+  EXPECT_TRUE(
+      ballJoint->getRelativeTransform().linear().isApprox(xyzRotation, 1e-10));
+
+  const Eigen::Matrix3d xyzRelative
+      = ballJoint->getRelativeTransform().linear();
+  ballJoint->setCoordinateChart(BallJoint::CoordinateChart::EULER_ZYX);
+  EXPECT_EQ(
+      ballJoint->getCoordinateChart(), BallJoint::CoordinateChart::EULER_ZYX);
+  EXPECT_TRUE(
+      ballJoint->getRelativeTransform().linear().isApprox(xyzRelative, 1e-10));
+
+  const Eigen::Vector3d zyxAngles(0.3, -0.2, 0.15);
+  const Eigen::Matrix3d zyxRotation = math::eulerZYXToMatrix(zyxAngles);
+  const Eigen::Vector3d zyxPositions = BallJoint::convertToPositions(
+      zyxRotation, BallJoint::CoordinateChart::EULER_ZYX);
+  ballJoint->setPositions(zyxPositions);
+  EXPECT_TRUE(
+      ballJoint->getRelativeTransform().linear().isApprox(zyxRotation, 1e-10));
+}
+
+//==============================================================================
+TEST_F(JOINTS, FreeJointCoordinateChart)
+{
+  SkeletonPtr skel = Skeleton::create("free_chart");
+
+  FreeJoint::Properties freeProps;
+  freeProps.mCoordinateChart = FreeJoint::CoordinateChart::EULER_ZYX;
+
+  auto [freeJoint, freeBody]
+      = skel->createJointAndBodyNodePair<FreeJoint>(nullptr, freeProps);
+  (void)freeBody;
+
+  EXPECT_EQ(
+      freeJoint->getCoordinateChart(), FreeJoint::CoordinateChart::EULER_ZYX);
+
+  const Eigen::Vector3d zyxAngles(0.1, -0.25, 0.05);
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.linear() = math::eulerZYXToMatrix(zyxAngles);
+  tf.translation() = Eigen::Vector3d(0.4, -0.2, 0.3);
+
+  const Eigen::Vector6d positions = FreeJoint::convertToPositions(
+      tf, FreeJoint::CoordinateChart::EULER_ZYX);
+  freeJoint->setPositions(positions);
+  EXPECT_TRUE(
+      freeJoint->getRelativeTransform().linear().isApprox(tf.linear(), 1e-10));
+  EXPECT_TRUE(freeJoint->getRelativeTransform().translation().isApprox(
+      tf.translation(), 1e-12));
+
+  const Eigen::Isometry3d relativeTransform = freeJoint->getRelativeTransform();
+  freeJoint->setCoordinateChart(FreeJoint::CoordinateChart::EULER_XYZ);
+  EXPECT_EQ(
+      freeJoint->getCoordinateChart(), FreeJoint::CoordinateChart::EULER_XYZ);
+  EXPECT_TRUE(freeJoint->getRelativeTransform().linear().isApprox(
+      relativeTransform.linear(), 1e-10));
+  EXPECT_TRUE(freeJoint->getRelativeTransform().translation().isApprox(
+      relativeTransform.translation(), 1e-12));
+}
+
+//==============================================================================
 TEST_F(JOINTS, FREE_JOINT_RELATIVE_TRANSFORM_VELOCITY_ACCELERATION)
 {
   const std::size_t numTests = 50;


### PR DESCRIPTION
Backports #2351 (coordinate charts for BallJoint and FreeJoint) to `release-6.20`.

**Backward compatibility:** additive / opt-in only. The coordinate-chart property defaults to `EXP_MAP`, which is the existing behavior, so default Ball/FreeJoint conversions are unchanged — gz-physics / gz-sim paths are unaffected.

**Local verification (CI gridlocked → verified locally):**
- `pixi run test-all` — full C++ + Python suite green.
- gz checkpoint (`pixi run -e gazebo test-gz`) on the cumulative release-6.20 state: gz-physics 199 + 4 perf + gz-sim `INTEGRATION_entity_system` green.

Adapted to the DART-6 layout (PascalCase headers, pybind11). Port notes: `docs/dev_tasks/dart6_backport_audit`.