### PR TITLE
dartpy: suppress MeshShape Assimp-API deprecation under -Werror (fix arm64/FreeBSD)

### DIFF
--- a/python/dartpy/dynamics/Shape.cpp
+++ b/python/dartpy/dynamics/Shape.cpp
@@ -297,6 +297,12 @@ void Shape(py::module& m)
           ::py::arg("height"),
           ::py::arg("mass"));
 
+  // MeshShape's Assimp (aiScene/aiMesh) constructors and setters are kept as
+  // deprecated DART 6 compatibility shims (TriMesh APIs are the replacement).
+  // Binding them deliberately uses those deprecated APIs, so suppress
+  // -Wdeprecated-declarations here — otherwise -Werror builds (e.g. macOS arm64)
+  // fail compiling this binding.
+  DART_SUPPRESS_DEPRECATED_BEGIN
   ::py::class_<
       dart::dynamics::MeshShape,
       dart::dynamics::Shape,
@@ -462,6 +468,7 @@ void Shape(py::module& m)
             return dart::dynamics::MeshShape::getStaticType();
           },
           ::py::return_value_policy::reference_internal);
+  DART_SUPPRESS_DEPRECATED_END
 
   auto attr = m.attr("MeshShape");
 


### PR DESCRIPTION
Fixes the `arm64-Debug` / `arm64-Release` (macOS arm64) CI failures on `release-6.20` — and likely `FreeBSD repro (VM)` (also clang).

**Root cause:** `python/dartpy/dynamics/Shape.cpp` binds MeshShape's `aiScene`/`aiMesh` constructors and setters, which are deprecated DART 6 compatibility shims (`[[deprecated("Use TriMesh-based APIs…")]]`, from #3145/#2325). The binding deliberately exposes them, but under **`-Werror -Wdeprecated-declarations`** (macOS arm64 + FreeBSD use clang) the deprecation becomes a hard compile error:
```
error: 'MeshShape' is deprecated: Use TriMesh-based APIs… [-Werror,-Wdeprecated-declarations]
```
The local Linux build (gcc) only warns, so it slipped through. This is a pre-existing latent break since #3145 that only surfaced now that the runner-gridlocked macOS arm64 job finally ran to the dartpy build step.

**Fix:** wrap the MeshShape `class_` binding block in `DART_SUPPRESS_DEPRECATED_BEGIN/END` (the standard pattern for binding deliberately-deprecated APIs; clang-aware). Only `Shape.cpp` binds the Assimp APIs, so no other binding is affected.

**Verification:** compiles clean locally (gcc; and the TU under `-Werror -Wdeprecated-declarations`). The exact Apple-clang/libc++ toolchain can't be reproduced locally, but the suppression macro emits the correct `#pragma clang diagnostic ignored "-Wdeprecated-declarations"`. Not in the in-flight perf-lane footprint.