### PR TITLE
Cache default contact surface decisions by version

### DIFF
--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1194,6 +1194,7 @@ void ConstraintSolver::updateConstraints()
         defaultSurfaceCache{};
     static thread_local std::size_t defaultSurfaceCacheEpoch = 0u;
     ++defaultSurfaceCacheEpoch;
+    // LCOV_EXCL_START: requires wrapping size_t solver-update epochs.
     if (defaultSurfaceCacheEpoch == 0u) {
       std::fill(
           defaultSurfaceCache.begin(),
@@ -1201,6 +1202,7 @@ void ConstraintSolver::updateConstraints()
           DefaultSurfaceCacheEntry{});
       ++defaultSurfaceCacheEpoch;
     }
+    // LCOV_EXCL_STOP
 
     const auto queryDefaultContactSurfaceProperties
         = [&](const dynamics::ShapeNode* shapeNode) {

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1186,40 +1186,64 @@ void ConstraintSolver::updateConstraints()
     struct DefaultSurfaceCacheEntry
     {
       const dynamics::ShapeNode* shapeNode{nullptr};
+      std::size_t shapeNodeVersion{std::numeric_limits<std::size_t>::max()};
+      std::size_t updateEpoch{0u};
       bool hasDefaultProperties{false};
     };
-    std::array<DefaultSurfaceCacheEntry, 256u> defaultSurfaceCache{};
+    static thread_local std::array<DefaultSurfaceCacheEntry, 8192u>
+        defaultSurfaceCache{};
+    static thread_local std::size_t defaultSurfaceCacheEpoch = 0u;
+    ++defaultSurfaceCacheEpoch;
+    if (defaultSurfaceCacheEpoch == 0u) {
+      std::fill(
+          defaultSurfaceCache.begin(),
+          defaultSurfaceCache.end(),
+          DefaultSurfaceCacheEntry{});
+      ++defaultSurfaceCacheEpoch;
+    }
 
-    const auto queryDefaultContactSurfaceProperties =
-        [&](const dynamics::ShapeNode* shapeNode) {
-          if (shapeNode == nullptr)
-            return false;
+    const auto queryDefaultContactSurfaceProperties
+        = [&](const dynamics::ShapeNode* shapeNode) {
+            if (shapeNode == nullptr)
+              return false;
 
-          const auto shapeNodeKey
-              = reinterpret_cast<std::uintptr_t>(shapeNode) >> 4u;
-          auto& entry
-              = defaultSurfaceCache[shapeNodeKey % defaultSurfaceCache.size()];
-          if (entry.shapeNode == shapeNode)
-            return entry.hasDefaultProperties;
+            const auto shapeNodeVersion = shapeNode->getVersion();
+            auto shapeNodeKey = static_cast<std::uint64_t>(
+                reinterpret_cast<std::uintptr_t>(shapeNode) >> 4u);
+            shapeNodeKey ^= shapeNodeKey >> 33u;
+            shapeNodeKey *= 0xff51afd7ed558ccdULL;
+            shapeNodeKey ^= shapeNodeKey >> 33u;
+            auto& entry = defaultSurfaceCache
+                [static_cast<std::size_t>(shapeNodeKey)
+                 % defaultSurfaceCache.size()];
+            if (entry.updateEpoch == defaultSurfaceCacheEpoch
+                && entry.shapeNode == shapeNode
+                && entry.shapeNodeVersion == shapeNodeVersion) {
+              return entry.hasDefaultProperties;
+            }
 
-          const auto* dynamicAspect = shapeNode->getDynamicsAspect();
-          const bool hasDefaultProperties
-              = dynamicAspect != nullptr
-                && dynamicAspect->getRestitutionCoeff()
-                       == DART_DEFAULT_RESTITUTION_COEFF
-                && dynamicAspect->getPrimaryFrictionCoeff()
-                       == DART_DEFAULT_FRICTION_COEFF
-                && dynamicAspect->getSecondaryFrictionCoeff()
-                       == DART_DEFAULT_FRICTION_COEFF
-                && dynamicAspect->getPrimarySlipCompliance() == -1.0
-                && dynamicAspect->getSecondarySlipCompliance() == -1.0
-                && dynamicAspect->getFirstFrictionDirectionFrame() == nullptr
-                && dynamicAspect->getFirstFrictionDirection().squaredNorm()
-                       < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
+            const auto* dynamicAspect = shapeNode->getDynamicsAspect();
+            const bool hasDefaultProperties
+                = dynamicAspect != nullptr
+                  && dynamicAspect->getRestitutionCoeff()
+                         == DART_DEFAULT_RESTITUTION_COEFF
+                  && dynamicAspect->getPrimaryFrictionCoeff()
+                         == DART_DEFAULT_FRICTION_COEFF
+                  && dynamicAspect->getSecondaryFrictionCoeff()
+                         == DART_DEFAULT_FRICTION_COEFF
+                  && dynamicAspect->getPrimarySlipCompliance() == -1.0
+                  && dynamicAspect->getSecondarySlipCompliance() == -1.0
+                  && dynamicAspect->getFirstFrictionDirectionFrame() == nullptr
+                  && dynamicAspect->getFirstFrictionDirection().squaredNorm()
+                         < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
 
-          entry = {shapeNode, hasDefaultProperties};
-          return hasDefaultProperties;
-        };
+            entry
+                = {shapeNode,
+                   shapeNodeVersion,
+                   defaultSurfaceCacheEpoch,
+                   hasDefaultProperties};
+            return hasDefaultProperties;
+          };
     const dynamics::ShapeNode* lastContactShapeNode1 = nullptr;
     const dynamics::ShapeNode* lastContactShapeNode2 = nullptr;
     bool lastContactShapeNode1HasDefaultProperties = false;
@@ -1456,19 +1480,29 @@ void ConstraintSolver::updateConstraints()
         return {recordSharedBodyIfUnique(bodyNode), false};
       };
 
