### PR TITLE
Audit docs: don't claim CI matrix green before a completed run (fix-forward for #3185)

### DIFF
--- a/docs/dev_tasks/dart6_backport_audit/02-execution-log.md
+++ b/docs/dev_tasks/dart6_backport_audit/02-execution-log.md
@@ -6,13 +6,15 @@ per-item plan/evidence, [`RESUME.md`](RESUME.md) owns next steps — and this fi
 owns the **record of what was actually ported, how it was verified, and how
 conflicts with the parallel performance lane were avoided**.
 
-**Status: COMPLETE (2026-06-25).** All accepted feature backports, the in-scope
-CI/build tooling, and the spell-lint (including its temporary-skip cleanup) are
-merged to `release-6.20`. After the GitHub CI runner gridlock cleared, the full
-matrix surfaced several *latent* platform-specific failures (clang `-Werror`,
-macOS arm64, FreeBSD VM patches, MSVC) — all now resolved (§10). Two of them were
-fixed by the parallel performance lane in DART-6 code this effort had backported.
-Nothing remains open. Final green HEAD: see §10.
+**Status (2026-06-25): all work merged; a clean green-matrix run is the only
+remaining gate.** All accepted feature backports, the in-scope CI/build tooling,
+and the spell-lint (including its temporary-skip cleanup) are merged to
+`release-6.20`. After the GitHub CI runner gridlock cleared, the full matrix
+surfaced several *latent* platform-specific failures (clang `-Werror`, macOS arm64,
+FreeBSD VM patches, MSVC) — all now resolved (§9). Two of them were fixed by the
+parallel performance lane in DART-6 code this effort had backported. No code items
+remain; a clean, uninterrupted green run of the required matrix is the closing
+confirmation (§10).
 
 ---
 
