### PR TITLE
Backport polygon mesh support to release-6.20 (#2340)

### DIFF
--- a/dart/dynamics/MeshShape.cpp
+++ b/dart/dynamics/MeshShape.cpp
@@ -149,6 +149,7 @@ MeshShape::MeshShape(
     MeshOwnership ownership)
   : Shape(MESH),
     mTriMesh(nullptr),
+    mPolygonMesh(nullptr),
     mCachedAiScene(nullptr),
     mDisplayList(0),
     mScale(scale),
@@ -179,6 +180,7 @@ MeshShape::MeshShape(
     common::ResourceRetrieverPtr resourceRetriever)
   : Shape(MESH),
     mTriMesh(std::move(mesh)),
+    mPolygonMesh(nullptr),
     mCachedAiScene(nullptr),
     mMeshUri(uri),
     mResourceRetriever(std::move(resourceRetriever)),
@@ -202,6 +204,7 @@ MeshShape::MeshShape(
     common::ResourceRetrieverPtr resourceRetriever)
   : Shape(MESH),
     mTriMesh(nullptr),
+    mPolygonMesh(nullptr),
     mCachedAiScene(nullptr),
     mDisplayList(0),
     mScale(scale),
@@ -230,6 +233,7 @@ MeshShape::~MeshShape()
 void MeshShape::releaseMesh()
 {
   mMesh.reset();
+  mPolygonMesh.reset();
 }
 
 //==============================================================================
@@ -406,6 +410,44 @@ std::shared_ptr<math::TriMesh<double>> MeshShape::getTriMesh() const
 }
 
 //==============================================================================
+std::shared_ptr<math::PolygonMesh<double>> MeshShape::getPolygonMesh() const
+{
+  if (mPolygonMesh)
+    return mPolygonMesh;
+
+  // Preferred path: re-import from the source URI without triangulation so the
+  // original polygon topology (quads/n-gons) is preserved. This is independent
+  // of the (triangulated) aiScene/TriMesh used by the collision/render paths,
+  // so it does not affect existing triangle-mesh behavior.
+  if (!mMeshUri.toString().empty()) {
+    const common::ResourceRetrieverPtr retriever
+        = mResourceRetriever
+              ? mResourceRetriever
+              : std::make_shared<common::LocalResourceRetriever>();
+    if (const aiScene* polygonScene = loadPolygonScene(mMeshUri, retriever)) {
+      mPolygonMesh = convertAssimpPolygonMesh(polygonScene);
+      aiReleaseImport(polygonScene);
+      if (mPolygonMesh)
+        return mPolygonMesh;
+    }
+  }
+
+  // Fallback: derive a PolygonMesh from whatever representation is available.
+  const aiScene* scene = nullptr;
+  if (mMesh)
+    scene = mMesh.get();
+  else if (mCachedAiScene)
+    scene = mCachedAiScene;
+
+  if (scene)
+    mPolygonMesh = convertAssimpPolygonMesh(scene);
+  else if (const auto triMesh = getTriMesh())
+    mPolygonMesh = convertTriMeshToPolygonMesh(*triMesh);
+
+  return mPolygonMesh;
+}
+
+//==============================================================================
 std::shared_ptr<math::TriMesh<double>> MeshShape::convertAssimpMesh(
     const aiScene* scene)
 {
@@ -488,6 +530,84 @@ std::shared_ptr<math::TriMesh<double>> MeshShape::convertAssimpMesh(
   }
 
   return triMesh;
+}
+
+//==============================================================================
+std::shared_ptr<math::PolygonMesh<double>> MeshShape::convertAssimpPolygonMesh(
+    const aiScene* scene)
+{
+  if (!scene)
+    return nullptr;
+
+  auto polygonMesh = std::make_shared<math::PolygonMesh<double>>();
+
+  std::size_t totalVertices = 0;
+  std::size_t totalFaces = 0;
+  for (auto i = 0u; i < scene->mNumMeshes; ++i) {
+    const aiMesh* assimpMesh = scene->mMeshes[i];
+    if (!assimpMesh)
+      continue;
+
+    totalVertices += assimpMesh->mNumVertices;
+    totalFaces += assimpMesh->mNumFaces;
+  }
+
+  polygonMesh->reserveVertices(totalVertices);
+  polygonMesh->reserveFaces(totalFaces);
+  polygonMesh->reserveVertexNormals(totalVertices);
+
+  for (auto meshIndex = 0u; meshIndex < scene->mNumMeshes; ++meshIndex) {
+    const aiMesh* assimpMesh = scene->mMeshes[meshIndex];
+    if (!assimpMesh)
+      continue;
+
+    const std::size_t vertexOffset = polygonMesh->getVertices().size();
+
+    for (auto i = 0u; i < assimpMesh->mNumVertices; ++i) {
+      const aiVector3D& vertex = assimpMesh->mVertices[i];
+      polygonMesh->addVertex(vertex.x, vertex.y, vertex.z);
+    }
+
+    for (auto i = 0u; i < assimpMesh->mNumFaces; ++i) {
+      const aiFace& face = assimpMesh->mFaces[i];
+      if (face.mNumIndices < 3)
+        continue;
+
+      math::PolygonMesh<double>::Face polygonFace;
+      polygonFace.reserve(face.mNumIndices);
+      for (auto index = 0u; index < face.mNumIndices; ++index)
+        polygonFace.push_back(face.mIndices[index] + vertexOffset);
+      polygonMesh->addFace(std::move(polygonFace));
+    }
+
+    if (assimpMesh->mNormals) {
+      for (auto i = 0u; i < assimpMesh->mNumVertices; ++i) {
+        const aiVector3D& normal = assimpMesh->mNormals[i];
+        polygonMesh->addVertexNormal(normal.x, normal.y, normal.z);
+      }
+    }
+  }
+
+  return polygonMesh;
+}
+
+//==============================================================================
+std::shared_ptr<math::PolygonMesh<double>>
+MeshShape::convertTriMeshToPolygonMesh(const math::TriMesh<double>& mesh)
+{
+  auto polygonMesh = std::make_shared<math::PolygonMesh<double>>();
+
+  polygonMesh->reserveVertices(mesh.getVertices().size());
+  polygonMesh->reserveFaces(mesh.getTriangles().size());
+
+  polygonMesh->getVertices() = mesh.getVertices();
+  if (mesh.hasVertexNormals())
+    polygonMesh->getVertexNormals() = mesh.getVertexNormals();
+
+  for (const auto& triangle : mesh.getTriangles())
+    polygonMesh->addFace({triangle[0], triangle[1], triangle[2]});
+
+  return polygonMesh;
 }
 
 //==============================================================================
