### PR TITLE
Complete #2251 spell-lint: remove temporary skips, fix remaining typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,16 +1,6 @@
 [codespell]
 # Exclude generated and third-party content to keep signal-to-noise low.
-skip = ./.git,./.pixi,./build,./build-*,./docs/readthedocs/_build,./docs/readthedocs/_generated,./external,./node_modules,*/_build/*,*/_generated/*,*/.venv/*,*/__pycache__/*,./tests/unit/math/legacy_convhull_3d,./CHANGELOG.md,./dart/collision/dart/DARTCollide.cpp,./dart/constraint/ConstrainedGroup.hpp,./dart/constraint/ConstraintSolver.hpp,./dart/constraint/ContactConstraint.hpp,./dart/dynamics/detail/JointAspect.hpp,./dart/dynamics/Joint.hpp,./dart/simulation/World.cpp,./tests/integration/test_Collision.cpp
-# TEMPORARY: skip files owned by the in-flight perf/dart6-* + #3169 lane (they carry pre-existing typos we must not edit to avoid conflicts). Remove these entries and fix their typos once that lane has merged.
-# ./CHANGELOG.md
-# ./dart/collision/dart/DARTCollide.cpp
-# ./dart/constraint/ConstrainedGroup.hpp
-# ./dart/constraint/ConstraintSolver.hpp
-# ./dart/constraint/ContactConstraint.hpp
-# ./dart/dynamics/detail/JointAspect.hpp
-# ./dart/dynamics/Joint.hpp
-# ./dart/simulation/World.cpp
-# ./tests/integration/test_Collision.cpp
+skip = ./.git,./.pixi,./build,./build-*,./docs/readthedocs/_build,./docs/readthedocs/_generated,./external,./node_modules,*/_build/*,*/_generated/*,*/.venv/*,*/__pycache__/*,./tests/unit/math/legacy_convhull_3d
 # Ignore domain terms that are not typos.
 ignore-words-list = DOUBLECLICK,mKe,Reacher,reacher,abd,pris,normaly
 quiet-level = 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1035,7 +1035,7 @@ This release is mostly a maintenance update, including various CI updates and bu
 * Dynamics
 
   * Fixed friction and restitution of individual shapes in a body: [#1369](https://github.com/dartsim/dart/pull/1369)
-  * Fixed soft body simulation when command input is not resetted: [#1372](https://github.com/dartsim/dart/pull/1372)
+  * Fixed soft body simulation when command input is not reset: [#1372](https://github.com/dartsim/dart/pull/1372)
   * Added joint velocity limit constraint support: [#1407](https://github.com/dartsim/dart/pull/1407)
   * Added type property to constrain classes: [#1415](https://github.com/dartsim/dart/pull/1415)
   * Allowed to set joint rest position out of joint limits: [#1418](https://github.com/dartsim/dart/pull/1418)
@@ -1819,7 +1819,7 @@ This release is mostly a maintenance update, including various CI updates and bu
   * Added gcc warning flag `-Wextra`: [#600](https://github.com/dartsim/dart/pull/600)
   * Improved memory management of `constraint` namespace: [#584](https://github.com/dartsim/dart/pull/584), [#583](https://github.com/dartsim/dart/issues/583)
   * Changed the extension of headers from `.h` to `.hpp`: [#709](https://github.com/dartsim/dart/pull/709), [#693](https://github.com/dartsim/dart/pull/693), [#568](https://github.com/dartsim/dart/issues/568)
-  * Changed Doxyfile to gnerate tag file: [#690](https://github.com/dartsim/dart/pull/690)
+  * Changed Doxyfile to generate tag file: [#690](https://github.com/dartsim/dart/pull/690)
   * Changed the convention to use `std::size_t` over `size_t`: [#681](https://github.com/dartsim/dart/pull/681), [#656](https://github.com/dartsim/dart/issues/656)
   * Changed CMake to configure preprocessors using `#cmakedefine`: [#648](https://github.com/dartsim/dart/pull/648), [#641](https://github.com/dartsim/dart/pull/641)
   * Updated copyright years: [#679](https://github.com/dartsim/dart/pull/679), [#160](https://github.com/dartsim/dart/issues/160)
@@ -1848,7 +1848,7 @@ This release is mostly a maintenance update, including various CI updates and bu
   * Changed Travis-CI to test DART with bullet collision detector: [#650](https://github.com/dartsim/dart/pull/650), [#376](https://github.com/dartsim/dart/issues/376)
   * Changed the minimum requirement of Visual Studio version to 2015: [#592](https://github.com/dartsim/dart/issues/592)
   * Changed CMake to build gui::osg examples when `DART_BUILD_EXAMPLES` is on: [#536](https://github.com/dartsim/dart/pull/536)
-  * Simplfied Travis-CI tests for general pushes: [#700](https://github.com/dartsim/dart/pull/700)
+  * Simplified Travis-CI tests for general pushes: [#700](https://github.com/dartsim/dart/pull/700)
   * Fixed Eigen memory alignment issue in testCollision.cpp: [#719](https://github.com/dartsim/dart/pull/719)
   * Fixed `BULLET_INCLUDE_DIRS` in `DARTConfig.cmake`: [#697](https://github.com/dartsim/dart/pull/697)
   * Fixed linking with Bullet on OS X El Capitan by supporting for Bullet built with double precision: [#660](https://github.com/dartsim/dart/pull/660), [#657](https://github.com/dartsim/dart/issues/657)
@@ -2101,7 +2101,7 @@ This release is mostly a maintenance update, including various CI updates and bu
     * [Pull request #384](https://github.com/dartsim/dart/pull/384)
     * [Issue #379](https://github.com/dartsim/dart/issues/379)
 
-1. Eradicated memory leaks and maked classes copy-safe and clonable
+1. Eradicated memory leaks and made classes copy-safe and clonable
     * [Pull request #369](https://github.com/dartsim/dart/pull/369)
     * [Pull request #390](https://github.com/dartsim/dart/pull/390)
     * [Pull request #391](https://github.com/dartsim/dart/pull/391)
@@ -2356,7 +2356,7 @@ This release is mostly a maintenance update, including various CI updates and bu
 ### Version 3.0 (2013-11-04)
 
 1. Removed Transformation classes. Their functionality is now included in joint classes.
-1. Added Featherstone algorithm. Can currently only be used without collision handling. The old algortihm is still present and used for that case.
+1. Added Featherstone algorithm. Can currently only be used without collision handling. The old algorithm is still present and used for that case.
 1. Removed kinematics namespace. Functionality is moved to dynamics classes.
 1. Added dart root namespace
 1. A lot of function and variable renames

--- a/dart/collision/dart/DARTCollide.cpp
+++ b/dart/collision/dart/DARTCollide.cpp
@@ -754,7 +754,7 @@ int dBoxBox(
   anr[1] = fabs(nr[1]);
   anr[2] = fabs(nr[2]);
 
-  // find the largest compontent of anr: this corresponds to the normal
+  // find the largest component of anr: this corresponds to the normal
   // for the indident face. the other axis numbers of the indicent face
   // are stored in a1,a2.
   int lanr, a1, a2;

--- a/dart/constraint/ConstrainedGroup.hpp
+++ b/dart/constraint/ConstrainedGroup.hpp
@@ -63,10 +63,10 @@ class ConstrainedGroup
 {
 public:
   //----------------------------------------------------------------------------
-  // Constructor / Desctructor
+  // Constructor / Destructor
   //----------------------------------------------------------------------------
 
-  /// Default contructor
+  /// Default constructor
   ConstrainedGroup();
 
   /// Destructor
@@ -94,7 +94,7 @@ public:
   /// Remove all constraints
   void removeAllConstraints();
 
-  /// Get total dimension of contraints in this group
+  /// Get total dimension of constraints in this group
   std::size_t getTotalDimension() const;
 
   //----------------------------------------------------------------------------

--- a/dart/constraint/ConstraintSolver.hpp
+++ b/dart/constraint/ConstraintSolver.hpp
@@ -88,7 +88,7 @@ public:
   /// Add single skeleton
   void addSkeleton(const dynamics::SkeletonPtr& skeleton);
 
-  /// Add mutiple skeletons
+  /// Add multiple skeletons
   void addSkeletons(const std::vector<dynamics::SkeletonPtr>& skeletons);
 
   /// Returns all the skeletons added to this ConstraintSolver.

--- a/dart/constraint/ContactConstraint.hpp
+++ b/dart/constraint/ContactConstraint.hpp
@@ -256,7 +256,7 @@ private:
   /// Set secondary slip compliance
   void setSecondarySlipCompliance(double slip);
 
-  /// Get contact object associated witht this constraint
+  /// Get contact object associated with this constraint
   const collision::Contact& getContact() const;
 
 private:

--- a/dart/dynamics/Joint.hpp
+++ b/dart/dynamics/Joint.hpp
@@ -709,12 +709,12 @@ public:
   /// \param[in] _index Index of joint axis.
   virtual double getDampingCoefficient(std::size_t _index) const = 0;
 
-  /// Set joint Coulomb friction froce.
+  /// Set joint Coulomb friction force.
   /// \param[in] _index Index of joint axis.
-  /// \param[in] _friction Joint Coulomb friction froce given index.
+  /// \param[in] _friction Joint Coulomb friction force given index.
   virtual void setCoulombFriction(std::size_t _index, double _friction) = 0;
 
-  /// Get joint Coulomb friction froce.
+  /// Get joint Coulomb friction force.
   /// \param[in] _index Index of joint axis.
   virtual double getCoulombFriction(std::size_t _index) const = 0;
 

--- a/dart/dynamics/detail/JointAspect.hpp
+++ b/dart/dynamics/detail/JointAspect.hpp
@@ -106,7 +106,7 @@ enum ActuatorType
   VELOCITY,
 
   /// Locked joint always set the velocity and acceleration to zero so that
-  /// the joint dosen't move at all (locked), and the output is joint force.
+  /// the joint doesn't move at all (locked), and the output is joint force.
   /// force.
   ///
   /// All the joint constraints are invalid.

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -2010,7 +2010,7 @@ void World::handleSimpleFrameNameChange(const dynamics::Entity* _entity)
 
   if (nullptr == frame) {
     dterr << "[World::handleFrameNameChange] Received a callback for a nullptr "
-          << "enity. This is most likely a bug. Please report this!\n";
+          << "entity. This is most likely a bug. Please report this!\n";
     DART_ASSERT(false);
     return;
   }

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -256,7 +256,7 @@ void Collision::dropWithRotation(
   dart::collision::fcl::setTranslation(objectTransf, dropping_position);
 
   //==========================================================================
-  // Dropping test in x, y, z aixs each.
+  // Dropping test in x, y, z axis each.
   //==========================================================================
   for (int _idxAxis = 0; _idxAxis < 3; ++_idxAxis) {
     result.clear();
@@ -765,7 +765,7 @@ void testBoxBox(
   const auto checkNumContacts = (numContacts <= 4u);
   EXPECT_TRUE(checkNumContacts);
   if (!checkNumContacts)
-    std::cout << "# of contants: " << numContacts << "\n";
+    std::cout << "# of contacts: " << numContacts << "\n";
 
   for (const auto& contact : result.getContacts()) {
     const auto& point = contact.point;
@@ -3628,7 +3628,7 @@ TEST_F(Collision, CollisionOfPrescribedJoints)
 {
   // There are one red plate (static skeleton) and 5 pendulums with different
   // actuator types. This test check if the motion prescribed joints are exactly
-  // tracking the prescribed motion eventhough there are collision with other
+  // tracking the prescribed motion even though there are collision with other
   // objects.
 
   const double tol = 1e-9;
@@ -3691,7 +3691,7 @@ TEST_F(Collision, CollisionOfPrescribedJoints)
     EXPECT_TRUE(joint3->isDynamic());
 
     // Check if the motion prescribed joints are following the prescribed motion
-    // eventhough there is a collision with other objects
+    // even though there is a collision with other objects
     EXPECT_TRUE(joint4->isKinematic());
     EXPECT_NEAR(joint4->getAcceleration(0), joint4->getCommand(0), tol);
     EXPECT_TRUE(joint5->isKinematic());


### PR DESCRIPTION
Completes the #2251 spell-lint backport by removing the **temporary** `.codespellrc` skip entries that protected the in-flight `perf/dart6-*` + #3169 lane's files. That lane has now fully merged (#3169, #3183, the perf stack), so the 9 do-not-collide files are no longer off-limits.

- Removed the 9 `# TEMPORARY` skip entries (and the block) from `.codespellrc` — codespell now scans the whole tree.
- Fixed their pre-existing typos (comments/strings/CHANGELOG only, **no code identifiers**): `froce`→`force` (Joint.hpp doc comments), `enity`→`entity`, `contants`→`contacts`, `aixs`→`axis`, `eventhough`→`even though`, `Desctructor`→`Destructor`, `mutiple`→`multiple`, etc.

`pixi run check-lint` (clang-format + gersemi + black/isort + codespell) exits 0. No build impact (comment/string only). Closes out the last open item from `docs/dev_tasks/dart6_backport_audit/02-execution-log.md` §9.