@@ -197,4 +199,10 @@ so the required CI matrix — Debug, Release (Linux + Windows), Asserts-enabled,
 `arm64-Debug/Release`, FreeBSD, coverage, gcc/clang, the Eigen over-alignment
 guard, and all manylinux/macOS wheels — has **no remaining known failures**. The
 `#2251` spell-lint cleanup (#3184) is the final change and is comment/string-only
-(no build impact). The DART 6.20 backport effort is **closed**.
+(no build impact).
+
+**Closing gate:** the matrix is not yet *confirmed* green — the runs on the most
+recent docs-only heads were **cancelled** by superseding pushes (not failures), so
+no single completed all-green run exists yet. The closing session must let the full
+required matrix complete on the final head and confirm green before declaring the
+effort done. All engineering work is complete; this is the only remaining step.

--- a/docs/dev_tasks/dart6_backport_audit/README.md
+++ b/docs/dev_tasks/dart6_backport_audit/README.md
@@ -286,27 +286,25 @@ Each backport PR carries its own gate, sized to the touched surface:
 - **Always** run `pixi run lint`.
 - Milestone **DART 6.20** on every backport PR.
 
-## Remaining work
+## Remaining work — none (effort complete)
 
-1. **Compat-critical backport queue** — #2509 is carried by
-   [#3130](https://github.com/dartsim/dart/pull/3130), and #2339 is carried by
-   [#3131](https://github.com/dartsim/dart/pull/3131). Port the remaining five
-   compat-critical items (#3115/#3117, #2233, #2271, #2285, #2247) in the order
-   and with the per-surface gates given in [`RESUME.md`](RESUME.md) section 1.
-   #3115/#3117 is a forward-port of the DART-6-shaped #3117 twin. Run the gz
-   gate on every collision/constraint/parser surface.
-2. **CI/tooling bumps** — selective action-version bumps to `release-6.20`
-   workflows only where the workflow is shared with `main`; skip `main`-only
-   actions.
-3. **#3108 fmt fallback** — do **not** backport by default; it is
-   `feature_optional`. Open it only if `release-6.20` CI starts hitting the
-   broken-system-fmt mode, and first confirm whether an
-   `altlinux-fmt-fetchcontent` branch / open PR exists to avoid duplicate work.
-4. **Maintainer decisions** — get go/no-go on the `feature_optional` list (#2338
-   convex-mesh and #2325 MeshShape TriMesh costed, plus the rest of the 14 in the
-   inventory). Default is defer.
-5. Keep this README and `RESUME.md` in sync as items land; move durable
-   outcomes to `release-management.md` / changelog when a backport merges.
+> **All planned work has landed. The only outstanding step is confirming a clean,
+> uninterrupted green run of the required CI matrix** (see
+> [`02-execution-log.md`](02-execution-log.md) §10). A future session must **not**
+> re-port any item below — they are all merged.
 
-See [`RESUME.md`](RESUME.md) for exact next steps and
-[`01-backport-inventory.md`](01-backport-inventory.md) for the full evidence.
+For history, the item → landing-PR mapping:
+
+1. **Compat-critical backport queue** — all done: #2509 (#3130), #2339 (#3131),
+   #3115/#3117 (#3132), #2233 (#3134), #2271 (#3136), #2285 (superseded by #2325 /
+   #3145), #2247 (#3137).
+2. **Maintainer-decision `feature_optional` set** — all ported: the 13 features
+   #3156–#3168, plus #2325 (#3145).
+3. **CI/build tooling** — #3108, #2736, #2185, #2541 (combined #3174); #2251
+   spell-lint (#3177 + cleanup #3184). #2655 was a no-op on 6.20 (skipped).
+4. **CI/tooling action bumps** — Dependabot pin currency; a per-branch watch item,
+   not a backport obligation.
+
+The full execution record is in [`02-execution-log.md`](02-execution-log.md); the
+[`RESUME.md`](RESUME.md) checklists and
+[`01-backport-inventory.md`](01-backport-inventory.md) evidence are historical.

--- a/docs/dev_tasks/dart6_backport_audit/README.md
+++ b/docs/dev_tasks/dart6_backport_audit/README.md
@@ -19,7 +19,9 @@ framing, and decisions; the inventory owns the detailed evidence;
 [`RESUME.md`](RESUME.md) owns the exact, prioritized next steps; and
 [`02-execution-log.md`](02-execution-log.md) owns the record of what was actually
 ported, how it was verified, and the conflict resolutions — this effort is
-**DONE and closed** (all backports merged, full CI matrix green; see that log).
+all backports merged and every post-gridlock failure fixed; the required CI matrix
+has no remaining known failures (a final, uninterrupted green run is the closing
+confirmation — see that log).
 
 What this task is **not**:
 

--- a/docs/dev_tasks/dart6_backport_audit/RESUME.md
+++ b/docs/dev_tasks/dart6_backport_audit/RESUME.md
@@ -138,7 +138,7 @@ nanobind) — see the recipe in section 2.
     DART 6 Bullet stack.
   - Gate: build + `collision` (Bullet) focused unit tests **+ gz gate** —
     collision surface.
-- [ ] **[#2285](https://github.com/dartsim/dart/pull/2285) — aiScene ownership
+- [x] **[#2285](https://github.com/dartsim/dart/pull/2285) — aiScene ownership
   via shared_ptr custom deleters (makeMeshHandle)** *(memory-correctness;
   public API change)*
   - Commit `ee5be94c6f898e762767141aa44b3cb1bf6b169a`. release-6.20 owns a raw
@@ -160,7 +160,7 @@ nanobind) — see the recipe in section 2.
     `main` by #2325** (TriMesh adoption, §4) — prefer porting #2325, whose
     `getMesh()` stays raw `const aiScene*` (deprecated) so it needs no
     `shared_ptr` return-type break.
-- [ ] **[#2247](https://github.com/dartsim/dart/pull/2247) — mimic/coupler
+- [x] **[#2247](https://github.com/dartsim/dart/pull/2247) — mimic/coupler
   constraint correctness (ERP + force-mixing/limit-clamp)** *(gz mimic repro;
   most surgical — must split bug fix from feature)*
   - Commit `94a5d5bcad5fe663c3850929f8bc274d3118792d`. PR title targets the
@@ -246,7 +246,7 @@ wants release-6.20 dev ergonomics aligned with main, batch them into a single
 `backport/ci-tooling-to-release-6.20` branch (milestone DART 6.20,
 `pixi run lint` gate only):
 
-- [ ] **[#3108](https://github.com/dartsim/dart/pull/3108)** — `DART_USE_SYSTEM_FMT`
+- [x] **[#3108](https://github.com/dartsim/dart/pull/3108)** — `DART_USE_SYSTEM_FMT`
   + FetchContent fmt fallback. **`feature_optional` (build-convenience) — do NOT
   backport by default.** **In-flight note:** the local WIP branch
   `altlinux-fmt-fetchcontent` (commit `a0abf624bd2`) is **gone from the remote**;
@@ -254,20 +254,20 @@ wants release-6.20 dev ergonomics aligned with main, batch them into a single
   against system fmt via `find_package(fmt)`; backport only if release CI starts
   hitting the broken-system-fmt failure mode. (Alt Linux is a non-required
   canary.)
-- [ ] **[#2541](https://github.com/dartsim/dart/pull/2541)** — Eigen
+- [x] **[#2541](https://github.com/dartsim/dart/pull/2541)** — Eigen
   over-alignment CI guard. Low value on a stable DART 6 ABI; watch only.
-- [ ] **[#2736](https://github.com/dartsim/dart/pull/2736)** — gersemi CMake
+- [x] **[#2736](https://github.com/dartsim/dart/pull/2736)** — gersemi CMake
   formatting (`lint-cmake`). Dev formatting only.
-- [ ] **[#2185](https://github.com/dartsim/dart/pull/2185)** — Taplo TOML
+- [x] **[#2185](https://github.com/dartsim/dart/pull/2185)** — Taplo TOML
   linting (`lint-toml`). Dev formatting only.
-- [ ] **[#2251](https://github.com/dartsim/dart/pull/2251)** — codespell spell
+- [x] **[#2251](https://github.com/dartsim/dart/pull/2251)** — codespell spell
   lint + cosmetic typo fixes. Backport a typo only if it touches a user-facing
   string a DART 6 consumer depends on (none identified).
-- [ ] **[#2655](https://github.com/dartsim/dart/pull/2655)** — centralized CI
+- [x] **[#2655](https://github.com/dartsim/dart/pull/2655)** — centralized CI
   path filters (`ci-code.yml` + `ci-scope`). Coupled to main's multi-workflow
   layout; a port would require reworking release-6.20's distinct workflow set
   with no correctness benefit.
-- [ ] **GitHub Action version currency (Dependabot pin skew)** — checkout
+- [x] **GitHub Action version currency (Dependabot pin skew)** — checkout
   v6->v7, codecov v5->v7, etc. **Not a porting obligation:** Dependabot updates
   pins per-branch on its own cadence. Monitor only.
 

--- a/docs/dev_tasks/dart6_backport_audit/RESUME.md
+++ b/docs/dev_tasks/dart6_backport_audit/RESUME.md
@@ -1,11 +1,13 @@
 # RESUME: DART 6 Backport Audit (release-6.20)
 
-> **Status (2026-06-25): DONE — the backport effort is fully CLOSED.** Every
-> accepted feature backport, the in-scope CI/build tooling, and the spell-lint
-> (including its temporary-skip cleanup, #3184) are merged to `release-6.20`, and
-> the full required CI matrix is green. The post-gridlock platform-specific
-> failures were all resolved (two by the parallel performance lane). There are no
-> outstanding items. See [`02-execution-log.md`](02-execution-log.md) for the full
+> **Status (2026-06-25): all backport work merged; final green-matrix run still
+> pending.** Every accepted feature backport, the in-scope CI/build tooling, and the
+> spell-lint (including its temporary-skip cleanup, #3184) are merged to
+> `release-6.20`, and every post-gridlock platform failure is fixed (§9), so the
+> required CI matrix has **no remaining known failures**. It is **not yet confirmed
+> green**: the runs on the most recent docs-only heads were *cancelled* by superseding
+> pushes (not real failures), so the closing session must let the full required matrix
+> complete on the final head before declaring green. No code items remain. See [`02-execution-log.md`](02-execution-log.md) for the full
 > record — merged PRs, verification, conflict resolutions, cross-lane safety, and
 > the §9 post-gridlock CI resolution. The checklists below are historical.
 


### PR DESCRIPTION
Fix-forward for [Codex's review on #3185](https://github.com/dartsim/dart/pull/3185): the audit docs claimed the required CI matrix is **green**, but the runs on the recent docs-only heads were **cancelled** by superseding pushes (not failures), so no completed all-green run exists yet — the claim was unsupported.

Reworded `RESUME.md`, `README.md`, and `02-execution-log.md` (header, §10) to state accurately: all engineering work is merged and every post-gridlock platform failure is fixed (no remaining *known* failures), with **a clean, uninterrupted green run of the required matrix as the explicit closing gate** (not yet confirmed).

Docs-only. `pixi run check-lint` (incl. codespell) exits 0.

@codex review