### PR TITLE
Fix Check Lint failures on release-6.20 (codespell doc + clang-format)

### DIFF
--- a/dart/collision/CollisionDetector.hpp
+++ b/dart/collision/CollisionDetector.hpp
@@ -96,8 +96,8 @@ public:
   /// Helper function that creates and returns CollisionGroup as a shared_ptr.
   ///
   /// Internally, this function creates a shared_ptr from unique_ptr returned
-  /// from createCollisionGroup() so the performance would be slightly worse than
-  /// using std::make_unique.
+  /// from createCollisionGroup() so the performance would be slightly worse
+  /// than using std::make_unique.
   std::shared_ptr<CollisionGroup> createCollisionGroupAsSharedPtr();
 
   /// Create a collision group from any objects that are supported by

--- a/dart/dynamics/detail/GenericJoint.hpp
+++ b/dart/dynamics/detail/GenericJoint.hpp
@@ -48,7 +48,7 @@
 
 #define GenericJoint_REPORT_DIM_MISMATCH(func, arg)                            \
   {                                                                            \
-    dterr << "[GenericJoint::" #func "] Mismatch between size of "            \
+    dterr << "[GenericJoint::" #func "] Mismatch between size of "             \
           << #arg " [" << arg.size() << "] and the number of "                 \
           << "DOFs [" << getNumDofs() << "] for Joint named ["                 \
           << this->getName() << "].\n";                                        \

--- a/docs/dev_tasks/dart6_backport_audit/02-execution-log.md
+++ b/docs/dev_tasks/dart6_backport_audit/02-execution-log.md
@@ -122,8 +122,8 @@ dropped or re-homed.
   fixes ~270 typos across 128 files (comments/docs/strings/local vars; no
   behavioral change). Wiring the gate would normally red-X the parallel lane's
   open PRs and its fixes would edit do-not-collide files — so the 9 do-not-collide
-  files that carry pre-existing typos (`froce` in `Joint.hpp`, `enity` in
-  `World.cpp`, `witht` in `ContactConstraint.hpp`, etc.) are **temporarily
+  files that carry pre-existing typos (e.g. misspelled "force" in `Joint.hpp`,
+  "entity" in `World.cpp`, "with" in `ContactConstraint.hpp`) are **temporarily
   skipped** in `.codespellrc` under a labeled block. The gate therefore passes
   without editing their files and does **not** trip the other lane's PRs. Vendored
   `tests/unit/math/legacy_convhull_3d` is permanently skipped. **Cleanup hook in

--- a/tests/integration/test_Joints.cpp
+++ b/tests/integration/test_Joints.cpp
@@ -1046,14 +1046,16 @@ void testServoMotor()
     //     posLowerLimit - expected_vel * timeStep);
     // TODO(JS): Position limits and servo motor with infinite force limits
     // doesn't work together because they compete against each other to achieve
-    // different joint velocities with their infinite force limits. In this case,
-    // the position limit constraint should dominant the servo motor constraint.
+    // different joint velocities with their infinite force limits. In this
+    // case, the position limit constraint should dominant the servo motor
+    // constraint.
     EXPECT_NEAR(jointVels[5], 0.0, tol * 1e+2);
     // EXPECT_NEAR(jointVels[6], 0.0, tol * 1e+2);
     // TODO(JS): Servo motor with infinite force limits and infinite Coulomb
     // friction doesn't work because they compete against each other to achieve
-    // different joint velocities with their infinite force limits. In this case,
-    // the friction constraints should dominant the servo motor constraints.
+    // different joint velocities with their infinite force limits. In this
+    // case, the friction constraints should dominant the servo motor
+    // constraints.
   }
 }
 


### PR DESCRIPTION
Fixes the failing **Check Lint** CI step on `release-6.20` (the `Release`/`Debug` jobs run `pixi run check-lint`), introduced by the newly-enforced codespell gate from #2251/#3177:

1. **codespell** flagged the literal example typos in `02-execution-log.md` (the doc that *describes* the other lane's typos). Reworded to name the misspelled words without embedding the literal misspellings.
2. **clang-format-14** flagged 3 files (`CollisionDetector.hpp`, `detail/GenericJoint.hpp`, `test_Joints.cpp`) whose comment/string lengths shifted past the wrap threshold when #3177 fixed typos in them. Whitespace-only reformat (token-preserving).

`pixi run check-lint` now exits 0 (clang-format + gersemi + black/isort + codespell all clean). None of the touched files are in the in-flight `perf/dart6-*` / #3169 footprint.