### PR TITLE
tests: right-size the deformable raw-malloc coverage gate (fix flaky Coverage (Debug) timeout)

### DIFF
--- a/tests/unit/simulation/world/test_world.cpp
+++ b/tests/unit/simulation/world/test_world.cpp
@@ -1114,7 +1114,8 @@ template <typename ConfigureScene>
 HeapAllocationSnapshot countRawHeapAllocationsDuringFirstPostBakeSteps(
     std::string_view scene,
     ConfigureScene&& configureScene,
-    bool requireInitialContact = false)
+    bool requireInitialContact = false,
+    int postBakeSteps = 4)
 {
   namespace sx = dart::simulation;
 
@@ -1128,7 +1129,7 @@ HeapAllocationSnapshot countRawHeapAllocationsDuringFirstPostBakeSteps(
   world.enterSimulationMode();
 
   ScopedRawHeapAllocationCounter rawCounter;
-  for (int i = 0; i < 4; ++i) {
+  for (int i = 0; i < postBakeSteps; ++i) {
     world.step();
   }
   rawCounter.stop();
@@ -1140,13 +1141,15 @@ template <typename ConfigureScene>
 void expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
     std::string_view scene,
     ConfigureScene&& configureScene,
-    bool requireInitialContact = false)
+    bool requireInitialContact = false,
+    int postBakeSteps = 4)
 {
   SCOPED_TRACE(scene);
   const auto rawCounter = countRawHeapAllocationsDuringFirstPostBakeSteps(
       scene,
       std::forward<ConfigureScene>(configureScene),
-      requireInitialContact);
+      requireInitialContact,
+      postBakeSteps);
 
   EXPECT_EQ(rawCounter.allocationCount, 0u)
       << "raw heap (malloc) bytes allocated during first post-bake steps: "
@@ -7867,21 +7870,6 @@ TEST(World, BakedBasicDeformableRowsDoNotMallocOnHeap)
       });
 
   expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
-      "deformable self-contact friction patch",
-      configureDeformableSelfContactFrictionPatchScene);
-  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
-      "deformable iterative FEM ground friction block",
-      configureDeformableIterativeFemGroundFrictionBlockScene);
-  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
-      "deformable matrix-free self-contact production grid",
-      configureDeformableSelfContactFrictionLargerMatrixFreeProductionGridScene);
-  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
-      "deformable static obstacle barriers",
-      configureDeformableStaticObstacleBarrierScene);
-  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
-      "deformable static obstacle friction matrix-free production patch",
-      configureDeformableStaticObstacleFrictionMatrixFreeProductionScene);
-  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
       "small mixed deformable storage paths", [](sx::World& world) {
         configureDeformableSelfContactFrictionGridSceneWithShapeAndMotion(
             world,
@@ -7902,6 +7890,77 @@ TEST(World, BakedBasicDeformableRowsDoNotMallocOnHeap)
             true,
             Eigen::Vector3d(3.0, 0.0, 0.0));
       });
