### PR TITLE
Parallelize default surface scans

### DIFF
--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1190,6 +1190,26 @@ void ConstraintSolver::updateConstraints()
     };
     std::array<DefaultSurfaceCacheEntry, 256u> defaultSurfaceCache{};
 
+    const auto queryDefaultContactSurfacePropertiesUncached
+        = [&](const dynamics::ShapeNode* shapeNode) {
+            if (shapeNode == nullptr)
+              return false;
+
+            const auto* dynamicAspect = shapeNode->getDynamicsAspect();
+            return dynamicAspect != nullptr
+                   && dynamicAspect->getRestitutionCoeff()
+                          == DART_DEFAULT_RESTITUTION_COEFF
+                   && dynamicAspect->getPrimaryFrictionCoeff()
+                          == DART_DEFAULT_FRICTION_COEFF
+                   && dynamicAspect->getSecondaryFrictionCoeff()
+                          == DART_DEFAULT_FRICTION_COEFF
+                   && dynamicAspect->getPrimarySlipCompliance() == -1.0
+                   && dynamicAspect->getSecondarySlipCompliance() == -1.0
+                   && dynamicAspect->getFirstFrictionDirectionFrame() == nullptr
+                   && dynamicAspect->getFirstFrictionDirection().squaredNorm()
+                          < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
+          };
+
     const auto queryDefaultContactSurfaceProperties =
         [&](const dynamics::ShapeNode* shapeNode) {
           if (shapeNode == nullptr)
@@ -1202,20 +1222,8 @@ void ConstraintSolver::updateConstraints()
           if (entry.shapeNode == shapeNode)
             return entry.hasDefaultProperties;
 
-          const auto* dynamicAspect = shapeNode->getDynamicsAspect();
           const bool hasDefaultProperties
-              = dynamicAspect != nullptr
-                && dynamicAspect->getRestitutionCoeff()
-                       == DART_DEFAULT_RESTITUTION_COEFF
-                && dynamicAspect->getPrimaryFrictionCoeff()
-                       == DART_DEFAULT_FRICTION_COEFF
-                && dynamicAspect->getSecondaryFrictionCoeff()
-                       == DART_DEFAULT_FRICTION_COEFF
-                && dynamicAspect->getPrimarySlipCompliance() == -1.0
-                && dynamicAspect->getSecondarySlipCompliance() == -1.0
-                && dynamicAspect->getFirstFrictionDirectionFrame() == nullptr
-                && dynamicAspect->getFirstFrictionDirection().squaredNorm()
-                       < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED;
+              = queryDefaultContactSurfacePropertiesUncached(shapeNode);
 
           entry = {shapeNode, hasDefaultProperties};
           return hasDefaultProperties;
@@ -1456,19 +1464,65 @@ void ConstraintSolver::updateConstraints()
         return {recordSharedBodyIfUnique(bodyNode), false};
       };
 
-      for (auto& contactPairCount : contactPairCounts) {
-        const auto body1Check
-            = checkBodyForParallelDefaultContact(contactPairCount.bodyNode1);
-        const auto body2Check
-            = checkBodyForParallelDefaultContact(contactPairCount.bodyNode2);
-        if (!body1Check.canBuild || !body2Check.canBuild)
-          return false;
+      {
+        DART_PROFILE_SCOPED_N(
+            "build contact constraints - shared-body body scan");
+        for (auto& contactPairCount : contactPairCounts) {
+          const auto body1Check
+              = checkBodyForParallelDefaultContact(contactPairCount.bodyNode1);
+          const auto body2Check
+              = checkBodyForParallelDefaultContact(contactPairCount.bodyNode2);
+          if (!body1Check.canBuild || !body2Check.canBuild)
+            return false;
 
-        contactPairCount.skipRelVelocityBody1 = body1Check.skipRelVelocity;
-        contactPairCount.skipRelVelocityBody2 = body2Check.skipRelVelocity;
+          contactPairCount.skipRelVelocityBody1 = body1Check.skipRelVelocity;
+          contactPairCount.skipRelVelocityBody2 = body2Check.skipRelVelocity;
+        }
+      }
 
-        if (!ensureDefaultSurfaceParamsChecked(contactPairCount))
-          needsSurfaceParamsPrepass = true;
+      {
+        DART_PROFILE_SCOPED_N(
+            "build contact constraints - shared-body surface scan");
+        if (contactPairCounts.size() >= 512u) {
+          static thread_local std::vector<char> surfaceParamsPrepassScratch;
+          surfaceParamsPrepassScratch.resize(contactPairCounts.size());
+
+          auto* contactPairCountsForSurfaceScan = &contactPairCounts;
+          auto* surfaceParamsPrepassScratchForScan
+              = &surfaceParamsPrepassScratch;
+          auto scanDefaultSurfaceParams = [&](std::size_t pairIndex) {
+            auto& contactPairCount
+                = (*contactPairCountsForSurfaceScan)[pairIndex];
+            const bool canUseDefaultSurfaceParams
+                = useBuiltInDefaultSurfaceParamsCache
+                  && queryDefaultContactSurfacePropertiesUncached(
+                      contactPairCount.shapeNode1)
+                  && queryDefaultContactSurfacePropertiesUncached(
+                      contactPairCount.shapeNode2);
+            contactPairCount.canUseDefaultSurfaceParams
+                = canUseDefaultSurfaceParams;
+            contactPairCount.defaultSurfaceParamsChecked = true;
+            (*surfaceParamsPrepassScratchForScan)[pairIndex]
+                = canUseDefaultSurfaceParams ? 0 : 1;
+          };
+
+          mConstraintThreadPool->parallelFor(
+              contactPairCountsForSurfaceScan->size(),
+              mNumSimulationThreads,
+              scanDefaultSurfaceParams);
+
+          for (const char needsPrepass : surfaceParamsPrepassScratch) {
+            if (needsPrepass) {
+              needsSurfaceParamsPrepass = true;
+              break;
+            }
+          }
+        } else {
+          for (auto& contactPairCount : contactPairCounts) {
+            if (!ensureDefaultSurfaceParamsChecked(contactPairCount))
+              needsSurfaceParamsPrepass = true;
+          }
+        }
       }
 
       parallelDefaultContactBuildNeedsSurfaceParamsPrepass

--- a/dart/constraint/ConstraintSolver.cpp
+++ b/dart/constraint/ConstraintSolver.cpp
@@ -1343,6 +1343,8 @@ void ConstraintSolver::updateConstraints()
           }
         };
 