@@ -858,6 +978,13 @@ ShapePtr MeshShape::clone() const
   new_shape->mMaterials = mMaterials;
   new_shape->mSubMeshRanges = mSubMeshRanges;
 
+  // Carry over an already-cached polygon mesh, if any. setLegacyMesh() above
+  // resets it, so this assignment must come last.
+  if (mPolygonMesh) {
+    new_shape->mPolygonMesh
+        = std::make_shared<math::PolygonMesh<double>>(*mPolygonMesh);
+  }
+
   return new_shape;
 }
 
@@ -1021,6 +1148,57 @@ const aiScene* MeshShape::loadMesh(const std::string& filePath)
   DART_SUPPRESS_DEPRECATED_BEGIN
   const aiScene* scene = loadMesh("file://" + filePath, retriever);
   DART_SUPPRESS_DEPRECATED_END
+  return scene;
+}
+
+//==============================================================================
+const aiScene* MeshShape::loadPolygonScene(
+    const common::Uri& uri, const common::ResourceRetrieverPtr& retriever)
+{
+  // This mirrors loadMesh() but intentionally omits aiProcess_Triangulate so
+  // that the original polygon topology (quads/n-gons) is preserved. It is used
+  // only by getPolygonMesh(); the triangulated loadMesh() path used by the
+  // collision/render representations is left unchanged.
+  const std::string uriString = uri.toString();
+  const bool isCollada = isColladaResource(uriString, retriever);
+
+  aiPropertyStore* propertyStore = aiCreatePropertyStore();
+  aiSetImportPropertyInteger(
+      propertyStore,
+      AI_CONFIG_PP_SBP_REMOVE,
+      aiPrimitiveType_POINT | aiPrimitiveType_LINE);
+
+#ifdef AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION
+  if (isCollada) {
+    aiSetImportPropertyInteger(
+        propertyStore, AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION, 1);
+  }
+#endif
+
+  AssimpInputResourceRetrieverAdaptor systemIO(retriever);
+  aiFileIO fileIO = createFileIO(&systemIO);
+
+  const aiScene* scene = aiImportFileExWithProperties(
+      uriString.c_str(),
+      aiProcess_GenNormals | aiProcess_JoinIdenticalVertices
+          | aiProcess_SortByPType | aiProcess_OptimizeMeshes,
+      &fileIO,
+      propertyStore);
+
+  if (!scene) {
+    aiReleasePropertyStore(propertyStore);
+    return nullptr;
+  }
+
+#if !defined(AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION)
+  if (isCollada && scene->mRootNode)
+    scene->mRootNode->mTransformation = aiMatrix4x4();
+#endif
+
+  scene = aiApplyPostProcessing(scene, aiProcess_PreTransformVertices);
+
+  aiReleasePropertyStore(propertyStore);
+
   return scene;
 }
 

--- a/dart/dynamics/MeshShape.hpp
+++ b/dart/dynamics/MeshShape.hpp
@@ -36,6 +36,7 @@
 #include <dart/dynamics/MeshMaterial.hpp>
 #include <dart/dynamics/Shape.hpp>
 
+#include <dart/math/PolygonMesh.hpp>
 #include <dart/math/TriMesh.hpp>
 
 #include <dart/common/ResourceRetriever.hpp>