-      for (auto& contactPairCount : contactPairCounts) {
-        const auto body1Check
-            = checkBodyForParallelDefaultContact(contactPairCount.bodyNode1);
-        const auto body2Check
-            = checkBodyForParallelDefaultContact(contactPairCount.bodyNode2);
-        if (!body1Check.canBuild || !body2Check.canBuild)
-          return false;
+      {
+        DART_PROFILE_SCOPED_N(
+            "build contact constraints - shared-body body scan");
+        for (auto& contactPairCount : contactPairCounts) {
+          const auto body1Check
+              = checkBodyForParallelDefaultContact(contactPairCount.bodyNode1);
+          const auto body2Check
+              = checkBodyForParallelDefaultContact(contactPairCount.bodyNode2);
+          if (!body1Check.canBuild || !body2Check.canBuild)
+            return false;
 
-        contactPairCount.skipRelVelocityBody1 = body1Check.skipRelVelocity;
-        contactPairCount.skipRelVelocityBody2 = body2Check.skipRelVelocity;
+          contactPairCount.skipRelVelocityBody1 = body1Check.skipRelVelocity;
+          contactPairCount.skipRelVelocityBody2 = body2Check.skipRelVelocity;
+        }
+      }
 
-        if (!ensureDefaultSurfaceParamsChecked(contactPairCount))
-          needsSurfaceParamsPrepass = true;
+      {
+        DART_PROFILE_SCOPED_N(
+            "build contact constraints - shared-body surface scan");
+        for (auto& contactPairCount : contactPairCounts) {
+          if (!ensureDefaultSurfaceParamsChecked(contactPairCount))
+            needsSurfaceParamsPrepass = true;
+        }
       }
 
       parallelDefaultContactBuildNeedsSurfaceParamsPrepass

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -108,7 +108,7 @@ dynamics, deactivation disabled, `--world-threads 16`,
 | Local axis-plane contact-bounds experiment, no profile | DART native | `0.185536` FreeJoint parent comparison rerun; `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | Local axis-plane contact-bounds experiment, text profile | DART native | `0.227034` compact-bound rerun; `0.207763` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003`; latest projected contact-bound separation `16.32 ms`, finite-plane pairs `113.66 ms`, `collide` `268.50 ms`, `build contact constraints` `225.11 ms`, `solveConstrainedGroups` `245.09 ms` |
 | Local FreeJoint root-integration experiment, no profile | DART native | `0.189437` direct PR-head comparison rerun | finite, same hash, contacts `5005`, pairs `3003` |
-| Local default-surface version-cache experiment, no profile | DART native | `0.181107` fresh comparison rerun; `0.173761` immediate repeat; `0.205759` earlier post-review-fix rerun; `0.209501` post-rebase rerun; `0.230490` prior rerun | finite, same hash, contacts `5005`, pairs `3003` |
+| Local default-surface version-cache experiment, no profile | DART native | `0.207410` current merged-base guardrail rerun; `0.181107` fresh comparison rerun; `0.173761` immediate repeat; `0.205759` earlier post-review-fix rerun; `0.209501` post-rebase rerun; `0.230490` prior rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | Local default-surface version-cache experiment, text profile | DART native | `0.227376` | finite, same hash, contacts `5005`, pairs `3003`; `build contact constraints` `183.10 ms`, `shared-body check` `85.97 ms`, `shared-body surface scan` `54.71 ms`, `shared-body body scan` `26.36 ms`, `parallel reset` `65.45 ms`, `collide` `278.13 ms` |
 | #3183 local candidate, no profile | FCL primitive | `0.145341` | finite, hash `0x6088ea0177efa6a`, contacts `3003`, pairs `3003` |
 | #3183 local candidate, no profile | Bullet | `0.144310` | finite, hash `0x11fdd70a9952f98e`, contacts `5005`, pairs `3003` |
@@ -160,8 +160,15 @@ repeat at RTF `0.173761`. Earlier same-code/post-review-fix and post-rebase
 no-profile reruns reached RTF `0.205759` and `0.209501`; the prior no-profile
 rerun reached RTF `0.230490`.
 
+After merging the #3193 base, the default-surface version-cache experiment
+recorded active 3k SDF guardrail RTF `0.207410`, default-sleeping 3k RTF
+`90.3225`, `diff_drive_skid` RTF `50.1021`, generated 900-object RTF
+`0.648297`, and generated 90-object RTF `2.27391` for the PR head. All rows
+kept the same final hash, contact count, and pair count as the baseline and
+parent comparisons.
+
 On the original default-sleeping target command, the same current local head
-reaches RTF `61.1724` for 3000 steps with DART-native collision, advances
+reaches RTF `90.3225` for 3000 steps with DART-native collision, advances
 `3000 / 3000` frames, ends finite with hash `0x131b6af79a44ff90`, and has all
 `3003 / 3003` mobile skeletons resting with zero final contacts.
 
@@ -211,7 +218,12 @@ The local default-surface version-cache experiment has passed: `pixi run lint`,
 no-profile/profile benchmark runs above. The focused solver regression heats
 the default-surface cache, mutates the contact dynamics, and verifies the
 versioned cache tracks the same state as a cold-cache reference after the
-mutation.
+mutation. After merging #3193, the combined focused gate passed `pixi run lint`,
+`cmake --build build/default/cpp/Release --parallel 5 --target test_Joints test_ConstraintSolver contact_benchmark`,
+and
+`ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_Joints|test_ConstraintSolver)$'`;
+the merged-base guardrail matrix is recorded in
+`/tmp/dart-3192-merged-head.kAKUBi/summary.tsv`.
 
 An earlier fixed-support contact-build relaxation crashed because the parallel
 worker indexed `thread_local` contact-pair scratch storage from the worker

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -11,10 +11,13 @@ experiment, `perf/dart6-contact-pair-skip-flags`, is stacked above that slice
 and must stay unpublished until the metadata-cache PR lands separately. The
 next local-only branch, `perf/dart6-axis-plane-contact-bounds`, is stacked
 above skip-flags and must remain unpublished until the earlier slices land in
-order. Remaining local follow-up slices must also stay unpublished until each
-is ready to publish directly against `release-6.20`; do not open them against
-another PR branch. Opening stacked PRs against parent PR branches lets GitHub
-close or supersede child PRs when the parent branch is merged or deleted.
+order. The latest local-only branch,
+`perf/dart6-default-surface-version-cache`, is stacked above the axis-plane
+slice and must also remain unpublished until the earlier slices land in order.
+Remaining local follow-up slices must also stay unpublished until each is ready
+to publish directly against `release-6.20`; do not open them against another PR
+branch. Opening stacked PRs against parent PR branches lets GitHub close or
+supersede child PRs when the parent branch is merged or deleted.
 
 The merged #3172 slice adds a narrow native broadphase setup fast path.
 DART-native collision objects cache local bounds center/half-extents when their
@@ -52,6 +55,15 @@ axis to the plane point. The proof also stores only projected min/max bounds in
 scratch instead of copying full broadphase entries through the sort. Non-axis
 planes keep the original corner-projection path.
 
+The newest local solver follow-up keeps the per-step `ContactPairCount` surface
+decision cache, then extends the lower-level default-surface-property cache into
+a larger thread-local, versioned direct-mapped cache. Each entry keys on the
+`ShapeNode` pointer and `ShapeNode::getVersion()`, so friction, slip,
+restitution, or friction-direction updates invalidate cached default-material
+decisions while steady-state default scenes avoid repeated dynamics-aspect
+queries. The branch also splits the shared-body profiling scope into body-scan
+and surface-scan subscopes.
+
 The #3183 candidate folds default contact-surface parameter
 initialization into the existing per-pair parallel default-contact rebuild. The
 serial cached prepass remains for fallback paths. Default-material pairs compute
@@ -86,6 +98,8 @@ dynamics, deactivation disabled, `--world-threads 16`,
 | Local skip-flags/body-set experiment, text profile | DART native | `0.171489` current noisy rerun; `0.205666` retained-bucket rerun; `0.189984`, `0.165932` noisy reruns; `0.212505`, `0.215980` prior runs | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `307.89 ms`, `shared-body check` `193.68 ms`, `parallel reset` `73.30 ms`, `solveConstrainedGroups` `283.68 ms`, `collide` `406.00 ms`; retained-bucket profile had `build contact constraints` `239.58 ms`, `shared-body check` `138.92 ms`, `parallel reset` `68.59 ms` |
 | Local axis-plane contact-bounds experiment, no profile | DART native | `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | Local axis-plane contact-bounds experiment, text profile | DART native | `0.227034` compact-bound rerun; `0.207763` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003`; latest projected contact-bound separation `16.32 ms`, finite-plane pairs `113.66 ms`, `collide` `268.50 ms`, `build contact constraints` `225.11 ms`, `solveConstrainedGroups` `245.09 ms` |
+| Local default-surface version-cache experiment, no profile | DART native | `0.181107` fresh comparison rerun; `0.173761` immediate repeat; `0.205759` earlier post-review-fix rerun; `0.209501` post-rebase rerun; `0.230490` prior rerun | finite, same hash, contacts `5005`, pairs `3003` |
+| Local default-surface version-cache experiment, text profile | DART native | `0.227376` | finite, same hash, contacts `5005`, pairs `3003`; `build contact constraints` `183.10 ms`, `shared-body check` `85.97 ms`, `shared-body surface scan` `54.71 ms`, `shared-body body scan` `26.36 ms`, `parallel reset` `65.45 ms`, `collide` `278.13 ms` |
 | #3183 local candidate, no profile | FCL primitive | `0.145341` | finite, hash `0x6088ea0177efa6a`, contacts `3003`, pairs `3003` |
 | #3183 local candidate, no profile | Bullet | `0.144310` | finite, hash `0x11fdd70a9952f98e`, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | ODE | `0.0100767` | finite, hash `0x2a3d53060f661c4c`, contacts `9009`, pairs `3003` |
@@ -119,6 +133,17 @@ cutting the projected contact-bound separation proof from the prior local
 to `268.50 ms`. The current post-rebase no-profile repeat reached RTF
 `0.203003`. Treat this as a later collision follow-up after the
 contact-construction slices.
+
+The default-surface version-cache experiment keeps the same final hash, contact
+count, and pair count while reducing the measured surface portion of the
+parallel eligibility scan. In the latest text-profile sample,
+`build contact constraints` dropped from the axis-plane `225.11 ms` sample to
+`183.10 ms`, `shared-body check` dropped from the repeated local `101.66 ms`
+sample to `85.97 ms`, and the newly split surface scan was `54.71 ms`. The
+fresh comparison no-profile rerun reached RTF `0.181107`, with an immediate
+repeat at RTF `0.173761`. Earlier same-code/post-review-fix and post-rebase
+no-profile reruns reached RTF `0.205759` and `0.209501`; the prior no-profile
+rerun reached RTF `0.230490`.
 
 On the original default-sleeping target command, the same current local head
 reaches RTF `61.1724` for 3000 steps with DART-native collision, advances
@@ -154,6 +179,16 @@ The local axis-plane contact-bounds experiment has passed:
 `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all`
 (C++ tests `115/115`, Python tests `60/60`), and the exact issue-scene
 no-profile/profile benchmark runs above.
+
+The local default-surface version-cache experiment has passed: `pixi run lint`,
+`cmake --build build/default/cpp/Release --parallel 5 --target test_ConstraintSolver contact_benchmark`,
+`ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_ConstraintSolver$'`,
+`DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all`
+(C++ tests `115/115`, Python tests `60/60`), and the exact issue-scene
+no-profile/profile benchmark runs above. The focused
+solver regression heats the default-surface cache, mutates the contact dynamics,
+and verifies the versioned cache tracks the same state as a cold-cache reference
+after the mutation.
 
 An earlier fixed-support contact-build relaxation crashed because the parallel
 worker indexed `thread_local` contact-pair scratch storage from the worker

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -542,6 +542,74 @@ std::shared_ptr<World> createManySingleFreeBodyContactWorld(
 }
 
 //==============================================================================
+void setManySingleFreeBodyContactSurfaceParams(
+    const std::shared_ptr<World>& world, std::size_t numBoxes)
+{
+  for (std::size_t i = 0u; i < numBoxes; ++i) {
+    const auto name = "box_" + std::to_string(i);
+    auto box = world->getSkeleton(name);
+    ASSERT_NE(nullptr, box) << name;
+
+    auto* body = box->getBodyNode(0);
+    ASSERT_NE(nullptr, body) << name;
+    auto* shapeNode = body->getShapeNode(0);
+    ASSERT_NE(nullptr, shapeNode) << name;
+    auto* dynamics = shapeNode->getDynamicsAspect();
+    ASSERT_NE(nullptr, dynamics) << name;
+
+    dynamics->setPrimaryFrictionCoeff(0.75);
+    dynamics->setSecondaryFrictionCoeff(0.5);
+    dynamics->setPrimarySlipCompliance(0.005);
+    dynamics->setSecondarySlipCompliance(0.01);
+    dynamics->setFirstFrictionDirection(Eigen::Vector3d::UnitX());
+
+    auto* joint = static_cast<dynamics::FreeJoint*>(body->getParentJoint());
+    ASSERT_NE(nullptr, joint) << name;
+    joint->setLinearVelocity(Eigen::Vector3d(0.2, 0.0, 0.0));
+  }
+}
+
+//==============================================================================
+void expectManySingleFreeBodyContactWorldsMatch(
+    const std::shared_ptr<World>& expectedWorld,
+    const std::shared_ptr<World>& actualWorld,
+    std::size_t numBoxes)
+{
+  const auto& expectedContacts
+      = expectedWorld->getConstraintSolver()->getLastCollisionResult();
+  const auto& actualContacts
+      = actualWorld->getConstraintSolver()->getLastCollisionResult();
+  EXPECT_GE(expectedContacts.getNumContacts(), numBoxes * 3u);
+  EXPECT_EQ(expectedContacts.getNumContacts(), actualContacts.getNumContacts());
+
+  for (std::size_t i = 0u; i < numBoxes; ++i) {
+    const auto name = "box_" + std::to_string(i);
+    const auto expectedBox = expectedWorld->getSkeleton(name);
+    const auto actualBox = actualWorld->getSkeleton(name);
+    ASSERT_NE(nullptr, expectedBox) << name;
+    ASSERT_NE(nullptr, actualBox) << name;
+
+    EXPECT_TRUE(
+        expectedBox->getPositions().isApprox(actualBox->getPositions(), 1e-12))
+        << name;
+    EXPECT_TRUE(expectedBox->getVelocities().isApprox(
+        actualBox->getVelocities(), 1e-12))
+        << name;
+
+    const auto* expectedBody = expectedBox->getBodyNode(0);
+    const auto* actualBody = actualBox->getBodyNode(0);
+    ASSERT_NE(nullptr, expectedBody) << name;
+    ASSERT_NE(nullptr, actualBody) << name;
+    EXPECT_TRUE(expectedBody->getWorldTransform().matrix().isApprox(
+        actualBody->getWorldTransform().matrix(), 1e-12))
+        << name;
+    EXPECT_TRUE(expectedBody->getSpatialVelocity().isApprox(
+        actualBody->getSpatialVelocity(), 1e-12))
+        << name;
+  }
+}
+
+//==============================================================================
 TEST(ConstraintSolver, DirectSingleFreeBodyContactsMatchLegacyAssembly)
 {
   auto directWorld = createSingleFreeBodyContactWorld(false);
@@ -663,6 +731,36 @@ TEST(ConstraintSolver, ThreadedDefaultContactRebuildMatchesSerialSurfaceParams)
         threadedBox->getVelocities(), 1e-12))
         << name;
   }
