### PR TITLE
Regenerate FreeBSD CMakeLists patch for gersemi-reformatted source

### DIFF
--- a/tools/freebsd/patches/patch-CMakeLists.txt
+++ b/tools/freebsd/patches/patch-CMakeLists.txt
@@ -1,24 +1,24 @@
---- CMakeLists.txt.orig	2024-06-25 05:13:56 UTC
+--- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -294,7 +294,7 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
-     # TODO: These warnings should be properly addressed and these compiler options removed
-     add_compile_options(-Wno-overloaded-virtual -Wno-alloc-size-larger-than -Wno-dangling-pointer)
+@@ -405,7 +405,7 @@
+       -Wno-dangling-pointer
+     )
    endif()
 -  set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 +  set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG")
-   set(CMAKE_CXX_FLAGS_DEBUG "-g -fno-omit-frame-pointer -fno-inline-functions -fno-inline-functions-called-once -fno-optimize-sibling-calls")
-   if(DART_FAST_DEBUG)
-     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1")
-@@ -322,7 +322,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+   set(
+     CMAKE_CXX_FLAGS_DEBUG
+     "-g -fno-omit-frame-pointer -fno-inline-functions -fno-inline-functions-called-once -fno-optimize-sibling-calls"
+@@ -442,7 +442,7 @@
    if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
    endif()
 -  set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 +  set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG")
-   set(CMAKE_CXX_FLAGS_DEBUG "-g -fno-omit-frame-pointer -fno-inline-functions -fno-optimize-sibling-calls")
-   if(DART_FAST_DEBUG)
-     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1")
-@@ -390,20 +390,20 @@ if(TARGET dart)
+   set(
+     CMAKE_CXX_FLAGS_DEBUG
+     "-g -fno-omit-frame-pointer -fno-inline-functions -fno-optimize-sibling-calls"
+@@ -517,20 +517,20 @@
    if(MSVC)
      add_subdirectory(examples)
    else()


### PR DESCRIPTION
Fixes the `FreeBSD repro (VM)` CI failure on `release-6.20`.

**Root cause:** the FreeBSD job applies `tools/freebsd/patches/patch-CMakeLists.txt` (`patch -p0`) to make DART build on FreeBSD (drop `-O3` from the Release flags, skip building examples). The gersemi CMake reformat (#2736) split the long `add_compile_options(...)` / `set(...FLAGS_DEBUG...)` lines and the `DART_USE_SYSTEM_FMT` option (#3108) shifted line numbers, so the patch context no longer matched — **2 of 3 hunks failed** (`saving rejects to CMakeLists.txt.rej`) and the FreeBSD build aborted before configuring.

**Fix:** regenerated `patch-CMakeLists.txt` against the current (gersemi-formatted) `CMakeLists.txt`, preserving the exact same FreeBSD adaptations. `CMakeLists.txt` itself is **unchanged** (the patch only applies inside the FreeBSD VM).

**Verification:** `patch -p0 --dry-run` now applies all six FreeBSD patches cleanly (previously `patch-CMakeLists.txt` failed). `pixi run check-lint` exit 0. Not in the in-flight perf-lane footprint.

Note: this was a latent consequence of #2736/#3108 that only surfaced once the runner-gridlocked FreeBSD VM job actually ran.