@@ -133,6 +134,15 @@ public:
 
   /// Returns the TriMesh representation of this mesh.
   std::shared_ptr<math::TriMesh<double>> getTriMesh() const;
+
+  /// Returns the polygon mesh representation of this mesh, if available.
+  ///
+  /// This is intended for rendering/export pipelines that want to preserve
+  /// non-triangular faces. The returned mesh is generated lazily: when the mesh
+  /// can be re-imported from its source URI, the original polygon topology
+  /// (quads/n-gons) is preserved; otherwise a triangulated representation is
+  /// returned.
+  std::shared_ptr<math::PolygonMesh<double>> getPolygonMesh() const;
 
   /// Returns the aiScene representation of this mesh.
   [[deprecated(
@@ -328,6 +338,21 @@ protected:
   static std::shared_ptr<math::TriMesh<double>> convertAssimpMesh(
       const aiScene* scene, std::vector<SubMeshRange>* subMeshes);
 
+  /// Converts an aiScene into a PolygonMesh, preserving original face topology
+  /// (quads/n-gons are not pre-triangulated).
+  static std::shared_ptr<math::PolygonMesh<double>> convertAssimpPolygonMesh(
+      const aiScene* scene);
+
+  /// Converts a TriMesh into a PolygonMesh (each triangle becomes one face).
+  static std::shared_ptr<math::PolygonMesh<double>> convertTriMeshToPolygonMesh(
+      const math::TriMesh<double>& mesh);
+
+  /// Imports an aiScene from a URI without triangulation, preserving polygon
+  /// faces. The caller owns the returned scene and must free it with
+  /// aiReleaseImport(). Used only by getPolygonMesh().
+  static const aiScene* loadPolygonScene(
+      const common::Uri& uri, const common::ResourceRetrieverPtr& retriever);
+
   /// Converts TriMesh back to aiScene for backward compatibility.
   const aiScene* convertToAssimpMesh() const;
 
@@ -335,6 +360,9 @@ protected:
 
   /// TriMesh representation.
   std::shared_ptr<math::TriMesh<double>> mTriMesh;
+
+  /// Polygon mesh representation (optional, cached on demand).
+  mutable std::shared_ptr<math::PolygonMesh<double>> mPolygonMesh;
 
   /// Submesh ranges extracted from Assimp.
   std::vector<SubMeshRange> mSubMeshRanges;

--- a/dart/gui/osg/render/MeshShapeNode.cpp
+++ b/dart/gui/osg/render/MeshShapeNode.cpp
@@ -39,6 +39,7 @@
 #include "dart/dynamics/MeshShape.hpp"
 #include "dart/dynamics/SimpleFrame.hpp"
 #include "dart/gui/osg/Utils.hpp"
+#include "dart/math/PolygonMesh.hpp"
 
 #include <osg/CullFace>
 #include <osg/Depth>
@@ -636,30 +637,68 @@ void MeshShapeGeometry::extractData(bool firstTime)
 
   if (mShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_ELEMENTS)
       || firstTime) {
-    ::osg::ref_ptr<::osg::DrawElementsUInt> elements[4];
+    ::osg::ref_ptr<::osg::DrawElementsUInt> elements[3];
     elements[0] = new ::osg::DrawElementsUInt(GL_POINTS);
     elements[1] = new ::osg::DrawElementsUInt(GL_LINES);
     elements[2] = new ::osg::DrawElementsUInt(GL_TRIANGLES);
-    elements[3] = new ::osg::DrawElementsUInt(GL_QUADS);
+
+    std::vector<Eigen::Vector3d> vertices;
+    vertices.reserve(mAiMesh->mNumVertices);
+    for (std::size_t i = 0; i < mAiMesh->mNumVertices; ++i) {
+      const aiVector3D& vertex = mAiMesh->mVertices[i];
+      vertices.emplace_back(vertex.x, vertex.y, vertex.z);
+    }
+
+    std::vector<std::size_t> polygon;
+    std::vector<Eigen::Matrix<std::size_t, 3, 1>> triangles;
 
     for (std::size_t i = 0; i < mAiMesh->mNumFaces; ++i) {
       const aiFace& face = mAiMesh->mFaces[i];
 
-      if (face.mNumIndices > 4) // We have some arbitrary polygon
-      {
-        ::osg::ref_ptr<::osg::DrawElementsUInt> polygon
-            = new ::osg::DrawElementsUInt(GL_POLYGON);
-        for (std::size_t j = 0; j < face.mNumIndices; ++j)
-          polygon->push_back(face.mIndices[j]);
-        addPrimitiveSet(polygon);
-      } else if (face.mNumIndices > 0) {
+      if (face.mNumIndices == 0) {
+        continue;
+      }
+
+      if (face.mNumIndices < 3) {
         ::osg::DrawElementsUInt* elem = elements[face.mNumIndices - 1];
         for (std::size_t j = 0; j < face.mNumIndices; ++j)
           elem->push_back(face.mIndices[j]);
+        continue;
+      }
+
+      if (face.mNumIndices == 3) {
+        ::osg::DrawElementsUInt* elem = elements[2];
+        for (std::size_t j = 0; j < face.mNumIndices; ++j)
+          elem->push_back(face.mIndices[j]);
+        continue;
+      }
+
+      polygon.clear();
+      polygon.reserve(face.mNumIndices);
+      for (std::size_t j = 0; j < face.mNumIndices; ++j) {
+        polygon.push_back(face.mIndices[j]);
+      }
+
+      triangles.clear();
+      if (!dart::math::detail::triangulateFaceEarClipping(
+              polygon, vertices, triangles)) {
+        const std::size_t v0 = polygon[0];
+        for (std::size_t j = 1; j + 1 < polygon.size(); ++j) {
+          elements[2]->push_back(v0);
+          elements[2]->push_back(polygon[j]);
+          elements[2]->push_back(polygon[j + 1]);
+        }
+        continue;
+      }
+
+      for (const auto& triangle : triangles) {
+        elements[2]->push_back(triangle[0]);
+        elements[2]->push_back(triangle[1]);
+        elements[2]->push_back(triangle[2]);
       }
     }
 
-    for (std::size_t i = 0; i < 4; ++i)
+    for (std::size_t i = 0; i < 3; ++i)
       if (elements[i]->size() > 0)
         addPrimitiveSet(elements[i]);
   }

--- a/dart/math/PolygonMesh.cpp
+++ b/dart/math/PolygonMesh.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/math/PolygonMesh.hpp"
+
+namespace dart {
+namespace math {
+
+template class PolygonMesh<double>;
+
+} // namespace math
+} // namespace dart

--- a/dart/math/PolygonMesh.hpp
+++ b/dart/math/PolygonMesh.hpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_MATH_POLYGONMESH_HPP_
+#define DART_MATH_POLYGONMESH_HPP_
+
+#include <dart/math/Mesh.hpp>
+#include <dart/math/TriMesh.hpp>
+
+#include <initializer_list>
+#include <vector>
+
+namespace dart {
+namespace math {
+
+/// This class represents polygon meshes with variable-length faces.
+template <typename S_>
+class PolygonMesh : public Mesh<S_>
+{
+public:
+  // Type aliases
+  using S = S_;
+  using Base = Mesh<S>;
+  using Index = typename Base::Index;
+  using Vector3 = typename Base::Vector3;
+  using Vertices = typename Base::Vertices;
+  using Normals = typename Base::Normals;
+  using Face = std::vector<Index>;
+  using Faces = std::vector<Face>;
+  using TriMeshType = TriMesh<S>;
+
+  /// Default constructor.
+  PolygonMesh();
+
+  /// Destructor.
+  ~PolygonMesh() override = default;
+
+  /// Reserves space for faces.
+  void reserveFaces(std::size_t n);
+
+  /// Reserves space for vertices.
+  void reserveVertices(std::size_t n);
+
+  /// Adds a vertex to the mesh.
+  void addVertex(S x, S y, S z);
+
+  /// Adds a vertex to the mesh.
+  void addVertex(const Vector3& vertex);
+
+  /// Reserves space for vertex normals.
+  void reserveVertexNormals(std::size_t n);
+
+  /// Adds a vertex normal to the mesh.
+  void addVertexNormal(S x, S y, S z);
+
+  /// Adds a vertex normal to the mesh.
+  void addVertexNormal(const Vector3& normal);
+
+  /// Adds a face to the mesh.
+  void addFace(const Face& face);
+
+  /// Adds a face to the mesh.
+  void addFace(Face&& face);
+
+  /// Adds a face to the mesh.
+  void addFace(std::initializer_list<Index> indices);
+
+  /// Returns true if the mesh contains faces.
+  bool hasFaces() const;
+
+  /// Returns the number of faces.
+  std::size_t getNumFaces() const;
+
+  /// Returns the faces of the mesh.
+  const Faces& getFaces() const;
+
+  /// Returns the faces of the mesh.
+  Faces& getFaces();
+
+  /// Clears all data in the mesh.
+  void clear() override;
+
+  /// Triangulates the polygon mesh into a TriMesh using ear clipping on a
+  /// projected plane; faces are assumed simple and planar.
+  TriMeshType triangulate() const;
+
+protected:
+  /// Faces of the mesh.
+  Faces mFaces;
+};
+
+using PolygonMeshf = PolygonMesh<float>;
+using PolygonMeshd = PolygonMesh<double>;
+
+} // namespace math
+} // namespace dart
+
+#include <dart/math/detail/PolygonMesh-impl.hpp>
+
+#endif // DART_MATH_POLYGONMESH_HPP_

--- a/dart/math/detail/PolygonMesh-impl.hpp
+++ b/dart/math/detail/PolygonMesh-impl.hpp
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_MATH_DETAIL_POLYGONMESH_IMPL_HPP_
+#define DART_MATH_DETAIL_POLYGONMESH_IMPL_HPP_
+
+#include <dart/math/PolygonMesh.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include <cmath>
+#include <cstddef>
+
+namespace dart {
+namespace math {
+
+namespace detail {
+
+struct ProjectedPoint
+{
+  double x{0.0};
+  double y{0.0};
+};
+
+inline double cross(
+    const ProjectedPoint& a, const ProjectedPoint& b, const ProjectedPoint& c)
+{
+  return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+}
+
+inline double polygonArea2(const std::vector<ProjectedPoint>& points)
+{
+  const std::size_t count = points.size();
+  double area2 = 0.0;
+  for (std::size_t i = 0; i < count; ++i) {
+    const auto& current = points[i];
+    const auto& next = points[(i + 1) % count];
+    area2 += current.x * next.y - next.x * current.y;
+  }
+  return area2;
+}
+
+template <typename Index, typename Vector3, typename Triangle>
+bool triangulateFaceEarClipping(
+    const std::vector<Index>& face,
+    const std::vector<Vector3>& vertices,
+    std::vector<Triangle>& triangles)
+{
+  triangles.clear();
+  const std::size_t count = face.size();
+  if (count < 3) {
+    return false;
+  }
+
+  if (count == 3) {
+    triangles.emplace_back(face[0], face[1], face[2]);
+    return true;
+  }
+
+  double normalX = 0.0;
+  double normalY = 0.0;
+  double normalZ = 0.0;
+  for (std::size_t i = 0; i < count; ++i) {
+    const auto& current = vertices[face[i]];
+    const auto& next = vertices[face[(i + 1) % count]];
+    const double cx = static_cast<double>(current.x());
+    const double cy = static_cast<double>(current.y());
+    const double cz = static_cast<double>(current.z());
+    const double nx = static_cast<double>(next.x());
+    const double ny = static_cast<double>(next.y());
+    const double nz = static_cast<double>(next.z());
+    normalX += (cy - ny) * (cz + nz);
+    normalY += (cz - nz) * (cx + nx);
+    normalZ += (cx - nx) * (cy + ny);
+  }
+
+  const double absX = std::abs(normalX);
+  const double absY = std::abs(normalY);
+  const double absZ = std::abs(normalZ);
+  if (absX <= std::numeric_limits<double>::epsilon()
+      && absY <= std::numeric_limits<double>::epsilon()
+      && absZ <= std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  enum class DropAxis
+  {
+    X,
+    Y,
+    Z
+  };
+
+  DropAxis dropAxis = DropAxis::Z;
+  if (absX >= absY && absX >= absZ) {
+    dropAxis = DropAxis::X;
+  } else if (absY >= absZ) {
+    dropAxis = DropAxis::Y;
+  }
+
+  std::vector<ProjectedPoint> projected;
+  projected.reserve(count);
+  double scale = 0.0;
+  for (std::size_t i = 0; i < count; ++i) {
+    const auto& vertex = vertices[face[i]];
+    ProjectedPoint point;
+    if (dropAxis == DropAxis::X) {
+      point.x = static_cast<double>(vertex.y());
+      point.y = static_cast<double>(vertex.z());
+    } else if (dropAxis == DropAxis::Y) {
+      point.x = static_cast<double>(vertex.x());
+      point.y = static_cast<double>(vertex.z());
+    } else {
+      point.x = static_cast<double>(vertex.x());
+      point.y = static_cast<double>(vertex.y());
+    }
+    scale = std::max(scale, std::max(std::abs(point.x), std::abs(point.y)));
+    projected.emplace_back(point);
+  }
+
+  if (scale < 1.0) {
+    scale = 1.0;
+  }
+  const double eps = std::max(
+      1e-12, std::numeric_limits<double>::epsilon() * scale * scale * 100.0);
+
+  const double area2 = polygonArea2(projected);
+  if (std::abs(area2) <= eps) {
+    return false;
+  }
+  const bool isCCW = area2 > 0.0;
+
+  std::vector<std::size_t> polygon(count);
+  for (std::size_t i = 0; i < count; ++i) {
+    polygon[i] = i;
+  }
+
+  bool removedColinear = true;
+  while (removedColinear && polygon.size() > 3) {
+    removedColinear = false;
+    for (std::size_t i = 0; i < polygon.size(); ++i) {
+      const std::size_t prev
+          = polygon[(i + polygon.size() - 1) % polygon.size()];
+      const std::size_t curr = polygon[i];
+      const std::size_t next = polygon[(i + 1) % polygon.size()];
+      if (std::abs(cross(projected[prev], projected[curr], projected[next]))
+          <= eps) {
+        polygon.erase(polygon.begin() + static_cast<std::ptrdiff_t>(i));
+        removedColinear = true;
+        break;
+      }
+    }
+  }
+
+  if (polygon.size() < 3) {
+    return false;
+  }
+
+  triangles.reserve(polygon.size() - 2);
+  const std::size_t maxIterations = polygon.size() * polygon.size();
+  std::size_t iterations = 0;
+
+  auto isConvex = [&](std::size_t prev, std::size_t curr, std::size_t next) {
+    const double turn
+        = cross(projected[prev], projected[curr], projected[next]);
+    return isCCW ? (turn > eps) : (turn < -eps);
+  };
+
+  auto containsPoint = [&](std::size_t prev,
+                           std::size_t curr,
+                           std::size_t next,
+                           std::size_t idx) -> bool {
+    const auto& point = projected[idx];
+    const double c1 = cross(projected[prev], projected[curr], point);
+    const double c2 = cross(projected[curr], projected[next], point);
+    const double c3 = cross(projected[next], projected[prev], point);
+    if (isCCW) {
+      return c1 >= -eps && c2 >= -eps && c3 >= -eps;
+    }
+    return c1 <= eps && c2 <= eps && c3 <= eps;
+  };
+
+  while (polygon.size() > 3 && iterations < maxIterations) {
+    bool earFound = false;
+    for (std::size_t i = 0; i < polygon.size(); ++i) {
+      const std::size_t prev
+          = polygon[(i + polygon.size() - 1) % polygon.size()];
+      const std::size_t curr = polygon[i];
+      const std::size_t next = polygon[(i + 1) % polygon.size()];
+
+      if (!isConvex(prev, curr, next)) {
+        continue;
+      }
+
+      bool hasInteriorPoint = false;
+      for (std::size_t j = 0; j < polygon.size(); ++j) {
+        const std::size_t idx = polygon[j];
+        if (idx == prev || idx == curr || idx == next) {
+          continue;
+        }
+        if (containsPoint(prev, curr, next, idx)) {
+          hasInteriorPoint = true;
+          break;
+        }
+      }
+      if (hasInteriorPoint) {
+        continue;
+      }
+
+      triangles.emplace_back(face[prev], face[curr], face[next]);
+      polygon.erase(polygon.begin() + static_cast<std::ptrdiff_t>(i));
+      earFound = true;
+      break;
+    }
+
+    if (!earFound) {
+      return false;
+    }
+    ++iterations;
+  }
+
+  if (polygon.size() == 3) {
+    triangles.emplace_back(
+        face[polygon[0]], face[polygon[1]], face[polygon[2]]);
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace detail
+
+//==============================================================================
+template <typename S>
+PolygonMesh<S>::PolygonMesh()
+{
+  // Do nothing
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::reserveFaces(std::size_t n)
+{
+  mFaces.reserve(n);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::reserveVertices(std::size_t n)
+{
+  this->mVertices.reserve(n);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::addVertex(S x, S y, S z)
+{
+  this->mVertices.emplace_back(x, y, z);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::addVertex(const Vector3& vertex)
+{
+  this->mVertices.push_back(vertex);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::reserveVertexNormals(std::size_t n)
+{
+  this->mVertexNormals.reserve(n);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::addVertexNormal(S x, S y, S z)
+{
+  this->mVertexNormals.emplace_back(x, y, z);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::addVertexNormal(const Vector3& normal)
+{
+  this->mVertexNormals.push_back(normal);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::addFace(const Face& face)
+{
+  mFaces.push_back(face);
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::addFace(Face&& face)
+{
+  mFaces.push_back(std::move(face));
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::addFace(std::initializer_list<Index> indices)
+{
+  mFaces.emplace_back(indices);
+}
+
+//==============================================================================
+template <typename S>
+bool PolygonMesh<S>::hasFaces() const
+{
+  return !mFaces.empty();
+}
+
+//==============================================================================
+template <typename S>
+std::size_t PolygonMesh<S>::getNumFaces() const
+{
+  return mFaces.size();
+}
+
+//==============================================================================
+template <typename S>
+const typename PolygonMesh<S>::Faces& PolygonMesh<S>::getFaces() const
+{
+  return mFaces;
+}
+
+//==============================================================================
+template <typename S>
+typename PolygonMesh<S>::Faces& PolygonMesh<S>::getFaces()
+{
+  return mFaces;
+}
+
+//==============================================================================
+template <typename S>
+void PolygonMesh<S>::clear()
+{
+  mFaces.clear();
+  Base::clear();
+}
+
+//==============================================================================
+template <typename S>
+typename PolygonMesh<S>::TriMeshType PolygonMesh<S>::triangulate() const
+{
+  TriMeshType triMesh;
+
+  triMesh.getVertices() = this->mVertices;
+  if (this->hasVertexNormals()) {
+    triMesh.getVertexNormals() = this->mVertexNormals;
+  }
+
+  std::size_t triangleCount = 0;
+  for (const auto& face : mFaces) {
+    if (face.size() >= 3) {
+      triangleCount += face.size() - 2;
+    }
+  }
+  triMesh.reserveTriangles(triangleCount);
+
+  std::vector<typename TriMeshType::Triangle> triangles;
+  for (const auto& face : mFaces) {
+    if (face.size() < 3) {
+      continue;
+    }
+    triangles.clear();
+    if (!detail::triangulateFaceEarClipping(face, this->mVertices, triangles)) {
+      const Index v0 = face[0];
+      for (std::size_t i = 1; i + 1 < face.size(); ++i) {
+        triMesh.addTriangle(v0, face[i], face[i + 1]);
+      }
+      continue;
+    }
+    for (const auto& triangle : triangles) {
+      triMesh.addTriangle(triangle[0], triangle[1], triangle[2]);
+    }
+  }
+
+  if (triMesh.hasTriangles()
+      && triMesh.getVertexNormals().size() != triMesh.getVertices().size()) {
+    triMesh.computeVertexNormals();
+  }
+
+  return triMesh;
+}
+
+} // namespace math
+} // namespace dart
+
+#endif // DART_MATH_DETAIL_POLYGONMESH_IMPL_HPP_

--- a/data/obj/Concave.obj
+++ b/data/obj/Concave.obj
@@ -1,0 +1,8 @@
+# Concave polygon in the XY plane
+o Concave
+v 0 0 0
+v 2 0 0
+v 2 2 0
+v 1 1 0
+v 0 2 0
+f 1 2 3 4 5

--- a/data/obj/Quad.obj
+++ b/data/obj/Quad.obj
@@ -1,0 +1,7 @@
+# Simple quad for polygon mesh tests
+o Quad
+v 0 0 0
+v 1 0 0
+v 1 1 0
+v 0 1 0
+f 1 2 3 4

--- a/docs/dev_tasks/mesh/mesh-topology.md
+++ b/docs/dev_tasks/mesh/mesh-topology.md
@@ -1,0 +1,37 @@
+# Mesh Topology Preservation (Triangles vs Quads)
+
+## Status
+
+In progress. Polygon mesh storage, loader triangulation, and unit coverage are
+in place; remaining work focuses on wiring polygon meshes into rendering paths
+and validating downstream usage.
+
+## Goals
+
+- Preserve original polygon topology (quads/ngons) for rendering and export.
+- Keep triangle meshes as the canonical collision/physics representation.
+- Ensure loaders triangulate non-triangular faces instead of dropping them.
+
+## Decisions
+
+- TriMesh remains the canonical geometry for collision backends.
+- A polygon mesh container stores variable-length faces and can triangulate
+  deterministically for collision usage.
+- Rendering continues to use Assimp scene data until the Assimp deprecation
+  path is complete.
+- Polygon-aware imports avoid Assimp pre-triangulation so face sizes are
+  preserved for rendering/export.
+- Triangulation uses ear clipping on a projected plane; faces are assumed
+  simple and planar (concave supported).
+- Rendering triangulates polygon faces using the same ear clipping path as
+  PolygonMesh::triangulate for collision consistency.
+
+## Plan
+
+1. Add a polygon mesh container in `dart::math` with a deterministic
+   triangulation routine that yields a `TriMesh`.
+2. Update mesh loaders to populate polygon faces and build a triangulated
+   `TriMesh` (no skipped faces).
+3. Add unit coverage for quad triangulation and non-tri face handling.
+4. Expose optional polygon mesh accessors in `MeshShape` and document the
+   rendering/physics split.

--- a/tests/unit/dynamics/test_MeshShape.cpp
+++ b/tests/unit/dynamics/test_MeshShape.cpp
@@ -343,4 +343,24 @@ TEST(MeshShapeTest, ColladaUriWithoutExtensionStillLoads)
       << ", canonicalExtents=" << canonicalExtents.transpose();
 }
 
+TEST(MeshShapeTest, PolygonMeshPreservesQuadFaces)
+{
+  const std::string filePath = DART_DATA_LOCAL_PATH "obj/Quad.obj";
+  const std::string fileUri = common::Uri::createFromPath(filePath).toString();
+  ASSERT_FALSE(fileUri.empty());
+
+  auto retriever = std::make_shared<common::LocalResourceRetriever>();
+  const aiScene* scene = dynamics::MeshShape::loadMesh(fileUri, retriever);
+  ASSERT_NE(scene, nullptr);
+
+  auto shape = std::make_shared<dynamics::MeshShape>(
+      Eigen::Vector3d::Ones(), scene, fileUri, retriever);
+
+  const auto polygonMesh = shape->getPolygonMesh();
+  ASSERT_NE(polygonMesh, nullptr);
+  ASSERT_TRUE(polygonMesh->hasFaces());
+  ASSERT_EQ(polygonMesh->getFaces().size(), 1u);
+  EXPECT_EQ(polygonMesh->getFaces()[0].size(), 4u);
+}
+
 DART_SUPPRESS_DEPRECATED_END

--- a/tests/unit/math/test_PolygonMesh.cpp
+++ b/tests/unit/math/test_PolygonMesh.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/math/PolygonMesh.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace dart;
+using namespace math;
+
+//==============================================================================
+TEST(PolygonMeshTests, TriangulateQuad)
+{
+  PolygonMeshd mesh;
+  mesh.reserveVertices(4);
+  mesh.reserveFaces(1);
+
+  mesh.addVertex(0.0, 0.0, 0.0);
+  mesh.addVertex(1.0, 0.0, 0.0);
+  mesh.addVertex(1.0, 1.0, 0.0);
+  mesh.addVertex(0.0, 1.0, 0.0);
+  mesh.addFace({0, 1, 2, 3});
+
+  const auto triMesh = mesh.triangulate();
+  EXPECT_EQ(triMesh.getVertices().size(), 4u);
+  EXPECT_EQ(triMesh.getTriangles().size(), 2u);
+
+  const auto& vertices = triMesh.getVertices();
+  const auto& face = mesh.getFaces()[0];
+  double polygonArea = 0.0;
+  for (std::size_t i = 0; i < face.size(); ++i) {
+    const auto& p = vertices[face[i]];
+    const auto& q = vertices[face[(i + 1) % face.size()]];
+    polygonArea += p.x() * q.y() - q.x() * p.y();
+  }
+  polygonArea = 0.5 * std::abs(polygonArea);
+
+  double triangleArea = 0.0;
+  for (const auto& triangle : triMesh.getTriangles()) {
+    const auto& a = vertices[triangle[0]];
+    const auto& b = vertices[triangle[1]];
+    const auto& c = vertices[triangle[2]];
+    const auto cross = (b - a).cross(c - a);
+    triangleArea += 0.5 * std::abs(cross.z());
+  }
+
+  EXPECT_NEAR(triangleArea, polygonArea, 1e-12);
+}
+
+//==============================================================================
+TEST(PolygonMeshTests, TriangulateConcave)
+{
+  PolygonMeshd mesh;
+  mesh.reserveVertices(5);
+  mesh.reserveFaces(1);
+
+  mesh.addVertex(0.0, 0.0, 0.0);
+  mesh.addVertex(2.0, 0.0, 0.0);
+  mesh.addVertex(2.0, 2.0, 0.0);
+  mesh.addVertex(1.0, 1.0, 0.0);
+  mesh.addVertex(0.0, 2.0, 0.0);
+  mesh.addFace({0, 1, 2, 3, 4});
+
+  const auto triMesh = mesh.triangulate();
+  EXPECT_EQ(triMesh.getTriangles().size(), 3u);
+
+  const auto& vertices = triMesh.getVertices();
+  const auto& face = mesh.getFaces()[0];
+  double polygonArea = 0.0;
+  for (std::size_t i = 0; i < face.size(); ++i) {
+    const auto& p = vertices[face[i]];
+    const auto& q = vertices[face[(i + 1) % face.size()]];
+    polygonArea += p.x() * q.y() - q.x() * p.y();
+  }
+  polygonArea = 0.5 * std::abs(polygonArea);
+
+  double triangleArea = 0.0;
+  for (const auto& triangle : triMesh.getTriangles()) {
+    const auto& a = vertices[triangle[0]];
+    const auto& b = vertices[triangle[1]];
+    const auto& c = vertices[triangle[2]];
+    const auto cross = (b - a).cross(c - a);
+    triangleArea += 0.5 * std::abs(cross.z());
+  }
+
+  EXPECT_NEAR(triangleArea, polygonArea, 1e-12);
+}
+
+//==============================================================================
+TEST(PolygonMeshTests, TriangulateComputesNormals)
+{
+  PolygonMeshd mesh;
+  mesh.addVertex(0.0, 0.0, 0.0);
+  mesh.addVertex(1.0, 0.0, 0.0);
+  mesh.addVertex(0.0, 1.0, 0.0);
+  mesh.addFace({0, 1, 2});
+
+  const auto triMesh = mesh.triangulate();
+  EXPECT_TRUE(triMesh.hasVertexNormals());
+  EXPECT_EQ(triMesh.getVertexNormals().size(), triMesh.getVertices().size());
+}


### PR DESCRIPTION
Backports #2340 (polygon / n-gon mesh support) to `release-6.20`.

**Backward compatibility:** additive. Adds a `PolygonMesh` representation + ear-clipping triangulation and `MeshShape::getPolygonMesh()` / `loadPolygonScene()`; the existing mesh load/collision/render path keeps `aiProcess_Triangulate`, so it only ever sees triangles and is unchanged. gz-physics / gz-sim mesh handling is unaffected.

**Local verification (CI gridlocked → verified locally):**
- `pixi run test-all` — full C++ + Python suite green (incl. `test_PolygonMesh`, `MeshShapeTest.PolygonMeshPreservesQuadFaces`).
- gz checkpoint (`pixi run -e gazebo test-gz`) on the cumulative release-6.20 state: gz-physics 199 + 4 perf + gz-sim integration green.

Adapted to the DART-6 layout (PolygonMesh delivered via `MeshShape::getPolygonMesh()` since DART-7's `MeshLoader` class is absent on 6.20; OSG render-node tessellation in `dart/gui/osg/render`). Note: the DART-7 GUI render-node integration test is not ported — 6.20 has no `tests/unit/gui` tree (same justified skip as #2338); the tessellation algorithm is covered by `test_PolygonMesh`. Port notes: `docs/dev_tasks/dart6_backport_audit`.