+    constexpr std::size_t kParallelDefaultSurfacePrepassMinPairs = 1024u;
+
     bool parallelDefaultContactBuildNeedsSurfaceParamsPrepass = false;
     const auto canBuildDefaultContactsByPairInParallel = [&]() {
       parallelDefaultContactBuildNeedsSurfaceParamsPrepass = false;
@@ -1464,9 +1466,7 @@ void ConstraintSolver::updateConstraints()
         return {recordSharedBodyIfUnique(bodyNode), false};
       };
 
-      {
-        DART_PROFILE_SCOPED_N(
-            "build contact constraints - shared-body body scan");
+      if (contactPairCounts.size() < kParallelDefaultSurfacePrepassMinPairs) {
         for (auto& contactPairCount : contactPairCounts) {
           const auto body1Check
               = checkBodyForParallelDefaultContact(contactPairCount.bodyNode1);
@@ -1477,13 +1477,30 @@ void ConstraintSolver::updateConstraints()
 
           contactPairCount.skipRelVelocityBody1 = body1Check.skipRelVelocity;
           contactPairCount.skipRelVelocityBody2 = body2Check.skipRelVelocity;
-        }
-      }
 
-      {
-        DART_PROFILE_SCOPED_N(
-            "build contact constraints - shared-body surface scan");
-        if (contactPairCounts.size() >= 512u) {
+          if (!ensureDefaultSurfaceParamsChecked(contactPairCount))
+            needsSurfaceParamsPrepass = true;
+        }
+      } else {
+        {
+          DART_PROFILE_SCOPED_N(
+              "build contact constraints - shared-body body scan");
+          for (auto& contactPairCount : contactPairCounts) {
+            const auto body1Check = checkBodyForParallelDefaultContact(
+                contactPairCount.bodyNode1);
+            const auto body2Check = checkBodyForParallelDefaultContact(
+                contactPairCount.bodyNode2);
+            if (!body1Check.canBuild || !body2Check.canBuild)
+              return false;
+
+            contactPairCount.skipRelVelocityBody1 = body1Check.skipRelVelocity;
+            contactPairCount.skipRelVelocityBody2 = body2Check.skipRelVelocity;
+          }
+        }
+
+        {
+          DART_PROFILE_SCOPED_N(
+              "build contact constraints - shared-body surface scan");
           static thread_local std::vector<char> surfaceParamsPrepassScratch;
           surfaceParamsPrepassScratch.resize(contactPairCounts.size());
 
@@ -1516,11 +1533,6 @@ void ConstraintSolver::updateConstraints()
               needsSurfaceParamsPrepass = true;
               break;
             }
-          }
-        } else {
-          for (auto& contactPairCount : contactPairCounts) {
-            if (!ensureDefaultSurfaceParamsChecked(contactPairCount))
-              needsSurfaceParamsPrepass = true;
           }
         }
       }

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -105,7 +105,7 @@ identified real tradeoffs that were hidden by the single issue-scene table:
 | Best landed settled row, #3154 `0748544d6a7` | `0.157291` | `85.8344` | `37.5185` | Settled issue scene peak |
 | Best landed non-default-surface row, #3147 `f72966f7ebf` | `0.128060` | `30.0080` | `47.7164` | `diff_drive_skid` peak |
 | Current landed #3191 `6137899a0f8` | `0.120256` | `55.8996` | `32.8497` | Only `0.67x` of best active, `0.65x` of best settled, and `0.69x` of best non-default-surface row |