+#endif
+}
+
+// The deformable raw-malloc allocation gates below were split out of a single
+// monolithic BakedBasicDeformableRowsDoNotMallocOnHeap test so that each scene
+// is its own focused gate, matching the one-scene-per-gate convention used by
+// the surrounding deformable allocation gates. Splitting also isolates the
+// matrix-free self-contact production grid -- the single dominant cost of the
+// test_world_raw_malloc shard under the Debug + gcov Coverage job -- so its
+// coverage-specific step reduction (see the TEST below) stays self-contained.
+// The set of scenes exercised is unchanged.
+TEST(World, BakedDeformableFrictionPatchStepsDoNotMallocOnHeap)
+{
+#if !defined(DART_TEST_HAS_RAW_MALLOC_INTERPOSE)
+  GTEST_SKIP() << "raw malloc interposer unavailable on this platform/build";
+#else
+  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
+      "deformable self-contact friction patch",
+      configureDeformableSelfContactFrictionPatchScene);
+  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
+      "deformable iterative FEM ground friction block",
+      configureDeformableIterativeFemGroundFrictionBlockScene);
+  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
+      "deformable static obstacle barriers",
+      configureDeformableStaticObstacleBarrierScene);
+#endif
+}
+
+TEST(World, BakedDeformableMatrixFreeProductionGridStepsDoNotMallocOnHeap)
+{
+#if !defined(DART_TEST_HAS_RAW_MALLOC_INTERPOSE)
+  GTEST_SKIP() << "raw malloc interposer unavailable on this platform/build";
+#elif defined(DART_CODECOV)
+  // A single step of the full 17x17 matrix-free self-contact production grid
+  // costs ~850s under the Debug + gcov build, so the usual four-step gate ran
+  // ~3400s and on its own overran the test_world_raw_malloc shard. Keep the
+  // full production grid here -- so the Coverage job retains gcov line coverage
+  // of the matrix-free self-contact solver at production scale -- but assert
+  // the no-raw-malloc property over a single post-bake step. The full four-step
+  // assertion still runs at this size in normal Release/Debug CI. This gate is
+  // the only place the scene runs under coverage: the sibling no-growth and
+  // global-heap monolith gates GTEST_SKIP it, and the *...IsActive correctness
+  // test compiles out, under DART_CODECOV.
+  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
+      "deformable matrix-free self-contact production grid",
+      configureDeformableSelfContactFrictionLargerMatrixFreeProductionGridScene,
+      /*requireInitialContact=*/false,
+      /*postBakeSteps=*/1);
+#else
+  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
+      "deformable matrix-free self-contact production grid",
+      configureDeformableSelfContactFrictionLargerMatrixFreeProductionGridScene);
+#endif
+}
+
+TEST(World, BakedDeformableStaticObstacleProductionStepsDoNotMallocOnHeap)
+{
+#if !defined(DART_TEST_HAS_RAW_MALLOC_INTERPOSE)
+  GTEST_SKIP() << "raw malloc interposer unavailable on this platform/build";
+#else
+  expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
+      "deformable static obstacle friction matrix-free production patch",
+      configureDeformableStaticObstacleFrictionMatrixFreeProductionScene);
+#endif
+}
+
+TEST(World, BakedDeformableSurfaceCcdCrossingStepsDoNotMallocOnHeap)
+{
+#if !defined(DART_TEST_HAS_RAW_MALLOC_INTERPOSE)
+  GTEST_SKIP() << "raw malloc interposer unavailable on this platform/build";
+#else
   expectNoRawHeapAllocationsDuringFirstPostBakeSteps(
       "deformable moving rigid surface CCD crossing",
       configureDeformableMovingRigidSurfaceCcdCrossingScene);


### PR DESCRIPTION
Fixes the flaky `Coverage (Debug)` failure on `main` (`test_world_raw_malloc` **Timeout at 3600s**) at its root.

## Root cause

`test_world_raw_malloc` runs every `World.*DoNotMallocOnHeap` gate. After excluding the rigid-IPC gates that already `GTEST_SKIP` under coverage, one test dominated: `BakedBasicDeformableRowsDoNotMallocOnHeap` was a single monolithic gate bundling **12 deformable sub-scenes**, one of which — a **17×17 matrix-free self-contact "production" grid** — is by far the most expensive scene in the shard under the Debug + gcov build, so its four post-bake steps dominated the runtime. A gtest `TEST` is atomic to ctest, so neither a bigger timeout nor ctest-filter splitting could fix it.

## Fix (keeps full-size gcov coverage)

- **Split** the monolith into focused one-scene gates, matching the one-scene-per-gate convention used by every other deformable allocation gate.
- Add an `int postBakeSteps = 4` parameter to the raw-malloc gate helpers and run the matrix-free production-grid gate for a **single post-bake step under `DART_CODECOV`** (the full four-step assertion stays in Release/Debug CI). The grid **keeps its full 17×17 size**, so the Coverage job still exercises the matrix-free self-contact solver at production scale — only the redundant extra steps are dropped.

> Updated per Codex review: the first revision shrank the grid to 8×8 under coverage, but Codex correctly noted the full 17×17 scene would then run **nowhere** under the Coverage job (the sibling no-growth/global-heap gates `GTEST_SKIP`, and the `…IsActive` correctness test compiles out, under `DART_CODECOV`). Reducing the step count instead keeps the full production grid and its gcov line coverage; only this gate runs it under coverage.

## Verification (local, real `-O0` + gcov build)

| | before | after |
|---|---|---|
| `World.*DoNotMallocOnHeap` shard | ~570s | **274s** |
| 17×17 production-grid gate | ~416s (4 steps) | **104s** (1 step, full size) |
| result | timeout on CI | **17 passed, 5 coverage-skipped, 0 failed** |

Release suite for these gates: **22 passed** at the full 17×17 size. `pixi run check-lint` passes. (Local desktop is several× faster than the CI runner for this gcov workload, which is why the same shard hit the 3600s limit on CI; the PR’s own `Coverage (Debug)` job confirms the absolute.) New gates match `World.*DoNotMallocOnHeap`, so they flow into the existing shard automatically — no CMakeLists change.

@codex review