+}
+
+//==============================================================================
+TEST(ConstraintSolver, DefaultSurfaceCacheInvalidatesAfterDynamicsUpdate)
+{
+  constexpr std::size_t kNumBoxes = 192u;
+  auto cachedWorld = createManySingleFreeBodyContactWorld(kNumBoxes, 4u);
+  auto referenceWorld = createManySingleFreeBodyContactWorld(kNumBoxes, 4u);
+
+  for (std::size_t i = 0u; i < 5u; ++i) {
+    cachedWorld->step();
+    referenceWorld->step();
+  }
+
+  ASSERT_NO_FATAL_FAILURE(
+      setManySingleFreeBodyContactSurfaceParams(cachedWorld, kNumBoxes));
+  ASSERT_NO_FATAL_FAILURE(
+      setManySingleFreeBodyContactSurfaceParams(referenceWorld, kNumBoxes));
+
+  for (std::size_t i = 0u; i < 40u; ++i)
+    cachedWorld->step();
+
+  std::thread referenceThread([&]() {
+    for (std::size_t i = 0u; i < 40u; ++i)
+      referenceWorld->step();
+  });
+  referenceThread.join();
+
+  ASSERT_NO_FATAL_FAILURE(expectManySingleFreeBodyContactWorldsMatch(
+      referenceWorld, cachedWorld, kNumBoxes));
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Extend the default-surface-property cache to a larger retained thread-local direct-mapped cache keyed by `ShapeNode*` and `ShapeNode::getVersion()`.
- Scope retained cache entries to each solver update so stale pointer/version pairs cannot survive `ShapeNode` lifetimes.
- Add focused `ConstraintSolver` regression coverage for dynamics-aspect cache invalidation.
- Exclude the epoch-wrap recovery guard from lcov because exercising it requires wrapping `size_t` solver-update epochs.
- Merge the latest `release-6.20` base after #3193 landed and refresh the broadened guardrail evidence.

## Motivation / Problem

- The #3056 no-deactivation benchmark still spends measurable contact-build time rechecking default surface properties across repeated shape pairs.
- Version-keyed cache entries can avoid repeated lookups within an update while preserving correctness when shape node state changes.
- The optimization needs to stay broad enough for other DART-native contact workloads, not only the original 3k-shape scene.

## Changes / Key Changes

- Track `ShapeNode` versions on cached default-surface-property entries.
- Reuse cached default-surface decisions through a direct-mapped thread-local cache scoped by update epoch.
- Cover dynamics-aspect mutation with a cold-cache reference regression test.
- Keep the unreachable epoch-wrap recovery branch out of lcov patch coverage.
- Record current issue-scene benchmark evidence in the dev-task handoff.

## Performance Comparison

RTF is higher-is-better. Current branch head is `0f926f187e9`; the benchmarked executable code is `ed81e74f4eb`, with the later commit only updating audit documentation. Parent `45d026447ce` is the merged #3193 release head; the parent benchmark rows used the code-equivalent #3193 PR head `01a1f5003b1` from the same broadened matrix. Final hashes, contact counts, and pair counts matched for each scenario.

Primary active issue-scene command:

```bash
pixi run ex contact_benchmark -- .deps/gz-sim/examples/worlds/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --max-contacts-per-pair 4 --disable-deactivation
```

| Scenario | Command difference from primary command | #3172 baseline `382254394d7` | #3193 parent `45d026447ce` | This PR `0f926f187e9` | This PR vs #3172 | This PR vs parent | Final state |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| Active 3k SDF issue scene | Primary command above | `0.139629` | `0.132072` | `0.207410` | `1.49x` | `1.57x` | hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003` |
| Default-sleeping 3k SDF | `--steps 3000`, no `--disable-deactivation` | `70.7150` | `60.0562` | `90.3225` | `1.28x` | `1.50x` | hash `0x131b6af79a44ff90`, contacts `0`, pairs `0` |
| Non-default-surface SDF | replace SDF with `.deps/gz-sim/examples/worlds/diff_drive_skid.sdf`; `--steps 3000` | `34.8135` | `30.0443` | `50.1021` | `1.44x` | `1.67x` | hash `0xe5880f64423ce963`, contacts `4`, pairs `4` |
| Generated 900-object medium-large guard | `--generate-objects 900`, no SDF / `--sdf-plane-shapes` | `0.614375` | `0.384615` | `0.648297` | `1.06x` | `1.69x` | hash `0xcd1ecb32a4d1ad57`, contacts `1800`, pairs `900` |
| Generated 90-object serial guard | `--generate-objects 90`, no SDF / `--sdf-plane-shapes` | `2.03311` | `1.55356` | `2.27391` | `1.12x` | `1.46x` | hash `0x9ac4f80005c47da8`, contacts `180`, pairs `90` |

The earlier broadened matrix on the #3191 parent showed this optimization was not a universal win before the #3193 base merge. After merging #3193 and rerunning the guardrails, the current head improves every listed scenario versus the parent while preserving final state. The branch still remains scoped to default-surface lookup/cache behavior; it does not change contact generation or public API.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --parallel 5 --target test_ConstraintSolver contact_benchmark`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_ConstraintSolver$'`
- After merging #3193 base:
  - `pixi run lint`
  - `cmake --build build/default/cpp/Release --parallel 5 --target test_Joints test_ConstraintSolver contact_benchmark`
  - `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_Joints|test_ConstraintSolver)$'`
- Broadened benchmark matrices:
  - `/tmp/dart-3193-overfit.zEklSW/summary.tsv` for the #3172 baseline and #3193 parent rows above
  - `/tmp/dart-3192-merged-head.kAKUBi/summary.tsv` for the current #3192 merged-base head rows above
  - Earlier matrix before the #3193 base merge: `/tmp/dart-overfit-bench.5whAtX/summary.tsv`
- Previous head before the coverage-only follow-up: `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all` (C++ tests `115/115`, Python tests `60/60`)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Contributes to #3056
- Follows #3191 and #3193

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required (not required; internal performance slice)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (not applicable; no public API)
- [x] Add Python bindings (dartpy) if applicable (not applicable)