### PR TITLE
Backport SDF mimic joint parsing to release-6.20 (#2254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,13 @@
 
 * Dynamics
 
+  * `dart::utils::SdfParser` now imports SDF `<mimic>` metadata (reference
+    joint/DoF, multiplier, and offset) from a joint's `<axis>`/`<axis2>`
+    elements and wires the parsed follower DoFs to the existing per-DoF mimic
+    runtime (`MimicDofProperties`, `Joint::MIMIC` actuator), so SDF models can
+    declare mimic joints directly. SDF files without `<mimic>` parse
+    identically: [#2254](https://github.com/dartsim/dart/pull/2254)
+
   * Add TriMesh-backed `MeshShape` storage and material metadata while keeping
     the legacy Assimp `aiScene` APIs available as deprecated DART 6
     compatibility shims, and route mesh collision backends through the new

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -46,6 +46,7 @@
 #include "dart/dynamics/CylinderShape.hpp"
 #include "dart/dynamics/FreeJoint.hpp"
 #include "dart/dynamics/MeshShape.hpp"
+#include "dart/dynamics/MimicDofProperties.hpp"
 #include "dart/dynamics/PlaneShape.hpp"
 #include "dart/dynamics/PrismaticJoint.hpp"
 #include "dart/dynamics/RevoluteJoint.hpp"
@@ -65,11 +66,13 @@
 #include <Eigen/StdVector>
 #include <tinyxml2.h>
 
+#include <algorithm>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace dart {
 namespace utils {
@@ -96,13 +99,27 @@ struct SDFJoint
   std::string parentName;
   std::string childName;
   std::string type;
+  struct MimicInfo
+  {
+    std::string referenceJointName;
+    std::size_t referenceDof = 0;
+    double multiplier = 1.0;
+    double offset = 0.0;
+  };
+  std::vector<MimicInfo> mimicInfos;
 };
+
+std::vector<SDFJoint::MimicInfo> readMimicElements(
+    const tinyxml2::XMLElement* axisElement);
 
 // Maps the name of a BodyNode to its properties
 using BodyMap = common::aligned_map<std::string, SDFBodyNode>;
 
 // Maps a child BodyNode to the properties of its parent Joint
 using JointMap = std::map<std::string, SDFJoint>;
+
+void applyMimicConstraints(
+    const dynamics::SkeletonPtr& skeleton, const JointMap& sdfJoints);
 
 simulation::WorldPtr readWorld(
     tinyxml2::XMLElement* worldElement,
@@ -543,6 +560,8 @@ dynamics::SkeletonPtr readSkeleton(
   // Set positions to their initial values
   newSkeleton->resetPositions();
 
+  applyMimicConstraints(newSkeleton, sdfJoints);
+
   return newSkeleton;
 }
 
@@ -612,6 +631,56 @@ NextResult getNextJointAndNodePair(
   }
 
   return VALID;
+}
+
+//==============================================================================
+void applyMimicConstraints(
+    const dynamics::SkeletonPtr& skeleton, const JointMap& sdfJoints)
+{
+  for (const auto& entry : sdfJoints) {
+    const auto& jointInfo = entry.second;
+    if (jointInfo.mimicInfos.empty())
+      continue;
+
+    auto* joint = skeleton->getJoint(jointInfo.properties->mName);
+    if (!joint)
+      continue;
+
+    std::vector<dynamics::MimicDofProperties> props
+        = joint->getMimicDofProperties();
+    props.resize(joint->getNumDofs());
+
+    bool applied = false;
+    for (const auto& mimic : jointInfo.mimicInfos) {
+      auto* ref = skeleton->getJoint(mimic.referenceJointName);
+      if (!ref) {
+        DART_WARN(
+            "[SdfParser] Ignoring mimic joint [{}] referencing missing joint "
+            "[{}]",
+            jointInfo.properties->mName,
+            mimic.referenceJointName);
+        continue;
+      }
+
+      const std::size_t followerIndex
+          = std::min(mimic.referenceDof, joint->getNumDofs() - 1);
+      const std::size_t referenceIndex
+          = std::min(mimic.referenceDof, ref->getNumDofs() - 1);
+
+      auto& prop = props[followerIndex];
+      prop.mReferenceJoint = ref;
+      prop.mReferenceDofIndex = referenceIndex;
+      prop.mMultiplier = mimic.multiplier;
+      prop.mOffset = mimic.offset;
+      applied = true;
+    }
+
+    if (!applied)
+      continue;
+
+    joint->setMimicJointDofs(props);
+    joint->setActuatorType(dynamics::Joint::MIMIC);
+  }
 }
 
 dynamics::SkeletonPtr makeSkeleton(
@@ -1211,6 +1280,34 @@ JointMap readAllJoints(
   return sdfJoints;
 }
 
+std::vector<SDFJoint::MimicInfo> readMimicElements(
+    const tinyxml2::XMLElement* axisElement)
+{
+  std::vector<SDFJoint::MimicInfo> mimics;
+  if (!axisElement || !hasElement(axisElement, "mimic"))
+    return mimics;
+
+  const tinyxml2::XMLElement* mimicElement = getElement(axisElement, "mimic");
+  if (!mimicElement)
+    return mimics;
+
+  SDFJoint::MimicInfo info;
+  info.referenceJointName = getAttributeString(mimicElement, "joint");
+  if (hasAttribute(mimicElement, "axis")) {
+    const auto axisAttr = getAttributeString(mimicElement, "axis");
+    info.referenceDof = axisAttr == "axis2" ? 1u : 0u;
+  }
+  info.multiplier = hasElement(mimicElement, "multiplier")
+                        ? getValueDouble(mimicElement, "multiplier")
+                        : 1.0;
+  info.offset = hasElement(mimicElement, "offset")
+                    ? getValueDouble(mimicElement, "offset")
+                    : 0.0;
+  mimics.push_back(info);
+
+  return mimics;
+}
+
 SDFJoint readJoint(
     tinyxml2::XMLElement* _jointElement,
     const BodyMap& _sdfBodyNodes,
@@ -1274,6 +1371,24 @@ SDFJoint readJoint(
   newJoint.parentName
       = (parent_it == _sdfBodyNodes.end()) ? "" : parent_it->first;
   newJoint.childName = (child_it == _sdfBodyNodes.end()) ? "" : child_it->first;
+
+  //--------------------------------------------------------------------------
+  // Mimic metadata (captured before joint creation)
+  if (hasElement(_jointElement, "axis")) {
+    const tinyxml2::XMLElement* axisElement = getElement(_jointElement, "axis");
+    const auto mimics = readMimicElements(axisElement);
+    newJoint.mimicInfos.insert(
+        newJoint.mimicInfos.end(), mimics.begin(), mimics.end());
+  }
+  if (hasElement(_jointElement, "axis2")) {
+    const tinyxml2::XMLElement* axis2Element
+        = getElement(_jointElement, "axis2");
+    auto mimics = readMimicElements(axis2Element);
+    for (auto& m : mimics)
+      m.referenceDof = 1u; // axis2 maps to the second DoF
+    newJoint.mimicInfos.insert(
+        newJoint.mimicInfos.end(), mimics.begin(), mimics.end());
+  }
 
   //--------------------------------------------------------------------------
   // transformation

--- a/data/sdf/test/mimic_joint_test.sdf
+++ b/data/sdf/test/mimic_joint_test.sdf
@@ -1,0 +1,146 @@
+<?xml version="1.0" ?>
+<!-- Minimal model exercising the SDF <mimic> parsing wired into SdfParser.
+     The follower joint mimics the reference joint with a non-default
+     multiplier/offset so the parsed MimicDofProperties can be verified.
+     Models without <mimic> must parse identically (see the sibling
+     reference-only model below). -->
+<sdf version="1.6">
+  <world name="default">
+    <gravity>0 0 0</gravity>
+    <physics type="dart">
+      <max_step_size>0.001</max_step_size>
+    </physics>
+
+    <model name="mimic_model">
+      <pose>0 0 0 0 0 0</pose>
+
+      <link name="base">
+        <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <mass>10.0</mass>
+          <inertia>
+            <ixx>1.0</ixx>
+            <iyy>1.0</iyy>
+            <izz>1.0</izz>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyz>0.0</iyz>
+          </inertia>
+        </inertial>
+      </link>
+
+      <link name="reference_link">
+        <pose>0 0 1 0 0 0</pose>
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <iyy>0.1</iyy>
+            <izz>0.1</izz>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyz>0.0</iyz>
+          </inertia>
+        </inertial>
+        <visual name="ref_vis">
+          <geometry>
+            <box>
+              <size>0.2 0.2 1.0</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name="follower_link">
+        <pose>1 0 1 0 0 0</pose>
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <iyy>0.1</iyy>
+            <izz>0.1</izz>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyz>0.0</iyz>
+          </inertia>
+        </inertial>
+        <visual name="follow_vis">
+          <geometry>
+            <box>
+              <size>0.2 0.2 1.0</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <joint name="reference_joint" type="revolute">
+        <parent>base</parent>
+        <child>reference_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+        </axis>
+      </joint>
+
+      <joint name="follower_joint" type="revolute">
+        <parent>base</parent>
+        <child>follower_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <mimic joint="reference_joint" axis="axis">
+            <multiplier>2.0</multiplier>
+            <offset>0.25</offset>
+          </mimic>
+        </axis>
+      </joint>
+    </model>
+
+    <model name="plain_model">
+      <pose>5 0 0 0 0 0</pose>
+
+      <link name="base">
+        <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <mass>10.0</mass>
+          <inertia>
+            <ixx>1.0</ixx>
+            <iyy>1.0</iyy>
+            <izz>1.0</izz>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyz>0.0</iyz>
+          </inertia>
+        </inertial>
+      </link>
+
+      <link name="plain_link">
+        <pose>0 0 1 0 0 0</pose>
+        <inertial>
+          <mass>1.0</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <iyy>0.1</iyy>
+            <izz>0.1</izz>
+            <ixy>0.0</ixy>
+            <ixz>0.0</ixz>
+            <iyz>0.0</iyz>
+          </inertia>
+        </inertial>
+        <visual name="plain_vis">
+          <geometry>
+            <box>
+              <size>0.2 0.2 1.0</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <joint name="plain_joint" type="revolute">
+        <parent>base</parent>
+        <child>plain_link</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+        </axis>
+      </joint>
+    </model>
+  </world>
+</sdf>

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -61,6 +61,9 @@ if(TARGET dart-utils)
     target_link_libraries(test_SdfParser dart-collision-bullet)
   endif()
 
+  dart_add_test("integration" test_MimicConstraint)
+  target_link_libraries(test_MimicConstraint dart-utils)
+
   dart_add_test("integration" test_SkelParser)
   target_link_libraries(test_SkelParser dart-utils)
 

--- a/tests/integration/test_MimicConstraint.cpp
+++ b/tests/integration/test_MimicConstraint.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/dynamics/Joint.hpp"
+#include "dart/dynamics/MimicDofProperties.hpp"
+#include "dart/dynamics/Skeleton.hpp"
+#include "dart/simulation/World.hpp"
+#include "dart/utils/sdf/SdfParser.hpp"
+
+#include <gtest/gtest.h>
+
+using dart::dynamics::Joint;
+using dart::dynamics::SkeletonPtr;
+using dart::simulation::WorldPtr;
+
+//==============================================================================
+// The SDF parser should import a joint's <mimic> metadata and wire the follower
+// DoF to the referenced joint through the existing per-DoF mimic runtime.
+TEST(MimicConstraint, ParsesMimicMetadataFromSdf)
+{
+  const std::string worldUri = "dart://sample/sdf/test/mimic_joint_test.sdf";
+
+  WorldPtr world = dart::utils::SdfParser::readWorld(worldUri);
+  ASSERT_TRUE(world != nullptr);
+
+  const SkeletonPtr mimicModel = world->getSkeleton("mimic_model");
+  ASSERT_TRUE(mimicModel != nullptr);
+
+  auto* referenceJoint = mimicModel->getJoint("reference_joint");
+  auto* followerJoint = mimicModel->getJoint("follower_joint");
+  ASSERT_NE(nullptr, referenceJoint);
+  ASSERT_NE(nullptr, followerJoint);
+  ASSERT_EQ(1u, followerJoint->getNumDofs());
+
+  // The reference joint carries no <mimic>, so it stays a regular force joint.
+  EXPECT_NE(referenceJoint->getActuatorType(), Joint::MIMIC);
+  EXPECT_EQ(nullptr, referenceJoint->getMimicJoint(0));
+
+  // The follower joint was switched to the MIMIC actuator by the parser.
+  EXPECT_EQ(followerJoint->getActuatorType(), Joint::MIMIC);
+
+  const auto props = followerJoint->getMimicDofProperties();
+  ASSERT_FALSE(props.empty());
+  EXPECT_EQ(props[0].mReferenceJoint, referenceJoint);
+  EXPECT_EQ(props[0].mReferenceDofIndex, 0u);
+  EXPECT_DOUBLE_EQ(props[0].mMultiplier, 2.0);
+  EXPECT_DOUBLE_EQ(props[0].mOffset, 0.25);
+
+  // The convenience accessors agree with the parsed properties.
+  EXPECT_EQ(followerJoint->getMimicJoint(0), referenceJoint);
+  EXPECT_DOUBLE_EQ(followerJoint->getMimicMultiplier(0), 2.0);
+  EXPECT_DOUBLE_EQ(followerJoint->getMimicOffset(0), 0.25);
+}
+
+//==============================================================================
+// A model without any <mimic> element must parse exactly as before: the parser
+// addition is purely additive and never alters non-mimic joints (gz-physics /
+// gz-sim SDF loads stay unaffected).
+TEST(MimicConstraint, ModelWithoutMimicIsUnchanged)
+{
+  const std::string worldUri = "dart://sample/sdf/test/mimic_joint_test.sdf";
+
+  WorldPtr world = dart::utils::SdfParser::readWorld(worldUri);
+  ASSERT_TRUE(world != nullptr);
+
+  const SkeletonPtr plainModel = world->getSkeleton("plain_model");
+  ASSERT_TRUE(plainModel != nullptr);
+
+  auto* plainJoint = plainModel->getJoint("plain_joint");
+  ASSERT_NE(nullptr, plainJoint);
+
+  // No <mimic> means no MIMIC actuator and no reference joint wiring.
+  EXPECT_NE(plainJoint->getActuatorType(), Joint::MIMIC);
+  EXPECT_EQ(nullptr, plainJoint->getMimicJoint(0));
+}
+
+//==============================================================================
+// Loading an SDF that contains no <mimic> at all must succeed and leave every
+// joint as a non-mimic joint, matching pre-backport behavior byte-for-byte.
+TEST(MimicConstraint, ExistingNonMimicSdfParsesUnchanged)
+{
+  const std::string worldUri
+      = "dart://sample/sdf/test/issue1193_revolute_test.sdf";
+
+  WorldPtr world = dart::utils::SdfParser::readWorld(worldUri);
+  ASSERT_TRUE(world != nullptr);
+
+  const SkeletonPtr skeleton = world->getSkeleton(0);
+  ASSERT_TRUE(skeleton != nullptr);
+
+  for (std::size_t i = 0; i < skeleton->getNumJoints(); ++i) {
+    auto* joint = skeleton->getJoint(i);
+    ASSERT_NE(nullptr, joint);
+    EXPECT_NE(joint->getActuatorType(), Joint::MIMIC);
+  }
+}


### PR DESCRIPTION
Backports #2254 (Parse SDF mimic joints) to `release-6.20`.

**Backward compatibility:** additive / opt-in. Adds `<mimic>` parsing to the SDF reader only; mimic wiring uses the existing Motor-based `Joint::MIMIC` actuator (the DART-7-only coupler path is not present on 6.20 and is never taken). gz-physics / gz-sim do not use DART's SDF parser, so their paths are unaffected.

**Local verification (CI gridlocked → verified locally):**
- `pixi run test-all` — full C++ + Python suite green.
- gz checkpoint (`pixi run -e gazebo test-gz`) on the cumulative release-6.20 state: gz-physics 199 + 4 perf + gz-sim integration green.

Adapted to the DART-6 layout (tinyxml2 SDF API, pybind11). Port notes: `docs/dev_tasks/dart6_backport_audit`.