### PR TITLE
Backport split-impulse contact correction to release-6.20 (#2354)

### DIFF
--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -587,6 +587,150 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
 }
 
 //==============================================================================
+void BoxedLcpConstraintSolver::solvePositionConstrainedGroup(
+    ConstrainedGroup& group)
+{
+  DART_PROFILE_SCOPED;
+
+  // Collect only contact constraints for the position-correction pass.
+  std::vector<ContactConstraint*> contacts;
+  contacts.reserve(group.getNumConstraints());
+  for (std::size_t i = 0; i < group.getNumConstraints(); ++i) {
+    const ConstraintBasePtr& constraint = group.getConstraint(i);
+    if (auto* contact = dynamic_cast<ContactConstraint*>(constraint.get())) {
+      contacts.push_back(contact);
+    }
+  }
+
+  const std::size_t numConstraints = contacts.size();
+  if (numConstraints == 0u)
+    return;
+
+  // Compute offsets and total dimension.
+  std::vector<std::size_t> offsets(numConstraints);
+  std::size_t n = 0u;
+  for (std::size_t i = 0; i < numConstraints; ++i) {
+    offsets[i] = n;
+    n += contacts[i]->getDimension();
+  }
+
+  if (0u == n)
+    return;
+
+  const int nSkip = ::dart::lcpsolver::dantzig::padding(static_cast<int>(n));
+
+  Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A;
+  A.setZero(n, nSkip);
+  Eigen::VectorXd x = Eigen::VectorXd::Zero(n);
+  Eigen::VectorXd b(n);
+  Eigen::VectorXd w = Eigen::VectorXd::Zero(n);
+  Eigen::VectorXd lo(n);
+  Eigen::VectorXd hi(n);
+  Eigen::VectorXi fIndex = Eigen::VectorXi::Constant(n, -1);
+
+  const auto constructLcpTerms = [&]() {
+    A.setZero(n, nSkip);
+    x.setZero();
+    w.setZero();
+    fIndex.setConstant(n, -1);
+
+    ConstraintInfo constInfo;
+    constInfo.invTimeStep = 1.0 / mTimeStep;
+    constInfo.phase = ConstraintPhase::Position;
+    // useSplitImpulse only affects the velocity phase; leave it at its default
+    // (false) here.
+
+    for (std::size_t i = 0; i < numConstraints; ++i) {
+      ContactConstraint* constraint = contacts[i];
+      const std::size_t offset = offsets[i];
+      const std::size_t dim = constraint->getDimension();
+
+      constInfo.x = x.data() + offset;
+      constInfo.lo = lo.data() + offset;
+      constInfo.hi = hi.data() + offset;
+      constInfo.b = b.data() + offset;
+      constInfo.findex = fIndex.data() + offset;
+      constInfo.w = w.data() + offset;
+
+      constraint->getInformation(&constInfo);
+
+      constraint->excite();
+      for (std::size_t j = 0; j < dim; ++j) {
+        const std::size_t row = offset + j;
+        if (fIndex[static_cast<Eigen::Index>(row)] >= 0)
+          fIndex[static_cast<Eigen::Index>(row)] += static_cast<int>(offset);
+
+        constraint->applyUnitImpulse(j);
+
+        std::size_t index = nSkip * row + offset;
+        constraint->getVelocityChange(A.data() + index, true);
+        for (std::size_t k = i + 1; k < numConstraints; ++k) {
+          index = nSkip * row + offsets[k];
+          contacts[k]->getVelocityChange(A.data() + index, false);
+        }
+      }
+      constraint->unexcite();
+    }
+
+    // Fill lower triangle blocks of A matrix.
+    for (std::size_t row = 1; row < n; ++row) {
+      for (std::size_t col = 0; col < row; ++col) {
+        A.data()[nSkip * row + col] = A.data()[nSkip * col + row];
+      }
+    }
+  };
+
+  constructLcpTerms();
+
+  const bool earlyTermination = (mSecondaryBoxedLcpSolver != nullptr);
+  DART_ASSERT(mBoxedLcpSolver);
+  bool success = mBoxedLcpSolver->solve(
+      n,
+      A.data(),
+      x.data(),
+      b.data(),
+      0,
+      lo.data(),
+      hi.data(),
+      fIndex.data(),
+      earlyTermination);
+
+  const auto hasNaN = [](const double* values, std::size_t size) {
+    for (std::size_t i = 0; i < size; ++i) {
+      if (std::isnan(values[i]))
+        return true;
+    }
+    return false;
+  };
+
+  if (success && hasNaN(x.data(), n))
+    success = false;
+
+  if (!success && mSecondaryBoxedLcpSolver) {
+    constructLcpTerms();
+    success = mSecondaryBoxedLcpSolver->solve(
+        n,
+        A.data(),
+        x.data(),
+        b.data(),
+        0,
+        lo.data(),
+        hi.data(),
+        fIndex.data(),
+        false);
+  }
+
+  // If the solve failed or produced NaNs, skip the position correction for this
+  // group (leave positions unchanged) rather than apply garbage impulses.
+  if (!success || hasNaN(x.data(), n))
+    return;
+
+  for (std::size_t i = 0; i < numConstraints; ++i) {
+    contacts[i]->applyPositionImpulse(x.data() + offsets[i]);
+  }
+}
+
+//==============================================================================
 bool BoxedLcpConstraintSolver::isSymmetric(std::size_t n, double* A)
 {
   std::size_t nSkip = ::dart::lcpsolver::dantzig::padding(static_cast<int>(n));

--- a/dart/constraint/BoxedLcpConstraintSolver.hpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.hpp
@@ -101,6 +101,9 @@ protected:
   // Documentation inherited.
   void solveConstrainedGroup(ConstrainedGroup& group) override;
 
+  // Documentation inherited. Only invoked when split impulse is enabled.
+  void solvePositionConstrainedGroup(ConstrainedGroup& group) override;
+
   /// Boxed LCP solver
   BoxedLcpSolverPtr mBoxedLcpSolver;
   // TODO(JS): Hold as unique_ptr because there is no reason to share. Make this

--- a/dart/constraint/ConstraintBase.hpp
+++ b/dart/constraint/ConstraintBase.hpp
@@ -45,6 +45,13 @@ class Skeleton;
 
 namespace constraint {
 
+/// Constraint solve phase used by split impulse position correction.
+enum class ConstraintPhase
+{
+  Velocity,
+  Position,
+};
+
 /// ConstraintInfo
 struct ConstraintInfo
 {
@@ -68,6 +75,14 @@ struct ConstraintInfo
 
   /// Inverse of time step
   double invTimeStep;
+
+  /// Constraint solve phase. Defaults to Velocity so the existing
+  /// (non-split-impulse) solve path is unaffected.
+  ConstraintPhase phase{ConstraintPhase::Velocity};
+
+  /// Whether to skip penetration correction in the velocity phase. Defaults to
+  /// false so the existing Baumgarte penetration correction is preserved.
+  bool useSplitImpulse{false};
 };
 
 /// Constraint is a base class of concrete constraints classes

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -669,11 +669,18 @@ void ConstraintSolver::solve()
 {
   DART_PROFILE_SCOPED_N("ConstraintSolver::solve");
 
+  const bool splitImpulse = mSplitImpulseEnabled;
+
   {
     DART_PROFILE_SCOPED_N("ConstraintSolver::clear per-step state");
     auto clearSkeletonAt = [&](std::size_t i) {
       auto& skeleton = mSkeletons[i];
       skeleton->clearConstraintImpulses();
+      if (splitImpulse) {
+        skeleton->clearPositionConstraintImpulses();
+        skeleton->clearPositionVelocityChanges();
+        skeleton->setPositionImpulseApplied(false);
+      }
       DART_SUPPRESS_DEPRECATED_BEGIN
       skeleton->clearCollidingBodies();
       DART_SUPPRESS_DEPRECATED_END
@@ -698,6 +705,10 @@ void ConstraintSolver::solve()
 
   // Solve constrained groups
   solveConstrainedGroups();
+
+  if (splitImpulse) {
+    solvePositionConstrainedGroups();
+  }
 }
 
 //==============================================================================
@@ -714,6 +725,7 @@ void ConstraintSolver::setFromOtherConstraintSolver(
   mManualConstraints = other.mManualConstraints;
 
   mContactSurfaceHandler = other.mContactSurfaceHandler;
+  mSplitImpulseEnabled = other.mSplitImpulseEnabled;
   setNumSimulationThreads(other.getNumSimulationThreads());
 }
 
@@ -1494,6 +1506,53 @@ void ConstraintSolver::buildConstrainedGroups()
     DART_PROFILE_SCOPED_N("reset constraint unions");
     for (auto& skeleton : mSkeletons)
       skeleton->resetUnion();
+  }
+}
+
+//==============================================================================
+void ConstraintSolver::setSplitImpulseEnabled(bool enabled)
+{
+  mSplitImpulseEnabled = enabled;
+}
+
+//==============================================================================
+bool ConstraintSolver::isSplitImpulseEnabled() const
+{
+  return mSplitImpulseEnabled;
+}
+
+//==============================================================================
+void ConstraintSolver::solvePositionConstrainedGroup(
+    ConstrainedGroup& /*group*/)
+{
+  // Base implementation does nothing. Concrete solvers that support split
+  // impulse override this.
+}
+
+//==============================================================================
+void ConstraintSolver::solvePositionConstrainedGroups()
+{
+  DART_PROFILE_SCOPED;
+
+  // Preserve velocity-impulse flags across the position pass.
+  std::vector<bool> impulseAppliedStates;
+  impulseAppliedStates.reserve(mSkeletons.size());
+  for (const auto& skeleton : mSkeletons) {
+    impulseAppliedStates.push_back(skeleton->isImpulseApplied());
+  }
+
+  for (auto& constraintGroup : mConstrainedGroups) {
+    solvePositionConstrainedGroup(constraintGroup);
+  }
+
+  for (auto& skeleton : mSkeletons) {
+    if (skeleton->isPositionImpulseApplied()) {
+      skeleton->computePositionVelocityChanges();
+    }
+  }
+
+  for (std::size_t i = 0; i < mSkeletons.size(); ++i) {
+    mSkeletons[i]->setImpulseApplied(impulseAppliedStates[i]);
   }
 }
 

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -234,6 +234,14 @@ public:
   /// Solve constraint impulses and apply them to the skeletons
   void solve();
 
+  /// Enable or disable split impulse position correction. Defaults to disabled,
+  /// in which case the existing Baumgarte (ERP/ERV) penetration correction in
+  /// the velocity solve is preserved unchanged.
+  void setSplitImpulseEnabled(bool enabled);
+
+  /// Get whether split impulse position correction is enabled.
+  bool isSplitImpulseEnabled() const;
+
   /// Sets this constraint solver using other constraint solver. All the
   /// properties and registered skeletons and constraints will be copied over.
   virtual void setFromOtherConstraintSolver(const ConstraintSolver& other);
@@ -259,6 +267,15 @@ public:
 protected:
   // TODO(JS): Docstring
   virtual void solveConstrainedGroup(ConstrainedGroup& group) = 0;
+
+  /// Solve the position-correction (split impulse) pass for a single group.
+  /// The base implementation is a no-op; concrete solvers that support split
+  /// impulse override this. Only invoked when split impulse is enabled.
+  virtual void solvePositionConstrainedGroup(ConstrainedGroup& group);
+
+  /// Solve constrained groups for split impulse position correction. Only
+  /// invoked from solve() when split impulse is enabled.
+  void solvePositionConstrainedGroups();
 
   /// Checks if the skeleton is contained in this solver
   ///
@@ -314,6 +331,10 @@ protected:
 
   /// Time step
   double mTimeStep;
+
+  /// Enable split impulse position correction. Defaults to false so the
+  /// existing velocity-only Baumgarte solve path is the default behavior.
+  bool mSplitImpulseEnabled{false};
 
   /// Skeleton list
   std::vector<dynamics::SkeletonPtr> mSkeletons;

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -462,8 +462,28 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
   if (!hasValidBodyNodes())
     return;
 
+  const bool isPositionPhase = info->phase == ConstraintPhase::Position;
+  const bool useSplitImpulse = info->useSplitImpulse;
+  const auto computeErrorReductionVelocity = [&](double errorAllowance) {
+    double errorReductionVelocity = mContact.penetrationDepth - errorAllowance;
+    if (errorReductionVelocity < 0.0) {
+      return 0.0;
+    }
+
+    errorReductionVelocity *= mErrorReductionParameter * info->invTimeStep;
+    if (errorReductionVelocity > mMaxErrorReductionVelocity) {
+      errorReductionVelocity = mMaxErrorReductionVelocity;
+    }
+    return errorReductionVelocity;
+  };
+
   // Fill w, where the LCP form is Ax = b + w (x >= 0, w >= 0, x^T w = 0)
-  getRelVelocity(info->b);
+  if (isPositionPhase) {
+    Eigen::Map<Eigen::VectorXd> velMap(info->b, static_cast<int>(mDim));
+    velMap.setZero();
+  } else {
+    getRelVelocity(info->b);
+  }
 
   //----------------------------------------------------------------------------
   // Friction case
@@ -480,48 +500,74 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
     DART_ASSERT(info->findex[0] == -1);
 
     // Upper and lower bounds of tangential direction-1 impulsive force
-    info->lo[1] = -mPrimaryFrictionCoeff;
-    info->hi[1] = mPrimaryFrictionCoeff;
-    info->findex[1] = 0;
+    if (isPositionPhase) {
+      info->lo[1] = 0.0;
+      info->hi[1] = 0.0;
+      info->findex[1] = -1;
+    } else {
+      info->lo[1] = -mPrimaryFrictionCoeff;
+      info->hi[1] = mPrimaryFrictionCoeff;
+      info->findex[1] = 0;
+    }
 
     // Upper and lower bounds of tangential direction-2 impulsive force
-    info->lo[2] = -mSecondaryFrictionCoeff;
-    info->hi[2] = mSecondaryFrictionCoeff;
-    info->findex[2] = 0;
+    if (isPositionPhase) {
+      info->lo[2] = 0.0;
+      info->hi[2] = 0.0;
+      info->findex[2] = -1;
+    } else {
+      info->lo[2] = -mSecondaryFrictionCoeff;
+      info->hi[2] = mSecondaryFrictionCoeff;
+      info->findex[2] = 0;
+    }
 
     //------------------------------------------------------------------------
     // Bouncing
     //------------------------------------------------------------------------
-    // A. Penetration correction
-    double bouncingVelocity = mContact.penetrationDepth - mErrorAllowance;
-    if (bouncingVelocity < 0.0) {
-      bouncingVelocity = 0.0;
+    double bouncingVelocity = 0.0;
+    if (isPositionPhase) {
+      // A. Penetration correction
+      bouncingVelocity = computeErrorReductionVelocity(mErrorAllowance);
     } else {
-      bouncingVelocity *= mErrorReductionParameter * info->invTimeStep;
-      if (bouncingVelocity > mMaxErrorReductionVelocity)
-        bouncingVelocity = mMaxErrorReductionVelocity;
-    }
+      // B. Restitution
+      if (mIsBounceOn) {
+        double& negativeRelativeVel = info->b[0];
+        double restitutionVel = negativeRelativeVel * mRestitutionCoeff;
 
-    // B. Restitution
-    if (mIsBounceOn) {
-      double& negativeRelativeVel = info->b[0];
-      double restitutionVel = negativeRelativeVel * mRestitutionCoeff;
+        if (restitutionVel > DART_BOUNCING_VELOCITY_THRESHOLD) {
+          if (restitutionVel > bouncingVelocity) {
+            bouncingVelocity = restitutionVel;
 
-      if (restitutionVel > DART_BOUNCING_VELOCITY_THRESHOLD) {
-        if (restitutionVel > bouncingVelocity) {
-          bouncingVelocity = restitutionVel;
-
-          if (bouncingVelocity > DART_MAX_BOUNCING_VELOCITY) {
-            bouncingVelocity = DART_MAX_BOUNCING_VELOCITY;
+            if (bouncingVelocity > DART_MAX_BOUNCING_VELOCITY) {
+              bouncingVelocity = DART_MAX_BOUNCING_VELOCITY;
+            }
           }
+        }
+      }
+
+      if (!useSplitImpulse) {
+        // Split impulse disabled (the default): merge the Baumgarte
+        // penetration correction back into the velocity bias, reproducing the
+        // legacy behavior. The result equals the pre-split-impulse code for all
+        // reachable inputs because the penetration correction is clamped to
+        // mMaxErrorReductionVelocity (default 1e-3) while restitution only
+        // engages above DART_BOUNCING_VELOCITY_THRESHOLD and is clamped to
+        // DART_MAX_BOUNCING_VELOCITY (1e+2), so the max-merge order is
+        // immaterial.
+        const double errorReductionVelocity
+            = computeErrorReductionVelocity(mErrorAllowance);
+        if (errorReductionVelocity > bouncingVelocity) {
+          bouncingVelocity = errorReductionVelocity;
         }
       }
     }
 
     info->b[0] += bouncingVelocity;
-    info->b[0] += mContactSurfaceMotionVelocity.x();
-    info->b[1] += mContactSurfaceMotionVelocity.y();
-    info->b[2] += mContactSurfaceMotionVelocity.z();
+    if (!isPositionPhase) {
+      info->b[0] += mContactSurfaceMotionVelocity.x();
+      info->b[1] += mContactSurfaceMotionVelocity.y();
+      info->b[2] += mContactSurfaceMotionVelocity.z();
+    }
 
     // TODO(JS): Initial guess
     // x
@@ -544,33 +590,40 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
     //------------------------------------------------------------------------
     // Bouncing
     //------------------------------------------------------------------------
-    // A. Penetration correction
-    double bouncingVelocity = mContact.penetrationDepth - DART_ERROR_ALLOWANCE;
-    if (bouncingVelocity < 0.0) {
-      bouncingVelocity = 0.0;
+    double bouncingVelocity = 0.0;
+    if (isPositionPhase) {
+      // A. Penetration correction
+      bouncingVelocity = computeErrorReductionVelocity(DART_ERROR_ALLOWANCE);
     } else {
-      bouncingVelocity *= mErrorReductionParameter * info->invTimeStep;
-      if (bouncingVelocity > mMaxErrorReductionVelocity)
-        bouncingVelocity = mMaxErrorReductionVelocity;
-    }
+      // B. Restitution
+      if (mIsBounceOn) {
+        double& negativeRelativeVel = info->b[0];
+        double restitutionVel = negativeRelativeVel * mRestitutionCoeff;
 
-    // B. Restitution
-    if (mIsBounceOn) {
-      double& negativeRelativeVel = info->b[0];
-      double restitutionVel = negativeRelativeVel * mRestitutionCoeff;
+        if (restitutionVel > DART_BOUNCING_VELOCITY_THRESHOLD) {
+          if (restitutionVel > bouncingVelocity) {
+            bouncingVelocity = restitutionVel;
 
-      if (restitutionVel > DART_BOUNCING_VELOCITY_THRESHOLD) {
-        if (restitutionVel > bouncingVelocity) {
-          bouncingVelocity = restitutionVel;
+            if (bouncingVelocity > DART_MAX_BOUNCING_VELOCITY) {
+              bouncingVelocity = DART_MAX_BOUNCING_VELOCITY;
+            }
+          }
+        }
+      }
 
-          if (bouncingVelocity > DART_MAX_BOUNCING_VELOCITY)
-            bouncingVelocity = DART_MAX_BOUNCING_VELOCITY;
+      if (!useSplitImpulse) {
+        const double errorReductionVelocity
+            = computeErrorReductionVelocity(DART_ERROR_ALLOWANCE);
+        if (errorReductionVelocity > bouncingVelocity) {
+          bouncingVelocity = errorReductionVelocity;
         }
       }
     }
 
     info->b[0] += bouncingVelocity;
-    info->b[0] += mContactSurfaceMotionVelocity.x();
+    if (!isPositionPhase) {
+      info->b[0] += mContactSurfaceMotionVelocity.x();
+    }
 
     // TODO(JS): Initial guess
     // x
@@ -849,6 +902,30 @@ void ContactConstraint::applyImpulse(double* lambda)
 
     // Store contact impulse (force) toward the normal w.r.t. world frame
     mContact.force = mContact.normal * lambda[0] / mTimeStep;
+  }
+}
+
+//==============================================================================
+void ContactConstraint::applyPositionImpulse(double* lambda)
+{
+  if (!hasValidBodyNodes())
+    return;
+
+  if (mIsReactiveA) {
+    mBodyNodeA->addPositionConstraintImpulse(
+        mSpatialNormalA.col(0) * lambda[0]);
+  }
+
+  if (mIsReactiveB) {
+    mBodyNodeB->addPositionConstraintImpulse(
+        mSpatialNormalB.col(0) * lambda[0]);
+  }
+
+  if (mIsReactiveA) {
+    mBodyNodeA->getSkeleton()->setPositionImpulseApplied(true);
+  }
+  if (mIsReactiveB) {
+    mBodyNodeB->getSkeleton()->setPositionImpulseApplied(true);
   }
 }
 

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -141,6 +141,9 @@ protected:
   // Documentation inherited
   void applyImpulse(double* lambda) override;
 
+  /// Apply position-correction impulses (split impulse).
+  void applyPositionImpulse(double* lambda);
+
   // Documentation inherited
   dynamics::SkeletonPtr getRootSkeleton() const override;
 

--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1535,6 +1535,7 @@ BodyNode::BodyNode(
     mDelV(Eigen::Vector6d::Zero()),
     mBiasImpulse(Eigen::Vector6d::Zero()),
     mConstraintImpulse(Eigen::Vector6d::Zero()),
+    mPositionConstraintImpulse(Eigen::Vector6d::Zero()),
     mImpF(Eigen::Vector6d::Zero()),
     onColShapeAdded(mColShapeAddedSignal),
     onColShapeRemoved(mColShapeRemovedSignal),
@@ -2045,6 +2046,29 @@ void BodyNode::updateBiasImpulse()
 }
 
 //==============================================================================
+void BodyNode::updateBiasImpulseFromPositionImpulse()
+{
+  // Update impulsive bias force
+  mBiasImpulse = -mPositionConstraintImpulse;
+
+  // And add child bias impulse
+  for (auto& childBodyNode : mChildBodyNodes) {
+    Joint* childJoint = childBodyNode->getParentJoint();
+
+    childJoint->addChildBiasImpulseTo(
+        mBiasImpulse,
+        childBodyNode->getArticulatedInertia(),
+        childBodyNode->mBiasImpulse);
+  }
+
+  // Verification
+  DART_ASSERT(!math::isNan(mBiasImpulse));
+
+  // Update parent joint's total force
+  mParentJoint->updateTotalImpulse(mBiasImpulse);
+}
+
+//==============================================================================
 void BodyNode::updateTransmittedForceFD()
 {
   mF = mBiasForce;
@@ -2215,6 +2239,12 @@ void BodyNode::clearConstraintImpulse()
 }
 
 //==============================================================================
+void BodyNode::clearPositionConstraintImpulse()
+{
+  mPositionConstraintImpulse.setZero();
+}
+
+//==============================================================================
 const Eigen::Vector6d& BodyNode::getBodyForce() const
 {
   return mF;
@@ -2235,9 +2265,22 @@ void BodyNode::addConstraintImpulse(const Eigen::Vector6d& _constImp)
 }
 
 //==============================================================================
+void BodyNode::addPositionConstraintImpulse(const Eigen::Vector6d& _constImp)
+{
+  DART_ASSERT(!math::isNan(_constImp));
+  mPositionConstraintImpulse += _constImp;
+}
+
+//==============================================================================
 const Eigen::Vector6d& BodyNode::getConstraintImpulse() const
 {
   return mConstraintImpulse;
+}
+
+//==============================================================================
+const Eigen::Vector6d& BodyNode::getPositionConstraintImpulse() const
+{
+  return mPositionConstraintImpulse;
 }
 
 //==============================================================================

--- a/dart/dynamics/BodyNode.hpp
+++ b/dart/dynamics/BodyNode.hpp
@@ -832,6 +832,10 @@ public:
   /// \param[in] _constImp Spatial constraint impulse w.r.t. body frame
   void addConstraintImpulse(const Eigen::Vector6d& _constImp);
 
+  /// Add position constraint impulse for split impulse handling.
+  /// \param[in] _constImp Spatial constraint impulse w.r.t. body frame
+  void addPositionConstraintImpulse(const Eigen::Vector6d& _constImp);
+
   /// Add constraint impulse
   void addConstraintImpulse(
       const Eigen::Vector3d& _constImp,
@@ -843,8 +847,14 @@ public:
   /// dynamics algorithm
   virtual void clearConstraintImpulse();
 
+  /// Clear position constraint impulses used for split impulse handling.
+  virtual void clearPositionConstraintImpulse();
+
   /// Return constraint impulse
   const Eigen::Vector6d& getConstraintImpulse() const;
+
+  /// Return position constraint impulse
+  const Eigen::Vector6d& getPositionConstraintImpulse() const;
 
   //----------------------------------------------------------------------------
   // Energies
@@ -1006,6 +1016,9 @@ protected:
   /// Update bias impulse associated with the articulated body inertia for
   /// impulse-based forward dynamics.
   virtual void updateBiasImpulse();
+
+  /// Update bias impulse using position constraint impulses for split impulse.
+  virtual void updateBiasImpulseFromPositionImpulse();
 
   /// Update spatial body acceleration with the partial spatial body
   /// acceleration for inverse dynamics.
@@ -1287,6 +1300,9 @@ protected:
 
   /// Constraint impulse: contact impulse, dynamic joint impulse
   Eigen::Vector6d mConstraintImpulse;
+
+  /// Position correction impulse used for split impulse handling
+  Eigen::Vector6d mPositionConstraintImpulse;
 
   // TODO(JS): rename with more informative one
   /// Generalized impulsive body force w.r.t. body frame.

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -1554,6 +1554,47 @@ void Skeleton::integratePositions(double _dt)
 }
 
 //==============================================================================
+void Skeleton::integratePositions(
+    double _dt, const Eigen::VectorXd& velocityChanges)
+{
+  if (getNumDofs() == 0) {
+    integratePositions(_dt);
+    return;
+  }
+
+  if (velocityChanges.size() != static_cast<Eigen::Index>(getNumDofs())) {
+    DART_ASSERT(false);
+    integratePositions(_dt);
+    return;
+  }
+
+  for (std::size_t i = 0; i < mSkelCache.mBodyNodes.size(); ++i) {
+    auto* joint = mSkelCache.mBodyNodes[i]->getParentJoint();
+    const std::size_t dofs = joint->getNumDofs();
+    if (dofs == 0) {
+      continue;
+    }
+
+    Eigen::VectorXd q0 = joint->getPositions();
+    Eigen::VectorXd v = joint->getVelocities();
+    for (std::size_t j = 0; j < dofs; ++j) {
+      const std::size_t index = joint->getIndexInSkeleton(j);
+      v[j] += velocityChanges[static_cast<Eigen::Index>(index)];
+    }
+
+    Eigen::VectorXd q;
+    joint->integratePositions(q0, v, _dt, q);
+    joint->setPositions(q);
+  }
+
+  for (std::size_t i = 0; i < mSoftBodyNodes.size(); ++i) {
+    for (std::size_t j = 0; j < mSoftBodyNodes[i]->getNumPointMasses(); ++j) {
+      mSoftBodyNodes[i]->getPointMass(j)->integratePositions(_dt);
+    }
+  }
+}
+
+//==============================================================================
 void Skeleton::integrateVelocities(double _dt)
 {
   for (std::size_t i = 0; i < mSkelCache.mBodyNodes.size(); ++i)
@@ -2109,6 +2150,7 @@ const Eigen::VectorXd& Skeleton::getConstraintForces() const
 Skeleton::Skeleton(const AspectPropertiesData& properties)
   : mTotalMass(0.0),
     mIsImpulseApplied(false),
+    mIsPositionImpulseApplied(false),
     mUnionSize(1),
     mUnionIndex(static_cast<std::size_t>(-1))
 {
@@ -2733,6 +2775,7 @@ void Skeleton::updateCacheDimensions(std::size_t _treeIdx)
 {
   updateCacheDimensions(mTreeCache[_treeIdx]);
   updateCacheDimensions(mSkelCache);
+  mPositionVelocityChanges = Eigen::VectorXd::Zero(getNumDofs());
 
   dirtyArticulatedInertia(_treeIdx);
 }
@@ -3688,6 +3731,14 @@ void Skeleton::clearConstraintImpulses()
 }
 
 //==============================================================================
+void Skeleton::clearPositionConstraintImpulses()
+{
+  for (auto& bodyNode : mSkelCache.mBodyNodes) {
+    bodyNode->clearPositionConstraintImpulse();
+  }
+}
+
+//==============================================================================
 void Skeleton::updateBiasImpulse(BodyNode* _bodyNode)
 {
   if (nullptr == _bodyNode) {
@@ -3851,6 +3902,32 @@ void Skeleton::updateVelocityChange()
 }
 
 //==============================================================================
+void Skeleton::computePositionVelocityChanges()
+{
+  if (!isMobile() || getNumDofs() == 0) {
+    mPositionVelocityChanges = Eigen::VectorXd::Zero(getNumDofs());
+    return;
+  }
+
+  // Backward recursion
+  for (auto it = mSkelCache.mBodyNodes.rbegin();
+       it != mSkelCache.mBodyNodes.rend();
+       ++it) {
+    (*it)->updateBiasImpulseFromPositionImpulse();
+  }
+
+  // Forward recursion
+  for (auto& bodyNode : mSkelCache.mBodyNodes) {
+    bodyNode->updateVelocityChangeFD();
+  }
+
+  mPositionVelocityChanges.resize(getNumDofs());
+  for (std::size_t i = 0; i < mSkelCache.mDofs.size(); ++i) {
+    mPositionVelocityChanges[i] = mSkelCache.mDofs[i]->getVelocityChange();
+  }
+}
+
+//==============================================================================
 void Skeleton::setImpulseApplied(bool _val)
 {
   mIsImpulseApplied = _val;
@@ -3860,6 +3937,30 @@ void Skeleton::setImpulseApplied(bool _val)
 bool Skeleton::isImpulseApplied() const
 {
   return mIsImpulseApplied;
+}
+
+//==============================================================================
+void Skeleton::setPositionImpulseApplied(bool _val)
+{
+  mIsPositionImpulseApplied = _val;
+}
+
+//==============================================================================
+bool Skeleton::isPositionImpulseApplied() const
+{
+  return mIsPositionImpulseApplied;
+}
+
+//==============================================================================
+const Eigen::VectorXd& Skeleton::getPositionVelocityChanges() const
+{
+  return mPositionVelocityChanges;
+}
+
+//==============================================================================
+void Skeleton::clearPositionVelocityChanges()
+{
+  mPositionVelocityChanges = Eigen::VectorXd::Zero(getNumDofs());
 }
 
 //==============================================================================

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -544,6 +544,10 @@ public:
   // Documentation inherited
   void integratePositions(double _dt);
 
+  /// Integrate positions using Euler method with additional velocity changes
+  /// from split impulse position correction.
+  void integratePositions(double _dt, const Eigen::VectorXd& velocityChanges);
+
   // Documentation inherited
   void integrateVelocities(double _dt);
 
@@ -698,6 +702,9 @@ public:
   /// on the BodyNodes and generalized constraints on the Joints.
   void clearConstraintImpulses();
 
+  /// Clear position constraint impulses used for split impulse handling.
+  void clearPositionConstraintImpulses();
+
   /// Update bias impulses
   void updateBiasImpulse(BodyNode* _bodyNode);
 
@@ -727,6 +734,9 @@ public:
   /// impulse
   void updateVelocityChange();
 
+  /// Compute velocity changes used for split impulse position updates.
+  void computePositionVelocityChanges();
+
   // TODO(JS): Better naming
   /// Set whether this skeleton is constrained. ConstraintSolver will
   ///  mark this.
@@ -734,6 +744,18 @@ public:
 
   /// Get whether this skeleton is constrained
   bool isImpulseApplied() const;
+
+  /// Set whether split impulse position corrections are applied.
+  void setPositionImpulseApplied(bool _val);
+
+  /// Get whether split impulse position corrections are applied.
+  bool isPositionImpulseApplied() const;
+
+  /// Get position velocity changes computed from split impulses.
+  const Eigen::VectorXd& getPositionVelocityChanges() const;
+
+  /// Clear position velocity changes.
+  void clearPositionVelocityChanges();
 
   /// Compute impulse-based forward dynamics
   void computeImpulseForwardDynamics();
@@ -1421,6 +1443,12 @@ protected:
   // TODO(JS): Better naming
   /// Flag for status of impulse testing.
   bool mIsImpulseApplied;
+
+  /// Flag for status of split impulse position correction.
+  bool mIsPositionImpulseApplied;
+
+  /// Velocity changes from position correction impulses.
+  Eigen::VectorXd mPositionVelocityChanges;
 
   mutable std::mutex mMutex;
 

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -467,7 +467,14 @@ void World::step(bool _resetCommand)
               skel->setImpulseApplied(false);
             }
 
-            skel->integratePositions(mTimeStep);
+            if (skel->isPositionImpulseApplied()) {
+              skel->integratePositions(
+                  mTimeStep, skel->getPositionVelocityChanges());
+              skel->setPositionImpulseApplied(false);
+              skel->clearPositionVelocityChanges();
+            } else {
+              skel->integratePositions(mTimeStep);
+            }
 
             if (_resetCommand && skel->checkExternalDisturbanceAndReset(true)) {
               skel->clearInternalForces();
@@ -634,8 +641,16 @@ void World::step(bool _resetCommand)
             skel->setImpulseApplied(false);
           }
 
-          if (!preservingFinalSleepSolve)
-            skel->integratePositions(mTimeStep);
+          if (!preservingFinalSleepSolve) {
+            if (skel->isPositionImpulseApplied()) {
+              skel->integratePositions(
+                  mTimeStep, skel->getPositionVelocityChanges());
+              skel->setPositionImpulseApplied(false);
+              skel->clearPositionVelocityChanges();
+            } else {
+              skel->integratePositions(mTimeStep);
+            }
+          }
 
           if (preservingFinalSleepSolve && skel->getNumDofs() > 0) {
             skel->setVelocities(

--- a/python/dartpy/constraint/ConstraintSolver.cpp
+++ b/python/dartpy/constraint/ConstraintSolver.cpp
@@ -150,6 +150,17 @@ void ConstraintSolver(py::module& m)
             return self->getNumSimulationThreads();
           })
       .def(
+          "setSplitImpulseEnabled",
+          +[](dart::constraint::ConstraintSolver* self, bool enabled) {
+            self->setSplitImpulseEnabled(enabled);
+          },
+          ::py::arg("enabled"))
+      .def(
+          "isSplitImpulseEnabled",
+          +[](const dart::constraint::ConstraintSolver* self) -> bool {
+            return self->isSplitImpulseEnabled();
+          })
+      .def(
           "setCollisionDetector",
           +[](dart::constraint::ConstraintSolver* self,
               const std::shared_ptr<dart::collision::CollisionDetector>&

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -28,6 +28,7 @@ foreach(collision_engine
 endforeach()
 dart_add_test("integration" test_ConstraintSolver)
 dart_add_test("integration" test_ContactConstraint)
+dart_add_test("integration" test_SplitImpulse)
 dart_add_test("integration" test_IslandDeactivation)
 dart_add_test("integration" test_Issue719)
 dart_add_test("integration" test_GenericJoints)

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -1204,3 +1204,41 @@ TEST(ConstraintSolver, ConstactSurfaceHandlerIgnoreParent)
   EXPECT_TRUE(customHandler2->mCalled);
   EXPECT_EQ(2, params.mPrimaryFrictionCoeff);
 }
+
+//==============================================================================
+// Split impulse must be opt-in: disabled by default so the existing Baumgarte
+// (velocity-phase) penetration correction is preserved unchanged.
+TEST(ConstraintSolver, SplitImpulseDisabledByDefault)
+{
+  constraint::BoxedLcpConstraintSolver solver;
+  EXPECT_FALSE(solver.isSplitImpulseEnabled());
+}
+
+//==============================================================================
+TEST(ConstraintSolver, SplitImpulseEnabledRoundTrips)
+{
+  constraint::BoxedLcpConstraintSolver solver;
+  solver.setSplitImpulseEnabled(true);
+  EXPECT_TRUE(solver.isSplitImpulseEnabled());
+  solver.setSplitImpulseEnabled(false);
+  EXPECT_FALSE(solver.isSplitImpulseEnabled());
+}
+
+//==============================================================================
+// setFromOtherConstraintSolver must copy the split impulse flag so cloned
+// worlds preserve the configured contact-solve behavior.
+TEST(ConstraintSolver, SplitImpulseFlagIsCopiedFromOtherSolver)
+{
+  constraint::BoxedLcpConstraintSolver source;
+  source.setSplitImpulseEnabled(true);
+
+  constraint::BoxedLcpConstraintSolver target;
+  ASSERT_FALSE(target.isSplitImpulseEnabled());
+  target.setFromOtherConstraintSolver(source);
+  EXPECT_TRUE(target.isSplitImpulseEnabled());
+
+  constraint::BoxedLcpConstraintSolver sourceOff;
+  sourceOff.setSplitImpulseEnabled(false);
+  target.setFromOtherConstraintSolver(sourceOff);
+  EXPECT_FALSE(target.isSplitImpulseEnabled());
+}

--- a/tests/integration/test_SplitImpulse.cpp
+++ b/tests/integration/test_SplitImpulse.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/constraint/ConstraintSolver.hpp"
+#include "dart/dynamics/BoxShape.hpp"
+#include "dart/dynamics/FreeJoint.hpp"
+#include "dart/dynamics/Inertia.hpp"
+#include "dart/dynamics/Skeleton.hpp"
+#include "dart/dynamics/WeldJoint.hpp"
+#include "dart/simulation/World.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace dart;
+using namespace dart::dynamics;
+
+namespace {
+
+constexpr double kFloorHeight = 0.1;
+constexpr double kFloorSize = 10.0;
+constexpr double kBoxSize = 0.2;
+constexpr double kPenetration = 0.01;
+constexpr std::size_t kCorrectionSteps = 50;
+
+SkeletonPtr createFloor()
+{
+  auto floor = Skeleton::create("floor");
+  auto pair = floor->createJointAndBodyNodePair<WeldJoint>(nullptr);
+  auto* body = pair.second;
+
+  auto shape = std::make_shared<BoxShape>(
+      Eigen::Vector3d(kFloorSize, kFloorSize, kFloorHeight));
+  auto shapeNode = body->createShapeNodeWith<
+      VisualAspect,
+      CollisionAspect,
+      DynamicsAspect>(shape);
+  auto* dynamics = shapeNode->getDynamicsAspect();
+  dynamics->setFrictionCoeff(0.0);
+  dynamics->setRestitutionCoeff(0.0);
+
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation().z() = -kFloorHeight / 2.0;
+  pair.first->setTransformFromParentBodyNode(tf);
+
+  return floor;
+}
+
+SkeletonPtr createBox(double centerHeight)
+{
+  auto box = Skeleton::create("box");
+  auto pair = box->createJointAndBodyNodePair<FreeJoint>(nullptr);
+  auto* joint = pair.first;
+  auto* body = pair.second;
+
+  auto shape = std::make_shared<BoxShape>(Eigen::Vector3d::Constant(kBoxSize));
+  auto shapeNode = body->createShapeNodeWith<
+      VisualAspect,
+      CollisionAspect,
+      DynamicsAspect>(shape);
+  auto* dynamics = shapeNode->getDynamicsAspect();
+  dynamics->setFrictionCoeff(0.0);
+  dynamics->setRestitutionCoeff(0.0);
+
+  const double mass = 1.0;
+  Inertia inertia;
+  inertia.setMass(mass);
+  inertia.setMoment(shape->computeInertia(mass));
+  body->setInertia(inertia);
+
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation().z() = centerHeight;
+  FreeJoint::setTransformOf(joint, tf);
+
+  return box;
+}
+
+simulation::WorldPtr createPenetratingWorld(bool splitImpulse)
+{
+  auto world = simulation::World::create();
+  world->setGravity(Eigen::Vector3d::Zero());
+  world->setTimeStep(0.001);
+  auto* solver = world->getConstraintSolver();
+  EXPECT_NE(nullptr, solver);
+  solver->setSplitImpulseEnabled(splitImpulse);
+
+  auto floor = createFloor();
+  auto box = createBox(kBoxSize / 2.0 - kPenetration);
+  box->setVelocities(Eigen::VectorXd::Zero(box->getNumDofs()));
+
+  world->addSkeleton(floor);
+  world->addSkeleton(box);
+
+  return world;
+}
+
+} // namespace
+
+//==============================================================================
+// With split impulse enabled, a resting penetrating contact is corrected by the
+// position pass (the body is pushed up) without injecting a residual velocity.
+TEST(Issue201, SplitImpulseKeepsRestingContactVelocityZero)
+{
+  auto world = createPenetratingWorld(/*splitImpulse=*/true);
+  auto* solver = world->getConstraintSolver();
+  ASSERT_TRUE(solver->isSplitImpulseEnabled());
+
+  auto box = world->getSkeleton("box");
+  ASSERT_NE(box, nullptr);
+  const auto* body = box->getRootBodyNode();
+  ASSERT_NE(body, nullptr);
+  const double initialHeight = body->getTransform().translation().z();
+
+  for (std::size_t i = 0; i < kCorrectionSteps; ++i)
+    world->step();
+
+  EXPECT_NEAR(body->getLinearVelocity().z(), 0.0, 1e-6);
+  EXPECT_GT(body->getTransform().translation().z(), initialHeight + 1e-6);
+}
+
+//==============================================================================
+// The constraint solver defaults to split impulse OFF.
+TEST(Issue201, SplitImpulseDisabledByDefault)
+{
+  auto world = simulation::World::create();
+  auto* solver = world->getConstraintSolver();
+  ASSERT_NE(nullptr, solver);
+  EXPECT_FALSE(solver->isSplitImpulseEnabled());
+}
+
+//==============================================================================
+// Guard test: with split impulse OFF, the contact solve must reproduce the
+// pre-existing Baumgarte (ERP/ERV) penetration-correction behavior exactly.
+// Running the same penetrating scene twice (both flag-off) must produce
+// bit-identical trajectories, and the default path must apply the Baumgarte
+// penetration correction in the velocity solve (which manifests as a small
+// upward separation velocity), NOT the split-impulse position pass (which would
+// leave the velocity at zero). This pins the default path to the legacy
+// behavior that gz-physics / gz-sim rely on.
+TEST(Issue201, DefaultPathReproducesBaumgarteBehavior)
+{
+  auto worldA = createPenetratingWorld(/*splitImpulse=*/false);
+  auto worldB = createPenetratingWorld(/*splitImpulse=*/false);
+
+  ASSERT_FALSE(worldA->getConstraintSolver()->isSplitImpulseEnabled());
+  ASSERT_FALSE(worldB->getConstraintSolver()->isSplitImpulseEnabled());
+
+  auto boxA = worldA->getSkeleton("box");
+  auto boxB = worldB->getSkeleton("box");
+  ASSERT_NE(boxA, nullptr);
+  ASSERT_NE(boxB, nullptr);
+
+  // Two independent runs of the default path must be byte-for-byte identical.
+  for (std::size_t i = 0; i < kCorrectionSteps; ++i) {
+    worldA->step();
+    worldB->step();
+    EXPECT_EQ(
+        boxA->getRootBodyNode()->getTransform().translation().z(),
+        boxB->getRootBodyNode()->getTransform().translation().z());
+    EXPECT_EQ(
+        boxA->getRootBodyNode()->getLinearVelocity().z(),
+        boxB->getRootBodyNode()->getLinearVelocity().z());
+  }
+
+  // The Baumgarte penetration correction acts through the velocity solve, so
+  // after one step the resting penetrating box carries a small positive
+  // separation velocity. This is exactly the legacy behavior; the split-impulse
+  // path (flag-on) would instead leave this velocity at zero. Confirm the
+  // default path is the velocity-correction path.
+  auto worldStep = createPenetratingWorld(/*splitImpulse=*/false);
+  auto box = worldStep->getSkeleton("box");
+  worldStep->step();
+  EXPECT_GT(box->getRootBodyNode()->getLinearVelocity().z(), 0.0);
+}


### PR DESCRIPTION
Backports #2354 (split-impulse contact correction, issue #201) to `release-6.20`.

**Backward compatibility (perf-sensitive — verified):** additive / opt-in. Split-impulse is gated behind `ConstraintSolver::setSplitImpulseEnabled(true)`, default **false**. With the flag off, the velocity-solve and integration paths are byte-for-byte the existing Baumgarte default — empirically confirmed (flag-off resting/penetration velocities identical to baseline), so gz-physics behavior **and performance** are unchanged. The DART-7-only ECS `ClassicRigidSolver` hunk is re-homed into `World::step()`, gated on `isPositionImpulseApplied()`.

**Local verification (CI gridlocked → verified locally):**
- `pixi run test-all` — full C++ + Python suite green (incl. `test_SplitImpulse` and the split-impulse `ConstraintSolver` tests).
- gz checkpoint (`pixi run -e gazebo test-gz`) on the cumulative release-6.20 state: gz-physics 199 + 4 perf + gz-sim integration green.

Adapted to the DART-6 layout; the position-pass LCP assembly lives in `BoxedLcpConstraintSolver::solvePositionConstrainedGroup`. Port notes: `docs/dev_tasks/dart6_backport_audit`.