### PR TITLE
tests: raise Coverage (Debug) timeout for world allocation shards (fix flaky main CI)

### DIFF
--- a/tests/unit/simulation/CMakeLists.txt
+++ b/tests/unit/simulation/CMakeLists.txt
@@ -339,7 +339,10 @@ if(DART_SIMULATION_BUILD_TESTS)
       test_world_rest
     )
       if(TEST ${_dart_world_shard})
-        set_tests_properties(${_dart_world_shard} PROPERTIES TIMEOUT 3600)
+        # The gcov-instrumented build runs these allocation-gate corpora close to
+        # the 3600s ctest limit; test_world_raw_malloc has timed out at ~3600.1s on
+        # loaded Coverage (Debug) runners. Give the shards extra coverage headroom.
+        set_tests_properties(${_dart_world_shard} PROPERTIES TIMEOUT 5400)
       endif()
     endforeach()
     if(TARGET test_compute_graph)


### PR DESCRIPTION
Fixes the flaky `Coverage (Debug)` failure on `main`.

**Symptom:** `Coverage (Debug)` failed on `main` (currently red on `dcb5c688260`/#3189) — CTest exit 8, `test_world_raw_malloc` **Timeout at 3600.13s**.

**Root cause (not a code regression):** `test_world_raw_malloc` is one of five sharded world allocation gates that already get a coverage-specific `TIMEOUT 3600` (the gcov-instrumented build is much slower). It ran ~0.13s over the limit — i.e. it sits right at the boundary and load-flakes. The same `Coverage (Debug)` job also failed on the preceding commit **#3127** (an `actions/checkout` version bump) and passed on the two before that; neither that bump nor the docs-only #3189 can affect test runtime. So this is a flaky coverage timeout, surfaced by runner load, not anything those commits introduced.

**Fix:** raise the coverage-only timeout for the world allocation shards from 3600s → **5400s** (50% headroom). Coverage-only; no effect on normal CI timing or runtime behavior.

Verified: `check-lint-cmake` (gersemi) and codespell clean. The PR's own `Coverage (Debug)` run exercises the new headroom.

@codex review