-| Current #3194 head `8a42e8db747` | `0.221884` | `74.7945` | `38.1284` | Clean rerun after host build pressure cleared; recovers active and improves the two guardrails versus #3191, but does not fully recover historical settled/non-default-surface peaks |
+| Current #3194 branch `bec682c9655` | `0.221884` | `74.7945` | `38.1284` | Clean rerun after host build pressure cleared on code commit `8a42e8db747`; the branch head only records this audit. Recovers active and improves the two guardrails versus #3191, but does not fully recover historical settled/non-default-surface peaks |
 
 Follow-up implication: #3194 addresses the active issue-scene regression from
 the merged #3183/#3188/#3190/#3191 tail and improves the SDF guardrails versus

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -76,6 +76,43 @@ DART-native improvements are not considered complete on this workload unless
 the evidence shows native collision ahead of all three backends on the same
 DART 6 dynamics and solver pipeline.
 
+Anti-overfitting rule: every new performance PR in this stack must include a
+real-number comparison for the baseline commit, the immediate parent, and the
+PR head on more than the single issue scene. At minimum, include the active
+3k issue scene, the default-sleeping 3k scene, one non-default-surface SDF
+scene, and one generated medium/large scene when the compared commits support
+that generated geometry. Preserve and report final-state hashes, contact
+counts, and pair counts for every row.
+
+Retrospective SDF audit across the landed issue-3056 chain used three
+sequential DART-native guardrails:
+
+- Active issue scene:
+  `.deps/gz-sim/examples/worlds/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --max-contacts-per-pair 4 --disable-deactivation`
+- Default-sleeping issue scene: same command, but `--steps 3000` and no
+  `--disable-deactivation`.
+- Non-default-surface SDF:
+  `.deps/gz-sim/examples/worlds/diff_drive_skid.sdf --steps 3000 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --max-contacts-per-pair 4 --disable-deactivation`
+
+All retrospective SDF rows preserved their per-scenario final hash, contact
+count, and pair count across the landed commits. The full landed-chain scan
+identified real tradeoffs that were hidden by the single issue-scene table:
+
+| Checkpoint | Active 3k RTF | Settled 3k RTF | `diff_drive_skid` RTF | Notes |
+| --- | ---: | ---: | ---: | --- |
+| #3144 parent `39aada80472` | `0.104916` | `3.59748` | `46.2657` | Start of comparable SDF audit window |
+| Best landed active row, #3172 `382254394d7` | `0.179023` | `69.0482` | `35.4684` | Active issue scene peak before later regressions |
+| Best landed settled row, #3154 `0748544d6a7` | `0.157291` | `85.8344` | `37.5185` | Settled issue scene peak |
+| Best landed non-default-surface row, #3147 `f72966f7ebf` | `0.128060` | `30.0080` | `47.7164` | `diff_drive_skid` peak |
+| Current landed #3191 `6137899a0f8` | `0.120256` | `55.8996` | `32.8497` | Only `0.67x` of best active, `0.65x` of best settled, and `0.69x` of best non-default-surface row |
+| Current #3194 head `8a42e8db747` | `0.221884` | `74.7945` | `38.1284` | Clean rerun after host build pressure cleared; recovers active and improves the two guardrails versus #3191, but does not fully recover historical settled/non-default-surface peaks |
+
+Follow-up implication: #3194 addresses the active issue-scene regression from
+the merged #3183/#3188/#3190/#3191 tail and improves the SDF guardrails versus
+the current landed head. Later follow-ups should explicitly target the remaining
+settled-scene and non-default-surface gaps instead of optimizing only the active
+3k scene.
+
 Active issue-scene evidence,
 `.deps/gz-sim/examples/worlds/3k_shapes.sdf`, DART-native collision, DART 6
 dynamics, deactivation disabled, `--world-threads 16`,
@@ -92,7 +129,7 @@ dynamics, deactivation disabled, `--world-threads 16`,
 | Local skip-flags/body-set experiment, text profile | DART native | `0.171489` current noisy rerun; `0.205666` retained-bucket rerun; `0.189984`, `0.165932` noisy reruns; `0.212505`, `0.215980` prior runs | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `307.89 ms`, `shared-body check` `193.68 ms`, `parallel reset` `73.30 ms`, `solveConstrainedGroups` `283.68 ms`, `collide` `406.00 ms`; retained-bucket profile had `build contact constraints` `239.58 ms`, `shared-body check` `138.92 ms`, `parallel reset` `68.59 ms` |
 | Local axis-plane contact-bounds experiment, no profile | DART native | `0.189566` parallel-surface parent comparison rerun; `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | Local axis-plane contact-bounds experiment, text profile | DART native | `0.227034` compact-bound rerun; `0.207763` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003`; latest projected contact-bound separation `16.32 ms`, finite-plane pairs `113.66 ms`, `collide` `268.50 ms`, `build contact constraints` `225.11 ms`, `solveConstrainedGroups` `245.09 ms` |
