### PR TITLE
Fix release-6.19 CI toolchain drift (cmake wheel pin + Clang literal-operator)

### DIFF
--- a/dart/math/Helpers.hpp
+++ b/dart/math/Helpers.hpp
@@ -325,39 +325,39 @@ inline Eigen::VectorXd randomVectorXd(std::size_t size, double limit)
 namespace suffixes {
 
 //==============================================================================
-constexpr double operator"" _pi(long double x)
+constexpr double operator""_pi(long double x)
 {
   return x * constants<double>::pi();
 }
 
 //==============================================================================
-constexpr double operator"" _pi(unsigned long long int x)
+constexpr double operator""_pi(unsigned long long int x)
 {
-  return operator"" _pi(static_cast<long double>(x));
+  return operator""_pi(static_cast<long double>(x));
 }
 
 //==============================================================================
-constexpr double operator"" _rad(long double angle)
+constexpr double operator""_rad(long double angle)
 {
   return angle;
 }
 
 //==============================================================================
-constexpr double operator"" _rad(unsigned long long int angle)
+constexpr double operator""_rad(unsigned long long int angle)
 {
-  return operator"" _rad(static_cast<long double>(angle));
+  return operator""_rad(static_cast<long double>(angle));
 }
 
 //==============================================================================
-constexpr double operator"" _deg(long double angle)
+constexpr double operator""_deg(long double angle)
 {
   return toRadian(angle);
 }
 
 //==============================================================================
-constexpr double operator"" _deg(unsigned long long int angle)
+constexpr double operator""_deg(unsigned long long int angle)
 {
-  return operator"" _deg(static_cast<long double>(angle));
+  return operator""_deg(static_cast<long double>(angle));
 }
 
 } // namespace suffixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,12 @@
 # All rights reserved.
 
 [build-system]
-requires = ["setuptools>=42", "wheel", "ninja", "cmake>=3.12"]
+# Pin cmake below 4.3.4: that release regressed GLUT/OpenGL detection in the
+# manylinux_2_28 wheel container, so find_package(GLUT) fails, the dart-gui
+# target is skipped, and dartpy aborts with "Cannot find the library dart-gui".
+# 4.3.2 (the last version used by a green wheel build) works. Relax once a fixed
+# cmake ships.
+requires = ["setuptools>=42", "wheel", "ninja", "cmake>=3.12,<4.3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/tests/unit/math/test_Math.cpp
+++ b/tests/unit/math/test_Math.cpp
@@ -1285,6 +1285,28 @@ TEST(MATH, UTILS)
 }
 
 //==============================================================================
+TEST(MATH, USER_DEFINED_LITERALS)
+{
+  using namespace dart::math::suffixes;
+
+  const double pi = constants<double>::pi();
+
+  // _pi scales by pi, via both the floating-point and integer overloads.
+  EXPECT_NEAR(1.0_pi, pi, MATH_EPS);
+  EXPECT_NEAR(0.5_pi, 0.5 * pi, MATH_EPS);
+  EXPECT_NEAR(2_pi, 2.0 * pi, MATH_EPS);
+
+  // _rad is the identity (the value is already in radians), via both overloads.
+  EXPECT_NEAR(1.5_rad, 1.5, MATH_EPS);
+  EXPECT_NEAR(3_rad, 3.0, MATH_EPS);
+
+  // _deg converts degrees to radians, via both overloads.
+  EXPECT_NEAR(180.0_deg, pi, MATH_EPS);
+  EXPECT_NEAR(90_deg, 0.5 * pi, MATH_EPS);
+  EXPECT_NEAR(360_deg, 2.0 * pi, MATH_EPS);
+}
+
+//==============================================================================
 Jacobian AdTJac1(const Eigen::Isometry3d& _T, const Jacobian& _J)
 {
   Jacobian res = Jacobian::Zero(6, _J.cols());


### PR DESCRIPTION
Two independent **toolchain-drift** failures are blocking the DART 6.19.3 release on `release-6.19`. Both passed on the tip days ago and broke only because hosted runner toolchains advanced; neither is a source regression.

## 1. manylinux wheels — `cmake` 4.3.4 regression

The **Publish dartpy** workflow fails on all `ubuntu-latest-cpXX-manylinux_x86_64` jobs:

```
CMake Error at python/dartpy/CMakeLists.txt:54 (message):
  Cannot find the library dart-gui.  (Looking for freeglut3 - NOT found)
```

`[build-system].requires` pinned `cmake>=3.12` with no upper bound, so cibuildwheel grabbed the latest cmake. **4.3.4** (PyPI'd 2026-06-20) regressed GLUT/OpenGL detection in the pinned `manylinux_2_28-v6.15` container, so `dart-gui` is skipped and dartpy aborts.

| Build | cmake | freeglut3 | Result |
|-------|-------|-----------|--------|
| `v6.19.2` tag (06-19) | 4.3.2 | found | ✅ |
| `release-6.19` tip (06-21) | 4.3.4 | NOT found | ❌ |

**Fix:** `cmake>=3.12,<4.3.4` — resolves back to the known-good 4.3.2; no GUI logic touched. Verified: `cp312-manylinux_x86_64` builds green on a `workflow_dispatch` of this branch.

## 2. macOS arm64 — Clang `-Wdeprecated-literal-operator`

`macos-latest`'s Clang now errors on the deprecated user-defined-literal form `operator"" _x` (whitespace before suffix) under `DART_TREAT_WARNINGS_AS_ERRORS`, breaking `arm64-Release`/`arm64-Debug` in `dart/math/Helpers.hpp` (`_pi`, `_rad`, `_deg`):

```
error: identifier '_rad' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
```

**Fix:** use the non-deprecated `operator""_x` form. Identical behavior, valid on all supported compilers; main (DART 7) already uses this form.

## Verification
Merging to `release-6.19` re-runs `publish_dartpy.yml` (full manylinux matrix) and the macOS arm64 CI; both should be green, unblocking the 6.19.3 packaging + tag.