### PR TITLE
Add single-body RevoluteJointConstraint coverage test

### DIFF
--- a/tests/integration/test_World.cpp
+++ b/tests/integration/test_World.cpp
@@ -701,6 +701,39 @@ TEST(World, RevoluteJointConstraintBasics)
 }
 
 //==============================================================================
+// Exercises the single-body RevoluteJointConstraint constructor, which anchors
+// one body to a fixed point in the world about a hinge axis. The body-to-body
+// test above does not cover this overload.
+TEST(World, RevoluteJointConstraintSingleBodyAnchorsToWorld)
+{
+  simulation::WorldPtr world
+      = utils::SkelParser::readWorld("dart://sample/skel/chain.skel");
+  ASSERT_TRUE(world != nullptr);
+
+  world->setGravity(Eigen::Vector3d(0.0, -9.81, 0.0));
+  world->setTimeStep(1.0 / 2000);
+
+  BodyNode* body = world->getSkeleton(0)->getBodyNode("link 6");
+  ASSERT_TRUE(body != nullptr);
+
+  const Eigen::Vector3d offset(0.0, 0.025, 0.0);
+  const Eigen::Vector3d anchorWorld = body->getTransform() * offset;
+
+  auto hinge = std::make_shared<constraint::RevoluteJointConstraint>(
+      body, anchorWorld, Eigen::Vector3d::UnitZ());
+  world->getConstraintSolver()->addConstraint(hinge);
+  ASSERT_EQ(world->getConstraintSolver()->getNumConstraints(), 1);
+
+  for (int i = 0; i < 200; ++i)
+    world->step();
+
+  // The anchored material point on the body must stay near the fixed world
+  // anchor despite gravity (the revolute constraint pins it to the world).
+  const Eigen::Vector3d anchorNow = body->getTransform() * offset;
+  EXPECT_LT((anchorNow - anchorWorld).norm(), 5e-2);
+}
+
+//==============================================================================
 TEST(World, SimulationThreadCount)
 {
   auto world = World::create();


### PR DESCRIPTION
Adds a focused test for the **single-body** `RevoluteJointConstraint` constructor (body-to-world anchor), which the existing `RevoluteJointConstraintBasics` test left uncovered (it only exercises the two-body overload).

Found via a local `lcov` run on the merged DART 6.20 backports: in `dart/constraint/RevoluteJointConstraint.cpp` the single-body constructor (lines ~59–88) and its world-axis paths were never executed by the suite. The new `World.RevoluteJointConstraintSingleBodyAnchorsToWorld` anchors a chain body to a fixed world point about a hinge axis and verifies the anchor holds under gravity.

Test-only; conflict-safe (`tests/integration/test_World.cpp` is not touched by the in-flight `perf/dart6-*` / `#3169` lane). Verified locally: new test passes and the full `test_World` suite is green (15/15).