-| Local parallel surface-scan experiment, no profile | DART native | `0.217070` current race-free PR-head rerun; `0.231146` pre-review shared-cache rerun | finite, same hash, contacts `5005`, pairs `3003` |
+| Local parallel surface-scan experiment, no profile | DART native | `0.221884` clean SDF guardrail rerun after raising the threaded prepass cutoff; `0.217070` earlier race-free PR-head rerun; `0.231146` pre-review shared-cache rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | FCL primitive | `0.145341` | finite, hash `0x6088ea0177efa6a`, contacts `3003`, pairs `3003` |
 | #3183 local candidate, no profile | Bullet | `0.144310` | finite, hash `0x11fdd70a9952f98e`, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | ODE | `0.0100767` | finite, hash `0x2a3d53060f661c4c`, contacts `9009`, pairs `3003` |
@@ -128,13 +165,13 @@ to `268.50 ms`. The current post-rebase no-profile repeat reached RTF
 contact-construction slices.
 
 The parallel surface-scan experiment has been restacked directly on the current
-#3191 release head. The fresh race-free comparison run recorded RTF `0.217070`
-for the PR head, versus `0.189566` for the #3191 parent and `0.172600` for the
-#3172 baseline. All three rows kept the same final hash, contact count, and
-pair count.
+#3191 release head. The clean post-cutoff SDF guardrail rerun recorded active
+3k RTF `0.221884` for the PR head, versus `0.120256` for the landed #3191 head
+in the same retrospective SDF audit and `0.179023` for the landed #3172 active
+peak. All rows kept the same final hash, contact count, and pair count.
 
 On the original default-sleeping target command, the same current local head
-reaches RTF `61.1724` for 3000 steps with DART-native collision, advances
+reaches RTF `74.7945` for 3000 steps with DART-native collision, advances
 `3000 / 3000` frames, ends finite with hash `0x131b6af79a44ff90`, and has all
 `3003 / 3003` mobile skeletons resting with zero final contacts.
 

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -112,7 +112,7 @@ identified real tradeoffs that were hidden by the single issue-scene table:
 | Best landed settled row, #3154 `0748544d6a7` | `0.157291` | `85.8344` | `37.5185` | Settled issue scene peak |
 | Best landed non-default-surface row, #3147 `f72966f7ebf` | `0.128060` | `30.0080` | `47.7164` | `diff_drive_skid` peak |
 | Current landed #3191 `6137899a0f8` | `0.120256` | `55.8996` | `32.8497` | Only `0.67x` of best active, `0.65x` of best settled, and `0.69x` of best non-default-surface row |
-| Current #3194 branch `bec682c9655` | `0.221884` | `74.7945` | `38.1284` | Clean rerun after host build pressure cleared on code commit `8a42e8db747`; the branch head only records this audit. Recovers active and improves the two guardrails versus #3191, but does not fully recover historical settled/non-default-surface peaks |
+| Current #3194 branch `0b30724d53f` | `0.229680` | `78.8741` | `35.2788` | Clean rerun after merging the #3193 base. Recovers active and improves the two guardrails versus #3191, but does not fully recover the historical non-default-surface peak |
 
 Follow-up implication: #3194 addresses the active issue-scene regression from
 the merged #3183/#3188/#3190/#3191 tail and improves the SDF guardrails versus
@@ -137,7 +137,7 @@ dynamics, deactivation disabled, `--world-threads 16`,
 | Local axis-plane contact-bounds experiment, no profile | DART native | `0.189566` parallel-surface parent comparison rerun; `0.185536` FreeJoint parent comparison rerun; `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | Local axis-plane contact-bounds experiment, text profile | DART native | `0.227034` compact-bound rerun; `0.207763` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003`; latest projected contact-bound separation `16.32 ms`, finite-plane pairs `113.66 ms`, `collide` `268.50 ms`, `build contact constraints` `225.11 ms`, `solveConstrainedGroups` `245.09 ms` |
 | Local FreeJoint root-integration experiment, no profile | DART native | `0.189437` direct PR-head comparison rerun | finite, same hash, contacts `5005`, pairs `3003` |
-| Local parallel surface-scan experiment, no profile | DART native | `0.221884` clean SDF guardrail rerun after raising the threaded prepass cutoff before merging the #3193 base; `0.217070` earlier race-free PR-head rerun; `0.231146` pre-review shared-cache rerun | finite, same hash, contacts `5005`, pairs `3003` |
+| Local parallel surface-scan experiment, no profile | DART native | `0.229680` current merged-base guardrail rerun; `0.221884` clean SDF guardrail rerun after raising the threaded prepass cutoff before merging the #3193 base; `0.217070` earlier race-free PR-head rerun; `0.231146` pre-review shared-cache rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | FCL primitive | `0.145341` | finite, hash `0x6088ea0177efa6a`, contacts `3003`, pairs `3003` |
 | #3183 local candidate, no profile | Bullet | `0.144310` | finite, hash `0x11fdd70a9952f98e`, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | ODE | `0.0100767` | finite, hash `0x2a3d53060f661c4c`, contacts `9009`, pairs `3003` |
