### PR TITLE
Fix clang-format violations in DART 6.20 backports

### DIFF
--- a/dart/dynamics/WeldJoint.cpp
+++ b/dart/dynamics/WeldJoint.cpp
@@ -89,7 +89,8 @@ BodyNode* WeldJoint::merge()
   // Before:
   //   parent --[WeldJoint]--> child --[any joints]--> grandchildren...
   // After:
-  //   parent absorbs child (inertia, forces, nodes) and grandchildren attach to parent.
+  //   parent absorbs child (inertia, forces, nodes) and grandchildren attach to
+  //   parent.
   BodyNode* parent = getParentBodyNode();
   BodyNode* child = getChildBodyNode();
 

--- a/python/dartpy/collision/RaycastOption.cpp
+++ b/python/dartpy/collision/RaycastOption.cpp
@@ -50,10 +50,8 @@ void RaycastOption(py::module& m)
           ::py::arg("enableAllHits"),
           ::py::arg("sortByClosest"))
       .def(
-          ::py::init<
-              bool,
-              bool,
-              dart::collision::RaycastOption::RaycastFilter>(),
+          ::py::
+              init<bool, bool, dart::collision::RaycastOption::RaycastFilter>(),
           ::py::arg("enableAllHits"),
           ::py::arg("sortByClosest"),
           ::py::arg("filter") = nullptr)
@@ -61,8 +59,7 @@ void RaycastOption(py::module& m)
           "mEnableAllHits", &dart::collision::RaycastOption::mEnableAllHits)
       .def_readwrite(
           "mSortByClosest", &dart::collision::RaycastOption::mSortByClosest)
-      .def_readwrite(
-          "mFilter", &dart::collision::RaycastOption::mFilter);
+      .def_readwrite("mFilter", &dart::collision::RaycastOption::mFilter);
 }
 
 } // namespace python

--- a/python/dartpy/dynamics/Joint.cpp
+++ b/python/dartpy/dynamics/Joint.cpp
@@ -367,9 +367,8 @@ void Joint(py::module& m)
           ::py::arg("enforced"))
       .def(
           "areLimitsEnforced",
-          +[](const dart::dynamics::Joint* self) -> bool {
-            return self->areLimitsEnforced();
-          })
+          +[](const dart::dynamics::Joint* self)
+              -> bool { return self->areLimitsEnforced(); })
       .def(
           "getIndexInSkeleton",
           +[](const dart::dynamics::Joint* self, std::size_t index)


### PR DESCRIPTION
Fixes the failing `Check Lint` CI step (clang-format-14 `check-format`) on `release-6.20` after the DART 6.20 feature backports.

Three backported files carried clang-format-14 nits that the build-only local gate did not catch:
- `dart/dynamics/WeldJoint.cpp` (#2242) — comment line-length rewrap
- `python/dartpy/collision/RaycastOption.cpp` (#2279) — `py::init<>` + `def_readwrite` reflow
- `python/dartpy/dynamics/Joint.cpp` (#2222) — lambda body reflow

Whitespace-only (clang-format is token-preserving) — no semantic change. `pixi run check-lint` passes locally.