### PR TITLE
Fast-path axis-aligned plane contact bounds

### DIFF
--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -273,6 +273,12 @@ struct BroadphaseEntry
   bool plane{false};
 };
 
+struct ContactBoundEntry
+{
+  Eigen::Vector3d min{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d max{Eigen::Vector3d::Zero()};
+};
+
 constexpr double kContactDuplicateTolerance = 3.0e-12;
 constexpr double kContactPointCellSize = 4.0 * kContactDuplicateTolerance;
 constexpr double kContactPointKeyLowerBound = -9223372036854775808.0;
@@ -345,7 +351,7 @@ struct BroadphaseScratch
   std::vector<const BroadphaseEntry*> sortedEntries1;
   std::vector<const BroadphaseEntry*> sortedEntries2;
   std::vector<BroadphaseEntry> contactBoundFiniteEntries;
-  std::vector<BroadphaseEntry> contactBoundEntries;
+  std::vector<ContactBoundEntry> contactBoundEntries;
   std::vector<std::size_t> parallelPairIndices;
   std::vector<ScratchCollisionResult> parallelPairResults;
   std::vector<char> parallelPairCollisions;
@@ -424,14 +430,14 @@ bool canSkipBodyNodeFilterForFinitePlanePairs(
 bool overlaps(const BroadphaseEntry& entry1, const BroadphaseEntry& entry2);
 
 bool contactBoundsOverlap(
-    const BroadphaseEntry& entry1,
-    const BroadphaseEntry& entry2,
+    const ContactBoundEntry& entry1,
+    const ContactBoundEntry& entry2,
     double padding);
 
 bool haveMutuallyDisjointProjectedContactBounds(
     const std::vector<BroadphaseEntry>& finiteEntries,
     const BroadphaseEntry& planeEntry,
-    std::vector<BroadphaseEntry>& projectedEntries);
+    std::vector<ContactBoundEntry>& projectedEntries);
 
 bool processFinitePlanePairs(
     const std::vector<BroadphaseEntry>& finiteEntries,
@@ -1898,13 +1904,10 @@ bool overlaps(const BroadphaseEntry& entry1, const BroadphaseEntry& entry2)
 
 //==============================================================================
 bool contactBoundsOverlap(
-    const BroadphaseEntry& entry1,
-    const BroadphaseEntry& entry2,
+    const ContactBoundEntry& entry1,
+    const ContactBoundEntry& entry2,
     double padding)
 {
-  if (!entry1.finite || !entry2.finite)
-    return true;
-
   for (int axis = 0; axis < 3; ++axis) {
     if (entry1.max[axis] + padding < entry2.min[axis]
         || entry2.max[axis] + padding < entry1.min[axis]) {
@@ -1949,17 +1952,40 @@ bool getPlaneProjection(
 }
 
 //==============================================================================
+int getExactAxisAlignedNormalAxis(const Eigen::Vector3d& normal)
+{
+  for (int axis = 0; axis < 3; ++axis) {
+    const int axis1 = (axis + 1) % 3;
+    const int axis2 = (axis + 2) % 3;
+    if (std::abs(normal[axis]) == 1.0 && normal[axis1] == 0.0
+        && normal[axis2] == 0.0) {
+      return axis;
+    }
+  }
+  return -1;
+}
+
+//==============================================================================
 bool makeProjectedContactBounds(
     const BroadphaseEntry& entry,
     const Eigen::Vector3d& planeNormal,
     const Eigen::Vector3d& planePoint,
-    BroadphaseEntry& projectedEntry)
+    int axisAlignedNormalAxis,
+    ContactBoundEntry& projectedEntry)
 {
   if (!entry.finite)
     return false;
 
-  projectedEntry = BroadphaseEntry();
-  projectedEntry.finite = true;
+  if (axisAlignedNormalAxis >= 0) {
+    projectedEntry.min = entry.min;
+    projectedEntry.max = entry.max;
+    projectedEntry.min[axisAlignedNormalAxis]
+        = planePoint[axisAlignedNormalAxis];
+    projectedEntry.max[axisAlignedNormalAxis]
+        = planePoint[axisAlignedNormalAxis];
+    return projectedEntry.min.allFinite() && projectedEntry.max.allFinite();
+  }
+
   projectedEntry.min
       = Eigen::Vector3d::Constant(std::numeric_limits<double>::infinity());
   projectedEntry.max
@@ -1987,7 +2013,7 @@ bool makeProjectedContactBounds(
 bool haveMutuallyDisjointProjectedContactBounds(
     const std::vector<BroadphaseEntry>& finiteEntries,
     const BroadphaseEntry& planeEntry,
-    std::vector<BroadphaseEntry>& projectedEntries)
+    std::vector<ContactBoundEntry>& projectedEntries)
 {
   if (finiteEntries.size() < 2u)
     return true;
@@ -1998,13 +2024,18 @@ bool haveMutuallyDisjointProjectedContactBounds(
   Eigen::Vector3d planePoint;
   if (!getPlaneProjection(planeEntry, planeNormal, planePoint))
     return false;
+  const int axisAlignedNormalAxis = getExactAxisAlignedNormalAxis(planeNormal);
 
   projectedEntries.clear();
   projectedEntries.reserve(finiteEntries.size());
   for (const auto& entry : finiteEntries) {
-    BroadphaseEntry projectedEntry;
+    ContactBoundEntry projectedEntry;
     if (!makeProjectedContactBounds(
-            entry, planeNormal, planePoint, projectedEntry)) {
+            entry,
+            planeNormal,
+            planePoint,
+            axisAlignedNormalAxis,
+            projectedEntry)) {
       return false;
     }
     projectedEntries.push_back(projectedEntry);
@@ -2013,7 +2044,7 @@ bool haveMutuallyDisjointProjectedContactBounds(
   std::sort(
       projectedEntries.begin(),
       projectedEntries.end(),
-      [](const BroadphaseEntry& lhs, const BroadphaseEntry& rhs) {
+      [](const ContactBoundEntry& lhs, const ContactBoundEntry& rhs) {
         return lhs.min.x() < rhs.min.x();
       });
 

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -8,11 +8,13 @@ Bottom line: #3129, #3133, #3135, #3139, #3140, #3141, #3142, #3143,
 The active PR-ready local slice is `perf/dart6-contact-pair-metadata-cache`,
 rebuilt directly on the merged `release-6.20` head. The further local-only
 experiment, `perf/dart6-contact-pair-skip-flags`, is stacked above that slice
-and must stay unpublished until the metadata-cache PR lands separately.
-Remaining local follow-up slices must also stay unpublished until each is ready
-to publish directly against `release-6.20`; do not open them against another PR
-branch. Opening stacked PRs against parent PR branches lets GitHub close or
-supersede child PRs when the parent branch is merged or deleted.
+and must stay unpublished until the metadata-cache PR lands separately. The
+next local-only branch, `perf/dart6-axis-plane-contact-bounds`, is stacked
+above skip-flags and must remain unpublished until the earlier slices land in
+order. Remaining local follow-up slices must also stay unpublished until each
+is ready to publish directly against `release-6.20`; do not open them against
+another PR branch. Opening stacked PRs against parent PR branches lets GitHub
+close or supersede child PRs when the parent branch is merged or deleted.
 
 The merged #3172 slice adds a narrow native broadphase setup fast path.
 DART-native collision objects cache local bounds center/half-extents when their
@@ -40,6 +42,15 @@ check. The parallel reset maps those pair-order flags back to each contact's
 original object order, avoiding repeated body lookups and hash-set probes in the
 worker loop while keeping the same `ContactConstraint::initialize()` fallback
 checks for every side that was not proven skippable.
+
+The next local collision follow-up accelerates the DART-native disjoint contact
+proof for exact world-axis planes. The finite-plane duplicate-contact proof
+normally projects each finite AABB through all eight corners onto the plane. If
+the normalized plane normal is exactly aligned with a world axis, the projection
+keeps the two orthogonal AABB ranges unchanged and collapses only the plane
+axis to the plane point. The proof also stores only projected min/max bounds in
+scratch instead of copying full broadphase entries through the sort. Non-axis
+planes keep the original corner-projection path.
 
 The #3183 candidate folds default contact-surface parameter
 initialization into the existing per-pair parallel default-contact rebuild. The
@@ -73,6 +84,8 @@ dynamics, deactivation disabled, `--world-threads 16`,
 | Metadata-cache candidate rebased on #3185 base, text profile | DART native | `0.185689`; pre-#3184 rerun `0.203355` | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `266.09 ms`, `shared-body check` `150.77 ms`, `parallel reset` `74.14 ms`, `solveConstrainedGroups` `271.31 ms`, `collide` `377.69 ms` |
 | Local skip-flags/body-set experiment, no profile | DART native | `0.192959` current rerun; `0.196971`, `0.196594` post-rebase reruns; `0.185274` retained-bucket rerun; `0.213820`, `0.215162`, `0.199266`, `0.198770` prior repeats | finite, same hash, contacts `5005`, pairs `3003` |
 | Local skip-flags/body-set experiment, text profile | DART native | `0.171489` current noisy rerun; `0.205666` retained-bucket rerun; `0.189984`, `0.165932` noisy reruns; `0.212505`, `0.215980` prior runs | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `307.89 ms`, `shared-body check` `193.68 ms`, `parallel reset` `73.30 ms`, `solveConstrainedGroups` `283.68 ms`, `collide` `406.00 ms`; retained-bucket profile had `build contact constraints` `239.58 ms`, `shared-body check` `138.92 ms`, `parallel reset` `68.59 ms` |
+| Local axis-plane contact-bounds experiment, no profile | DART native | `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
+| Local axis-plane contact-bounds experiment, text profile | DART native | `0.227034` compact-bound rerun; `0.207763` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003`; latest projected contact-bound separation `16.32 ms`, finite-plane pairs `113.66 ms`, `collide` `268.50 ms`, `build contact constraints` `225.11 ms`, `solveConstrainedGroups` `245.09 ms` |
 | #3183 local candidate, no profile | FCL primitive | `0.145341` | finite, hash `0x6088ea0177efa6a`, contacts `3003`, pairs `3003` |
 | #3183 local candidate, no profile | Bullet | `0.144310` | finite, hash `0x11fdd70a9952f98e`, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | ODE | `0.0100767` | finite, hash `0x2a3d53060f661c4c`, contacts `9009`, pairs `3003` |
@@ -99,6 +112,13 @@ collision timings), while the retained-bucket profile recorded `0.205666` and
 reduced the local contact-construction slices versus the metadata-cache profile.
 Treat this as the next local follow-up after the metadata-cache slice, not as
 part of that publishable PR.
+
+The axis-plane contact-bounds experiment keeps the same final hash while
+cutting the projected contact-bound separation proof from the prior local
+`46.31 ms` sample to `16.32 ms`. In the same profiled run, `collide` dropped
+to `268.50 ms`. The current post-rebase no-profile repeat reached RTF
+`0.203003`. Treat this as a later collision follow-up after the
+contact-construction slices.
 
 On the original default-sleeping target command, the same current local head
 reaches RTF `61.1724` for 3000 steps with DART-native collision, advances
@@ -127,6 +147,13 @@ passed on the current local skip-flags branch; the full gate reported C++ tests
 `115/115` and Python tests `60/60`. The current post-rebase no-profile rerun
 recorded RTF `0.192959`; the current text-profile rerun recorded RTF
 `0.171489`; both kept the same final hash, contacts, and pair count.
+
+The local axis-plane contact-bounds experiment has passed:
+`cmake --build build/default/cpp/Release --parallel 5 --target test_Collision test_DARTCollisionDetector contact_benchmark`,
+`ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_Collision|test_DARTCollisionDetector)$'`,
+`DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all`
+(C++ tests `115/115`, Python tests `60/60`), and the exact issue-scene
+no-profile/profile benchmark runs above.
 
 An earlier fixed-support contact-build relaxation crashed because the parallel
 worker indexed `thread_local` contact-pair scratch storage from the worker


### PR DESCRIPTION
## Summary

- Fast-path projected contact bounds for exact world-axis planes in the DART-native finite-plane duplicate-contact proof.
- Store compact projected min/max bounds instead of copying full broadphase entries through the contact-bound separation sort.
- Preserve the existing corner-projection path for non-axis-aligned planes.

## Motivation / Problem

- The issue #3056 active DART-native workload still spends time proving finite-plane contact footprints are mutually disjoint.
- The exact issue scene uses a world-axis ground plane, where the projection can collapse the plane axis directly instead of projecting all eight AABB corners.

## Changes / Key Changes

- Add `ContactBoundEntry` for projected contact min/max scratch state.
- Detect exact axis-aligned plane normals after normalizing the plane projection.
- For axis-aligned planes, reuse the finite object's two orthogonal AABB ranges and collapse only the plane axis to the plane point.
- Keep finite/non-finite safeguards and the existing generic projection path for all other planes.
- Refresh the issue #3056 task notes with local gate and benchmark evidence.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --parallel 5 --target test_Collision test_DARTCollisionDetector contact_benchmark`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_Collision|test_DARTCollisionDetector)$'`
- `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all` (C++ 115/115, Python 60/60)
- `pixi run ex contact_benchmark -- .deps/gz-sim/examples/worlds/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --max-contacts-per-pair 4 --disable-deactivation` (RTF `0.203003`, finite, hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003`)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Continues #3056
- Follows #3190

---

#### Checklist

- [ ] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required (not required: internal performance path and task notes)
- [x] Add unit tests for new functionality (covered by existing/focused collision tests)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)