@@ -177,14 +177,16 @@ the PR head, versus `0.185536` for the #3191 parent and `0.161033` for the
 #3172 baseline in that comparison run. All three rows kept the same final hash,
 contact count, and pair count.
 
-Before merging the #3193 base, the parallel surface-scan experiment recorded a
-clean post-cutoff active 3k SDF guardrail RTF `0.221884` for the PR head,
-versus `0.120256` for the landed #3191 head in the same retrospective SDF audit
-and `0.179023` for the landed #3172 active peak. All rows kept the same final
-hash, contact count, and pair count.
+After merging the #3193 base, the parallel surface-scan experiment recorded
+active 3k SDF guardrail RTF `0.229680`, default-sleeping 3k RTF `78.8741`, and
+`diff_drive_skid` RTF `35.2788` for the PR head. All rows kept the same final
+hash, contact count, and pair count as the baseline and parent comparisons. The
+active row is above the landed #3172 active peak (`0.179023`) and the settled
+row is above the landed #3172 settled row (`69.0482`), but the non-default SDF
+row remains below the historical #3147 `diff_drive_skid` peak (`47.7164`).
 
 On the original default-sleeping target command, the same current local head
-reaches RTF `74.7945` for 3000 steps with DART-native collision, advances
+reaches RTF `78.8741` for 3000 steps with DART-native collision, advances
 `3000 / 3000` frames, ends finite with hash `0x131b6af79a44ff90`, and has all
 `3003 / 3003` mobile skeletons resting with zero final contacts.
 
@@ -231,7 +233,13 @@ The local parallel surface-scan experiment has passed: `pixi run lint`,
 `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_ConstraintSolver$'`,
 `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all`
 (C++ tests `115/115`, Python tests `60/60`), and the fresh exact issue-scene
-benchmark comparison rows above.
+benchmark comparison rows above. After merging #3193, the combined focused
+gate passed `pixi run lint`,
+`cmake --build build/default/cpp/Release --parallel 5 --target test_Joints test_ConstraintSolver contact_benchmark`,
+and
+`ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_Joints|test_ConstraintSolver)$'`;
+the merged-base guardrail matrix is recorded in
+`/tmp/dart-3194-merged-head.aZ9QPT/summary.tsv`.
 
 An earlier fixed-support contact-build relaxation crashed because the parallel
 worker indexed `thread_local` contact-pair scratch storage from the worker

--- a/docs/dev_tasks/issue_3056_dart6_performance/README.md
+++ b/docs/dev_tasks/issue_3056_dart6_performance/README.md
@@ -4,17 +4,15 @@
 
 Bottom line: #3129, #3133, #3135, #3139, #3140, #3141, #3142, #3143,
 #3144, #3146, #3147, #3148, #3149, #3150, #3151, #3152, #3153, #3154,
-#3170, #3171, #3172, and #3183 are merged. There are no open performance PRs.
-The active PR-ready local slice is `perf/dart6-contact-pair-metadata-cache`,
-rebuilt directly on the merged `release-6.20` head. The further local-only
-experiment, `perf/dart6-contact-pair-skip-flags`, is stacked above that slice
-and must stay unpublished until the metadata-cache PR lands separately. The
-next local-only branch, `perf/dart6-axis-plane-contact-bounds`, is stacked
-above skip-flags and must remain unpublished until the earlier slices land in
-order. Remaining local follow-up slices must also stay unpublished until each
-is ready to publish directly against `release-6.20`; do not open them against
-another PR branch. Opening stacked PRs against parent PR branches lets GitHub
-close or supersede child PRs when the parent branch is merged or deleted.
+#3170, #3171, #3172, #3183, #3188, #3190, and #3191 are merged. #3192
+remains open as a draft because its safe cache revision did not beat the #3191
+parent in the fresh comparison run. #3193 is open and ready for review. The
+current local solver candidate is `perf/dart6-parallel-surface-scan`, rebuilt
+directly on the merged `release-6.20` head. Remaining local follow-up slices
+must stay unpublished until each is ready to publish directly against
+`release-6.20`; do not open them against another PR branch. Opening stacked PRs
+against parent PR branches lets GitHub close or supersede child PRs when the
+parent branch is merged or deleted.
 
 The merged #3172 slice adds a narrow native broadphase setup fast path.
 DART-native collision objects cache local bounds center/half-extents when their
@@ -52,6 +50,14 @@ axis to the plane point. The proof also stores only projected min/max bounds in
 scratch instead of copying full broadphase entries through the sort. Non-axis
 planes keep the original corner-projection path.
 
+The newest local solver follow-up parallelizes the default-surface-property
+scan that remains before contact-constraint rebuild. The shared-body/body
+duplicate scan stays serial, but large contact-pair sets now compute the
+default-material predicate in the existing constraint thread pool and then
+reduce a scratch flag back on the main thread. Small contact sets and any
+fallback surface-parameter path keep the original serial
+`ensureDefaultSurfaceParamsChecked()` behavior.
+
 The #3183 candidate folds default contact-surface parameter
 initialization into the existing per-pair parallel default-contact rebuild. The
 serial cached prepass remains for fallback paths. Default-material pairs compute
