### PR TITLE
Fast-path FreeJoint root integration

### DIFF
--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -43,6 +43,16 @@
 namespace dart {
 namespace dynamics {
 
+namespace {
+
+//==============================================================================
+bool isIdentityTransform(const Eigen::Isometry3d& transform)
+{
+  return transform.matrix().isIdentity(0.0);
+}
+
+} // namespace
+
 //==============================================================================
 FreeJoint::~FreeJoint()
 {
@@ -706,6 +716,33 @@ void FreeJoint::integratePositions(double _dt)
   const Eigen::Isometry3d& childBodyToJoint
       = Joint::mAspectProperties.mT_ChildBodyToJoint;
 
+  if (isIdentityTransform(childBodyToJoint)) {
+    Eigen::Isometry3d nextQ = Eigen::Isometry3d::Identity();
+    if (parentBodyToJoint.linear().isIdentity(0.0)) {
+      nextQ.linear() = nextRelativeTransform.linear();
+      nextQ.translation() = nextRelativeTransform.translation()
+                            - parentBodyToJoint.translation();
+    } else {
+      const Eigen::Matrix3d parentRotationTranspose
+          = parentBodyToJoint.linear().transpose();
+      nextQ.linear().noalias()
+          = parentRotationTranspose * nextRelativeTransform.linear();
+      nextQ.translation().noalias() = parentRotationTranspose
+                                      * (nextRelativeTransform.translation()
+                                         - parentBodyToJoint.translation());
+    }
+
+    if (getCoordinateChart() == CoordinateChart::EXP_MAP) {
+      Eigen::Vector6d nextPositions;
+      nextPositions.head<3>() = math::logMap(nextQ.linear());
+      nextPositions.tail<3>() = nextQ.translation();
+      setPositionsStatic(nextPositions);
+    } else {
+      setPositionsStatic(convertToPositions(nextQ, getCoordinateChart()));
+    }
+    return;
+  }
+
   const Eigen::Isometry3d nextQ
       = parentBodyToJoint.inverse() * nextRelativeTransform * childBodyToJoint;
 
@@ -803,8 +840,21 @@ void FreeJoint::updateRelativeTransform() const
 {
   mQ = convertToTransform(getPositionsStatic(), getCoordinateChart());
 
-  mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mQ
-       * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
+  const Eigen::Isometry3d& parentBodyToJoint
+      = Joint::mAspectProperties.mT_ParentBodyToJoint;
+  const Eigen::Isometry3d& childBodyToJoint
+      = Joint::mAspectProperties.mT_ChildBodyToJoint;
+
+  if (isIdentityTransform(childBodyToJoint)) {
+    if (parentBodyToJoint.linear().isIdentity(0.0)) {
+      mT = mQ;
+      mT.translation() += parentBodyToJoint.translation();
+    } else {
+      mT = parentBodyToJoint * mQ;
+    }
+  } else {
+    mT = parentBodyToJoint * mQ * childBodyToJoint.inverse();
+  }
 
   if (!math::verifyTransform(mT)) {
     dtwarn << "[FreeJoint::updateRelativeTransform] Non-finite relative "
@@ -819,8 +869,17 @@ void FreeJoint::updateRelativeJacobian(bool) const
 {
   const Eigen::Matrix3d rotationTranspose
       = getRelativeTransform().linear().transpose();
-  const Eigen::Matrix6d baseJac
-      = math::getAdTMatrix(Joint::mAspectProperties.mT_ChildBodyToJoint);
+  const Eigen::Isometry3d& childBodyToJoint
+      = Joint::mAspectProperties.mT_ChildBodyToJoint;
+
+  if (isIdentityTransform(childBodyToJoint)) {
+    mJacobian.setZero();
+    mJacobian.topLeftCorner<3, 3>() = rotationTranspose;
+    mJacobian.bottomRightCorner<3, 3>() = rotationTranspose;
+    return;
+  }
+
+  const Eigen::Matrix6d baseJac = math::getAdTMatrix(childBodyToJoint);
 
   mJacobian.topRows<3>() = rotationTranspose * baseJac.topRows<3>();
   mJacobian.bottomRows<3>() = rotationTranspose * baseJac.bottomRows<3>();
@@ -831,14 +890,22 @@ void FreeJoint::updateRelativeJacobianTimeDeriv() const
 {
   const Eigen::Matrix3d rotationTranspose
       = getRelativeTransform().linear().transpose();
-  const Eigen::Matrix6d baseJac
-      = math::getAdTMatrix(Joint::mAspectProperties.mT_ChildBodyToJoint);
+  const Eigen::Isometry3d& childBodyToJoint
+      = Joint::mAspectProperties.mT_ChildBodyToJoint;
 
   const Eigen::Vector3d omega = getRelativeSpatialVelocity().head<3>();
   const Eigen::Matrix3d rotationDeriv
       = -math::makeSkewSymmetric(omega) * rotationTranspose;
 
   mJacobianDeriv.setZero();
+  if (isIdentityTransform(childBodyToJoint)) {
+    mJacobianDeriv.topLeftCorner<3, 3>() = rotationDeriv;
+    mJacobianDeriv.bottomRightCorner<3, 3>() = rotationDeriv;
+    return;
+  }
+
+  const Eigen::Matrix6d baseJac = math::getAdTMatrix(childBodyToJoint);
+
   mJacobianDeriv.topRows<3>() = rotationDeriv * baseJac.topRows<3>();
   mJacobianDeriv.bottomRows<3>() = rotationDeriv * baseJac.bottomRows<3>();
 }

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -4,17 +4,15 @@
 
 Bottom line: #3129, #3133, #3135, #3139, #3140, #3141, #3142, #3143,
 #3144, #3146, #3147, #3148, #3149, #3150, #3151, #3152, #3153, #3154,
-#3170, #3171, #3172, and #3183 are merged. There are no open performance PRs.
-The active PR-ready local slice is `perf/dart6-contact-pair-metadata-cache`,
-rebuilt directly on the merged `release-6.20` head. The further local-only
-experiment, `perf/dart6-contact-pair-skip-flags`, is stacked above that slice
-and must stay unpublished until the metadata-cache PR lands separately. The
-next local-only branch, `perf/dart6-axis-plane-contact-bounds`, is stacked
-above skip-flags and must remain unpublished until the earlier slices land in
-order. Remaining local follow-up slices must also stay unpublished until each
-is ready to publish directly against `release-6.20`; do not open them against
-another PR branch. Opening stacked PRs against parent PR branches lets GitHub
-close or supersede child PRs when the parent branch is merged or deleted.
+#3170, #3171, #3172, #3183, #3188, #3190, and #3191 are merged. #3192
+remains open as a draft because its safe cache revision did not beat the #3191
+parent in the fresh comparison run. The current local integration candidate is
+`perf/dart6-free-joint-root-integration`, rebuilt directly on the merged
+`release-6.20` head. Remaining local follow-up slices must stay unpublished
+until each is ready to publish directly against `release-6.20`; do not open
+them against another PR branch. Opening stacked PRs against parent PR branches
+lets GitHub close or supersede child PRs when the parent branch is merged or
+deleted.
 
 The merged #3172 slice adds a narrow native broadphase setup fast path.
 DART-native collision objects cache local bounds center/half-extents when their
@@ -52,6 +50,13 @@ axis to the plane point. The proof also stores only projected min/max bounds in
 scratch instead of copying full broadphase entries through the sort. Non-axis
 planes keep the original corner-projection path.
 
+The newest local integration follow-up narrows `FreeJoint` hot paths for the
+root-joint shape used by the SDF issue scene: identity child joint frames and
+translation-only parent model poses. Position integration, relative-transform
+refresh, and relative-Jacobian refresh skip the general child-frame inverse and
+full transform products in those cases. Non-identity child joint frames and
+rotated parent joint frames keep the general path.
+
 The #3183 candidate folds default contact-surface parameter
 initialization into the existing per-pair parallel default-contact rebuild. The
 serial cached prepass remains for fallback paths. Default-material pairs compute
@@ -77,15 +82,16 @@ dynamics, deactivation disabled, `--world-threads 16`,
 
 | Run | Collision backend | RTF | Final state |
 | --- | --- | ---: | --- |
-| #3172 merged baseline, no profile | DART native | `0.179381` | finite, hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003` |
+| #3172 merged baseline, no profile | DART native | `0.161033` FreeJoint comparison rerun; `0.179381` prior rerun | finite, hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003` |
 | #3183 head `0b158d44126`, no profile | DART native | `0.127794` | finite, same hash, contacts `5005`, pairs `3003` |
 | #3183 head `0b158d44126`, text profile | DART native | `0.128960` | finite, same hash, contacts `5005`, pairs `3003`; `build contact constraints` `605.13 ms`, `shared-body check` `388.96 ms`, `parallel reset` `108.10 ms`, `solveConstrainedGroups` `318.56 ms`, `collide` `477.22 ms` |
 | Metadata-cache candidate rebased on #3185 base, no profile | DART native | `0.186148`; pre-#3184 rerun `0.182836`; earlier repeats `0.202726`, `0.187945`, `0.204494`, `0.204368`, `0.212991`, `0.195666` | finite, same hash, contacts `5005`, pairs `3003` |
 | Metadata-cache candidate rebased on #3185 base, text profile | DART native | `0.185689`; pre-#3184 rerun `0.203355` | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `266.09 ms`, `shared-body check` `150.77 ms`, `parallel reset` `74.14 ms`, `solveConstrainedGroups` `271.31 ms`, `collide` `377.69 ms` |
 | Local skip-flags/body-set experiment, no profile | DART native | `0.192959` current rerun; `0.196971`, `0.196594` post-rebase reruns; `0.185274` retained-bucket rerun; `0.213820`, `0.215162`, `0.199266`, `0.198770` prior repeats | finite, same hash, contacts `5005`, pairs `3003` |
 | Local skip-flags/body-set experiment, text profile | DART native | `0.171489` current noisy rerun; `0.205666` retained-bucket rerun; `0.189984`, `0.165932` noisy reruns; `0.212505`, `0.215980` prior runs | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `307.89 ms`, `shared-body check` `193.68 ms`, `parallel reset` `73.30 ms`, `solveConstrainedGroups` `283.68 ms`, `collide` `406.00 ms`; retained-bucket profile had `build contact constraints` `239.58 ms`, `shared-body check` `138.92 ms`, `parallel reset` `68.59 ms` |
-| Local axis-plane contact-bounds experiment, no profile | DART native | `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
+| Local axis-plane contact-bounds experiment, no profile | DART native | `0.185536` FreeJoint parent comparison rerun; `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | Local axis-plane contact-bounds experiment, text profile | DART native | `0.227034` compact-bound rerun; `0.207763` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003`; latest projected contact-bound separation `16.32 ms`, finite-plane pairs `113.66 ms`, `collide` `268.50 ms`, `build contact constraints` `225.11 ms`, `solveConstrainedGroups` `245.09 ms` |
+| Local FreeJoint root-integration experiment, no profile | DART native | `0.189437` direct PR-head comparison rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | FCL primitive | `0.145341` | finite, hash `0x6088ea0177efa6a`, contacts `3003`, pairs `3003` |
 | #3183 local candidate, no profile | Bullet | `0.144310` | finite, hash `0x11fdd70a9952f98e`, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | ODE | `0.0100767` | finite, hash `0x2a3d53060f661c4c`, contacts `9009`, pairs `3003` |
@@ -119,6 +125,12 @@ cutting the projected contact-bound separation proof from the prior local
 to `268.50 ms`. The current post-rebase no-profile repeat reached RTF
 `0.203003`. Treat this as a later collision follow-up after the
 contact-construction slices.
+
+The FreeJoint root-integration experiment has been restacked directly on the
+current #3191 release head. The fresh comparison run recorded RTF `0.189437`
+for the PR head, versus `0.185536` for the #3191 parent and `0.161033` for the
+#3172 baseline. All three rows kept the same final hash, contact count, and
+pair count.
 
 On the original default-sleeping target command, the same current local head
 reaches RTF `61.1724` for 3000 steps with DART-native collision, advances
@@ -154,6 +166,14 @@ The local axis-plane contact-bounds experiment has passed:
 `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all`
 (C++ tests `115/115`, Python tests `60/60`), and the exact issue-scene
 no-profile/profile benchmark runs above.
+
+The local FreeJoint root-integration experiment has passed: `pixi run lint`,
+`cmake --build build/default/cpp/Release --parallel 5 --target test_Joints contact_benchmark`,
+`ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_Joints$'`,
+and the fresh exact issue-scene benchmark comparison rows above. The focused
+regression compares `Skeleton::integratePositions()` against the public
+stateless integration overload for identity-frame, translated-parent, and
+fully offset FreeJoint frame configurations.
 
 An earlier fixed-support contact-build relaxation crashed because the parallel
 worker indexed `thread_local` contact-pair scratch storage from the worker

--- a/tests/integration/test_Joints.cpp
+++ b/tests/integration/test_Joints.cpp
@@ -1817,6 +1817,77 @@ TEST_F(JOINTS, FreeJointCoordinateChart)
 }
 
 //==============================================================================
+TEST_F(JOINTS, FreeJointIntegratePositionsMatchesVectorOverload)
+{
+  auto expectMatchesVectorOverload
+      = [](const Eigen::Isometry3d& parentBodyToJoint,
+           const Eigen::Isometry3d& childBodyToJoint,
+           const char* label) {
+          SkeletonPtr skel = Skeleton::create(label);
+
+          auto [freeJoint, freeBody]
+              = skel->createJointAndBodyNodePair<FreeJoint>();
+          (void)freeBody;
+
+          freeJoint->setTransformFromParentBodyNode(parentBodyToJoint);
+          freeJoint->setTransformFromChildBodyNode(childBodyToJoint);
+
+          Eigen::Isometry3d initialTransform = Eigen::Isometry3d::Identity();
+          initialTransform.linear()
+              = (Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitX())
+                 * Eigen::AngleAxisd(-0.1, Eigen::Vector3d::UnitY())
+                 * Eigen::AngleAxisd(0.05, Eigen::Vector3d::UnitZ()))
+                    .toRotationMatrix();
+          initialTransform.translation() = Eigen::Vector3d(0.4, -0.2, 0.3);
+
+          const Eigen::Vector6d q0
+              = FreeJoint::convertToPositions(initialTransform);
+          Eigen::Vector6d v;
+          v << 0.17, -0.11, 0.07, 0.4, -0.2, 0.1;
+
+          freeJoint->setPositions(q0);
+          freeJoint->setVelocities(v);
+
+          const double dt = 0.003;
+          const Eigen::VectorXd expected
+              = static_cast<const Joint*>(freeJoint)->integratePositions(
+                  q0, v, dt);
+          skel->integratePositions(dt);
+
+          EXPECT_TRUE(freeJoint->getPositions().isApprox(expected, 1e-12))
+              << label << "\nexpected: " << expected.transpose()
+              << "\nactual: " << freeJoint->getPositions().transpose();
+        };
+
+  expectMatchesVectorOverload(
+      Eigen::Isometry3d::Identity(),
+      Eigen::Isometry3d::Identity(),
+      "identity joint frames");
+
+  Eigen::Isometry3d parentBodyToJoint = Eigen::Isometry3d::Identity();
+  parentBodyToJoint.linear()
+      = Eigen::AngleAxisd(0.13, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  parentBodyToJoint.translation() = Eigen::Vector3d(0.03, -0.05, 0.07);
+
+  Eigen::Isometry3d translatedParentBodyToJoint = Eigen::Isometry3d::Identity();
+  translatedParentBodyToJoint.translation()
+      = Eigen::Vector3d(0.03, -0.05, 0.07);
+
+  expectMatchesVectorOverload(
+      translatedParentBodyToJoint,
+      Eigen::Isometry3d::Identity(),
+      "translated parent joint frame");
+
+  Eigen::Isometry3d childBodyToJoint = Eigen::Isometry3d::Identity();
+  childBodyToJoint.linear()
+      = Eigen::AngleAxisd(-0.08, Eigen::Vector3d::UnitY()).toRotationMatrix();
+  childBodyToJoint.translation() = Eigen::Vector3d(-0.02, 0.04, -0.06);
+
+  expectMatchesVectorOverload(
+      parentBodyToJoint, childBodyToJoint, "offset joint frames");
+}
+
+//==============================================================================
 TEST_F(JOINTS, FREE_JOINT_RELATIVE_TRANSFORM_VELOCITY_ACCELERATION)
 {
   const std::size_t numTests = 50;


### PR DESCRIPTION
## Summary

- Add narrow `FreeJoint` fast paths for the common root-joint frame layout used by the #3056 SDF issue scene.
- Preserve the general transform/Jacobian paths for offset child joint frames and rotated parent frames.
- Add regression coverage comparing skeleton position integration against the existing stateless joint integration overload.
- Add broadened benchmark evidence so the FreeJoint optimization is checked against non-issue workloads too.

## Motivation / Problem

- The active #3056 no-deactivation benchmark still spends measurable time in the per-step integration path after the collision/contact construction slices.
- Many loaded SDF models use `FreeJoint` roots with identity child joint frames and translation-only parent model poses, so the generic child-frame inverse and full transform products are avoidable in that hot path.
- The fast path must remain narrow and fall back to the existing equations outside those frame-layout assumptions.

## Changes / Key Changes

- Fast-path `FreeJoint::integratePositions(double)` when the child joint frame is identity, with a further translation-only parent-frame shortcut.
- Fast-path `FreeJoint::updateRelativeTransform()`, `updateRelativeJacobian()`, and `updateRelativeJacobianTimeDeriv()` for identity child joint frames.
- Keep non-identity child frames and rotated parent frames on the existing general equations.
- Extend `test_Joints` to compare `Skeleton::integratePositions()` against the public stateless overload for identity-frame, translated-parent, and fully offset frame configurations.

## Performance Comparison

RTF is higher-is-better. The table below is a fresh broadened anti-overfitting matrix run on #3172 baseline, #3191 parent, and this PR head. Final hashes, contact counts, and pair counts matched for each scenario.

Primary active issue-scene command:

```bash
pixi run ex contact_benchmark -- .deps/gz-sim/examples/worlds/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --max-contacts-per-pair 4 --disable-deactivation
```

| Scenario | Command difference from primary command | #3172 baseline `382254394d7` | #3191 parent `6137899a0f8` | This PR `01a1f5003b1` | This PR vs #3172 | This PR vs parent | Final state |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| Active 3k SDF issue scene | Primary command above | `0.139629` | `0.125306` | `0.132072` | `0.95x` | `1.05x` | hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003` |
| Default-sleeping 3k SDF | `--steps 3000`, no `--disable-deactivation` | `70.7150` | `60.8566` | `60.0562` | `0.85x` | `0.99x` | hash `0x131b6af79a44ff90`, contacts `0`, pairs `0` |
| Non-default-surface SDF | replace SDF with `.deps/gz-sim/examples/worlds/diff_drive_skid.sdf`; `--steps 3000` | `34.8135` | `24.0793` | `30.0443` | `0.86x` | `1.25x` | hash `0xe5880f64423ce963`, contacts `4`, pairs `4` |
| Generated 900-object guard | `--generate-objects 900`, no SDF / `--sdf-plane-shapes` | `0.614375` | `0.386311` | `0.384615` | `0.63x` | `1.00x` | hash `0xcd1ecb32a4d1ad57`, contacts `1800`, pairs `900` |
| Generated 90-object serial guard | `--generate-objects 90`, no SDF / `--sdf-plane-shapes` | `2.03311` | `1.67984` | `1.55356` | `0.76x` | `0.92x` | hash `0x9ac4f80005c47da8`, contacts `180`, pairs `90` |

A prior active-scene-only comparison recorded this PR at RTF `0.189437`, or `1.18x` the #3172 baseline and `1.02x` the #3191 parent in that run. The broadened matrix is the acceptance guardrail: this is a narrow FreeJoint fast path, not a universal workload win. It improves active 3k and the non-default-surface SDF row versus the #3191 parent, is roughly neutral on settled 3k and generated 900, and shows a short generated 90-object regression that should be treated as follow-up evidence rather than hidden in a single-scene table.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --parallel 5 --target test_Joints contact_benchmark`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_Joints$'`
- `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all` (completed successfully; dartpy pytest tail showed `60 passed`)
- Broadened benchmark matrix: `/tmp/dart-3193-overfit.zEklSW/summary.tsv`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Contributes to #3056
- Follows #3191

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required (not required; internal performance slice)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (not applicable; no public API)
- [x] Add Python bindings (dartpy) if applicable (not applicable)