@@ -77,15 +83,16 @@ dynamics, deactivation disabled, `--world-threads 16`,
 
 | Run | Collision backend | RTF | Final state |
 | --- | --- | ---: | --- |
-| #3172 merged baseline, no profile | DART native | `0.179381` | finite, hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003` |
+| #3172 merged baseline, no profile | DART native | `0.172600` parallel-surface comparison rerun; `0.179381` prior rerun | finite, hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003` |
 | #3183 head `0b158d44126`, no profile | DART native | `0.127794` | finite, same hash, contacts `5005`, pairs `3003` |
 | #3183 head `0b158d44126`, text profile | DART native | `0.128960` | finite, same hash, contacts `5005`, pairs `3003`; `build contact constraints` `605.13 ms`, `shared-body check` `388.96 ms`, `parallel reset` `108.10 ms`, `solveConstrainedGroups` `318.56 ms`, `collide` `477.22 ms` |
 | Metadata-cache candidate rebased on #3185 base, no profile | DART native | `0.186148`; pre-#3184 rerun `0.182836`; earlier repeats `0.202726`, `0.187945`, `0.204494`, `0.204368`, `0.212991`, `0.195666` | finite, same hash, contacts `5005`, pairs `3003` |
 | Metadata-cache candidate rebased on #3185 base, text profile | DART native | `0.185689`; pre-#3184 rerun `0.203355` | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `266.09 ms`, `shared-body check` `150.77 ms`, `parallel reset` `74.14 ms`, `solveConstrainedGroups` `271.31 ms`, `collide` `377.69 ms` |
 | Local skip-flags/body-set experiment, no profile | DART native | `0.192959` current rerun; `0.196971`, `0.196594` post-rebase reruns; `0.185274` retained-bucket rerun; `0.213820`, `0.215162`, `0.199266`, `0.198770` prior repeats | finite, same hash, contacts `5005`, pairs `3003` |
 | Local skip-flags/body-set experiment, text profile | DART native | `0.171489` current noisy rerun; `0.205666` retained-bucket rerun; `0.189984`, `0.165932` noisy reruns; `0.212505`, `0.215980` prior runs | finite, same hash, contacts `5005`, pairs `3003`; current `build contact constraints` `307.89 ms`, `shared-body check` `193.68 ms`, `parallel reset` `73.30 ms`, `solveConstrainedGroups` `283.68 ms`, `collide` `406.00 ms`; retained-bucket profile had `build contact constraints` `239.58 ms`, `shared-body check` `138.92 ms`, `parallel reset` `68.59 ms` |
-| Local axis-plane contact-bounds experiment, no profile | DART native | `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
+| Local axis-plane contact-bounds experiment, no profile | DART native | `0.189566` parallel-surface parent comparison rerun; `0.203003` current post-rebase rerun; `0.223206` compact-bound rerun; `0.213167` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | Local axis-plane contact-bounds experiment, text profile | DART native | `0.227034` compact-bound rerun; `0.207763` prior axis-only rerun | finite, same hash, contacts `5005`, pairs `3003`; latest projected contact-bound separation `16.32 ms`, finite-plane pairs `113.66 ms`, `collide` `268.50 ms`, `build contact constraints` `225.11 ms`, `solveConstrainedGroups` `245.09 ms` |
+| Local parallel surface-scan experiment, no profile | DART native | `0.217070` current race-free PR-head rerun; `0.231146` pre-review shared-cache rerun | finite, same hash, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | FCL primitive | `0.145341` | finite, hash `0x6088ea0177efa6a`, contacts `3003`, pairs `3003` |
 | #3183 local candidate, no profile | Bullet | `0.144310` | finite, hash `0x11fdd70a9952f98e`, contacts `5005`, pairs `3003` |
 | #3183 local candidate, no profile | ODE | `0.0100767` | finite, hash `0x2a3d53060f661c4c`, contacts `9009`, pairs `3003` |
@@ -119,6 +126,12 @@ cutting the projected contact-bound separation proof from the prior local
 to `268.50 ms`. The current post-rebase no-profile repeat reached RTF
 `0.203003`. Treat this as a later collision follow-up after the
 contact-construction slices.
+
+The parallel surface-scan experiment has been restacked directly on the current
+#3191 release head. The fresh race-free comparison run recorded RTF `0.217070`
+for the PR head, versus `0.189566` for the #3191 parent and `0.172600` for the
+#3172 baseline. All three rows kept the same final hash, contact count, and
+pair count.
 
 On the original default-sleeping target command, the same current local head
 reaches RTF `61.1724` for 3000 steps with DART-native collision, advances
@@ -154,6 +167,13 @@ The local axis-plane contact-bounds experiment has passed:
 `DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all`
 (C++ tests `115/115`, Python tests `60/60`), and the exact issue-scene
 no-profile/profile benchmark runs above.
+
+The local parallel surface-scan experiment has passed: `pixi run lint`,
+`cmake --build build/default/cpp/Release --parallel 5 --target test_ConstraintSolver contact_benchmark`,
+`ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_ConstraintSolver$'`,
+`DART_PARALLEL_JOBS=5 CTEST_PARALLEL_LEVEL=5 CMAKE_BUILD_PARALLEL_LEVEL=5 pixi run test-all`
+(C++ tests `115/115`, Python tests `60/60`), and the fresh exact issue-scene
+benchmark comparison rows above.
 
 An earlier fixed-support contact-build relaxation crashed because the parallel
 worker indexed `thread_local` contact-pair scratch storage from the worker

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -708,7 +708,7 @@ TEST(ConstraintSolver, ThreadedDefaultContactRebuildMatchesSerialSurfaceParams)
 //==============================================================================
 TEST(ConstraintSolver, ThreadedSurfacePrepassMatchesSerialForLargeBatches)
 {
-  constexpr std::size_t kNumBoxes = 520u;
+  constexpr std::size_t kNumBoxes = 1040u;
 
   const auto runCase = [](bool useNonDefaultSurfaceParams) {
     auto serialWorld = createManySingleFreeBodyContactWorld(

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -542,6 +542,46 @@ std::shared_ptr<World> createManySingleFreeBodyContactWorld(
 }
 
 //==============================================================================
+void expectManySingleFreeBodyContactWorldsMatch(
+    const std::shared_ptr<World>& expectedWorld,
+    const std::shared_ptr<World>& actualWorld,
+    std::size_t numBoxes)
+{
+  const auto& expectedContacts
+      = expectedWorld->getConstraintSolver()->getLastCollisionResult();
+  const auto& actualContacts
+      = actualWorld->getConstraintSolver()->getLastCollisionResult();
+  EXPECT_GE(expectedContacts.getNumContacts(), numBoxes * 3u);
+  EXPECT_EQ(expectedContacts.getNumContacts(), actualContacts.getNumContacts());
+
+  for (std::size_t i = 0u; i < numBoxes; ++i) {
+    const auto name = "box_" + std::to_string(i);
+    const auto expectedBox = expectedWorld->getSkeleton(name);
+    const auto actualBox = actualWorld->getSkeleton(name);
+    ASSERT_NE(nullptr, expectedBox) << name;
+    ASSERT_NE(nullptr, actualBox) << name;
+
+    EXPECT_TRUE(
+        expectedBox->getPositions().isApprox(actualBox->getPositions(), 1e-12))
+        << name;
+    EXPECT_TRUE(expectedBox->getVelocities().isApprox(
+        actualBox->getVelocities(), 1e-12))
+        << name;
+
+    const auto* expectedBody = expectedBox->getBodyNode(0);
+    const auto* actualBody = actualBox->getBodyNode(0);
+    ASSERT_NE(nullptr, expectedBody) << name;
+    ASSERT_NE(nullptr, actualBody) << name;
+    EXPECT_TRUE(expectedBody->getWorldTransform().matrix().isApprox(
+        actualBody->getWorldTransform().matrix(), 1e-12))
+        << name;
+    EXPECT_TRUE(expectedBody->getSpatialVelocity().isApprox(
+        actualBody->getSpatialVelocity(), 1e-12))
+        << name;
+  }
+}
+
+//==============================================================================
 TEST(ConstraintSolver, DirectSingleFreeBodyContactsMatchLegacyAssembly)
 {
   auto directWorld = createSingleFreeBodyContactWorld(false);
@@ -663,6 +703,30 @@ TEST(ConstraintSolver, ThreadedDefaultContactRebuildMatchesSerialSurfaceParams)
         threadedBox->getVelocities(), 1e-12))
         << name;
   }
+}
+
+//==============================================================================
+TEST(ConstraintSolver, ThreadedSurfacePrepassMatchesSerialForLargeBatches)
+{
+  constexpr std::size_t kNumBoxes = 520u;
+
+  const auto runCase = [](bool useNonDefaultSurfaceParams) {
+    auto serialWorld = createManySingleFreeBodyContactWorld(
+        kNumBoxes, 1u, useNonDefaultSurfaceParams);
+    auto threadedWorld = createManySingleFreeBodyContactWorld(
+        kNumBoxes, 4u, useNonDefaultSurfaceParams);
+
+    for (std::size_t i = 0u; i < 6u; ++i) {
+      serialWorld->step();
+      threadedWorld->step();
+    }
+
+    ASSERT_NO_FATAL_FAILURE(expectManySingleFreeBodyContactWorldsMatch(
+        serialWorld, threadedWorld, kNumBoxes));
+  };
+
+  runCase(false);
+  runCase(true);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Parallelizes the default contact-surface property prepass only for very large DART-native contact-pair batches.
- Keeps small and medium batches on the existing serial cached scan path after the #3192 base merge.
- Merges the latest `release-6.20` base after #3192/#3193 landed and refreshes the anti-overfitting benchmark evidence.
- Records the paired parent/head guardrail audit in `docs/dev_tasks/issue_3056_dart6_performance/README.md`.

## Motivation / Problem

The issue #3056 3k-shape benchmark still spends measurable time scanning default contact-surface properties after the earlier DART-native contact-build improvements. Very large batches can split that read-only default-surface predicate across the existing constraint solver thread pool without changing generated contacts or final state. The optimization is deliberately gated so it does not tune only for the 3k-shape issue scene.

## Changes / Key Changes

- Adds a parallel default-surface scan path when the contact-pair batch has at least 1024 pairs.
- Uses an uncached read-only surface-property query in the parallel prepass so workers do not share mutable cache state.
- Restores the #3192 cached serial miss path for sub-threshold batches and normal serial scans.
- Keeps the serial shared-body/body duplicate scan before the parallel surface scan.
- Adds focused coverage for large threaded surface prepasses with default and non-default contact surfaces.
- Updates the issue #3056 dev-task audit with paired #3192 parent and #3194 head benchmark rows.

## Performance

RTF is higher-is-better. Current branch head is `88fdc019df6`. Parent `74ed758687a` is the merged #3192 `release-6.20` head. The #3172 baseline rows come from the same broadened guardrail suite used earlier in this stack. Final hashes, contact counts, and pair counts matched for each scenario.

Primary active issue-scene command:

```bash
pixi run ex contact_benchmark -- .deps/gz-sim/examples/worlds/3k_shapes.sdf --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --sdf-plane-shapes --world-threads 16 --max-contacts 12000 --max-contacts-per-pair 4 --disable-deactivation
```

| Scenario | Command difference from primary command | #3172 baseline `382254394d7` | #3192 parent `74ed758687a` | This PR `88fdc019df6` | This PR vs #3172 | This PR vs parent | Final state |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| Active 3k SDF issue scene | Primary command above | `0.139629` | `0.203386` | `0.211067` | `1.51x` | `1.04x` | hash `0x6a043ac1e7558218`, contacts `5005`, pairs `3003` |
| Default-sleeping 3k SDF | `--steps 3000`, no `--disable-deactivation` | `70.7150` | `74.3664` | `81.0689` | `1.15x` | `1.09x` | hash `0x131b6af79a44ff90`, contacts `0`, pairs `0` |
| Non-default-surface SDF | Replace SDF with `.deps/gz-sim/examples/worlds/diff_drive_skid.sdf`; `--steps 3000` | `34.8135` | `42.1516` | `41.8279` | `1.20x` | `0.99x` | hash `0xe5880f64423ce963`, contacts `4`, pairs `4` |
| Generated 900-object guard | `--generate-objects 900`, no SDF / `--sdf-plane-shapes` | `0.614375` | `0.634593` | `0.595790` | `0.97x` | `0.94x` | hash `0xcd1ecb32a4d1ad57`, contacts `1800`, pairs `900` |
| Generated 90-object serial guard | `--generate-objects 90`, no SDF / `--sdf-plane-shapes` | `2.03311` | `2.06178` | `2.09921` | `1.03x` | `1.02x` | hash `0x9ac4f80005c47da8`, contacts `180`, pairs `90` |

Generated 900 is noisy and stays on the serial cached path because it has only 900 contact pairs, below the 1024-pair parallel cutoff. Three immediate repeats of the final head produced RTF `0.599612`, `0.643204`, and `0.608259`, all with the same hash `0xcd1ecb32a4d1ad57`, contacts `1800`, and pairs `900`; the parent sample `0.634593` is inside that observed head range. I am treating that guard as neutral/noisy rather than a stable improvement.

The paired matrix says this PR is still useful after #3192: it improves the active and default-sleeping 3k SDF workloads, keeps the non-default SDF row effectively neutral, preserves generated 90, and does not change final state on any guardrail. It does not close the historical `diff_drive_skid` gap; that remains a follow-up target in the dev-task audit.

## Testing

- `pixi run lint`
- `cmake --build build/default/cpp/Release --parallel 5 --target test_ConstraintSolver contact_benchmark`
- `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^test_ConstraintSolver$'`
- After merging #3192/#3193 base during this refresh:
  - `cmake --build build/default/cpp/Release --parallel 5 --target test_Joints test_ConstraintSolver contact_benchmark`
  - `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(test_Joints|test_ConstraintSolver)$'`
- Broadened benchmark suites:
  - `/tmp/dart-3193-overfit.zEklSW/summary.tsv` for the #3172 baseline rows above
  - `/tmp/dart-3192-parent-live.ZcOv34` for the paired #3192 parent rows above
  - `/tmp/dart-3194-restored-serial.EsDnDb` for the final #3194 head rows above
  - `/tmp/dart-3194-gen900-repeats.CEqf3y` for generated-900 repeat evidence

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes #3056
- Follows #3172, #3192, and #3193 on `release-6.20`

---

#### Checklist

- [x] Milestone set (DART 6.20.0 for `release-6.20`)
- [x] CHANGELOG.md updated if required (not required: internal performance path, no API change)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
